### PR TITLE
fix(ci): correct input name for core coverage summary

### DIFF
--- a/.github/actions/post-coverage-comment/action.yml
+++ b/.github/actions/post-coverage-comment/action.yml
@@ -65,7 +65,7 @@ runs:
 
         # CLI Package - Collapsible Section (with full text summary from file)
         echo "<details>" >> "$comment_file"
-        echo "<summary>CLI Package - Full Text Report</summary>"
+        echo "<summary>CLI Package - Full Text Report</summary>" >> "$comment_file"
         echo "" >> "$comment_file"
         echo '```text' >> "$comment_file"
         if [ -f "$cli_full_text_summary_file" ]; then
@@ -74,12 +74,12 @@ runs:
           echo "CLI full-text-summary.txt not found at: $cli_full_text_summary_file" >> "$comment_file"
         fi
         echo '```' >> "$comment_file"
-        echo "</details>"
+        echo "</details>" >> "$comment_file"
         echo "" >> "$comment_file"
 
         # Core Package - Collapsible Section (with full text summary from file)
         echo "<details>" >> "$comment_file"
-        echo "<summary>Core Package - Full Text Report</summary>"
+        echo "<summary>Core Package - Full Text Report</summary>" >> "$comment_file"
         echo "" >> "$comment_file"
         echo '```text' >> "$comment_file"
         if [ -f "$core_full_text_summary_file" ]; then
@@ -88,7 +88,7 @@ runs:
           echo "Core full-text-summary.txt not found at: $core_full_text_summary_file" >> "$comment_file"
         fi
         echo '```' >> "$comment_file"
-        echo "</details>"
+        echo "</details>" >> "$comment_file"
         echo "" >> "$comment_file"
 
         echo "_For detailed HTML reports, please see the 'coverage-reports-${{ inputs.node_version }}' artifact from the main CI run._" >> "$comment_file"

--- a/.github/actions/post-coverage-comment/action.yml
+++ b/.github/actions/post-coverage-comment/action.yml
@@ -65,7 +65,8 @@ runs:
 
         # CLI Package - Collapsible Section (with full text summary from file)
         echo "<details>" >> "$comment_file"
-        echo "<summary>CLI Package - Full Text Report</summary>" >> "$comment_file"
+        echo "<summary>CLI Package - Full Text Report</summary>"
+        echo "" >> "$comment_file"
         echo '```text' >> "$comment_file"
         if [ -f "$cli_full_text_summary_file" ]; then
           cat "$cli_full_text_summary_file" >> "$comment_file"
@@ -78,7 +79,8 @@ runs:
 
         # Core Package - Collapsible Section (with full text summary from file)
         echo "<details>" >> "$comment_file"
-        echo "<summary>Core Package - Full Text Report</summary>" >> "$comment_file"
+        echo "<summary>Core Package - Full Text Report</summary>"
+        echo "" >> "$comment_file"
         echo '```text' >> "$comment_file"
         if [ -f "$core_full_text_summary_file" ]; then
           cat "$core_full_text_summary_file" >> "$comment_file"

--- a/.github/actions/post-coverage-comment/action.yml
+++ b/.github/actions/post-coverage-comment/action.yml
@@ -65,8 +65,7 @@ runs:
 
         # CLI Package - Collapsible Section (with full text summary from file)
         echo "<details>" >> "$comment_file"
-        echo "<summary>CLI Package - Full Text Report</summary>"
-        echo "" >> "$comment_file"
+        echo "<summary>CLI Package - Full Text Report</summary>" >> "$comment_file"
         echo '```text' >> "$comment_file"
         if [ -f "$cli_full_text_summary_file" ]; then
           cat "$cli_full_text_summary_file" >> "$comment_file"
@@ -79,8 +78,7 @@ runs:
 
         # Core Package - Collapsible Section (with full text summary from file)
         echo "<details>" >> "$comment_file"
-        echo "<summary>Core Package - Full Text Report</summary>"
-        echo "" >> "$comment_file"
+        echo "<summary>Core Package - Full Text Report</summary>" >> "$comment_file"
         echo '```text' >> "$comment_file"
         if [ -f "$core_full_text_summary_file" ]; then
           cat "$core_full_text_summary_file" >> "$comment_file"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,6 @@ jobs:
           cli_json_file: coverage_artifact/cli/coverage/coverage-summary.json
           core_json_file: coverage_artifact/core/coverage/coverage-summary.json
           cli_full_text_summary_file: coverage_artifact/cli/coverage/full-text-summary.txt
-          server_full_text_summary_file: coverage_artifact/core/coverage/full-text-summary.txt
+          core_full_text_summary_file: coverage_artifact/core/coverage/full-text-summary.txt
           node_version: ${{ matrix.node-version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates the GitHub Actions workflow to use the correct input name `core_full_text_summary_file` instead of
`server_full_text_summary_file` when calling the
post-coverage-comment composite action.

This aligns with the composite action's expected input name and ensures the core package's coverage report is correctly processed.