### PR TITLE
feat: Allow cancellation of in-progress Gemini requests and pre-execution checks

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -95,9 +95,11 @@ async function main() {
   const geminiClient = new GeminiClient(config);
   const chat = await geminiClient.startChat();
   try {
-    for await (const event of geminiClient.sendMessageStream(chat, [
-      { text: input },
-    ])) {
+    for await (const event of geminiClient.sendMessageStream(
+      chat,
+      [{ text: input }],
+      new AbortController().signal,
+    )) {
       if (event.type === 'content') {
         process.stdout.write(event.value);
       }

--- a/packages/cli/src/ui/hooks/useToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.ts
@@ -142,7 +142,10 @@ export function useToolScheduler(
 
         const { request: r, tool } = initialCall;
         try {
-          const userApproval = await tool.shouldConfirmExecute(r.args);
+          const userApproval = await tool.shouldConfirmExecute(
+            r.args,
+            abortController.signal,
+          );
           if (userApproval) {
             // Confirmation is needed. Update status to 'awaiting_approval'.
             setToolCalls(
@@ -183,7 +186,7 @@ export function useToolScheduler(
         }
       });
     },
-    [isRunning, setToolCalls, toolRegistry],
+    [isRunning, setToolCalls, toolRegistry, abortController.signal],
   );
 
   const cancel = useCallback(

--- a/packages/server/src/core/geminiChat.ts
+++ b/packages/server/src/core/geminiChat.ts
@@ -155,7 +155,7 @@ export class GeminiChat {
     const responsePromise = this.modelsModule.generateContent({
       model: this.model,
       contents: this.getHistory(true).concat(userContent),
-      config: params.config ?? this.config,
+      config: { ...this.config, ...params.config },
     });
     this.sendPromise = (async () => {
       const response = await responsePromise;
@@ -219,7 +219,7 @@ export class GeminiChat {
     const streamResponse = this.modelsModule.generateContentStream({
       model: this.model,
       contents: this.getHistory(true).concat(userContent),
-      config: params.config ?? this.config,
+      config: { ...this.config, ...params.config },
     });
     // Resolve the internal tracking of send completion promise - `sendPromise`
     // for both success and failure response. The actual failure is still

--- a/packages/server/src/core/turn.test.ts
+++ b/packages/server/src/core/turn.test.ts
@@ -85,11 +85,17 @@ describe('Turn', () => {
 
       const events = [];
       const reqParts: Part[] = [{ text: 'Hi' }];
-      for await (const event of turn.run(reqParts)) {
+      for await (const event of turn.run(
+        reqParts,
+        new AbortController().signal,
+      )) {
         events.push(event);
       }
 
-      expect(mockSendMessageStream).toHaveBeenCalledWith({ message: reqParts });
+      expect(mockSendMessageStream).toHaveBeenCalledWith({
+        message: reqParts,
+        config: { abortSignal: expect.any(AbortSignal) },
+      });
       expect(events).toEqual([
         { type: GeminiEventType.Content, value: 'Hello' },
         { type: GeminiEventType.Content, value: ' world' },
@@ -110,7 +116,10 @@ describe('Turn', () => {
 
       const events = [];
       const reqParts: Part[] = [{ text: 'Use tools' }];
-      for await (const event of turn.run(reqParts)) {
+      for await (const event of turn.run(
+        reqParts,
+        new AbortController().signal,
+      )) {
         events.push(event);
       }
 
@@ -179,7 +188,10 @@ describe('Turn', () => {
       mockGetHistory.mockReturnValue(historyContent);
 
       const events = [];
-      for await (const event of turn.run(reqParts)) {
+      for await (const event of turn.run(
+        reqParts,
+        new AbortController().signal,
+      )) {
         events.push(event);
       }
 
@@ -210,7 +222,10 @@ describe('Turn', () => {
 
       const events = [];
       const reqParts: Part[] = [{ text: 'Test undefined tool parts' }];
-      for await (const event of turn.run(reqParts)) {
+      for await (const event of turn.run(
+        reqParts,
+        new AbortController().signal,
+      )) {
         events.push(event);
       }
 
@@ -261,7 +276,7 @@ describe('Turn', () => {
       })();
       mockSendMessageStream.mockResolvedValue(mockResponseStream);
       const reqParts: Part[] = [{ text: 'Hi' }];
-      for await (const _ of turn.run(reqParts)) {
+      for await (const _ of turn.run(reqParts, new AbortController().signal)) {
         // consume stream
       }
       expect(turn.getDebugResponses()).toEqual([resp1, resp2]);

--- a/packages/server/src/tools/edit.test.ts
+++ b/packages/server/src/tools/edit.test.ts
@@ -223,7 +223,9 @@ describe('EditTool', () => {
         old_string: 'old',
         new_string: 'new',
       };
-      expect(await tool.shouldConfirmExecute(params)).toBe(false);
+      expect(
+        await tool.shouldConfirmExecute(params, new AbortController().signal),
+      ).toBe(false);
     });
 
     it('should request confirmation for valid edit', async () => {
@@ -235,7 +237,10 @@ describe('EditTool', () => {
       };
       // ensureCorrectEdit will be called by shouldConfirmExecute
       mockEnsureCorrectEdit.mockResolvedValueOnce({ params, occurrences: 1 });
-      const confirmation = await tool.shouldConfirmExecute(params);
+      const confirmation = await tool.shouldConfirmExecute(
+        params,
+        new AbortController().signal,
+      );
       expect(confirmation).toEqual(
         expect.objectContaining({
           title: `Confirm Edit: ${testFile}`,
@@ -253,7 +258,9 @@ describe('EditTool', () => {
         new_string: 'new',
       };
       mockEnsureCorrectEdit.mockResolvedValueOnce({ params, occurrences: 0 });
-      expect(await tool.shouldConfirmExecute(params)).toBe(false);
+      expect(
+        await tool.shouldConfirmExecute(params, new AbortController().signal),
+      ).toBe(false);
     });
 
     it('should return false if multiple occurrences of old_string are found (ensureCorrectEdit returns > 1)', async () => {
@@ -264,7 +271,9 @@ describe('EditTool', () => {
         new_string: 'new',
       };
       mockEnsureCorrectEdit.mockResolvedValueOnce({ params, occurrences: 2 });
-      expect(await tool.shouldConfirmExecute(params)).toBe(false);
+      expect(
+        await tool.shouldConfirmExecute(params, new AbortController().signal),
+      ).toBe(false);
     });
 
     it('should request confirmation for creating a new file (empty old_string)', async () => {
@@ -279,7 +288,10 @@ describe('EditTool', () => {
       // as shouldConfirmExecute handles this for diff generation.
       // If it is called, it should return 0 occurrences for a new file.
       mockEnsureCorrectEdit.mockResolvedValueOnce({ params, occurrences: 0 });
-      const confirmation = await tool.shouldConfirmExecute(params);
+      const confirmation = await tool.shouldConfirmExecute(
+        params,
+        new AbortController().signal,
+      );
       expect(confirmation).toEqual(
         expect.objectContaining({
           title: `Confirm Edit: ${newFileName}`,
@@ -328,6 +340,7 @@ describe('EditTool', () => {
 
       const confirmation = (await tool.shouldConfirmExecute(
         params,
+        new AbortController().signal,
       )) as FileDiff;
 
       expect(mockCalled).toBe(true); // Check if the mock implementation was run

--- a/packages/server/src/tools/edit.ts
+++ b/packages/server/src/tools/edit.ts
@@ -174,7 +174,10 @@ Expectation for parameters:
    * @returns An object describing the potential edit outcome
    * @throws File system errors if reading the file fails unexpectedly (e.g., permissions)
    */
-  private async calculateEdit(params: EditToolParams): Promise<CalculatedEdit> {
+  private async calculateEdit(
+    params: EditToolParams,
+    abortSignal: AbortSignal,
+  ): Promise<CalculatedEdit> {
     const expectedReplacements = 1;
     let currentContent: string | null = null;
     let fileExists = false;
@@ -210,6 +213,7 @@ Expectation for parameters:
         currentContent,
         params,
         this.client,
+        abortSignal,
       );
       finalOldString = correctedEdit.params.old_string;
       finalNewString = correctedEdit.params.new_string;
@@ -262,6 +266,7 @@ Expectation for parameters:
    */
   async shouldConfirmExecute(
     params: EditToolParams,
+    abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false> {
     if (this.config.getAlwaysSkipModificationConfirmation()) {
       return false;
@@ -300,6 +305,7 @@ Expectation for parameters:
         currentContent,
         params,
         this.client,
+        abortSignal,
       );
       finalOldString = correctedEdit.params.old_string;
       finalNewString = correctedEdit.params.new_string;
@@ -376,7 +382,7 @@ Expectation for parameters:
 
     let editData: CalculatedEdit;
     try {
-      editData = await this.calculateEdit(params);
+      editData = await this.calculateEdit(params, _signal);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       return {

--- a/packages/server/src/tools/shell.ts
+++ b/packages/server/src/tools/shell.ts
@@ -98,6 +98,7 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
 
   async shouldConfirmExecute(
     params: ShellToolParams,
+    _abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false> {
     if (this.validateToolParams(params)) {
       return false; // skip confirmation, execute call will fail immediately

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -57,6 +57,7 @@ export interface Tool<
    */
   shouldConfirmExecute(
     params: TParams,
+    abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false>;
 
   /**
@@ -137,6 +138,8 @@ export abstract class BaseTool<
   shouldConfirmExecute(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     params: TParams,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false> {
     return Promise.resolve(false);
   }

--- a/packages/server/src/tools/write-file.ts
+++ b/packages/server/src/tools/write-file.ts
@@ -141,6 +141,7 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
    */
   async shouldConfirmExecute(
     params: WriteFileToolParams,
+    abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false> {
     if (this.config.getAlwaysSkipModificationConfirmation()) {
       return false;
@@ -154,6 +155,7 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
     const correctedContentResult = await this._getCorrectedFileContent(
       params.file_path,
       params.content,
+      abortSignal,
     );
 
     if (correctedContentResult.error) {
@@ -193,7 +195,7 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
 
   async execute(
     params: WriteFileToolParams,
-    _signal: AbortSignal,
+    abortSignal: AbortSignal,
   ): Promise<ToolResult> {
     const validationError = this.validateToolParams(params);
     if (validationError) {
@@ -206,6 +208,7 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
     const correctedContentResult = await this._getCorrectedFileContent(
       params.file_path,
       params.content,
+      abortSignal,
     );
 
     if (correctedContentResult.error) {
@@ -277,6 +280,7 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
   private async _getCorrectedFileContent(
     filePath: string,
     proposedContent: string,
+    abortSignal: AbortSignal,
   ): Promise<GetCorrectedFileContentResult> {
     let originalContent = '';
     let fileExists = false;
@@ -316,6 +320,7 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
           file_path: filePath,
         },
         this.client,
+        abortSignal,
       );
       correctedContent = correctedParams.new_string;
     } else {
@@ -323,6 +328,7 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
       correctedContent = await ensureCorrectFileContent(
         proposedContent,
         this.client,
+        abortSignal,
       );
     }
     return { originalContent, correctedContent, fileExists };

--- a/packages/server/src/utils/editCorrector.test.ts
+++ b/packages/server/src/utils/editCorrector.test.ts
@@ -132,6 +132,7 @@ describe('editCorrector', () => {
     let mockGeminiClientInstance: Mocked<GeminiClient>;
     let mockToolRegistry: Mocked<ToolRegistry>;
     let mockConfigInstance: Config;
+    const abortSignal = new AbortController().signal;
 
     beforeEach(() => {
       mockToolRegistry = new ToolRegistry({} as Config) as Mocked<ToolRegistry>;
@@ -187,12 +188,18 @@ describe('editCorrector', () => {
 
       callCount = 0;
       mockResponses.length = 0;
-      mockGenerateJson = vi.fn().mockImplementation(() => {
-        const response = mockResponses[callCount];
-        callCount++;
-        if (response === undefined) return Promise.resolve({});
-        return Promise.resolve(response);
-      });
+      mockGenerateJson = vi
+        .fn()
+        .mockImplementation((_contents, _schema, signal) => {
+          // Check if the signal is aborted. If so, throw an error or return a specific response.
+          if (signal && signal.aborted) {
+            return Promise.reject(new Error('Aborted')); // Or some other specific error/response
+          }
+          const response = mockResponses[callCount];
+          callCount++;
+          if (response === undefined) return Promise.resolve({});
+          return Promise.resolve(response);
+        });
       mockStartChat = vi.fn();
       mockSendMessageStream = vi.fn();
 
@@ -217,6 +224,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(1);
         expect(result.params.new_string).toBe('replace with "this"');
@@ -234,6 +242,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(0);
         expect(result.params.new_string).toBe('replace with this');
@@ -254,6 +263,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(1);
         expect(result.params.new_string).toBe('replace with "this"');
@@ -271,6 +281,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(0);
         expect(result.params.new_string).toBe('replace with this');
@@ -292,6 +303,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(1);
         expect(result.params.new_string).toBe('replace with "this"');
@@ -309,6 +321,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(0);
         expect(result.params.new_string).toBe('replace with this');
@@ -329,6 +342,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(1);
         expect(result.params.new_string).toBe('replace with foobar');
@@ -351,6 +365,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(1);
         expect(result.params.new_string).toBe(llmNewString);
@@ -372,6 +387,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(2);
         expect(result.params.new_string).toBe(llmNewString);
@@ -391,6 +407,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(1);
         expect(result.params.new_string).toBe('replace with "this"');
@@ -412,6 +429,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(1);
         expect(result.params.new_string).toBe(newStringForLLMAndReturnedByLLM);
@@ -432,6 +450,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(1);
         expect(result.params).toEqual(originalParams);
@@ -449,6 +468,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(0);
         expect(result.params).toEqual(originalParams);
@@ -471,6 +491,7 @@ describe('editCorrector', () => {
           currentContent,
           originalParams,
           mockGeminiClientInstance,
+          abortSignal,
         );
         expect(mockGenerateJson).toHaveBeenCalledTimes(2);
         expect(result.params.old_string).toBe(currentContent);

--- a/packages/server/src/utils/nextSpeakerChecker.test.ts
+++ b/packages/server/src/utils/nextSpeakerChecker.test.ts
@@ -44,6 +44,7 @@ describe('checkNextSpeaker', () => {
   let chatInstance: GeminiChat;
   let mockGeminiClient: GeminiClient;
   let MockConfig: Mock;
+  const abortSignal = new AbortController().signal;
 
   beforeEach(() => {
     MockConfig = vi.mocked(Config);
@@ -71,7 +72,7 @@ describe('checkNextSpeaker', () => {
       mockGoogleGenAIInstance, // This will be the instance returned by the mocked GoogleGenAI constructor
       mockModelsInstance, // This is the instance returned by mockGoogleGenAIInstance.getGenerativeModel
       'gemini-pro', // model name
-      {}, // config
+      {},
       [], // initial history
     );
 
@@ -85,7 +86,11 @@ describe('checkNextSpeaker', () => {
 
   it('should return null if history is empty', async () => {
     (chatInstance.getHistory as Mock).mockReturnValue([]);
-    const result = await checkNextSpeaker(chatInstance, mockGeminiClient);
+    const result = await checkNextSpeaker(
+      chatInstance,
+      mockGeminiClient,
+      abortSignal,
+    );
     expect(result).toBeNull();
     expect(mockGeminiClient.generateJson).not.toHaveBeenCalled();
   });
@@ -94,7 +99,11 @@ describe('checkNextSpeaker', () => {
     (chatInstance.getHistory as Mock).mockReturnValue([
       { role: 'user', parts: [{ text: 'Hello' }] },
     ] as Content[]);
-    const result = await checkNextSpeaker(chatInstance, mockGeminiClient);
+    const result = await checkNextSpeaker(
+      chatInstance,
+      mockGeminiClient,
+      abortSignal,
+    );
     expect(result).toBeNull();
     expect(mockGeminiClient.generateJson).not.toHaveBeenCalled();
   });
@@ -109,7 +118,11 @@ describe('checkNextSpeaker', () => {
     };
     (mockGeminiClient.generateJson as Mock).mockResolvedValue(mockApiResponse);
 
-    const result = await checkNextSpeaker(chatInstance, mockGeminiClient);
+    const result = await checkNextSpeaker(
+      chatInstance,
+      mockGeminiClient,
+      abortSignal,
+    );
     expect(result).toEqual(mockApiResponse);
     expect(mockGeminiClient.generateJson).toHaveBeenCalledTimes(1);
   });
@@ -124,7 +137,11 @@ describe('checkNextSpeaker', () => {
     };
     (mockGeminiClient.generateJson as Mock).mockResolvedValue(mockApiResponse);
 
-    const result = await checkNextSpeaker(chatInstance, mockGeminiClient);
+    const result = await checkNextSpeaker(
+      chatInstance,
+      mockGeminiClient,
+      abortSignal,
+    );
     expect(result).toEqual(mockApiResponse);
   });
 
@@ -138,7 +155,11 @@ describe('checkNextSpeaker', () => {
     };
     (mockGeminiClient.generateJson as Mock).mockResolvedValue(mockApiResponse);
 
-    const result = await checkNextSpeaker(chatInstance, mockGeminiClient);
+    const result = await checkNextSpeaker(
+      chatInstance,
+      mockGeminiClient,
+      abortSignal,
+    );
     expect(result).toEqual(mockApiResponse);
   });
 
@@ -153,7 +174,11 @@ describe('checkNextSpeaker', () => {
       new Error('API Error'),
     );
 
-    const result = await checkNextSpeaker(chatInstance, mockGeminiClient);
+    const result = await checkNextSpeaker(
+      chatInstance,
+      mockGeminiClient,
+      abortSignal,
+    );
     expect(result).toBeNull();
     consoleWarnSpy.mockRestore();
   });
@@ -166,7 +191,11 @@ describe('checkNextSpeaker', () => {
       reasoning: 'This is incomplete.',
     } as unknown as NextSpeakerResponse); // Type assertion to simulate invalid response
 
-    const result = await checkNextSpeaker(chatInstance, mockGeminiClient);
+    const result = await checkNextSpeaker(
+      chatInstance,
+      mockGeminiClient,
+      abortSignal,
+    );
     expect(result).toBeNull();
   });
 
@@ -179,7 +208,11 @@ describe('checkNextSpeaker', () => {
       next_speaker: 123, // Invalid type
     } as unknown as NextSpeakerResponse);
 
-    const result = await checkNextSpeaker(chatInstance, mockGeminiClient);
+    const result = await checkNextSpeaker(
+      chatInstance,
+      mockGeminiClient,
+      abortSignal,
+    );
     expect(result).toBeNull();
   });
 
@@ -192,7 +225,11 @@ describe('checkNextSpeaker', () => {
       next_speaker: 'neither', // Invalid enum value
     } as unknown as NextSpeakerResponse);
 
-    const result = await checkNextSpeaker(chatInstance, mockGeminiClient);
+    const result = await checkNextSpeaker(
+      chatInstance,
+      mockGeminiClient,
+      abortSignal,
+    );
     expect(result).toBeNull();
   });
 });

--- a/packages/server/src/utils/nextSpeakerChecker.ts
+++ b/packages/server/src/utils/nextSpeakerChecker.ts
@@ -61,6 +61,7 @@ export interface NextSpeakerResponse {
 export async function checkNextSpeaker(
   chat: GeminiChat,
   geminiClient: GeminiClient,
+  abortSignal: AbortSignal,
 ): Promise<NextSpeakerResponse | null> {
   // We need to capture the curated history because there are many moments when the model will return invalid turns
   // that when passed back up to the endpoint will break subsequent calls. An example of this is when the model decides
@@ -129,6 +130,7 @@ export async function checkNextSpeaker(
     const parsedResponse = (await geminiClient.generateJson(
       contents,
       RESPONSE_SCHEMA,
+      abortSignal,
     )) as unknown as NextSpeakerResponse;
 
     if (


### PR DESCRIPTION
- Implements cancellation for Gemini requests while they are actively being processed by the model.
- Extends cancellation support to the  logic within tools. This allows users to cancel operations during the phase where the system is determining if a tool execution requires user confirmation, which can include potentially long-running pre-flight checks or LLM-based corrections.
- Underlying LLM calls for edit corrections (within  and ) and next speaker checks can now also be cancelled.
- Previously, cancellation of the main request was not possible until text started streaming, and pre-execution checks were not cancellable.
- This change leverages the updated SDK's ability to accept an abort token and threads s throughout the request, tool execution, and pre-execution check lifecycle.

Fixes https://github.com/google-gemini/gemini-cli/issues/531