### PR TITLE
Fix instructions for globally linking the gemini script

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To test your local version of `gemini` in other directories on your system, you 
 From the root of this repository, run:
 
 ```bash
-npm link packages/cli
+npm link ./packages/cli
 ```
 
 Then, navigate to any other directory where you want to use your local `gemini` and run:


### PR DESCRIPTION
In the environments tested (zsh on macOS and Debian) the `npm link packages/cli` command line doesn't resolve packages/cli as a file path, so it instead tries to fall back and link `ssh://git@github.com/packages/cli.git`, which obviously doesn't exist either and also fails. (And actually would appear to introduce a serious security risk if someone reserved that repo and path on GitHub...)

Replacing the instructions to use an explicit relative file path of `npm link ./packages/cli`, which seems to work as tested.

Note, I suspect these instructions will still fail if the user doesn't have write permissions in the target directory (for me it seems to be the same parent directory as npm itself) but we can document a workaround for that, too.