### PR TITLE
Show model decline/cancellation states.

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -509,6 +509,15 @@ export const useGeminiStream = (
               error: new Error(declineMessage),
             };
 
+            // Update conversation history without re-issuing another request to indicate the decline.
+            const history = chatSessionRef.current?.getHistory();
+            if (history) {
+              history.push({
+                role: 'model',
+                parts: [functionResponse],
+              });
+            }
+
             // Update UI to show cancellation/error
             updateFunctionResponseUI(responseInfo, status);
             setStreamingState(StreamingState.Idle);


### PR DESCRIPTION
- Upon decline / cancellation we weren't showing the model the cancellation status or states. Therefore it didn't know why things would or wouldn't happen

Note: there's a message history ordering bug being shown here BUT the last user message is indeed after the sleep.
![image](https://github.com/user-attachments/assets/cf146f39-998e-4586-9383-435175bafc83)

Fixes https://b.corp.google.com/issues/416797704