### PR TITLE
fix: remove circular dependency in background terminal analyzer

### DIFF
--- a/packages/server/src/utils/BackgroundTerminalAnalyzer.ts
+++ b/packages/server/src/utils/BackgroundTerminalAnalyzer.ts
@@ -5,11 +5,8 @@
  */
 
 import { Content, SchemaUnion, Type } from '@google/genai';
-import {
-  getErrorMessage,
-  isNodeError,
-  GeminiClient,
-} from '@gemini-code/server';
+import { getErrorMessage, isNodeError } from '../utils/errors.js';
+import { GeminiClient } from '../core/gemini-client.js';
 import { Config } from '../config/config.js';
 import { promises as fs } from 'fs';
 import { exec as _exec } from 'child_process';


### PR DESCRIPTION
Was causing the [TS5055](https://stackoverflow.com/a/66581260/23363012) on partial rebuilds.

TODO(b/412422717): add a lint rule to prevent this