### PR TITLE
Docs: Update architecture diagram with Google colors (for future aricles)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,20 +36,20 @@ The Gemini CLI is primarily composed of two main packages, along with a suite of
 A typical interaction with the Gemini CLI follows this general flow:
 
 1.  **User Input:** The user types a prompt or command into the CLI (`packages/cli`).
-2.  **Request to Core:** The CLI package sends the user\'s input to the Core package (`packages/core`).
+2.  **Request to Core:** The CLI package sends the user's input to the Core package (`packages/core`).
 3.  **Core Processes Request:** The `packages/core` package:
     - Constructs an appropriate prompt for the Gemini API, possibly including conversation history and available tool definitions.
     - Sends the prompt to the Gemini API.
 4.  **Gemini API Response:** The Gemini API processes the prompt and returns a response. This response might be a direct answer or a request to use one of the available tools.
 5.  **Tool Execution (if applicable):**
-    - If the Gemini API requests a tool, the `packages/core` package prepares to execute it.
+    - If the Gemini API requests a tool, the Core package prepares to execute it.
     - **User Confirmation for Potentially Impactful Tools:** If the requested tool can modify the file system (e.g., file edits, writes) or execute shell commands, the CLI (`packages/cli`) displays a confirmation prompt to the user. This prompt details the tool and its arguments, and the user must approve the execution. Read-only operations (e.g., reading files, listing directories) may not always require this explicit confirmation step.
-    - If confirmed (or if confirmation is not required for the specific tool), the `packages/core` package identifies and executes the relevant tool (e.g., `read_file`, `execute_bash_command`).
+    - If confirmed (or if confirmation is not required for the specific tool), the Core package identifies and executes the relevant tool (e.g., `read_file`, `execute_bash_command`).
     - The tool performs its action (e.g., reads a file from the disk).
     - The result of the tool execution is sent back to the Gemini API by the Core.
     - The Gemini API processes the tool result and generates a final response.
-6.  **Response to CLI:** The `packages/core` package sends the final response (or intermediate tool messages) back to the `packages/cli` package.
-7.  **Display to User:** The `packages/cli` package formats and displays the response to the user in the terminal.
+6.  **Response to CLI:** The Core package sends the final response (or intermediate tool messages) back to the CLI package.
+7.  **Display to User:** The CLI package formats and displays the response to the user in the terminal.
 
 ## Diagram (Conceptual)
 
@@ -85,4 +85,4 @@ graph TD
 - **Extensibility:** The tool system is designed to be extensible, allowing new capabilities to be added.
 - **User Experience:** The CLI focuses on providing a rich and interactive terminal experience.
 
-This overview should provide a foundational understanding of the Gemini CLI\'s architecture. For more detailed information, refer to the specific documentation for each package and the development guides.
+This overview should provide a foundational understanding of the Gemini CLI's architecture. For more detailed information, refer to the specific documentation for each package and the development guides.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Gemini CLI Architecture Overview
 
-This document provides a high-level overview of the Gemini CLI\'s architecture. Understanding the main components and their interactions can be helpful for both users and developers.
+This document provides a high-level overview of the Gemini CLI's architecture. Understanding the main components and their interactions can be helpful for both users and developers.
 
 ## Core Components
 
@@ -37,7 +37,7 @@ A typical interaction with the Gemini CLI follows this general flow:
 
 1.  **User Input:** The user types a prompt or command into the CLI (`packages/cli`).
 2.  **Request to Core:** The CLI package sends the user's input to the Core package (`packages/core`).
-3.  **Core Processes Request:** The `packages/core` package:
+3.  **Core Processes Request:** The Core package:
     - Constructs an appropriate prompt for the Gemini API, possibly including conversation history and available tool definitions.
     - Sends the prompt to the Gemini API.
 4.  **Gemini API Response:** The Gemini API processes the prompt and returns a response. This response might be a direct answer or a request to use one of the available tools.
@@ -55,15 +55,15 @@ A typical interaction with the Gemini CLI follows this general flow:
 
 ```mermaid
 graph TD
-    User[User via Terminal] -- Input --> CLI["packages/cli"]
-    CLI -- Request --> Core["packages/core"]
-    Core -- Prompt/Tool Info --> GeminiAPI[Gemini API]
-    GeminiAPI -- Response/Tool Call --> Core
-    Core -- Tool Details --> CLI
-    CLI -- User Confirms --> Core
-    Core -- Execute Tool --> Tools[Tools e.g., read_file, shell]
-    Tools -- Tool Result --> Core
-    Core -- Final Response --> CLI
+    User[User via Terminal] -- Input --> CLI[packages/cli]
+    CLI -- Request --> Core[packages/core]
+    Core -- Prompt/ToolInfo --> GeminiAPI[Gemini API]
+    GeminiAPI -- Response/ToolCall --> Core
+    Core -- ToolDetails --> CLI
+    CLI -- UserConfirms --> Core
+    Core -- ExecuteTool --> Tools[Tools e.g., read_file, shell]
+    Tools -- ToolResult --> Core
+    Core -- FinalResponse --> CLI
     CLI -- Output --> User
 
     classDef userStyle fill:#FFFFFF,stroke:#333333,stroke-width:2px

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Gemini CLI Architecture Overview
 
-This document provides a high-level overview of the Gemini CLI's architecture. Understanding the main components and their interactions can be helpful for both users and developers.
+This document provides a high-level overview of the Gemini CLI\'s architecture. Understanding the main components and their interactions can be helpful for both users and developers.
 
 ## Core Components
 
@@ -36,27 +36,27 @@ The Gemini CLI is primarily composed of two main packages, along with a suite of
 A typical interaction with the Gemini CLI follows this general flow:
 
 1.  **User Input:** The user types a prompt or command into the CLI (`packages/cli`).
-2.  **Request to Core:** The CLI package sends the user's input to the Core package (`packages/core`).
-3.  **Core Processes Request:** The Core package:
+2.  **Request to Core:** The CLI package sends the user\'s input to the Core package (`packages/core`).
+3.  **Core Processes Request:** The `packages/core` package:
     - Constructs an appropriate prompt for the Gemini API, possibly including conversation history and available tool definitions.
     - Sends the prompt to the Gemini API.
 4.  **Gemini API Response:** The Gemini API processes the prompt and returns a response. This response might be a direct answer or a request to use one of the available tools.
 5.  **Tool Execution (if applicable):**
-    - If the Gemini API requests a tool, the Core package prepares to execute it.
+    - If the Gemini API requests a tool, the `packages/core` package prepares to execute it.
     - **User Confirmation for Potentially Impactful Tools:** If the requested tool can modify the file system (e.g., file edits, writes) or execute shell commands, the CLI (`packages/cli`) displays a confirmation prompt to the user. This prompt details the tool and its arguments, and the user must approve the execution. Read-only operations (e.g., reading files, listing directories) may not always require this explicit confirmation step.
-    - If confirmed (or if confirmation is not required for the specific tool), the Core package identifies and executes the relevant tool (e.g., `read_file`, `execute_bash_command`).
+    - If confirmed (or if confirmation is not required for the specific tool), the `packages/core` package identifies and executes the relevant tool (e.g., `read_file`, `execute_bash_command`).
     - The tool performs its action (e.g., reads a file from the disk).
     - The result of the tool execution is sent back to the Gemini API by the Core.
     - The Gemini API processes the tool result and generates a final response.
-6.  **Response to CLI:** The Core package sends the final response (or intermediate tool messages) back to the CLI package.
-7.  **Display to User:** The CLI package formats and displays the response to the user in the terminal.
+6.  **Response to CLI:** The `packages/core` package sends the final response (or intermediate tool messages) back to the `packages/cli` package.
+7.  **Display to User:** The `packages/cli` package formats and displays the response to the user in the terminal.
 
 ## Diagram (Conceptual)
 
 ```mermaid
 graph TD
-    User[User via Terminal] -- Input --> CLI[packages/cli]
-    CLI -- Request --> Core[packages/core]
+    User[User via Terminal] -- Input --> CLI["packages/cli"]
+    CLI -- Request --> Core["packages/core"]
     Core -- Prompt/Tool Info --> GeminiAPI[Gemini API]
     GeminiAPI -- Response/Tool Call --> Core
     Core -- Tool Details --> CLI
@@ -65,6 +65,18 @@ graph TD
     Tools -- Tool Result --> Core
     Core -- Final Response --> CLI
     CLI -- Output --> User
+
+    classDef userStyle fill:#FFFFFF,stroke:#333333,stroke-width:2px
+    classDef cliStyle fill:#FBBC05,stroke:#000000,stroke-width:2px
+    classDef coreStyle fill:#34A853,stroke:#000000,stroke-width:2px
+    classDef apiStyle fill:#4285F4,stroke:#3F51B5,stroke-width:2px
+    classDef toolsStyle fill:#EA4335,stroke:#000000,stroke-width:2px
+
+    class User userStyle
+    class CLI cliStyle
+    class Core coreStyle
+    class GeminiAPI apiStyle
+    class Tools toolsStyle
 ```
 
 ## Key Design Principles
@@ -73,4 +85,4 @@ graph TD
 - **Extensibility:** The tool system is designed to be extensible, allowing new capabilities to be added.
 - **User Experience:** The CLI focuses on providing a rich and interactive terminal experience.
 
-This overview should provide a foundational understanding of the Gemini CLI's architecture. For more detailed information, refer to the specific documentation for each package and the development guides.
+This overview should provide a foundational understanding of the Gemini CLI\'s architecture. For more detailed information, refer to the specific documentation for each package and the development guides.

--- a/docs/core/tools-api.md
+++ b/docs/core/tools-api.md
@@ -70,4 +70,4 @@ While direct programmatic registration of new tools by users isn't explicitly de
   \
 - **MCP Server(s):** For more complex scenarios, one or more MCP servers can be set up and configured via the `mcpServers` setting in `settings.json`. The Gemini CLI core can then discover and use tools exposed by these servers. As mentioned, if you have multiple MCP servers, the tool names will be prefixed with the server name from your configuration (e.g., `serverAlias__actualToolName`).
 
-This tool system provides a flexible and powerful way to augment the Gemini model\'s capabilities, making the Gemini CLI a versatile assistant for a wide range of tasks.
+This tool system provides a flexible and powerful way to augment the Gemini model's capabilities, making the Gemini CLI a versatile assistant for a wide range of tasks.


### PR DESCRIPTION
This is me testing a - hopefully - trivial PR. Since I'm trying to write an article about this, I wanted the mermaid diagram to be a bit more googley so i've asked `gemini-cli` (yes, my first OSS utilization!) to change it.

Here's how the new diagram looks like: 

![image](https://github.com/user-attachments/assets/60cd1f7d-b179-4a23-a8a1-d513b3f86b61)

If you wonder why the  `packages/core` and  `packages/cli` changes, I've asked Gemini to give a TT vibe to the two parts, but it failed, so now it has backquotes in other parts. I hope it's ok. If not I can change this.