### PR TITLE
[DRAFT] Markdown option for /help

### DIFF
--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -31,7 +31,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
     {item.type === 'gemini_content' && (
       <GeminiMessageContent text={item.text} />
     )}
-    {item.type === 'info' && <InfoMessage text={item.text} />}
+    {item.type === 'info' && <InfoMessage text={item.text} style={item.style} />}
     {item.type === 'error' && <ErrorMessage text={item.text} />}
     {item.type === 'tool_group' && (
       <ToolGroupMessage

--- a/packages/cli/src/ui/components/messages/InfoMessage.tsx
+++ b/packages/cli/src/ui/components/messages/InfoMessage.tsx
@@ -6,13 +6,16 @@
 
 import React from 'react';
 import { Text, Box } from 'ink';
+import { MarkdownRenderer } from '../../utils/MarkdownRenderer.js';
 import { Colors } from '../../colors.js';
+
 
 interface InfoMessageProps {
   text: string;
+  style: 'markdown' | 'text' | undefined;
 }
 
-export const InfoMessage: React.FC<InfoMessageProps> = ({ text }) => {
+export const InfoMessage: React.FC<InfoMessageProps> = ({ text, style }) => {
   const prefix = 'ℹ ';
   const prefixWidth = prefix.length;
 
@@ -21,11 +24,17 @@ export const InfoMessage: React.FC<InfoMessageProps> = ({ text }) => {
       <Box width={prefixWidth}>
         <Text color={Colors.AccentYellow}>{prefix}</Text>
       </Box>
+      {style === 'markdown' ? (
+      <Box flexGrow={1} flexDirection="column">
+        {MarkdownRenderer.render(text)}
+      </Box>
+      ) : (
       <Box flexGrow={1}>
-        <Text wrap="wrap" color={Colors.AccentYellow}>
+        <Text color={Colors.AccentYellow}>
           {text}
         </Text>
       </Box>
+      )}
     </Box>
   );
 };

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -44,9 +44,17 @@ export const useSlashCommandProcessor = (
           'and write files, search code, execute bash commands, and more ' +
           'to assist with development workflows. I will explain commands ' +
           'and ask for permission before running them and will not ' +
-          'commit changes unless explicitly instructed.';
+          'commit changes unless explicitly instructed.' +
+          '\n\n' +
+          ' * /help\n' +
+          ' * /clear\n' +
+          ' * /theme\n' +
+          ' * /exit or /quit\n' +
+          '\n\n';
         const timestamp = getNextMessageId(Date.now());
-        addHistoryItem(setHistory, { type: 'info', text: helpText }, timestamp);
+        addHistoryItem(setHistory,
+          { type: 'info', style: 'markdown', text: helpText } as Omit<HistoryItem, 'id'>,
+          timestamp);
       },
     },
     {

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -60,7 +60,7 @@ export type HistoryItem = HistoryItemBase &
     | { type: 'user'; text: string }
     | { type: 'gemini'; text: string }
     | { type: 'gemini_content'; text: string }
-    | { type: 'info'; text: string }
+    | { type: 'info'; style: 'markdown' | 'text' | undefined; text: string }
     | { type: 'error'; text: string }
     | { type: 'tool_group'; tools: IndividualToolCallDisplay[] }
   );


### PR DESCRIPTION
This isn't as nice as #251 because the slash commands can be programmatically rendered and color control is harder. It does add markdown rendering as an option for the info stream which is nice.