### PR TITLE
Fix broken documentation links after server->core folder rename

### DIFF
--- a/docs/core/tools-api.md
+++ b/docs/core/tools-api.md
@@ -67,7 +67,6 @@ Each of these tools extends `BaseTool` and implements the required methods for i
 While direct programmatic registration of new tools by users isn't explicitly detailed as a primary workflow in the provided files for typical end-users, the architecture supports extension through:
 
 - **Command-based Discovery:** Advanced users or project administrators can define a `toolDiscoveryCommand` in `settings.json`. This command, when run by the Gemini CLI core, should output a JSON array of `FunctionDeclaration` objects. The core will then make these available as `DiscoveredTool` instances. The corresponding `toolCallCommand` would then be responsible for actually executing these custom tools.
-  \
 - **MCP Server(s):** For more complex scenarios, one or more MCP servers can be set up and configured via the `mcpServers` setting in `settings.json`. The Gemini CLI core can then discover and use tools exposed by these servers. As mentioned, if you have multiple MCP servers, the tool names will be prefixed with the server name from your configuration (e.g., `serverAlias__actualToolName`).
 
 This tool system provides a flexible and powerful way to augment the Gemini model\'s capabilities, making the Gemini CLI a versatile assistant for a wide range of tasks.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,10 +15,10 @@ This documentation is organized into the following sections:
   - **[CLI Introduction](./cli/index.md):** An overview of the command-line interface.
   - **[Commands](./cli/commands.md):** Detailed descriptions of all available CLI commands.
   - **[Configuration](./cli/configuration.md):** How to configure the CLI.
-- **Server Details:**
-  - **[Server Introduction](./server/index.md):** An overview of the server component.
-  - **[Configuration](./server/configuration.md):** How to configure the server.
-  - **[Tools API](./server/tools-api.md):** Information on how the server manages and exposes tools.
+- **Core Details:**
+  - **[Core Introduction](./core/index.md):** An overview of the core component.
+  - **[Configuration](./core/configuration.md):** How to configure the core.
+  - **[Tools API](./core/tools-api.md):** Information on how the core manages and exposes tools.
 - **Tools:**
   - **[Tools Overview](./tools/index.md):** A general look at the available tools.
   - **[File System Tools](./tools/file-system.md):** Documentation for tools like `read_file`, `write_file`, etc.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -6,7 +6,7 @@ The Gemini CLI is equipped with a powerful set of built-in tools that the Gemini
 
 In the context of the Gemini CLI, tools are specific functions or modules that the Gemini model can request to be executed. For example, if you ask Gemini to "Summarize the contents of `my_document.txt`," the model will likely identify the need to read that file and will request the execution of the `read_file` tool.
 
-The server component (`packages/core`) manages these tools, presents their definitions (schemas) to the Gemini model, executes them when requested, and returns the results to the model for further processing into a user-facing response.
+The core component (`packages/core`) manages these tools, presents their definitions (schemas) to the Gemini model, executes them when requested, and returns the results to the model for further processing into a user-facing response.
 
 ## Why are Tools Important?
 
@@ -19,12 +19,12 @@ The server component (`packages/core`) manages these tools, presents their defin
 ## How Tools are Used
 
 1.  You provide a prompt to the Gemini CLI.
-2.  The CLI sends the prompt to the server.
-3.  The server, along with your prompt and conversation history, sends a list of available tools and their descriptions/schemas to the Gemini API.
+2.  The CLI sends the prompt to the core.
+3.  The core, along with your prompt and conversation history, sends a list of available tools and their descriptions/schemas to the Gemini API.
 4.  The Gemini model analyzes your request. If it determines that a tool is needed, its response will include a request to execute a specific tool with certain parameters.
-5.  The server receives this tool request, validates it, and (often after user confirmation for sensitive operations) executes the tool.
+5.  The core receives this tool request, validates it, and (often after user confirmation for sensitive operations) executes the tool.
 6.  The output from the tool is sent back to the Gemini model.
-7.  The Gemini model uses the tool's output to formulate its final answer, which is then sent back through the server to the CLI and displayed to you.
+7.  The Gemini model uses the tool's output to formulate its final answer, which is then sent back through the core to the CLI and displayed to you.
 
 You will typically see messages in the CLI indicating when a tool is being called and whether it succeeded or failed.
 


### PR DESCRIPTION
## Summary
- Fixed broken documentation links that were pointing to the old 'server' folder to correctly reference the 'core' folder
- Updated navigation links in main docs index to point to core/ instead of server/
- Updated component references throughout tool documentation to use "core" terminology

## Test plan
- [x] Verified all referenced files exist in the core/ directory
- [x] Ran build, tests, lint, and typecheck - all passing
- [x] Confirmed documentation structure is consistent