### PR TITLE
Refactor: Make MCP server discovery non-blocking

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -254,7 +254,7 @@ export function createServerConfig(params: ConfigParameters): Config {
   });
 }
 
-export function createToolRegistry(config: Config): Promise<ToolRegistry> {
+function createToolRegistry(config: Config): Promise<ToolRegistry> {
   const registry = new ToolRegistry(config);
   const targetDir = config.getTargetDir();
   const tools = config.getCoreTools()
@@ -281,8 +281,12 @@ export function createToolRegistry(config: Config): Promise<ToolRegistry> {
   registerCoreTool(ShellTool, config);
   registerCoreTool(MemoryTool);
   registerCoreTool(WebSearchTool, config);
-  return (async () => {
-    await registry.discoverTools();
-    return registry;
-  })();
+
+  // This is async, but we can't wait for it to finish because when we register
+  // discovered tools, we need to see if existing tools already exist in order to
+  // avoid duplicates.
+  registry.discoverTools();
+
+  // Maintain an async registry return so it's easy in the future to add async behavior to this instantiation.
+  return Promise.resolve(registry);
 }

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -132,7 +132,7 @@ You are running outside of a sandbox container, directly on the user's system. F
 ${(function () {
   // note git repo can change so we need to check every time system prompt is generated
   const gitRootCmd = 'git rev-parse --show-toplevel 2>/dev/null || true';
-  const gitRoot = execSync(gitRootCmd).toString().trim();
+  const gitRoot = execSync(gitRootCmd)?.toString()?.trim();
   if (gitRoot) {
     return `
 # Git Repository


### PR DESCRIPTION
- Removed await for MCP server discovery in `Config`.
- This allows the main application flow to continue without waiting for all MCP servers to establish connections and announce their tools.
- Unexported the discover mcp tools function so we can ensure it only happens once.

Fixes https://github.com/google-gemini/gemini-cli/issues/712