### PR TITLE
feat: Add User-Agent to API requests

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -13,6 +13,7 @@ import {
   createServerConfig,
 } from '@gemini-code/server';
 import { Settings } from './settings.js';
+import { readPackageUp } from 'read-package-up';
 
 const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro-preview-05-06';
 
@@ -80,6 +81,8 @@ export async function loadCliConfig(settings: Settings): Promise<Config> {
   // Parse CLI arguments
   const argv = await parseArguments();
 
+  const userAgent = await createUserAgent();
+
   // Create config using factory from server package
   return createServerConfig(
     process.env.GEMINI_API_KEY,
@@ -92,5 +95,12 @@ export async function loadCliConfig(settings: Settings): Promise<Config> {
     settings.toolDiscoveryCommand,
     settings.toolCallCommand,
     settings.mcpServerCommand,
+    userAgent,
   );
+}
+
+async function createUserAgent(): Promise<string> {
+  const packageJsonInfo = await readPackageUp({ cwd: import.meta.url });
+  const cliVersion = packageJsonInfo?.packageJson.version || 'unknown';
+  return `GeminiCLI/${cliVersion} Node.js/${process.version} (${process.platform}; ${process.arch})`;
 }

--- a/packages/server/src/config/config.ts
+++ b/packages/server/src/config/config.ts
@@ -34,6 +34,7 @@ export class Config {
     private readonly toolDiscoveryCommand: string | undefined,
     private readonly toolCallCommand: string | undefined,
     private readonly mcpServerCommand: string | undefined,
+    private readonly userAgent: string,
   ) {
     // toolRegistry still needs initialization based on the instance
     this.toolRegistry = createToolRegistry(this);
@@ -81,6 +82,10 @@ export class Config {
   getMcpServerCommand(): string | undefined {
     return this.mcpServerCommand;
   }
+
+  getUserAgent(): string {
+    return this.userAgent;
+  }
 }
 
 function findEnvFile(startDir: string): string | null {
@@ -117,6 +122,7 @@ export function createServerConfig(
   toolDiscoveryCommand?: string,
   toolCallCommand?: string,
   mcpServerCommand?: string,
+  userAgent?: string,
 ): Config {
   return new Config(
     apiKey,
@@ -129,6 +135,7 @@ export function createServerConfig(
     toolDiscoveryCommand,
     toolCallCommand,
     mcpServerCommand,
+    userAgent ?? 'GeminiCLI/unknown', // Default user agent
   );
 }
 

--- a/packages/server/src/core/client.ts
+++ b/packages/server/src/core/client.ts
@@ -34,7 +34,15 @@ export class GeminiClient {
   private readonly MAX_TURNS = 100;
 
   constructor(private config: Config) {
-    this.client = new GoogleGenAI({ apiKey: config.getApiKey() });
+    const userAgent = config.getUserAgent();
+    this.client = new GoogleGenAI({
+      apiKey: config.getApiKey(),
+      httpOptions: {
+        headers: {
+          'User-Agent': userAgent,
+        },
+      },
+    });
     this.model = config.getModel();
   }
 


### PR DESCRIPTION
This change introduces a User-Agent header to all API requests made by the Gemini CLI.

- The User-Agent string includes the CLI version, Node.js version, operating system, and architecture. This will help in tracking usage and identifying potential issues.

Example user agent from this: `GeminiCLI/0.1.0 Node.js/v22.14.0 (darwin; arm64)`

Fixes https://b.corp.google.com/issues/416353675

Signed-off-by: Gemini