### PR TITLE
Support syntax highlighting for more languages

### DIFF
--- a/packages/cli/src/ui/utils/CodeColorizer.tsx
+++ b/packages/cli/src/ui/utils/CodeColorizer.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { Text } from 'ink';
-import { common, createLowlight } from 'lowlight';
+import { all, createLowlight } from 'lowlight';
 import type {
   Root,
   Element,
@@ -18,7 +18,7 @@ import { themeManager } from '../themes/theme-manager.js';
 import { Theme } from '../themes/theme.js';
 
 // Configure themeing and parsing utilities.
-const lowlight = createLowlight(common);
+const lowlight = createLowlight(all);
 
 function renderHastNode(
   node: Root | Element | HastText | RootContent,


### PR DESCRIPTION
Dart wasn't supported with the common list. Supporting could be nice for people using this to write Flutter apps.
With the tweak, syntax highlighting for Dart isn't great but isn't distracting.
![Screenshot 2025-05-01 at 11 33 53 AM](https://github.com/user-attachments/assets/6dc63ede-7d87-4544-88fe-8aedb2242dbb)
