### PR TITLE
Use `Enter` on slash commands to execute

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -60,6 +60,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         const base = query.substring(0, slashIndex + 1);
         const newValue = base + selectedSuggestion.value;
         onChangeAndMoveCursor(newValue);
+        onSubmit(newValue); // Execute the command
       } else {
         // Handle @ command completion
         const atIndex = query.lastIndexOf('@');
@@ -85,7 +86,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
       resetCompletion(); // Hide suggestions after selection
     },
-    [query, suggestions, resetCompletion, onChangeAndMoveCursor],
+    [query, suggestions, resetCompletion, onChangeAndMoveCursor, onSubmit],
   );
 
   const inputPreprocessor = useCallback(


### PR DESCRIPTION
This improves how the slash commands work, instead of requiring multiple `Enter` presses we can execute on the first press.

## Before

https://github.com/user-attachments/assets/6dfa31b8-24b4-4de8-9cd0-17fb525b7c87



## After

https://github.com/user-attachments/assets/5814e83e-15bb-4fc6-8c39-5671621f3c51

