### PR TITLE
Refactor: Enhance @-command, Autocomplete, and Input Stability

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -96,17 +96,8 @@ export const App = ({ config, settings, cliVersion }: AppProps) => {
 
   const isInputActive = streamingState === StreamingState.Idle && !initError;
 
-  const {
-    query,
-    setQuery,
-    handleSubmit: handleHistorySubmit,
-    inputKey,
-    setInputKey,
-  } = useInputHistory({
-    userMessages,
-    onSubmit: handleFinalSubmit,
-    isActive: isInputActive,
-  });
+  // query and setQuery are now managed by useState here
+  const [query, setQuery] = useState('');
 
   const completion = useCompletion(
     query,
@@ -114,6 +105,22 @@ export const App = ({ config, settings, cliVersion }: AppProps) => {
     isInputActive && (isAtCommand(query) || isSlashCommand(query)),
     slashCommands,
   );
+
+  const {
+    handleSubmit: handleHistorySubmit,
+    inputKey,
+    setInputKey,
+  } = useInputHistory({
+    userMessages,
+    onSubmit: (value) => {
+      // Adapt onSubmit to use the lifted setQuery
+      handleFinalSubmit(value);
+      setQuery(''); // Clear query from the App's state
+    },
+    isActive: isInputActive && !completion.showSuggestions,
+    query,
+    setQuery,
+  });
 
   // --- Render Logic ---
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -131,8 +131,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             // This onSubmit is for the TextInput component itself.
             // It should only fire if suggestions are NOT showing,
             // as useInput handles Enter when suggestions are visible.
-            if (!showSuggestions && query.trim()) {
-              onSubmit(query.trim());
+            const trimmedQuery = query.trim();
+            if (!showSuggestions && trimmedQuery) {
+              onSubmit(trimmedQuery);
             }
             // If suggestions ARE showing, useInput's Enter handler
             // would have already dealt with it (either completing or submitting).

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -39,93 +39,83 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 }) => {
   const { isFocused } = useFocus({ autoFocus: true });
 
-  const handleAutocomplete = useCallback(() => {
-    if (
-      activeSuggestionIndex < 0 ||
-      activeSuggestionIndex >= suggestions.length
-    ) {
-      return;
-    }
-    const selectedSuggestion = suggestions[activeSuggestionIndex];
-    const trimmedQuery = query.trimStart();
+  const handleAutocomplete = useCallback(
+    (indexToUse: number) => {
+      if (indexToUse < 0 || indexToUse >= suggestions.length) {
+        return;
+      }
+      const selectedSuggestion = suggestions[indexToUse];
+      const trimmedQuery = query.trimStart();
 
-    if (trimmedQuery.startsWith('/')) {
-      // Handle / command completion
-      const slashIndex = query.indexOf('/');
-      const base = query.substring(0, slashIndex + 1);
-      const newValue = base + selectedSuggestion.value;
-      setQuery(newValue);
-    } else {
-      // Handle @ command completion
-      const atIndex = query.lastIndexOf('@');
-      if (atIndex === -1) return;
-
-      // Find the part of the query after the '@'
-      const pathPart = query.substring(atIndex + 1);
-      // Find the last slash within that part
-      const lastSlashIndexInPath = pathPart.lastIndexOf('/');
-
-      let base = '';
-      if (lastSlashIndexInPath === -1) {
-        // No slash after '@', replace everything after '@'
-        base = query.substring(0, atIndex + 1);
+      if (trimmedQuery.startsWith('/')) {
+        // Handle / command completion
+        const slashIndex = query.indexOf('/');
+        const base = query.substring(0, slashIndex + 1);
+        const newValue = base + selectedSuggestion.value;
+        setQuery(newValue);
       } else {
-        // Slash found, keep everything up to and including the last slash
-        base = query.substring(0, atIndex + 1 + lastSlashIndexInPath + 1);
+        // Handle @ command completion
+        const atIndex = query.lastIndexOf('@');
+        if (atIndex === -1) return;
+
+        // Find the part of the query after the '@'
+        const pathPart = query.substring(atIndex + 1);
+        // Find the last slash within that part
+        const lastSlashIndexInPath = pathPart.lastIndexOf('/');
+
+        let base = '';
+        if (lastSlashIndexInPath === -1) {
+          // No slash after '@', replace everything after '@'
+          base = query.substring(0, atIndex + 1);
+        } else {
+          // Slash found, keep everything up to and including the last slash
+          base = query.substring(0, atIndex + 1 + lastSlashIndexInPath + 1);
+        }
+
+        const newValue = base + selectedSuggestion.value;
+        setQuery(newValue);
       }
 
-      const newValue = base + selectedSuggestion.value;
-      setQuery(newValue);
-    }
-
-    resetCompletion(); // Hide suggestions after selection
-    setInputKey((k) => k + 1); // Increment key to force re-render and cursor reset
-  }, [
-    query,
-    setQuery,
-    suggestions,
-    activeSuggestionIndex,
-    resetCompletion,
-    setInputKey,
-  ]);
+      resetCompletion(); // Hide suggestions after selection
+      setInputKey((k) => k + 1); // Increment key to force re-render and cursor reset
+    },
+    [query, setQuery, suggestions, resetCompletion, setInputKey],
+  );
 
   useInput(
     (input: string, key: Key) => {
-      let handled = false;
+      if (!isFocused) {
+        return;
+      }
 
       if (showSuggestions) {
         if (key.upArrow) {
           navigateUp();
-          handled = true;
         } else if (key.downArrow) {
           navigateDown();
-          handled = true;
-        } else if ((key.tab || key.return) && activeSuggestionIndex >= 0) {
-          handleAutocomplete();
-          handled = true;
+        } else if (key.tab) {
+          if (suggestions.length > 0) {
+            const targetIndex =
+              activeSuggestionIndex === -1 ? 0 : activeSuggestionIndex;
+            if (targetIndex < suggestions.length) {
+              handleAutocomplete(targetIndex);
+            }
+          }
+        } else if (key.return) {
+          if (activeSuggestionIndex >= 0) {
+            handleAutocomplete(activeSuggestionIndex);
+          } else {
+            if (query.trim()) {
+              onSubmit(query);
+            }
+          }
         } else if (key.escape) {
           resetCompletion();
-          handled = true;
         }
       }
-
-      // Only submit on Enter if it wasn't handled above
-      if (!handled && key.return) {
-        if (query.trim()) {
-          onSubmit(query);
-        }
-        handled = true;
-      }
-
-      if (
-        handled &&
-        showSuggestions &&
-        (key.upArrow || key.downArrow || key.tab || key.escape || key.return)
-      ) {
-        // No explicit preventDefault needed, handled flag stops further processing
-      }
+      // Enter key when suggestions are NOT showing is handled by TextInput's onSubmit prop below
     },
-    { isActive: isFocused },
+    { isActive: true },
   );
 
   return (
@@ -138,7 +128,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           onChange={setQuery}
           placeholder="Enter your message or use tools (e.g., @src/file.txt)..."
           onSubmit={() => {
-            /* onSubmit is handled by useInput hook above */
+            // This onSubmit is for the TextInput component itself.
+            // It should only fire if suggestions are NOT showing,
+            // as useInput handles Enter when suggestions are visible.
+            if (!showSuggestions && query.trim()) {
+              onSubmit(query.trim());
+            }
+            // If suggestions ARE showing, useInput's Enter handler
+            // would have already dealt with it (either completing or submitting).
           }}
         />
       </Box>

--- a/packages/cli/src/ui/hooks/useInputHistory.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.ts
@@ -11,7 +11,7 @@ interface UseInputHistoryProps {
   userMessages: readonly string[];
   onSubmit: (value: string) => void;
   isActive: boolean;
-  query: string; // Added
+  query: string;
   setQuery: React.Dispatch<React.SetStateAction<string>>;
 }
 

--- a/packages/cli/src/ui/hooks/useInputHistory.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.ts
@@ -4,13 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useInput } from 'ink';
 
 interface UseInputHistoryProps {
   userMessages: readonly string[];
   onSubmit: (value: string) => void;
   isActive: boolean;
+  query: string; // Added
+  setQuery: React.Dispatch<React.SetStateAction<string>>;
 }
 
 interface UseInputHistoryReturn {
@@ -25,8 +27,9 @@ export function useInputHistory({
   userMessages,
   onSubmit,
   isActive,
+  query,
+  setQuery,
 }: UseInputHistoryProps): UseInputHistoryReturn {
-  const [query, setQuery] = useState('');
   const [historyIndex, setHistoryIndex] = useState<number>(-1);
   const [originalQueryBeforeNav, setOriginalQueryBeforeNav] =
     useState<string>('');
@@ -41,9 +44,8 @@ export function useInputHistory({
     (value: string) => {
       const trimmedValue = value.trim();
       if (trimmedValue) {
-        onSubmit(trimmedValue);
+        onSubmit(trimmedValue); // This will call handleFinalSubmit, which then calls setQuery('') from App.tsx
       }
-      setQuery('');
       resetHistoryNav();
     },
     [onSubmit, resetHistoryNav],

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -13,8 +13,8 @@
  * @returns True if the query looks like an '@' command, false otherwise.
  */
 export const isAtCommand = (query: string): boolean =>
-  // Check if starts with @ OR has a space, then @, then a non-space character.
-  query.startsWith('@') || /\s@\S/.test(query);
+  // Check if starts with @ OR has a space, then @
+  query.startsWith('@') || /\s@/.test(query);
 
 /**
  * Checks if a query string potentially represents an '/' command.


### PR DESCRIPTION
This PR introduces several improvements and bug fixes to the CLI's input handling, particularly around "@" commands and autocompletion:

Enhancements & Fixes:

   * @-Command Trigger:
       * Adjusted the trigger logic for "@" commands to activate if an "@" is preceded by a space, regardless of the character following it (previously required a non-space character after "@").
       * A lone "@" character in the input (e.g., explain @) is now passed directly to the language model as part of the query, instead of attempting to read files or erroring. Previously, it would either error.


   * Autocomplete & Input:
       * Tab Key for Selection: The Tab key now correctly selects the highlighted suggestion in the autocomplete list. If no suggestion is highlighted by arrow keys, Tab will select the first available suggestion.
       * ESC Key and Enter Focus: Resolved a bug where pressing ESC to dismiss the autocomplete suggestion list would prevent the Enter key from submitting commands afterwards. Input submission is now robust after dismissing
         suggestions.
       * Up-Arrow Navigation: Fixed an issue where pressing the up-arrow key when the autocomplete list first appeared would navigate the command history instead of the suggestion list. Suggestion list navigation now correctly
         takes precedence.
       * Double Submission/UI: Corrected a bug where using an "@" command could sometimes lead to the "read many files" UI or action being triggered twice.


  Overall Impact:

These changes result in a more intuitive, robust, and user-friendly experience when using "@" commands and interacting with the autocomplete suggestions. The input handling is now more predictable, especially in edge cases involving focus and event propagation.

