### PR TITLE
Enable tools to cancel active execution.

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -26,6 +26,7 @@ interface HandleAtCommandParams {
   addItem: UseHistoryManagerReturn['addItem'];
   setDebugMessage: React.Dispatch<React.SetStateAction<string>>;
   messageId: number;
+  signal: AbortSignal;
 }
 
 interface HandleAtCommandResult {
@@ -90,6 +91,7 @@ export async function handleAtCommand({
   addItem,
   setDebugMessage,
   messageId: userMessageTimestamp,
+  signal,
 }: HandleAtCommandParams): Promise<HandleAtCommandResult> {
   const trimmedQuery = query.trim();
   const parsedCommand = parseAtCommand(trimmedQuery);
@@ -163,7 +165,7 @@ export async function handleAtCommand({
   let toolCallDisplay: IndividualToolCallDisplay;
 
   try {
-    const result = await readManyFilesTool.execute(toolArgs);
+    const result = await readManyFilesTool.execute(toolArgs, signal);
     const fileContent = result.llmContent || '';
 
     toolCallDisplay = {

--- a/packages/server/src/core/client.ts
+++ b/packages/server/src/core/client.ts
@@ -64,10 +64,13 @@ export class GeminiClient {
           .getTool('read_many_files') as ReadManyFilesTool;
         if (readManyFilesTool) {
           // Read all files in the target directory
-          const result = await readManyFilesTool.execute({
-            paths: ['**/*'], // Read everything recursively
-            useDefaultExcludes: true, // Use default excludes
-          });
+          const result = await readManyFilesTool.execute(
+            {
+              paths: ['**/*'], // Read everything recursively
+              useDefaultExcludes: true, // Use default excludes
+            },
+            AbortSignal.timeout(30000),
+          );
           if (result.llmContent) {
             initialParts.push({
               text: `\n--- Full File Context ---\n${result.llmContent}`,

--- a/packages/server/src/tools/edit.ts
+++ b/packages/server/src/tools/edit.ts
@@ -333,7 +333,10 @@ Expectation for parameters:
    * @param params Parameters for the edit operation
    * @returns Result of the edit operation
    */
-  async execute(params: EditToolParams): Promise<ToolResult> {
+  async execute(
+    params: EditToolParams,
+    _signal: AbortSignal,
+  ): Promise<ToolResult> {
     const validationError = this.validateParams(params);
     if (validationError) {
       return {

--- a/packages/server/src/tools/glob.ts
+++ b/packages/server/src/tools/glob.ts
@@ -138,7 +138,10 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
   /**
    * Executes the glob search with the given parameters
    */
-  async execute(params: GlobToolParams): Promise<ToolResult> {
+  async execute(
+    params: GlobToolParams,
+    _signal: AbortSignal,
+  ): Promise<ToolResult> {
     const validationError = this.validateToolParams(params);
     if (validationError) {
       return {

--- a/packages/server/src/tools/grep.ts
+++ b/packages/server/src/tools/grep.ts
@@ -166,7 +166,10 @@ export class GrepTool extends BaseTool<GrepToolParams, ToolResult> {
    * @param params Parameters for the grep search
    * @returns Result of the grep search
    */
-  async execute(params: GrepToolParams): Promise<ToolResult> {
+  async execute(
+    params: GrepToolParams,
+    _signal: AbortSignal,
+  ): Promise<ToolResult> {
     const validationError = this.validateToolParams(params);
     if (validationError) {
       console.error(

--- a/packages/server/src/tools/ls.ts
+++ b/packages/server/src/tools/ls.ts
@@ -184,7 +184,10 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
    * @param params Parameters for the LS operation
    * @returns Result of the LS operation
    */
-  async execute(params: LSToolParams): Promise<ToolResult> {
+  async execute(
+    params: LSToolParams,
+    _signal: AbortSignal,
+  ): Promise<ToolResult> {
     const validationError = this.validateToolParams(params);
     if (validationError) {
       return this.errorResult(

--- a/packages/server/src/tools/read-file.ts
+++ b/packages/server/src/tools/read-file.ts
@@ -193,7 +193,10 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
    * @param params Parameters for the file reading
    * @returns Result with file contents
    */
-  async execute(params: ReadFileToolParams): Promise<ToolResult> {
+  async execute(
+    params: ReadFileToolParams,
+    _signal: AbortSignal,
+  ): Promise<ToolResult> {
     const validationError = this.validateToolParams(params);
     if (validationError) {
       return {

--- a/packages/server/src/tools/read-many-files.ts
+++ b/packages/server/src/tools/read-many-files.ts
@@ -237,7 +237,10 @@ Default excludes apply to common non-text files and large dependency directories
     return `Will attempt to read and concatenate files ${pathDesc}. ${excludeDesc}. File encoding: ${DEFAULT_ENCODING}. Separator: "${DEFAULT_OUTPUT_SEPARATOR_FORMAT.replace('{filePath}', 'path/to/file.ext')}".`;
   }
 
-  async execute(params: ReadManyFilesParams): Promise<ToolResult> {
+  async execute(
+    params: ReadManyFilesParams,
+    _signal: AbortSignal,
+  ): Promise<ToolResult> {
     const validationError = this.validateParams(params);
     if (validationError) {
       return {

--- a/packages/server/src/tools/terminal.ts
+++ b/packages/server/src/tools/terminal.ts
@@ -265,7 +265,10 @@ Use this tool for running build steps (\`npm install\`, \`make\`), linters (\`es
     return confirmationDetails;
   }
 
-  async execute(params: TerminalToolParams): Promise<ToolResult> {
+  async execute(
+    params: TerminalToolParams,
+    _signal: AbortSignal,
+  ): Promise<ToolResult> {
     const validationError = this.validateToolParams(params);
     if (validationError) {
       return {

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -64,7 +64,7 @@ export interface Tool<
    * @param params Parameters for the tool execution
    * @returns Result of the tool execution
    */
-  execute(params: TParams): Promise<TResult>;
+  execute(params: TParams, signal: AbortSignal): Promise<TResult>;
 }
 
 /**
@@ -141,9 +141,10 @@ export abstract class BaseTool<
    * Abstract method to execute the tool with the given parameters
    * Must be implemented by derived classes
    * @param params Parameters for the tool execution
+   * @param signal AbortSignal for tool cancellation
    * @returns Result of the tool execution
    */
-  abstract execute(params: TParams): Promise<TResult>;
+  abstract execute(params: TParams, signal: AbortSignal): Promise<TResult>;
 }
 
 export interface ToolResult {

--- a/packages/server/src/tools/web-fetch.ts
+++ b/packages/server/src/tools/web-fetch.ts
@@ -70,7 +70,10 @@ export class WebFetchTool extends BaseTool<WebFetchToolParams, ToolResult> {
     return `Fetching content from ${displayUrl}`;
   }
 
-  async execute(params: WebFetchToolParams): Promise<ToolResult> {
+  async execute(
+    params: WebFetchToolParams,
+    _signal: AbortSignal,
+  ): Promise<ToolResult> {
     const validationError = this.validateParams(params);
     if (validationError) {
       return {

--- a/packages/server/src/tools/write-file.ts
+++ b/packages/server/src/tools/write-file.ts
@@ -150,7 +150,10 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
     return confirmationDetails;
   }
 
-  async execute(params: WriteFileToolParams): Promise<ToolResult> {
+  async execute(
+    params: WriteFileToolParams,
+    _signal: AbortSignal,
+  ): Promise<ToolResult> {
     const validationError = this.validateParams(params);
     if (validationError) {
       return {


### PR DESCRIPTION
- Plumbed abort signals through to tools
- Updated the shell tool to properly cancel active requests by killing the entire child process tree of the underlying shell process and then report that the shell itself was canceled.

Fixes https://b.corp.google.com/issues/416829935