### PR TITLE
Reduce excessive diff separators in CLI.

### DIFF
--- a/packages/cli/src/ui/components/messages/DiffRenderer.test.tsx
+++ b/packages/cli/src/ui/components/messages/DiffRenderer.test.tsx
@@ -140,4 +140,34 @@ index 123..456 100644
     expect(output).toContain('added line');
     expect(output).toContain('context line 10');
   });
+
+  it('should not render a gap indicator for small gaps (<= MAX_CONTEXT_LINES_WITHOUT_GAP)', () => {
+    const diffWithSmallGap = `
+diff --git a/file.txt b/file.txt
+index abc..def 100644
+--- a/file.txt
++++ b/file.txt
+@@ -1,5 +1,5 @@
+ context line 1
+ context line 2
+ context line 3
+ context line 4
+ context line 5
+@@ -11,5 +11,5 @@
+ context line 11
+ context line 12
+ context line 13
+ context line 14
+ context line 15
+`;
+    const { lastFrame } = render(
+      <DiffRenderer diffContent={diffWithSmallGap} filename="file.txt" />,
+    );
+    const output = lastFrame();
+    expect(output).not.toContain('═'); // Ensure no separator is rendered
+
+    // Verify that lines before and after the gap are rendered
+    expect(output).toContain('context line 5');
+    expect(output).toContain('context line 11');
+  });
 });

--- a/packages/cli/src/ui/components/messages/DiffRenderer.tsx
+++ b/packages/cli/src/ui/components/messages/DiffRenderer.tsx
@@ -188,7 +188,7 @@ const renderDiffContent = (
     : `diff-box-${crypto.createHash('sha1').update(JSON.stringify(parsedLines)).digest('hex')}`;
 
   let lastLineNumber: number | null = null;
-  const MAX_CONTEXT_LINES_WITHOUT_GAP = 1;
+  const MAX_CONTEXT_LINES_WITHOUT_GAP = 5;
 
   return (
     <Box flexDirection="column" key={key}>


### PR DESCRIPTION
Increases the threshold for rendering diff separators in the CLI's diff display. Previously, a separator was shown for gaps of more than one context line, leading to excessive separators in diffs with many small changes close together (Issue #534).

By increasing `MAX_CONTEXT_LINES_WITHOUT_GAP` to 5, we allow for more context lines before a separator is added, significantly reducing visual clutter in such diffs.

Added a test case to `DiffRenderer.test.tsx` to verify that separators are not rendered for small gaps within the new threshold.