### PR TITLE
Update color styles for yes/no questions

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -31,7 +31,7 @@ export const ToolMessage: React.FC<IndividualToolCallDisplay> = ({
             <Text color={Colors.AccentGreen}>✔</Text>
           )}
           {status === ToolCallStatus.Confirming && (
-            <Text color={Colors.AccentPurple}>?</Text>
+            <Text color={Colors.AccentYellow}>?</Text>
           )}
           {status === ToolCallStatus.Canceled && (
             <Text color={Colors.AccentYellow} bold>

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -76,19 +76,11 @@ export function RadioButtonSelect<T>({
   function DynamicRadioIndicator({
     isSelected = false,
   }: InkSelectIndicatorProps): React.JSX.Element {
-    let indicatorColor = Colors.Foreground; // Default for not selected
-    if (isSelected) {
-      if (isFocused) {
-        // Group is focused, selected item is AccentGreen
-        indicatorColor = Colors.AccentGreen;
-      } else {
-        // Group is NOT focused, selected item is Foreground
-        indicatorColor = Colors.Foreground;
-      }
-    }
     return (
       <Box marginRight={1}>
-        <Text color={indicatorColor}>{isSelected ? '●' : '○'}</Text>
+        <Text color={isSelected ? Colors.AccentGreen : Colors.Foreground}>
+          {isSelected ? '●' : '○'}
+        </Text>
       </Box>
     );
   }
@@ -109,7 +101,7 @@ export function RadioButtonSelect<T>({
 
     let textColor = Colors.Foreground;
     if (isSelected) {
-      textColor = isFocused ? Colors.AccentGreen : Colors.Foreground;
+      textColor = Colors.AccentGreen;
     }
 
     if (


### PR DESCRIPTION
I somehow didn't properly update the yes/now selection color:
- Made active selection to use `AccentGreen`
- Made the status `?` to be the same color (`AccentYellow`) when confirming changes

## Before

![CleanShot 2025-05-15 at 13 22 58@2x](https://github.com/user-attachments/assets/9cba2855-02d8-45db-90ae-c2a64de95408)

## After

![CleanShot 2025-05-15 at 13 22 59@2x](https://github.com/user-attachments/assets/7535c2dc-4f5a-4071-a326-25cca93cb7bc)
