### PR TITLE
UI improvements for suggestions & status

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -310,6 +310,7 @@ export const App = ({
                     isLoading={completion.isLoadingSuggestions}
                     width={suggestionsWidth}
                     scrollOffset={completion.visibleStartIndex}
+                    userInput={query}
                   />
                 </Box>
               )}

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -24,7 +24,7 @@ export const Footer: React.FC<FooterProps> = ({
   cliVersion,
   geminiMdFileCount,
 }) => (
-  <Box>
+  <Box marginTop={1}>
     <Box>
       {geminiMdFileCount > 0 && (
         <Text color={Colors.SubtleComment}>

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -17,6 +17,7 @@ interface SuggestionsDisplayProps {
   isLoading: boolean;
   width: number;
   scrollOffset: number;
+  userInput: string;
 }
 
 export const MAX_SUGGESTIONS_TO_SHOW = 8;
@@ -27,6 +28,7 @@ export function SuggestionsDisplay({
   isLoading,
   width,
   scrollOffset,
+  userInput,
 }: SuggestionsDisplayProps) {
   if (isLoading) {
     return (
@@ -60,9 +62,15 @@ export function SuggestionsDisplay({
         return (
           <Box key={`${suggestion}-${originalIndex}`} width={width}>
             <Box flexDirection="row">
-              <Box width={20} flexShrink={0}>
+              {userInput.startsWith('/') ? (
+                // only use box model for (/) command mode
+                <Box width={20} flexShrink={0}>
+                  <Text color={textColor}>{suggestion.label}</Text>
+                </Box>
+              ) : (
+                // use regular text for other modes (@ context)
                 <Text color={textColor}>{suggestion.label}</Text>
-              </Box>
+              )}
               {suggestion.description ? (
                 <Box flexGrow={1}>
                   <Text color={textColor} wrap="wrap">

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -102,7 +102,7 @@ export function ThemeDialog({
   return (
     <Box
       borderStyle="round"
-      borderColor={Colors.AccentPurple}
+      borderColor={Colors.SubtleComment}
       flexDirection="row"
       padding={1}
       width="100%"

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -24,7 +24,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   const hasPending = !toolCalls.every(
     (t) => t.status === ToolCallStatus.Success,
   );
-  const borderColor = hasPending ? Colors.AccentYellow : Colors.AccentPurple;
+  const borderColor = hasPending ? Colors.AccentYellow : Colors.SubtleComment;
 
   return (
     <Box


### PR DESCRIPTION
Fixes an issue where context strings were being wrapped:

**Before**
![CleanShot 2025-05-15 at 16 16 49@2x](https://github.com/user-attachments/assets/e98faa50-ffd4-4a16-8c3d-ae7a666c8e7e)

**After**
![CleanShot 2025-05-15 at 16 17 44@2x](https://github.com/user-attachments/assets/ffb0906f-452c-4588-86ac-4da6a5cf93bc)

Update previous status to reduce visual noise

**Before**
![CleanShot 2025-05-15 at 16 19 04@2x](https://github.com/user-attachments/assets/9a8ae3f5-bf6c-4b22-b636-c8d5a19f3425)

**After**
![CleanShot 2025-05-15 at 16 18 56@2x](https://github.com/user-attachments/assets/76336e31-c220-4a2f-a5bb-51c7feda5f38)

Also added a bit of margin to footer for some breathing room