### PR TITLE
refactor: Remove console.error from WriteFileTool

### DIFF
--- a/packages/server/src/tools/write-file.ts
+++ b/packages/server/src/tools/write-file.ts
@@ -132,9 +132,6 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
 
     const validationError = this.validateToolParams(params);
     if (validationError) {
-      console.error(
-        `[WriteFile Wrapper] Attempted confirmation with invalid parameters: ${validationError}`,
-      );
       return false;
     }
 


### PR DESCRIPTION
- Removes an unnecessary `console.error` call from the `shouldConfirmExecute` method in the `WriteFileTool` class.
- This logging was redundant as validation errors are already handled and returned by the method.
- Additionally, `console.error` is not suitable for this scenario, as incorrect arguments can be provided by the LLM, and these are anticipated and managed without needing an error log.

Fixes https://b.corp.google.com/issues/418491206