### PR TITLE
Fix(chat): Prevent empty model response after function call

### DIFF
--- a/packages/server/src/core/geminiChat.ts
+++ b/packages/server/src/core/geminiChat.ts
@@ -16,6 +16,7 @@ import {
   GoogleGenAI,
   createUserContent,
 } from '@google/genai';
+import { isFunctionResponse } from '../utils/messageInspectors.js';
 
 /**
  * Returns true if the response is valid, false otherwise.
@@ -292,12 +293,15 @@ export class GeminiChat {
     ) {
       outputContents = modelOutput;
     } else {
-      // Appends an empty content when model returns empty response, so that the
+      // When not a function response appends an empty content when model returns empty response, so that the
       // history is always alternating between user and model.
-      outputContents.push({
-        role: 'model',
-        parts: [],
-      } as Content);
+      // Workaround for: https://b.corp.google.com/issues/420354090
+      if (!isFunctionResponse(userInput)) {
+        outputContents.push({
+          role: 'model',
+          parts: [],
+        } as Content);
+      }
     }
     if (
       automaticFunctionCallingHistory &&

--- a/packages/server/src/utils/messageInspectors.ts
+++ b/packages/server/src/utils/messageInspectors.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Content } from '@google/genai';
+
+export function isFunctionResponse(content: Content): boolean {
+  return (
+    content.role === 'user' &&
+    !!content.parts &&
+    content.parts.every((part) => !!part.functionResponse)
+  );
+}


### PR DESCRIPTION
- Addresses a Gemini model bug where it may return an empty content object after a function response.
- Previously, the SDK attempted to inject an empty model message, which could disrupt curated history.
- This change modifies our custom  class to detect this scenario using an  utility and avoid pushing an unnecessary empty model message, thus preserving history integrity.

Workaround for https://b.corp.google.com/issues/420354090 Part of https://github.com/google-gemini/gemini-cli/issues/551