### PR TITLE
Title & Big text Updates

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -337,7 +337,7 @@ export const App = ({
           key={staticKey}
           items={[
             <Box flexDirection="column" key="header">
-              <Header />
+              <Header title={process.env.GEMINI_CLI_TITLE}/>
               <Tips config={config} />
             </Box>,
             ...history.map((h) => (

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -337,7 +337,7 @@ export const App = ({
           key={staticKey}
           items={[
             <Box flexDirection="column" key="header">
-              <Header title={process.env.GEMINI_CLI_TITLE}/>
+              <Header title={process.env.GEMINI_CLI_TITLE} />
               <Tips config={config} />
             </Box>,
             ...history.map((h) => (

--- a/packages/cli/src/ui/components/Header.tsx
+++ b/packages/cli/src/ui/components/Header.tsx
@@ -23,7 +23,6 @@ interface HeaderProps {
 }
 
 export const Header: React.FC<HeaderProps> = ({ title = asciiArtLogo }) => (
-
   <>
     <Box marginBottom={1} alignItems="flex-start">
       {Colors.GradientColors ? (

--- a/packages/cli/src/ui/components/Header.tsx
+++ b/packages/cli/src/ui/components/Header.tsx
@@ -18,15 +18,20 @@ const asciiArtLogo = `
  ╚═════╝ ╚══════╝╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚═╝
 `;
 
-export const Header: React.FC = () => (
+interface HeaderProps {
+  title?: string;
+}
+
+export const Header: React.FC<HeaderProps> = ({ title = asciiArtLogo }) => (
+
   <>
     <Box marginBottom={1} alignItems="flex-start">
       {Colors.GradientColors ? (
         <Gradient colors={Colors.GradientColors}>
-          <Text>{asciiArtLogo}</Text>
+          <Text>{title}</Text>
         </Gradient>
       ) : (
-        <Text>{asciiArtLogo}</Text>
+        <Text>{title}</Text>
       )}
     </Box>
   </>


### PR DESCRIPTION
## Solves
This pr ensures that

1. When users install gemini-code cli via NPX they see the proper title screen and not an error
2. That the code-assist cli can override the title.

## Background
1. when Big text was added https://github.com/google-gemini/gemini-cli/commit/42bedbc3d39265932cbd6c9b818b6a7fbcbdd022 we broke NPX title screen loading as fonts weren't bundled with it. This is only an issue for NPX installs and not local dev
2. Over several PR's code assist team added or attempted to add extensibility functionality. See https://github.com/google-gemini/gemini-cli/pull/706, https://github.com/google-gemini/gemini-cli/pull/748, https://github.com/google-gemini/gemini-cli/pull/741
4. After determining the broken NPX behavior the BigText and extensibility changes were rolled back here: https://github.com/google-gemini/gemini-cli/pull/759

### Solution

Despite several hours of investigation a lack of familiarity with node and package has prevented proper packaging and deployment of cfonts resources with our NPX package.

As such a simpler approach is taken. This PR removes the usage of BigText and re-adds the ability to pass a title in via an env variable.  The notable change is that the `cfonts` package was used to generate equivalent `Code Assist` ASCII art and that ASCII art is what is passed in from the code assist cli. This way both gemini and code assist present similarly branded logos and no further time is spent now on bundling.

This PR also closes out the need for https://github.com/google-gemini/gemini-cli/pull/760 and https://github.com/google-gemini/gemini-cli/pull/761 since we are opting to not use big text at the moment. Same for https://github.com/GoogleCloudPlatform/code-assist-cli/pull/47

Future work from a dedicated work stream can properly package, bundle and publish Big text.

### PS
This solution is not different than some of what came before, but there were so many things in flight it was hard to track, and when failing to make the fonts publish created this net new to avoid getting any misalignment