### PR TITLE
feat: add alias to the cli bin directive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6520,7 +6520,7 @@
         "yargs": "^17.7.2"
       },
       "bin": {
-        "cli": "dist/index.js"
+        "gemini-code": "dist/index.js"
       },
       "devDependencies": {
         "@types/diff": "^7.0.2",

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * @license
  * Copyright 2025 Google LLC

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,9 @@
   "description": "Gemini Code CLI",
   "type": "module",
   "main": "dist/index.js",
-  "bin": "dist/index.js",
+  "bin": {
+    "gemini-code": "dist/index.js"
+  },
   "scripts": {
     "build": "tsc --build && touch dist/.last_build",
     "clean": "rm -rf dist",


### PR DESCRIPTION
BUG=b/411429188

What this do: When users install this npm package globally, they'll be able to call it with `gemini-code` from the terminal.