### PR TITLE
Improve read-many-files display message

### DIFF
--- a/packages/server/src/tools/read-many-files.ts
+++ b/packages/server/src/tools/read-many-files.ts
@@ -351,7 +351,7 @@ Default excludes apply to common non-text files and large dependency directories
     let displayMessage = `### ReadManyFiles Result (Target Dir: \`${this.targetDir}\`)\n\n`;
     if (processedFilesRelativePaths.length > 0) {
       displayMessage += `Successfully read and concatenated content from **${processedFilesRelativePaths.length} file(s)**.\n`;
-      displayMessage += `\n**Processed Files (up to 10 shown):**\n`;
+      displayMessage += `\n**Processed Files:**\n`;
       processedFilesRelativePaths
         .slice(0, 10)
         .forEach((p) => (displayMessage += `- \`${p}\`\n`));


### PR DESCRIPTION
Feels silly to say "up to 10" when we list the number of files above and below

<img width="671" alt="Screenshot 2025-05-14 at 4 42 32 PM" src="https://github.com/user-attachments/assets/7ff747c0-8e6f-4410-affd-2e2c7121199f" />
