### PR TITLE
fix: build image with --no-cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Thumbs.db
 
 # Ignore built ts files
 dist
+
+# Docker folder to help skip auth refreshes
+.docker

--- a/scripts/build_sandbox.sh
+++ b/scripts/build_sandbox.sh
@@ -67,10 +67,10 @@ echo "building $IMAGE ... (can be slow first time)"
 
 if [[ "$CMD" == "podman" ]]; then
     # use empty --authfile to skip unnecessary auth refresh overhead
-    $CMD build --authfile=<(echo '{}') -f "$DOCKERFILE" -t "$IMAGE" .
+    $CMD build --authfile=<(echo '{}') --no-cache -f "$DOCKERFILE" -t "$IMAGE" .
 elif [[ "$CMD" == "docker" ]]; then
-    # use an empty config directory to skip unnecessary auth refresh overhead
-    $CMD --config="empty" buildx build -f "$DOCKERFILE" -t "$IMAGE" .
+    # use config directory to skip unnecessary auth refresh overhead
+    $CMD --config=".docker" buildx build --no-cache -f "$DOCKERFILE" -t "$IMAGE" .
 else
     $CMD build -f "$DOCKERFILE" -t "$IMAGE" . >/dev/null
 fi


### PR DESCRIPTION
prevents stale images as the cost of slower rebuilds. in a followup, I'll separate out the longest running part of the Dockerfile into its own "base" image. That part can remained cached. 

Drive by change: `docker buildx` writes files to the "empty" directory. Renamed it to not confuse anyone and added to the .gitignore