### PR TITLE
Workaround Gemini API break - Use flash 04-17

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -34,8 +34,11 @@ const logger = {
   error: (...args: any[]) => console.error('[ERROR]', ...args),
 };
 
-export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro-preview-05-06';
-export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash-preview-05-20';
+export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash-04-17';
+export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash-04-17';
+
+// export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro-preview-05-06';
+// export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash-preview-05-20';
 
 interface CliArgs {
   model: string | undefined;


### PR DESCRIPTION
- Right now pro and 05-20 flash models don't seem to be working. Reverting to 04-17 gets things back in a reasonable state.