### PR TITLE
feat: initial configs for npm publishing

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+; TODO(b/411429188): move this to an artifact registry in the official gemini-code gcp project
+@google:registry=https://us-west1-npm.pkg.dev/kkb-dev/gemini-code/
+//us-west1-npm.pkg.dev/kkb-dev/gemini-code/:always-auth=true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "npm run test --workspaces",
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit --jsx react",
-    "start": "npm run start --workspace=gemini-code-cli -- \"$@\"",
+    "start": "npm run start --workspace=@google/gemini-code -- \"$@\"",
     "format": "prettier --write .",
     "artifactregistry-login": "npx google-artifactregistry-auth"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit --jsx react",
     "start": "npm run start --workspace=gemini-code-cli -- \"$@\"",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "artifactregistry-login": "npx google-artifactregistry-auth"
   },
   "devDependencies": {
     "eslint": "^9.24.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "gemini.js",
   "scripts": {
-    "build": "tsc && cp package.json README.md dist/",
+    "build": "tsc && cp package.json README.md ../../LICENSE dist/",
     "clean": "rm -rf dist",
     "start": "node dist/gemini.js",
     "debug": "node --inspect-brk dist/gemini.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "gemini-code-cli",
+  "name": "@google/gemini-code",
   "version": "1.0.0",
   "description": "Gemini Code CLI",
   "type": "module",
-  "main": "dist/gemini.js",
+  "main": "gemini.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp package.json README.md dist/",
+    "clean": "rm -rf dist",
     "start": "node dist/gemini.js",
     "debug": "node --inspect-brk dist/gemini.js",
     "lint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
BUG=b/411429188

add a per-project .npmrc to indicate where the app should be published to.

update `npm run build` to copy `package.json` into the `dist/` folder. npm uses this for metadata on the published package. also added an extra `npm run clean` command.

`npm run artifactregistry-login` to authenticate to the artifact registry locally

NOTE: we need to bundle the node_modules with this before it just works with `npm install -g @google/gemini-code`
