### PR TITLE
Fix: Update code coverage reporting for core rename

### DIFF
--- a/.github/actions/post-coverage-comment/action.yml
+++ b/.github/actions/post-coverage-comment/action.yml
@@ -5,14 +5,14 @@ inputs:
   cli_json_file:
     description: 'Path to CLI coverage-summary.json'
     required: true
-  server_json_file:
-    description: 'Path to Server coverage-summary.json'
+  core_json_file:
+    description: 'Path to Core coverage-summary.json'
     required: true
   cli_full_text_summary_file:
     description: 'Path to CLI full-text-summary.txt'
     required: true
-  server_full_text_summary_file:
-    description: 'Path to Server full-text-summary.txt'
+  core_full_text_summary_file:
+    description: 'Path to Core full-text-summary.txt'
     required: true
   node_version:
     description: 'Node.js version for context in messages'
@@ -29,9 +29,9 @@ runs:
       shell: bash
       run: |
         cli_json_file="${{ inputs.cli_json_file }}"
-        server_json_file="${{ inputs.server_json_file }}"
+        core_json_file="${{ inputs.core_json_file }}"
         cli_full_text_summary_file="${{ inputs.cli_full_text_summary_file }}"
-        server_full_text_summary_file="${{ inputs.server_full_text_summary_file }}"
+        core_full_text_summary_file="${{ inputs.core_full_text_summary_file }}"
         comment_file="coverage-comment.md"
 
         # Extract percentages using jq for the main table
@@ -45,14 +45,14 @@ runs:
           echo "CLI coverage-summary.json not found at: $cli_json_file" >&2 # Error to stderr
         fi
 
-        if [ -f "$server_json_file" ]; then
-          server_lines_pct=$(jq -r '.total.lines.pct' "$server_json_file")
-          server_statements_pct=$(jq -r '.total.statements.pct' "$server_json_file")
-          server_functions_pct=$(jq -r '.total.functions.pct' "$server_json_file")
-          server_branches_pct=$(jq -r '.total.branches.pct' "$server_json_file")
+        if [ -f "$core_json_file" ]; then
+          core_lines_pct=$(jq -r '.total.lines.pct' "$core_json_file")
+          core_statements_pct=$(jq -r '.total.statements.pct' "$core_json_file")
+          core_functions_pct=$(jq -r '.total.functions.pct' "$core_json_file")
+          core_branches_pct=$(jq -r '.total.branches.pct' "$core_json_file")
         else
-          server_lines_pct="N/A"; server_statements_pct="N/A"; server_functions_pct="N/A"; server_branches_pct="N/A"
-          echo "Server coverage-summary.json not found at: $server_json_file" >&2 # Error to stderr
+          core_lines_pct="N/A"; core_statements_pct="N/A"; core_functions_pct="N/A"; core_branches_pct="N/A"
+          echo "Core coverage-summary.json not found at: $core_json_file" >&2 # Error to stderr
         fi
 
         echo "## Code Coverage Summary" > "$comment_file"
@@ -60,12 +60,12 @@ runs:
         echo "| Package | Lines | Statements | Functions | Branches |" >> "$comment_file"
         echo "|---|---|---|---|---|" >> "$comment_file"
         echo "| CLI | ${cli_lines_pct}% | ${cli_statements_pct}% | ${cli_functions_pct}% | ${cli_branches_pct}% |" >> "$comment_file"
-        echo "| Server | ${server_lines_pct}% | ${server_statements_pct}% | ${server_functions_pct}% | ${server_branches_pct}% |" >> "$comment_file"
+        echo "| Core | ${core_lines_pct}% | ${core_statements_pct}% | ${core_functions_pct}% | ${core_branches_pct}% |" >> "$comment_file"
         echo "" >> "$comment_file"
 
         # CLI Package - Collapsible Section (with full text summary from file)
         echo "<details>" >> "$comment_file"
-        echo "<summary>CLI Package - Full Text Report</summary>" >> "$comment_file"
+        echo "<summary>CLI Package - Full Text Report</summary>"
         echo "" >> "$comment_file"
         echo '```text' >> "$comment_file"
         if [ -f "$cli_full_text_summary_file" ]; then
@@ -74,21 +74,21 @@ runs:
           echo "CLI full-text-summary.txt not found at: $cli_full_text_summary_file" >> "$comment_file"
         fi
         echo '```' >> "$comment_file"
-        echo "</details>" >> "$comment_file"
+        echo "</details>"
         echo "" >> "$comment_file"
 
-        # Server Package - Collapsible Section (with full text summary from file)
+        # Core Package - Collapsible Section (with full text summary from file)
         echo "<details>" >> "$comment_file"
-        echo "<summary>Server Package - Full Text Report</summary>" >> "$comment_file"
+        echo "<summary>Core Package - Full Text Report</summary>"
         echo "" >> "$comment_file"
         echo '```text' >> "$comment_file"
-        if [ -f "$server_full_text_summary_file" ]; then
-          cat "$server_full_text_summary_file" >> "$comment_file"
+        if [ -f "$core_full_text_summary_file" ]; then
+          cat "$core_full_text_summary_file" >> "$comment_file"
         else
-          echo "Server full-text-summary.txt not found at: $server_full_text_summary_file" >> "$comment_file"
+          echo "Core full-text-summary.txt not found at: $core_full_text_summary_file" >> "$comment_file"
         fi
         echo '```' >> "$comment_file"
-        echo "</details>" >> "$comment_file"
+        echo "</details>"
         echo "" >> "$comment_file"
 
         echo "_For detailed HTML reports, please see the 'coverage-reports-${{ inputs.node_version }}' artifact from the main CI run._" >> "$comment_file"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,8 @@ jobs:
         uses: ./.github/actions/post-coverage-comment # Path to the composite action directory
         with:
           cli_json_file: coverage_artifact/cli/coverage/coverage-summary.json
-          server_json_file: coverage_artifact/server/coverage/coverage-summary.json
+          core_json_file: coverage_artifact/core/coverage/coverage-summary.json
           cli_full_text_summary_file: coverage_artifact/cli/coverage/full-text-summary.txt
-          server_full_text_summary_file: coverage_artifact/server/coverage/full-text-summary.txt
+          server_full_text_summary_file: coverage_artifact/core/coverage/full-text-summary.txt
           node_version: ${{ matrix.node-version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Renames "server" to "core" in GitHub Actions workflow and comment posting action.
- This ensures that code coverage paths and labels are accurate after the package rename.