### PR TITLE
feat(accessibility): Add option to disable loading phrases

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -214,6 +214,7 @@ export async function loadCliConfig(
     vertexai: useVertexAI,
     showMemoryUsage:
       argv.show_memory_usage || settings.showMemoryUsage || false,
+    accessibility: settings.accessibility,
     // Git-aware file filtering settings
     fileFilteringRespectGitIgnore: settings.fileFiltering?.respectGitIgnore,
     fileFilteringAllowBuildArtifacts:

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -21,6 +21,10 @@ export enum SettingScope {
   Workspace = 'Workspace',
 }
 
+export interface AccessibilitySettings {
+  disableLoadingPhrases?: boolean;
+}
+
 export interface Settings {
   theme?: string;
   sandbox?: boolean | string;
@@ -32,6 +36,7 @@ export interface Settings {
   showMemoryUsage?: boolean;
   contextFileName?: string;
   title?: string;
+  accessibility?: AccessibilitySettings;
 
   // Git-aware file filtering settings
   fileFiltering?: {

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -12,6 +12,7 @@ import {
   MCPServerConfig,
   ApprovalMode,
   ToolRegistry,
+  AccessibilitySettings,
 } from '@gemini-code/core';
 import { LoadedSettings, SettingsFile, Settings } from '../config/settings.js';
 
@@ -35,6 +36,7 @@ interface MockServerConfig {
   approvalMode: ApprovalMode;
   vertexai?: boolean;
   showMemoryUsage?: boolean;
+  accessibility?: AccessibilitySettings;
 
   getApiKey: Mock<() => string>;
   getModel: Mock<() => string>;
@@ -58,6 +60,7 @@ interface MockServerConfig {
   setApprovalMode: Mock<(skip: ApprovalMode) => void>;
   getVertexAI: Mock<() => boolean | undefined>;
   getShowMemoryUsage: Mock<() => boolean>;
+  getAccessibility: Mock<() => AccessibilitySettings>;
 }
 
 // Mock @gemini-code/core and its Config class
@@ -87,6 +90,7 @@ vi.mock('@gemini-code/core', async (importOriginal) => {
         approvalMode: opts.approvalMode ?? ApprovalMode.DEFAULT,
         vertexai: opts.vertexai,
         showMemoryUsage: opts.showMemoryUsage ?? false,
+        accessibility: opts.accessibility ?? {},
 
         getApiKey: vi.fn(() => opts.apiKey || 'test-key'),
         getModel: vi.fn(() => opts.model || 'test-model-in-mock-factory'),
@@ -112,6 +116,7 @@ vi.mock('@gemini-code/core', async (importOriginal) => {
         setApprovalMode: vi.fn(),
         getVertexAI: vi.fn(() => opts.vertexai),
         getShowMemoryUsage: vi.fn(() => opts.showMemoryUsage ?? false),
+        getAccessibility: vi.fn(() => opts.accessibility ?? {}),
       };
     });
   return {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -399,7 +399,11 @@ export const App = ({
           ) : (
             <>
               <LoadingIndicator
-                currentLoadingPhrase={currentLoadingPhrase}
+                currentLoadingPhrase={
+                  config.getAccessibility()?.disableLoadingPhrases
+                    ? undefined
+                    : currentLoadingPhrase
+                }
                 elapsedTime={elapsedTime}
               />
               <Box

--- a/packages/cli/src/ui/components/LoadingIndicator.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.tsx
@@ -12,7 +12,7 @@ import { StreamingState } from '../types.js';
 import { GeminiRespondingSpinner } from './GeminiRespondingSpinner.js';
 
 interface LoadingIndicatorProps {
-  currentLoadingPhrase: string;
+  currentLoadingPhrase?: string;
   elapsedTime: number;
   rightContent?: React.ReactNode;
 }
@@ -37,7 +37,9 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
           }
         />
       </Box>
-      <Text color={Colors.AccentPurple}>{currentLoadingPhrase}</Text>
+      {currentLoadingPhrase && (
+        <Text color={Colors.AccentPurple}>{currentLoadingPhrase}</Text>
+      )}
       <Text color={Colors.SubtleComment}>
         {streamingState === StreamingState.WaitingForConfirmation
           ? ''

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -31,6 +31,10 @@ export enum ApprovalMode {
   YOLO = 'yolo',
 }
 
+export interface AccessibilitySettings {
+  disableLoadingPhrases?: boolean;
+}
+
 export class MCPServerConfig {
   constructor(
     // For stdio transport
@@ -66,6 +70,7 @@ export interface ConfigParameters {
   vertexai?: boolean;
   showMemoryUsage?: boolean;
   contextFileName?: string;
+  accessibility?: AccessibilitySettings;
   fileFilteringRespectGitIgnore?: boolean;
   fileFilteringAllowBuildArtifacts?: boolean;
 }
@@ -90,6 +95,7 @@ export class Config {
   private approvalMode: ApprovalMode;
   private readonly vertexai: boolean | undefined;
   private readonly showMemoryUsage: boolean;
+  private readonly accessibility: AccessibilitySettings;
   private readonly geminiClient: GeminiClient;
   private readonly fileFilteringRespectGitIgnore: boolean;
   private readonly fileFilteringAllowBuildArtifacts: boolean;
@@ -114,6 +120,7 @@ export class Config {
     this.approvalMode = params.approvalMode ?? ApprovalMode.DEFAULT;
     this.vertexai = params.vertexai;
     this.showMemoryUsage = params.showMemoryUsage ?? false;
+    this.accessibility = params.accessibility ?? {};
     this.fileFilteringRespectGitIgnore =
       params.fileFilteringRespectGitIgnore ?? true;
     this.fileFilteringAllowBuildArtifacts =
@@ -212,6 +219,10 @@ export class Config {
 
   getShowMemoryUsage(): boolean {
     return this.showMemoryUsage;
+  }
+
+  getAccessibility(): AccessibilitySettings {
+    return this.accessibility;
   }
 
   getGeminiClient(): GeminiClient {


### PR DESCRIPTION
- Introduces a new accessibility setting, `disableLoadingPhrrases`, to provide users with the option to turn off the witty loading phrases displayed in the spinner.
- When this setting is enabled, only the spinner and the elapsed time will be shown, reducing potential distractions for users who prefer a more minimal interface.
- The setting is located under a new `accessibility` object in the settings files (`settings.json`) to allow for future accessibility-related features.

Can be set in `settings.json`:
```json
{
    "accessibility": { "disableLoadingPhrases": true }
}
```

Fixes https://b.corp.google.com/issues/422344427