### PR TITLE
fix: forward entire tool call confirmation object through useToolScheduler

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -10,7 +10,6 @@ import { DiffRenderer } from './DiffRenderer.js';
 import { Colors } from '../../colors.js';
 import {
   ToolCallConfirmationDetails,
-  ToolEditConfirmationDetails,
   ToolConfirmationOutcome,
   ToolExecuteConfirmationDetails,
 } from '@gemini-code/server';
@@ -21,12 +20,6 @@ import {
 
 export interface ToolConfirmationMessageProps {
   confirmationDetails: ToolCallConfirmationDetails;
-}
-
-function isEditDetails(
-  props: ToolCallConfirmationDetails,
-): props is ToolEditConfirmationDetails {
-  return (props as ToolEditConfirmationDetails).fileName !== undefined;
 }
 
 export const ToolConfirmationMessage: React.FC<
@@ -49,7 +42,7 @@ export const ToolConfirmationMessage: React.FC<
     RadioSelectItem<ToolConfirmationOutcome>
   >();
 
-  if (isEditDetails(confirmationDetails)) {
+  if (confirmationDetails.type === 'edit') {
     // Body content is now the DiffRenderer, passing filename to it
     // The bordered box is removed from here and handled within DiffRenderer
     bodyContent = (

--- a/packages/server/src/tools/edit.ts
+++ b/packages/server/src/tools/edit.ts
@@ -291,6 +291,7 @@ Expectation for parameters:
       { context: 3 },
     );
     const confirmationDetails: ToolEditConfirmationDetails = {
+      type: 'edit',
       title: `Confirm Edit: ${shortenPath(makeRelative(params.file_path, this.rootDirectory))}`,
       fileName,
       fileDiff,

--- a/packages/server/src/tools/shell.ts
+++ b/packages/server/src/tools/shell.ts
@@ -107,6 +107,7 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
       return false; // already approved and whitelisted
     }
     const confirmationDetails: ToolExecuteConfirmationDetails = {
+      type: 'exec',
       title: 'Confirm Shell Command',
       command: params.command,
       rootCommand,

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -171,25 +171,23 @@ export interface FileDiff {
   fileName: string;
 }
 
-export interface ToolCallConfirmationDetailsDefault {
+export interface ToolEditConfirmationDetails {
+  type: 'edit';
   title: string;
   onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
-}
-
-export interface ToolEditConfirmationDetails
-  extends ToolCallConfirmationDetailsDefault {
   fileName: string;
   fileDiff: string;
 }
 
-export interface ToolExecuteConfirmationDetails
-  extends ToolCallConfirmationDetailsDefault {
+export interface ToolExecuteConfirmationDetails {
+  type: 'exec';
+  title: string;
+  onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
   command: string;
   rootCommand: string;
 }
 
 export type ToolCallConfirmationDetails =
-  | ToolCallConfirmationDetailsDefault
   | ToolEditConfirmationDetails
   | ToolExecuteConfirmationDetails;
 

--- a/packages/server/src/tools/write-file.ts
+++ b/packages/server/src/tools/write-file.ts
@@ -158,6 +158,7 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
     );
 
     const confirmationDetails: ToolEditConfirmationDetails = {
+      type: 'edit',
       title: `Confirm Write: ${shortenPath(relativePath)}`,
       fileName,
       fileDiff,

--- a/packages/server/src/utils/nextSpeakerChecker.ts
+++ b/packages/server/src/utils/nextSpeakerChecker.ts
@@ -94,7 +94,7 @@ export async function checkNextSpeaker(
     return null;
   } catch (error) {
     console.warn(
-      'Failed to talk to Gemiin endpoint when seeing if conversation should continue.',
+      'Failed to talk to Gemini endpoint when seeing if conversation should continue.',
       error,
     );
     return null;


### PR DESCRIPTION
file diffs were not getting displayed in the tool call confirmation boxes