### PR TITLE
Make cancel not explode.

### DIFF
--- a/packages/cli/src/ui/components/messages/InfoMessage.tsx
+++ b/packages/cli/src/ui/components/messages/InfoMessage.tsx
@@ -17,7 +17,7 @@ export const InfoMessage: React.FC<InfoMessageProps> = ({ text }) => {
   const prefixWidth = prefix.length;
 
   return (
-    <Box flexDirection="row">
+    <Box flexDirection="row" marginTop={1}>
       <Box width={prefixWidth}>
         <Text color={Colors.AccentYellow}>{prefix}</Text>
       </Box>


### PR DESCRIPTION
- We were console.erroring, throwing and early aborting. Instead we now treat cancels like a normal user message and show an indicator in the UI

Instead of an error you now get:
![image](https://github.com/user-attachments/assets/8582d9b5-632a-4515-b6d5-ebe836f1963e)

Fixes https://b.corp.google.com/issues/416515841