### PR TITLE
feat: Enable npx execution on tagged versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "gemini-code",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "workspaces": [
     "packages/*"
@@ -32,10 +31,8 @@
   },
   "files": [
     "bundle/",
-    "packages/cli/dist",
-    "packages/cli/package.json",
-    "packages/server/dist",
-    "packages/server/package.json"
+    "README.md",
+    "LICENSE"
   ],
   "dependencies": {
     "sqlite3": "^5.1.7"


### PR DESCRIPTION
- Modify root package.json to allow publishing
- Update "files" to include only essential bundled assets

This change makes it possible to use npx with tagged versions of the gemini-cli package (e.g., npx https://github.com/google-gemini/gemini-cli@early-access). It removes "private: true" and refines the "files" array to ensure that only the necessary bundled assets are included when the package is fetched by npx, optimizing download size and ensuring correct execution.