### PR TITLE
Add additional readline-like keybindings.

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -84,8 +84,7 @@ export const App = ({
     [consoleMessages],
   );
   useInput((input: string, key: InkKeyType) => {
-    // Check for Ctrl+D key press
-    if (key.ctrl && (input === 'd' || input === 'D')) {
+    if (key.ctrl && input === 'o') {
       setShowErrorDetails((prev) => !prev);
       refreshStatic();
     }

--- a/packages/cli/src/ui/components/ConsoleSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ConsoleSummaryDisplay.tsx
@@ -27,7 +27,7 @@ export const ConsoleSummaryDisplay: React.FC<ConsoleSummaryDisplayProps> = ({
       {errorCount > 0 && (
         <Text color={Colors.AccentRed}>
           {errorIcon} {errorCount} error{errorCount > 1 ? 's' : ''}{' '}
-          <Text color={Colors.SubtleComment}>(CTRL-D for details)</Text>
+          <Text color={Colors.SubtleComment}>(CTRL-O for details)</Text>
         </Text>
       )}
     </Box>

--- a/packages/cli/src/ui/components/DetailedMessagesDisplay.tsx
+++ b/packages/cli/src/ui/components/DetailedMessagesDisplay.tsx
@@ -33,7 +33,7 @@ export const DetailedMessagesDisplay: React.FC<
       <Box marginBottom={1}>
         <Text bold color={Colors.Foreground}>
           Debug Console{' '}
-          <Text color={Colors.SubtleComment}>(CTRL-D to close)</Text>
+          <Text color={Colors.SubtleComment}>(CTRL-O to close)</Text>
         </Text>
       </Box>
       {messages.map((msg, index) => {

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1186,10 +1186,11 @@ export function useTextBuffer({
       else if (
         key['backspace'] ||
         input === '\x7f' ||
+        (key['ctrl'] && input === 'h') ||
         (key['delete'] && !key['shift'])
       )
         backspace();
-      else if (key['delete']) del();
+      else if (key['delete'] || (key['ctrl'] && input === 'd')) del();
       else if (input && !key['ctrl'] && !key['meta']) {
         // Heuristic for paste: if input is longer than 1 char (potential paste)
         // strip ANSI escape codes.


### PR DESCRIPTION
Adds the following conventional readline-like keybindings:

  - `Ctrl+H`: Delete the previous character.
  - `Ctrl+D`: Delete the next character.

Additionally, remaps the Debug Console command from Ctrl+D to Ctrl+O, which had been first introduced in PR #486.