### PR TITLE
fix(cli): Handle VSCode Shift+Enter in text buffer

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -508,6 +508,12 @@ describe('useTextBuffer', () => {
       act(() => result.current.handleInput(textWithAnsi, {}));
       expect(getBufferState(result).text).toBe('Hello World');
     });
+
+    it('should handle VSCode terminal Shift+Enter as newline', () => {
+      const { result } = renderHook(() => useTextBuffer({ viewport }));
+      act(() => result.current.handleInput('\r', {})); // Simulates Shift+Enter in VSCode terminal
+      expect(getBufferState(result).lines).toEqual(['', '']);
+    });
   });
 
   // More tests would be needed for:

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1151,7 +1151,13 @@ export function useTextBuffer({
 
       if (key['escape']) return false;
 
-      if (key['return'] || input === '\r' || input === '\n') newline();
+      if (
+        key['return'] ||
+        input === '\r' ||
+        input === '\n' ||
+        input === '\\\r' // VSCode terminal represents shift + enter this way
+      )
+        newline();
       else if (key['leftArrow'] && !key['meta'] && !key['ctrl'] && !key['alt'])
         move('left');
       else if (key['ctrl'] && input === 'b') move('left');


### PR DESCRIPTION
- The text buffer now correctly interprets `\\\r` (produced by Shift+Enter in the VSCode terminal) as a newline character.
- Added a corresponding test case to `text-buffer.test.ts`.
- Without this change the VSCode terminal would enter a `\` at the end of each newline.

Fixes https://buganizer.corp.google.com/issues/418505364