### PR TITLE
fix(ci): Only run post_coverage_comment job on pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     name: Post Coverage Comment
     runs-on: ubuntu-latest
     needs: test
-    if: always()
+    if: always() && github.event_name == 'pull_request'
     continue-on-error: true
     permissions:
       contents: read # For checkout


### PR DESCRIPTION
The `post_coverage_comment` job uses an action (`thollander/actions-comment-pull-request`) that is designed to comment on pull requests. When this job runs on direct pushes to the `main` branch (e.g., after a PR is merged), it fails because there is no associated pull request context.

This commit updates the `if` condition for the `post_coverage_comment` job to `always() && github.event_name == 'pull_request'`. This ensures the job only attempts to run when the workflow is triggered by a pull_request event, preventing the error on main branch builds. The `always()` condition is kept to ensure the job still attempts to run even if the preceding `test` job fails within a PR context.

This should fix #579