### PR TITLE
Add readline-like keybindings to the input prompts.

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -170,6 +170,11 @@ export const App = ({
     [setQuery, setEditorState],
   );
 
+  const handleClearScreen = useCallback(() => {
+    clearItems();
+    refreshStatic();
+  }, [clearItems, refreshStatic]);
+
   const completion = useCompletion(
     query,
     config.getTargetDir(),
@@ -288,6 +293,8 @@ export const App = ({
                 navigateSuggestionUp={completion.navigateUp}
                 navigateSuggestionDown={completion.navigateDown}
                 resetCompletion={completion.resetCompletionState}
+                setEditorState={setEditorState} // Added setEditorState prop
+                onClearScreen={handleClearScreen} // Added onClearScreen prop
               />
               {completion.showSuggestions && (
                 <Box marginTop={1}>

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -317,7 +317,7 @@ export const App = ({
                 navigateSuggestionUp={completion.navigateUp}
                 navigateSuggestionDown={completion.navigateDown}
                 resetCompletion={completion.resetCompletionState}
-                setEditorState={setEditorState} // Added setEditorState prop
+                setEditorState={setEditorState}
                 onClearScreen={handleClearScreen} // Added onClearScreen prop
               />
               {completion.showSuggestions && (

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -109,7 +109,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   );
 
   const inputPreprocessor = useCallback(
-    (input: string, key: Key, _currentText?: string, _cursorOffset?: number) => {
+    (
+      input: string,
+      key: Key,
+      _currentText?: string,
+      _cursorOffset?: number,
+    ) => {
       if (showSuggestions) {
         if (key.upArrow) {
           navigateSuggestionUp();
@@ -142,11 +147,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       } else {
         // Keybindings when suggestions are not shown
         if (key.ctrl && input === 'a') {
-          setEditorState(s => ({ key: s.key + 1, initialCursorOffset: 0 }));
+          setEditorState((s) => ({ key: s.key + 1, initialCursorOffset: 0 }));
           return true;
         }
         if (key.ctrl && input === 'e') {
-          setEditorState(s => ({ key: s.key + 1, initialCursorOffset: query.length }));
+          setEditorState((s) => ({
+            key: s.key + 1,
+            initialCursorOffset: query.length,
+          }));
           return true;
         }
         if (key.ctrl && input === 'l') {

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -175,7 +175,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       activeSuggestionIndex,
       handleSubmit,
       inputHistory,
-      onChangeAndMoveCursor,
       setEditorState,
       onClearScreen,
     ],

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -24,6 +24,8 @@ interface InputPromptProps {
   userMessages: readonly string[];
   navigateSuggestionUp: () => void;
   navigateSuggestionDown: () => void;
+  setEditorState: (updater: (prevState: EditorState) => EditorState) => void;
+  onClearScreen: () => void;
 }
 
 export interface EditorState {
@@ -44,6 +46,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   navigateSuggestionUp,
   navigateSuggestionDown,
   resetCompletion,
+  setEditorState,
+  onClearScreen,
 }) => {
   const handleSubmit = useCallback(
     (submittedValue: string) => {
@@ -105,7 +109,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   );
 
   const inputPreprocessor = useCallback(
-    (input: string, key: Key) => {
+    (input: string, key: Key, _currentText?: string, _cursorOffset?: number) => {
       if (showSuggestions) {
         if (key.upArrow) {
           navigateSuggestionUp();
@@ -135,6 +139,28 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           resetCompletion();
           return true;
         }
+      } else {
+        // Keybindings when suggestions are not shown
+        if (key.ctrl && input === 'a') {
+          setEditorState(s => ({ key: s.key + 1, initialCursorOffset: 0 }));
+          return true;
+        }
+        if (key.ctrl && input === 'e') {
+          setEditorState(s => ({ key: s.key + 1, initialCursorOffset: query.length }));
+          return true;
+        }
+        if (key.ctrl && input === 'l') {
+          onClearScreen();
+          return true;
+        }
+        if (key.ctrl && input === 'p') {
+          inputHistory.navigateUp();
+          return true;
+        }
+        if (key.ctrl && input === 'n') {
+          inputHistory.navigateDown();
+          return true;
+        }
       }
       return false;
     },
@@ -148,6 +174,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       resetCompletion,
       activeSuggestionIndex,
       handleSubmit,
+      inputHistory,
+      onChangeAndMoveCursor,
+      setEditorState,
+      onClearScreen,
     ],
   );
 

--- a/packages/cli/src/ui/components/shared/multiline-editor.tsx
+++ b/packages/cli/src/ui/components/shared/multiline-editor.tsx
@@ -113,6 +113,11 @@ export const MultilineTextEditor = ({
         return;
       }
 
+      if (key.ctrl && input === 'u') {
+        buffer.killLineLeft();
+        return;
+      }
+
       const isCtrlX =
         (key.ctrl && (input === 'x' || input === '\x18')) || input === '\x18';
       const isCtrlE =

--- a/packages/cli/src/ui/components/shared/multiline-editor.tsx
+++ b/packages/cli/src/ui/components/shared/multiline-editor.tsx
@@ -43,7 +43,12 @@ export interface MultilineTextEditorProps {
 
   // Called on all key events to allow the caller. Returns true if the
   // event was handled and should not be passed to the editor.
-  readonly inputPreprocessor?: (input: string, key: Key) => boolean;
+  readonly inputPreprocessor?: (
+    input: string,
+    key: Key,
+    currentText: string,
+    cursorOffset: number,
+  ) => boolean;
 
   // Optional initial cursor position (character offset)
   readonly initialCursorOffset?: number;
@@ -92,7 +97,20 @@ export const MultilineTextEditor = ({
         return;
       }
 
-      if (inputPreprocessor?.(input, key) === true) {
+      // Calculate cursorOffset for inputPreprocessor
+      let charOffset = 0;
+      for (let i = 0; i < buffer.cursor[0]; i++) {
+        charOffset += buffer.lines[i].length + 1; // +1 for newline
+      }
+      charOffset += buffer.cursor[1];
+
+      if (inputPreprocessor?.(input, key, buffer.text, charOffset) === true) {
+        return;
+      }
+
+      // Ctrl+K for killLineRight
+      if (key.ctrl && input === 'k') {
+        buffer.killLineRight();
         return;
       }
 

--- a/packages/cli/src/ui/components/shared/multiline-editor.tsx
+++ b/packages/cli/src/ui/components/shared/multiline-editor.tsx
@@ -108,7 +108,6 @@ export const MultilineTextEditor = ({
         return;
       }
 
-      // Ctrl+K for killLineRight
       if (key.ctrl && input === 'k') {
         buffer.killLineRight();
         return;

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -372,9 +372,9 @@ export function useTextBuffer({
     pushUndo,
     cursorRow,
     cursorCol,
-    lines,
     currentLine,
     currentLineLen,
+    lines.length,
     setPreferredCol,
   ]);
 
@@ -521,9 +521,9 @@ export function useTextBuffer({
     pushUndo,
     cursorRow,
     cursorCol,
-    lines,
     currentLine,
     del,
+    lines.length,
     setPreferredCol,
   ]);
 
@@ -541,7 +541,7 @@ export function useTextBuffer({
       // No change to preferredCol as it's a line modification, not vertical movement.
     }
     // If cursorCol is at or beyond the end of the line, do nothing.
-  }, [pushUndo, cursorRow, cursorCol, lines, currentLine, currentLineLen]);
+  }, [pushUndo, cursorRow, cursorCol, currentLine, currentLineLen]);
 
   const move = useCallback(
     (dir: Direction): void => {

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -528,8 +528,8 @@ export function useTextBuffer({
   ]);
 
   const killLineRight = useCallback((): void => {
-    dbg('killLineRight', { beforeCursor: [cursorRow, cursorCol] });
     const lineContent = currentLine(cursorRow);
+    // Only act if the cursor is not at the end of the line
     if (cursorCol < currentLineLen(cursorRow)) {
       pushUndo();
       setLines((prevLines) => {
@@ -537,10 +537,7 @@ export function useTextBuffer({
         newLines[cursorRow] = cpSlice(lineContent, 0, cursorCol);
         return newLines;
       });
-      // Cursor position does not change, but text to the right is gone.
-      // No change to preferredCol as it's a line modification, not vertical movement.
     }
-    // If cursorCol is at or beyond the end of the line, do nothing.
   }, [pushUndo, cursorRow, cursorCol, currentLine, currentLineLen]);
 
   const move = useCallback(

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -529,16 +529,34 @@ export function useTextBuffer({
 
   const killLineRight = useCallback((): void => {
     const lineContent = currentLine(cursorRow);
-    // Only act if the cursor is not at the end of the line
     if (cursorCol < currentLineLen(cursorRow)) {
+      // Cursor is before the end of the line's content, delete text to the right
       pushUndo();
       setLines((prevLines) => {
         const newLines = [...prevLines];
         newLines[cursorRow] = cpSlice(lineContent, 0, cursorCol);
         return newLines;
       });
+      // Cursor position and preferredCol do not change in this case
+    } else if (
+      cursorCol === currentLineLen(cursorRow) &&
+      cursorRow < lines.length - 1
+    ) {
+      // Cursor is at the end of the line's content (or line is empty),
+      // and it's not the last line. Delete the newline.
+      // `del()` handles pushUndo and setPreferredCol.
+      del();
     }
-  }, [pushUndo, cursorRow, cursorCol, currentLine, currentLineLen]);
+    // If cursor is at the end of the line and it's the last line, do nothing.
+  }, [
+    pushUndo,
+    cursorRow,
+    cursorCol,
+    currentLine,
+    currentLineLen,
+    lines.length,
+    del,
+  ]);
 
   const killLineLeft = useCallback((): void => {
     const lineContent = currentLine(cursorRow);

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -527,6 +527,22 @@ export function useTextBuffer({
     setPreferredCol,
   ]);
 
+  const killLineRight = useCallback((): void => {
+    dbg('killLineRight', { beforeCursor: [cursorRow, cursorCol] });
+    const lineContent = currentLine(cursorRow);
+    if (cursorCol < currentLineLen(cursorRow)) {
+      pushUndo();
+      setLines((prevLines) => {
+        const newLines = [...prevLines];
+        newLines[cursorRow] = cpSlice(lineContent, 0, cursorCol);
+        return newLines;
+      });
+      // Cursor position does not change, but text to the right is gone.
+      // No change to preferredCol as it's a line modification, not vertical movement.
+    }
+    // If cursorCol is at or beyond the end of the line, do nothing.
+  }, [pushUndo, cursorRow, cursorCol, lines, currentLine, currentLineLen]);
+
   const move = useCallback(
     (dir: Direction): void => {
       const before = [cursorRow, cursorCol];
@@ -772,6 +788,7 @@ export function useTextBuffer({
     replaceRange,
     deleteWordLeft,
     deleteWordRight,
+    killLineRight,
     handleInput,
     openInExternalEditor,
 
@@ -872,6 +889,10 @@ export interface TextBuffer {
    * follows the caret and the next contiguous run of word characters.
    */
   deleteWordRight: () => void;
+  /**
+   * Deletes text from the cursor to the end of the current line.
+   */
+  killLineRight: () => void;
   /**
    * High level "handleInput" – receives what Ink gives us.
    */

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -540,6 +540,21 @@ export function useTextBuffer({
     }
   }, [pushUndo, cursorRow, cursorCol, currentLine, currentLineLen]);
 
+  const killLineLeft = useCallback((): void => {
+    const lineContent = currentLine(cursorRow);
+    // Only act if the cursor is not at the beginning of the line
+    if (cursorCol > 0) {
+      pushUndo();
+      setLines((prevLines) => {
+        const newLines = [...prevLines];
+        newLines[cursorRow] = cpSlice(lineContent, cursorCol);
+        return newLines;
+      });
+      setCursorCol(0);
+      setPreferredCol(null);
+    }
+  }, [pushUndo, cursorRow, cursorCol, currentLine, setPreferredCol]);
+
   const move = useCallback(
     (dir: Direction): void => {
       const before = [cursorRow, cursorCol];
@@ -786,6 +801,7 @@ export function useTextBuffer({
     deleteWordLeft,
     deleteWordRight,
     killLineRight,
+    killLineLeft,
     handleInput,
     openInExternalEditor,
 
@@ -890,6 +906,10 @@ export interface TextBuffer {
    * Deletes text from the cursor to the end of the current line.
    */
   killLineRight: () => void;
+  /**
+   * Deletes text from the start of the current line to the cursor.
+   */
+  killLineLeft: () => void;
   /**
    * High level "handleInput" – receives what Ink gives us.
    */


### PR DESCRIPTION
New keybindings in the main input prompt (when auto-suggestions are not active):
  - `Ctrl+L`: Clears the entire screen.
  - `Ctrl+A`: Moves the cursor to the beginning of the current input line.
  - `Ctrl+E`: Moves the cursor to the end of the current input line.
  - `Ctrl+P`: Navigates to the previous command in the input history.
  - `Ctrl+N`: Navigates to the next command in the input history.

In the multiline text editor (e.g., when editing a previous message):
   - `Ctrl+K`: Deletes text from the current cursor position to the end of the line ("kill line right").