### PR TITLE
Add default build task for VS Code

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "build",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": [],
+      "label": "npm: build",
+      "detail": "scripts/build.sh"
+    }
+  ]
+}


### PR DESCRIPTION
Simple addition that allows devs to hit `Cmd+Shift+B` when building the repo. Super handy shortcut.