### PR TITLE
Workaround model bug where it returns invalid history items.

### DIFF
--- a/packages/server/src/utils/nextSpeakerChecker.ts
+++ b/packages/server/src/utils/nextSpeakerChecker.ts
@@ -60,7 +60,12 @@ export async function checkNextSpeaker(
   chat: Chat,
   geminiClient: GeminiClient,
 ): Promise<NextSpeakerResponse | null> {
-  const history = await chat.getHistory();
+  // We need to capture the curated history because there are many moments when the model will return invalid turns
+  // that when passed back up to the endpoint will break subsequent calls. An example of this is when the model decides
+  // to respond with an empty part collection if you were to send that message back to the server it will respond with
+  // a 400 indicating that model part collections MUST have content.
+  const history = await chat.getHistory(/* curated */ true);
+
   // Ensure there's a model response to analyze
   if (history.length === 0 || history[history.length - 1].role !== 'model') {
     // Cannot determine next speaker if the last turn wasn't from the model


### PR DESCRIPTION
- Currently there's a bug in the API (or SDK?) where the SDK endpoint will commonly fail with:

```
Error: Failed to generate JSON content: got status: 400 Bad Request. {"error":{"code":400,"message":"* GenerateContentRequest.contents[5].parts: contents.parts must not be empty.\n","status":"INVALID_ARGUMENT"}}
```

- At times the model will respond with an empty parts list where if we send that back up to the API endpoint it explodes with the above. Using a curated history seems like a total hack around this prolbem, and even in the SDK (i'm following up on this), BUT helps mitigate this issue.