### PR TITLE
Fix confirmations.

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -52,15 +52,7 @@ export const App = ({ config }: AppProps) => {
     [history],
   );
 
-  const isWaitingForToolConfirmation = history.some(
-    (item) =>
-      item.type === 'tool_group' &&
-      item.tools.some((tool) => tool.confirmationDetails !== undefined),
-  );
-  const isInputActive =
-    streamingState === StreamingState.Idle &&
-    !initError &&
-    !isWaitingForToolConfirmation;
+  const isInputActive = streamingState === StreamingState.Idle && !initError;
 
   const { query, handleSubmit: handleHistorySubmit } = useInputHistory({
     userMessages,
@@ -88,39 +80,37 @@ export const App = ({ config }: AppProps) => {
         </Box>
       )}
 
-      {initError &&
-        streamingState !== StreamingState.Responding &&
-        !isWaitingForToolConfirmation && (
-          <Box
-            borderStyle="round"
-            borderColor={Colors.AccentRed}
-            paddingX={1}
-            marginBottom={1}
-          >
-            {history.find(
-              (item) => item.type === 'error' && item.text?.includes(initError),
-            )?.text ? (
+      {initError && streamingState !== StreamingState.Responding && (
+        <Box
+          borderStyle="round"
+          borderColor={Colors.AccentRed}
+          paddingX={1}
+          marginBottom={1}
+        >
+          {history.find(
+            (item) => item.type === 'error' && item.text?.includes(initError),
+          )?.text ? (
+            <Text color={Colors.AccentRed}>
+              {
+                history.find(
+                  (item) =>
+                    item.type === 'error' && item.text?.includes(initError),
+                )?.text
+              }
+            </Text>
+          ) : (
+            <>
               <Text color={Colors.AccentRed}>
-                {
-                  history.find(
-                    (item) =>
-                      item.type === 'error' && item.text?.includes(initError),
-                  )?.text
-                }
+                Initialization Error: {initError}
               </Text>
-            ) : (
-              <>
-                <Text color={Colors.AccentRed}>
-                  Initialization Error: {initError}
-                </Text>
-                <Text color={Colors.AccentRed}>
-                  {' '}
-                  Please check API key and configuration.
-                </Text>
-              </>
-            )}
-          </Box>
-        )}
+              <Text color={Colors.AccentRed}>
+                {' '}
+                Please check API key and configuration.
+              </Text>
+            </>
+          )}
+        </Box>
+      )}
 
       <Box flexDirection="column">
         <HistoryDisplay history={history} onSubmit={submitQuery} />

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -11,11 +11,6 @@ import { IndividualToolCallDisplay, ToolCallStatus } from '../../types.js';
 import { DiffRenderer } from './DiffRenderer.js';
 import { FileDiff, ToolResultDisplay } from '../../../tools/tools.js';
 import { Colors } from '../../colors.js';
-import {
-  ToolCallConfirmationDetails,
-  ToolEditConfirmationDetails,
-  ToolExecuteConfirmationDetails,
-} from '@gemini-code/server';
 
 export const ToolMessage: React.FC<IndividualToolCallDisplay> = ({
   callId,
@@ -23,12 +18,7 @@ export const ToolMessage: React.FC<IndividualToolCallDisplay> = ({
   description,
   resultDisplay,
   status,
-  confirmationDetails,
 }) => {
-  // Explicitly type the props to help the type checker
-  const typedConfirmationDetails = confirmationDetails as
-    | ToolCallConfirmationDetails
-    | undefined;
   const typedResultDisplay = resultDisplay as ToolResultDisplay | undefined;
 
   let color = Colors.SubtleComment;
@@ -78,30 +68,6 @@ export const ToolMessage: React.FC<IndividualToolCallDisplay> = ({
             : ` - ${description}`}
         </Text>
       </Box>
-      {status === ToolCallStatus.Confirming && typedConfirmationDetails && (
-        <Box flexDirection="column" marginLeft={2}>
-          {/* Display diff for edit/write */}
-          {'fileDiff' in typedConfirmationDetails && (
-            <DiffRenderer
-              diffContent={
-                (typedConfirmationDetails as ToolEditConfirmationDetails)
-                  .fileDiff
-              }
-            />
-          )}
-          {/* Display command for execute */}
-          {'command' in typedConfirmationDetails && (
-            <Text color={Colors.AccentYellow}>
-              Command:{' '}
-              {
-                (typedConfirmationDetails as ToolExecuteConfirmationDetails)
-                  .command
-              }
-            </Text>
-          )}
-          {/* <ConfirmInput onConfirm={handleConfirm} isFocused={isFocused} /> */}
-        </Box>
-      )}
       {status === ToolCallStatus.Success && typedResultDisplay && (
         <Box flexDirection="column" marginLeft={2}>
           {typeof typedResultDisplay === 'string' ? (

--- a/packages/server/src/core/turn.ts
+++ b/packages/server/src/core/turn.ts
@@ -130,83 +130,78 @@ export class Turn {
           yield event;
         }
       }
+    }
 
-      // Execute pending tool calls
-      const toolPromises = this.pendingToolCalls.map(
-        async (pendingToolCall): Promise<ServerToolExecutionOutcome> => {
-          const tool = this.availableTools.get(pendingToolCall.name);
-          if (!tool) {
-            return {
-              ...pendingToolCall,
-              error: new Error(
-                `Tool "${pendingToolCall.name}" not found or not provided to Turn.`,
-              ),
-              confirmationDetails: undefined,
-            };
-          }
-
-          try {
-            const confirmationDetails = await tool.shouldConfirmExecute(
-              pendingToolCall.args,
-            );
-            if (confirmationDetails) {
-              return { ...pendingToolCall, confirmationDetails };
-            } else {
-              const result = await tool.execute(pendingToolCall.args);
-              return {
-                ...pendingToolCall,
-                result,
-                confirmationDetails: undefined,
-              };
-            }
-          } catch (execError: unknown) {
-            return {
-              ...pendingToolCall,
-              error: new Error(
-                `Tool execution failed: ${execError instanceof Error ? execError.message : String(execError)}`,
-              ),
-              confirmationDetails: undefined,
-            };
-          }
-        },
-      );
-      const outcomes = await Promise.all(toolPromises);
-
-      // Process outcomes and prepare function responses
-      this.pendingToolCalls = []; // Clear pending calls for this turn
-
-      for (let i = 0; i < outcomes.length; i++) {
-        const outcome = outcomes[i];
-        if (outcome.confirmationDetails) {
-          this.confirmationDetails.push(outcome.confirmationDetails);
-          const serverConfirmationetails: ServerToolCallConfirmationDetails = {
-            request: {
-              callId: outcome.callId,
-              name: outcome.name,
-              args: outcome.args,
-            },
-            details: outcome.confirmationDetails,
+    // Execute pending tool calls
+    const toolPromises = this.pendingToolCalls.map(
+      async (pendingToolCall): Promise<ServerToolExecutionOutcome> => {
+        const tool = this.availableTools.get(pendingToolCall.name);
+        if (!tool) {
+          return {
+            ...pendingToolCall,
+            error: new Error(
+              `Tool "${pendingToolCall.name}" not found or not provided to Turn.`,
+            ),
+            confirmationDetails: undefined,
           };
-          yield {
-            type: GeminiEventType.ToolCallConfirmation,
-            value: serverConfirmationetails,
-          };
-        } else {
-          const responsePart = this.buildFunctionResponse(outcome);
-          this.fnResponses.push(responsePart);
-          const responseInfo: ToolCallResponseInfo = {
-            callId: outcome.callId,
-            responsePart,
-            resultDisplay: outcome.result?.returnDisplay,
-            error: outcome.error,
-          };
-          yield { type: GeminiEventType.ToolCallResponse, value: responseInfo };
         }
-      }
 
-      // If there were function responses, the caller (GeminiService) will loop
-      // and call run() again with these responses.
-      // If no function responses, the turn ends here.
+        try {
+          const confirmationDetails = await tool.shouldConfirmExecute(
+            pendingToolCall.args,
+          );
+          if (confirmationDetails) {
+            return { ...pendingToolCall, confirmationDetails };
+          } else {
+            const result = await tool.execute(pendingToolCall.args);
+            return {
+              ...pendingToolCall,
+              result,
+              confirmationDetails: undefined,
+            };
+          }
+        } catch (execError: unknown) {
+          return {
+            ...pendingToolCall,
+            error: new Error(
+              `Tool execution failed: ${execError instanceof Error ? execError.message : String(execError)}`,
+            ),
+            confirmationDetails: undefined,
+          };
+        }
+      },
+    );
+    const outcomes = await Promise.all(toolPromises);
+
+    // Process outcomes and prepare function responses
+    this.pendingToolCalls = []; // Clear pending calls for this turn
+
+    for (const outcome of outcomes) {
+      if (outcome.confirmationDetails) {
+        this.confirmationDetails.push(outcome.confirmationDetails);
+        const serverConfirmationetails: ServerToolCallConfirmationDetails = {
+          request: {
+            callId: outcome.callId,
+            name: outcome.name,
+            args: outcome.args,
+          },
+          details: outcome.confirmationDetails,
+        };
+        yield {
+          type: GeminiEventType.ToolCallConfirmation,
+          value: serverConfirmationetails,
+        };
+      } else {
+        const responsePart = this.buildFunctionResponse(outcome);
+        this.fnResponses.push(responsePart);
+        const responseInfo: ToolCallResponseInfo = {
+          callId: outcome.callId,
+          responsePart,
+          resultDisplay: outcome.result?.returnDisplay,
+          error: outcome.error,
+        };
+        yield { type: GeminiEventType.ToolCallResponse, value: responseInfo };
+      }
     }
   }
 


### PR DESCRIPTION
- This fixes what it means to get confirmations in GC. Prior to this they had just been accidentally unwired as part of all of the refactorings to turns + to server/core.
  - The key piece of this is that we wrap the onConfirm in the gemini stream hook in order to resubmit function responses. This isn't 100% ideal but gets the job done for now.
- Fixed history not updating properly with confirmations.

Fixes https://b.corp.google.com/issues/412323656