### PR TITLE
Don't crash on 429/500s.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -797,9 +797,9 @@
       "link": true
     },
     "node_modules/@google/genai": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-0.10.0.tgz",
-      "integrity": "sha512-LAbp0em5A+wRtQR2+r5ckRBg2U2cBy8cJHgyTHa9PUbK8zucApw6A93HWyom/qlUQBNCpnIHFp20RiJuYMQwAw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-0.13.0.tgz",
+      "integrity": "sha512-eaEncWt875H7046T04mOpxpHJUM+jLIljEf+5QctRyOeChylE/nhpwm1bZWTRWoOu/t46R9r+PmgsJFhTpE7tQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.14.2",
@@ -8167,7 +8167,7 @@
       "name": "@gemini-code/server",
       "version": "0.1.0",
       "dependencies": {
-        "@google/genai": "^0.10.0",
+        "@google/genai": "^0.13.0",
         "@modelcontextprotocol/sdk": "^1.11.0",
         "diff": "^7.0.0",
         "dotenv": "^16.4.7",

--- a/packages/cli/src/gemini.ts
+++ b/packages/cli/src/gemini.ts
@@ -86,27 +86,6 @@ async function main() {
 
 // --- Global Unhandled Rejection Handler ---
 process.on('unhandledRejection', (reason, _promise) => {
-  // Check if this is the known 429 ClientError that sometimes escapes
-  // this is a workaround for a specific issue with the way we are calling gemini
-  // where a 429 error is thrown but not caught, causing an unhandled rejection
-  // TODO(adh): Remove this when the race condition is fixed
-  const isKnownEscaped429 =
-    reason instanceof Error &&
-    reason.name === 'ClientError' &&
-    reason.message.includes('got status: 429');
-
-  if (isKnownEscaped429) {
-    // Log it differently and DON'T exit, as it's likely already handled visually
-    console.warn('-----------------------------------------');
-    console.warn(
-      'WORKAROUND: Suppressed known escaped 429 Unhandled Rejection.',
-    );
-    console.warn('-----------------------------------------');
-    console.warn('Reason:', reason);
-    return;
-    // No process.exit(1); Don't exit.
-  }
-
   // Log other unexpected unhandled rejections as critical errors
   console.error('=========================================');
   console.error('CRITICAL: Unhandled Promise Rejection!');

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,7 @@
     "dist"
   ],
   "dependencies": {
-    "@google/genai": "^0.10.0",
+    "@google/genai": "^0.13.0",
     "@modelcontextprotocol/sdk": "^1.11.0",
     "diff": "^7.0.0",
     "dotenv": "^16.4.7",


### PR DESCRIPTION
- The root of this issue was actually a genai SDK bug that was fixed here: https://critique.corp.google.com/cl/753255997
- Upgrade to latest genai SDK for latest bug fixes (including the above)
- Removed specific 429 handling for uncaught rejections.

Fixes https://b.corp.google.com/issues/413760164