### PR TITLE
refactor: maintain 1 GeminiChat per GeminiClient

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -39,7 +39,7 @@ describe('runNonInteractive', () => {
       sendMessageStream: vi.fn(),
     };
     mockGeminiClient = {
-      startChat: vi.fn().mockResolvedValue(mockChat),
+      getChat: vi.fn().mockResolvedValue(mockChat),
     } as unknown as GeminiClient;
     mockToolRegistry = {
       getFunctionDeclarations: vi.fn().mockReturnValue([]),
@@ -80,7 +80,6 @@ describe('runNonInteractive', () => {
 
     await runNonInteractive(mockConfig, 'Test input');
 
-    expect(mockGeminiClient.startChat).toHaveBeenCalled();
     expect(mockChat.sendMessageStream).toHaveBeenCalledWith({
       message: [{ text: 'Test input' }],
       config: {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -42,7 +42,7 @@ export async function runNonInteractive(
   const geminiClient = new GeminiClient(config);
   const toolRegistry: ToolRegistry = await config.getToolRegistry();
 
-  const chat = await geminiClient.startChat();
+  const chat = await geminiClient.getChat();
   const abortController = new AbortController();
   let currentMessages: Content[] = [{ role: 'user', parts: [{ text: input }] }];
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -405,10 +405,9 @@ describe('useGeminiStream', () => {
       } as TrackedCancelledToolCall,
     ];
 
-    let hookResult: any;
-    await act(async () => {
-      hookResult = renderTestHook(simplifiedToolCalls);
-    });
+    const hookResult = await act(async () =>
+      renderTestHook(simplifiedToolCalls),
+    );
 
     const {
       mockMarkToolsAsSubmitted,
@@ -431,9 +430,8 @@ describe('useGeminiStream', () => {
       toolCall2ResponseParts,
     ]);
     expect(localMockSendMessageStream).toHaveBeenCalledWith(
-      expect.anything(),
       expectedMergedResponse,
-      expect.anything(),
+      expect.any(AbortSignal),
     );
   });
 });

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -35,6 +35,7 @@ vi.mock('../tools/memoryTool', () => ({
   setGeminiMdFilename: vi.fn(),
   getCurrentGeminiMdFilename: vi.fn(() => 'GEMINI.md'), // Mock the original filename
   DEFAULT_CONTEXT_FILENAME: 'GEMINI.md',
+  GEMINI_CONFIG_DIR: '.gemini',
 }));
 
 describe('Server Config (config.ts)', () => {

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -56,10 +56,10 @@ Signal: Signal number or \`(none)\` if no signal was received.
     let stdout = '';
     let stderr = '';
     child.stdout.on('data', (data) => {
-      stdout += data.toString();
+      stdout += data?.toString();
     });
     child.stderr.on('data', (data) => {
-      stderr += data.toString();
+      stderr += data?.toString();
     });
     let error: Error | null = null;
     child.on('error', (err: Error) => {


### PR DESCRIPTION
CHILD=#711
ISSUE=#494

Preliminary refactor for chat history compression. This way GeminiClient can compress history under the hood without GeminiChat references in other parts of the code going stale. Took a pass through and it didn't seem like we were creating multiple chats for a single client anyways