### PR TITLE
Refactor: Add GeminiRespondingSpinner to make use of streamingState idiomatic

### DIFF
--- a/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
+++ b/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Text } from 'ink';
+import Spinner from 'ink-spinner';
+import type { SpinnerName } from 'cli-spinners';
+import { useStreamingContext } from '../contexts/StreamingContext.js';
+import { StreamingState } from '../types.js';
+
+interface GeminiRespondingSpinnerProps {
+  /**
+   * Optional string to display when not in Responding state.
+   * If not provided and not Responding, renders null.
+   */
+  nonRespondingDisplay?: string;
+  spinnerType?: SpinnerName;
+}
+
+export const GeminiRespondingSpinner: React.FC<
+  GeminiRespondingSpinnerProps
+> = ({ nonRespondingDisplay, spinnerType = 'dots' }) => {
+  const { streamingState } = useStreamingContext();
+
+  if (streamingState === StreamingState.Responding) {
+    return <Spinner type={spinnerType} />;
+  } else if (nonRespondingDisplay) {
+    return <Text>{nonRespondingDisplay}</Text>;
+  }
+  return null;
+};

--- a/packages/cli/src/ui/components/LoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.test.tsx
@@ -15,9 +15,21 @@ import {
 import { StreamingState } from '../types.js';
 import { vi } from 'vitest';
 
-// Mock ink-spinner
-vi.mock('ink-spinner', () => ({
-  default: () => <Text>MockSpinner</Text>,
+// Mock GeminiRespondingSpinner
+vi.mock('./GeminiRespondingSpinner.js', () => ({
+  GeminiRespondingSpinner: ({
+    nonRespondingDisplay,
+  }: {
+    nonRespondingDisplay?: string;
+  }) => {
+    const { streamingState } = React.useContext(StreamingContext)!;
+    if (streamingState === StreamingState.Responding) {
+      return <Text>MockRespondingSpinner</Text>;
+    } else if (nonRespondingDisplay) {
+      return <Text>{nonRespondingDisplay}</Text>;
+    }
+    return null;
+  },
 }));
 
 const renderWithContext = (
@@ -54,12 +66,12 @@ describe('<LoadingIndicator />', () => {
       StreamingState.Responding,
     );
     const output = lastFrame();
-    expect(output).toContain('MockSpinner');
+    expect(output).toContain('MockRespondingSpinner');
     expect(output).toContain('Loading...');
     expect(output).toContain('(esc to cancel, 5s)');
   });
 
-  it('should render phrase and time but no spinner when streamingState is WaitingForConfirmation', () => {
+  it('should render spinner (static), phrase but no time/cancel when streamingState is WaitingForConfirmation', () => {
     const props = {
       currentLoadingPhrase: 'Confirm action',
       elapsedTime: 10,
@@ -69,7 +81,7 @@ describe('<LoadingIndicator />', () => {
       StreamingState.WaitingForConfirmation,
     );
     const output = lastFrame();
-    expect(output).not.toContain('MockSpinner');
+    expect(output).toContain('⠏'); // Static char for WaitingForConfirmation
     expect(output).toContain('Confirm action');
     expect(output).not.toContain('(esc to cancel)');
     expect(output).not.toContain(', 10s');
@@ -127,7 +139,7 @@ describe('<LoadingIndicator />', () => {
       </StreamingContext.Provider>,
     );
     let output = lastFrame();
-    expect(output).toContain('MockSpinner');
+    expect(output).toContain('MockRespondingSpinner');
     expect(output).toContain('Now Responding');
     expect(output).toContain('(esc to cancel, 2s)');
 
@@ -143,7 +155,7 @@ describe('<LoadingIndicator />', () => {
       </StreamingContext.Provider>,
     );
     output = lastFrame();
-    expect(output).not.toContain('MockSpinner');
+    expect(output).toContain('⠏');
     expect(output).toContain('Please Confirm');
     expect(output).not.toContain('(esc to cancel)');
     expect(output).not.toContain(', 15s');

--- a/packages/cli/src/ui/components/LoadingIndicator.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.tsx
@@ -32,7 +32,6 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
     <Box marginTop={1} paddingLeft={0}>
       <Box marginRight={1}>
         <GeminiRespondingSpinner
-          spinnerType="dots"
           nonRespondingDisplay={
             streamingState === StreamingState.WaitingForConfirmation ? '⠏' : ''
           }

--- a/packages/cli/src/ui/components/LoadingIndicator.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.tsx
@@ -6,10 +6,10 @@
 
 import React from 'react';
 import { Box, Text } from 'ink';
-import Spinner from 'ink-spinner';
 import { Colors } from '../colors.js';
 import { useStreamingContext } from '../contexts/StreamingContext.js';
 import { StreamingState } from '../types.js';
+import { GeminiRespondingSpinner } from './GeminiRespondingSpinner.js';
 
 interface LoadingIndicatorProps {
   currentLoadingPhrase: string;
@@ -30,11 +30,14 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
 
   return (
     <Box marginTop={1} paddingLeft={0}>
-      {streamingState === StreamingState.Responding && (
-        <Box marginRight={1}>
-          <Spinner type="dots" />
-        </Box>
-      )}
+      <Box marginRight={1}>
+        <GeminiRespondingSpinner
+          spinnerType="dots"
+          nonRespondingDisplay={
+            streamingState === StreamingState.WaitingForConfirmation ? '⠏' : ''
+          }
+        />
+      </Box>
       <Text color={Colors.AccentPurple}>
         {currentLoadingPhrase}
         {streamingState === StreamingState.WaitingForConfirmation

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -6,16 +6,11 @@
 
 import React from 'react';
 import { Box, Text } from 'ink';
-import Spinner from 'ink-spinner';
-import {
-  IndividualToolCallDisplay,
-  StreamingState,
-  ToolCallStatus,
-} from '../../types.js';
+import { IndividualToolCallDisplay, ToolCallStatus } from '../../types.js';
 import { DiffRenderer } from './DiffRenderer.js';
 import { Colors } from '../../colors.js';
 import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
-import { useStreamingContext } from '../../contexts/StreamingContext.js';
+import { GeminiRespondingSpinner } from '../GeminiRespondingSpinner.js';
 
 const STATIC_HEIGHT = 1;
 const RESERVED_LINE_COUNT = 5; // for tool name, status, padding etc.
@@ -61,7 +56,6 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   return (
     <Box paddingX={1} paddingY={0} flexDirection="column">
       <Box minHeight={1}>
-        {/* Status Indicator */}
         <ToolStatusIndicator status={status} />
         <ToolInfo
           name={name}
@@ -107,41 +101,38 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
 type ToolStatusIndicatorProps = {
   status: ToolCallStatus;
 };
+
 const ToolStatusIndicator: React.FC<ToolStatusIndicatorProps> = ({
   status,
-}) => {
-  const { streamingState } = useStreamingContext();
-  return (
-    <Box minWidth={STATUS_INDICATOR_WIDTH}>
-      {status === ToolCallStatus.Pending && (
-        <Text color={Colors.AccentGreen}>o</Text>
-      )}
-      {status === ToolCallStatus.Executing &&
-        (streamingState === StreamingState.Responding ? (
-          <Spinner type="toggle" />
-        ) : (
-          // Paused spinner to avoid flicker.
-          <Text>⠇</Text>
-        ))}
-      {status === ToolCallStatus.Success && (
-        <Text color={Colors.AccentGreen}>✔</Text>
-      )}
-      {status === ToolCallStatus.Confirming && (
-        <Text color={Colors.AccentYellow}>?</Text>
-      )}
-      {status === ToolCallStatus.Canceled && (
-        <Text color={Colors.AccentYellow} bold>
-          -
-        </Text>
-      )}
-      {status === ToolCallStatus.Error && (
-        <Text color={Colors.AccentRed} bold>
-          x
-        </Text>
-      )}
-    </Box>
-  );
-};
+}) => (
+  <Box minWidth={STATUS_INDICATOR_WIDTH}>
+    {status === ToolCallStatus.Pending && (
+      <Text color={Colors.AccentGreen}>o</Text>
+    )}
+    {status === ToolCallStatus.Executing && (
+      <GeminiRespondingSpinner
+        spinnerType="toggle"
+        nonRespondingDisplay={'⊷'}
+      />
+    )}
+    {status === ToolCallStatus.Success && (
+      <Text color={Colors.AccentGreen}>✔</Text>
+    )}
+    {status === ToolCallStatus.Confirming && (
+      <Text color={Colors.AccentYellow}>?</Text>
+    )}
+    {status === ToolCallStatus.Canceled && (
+      <Text color={Colors.AccentYellow} bold>
+        -
+      </Text>
+    )}
+    {status === ToolCallStatus.Error && (
+      <Text color={Colors.AccentRed} bold>
+        x
+      </Text>
+    )}
+  </Box>
+);
 
 type ToolInfo = {
   name: string;


### PR DESCRIPTION
This Spinner should be used everywhere in the UI where we want to use a spinner to avoid flicker caused by showing spinners when we are not responding. Using context in this way makes the way we are using Context more idiomatic as this context is now basically the state to theme how responding spinners are rendered.

- If `streamingState` is `Responding`, the component renders a spinner.
- If `nonRespondingDisplay` is  set it days the fallback content.
- Otherwise (not `Responding` and no `nonRespondingDisplay`), it renders `null`.

Usage in `LoadingIndicator.tsx` and `ToolMessage.tsx` has been updated to pass the appropriate `nonRespondingDisplay` string to maintain previous visual behavior. Tests for `LoadingIndicator.test.tsx` and `ToolMessage.test.tsx` have been updated accordingly. Fix bug where the default display for the Spinner in ToolMessage wasn't aligned with the Spinner type.
