### PR TITLE
Fix(cli): Prevent premature input box reactivation during tool confirmation

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -109,7 +109,10 @@ export const useGeminiStream = (
     if (
       isResponding ||
       toolCalls.some(
-        (t) => t.status === 'executing' || t.status === 'scheduled',
+        (t) =>
+          t.status === 'executing' ||
+          t.status === 'scheduled' ||
+          t.status === 'validating',
       )
     ) {
       return StreamingState.Responding;


### PR DESCRIPTION
- Introduced a 'validating' state for tool calls to prevent the input box from reappearing while waiting for a tool's `shouldConfirmExecute` method to complete.
- When a tool call is initiated, it's now immediately set to a 'validating' status. This ensures the UI remains in a busy/responding state.
- `useGeminiStream` now considers the 'validating' state as part of `StreamingState.Responding`.
- `useToolScheduler` has been updated to:
    - Set the initial status of new tool calls to 'validating'.
    - Asynchronously perform the `shouldConfirmExecute` check.
    - Transition to 'awaiting_approval' or 'scheduled' based on the check's outcome.
- This resolves an issue where a slow `shouldConfirmExecute` could lead to the input prompt becoming active again before the tool call lifecycle was fully determined. While 'validating' is currently treated similarly to 'executing' in the UI, this new state provides a foundation for more customized user experiences during this phase in the future.

# Before

https://screencast.googleplex.com/cast/NTY3NDY1MTcxNDg0NjcyMHxjMDFhZTdmYS0zNw

# After

https://screencast.googleplex.com/cast/NjI1MDg2NzY5Mzk3NzYwMHw0OWE2YTY2OS03MA


Fixes https://github.com/google-gemini/gemini-cli/issues/527