### PR TITLE
Fix Tool -> Text -> Confirmation bu that results in disordered history

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -217,6 +217,11 @@ export const useGeminiStream = (
             // For content events, accumulate the text and update an existing message or create a new one
             currentGeminiText += event.value;
 
+            // Reset group because we're now adding a user message to the history. If we didn't reset the
+            // group here then any subsequent tool calls would get grouped before this message resulting in
+            // a misordering of history.
+            currentToolGroupId = null;
+
             if (!hasInitialGeminiResponse) {
               // Create a new Gemini message if this is the first content event
               hasInitialGeminiResponse = true;


### PR DESCRIPTION
- We weren't reseting the tool group inbetween content which meant we'd start a new group on the first tool call, and if regular textual content followed it'd effectively close that group; however, we weren't updating our state to really close that group. Meaning, any subsequent tool calls or confirmations would get grouped with the original grouping.
  - When we see textual content from Gemini we now reset the tool call group.

## Before
![image](https://github.com/user-attachments/assets/869dfadc-f51c-4cd0-bcde-923982e1122e)

## After
![image](https://github.com/user-attachments/assets/1f6c4469-8df0-4506-a532-b18387a13da5)

Fixes https://b.corp.google.com/issues/412605330