### PR TITLE
feat: Implement delayed Ctrl+C exit prompt

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -78,6 +78,7 @@ async function main() {
           startupWarnings={startupWarnings}
         />
       </React.StrictMode>,
+      { exitOnCtrlC: false },
     );
     return;
   }


### PR DESCRIPTION
This change introduces a small delay after the first Ctrl+C press, prompting the user to press Ctrl+C again to exit. This helps prevent accidental termination of the application.

- Added `exitOnCtrlC={false}` to the Ink render options in `gemini.tsx` to enable custom Ctrl+C handling.
- Implemented logic in `App.tsx` to:
    - Display "Press Ctrl+C again to exit." for 1 seconds after the first Ctrl+C.
    - Exit the application if Ctrl+C is pressed again during this period.
    - Revert to normal operation if the second Ctrl+C is not pressed within the timeout.
- Defined a constant `CTRL_C_PROMPT_DURATION_MS` for the timeout duration.

Fixes https://github.com/google-gemini/gemini-cli/issues/621

![image (3)](https://github.com/user-attachments/assets/44caf318-5193-4752-95d1-1cae98ad9ba3)

