### PR TITLE
Change ReadFile to not have a result display.

### DIFF
--- a/packages/server/src/utils/fileUtils.test.ts
+++ b/packages/server/src/utils/fileUtils.test.ts
@@ -258,7 +258,7 @@ describe('fileUtils', () => {
         tempRootDir,
       );
       expect(result.llmContent).toBe(content);
-      expect(result.returnDisplay).toContain('Read text file: test.txt');
+      expect(result.returnDisplay).toBe('');
       expect(result.error).toBeUndefined();
     });
 
@@ -380,9 +380,7 @@ describe('fileUtils', () => {
       expect(result.llmContent).toContain(
         '[File content truncated: showing lines 6-10 of 20 total lines. Use offset/limit parameters to view more.]',
       );
-      expect(result.returnDisplay).toContain(
-        'Read text file: test.txt (truncated)',
-      );
+      expect(result.returnDisplay).toBe('(truncated)');
       expect(result.isTruncated).toBe(true);
       expect(result.originalLineCount).toBe(20);
       expect(result.linesShown).toEqual([6, 10]);
@@ -401,7 +399,7 @@ describe('fileUtils', () => {
       const expectedContent = lines.join('\n');
 
       expect(result.llmContent).toBe(expectedContent);
-      expect(result.returnDisplay).toContain('Read text file: test.txt');
+      expect(result.returnDisplay).toBe('');
       expect(result.isTruncated).toBe(false);
       expect(result.originalLineCount).toBe(2);
       expect(result.linesShown).toEqual([1, 2]);

--- a/packages/server/src/utils/fileUtils.ts
+++ b/packages/server/src/utils/fileUtils.ts
@@ -236,7 +236,7 @@ export async function processSingleFileContent(
 
         return {
           llmContent: llmTextContent,
-          returnDisplay: `Read text file: ${relativePathForDisplay}${isTruncated ? ' (truncated)' : ''}`,
+          returnDisplay: isTruncated ? '(truncated)' : '',
           isTruncated,
           originalLineCount,
           linesShown: [actualStartLine + 1, endLine],


### PR DESCRIPTION
- It's verbose on its own; however, if file content is truncated we'll indicate that in the result display.

@jacob314 this is one "fix" I did tonight. I felt like the extra result display didn't add enough value on its own.