### PR TITLE
fix(cli): Disable slash commands and suggestions in shell mode

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -207,7 +207,9 @@ export const App = ({
   const completion = useCompletion(
     query,
     config.getTargetDir(),
-    isInputActive && (isAtCommand(query) || isSlashCommand(query)),
+    !shellModeActive &&
+      isInputActive &&
+      (isAtCommand(query) || isSlashCommand(query)),
     slashCommands,
   );
 
@@ -380,7 +382,7 @@ export const App = ({
                   shellModeActive={shellModeActive}
                   setShellModeActive={setShellModeActive}
                 />
-                {completion.showSuggestions && (
+                {completion.showSuggestions && !shellModeActive && (
                   <Box>
                     <SuggestionsDisplay
                       suggestions={completion.suggestions}


### PR DESCRIPTION
- Prevents slash commands from being triggered and suggestions from being displayed when shell mode is active. This ensures that user input is correctly interpreted as shell commands.

Fixes https://buganizer.corp.google.com/issues/418560826