### PR TITLE
Remove dead methods from ToolRegistry

### DIFF
--- a/packages/server/src/tools/tool-registry.ts
+++ b/packages/server/src/tools/tool-registry.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ToolListUnion, FunctionDeclaration } from '@google/genai';
+import { FunctionDeclaration } from '@google/genai';
 import { Tool } from './tools.js';
 
 export class ToolRegistry {
@@ -38,29 +38,10 @@ export class ToolRegistry {
   }
 
   /**
-   * Deprecated/Internal? Retrieves schemas in the ToolListUnion format.
-   * Kept for reference, prefer getFunctionDeclarations.
-   */
-  getToolSchemas(): ToolListUnion {
-    const declarations = this.getFunctionDeclarations();
-    if (declarations.length === 0) {
-      return [];
-    }
-    return [{ functionDeclarations: declarations }];
-  }
-
-  /**
    * Returns an array of all registered tool instances.
    */
   getAllTools(): Tool[] {
     return Array.from(this.tools.values());
-  }
-
-  /**
-   * Optional: Get a list of registered tool names.
-   */
-  listAvailableTools(): string[] {
-    return Array.from(this.tools.keys());
   }
 
   /**


### PR DESCRIPTION
* getToolSchemas is deprecated.
* listAvailableTools is now getAllTools.