### PR TITLE
Prevent UI hang on long tool confirmations.

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -25,7 +25,8 @@ export const ToolMessage: React.FC<IndividualToolCallDisplay> = ({
       <Box minHeight={1}>
         {/* Status Indicator */}
         <Box minWidth={statusIndicatorWidth}>
-          {status === ToolCallStatus.Pending && <Spinner type="dots" />}
+          {(status === ToolCallStatus.Pending ||
+            status === ToolCallStatus.Executing) && <Spinner type="dots" />}
           {status === ToolCallStatus.Success && (
             <Text color={Colors.AccentGreen}>✔</Text>
           )}

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -27,6 +27,7 @@ export enum ToolCallStatus {
   Pending = 'Pending',
   Canceled = 'Canceled',
   Confirming = 'Confirming',
+  Executing = 'Executing',
   Success = 'Success',
   Error = 'Error',
 }


### PR DESCRIPTION
Problem:
When a tool confirmation dialog appeared for a potentially long-running operation (e.g., `npm install`), accepting the confirmation would cause the UI to appear to hang. The confirmation dialog would remain visible, and no further UI updates would occur until the long-running task completed. This provided a poor user experience as the application seemed unresponsive.

Fix:
This change addresses the issue by ensuring the UI is updated to remove the confirmation dialog *before* the long-running operation begins. It also marks the tool as executing so a spinner can be shown.

Fixes https://b.corp.google.com/issues/415844994

Signed, sealed, delivered, it's yours!
   - Gemini, your friendly neighborhood code-slinger