### PR TITLE
Fix: Use Node.js script for cross-platform file copying in build

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -154,6 +154,34 @@ export default tseslint.config(
       },
     },
   },
+  // Override for .cjs files to use CommonJS
+  {
+    files: ['**/*.cjs'],
+    languageOptions: {
+      sourceType: 'commonjs',
+      globals: {
+        ...globals.node, // Add all Node.js globals
+        __dirname: 'readonly',
+        __filename: 'readonly',
+        exports: 'writable',
+        module: 'readonly',
+        require: 'readonly',
+      },
+    },
+    rules: {
+      // Disable rules that are not applicable to CommonJS
+      '@typescript-eslint/no-require-imports': 'off',
+      'no-restricted-syntax': [
+        'error',
+        // Keep other restricted syntaxes, but allow require for .cjs
+        {
+          selector: 'ThrowStatement > Literal:not([value=/^\\\\w+Error:/])',
+          message:
+            'Do not throw string literals or non-Error objects. Throw new Error("...") instead.',
+        },
+      ],
+    },
+  },
   // Prettier config must be last
   prettierConfig,
   // Custom eslint rules for this repo

--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -26,8 +26,8 @@ fi
 # build typescript files
 tsc --build
 
-# copy .{md,json} files  (replace -q with -i to see itemized changes)
-rsync -aq --delete --include='*.md' --include='*.json' --include='*.sb' --include='*/' --exclude='*' ./src/ ./dist/src/
+# copy .{md,json} files
+node ../../scripts/copy_files.cjs
 
 # touch dist/.last_build
 touch dist/.last_build

--- a/scripts/copy_files.cjs
+++ b/scripts/copy_files.cjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const fs = require('fs');
+const path = require('path');
+
+const sourceDir = path.join('src');
+const targetDir = path.join('dist', 'src');
+
+const extensionsToCopy = ['.md', '.json', '.sb'];
+
+function copyFilesRecursive(source, target) {
+  if (!fs.existsSync(target)) {
+    fs.mkdirSync(target, { recursive: true });
+  }
+
+  const items = fs.readdirSync(source, { withFileTypes: true });
+
+  for (const item of items) {
+    const sourcePath = path.join(source, item.name);
+    const targetPath = path.join(target, item.name);
+
+    if (item.isDirectory()) {
+      copyFilesRecursive(sourcePath, targetPath);
+    } else if (extensionsToCopy.includes(path.extname(item.name))) {
+      fs.copyFileSync(sourcePath, targetPath);
+    }
+  }
+}
+
+if (!fs.existsSync(sourceDir)) {
+  console.error(`Source directory ${sourceDir} not found.`);
+  process.exit(1);
+}
+
+copyFilesRecursive(sourceDir, targetDir);
+console.log('Successfully copied files.');


### PR DESCRIPTION
- Replaces the rsync command in the build_package.sh script with a Node.js script (copy_files.cjs) to handle copying necessary files (e.g., .md, .json, .sb) during the build process.
- Addresses an issue where the build would fail on systems that do not have rsync installed (e.g., some Windows environments or minimal Linux distributions) by using a Node.js script, providing a cross-platform solution as Node.js is already a project dependency.
- Updates the ESLint configuration to correctly lint .cjs files as CommonJS modules.

Fixes https://github.com/google-gemini/gemini-cli/issues/387