### PR TITLE
feat: Enhance web_fetch tool to process prompts with URLs using Gemini API

### DIFF
--- a/packages/server/src/config/config.ts
+++ b/packages/server/src/config/config.ts
@@ -236,7 +236,7 @@ export function createToolRegistry(config: Config): ToolRegistry {
   registerCoreTool(GlobTool, targetDir);
   registerCoreTool(EditTool, config);
   registerCoreTool(WriteFileTool, config);
-  registerCoreTool(WebFetchTool);
+  registerCoreTool(WebFetchTool, config);
   registerCoreTool(ReadManyFilesTool, targetDir);
   registerCoreTool(ShellTool, config);
   registerCoreTool(MemoryTool);


### PR DESCRIPTION
This commit refactors the  tool to leverage the Gemini API for processing natural language prompts that include URLs. Instead of simply fetching the content of a single URL, the tool can now accept a prompt with instructions and multiple URLs (up to 20).

The Gemini API will be used to understand the instructions and process the content from the provided URLs. This allows for more complex operations like summarization, data extraction, and question answering based on web content.

The tool now expects a  parameter instead of  and includes logic to handle grounding metadata (sources and citations) from the Gemini API response, appending them to the processed content. Error handling has also been updated to reflect the new API interaction.

The  is updated to pass the necessary  object to the
 constructor.