### PR TITLE
React to Gemini API break - Thought Inclusion

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -342,6 +342,10 @@ export class GeminiChat {
     // Consolidate adjacent model roles in outputContents
     const consolidatedOutputContents: Content[] = [];
     for (const content of outputContents) {
+      if (this.isThoughtContent(content)) {
+        continue;
+      }
+
       const lastContent =
         consolidatedOutputContents[consolidatedOutputContents.length - 1];
       if (this.isTextContent(lastContent) && this.isTextContent(content)) {
@@ -392,6 +396,19 @@ export class GeminiChat {
       content.parts.length > 0 &&
       typeof content.parts[0].text === 'string' &&
       content.parts[0].text !== ''
+    );
+  }
+
+  private isThoughtContent(
+    content: Content | undefined,
+  ): content is Content & { parts: [{ thought: boolean }, ...Part[]] } {
+    return !!(
+      content &&
+      content.role === 'model' &&
+      content.parts &&
+      content.parts.length > 0 &&
+      typeof content.parts[0].thought === 'boolean' &&
+      content.parts[0].thought === true
     );
   }
 }


### PR DESCRIPTION
- Gemini API just released https://ai.google.dev/gemini-api/docs/thinking#signatures but turns out this is somewhat of a breaking change for our world. There's now "thought" aprts which get passed to and from the API. While this could be useful in our case it confuses the model significantly.
- This PR addresses this break by removing thoughts from our history so they're not re-included in requests.

Fixes https://b.corp.google.com/issues/421850376