### PR TITLE
Update UI of tool and user messages

### DIFF
--- a/packages/cli/src/ui/colors.ts
+++ b/packages/cli/src/ui/colors.ts
@@ -5,7 +5,6 @@
  */
 
 export const Colors = {
-  Background: '#1E1E2E',
   Foreground: 'white',
   LightBlue: '#CDD6F4',
   AccentBlue: '#89B4FA',
@@ -15,4 +14,5 @@ export const Colors = {
   AccentYellow: '#F9E2AF',
   AccentRed: '#F38BA8',
   SubtleComment: '#6C7086',
+  Gray: 'gray',
 };

--- a/packages/cli/src/ui/components/messages/DiffRenderer.tsx
+++ b/packages/cli/src/ui/components/messages/DiffRenderer.tsx
@@ -138,11 +138,7 @@ export const DiffRenderer: React.FC<DiffRendererProps> = ({
   // --- End Modification ---
 
   return (
-    <Box
-      borderStyle="round"
-      borderColor={Colors.SubtleComment}
-      flexDirection="column"
-    >
+    <Box flexDirection="column">
       {/* Iterate over the lines that should be displayed (already normalized) */}
       {displayableLines.map((line, index) => {
         const key = `diff-line-${index}`;
@@ -179,7 +175,7 @@ export const DiffRenderer: React.FC<DiffRendererProps> = ({
         return (
           // Using your original rendering structure
           <Box key={key} flexDirection="row">
-            <Text color={Colors.SubtleComment}>{gutterNumStr} </Text>
+            <Text color={Colors.Foreground}>{gutterNumStr} </Text>
             <Text color={color} dimColor={dim}>
               {prefixSymbol}{' '}
             </Text>

--- a/packages/cli/src/ui/components/messages/GeminiMessage.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessage.tsx
@@ -16,28 +16,13 @@ interface GeminiMessageProps {
 export const GeminiMessage: React.FC<GeminiMessageProps> = ({ text }) => {
   const prefix = '✦ ';
   const prefixWidth = prefix.length;
-
-  // Handle potentially null or undefined text gracefully
-  const safeText = text || '';
-
-  // Use the static render method from the MarkdownRenderer class
-  // Pass safeText which is guaranteed to be a string
-  const renderedBlocks = MarkdownRenderer.render(safeText);
-
-  // If the original text was actually empty/null, render the minimal state
-  if (!safeText && renderedBlocks.length === 0) {
-    return (
-      <Box flexDirection="row">
-        <Box width={prefixWidth}>
-          <Text color={Colors.AccentPurple}>{prefix}</Text>
-        </Box>
-        <Box flexGrow={1}></Box>
-      </Box>
-    );
-  }
+  const renderedBlocks = MarkdownRenderer.render(text);
 
   return (
     <Box flexDirection="row">
+      <Box width={prefixWidth}>
+        <Text color={Colors.AccentPurple}>{prefix}</Text>
+      </Box>
       <Box flexGrow={1} flexDirection="column">
         {renderedBlocks}
       </Box>

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -22,11 +22,18 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   toolCalls,
   onSubmit,
 }) => {
-  const hasPending = toolCalls.some((t) => t.status === ToolCallStatus.Pending);
-  const borderColor = hasPending ? Colors.AccentYellow : Colors.AccentBlue;
+  const hasPending = !toolCalls.every(
+    (t) => t.status === ToolCallStatus.Success,
+  );
+  const borderColor = hasPending ? Colors.AccentYellow : Colors.AccentCyan;
 
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor={borderColor}>
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderDimColor={hasPending}
+      borderColor={borderColor}
+    >
       {toolCalls.map((tool) => (
         <React.Fragment key={tool.callId}>
           <ToolMessage

--- a/packages/cli/src/ui/components/messages/UserMessage.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.tsx
@@ -19,10 +19,12 @@ export const UserMessage: React.FC<UserMessageProps> = ({ text }) => {
   return (
     <Box flexDirection="row">
       <Box width={prefixWidth}>
-        <Text color={Colors.SubtleComment}>{prefix}</Text>
+        <Text color={Colors.Gray}>{prefix}</Text>
       </Box>
       <Box flexGrow={1}>
-        <Text wrap="wrap">{text}</Text>
+        <Text wrap="wrap" color={Colors.Gray}>
+          {text}
+        </Text>
       </Box>
     </Box>
   );

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -269,7 +269,7 @@ export const useGeminiStream = (
             // Create the UI display object matching IndividualToolCallDisplay
             const toolCallDisplay: IndividualToolCallDisplay = {
               callId,
-              name,
+              name: cliTool.displayName,
               description,
               status: ToolCallStatus.Pending,
               resultDisplay: undefined,

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -25,7 +25,7 @@ export enum GeminiEventType {
 
 export enum ToolCallStatus {
   Pending = 'Pending',
-  Invoked = 'Invoked',
+  Canceled = 'Canceled',
   Confirming = 'Confirming',
   Success = 'Success',
   Error = 'Error',


### PR DESCRIPTION
- Bring tool messages in line with original envisioned UI of: https://screenshot.googleplex.com/9yZCX636LzpMrgc
  - In particular this represents more descriptive names. FWIW we already had this tech we just weren't passing around information correctly (`displayName` vs. `name`)
 - Add gray to our list of color pallete's and removed Background (unused)
 - Re-enabled representing canceled messages
 - Migrated back towards a cleaner tool message design of status symbols & border colors vs. overly verbose text.
 - Removed border from confirmation diffs.

## Before
![image](https://github.com/user-attachments/assets/c93454a8-206a-4886-9a99-f2108b9acfc6)

## After
![image](https://github.com/user-attachments/assets/be6f3783-988d-40f2-8858-04c65a28ce12)

 
 Fixes https://b.corp.google.com/issues/412598909