### PR TITLE
fix: add shell-quote to server deps

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -27,6 +27,7 @@
     "diff": "^7.0.0",
     "dotenv": "^16.4.7",
     "fast-glob": "^3.3.3",
+    "shell-quote": "^1.8.2",
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
this was breaking the prod sandbox. 

iiuc, it was because `npm pack` packages the cli and server packages separately, but only the cli package specified `shell-quote` in it's deps even though both use it