### PR TITLE
Remove redundant else branches

### DIFF
--- a/packages/cli/src/gemini.ts
+++ b/packages/cli/src/gemini.ts
@@ -54,20 +54,21 @@ process.on('unhandledRejection', (reason, _promise) => {
     );
     console.warn('-----------------------------------------');
     console.warn('Reason:', reason);
-    // No process.exit(1);
-  } else {
-    // Log other unexpected unhandled rejections as critical errors
-    console.error('=========================================');
-    console.error('CRITICAL: Unhandled Promise Rejection!');
-    console.error('=========================================');
-    console.error('Reason:', reason);
-    console.error('Stack trace may follow:');
-    if (!(reason instanceof Error)) {
-      console.error(reason);
-    }
-    // Exit for genuinely unhandled errors
-    process.exit(1);
+    return;
+    // No process.exit(1); Don't exit.
   }
+
+  // Log other unexpected unhandled rejections as critical errors
+  console.error('=========================================');
+  console.error('CRITICAL: Unhandled Promise Rejection!');
+  console.error('=========================================');
+  console.error('Reason:', reason);
+  console.error('Stack trace may follow:');
+  if (!(reason instanceof Error)) {
+    console.error(reason);
+  }
+  // Exit for genuinely unhandled errors
+  process.exit(1);
 });
 
 // --- Global Entry Point ---

--- a/packages/cli/src/ui/hooks/useStdin.ts
+++ b/packages/cli/src/ui/hooks/useStdin.ts
@@ -70,12 +70,12 @@ export function usePipedInput(): PipedInputState {
         stdin.removeListener('error', handleError);
         stdin.removeListener('end', handleEnd);
       };
-    } else {
-      // No piped input (running interactively)
-      setIsLoading(false);
-      // Optionally set an 'info' state or just let isLoading=false & isPiped=false suffice
-      // setError('No piped input detected.'); // Maybe don't treat this as an 'error'
     }
+
+    // No piped input (running interactively)
+    setIsLoading(false);
+    // Optionally set an 'info' state or just let isLoading=false & isPiped=false suffice
+    // setError('No piped input detected.'); // Maybe don't treat this as an 'error'
 
     // Intentionally run only once on mount or when stdin theoretically changes
   }, [stdin, isRawModeSupported, setRawMode /*, exit */]);

--- a/packages/server/src/core/gemini-client.ts
+++ b/packages/server/src/core/gemini-client.ts
@@ -129,10 +129,9 @@ export class GeminiClient {
       if (error instanceof Error && error.name === 'AbortError') {
         console.log('Gemini stream request aborted by user.');
         throw error;
-      } else {
-        console.error(`Error during Gemini stream or tool interaction:`, error);
-        throw error;
       }
+      console.error(`Error during Gemini stream or tool interaction:`, error);
+      throw error;
     }
   }
 

--- a/packages/server/src/utils/BackgroundTerminalAnalyzer.ts
+++ b/packages/server/src/utils/BackgroundTerminalAnalyzer.ts
@@ -299,32 +299,31 @@ export class BackgroundTerminalAnalyzer {
         const { stdout } = await execAsync(command);
         // Check if the output contains the process information (it will have the image name if found)
         return stdout.toLowerCase().includes('.exe'); // A simple check, adjust if needed
-      } else {
-        // Linux/macOS/Unix-like: Use kill -0 signal
-        // process.kill sends signal 0 to check existence without killing
-        process.kill(pid, 0);
-        return true; // If no error is thrown, process exists
       }
+      // Linux/macOS/Unix-like: Use kill -0 signal
+      // process.kill sends signal 0 to check existence without killing
+      process.kill(pid, 0);
+      return true; // If no error is thrown, process exists
     } catch (error: unknown) {
       if (isNodeError(error) && error.code === 'ESRCH') {
         // ESRCH: Standard error code for "No such process" on Unix-like systems
         return false;
-      } else if (
+      }
+      if (
         process.platform === 'win32' &&
         getErrorMessage(error).includes('No tasks are running')
       ) {
         // tasklist specific error when PID doesn't exist
         return false;
-      } else {
-        // Other errors (e.g., EPERM - permission denied) mean we couldn't determine status.
-        // Re-throwing might be appropriate depending on desired behavior.
-        // Here, we log it and cautiously return true, assuming it *might* still be running.
-        console.warn(
-          `isProcessRunning(${pid}) encountered error: ${getErrorMessage(error)}. Assuming process might still exist.`,
-        );
-        // Or you could throw the error: throw new Error(`Failed to check process status for PID ${pid}: ${error.message}`);
-        return true; // Cautious assumption
       }
+      // Other errors (e.g., EPERM - permission denied) mean we couldn't determine status.
+      // Re-throwing might be appropriate depending on desired behavior.
+      // Here, we log it and cautiously return true, assuming it *might* still be running.
+      console.warn(
+        `isProcessRunning(${pid}) encountered error: ${getErrorMessage(error)}. Assuming process might still exist.`,
+      );
+      // Or you could throw the error: throw new Error(`Failed to check process status for PID ${pid}: ${error.message}`);
+      return true; // Cautious assumption
     }
   }
 


### PR DESCRIPTION
Else branches are an anti pattern especially if you can easily return from the previous branch. Over time, else branches cause deep nesting and make code unreadable and unmaintainable. Remove elses where possible.