### PR TITLE
refactor: shorten 'gemini' binary name

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Alternatively, you can use the "Launch Program" configuration in VS Code if you 
 
 ## Using Gemini Code source in other directories
 
-To test your local version of `gemini-code` in other directories on your system, you can use `npm link`. Note, this is not the same as globally installing the released version of Gemini Code via `npm install -g @gemini-code/cli`. Rather, this creates a global symlink to your local project.
+To test your local version of `gemini` in other directories on your system, you can use `npm link`. Note, this is not the same as globally installing the released version of Gemini Code via `npm install -g @gemini-code/cli`. Rather, this creates a global symlink to your local project.
 
 From the root of this repository, run:
 
@@ -70,16 +70,16 @@ From the root of this repository, run:
 npm link packages/cli
 ```
 
-Then, navigate to any other directory where you want to use your local `gemini-code` and run:
+Then, navigate to any other directory where you want to use your local `gemini` and run:
 
 ```bash
-gemini-code
+gemini
 ```
 
 To breakpoint inside the sandbox container run:
 
 ```bash
-DEBUG=1 gemini-code
+DEBUG=1 gemini
 ```
 
 Note that using `npm link` simulates a production environment. If you are testing sandboxed mode via `npm link`, you must run the full build with `npm run build:all` from the repository root after any code changes to ensure the linked version is up to date.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "gemini-code": "dist/index.js"
+    "gemini-code": "dist/index.js",
+    "gemini": "dist/index.js"
   },
   "image": "us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-cli",
   "scripts": {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -127,7 +127,7 @@ function entrypoint(workdir: string): string[] {
     ),
   );
 
-  // append remaining args (bash -c "gemini-code cli_args...")
+  // append remaining args (bash -c "gemini cli_args...")
   // cli_args need to be quoted before being inserted into bash_cmd
   const cliArgs = process.argv.slice(2).map((arg) => quote([arg]));
   const cliCmd =
@@ -136,8 +136,8 @@ function entrypoint(workdir: string): string[] {
         ? 'npm run debug --'
         : 'npm run start --'
       : process.env.DEBUG // for production binary debugging
-        ? `node --inspect-brk=0.0.0.0:${process.env.DEBUG_PORT || '9229'} $(which gemini-code)`
-        : 'gemini-code';
+        ? `node --inspect-brk=0.0.0.0:${process.env.DEBUG_PORT || '9229'} $(which gemini)`
+        : 'gemini';
 
   const args = [...bashCmds, cliCmd, ...cliArgs];
 
@@ -197,7 +197,7 @@ export async function start_sandbox(sandbox: string) {
   console.log(`hopping into sandbox (command: ${sandbox}) ...`);
 
   // determine full path for gemini-code to distinguish linked vs installed setting
-  const gcPath = execSync(`realpath $(which gemini-code)`).toString().trim();
+  const gcPath = execSync(`realpath $(which gemini)`).toString().trim();
 
   const image = process.env.GEMINI_CODE_SANDBOX_IMAGE ?? 'gemini-code-sandbox';
   const workdir = process.cwd();
@@ -207,7 +207,7 @@ export async function start_sandbox(sandbox: string) {
   if (process.env.BUILD_SANDBOX) {
     if (!gcPath.includes('gemini-code/packages/')) {
       console.error(
-        'ERROR: cannot BUILD_SANDBOX using installed gemini-code binary; ' +
+        'ERROR: cannot BUILD_SANDBOX using installed gemini binary; ' +
           'run `npm link ./packages/cli` under gemini-code repo to switch to linked binary.',
       );
       process.exit(1);


### PR DESCRIPTION
BUG=b/416899413

This keeps the original `gemini-code` binary for now. Planning to update the internal dogfood docs to reference `gemini` first, then will remove the `gemini-code` binary from the repo.