### PR TITLE
refactor: async-ify yargs

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -23,8 +23,8 @@ interface CliArgs {
   full_context: boolean | undefined;
 }
 
-function parseArguments(): CliArgs {
-  const argv = yargs(hideBin(process.argv))
+async function parseArguments(): Promise<CliArgs> {
+  const argv = await yargs(hideBin(process.argv))
     .option('model', {
       alias: 'm',
       type: 'string',
@@ -53,11 +53,11 @@ function parseArguments(): CliArgs {
     .help()
     .alias('h', 'help')
     .strict().argv;
-  return argv as unknown as CliArgs;
+  return argv;
 }
 
 // Renamed function for clarity
-export function loadCliConfig(): Config {
+export async function loadCliConfig(): Promise<Config> {
   // Load .env file using logic from server package
   loadEnvironment();
 
@@ -71,7 +71,7 @@ export function loadCliConfig(): Config {
   }
 
   // Parse CLI arguments
-  const argv = parseArguments();
+  const argv = await parseArguments();
 
   // Create config using factory from server package
   return createServerConfig(

--- a/packages/cli/src/gemini.ts
+++ b/packages/cli/src/gemini.ts
@@ -19,7 +19,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 async function main() {
-  const config = loadCliConfig();
+  const config = await loadCliConfig();
   let input = config.getQuestion();
 
   // hop into sandbox if we are outside and sandboxing is enabled


### PR DESCRIPTION
Mostly just splitting this change out from a different working branch (dev/prod sandbox consolidation) to keep that eventual diff more scoped. But this also at least allows us to remove the type assertion `as unknown as CliArgs`.