### PR TITLE
refactor: Unify file modification confirmation state

### DIFF
--- a/packages/server/src/config/config.ts
+++ b/packages/server/src/config/config.ts
@@ -43,6 +43,7 @@ export class Config {
     private readonly userAgent: string,
     private userMemory: string = '', // Made mutable for refresh
     private geminiMdFileCount: number = 0,
+    private alwaysSkipModificationConfirmation: boolean = false,
   ) {
     // toolRegistry still needs initialization based on the instance
     this.toolRegistry = createToolRegistry(this);
@@ -114,6 +115,14 @@ export class Config {
   setGeminiMdFileCount(count: number): void {
     this.geminiMdFileCount = count;
   }
+
+  getAlwaysSkipModificationConfirmation(): boolean {
+    return this.alwaysSkipModificationConfirmation;
+  }
+
+  setAlwaysSkipModificationConfirmation(skip: boolean): void {
+    this.alwaysSkipModificationConfirmation = skip;
+  }
 }
 
 function findEnvFile(startDir: string): string | null {
@@ -159,6 +168,7 @@ export function createServerConfig(
   userAgent?: string,
   userMemory?: string,
   geminiMdFileCount?: number,
+  alwaysSkipModificationConfirmation?: boolean,
 ): Config {
   return new Config(
     apiKey,
@@ -175,6 +185,7 @@ export function createServerConfig(
     userAgent ?? 'GeminiCLI/unknown', // Default user agent
     userMemory ?? '',
     geminiMdFileCount ?? 0,
+    alwaysSkipModificationConfirmation ?? false,
   );
 }
 
@@ -188,7 +199,7 @@ function createToolRegistry(config: Config): ToolRegistry {
     new GrepTool(targetDir),
     new GlobTool(targetDir),
     new EditTool(config),
-    new WriteFileTool(targetDir),
+    new WriteFileTool(config),
     new WebFetchTool(),
     new ReadManyFilesTool(targetDir),
     new ShellTool(config),

--- a/packages/server/src/tools/edit.ts
+++ b/packages/server/src/tools/edit.ts
@@ -56,7 +56,7 @@ interface CalculatedEdit {
  */
 export class EditTool extends BaseTool<EditToolParams, ToolResult> {
   static readonly Name = 'replace';
-  private shouldAlwaysEdit = false;
+  private readonly config: Config;
   private readonly rootDirectory: string;
   private readonly client: GeminiClient;
 
@@ -98,8 +98,9 @@ Expectation for parameters:
         type: 'object',
       },
     );
-    this.rootDirectory = path.resolve(config.getTargetDir());
-    this.client = new GeminiClient(config);
+    this.config = config;
+    this.rootDirectory = path.resolve(this.config.getTargetDir());
+    this.client = new GeminiClient(this.config);
   }
 
   /**
@@ -234,7 +235,7 @@ Expectation for parameters:
   async shouldConfirmExecute(
     params: EditToolParams,
   ): Promise<ToolCallConfirmationDetails | false> {
-    if (this.shouldAlwaysEdit) {
+    if (this.config.getAlwaysSkipModificationConfirmation()) {
       return false;
     }
     const validationError = this.validateToolParams(params);
@@ -295,7 +296,7 @@ Expectation for parameters:
       fileDiff,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
-          this.shouldAlwaysEdit = true;
+          this.config.setAlwaysSkipModificationConfirmation(true);
         }
       },
     };


### PR DESCRIPTION
- Modifies `EditTool` and `WriteFileTool` to share a single confirmation preference.
- The "Always Proceed" choice for file modifications is now stored in `Config.alwaysSkipModificationConfirmation`.
- This ensures that if a user chooses to always skip confirmation for one file modification tool, this preference is respected by the other.
- `WriteFileTool` constructor now accepts `Config` instead of `targetDir` to facilitate this shared state.
- Tests updated to reflect the new shared confirmation logic.

Fixes https://b.corp.google.com/issues/415897960