### PR TITLE
Fix: Configure React version for ESLint to resolve preflight warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,6 +41,14 @@ export default tseslint.config(
   reactPlugin.configs.flat.recommended,
   reactPlugin.configs.flat['jsx-runtime'], // Add this if you are using React 17+
   {
+    // Settings for eslint-plugin-react
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+  },
+  {
     // Import specific config
     files: ['packages/cli/src/**/*.{ts,tsx}'], // Target only TS/TSX in the cli package
     plugins: {


### PR DESCRIPTION
Explicitly set the React version to detect in the ESLint configuration. This resolves warnings encountered during the `npm run preflight` script by ensuring that eslint-plugin-react can automatically determine the React version in use, preventing potential linting errors or misconfigurations related to version-specific rules.