### PR TITLE
Prevent flickering on confirmation decline.

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -483,6 +483,10 @@ export const useGeminiStream = (
                 error: undefined,
               };
               updateFunctionResponseUI(responseInfo, ToolCallStatus.Success);
+              if (pendingHistoryItemRef.current) {
+                addItem(pendingHistoryItemRef.current, Date.now());
+                setPendingHistoryItem(null);
+              }
               setStreamingState(StreamingState.Idle);
               await submitQuery(functionResponse);
             } finally {
@@ -529,6 +533,10 @@ export const useGeminiStream = (
 
             // Update UI to show cancellation/error
             updateFunctionResponseUI(responseInfo, status);
+            if (pendingHistoryItemRef.current) {
+              addItem(pendingHistoryItemRef.current, Date.now());
+              setPendingHistoryItem(null);
+            }
             setStreamingState(StreamingState.Idle);
           }
         };


### PR DESCRIPTION
- When larger confirmations were shown and then declined you'd typicaly get large chunks of content flickering upon typing or sending a subsequent request. This was primarily due to us leaving the latest confirmation as "updateable" / pending. This changeset addresses that by flushing any pending confirmation to the static container.

Part of https://b.corp.google.com/issues/414196943