### PR TITLE
env flags SANDBOX_{MOUNTS,ENV}, improved debugging through sandbox that should now work in all scenarios

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,11 +10,9 @@
       "request": "attach",
       "skipFiles": ["<node_internals>/**"],
       "type": "node",
-      // fix source mapping when debugging in sandbox
-      // we assume debugging is done on gemini-code project itself (see CLI_PATH setup in start_sandbox.sh)
-      // there seems to be no way to map two distinct remoteRoots to same localRoot under same configuration
-      // "remoteRoot": "/usr/local/share/npm-global/lib/node_modules/@gemini-code",
-      "remoteRoot": "/sandbox/gemini-code/packages",
+      // fix source mapping when debugging in sandbox using global installation
+      // note this does not interfere when remoteRoot is also ${workspaceFolder}/packages
+      "remoteRoot": "/usr/local/share/npm-global/lib/node_modules/@gemini-code",
       "localRoot": "${workspaceFolder}/packages"
     },
     {


### PR DESCRIPTION
- SANDBOX_MOUNTS can now list mount paths or specs (from:to:opts), default spec being to mount on same path as read-only; paths must be absolute, can be ancestors of project root (root remains read-write even if ancestors are read-only)
- SANDBOX_ENV can list key=value pairs to set as environment variables inside sandbox
- Sandbox will now maintain project root path from host instead of changing to /sandbox/...
- Debugging through sandbox should now work in all scenarios (via npm run debug or DEBUG=1 gemini-code, inside or outside repo root)