### PR TITLE
fix: Display MCP server count in context summary

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -286,4 +286,45 @@ describe('App UI', () => {
     await Promise.resolve();
     expect(lastFrame()).not.toContain('ANY_FILE.MD');
   });
+
+  it('should display GEMINI.md and MCP server count when both are present', async () => {
+    mockConfig.getGeminiMdFileCount.mockReturnValue(2);
+    mockConfig.getMcpServers.mockReturnValue({
+      server1: {} as MCPServerConfig,
+    });
+    mockConfig.getDebugMode.mockReturnValue(false);
+    mockConfig.getShowMemoryUsage.mockReturnValue(false);
+
+    const { lastFrame, unmount } = render(
+      <App
+        config={mockConfig as unknown as ServerConfig}
+        settings={mockSettings}
+        cliVersion="1.0.0"
+      />,
+    );
+    currentUnmount = unmount;
+    await Promise.resolve();
+    expect(lastFrame()).toContain('server');
+  });
+
+  it('should display only MCP server count when GEMINI.md count is 0', async () => {
+    mockConfig.getGeminiMdFileCount.mockReturnValue(0);
+    mockConfig.getMcpServers.mockReturnValue({
+      server1: {} as MCPServerConfig,
+      server2: {} as MCPServerConfig,
+    });
+    mockConfig.getDebugMode.mockReturnValue(false);
+    mockConfig.getShowMemoryUsage.mockReturnValue(false);
+
+    const { lastFrame, unmount } = render(
+      <App
+        config={mockConfig as unknown as ServerConfig}
+        settings={mockSettings}
+        cliVersion="1.0.0"
+      />,
+    );
+    currentUnmount = unmount;
+    await Promise.resolve();
+    expect(lastFrame()).toContain('Using 2 MCP servers');
+  });
 });

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -37,6 +37,7 @@ import { Tips } from './components/Tips.js';
 import { useConsolePatcher } from './components/ConsolePatcher.js';
 import { DetailedMessagesDisplay } from './components/DetailedMessagesDisplay.js';
 import { HistoryItemDisplay } from './components/HistoryItemDisplay.js';
+import { ContextSummaryDisplay } from './components/ContextSummaryDisplay.js';
 import { useHistory } from './hooks/useHistoryManager.js';
 import process from 'node:process';
 import {
@@ -400,16 +401,15 @@ export const App = ({
                     <Text color={Colors.AccentYellow}>
                       Press Ctrl+C again to exit.
                     </Text>
-                  ) : geminiMdFileCount > 0 ? (
-                    <Text color={Colors.SubtleComment}>
-                      Using {geminiMdFileCount}{' '}
-                      {settings.merged.contextFileName ||
-                        getCurrentGeminiMdFilename()}{' '}
-                      file
-                      {geminiMdFileCount > 1 ? 's' : ''}
-                    </Text>
                   ) : (
-                    <Text> </Text> // Render an empty space to reserve height
+                    <ContextSummaryDisplay
+                      geminiMdFileCount={geminiMdFileCount}
+                      contextFileName={
+                        settings.merged.contextFileName ||
+                        getCurrentGeminiMdFilename()
+                      }
+                      mcpServers={config.getMcpServers()}
+                    />
                   )}
                 </Box>
                 <Box>

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Text } from 'ink';
+import { Colors } from '../colors.js';
+import { type MCPServerConfig } from '@gemini-code/core';
+
+interface ContextSummaryDisplayProps {
+  geminiMdFileCount: number;
+  contextFileName: string;
+  mcpServers?: Record<string, MCPServerConfig>;
+}
+
+export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
+  geminiMdFileCount,
+  contextFileName,
+  mcpServers,
+}) => {
+  const mcpServerCount = Object.keys(mcpServers || {}).length;
+
+  if (geminiMdFileCount === 0 && mcpServerCount === 0) {
+    return <Text> </Text>; // Render an empty space to reserve height
+  }
+
+  const geminiMdText =
+    geminiMdFileCount > 0
+      ? `${geminiMdFileCount} ${contextFileName} file${geminiMdFileCount > 1 ? 's' : ''}`
+      : '';
+
+  const mcpText =
+    mcpServerCount > 0
+      ? `${mcpServerCount} MCP server${mcpServerCount > 1 ? 's' : ''}`
+      : '';
+
+  let summaryText = 'Using ';
+  if (geminiMdText) {
+    summaryText += geminiMdText;
+  }
+  if (geminiMdText && mcpText) {
+    summaryText += ' and ';
+  }
+  if (mcpText) {
+    summaryText += mcpText;
+  }
+
+  return <Text color={Colors.SubtleComment}>{summaryText}</Text>;
+};


### PR DESCRIPTION
- Add ContextSummaryDisplay component to show the number of connected MCP servers and active GEMINI.md files.
- Update App.tsx to use the new component.
- Add tests for various scenarios, including when 0 MCP servers are present.
![image](https://github.com/user-attachments/assets/f80461b2-7f2f-43c4-8dea-c288d290fc5b)

Fixes https://github.com/google-gemini/gemini-cli/issues/673