### PR TITLE
switch to spawn for shell mode

### DIFF
--- a/packages/server/src/tools/shell.ts
+++ b/packages/server/src/tools/shell.ts
@@ -178,6 +178,8 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
     let error: Error | null = null;
     shell.on('error', (err: Error) => {
       error = err;
+      // remove wrapper from user's command in error message
+      error.message = error.message.replace(command, params.command);
     });
 
     let code: number | null = null;


### PR DESCRIPTION
- fixes bug where interactive commands would hang with a message as if model was being invoked
- opens door to potentially handling interactive commands in subsequent changes
- maintain ability to inject exec-like functions for testing
- improved error messages in all cases