### PR TITLE
Fix flicker in iterm2

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -36,7 +36,7 @@ interface AppProps {
 }
 
 export const App = ({ config, settings, cliVersion }: AppProps) => {
-  const { history, addItem, updateItem, clearItems } = useHistory();
+  const { history, addItem, clearItems } = useHistory();
   const [startupWarnings, setStartupWarnings] = useState<string[]>([]);
   const [showHelp, setShowHelp] = useState<boolean>(false);
   const {
@@ -60,7 +60,6 @@ export const App = ({ config, settings, cliVersion }: AppProps) => {
     pendingHistoryItem,
   } = useGeminiStream(
     addItem,
-    updateItem,
     clearItems,
     refreshStatic,
     setShowHelp,
@@ -160,8 +159,9 @@ export const App = ({ config, settings, cliVersion }: AppProps) => {
       </Static>
       {pendingHistoryItem && (
         <HistoryItemDisplay
-          key={'history-' + pendingHistoryItem.id}
-          item={pendingHistoryItem}
+          // TODO(taehykim): It seems like references to ids aren't necessary in
+          // HistoryItemDisplay. Refactor later. Use a fake id for now.
+          item={{ ...pendingHistoryItem, id: 0 }}
           onSubmit={submitQuery}
         />
       )}

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -156,13 +156,11 @@ export const App = ({ config, settings, cliVersion }: AppProps) => {
         }}
       </Static>
       {pendingHistoryItem && (
-        <Box flexDirection="column" alignItems="flex-start">
-          <HistoryItemDisplay
-            key={'history-' + pendingHistoryItem.id}
-            item={pendingHistoryItem}
-            onSubmit={submitQuery}
-          />
-        </Box>
+        <HistoryItemDisplay
+          key={'history-' + pendingHistoryItem.id}
+          item={pendingHistoryItem}
+          onSubmit={submitQuery}
+        />
       )}
       {showHelp && <Help commands={slashCommands} />}
 

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -24,7 +24,6 @@ interface HandleAtCommandParams {
   query: string;
   config: Config;
   addItem: UseHistoryManagerReturn['addItem'];
-  updateItem: UseHistoryManagerReturn['updateItem'];
   setDebugMessage: React.Dispatch<React.SetStateAction<string>>;
   messageId: number;
 }
@@ -88,7 +87,7 @@ function parseAtCommand(
 export async function handleAtCommand({
   query,
   config,
-  addItem: addItem,
+  addItem,
   setDebugMessage,
   messageId: userMessageTimestamp,
 }: HandleAtCommandParams): Promise<HandleAtCommandResult> {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -166,7 +166,6 @@ export const useGeminiStream = (
       setStreamingState(StreamingState.Responding);
       setInitError(null);
       const chat = chatSessionRef.current;
-      let currentToolGroupMessageId: number | null = null;
 
       try {
         abortControllerRef.current = new AbortController();

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -23,7 +23,6 @@ import {
 import { type Chat, type PartListUnion, type Part } from '@google/genai';
 import {
   StreamingState,
-  HistoryItem,
   IndividualToolCallDisplay,
   ToolCallStatus,
   HistoryItemWithoutId,
@@ -459,15 +458,14 @@ export const useGeminiStream = (
     },
     [
       streamingState,
-      config,
+      setShowHelp,
       handleSlashCommand,
       handleShellCommand,
-      setDebugMessage,
-      setStreamingState,
+      config,
       addItem,
-      setShowHelp,
+      pendingHistoryItemRef,
+      setPendingHistoryItem,
       toolRegistry,
-      setInitError,
       refreshStatic,
     ],
   );

--- a/packages/cli/src/ui/hooks/useHistoryManager.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.ts
@@ -49,7 +49,13 @@ export function useHistory(): UseHistoryManagerReturn {
     [getNextMessageId],
   );
 
-  // Updates an existing history item identified by its ID.
+  /**
+   * Updates an existing history item identified by its ID.
+   * @deprecated Prefer not to update history item directly as we are currently
+   * rendering all history items in <Static /> for performance reasons. Only use
+   * if ABSOLUTELY NECESSARY
+   */
+  //
   const updateItem = useCallback(
     (
       id: number,

--- a/packages/cli/src/ui/hooks/useStateAndRef.ts
+++ b/packages/cli/src/ui/hooks/useStateAndRef.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+
+// Hook to return state, state setter, and ref to most up-to-date value of state.
+// We need this in order to setState and reference the updated state multiple
+// times in the same function.
+export const useStateAndRef = <
+  // Everything but function.
+  T extends object | null | undefined | number | string,
+>(
+  initialValue: T,
+) => {
+  const [_, setState] = React.useState<T>(initialValue);
+  const ref = React.useRef<T>(initialValue);
+
+  const setStateInternal = React.useCallback<typeof setState>(
+    (newStateOrCallback) => {
+      let newValue: T;
+      if (typeof newStateOrCallback === 'function') {
+        newValue = newStateOrCallback(ref.current);
+      } else {
+        newValue = newStateOrCallback;
+      }
+      setState(newValue);
+      ref.current = newValue;
+    },
+    [],
+  );
+
+  return [ref, setStateInternal] as const;
+};


### PR DESCRIPTION
The flicker seems to happen because sometimes our updateable history gets longer than the viewport height and then starts to clear the entire terminal. 

https://github.com/vadimdemedes/ink/blob/991aaa54eae39e1ad6d1964e747ea936d5a4ad12/src/ink.tsx#L173-L179

This PR introduces a new `pendingHistory` state so that we can be smarter about when history is updateable or not. Going forward, we should only add to `history` if the `historyItem` is no longer updateable. This makes a big difference because when the `InputPrompt` is active, we can guarantee that all the content above it is static and won't cause flickers as long as the terminal heigh is bigger than the `InputPrompt` and `Footer`. 

Some other changes:
1. Check for split points in the initial gemini text response. No reason not to? 🤷 
2. Remove `currentToolGroupMessageId` and `currentGeminiMessageIdRef` and rather use `pendingHistoryItemRef.current?.type` to track whether we have existing messages or tools.