### PR TITLE
fix: Prevent WriteFileTool from writing to directory paths

### DIFF
--- a/packages/server/src/tools/write-file.test.ts
+++ b/packages/server/src/tools/write-file.test.ts
@@ -101,14 +101,15 @@ describe('WriteFileTool', () => {
       );
     });
 
-    it('should return null for path that is the root itself', () => {
+    it('should return error for path that is the root itself', () => {
       const params = {
-        file_path: rootDir, // Attempting to write to the root directory itself (as a file)
+        file_path: rootDir, // Attempting to write to the root directory itself
         content: 'hello',
       };
-      // This is a tricky case. The validation should allow it if it's treated as a file path.
-      // The actual write operation might fail if it's a directory, but validation should pass.
-      expect(tool.validateToolParams(params)).toBeNull();
+      // With the new validation, this should now return an error as rootDir is a directory.
+      expect(tool.validateToolParams(params)).toMatch(
+        `Path is a directory, not a file: ${rootDir}`,
+      );
     });
 
     it('should return error for path that is just / and root is not /', () => {


### PR DESCRIPTION
- Enhances WriteFileTool validation to check if the target file_path is an existing directory.
- If it is, the tool now returns a validation error "Path is a directory, not a file: <filePath>", preventing the attempt to write.
- This proactive check avoids underlying file system errors that would occur if fs.writeFileSync were called on a directory path, which could lead to console errors.
- Test cases have been updated to reflect this stricter validation.

Fixes https://b.corp.google.com/issues/418348176