### PR TITLE
Fix(diff): Hide whitespace changes in diffs with content changes

### DIFF
--- a/packages/server/src/tools/diffOptions.ts
+++ b/packages/server/src/tools/diffOptions.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Diff from 'diff';
+
+export const DEFAULT_DIFF_OPTIONS: Diff.PatchOptions = {
+  context: 3,
+  ignoreWhitespace: true,
+};

--- a/packages/server/src/tools/edit.ts
+++ b/packages/server/src/tools/edit.ts
@@ -22,6 +22,7 @@ import { ReadFileTool } from './read-file.js';
 import { GeminiClient } from '../core/client.js';
 import { Config } from '../config/config.js';
 import { ensureCorrectEdit } from '../utils/editCorrector.js';
+import { DEFAULT_DIFF_OPTIONS } from './diffOptions.js';
 
 /**
  * Parameters for the Edit tool
@@ -326,7 +327,7 @@ Expectation for parameters:
       newContent,
       'Current',
       'Proposed',
-      { context: 3 },
+      DEFAULT_DIFF_OPTIONS,
     );
     const confirmationDetails: ToolEditConfirmationDetails = {
       type: 'edit',
@@ -408,7 +409,7 @@ Expectation for parameters:
           editData.newContent,
           'Current',
           'Proposed',
-          { context: 3 },
+          DEFAULT_DIFF_OPTIONS,
         );
         displayResult = { fileDiff, fileName };
       }

--- a/packages/server/src/tools/write-file.ts
+++ b/packages/server/src/tools/write-file.ts
@@ -24,6 +24,7 @@ import {
   ensureCorrectFileContent,
 } from '../utils/editCorrector.js';
 import { GeminiClient } from '../core/client.js';
+import { DEFAULT_DIFF_OPTIONS } from './diffOptions.js';
 
 /**
  * Parameters for the WriteFile tool
@@ -173,7 +174,7 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
       correctedContent, // Content after potential correction
       'Current',
       'Proposed',
-      { context: 3 },
+      DEFAULT_DIFF_OPTIONS,
     );
 
     const confirmationDetails: ToolEditConfirmationDetails = {
@@ -251,7 +252,7 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
         fileContent,
         'Original',
         'Written',
-        { context: 3 },
+        DEFAULT_DIFF_OPTIONS,
       );
 
       const llmSuccessMessage = isNewFile


### PR DESCRIPTION
- Updated the diff generation in `edit.ts` and `write-file.ts` to include the `ignoreWhitespace: true` option.
- This ensures that whitespace-only changes are not highlighted in the diff output when there are other content modifications, making the diffs cleaner and easier to review.
- Extract default diffing options into single source of truth.

Fixes https://github.com/google-gemini/gemini-cli/issues/548