### PR TITLE
Dont match slash commands in history

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+packages/server/dist

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -188,6 +188,11 @@ async function createContentGeneratorConfig(
   const hasVertexProjectLocationConfig =
     !!googleCloudProject && !!googleCloudLocation;
 
+  if (hasGeminiApiKey && hasGoogleApiKey) {
+    logger.warn(
+      'Both GEMINI_API_KEY and GOOGLE_API_KEY are set. Using GOOGLE_API_KEY.',
+    );
+  }
   if (!hasGeminiApiKey && !hasGoogleApiKey && !hasVertexProjectLocationConfig) {
     logger.error(
       'No valid API authentication configuration found. Please set ONE of the following combinations in your environment variables or .env file:\n' +
@@ -203,7 +208,7 @@ async function createContentGeneratorConfig(
 
   const config: ContentGeneratorConfig = {
     model: argv.model || DEFAULT_GEMINI_MODEL,
-    apiKey: geminiApiKey || googleApiKey || '',
+    apiKey: googleApiKey || geminiApiKey || '',
     vertexai: hasGeminiApiKey ? false : undefined,
   };
 


### PR DESCRIPTION
pressing up to a slash commands triggers the autocomplete box which interferes with pressing up (until you backspace the entire command). This is majorly frustrating. This fixes that by just ignoring slash commands in history. Maybe we'll want to do the same with at commands later but that's not bitting me in the same way yet.