### PR TITLE
Make model-generated code copyable

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -69,7 +69,7 @@ export const App = ({ config }: AppProps) => {
   });
 
   return (
-    <Box flexDirection="column" padding={1} marginBottom={1} width="100%">
+    <Box flexDirection="column" marginBottom={1} width="100%">
       <Header />
 
       {startupWarnings.length > 0 && (

--- a/packages/cli/src/ui/components/messages/GeminiMessage.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessage.tsx
@@ -38,9 +38,6 @@ export const GeminiMessage: React.FC<GeminiMessageProps> = ({ text }) => {
 
   return (
     <Box flexDirection="row">
-      <Box width={prefixWidth}>
-        <Text color={Colors.AccentPurple}>{prefix}</Text>
-      </Box>
       <Box flexGrow={1} flexDirection="column">
         {renderedBlocks}
       </Box>

--- a/packages/cli/src/ui/utils/MarkdownRenderer.tsx
+++ b/packages/cli/src/ui/utils/MarkdownRenderer.tsx
@@ -160,11 +160,12 @@ export class MarkdownRenderer {
       <Box
         key={key}
         borderStyle="round"
-        paddingX={1}
         borderColor={Colors.SubtleComment}
+        borderLeft={false}
+        borderRight={false}
         flexDirection="column"
       >
-        {lang && <Text dimColor> {lang}</Text>}
+        {lang && <Text dimColor>{lang}</Text>}
         {/* Render each line preserving whitespace (within Text component) */}
         {content.map((line, idx) => (
           <Text key={idx}>{line}</Text>


### PR DESCRIPTION
Before model generated code snippets look like this:

```
 ✦ ╭─────────────────────────────────╮
   │  javascript                     │
   │ const num1 = 5;                 │
   │ const num2 = 10;                │
   │ const sum = num1 + num2;        │
   │ console.log(sum); // Output: 15 │
   ╰─────────────────────────────────╯
```

This looks pretty but makes it impossible to copy the code snippet.

Now it looks like this

```
──────────────────────────────────────
javascript
const num1 = 5;
const num2 = 10;
const sum = num1 + num2;
console.log(sum); // Output: 15
──────────────────────────────────────
```