### PR TITLE
infra: emit errors on no-explicit-any eslint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -90,7 +90,7 @@ export default tseslint.config(
         'error',
         { accessibility: 'no-public' },
       ],
-      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-inferrable-types': [
         'error',
         { ignoreParameters: true, ignoreProperties: true },

--- a/packages/server/src/utils/memoryDiscovery.test.ts
+++ b/packages/server/src/utils/memoryDiscovery.test.ts
@@ -174,6 +174,7 @@ describe('loadServerHierarchicalMemory', () => {
         ] as Dirent[];
       }
       return [] as Dirent[];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any);
 
     const { memoryContent, fileCount } = await loadServerHierarchicalMemory(
@@ -246,6 +247,7 @@ describe('loadServerHierarchicalMemory', () => {
         ] as Dirent[];
       }
       return [] as Dirent[];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any);
 
     const { memoryContent, fileCount } = await loadServerHierarchicalMemory(
@@ -324,6 +326,7 @@ describe('loadServerHierarchicalMemory', () => {
         ] as Dirent[];
       }
       return [] as Dirent[];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any);
 
     const { memoryContent, fileCount } = await loadServerHierarchicalMemory(
@@ -362,6 +365,7 @@ describe('loadServerHierarchicalMemory', () => {
       if (p.toString().startsWith(path.join(CWD, 'deep_dir_')))
         return [] as Dirent[];
       return [] as Dirent[];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any);
     mockFs.access.mockRejectedValue(new Error('not found'));
 


### PR DESCRIPTION
This is a pretty standard/important eslint [rule](https://typescript-eslint.io/rules/no-explicit-any/). Making it emit 'error' instead of 'warning', and fixed a few of the existing violations. I don't like just ignoring them, but its probably okay for now since they're just tests. we should push back on these comment exceptions for production files though