### PR TITLE
fix(cli): Handle non-array tool response parts

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -94,9 +94,19 @@ export async function runNonInteractive(
             console.error(
               `Error executing tool ${fc.name}: ${toolResponse.resultDisplay || toolResponse.error.message}`,
             );
-            toolResponseParts.push(...(toolResponse.responseParts as Part[]));
-          } else {
-            toolResponseParts.push(...(toolResponse.responseParts as Part[]));
+          }
+
+          if (toolResponse.responseParts) {
+            const parts = Array.isArray(toolResponse.responseParts)
+              ? toolResponse.responseParts
+              : [toolResponse.responseParts];
+            for (const part of parts) {
+              if (typeof part === 'string') {
+                toolResponseParts.push({ text: part });
+              } else if (part) {
+                toolResponseParts.push(part);
+              }
+            }
           }
         }
         currentMessages = [{ role: 'user', parts: toolResponseParts }];


### PR DESCRIPTION
- Ensures that tool response parts are always handled as an array to prevent errors with spread syntax.
- Wraps string parts in the expected  object structure for consistency.