### PR TITLE
Revert "Support syntax highlighting for more languages (#246)"

### DIFF
--- a/packages/cli/src/ui/utils/CodeColorizer.tsx
+++ b/packages/cli/src/ui/utils/CodeColorizer.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { Text } from 'ink';
-import { all, createLowlight } from 'lowlight';
+import { common, createLowlight } from 'lowlight';
 import type {
   Root,
   Element,
@@ -18,7 +18,7 @@ import { themeManager } from '../themes/theme-manager.js';
 import { Theme } from '../themes/theme.js';
 
 // Configure themeing and parsing utilities.
-const lowlight = createLowlight(all);
+const lowlight = createLowlight(common);
 
 function renderHastNode(
   node: Root | Element | HastText | RootContent,


### PR DESCRIPTION
This reverts commit 2b309a8abbc6619a8ca4aeb6b5a82589efcdaeb7.

This was unexpectedly causing regressions for some languages.