### PR TITLE
Fix: Prevent UI tearing and improve display of long content

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Box, Static, Text, useStdout } from 'ink';
+import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
+import { Box, DOMElement, measureElement, Static, Text, useStdout } from 'ink';
 import { StreamingState, type HistoryItem } from './types.js';
 import { useGeminiStream } from './hooks/useGeminiStream.js';
 import { useLoadingIndicator } from './hooks/useLoadingIndicator.js';
@@ -46,6 +46,7 @@ export const App = ({
   startupWarnings = [],
 }: AppProps) => {
   const { history, addItem, clearItems } = useHistory();
+  const [staticNeedsRefresh, setStaticNeedsRefresh] = useState(false);
   const [staticKey, setStaticKey] = useState(0);
   const refreshStatic = useCallback(() => {
     setStaticKey((prev) => prev + 1);
@@ -55,7 +56,8 @@ export const App = ({
   const [debugMessage, setDebugMessage] = useState<string>('');
   const [showHelp, setShowHelp] = useState<boolean>(false);
   const [themeError, setThemeError] = useState<string | null>(null);
-
+  const [availableTerminalHeight, setAvailableTerminalHeight] =
+    useState<number>(0);
   const {
     isThemeDialogOpen,
     openThemeDialog,
@@ -193,11 +195,50 @@ export const App = ({
 
   // --- Render Logic ---
 
-  // Get terminal width
+  // Get terminal dimensions
+
   const { stdout } = useStdout();
   const terminalWidth = stdout?.columns ?? 80;
+  const terminalHeight = stdout?.rows ?? 24;
+  const footerRef = useRef<DOMElement>(null);
+  const pendingHistoryItemRef = useRef<DOMElement>(null);
+
   // Calculate width for suggestions, leave some padding
   const suggestionsWidth = Math.max(60, Math.floor(terminalWidth * 0.8));
+
+  useEffect(() => {
+    const staticExtraHeight = /* margins and padding */ 3;
+    const fullFooterMeasurement = measureElement(footerRef.current!);
+    const fullFooterHeight = fullFooterMeasurement.height;
+
+    setAvailableTerminalHeight(
+      terminalHeight - fullFooterHeight - staticExtraHeight,
+    );
+  }, [terminalHeight]);
+
+  useEffect(() => {
+    if (!pendingHistoryItem) {
+      return;
+    }
+
+    const pendingItemDimensions = measureElement(
+      pendingHistoryItemRef.current!,
+    );
+
+    // If our pending history item happens to exceed the terminal height we will most likely need to refresh
+    // our static collection to ensure no duplication or tearing. This is currently working around a core bug
+    // in Ink which we have a PR out to fix: https://github.com/vadimdemedes/ink/pull/717
+    if (pendingItemDimensions.height > availableTerminalHeight) {
+      setStaticNeedsRefresh(true);
+    }
+  }, [pendingHistoryItem, availableTerminalHeight, streamingState]);
+
+  useEffect(() => {
+    if (streamingState === StreamingState.Idle && staticNeedsRefresh) {
+      setStaticNeedsRefresh(false);
+      refreshStatic();
+    }
+  }, [streamingState, refreshStatic, staticNeedsRefresh]);
 
   return (
     <Box flexDirection="column" marginBottom={1} width="90%">
@@ -219,146 +260,151 @@ export const App = ({
             <Header />
             <Tips />
           </Box>,
-          ...history.map((h) => <HistoryItemDisplay key={h.id} item={h} />),
+          ...history.map((h) => <HistoryItemDisplay availableTerminalHeight={availableTerminalHeight} key={h.id} item={h} />),
         ]}
       >
         {(item) => item}
       </Static>
       {pendingHistoryItem && (
-        <HistoryItemDisplay
-          // TODO(taehykim): It seems like references to ids aren't necessary in
-          // HistoryItemDisplay. Refactor later. Use a fake id for now.
-          item={{ ...pendingHistoryItem, id: 0 }}
-        />
+        <Box ref={pendingHistoryItemRef}>
+          <HistoryItemDisplay
+            availableTerminalHeight={availableTerminalHeight}
+            // TODO(taehykim): It seems like references to ids aren't necessary in
+            // HistoryItemDisplay. Refactor later. Use a fake id for now.
+            item={{ ...pendingHistoryItem, id: 0 }}
+          />
+        </Box>
       )}
       {showHelp && <Help commands={slashCommands} />}
 
-      {startupWarnings.length > 0 && (
-        <Box
-          borderStyle="round"
-          borderColor={Colors.AccentYellow}
-          paddingX={1}
-          marginY={1}
-          flexDirection="column"
-        >
-          {startupWarnings.map((warning, index) => (
-            <Text key={index} color={Colors.AccentYellow}>
-              {warning}
-            </Text>
-          ))}
-        </Box>
-      )}
+      <Box flexDirection="column" ref={footerRef}>
+        {startupWarnings.length > 0 && (
+          <Box
+            borderStyle="round"
+            borderColor={Colors.AccentYellow}
+            paddingX={1}
+            marginY={1}
+            flexDirection="column"
+          >
+            {startupWarnings.map((warning, index) => (
+              <Text key={index} color={Colors.AccentYellow}>
+                {warning}
+              </Text>
+            ))}
+          </Box>
+        )}
 
-      {isThemeDialogOpen ? (
-        <Box flexDirection="column">
-          {themeError && (
-            <Box marginBottom={1}>
-              <Text color={Colors.AccentRed}>{themeError}</Text>
-            </Box>
-          )}
-          <ThemeDialog
-            onSelect={handleThemeSelect}
-            onHighlight={handleThemeHighlight}
-            settings={settings}
-            setQuery={setQuery}
-          />
-        </Box>
-      ) : (
-        <>
-          <LoadingIndicator
-            isLoading={streamingState === StreamingState.Responding}
-            currentLoadingPhrase={currentLoadingPhrase}
-            elapsedTime={elapsedTime}
-          />
-          {isInputActive && (
-            <>
-              <Box
-                marginTop={1}
-                display="flex"
-                justifyContent="space-between"
-                width="100%"
-              >
-                <Box>
-                  <Text color={Colors.SubtleComment}>cwd: </Text>
-                  <Text color={Colors.LightBlue}>
-                    {shortenPath(config.getTargetDir(), 70)}
-                  </Text>
-                </Box>
+        {isThemeDialogOpen ? (
+          <Box flexDirection="column">
+            {themeError && (
+              <Box marginBottom={1}>
+                <Text color={Colors.AccentRed}>{themeError}</Text>
               </Box>
-
-              <InputPrompt
-                query={query}
-                onChange={setQuery}
-                onChangeAndMoveCursor={onChangeAndMoveCursor}
-                editorState={editorState}
-                onSubmit={handleFinalSubmit} // Pass handleFinalSubmit directly
-                showSuggestions={completion.showSuggestions}
-                suggestions={completion.suggestions}
-                activeSuggestionIndex={completion.activeSuggestionIndex}
-                userMessages={userMessages} // Pass userMessages
-                navigateSuggestionUp={completion.navigateUp}
-                navigateSuggestionDown={completion.navigateDown}
-                resetCompletion={completion.resetCompletionState}
-                setEditorState={setEditorState}
-                onClearScreen={handleClearScreen} // Added onClearScreen prop
-              />
-              {completion.showSuggestions && (
-                <Box>
-                  <SuggestionsDisplay
-                    suggestions={completion.suggestions}
-                    activeIndex={completion.activeSuggestionIndex}
-                    isLoading={completion.isLoadingSuggestions}
-                    width={suggestionsWidth}
-                    scrollOffset={completion.visibleStartIndex}
-                    userInput={query}
-                  />
+            )}
+            <ThemeDialog
+              onSelect={handleThemeSelect}
+              onHighlight={handleThemeHighlight}
+              settings={settings}
+              setQuery={setQuery}
+            />
+          </Box>
+        ) : (
+          <>
+            <LoadingIndicator
+              isLoading={streamingState === StreamingState.Responding}
+              currentLoadingPhrase={currentLoadingPhrase}
+              elapsedTime={elapsedTime}
+            />
+            {isInputActive && (
+              <>
+                <Box
+                  marginTop={1}
+                  display="flex"
+                  justifyContent="space-between"
+                  width="100%"
+                >
+                  <Box>
+                    <Text color={Colors.SubtleComment}>cwd: </Text>
+                    <Text color={Colors.LightBlue}>
+                      {shortenPath(config.getTargetDir(), 70)}
+                    </Text>
+                  </Box>
                 </Box>
-              )}
-            </>
-          )}
-        </>
-      )}
 
-      {initError && streamingState !== StreamingState.Responding && (
-        <Box
-          borderStyle="round"
-          borderColor={Colors.AccentRed}
-          paddingX={1}
-          marginBottom={1}
-        >
-          {history.find(
-            (item) => item.type === 'error' && item.text?.includes(initError),
-          )?.text ? (
-            <Text color={Colors.AccentRed}>
-              {
-                history.find(
-                  (item) =>
-                    item.type === 'error' && item.text?.includes(initError),
-                )?.text
-              }
-            </Text>
-          ) : (
-            <>
-              <Text color={Colors.AccentRed}>
-                Initialization Error: {initError}
-              </Text>
-              <Text color={Colors.AccentRed}>
-                {' '}
-                Please check API key and configuration.
-              </Text>
-            </>
-          )}
-        </Box>
-      )}
+                <InputPrompt
+                  query={query}
+                  onChange={setQuery}
+                  onChangeAndMoveCursor={onChangeAndMoveCursor}
+                  editorState={editorState}
+                  onSubmit={handleFinalSubmit} // Pass handleFinalSubmit directly
+                  showSuggestions={completion.showSuggestions}
+                  suggestions={completion.suggestions}
+                  activeSuggestionIndex={completion.activeSuggestionIndex}
+                  userMessages={userMessages} // Pass userMessages
+                  navigateSuggestionUp={completion.navigateUp}
+                  navigateSuggestionDown={completion.navigateDown}
+                  resetCompletion={completion.resetCompletionState}
+                  setEditorState={setEditorState}
+                  onClearScreen={handleClearScreen} // Added onClearScreen prop
+                />
+                {completion.showSuggestions && (
+                  <Box>
+                    <SuggestionsDisplay
+                      suggestions={completion.suggestions}
+                      activeIndex={completion.activeSuggestionIndex}
+                      isLoading={completion.isLoadingSuggestions}
+                      width={suggestionsWidth}
+                      scrollOffset={completion.visibleStartIndex}
+                      userInput={query}
+                    />
+                  </Box>
+                )}
+              </>
+            )}
+          </>
+        )}
 
-      <Footer
-        config={config}
-        debugMode={config.getDebugMode()}
-        debugMessage={debugMessage}
-        cliVersion={cliVersion}
-        geminiMdFileCount={geminiMdFileCount}
-      />
-      <ConsoleOutput />
+        {initError && streamingState !== StreamingState.Responding && (
+          <Box
+            borderStyle="round"
+            borderColor={Colors.AccentRed}
+            paddingX={1}
+            marginBottom={1}
+          >
+            {history.find(
+              (item) => item.type === 'error' && item.text?.includes(initError),
+            )?.text ? (
+              <Text color={Colors.AccentRed}>
+                {
+                  history.find(
+                    (item) =>
+                      item.type === 'error' && item.text?.includes(initError),
+                  )?.text
+                }
+              </Text>
+            ) : (
+              <>
+                <Text color={Colors.AccentRed}>
+                  Initialization Error: {initError}
+                </Text>
+                <Text color={Colors.AccentRed}>
+                  {' '}
+                  Please check API key and configuration.
+                </Text>
+              </>
+            )}
+          </Box>
+        )}
+
+        <Footer
+          config={config}
+          debugMode={config.getDebugMode()}
+          debugMessage={debugMessage}
+          cliVersion={cliVersion}
+          geminiMdFileCount={geminiMdFileCount}
+        />
+        <ConsoleOutput />
+      </Box>
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -16,10 +16,12 @@ import { Box } from 'ink';
 
 interface HistoryItemDisplayProps {
   item: HistoryItem;
+  availableTerminalHeight: number;
 }
 
 export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
   item,
+  availableTerminalHeight,
 }) => (
   <Box flexDirection="column" key={item.id}>
     {/* Render standard message types */}
@@ -31,7 +33,11 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
     {item.type === 'info' && <InfoMessage text={item.text} />}
     {item.type === 'error' && <ErrorMessage text={item.text} />}
     {item.type === 'tool_group' && (
-      <ToolGroupMessage toolCalls={item.tools} groupId={item.id} />
+      <ToolGroupMessage
+        toolCalls={item.tools}
+        groupId={item.id}
+        availableTerminalHeight={availableTerminalHeight}
+      />
     )}
   </Box>
 );

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -17,18 +17,30 @@ import { Box } from 'ink';
 interface HistoryItemDisplayProps {
   item: HistoryItem;
   availableTerminalHeight: number;
+  isPending: boolean;
 }
 
 export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
   item,
   availableTerminalHeight,
+  isPending,
 }) => (
   <Box flexDirection="column" key={item.id}>
     {/* Render standard message types */}
     {item.type === 'user' && <UserMessage text={item.text} />}
-    {item.type === 'gemini' && <GeminiMessage text={item.text} />}
+    {item.type === 'gemini' && (
+      <GeminiMessage
+        text={item.text}
+        isPending={isPending}
+        availableTerminalHeight={availableTerminalHeight}
+      />
+    )}
     {item.type === 'gemini_content' && (
-      <GeminiMessageContent text={item.text} />
+      <GeminiMessageContent
+        text={item.text}
+        isPending={isPending}
+        availableTerminalHeight={availableTerminalHeight}
+      />
     )}
     {item.type === 'info' && <InfoMessage text={item.text} />}
     {item.type === 'error' && <ErrorMessage text={item.text} />}

--- a/packages/cli/src/ui/components/messages/GeminiMessage.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessage.tsx
@@ -11,9 +11,15 @@ import { Colors } from '../../colors.js';
 
 interface GeminiMessageProps {
   text: string;
+  isPending: boolean;
+  availableTerminalHeight: number;
 }
 
-export const GeminiMessage: React.FC<GeminiMessageProps> = ({ text }) => {
+export const GeminiMessage: React.FC<GeminiMessageProps> = ({
+  text,
+  isPending,
+  availableTerminalHeight,
+}) => {
   const prefix = '✦ ';
   const prefixWidth = prefix.length;
 
@@ -23,7 +29,11 @@ export const GeminiMessage: React.FC<GeminiMessageProps> = ({ text }) => {
         <Text color={Colors.AccentPurple}>{prefix}</Text>
       </Box>
       <Box flexGrow={1} flexDirection="column">
-        <MarkdownDisplay text={text} />
+        <MarkdownDisplay
+          text={text}
+          isPending={isPending}
+          availableTerminalHeight={availableTerminalHeight}
+        />
       </Box>
     </Box>
   );

--- a/packages/cli/src/ui/components/messages/GeminiMessageContent.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessageContent.tsx
@@ -10,6 +10,8 @@ import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
 
 interface GeminiMessageContentProps {
   text: string;
+  isPending: boolean;
+  availableTerminalHeight: number;
 }
 
 /*
@@ -20,13 +22,19 @@ interface GeminiMessageContentProps {
  */
 export const GeminiMessageContent: React.FC<GeminiMessageContentProps> = ({
   text,
+  isPending,
+  availableTerminalHeight,
 }) => {
   const originalPrefix = '✦ ';
   const prefixWidth = originalPrefix.length;
 
   return (
     <Box flexDirection="column" paddingLeft={prefixWidth}>
-      <MarkdownDisplay text={text} />
+      <MarkdownDisplay
+        text={text}
+        isPending={isPending}
+        availableTerminalHeight={availableTerminalHeight}
+      />
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -29,7 +29,6 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   const borderColor = hasPending ? Colors.AccentYellow : Colors.SubtleComment;
 
   const staticHeight = /* border */ 2 + /* marginBottom */ 1;
-  availableTerminalHeight -= staticHeight;
 
   return (
     <Box
@@ -58,7 +57,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
             resultDisplay={tool.resultDisplay}
             status={tool.status}
             confirmationDetails={tool.confirmationDetails}
-            availableTerminalHeight={availableTerminalHeight}
+            availableTerminalHeight={availableTerminalHeight - staticHeight}
           />
           {tool.status === ToolCallStatus.Confirming &&
             tool.confirmationDetails && (

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -14,17 +14,22 @@ import { Colors } from '../../colors.js';
 interface ToolGroupMessageProps {
   groupId: number;
   toolCalls: IndividualToolCallDisplay[];
+  availableTerminalHeight: number;
 }
 
 // Main component renders the border and maps the tools using ToolMessage
 export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   groupId,
   toolCalls,
+  availableTerminalHeight,
 }) => {
   const hasPending = !toolCalls.every(
     (t) => t.status === ToolCallStatus.Success,
   );
   const borderColor = hasPending ? Colors.AccentYellow : Colors.SubtleComment;
+
+  const staticHeight = /* border */ 2 + /* marginBottom */ 1;
+  availableTerminalHeight -= staticHeight;
 
   return (
     <Box
@@ -46,13 +51,14 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
       {toolCalls.map((tool) => (
         <Box key={groupId + '-' + tool.callId} flexDirection="column">
           <ToolMessage
-            key={tool.callId} // Use callId as the key
-            callId={tool.callId} // Pass callId
+            key={tool.callId}
+            callId={tool.callId}
             name={tool.name}
             description={tool.description}
             resultDisplay={tool.resultDisplay}
             status={tool.status}
-            confirmationDetails={tool.confirmationDetails} // Pass confirmationDetails
+            confirmationDetails={tool.confirmationDetails}
+            availableTerminalHeight={availableTerminalHeight}
           />
           {tool.status === ToolCallStatus.Confirming &&
             tool.confirmationDetails && (

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -26,7 +26,6 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   const statusIndicatorWidth = 3;
   const hasResult = resultDisplay && resultDisplay.toString().trim().length > 0;
   const staticHeight = /* Header */ 1;
-  availableTerminalHeight -= staticHeight;
 
   let displayableResult = resultDisplay;
   let hiddenLines = 0;
@@ -37,7 +36,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
     const lines = resultDisplay.split('\n');
     // Estimate available height for this specific tool message content area
     // This is a rough estimate; ideally, we'd have a more precise measurement.
-    const contentHeightEstimate = availableTerminalHeight - 5; // Subtracting lines for tool name, status, padding etc.
+    const contentHeightEstimate = availableTerminalHeight - staticHeight - 5; // Subtracting lines for tool name, status, padding etc.
     if (lines.length > contentHeightEstimate && contentHeightEstimate > 0) {
       displayableResult = lines.slice(0, contentHeightEstimate).join('\n');
       hiddenLines = lines.length - contentHeightEstimate;
@@ -83,7 +82,11 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
           <Box flexDirection="column">
             {typeof displayableResult === 'string' && (
               <Box flexDirection="column">
-                <MarkdownDisplay text={displayableResult} />
+                <MarkdownDisplay
+                  text={displayableResult}
+                  isPending={false}
+                  availableTerminalHeight={availableTerminalHeight}
+                />
               </Box>
             )}
             {typeof displayableResult === 'object' && (


### PR DESCRIPTION
**Note: Review this with whitespace diffing off››**

This commit introduces several changes to better manage terminal height and prevent UI tearing, especially when displaying long tool outputs or when the pending history item exceeds the available terminal height.

- Calculate and utilize available terminal height in `App.tsx`, `HistoryItemDisplay.tsx`, `ToolGroupMessage.tsx`, and `ToolMessage.tsx`.
- Refresh the static display area in `App.tsx` when a pending history item is too large, working around an Ink bug (see https://github.com/vadimdemedes/ink/pull/717).
- Truncate long tool output in `ToolMessage.tsx` and indicate the number of hidden lines.
![image](https://github.com/user-attachments/assets/e5e080fe-bca1-4058-9be4-511793c7924d)

- Refactor `App.tsx` to correctly measure and account for footer height.

Fixes https://b.corp.google.com/issues/414196943