### PR TITLE
refactor: remove unnecessary useRefs

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -117,6 +117,7 @@ vi.mock('@gemini-code/core', async (importOriginal) => {
         getVertexAI: vi.fn(() => opts.vertexai),
         getShowMemoryUsage: vi.fn(() => opts.showMemoryUsage ?? false),
         getAccessibility: vi.fn(() => opts.accessibility ?? {}),
+        getGeminiClient: vi.fn(() => ({})),
       };
     });
   return {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -201,6 +201,7 @@ export const App = ({
 
   const { streamingState, submitQuery, initError, pendingHistoryItems } =
     useGeminiStream(
+      config.getGeminiClient(),
       addItem,
       setShowHelp,
       config,

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -304,6 +304,7 @@ describe('useGeminiStream', () => {
 
     const { result, rerender } = renderHook(() =>
       useGeminiStream(
+        mockConfig.getGeminiClient(),
         mockAddItem as unknown as UseHistoryManagerReturn['addItem'],
         mockSetShowHelp,
         mockConfig,


### PR DESCRIPTION
`useEffect` can be a source of unnecessary re-renders in React apps. 

`useRef` can cause inconsistencies between re-renders as it holds state outside of the standard React prop stream. 

This replaces some of the existing unnecessary use-cases for `useEffect` and `useRef` that gemini detected in the app. 

Drive by change: removed the try-catch around `getGeminiClient()` since that motivated the unnecessary useEffect. This getter is just a one-liner return on `this.geminiClient` (in config.ts), so nothing would get thrown here anyway. Any initialization errors should've happened on `Config` initialization. 