### PR TITLE
Avoid console.log for MCP

### DIFF
--- a/packages/server/src/tools/tool-registry.ts
+++ b/packages/server/src/tools/tool-registry.ts
@@ -221,7 +221,7 @@ export class ToolRegistry {
         transport.stderr.on('data', (data) => {
           // filter out INFO messages logged for each request received
           if (!data.toString().includes('] INFO')) {
-            console.log('MCP STDERR', data.toString());
+            console.debug('MCP STDERR', data.toString());
           }
         });
         const result = await mcpClient.listTools();


### PR DESCRIPTION
- Prior to this when attached MCP servers would report content we'd fall back to `console.log` which doesn't work well in  an Ink application.

Fixes https://github.com/google-gemini/gemini-cli/issues/397