### PR TITLE
refactor: remove node_modules reference in start command

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -26,8 +26,8 @@ else
     # DEV=true to enable React Dev Tools (https://github.com/vadimdemedes/ink?tab=readme-ov-file#using-react-devtools)
     # CLI_VERSION to display in the app ui footer
     if [ -n "${DEBUG:-}" ]; then
-        CLI_VERSION='development' DEV=true node --inspect-brk node_modules/@gemini-code/cli "$@"
+        CLI_VERSION='development' DEV=true npm run debug --workspace=@gemini-code/cli -- "$@"
     else
-        CLI_VERSION='development' DEV=true node node_modules/@gemini-code/cli "$@"
+        CLI_VERSION='development' DEV=true npm run start --workspace=@gemini-code/cli -- "$@"
     fi
 fi


### PR DESCRIPTION
IIUC, it's a bit of an npm [sin](https://julie.io/writing/javascript-node-modules/#never-reference-nodemodules) to refer directly to things in `node_modules`