### PR TITLE
Fix Docker Build permission issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ USER node
 # install gemini-code and clean up
 COPY packages/cli/dist/gemini-code-cli-*.tgz /usr/local/share/npm-global/gemini-code-cli.tgz
 COPY packages/server/dist/gemini-code-server-*.tgz /usr/local/share/npm-global/gemini-code-server.tgz
-RUN npm install -g /usr/local/share/npm-global/gemini-code-cli.tgz /usr/local/share/npm-global/gemini-code-server.tgz \
+RUN npm install -g /usr/local/share/npm-global/gemini-code-{cli,server}.tgz \
   && npm cache clean --force \
-  && rm -f /usr/local/share/npm-global/gemini-code-cli.tgz \
-  && rm -f /usr/local/share/npm-global/gemini-code-server.tgz
+  && rm -f /usr/local/share/npm-global/gemini-code-{cli,server}.tgz
 

--- a/scripts/build_sandbox.sh
+++ b/scripts/build_sandbox.sh
@@ -57,6 +57,9 @@ echo "packing @gemini-code/server ..."
 rm -f packages/server/dist/gemini-code-server-*.tgz
 npm pack -w @gemini-code/server --pack-destination ./packages/server/dist &> /dev/null
 
+# Give node user access to tgz files
+chmod 755 packages/*/dist/gemini-code-*.tgz
+
 # build container image & prune older unused images
 # use empty --authfile to skip unnecessary auth refresh overhead
 echo "building $IMAGE ... (can be slow first time)"


### PR DESCRIPTION
During docker build`npm install` running as node was exiting with 243 (EACCES) from trying to install the tgz files because `npm pack` created the files with 400 permissions on my system.