### PR TITLE
feat(cli): respect the NO_COLOR env variable 

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -15,6 +15,7 @@ import {
   AccessibilitySettings,
 } from '@gemini-code/core';
 import { LoadedSettings, SettingsFile, Settings } from '../config/settings.js';
+import process from 'node:process';
 
 // Define a more complete mock server config based on actual Config
 interface MockServerConfig {
@@ -344,20 +345,52 @@ describe('App UI', () => {
     expect(lastFrame()).toContain('Using 2 MCP servers');
   });
 
-  it('should display theme dialog if no theme is set in settings', async () => {
-    mockSettings = createMockSettings({});
-    mockConfig.getDebugMode.mockReturnValue(false);
-    mockConfig.getShowMemoryUsage.mockReturnValue(false);
+  describe('when no theme is set', () => {
+    let originalNoColor: string | undefined;
 
-    const { lastFrame, unmount } = render(
-      <App
-        config={mockConfig as unknown as ServerConfig}
-        settings={mockSettings}
-        cliVersion="1.0.0"
-      />,
-    );
-    currentUnmount = unmount;
+    beforeEach(() => {
+      originalNoColor = process.env.NO_COLOR;
+      // Ensure no theme is set for these tests
+      mockSettings = createMockSettings({});
+      mockConfig.getDebugMode.mockReturnValue(false);
+      mockConfig.getShowMemoryUsage.mockReturnValue(false);
+    });
 
-    expect(lastFrame()).toContain('Select Theme');
+    afterEach(() => {
+      process.env.NO_COLOR = originalNoColor;
+    });
+
+    it('should display theme dialog if NO_COLOR is not set', async () => {
+      delete process.env.NO_COLOR;
+
+      const { lastFrame, unmount } = render(
+        <App
+          config={mockConfig as unknown as ServerConfig}
+          settings={mockSettings}
+          cliVersion="1.0.0"
+        />,
+      );
+      currentUnmount = unmount;
+
+      expect(lastFrame()).toContain('Select Theme');
+    });
+
+    it('should display a message if NO_COLOR is set', async () => {
+      process.env.NO_COLOR = 'true';
+
+      const { lastFrame, unmount } = render(
+        <App
+          config={mockConfig as unknown as ServerConfig}
+          settings={mockSettings}
+          cliVersion="1.0.0"
+        />,
+      );
+      currentUnmount = unmount;
+
+      expect(lastFrame()).toContain(
+        'Theme configuration unavailable due to NO_COLOR env variable.',
+      );
+      expect(lastFrame()).not.toContain('Select Theme');
+    });
   });
 });

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -136,7 +136,7 @@ export const App = ({
     openThemeDialog,
     handleThemeSelect,
     handleThemeHighlight,
-  } = useThemeCommand(settings, setThemeError);
+  } = useThemeCommand(settings, setThemeError, addItem);
 
   useEffect(() => {
     if (config) {

--- a/packages/cli/src/ui/themes/no-color.ts
+++ b/packages/cli/src/ui/themes/no-color.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Theme, ColorsTheme } from './theme.js';
+
+const noColorColorsTheme: ColorsTheme = {
+  type: 'ansi',
+  Background: '',
+  Foreground: '',
+  LightBlue: '',
+  AccentBlue: '',
+  AccentPurple: '',
+  AccentCyan: '',
+  AccentGreen: '',
+  AccentYellow: '',
+  AccentRed: '',
+  SubtleComment: '',
+  Gray: '',
+};
+
+export const NoColorTheme: Theme = new Theme(
+  'No Color',
+  'dark',
+  {
+    hljs: {
+      display: 'block',
+      overflowX: 'auto',
+      padding: '0.5em',
+    },
+    'hljs-keyword': {},
+    'hljs-literal': {},
+    'hljs-symbol': {},
+    'hljs-name': {},
+    'hljs-link': {
+      textDecoration: 'underline',
+    },
+    'hljs-built_in': {},
+    'hljs-type': {},
+    'hljs-number': {},
+    'hljs-class': {},
+    'hljs-string': {},
+    'hljs-meta-string': {},
+    'hljs-regexp': {},
+    'hljs-template-tag': {},
+    'hljs-subst': {},
+    'hljs-function': {},
+    'hljs-title': {},
+    'hljs-params': {},
+    'hljs-formula': {},
+    'hljs-comment': {
+      fontStyle: 'italic',
+    },
+    'hljs-quote': {
+      fontStyle: 'italic',
+    },
+    'hljs-doctag': {},
+    'hljs-meta': {},
+    'hljs-meta-keyword': {},
+    'hljs-tag': {},
+    'hljs-variable': {},
+    'hljs-template-variable': {},
+    'hljs-attr': {},
+    'hljs-attribute': {},
+    'hljs-builtin-name': {},
+    'hljs-section': {},
+    'hljs-emphasis': {
+      fontStyle: 'italic',
+    },
+    'hljs-strong': {
+      fontWeight: 'bold',
+    },
+    'hljs-bullet': {},
+    'hljs-selector-tag': {},
+    'hljs-selector-id': {},
+    'hljs-selector-class': {},
+    'hljs-selector-attr': {},
+    'hljs-selector-pseudo': {},
+    'hljs-addition': {
+      display: 'inline-block',
+      width: '100%',
+    },
+    'hljs-deletion': {
+      display: 'inline-block',
+      width: '100%',
+    },
+  },
+  noColorColorsTheme,
+);

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -17,6 +17,8 @@ import { XCode } from './xcode.js';
 import { Theme, ThemeType } from './theme.js';
 import { ANSI } from './ansi.js';
 import { ANSILight } from './ansi-light.js';
+import { NoColorTheme } from './no-color.js';
+import process from 'node:process';
 
 export interface ThemeDisplay {
   name: string;
@@ -110,6 +112,9 @@ class ThemeManager {
    * Returns the currently active theme object.
    */
   getActiveTheme(): Theme {
+    if (process.env.NO_COLOR) {
+      return NoColorTheme;
+    }
     return this.activeTheme;
   }
 }


### PR DESCRIPTION
For background see [https://no-color.org/)](https://no-color.org/)

When the NO_COLOR env variable is set we ignore the users theme and use a new theme that does not use any colors. This makes the app more accessible. We also avoid opening the theme dialog on startup as it is not relevant in NO_COLOR mode.

When the `NO_COLOR` environment variable is set, attempting to open the theme selection dialog displays an informational message in the chat history instead of opening the dialog.

This prevents rendering a broken or unusable dialog in environments where color is explicitly disabled.