### PR TITLE
Bring back 2.5-pro usage

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -34,11 +34,8 @@ const logger = {
   error: (...args: any[]) => console.error('[ERROR]', ...args),
 };
 
-export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash-preview-04-17';
-export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash-preview-04-17';
-
-// export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro-preview-05-06';
-// export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash-preview-05-20';
+export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro-preview-05-06';
+export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash-preview-05-20';
 
 interface CliArgs {
   model: string | undefined;


### PR DESCRIPTION
- 2.5-flash-04-17 while it didn't have as many quirks its intelligence was probably even worse than pro's. Bringing 2.5-pro default back.