### PR TITLE
Revert braces in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,5 @@ COPY packages/cli/dist/gemini-code-cli-*.tgz /usr/local/share/npm-global/gemini-
 COPY packages/server/dist/gemini-code-server-*.tgz /usr/local/share/npm-global/gemini-code-server.tgz
 RUN npm install -g /usr/local/share/npm-global/gemini-code-cli.tgz /usr/local/share/npm-global/gemini-code-server.tgz \
   && npm cache clean --force \
-  && rm -f /usr/local/share/npm-global/gemini-code-{cli,server}.tgz
-
+  && rm -f /usr/local/share/npm-global/gemini-code-cli.tgz \
+  && rm -f /usr/local/share/npm-global/gemini-code-server.tgz


### PR DESCRIPTION
Brace expansion is supported by docker but not podman. I only tested my first change (#95) with `docker` before I had `podman` setup on my cloudtop.