### PR TITLE
Fix: Cloud Build CI - Update sandbox build to use new core package name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,10 @@ USER node
 
 # install gemini-cli and clean up
 COPY packages/cli/dist/gemini-code-cli-*.tgz /usr/local/share/npm-global/gemini-code-cli.tgz
-COPY packages/core/dist/gemini-code-server-*.tgz /usr/local/share/npm-global/gemini-code-server.tgz
-RUN npm install -g /usr/local/share/npm-global/gemini-code-cli.tgz /usr/local/share/npm-global/gemini-code-server.tgz \
+COPY packages/core/dist/gemini-code-core-*.tgz /usr/local/share/npm-global/gemini-code-core.tgz
+RUN npm install -g /usr/local/share/npm-global/gemini-code-cli.tgz /usr/local/share/npm-global/gemini-code-core.tgz \
   && npm cache clean --force \
-  && rm -f /usr/local/share/npm-global/gemini-code-{cli,server}.tgz
+  && rm -f /usr/local/share/npm-global/gemini-code-{cli,core}.tgz
 
 # default entrypoint when none specified
 CMD ["gemini"]

--- a/scripts/build_sandbox.sh
+++ b/scripts/build_sandbox.sh
@@ -59,7 +59,7 @@ rm -f packages/cli/dist/gemini-code-cli-*.tgz
 npm pack -w @gemini-code/cli --pack-destination ./packages/cli/dist &>/dev/null
 # pack core
 echo "packing @gemini-code/core ..."
-rm -f packages/core/dist/gemini-code-server-*.tgz
+rm -f packages/core/dist/gemini-code-core-*.tgz
 npm pack -w @gemini-code/core --pack-destination ./packages/core/dist &>/dev/null
 # give node user (used during installation, see Dockerfile) access to these files
 chmod 755 packages/*/dist/gemini-code-*.tgz


### PR DESCRIPTION
- The `packages/core` tarball name changed from `gemini-code-server-*.tgz` to `gemini-code-core-*.tgz` after the `server` to `core` rename.
- This updates `scripts/build_sandbox.sh` and the root `Dockerfile` to use the new `gemini-code-core-*.tgz` naming, resolving the CI failure during the Docker build step of the publish process.