### PR TITLE
Support calling commands without slash

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -7,7 +7,7 @@
 import { useCallback } from 'react';
 import { type PartListUnion } from '@google/genai';
 import { HistoryItem } from '../types.js';
-import { isSlashCommand } from '../utils/commandUtils.js';
+import { getCommandFromQuery } from '../utils/commandUtils.js';
 
 export interface SlashCommand {
   name: string; // slash command
@@ -88,30 +88,31 @@ export const useSlashCommandProcessor = (
     // Removed /theme command, handled in App.tsx
   ];
 
-  // Checks if the query is a slash command and executes it if it is.
+  // Checks if the query is a slash command and executes the command if it is.
   const handleSlashCommand = useCallback(
     (rawQuery: PartListUnion): boolean => {
       if (typeof rawQuery !== 'string') {
         return false;
       }
 
-      const trimmedQuery = rawQuery.trim();
-      if (!isSlashCommand(trimmedQuery)) {
-        return false; // Not a slash command
+      const trimmed = rawQuery.trim();
+      let [symbol, test] = getCommandFromQuery(trimmed);
+
+      // Skip non slash commands (unless single word without symbol)
+      if (symbol !== '/' && trimmed !== test) {
+        return false;
       }
 
-      const commandName = trimmedQuery.slice(1).split(/\s+/)[0]; // Get command name after '/'
-
       for (const cmd of slashCommands) {
-        if (commandName === cmd.name) {
+        if (test === cmd.name) {
           // Add user message *before* execution
           const userMessageTimestamp = Date.now();
           addHistoryItem(
             setHistory,
-            { type: 'user', text: trimmedQuery },
+            { type: 'user', text: trimmed },
             userMessageTimestamp,
           );
-          cmd.action(trimmedQuery);
+          cmd.action(trimmed);
           return true; // Command was handled
         }
       }

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -16,11 +16,19 @@ export const isAtCommand = (query: string): boolean =>
   // Check if starts with @ OR has a space, then @, then a non-space character.
   query.startsWith('@') || /\s@\S/.test(query);
 
+const control_symbols: string[] = ['/', '@', '!', '?'];
 /**
- * Checks if a query string represents a slash command (starts with '/').
+ * Returns the first word of query with optional leading slash, ampersand, bang.
  *
  * @param query The input query string.
- * @returns True if the query is a slash command, false otherwise.
+ * @returns optional leading symbol and first word of query
  */
-export const isSlashCommand = (query: string): boolean =>
-  query.trim().startsWith('/');
+export const getCommandFromQuery = (
+  query: string,
+): [string | undefined, string] => {
+  const word = query.trim().split(/\s/, 1)[0];
+  if (word.length > 0 && control_symbols.includes(word[0])) {
+    return [word[0], word.slice(1)];
+  }
+  return [undefined, word];
+};


### PR DESCRIPTION
I like being able to type 'exit' or 'quit' instead of '/exit' and I think it's a pretty reasonable that if you type just the single word we can understand that it's a command and not you asking gemini to exit (which won't do anything but confuse the user).