### PR TITLE
refactor: Decouple new_string correction from old_string

### DIFF
--- a/packages/server/src/utils/editCorrector.ts
+++ b/packages/server/src/utils/editCorrector.ts
@@ -78,7 +78,14 @@ export async function ensureCorrectEdit(
 
     if (occurrences === 1) {
       finalOldString = unescapedOldStringAttempt;
-      finalNewString = unescapeStringForGeminiBug(originalParams.new_string);
+      if (newStringPotentiallyEscaped) {
+        finalNewString = await correctNewString(
+          client,
+          originalParams.old_string, // original old
+          unescapedOldStringAttempt, // corrected old
+          originalParams.new_string, // original new (which is potentially escaped)
+        );
+      }
     } else if (occurrences === 0) {
       const llmCorrectedOldString = await correctOldStringMismatch(
         client,


### PR DESCRIPTION
- Previously, `new_string` was assumed to be over-escaped if `old_string` was.
- This change introduces an explicit check (`newStringPotentiallyEscaped`) to determine if `new_string` itself needs correction.
- If `new_string` is potentially escaped, its corrected using an LLM call; otherwise, the original `new_string` is used.
- This avoids unnecessary corrections to `new_string` when only `old_string` was problematic.

**NOTE:** I plan to update all the tests once all these edit corrector fixes go in (conflict hell)

Part of https://github.com/google-gemini/gemini-cli/issues/484