### PR TITLE
Unify Docker build commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM docker.io/library/node:20-slim
 
 # install minimal set of packages, then clean up
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/scripts/build_sandbox.sh
+++ b/scripts/build_sandbox.sh
@@ -61,8 +61,7 @@ npm pack -w @gemini-code/server --pack-destination ./packages/server/dist &> /de
 chmod 755 packages/*/dist/gemini-code-*.tgz
 
 # build container image & prune older unused images
-# use empty --authfile to skip unnecessary auth refresh overhead
 echo "building $IMAGE ... (can be slow first time)"
-$CMD build --authfile <(echo '{}') -t "$IMAGE" . >/dev/null
+$CMD build -t "$IMAGE" . >/dev/null
 $CMD image prune -f
 echo "built $IMAGE"


### PR DESCRIPTION
`--authfile` is a podman only command. This flag is being added to work around long hangs from `docker build` when searching multiple registries.

See the warning from `gcloud auth configure-docker`.
> WARNING: A long list of credential helpers may cause delays running 'docker build'. We recommend passing the registry name to configure only the registry you are using.

Work around this issue by fully qualifying the 'FROM' command as docker.io's node project.