### PR TITLE
fix: point server 'main' to dist folder

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Gemini Code Server",
   "type": "module",
-  "main": "src/index.js",
+  "main": "dist/src/index.js",
   "scripts": {
     "build": "tsc --build && cp package.json dist/",
     "clean": "rm -rf dist",


### PR DESCRIPTION
was causing another import issue on `npm run start`

TODO(b/411707095): make these `dist` references more consistent between each package