### PR TITLE
fix: handle undefined file_path in WriteFileTool.getDescription

### DIFF
--- a/packages/server/src/tools/write-file.test.ts
+++ b/packages/server/src/tools/write-file.test.ts
@@ -190,6 +190,26 @@ describe('WriteFileTool', () => {
     });
   });
 
+  describe('getDescription', () => {
+    it('should return a generic description if file_path is undefined', () => {
+      const params = { content: 'some content' } as any;
+      expect(tool.getDescription(params)).toBe('Writing new file content');
+    });
+
+    it('should return a generic description if file_path is an empty string', () => {
+      const params = { file_path: '', content: 'some content' };
+      expect(tool.getDescription(params)).toBe('Writing new file content');
+    });
+
+    it('should return the correct description if file_path is provided', () => {
+      const params = {
+        file_path: path.join(rootDir, 'test.txt'),
+        content: 'hello',
+      };
+      expect(tool.getDescription(params)).toBe('Writing to test.txt');
+    });
+  });
+
   describe('_getCorrectedFileContent', () => {
     it('should call ensureCorrectFileContent for a new file', async () => {
       const filePath = path.join(rootDir, 'new_corrected_file.txt');

--- a/packages/server/src/tools/write-file.ts
+++ b/packages/server/src/tools/write-file.ts
@@ -129,6 +129,13 @@ export class WriteFileTool extends BaseTool<WriteFileToolParams, ToolResult> {
   }
 
   getDescription(params: WriteFileToolParams): string {
+    if (!params.file_path) {
+      // If file_path is not provided (e.g., for a new file in planning stage),
+      // return a generic description.
+      // We could also try to use params.content to generate a more specific description,
+      // but for now, a generic one is safer.
+      return 'Writing new file content'; // Or "Writing content to a new file"
+    }
     const relativePath = makeRelative(
       params.file_path,
       this.config.getTargetDir(),


### PR DESCRIPTION
### 🦑 **Courtesy of Jules** 🐙 

The WriteFileTool's getDescription method would crash if params.file_path was undefined. This could happen when I tried to get a description for a file creation operation before the file path was fully determined.

This commit adds a check for an undefined or empty file_path in getDescription. If the file_path is not available, it now returns a generic description "Writing new file content" instead of attempting to calculate a relative path, which would lead to a crash.

I added test cases to verify this fix and prevent regressions. This addresses issue #581 and is related to issue #523.