### PR TITLE
feat: add scripts to prep package versions before release

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 ; TODO(b/411429188): re-enable and migrate once our private GCP project is up
-# @gemin-code-dev:registry=https://us-west1-npm.pkg.dev/kkb-dev/gemini-code/
-# //us-west1-npm.pkg.dev/kkb-dev/gemini-code/:always-auth=true
+; @gemini-code:registry=https://us-west1-npm.pkg.dev/gemini-code-dev/gemini-code/
+; //us-west1-npm.pkg.dev/gemini-code-dev/gemini-code/:always-auth=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gemini-code",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gemini-code",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "workspaces": [
         "packages/*"
       ],
@@ -18,6 +18,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "globals": "^16.0.0",
+        "lodash": "^4.17.21",
         "prettier": "^3.5.3",
         "typescript-eslint": "^8.30.1"
       }
@@ -4343,6 +4344,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-code",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "workspaces": [
@@ -17,7 +17,8 @@
     "typecheck": "tsc --noEmit --jsx react",
     "format": "prettier --write .",
     "preflight": "npm run format --workspaces --if-present && npm run lint --workspaces --if-present && npm run test --workspaces --if-present",
-    "artifactregistry-login": "npx google-artifactregistry-auth"
+    "artifactregistry-login": "npx google-artifactregistry-auth",
+    "stage": "npm run stage:version --workspaces && npm run stage:deps --workspaces"
   },
   "devDependencies": {
     "eslint": "^9.24.0",
@@ -27,6 +28,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "globals": "^16.0.0",
+    "lodash": "^4.17.21",
     "prettier": "^3.5.3",
     "typescript-eslint": "^8.30.1"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,9 @@
     "debug": "node --inspect-brk dist/gemini.js",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "stage:version": "node ../../scripts/bind_package_version.js",
+    "stage:deps": "node ../../scripts/bind_package_dependencies.js"
   },
   "files": [
     "dist"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,9 @@
     "clean": "rm -rf dist",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "stage:version": "node ../../scripts/bind_package_version.js",
+    "stage:deps": "node ../../scripts/bind_package_dependencies.js"
   },
   "files": [
     "dist"

--- a/scripts/bind_package_dependencies.js
+++ b/scripts/bind_package_dependencies.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import _ from 'lodash';
+
+function bindPackageDependencies() {
+  const scriptDir = process.cwd();
+  const currentPkgJsonPath = path.join(scriptDir, 'package.json');
+  const currentPkg = JSON.parse(fs.readFileSync(currentPkgJsonPath));
+  // assume packages are all under /<repo_root>/packages/
+  const packagesDir = path.join(path.dirname(scriptDir));
+
+  const geminiCodePkgs = fs
+    .readdirSync(packagesDir)
+    .filter(
+      (name) =>
+        fs.statSync(path.join(packagesDir, name)).isDirectory() &&
+        fs.existsSync(path.join(packagesDir, name, 'package.json')),
+    )
+    .map((packageDirname) => {
+      const packageJsonPath = path.join(
+        packagesDir,
+        packageDirname,
+        'package.json',
+      );
+      return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    })
+    .reduce((pkgs, pkg) => ({ ...pkgs, [pkg.name]: pkg }), {});
+  currentPkg.dependencies = _.mapValues(
+    currentPkg.dependencies,
+    (value, key) => {
+      if (geminiCodePkgs[key]) {
+        console.log(
+          `Package ${currentPkg.name} has a dependency on ${key}. Updating dependent version.`,
+        );
+        return geminiCodePkgs[key].version;
+      }
+      return value;
+    },
+  );
+  const updatedPkgJson = JSON.stringify(currentPkg, null, 2) + '\n';
+  fs.writeFileSync(currentPkgJsonPath, updatedPkgJson);
+}
+
+bindPackageDependencies();

--- a/scripts/bind_package_version.js
+++ b/scripts/bind_package_version.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Assuming script is run from a package directory (e.g., packages/cli)
+const packageDir = process.cwd();
+const rootDir = path.join(packageDir, '..', '..'); // Go up two directories to find the repo root
+
+function getBaseVersion() {
+  // Read root package.json
+  const rootPackageJsonPath = path.join(rootDir, 'package.json');
+  const rootPackage = JSON.parse(fs.readFileSync(rootPackageJsonPath, 'utf8'));
+  let baseVersion = rootPackage.version;
+
+  // Append nightly suffix
+  const today = new Date();
+  const yyyy = today.getFullYear();
+  const mm = String(today.getMonth() + 1).padStart(2, '0'); // Months are 0-indexed
+  const dd = String(today.getDate()).padStart(2, '0');
+  const nightlySuffix = `-nightly-${yyyy}${mm}${dd}`;
+  return `${baseVersion}${nightlySuffix}`;
+}
+
+const newVersion = getBaseVersion();
+console.log(`Setting package version to: ${newVersion}`);
+
+const packageJsonPath = path.join(packageDir, 'package.json');
+
+if (fs.existsSync(packageJsonPath)) {
+  console.log(`Updating version for ${packageJsonPath}`);
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  packageJson.version = newVersion;
+  fs.writeFileSync(
+    packageJsonPath,
+    JSON.stringify(packageJson, null, 2) + '\n',
+    'utf8',
+  );
+} else {
+  console.error(
+    `Error: package.json not found in the current directory: ${packageJsonPath}`,
+  );
+  process.exit(1);
+}
+
+console.log('Done.');


### PR DESCRIPTION
BUG=b/411429188
DIFFBASE=#109

Followup PR will execute these along with `npm publish --workspaces` on a nightly basis.

Drive-by change: update .npmrc to tentatively point to the new artifact registry on our dedicated GCP project. still commented out since some people experienced auth issues last time.