### PR TITLE
Add Gemini code review agent to repo

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,10 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: HIGH
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: false
+ignore_patterns: []

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # gemini-code settings
 .gemini/
+!gemini/config.yaml
 
 # Dependency directory
 node_modules


### PR DESCRIPTION
With this config, the bot is only invoked via slash commands, e.g. `/gemini review` for people who want reviews.