### PR TITLE
fix: use process.env.CLI_VERSION to avoid conflicts with NODE_ENV

### DIFF
--- a/packages/cli/src/gemini.ts
+++ b/packages/cli/src/gemini.ts
@@ -25,9 +25,7 @@ async function main() {
   if (process.stdin.isTTY && input?.length === 0) {
     const readUpResult = await readPackageUp({ cwd: __dirname });
     const cliVersion =
-      process.env.NODE_ENV === 'development'
-        ? 'local'
-        : (readUpResult?.packageJson.version ?? 'unknown');
+      process.env.CLI_VERSION || readUpResult?.packageJson.version || 'unknown';
 
     render(
       React.createElement(App, {

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -24,8 +24,8 @@ if scripts/sandbox_command.sh -q; then
 else
     echo "WARNING: OUTSIDE SANDBOX. See README.md to enable sandboxing."
     if [ -n "${DEBUG:-}" ]; then
-        NODE_ENV='development' node --inspect-brk node_modules/@gemini-code/cli "$@"
+        CLI_VERSION='development' node --inspect-brk node_modules/@gemini-code/cli "$@"
     else
-        NODE_ENV='development' node node_modules/@gemini-code/cli "$@"
+        CLI_VERSION='development' node node_modules/@gemini-code/cli "$@"
     fi
 fi


### PR DESCRIPTION
Turns out `process.env.NODE_ENV` is an anti-pattern: https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production#why-is-node_env-considered-an-antipattern