### PR TITLE
Update sandbox script to not require term variables

### DIFF
--- a/scripts/start_sandbox.sh
+++ b/scripts/start_sandbox.sh
@@ -50,7 +50,7 @@ run_args+=(--name "$IMAGE-$INDEX" --hostname "$IMAGE-$INDEX")
 run_args+=(--env "SANDBOX=$IMAGE-$INDEX")
 
 # pass TERM and COLORTERM to container to maintain terminal colors
-run_args+=(--env "TERM=$TERM" --env "COLORTERM=$COLORTERM")
+run_args+=(--env "TERM=${TERM:-}" --env "COLORTERM=${COLORTERM:-}")
 
 # enable debugging via node --inspect-brk (and $DEBUG_PORT) if DEBUG is set
 node_args=()


### PR DESCRIPTION
If `nounset` is active, it'll require that TERM and COLORTERM is set in the environment. It's not necessary that these variables are set and it should be passed to the sandbox. This change just causes the TERM and COLORTERM to be set to an empty string if they are unset.
