### PR TITLE
Upgrade @google/genai to latest.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -658,13 +658,15 @@
       "link": true
     },
     "node_modules/@google/genai": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-0.8.0.tgz",
-      "integrity": "sha512-Zs+OGyZKyMbFofGJTR9/jTQSv8kITh735N3tEuIZj4VlMQXTC0soCFahysJ9NaeenRlD7xGb6fyqmX+FwrpU6Q==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-0.10.0.tgz",
+      "integrity": "sha512-LAbp0em5A+wRtQR2+r5ckRBg2U2cBy8cJHgyTHa9PUbK8zucApw6A93HWyom/qlUQBNCpnIHFp20RiJuYMQwAw==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.14.2",
-        "ws": "^8.18.0"
+        "ws": "^8.18.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.4"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -6814,6 +6816,24 @@
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
       "license": "MIT"
     },
+    "node_modules/zod": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
+      }
+    },
     "packages/cli": {
       "name": "@gemini-code/cli",
       "version": "0.1.0-dev-62cc889.0",
@@ -6853,7 +6873,7 @@
       "name": "@gemini-code/server",
       "version": "0.1.0-dev-62cc889.0",
       "dependencies": {
-        "@google/genai": "^0.8.0",
+        "@google/genai": "^0.10.0",
         "diff": "^7.0.0",
         "dotenv": "^16.4.7",
         "fast-glob": "^3.3.3"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,7 @@
     "dist"
   ],
   "dependencies": {
-    "@google/genai": "^0.8.0",
+    "@google/genai": "^0.10.0",
     "fast-glob": "^3.3.3",
     "diff": "^7.0.0",
     "dotenv": "^16.4.7"


### PR DESCRIPTION
- Motivation of this upgrade is to enable us to get convenient access to the thinking budget config changes for 2.5 thinking models. This will be key to getting our model to take a bit more time for various requests.