### PR TITLE
feat: Allow Esc to exit shell mode

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -189,6 +189,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           return true;
         }
         if (key.escape) {
+          if (shellModeActive) {
+            setShellModeActive(false);
+            return;
+          }
           completion.resetCompletionState();
           return;
         }

--- a/packages/cli/src/ui/components/ShellModeIndicator.tsx
+++ b/packages/cli/src/ui/components/ShellModeIndicator.tsx
@@ -12,7 +12,7 @@ export const ShellModeIndicator: React.FC = () => (
   <Box>
     <Text color={Colors.AccentYellow}>
       shell mode enabled
-      <Text color={Colors.SubtleComment}> (! to toggle)</Text>
+      <Text color={Colors.SubtleComment}> (esc to disable)</Text>
     </Text>
   </Box>
 );


### PR DESCRIPTION
- Update InputPrompt.tsx to handle Esc key for exiting shell mode.
- Modify ShellModeIndicator.tsx to reflect the new keybinding. Fixes https://buganizer.corp.google.com/issues/419087952