### PR TITLE
Refactor: Update streaming state logic to hide loader during confirmation

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -394,13 +394,15 @@ export const useGeminiStream = (
     return StreamProcessingStatus.Completed;
   };
 
-  const streamingState: StreamingState =
-    isResponding ||
-    toolCalls.some(
-      (t) => t.status === 'awaiting_approval' || t.status === 'executing',
-    )
-      ? StreamingState.Responding
-      : StreamingState.Idle;
+  const streamingState: StreamingState = (() => {
+    if (toolCalls.some((t) => t.status === 'awaiting_approval')) {
+      return StreamingState.WaitingForConfirmation;
+    }
+    if (isResponding || toolCalls.some((t) => t.status === 'executing')) {
+      return StreamingState.Responding;
+    }
+    return StreamingState.Idle;
+  })();
 
   const submitQuery = useCallback(
     async (query: PartListUnion) => {


### PR DESCRIPTION
- The streaming state logic in `useGeminiStream.ts` has been updated.
- Previously, the loading indicator was displayed even when the system was waiting for user confirmation on a tool call.
- This change introduces a `WaitingForConfirmation` state to ensure the loading indicator is hidden during these confirmation prompts, improving the user experience.

/cc @jacob314 feel free to undo this with your change if you need. Just getting this in to unblock my own workflow for now.