### PR TITLE
Add @ command handling to useGeminiStream

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -27,7 +27,7 @@ import {
   IndividualToolCallDisplay,
   ToolCallStatus,
 } from '../types.js';
-import { isPotentiallyAtCommand } from '../utils/commandUtils.js'; // Import the @ command checker
+import { isAtCommand } from '../utils/commandUtils.js'; // Import the @ command checker
 import { useSlashCommandProcessor } from './slashCommandProcessor.js';
 import { usePassthroughProcessor } from './passthroughCommandProcessor.js';
 import { handleAtCommand } from './atCommandProcessor.js'; // Import the @ command handler
@@ -165,7 +165,7 @@ export const useGeminiStream = (
         }
 
         // 3. Check for @ Commands using the utility function
-        if (isPotentiallyAtCommand(trimmedQuery)) {
+        if (isAtCommand(trimmedQuery)) {
           const atCommandResult = await handleAtCommand({
             query: trimmedQuery,
             config,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -222,7 +222,6 @@ export const useGeminiStream = (
 
       setStreamingState(StreamingState.Responding);
       setInitError(null);
-      // messageIdCounterRef.current = 0; // Reset counter for new submission << MOVED TO START OF FUNCTION
       const chat = chatSessionRef.current;
       let currentToolGroupId: number | null = null;
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -27,10 +27,11 @@ import {
   IndividualToolCallDisplay,
   ToolCallStatus,
 } from '../types.js';
-import { findSafeSplitPoint } from '../utils/markdownUtilities.js';
+import { isPotentiallyAtCommand } from '../utils/commandUtils.js'; // Import the @ command checker
 import { useSlashCommandProcessor } from './slashCommandProcessor.js';
 import { usePassthroughProcessor } from './passthroughCommandProcessor.js';
 import { handleAtCommand } from './atCommandProcessor.js'; // Import the @ command handler
+import { findSafeSplitPoint } from '../utils/markdownUtilities.js'; // Import the split point finder
 
 const addHistoryItem = (
   setHistory: React.Dispatch<React.SetStateAction<HistoryItem[]>>,
@@ -163,8 +164,8 @@ export const useGeminiStream = (
           return; // Handled, exit
         }
 
-        // 3. Check for @ Commands
-        if (trimmedQuery.startsWith('@')) {
+        // 3. Check for @ Commands using the utility function
+        if (isPotentiallyAtCommand(trimmedQuery)) {
           const atCommandResult = await handleAtCommand({
             query: trimmedQuery,
             config,

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -12,7 +12,7 @@
  * @param query The input query string.
  * @returns True if the query looks like an '@' command, false otherwise.
  */
-export const isPotentiallyAtCommand = (query: string): boolean =>
+export const isAtCommand = (query: string): boolean =>
   // Check if starts with @ OR has a space, then @, then a non-space character.
   query.startsWith('@') || /\s@\S/.test(query);
 


### PR DESCRIPTION
This PR supports the @file command pattern in useGeminiStream. It will correctly handle the @ command anywhere in the input string so you can run:

@packages
which will call the read many files tool and stuff the context with everything under packages

Explain @package.json to me like I'm a C++ programmer
which will create a multipart message to send to gemini with part 0 being "Explain", part 1 being the context of the file/s, and part 2 being "to me like I'm a C++ programmer"