### PR TITLE
Upon finding > 1 occurrences do not attempt auto-correction.

### DIFF
--- a/packages/server/src/utils/editCorrector.ts
+++ b/packages/server/src/utils/editCorrector.ts
@@ -69,6 +69,12 @@ export async function ensureCorrectEdit(
         originalParams.new_string,
       );
     }
+  } else if (occurrences > 1) {
+    const result: CorrectedEditResult = {
+      params: { ...originalParams },
+      occurrences,
+    };
+    return result;
   } else {
     // occurrences is 0 or some other unexpected state initially
     const unescapedOldStringAttempt = unescapeStringForGeminiBug(


### PR DESCRIPTION
- When correcting edits prior to this if we found more than one occurrence we would try to auto-correct the old/new strings. There's no need in this situation because the tool has already provided too vague of an old_string to act upon. Instantly return.

**NOTE:** I plan to update all the tests once all these edit corrector fixes go in (conflict hell)

Part of https://github.com/google-gemini/gemini-cli/issues/484