### PR TITLE
Pass GEMINI_API_KEY env variable to sandbox

### DIFF
--- a/scripts/start_sandbox.sh
+++ b/scripts/start_sandbox.sh
@@ -46,7 +46,12 @@ run_args+=(--name "$IMAGE-$INDEX" --hostname "$IMAGE-$INDEX")
 run_args+=(--env "SANDBOX=$IMAGE-$INDEX")
 
 # pass TERM and COLORTERM to container to maintain terminal colors
-run_args+=(--env "TERM=${TERM:-}" --env "COLORTERM=${COLORTERM:-}")
+run_args+=(--env TERM --env COLORTERM)
+
+# set GEMINI_API_KEY environment variable if it exists
+if [ -n "${GEMINI_API_KEY:-}" ]; then
+    run_args+=(--env GEMINI_API_KEY)
+fi
 
 # enable debugging via node --inspect-brk (and $DEBUG_PORT) if DEBUG is set
 node_args=()


### PR DESCRIPTION
GEMINI_API_KEY in .env is broken (at least for me) in docker because the .env file is probably not shared with podman/docker.

After this change I can get to the gemini-code cli inside podman!