### PR TITLE
refactor(core): Centralize tool response formatting

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { convertToFunctionResponse } from './coreToolScheduler.js';
+import { Part, PartListUnion } from '@google/genai';
+
+describe('convertToFunctionResponse', () => {
+  const toolName = 'testTool';
+  const callId = 'call1';
+
+  it('should handle simple string llmContent', () => {
+    const llmContent = 'Simple text output';
+    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    expect(result).toEqual({
+      functionResponse: {
+        name: toolName,
+        id: callId,
+        response: { output: 'Simple text output' },
+      },
+    });
+  });
+
+  it('should handle llmContent as a single Part with text', () => {
+    const llmContent: Part = { text: 'Text from Part object' };
+    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    expect(result).toEqual({
+      functionResponse: {
+        name: toolName,
+        id: callId,
+        response: { output: 'Text from Part object' },
+      },
+    });
+  });
+
+  it('should handle llmContent as a PartListUnion array with a single text Part', () => {
+    const llmContent: PartListUnion = [{ text: 'Text from array' }];
+    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    expect(result).toEqual({
+      functionResponse: {
+        name: toolName,
+        id: callId,
+        response: { output: 'Text from array' },
+      },
+    });
+  });
+
+  it('should handle llmContent with inlineData', () => {
+    const llmContent: Part = {
+      inlineData: { mimeType: 'image/png', data: 'base64...' },
+    };
+    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    expect(result).toEqual([
+      {
+        functionResponse: {
+          name: toolName,
+          id: callId,
+          response: {
+            output: 'Binary content of type image/png was processed.',
+          },
+        },
+      },
+      llmContent,
+    ]);
+  });
+
+  it('should handle llmContent with fileData', () => {
+    const llmContent: Part = {
+      fileData: { mimeType: 'application/pdf', fileUri: 'gs://...' },
+    };
+    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    expect(result).toEqual([
+      {
+        functionResponse: {
+          name: toolName,
+          id: callId,
+          response: {
+            output: 'Binary content of type application/pdf was processed.',
+          },
+        },
+      },
+      llmContent,
+    ]);
+  });
+
+  it('should handle llmContent as an array of multiple Parts (text and inlineData)', () => {
+    const llmContent: PartListUnion = [
+      { text: 'Some textual description' },
+      { inlineData: { mimeType: 'image/jpeg', data: 'base64data...' } },
+      { text: 'Another text part' },
+    ];
+    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    expect(result).toEqual([
+      {
+        functionResponse: {
+          name: toolName,
+          id: callId,
+          response: { output: 'Tool execution succeeded.' },
+        },
+      },
+      ...llmContent,
+    ]);
+  });
+
+  it('should handle llmContent as an array with a single inlineData Part', () => {
+    const llmContent: PartListUnion = [
+      { inlineData: { mimeType: 'image/gif', data: 'gifdata...' } },
+    ];
+    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    expect(result).toEqual([
+      {
+        functionResponse: {
+          name: toolName,
+          id: callId,
+          response: {
+            output: 'Binary content of type image/gif was processed.',
+          },
+        },
+      },
+      ...llmContent,
+    ]);
+  });
+
+  it('should handle llmContent as a generic Part (not text, inlineData, or fileData)', () => {
+    const llmContent: Part = { functionCall: { name: 'test', args: {} } };
+    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    expect(result).toEqual({
+      functionResponse: {
+        name: toolName,
+        id: callId,
+        response: { output: 'Tool execution succeeded.' },
+      },
+    });
+  });
+
+  it('should handle empty string llmContent', () => {
+    const llmContent = '';
+    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    expect(result).toEqual({
+      functionResponse: {
+        name: toolName,
+        id: callId,
+        response: { output: '' },
+      },
+    });
+  });
+
+  it('should handle llmContent as an empty array', () => {
+    const llmContent: PartListUnion = [];
+    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    expect(result).toEqual([
+      {
+        functionResponse: {
+          name: toolName,
+          id: callId,
+          response: { output: 'Tool execution succeeded.' },
+        },
+      },
+    ]);
+  });
+
+  it('should handle llmContent as a Part with undefined inlineData/fileData/text', () => {
+    const llmContent: Part = {}; // An empty part object
+    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    expect(result).toEqual({
+      functionResponse: {
+        name: toolName,
+        id: callId,
+        response: { output: 'Tool execution succeeded.' },
+      },
+    });
+  });
+});

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -81,15 +81,13 @@ describe('executeToolCall', () => {
     expect(response.callId).toBe('call1');
     expect(response.error).toBeUndefined();
     expect(response.resultDisplay).toBe('Success!');
-    expect(response.responseParts).toEqual([
-      {
-        functionResponse: {
-          name: 'testTool',
-          id: 'call1',
-          response: { output: 'Tool executed successfully' },
-        },
+    expect(response.responseParts).toEqual({
+      functionResponse: {
+        name: 'testTool',
+        id: 'call1',
+        response: { output: 'Tool executed successfully' },
       },
-    ]);
+    });
   });
 
   it('should return an error if tool is not found', async () => {
@@ -225,7 +223,7 @@ describe('executeToolCall', () => {
           name: 'testTool',
           id: 'call5',
           response: {
-            status: 'Binary content of type image/png was processed.',
+            output: 'Binary content of type image/png was processed.',
           },
         },
       },

--- a/packages/core/src/core/nonInteractiveToolExecutor.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.ts
@@ -4,14 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Part } from '@google/genai';
 import {
   ToolCallRequestInfo,
   ToolCallResponseInfo,
   ToolRegistry,
   ToolResult,
 } from '../index.js';
-import { formatLlmContentForFunctionResponse } from './coreToolScheduler.js';
+import { convertToFunctionResponse } from './coreToolScheduler.js';
 
 /**
  * Executes a single tool call non-interactively.
@@ -54,20 +53,15 @@ export async function executeToolCall(
       // No live output callback for non-interactive mode
     );
 
-    const { functionResponseJson, additionalParts } =
-      formatLlmContentForFunctionResponse(toolResult.llmContent);
-
-    const functionResponsePart: Part = {
-      functionResponse: {
-        name: toolCallRequest.name,
-        id: toolCallRequest.callId,
-        response: functionResponseJson,
-      },
-    };
+    const response = convertToFunctionResponse(
+      toolCallRequest.name,
+      toolCallRequest.callId,
+      toolResult.llmContent,
+    );
 
     return {
       callId: toolCallRequest.callId,
-      responseParts: [functionResponsePart, ...additionalParts],
+      responseParts: response,
       resultDisplay: toolResult.returnDisplay,
       error: undefined,
     };

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -138,12 +138,7 @@ describe('DiscoveredMCPTool', () => {
       const stringifiedResponseContent = JSON.stringify(
         mockToolSuccessResultObject,
       );
-      // getStringifiedResultForDisplay joins text parts, then wraps the array of processed parts in JSON
-      const expectedDisplayOutput =
-        '```json\n' +
-        JSON.stringify([stringifiedResponseContent], null, 2) +
-        '\n```';
-      expect(toolResult.returnDisplay).toBe(expectedDisplayOutput);
+      expect(toolResult.returnDisplay).toBe(stringifiedResponseContent);
     });
 
     it('should handle empty result from getStringifiedResultForDisplay', async () => {

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -149,6 +149,13 @@ function getStringifiedResultForDisplay(result: Part[]) {
     return part; // Fallback for unexpected structure or non-FunctionResponsePart
   };
 
-  const processedResults = result.map(processFunctionResponse);
+  const processedResults =
+    result.length === 1
+      ? processFunctionResponse(result[0])
+      : result.map(processFunctionResponse);
+  if (typeof processedResults === 'string') {
+    return processedResults;
+  }
+
   return '```json\n' + JSON.stringify(processedResults, null, 2) + '\n```';
 }

--- a/packages/core/src/utils/generateContentResponseUtilities.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GenerateContentResponse } from '@google/genai';
+import { GenerateContentResponse, Part } from '@google/genai';
 
 export function getResponseText(
   response: GenerateContentResponse,
@@ -14,4 +14,8 @@ export function getResponseText(
       ?.map((part) => part.text)
       .join('') || undefined
   );
+}
+
+export function getResponseTextFromParts(parts: Part[]): string | undefined {
+  return parts?.map((part) => part.text).join('') || undefined;
 }


### PR DESCRIPTION
- Moves tool response formatting logic from the  package to the  package.
- Replaces the  function with the cleaner and more robust  function.
- The new function simplifies the response structure by returning a  directly, removing the need for intermediate objects.
- Updates the interactive and non-interactive tool schedulers to use the new centralized function.
- Simplifies the display output for MCP tool responses.

Fixes https://github.com/google-gemini/gemini-cli/issues/731