### PR TITLE
feat: useToolScheduler hook to manage parallel tool calls

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -134,7 +134,7 @@ export const App = ({
     cliVersion,
   );
 
-  const { streamingState, submitQuery, initError, pendingHistoryItem } =
+  const { streamingState, submitQuery, initError, pendingHistoryItems } =
     useGeminiStream(
       addItem,
       refreshStatic,
@@ -209,7 +209,7 @@ export const App = ({
   }, [terminalHeight, footerHeight]);
 
   useEffect(() => {
-    if (!pendingHistoryItem) {
+    if (!pendingHistoryItems.length) {
       return;
     }
 
@@ -223,7 +223,7 @@ export const App = ({
     if (pendingItemDimensions.height > availableTerminalHeight) {
       setStaticNeedsRefresh(true);
     }
-  }, [pendingHistoryItem, availableTerminalHeight, streamingState]);
+  }, [pendingHistoryItems.length, availableTerminalHeight, streamingState]);
 
   useEffect(() => {
     if (streamingState === StreamingState.Idle && staticNeedsRefresh) {
@@ -264,17 +264,18 @@ export const App = ({
       >
         {(item) => item}
       </Static>
-      {pendingHistoryItem && (
-        <Box ref={pendingHistoryItemRef}>
+      <Box ref={pendingHistoryItemRef}>
+        {pendingHistoryItems.map((item, i) => (
           <HistoryItemDisplay
+            key={i}
             availableTerminalHeight={availableTerminalHeight}
             // TODO(taehykim): It seems like references to ids aren't necessary in
             // HistoryItemDisplay. Refactor later. Use a fake id for now.
-            item={{ ...pendingHistoryItem, id: 0 }}
+            item={{ ...item, id: 0 }}
             isPending={true}
           />
-        </Box>
-      )}
+        ))}
+      </Box>
       {showHelp && <Help commands={slashCommands} />}
 
       <Box flexDirection="column" ref={mainControlsRef}>

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Box } from 'ink';
 import { IndividualToolCallDisplay, ToolCallStatus } from '../../types.js';
 import { ToolMessage } from './ToolMessage.js';
@@ -19,7 +19,6 @@ interface ToolGroupMessageProps {
 
 // Main component renders the border and maps the tools using ToolMessage
 export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
-  groupId,
   toolCalls,
   availableTerminalHeight,
 }) => {
@@ -30,9 +29,13 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
 
   const staticHeight = /* border */ 2 + /* marginBottom */ 1;
 
+  const toolAwaitingApproval = useMemo(
+    () => toolCalls.find((tc) => tc.status === ToolCallStatus.Confirming),
+    [toolCalls],
+  );
+
   return (
     <Box
-      key={groupId}
       flexDirection="column"
       borderStyle="round"
       /*
@@ -48,7 +51,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
       marginBottom={1}
     >
       {toolCalls.map((tool) => (
-        <Box key={groupId + '-' + tool.callId} flexDirection="column">
+        <Box key={tool.callId} flexDirection="column">
           <ToolMessage
             key={tool.callId}
             callId={tool.callId}
@@ -60,6 +63,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
             availableTerminalHeight={availableTerminalHeight - staticHeight}
           />
           {tool.status === ToolCallStatus.Confirming &&
+            tool.callId === toolAwaitingApproval?.callId &&
             tool.confirmationDetails && (
               <ToolConfirmationMessage
                 confirmationDetails={tool.confirmationDetails}

--- a/packages/server/src/core/client.ts
+++ b/packages/server/src/core/client.ts
@@ -155,10 +155,9 @@ export class GeminiClient {
     signal?: AbortSignal,
   ): AsyncGenerator<ServerGeminiStreamEvent> {
     let turns = 0;
-    const availableTools = this.config.getToolRegistry().getAllTools();
     while (turns < this.MAX_TURNS) {
       turns++;
-      const turn = new Turn(chat, availableTools);
+      const turn = new Turn(chat);
       const resultStream = turn.run(request, signal);
       let seenError = false;
       for await (const event of resultStream) {

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -171,22 +171,27 @@ export interface FileDiff {
   fileName: string;
 }
 
-export interface ToolCallConfirmationDetails {
+export interface ToolCallConfirmationDetailsDefault {
   title: string;
   onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
 }
 
 export interface ToolEditConfirmationDetails
-  extends ToolCallConfirmationDetails {
+  extends ToolCallConfirmationDetailsDefault {
   fileName: string;
   fileDiff: string;
 }
 
 export interface ToolExecuteConfirmationDetails
-  extends ToolCallConfirmationDetails {
+  extends ToolCallConfirmationDetailsDefault {
   command: string;
   rootCommand: string;
 }
+
+export type ToolCallConfirmationDetails =
+  | ToolCallConfirmationDetailsDefault
+  | ToolEditConfirmationDetails
+  | ToolExecuteConfirmationDetails;
 
 export enum ToolConfirmationOutcome {
   ProceedOnce,


### PR DESCRIPTION
BUG=b/411426253
DIFFBASE: #468
DEMO: https://screencast.googleplex.com/cast/NjQwODk5NDU2NTM5MDMzNnwwM2Y2MDQ2MS1kOA

Incorporates the changes from the diffbase into the `useGeminiStream` hook.

# Bug Context

- parallel tool calls in general were just broken. The cli would confirm the first, then ignore the rest entirely. 
  - this was because we [stop iterating](https://github.com/google-gemini/gemini-cli/blob/2970f0a06c234d1cb2fafb2e02754973bd1fa26a/packages/cli/src/ui/hooks/useGeminiStream.ts#L294) through Gemini's response (an async iterable) after seeing a tool call confirmation request
  - additionally, moving the async iterator to the next item would continue [here](https://github.com/google-gemini/gemini-cli/blob/2970f0a06c234d1cb2fafb2e02754973bd1fa26a/packages/server/src/core/turn.ts#L205-L233), where the turn.ts would just immediately try to parse the response for a function that was never executed.
- Once that was addressed, there was an issue where tool call responses and incoming gemini messages (ie text responses to the function responses) were clashing with each other. 
  - This is because we only had [1 pending history item](https://github.com/google-gemini/gemini-cli/blob/2970f0a06c234d1cb2fafb2e02754973bd1fa26a/packages/cli/src/ui/hooks/useGeminiStream.ts#L59) component for both incoming Gemini messages _and_ tool call confirmation dialogs. 
  - Once one tool call finished, we'd kick off a [nested/recursive query](https://github.com/google-gemini/gemini-cli/blob/2970f0a06c234d1cb2fafb2e02754973bd1fa26a/packages/cli/src/ui/hooks/useGeminiStream.ts#L489) to gemini. 
  - Gemini would then respond while the next tool call was still running. 
- Lastly, there was a bit of duplicate state (tbh still is) between the cli and the server package for tool confirmations. both packages had logic to detect tool call confirmation requirements, and execute followup tool calls. 
  - to minimize the back and forth between cli + server in these confirmations, I opted to just move the tool call confirmation/scheduling state management entirely into the cli.
  - there's probably an argument for moving this entirely in the server, but I just stuck with the cli-side since React hooks inherently offer async state management utilities. coordinating that with the async-iterator between cli and server got a little messy. 
  - side note, we also may want to consider abstracting more of our state behind something like useReducer as it's pretty effective at more compelx state management.