### PR TITLE
UI Polish for theme selector

### DIFF
--- a/packages/cli/src/ui/colors.ts
+++ b/packages/cli/src/ui/colors.ts
@@ -8,6 +8,9 @@ import { themeManager } from './themes/theme-manager.js';
 import { ColorsTheme } from './themes/theme.js';
 
 export const Colors: ColorsTheme = {
+  get type() {
+    return themeManager.getActiveTheme().colors.type;
+  },
   get Foreground() {
     return themeManager.getActiveTheme().colors.Foreground;
   },

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Box, Text } from 'ink';
+import { Colors } from '../colors.js';
 export interface Suggestion {
   label: string;
   value: string;
@@ -48,7 +49,7 @@ export function SuggestionsDisplay({
 
   return (
     <Box borderStyle="round" flexDirection="column" paddingX={1} width={width}>
-      {scrollOffset > 0 && <Text color="gray">▲</Text>}
+      {scrollOffset > 0 && <Text color={Colors.Foreground}>▲</Text>}
 
       {visibleSuggestions.map((suggestion, index) => {
         const originalIndex = startIndex + index;
@@ -56,8 +57,8 @@ export function SuggestionsDisplay({
         return (
           <Text
             key={`${suggestion}-${originalIndex}`}
-            color={isActive ? 'black' : 'white'}
-            backgroundColor={isActive ? 'blue' : undefined}
+            color={isActive ? Colors.Background : Colors.Foreground}
+            backgroundColor={isActive ? Colors.AccentBlue : undefined}
           >
             {suggestion.label}
           </Text>

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -32,13 +32,25 @@ export function ThemeDialog({
     SettingScope.User,
   );
 
-  const activeThemeName = settings.merged.theme || DEFAULT_THEME.name;
+  // Determine the theme that is effectively active for the *currently selected scope*
+  const themeExplicitlySetForScope = settings.forScope(selectedScope).settings.theme;
+  const currentThemeForScope =
+    themeExplicitlySetForScope !== undefined
+      ? themeExplicitlySetForScope
+      : settings.merged.theme || DEFAULT_THEME.name;
+
+  // Generate theme items, marking the one active for the current scope
   const themeItems = themeManager.getAvailableThemes().map((theme) => ({
-    label: theme.name === activeThemeName ? `${theme.name} (Current)` : theme.name,
+    label:
+      theme.name === currentThemeForScope
+        ? `${theme.name} (Current)`
+        : theme.name,
     value: theme.name,
   }));
   const [selectInputKey, setSelectInputKey] = useState(Date.now());
 
+  // Determine which radio button should be initially selected in the theme list
+  // This should reflect the theme *saved* for the selected scope, or the default
   const initialThemeIndex = themeItems.findIndex(
     (item) =>
       item.value ===

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -90,44 +90,48 @@ export function ThemeDialog({
     <Box
       borderStyle="round"
       borderColor={Colors.AccentCyan}
-      flexDirection="column"
+      flexDirection="row" // Changed to row for side-by-side layout
       padding={1}
-      width="50%"
+      width="90%" // Increased width to accommodate side-by-side
     >
-      <Text bold={focusedSection === 'theme'}>
-        {focusedSection === 'theme' ? '> ' : '  '}Select Theme{' '}
-        <Text color={Colors.SubtleComment}>{otherScopeModifiedMessage}</Text>
-      </Text>
-
-      <RadioButtonSelect
-        key={selectInputKey}
-        items={themeItems}
-        initialIndex={initialThemeIndex}
-        onSelect={handleThemeSelect} // Use the wrapper handler
-        onHighlight={onHighlight}
-        isFocused={focusedSection === 'theme'}
-      />
-      {/* Scope Selection */}
-      <Box marginTop={1} flexDirection="column">
-        <Text bold={focusedSection === 'scope'}>
-          {focusedSection === 'scope' ? '> ' : '  '}Apply To
+      {/* Left Column: Selection */}
+      <Box flexDirection="column" width="50%" paddingRight={2}>
+        <Text bold={focusedSection === 'theme'}>
+          {focusedSection === 'theme' ? '> ' : '  '}Select Theme{' '}
+          <Text color={Colors.SubtleComment}>{otherScopeModifiedMessage}</Text>
         </Text>
         <RadioButtonSelect
-          items={scopeItems}
-          initialIndex={0} // Default to User Settings
-          onSelect={handleScopeSelect}
-          onHighlight={handleScopeHighlight}
-          isFocused={focusedSection === 'scope'}
+          key={selectInputKey}
+          items={themeItems}
+          initialIndex={initialThemeIndex}
+          onSelect={handleThemeSelect}
+          onHighlight={onHighlight}
+          isFocused={focusedSection === 'theme'}
         />
+
+        {/* Scope Selection */}
+        <Box marginTop={1} flexDirection="column">
+          <Text bold={focusedSection === 'scope'}>
+            {focusedSection === 'scope' ? '> ' : '  '}Apply To
+          </Text>
+          <RadioButtonSelect
+            items={scopeItems}
+            initialIndex={0} // Default to User Settings
+            onSelect={handleScopeSelect}
+            onHighlight={handleScopeHighlight}
+            isFocused={focusedSection === 'scope'}
+          />
+        </Box>
+
+        <Box marginTop={1}>
+          <Text color={Colors.SubtleComment}>
+            (Use ↑/↓ arrows and Enter to select, Tab to change focus)
+          </Text>
+        </Box>
       </Box>
 
-      <Box marginTop={1}>
-        <Text color={Colors.SubtleComment}>
-          (Use ↑/↓ arrows and Enter to select, Tab to change focus)
-        </Text>
-      </Box>
-
-      <Box marginTop={1} flexDirection="column">
+      {/* Right Column: Preview */}
+      <Box flexDirection="column" width="50%">
         <Text bold>Preview</Text>
         <Box
           borderStyle="single"

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -32,8 +32,9 @@ export function ThemeDialog({
     SettingScope.User,
   );
 
+  const activeThemeName = settings.merged.theme || DEFAULT_THEME.name;
   const themeItems = themeManager.getAvailableThemes().map((theme) => ({
-    label: theme.active ? `${theme.name} (Active)` : theme.name,
+    label: theme.name === activeThemeName ? `${theme.name} (Current)` : theme.name,
     value: theme.name,
   }));
   const [selectInputKey, setSelectInputKey] = useState(Date.now());

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -40,13 +40,21 @@ export function ThemeDialog({
       : settings.merged.theme || DEFAULT_THEME.name;
 
   // Generate theme items, marking the one active for the current scope
-  const themeItems = themeManager.getAvailableThemes().map((theme) => ({
-    label:
-      theme.name === currentThemeForScope
-        ? `${theme.name} (Current)`
-        : theme.name,
-    value: theme.name,
-  }));
+  const themeItems = themeManager.getAvailableThemes().map((theme) => {
+    const typeString = theme.type.charAt(0).toUpperCase() + theme.type.slice(1);
+    const isCurrent = theme.name === currentThemeForScope;
+    // Keep the primary label as a simple string for compatibility with RadioButtonSelect
+    const labelString = theme.name + (isCurrent ? ' - Current' : '');
+
+    return {
+      label: labelString, // This will be used by the default itemComponent
+      value: theme.name,
+      // Add custom properties for our enhanced itemComponent
+      themeNameDisplay: theme.name, // The base name of the theme
+      themeTypeDisplay: typeString, // The type string (e.g., "Dark")
+      isCurrentDisplay: isCurrent, // Boolean to indicate if it's the current theme
+    };
+  });
   const [selectInputKey, setSelectInputKey] = useState(Date.now());
 
   // Determine which radio button should be initially selected in the theme list
@@ -101,7 +109,7 @@ export function ThemeDialog({
   return (
     <Box
       borderStyle="round"
-      borderColor={Colors.AccentCyan}
+      borderColor={Colors.AccentPurple}
       flexDirection="row" // Changed to row for side-by-side layout
       padding={1}
       width="90%" // Increased width to accommodate side-by-side
@@ -143,7 +151,7 @@ export function ThemeDialog({
       </Box>
 
       {/* Right Column: Preview */}
-      <Box flexDirection="column" width="50%">
+      <Box flexDirection="column" width="50%" paddingLeft={2}>
         <Text bold>Preview</Text>
         <Box
           borderStyle="single"

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -32,28 +32,14 @@ export function ThemeDialog({
     SettingScope.User,
   );
 
-  // Determine the theme that is effectively active for the *currently selected scope*
-  const themeExplicitlySetForScope =
-    settings.forScope(selectedScope).settings.theme;
-  const currentThemeForScope =
-    themeExplicitlySetForScope !== undefined
-      ? themeExplicitlySetForScope
-      : settings.merged.theme || DEFAULT_THEME.name;
-
-  // Generate theme items, marking the one active for the current scope
+  // Generate theme items
   const themeItems = themeManager.getAvailableThemes().map((theme) => {
     const typeString = theme.type.charAt(0).toUpperCase() + theme.type.slice(1);
-    const isCurrent = theme.name === currentThemeForScope;
-    // Keep the primary label as a simple string for compatibility with RadioButtonSelect
-    const labelString = theme.name + (isCurrent ? ' - Current' : '');
-
     return {
-      label: labelString, // This will be used by the default itemComponent
+      label: theme.name,
       value: theme.name,
-      // Add custom properties for our enhanced itemComponent
-      themeNameDisplay: theme.name, // The base name of the theme
-      themeTypeDisplay: typeString, // The type string (e.g., "Dark")
-      isCurrentDisplay: isCurrent, // Boolean to indicate if it's the current theme
+      themeNameDisplay: theme.name,
+      themeTypeDisplay: typeString,
     };
   });
   const [selectInputKey, setSelectInputKey] = useState(Date.now());
@@ -61,9 +47,7 @@ export function ThemeDialog({
   // Determine which radio button should be initially selected in the theme list
   // This should reflect the theme *saved* for the selected scope, or the default
   const initialThemeIndex = themeItems.findIndex(
-    (item) =>
-      item.value ===
-      (settings.forScope(selectedScope).settings.theme || DEFAULT_THEME.name),
+    (item) => item.value === (settings.merged.theme || DEFAULT_THEME.name),
   );
 
   const scopeItems = [

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -97,7 +97,7 @@ export function ThemeDialog({
       borderColor={Colors.AccentPurple}
       flexDirection="row"
       padding={1}
-      width="90%"
+      width="100%"
     >
       {/* Left Column: Selection */}
       <Box flexDirection="column" width="50%" paddingRight={2}>
@@ -136,7 +136,7 @@ export function ThemeDialog({
       </Box>
 
       {/* Right Column: Preview */}
-      <Box flexDirection="column" width="50%" paddingLeft={2}>
+      <Box flexDirection="column" width="50%" paddingLeft={3}>
         <Text bold>Preview</Text>
         <Box
           borderStyle="single"

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -33,7 +33,8 @@ export function ThemeDialog({
   );
 
   // Determine the theme that is effectively active for the *currently selected scope*
-  const themeExplicitlySetForScope = settings.forScope(selectedScope).settings.theme;
+  const themeExplicitlySetForScope =
+    settings.forScope(selectedScope).settings.theme;
   const currentThemeForScope =
     themeExplicitlySetForScope !== undefined
       ? themeExplicitlySetForScope

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -111,9 +111,9 @@ export function ThemeDialog({
     <Box
       borderStyle="round"
       borderColor={Colors.AccentPurple}
-      flexDirection="row" // Changed to row for side-by-side layout
+      flexDirection="row"
       padding={1}
-      width="90%" // Increased width to accommodate side-by-side
+      width="90%"
     >
       {/* Left Column: Selection */}
       <Box flexDirection="column" width="50%" paddingRight={2}>

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -27,7 +27,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   const hasPending = !toolCalls.every(
     (t) => t.status === ToolCallStatus.Success,
   );
-  const borderColor = hasPending ? Colors.AccentYellow : Colors.AccentCyan;
+  const borderColor = hasPending ? Colors.AccentYellow : Colors.AccentPurple;
 
   return (
     <Box

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -43,33 +43,6 @@ export interface RadioButtonSelectProps<T> {
 }
 
 /**
- * Custom indicator component displaying radio button style (◉/○).
- */
-function RadioIndicator({
-  isSelected = false,
-}: InkSelectIndicatorProps): React.JSX.Element {
-  return (
-    <Box marginRight={1}>
-      <Text color={isSelected ? Colors.AccentGreen : Colors.Gray}>
-        {isSelected ? '●' : '○'}
-      </Text>
-    </Box>
-  );
-}
-
-/**
- * Custom item component for displaying the label with appropriate color.
- */
-function RadioItem({
-  isSelected = false,
-  label,
-}: InkSelectItemProps): React.JSX.Element {
-  return (
-    <Text color={isSelected ? Colors.AccentGreen : Colors.Gray}>{label}</Text>
-  );
-}
-
-/**
  * A specialized SelectInput component styled to look like radio buttons.
  * It uses '◉' for selected and '○' for unselected items.
  *
@@ -80,7 +53,7 @@ export function RadioButtonSelect<T>({
   initialIndex,
   onSelect,
   onHighlight,
-  isFocused,
+  isFocused, // This prop indicates if the current RadioButtonSelect group is focused
 }: RadioButtonSelectProps<T>): React.JSX.Element {
   const handleSelect = (item: RadioSelectItem<T>) => {
     onSelect(item.value);
@@ -90,16 +63,62 @@ export function RadioButtonSelect<T>({
       onHighlight(item.value);
     }
   };
+
+  /**
+   * Custom indicator component displaying radio button style (◉/○).
+   * Color changes based on whether the item is selected and if its group is focused.
+   */
+  function DynamicRadioIndicator({
+    isSelected = false,
+  }: InkSelectIndicatorProps): React.JSX.Element {
+    let indicatorColor = Colors.Foreground; // Default for not selected
+    if (isSelected) {
+      if (isFocused) {
+        // Group is focused, selected item is AccentGreen
+        indicatorColor = Colors.AccentGreen;
+      } else {
+        // Group is NOT focused, selected item is Foreground
+        indicatorColor = Colors.Foreground;
+      }
+    }
+    return (
+      <Box marginRight={1}>
+        <Text color={indicatorColor}>{isSelected ? '●' : '○'}</Text>
+      </Box>
+    );
+  }
+
+  /**
+   * Custom item component for displaying the label.
+   * Color changes based on whether the item is selected and if its group is focused.
+   */
+  function DynamicRadioItem({
+    isSelected = false,
+    label,
+  }: InkSelectItemProps): React.JSX.Element {
+    let textColor = Colors.Foreground; // Default for not selected
+    if (isSelected) {
+      if (isFocused) {
+        // Group is focused, selected item is AccentGreen
+        textColor = Colors.AccentGreen;
+      } else {
+        // Group is NOT focused, selected item is Foreground
+        textColor = Colors.Foreground;
+      }
+    }
+    return <Text color={textColor}>{label}</Text>;
+  }
+
   initialIndex = initialIndex ?? 0;
   return (
     <SelectInput
-      indicatorComponent={RadioIndicator}
-      itemComponent={RadioItem}
+      indicatorComponent={DynamicRadioIndicator} // Use the new dynamic indicator
+      itemComponent={DynamicRadioItem} // Use the new dynamic item
       items={items}
       initialIndex={initialIndex}
       onSelect={handleSelect}
       onHighlight={handleHighlight}
-      isFocused={isFocused}
+      isFocused={isFocused} // This prop is for ink-select-input to handle keyboard input
     />
   );
 }

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -136,7 +136,7 @@ export function RadioButtonSelect<T>({
   return (
     <SelectInput
       indicatorComponent={DynamicRadioIndicator}
-      itemComponent={CustomThemeItemComponent} // Use the new custom item component
+      itemComponent={CustomThemeItemComponent}
       items={items}
       initialIndex={initialIndex}
       onSelect={handleSelect}

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -27,7 +27,12 @@ export interface RadioSelectItem<T> {
  */
 export interface RadioButtonSelectProps<T> {
   /** An array of items to display as radio options. */
-  items: Array<RadioSelectItem<T> & { themeNameDisplay?: string; themeTypeDisplay?: string }>;
+  items: Array<
+    RadioSelectItem<T> & {
+      themeNameDisplay?: string;
+      themeTypeDisplay?: string;
+    }
+  >;
 
   /** The initial index selected */
   initialIndex?: number;
@@ -121,11 +126,7 @@ export function RadioButtonSelect<T>({
       );
     }
 
-    return (
-      <Text color={textColor}>
-        {label}
-      </Text>
-    );
+    return <Text color={textColor}>{label}</Text>;
   }
 
   initialIndex = initialIndex ?? 0;

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -51,7 +51,7 @@ function RadioIndicator({
   return (
     <Box marginRight={1}>
       <Text color={isSelected ? Colors.AccentGreen : Colors.Gray}>
-        {isSelected ? '◉' : '○'}
+        {isSelected ? '●' : '○'}
       </Text>
     </Box>
   );

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -27,7 +27,7 @@ export interface RadioSelectItem<T> {
  */
 export interface RadioButtonSelectProps<T> {
   /** An array of items to display as radio options. */
-  items: Array<RadioSelectItem<T>>;
+  items: Array<RadioSelectItem<T> & { themeNameDisplay?: string; themeTypeDisplay?: string }>;
 
   /** The initial index selected */
   initialIndex?: number;
@@ -97,20 +97,16 @@ export function RadioButtonSelect<T>({
     props: InkSelectItemProps,
   ): React.JSX.Element {
     const { isSelected = false, label } = props;
-    // Attempt to access custom properties passed via items
-    // These might not exist on all items (e.g. scope selection uses simple strings)
     const itemWithThemeProps = props as typeof props & {
       themeNameDisplay?: string;
       themeTypeDisplay?: string;
-      isCurrentDisplay?: boolean;
     };
 
-    let textColor = Colors.Foreground; // Default for not selected
+    let textColor = Colors.Foreground;
     if (isSelected) {
       textColor = isFocused ? Colors.AccentGreen : Colors.Foreground;
     }
 
-    // If custom theme properties are available, use them for richer display
     if (
       itemWithThemeProps.themeNameDisplay &&
       itemWithThemeProps.themeTypeDisplay
@@ -121,15 +117,15 @@ export function RadioButtonSelect<T>({
           <Text color={Colors.SubtleComment}>
             {itemWithThemeProps.themeTypeDisplay}
           </Text>
-          {itemWithThemeProps.isCurrentDisplay && (
-            <Text color={Colors.Foreground}> Active</Text>
-          )}
         </Text>
       );
     }
 
-    // Fallback to simple label if custom props aren't there
-    return <Text color={textColor}>{label}</Text>;
+    return (
+      <Text color={textColor}>
+        {label}
+      </Text>
+    );
   }
 
   initialIndex = initialIndex ?? 0;

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -93,7 +93,9 @@ export function RadioButtonSelect<T>({
    * Color changes based on whether the item is selected and if its group is focused.
    * Now also handles displaying theme type with custom color.
    */
-  function CustomThemeItemComponent(props: InkSelectItemProps): React.JSX.Element {
+  function CustomThemeItemComponent(
+    props: InkSelectItemProps,
+  ): React.JSX.Element {
     const { isSelected = false, label } = props;
     // Attempt to access custom properties passed via items
     // These might not exist on all items (e.g. scope selection uses simple strings)
@@ -109,12 +111,19 @@ export function RadioButtonSelect<T>({
     }
 
     // If custom theme properties are available, use them for richer display
-    if (itemWithThemeProps.themeNameDisplay && itemWithThemeProps.themeTypeDisplay) {
+    if (
+      itemWithThemeProps.themeNameDisplay &&
+      itemWithThemeProps.themeTypeDisplay
+    ) {
       return (
         <Text color={textColor}>
           {itemWithThemeProps.themeNameDisplay}{' '}
-          <Text color={Colors.SubtleComment}>{itemWithThemeProps.themeTypeDisplay}</Text>
-          {itemWithThemeProps.isCurrentDisplay && <Text color={Colors.Foreground}> Active</Text>}
+          <Text color={Colors.SubtleComment}>
+            {itemWithThemeProps.themeTypeDisplay}
+          </Text>
+          {itemWithThemeProps.isCurrentDisplay && (
+            <Text color={Colors.Foreground}> Active</Text>
+          )}
         </Text>
       );
     }

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -91,34 +91,48 @@ export function RadioButtonSelect<T>({
   /**
    * Custom item component for displaying the label.
    * Color changes based on whether the item is selected and if its group is focused.
+   * Now also handles displaying theme type with custom color.
    */
-  function DynamicRadioItem({
-    isSelected = false,
-    label,
-  }: InkSelectItemProps): React.JSX.Element {
+  function CustomThemeItemComponent(props: InkSelectItemProps): React.JSX.Element {
+    const { isSelected = false, label } = props;
+    // Attempt to access custom properties passed via items
+    // These might not exist on all items (e.g. scope selection uses simple strings)
+    const itemWithThemeProps = props as typeof props & {
+      themeNameDisplay?: string;
+      themeTypeDisplay?: string;
+      isCurrentDisplay?: boolean;
+    };
+
     let textColor = Colors.Foreground; // Default for not selected
     if (isSelected) {
-      if (isFocused) {
-        // Group is focused, selected item is AccentGreen
-        textColor = Colors.AccentGreen;
-      } else {
-        // Group is NOT focused, selected item is Foreground
-        textColor = Colors.Foreground;
-      }
+      textColor = isFocused ? Colors.AccentGreen : Colors.Foreground;
     }
+
+    // If custom theme properties are available, use them for richer display
+    if (itemWithThemeProps.themeNameDisplay && itemWithThemeProps.themeTypeDisplay) {
+      return (
+        <Text color={textColor}>
+          {itemWithThemeProps.themeNameDisplay}{' '}
+          <Text color={Colors.SubtleComment}>{itemWithThemeProps.themeTypeDisplay}</Text>
+          {itemWithThemeProps.isCurrentDisplay && <Text color={Colors.Foreground}> Active</Text>}
+        </Text>
+      );
+    }
+
+    // Fallback to simple label if custom props aren't there
     return <Text color={textColor}>{label}</Text>;
   }
 
   initialIndex = initialIndex ?? 0;
   return (
     <SelectInput
-      indicatorComponent={DynamicRadioIndicator} // Use the new dynamic indicator
-      itemComponent={DynamicRadioItem} // Use the new dynamic item
+      indicatorComponent={DynamicRadioIndicator}
+      itemComponent={CustomThemeItemComponent} // Use the new custom item component
       items={items}
       initialIndex={initialIndex}
       onSelect={handleSelect}
       onHighlight={handleHighlight}
-      isFocused={isFocused} // This prop is for ink-select-input to handle keyboard input
+      isFocused={isFocused}
     />
   );
 }

--- a/packages/cli/src/ui/hooks/useThemeCommand.ts
+++ b/packages/cli/src/ui/hooks/useThemeCommand.ts
@@ -19,7 +19,7 @@ interface UseThemeCommandReturn {
 }
 
 export const useThemeCommand = (
-  loadedSettings: LoadedSettings, // Changed parameter
+  loadedSettings: LoadedSettings,
 ): UseThemeCommandReturn => {
   // Determine the effective theme
   const effectiveTheme = loadedSettings.merged.theme;

--- a/packages/cli/src/ui/themes/ansi.ts
+++ b/packages/cli/src/ui/themes/ansi.ts
@@ -7,7 +7,8 @@
 import { ansiTheme, Theme } from './theme.js';
 
 export const ANSI: Theme = new Theme(
-  'ANSI colors only',
+  'ANSI',
+  'ansi',
   {
     hljs: {
       display: 'block',

--- a/packages/cli/src/ui/themes/atom-one-dark.ts
+++ b/packages/cli/src/ui/themes/atom-one-dark.ts
@@ -7,7 +7,8 @@
 import { darkTheme, Theme } from './theme.js';
 
 export const AtomOneDark: Theme = new Theme(
-  'Atom One Dark',
+  'Atom One',
+  'dark',
   {
     hljs: {
       display: 'block',

--- a/packages/cli/src/ui/themes/dracula.ts
+++ b/packages/cli/src/ui/themes/dracula.ts
@@ -8,6 +8,7 @@ import { darkTheme, Theme } from './theme.js';
 
 export const Dracula: Theme = new Theme(
   'Dracula',
+  'dark',
   {
     hljs: {
       display: 'block',

--- a/packages/cli/src/ui/themes/github.ts
+++ b/packages/cli/src/ui/themes/github.ts
@@ -8,6 +8,7 @@ import { lightTheme, Theme } from './theme.js';
 
 export const GitHub: Theme = new Theme(
   'GitHub',
+  'light',
   {
     hljs: {
       display: 'block',

--- a/packages/cli/src/ui/themes/googlecode.ts
+++ b/packages/cli/src/ui/themes/googlecode.ts
@@ -8,6 +8,7 @@ import { lightTheme, Theme } from './theme.js';
 
 export const GoogleCode: Theme = new Theme(
   'Google Code',
+  'light',
   {
     hljs: {
       display: 'block',

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -17,7 +17,6 @@ import { ANSI } from './ansi.js';
 export interface ThemeDisplay {
   name: string;
   type: ThemeType;
-  active: boolean;
 }
 
 export const DEFAULT_THEME: Theme = VS2015;
@@ -68,7 +67,6 @@ class ThemeManager {
     return sortedThemes.map((theme) => ({
       name: theme.name,
       type: theme.type,
-      active: theme === this.activeTheme,
     }));
   }
 

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -11,11 +11,12 @@ import { GoogleCode } from './googlecode.js';
 import { VS } from './vs.js';
 import { VS2015 } from './vs2015.js';
 import { XCode } from './xcode.js';
-import { Theme } from './theme.js';
+import { Theme, ThemeType } from './theme.js';
 import { ANSI } from './ansi.js';
 
 export interface ThemeDisplay {
   name: string;
+  type: ThemeType;
   active: boolean;
 }
 
@@ -43,8 +44,30 @@ class ThemeManager {
    * Returns a list of available theme names.
    */
   getAvailableThemes(): ThemeDisplay[] {
-    return this.availableThemes.map((theme) => ({
+    const sortedThemes = [...this.availableThemes].sort((a, b) => {
+      const typeOrder = (type: ThemeType): number => {
+        switch (type) {
+          case 'dark':
+            return 1;
+          case 'light':
+            return 2;
+          case 'ansi':
+            return 3;
+          default:
+            return 4;
+        }
+      };
+
+      const typeComparison = typeOrder(a.type) - typeOrder(b.type);
+      if (typeComparison !== 0) {
+        return typeComparison;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    return sortedThemes.map((theme) => ({
       name: theme.name,
+      type: theme.type,
       active: theme === this.activeTheme,
     }));
   }

--- a/packages/cli/src/ui/themes/theme.ts
+++ b/packages/cli/src/ui/themes/theme.ts
@@ -5,7 +5,11 @@
  */
 
 import type { CSSProperties } from 'react';
+
+export type ThemeType = 'light' | 'dark' | 'ansi';
+
 export interface ColorsTheme {
+  type: ThemeType;
   Background: string;
   Foreground: string;
   LightBlue: string;
@@ -21,6 +25,7 @@ export interface ColorsTheme {
 }
 
 export const lightTheme: ColorsTheme = {
+  type: 'light',
   Background: '#FAFAFA',
   Foreground: '#3C3C43',
   LightBlue: '#ADD8E6',
@@ -36,6 +41,7 @@ export const lightTheme: ColorsTheme = {
 };
 
 export const darkTheme: ColorsTheme = {
+  type: 'dark',
   Background: '#1E1E2E',
   Foreground: '#CDD6F4',
   LightBlue: '#ADD8E6',
@@ -51,6 +57,7 @@ export const darkTheme: ColorsTheme = {
 };
 
 export const ansiTheme: ColorsTheme = {
+  type: 'ansi',
   Background: 'black',
   Foreground: 'white',
   LightBlue: 'blue',
@@ -250,6 +257,7 @@ export class Theme {
    */
   constructor(
     readonly name: string,
+    readonly type: ThemeType,
     rawMappings: Record<string, CSSProperties>,
     readonly colors: ColorsTheme,
   ) {

--- a/packages/cli/src/ui/themes/vs.ts
+++ b/packages/cli/src/ui/themes/vs.ts
@@ -8,6 +8,7 @@ import { lightTheme, Theme } from './theme.js';
 
 export const VS: Theme = new Theme(
   'VS',
+  'light',
   {
     hljs: {
       display: 'block',

--- a/packages/cli/src/ui/themes/vs2015.ts
+++ b/packages/cli/src/ui/themes/vs2015.ts
@@ -8,6 +8,7 @@ import { darkTheme, Theme } from './theme.js';
 
 export const VS2015: Theme = new Theme(
   'VS2015',
+  'dark',
   {
     hljs: {
       display: 'block',

--- a/packages/cli/src/ui/themes/xcode.ts
+++ b/packages/cli/src/ui/themes/xcode.ts
@@ -8,6 +8,7 @@ import { lightTheme, Theme } from './theme.js';
 
 export const XCode: Theme = new Theme(
   'XCode',
+  'light',
   {
     hljs: {
       display: 'block',


### PR DESCRIPTION
This cleans up the theme selector into 2 columns, updates suggestion colors so they have better contrast, adds theme labels for theme types, use ● for selected items, and updates the default border to use the purple accent color.

**Before**

https://github.com/user-attachments/assets/6a6bbca2-8bca-4042-b5b6-d546a52f53de

**After**

https://github.com/user-attachments/assets/a5fad1df-faa8-413e-88b2-bf347ee0a44a




