### PR TITLE
Refactor: Convert copy_files.cjs to ES module syntax

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -154,34 +154,6 @@ export default tseslint.config(
       },
     },
   },
-  // Override for .cjs files to use CommonJS
-  {
-    files: ['**/*.cjs'],
-    languageOptions: {
-      sourceType: 'commonjs',
-      globals: {
-        ...globals.node, // Add all Node.js globals
-        __dirname: 'readonly',
-        __filename: 'readonly',
-        exports: 'writable',
-        module: 'readonly',
-        require: 'readonly',
-      },
-    },
-    rules: {
-      // Disable rules that are not applicable to CommonJS
-      '@typescript-eslint/no-require-imports': 'off',
-      'no-restricted-syntax': [
-        'error',
-        // Keep other restricted syntaxes, but allow require for .cjs
-        {
-          selector: 'ThrowStatement > Literal:not([value=/^\\\\w+Error:/])',
-          message:
-            'Do not throw string literals or non-Error objects. Throw new Error("...") instead.',
-        },
-      ],
-    },
-  },
   // Prettier config must be last
   prettierConfig,
   // Custom eslint rules for this repo

--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -27,7 +27,7 @@ fi
 tsc --build
 
 # copy .{md,json} files
-node ../../scripts/copy_files.cjs
+node ../../scripts/copy_files.js
 
 # touch dist/.last_build
 touch dist/.last_build

--- a/scripts/copy_files.js
+++ b/scripts/copy_files.js
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
 
 const sourceDir = path.join('src');
 const targetDir = path.join('dist', 'src');


### PR DESCRIPTION
- Converted scripts/copy_files.cjs to use ES module syntax (renaming to copy_files.js).
- This change aligns with the project's preference for ES modules over CommonJS for better modernity and future-proofing.
- Updated eslint.config.js to remove the .cjs override.
- Adjusted scripts/build_package.sh to call the new .js file.