### PR TITLE
fix: Ensure all tool calls are complete before submitting responses

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -530,7 +530,10 @@ export const useGeminiStream = (
       },
     );
 
-    if (completedAndReadyToSubmitTools.length > 0) {
+    if (
+      completedAndReadyToSubmitTools.length > 0 &&
+      completedAndReadyToSubmitTools.length === toolCalls.length
+    ) {
       const responsesToSend: PartListUnion[] =
         completedAndReadyToSubmitTools.map(
           (toolCall) => toolCall.response.responseParts,


### PR DESCRIPTION
- Modifies `useGeminiStream.ts` to only submit tool responses when all scheduled tool calls have reached a completed state (success, error, or cancelled).
- Adds comprehensive tests for `useGeminiStream.ts` to cover various scenarios, including partial completion and full completion of tool calls.

Fixes https://github.com/google-gemini/gemini-cli/issues/687