### PR TITLE
Update edit tool validation function to override validateToolParams

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -178,14 +178,14 @@ describe('EditTool', () => {
     });
   });
 
-  describe('validateParams', () => {
+  describe('validateToolParams', () => {
     it('should return null for valid params', () => {
       const params: EditToolParams = {
         file_path: path.join(rootDir, 'test.txt'),
         old_string: 'old',
         new_string: 'new',
       };
-      expect(tool.validateParams(params)).toBeNull();
+      expect(tool.validateToolParams(params)).toBeNull();
     });
 
     it('should return error for relative path', () => {
@@ -194,7 +194,9 @@ describe('EditTool', () => {
         old_string: 'old',
         new_string: 'new',
       };
-      expect(tool.validateParams(params)).toMatch(/File path must be absolute/);
+      expect(tool.validateToolParams(params)).toMatch(
+        /File path must be absolute/,
+      );
     });
 
     it('should return error for path outside root', () => {
@@ -203,7 +205,7 @@ describe('EditTool', () => {
         old_string: 'old',
         new_string: 'new',
       };
-      expect(tool.validateParams(params)).toMatch(
+      expect(tool.validateToolParams(params)).toMatch(
         /File path must be within the root directory/,
       );
     });

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -126,7 +126,7 @@ Expectation for parameters:
    * @param params Parameters to validate
    * @returns Error message string or null if valid
    */
-  validateParams(params: EditToolParams): string | null {
+  validateToolParams(params: EditToolParams): string | null {
     if (
       this.schema.parameters &&
       !SchemaValidator.validate(
@@ -372,7 +372,7 @@ Expectation for parameters:
     params: EditToolParams,
     _signal: AbortSignal,
   ): Promise<ToolResult> {
-    const validationError = this.validateParams(params);
+    const validationError = this.validateToolParams(params);
     if (validationError) {
       return {
         llmContent: `Error: Invalid parameters provided. Reason: ${validationError}`,


### PR DESCRIPTION
This fixes #557.

`shouldConfirmExecute` is already calling `validateToolParams` to skip confirmation if params are invalid but `validateToolParams` is not overridden in the edit tool.

This PR simply renames existing validation function to `validateToolParams` to override it.