### PR TITLE
fix: default to Gemini API if GEMINI_API_KEY is set and when GOOGLE_GENAI_USE_VERTEXAI is set to True

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -132,6 +132,7 @@ export async function loadCliConfig(settings: Settings): Promise<Config> {
 
   const userAgent = await createUserAgent();
   const apiKeyForServer = geminiApiKey || googleApiKey || '';
+  const useVertexAI = hasGeminiApiKey ? false : undefined;
 
   return createServerConfig(
     apiKeyForServer,
@@ -149,6 +150,8 @@ export async function loadCliConfig(settings: Settings): Promise<Config> {
     userAgent,
     memoryContent,
     fileCount,
+    undefined, // alwaysSkipModificationConfirmation - not set by CLI args directly
+    useVertexAI,
   );
 }
 

--- a/packages/server/src/config/config.ts
+++ b/packages/server/src/config/config.ts
@@ -56,6 +56,7 @@ export class Config {
     private userMemory: string = '', // Made mutable for refresh
     private geminiMdFileCount: number = 0,
     private alwaysSkipModificationConfirmation: boolean = false,
+    private readonly vertexai?: boolean,
   ) {
     // toolRegistry still needs initialization based on the instance
     this.toolRegistry = createToolRegistry(this);
@@ -139,6 +140,10 @@ export class Config {
   setAlwaysSkipModificationConfirmation(skip: boolean): void {
     this.alwaysSkipModificationConfirmation = skip;
   }
+
+  getVertexAI(): boolean | undefined {
+    return this.vertexai;
+  }
 }
 
 function findEnvFile(startDir: string): string | null {
@@ -186,6 +191,7 @@ export function createServerConfig(
   userMemory?: string,
   geminiMdFileCount?: number,
   alwaysSkipModificationConfirmation?: boolean,
+  vertexai?: boolean,
 ): Config {
   return new Config(
     apiKey,
@@ -204,6 +210,7 @@ export function createServerConfig(
     userMemory ?? '',
     geminiMdFileCount ?? 0,
     alwaysSkipModificationConfirmation ?? false,
+    vertexai,
   );
 }
 

--- a/packages/server/src/core/client.ts
+++ b/packages/server/src/core/client.ts
@@ -36,8 +36,11 @@ export class GeminiClient {
   constructor(private config: Config) {
     const userAgent = config.getUserAgent();
     const apiKeyFromConfig = config.getApiKey();
+    const vertexaiFlag = config.getVertexAI();
+
     this.client = new GoogleGenAI({
       apiKey: apiKeyFromConfig === '' ? undefined : apiKeyFromConfig,
+      vertexai: vertexaiFlag,
       httpOptions: {
         headers: {
           'User-Agent': userAgent,


### PR DESCRIPTION
This will automatically default to using the Gemini API whe the `GEMINI_API_KEY` is set, even if `GOOGLE_GENAI_USE_VERTEXAI` is set to True.