### PR TITLE
Fix: Prevent hang in large directories by using BFS for getFolderStru…

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -144,7 +144,7 @@ async function collectDownwardGeminiFiles(
 
   if (debugMode)
     logger.debug(
-      `Scanning downward for GEMINI.md files in: ${directory} (scanned: ${scannedDirCount.count}/${maxScanDirs})`,
+      `Scanning downward for ${GEMINI_MD_FILENAME} files in: ${directory} (scanned: ${scannedDirCount.count}/${maxScanDirs})`,
     );
   const collectedPaths: string[] = [];
   try {
@@ -170,11 +170,13 @@ async function collectDownwardGeminiFiles(
           await fs.access(fullPath, fsSync.constants.R_OK);
           collectedPaths.push(fullPath);
           if (debugMode)
-            logger.debug(`Found readable downward GEMINI.md: ${fullPath}`);
+            logger.debug(
+              `Found readable downward ${GEMINI_MD_FILENAME}: ${fullPath}`,
+            );
         } catch {
           if (debugMode)
             logger.debug(
-              `Downward GEMINI.md not readable, skipping: ${fullPath}`,
+              `Downward ${GEMINI_MD_FILENAME} not readable, skipping: ${fullPath}`,
             );
         }
       }
@@ -202,18 +204,22 @@ export async function getGeminiMdFilePaths(
   const paths: string[] = [];
 
   if (debugMode)
-    logger.debug(`Searching for GEMINI.md starting from CWD: ${resolvedCwd}`);
+    logger.debug(
+      `Searching for ${GEMINI_MD_FILENAME} starting from CWD: ${resolvedCwd}`,
+    );
   if (debugMode) logger.debug(`User home directory: ${resolvedHome}`);
 
   try {
     await fs.access(globalMemoryPath, fsSync.constants.R_OK);
     paths.push(globalMemoryPath);
     if (debugMode)
-      logger.debug(`Found readable global GEMINI.md: ${globalMemoryPath}`);
+      logger.debug(
+        `Found readable global ${GEMINI_MD_FILENAME}: ${globalMemoryPath}`,
+      );
   } catch {
     if (debugMode)
       logger.debug(
-        `Global GEMINI.md not found or not readable: ${globalMemoryPath}`,
+        `Global ${GEMINI_MD_FILENAME} not found or not readable: ${globalMemoryPath}`,
       );
   }
 
@@ -231,7 +237,9 @@ export async function getGeminiMdFilePaths(
     currentDir !== path.dirname(currentDir)
   ) {
     if (debugMode)
-      logger.debug(`Checking for GEMINI.md in (upward scan): ${currentDir}`);
+      logger.debug(
+        `Checking for ${GEMINI_MD_FILENAME} in (upward scan): ${currentDir}`,
+      );
     if (currentDir === path.join(resolvedHome, GEMINI_CONFIG_DIR)) {
       if (debugMode)
         logger.debug(`Skipping check inside global config dir: ${currentDir}`);
@@ -242,11 +250,13 @@ export async function getGeminiMdFilePaths(
       await fs.access(potentialPath, fsSync.constants.R_OK);
       upwardPaths.unshift(potentialPath);
       if (debugMode)
-        logger.debug(`Found readable upward GEMINI.md: ${potentialPath}`);
+        logger.debug(
+          `Found readable upward ${GEMINI_MD_FILENAME}: ${potentialPath}`,
+        );
     } catch {
       if (debugMode)
         logger.debug(
-          `Upward GEMINI.md not found or not readable in: ${currentDir}`,
+          `Upward ${GEMINI_MD_FILENAME} not found or not readable in: ${currentDir}`,
         );
     }
     const parentDir = path.dirname(currentDir);
@@ -273,7 +283,7 @@ export async function getGeminiMdFilePaths(
   downwardPaths.sort();
   if (debugMode && downwardPaths.length > 0)
     logger.debug(
-      `Found downward GEMINI.md files (sorted): ${JSON.stringify(downwardPaths)}`,
+      `Found downward ${GEMINI_MD_FILENAME} files (sorted): ${JSON.stringify(downwardPaths)}`,
     );
   for (const dPath of downwardPaths) {
     if (!paths.includes(dPath)) {
@@ -283,7 +293,7 @@ export async function getGeminiMdFilePaths(
 
   if (debugMode)
     logger.debug(
-      `Final ordered GEMINI.md paths to read: ${JSON.stringify(paths)}`,
+      `Final ordered ${GEMINI_MD_FILENAME} paths to read: ${JSON.stringify(paths)}`,
     );
   return paths;
 }
@@ -309,7 +319,7 @@ async function readGeminiMdFiles(
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       logger.warn(
-        `Warning: Could not read GEMINI.md file at ${filePath}. Error: ${message}`,
+        `Warning: Could not read ${GEMINI_MD_FILENAME} file at ${filePath}. Error: ${message}`,
       );
       results.push({ filePath, content: null });
       if (debugMode) logger.debug(`Failed to read: ${filePath}`);

--- a/packages/server/src/utils/getFolderStructure.test.ts
+++ b/packages/server/src/utils/getFolderStructure.test.ts
@@ -1,0 +1,278 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import fsPromises from 'fs/promises';
+import { Dirent as FSDirent } from 'fs';
+import * as nodePath from 'path';
+import { getFolderStructure } from './getFolderStructure.js';
+
+vi.mock('path', async (importOriginal) => {
+  const original = (await importOriginal()) as typeof nodePath;
+  return {
+    ...original,
+    resolve: vi.fn((str) => str),
+    // Other path functions (basename, join, normalize, etc.) will use original implementation
+  };
+});
+
+vi.mock('fs/promises');
+
+// Import 'path' again here, it will be the mocked version
+import * as path from 'path';
+
+// Helper to create Dirent-like objects for mocking fs.readdir
+const createDirent = (name: string, type: 'file' | 'dir'): FSDirent => ({
+  name,
+  isFile: () => type === 'file',
+  isDirectory: () => type === 'dir',
+  isBlockDevice: () => false,
+  isCharacterDevice: () => false,
+  isSymbolicLink: () => false,
+  isFIFO: () => false,
+  isSocket: () => false,
+  parentPath: '',
+  path: '',
+});
+
+describe('getFolderStructure', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // path.resolve is now a vi.fn() due to the top-level vi.mock.
+    // We ensure its implementation is set for each test (or rely on the one from vi.mock).
+    // vi.resetAllMocks() clears call history but not the implementation set by vi.fn() in vi.mock.
+    // If we needed to change it per test, we would do it here:
+    (path.resolve as Mock).mockImplementation((str: string) => str);
+
+    // Re-apply/define the mock implementation for fsPromises.readdir for each test
+    (fsPromises.readdir as Mock).mockImplementation(
+      async (dirPath: string | Buffer | URL) => {
+        // path.normalize here will use the mocked path module.
+        // Since normalize is spread from original, it should be the real one.
+        const normalizedPath = path.normalize(dirPath.toString());
+        if (mockFsStructure[normalizedPath]) {
+          return mockFsStructure[normalizedPath];
+        }
+        throw Object.assign(
+          new Error(
+            `ENOENT: no such file or directory, scandir '${normalizedPath}'`,
+          ),
+          { code: 'ENOENT' },
+        );
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks(); // Restores spies (like fsPromises.readdir) and resets vi.fn mocks (like path.resolve)
+  });
+
+  const mockFsStructure: Record<string, FSDirent[]> = {
+    '/testroot': [
+      createDirent('file1.txt', 'file'),
+      createDirent('subfolderA', 'dir'),
+      createDirent('emptyFolder', 'dir'),
+      createDirent('.hiddenfile', 'file'),
+      createDirent('node_modules', 'dir'),
+    ],
+    '/testroot/subfolderA': [
+      createDirent('fileA1.ts', 'file'),
+      createDirent('fileA2.js', 'file'),
+      createDirent('subfolderB', 'dir'),
+    ],
+    '/testroot/subfolderA/subfolderB': [createDirent('fileB1.md', 'file')],
+    '/testroot/emptyFolder': [],
+    '/testroot/node_modules': [createDirent('somepackage', 'dir')],
+    '/testroot/manyFilesFolder': Array.from({ length: 10 }, (_, i) =>
+      createDirent(`file-${i}.txt`, 'file'),
+    ),
+    '/testroot/manyFolders': Array.from({ length: 5 }, (_, i) =>
+      createDirent(`folder-${i}`, 'dir'),
+    ),
+    ...Array.from({ length: 5 }, (_, i) => ({
+      [`/testroot/manyFolders/folder-${i}`]: [
+        createDirent('child.txt', 'file'),
+      ],
+    })).reduce((acc, val) => ({ ...acc, ...val }), {}),
+    '/testroot/deepFolders': [createDirent('level1', 'dir')],
+    '/testroot/deepFolders/level1': [createDirent('level2', 'dir')],
+    '/testroot/deepFolders/level1/level2': [createDirent('level3', 'dir')],
+    '/testroot/deepFolders/level1/level2/level3': [
+      createDirent('file.txt', 'file'),
+    ],
+  };
+
+  it('should return basic folder structure', async () => {
+    const structure = await getFolderStructure('/testroot/subfolderA');
+    const expected = `
+Showing up to 200 items (files + folders).
+
+/testroot/subfolderA/
+├───fileA1.ts
+├───fileA2.js
+└───subfolderB/
+    └───fileB1.md
+`.trim();
+    expect(structure.trim()).toBe(expected);
+  });
+
+  it('should handle an empty folder', async () => {
+    const structure = await getFolderStructure('/testroot/emptyFolder');
+    const expected = `
+Showing up to 200 items (files + folders).
+
+/testroot/emptyFolder/
+`.trim();
+    expect(structure.trim()).toBe(expected.trim());
+  });
+
+  it('should ignore folders specified in ignoredFolders (default)', async () => {
+    const structure = await getFolderStructure('/testroot');
+    const expected = `
+Showing up to 200 items (files + folders). Folders or files indicated with ... contain more items not shown, were ignored, or the display limit (200 items) was reached.
+
+/testroot/
+├───.hiddenfile
+├───file1.txt
+├───emptyFolder/
+├───node_modules/...
+└───subfolderA/
+    ├───fileA1.ts
+    ├───fileA2.js
+    └───subfolderB/
+        └───fileB1.md
+`.trim();
+    expect(structure.trim()).toBe(expected);
+  });
+
+  it('should ignore folders specified in custom ignoredFolders', async () => {
+    const structure = await getFolderStructure('/testroot', {
+      ignoredFolders: new Set(['subfolderA', 'node_modules']),
+    });
+    const expected = `
+Showing up to 200 items (files + folders). Folders or files indicated with ... contain more items not shown, were ignored, or the display limit (200 items) was reached.
+
+/testroot/
+├───.hiddenfile
+├───file1.txt
+├───emptyFolder/
+├───node_modules/...
+└───subfolderA/...
+`.trim();
+    expect(structure.trim()).toBe(expected);
+  });
+
+  it('should filter files by fileIncludePattern', async () => {
+    const structure = await getFolderStructure('/testroot/subfolderA', {
+      fileIncludePattern: /\.ts$/,
+    });
+    const expected = `
+Showing up to 200 items (files + folders).
+
+/testroot/subfolderA/
+├───fileA1.ts
+└───subfolderB/
+`.trim();
+    expect(structure.trim()).toBe(expected);
+  });
+
+  it('should handle maxItems truncation for files within a folder', async () => {
+    const structure = await getFolderStructure('/testroot/subfolderA', {
+      maxItems: 3,
+    });
+    const expected = `
+Showing up to 3 items (files + folders).
+
+/testroot/subfolderA/
+├───fileA1.ts
+├───fileA2.js
+└───subfolderB/
+`.trim();
+    expect(structure.trim()).toBe(expected);
+  });
+
+  it('should handle maxItems truncation for subfolders', async () => {
+    const structure = await getFolderStructure('/testroot/manyFolders', {
+      maxItems: 4,
+    });
+    const expectedRevised = `
+Showing up to 4 items (files + folders). Folders or files indicated with ... contain more items not shown, were ignored, or the display limit (4 items) was reached.
+
+/testroot/manyFolders/
+├───folder-0/
+├───folder-1/
+├───folder-2/
+├───folder-3/
+└───...
+`.trim();
+    expect(structure.trim()).toBe(expectedRevised);
+  });
+
+  it('should handle maxItems that only allows the root folder itself', async () => {
+    const structure = await getFolderStructure('/testroot/subfolderA', {
+      maxItems: 1,
+    });
+    const expectedRevisedMax1 = `
+Showing up to 1 items (files + folders). Folders or files indicated with ... contain more items not shown, were ignored, or the display limit (1 items) was reached.
+
+/testroot/subfolderA/
+├───fileA1.ts
+├───...
+└───...
+`.trim();
+    expect(structure.trim()).toBe(expectedRevisedMax1);
+  });
+
+  it('should handle non-existent directory', async () => {
+    // Temporarily make fsPromises.readdir throw ENOENT for this specific path
+    const originalReaddir = fsPromises.readdir;
+    (fsPromises.readdir as Mock).mockImplementation(
+      async (p: string | Buffer | URL) => {
+        if (p === '/nonexistent') {
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        }
+        return originalReaddir(p);
+      },
+    );
+
+    const structure = await getFolderStructure('/nonexistent');
+    expect(structure).toContain(
+      'Error: Could not read directory "/nonexistent"',
+    );
+  });
+
+  it('should handle deep folder structure within limits', async () => {
+    const structure = await getFolderStructure('/testroot/deepFolders', {
+      maxItems: 10,
+    });
+    const expected = `
+Showing up to 10 items (files + folders).
+
+/testroot/deepFolders/
+└───level1/
+    └───level2/
+        └───level3/
+            └───file.txt
+`.trim();
+    expect(structure.trim()).toBe(expected);
+  });
+
+  it('should truncate deep folder structure if maxItems is small', async () => {
+    const structure = await getFolderStructure('/testroot/deepFolders', {
+      maxItems: 3,
+    });
+    const expected = `
+Showing up to 3 items (files + folders).
+
+/testroot/deepFolders/
+└───level1/
+    └───level2/
+        └───level3/
+`.trim();
+    expect(structure.trim()).toBe(expected);
+  });
+});

--- a/packages/server/src/utils/getFolderStructure.ts
+++ b/packages/server/src/utils/getFolderStructure.ts
@@ -67,7 +67,6 @@ async function readFullStructure(
   ];
   let currentItemCount = 0;
   // Count the root node itself as one item if we are not just listing its content
-  // currentItemCount++;
 
   const processedPaths = new Set<string>(); // To avoid processing same path if symlinks create loops
 

--- a/packages/server/src/utils/getFolderStructure.ts
+++ b/packages/server/src/utils/getFolderStructure.ts
@@ -37,286 +37,206 @@ interface FullFolderInfo {
   path: string;
   files: string[];
   subFolders: FullFolderInfo[];
-  totalChildren: number; // Total files + subfolders recursively
-  totalFiles: number; // Total files recursively
+  totalChildren: number; // Number of files and subfolders included from this folder during BFS scan
+  totalFiles: number; // Number of files included from this folder during BFS scan
   isIgnored?: boolean; // Flag to easily identify ignored folders later
-}
-
-/** Represents the potentially truncated structure used for display. */
-interface ReducedFolderNode {
-  name: string; // Folder name
-  isRoot?: boolean;
-  files: string[]; // File names, might end with '...'
-  subFolders: ReducedFolderNode[]; // Subfolders, might be truncated
   hasMoreFiles?: boolean; // Indicates if files were truncated for this specific folder
   hasMoreSubfolders?: boolean; // Indicates if subfolders were truncated for this specific folder
 }
 
+// --- Interfaces ---
+
 // --- Helper Functions ---
 
-/**
- * Recursively reads the full directory structure without truncation.
- * Ignored folders are included but not recursed into.
- * @param folderPath The absolute path to the folder.
- * @param options Configuration options.
- * @returns A promise resolving to the FullFolderInfo or null if access denied/not found.
- */
 async function readFullStructure(
-  folderPath: string,
+  rootPath: string,
   options: MergedFolderStructureOptions,
 ): Promise<FullFolderInfo | null> {
-  const name = path.basename(folderPath);
-  const folderInfo: Omit<FullFolderInfo, 'totalChildren' | 'totalFiles'> = {
-    name,
-    path: folderPath,
+  const rootName = path.basename(rootPath);
+  const rootNode: FullFolderInfo = {
+    name: rootName,
+    path: rootPath,
     files: [],
     subFolders: [],
-    isIgnored: false,
+    totalChildren: 0,
+    totalFiles: 0,
   };
 
-  let totalChildrenCount = 0;
-  let totalFileCount = 0;
+  const queue: Array<{ folderInfo: FullFolderInfo; currentPath: string }> = [
+    { folderInfo: rootNode, currentPath: rootPath },
+  ];
+  let currentItemCount = 0;
+  // Count the root node itself as one item if we are not just listing its content
+  // currentItemCount++;
 
-  try {
-    const entries = await fs.readdir(folderPath, { withFileTypes: true });
+  const processedPaths = new Set<string>(); // To avoid processing same path if symlinks create loops
 
-    // Process directories first
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const subFolderName = entry.name;
-        const subFolderPath = path.join(folderPath, subFolderName);
+  while (queue.length > 0) {
+    const { folderInfo, currentPath } = queue.shift()!;
 
-        // Check if the folder should be ignored
-        if (options.ignoredFolders.has(subFolderName)) {
-          // Add ignored folder node but don't recurse
-          const ignoredFolderInfo: FullFolderInfo = {
-            name: subFolderName,
-            path: subFolderPath,
-            files: [],
-            subFolders: [],
-            totalChildren: 0, // No children explored
-            totalFiles: 0, // No files explored
-            isIgnored: true,
-          };
-          folderInfo.subFolders.push(ignoredFolderInfo);
-          // Skip recursion for this folder
-          continue;
-        }
+    if (processedPaths.has(currentPath)) {
+      continue;
+    }
+    processedPaths.add(currentPath);
 
-        // If not ignored, recurse as before
-        const subFolderInfo = await readFullStructure(subFolderPath, options);
-        // Add non-empty folders OR explicitly ignored folders
-        if (
-          subFolderInfo &&
-          (subFolderInfo.totalChildren > 0 ||
-            subFolderInfo.files.length > 0 ||
-            subFolderInfo.isIgnored)
-        ) {
-          folderInfo.subFolders.push(subFolderInfo);
-        }
-      }
+    if (currentItemCount >= options.maxItems) {
+      // If the root itself caused us to exceed, we can't really show anything.
+      // Otherwise, this folder won't be processed further.
+      // The parent that queued this would have set its own hasMoreSubfolders flag.
+      continue;
     }
 
-    // Then process files (only if the current folder itself isn't marked as ignored)
+    let entries;
+    try {
+      entries = await fs.readdir(currentPath, { withFileTypes: true });
+    } catch (error: unknown) {
+      if (
+        isNodeError(error) &&
+        (error.code === 'EACCES' || error.code === 'ENOENT')
+      ) {
+        console.warn(
+          `Warning: Could not read directory ${currentPath}: ${error.message}`,
+        );
+        // Mark as errored or simply skip. For now, skip.
+        continue;
+      }
+      throw error; // Rethrow other errors
+    }
+
+    const filesInCurrentDir: string[] = [];
+    const subFoldersInCurrentDir: FullFolderInfo[] = [];
+
+    // Process files first in the current directory
     for (const entry of entries) {
       if (entry.isFile()) {
+        if (currentItemCount >= options.maxItems) {
+          folderInfo.hasMoreFiles = true;
+          break;
+        }
         const fileName = entry.name;
         if (
           !options.fileIncludePattern ||
           options.fileIncludePattern.test(fileName)
         ) {
-          folderInfo.files.push(fileName);
+          filesInCurrentDir.push(fileName);
+          currentItemCount++;
+          folderInfo.totalFiles++;
+          folderInfo.totalChildren++;
         }
       }
     }
+    folderInfo.files = filesInCurrentDir;
 
-    // Calculate totals *after* processing children
-    // Ignored folders contribute 0 to counts here because we didn't look inside.
-    totalFileCount =
-      folderInfo.files.length +
-      folderInfo.subFolders.reduce((sum, sf) => sum + sf.totalFiles, 0);
-    // Count the ignored folder itself as one child item in the parent's count.
-    totalChildrenCount =
-      folderInfo.files.length +
-      folderInfo.subFolders.length +
-      folderInfo.subFolders.reduce((sum, sf) => sum + sf.totalChildren, 0);
-  } catch (error: unknown) {
-    if (
-      isNodeError(error) &&
-      (error.code === 'EACCES' || error.code === 'ENOENT')
-    ) {
-      console.warn(
-        `Warning: Could not read directory ${folderPath}: ${error.message}`,
-      );
-      return null;
-    }
-    throw error;
-  }
-
-  return {
-    ...folderInfo,
-    totalChildren: totalChildrenCount,
-    totalFiles: totalFileCount,
-  };
-}
-
-/**
- * Reduces the full folder structure based on the maxItems limit using BFS.
- * Handles explicitly ignored folders by showing them with a truncation indicator.
- * @param fullInfo The complete folder structure info.
- * @param maxItems The maximum number of items (files + folders) to include.
- * @param ignoredFolders The set of folder names that were ignored during the read phase.
- * @returns The root node of the reduced structure.
- */
-function reduceStructure(
-  fullInfo: FullFolderInfo,
-  maxItems: number,
-): ReducedFolderNode {
-  const rootReducedNode: ReducedFolderNode = {
-    name: fullInfo.name,
-    files: [],
-    subFolders: [],
-    isRoot: true,
-  };
-  const queue: Array<{
-    original: FullFolderInfo;
-    reduced: ReducedFolderNode;
-  }> = [];
-
-  // Don't count the root itself towards the limit initially
-  queue.push({ original: fullInfo, reduced: rootReducedNode });
-  let itemCount = 0; // Count folders + files added to the reduced structure
-
-  while (queue.length > 0) {
-    const { original: originalFolder, reduced: reducedFolder } = queue.shift()!;
-
-    // If the folder being processed was itself marked as ignored (shouldn't happen for root)
-    if (originalFolder.isIgnored) {
-      continue;
-    }
-
-    // Process Files
-    let fileLimitReached = false;
-    for (const file of originalFolder.files) {
-      // Check limit *before* adding the file
-      if (itemCount >= maxItems) {
-        if (!fileLimitReached) {
-          reducedFolder.files.push(TRUNCATION_INDICATOR);
-          reducedFolder.hasMoreFiles = true;
-          fileLimitReached = true;
+    // Then process directories and queue them
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (currentItemCount >= options.maxItems) {
+          folderInfo.hasMoreSubfolders = true;
+          break;
         }
-        break;
-      }
-      reducedFolder.files.push(file);
-      itemCount++;
-    }
 
-    // Process Subfolders
-    let subfolderLimitReached = false;
-    for (const subFolder of originalFolder.subFolders) {
-      // Count the folder itself towards the limit
-      itemCount++;
-      if (itemCount > maxItems) {
-        if (!subfolderLimitReached) {
-          // Add a placeholder node ONLY if we haven't already added one
-          const truncatedSubfolderNode: ReducedFolderNode = {
-            name: subFolder.name,
-            files: [TRUNCATION_INDICATOR], // Generic truncation
+        const subFolderName = entry.name;
+        const subFolderPath = path.join(currentPath, subFolderName);
+
+        if (options.ignoredFolders.has(subFolderName)) {
+          const ignoredSubFolder: FullFolderInfo = {
+            name: subFolderName,
+            path: subFolderPath,
+            files: [],
             subFolders: [],
-            hasMoreFiles: true,
+            totalChildren: 0,
+            totalFiles: 0,
+            isIgnored: true,
           };
-          reducedFolder.subFolders.push(truncatedSubfolderNode);
-          reducedFolder.hasMoreSubfolders = true;
-          subfolderLimitReached = true;
+          subFoldersInCurrentDir.push(ignoredSubFolder);
+          currentItemCount++; // Count the ignored folder itself
+          folderInfo.totalChildren++; // Also counts towards parent's children
+          continue;
         }
-        continue; // Stop processing further subfolders for this parent
-      }
 
-      // Handle explicitly ignored folders identified during the read phase
-      if (subFolder.isIgnored) {
-        const ignoredReducedNode: ReducedFolderNode = {
-          name: subFolder.name,
-          files: [TRUNCATION_INDICATOR], // Indicate contents ignored/truncated
-          subFolders: [],
-          hasMoreFiles: true, // Mark as truncated
-        };
-        reducedFolder.subFolders.push(ignoredReducedNode);
-        // DO NOT add the ignored folder to the queue for further processing
-      } else {
-        // If not ignored and within limit, create the reduced node and add to queue
-        const reducedSubFolder: ReducedFolderNode = {
-          name: subFolder.name,
+        const subFolderNode: FullFolderInfo = {
+          name: subFolderName,
+          path: subFolderPath,
           files: [],
           subFolders: [],
+          totalChildren: 0,
+          totalFiles: 0,
         };
-        reducedFolder.subFolders.push(reducedSubFolder);
-        queue.push({ original: subFolder, reduced: reducedSubFolder });
+        subFoldersInCurrentDir.push(subFolderNode);
+        currentItemCount++;
+        folderInfo.totalChildren++; // Counts towards parent's children
+
+        // Add to queue for processing its children later
+        queue.push({ folderInfo: subFolderNode, currentPath: subFolderPath });
       }
     }
+    folderInfo.subFolders = subFoldersInCurrentDir;
   }
 
-  return rootReducedNode;
-}
+  // Recalculate totalChildren and totalFiles for rootNode based on its actual children
+  // as the BFS processes level by level, these counts are built up from bottom-up in a DFS sense
+  // but for BFS, we need to sum them up after the fact if we want accurate totals for parent nodes
+  // based on *actually included* children.
+  // However, the current item counting should reflect what's *added* to the structure.
+  // The `totalChildren` and `totalFiles` on each node will reflect what *it* contains directly
+  // or what was added from its children before truncation.
 
-/** Calculates the total number of items present in the reduced structure. */
-function countReducedItems(node: ReducedFolderNode): number {
-  let count = 0;
-  // Count files, treating '...' as one item if present
-  count += node.files.length;
+  // For now, the item count is the primary driver, and local totals are fine.
 
-  // Count subfolders and recursively count their contents
-  count += node.subFolders.length;
-  for (const sub of node.subFolders) {
-    // Check if it's a placeholder ignored/truncated node
-    const isTruncatedPlaceholder =
-      sub.files.length === 1 &&
-      sub.files[0] === TRUNCATION_INDICATOR &&
-      sub.subFolders.length === 0;
-
-    if (!isTruncatedPlaceholder) {
-      count += countReducedItems(sub);
-    }
-    // Don't add count for items *inside* the placeholder node itself.
-  }
-  return count;
+  return rootNode;
 }
 
 /**
- * Formats the reduced folder structure into a tree-like string.
+ * Reads the directory structure using BFS, respecting maxItems.
  * @param node The current node in the reduced structure.
  * @param indent The current indentation string.
  * @param isLast Sibling indicator.
  * @param builder Array to build the string lines.
  */
-function formatReducedStructure(
-  node: ReducedFolderNode,
+function formatStructure(
+  node: FullFolderInfo,
   indent: string,
   isLast: boolean,
+  isRoot: boolean, // Added to handle root node name printing
   builder: string[],
 ): void {
   const connector = isLast ? '└───' : '├───';
   const linePrefix = indent + connector;
 
-  // Don't print the root node's name directly, only its contents
-  if (!node.isRoot) {
-    builder.push(`${linePrefix}${node.name}/`);
+  // Don't print the root node's name directly, only its contents, unless it's an ignored root
+  if (!isRoot || node.isIgnored) {
+    builder.push(
+      `${linePrefix}${node.name}/${node.isIgnored ? TRUNCATION_INDICATOR : ''}`,
+    );
   }
 
-  const childIndent = indent + (isLast || node.isRoot ? '    ' : '│   '); // Use " " if last, "│" otherwise
+  const childIndent = indent + (isLast || isRoot ? '    ' : '│   ');
 
   // Render files
   const fileCount = node.files.length;
   for (let i = 0; i < fileCount; i++) {
-    const isLastFile = i === fileCount - 1 && node.subFolders.length === 0;
+    const isLastFile =
+      i === fileCount - 1 &&
+      node.subFolders.length === 0 &&
+      !node.hasMoreSubfolders;
     const fileConnector = isLastFile ? '└───' : '├───';
     builder.push(`${childIndent}${fileConnector}${node.files[i]}`);
+  }
+  if (node.hasMoreFiles) {
+    const isLastFile = node.subFolders.length === 0 && !node.hasMoreSubfolders;
+    const fileConnector = isLastFile ? '└───' : '├───';
+    builder.push(`${childIndent}${fileConnector}${TRUNCATION_INDICATOR}`);
   }
 
   // Render subfolders
   const subFolderCount = node.subFolders.length;
   for (let i = 0; i < subFolderCount; i++) {
-    const isLastSub = i === subFolderCount - 1;
-    formatReducedStructure(node.subFolders[i], childIndent, isLastSub, builder);
+    const isLastSub = i === subFolderCount - 1 && !node.hasMoreSubfolders;
+    formatStructure(node.subFolders[i], childIndent, isLastSub, false, builder);
+  }
+  if (node.hasMoreSubfolders) {
+    // Create a dummy node for the truncation indicator to be formatted
+    builder.push(`${childIndent}└───${TRUNCATION_INDICATOR}`);
   }
 }
 
@@ -343,40 +263,48 @@ export async function getFolderStructure(
   };
 
   try {
-    // 1. Read the full structure (includes ignored folders marked as such)
-    const fullInfo = await readFullStructure(resolvedPath, mergedOptions);
+    // 1. Read the structure using BFS, respecting maxItems
+    const structureRoot = await readFullStructure(resolvedPath, mergedOptions);
 
-    if (!fullInfo) {
+    if (!structureRoot) {
       return `Error: Could not read directory "${resolvedPath}". Check path and permissions.`;
     }
 
-    // 2. Reduce the structure (handles ignored folders specifically)
-    const reducedRoot = reduceStructure(fullInfo, mergedOptions.maxItems);
-
-    // 3. Count items in the *reduced* structure for the summary
-    const rootNodeItselfCount = 0; // Don't count the root node in the items summary
-    const reducedItemCount =
-      countReducedItems(reducedRoot) - rootNodeItselfCount;
-
-    // 4. Format the reduced structure into a string
+    // 2. Format the structure into a string
     const structureLines: string[] = [];
-    formatReducedStructure(reducedRoot, '', true, structureLines);
+    // Pass true for isRoot for the initial call
+    formatStructure(structureRoot, '', true, true, structureLines);
 
-    // 5. Build the final output string
+    // 3. Build the final output string
     const displayPath = resolvedPath.replace(/\\/g, '/');
-    const totalOriginalChildren = fullInfo.totalChildren;
 
     let disclaimer = '';
-    // Check if any truncation happened OR if ignored folders were present
-    if (
-      reducedItemCount < totalOriginalChildren ||
-      fullInfo.subFolders.some((sf) => sf.isIgnored)
-    ) {
-      disclaimer = `Folders or files indicated with ${TRUNCATION_INDICATOR} contain more items not shown or were ignored.`;
+    // Check if truncation occurred anywhere or if ignored folders are present.
+    // A simple check: if any node indicates more files/subfolders, or is ignored.
+    let truncationOccurred = false;
+    function checkForTruncation(node: FullFolderInfo) {
+      if (node.hasMoreFiles || node.hasMoreSubfolders || node.isIgnored) {
+        truncationOccurred = true;
+      }
+      if (!truncationOccurred) {
+        for (const sub of node.subFolders) {
+          checkForTruncation(sub);
+          if (truncationOccurred) break;
+        }
+      }
+    }
+    checkForTruncation(structureRoot);
+
+    if (truncationOccurred) {
+      disclaimer = `Folders or files indicated with ${TRUNCATION_INDICATOR} contain more items not shown, were ignored, or the display limit (${mergedOptions.maxItems} items) was reached.`;
     }
 
+    // Count the number of items that will be displayed for the summary.
+    // This should ideally match the number of lines generated by formatStructure, plus files inside displayed folders.
+    // The `currentItemCount` from `readFullStructure` is the most accurate count of processed items.
+    // For the summary, we can state we are showing *up to* maxItems.
     const summary =
-      `Showing ${reducedItemCount} of ${totalOriginalChildren} items (files + folders). ${disclaimer}`.trim();
+      `Showing up to ${mergedOptions.maxItems} items (files + folders). ${disclaimer}`.trim();
 
     return `${summary}\n\n${displayPath}/\n${structureLines.join('\n')}`;
   } catch (error: unknown) {

--- a/packages/server/src/utils/getFolderStructure.ts
+++ b/packages/server/src/utils/getFolderStructure.ts
@@ -196,7 +196,7 @@ function formatStructure(
   node: FullFolderInfo,
   indent: string,
   isLast: boolean,
-  isRoot: boolean, // Added to handle root node name printing
+  isRoot: boolean,
   builder: string[],
 ): void {
   const connector = isLast ? '└───' : '├───';

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "lib": ["DOM", "DOM.Iterable", "ES2021"],
-    "composite": true
+    "composite": true,
+    "types": ["node", "vitest/globals"]
   },
   "include": ["index.ts", "src/**/*.ts", "src/**/*.json"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "module": "NodeNext",
     "moduleResolution": "nodenext",
     "target": "es2022",
-    "types": ["node"]
+    "types": ["node", "vitest/globals"]
   }
 }


### PR DESCRIPTION
…cture

Refactors `getFolderStructure` to use a Breadth-First Search (BFS) when reading directory contents. This prevents the application from hanging in directories with a very large number of files or deep nesting when the `maxItems` limit is approached.

The previous Depth-First Search (DFS) could exhaustively explore a single deep branch before hitting `maxItems`, leading to long delays. The new BFS approach ensures a more balanced traversal, providing a wider view of the directory structure within the item limit.

Changes include:
- Replaced recursive DFS `readFullStructure` with an iterative BFS implementation.
- Removed the now redundant `reduceStructure` function.
- Updated `formatStructure` to work with the new BFS output and handle truncation indicators (`hasMoreFiles`, `hasMoreSubfolders`).
- Adjusted the summary message in `getFolderStructure`.