### PR TITLE
feat: add --show_memory_usage flag to display memory usage in status bar

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -35,6 +35,7 @@ interface CliArgs {
   debug: boolean | undefined;
   prompt: string | undefined;
   all_files: boolean | undefined;
+  show_memory_usage: boolean | undefined;
 }
 
 async function parseArguments(): Promise<CliArgs> {
@@ -65,6 +66,11 @@ async function parseArguments(): Promise<CliArgs> {
       alias: 'a',
       type: 'boolean',
       description: 'Include ALL files in context?',
+      default: false,
+    })
+    .option('show_memory_usage', {
+      type: 'boolean',
+      description: 'Show memory usage in status bar',
       default: false,
     })
     .help()
@@ -152,6 +158,7 @@ export async function loadCliConfig(settings: Settings): Promise<Config> {
     userMemory: memoryContent,
     geminiMdFileCount: fileCount,
     vertexai: useVertexAI,
+    showMemoryUsage: argv.show_memory_usage || false,
   };
 
   return createServerConfig(configParams);

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -27,6 +27,7 @@ export interface Settings {
   toolCallCommand?: string;
   mcpServerCommand?: string;
   mcpServers?: Record<string, MCPServerConfig>;
+  showMemoryUsage?: boolean;
   // Add other settings here.
 }
 

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -442,6 +442,7 @@ export const App = ({
             corgiMode={corgiMode}
             errorCount={errorCount}
             showErrorDetails={showErrorDetails}
+            showMemoryUsage={config.getDebugMode() || config.getShowMemoryUsage()}
           />
         </Box>
       </Box>

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -442,7 +442,9 @@ export const App = ({
             corgiMode={corgiMode}
             errorCount={errorCount}
             showErrorDetails={showErrorDetails}
-            showMemoryUsage={config.getDebugMode() || config.getShowMemoryUsage()}
+            showMemoryUsage={
+              config.getDebugMode() || config.getShowMemoryUsage()
+            }
           />
         </Box>
       </Box>

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -9,6 +9,8 @@ import { Box, Text } from 'ink';
 import { Colors } from '../colors.js';
 import { shortenPath, tildeifyPath } from '@gemini-code/server';
 import { ConsoleSummaryDisplay } from './ConsoleSummaryDisplay.js';
+import process from 'node:process';
+import { MemoryUsageDisplay } from './MemoryUsageDisplay.js';
 
 interface FooterProps {
   model: string;
@@ -20,6 +22,7 @@ interface FooterProps {
   corgiMode: boolean;
   errorCount: number;
   showErrorDetails: boolean;
+  showMemoryUsage?: boolean;
 }
 
 export const Footer: React.FC<FooterProps> = ({
@@ -31,6 +34,7 @@ export const Footer: React.FC<FooterProps> = ({
   corgiMode,
   errorCount,
   showErrorDetails,
+  showMemoryUsage,
 }) => (
   <Box marginTop={1} justifyContent="space-between" width="100%">
     <Box>
@@ -86,6 +90,7 @@ export const Footer: React.FC<FooterProps> = ({
           <ConsoleSummaryDisplay errorCount={errorCount} />
         </Box>
       )}
+      {showMemoryUsage && <MemoryUsageDisplay />}
     </Box>
   </Box>
 );

--- a/packages/cli/src/ui/components/MemoryUsageDisplay.tsx
+++ b/packages/cli/src/ui/components/MemoryUsageDisplay.tsx
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Box, Text } from 'ink';
+import { Colors } from '../colors.js';
+import process from 'node:process';
+
+const formatMemoryUsage = (bytes: number): string => {
+  const gb = bytes / (1024 * 1024 * 1024);
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${gb.toFixed(2)} GB`;
+};
+
+export const MemoryUsageDisplay: React.FC = () => {
+  const [memoryUsage, setMemoryUsage] = useState<string>('');
+  const [memoryUsageColor, setMemoryUsageColor] = useState<string>(
+    Colors.SubtleComment,
+  );
+
+  useEffect(() => {
+    const updateMemory = () => {
+      const usage = process.memoryUsage().rss;
+      setMemoryUsage(formatMemoryUsage(usage));
+      setMemoryUsageColor(
+        usage >= 2 * 1024 * 1024 * 1024
+          ? Colors.AccentRed
+          : Colors.SubtleComment,
+      );
+    };
+    const intervalId = setInterval(updateMemory, 2000);
+    updateMemory(); // Initial update
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return (
+    <Box>
+      <Text color={Colors.SubtleComment}>| </Text>
+      <Text color={memoryUsageColor}>{memoryUsage}</Text>
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/MemoryUsageDisplay.tsx
+++ b/packages/cli/src/ui/components/MemoryUsageDisplay.tsx
@@ -8,17 +8,7 @@ import React, { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 import { Colors } from '../colors.js';
 import process from 'node:process';
-
-const formatMemoryUsage = (bytes: number): string => {
-  const gb = bytes / (1024 * 1024 * 1024);
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`;
-  }
-  if (bytes < 1024 * 1024 * 1024) {
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  }
-  return `${gb.toFixed(2)} GB`;
-};
+import { formatMemoryUsage } from '../utils/formatters.js';
 
 export const MemoryUsageDisplay: React.FC = () => {
   const [memoryUsage, setMemoryUsage] = useState<string>('');

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -9,9 +9,37 @@ const { mockProcessExit } = vi.hoisted(() => ({
 }));
 
 vi.mock('node:process', () => ({
+  default: {
+    exit: mockProcessExit,
+    cwd: vi.fn(() => '/mock/cwd'),
+    get env() {
+      return process.env;
+    }, // Use a getter to ensure current process.env is used
+    platform: 'test-platform',
+    version: 'test-node-version',
+    memoryUsage: vi.fn(() => ({
+      rss: 12345678,
+      heapTotal: 23456789,
+      heapUsed: 10234567,
+      external: 1234567,
+      arrayBuffers: 123456,
+    })),
+  },
+  // Provide top-level exports as well for compatibility
   exit: mockProcessExit,
   cwd: vi.fn(() => '/mock/cwd'),
-  env: { ...process.env },
+  get env() {
+    return process.env;
+  }, // Use a getter here too
+  platform: 'test-platform',
+  version: 'test-node-version',
+  memoryUsage: vi.fn(() => ({
+    rss: 12345678,
+    heapTotal: 23456789,
+    heapUsed: 10234567,
+    external: 1234567,
+    arrayBuffers: 123456,
+  })),
 }));
 
 vi.mock('node:fs/promises', () => ({
@@ -227,7 +255,7 @@ describe('useSlashCommandProcessor', () => {
       seatbeltProfileVar?: string,
     ) => {
       const cliVersion = 'test-version';
-      const osVersion = `${process.platform} ${process.version}`;
+      const osVersion = 'test-platform test-node-version';
       let sandboxEnvStr = 'no sandbox';
       if (sandboxEnvVar && sandboxEnvVar !== 'sandbox-exec') {
         sandboxEnvStr = sandboxEnvVar.replace(/^gemini-(?:code-)?/, '');
@@ -235,6 +263,8 @@ describe('useSlashCommandProcessor', () => {
         sandboxEnvStr = `sandbox-exec (${seatbeltProfileVar || 'unknown'})`;
       }
       const modelVersion = 'test-model';
+      // Use the mocked memoryUsage value
+      const memoryUsage = '11.8 MB';
 
       const diagnosticInfo = `
 ## Describe the bug
@@ -249,6 +279,7 @@ Add any other context about the problem here.
 *   **Operating System:** ${osVersion}
 *   **Sandbox Environment:** ${sandboxEnvStr}
 *   **Model Version:** ${modelVersion}
+*   **Memory Usage:** ${memoryUsage}
 `;
       let url =
         'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.md';

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -7,11 +7,13 @@
 import { useCallback, useMemo } from 'react';
 import { type PartListUnion } from '@google/genai';
 import open from 'open';
+import process from 'node:process';
 import { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { Config } from '@gemini-code/server';
 import { Message, MessageType, HistoryItemWithoutId } from '../types.js';
 import { createShowMemoryAction } from './useShowMemoryCommand.js';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
+import { formatMemoryUsage } from '../utils/formatters.js';
 
 export interface SlashCommandActionReturn {
   shouldScheduleTool?: boolean;
@@ -206,6 +208,7 @@ export const useSlashCommandProcessor = (
             sandboxEnv = `sandbox-exec (${process.env.SEATBELT_PROFILE || 'unknown'})`;
           }
           const modelVersion = config?.getModel() || 'Unknown';
+          const memoryUsage = formatMemoryUsage(process.memoryUsage().rss);
 
           const diagnosticInfo = `
 ## Describe the bug
@@ -220,6 +223,7 @@ Add any other context about the problem here.
 *   **Operating System:** ${osVersion}
 *   **Sandbox Environment:** ${sandboxEnv}
 *   **Model Version:** ${modelVersion}
+*   **Memory Usage:** ${memoryUsage}
 `;
 
           let bugReportUrl =

--- a/packages/cli/src/ui/utils/formatters.ts
+++ b/packages/cli/src/ui/utils/formatters.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const formatMemoryUsage = (bytes: number): string => {
+  const gb = bytes / (1024 * 1024 * 1024);
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${gb.toFixed(2)} GB`;
+};

--- a/packages/server/src/config/config.ts
+++ b/packages/server/src/config/config.ts
@@ -54,6 +54,7 @@ export interface ConfigParameters {
   geminiMdFileCount?: number;
   alwaysSkipModificationConfirmation?: boolean;
   vertexai?: boolean;
+  showMemoryUsage?: boolean;
 }
 
 export class Config {
@@ -75,6 +76,7 @@ export class Config {
   private geminiMdFileCount: number;
   private alwaysSkipModificationConfirmation: boolean;
   private readonly vertexai: boolean | undefined;
+  private readonly showMemoryUsage: boolean;
 
   constructor(params: ConfigParameters) {
     this.apiKey = params.apiKey;
@@ -95,6 +97,7 @@ export class Config {
     this.alwaysSkipModificationConfirmation =
       params.alwaysSkipModificationConfirmation ?? false;
     this.vertexai = params.vertexai;
+    this.showMemoryUsage = params.showMemoryUsage ?? false;
 
     this.toolRegistry = createToolRegistry(this);
   }
@@ -180,6 +183,10 @@ export class Config {
 
   getVertexAI(): boolean | undefined {
     return this.vertexai;
+  }
+
+  getShowMemoryUsage(): boolean {
+    return this.showMemoryUsage;
   }
 }
 


### PR DESCRIPTION
This commit introduces a new `--show_memory_usage` CLI flag. When this flag is set, the application will display the current memory usage (RSS) in the status bar, updating periodically.

The memory usage is displayed in a human-readable format (MB or GB). If usage exceeds 2GB, the text is shown in red to draw users attention.

This helps users monitor the application's memory footprint during runtime without using Chrome DevTools.

`npm start -- --show_memory_usage`

<img width="744" alt="Screenshot 2025-05-29 at 6 19 04 PM" src="https://github.com/user-attachments/assets/4b90a4b1-dba9-4850-9e35-1cab5043970c" />

Example when memory usage is high
<img width="736" alt="Screenshot 2025-05-29 at 6 18 09 PM" src="https://github.com/user-attachments/assets/a2a73c45-8208-443d-9707-ce00df380c60" />


