### PR TITLE
fix: use flat config for react eslint plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,6 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import reactPlugin from 'eslint-plugin-react';
-import reactRecommended from 'eslint-plugin-react/configs/recommended.js';
 import reactHooks from 'eslint-plugin-react-hooks';
 import prettierConfig from 'eslint-config-prettier';
 import importPlugin from 'eslint-plugin-import';
@@ -29,7 +28,7 @@ export default tseslint.config(
   {
     // Global ignores
     ignores: [
-      'node_modules/**',
+      'node_modules/*',
       'eslint.config.js',
       'packages/cli/dist/**',
       'packages/server/dist/**',
@@ -38,37 +37,9 @@ export default tseslint.config(
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
-  {
-    // React specific config
-    files: ['packages/cli/src/**/*.tsx'], // Target only TSX in the cli package
-    languageOptions: {
-      // Keep languageOptions from reactRecommended if needed, or define explicitly
-      parserOptions: {
-        ecmaFeatures: { jsx: true },
-      },
-      globals: {
-        ...globals.browser,
-      },
-    },
-    plugins: {
-      // Define the plugins used in this block
-      react: reactPlugin,
-      'react-hooks': reactHooks,
-    },
-    rules: {
-      // Apply recommended rules explicitly
-      ...reactRecommended.rules,
-      ...reactHooks.configs.recommended.rules,
-      // Custom overrides
-      'react/react-in-jsx-scope': 'off',
-      'react/prop-types': 'off',
-    },
-    settings: {
-      react: {
-        version: 'detect',
-      },
-    },
-  },
+  reactHooks.configs['recommended-latest'],
+  reactPlugin.configs.flat.recommended,
+  reactPlugin.configs.flat['jsx-runtime'], // Add this if you are using React 17+
   {
     // Import specific config
     files: ['packages/cli/src/**/*.{ts,tsx}'], // Target only TS/TSX in the cli package
@@ -117,7 +88,7 @@ export default tseslint.config(
       ],
       '@typescript-eslint/no-namespace': ['error', { allowDeclarations: true }],
       '@typescript-eslint/no-unused-vars': [
-        'warn',
+        'error',
         {
           argsIgnorePattern: '^_',
           varsIgnorePattern: '^_',

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Box, Static, Text, useStdout } from 'ink';
 import { StreamingState, type HistoryItem } from './types.js';
 import { useGeminiStream } from './hooks/useGeminiStream.js';

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
 import { Box, Text } from 'ink';
 export interface Suggestion {
   label: string;

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -68,7 +68,7 @@ export const useSlashCommandProcessor = (
       description: '',
       action: (_value: PartListUnion) => {
         setDebugMessage('Quitting. Good-bye.');
-        const timestamp = getNextMessageId(Date.now());
+        getNextMessageId(Date.now());
         process.exit(0);
       },
     },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "paths": {
       "@gemini-code/*": ["./packages/*"]

--- a/packages/server/src/core/prompts.ts
+++ b/packages/server/src/core/prompts.ts
@@ -11,7 +11,6 @@ import { GrepTool } from '../tools/grep.js';
 import { ReadFileTool } from '../tools/read-file.js';
 import { ReadManyFilesTool } from '../tools/read-many-files.js';
 import { ShellTool } from '../tools/shell.js';
-import { WebFetchTool } from '../tools/web-fetch.js';
 import { WriteFileTool } from '../tools/write-file.js';
 
 const contactEmail = 'gemini-code-dev@google.com';


### PR DESCRIPTION
A lot of our React hook violations weren't showing up on `npm run lint`. Switched to the flat config format for the plugins fixed this.

BEFORE:

```
/usr/local/google/home/brandonkeiji/git/gemini-code/packages/cli/src/ui/hooks/slashCommandProcessor.ts
  71:15  warning  'timestamp' is assigned a value but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

/usr/local/google/home/brandonkeiji/git/gemini-code/packages/server/src/core/prompts.ts
  14:10  warning  'WebFetchTool' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
```

AFTER

```
/usr/local/google/home/brandonkeiji/git/gemini-code/packages/cli/src/ui/hooks/slashCommandProcessor.ts
  112:5  warning  React Hook useCallback has unnecessary dependencies: 'getNextMessageId' and 'setDebugMessage'. Either exclude them or remove the dependency array  react-hooks/exhaustive-deps

/usr/local/google/home/brandonkeiji/git/gemini-code/packages/cli/src/ui/hooks/useCompletion.ts
  223:6  warning  React Hook useEffect has a missing dependency: 'slashCommands'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/usr/local/google/home/brandonkeiji/git/gemini-code/packages/cli/src/ui/hooks/useGeminiStream.ts
  104:6   warning  React Hook useEffect has a missing dependency: 'config'. Either include it or remove the dependency array                                                                                                                                                                            react-hooks/exhaustive-deps
  104:7   warning  React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked                                                                                                                                             react-hooks/exhaustive-deps
  104:27  warning  React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked                                                                                                                                             react-hooks/exhaustive-deps
  528:5   warning  React Hook useCallback has missing dependencies: 'handleShellCommand', 'setShowHelp', and 'toolRegistry'. Either include them or remove the dependency array. If 'setShowHelp' changes too often, find the parent component that defines it and wrap that definition in useCallback  react-hooks/exhaustive-deps

/usr/local/google/home/brandonkeiji/git/gemini-code/packages/cli/src/ui/hooks/useThemeCommand.ts
  38:3  warning  The 'applyTheme' function makes the dependencies of useCallback Hook (at line 51) change on every render. To fix this, wrap the definition of 'applyTheme' in its own useCallback() Hook  react-hooks/exhaustive-deps
  64:5  warning  React Hook useCallback has a missing dependency: 'loadedSettings'. Either include it or remove the dependency array                                                                       react-hooks/exhaustive-deps

```

Drive by changes:

- made `@typescript-eslint/no-unused-vars` emit an error when violated
- addressed the new errors from the `@typescript-eslint/no-unused-vars`
- updated tsconfig.json to transpile React 17 itself