### PR TITLE
rename dev image with -dev suffix

### DIFF
--- a/packages/server/src/tools/shell.ts
+++ b/packages/server/src/tools/shell.ts
@@ -24,6 +24,7 @@ export interface ShellToolParams {
 import { spawn } from 'child_process';
 
 export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
+  // name should match TerminalTool.Name used in prompts.ts for now
   static Name: string = 'execute_bash_command';
   private readonly config: Config;
   private whitelist: Set<string> = new Set();

--- a/scripts/build_sandbox.sh
+++ b/scripts/build_sandbox.sh
@@ -30,11 +30,14 @@ SKIP_NPM_INSTALL_BUILD=false
 while getopts "sd" opt; do
     case ${opt} in
     s) SKIP_NPM_INSTALL_BUILD=true ;;
-    d) DOCKERFILE=Dockerfile-dev ;;
+    d)
+        DOCKERFILE=Dockerfile-dev
+        IMAGE+="-dev"
+        ;;
     \?)
         echo "usage: $(basename "$0") [-s] [-d]"
         echo "  -s: skip npm install + npm run build"
-        echo "  -d: use Dockerfile-dev"
+        echo "  -d: build dev image (using Dockerfile-dev)"
         exit 1
         ;;
     esac

--- a/scripts/start_sandbox.sh
+++ b/scripts/start_sandbox.sh
@@ -23,25 +23,24 @@ fi
 CMD=$(scripts/sandbox_command.sh)
 IMAGE=gemini-code-sandbox
 DEBUG_PORT=9229
-
-# stop if image is missing
-if ! $CMD images -q "$IMAGE" | grep -q .; then
-    echo "ERROR: $IMAGE is missing. Try \`npm run build\` with sandboxing enabled."
-    exit 1
-fi
-
 PROJECT=$(basename "$PWD")
 WORKDIR=/sandbox/$PROJECT
 CLI_PATH=/usr/local/share/npm-global/lib/node_modules/\@gemini-code/cli
 
-# if project is gemini-code, then run CLI from $WORKDIR/packages/cli
-# note this means the global installation is not required in this case
+# if project is gemini-code, then switch to -dev image & run CLI from $WORKDIR/packages/cli
 if [[ "$PROJECT" == "gemini-code" ]]; then
+    IMAGE+="-dev"
     CLI_PATH="$WORKDIR/packages/cli"
 elif [ -n "${DEBUG:-}" ]; then
-    # refuse to debug using global installation
-    # (requires a separate attach config in launch.json, see comments there around remoteRoot)
+    # refuse to debug using global installation for now (can be added later)
+    # (requires a separate attach config, see comments in launch.json around remoteRoot)
     echo "ERROR: debugging is sandbox is not supported when target/root is not gemini-code"
+    exit 1
+fi
+
+# stop if image is missing
+if ! $CMD images -q "$IMAGE" | grep -q .; then
+    echo "ERROR: $IMAGE is missing. Try \`npm run build\` with sandboxing enabled."
     exit 1
 fi
 


### PR DESCRIPTION
- use different name for dev image that does not contain global installation and must be built using scripts/build_sandbox.sh (instead of npm run build), to avoid attempting to use dev image outside GC repo
- added minor comment in shell tool