### PR TITLE
/clear clears the console

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -71,6 +71,7 @@ export const useSlashCommandProcessor = (
         action: (_value: PartListUnion | string) => {
           onDebugMessage('Clearing terminal.');
           clearItems();
+          console.clear();
           refreshStatic();
         },
       },


### PR DESCRIPTION
This prevents lingering console artifacts from when the app was taller

