### PR TITLE
fix: use relative imports within the same package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6496,9 +6496,9 @@
     },
     "packages/cli": {
       "name": "@gemini-code/cli",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "dependencies": {
-        "@gemini-code/server": "1.0.0",
+        "@gemini-code/server": "*",
         "@google/genai": "^0.8.0",
         "diff": "^7.0.0",
         "dotenv": "^16.4.7",
@@ -6529,7 +6529,7 @@
     },
     "packages/server": {
       "name": "@gemini-code/server",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@google/genai": "^0.8.0",
         "diff": "^7.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gemini-code/cli",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Gemini Code CLI",
   "type": "module",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
     "dist"
   ],
   "dependencies": {
-    "@gemini-code/server": "1.0.0",
+    "@gemini-code/server": "*",
     "@google/genai": "^0.8.0",
     "diff": "^7.0.0",
     "dotenv": "^16.4.7",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gemini-code/server",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Gemini Code Server",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/src/tools/terminal.ts
+++ b/packages/server/src/tools/terminal.ts
@@ -13,11 +13,8 @@ import path from 'path';
 import os from 'os';
 import crypto from 'crypto';
 import { promises as fs } from 'fs';
-import {
-  SchemaValidator,
-  getErrorMessage,
-  isNodeError,
-} from '@gemini-code/server';
+import { SchemaValidator } from '../utils/schemaValidator.js';
+import { getErrorMessage, isNodeError } from '../utils/errors.js';
 import { Config } from '../config/config.js';
 import {
   BaseTool,


### PR DESCRIPTION
TODO(b/412422717): add a lint rule to prevent this

drive-by change: drop package versions down to `0.*.*` in preparation for canary release pipeline