### PR TITLE
Fix for validating getDescription in read_file tool call

### DIFF
--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -93,6 +93,9 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
   }
 
   getDescription(params: ReadFileToolParams): string {
+    if (!params || typeof params.path !== 'string' || params.path.trim() === '') {
+      return `[${ReadFileTool.Name}: Path information unavailable]`;
+    }
     const relativePath = makeRelative(params.path, this.rootDirectory);
     return shortenPath(relativePath);
   }

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -98,7 +98,7 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
       typeof params.path !== 'string' ||
       params.path.trim() === ''
     ) {
-      return `[${ReadFileTool.Name}: Path information unavailable]`;
+      return `Path unavailable`;
     }
     const relativePath = makeRelative(params.path, this.rootDirectory);
     return shortenPath(relativePath);

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -93,7 +93,11 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
   }
 
   getDescription(params: ReadFileToolParams): string {
-    if (!params || typeof params.path !== 'string' || params.path.trim() === '') {
+    if (
+      !params ||
+      typeof params.path !== 'string' ||
+      params.path.trim() === ''
+    ) {
       return `[${ReadFileTool.Name}: Path information unavailable]`;
     }
     const relativePath = makeRelative(params.path, this.rootDirectory);


### PR DESCRIPTION
Fixes https://github.com/google-gemini/gemini-cli/issues/533

* Adding an error check for the path params.
