### PR TITLE
Fix: Align WebSearchTool API key handling with GeminiClient

### DIFF
--- a/packages/server/src/tools/web-search.ts
+++ b/packages/server/src/tools/web-search.ts
@@ -83,13 +83,11 @@ export class WebSearchTool extends BaseTool<
       },
     );
 
-    const apiKey = this.config.getApiKey();
-    if (!apiKey) {
-      throw new Error(
-        'Google AI API key is not configured. WebSearchTool cannot be initialized.',
-      );
-    }
-    this.ai = new GoogleGenAI({ apiKey });
+    const apiKeyFromConfig = this.config.getApiKey();
+    // Initialize GoogleGenAI, allowing fallback to environment variables for API key
+    this.ai = new GoogleGenAI({
+      apiKey: apiKeyFromConfig === '' ? undefined : apiKeyFromConfig,
+    });
     this.modelName = this.config.getModel();
   }
 


### PR DESCRIPTION
This change modifies the WebSearchTool to initialize the GoogleGenAI client in the same way as GeminiClient. It now allows the API key to be sourced from environment variables if not explicitly provided in the Config object.

This resolves an issue where WebSearchTool would fail to initialize if the API key was only present in the environment, unlike GeminiClient which could handle this scenario.

Fixes #473