### PR TITLE
Fix bug updating the cursor after navigating history.

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -81,20 +81,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     [onSubmit, buffer, resetCompletionState],
   );
 
-  const onChangeAndMoveCursor = useCallback(
-    (newValue: string) => {
-      buffer.setText(newValue);
-      buffer.move('end');
-    },
-    [buffer],
-  );
-
   const inputHistory = useInputHistory({
     userMessages,
     onSubmit: handleSubmitAndClear,
     isActive: !completion.showSuggestions,
     currentQuery: buffer.text,
-    onChangeAndMoveCursor,
+    onChangeAndMoveCursor: buffer.setText,
   });
 
   const completionSuggestions = completion.suggestions;

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -86,7 +86,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     onSubmit: handleSubmitAndClear,
     isActive: !completion.showSuggestions,
     currentQuery: buffer.text,
-    onChangeAndMoveCursor: buffer.setText,
+    onChange: buffer.setText,
   });
 
   const completionSuggestions = completion.suggestions;

--- a/packages/cli/src/ui/hooks/useInputHistory.test.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.test.ts
@@ -1,0 +1,261 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { useInputHistory } from './useInputHistory.js';
+
+describe('useInputHistory', () => {
+  const mockOnSubmit = vi.fn();
+  const mockOnChangeAndMoveCursor = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const userMessages = ['message 1', 'message 2', 'message 3'];
+
+  it('should initialize with historyIndex -1 and empty originalQueryBeforeNav', () => {
+    const { result } = renderHook(() =>
+      useInputHistory({
+        userMessages: [],
+        onSubmit: mockOnSubmit,
+        isActive: true,
+        currentQuery: '',
+        onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+      }),
+    );
+
+    // Internal state is not directly testable, but we can infer from behavior.
+    // Attempting to navigate down should do nothing if historyIndex is -1.
+    act(() => {
+      result.current.navigateDown();
+    });
+    expect(mockOnChangeAndMoveCursor).not.toHaveBeenCalled();
+  });
+
+  describe('handleSubmit', () => {
+    it('should call onSubmit with trimmed value and reset history', () => {
+      const { result } = renderHook(() =>
+        useInputHistory({
+          userMessages,
+          onSubmit: mockOnSubmit,
+          isActive: true,
+          currentQuery: '  test query  ',
+          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSubmit('  submit value  ');
+      });
+
+      expect(mockOnSubmit).toHaveBeenCalledWith('submit value');
+      // Check if history is reset (e.g., by trying to navigate down)
+      act(() => {
+        result.current.navigateDown();
+      });
+      expect(mockOnChangeAndMoveCursor).not.toHaveBeenCalled();
+    });
+
+    it('should not call onSubmit if value is empty after trimming', () => {
+      const { result } = renderHook(() =>
+        useInputHistory({
+          userMessages,
+          onSubmit: mockOnSubmit,
+          isActive: true,
+          currentQuery: '',
+          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSubmit('   ');
+      });
+
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('navigateUp', () => {
+    it('should not navigate if isActive is false', () => {
+      const { result } = renderHook(() =>
+        useInputHistory({
+          userMessages,
+          onSubmit: mockOnSubmit,
+          isActive: false,
+          currentQuery: 'current',
+          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+        }),
+      );
+      act(() => {
+        const navigated = result.current.navigateUp();
+        expect(navigated).toBe(false);
+      });
+      expect(mockOnChangeAndMoveCursor).not.toHaveBeenCalled();
+    });
+
+    it('should not navigate if userMessages is empty', () => {
+      const { result } = renderHook(() =>
+        useInputHistory({
+          userMessages: [],
+          onSubmit: mockOnSubmit,
+          isActive: true,
+          currentQuery: 'current',
+          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+        }),
+      );
+      act(() => {
+        const navigated = result.current.navigateUp();
+        expect(navigated).toBe(false);
+      });
+      expect(mockOnChangeAndMoveCursor).not.toHaveBeenCalled();
+    });
+
+    it('should call onChangeAndMoveCursor with the last message when navigating up from initial state', () => {
+      const currentQuery = 'current query';
+      const { result } = renderHook(() =>
+        useInputHistory({
+          userMessages,
+          onSubmit: mockOnSubmit,
+          isActive: true,
+          currentQuery,
+          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+        }),
+      );
+
+      act(() => {
+        result.current.navigateUp();
+      });
+
+      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(userMessages[2]); // Last message
+    });
+
+    it('should store currentQuery as originalQueryBeforeNav on first navigateUp', () => {
+      const currentQuery = 'original user input';
+      const { result } = renderHook(() =>
+        useInputHistory({
+          userMessages,
+          onSubmit: mockOnSubmit,
+          isActive: true,
+          currentQuery,
+          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+        }),
+      );
+
+      act(() => {
+        result.current.navigateUp(); // historyIndex becomes 0
+      });
+      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(userMessages[2]);
+
+      // Navigate down to restore original query
+      act(() => {
+        result.current.navigateDown(); // historyIndex becomes -1
+      });
+      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(currentQuery);
+    });
+
+    it('should navigate through history messages on subsequent navigateUp calls', () => {
+      const { result } = renderHook(() =>
+        useInputHistory({
+          userMessages,
+          onSubmit: mockOnSubmit,
+          isActive: true,
+          currentQuery: '',
+          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+        }),
+      );
+
+      act(() => {
+        result.current.navigateUp(); // Navigates to 'message 3'
+      });
+      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(userMessages[2]);
+
+      act(() => {
+        result.current.navigateUp(); // Navigates to 'message 2'
+      });
+      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(userMessages[1]);
+
+      act(() => {
+        result.current.navigateUp(); // Navigates to 'message 1'
+      });
+      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(userMessages[0]);
+    });
+  });
+
+  describe('navigateDown', () => {
+    it('should not navigate if isActive is false', () => {
+      const initialProps = {
+        userMessages,
+        onSubmit: mockOnSubmit,
+        isActive: true, // Start active to allow setup navigation
+        currentQuery: 'current',
+        onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+      };
+      const { result, rerender } = renderHook(
+        (props) => useInputHistory(props),
+        {
+          initialProps,
+        },
+      );
+
+      // First navigate up to have something in history
+      act(() => {
+        result.current.navigateUp();
+      });
+      mockOnChangeAndMoveCursor.mockClear(); // Clear calls from setup
+
+      // Set isActive to false for the actual test
+      rerender({ ...initialProps, isActive: false });
+
+      act(() => {
+        const navigated = result.current.navigateDown();
+        expect(navigated).toBe(false);
+      });
+      expect(mockOnChangeAndMoveCursor).not.toHaveBeenCalled();
+    });
+
+    it('should not navigate if historyIndex is -1 (not in history navigation)', () => {
+      const { result } = renderHook(() =>
+        useInputHistory({
+          userMessages,
+          onSubmit: mockOnSubmit,
+          isActive: true,
+          currentQuery: 'current',
+          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+        }),
+      );
+      act(() => {
+        const navigated = result.current.navigateDown();
+        expect(navigated).toBe(false);
+      });
+      expect(mockOnChangeAndMoveCursor).not.toHaveBeenCalled();
+    });
+
+    it('should restore originalQueryBeforeNav when navigating down to initial state', () => {
+      const originalQuery = 'my original input';
+      const { result } = renderHook(() =>
+        useInputHistory({
+          userMessages,
+          onSubmit: mockOnSubmit,
+          isActive: true,
+          currentQuery: originalQuery,
+          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+        }),
+      );
+
+      act(() => {
+        result.current.navigateUp(); // Navigates to 'message 3', stores 'originalQuery'
+      });
+      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(userMessages[2]);
+      mockOnChangeAndMoveCursor.mockClear();
+
+      act(() => {
+        result.current.navigateDown(); // Navigates back to original query
+      });
+      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(originalQuery);
+    });
+  });
+});

--- a/packages/cli/src/ui/hooks/useInputHistory.test.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.test.ts
@@ -9,7 +9,7 @@ import { useInputHistory } from './useInputHistory.js';
 
 describe('useInputHistory', () => {
   const mockOnSubmit = vi.fn();
-  const mockOnChangeAndMoveCursor = vi.fn();
+  const mockOnChange = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -24,7 +24,7 @@ describe('useInputHistory', () => {
         onSubmit: mockOnSubmit,
         isActive: true,
         currentQuery: '',
-        onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+        onChange: mockOnChange,
       }),
     );
 
@@ -33,7 +33,7 @@ describe('useInputHistory', () => {
     act(() => {
       result.current.navigateDown();
     });
-    expect(mockOnChangeAndMoveCursor).not.toHaveBeenCalled();
+    expect(mockOnChange).not.toHaveBeenCalled();
   });
 
   describe('handleSubmit', () => {
@@ -44,7 +44,7 @@ describe('useInputHistory', () => {
           onSubmit: mockOnSubmit,
           isActive: true,
           currentQuery: '  test query  ',
-          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+          onChange: mockOnChange,
         }),
       );
 
@@ -57,7 +57,7 @@ describe('useInputHistory', () => {
       act(() => {
         result.current.navigateDown();
       });
-      expect(mockOnChangeAndMoveCursor).not.toHaveBeenCalled();
+      expect(mockOnChange).not.toHaveBeenCalled();
     });
 
     it('should not call onSubmit if value is empty after trimming', () => {
@@ -67,7 +67,7 @@ describe('useInputHistory', () => {
           onSubmit: mockOnSubmit,
           isActive: true,
           currentQuery: '',
-          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+          onChange: mockOnChange,
         }),
       );
 
@@ -87,14 +87,14 @@ describe('useInputHistory', () => {
           onSubmit: mockOnSubmit,
           isActive: false,
           currentQuery: 'current',
-          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+          onChange: mockOnChange,
         }),
       );
       act(() => {
         const navigated = result.current.navigateUp();
         expect(navigated).toBe(false);
       });
-      expect(mockOnChangeAndMoveCursor).not.toHaveBeenCalled();
+      expect(mockOnChange).not.toHaveBeenCalled();
     });
 
     it('should not navigate if userMessages is empty', () => {
@@ -104,17 +104,17 @@ describe('useInputHistory', () => {
           onSubmit: mockOnSubmit,
           isActive: true,
           currentQuery: 'current',
-          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+          onChange: mockOnChange,
         }),
       );
       act(() => {
         const navigated = result.current.navigateUp();
         expect(navigated).toBe(false);
       });
-      expect(mockOnChangeAndMoveCursor).not.toHaveBeenCalled();
+      expect(mockOnChange).not.toHaveBeenCalled();
     });
 
-    it('should call onChangeAndMoveCursor with the last message when navigating up from initial state', () => {
+    it('should call onChange with the last message when navigating up from initial state', () => {
       const currentQuery = 'current query';
       const { result } = renderHook(() =>
         useInputHistory({
@@ -122,7 +122,7 @@ describe('useInputHistory', () => {
           onSubmit: mockOnSubmit,
           isActive: true,
           currentQuery,
-          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+          onChange: mockOnChange,
         }),
       );
 
@@ -130,7 +130,7 @@ describe('useInputHistory', () => {
         result.current.navigateUp();
       });
 
-      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(userMessages[2]); // Last message
+      expect(mockOnChange).toHaveBeenCalledWith(userMessages[2]); // Last message
     });
 
     it('should store currentQuery as originalQueryBeforeNav on first navigateUp', () => {
@@ -141,20 +141,20 @@ describe('useInputHistory', () => {
           onSubmit: mockOnSubmit,
           isActive: true,
           currentQuery,
-          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+          onChange: mockOnChange,
         }),
       );
 
       act(() => {
         result.current.navigateUp(); // historyIndex becomes 0
       });
-      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(userMessages[2]);
+      expect(mockOnChange).toHaveBeenCalledWith(userMessages[2]);
 
       // Navigate down to restore original query
       act(() => {
         result.current.navigateDown(); // historyIndex becomes -1
       });
-      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(currentQuery);
+      expect(mockOnChange).toHaveBeenCalledWith(currentQuery);
     });
 
     it('should navigate through history messages on subsequent navigateUp calls', () => {
@@ -164,24 +164,24 @@ describe('useInputHistory', () => {
           onSubmit: mockOnSubmit,
           isActive: true,
           currentQuery: '',
-          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+          onChange: mockOnChange,
         }),
       );
 
       act(() => {
         result.current.navigateUp(); // Navigates to 'message 3'
       });
-      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(userMessages[2]);
+      expect(mockOnChange).toHaveBeenCalledWith(userMessages[2]);
 
       act(() => {
         result.current.navigateUp(); // Navigates to 'message 2'
       });
-      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(userMessages[1]);
+      expect(mockOnChange).toHaveBeenCalledWith(userMessages[1]);
 
       act(() => {
         result.current.navigateUp(); // Navigates to 'message 1'
       });
-      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(userMessages[0]);
+      expect(mockOnChange).toHaveBeenCalledWith(userMessages[0]);
     });
   });
 
@@ -192,7 +192,7 @@ describe('useInputHistory', () => {
         onSubmit: mockOnSubmit,
         isActive: true, // Start active to allow setup navigation
         currentQuery: 'current',
-        onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+        onChange: mockOnChange,
       };
       const { result, rerender } = renderHook(
         (props) => useInputHistory(props),
@@ -205,7 +205,7 @@ describe('useInputHistory', () => {
       act(() => {
         result.current.navigateUp();
       });
-      mockOnChangeAndMoveCursor.mockClear(); // Clear calls from setup
+      mockOnChange.mockClear(); // Clear calls from setup
 
       // Set isActive to false for the actual test
       rerender({ ...initialProps, isActive: false });
@@ -214,7 +214,7 @@ describe('useInputHistory', () => {
         const navigated = result.current.navigateDown();
         expect(navigated).toBe(false);
       });
-      expect(mockOnChangeAndMoveCursor).not.toHaveBeenCalled();
+      expect(mockOnChange).not.toHaveBeenCalled();
     });
 
     it('should not navigate if historyIndex is -1 (not in history navigation)', () => {
@@ -224,14 +224,14 @@ describe('useInputHistory', () => {
           onSubmit: mockOnSubmit,
           isActive: true,
           currentQuery: 'current',
-          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+          onChange: mockOnChange,
         }),
       );
       act(() => {
         const navigated = result.current.navigateDown();
         expect(navigated).toBe(false);
       });
-      expect(mockOnChangeAndMoveCursor).not.toHaveBeenCalled();
+      expect(mockOnChange).not.toHaveBeenCalled();
     });
 
     it('should restore originalQueryBeforeNav when navigating down to initial state', () => {
@@ -242,20 +242,20 @@ describe('useInputHistory', () => {
           onSubmit: mockOnSubmit,
           isActive: true,
           currentQuery: originalQuery,
-          onChangeAndMoveCursor: mockOnChangeAndMoveCursor,
+          onChange: mockOnChange,
         }),
       );
 
       act(() => {
         result.current.navigateUp(); // Navigates to 'message 3', stores 'originalQuery'
       });
-      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(userMessages[2]);
-      mockOnChangeAndMoveCursor.mockClear();
+      expect(mockOnChange).toHaveBeenCalledWith(userMessages[2]);
+      mockOnChange.mockClear();
 
       act(() => {
         result.current.navigateDown(); // Navigates back to original query
       });
-      expect(mockOnChangeAndMoveCursor).toHaveBeenCalledWith(originalQuery);
+      expect(mockOnChange).toHaveBeenCalledWith(originalQuery);
     });
   });
 });

--- a/packages/cli/src/ui/hooks/useInputHistory.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.ts
@@ -25,7 +25,7 @@ export function useInputHistory({
   onSubmit,
   isActive,
   currentQuery,
-  onChangeAndMoveCursor: setQueryAndMoveCursor,
+  onChangeAndMoveCursor,
 }: UseInputHistoryProps): UseInputHistoryReturn {
   const [historyIndex, setHistoryIndex] = useState<number>(-1);
   const [originalQueryBeforeNav, setOriginalQueryBeforeNav] =
@@ -65,14 +65,14 @@ export function useInputHistory({
     if (nextIndex !== historyIndex) {
       setHistoryIndex(nextIndex);
       const newValue = userMessages[userMessages.length - 1 - nextIndex];
-      setQueryAndMoveCursor(newValue); // Call the prop passed from parent
+      onChangeAndMoveCursor(newValue);
       return true;
     }
     return false;
   }, [
     historyIndex,
     setHistoryIndex,
-    setQueryAndMoveCursor,
+    onChangeAndMoveCursor,
     userMessages,
     isActive,
     currentQuery, // Use currentQuery from props
@@ -88,17 +88,17 @@ export function useInputHistory({
 
     if (nextIndex === -1) {
       // Reached the end of history navigation, restore original query
-      setQueryAndMoveCursor(originalQueryBeforeNav);
+      onChangeAndMoveCursor(originalQueryBeforeNav);
     } else {
       const newValue = userMessages[userMessages.length - 1 - nextIndex];
-      setQueryAndMoveCursor(newValue);
+      onChangeAndMoveCursor(newValue);
     }
     return true;
   }, [
     historyIndex,
     setHistoryIndex,
     originalQueryBeforeNav,
-    setQueryAndMoveCursor,
+    onChangeAndMoveCursor,
     userMessages,
     isActive,
   ]);

--- a/packages/cli/src/ui/hooks/useInputHistory.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.ts
@@ -11,7 +11,7 @@ interface UseInputHistoryProps {
   onSubmit: (value: string) => void;
   isActive: boolean;
   currentQuery: string; // Renamed from query to avoid confusion
-  onChangeAndMoveCursor: (value: string) => void;
+  onChange: (value: string) => void;
 }
 
 interface UseInputHistoryReturn {
@@ -25,7 +25,7 @@ export function useInputHistory({
   onSubmit,
   isActive,
   currentQuery,
-  onChangeAndMoveCursor,
+  onChange,
 }: UseInputHistoryProps): UseInputHistoryReturn {
   const [historyIndex, setHistoryIndex] = useState<number>(-1);
   const [originalQueryBeforeNav, setOriginalQueryBeforeNav] =
@@ -65,14 +65,14 @@ export function useInputHistory({
     if (nextIndex !== historyIndex) {
       setHistoryIndex(nextIndex);
       const newValue = userMessages[userMessages.length - 1 - nextIndex];
-      onChangeAndMoveCursor(newValue);
+      onChange(newValue);
       return true;
     }
     return false;
   }, [
     historyIndex,
     setHistoryIndex,
-    onChangeAndMoveCursor,
+    onChange,
     userMessages,
     isActive,
     currentQuery, // Use currentQuery from props
@@ -88,17 +88,17 @@ export function useInputHistory({
 
     if (nextIndex === -1) {
       // Reached the end of history navigation, restore original query
-      onChangeAndMoveCursor(originalQueryBeforeNav);
+      onChange(originalQueryBeforeNav);
     } else {
       const newValue = userMessages[userMessages.length - 1 - nextIndex];
-      onChangeAndMoveCursor(newValue);
+      onChange(newValue);
     }
     return true;
   }, [
     historyIndex,
     setHistoryIndex,
     originalQueryBeforeNav,
-    onChangeAndMoveCursor,
+    onChange,
     userMessages,
     isActive,
   ]);


### PR DESCRIPTION
The problem was calling 'home' immediately after setting the text resulted in inconsistent state as there wasn't the required async gapp to allow the state of textbuffer to update after calling setText. @KeijiBranshi curious if there is a clean way to avoid this issue.

The fix was as to just remove the call to move('home') as the call to  setText already moved the cursor to the end of the line as desired.
Added some tests although I left adding tests for InputPrompt itself for another pull request as that requires more thought to do reasonably.