### PR TITLE
refactor: gracefully exit when GEMINI_API_KEY is missing and provide a URL for setup

### DIFF
--- a/packages/cli/src/config/env.ts
+++ b/packages/cli/src/config/env.ts
@@ -24,17 +24,15 @@ export function loadEnvironment(): void {
   // Start searching from the current working directory by default
   const envFilePath = findEnvFile(process.cwd());
 
-  if (!envFilePath) {
-    return;
+  if (envFilePath) {
+    dotenv.config({ path: envFilePath });
   }
 
-  dotenv.config({ path: envFilePath });
-
-  if (!process.env.GEMINI_API_KEY) {
+  if (!process.env.GEMINI_API_KEY?.length) {
     console.error(
-      'Error: GEMINI_API_KEY environment variable is not set in the loaded .env file.',
+      'Error: GEMINI_API_KEY environment variable is not set. Please visit https://ai.google.dev/gemini-api/docs/api-key to set up a new one.',
     );
-    process.exit(1);
+    process.exit(0);
   }
 }
 
@@ -43,7 +41,7 @@ export function getApiKey(): string {
   const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) {
     throw new Error(
-      'GEMINI_API_KEY is missing. Ensure loadEnvironment() was called successfully.',
+      'GEMINI_API_KEY environment variable is not set. Please visit https://ai.google.dev/gemini-api/docs/api-key to set up a new one.',
     );
   }
   return apiKey;


### PR DESCRIPTION
Before:

```
 % npm start    

> gemini-code@1.0.0 start
> npm run start --workspace=gemini-code-cli -- "$@"


> gemini-code-cli@1.0.0 start
> node dist/gemini.js

(node:3469286) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
An unexpected critical error occurred:
GEMINI_API_KEY is missing. Ensure loadEnvironment() was called successfully.
npm error Lifecycle script `start` failed with error:
npm error code 1
npm error path /usr/local/google/home/brandonkeiji/git/gemini-code/packages/cli
npm error workspace gemini-code-cli@1.0.0
npm error location /usr/local/google/home/brandonkeiji/git/gemini-code/packages/cli
npm error command failed
npm error command sh -c node dist/gemini.js

```


After:

```
 % npm start                                           

> gemini-code@1.0.0 start
> npm run start --workspace=gemini-code-cli -- "$@"


> gemini-code-cli@1.0.0 start
> node dist/gemini.js

(node:3468497) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Error: GEMINI_API_KEY environment variable is not set. Please visit https://ai.google.dev/gemini-api/docs/api-key to set up a new one.
```