### PR TITLE
fix(ci): Adjust reporting for PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,14 +90,21 @@ jobs:
       - name: Run tests and generate reports
         run: NO_COLOR=true npm run test:ci
 
-      - name: Publish Test Report
+      - name: Publish Test Report (for non-forks)
+        if: always() && (github.event.pull_request.head.repo.full_name == github.repository)
         uses: dorny/test-reporter@v1
-        if: always()
         with:
           name: Test Results (Node ${{ matrix.node-version }})
           path: packages/*/junit.xml
           reporter: java-junit
           fail-on-error: 'false'
+
+      - name: Upload Test Results Artifact (for forks)
+        if: always() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-fork-${{ matrix.node-version }}
+          path: packages/*/junit.xml
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4
@@ -110,7 +117,7 @@ jobs:
     name: Post Coverage Comment
     runs-on: ubuntu-latest
     needs: test
-    if: always() && github.event_name == 'pull_request'
+    if: always() && github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository)
     continue-on-error: true
     permissions:
       contents: read # For checkout


### PR DESCRIPTION
Modifies the CI workflow to handle test and coverage reporting for pull requests originating from forks.

- Test reports (junit.xml) are now uploaded as artifacts for forked PRs, as the GITHUB_TOKEN has read-only permissions and cannot publish checks directly.
- The `dorny/test-reporter` action will only attempt to publish reports for PRs from the main repository.
- The `post_coverage_comment` job will only attempt to post comments for PRs from the main repository.

This prevents errors related to "Resource not accessible by integration" when workflows are triggered by PRs from forks, ensuring maintainers can still access test results via artifacts.