### PR TITLE
Run console.clear() in handleClearScreen when invoked by Ctrl-L.

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -182,6 +182,7 @@ export const App = ({
 
   const handleClearScreen = useCallback(() => {
     clearItems();
+    console.clear();
     refreshStatic();
   }, [clearItems, refreshStatic]);
 


### PR DESCRIPTION
Copied from sethtroisi@'s identical improvement to /clear in change #355.