### PR TITLE
Prevent console.warn's for tool calls.

### DIFF
--- a/packages/server/src/core/client.ts
+++ b/packages/server/src/core/client.ts
@@ -20,6 +20,7 @@ import { Turn, ServerGeminiStreamEvent } from './turn.js';
 import { Config } from '../config/config.js';
 import { getCoreSystemPrompt } from './prompts.js';
 import { ReadManyFilesTool } from '../tools/read-many-files.js'; // Import ReadManyFilesTool
+import { getResponseText } from '../utils/generateContentResponseUtilities.js';
 
 export class GeminiClient {
   private config: Config;
@@ -185,13 +186,14 @@ export class GeminiClient {
         },
         contents,
       });
-      if (!result || !result.text) {
+      const text = getResponseText(result);
+      if (!text) {
         throw new Error('API returned an empty response.');
       }
       try {
-        return JSON.parse(result.text);
+        return JSON.parse(text);
       } catch (parseError) {
-        console.error('Failed to parse JSON response:', result.text);
+        console.error('Failed to parse JSON response:', text);
         throw new Error(
           `Failed to parse API response as JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
         );

--- a/packages/server/src/core/turn.ts
+++ b/packages/server/src/core/turn.ts
@@ -18,6 +18,7 @@ import {
   ToolResult,
   ToolResultDisplay,
 } from '../tools/tools.js'; // Keep ToolResult for now
+import { getResponseText } from '../utils/generateContentResponseUtilities.js';
 // Removed gemini-stream import (types defined locally)
 
 // --- Types for Server Logic ---
@@ -102,7 +103,6 @@ export class Turn {
     this.confirmationDetails = [];
     this.debugResponses = [];
   }
-
   // The run method yields simpler events suitable for server logic
   async *run(
     req: PartListUnion,
@@ -115,10 +115,12 @@ export class Turn {
       if (signal?.aborted) {
         throw this.abortError();
       }
-      if (resp.text) {
-        yield { type: GeminiEventType.Content, value: resp.text };
-        continue;
+
+      const text = getResponseText(resp);
+      if (text) {
+        yield { type: GeminiEventType.Content, value: text };
       }
+
       if (!resp.functionCalls) {
         continue;
       }

--- a/packages/server/src/utils/generateContentResponseUtilities.ts
+++ b/packages/server/src/utils/generateContentResponseUtilities.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GenerateContentResponse } from '@google/genai';
+
+export function getResponseText(
+  response: GenerateContentResponse,
+): string | undefined {
+  return (
+    response.candidates?.[0]?.content?.parts
+      ?.map((part) => part.text)
+      .join('') || undefined
+  );
+}


### PR DESCRIPTION
- Added helper for extracting text content from responses without warning.

See fixed issue for more detail: https://b.corp.google.com/issues/414005146