### PR TITLE
Support escaping spaces in file paths.

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -8,6 +8,7 @@ import React, { useCallback } from 'react';
 import { Text, Box, useInput, useFocus, Key } from 'ink';
 import TextInput from 'ink-text-input';
 import { Colors } from '../colors.js';
+import { Suggestion } from './SuggestionsDisplay.js';
 
 interface InputPromptProps {
   query: string;
@@ -16,7 +17,7 @@ interface InputPromptProps {
   setInputKey: React.Dispatch<React.SetStateAction<number>>;
   onSubmit: (value: string) => void;
   showSuggestions: boolean;
-  suggestions: string[];
+  suggestions: Suggestion[]; // Changed to Suggestion[]
   activeSuggestionIndex: number;
   navigateUp: () => void;
   navigateDown: () => void;
@@ -63,7 +64,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       base = query.substring(0, atIndex + 1 + lastSlashIndexInPath + 1);
     }
 
-    const newValue = base + selectedSuggestion;
+    const newValue = base + selectedSuggestion.value;
     setQuery(newValue);
     resetCompletion(); // Hide suggestions after selection
     setInputKey((k) => k + 1); // Increment key to force re-render and cursor reset

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -6,9 +6,12 @@
 
 import React from 'react';
 import { Box, Text } from 'ink';
-
+export interface Suggestion {
+  label: string;
+  value: string;
+}
 interface SuggestionsDisplayProps {
-  suggestions: string[];
+  suggestions: Suggestion[];
   activeIndex: number;
   isLoading: boolean;
   width: number;
@@ -62,7 +65,7 @@ export function SuggestionsDisplay({
             color={isActive ? 'black' : 'white'}
             backgroundColor={isActive ? 'blue' : undefined}
           >
-            {suggestion}
+            {suggestion.label}
           </Text>
         );
       })}

--- a/packages/server/src/utils/paths.ts
+++ b/packages/server/src/utils/paths.ts
@@ -100,3 +100,26 @@ export function makeRelative(
   // If the paths are the same, path.relative returns '', return '.' instead
   return relativePath || '.';
 }
+
+/**
+ * Escapes spaces in a file path.
+ */
+export function escapePath(filePath: string): string {
+  let result = '';
+  for (let i = 0; i < filePath.length; i++) {
+    // Only escape spaces that are not already escaped.
+    if (filePath[i] === ' ' && (i === 0 || filePath[i - 1] !== '\\')) {
+      result += '\\ ';
+    } else {
+      result += filePath[i];
+    }
+  }
+  return result;
+}
+
+/**
+ * Unescapes spaces in a file path.
+ */
+export function unescapePath(filePath: string): string {
+  return filePath.replace(/\\ /g, ' ');
+}


### PR DESCRIPTION
Example:
`@some file.txt` is rewritten as `@some\ file.txt`
Modify the suggestions component to support
suggestions with different descriptions and
values to generically support this.

Video verifying that all workflows now function correctly with escaped paths.
https://screencast.googleplex.com/cast/NjEzODA0NTk0OTU0MjQwMHw0NTBjZjRhNS1hNA