### PR TITLE
Refactor: Improve console error/log display in CLI

### DIFF
--- a/packages/cli/src/ui/components/ConsoleSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ConsoleSummaryDisplay.tsx
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { Colors } from '../colors.js';
+
+interface ConsoleSummaryDisplayProps {
+  errorCount: number;
+  // logCount is not currently in the plan to be displayed in summary
+}
+
+export const ConsoleSummaryDisplay: React.FC<ConsoleSummaryDisplayProps> = ({
+  errorCount,
+}) => {
+  if (errorCount === 0) {
+    return null;
+  }
+
+  const errorIcon = '\u2716'; // Heavy multiplication x (✖)
+
+  return (
+    <Box>
+      {errorCount > 0 && (
+        <Text color={Colors.AccentRed}>
+          {errorIcon} {errorCount} error{errorCount > 1 ? 's' : ''}{' '}
+          <Text color={Colors.SubtleComment}>(CTRL-D for details)</Text>
+        </Text>
+      )}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/DetailedMessagesDisplay.tsx
+++ b/packages/cli/src/ui/components/DetailedMessagesDisplay.tsx
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { Colors } from '../colors.js';
+import { ConsoleMessageItem } from '../types.js';
+
+interface DetailedMessagesDisplayProps {
+  messages: ConsoleMessageItem[];
+  // debugMode is not needed here if App.tsx filters debug messages before passing them.
+  // If DetailedMessagesDisplay should handle filtering, add debugMode prop.
+}
+
+export const DetailedMessagesDisplay: React.FC<
+  DetailedMessagesDisplayProps
+> = ({ messages }) => {
+  if (messages.length === 0) {
+    return null; // Don't render anything if there are no messages
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      marginTop={1}
+      borderStyle="round"
+      borderColor={Colors.SubtleComment}
+      paddingX={1}
+    >
+      <Box marginBottom={1}>
+        <Text bold color={Colors.Foreground}>
+          Debug Console{' '}
+          <Text color={Colors.SubtleComment}>(CTRL-D to close)</Text>
+        </Text>
+      </Box>
+      {messages.map((msg, index) => {
+        let textColor = Colors.Foreground;
+        let icon = '\u2139'; // Information source (ℹ)
+
+        switch (msg.type) {
+          case 'warn':
+            textColor = Colors.AccentYellow;
+            icon = '\u26A0'; // Warning sign (⚠)
+            break;
+          case 'error':
+            textColor = Colors.AccentRed;
+            icon = '\u2716'; // Heavy multiplication x (✖)
+            break;
+          case 'debug':
+            textColor = Colors.SubtleComment; // Or Colors.Gray
+            icon = '\u1F50D'; // Left-pointing magnifying glass (????)
+            break;
+          case 'log':
+          default:
+            // Default textColor and icon are already set
+            break;
+        }
+
+        return (
+          <Box key={index} flexDirection="row">
+            <Text color={textColor}>{icon} </Text>
+            <Text color={textColor} wrap="wrap">
+              {msg.content}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import { Colors } from '../colors.js';
 import { shortenPath, tildeifyPath, Config } from '@gemini-code/server';
+import { ConsoleSummaryDisplay } from './ConsoleSummaryDisplay.js';
 
 interface FooterProps {
   config: Config;
@@ -15,6 +16,8 @@ interface FooterProps {
   debugMessage: string;
   cliVersion: string;
   corgiMode: boolean;
+  errorCount: number;
+  showErrorDetails: boolean;
 }
 
 export const Footer: React.FC<FooterProps> = ({
@@ -23,8 +26,10 @@ export const Footer: React.FC<FooterProps> = ({
   debugMessage,
   cliVersion,
   corgiMode,
+  errorCount,
+  showErrorDetails,
 }) => (
-  <Box marginTop={1}>
+  <Box marginTop={1} justifyContent="space-between" width="100%">
     <Box>
       <Text color={Colors.LightBlue}>
         {shortenPath(tildeifyPath(config.getTargetDir()), 70)}
@@ -56,8 +61,8 @@ export const Footer: React.FC<FooterProps> = ({
       )}
     </Box>
 
-    {/* Right Section: Gemini Label */}
-    <Box>
+    {/* Right Section: Gemini Label and Console Summary */}
+    <Box alignItems="center">
       <Text color={Colors.AccentBlue}> {config.getModel()} </Text>
       <Text color={Colors.SubtleComment}>| CLI {cliVersion} </Text>
       {corgiMode && (
@@ -69,6 +74,12 @@ export const Footer: React.FC<FooterProps> = ({
           <Text color={Colors.Foreground}>`)</Text>
           <Text color={Colors.AccentRed}>▼ </Text>
         </Text>
+      )}
+      {!showErrorDetails && errorCount > 0 && (
+        <Box>
+          <Text color={Colors.SubtleComment}>| </Text>
+          <ConsoleSummaryDisplay errorCount={errorCount} />
+        </Box>
       )}
     </Box>
   </Box>

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -119,3 +119,8 @@ export interface Message {
   content: string; // Renamed from text for clarity in this context
   timestamp: Date; // For consistency, though addItem might use its own timestamping
 }
+
+export interface ConsoleMessageItem {
+  type: 'log' | 'warn' | 'error' | 'debug';
+  content: string;
+}


### PR DESCRIPTION
This change refactors how console messages (errors, warnings, logs, debug output) are displayed in the CLI UI.

There is now a warning in the bottom right corner of the CLI with the number of errors if there are errors.
CTRL-D toggles showing and hiding a debug console showing the errors, warnings, and info.
@miguelsolorio please provide suggestions or submit follow up pull requests to make this more beautiful.
If this direction looks right I'll add some tests.
![Screenshot 2025-05-22 at 12 42 34 AM](https://github.com/user-attachments/assets/6354fa35-427d-4e77-ba90-f69739077fa0)
![Screenshot 2025-05-22 at 12 42 23 AM](https://github.com/user-attachments/assets/7784f737-d4fe-49c1-ab2b-7f48b7afef76)


Key changes:

- Introduces a summary display (`ConsoleSummaryDisplay.tsx`) that shows a count of errors and warnings when `showErrorDetails` is false (e.g., `(!) N errors occurred (F12 for info)`).
- Introduces a detailed display (`DetailedMessagesDisplay.tsx`) that lists all console messages with appropriate coloring when `showErrorDetails` is true.
- CTRL-D now toggles the `showErrorDetails` state in `App.tsx` to switch between the summary and detailed views.
- `ConsolePatcher.tsx` (formerly `ConsoleOutput.tsx`) has been refactored to no longer render messages directly. Instead, it calls an `onNewMessage` prop passed from `App.tsx`.
- `App.tsx` now manages the state for console messages and controls the visibility of the summary and detailed views.
- The old console output has been removed from `Footer.tsx`.
- Resolve
d various TypeScript and ESLint issues that arose during the refactoring, particularly around Ink key handling and type definitions