### PR TITLE
Fix bug pasting multiline strings

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -514,6 +514,34 @@ describe('useTextBuffer', () => {
       act(() => result.current.handleInput('\r', {})); // Simulates Shift+Enter in VSCode terminal
       expect(getBufferState(result).lines).toEqual(['', '']);
     });
+
+    it('should correctly handle repeated pasting of long text', () => {
+      const { result } = renderHook(() => useTextBuffer({ viewport }));
+      const longText = `not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+
+Why do we use it?
+It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).
+
+Where does it come from?
+Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lore
+`;
+
+      // Simulate pasting the long text multiple times
+      act(() => result.current.insertStr(longText));
+      act(() => result.current.insertStr(longText));
+      act(() => result.current.insertStr(longText));
+
+      const state = getBufferState(result);
+      // Check that the text is the result of three concatenations.
+      expect(state.lines).toStrictEqual(
+        (longText + longText + longText).split('\n'),
+      );
+      const expectedCursorPos = offsetToLogicalPos(
+        state.text,
+        state.text.length,
+      );
+      expect(state.cursor).toEqual(expectedCursorPos);
+    });
   });
 
   // More tests would be needed for:

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -524,35 +524,33 @@ export function useTextBuffer({
       const normalised = str.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
       const parts = normalised.split('\n');
 
-      setLines((prevLines) => {
-        const newLines = [...prevLines];
-        const lineContent = currentLine(cursorRow);
-        const before = cpSlice(lineContent, 0, cursorCol);
-        const after = cpSlice(lineContent, cursorCol);
+      const newLines = [...lines];
+      const lineContent = currentLine(cursorRow);
+      const before = cpSlice(lineContent, 0, cursorCol);
+      const after = cpSlice(lineContent, cursorCol);
 
-        newLines[cursorRow] = before + parts[0];
+      newLines[cursorRow] = before + parts[0];
 
-        if (parts.length > 1) {
-          // Adjusted condition for inserting multiple lines
-          const remainingParts = parts.slice(1);
-          const lastPartOriginal = remainingParts.pop() ?? '';
-          newLines.splice(cursorRow + 1, 0, ...remainingParts);
-          newLines.splice(
-            cursorRow + parts.length - 1,
-            0,
-            lastPartOriginal + after,
-          );
-          setCursorRow((prev) => prev + parts.length - 1);
-          setCursorCol(cpLen(lastPartOriginal));
-        } else {
-          setCursorCol(cpLen(before) + cpLen(parts[0]));
-        }
-        return newLines;
-      });
+      if (parts.length > 1) {
+        // Adjusted condition for inserting multiple lines
+        const remainingParts = parts.slice(1);
+        const lastPartOriginal = remainingParts.pop() ?? '';
+        newLines.splice(cursorRow + 1, 0, ...remainingParts);
+        newLines.splice(
+          cursorRow + parts.length - 1,
+          0,
+          lastPartOriginal + after,
+        );
+        setCursorRow(cursorRow + parts.length - 1);
+        setCursorCol(cpLen(lastPartOriginal));
+      } else {
+        setCursorCol(cpLen(before) + cpLen(parts[0]));
+      }
+      setLines(newLines);
       setPreferredCol(null);
       return true;
     },
-    [pushUndo, cursorRow, cursorCol, currentLine, setPreferredCol],
+    [pushUndo, cursorRow, cursorCol, lines, currentLine, setPreferredCol],
   );
 
   const insert = useCallback(
@@ -1275,6 +1273,7 @@ export function useTextBuffer({
 
     setText,
     insert,
+    insertStr,
     newline,
     backspace,
     del,
@@ -1354,6 +1353,7 @@ export interface TextBuffer {
    * Insert a single character or string without newlines.
    */
   insert: (ch: string) => void;
+  insertStr: (str: string) => boolean;
   newline: () => void;
   backspace: () => void;
   del: () => void;


### PR DESCRIPTION
This fixes the bug pasting in long multiline strings.
Sadly my test case passes without the fix so isn't quite right even though the fix robustly handles the real app.

@KeijiBranshi do you have an idea why my test isn't fixing the issue? More nuanced timing of multiple useState objects that I haven't quite wrapped my head around.