### PR TITLE
fix: Ensure CWD and auto-accept indicator are always visible (even through confirmations)

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -334,24 +334,22 @@ export const App = ({
                 showAutoAcceptIndicator ? <AutoAcceptIndicator /> : undefined
               }
             />
-            {isInputActive && (
-              <Box
-                marginTop={1}
-                display="flex"
-                justifyContent="space-between"
-                width="100%"
-              >
-                <Box>
-                  <>
-                    <Text color={Colors.SubtleComment}>cwd: </Text>
-                    <Text color={Colors.LightBlue}>
-                      {shortenPath(config.getTargetDir(), 70)}
-                    </Text>
-                  </>
-                </Box>
-                {showAutoAcceptIndicator && <AutoAcceptIndicator />}
+            <Box
+              marginTop={1}
+              display="flex"
+              justifyContent="space-between"
+              width="100%"
+            >
+              <Box>
+                <>
+                  <Text color={Colors.SubtleComment}>cwd: </Text>
+                  <Text color={Colors.LightBlue}>
+                    {shortenPath(config.getTargetDir(), 70)}
+                  </Text>
+                </>
               </Box>
-            )}
+              {showAutoAcceptIndicator && <AutoAcceptIndicator />}
+            </Box>
             {isInputActive && (
               <>
                 <InputPrompt


### PR DESCRIPTION
- This commit addresses an issue where the Current Working Directory (CWD) and the auto-accept indicator were not consistently visible, especially when tool confirmations were displayed.
- Previously, the CWD could be hidden during tool confirmation prompts, potentially leading to confusion about the context in which Gemini CLI was operating.

## When confirmations are shown:
![image](https://github.com/user-attachments/assets/cbdc4f8d-c676-4416-881d-e13e5e237c22)

## When loading:
![image](https://github.com/user-attachments/assets/ab02a2c1-af68-46bb-ab10-7c2f5785725b)

Fixes https://b.corp.google.com/issues/414289185