### PR TITLE
fix(cli): restore first-launch theme prompt

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -188,7 +188,8 @@ describe('App UI', () => {
     }
     mockConfig.getShowMemoryUsage.mockReturnValue(false); // Default for most tests
 
-    mockSettings = createMockSettings();
+    // Ensure a theme is set so the theme dialog does not appear.
+    mockSettings = createMockSettings({ theme: 'Default' });
   });
 
   afterEach(() => {
@@ -235,7 +236,10 @@ describe('App UI', () => {
   });
 
   it('should display custom contextFileName in footer when set and count is 1', async () => {
-    mockSettings = createMockSettings({ contextFileName: 'AGENTS.MD' });
+    mockSettings = createMockSettings({
+      contextFileName: 'AGENTS.MD',
+      theme: 'Default',
+    });
     mockConfig.getGeminiMdFileCount.mockReturnValue(1);
     mockConfig.getDebugMode.mockReturnValue(false);
     mockConfig.getShowMemoryUsage.mockReturnValue(false);
@@ -253,7 +257,10 @@ describe('App UI', () => {
   });
 
   it('should display custom contextFileName with plural when set and count is > 1', async () => {
-    mockSettings = createMockSettings({ contextFileName: 'MY_NOTES.TXT' });
+    mockSettings = createMockSettings({
+      contextFileName: 'MY_NOTES.TXT',
+      theme: 'Default',
+    });
     mockConfig.getGeminiMdFileCount.mockReturnValue(3);
     mockConfig.getDebugMode.mockReturnValue(false);
     mockConfig.getShowMemoryUsage.mockReturnValue(false);
@@ -271,7 +278,10 @@ describe('App UI', () => {
   });
 
   it('should not display context file message if count is 0, even if contextFileName is set', async () => {
-    mockSettings = createMockSettings({ contextFileName: 'ANY_FILE.MD' });
+    mockSettings = createMockSettings({
+      contextFileName: 'ANY_FILE.MD',
+      theme: 'Default',
+    });
     mockConfig.getGeminiMdFileCount.mockReturnValue(0);
     mockConfig.getDebugMode.mockReturnValue(false);
     mockConfig.getShowMemoryUsage.mockReturnValue(false);
@@ -327,5 +337,22 @@ describe('App UI', () => {
     currentUnmount = unmount;
     await Promise.resolve();
     expect(lastFrame()).toContain('Using 2 MCP servers');
+  });
+
+  it('should display theme dialog if no theme is set in settings', async () => {
+    mockSettings = createMockSettings({});
+    mockConfig.getDebugMode.mockReturnValue(false);
+    mockConfig.getShowMemoryUsage.mockReturnValue(false);
+
+    const { lastFrame, unmount } = render(
+      <App
+        config={mockConfig as unknown as ServerConfig}
+        settings={mockSettings}
+        cliVersion="1.0.0"
+      />,
+    );
+    currentUnmount = unmount;
+
+    expect(lastFrame()).toContain('Select Theme');
   });
 });

--- a/packages/cli/src/ui/hooks/useThemeCommand.ts
+++ b/packages/cli/src/ui/hooks/useThemeCommand.ts
@@ -26,18 +26,23 @@ export const useThemeCommand = (
   const effectiveTheme = loadedSettings.merged.theme;
 
   // Initial state: Open dialog if no theme is set in either user or workspace settings
-  const [isThemeDialogOpen, setIsThemeDialogOpen] = useState(false);
+  const [isThemeDialogOpen, setIsThemeDialogOpen] = useState(
+    effectiveTheme === undefined, // Open dialog if no theme is set initially
+  );
   // TODO: refactor how theme's are accessed to avoid requiring a forced render.
   const [, setForceRender] = useState(0);
 
   // Apply initial theme on component mount
   useEffect(() => {
-    if (!themeManager.setActiveTheme(effectiveTheme)) {
-      // If theme is not found during initial load, open the theme selection dialog and set error message
-      setIsThemeDialogOpen(true);
-      setThemeError(`Theme "${effectiveTheme}" not found.`);
-    } else {
-      setThemeError(null); // Clear any previous theme error on success
+    // Only try to set a theme if one is actually defined.
+    // If effectiveTheme was undefined, the dialog is already open due to useState above.
+    if (effectiveTheme !== undefined) {
+      if (!themeManager.setActiveTheme(effectiveTheme)) {
+        setIsThemeDialogOpen(true);
+        setThemeError(`Theme "${effectiveTheme}" not found.`);
+      } else {
+        setThemeError(null); // Clear any previous theme error on success
+      }
     }
   }, [effectiveTheme, setThemeError]); // Re-run if effectiveTheme or setThemeError changes
 


### PR DESCRIPTION
The theme selection dialog was not appearing on the first launch if no theme was previously set.

This was due to the `useThemeCommand` hook's interaction with `themeManager`.
- `themeManager.setActiveTheme(undefined)` would apply a default theme and return `true`.
- `useThemeCommand` interpreted this `true` return value as a theme being successfully loaded from settings, and thus would not trigger the theme selection dialog.

This change modifies `useThemeCommand` to:
- Initialize its `isThemeDialogOpen` state to `true` if no theme is found in the settings (`effectiveTheme` is `undefined`) upon hook initialization.
- Only attempt to set a theme via `themeManager.setActiveTheme` within its `useEffect` if a theme name is actually present in the settings.

This ensures that users are prompted to select a theme on their first run of the application.

add test for theme dialog on first launch