### PR TITLE
fix(cli): Clear input buffer before onSubmit in InputPrompt

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -74,8 +74,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const handleSubmitAndClear = useCallback(
     (submittedValue: string) => {
-      onSubmit(submittedValue);
+      // Clear the buffer *before* calling onSubmit to prevent potential re-submission
+      // if onSubmit triggers a re-render while the buffer still holds the old value.
       buffer.setText('');
+      onSubmit(submittedValue);
       resetCompletionState();
     },
     [onSubmit, buffer, resetCompletionState],


### PR DESCRIPTION
Moves `buffer.setText('')` to be called before `onSubmit` in the `handleSubmitAndClear` callback within the InputPrompt component.

This prevents a potential race condition where a re-render, triggered by state changes within the `onSubmit` handler (such as adding items to history via `addItem`), could occur while the input buffer still contains the submitted text. If the input handling logic were to re-evaluate the submission event due to the re-render, it could lead to the same input being processed multiple times. Clearing the buffer first ensures that any such re-evaluation would find an empty buffer, thus preventing duplicate submissions. This specifically addresses an issue where multiple `@file` arguments could lead to the `read_many_files` tool being invoked multiple times for a single user input.