### PR TITLE
Allow users to cancel out of theme selector

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -202,6 +202,7 @@ export const App = ({ config, settings, cliVersion }: AppProps) => {
             onSelect={handleThemeSelect}
             onHighlight={handleThemeHighlight}
             settings={settings}
+            setQuery={setQuery}
           />
         </Box>
       ) : (

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -29,6 +29,7 @@ export function ThemeDialog({
   onSelect,
   onHighlight,
   settings,
+  setQuery,
 }: ThemeDialogProps): React.JSX.Element {
   const [selectedScope, setSelectedScope] = useState<SettingScope>(
     SettingScope.User,
@@ -58,6 +59,7 @@ export function ThemeDialog({
   ];
 
   const handleThemeSelect = (themeName: string) => {
+    setQuery(''); // Clear the query when user selects a theme
     onSelect(themeName, selectedScope);
   };
 
@@ -80,6 +82,7 @@ export function ThemeDialog({
       setFocusedSection((prev) => (prev === 'theme' ? 'scope' : 'theme'));
     }
     if (key.escape) {
+      setQuery(''); // Clear the query when user hits escape
       onSelect(undefined, selectedScope);
     }
   });

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -21,6 +21,8 @@ interface ThemeDialogProps {
   onHighlight: (themeName: string | undefined) => void;
   /** The settings object */
   settings: LoadedSettings;
+  /** Callback to set the query */
+  setQuery: (query: string) => void;
 }
 
 export function ThemeDialog({
@@ -76,6 +78,9 @@ export function ThemeDialog({
   useInput((input, key) => {
     if (key.tab) {
       setFocusedSection((prev) => (prev === 'theme' ? 'scope' : 'theme'));
+    }
+    if (key.escape) {
+      onSelect(undefined, selectedScope);
     }
   });
 


### PR DESCRIPTION
This allows users to hit `Escape` while in the theme selector and goes back to the main page with a cleared input

https://github.com/user-attachments/assets/9c75fa54-cf61-4e13-9e17-9dcabfa5d746

