### PR TITLE
Add a keybinding for ctrl+w to delete the previous word.

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1176,6 +1176,7 @@ export function useTextBuffer({
       else if (key['ctrl'] && input === 'a') move('home');
       else if (key['end']) move('end');
       else if (key['ctrl'] && input === 'e') move('end');
+      else if (key['ctrl'] && input === 'w') deleteWordLeft();
       else if (
         (key['meta'] || key['ctrl'] || key['alt']) &&
         (key['backspace'] || input === '\x7f')


### PR DESCRIPTION
Adds the following new keybindings to the cli text input buffer:

- `Ctrl+W` : Delete previous word