### PR TITLE
Implement additional readline-like keybindings, including alt-left arrow and alt-right arrow.

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -374,7 +374,6 @@ export const App = ({
                   navigateSuggestionUp={completion.navigateUp}
                   navigateSuggestionDown={completion.navigateDown}
                   resetCompletion={completion.resetCompletionState}
-                  setEditorState={setEditorState}
                   onClearScreen={handleClearScreen} // Added onClearScreen prop
                   shellModeActive={shellModeActive}
                   setShellModeActive={setShellModeActive}

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -114,12 +114,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   );
 
   const inputPreprocessor = useCallback(
-    (
-      input: string,
-      key: Key,
-      _currentText?: string,
-      _cursorOffset?: number,
-    ) => {
+    (input: string, key: Key, currentText?: string, cursorOffset?: number) => {
       if (input === '!' && query === '' && !showSuggestions) {
         setShellModeActive(!shellModeActive);
         onChangeAndMoveCursor(''); // Clear the '!' from input
@@ -177,6 +172,21 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
         if (key.ctrl && input === 'n') {
           inputHistory.navigateDown();
+          return true;
+        }
+        if (key.ctrl && input === 'b' && typeof cursorOffset !== 'undefined') {
+          setEditorState((s) => ({
+            key: s.key + 1,
+            initialCursorOffset: Math.max(0, cursorOffset - 1),
+          }));
+          return true;
+        }
+        if (key.ctrl && input === 'f' && typeof cursorOffset !== 'undefined') {
+          const currentTextLength = currentText?.length ?? query.length;
+          setEditorState((s) => ({
+            key: s.key + 1,
+            initialCursorOffset: Math.min(currentTextLength, cursorOffset + 1),
+          }));
           return true;
         }
       }

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -24,7 +24,6 @@ interface InputPromptProps {
   userMessages: readonly string[];
   navigateSuggestionUp: () => void;
   navigateSuggestionDown: () => void;
-  setEditorState: (updater: (prevState: EditorState) => EditorState) => void;
   onClearScreen: () => void;
   shellModeActive: boolean;
   setShellModeActive: (value: boolean) => void;
@@ -48,7 +47,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   navigateSuggestionUp,
   navigateSuggestionDown,
   resetCompletion,
-  setEditorState,
   onClearScreen,
   shellModeActive,
   setShellModeActive,
@@ -114,7 +112,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   );
 
   const inputPreprocessor = useCallback(
-    (input: string, key: Key, currentText?: string, cursorOffset?: number) => {
+    (
+      input: string,
+      key: Key,
+      _currentText?: string,
+      _cursorOffset?: number,
+    ) => {
       if (input === '!' && query === '' && !showSuggestions) {
         setShellModeActive(!shellModeActive);
         onChangeAndMoveCursor(''); // Clear the '!' from input
@@ -151,19 +154,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
       } else {
         // Keybindings when suggestions are not shown
-        // Keybinding: Ctrl + A to move to the beginning of the line
-        if (key.ctrl && input === 'a') {
-          setEditorState((s) => ({ key: s.key + 1, initialCursorOffset: 0 }));
-          return true;
-        }
-        // Keybinding: Ctrl + E to move to the end of the line
-        if (key.ctrl && input === 'e') {
-          setEditorState((s) => ({
-            key: s.key + 1,
-            initialCursorOffset: query.length,
-          }));
-          return true;
-        }
         // Keybinding: Ctrl + L to refresh the screen
         if (key.ctrl && input === 'l') {
           onClearScreen();
@@ -177,63 +167,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         // Keybinding: Ctrl + N to navigate to the next item in the history
         if (key.ctrl && input === 'n') {
           inputHistory.navigateDown();
-          return true;
-        }
-        // Keybinding: Ctrl + B to move back one character
-        if (key.ctrl && input === 'b' && typeof cursorOffset !== 'undefined') {
-          setEditorState((s) => ({
-            key: s.key + 1,
-            initialCursorOffset: Math.max(0, cursorOffset - 1),
-          }));
-          return true;
-        }
-        // Keybinding: Ctrl + F to move forward one character
-        if (key.ctrl && input === 'f' && typeof cursorOffset !== 'undefined') {
-          const currentTextLength = currentText?.length ?? query.length;
-          setEditorState((s) => ({
-            key: s.key + 1,
-            initialCursorOffset: Math.min(currentTextLength, cursorOffset + 1),
-          }));
-          return true;
-        }
-        // Keybinding: Alt/Meta/Option + Left Arrow to move backward one word
-        if (key.meta && input === 'b' && typeof cursorOffset !== 'undefined') {
-          const text = currentText ?? query;
-          let i = cursorOffset - 1;
-          // Skip whitespace to the left of the cursor
-          while (i >= 0 && text[i] === ' ') {
-            i--;
-          }
-          // Skip non-whitespace characters (the word itself)
-          while (i >= 0 && text[i] !== ' ') {
-            i--;
-          }
-          // The new cursor position is after the space before the word, or 0
-          const newCursorOffset = Math.max(0, i + 1);
-          setEditorState((s) => ({
-            key: s.key + 1,
-            initialCursorOffset: newCursorOffset,
-          }));
-          return true;
-        }
-        // Keybinding: Alt/Meta/Option + Right Arrow to move forward one word
-        if (key.meta && input === 'f' && typeof cursorOffset !== 'undefined') {
-          const text = currentText ?? query;
-          let i = cursorOffset;
-          // Skip whitespace to the right of the cursor
-          while (i < text.length && text[i] === ' ') {
-            i++;
-          }
-          // Skip non-whitespace characters (the word itself)
-          while (i < text.length && text[i] !== ' ') {
-            i++;
-          }
-          // The new cursor position is after the word, or at the end of the text
-          const newCursorOffset = Math.min(text.length, i);
-          setEditorState((s) => ({
-            key: s.key + 1,
-            initialCursorOffset: newCursorOffset,
-          }));
           return true;
         }
       }
@@ -250,7 +183,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       activeSuggestionIndex,
       handleSubmit,
       inputHistory,
-      setEditorState,
       onClearScreen,
       shellModeActive,
       setShellModeActive,

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -216,6 +216,26 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           }));
           return true;
         }
+        // Keybinding: Alt/Meta/Option + Right Arrow to move forward one word
+        if (key.meta && input === 'f' && typeof cursorOffset !== 'undefined') {
+          const text = currentText ?? query;
+          let i = cursorOffset;
+          // Skip whitespace to the right of the cursor
+          while (i < text.length && text[i] === ' ') {
+            i++;
+          }
+          // Skip non-whitespace characters (the word itself)
+          while (i < text.length && text[i] !== ' ') {
+            i++;
+          }
+          // The new cursor position is after the word, or at the end of the text
+          const newCursorOffset = Math.min(text.length, i);
+          setEditorState((s) => ({
+            key: s.key + 1,
+            initialCursorOffset: newCursorOffset,
+          }));
+          return true;
+        }
       }
       return false;
     },

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -151,10 +151,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
       } else {
         // Keybindings when suggestions are not shown
+        // Keybinding: Ctrl + A to move to the beginning of the line
         if (key.ctrl && input === 'a') {
           setEditorState((s) => ({ key: s.key + 1, initialCursorOffset: 0 }));
           return true;
         }
+        // Keybinding: Ctrl + E to move to the end of the line
         if (key.ctrl && input === 'e') {
           setEditorState((s) => ({
             key: s.key + 1,
@@ -162,18 +164,22 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           }));
           return true;
         }
+        // Keybinding: Ctrl + L to refresh the screen
         if (key.ctrl && input === 'l') {
           onClearScreen();
           return true;
         }
+        // Keybinding: Ctrl + P to navigate to the previous item in the history
         if (key.ctrl && input === 'p') {
           inputHistory.navigateUp();
           return true;
         }
+        // Keybinding: Ctrl + N to navigate to the next item in the history
         if (key.ctrl && input === 'n') {
           inputHistory.navigateDown();
           return true;
         }
+        // Keybinding: Ctrl + B to move back one character
         if (key.ctrl && input === 'b' && typeof cursorOffset !== 'undefined') {
           setEditorState((s) => ({
             key: s.key + 1,
@@ -181,11 +187,32 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           }));
           return true;
         }
+        // Keybinding: Ctrl + F to move forward one character
         if (key.ctrl && input === 'f' && typeof cursorOffset !== 'undefined') {
           const currentTextLength = currentText?.length ?? query.length;
           setEditorState((s) => ({
             key: s.key + 1,
             initialCursorOffset: Math.min(currentTextLength, cursorOffset + 1),
+          }));
+          return true;
+        }
+        // Keybinding: Alt/Meta/Option + Left Arrow to move backward one word
+        if (key.meta && input === 'b' && typeof cursorOffset !== 'undefined') {
+          const text = currentText ?? query;
+          let i = cursorOffset - 1;
+          // Skip whitespace to the left of the cursor
+          while (i >= 0 && text[i] === ' ') {
+            i--;
+          }
+          // Skip non-whitespace characters (the word itself)
+          while (i >= 0 && text[i] !== ' ') {
+            i--;
+          }
+          // The new cursor position is after the space before the word, or 0
+          const newCursorOffset = Math.max(0, i + 1);
+          setEditorState((s) => ({
+            key: s.key + 1,
+            initialCursorOffset: newCursorOffset,
           }));
           return true;
         }

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -149,17 +149,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
       } else {
         // Keybindings when suggestions are not shown
-        // Keybinding: Ctrl + L to refresh the screen
         if (key.ctrl && input === 'l') {
           onClearScreen();
           return true;
         }
-        // Keybinding: Ctrl + P to navigate to the previous item in the history
         if (key.ctrl && input === 'p') {
           inputHistory.navigateUp();
           return true;
         }
-        // Keybinding: Ctrl + N to navigate to the next item in the history
         if (key.ctrl && input === 'n') {
           inputHistory.navigateDown();
           return true;

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -112,12 +112,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   );
 
   const inputPreprocessor = useCallback(
-    (
-      input: string,
-      key: Key,
-      _currentText?: string,
-      _cursorOffset?: number,
-    ) => {
+    (input: string, key: Key) => {
       if (input === '!' && query === '' && !showSuggestions) {
         setShellModeActive(!shellModeActive);
         onChangeAndMoveCursor(''); // Clear the '!' from input

--- a/packages/cli/src/ui/components/shared/multiline-editor.tsx
+++ b/packages/cli/src/ui/components/shared/multiline-editor.tsx
@@ -121,14 +121,7 @@ export const MultilineTextEditor = ({
 
       const isCtrlX =
         (key.ctrl && (input === 'x' || input === '\x18')) || input === '\x18';
-      const isCtrlE =
-        (key.ctrl && (input === 'e' || input === '\x05')) ||
-        input === '\x05' ||
-        (!key.ctrl &&
-          input === 'e' &&
-          input.length === 1 &&
-          input.charCodeAt(0) === 5);
-      if (isCtrlX || isCtrlE) {
+      if (isCtrlX) {
         buffer.openInExternalEditor();
         return;
       }

--- a/packages/cli/src/ui/components/shared/multiline-editor.tsx
+++ b/packages/cli/src/ui/components/shared/multiline-editor.tsx
@@ -44,12 +44,7 @@ export interface MultilineTextEditorProps {
 
   // Called on all key events to allow the caller. Returns true if the
   // event was handled and should not be passed to the editor.
-  readonly inputPreprocessor?: (
-    input: string,
-    key: Key,
-    currentText: string,
-    cursorOffset: number,
-  ) => boolean;
+  readonly inputPreprocessor?: (input: string, key: Key) => boolean;
 
   // Optional initial cursor position (character offset)
   readonly initialCursorOffset?: number;
@@ -98,14 +93,7 @@ export const MultilineTextEditor = ({
         return;
       }
 
-      // Calculate cursorOffset for inputPreprocessor
-      let charOffset = 0;
-      for (let i = 0; i < buffer.cursor[0]; i++) {
-        charOffset += buffer.lines[i].length + 1; // +1 for newline
-      }
-      charOffset += buffer.cursor[1];
-
-      if (inputPreprocessor?.(input, key, buffer.text, charOffset) === true) {
+      if (inputPreprocessor?.(input, key) === true) {
         return;
       }
 

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1104,16 +1104,22 @@ export function useTextBuffer({
       if (key['return'] || input === '\r' || input === '\n') newline();
       else if (key['leftArrow'] && !key['meta'] && !key['ctrl'] && !key['alt'])
         move('left');
+      else if (key['ctrl'] && input === 'b') move('left');
       else if (key['rightArrow'] && !key['meta'] && !key['ctrl'] && !key['alt'])
         move('right');
+      else if (key['ctrl'] && input === 'f') move('right');
       else if (key['upArrow']) move('up');
       else if (key['downArrow']) move('down');
-      else if ((key['meta'] || key['ctrl'] || key['alt']) && key['leftArrow'])
+      else if ((key['ctrl'] || key['alt']) && key['leftArrow'])
         move('wordLeft');
-      else if ((key['meta'] || key['ctrl'] || key['alt']) && key['rightArrow'])
+      else if (key['meta'] && input === 'b') move('wordLeft');
+      else if ((key['ctrl'] || key['alt']) && key['rightArrow'])
         move('wordRight');
+      else if (key['meta'] && input === 'f') move('wordRight');
       else if (key['home']) move('home');
+      else if (key['ctrl'] && input === 'a') move('home');
       else if (key['end']) move('end');
+      else if (key['ctrl'] && input === 'e') move('end');
       else if (
         (key['meta'] || key['ctrl'] || key['alt']) &&
         (key['backspace'] || input === '\x7f')


### PR DESCRIPTION
This change adds keybinding support for:

  - `Ctrl+B`: Moves the cursor backward one character.
  - `Ctrl+F`: Moves the cursor forward one character.
  - `Alt+Left Arrow`: Moves the cursor backward one word.
  - `Alt+Right Arrow`: Moves the cursor forward one word.

Note, the keybindings are consistent with terminal handling on macOS, and represented by the `key.meta` binding in `ink`.

Closes b/411469305.