### PR TITLE
feat: Support multiple MCP servers and refine tool discovery

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -51,8 +51,10 @@ When you create a `.gemini/settings.json` file for project-specific settings, or
   - Custom command for executing tool calls (if applicable to your setup).
   - Must take function name as first argument and function arguments as JSON on `stdin`
   - Must return JSON result of funcation call on `stdout`.
-- **`mcpServerCommand`** (string, advanced):
-  - Custom command for starting an MCP server with custom tools.
+- **`mcpServers`** (object, advanced):
+  - Configures connections to one or more Model-Context Protocol (MCP) servers for discovering and using custom tools.
+  - This is an object where each key is a server name and the value is an object with `command` (string, required) and `args` (array of strings, optional).
+  - Example: `"mcpServers": { "myServer": { "command": "python", "args": ["mcp_server.py", "--port", "8080"] } }`
 
 ### Example `settings.json`:
 
@@ -62,7 +64,15 @@ When you create a `.gemini/settings.json` file for project-specific settings, or
   "sandbox": "docker",
   "toolDiscoveryCommand": "bin/get_tools",
   "toolCallCommand": "bin/call_tool",
-  "mcpServerCommand": "bin/mcp_server.py"
+  "mcpServers": {
+    "mainServer": {
+      "command": "bin/mcp_server.py"
+    },
+    "anotherServer": {
+      "command": "node",
+      "args": ["mcp_server.js", "--verbose"]
+    }
+  }
 }
 ```
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -55,10 +55,10 @@ These are the main pieces of information the server `Config` object holds and us
 
 - **`toolDiscoveryCommand` (string | undefined):**
 - **`toolCallCommand` (string | undefined):**
-- **`mcpServerCommand` (string | undefined):**
+- **`mcpServers` (object | undefined):**
 
-  - **Source:** `settings.json` or environment variables.
-  - **Purpose:** Advanced settings for customizing how tools are discovered or how the server interacts with other potential components in a more complex setup.
+  - **Source:** `settings.json` (`mcpServers` key).
+  - **Purpose:** Advanced setting for configuring connections to Model-Context Protocol (MCP) servers. This is an object where each key is a server name and the value is an object containing `command` and optional `args` for starting that MCP server. Allows discovery and use of tools from multiple MCP sources.
 
 - **`userAgent` (string):**
 

--- a/docs/server/tools-api.md
+++ b/docs/server/tools-api.md
@@ -67,6 +67,6 @@ Each of these tools extends `BaseTool` and implements the required methods for i
 While direct programmatic registration of new tools by users isn't explicitly detailed as a primary workflow in the provided files for typical end-users, the architecture supports extension through:
 
 - **Command-based Discovery:** Advanced users or project administrators can define a `toolDiscoveryCommand` in `settings.json`. This command, when run by the Gemini CLI server, should output a JSON array of `FunctionDeclaration` objects. The server will then make these available as `DiscoveredTool` instances. The corresponding `toolCallCommand` would then be responsible for actually executing these custom tools.
-- **MCP Server:** For more complex scenarios, an MCP server can be set up (configured via `mcpServerCommand`) to expose tools that the Gemini CLI server can then discover and use.
+- **MCP Server(s):** For more complex scenarios, one or more MCP servers can be set up and configured via the `mcpServers` setting in `settings.json`. The Gemini CLI server can then discover and use tools exposed by these servers.
 
 This tool system provides a flexible and powerful way to augment the Gemini model's capabilities, making the Gemini CLI a versatile assistant for a wide range of tasks.

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -401,7 +401,7 @@ export async function loadCliConfig(settings: Settings): Promise<Config> {
     argv.all_files || false,
     settings.toolDiscoveryCommand,
     settings.toolCallCommand,
-    settings.mcpServerCommand,
+    settings.mcpServers,
     userAgent,
     memoryContent,
     fileCount,

--- a/packages/server/src/config/config.ts
+++ b/packages/server/src/config/config.ts
@@ -21,6 +21,15 @@ import { WebFetchTool } from '../tools/web-fetch.js';
 import { ReadManyFilesTool } from '../tools/read-many-files.js';
 import { BaseTool, ToolResult } from '../tools/tools.js';
 
+export interface McpServerConfig {
+  command: string;
+  args?: string[];
+}
+
+export interface McpServerConfigMap {
+  [serverName: string]: McpServerConfig;
+}
+
 export class Config {
   private toolRegistry: ToolRegistry;
 
@@ -34,7 +43,7 @@ export class Config {
     private readonly fullContext: boolean = false, // Default value here
     private readonly toolDiscoveryCommand: string | undefined,
     private readonly toolCallCommand: string | undefined,
-    private readonly mcpServerCommand: string | undefined,
+    private readonly mcpServers: McpServerConfigMap | undefined,
     private readonly userAgent: string,
     private userMemory: string = '', // Made mutable for refresh
     private geminiMdFileCount: number = 0,
@@ -82,8 +91,8 @@ export class Config {
     return this.toolCallCommand;
   }
 
-  getMcpServerCommand(): string | undefined {
-    return this.mcpServerCommand;
+  getMcpServers(): McpServerConfigMap | undefined {
+    return this.mcpServers;
   }
 
   getUserAgent(): string {
@@ -145,7 +154,7 @@ export function createServerConfig(
   fullContext?: boolean,
   toolDiscoveryCommand?: string,
   toolCallCommand?: string,
-  mcpServerCommand?: string,
+  mcpServers?: McpServerConfigMap,
   userAgent?: string,
   userMemory?: string,
   geminiMdFileCount?: number,
@@ -160,7 +169,7 @@ export function createServerConfig(
     fullContext,
     toolDiscoveryCommand,
     toolCallCommand,
-    mcpServerCommand,
+    mcpServers,
     userAgent ?? 'GeminiCLI/unknown', // Default user agent
     userMemory ?? '',
     geminiMdFileCount ?? 0,

--- a/packages/server/src/tools/edit.test.ts
+++ b/packages/server/src/tools/edit.test.ts
@@ -18,8 +18,8 @@ import { Config } from '../config/config.js';
 const mockEnsureCorrectEdit = vi.fn();
 vi.mock('../core/client.js', () => ({
   GeminiClient: vi.fn().mockImplementation(() => ({
-    // This is the method called by EditTool
-    ensureCorrectEdit: mockEnsureCorrectEdit,
+    ensureCorrectEdit: mockEnsureCorrectEdit, // Called by EditTool directly
+    generateJson: vi.fn(), // Called by the real ensureCorrectEdit from editCorrector
   })),
 }));
 

--- a/packages/server/src/tools/tool-registry.test.ts
+++ b/packages/server/src/tools/tool-registry.test.ts
@@ -1,0 +1,490 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  ToolRegistry,
+  DiscoveredTool,
+  DiscoveredMCPTool,
+} from './tool-registry.js';
+import { Config as OriginalConfig } from '../config/config.js';
+import { FunctionDeclaration, Schema, Type } from '@google/genai';
+import { Client as MCPClientOriginal } from '@modelcontextprotocol/sdk/client/index.js';
+import { EventEmitter } from 'node:events';
+import * as child_process from 'node:child_process'; // Import to access mocked functions
+
+// Mock child_process: define mocks inside the factory
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual_child_process = (await importOriginal()) as typeof child_process;
+  return {
+    ...actual_child_process, // Spread actual module to keep other exports intact
+    spawn: vi.fn(),
+    execSync: vi.fn(),
+  };
+});
+
+// Mock Config
+const mockGetToolDiscoveryCommand = vi.fn();
+const mockGetToolCallCommand = vi.fn();
+const mockGetMcpServers = vi.fn();
+
+vi.mock('../config/config.js', () => ({
+  Config: vi.fn().mockImplementation(() => ({
+    getToolDiscoveryCommand: mockGetToolDiscoveryCommand,
+    getToolCallCommand: mockGetToolCallCommand,
+    getMcpServers: mockGetMcpServers,
+  })),
+}));
+
+const MockedMCPClientProto = {
+  connect: vi.fn(),
+  listTools: vi.fn(),
+  callTool: vi.fn(),
+  close: vi.fn(),
+  onerror: vi.fn(),
+};
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: vi.fn().mockImplementation(() => MockedMCPClientProto),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => {
+  const StdioClientTransport = vi.fn().mockImplementation(() => ({
+    stderr: new EventEmitter(), // Ensure stderr is on the instance
+  }));
+  return { StdioClientTransport };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Config = OriginalConfig as any; // Use 'any' for simplicity in test setup
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const MCPClient = MCPClientOriginal as any; // Use 'any' for simplicity
+
+// Cast the imported child_process functions to any for use in tests
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockedSpawn = child_process.spawn as any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockedExecSync = child_process.execSync as any;
+
+describe('ToolRegistry', () => {
+  let mockConfigInstance: OriginalConfig;
+
+  beforeEach(() => {
+    mockConfigInstance = new Config();
+    // Reset all externally defined mock functions and mocked module functions
+    mockGetToolDiscoveryCommand.mockReset();
+    mockGetToolCallCommand.mockReset();
+    mockGetMcpServers.mockReset();
+    mockedSpawn.mockReset();
+    mockedExecSync.mockReset();
+    MockedMCPClientProto.connect.mockReset();
+    MockedMCPClientProto.listTools.mockReset();
+    MockedMCPClientProto.callTool.mockReset();
+    MockedMCPClientProto.close.mockReset();
+    // Clear calls for the MCPClient constructor mock itself
+    if (vi.isMockFunction(MCPClient)) {
+      MCPClient.mockClear();
+    }
+  });
+
+  describe('DiscoveredTool', () => {
+    const toolName = 'test-tool';
+    const toolDescription = 'A test tool';
+    const toolParams: Schema = {
+      type: Type.OBJECT,
+      properties: { param1: { type: Type.STRING } },
+    };
+    const discoveryCommand = 'discover';
+    const callCommand = 'call';
+
+    beforeEach(() => {
+      mockGetToolDiscoveryCommand.mockReturnValue(discoveryCommand);
+      mockGetToolCallCommand.mockReturnValue(callCommand);
+    });
+
+    it('should construct with correct schema and description', () => {
+      const tool = new DiscoveredTool(
+        mockConfigInstance,
+        toolName,
+        toolDescription,
+        toolParams as Record<string, unknown>,
+      );
+      expect(tool.name).toBe(toolName);
+      expect(tool.schema.name).toBe(toolName);
+      expect(tool.schema.description).toContain(toolDescription);
+      expect(tool.schema.description).toContain(discoveryCommand);
+      expect(tool.schema.description).toContain(callCommand);
+      expect(tool.schema.parameters).toEqual(toolParams);
+    });
+
+    it('execute should call spawn with correct params and return stdout on success', async () => {
+      const tool = new DiscoveredTool(
+        mockConfigInstance,
+        toolName,
+        toolDescription,
+        toolParams as Record<string, unknown>,
+      );
+      const mockChildEmitter = new EventEmitter();
+      const mockChildProcess = {
+        stdin: { write: vi.fn(), end: vi.fn() },
+        stdout: new EventEmitter(),
+        stderr: new EventEmitter(),
+        on: vi.fn((event, cb) => {
+          mockChildEmitter.on(event, cb);
+          return mockChildProcess;
+        }),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockedSpawn.mockReturnValue(mockChildProcess as any);
+      const executeParams = { param1: 'value1' };
+      const promise = tool.execute(executeParams);
+      mockChildProcess.stdout.emit('data', 'output data');
+      mockChildEmitter.emit('close', 0, null); // Simulate process close with success code
+      const result = await promise;
+      expect(mockedSpawn).toHaveBeenCalledWith(callCommand, [toolName]);
+      expect(mockChildProcess.stdin.write).toHaveBeenCalledWith(
+        JSON.stringify(executeParams),
+      );
+      expect(result.llmContent).toBe('output data');
+      expect(result.returnDisplay).toBe('output data');
+    });
+
+    it('execute should return error details on non-zero exit code', async () => {
+      const tool = new DiscoveredTool(
+        mockConfigInstance,
+        toolName,
+        toolDescription,
+        toolParams as Record<string, unknown>,
+      );
+      const mockChildEmitter = new EventEmitter();
+      const mockChildProcess = {
+        stdin: { write: vi.fn(), end: vi.fn() },
+        stdout: new EventEmitter(),
+        stderr: new EventEmitter(),
+        on: vi.fn((event, cb) => {
+          if (event === 'close' || event === 'error') {
+            mockChildEmitter.on(event, cb);
+          }
+          return mockChildProcess;
+        }),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockedSpawn.mockReturnValue(mockChildProcess as any);
+      const executePromise = tool.execute({});
+      mockChildProcess.stderr.emit('data', 'error data');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      mockChildEmitter.emit('close', 1, null);
+      const result = await executePromise;
+      expect(result.llmContent).toContain('Stderr: error data');
+      expect(result.llmContent).toContain('Exit Code: 1');
+    });
+  });
+
+  describe('DiscoveredMCPTool', () => {
+    let mockMcpClientInstance: MCPClientOriginal;
+    const toolName = 'mcp-tool';
+    const toolDescription = 'An MCP test tool';
+    const toolParams: Schema = {
+      type: Type.OBJECT,
+      properties: { mcp_param: { type: Type.NUMBER } },
+    };
+    const serverCommand = 'mcp-server --port 1234';
+
+    beforeEach(() => {
+      mockMcpClientInstance = new MCPClient({
+        name: 'test-mcp-client',
+        version: '0.0.1',
+      });
+    });
+
+    it('should construct with correct schema and description', () => {
+      const tool = new DiscoveredMCPTool(
+        mockMcpClientInstance,
+        toolName,
+        toolDescription,
+        toolParams as Record<string, unknown>,
+        serverCommand,
+      );
+      expect(tool.name).toBe(toolName);
+      expect(tool.schema.name).toBe(toolName);
+      expect(tool.schema.description).toContain(toolDescription);
+      expect(tool.schema.description).toContain(serverCommand);
+      expect(tool.schema.parameters).toEqual(toolParams);
+    });
+
+    it('execute should call mcpClient.callTool and return result', async () => {
+      const tool = new DiscoveredMCPTool(
+        mockMcpClientInstance,
+        toolName,
+        toolDescription,
+        toolParams as Record<string, unknown>,
+        serverCommand,
+      );
+      const callToolResponse = { success: true, data: 'mcp data' };
+      MockedMCPClientProto.callTool.mockResolvedValue(callToolResponse);
+      const executeParams = { mcp_param: 123 };
+      const result = await tool.execute(executeParams);
+      expect(MockedMCPClientProto.callTool).toHaveBeenCalledWith({
+        name: toolName,
+        arguments: executeParams,
+      });
+      expect(result.llmContent).toBe(JSON.stringify(callToolResponse, null, 2));
+      expect(result.returnDisplay).toBe(
+        JSON.stringify(callToolResponse, null, 2),
+      );
+    });
+  });
+
+  describe('ToolRegistry Core', () => {
+    let registry: ToolRegistry;
+    beforeEach(() => {
+      registry = new ToolRegistry(mockConfigInstance);
+      if (vi.isMockFunction(MCPClient)) {
+        MCPClient.mockClear();
+      }
+    });
+
+    it('should register and get a tool', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockTool = {
+        name: 'manual-tool',
+        schema: { name: 'manual-tool' } as FunctionDeclaration,
+      } as any;
+      registry.registerTool(mockTool);
+      expect(registry.getTool('manual-tool')).toBe(mockTool);
+      expect(registry.getAllTools()).toContain(mockTool);
+      expect(registry.getFunctionDeclarations()).toEqual([mockTool.schema]);
+    });
+
+    it('should overwrite a tool if registered with the same name', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockTool1 = {
+        name: 'same-name-tool',
+        schema: {
+          name: 'same-name-tool',
+          description: 'v1',
+        } as FunctionDeclaration,
+      } as any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockTool2 = {
+        name: 'same-name-tool',
+        schema: {
+          name: 'same-name-tool',
+          description: 'v2',
+        } as FunctionDeclaration,
+      } as any;
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+      registry.registerTool(mockTool1);
+      registry.registerTool(mockTool2);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Tool with name "same-name-tool" is already registered. Overwriting.',
+      );
+      expect(registry.getTool('same-name-tool')).toBe(mockTool2);
+      expect(registry.getAllTools().length).toBe(1);
+      consoleWarnSpy.mockRestore();
+    });
+
+    describe('discoverTools - Non-MCP', () => {
+      const discoveryCmd = 'my-discovery-script';
+      const callCmd = 'my-call-script';
+      beforeEach(() => {
+        mockGetToolDiscoveryCommand.mockReturnValue(discoveryCmd);
+        mockGetToolCallCommand.mockReturnValue(callCmd);
+        mockGetMcpServers.mockReturnValue(null);
+      });
+
+      it('should discover and register tools from discovery command', () => {
+        const discoveredFunctions: FunctionDeclaration[] = [
+          {
+            name: 'discovered-tool-1',
+            description: 'Desc 1',
+            parameters: { type: Type.OBJECT, properties: {} },
+          },
+          {
+            name: 'discovered-tool-2',
+            description: 'Desc 2',
+            parameters: { type: Type.OBJECT, properties: {} },
+          },
+        ];
+        mockedExecSync.mockReturnValue(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          JSON.stringify([
+            { function_declarations: discoveredFunctions },
+          ]) as any,
+        );
+        registry.discoverTools();
+        expect(mockedExecSync).toHaveBeenCalledWith(discoveryCmd);
+        const tools = registry.getAllTools();
+        expect(tools.length).toBe(2);
+        expect(tools[0].name).toBe('discovered-tool-1');
+        expect(tools[0]).toBeInstanceOf(DiscoveredTool);
+        expect(tools[1].name).toBe('discovered-tool-2');
+        expect(tools[1]).toBeInstanceOf(DiscoveredTool);
+      });
+
+      it('should remove previously discovered non-MCP tools before new discovery', () => {
+        mockedExecSync.mockReturnValue(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          JSON.stringify([
+            {
+              function_declarations: [
+                {
+                  name: 'old-tool',
+                  description: 'Old',
+                  parameters: { type: Type.OBJECT, properties: {} },
+                },
+              ],
+            },
+          ]) as any,
+        );
+        registry.discoverTools();
+        expect(registry.getTool('old-tool')).toBeDefined();
+        mockedExecSync.mockReturnValue(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          JSON.stringify([
+            {
+              function_declarations: [
+                {
+                  name: 'new-tool',
+                  description: 'New',
+                  parameters: { type: Type.OBJECT, properties: {} },
+                },
+              ],
+            },
+          ]) as any,
+        );
+        registry.discoverTools();
+        expect(registry.getTool('old-tool')).toBeUndefined();
+        expect(registry.getTool('new-tool')).toBeDefined();
+        expect(registry.getAllTools().length).toBe(1);
+      });
+
+      it('should handle errors during non-MCP discovery', () => {
+        mockedExecSync.mockImplementation(() => {
+          throw new Error('Discovery failed');
+        });
+        const consoleErrorSpy = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
+        registry.discoverTools();
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `Error during non-MCP tool discovery using command '${discoveryCmd}'`,
+          ),
+        );
+        expect(registry.getAllTools().length).toBe(0);
+        consoleErrorSpy.mockRestore();
+      });
+    });
+
+    describe('discoverTools - MCP', () => {
+      const mcpServerConfig = {
+        server1: { command: 'mcp-server-1', args: ['--port', '8080'] },
+      };
+      const mcpToolList = {
+        tools: [
+          {
+            name: 'mcp-discovered-tool-1',
+            description: 'MCP Desc 1',
+            inputSchema: { type: Type.OBJECT } as Schema,
+          },
+        ],
+      };
+
+      beforeEach(() => {
+        if (vi.isMockFunction(MCPClient)) {
+          MCPClient.mockClear();
+        }
+        mockGetToolDiscoveryCommand.mockReturnValue(null);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mockGetMcpServers.mockReturnValue(mcpServerConfig as any);
+        MockedMCPClientProto.connect.mockResolvedValue(undefined);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        MockedMCPClientProto.listTools.mockResolvedValue(mcpToolList as any);
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+      });
+
+      it('should discover and register tools from MCP servers', async () => {
+        registry.discoverTools();
+        await vi.advanceTimersToNextTimerAsync();
+        await vi.advanceTimersToNextTimerAsync();
+        const tools = registry.getAllTools();
+        expect(MCPClient).toHaveBeenCalledTimes(1);
+        expect(MockedMCPClientProto.connect).toHaveBeenCalledTimes(1);
+        expect(MockedMCPClientProto.listTools).toHaveBeenCalledTimes(1);
+        expect(tools.length).toBe(1);
+        expect(tools[0].name).toBe('mcp-discovered-tool-1');
+        expect(tools[0]).toBeInstanceOf(DiscoveredMCPTool);
+        expect(tools[0].schema.description).toContain(
+          'mcp-server-1 --port 8080',
+        );
+      });
+
+      it('should remove previously discovered MCP tools and close clients before new discovery', async () => {
+        registry.discoverTools();
+        await vi.advanceTimersToNextTimerAsync();
+        await vi.advanceTimersToNextTimerAsync();
+        expect(registry.getTool('mcp-discovered-tool-1')).toBeDefined();
+        expect(MCPClient).toHaveBeenCalledTimes(1);
+        MockedMCPClientProto.close.mockClear();
+
+        const newMcpToolList = {
+          tools: [
+            {
+              name: 'new-mcp-tool',
+              description: 'New MCP',
+              inputSchema: { type: Type.OBJECT } as Schema,
+            },
+          ],
+        };
+        MockedMCPClientProto.listTools.mockResolvedValueOnce(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          newMcpToolList as any,
+        );
+        if (vi.isMockFunction(MCPClient)) {
+          MCPClient.mockClear();
+        }
+        MockedMCPClientProto.connect.mockClear();
+        MockedMCPClientProto.listTools.mockClear();
+
+        registry.discoverTools();
+        await vi.advanceTimersToNextTimerAsync();
+        await vi.advanceTimersToNextTimerAsync();
+
+        expect(MockedMCPClientProto.close).toHaveBeenCalledTimes(1);
+        expect(MCPClient).toHaveBeenCalledTimes(1);
+        expect(registry.getTool('mcp-discovered-tool-1')).toBeUndefined();
+        expect(registry.getTool('new-mcp-tool')).toBeDefined();
+        expect(registry.getAllTools().length).toBe(1);
+      });
+
+      it('should handle errors during MCP discovery (e.g., connection failure)', async () => {
+        MockedMCPClientProto.connect.mockRejectedValueOnce(
+          new Error('MCP Connection Failed'),
+        );
+        const consoleErrorSpy = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
+        registry.discoverTools();
+        await vi.advanceTimersToNextTimerAsync();
+        await vi.advanceTimersToNextTimerAsync();
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "Failed to start, connect, or discover tools from MCP server 'server1'",
+          ),
+        );
+        expect(registry.getAllTools().length).toBe(0);
+        consoleErrorSpy.mockRestore();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This commit introduces the ability to configure and discover tools from multiple Model-Context Protocol (MCP) servers.

Key changes:
- Replaces the single `mcpServerCommand` setting with `mcpServers`, a map allowing multiple named server configurations (command and arguments).
- Updates CLI and server configurations to use the new `mcpServers` map.
- Modifies `ToolRegistry` to manage multiple MCP clients, one for each configured server.
- Enhances `DiscoveredMCPTool` to include the specific server command in its description, improving clarity when multiple MCP servers are used.
- Removes an unused `config` field and an unnecessary `serverCommandDisplay` field from `DiscoveredMCPTool`, simplifying the class.
- Ensures MCP client errors and stderr output are logged with the corresponding server name and command for better debugging.
- Cleans up previously discovered tools (both standard and MCP) and disposes of old MCP clients before each new discovery run.
- Updated documentation.
- Added tests to validate new tool registry behavior.

This change allows users to integrate tools from various MCP-compliant servers simultaneously, expanding the CLI_S extensibility.

Fixes https://github.com/google-gemini/gemini-cli/issues/388