### PR TITLE
feat: Strip schema props from MCP tool definitions

### DIFF
--- a/packages/server/src/tools/tool-registry.ts
+++ b/packages/server/src/tools/tool-registry.ts
@@ -226,6 +226,22 @@ export class ToolRegistry {
         });
         const result = await mcpClient.listTools();
         for (const tool of result.tools) {
+          // Recursively remove additionalProperties and $schema from the inputSchema
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- This function recursively navigates a deeply nested and potentially heterogeneous JSON schema object. Using 'any' is a pragmatic choice here to avoid overly complex type definitions for all possible schema variations.
+          const removeSchemaProps = (obj: any) => {
+            if (typeof obj !== 'object' || obj === null) {
+              return;
+            }
+            if (Array.isArray(obj)) {
+              obj.forEach(removeSchemaProps);
+            } else {
+              delete obj.additionalProperties;
+              delete obj.$schema;
+              Object.values(obj).forEach(removeSchemaProps);
+            }
+          };
+          removeSchemaProps(tool.inputSchema);
+
           this.registerTool(
             new DiscoveredMCPTool(
               mcpClient,


### PR DESCRIPTION
- This change modifies the tool discovery process for MCP (Model Context Protocol) tools.
- When tools are fetched from an MCP server, the `additionalProperties` and `$schema` fields are now recursively removed from their input schemas. This ensures cleaner and more concise tool definitions within the CLI, aligning with the expected schema structure and preventing potential conflicts or verbose outputs.
- The corresponding tests in `tool-registry.test.ts` have been updated to reflect this new behavior and verify the correct stripping of these properties.

@steren:
![image](https://github.com/user-attachments/assets/1d0761b5-ce4c-4360-9aae-934f82f2843f)

Workaround for https://github.com/google-gemini/gemini-cli/issues/398