### PR TITLE
Change tool call spinner to be differentiated from the loading spinner.

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -118,7 +118,7 @@ const ToolStatusIndicator: React.FC<ToolStatusIndicatorProps> = ({
       )}
       {status === ToolCallStatus.Executing &&
         (streamingState === StreamingState.Responding ? (
-          <Spinner type="dots" />
+          <Spinner type="toggle" />
         ) : (
           // Paused spinner to avoid flicker.
           <Text>⠇</Text>


### PR DESCRIPTION
- This differentiates the tool calling spinner from one that matches the normal loading indiator to somethign a little more seamless.

## Before

https://screencast.googleplex.com/cast/NTEzMTMyNjY4NzU0MzI5Nnw5NTI1ZTAyZi1lMg

## After

https://screencast.googleplex.com/cast/NDUxNzIzMDkyMTM4MzkzNnxiYjA2ZDAxMC1lZg