### PR TITLE
fix(cli): Remove duplicate auto-accept indicator

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -330,9 +330,6 @@ export const App = ({
               isLoading={streamingState === StreamingState.Responding}
               currentLoadingPhrase={currentLoadingPhrase}
               elapsedTime={elapsedTime}
-              rightContent={
-                showAutoAcceptIndicator ? <AutoAcceptIndicator /> : undefined
-              }
             />
             <Box
               marginTop={1}


### PR DESCRIPTION
- The auto-accept edits indicator was appearing in two places: once next to the loading indicator and again in the CWD bar.
- This was introduced when the CWD bar was made always visible.
- This commit removes the duplicate indicator, leaving only the one in the CWD bar.

Fixes https://b.corp.google.com/issues/413740468