### PR TITLE
Using `Enter` on slash commands will execute it

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -103,7 +103,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           }
         } else if (key.return) {
           // Check if suggestions are showing and an item is actively selected
-          if (showSuggestions && activeSuggestionIndex >= 0 && suggestions.length > 0) {
+          if (
+            showSuggestions &&
+            activeSuggestionIndex >= 0 &&
+            suggestions.length > 0
+          ) {
             const selectedSuggestion = suggestions[activeSuggestionIndex];
             // Determine if the context is for slash commands based on the current query.
             const currentQueryTrimmed = query.trimStart();

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -77,7 +77,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       resetCompletion(); // Hide suggestions after selection
-      setInputKey((k) => k + 1); // Increment key to force re-render and cursor reset
+      setInputKey((k: number) => k + 1); // Increment key to force re-render and cursor reset
     },
     [query, setQuery, suggestions, resetCompletion, setInputKey],
   );
@@ -118,13 +118,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
               onSubmit(commandToExecute);
               setQuery(''); // Clear input.
               resetCompletion(); // Hide suggestions.
-              setInputKey((k) => k + 1); // Refresh TextInput.
+              setInputKey((k: number) => k + 1); // Refresh TextInput.
             } else {
               // Other suggestion types: complete the input.
               handleAutocomplete(activeSuggestionIndex);
             }
           } else {
-            // No active suggestion or suggestions not showing: direct submission.
             const trimmedQuerySubmit = query.trim();
             if (trimmedQuerySubmit) {
               onSubmit(trimmedQuerySubmit);

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -102,11 +102,31 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             }
           }
         } else if (key.return) {
-          if (activeSuggestionIndex >= 0) {
-            handleAutocomplete(activeSuggestionIndex);
+          // Check if suggestions are showing and an item is actively selected
+          if (showSuggestions && activeSuggestionIndex >= 0 && suggestions.length > 0) {
+            const selectedSuggestion = suggestions[activeSuggestionIndex];
+            // Determine if the context is for slash commands based on the current query.
+            const currentQueryTrimmed = query.trimStart();
+
+            if (currentQueryTrimmed.startsWith('/')) {
+              // Slash command suggestion selected: execute it.
+              const commandToExecute = `/${selectedSuggestion.value}`;
+              onSubmit(commandToExecute);
+              setQuery(''); // Clear input.
+              resetCompletion(); // Hide suggestions.
+              setInputKey((k) => k + 1); // Refresh TextInput.
+            } else {
+              // Other suggestion types: complete the input.
+              handleAutocomplete(activeSuggestionIndex);
+            }
           } else {
-            if (query.trim()) {
-              onSubmit(query);
+            // No active suggestion or suggestions not showing: direct submission.
+            const trimmedQuerySubmit = query.trim();
+            if (trimmedQuerySubmit) {
+              onSubmit(trimmedQuerySubmit);
+              setQuery(''); // Clear input.
+              resetCompletion(); // Hide suggestions.
+              setInputKey((k) => k + 1); // Refresh TextInput.
             }
           }
         } else if (key.escape) {


### PR DESCRIPTION
This improves how the slash commands work, instead of requiring multiple `Enter` presses we can execute on the first press.

## Before

https://github.com/user-attachments/assets/6dfa31b8-24b4-4de8-9cd0-17fb525b7c87



## After

https://github.com/user-attachments/assets/5814e83e-15bb-4fc6-8c39-5671621f3c51

