### PR TITLE
feat(cli): Implement /bug command and add open dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2154,6 +2154,21 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2750,6 +2765,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -2766,6 +2809,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -4724,6 +4779,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4802,6 +4872,24 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5026,6 +5114,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -5717,6 +5820,24 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
+      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6433,6 +6554,18 @@
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -8157,6 +8290,7 @@
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
         "lowlight": "^3.3.0",
+        "open": "^10.1.2",
         "react": "^18.3.1",
         "read-package-up": "^11.0.0",
         "shell-quote": "^1.8.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
     "lowlight": "^3.3.0",
+    "open": "^10.1.2",
     "react": "^18.3.1",
     "read-package-up": "^11.0.0",
     "shell-quote": "^1.8.2",

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -149,12 +149,39 @@ export const useSlashCommandProcessor = (
           }
           bugDescription = bugDescription.trim();
 
+          const cliVersion = process.env.npm_package_version || 'Unknown';
+          const osVersion = `${process.platform} ${process.version}`;
+          let sandboxEnv = 'no sandbox';
+          if (process.env.SANDBOX && process.env.SANDBOX !== 'sandbox-exec') {
+            sandboxEnv = process.env.SANDBOX.replace(/^gemini-(?:code-)?/, '');
+          } else if (process.env.SANDBOX === 'sandbox-exec') {
+            sandboxEnv = `sandbox-exec (${process.env.SEATBELT_PROFILE || 'unknown'})`;
+          }
+          const modelVersion = config?.getModel() || 'Unknown';
+
+          const diagnosticInfo = `
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## Additional context
+Add any other context about the problem here.
+
+## Diagnostic Information
+*   **CLI Version:** ${cliVersion}
+*   **Operating System:** ${osVersion}
+*   **Sandbox Environment:** ${sandboxEnv}
+*   **Model Version:** ${modelVersion}
+`;
+
           let bugReportUrl =
-            'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml';
+            'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.md';
           if (bugDescription) {
             const encodedArgs = encodeURIComponent(bugDescription);
             bugReportUrl += `&title=${encodedArgs}`;
           }
+          const encodedBody = encodeURIComponent(diagnosticInfo);
+          bugReportUrl += `&body=${encodedBody}`;
+
           addMessage({
             type: MessageType.INFO,
             content: `To submit your bug report, please open the following URL in your browser:\n${bugReportUrl}`,
@@ -176,6 +203,7 @@ export const useSlashCommandProcessor = (
           })();
         },
       },
+
       {
         name: 'quit',
         altName: 'exit',
@@ -197,6 +225,7 @@ export const useSlashCommandProcessor = (
       addMemoryAction,
       addMessage,
       toggleCorgiMode,
+      config, // Added config to dependency array
     ],
   );
 

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -6,6 +6,7 @@
 
 import { useCallback, useMemo } from 'react';
 import { type PartListUnion } from '@google/genai';
+import open from 'open';
 import { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { Config } from '@gemini-code/server';
 import { Message, MessageType, HistoryItemWithoutId } from '../types.js';
@@ -136,6 +137,43 @@ export const useSlashCommandProcessor = (
         name: 'corgi',
         action: (_mainCommand, _subCommand, _args) => {
           toggleCorgiMode();
+        },
+      },
+      {
+        name: 'bug',
+        description: 'Submit a bug report.',
+        action: (_mainCommand, _subCommand, args) => {
+          let bugDescription = _subCommand || '';
+          if (args) {
+            bugDescription += ` ${args}`;
+          }
+          bugDescription = bugDescription.trim();
+
+          let bugReportUrl =
+            'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml';
+          if (bugDescription) {
+            const encodedArgs = encodeURIComponent(bugDescription);
+            bugReportUrl += `&title=${encodedArgs}`;
+          }
+          addMessage({
+            type: MessageType.INFO,
+            content: `To submit your bug report, please open the following URL in your browser:\n${bugReportUrl}`,
+            timestamp: new Date(),
+          });
+          // Open the URL in the default browser
+          (async () => {
+            try {
+              await open(bugReportUrl);
+            } catch (error) {
+              const errorMessage =
+                error instanceof Error ? error.message : String(error);
+              addMessage({
+                type: MessageType.ERROR,
+                content: `Could not open URL in browser: ${errorMessage}`,
+                timestamp: new Date(),
+              });
+            }
+          })();
         },
       },
       {


### PR DESCRIPTION
- Implements the /bug command in the CLI:
    - Opens the GitHub issue page with a pre-filled title if a bug description is provided.
    - Opens the generic GitHub issue page if no description is provided.
- Adds open as a dependency to packages/cli/package.json.
    - The open library is used to open URLs in the default browser in a robust and cross-platform manner.
- Updates tests for the /bug command.

Fixes b/413139077