### PR TITLE
Fix(chat): Ensure model responds when next speaker check indicates

### DIFF
--- a/packages/server/src/core/client.ts
+++ b/packages/server/src/core/client.ts
@@ -170,7 +170,7 @@ export class GeminiClient {
       const nextSpeakerCheck = await checkNextSpeaker(chat, this);
       if (nextSpeakerCheck?.next_speaker === 'model') {
         const nextRequest = [{ text: 'Please continue.' }];
-        return this.sendMessageStream(chat, nextRequest, signal, turns - 1);
+        yield* this.sendMessageStream(chat, nextRequest, signal, turns - 1);
       }
     }
   }


### PR DESCRIPTION
- Corrects an issue where the `nextSpeakerCheck` would determine the model should speak next, but the models response was not properly propagated due to a missing `yield*` in a recursive call within `sendMessageStream`.
- This change ensures that when the model is designated as the next speaker, its generated content is correctly unwoven and returned, allowing the conversation to proceed as expected.

Part of https://github.com/google-gemini/gemini-cli/issues/551