### PR TITLE
Enable "Debug Test" config to debug Server or CLI tests.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
         "run",
         "test",
         "-w",
-        "packages/cli", // Default to CLI, change if needed or prompt for package
+        "packages",
         "--",
         "--inspect-brk=9229",
         "--no-file-parallelism",


### PR DESCRIPTION
- Prior to this we were scoping the working directory to the cli dir (no need). Users have to specify a path anyways so this would just result in broken tests if you ever tried to debug a server test.