### PR TITLE
Ensure dogfood packaging more accurately mirrors local build.

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,6 @@
   },
   "image": "us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-cli",
   "scripts": {
-    "build:package": "tsc --build",
     "build:sandbox": "DOCKER_BUILDKIT=1 docker build --build-arg CLI_VERSION=$npm_package_version --no-cache --secret id=npmrc,src=$HOME/.npmrc -t us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-cli:$npm_package_version -f Dockerfile.sandbox .",
     "build": "../../scripts/build_package.sh",
     "publish:sandbox": "docker push us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-cli:$npm_package_version",
@@ -22,7 +21,7 @@
     "prerelease:version": "node ../../scripts/bind_package_version.js",
     "prerelease:deps": "node ../../scripts/bind_package_dependencies.js",
     "prepublishOnly": "npm publish --workspace=@gemini-code/server",
-    "prepack": "npm run build:package",
+    "prepack": "npm run build",
     "postpublish": "npm run build:sandbox && npm run publish:sandbox"
   },
   "files": [


### PR DESCRIPTION
- Removed `build:package` in favor of `npm run build`.
- The regular build does extra work to copy over relevant information into the `dist` dir. Alternatively without this we get a `dist` dir in the `cli` folder that has no seatbelt packaging.

Fixes https://b.corp.google.com/issues/416634356