### PR TITLE
feat: Enable CI test reporting and artifact management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,58 +4,97 @@ name: Gemini CLI CI
 
 on:
   push:
-    branches: [main] # Run on pushes to the main branch
+    branches: [main]
   pull_request:
-    branches: [main] # Run on pull requests targeting the main branch
+    branches: [main]
 
 jobs:
-  build_and_test:
-    name: Build and Test
+  build:
+    name: Build and Lint
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read # For checkout
     strategy:
       matrix:
-        # Specify the Node.js versions you want to test against
-        node-version: [20.x] # You can add more like [18.x, 20.x]
-
+        node-version: [20.x]
     steps:
-      # 1. Checkout Code
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # 2. Setup Node.js Environment
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm' # Enable caching for npm dependencies (speeds up subsequent runs)
+          cache: 'npm'
 
-      # 3. Install Dependencies
-      # Use 'ci' for cleaner, faster, deterministic installs based on lockfile
       - name: Install dependencies
         run: npm ci
 
-      # 4. Check Formatting
       - name: Run formatter check
         run: |
           npm run format
           git diff --exit-code
 
-      # 5. Linting
       - name: Run linter
         run: npm run lint
 
-      # 6. Type Checking
       - name: Run type check
         run: npm run typecheck
 
-      # 7. Build
-      # Optional if your tests run directly on TS files (e.g., using ts-jest, ts-node)
-      # But usually good practice to ensure the build itself works.
       - name: Build project
         run: npm run build
 
-      # 8. Testing
-      # Uncomment when we have tests.
-      #- name: Run tests
-      #  run: npm test
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts-${{ matrix.node-version }}
+          path: |
+            packages/*/dist
+            package-lock.json # Only upload dist and lockfile
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: build # This job depends on the 'build' job
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    strategy:
+      matrix:
+        node-version: [20.x] # Should match the build job's matrix
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-${{ matrix.node-version }}
+          path: . # Download to the root, this will include package-lock.json and packages/*/dist
+
+      # Restore/create package structure for dist folders if necessary.
+      # The download-artifact action with path: . should place them correctly if the
+      # upload paths were relative to the workspace root.
+      # Example: if uploaded `packages/cli/dist`, it will be at `./packages/cli/dist`.
+
+      - name: Install dependencies for testing
+        run: npm ci # Install fresh dependencies using the downloaded package-lock.json
+
+      - name: Run tests
+        run: npm run test:ci --workspaces --if-present
+
+      - name: Publish Test Report
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Test Results (Node ${{ matrix.node-version }})
+          path: packages/*/junit.xml
+          reporter: java-junit
+          fail-on-error: 'false'

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist
 .docker
 
 bundle
+
+# Test report files
+junit.xml

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit --jsx react-jsx",
     "format": "prettier --write .",
-    "preflight": "npm run format --workspaces --if-present && npm run lint --workspaces --if-present && npm run test --workspaces --if-present",
+    "preflight": "npm run format --workspaces --if-present && npm run lint && npm run test --workspaces --if-present",
     "auth:npm": "npx google-artifactregistry-auth",
     "auth:docker": "gcloud auth configure-docker us-west1-docker.pkg.dev",
     "auth": "npm run auth:npm && npm run auth:docker",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write .",
     "test": "vitest run",
+    "test:ci": "vitest run --reporter=junit --outputFile=junit.xml",
     "prerelease:version": "node ../../scripts/bind_package_version.js",
     "prerelease:deps": "node ../../scripts/bind_package_dependencies.js",
     "prepublishOnly": "npm publish --workspace=@gemini-code/server",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write .",
     "test": "vitest run",
+    "test:ci": "vitest run --reporter=junit --outputFile=junit.xml",
     "prerelease:version": "node ../../scripts/bind_package_version.js",
     "prerelease:deps": "node ../../scripts/bind_package_dependencies.js",
     "prepack": "npm run build"


### PR DESCRIPTION
This commit introduces several improvements to the CI workflow:

- Separates the build and test steps into distinct jobs. The test job now depends on the successful completion of the build job.
- Implements artifact management by uploading build artifacts (dist folders and package-lock.json) after the build job and downloading them before the test job. This ensures that tests are run against the exact build output.
- Adds a `test:ci` script to both `packages/cli` and `packages/server` to generate test reports in JUnit XML format.
- Updates `.gitignore` to exclude `junit.xml` files.
- Configures the CI to publish test results using `dorny/test-reporter`.

# Success case
![image](https://github.com/user-attachments/assets/b51bbf56-928b-4fb3-8e33-40e6d6ad2614)

# Failure case
Note: Supposedly the pending Build and Test will go away and is representative of a GH caching issue?
Link to failed test report: https://github.com/google-gemini/gemini-cli/pull/367/checks?check_run_id=42312925206
![image](https://github.com/user-attachments/assets/ee133887-9162-49ae-b063-716f7b2cb5ed)

