### PR TITLE
Refactor: Use String.prototype.replaceAll() and update TS lib

### DIFF
--- a/packages/server/src/tools/edit.ts
+++ b/packages/server/src/tools/edit.ts
@@ -205,8 +205,7 @@ Expectation for parameters:
         };
       } else {
         // Successful edit calculation
-        newContent = this.replaceAll(
-          currentContent,
+        newContent = currentContent.replaceAll(
           params.old_string,
           params.new_string,
         );
@@ -274,8 +273,7 @@ Expectation for parameters:
       if (correctedOccurrences === 0 || correctedOccurrences !== 1) {
         return false;
       }
-      newContent = this.replaceAll(
-        currentContent,
+      newContent = currentContent.replaceAll(
         params.old_string,
         params.new_string,
       );
@@ -390,19 +388,6 @@ Expectation for parameters:
         returnDisplay: `Error writing file: ${errorMsg}`,
       };
     }
-  }
-
-  /**
-   * Replaces all occurrences of a substring in a string
-   */
-  private replaceAll(str: string, find: string, replace: string): string {
-    if (find === '') {
-      return str;
-    }
-    // Use RegExp with global flag for true replacement of all instances
-    // Escape special regex characters in the find string
-    const escapedFind = find.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return str.replace(new RegExp(escapedFind, 'g'), replace);
   }
 
   /**

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "lib": ["DOM", "DOM.Iterable", "ES2021"],
     "composite": true
   },
   "include": ["index.ts", "src/**/*.ts", "src/**/*.json"],


### PR DESCRIPTION
- Replaces the custom `replaceAll` implementation in `packages/server/src/tools/edit.ts` with the standard `String.prototype.replaceAll()`.
- Updates `packages/server/tsconfig.json` to include `ES2021` in the `lib` compiler options to ensure TypeScript recognizes this method. This aligns with the project's Node.js version requirements \(Node.js 16.x+\).

Fixes https://github.com/google-gemini/gemini-cli/issues/7