### PR TITLE
feat: add emphasis to tool confirmations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10403,6 +10403,7 @@
         "diff": "^7.0.0",
         "dotenv": "^16.4.7",
         "fast-glob": "^3.3.3",
+        "shell-quote": "^1.8.2",
         "sqlite3": "^5.1.7"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "bundle": "esbuild packages/cli/index.ts --bundle --outfile=bundle/gemini.js --platform=node --format=esm --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url); globalThis.__filename = require('url').fileURLToPath(import.meta.url); globalThis.__dirname = require('path').dirname(globalThis.__filename);\" && bash scripts/copy_bundle_assets.sh"
   },
   "devDependencies": {
+    "@types/mime-types": "^2.1.4",
     "@vitest/coverage-v8": "^3.1.1",
     "esbuild": "^0.25.4",
-    "@types/mime-types": "^2.1.4",
     "eslint": "^9.24.0",
     "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-import": "^2.31.0",

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -29,6 +29,8 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
 
   const staticHeight = /* border */ 2 + /* marginBottom */ 1;
 
+  // only prompt for tool approval on the first 'confirming' tool in the list
+  // note, after the CTA, this automatically moves over to the next 'confirming' tool
   const toolAwaitingApproval = useMemo(
     () => toolCalls.find((tc) => tc.status === ToolCallStatus.Confirming),
     [toolCalls],
@@ -50,27 +52,38 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
       borderColor={borderColor}
       marginBottom={1}
     >
-      {toolCalls.map((tool) => (
-        <Box key={tool.callId} flexDirection="column">
-          <ToolMessage
-            key={tool.callId}
-            callId={tool.callId}
-            name={tool.name}
-            description={tool.description}
-            resultDisplay={tool.resultDisplay}
-            status={tool.status}
-            confirmationDetails={tool.confirmationDetails}
-            availableTerminalHeight={availableTerminalHeight - staticHeight}
-          />
-          {tool.status === ToolCallStatus.Confirming &&
-            tool.callId === toolAwaitingApproval?.callId &&
-            tool.confirmationDetails && (
-              <ToolConfirmationMessage
+      {toolCalls.map((tool) => {
+        const isConfirming = toolAwaitingApproval?.callId === tool.callId;
+        return (
+          <Box key={tool.callId} flexDirection="column">
+            <Box flexDirection="row" alignItems="center">
+              <ToolMessage
+                callId={tool.callId}
+                name={tool.name}
+                description={tool.description}
+                resultDisplay={tool.resultDisplay}
+                status={tool.status}
                 confirmationDetails={tool.confirmationDetails}
-              ></ToolConfirmationMessage>
-            )}
-        </Box>
-      ))}
+                availableTerminalHeight={availableTerminalHeight - staticHeight}
+                emphasis={
+                  isConfirming
+                    ? 'high'
+                    : toolAwaitingApproval
+                      ? 'low'
+                      : 'medium'
+                }
+              />
+            </Box>
+            {tool.status === ToolCallStatus.Confirming &&
+              isConfirming &&
+              tool.confirmationDetails && (
+                <ToolConfirmationMessage
+                  confirmationDetails={tool.confirmationDetails}
+                />
+              )}
+          </Box>
+        );
+      })}
     </Box>
   );
 };


### PR DESCRIPTION
DEMO=http://screen/BwDbY28GCYq2gDA

- use a green circle to indicate the status of 'scheduled' (but not yet 'executing') tool calls
- de-emphasize the text for non-focused tool calls during confirmation/cancellation
- added a trailing left-arrow indicator to the focused item during confirmation/cancellation
- drive by change: fix useToolScheduler to account for some but not all tool calls getting cancelled