### PR TITLE
feat: Patch console.debug and display only in debug mode

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -409,7 +409,7 @@ export const App = ({
           cliVersion={cliVersion}
           geminiMdFileCount={geminiMdFileCount}
         />
-        <ConsoleOutput />
+        <ConsoleOutput debugMode={config.getDebugMode()} />
       </Box>
     </Box>
   );


### PR DESCRIPTION
- Patches `console.debug` in `ConsolePatcher.tsx` to capture debug messages.
- Updates `ConsoleOutput` to only display debug messages when `debugMode` is enabled.
- Passes `debugMode` prop from `App.tsx` to `ConsoleOutput`.

Running with a `-d` parameter runs Gemini CLI in debug mode which will show any stderr information from MCP servers:
![image](https://github.com/user-attachments/assets/b1fe4a35-6010-4884-9f76-d4655a182050)

@steren hopefully this makes it a bit more approachable 😄 

Fixes https://github.com/google-gemini/gemini-cli/issues/397