### PR TITLE
fix(sandbox): add SHORT_SHA to image tag

### DIFF
--- a/.gcp/dogfood.yaml
+++ b/.gcp/dogfood.yaml
@@ -4,22 +4,21 @@ steps:
     entrypoint: 'npm'
     args: ['install']
 
-  # Step 2: Update version with build suffix
+  # Step 2: Update version in root package.json
   - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
-    entrypoint: 'npm'
+    entrypoint: 'bash'
     args:
-      [
-        'run',
-        'prerelease:version',
-        '--workspaces',
-        '--',
-        '--suffix="$SHORT_SHA.$_REVISION"',
-      ]
+      - -c # Use bash -c to allow for command substitution and string manipulation
+      - |
+        current_version=$(npm pkg get version | sed 's/"//g')
+        new_version="$${current_version}-$SHORT_SHA.$_REVISION"
+        npm pkg set "version=$${new_version}"
+        echo "Set root package.json version to: $${new_version}"
 
-  # Step 3: Bind dependencies to the new versions
+  # Step 3: Run prerelease:dev to update workspace versions and dependencies
   - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
     entrypoint: 'npm'
-    args: ['run', 'prerelease:deps', '--workspaces']
+    args: ['run', 'prerelease:dev'] # This will run prerelease:version and prerelease:deps
 
   # Step 4: Authenticate for Docker and NPM
   - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'

--- a/scripts/bind_package_version.js
+++ b/scripts/bind_package_version.js
@@ -6,41 +6,19 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import yargs from 'yargs';
-import { hideBin } from 'yargs/helpers';
-import { execSync } from 'node:child_process';
 
 // Assuming script is run from a package directory (e.g., packages/cli)
 const packageDir = process.cwd();
 const rootDir = path.join(packageDir, '..', '..'); // Go up two directories to find the repo root
 
-function getBaseVersion() {
+function getRepoVersion() {
   // Read root package.json
   const rootPackageJsonPath = path.join(rootDir, 'package.json');
   const rootPackage = JSON.parse(fs.readFileSync(rootPackageJsonPath, 'utf8'));
-  return rootPackage.version;
+  return rootPackage.version; // This version is now expected to be the full version string
 }
 
-function getDefaultSuffix() {
-  // Get latest commit hash
-  const commitHash = execSync('git rev-parse --short HEAD', {
-    encoding: 'utf8',
-  }).trim();
-
-  // Append dev suffix with commit hash
-  return `dev-${commitHash}.0`;
-}
-
-const argv = yargs(hideBin(process.argv))
-  .option('suffix', {
-    type: 'string',
-    description: 'Set the package version suffix',
-  })
-  .parse();
-
-const baseVersion = getBaseVersion();
-const suffix = argv['suffix'] ?? getDefaultSuffix();
-const newVersion = `${baseVersion}${suffix.length ? '-' : ''}${suffix}`;
+const newVersion = getRepoVersion();
 console.log(`Setting package version to: ${newVersion}`);
 
 const packageJsonPath = path.join(packageDir, 'package.json');


### PR DESCRIPTION
Our cicd pipeline was managing/tagging the published image based on metadata in the root package.json. Meanwhile, npm publishes based on the subdirectory package.json. 

We were only appending the SHORT_SHA to the subdirectory package.json versions. This moves that up to the root package.json.