### PR TITLE
fix: point start.sh to relative path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6860,8 +6860,7 @@
         "yargs": "^17.7.2"
       },
       "bin": {
-        "gemini-code": "dist/index.js",
-        "gemini-code-sandbox": "bin/sandbox.sh"
+        "gemini-code": "dist/index.js"
       },
       "devDependencies": {
         "@types/diff": "^7.0.2",

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -26,8 +26,8 @@ else
     # DEV=true to enable React Dev Tools (https://github.com/vadimdemedes/ink?tab=readme-ov-file#using-react-devtools)
     # CLI_VERSION to display in the app ui footer
     if [ -n "${DEBUG:-}" ]; then
-        CLI_VERSION='development' DEV=true npm run debug --workspace=@gemini-code/cli -- "$@"
+        CLI_VERSION='development' DEV=true node --inspect-brk ./packages/cli "$@"
     else
-        CLI_VERSION='development' DEV=true npm run start --workspace=@gemini-code/cli -- "$@"
+        CLI_VERSION='development' DEV=true node ./packages/cli "$@"
     fi
 fi


### PR DESCRIPTION
forgot that `--workspace` changes the `cwd` when starting the cli (see #198). resorting to directly referencing the package folder