### PR TITLE
[DRAFT] fix: manage items and pendingItem state in the same object

### DIFF
--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -25,7 +25,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
   availableTerminalHeight,
   isPending,
 }) => (
-  <Box flexDirection="column" key={item.id}>
+  <Box flexDirection="column">
     {/* Render standard message types */}
     {item.type === 'user' && <UserMessage text={item.text} />}
     {item.type === 'gemini' && (

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -30,7 +30,7 @@ export interface SlashCommand {
 export const useSlashCommandProcessor = (
   config: Config | null, // Add config here
   addItem: UseHistoryManagerReturn['addItem'],
-  clearItems: UseHistoryManagerReturn['clearItems'],
+  clearHistory: UseHistoryManagerReturn['clear'],
   refreshStatic: () => void,
   setShowHelp: React.Dispatch<React.SetStateAction<boolean>>,
   onDebugMessage: (message: string) => void,
@@ -70,7 +70,7 @@ export const useSlashCommandProcessor = (
         description: 'clear the screen',
         action: (_value: PartListUnion | string) => {
           onDebugMessage('Clearing terminal.');
-          clearItems();
+          clearHistory();
           console.clear();
           refreshStatic();
         },
@@ -107,7 +107,7 @@ export const useSlashCommandProcessor = (
       setShowHelp,
       refreshStatic,
       openThemeDialog,
-      clearItems,
+      clearHistory,
       performMemoryRefresh, // Add to dependencies
       showMemoryAction,
     ],

--- a/packages/cli/src/ui/hooks/useHistoryManager.test.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.test.ts
@@ -7,46 +7,48 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useHistory } from './useHistoryManager.js';
-import { HistoryItem } from '../types.js';
+import { HistoryItem, HistoryItemUser } from '../types.js';
 
 describe('useHistoryManager', () => {
-  it('should initialize with an empty history', () => {
+  it('should initialize with an empty history and no pending item', () => {
     const { result } = renderHook(() => useHistory());
-    expect(result.current.history).toEqual([]);
+    expect(result.current.items).toEqual([]);
+    expect(result.current.pendingItem).toBeUndefined();
   });
 
-  it('should add an item to history with a unique ID', () => {
+  it('should add an item directly to history with a unique ID using addItem', () => {
     const { result } = renderHook(() => useHistory());
     const timestamp = Date.now();
-    const itemData: Omit<HistoryItem, 'id'> = {
-      type: 'user', // Replaced HistoryItemType.User
-      text: 'Hello',
+    const itemData: Omit<HistoryItemUser, 'id'> = {
+      type: 'user',
+      text: 'Hello from addItem',
     };
 
+    let itemId!: number;
     act(() => {
-      result.current.addItem(itemData, timestamp);
+      itemId = result.current.addItem(itemData, timestamp);
     });
 
-    expect(result.current.history).toHaveLength(1);
-    expect(result.current.history[0]).toEqual(
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0]).toEqual(
       expect.objectContaining({
         ...itemData,
-        id: expect.any(Number),
+        id: itemId,
       }),
     );
-    // Basic check that ID incorporates timestamp
-    expect(result.current.history[0].id).toBeGreaterThanOrEqual(timestamp);
+    expect(result.current.pendingItem).toBeUndefined(); // addItem should not affect pendingItem
+    expect(itemId).toBeGreaterThanOrEqual(timestamp);
   });
 
-  it('should generate unique IDs for items added with the same base timestamp', () => {
+  it('should generate unique IDs for items added with the same base timestamp via addItem', () => {
     const { result } = renderHook(() => useHistory());
     const timestamp = Date.now();
-    const itemData1: Omit<HistoryItem, 'id'> = {
-      type: 'user', // Replaced HistoryItemType.User
+    const itemData1: Omit<HistoryItemUser, 'id'> = {
+      type: 'user',
       text: 'First',
     };
-    const itemData2: Omit<HistoryItem, 'id'> = {
-      type: 'gemini', // Replaced HistoryItemType.Gemini
+    const itemData2: Omit<HistoryItemUser, 'id'> = {
+      type: 'user', // Changed to user for simplicity, can be any valid type
       text: 'Second',
     };
 
@@ -58,84 +60,182 @@ describe('useHistoryManager', () => {
       id2 = result.current.addItem(itemData2, timestamp);
     });
 
-    expect(result.current.history).toHaveLength(2);
+    expect(result.current.items).toHaveLength(2);
     expect(id1).not.toEqual(id2);
-    expect(result.current.history[0].id).toEqual(id1);
-    expect(result.current.history[1].id).toEqual(id2);
-    // IDs should be sequential based on the counter
+    expect(result.current.items[0].id).toEqual(id1);
+    expect(result.current.items[1].id).toEqual(id2);
     expect(id2).toBeGreaterThan(id1);
   });
 
-  it('should update an existing history item', () => {
+  it('should set a new pending item with a temporary ID', () => {
     const { result } = renderHook(() => useHistory());
-    const timestamp = Date.now();
-    const initialItem: Omit<HistoryItem, 'id'> = {
-      type: 'gemini', // Replaced HistoryItemType.Gemini
-      text: 'Initial content',
+    const itemData: Omit<HistoryItemUser, 'id'> = {
+      type: 'user',
+      text: 'Pending item',
     };
-    let itemId!: number;
 
     act(() => {
-      itemId = result.current.addItem(initialItem, timestamp);
+      result.current.setPendingItem(itemData);
     });
 
-    const updatedText = 'Updated content';
-    act(() => {
-      result.current.updateItem(itemId, { text: updatedText });
-    });
-
-    expect(result.current.history).toHaveLength(1);
-    expect(result.current.history[0]).toEqual({
-      ...initialItem,
-      id: itemId,
-      text: updatedText,
-    });
+    expect(result.current.pendingItem).toEqual(
+      expect.objectContaining({
+        ...itemData,
+        id: 0, // Pending items have a temporary ID of 0
+      }),
+    );
+    expect(result.current.items).toEqual([]); // History should not be affected
   });
 
-  it('should not change history if updateHistoryItem is called with a non-existent ID', () => {
+  it('should update an existing pending item using the updater function', () => {
     const { result } = renderHook(() => useHistory());
-    const timestamp = Date.now();
-    const itemData: Omit<HistoryItem, 'id'> = {
-      type: 'user', // Replaced HistoryItemType.User
-      text: 'Hello',
+    const initialPendingItem: Omit<HistoryItemUser, 'id'> = {
+      type: 'user',
+      text: 'Initial pending',
     };
 
     act(() => {
-      result.current.addItem(itemData, timestamp);
+      result.current.setPendingItem(initialPendingItem);
     });
 
-    const originalHistory = [...result.current.history]; // Clone before update attempt
-
+    const updatedText = 'Updated pending text';
     act(() => {
-      result.current.updateItem(99999, { text: 'Should not apply' }); // Non-existent ID
+      result.current.setPendingItem((prev) => {
+        if (!prev) return undefined; // Return undefined instead of null
+        return { ...prev, text: updatedText } as HistoryItem; // Cast if necessary for specific subtypes
+      });
     });
 
-    expect(result.current.history).toEqual(originalHistory);
+    expect(result.current.pendingItem).toEqual(
+      expect.objectContaining({
+        ...initialPendingItem,
+        id: 0, // Pending items have a temporary ID of 0
+        text: updatedText,
+      }),
+    );
+    expect(result.current.items).toEqual([]);
   });
 
-  it('should clear the history', () => {
+  it('should clear pending item if updater function returns undefined', () => {
+    // Changed from null to undefined
+    const { result } = renderHook(() => useHistory());
+    const itemData: Omit<HistoryItemUser, 'id'> = {
+      type: 'user',
+      text: 'To be cleared',
+    };
+
+    act(() => {
+      result.current.setPendingItem(itemData);
+    });
+    expect(result.current.pendingItem).not.toBeUndefined(); // Check against undefined
+
+    act(() => {
+      result.current.setPendingItem(() => undefined); // Return undefined
+    });
+
+    expect(result.current.pendingItem).toBeUndefined(); // Expect undefined
+  });
+
+  it('should commit a pending item to history and return its new ID', () => {
+    const { result } = renderHook(() => useHistory());
+    const pendingData: Omit<HistoryItemUser, 'id'> = {
+      type: 'user',
+      text: 'Committing this',
+    };
+
+    act(() => {
+      result.current.setPendingItem(pendingData);
+    });
+
+    expect(result.current.pendingItem).not.toBeUndefined();
+    expect(result.current.pendingItem?.id).toBe(0);
+    expect(result.current.items).toEqual([]);
+
+    let committedId!: number;
+    act(() => {
+      committedId = result.current.commitPendingItem();
+    });
+
+    expect(result.current.pendingItem).toBeUndefined();
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0]).toEqual(
+      expect.objectContaining({
+        ...pendingData,
+        id: committedId,
+      }),
+    );
+    expect(committedId).toBeGreaterThanOrEqual(Date.now()); // Or a more precise check if needed
+  });
+
+  it('commitPendingItem should do nothing if no pending item exists', () => {
+    const { result } = renderHook(() => useHistory());
+
+    expect(result.current.pendingItem).toBeUndefined();
+    expect(result.current.items).toEqual([]);
+
+    act(() => {
+      result.current.commitPendingItem();
+    });
+
+    expect(result.current.pendingItem).toBeUndefined();
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('should clear the history and pending item', () => {
     const { result } = renderHook(() => useHistory());
     const timestamp = Date.now();
-    const itemData1: Omit<HistoryItem, 'id'> = {
-      type: 'user', // Replaced HistoryItemType.User
-      text: 'First',
+    const itemData1: Omit<HistoryItemUser, 'id'> = {
+      type: 'user',
+      text: 'First in history',
     };
-    const itemData2: Omit<HistoryItem, 'id'> = {
-      type: 'gemini', // Replaced HistoryItemType.Gemini
-      text: 'Second',
+    const pendingData: Omit<HistoryItemUser, 'id'> = {
+      type: 'user',
+      text: 'I am pending',
     };
 
     act(() => {
       result.current.addItem(itemData1, timestamp);
-      result.current.addItem(itemData2, timestamp);
+      result.current.setPendingItem(pendingData);
     });
 
-    expect(result.current.history).toHaveLength(2);
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.pendingItem).not.toBeUndefined();
 
     act(() => {
-      result.current.clearItems();
+      result.current.clear();
     });
 
-    expect(result.current.history).toEqual([]);
+    expect(result.current.items).toEqual([]);
+    expect(result.current.pendingItem).toBeUndefined();
+  });
+
+  it('ID counter should reset after clearHistory', () => {
+    const { result } = renderHook(() => useHistory());
+    const timestamp1 = Date.now();
+    const item1: Omit<HistoryItemUser, 'id'> = { type: 'user', text: 'item1' };
+
+    let id1!: number;
+    act(() => {
+      id1 = result.current.addItem(item1, timestamp1);
+    });
+    expect(result.current.items[0].id).toBe(id1);
+
+    act(() => {
+      result.current.clear();
+    });
+
+    const timestamp2 = Date.now() + 1000; // Ensure different base
+    const item2: Omit<HistoryItemUser, 'id'> = { type: 'user', text: 'item2' };
+    let id2!: number;
+    act(() => {
+      id2 = result.current.addItem(item2, timestamp2);
+    });
+
+    // Check if the counter part of the ID reset.
+    // If timestamp1 and timestamp2 are very close, id1 and id2 might be similar.
+    // A more robust check would be if id2 - timestamp2 is small (e.g., 1 or 2).
+    expect(id2 - timestamp2).toBeLessThanOrEqual(id1 - timestamp1 + 1); // +1 because counter starts at 1
+    // Or, if we know the counter starts at 1 after reset:
+    expect(id2).toBe(timestamp2 + 1);
   });
 });

--- a/packages/cli/src/ui/hooks/useHistoryManager.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.ts
@@ -7,29 +7,41 @@
 import { useState, useRef, useCallback } from 'react';
 import { HistoryItem } from '../types.js';
 
-// Type for the updater function passed to updateHistoryItem
-type HistoryItemUpdater = (
-  prevItem: HistoryItem,
-) => Partial<Omit<HistoryItem, 'id'>>;
+type PendingHistoryItem = HistoryItem | undefined;
+type History = {
+  items: HistoryItem[];
+  pendingItem: PendingHistoryItem;
+};
+
+// Type for the updater function passed to setPendingItem
+type PendingItemUpdater = (prevItem: PendingHistoryItem) => PendingHistoryItem;
+
+const EMPTY_HISTORY: History = { items: [], pendingItem: undefined };
 
 export interface UseHistoryManagerReturn {
-  history: HistoryItem[];
-  addItem: (itemData: Omit<HistoryItem, 'id'>, baseTimestamp: number) => number; // Returns the generated ID
-  updateItem: (
-    id: number,
-    updates: Partial<Omit<HistoryItem, 'id'>> | HistoryItemUpdater,
-  ) => void;
-  clearItems: () => void;
+  items: HistoryItem[];
+  pendingItem?: HistoryItem;
+  addItem: (
+    itemData: Omit<HistoryItem, 'id'>,
+    baseTimestamp?: number,
+  ) => HistoryItem['id'];
+  setPendingItem: {
+    (nextPendingItem: Omit<HistoryItem, 'id'>): void;
+    (updater: PendingItemUpdater): void;
+  };
+  commitPendingItem: () => HistoryItem['id'];
+  clear: () => void;
 }
 
 /**
- * Custom hook to manage the chat history state.
+ * Custom hook to manage the chat history state, including a pending item.
  *
- * Encapsulates the history array, message ID generation, adding items,
- * updating items, and clearing the history.
+ * Encapsulates the history array, a pending item, message ID generation,
+ * adding items directly to history, setting/updating the pending item,
+ * committing the pending item to history, and clearing the history.
  */
 export function useHistory(): UseHistoryManagerReturn {
-  const [history, setHistory] = useState<HistoryItem[]>([]);
+  const [{ items, pendingItem }, setHistory] = useState<History>(EMPTY_HISTORY);
   const messageIdCounterRef = useRef(0);
 
   // Generates a unique message ID based on a timestamp and a counter.
@@ -38,54 +50,73 @@ export function useHistory(): UseHistoryManagerReturn {
     return baseTimestamp + messageIdCounterRef.current;
   }, []);
 
-  // Adds a new item to the history state with a unique ID.
+  // Adds a new item directly to the history state with a unique ID.
   const addItem = useCallback(
-    (itemData: Omit<HistoryItem, 'id'>, baseTimestamp: number): number => {
+    (
+      itemData: Omit<HistoryItem, 'id'>,
+      baseTimestamp: number = Date.now(),
+    ): number => {
       const id = getNextMessageId(baseTimestamp);
       const newItem: HistoryItem = { ...itemData, id } as HistoryItem;
-      setHistory((prevHistory) => [...prevHistory, newItem]);
-      return id; // Return the generated ID
+      setHistory((prev) => ({
+        items: [...prev.items, newItem],
+        pendingItem: prev.pendingItem,
+      }));
+      return id;
     },
     [getNextMessageId],
   );
 
-  /**
-   * Updates an existing history item identified by its ID.
-   * @deprecated Prefer not to update history item directly as we are currently
-   * rendering all history items in <Static /> for performance reasons. Only use
-   * if ABSOLUTELY NECESSARY
-   */
-  //
-  const updateItem = useCallback(
+  // Sets a new pending item or updates the existing one.
+  const setPendingItem = useCallback(
     (
-      id: number,
-      updates: Partial<Omit<HistoryItem, 'id'>> | HistoryItemUpdater,
-    ) => {
-      setHistory((prevHistory) =>
-        prevHistory.map((item) => {
-          if (item.id === id) {
-            // Apply updates based on whether it's an object or a function
-            const newUpdates =
-              typeof updates === 'function' ? updates(item) : updates;
-            return { ...item, ...newUpdates } as HistoryItem;
-          }
-          return item;
-        }),
-      );
-    },
+      nextPendingItem:
+        | Omit<HistoryItem, 'id'>
+        | ((
+            prevPendingItem: HistoryItem | undefined,
+          ) => HistoryItem | undefined),
+    ): void =>
+      setHistory((prev) => ({
+        items: prev.items,
+        pendingItem:
+          typeof nextPendingItem === 'function'
+            ? nextPendingItem(prev.pendingItem)
+            : ({ id: 0, ...nextPendingItem } as HistoryItem),
+      })),
     [],
   );
 
-  // Clears the entire history state and resets the ID counter.
-  const clearItems = useCallback(() => {
-    setHistory([]);
+  // Commits the current pending item to the history.
+  const commitPendingItem = useCallback(() => {
+    const id = getNextMessageId(Date.now());
+    setHistory((prev) => {
+      if (!prev.pendingItem) {
+        return prev; // No pending item to commit
+      }
+      const nextItem: HistoryItem = {
+        ...prev.pendingItem,
+        id,
+      };
+      return {
+        items: [...prev.items, nextItem],
+        pendingItem: undefined,
+      };
+    });
+    return id;
+  }, [getNextMessageId, setHistory]);
+
+  // Clears the entire history state (both committed and pending) and resets the ID counter.
+  const clear = useCallback(() => {
+    setHistory(EMPTY_HISTORY);
     messageIdCounterRef.current = 0;
   }, []);
 
   return {
-    history,
+    items,
+    pendingItem,
     addItem,
-    updateItem,
-    clearItems,
+    setPendingItem,
+    commitPendingItem,
+    clear,
   };
 }


### PR DESCRIPTION
DIFFBASE=#384

see diffbase bug (http://go/scrcast/NTQ4NDE3NTQzMDc3ODg4MHwxMTA5ODRiZC1hNQ) where the pending item is shown twice. I think this was because the operation to move a pending item to the static history list is not atomic. It requires two separate `setState` calls, one of which is a `setRef` call under the hood. Since ref changes don't trigger re-renders, I think the UI hit the inbetween state where the pending item was added to the static history, but never refreshed the pending item to null. 

this fix/refactor moves the pendingItem state into the same stateful object as the rest of the history items. this allows us to make state changes between the two atomically. 