### PR TITLE
fix: add `--build` to tsc commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/gemini.js",
   "scripts": {
-    "build": "tsc && cp package.json README.md ../../LICENSE dist/ && touch dist/.last_build",
+    "build": "tsc --build && cp package.json README.md ../../LICENSE dist/ && touch dist/.last_build",
     "clean": "rm -rf dist",
     "start": "node dist/gemini.js",
     "debug": "node --inspect-brk dist/gemini.js",

--- a/packages/cli/src/gemini.ts
+++ b/packages/cli/src/gemini.ts
@@ -12,6 +12,10 @@ import { WriteFileTool } from './tools/write-file.tool.js';
 import { WebFetchTool } from './tools/web-fetch.tool.js';
 import { globalConfig } from './config/config.js';
 
+// TODO(b/411707095): remove. left here as an example of how to pull in inter-package deps
+import { helloServer } from '@gemini-code/server';
+helloServer();
+
 async function main() {
   // Configure tools
   registerTools(globalConfig.getTargetDir());
@@ -25,7 +29,7 @@ async function main() {
 }
 
 // --- Global Unhandled Rejection Handler ---
-process.on('unhandledRejection', (reason, _) => {
+process.on('unhandledRejection', (reason, promise) => {
   // Check if this is the known 429 ClientError that sometimes escapes
   // this is a workaround for a specific issue with the way we are calling gemini
   // where a 429 error is thrown but not caught, causing an unhandled rejection

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/index.js",
   "scripts": {
-    "build": "tsc && cp package.json dist/",
+    "build": "tsc --build && cp package.json dist/",
     "clean": "rm -rf dist",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write ."


### PR DESCRIPTION
`import { helloServer } from '@gemini-code/server';` was failing on cold `npm run build` executions. Added the `--build` flag to `tsc` so that it knows to build dependencies.