### PR TITLE
fix: synchronization between executed tools and turn loops

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -383,6 +383,7 @@ export const useGeminiStream = (
         toolCallRequests.push(event.value);
       } else if (event.type === ServerGeminiEventType.UserCancelled) {
         handleUserCancelledEvent(userMessageTimestamp);
+        cancel();
         return StreamProcessingStatus.UserCancelled;
       } else if (event.type === ServerGeminiEventType.Error) {
         handleErrorEvent(event.value, userMessageTimestamp);
@@ -393,12 +394,9 @@ export const useGeminiStream = (
     return StreamProcessingStatus.Completed;
   };
 
-  const streamingState: StreamingState = isResponding
-    ? StreamingState.Responding
-    : pendingToolCalls?.tools.some(
-          (t) => t.status === ToolCallStatus.Confirming,
-        )
-      ? StreamingState.WaitingForConfirmation
+  const streamingState: StreamingState =
+    isResponding || toolCalls.some((t) => t.status === 'awaiting_approval')
+      ? StreamingState.Responding
       : StreamingState.Idle;
 
   const submitQuery = useCallback(

--- a/packages/server/src/core/turn.ts
+++ b/packages/server/src/core/turn.ts
@@ -106,19 +106,15 @@ export type ServerGeminiStreamEvent =
 
 // A turn manages the agentic loop turn within the server context.
 export class Turn {
-  private pendingToolCalls: Array<{
+  readonly pendingToolCalls: Array<{
     callId: string;
     name: string;
     args: Record<string, unknown>;
   }>;
-  private fnResponses: Part[];
-  private confirmationDetails: ToolCallConfirmationDetails[];
   private debugResponses: GenerateContentResponse[];
 
   constructor(private readonly chat: Chat) {
     this.pendingToolCalls = [];
-    this.fnResponses = [];
-    this.confirmationDetails = [];
     this.debugResponses = [];
   }
   // The run method yields simpler events suitable for server logic
@@ -180,14 +176,6 @@ export class Turn {
     // Yield a request for the tool call, not the pending/confirming status
     const value: ToolCallRequestInfo = { callId, name, args };
     return { type: GeminiEventType.ToolCallRequest, value };
-  }
-
-  getConfirmationDetails(): ToolCallConfirmationDetails[] {
-    return this.confirmationDetails;
-  }
-
-  getFunctionResponses(): Part[] {
-    return this.fnResponses;
   }
 
   getDebugResponses(): GenerateContentResponse[] {


### PR DESCRIPTION
BUG=#485
- useToolScheduler:
  - use `Array.every` to check that all tools have been scheduled, and use `Promise.then()` to ensure we set tool status _before_ yielding the JS event loop inside the `forEach`
  - in a multi-item `toolCalls` array, the first item would go into `executing` state, that would trigger a re-render, this effect would run again, then we'd essentially have two threads/loops try to execute subsequent tool calls in the `toolCalls` array
- client.ts
  - with parallel function calls supported, the while loop would `continue` when some functions hadn't been run yet. the next prompt to gemini would be `Please continue`, but gemini is expecting the response for the function calls it requested on the previous loop
  - to decide whether gemini needs to continue, switched the `next_speaker` check to trigger on 0 pending tool calls
- Drive by change: use `Responding` state even when we're waiting confirmation to prevent the input prompt from appearing when we're not ready

