### PR TITLE
Setup Git repository for storing checkpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1163,6 +1163,21 @@
         "tslib": "2"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.1.tgz",
@@ -8487,6 +8502,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-git": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
+      "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
@@ -10244,6 +10274,7 @@
         "fast-glob": "^3.3.3",
         "minimatch": "^10.0.0",
         "shell-quote": "^1.8.2",
+        "simple-git": "^3.27.0",
         "strip-ansi": "^7.1.0"
       },
       "devDependencies": {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -46,6 +46,7 @@ interface CliArgs {
   show_memory_usage: boolean | undefined;
   yolo: boolean | undefined;
   telemetry: boolean | undefined;
+  checkpoint: boolean | undefined;
 }
 
 async function parseArguments(): Promise<CliArgs> {
@@ -93,6 +94,12 @@ async function parseArguments(): Promise<CliArgs> {
     .option('telemetry', {
       type: 'boolean',
       description: 'Enable telemetry?',
+    })
+    .option('checkpoint', {
+      alias: 'c',
+      type: 'boolean',
+      description: 'Enables checkpointing of file edits',
+      default: false,
     })
     .version() // This will enable the --version flag based on package.json
     .help()
@@ -227,6 +234,7 @@ export async function loadCliConfig(
     fileFilteringRespectGitIgnore: settings.fileFiltering?.respectGitIgnore,
     fileFilteringAllowBuildArtifacts:
       settings.fileFiltering?.allowBuildArtifacts,
+    checkpoint: argv.checkpoint,
   };
 
   const config = createServerConfig(configParams);

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -66,6 +66,11 @@ async function main() {
 
   // Initialize centralized FileDiscoveryService
   await config.getFileService();
+  try {
+    await config.getGitService();
+  } catch {
+    // For now swallow the error, later log it.
+  }
 
   if (modelWasSwitched && originalModelBeforeSwitch) {
     console.log(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
     "fast-glob": "^3.3.3",
     "minimatch": "^10.0.0",
     "shell-quote": "^1.8.2",
+    "simple-git": "^3.27.0",
     "strip-ansi": "^7.1.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-node": "^0.52.0",

--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -1,0 +1,253 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GitService, historyDirName } from './gitService.js';
+import * as path from 'path';
+import type * as FsPromisesModule from 'fs/promises';
+import type { ChildProcess } from 'node:child_process';
+
+const hoistedMockExec = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({
+  exec: hoistedMockExec,
+}));
+
+const hoistedMockMkdir = vi.hoisted(() => vi.fn());
+const hoistedMockReadFile = vi.hoisted(() => vi.fn());
+const hoistedMockWriteFile = vi.hoisted(() => vi.fn());
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof FsPromisesModule;
+  return {
+    ...actual,
+    mkdir: hoistedMockMkdir,
+    readFile: hoistedMockReadFile,
+    writeFile: hoistedMockWriteFile,
+  };
+});
+
+const hoistedMockSimpleGit = vi.hoisted(() => vi.fn());
+const hoistedMockCheckIsRepo = vi.hoisted(() => vi.fn());
+const hoistedMockInit = vi.hoisted(() => vi.fn());
+const hoistedMockRaw = vi.hoisted(() => vi.fn());
+const hoistedMockAdd = vi.hoisted(() => vi.fn());
+const hoistedMockCommit = vi.hoisted(() => vi.fn());
+vi.mock('simple-git', () => ({
+  simpleGit: hoistedMockSimpleGit.mockImplementation(() => ({
+    checkIsRepo: hoistedMockCheckIsRepo,
+    init: hoistedMockInit,
+    raw: hoistedMockRaw,
+    add: hoistedMockAdd,
+    commit: hoistedMockCommit,
+  })),
+  CheckRepoActions: { IS_REPO_ROOT: 'is-repo-root' },
+}));
+
+const hoistedIsGitRepositoryMock = vi.hoisted(() => vi.fn());
+vi.mock('../utils/gitUtils.js', () => ({
+  isGitRepository: hoistedIsGitRepositoryMock,
+}));
+
+const hoistedMockIsNodeError = vi.hoisted(() => vi.fn());
+vi.mock('../utils/errors.js', () => ({
+  isNodeError: hoistedMockIsNodeError,
+}));
+
+describe('GitService', () => {
+  const mockProjectRoot = '/test/project';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoistedIsGitRepositoryMock.mockReturnValue(true);
+    hoistedMockExec.mockImplementation((command, callback) => {
+      if (command === 'git --version') {
+        callback(null, 'git version 2.0.0');
+      } else {
+        callback(new Error('Command not mocked'));
+      }
+      return {};
+    });
+    hoistedMockMkdir.mockResolvedValue(undefined);
+    hoistedMockReadFile.mockResolvedValue('');
+    hoistedMockWriteFile.mockResolvedValue(undefined);
+    hoistedMockIsNodeError.mockImplementation((e) => e instanceof Error);
+
+    hoistedMockSimpleGit.mockImplementation(() => ({
+      checkIsRepo: hoistedMockCheckIsRepo,
+      init: hoistedMockInit,
+      raw: hoistedMockRaw,
+      add: hoistedMockAdd,
+      commit: hoistedMockCommit,
+    }));
+    hoistedMockCheckIsRepo.mockResolvedValue(false);
+    hoistedMockInit.mockResolvedValue(undefined);
+    hoistedMockRaw.mockResolvedValue('');
+    hoistedMockAdd.mockResolvedValue(undefined);
+    hoistedMockCommit.mockResolvedValue({
+      commit: 'initial',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should throw an error if projectRoot is not a Git repository', () => {
+      hoistedIsGitRepositoryMock.mockReturnValue(false);
+      expect(() => new GitService(mockProjectRoot)).toThrow(
+        'GitService requires a Git repository',
+      );
+    });
+
+    it('should successfully create an instance if projectRoot is a Git repository', () => {
+      expect(() => new GitService(mockProjectRoot)).not.toThrow();
+    });
+  });
+
+  describe('verifyGitAvailability', () => {
+    it('should resolve true if git --version command succeeds', async () => {
+      const service = new GitService(mockProjectRoot);
+      await expect(service.verifyGitAvailability()).resolves.toBe(true);
+    });
+
+    it('should resolve false if git --version command fails', async () => {
+      hoistedMockExec.mockImplementation((command, callback) => {
+        callback(new Error('git not found'));
+        return {} as ChildProcess;
+      });
+      const service = new GitService(mockProjectRoot);
+      await expect(service.verifyGitAvailability()).resolves.toBe(false);
+    });
+  });
+
+  describe('initialize', () => {
+    it('should throw an error if Git is not available', async () => {
+      hoistedMockExec.mockImplementation((command, callback) => {
+        callback(new Error('git not found'));
+        return {} as ChildProcess;
+      });
+      const service = new GitService(mockProjectRoot);
+      await expect(service.initialize()).rejects.toThrow(
+        'GitService requires Git to be installed',
+      );
+    });
+  });
+
+  it('should call setupHiddenGitRepository if Git is available', async () => {
+    const service = new GitService(mockProjectRoot);
+    const setupSpy = vi
+      .spyOn(service, 'setupHiddenGitRepository')
+      .mockResolvedValue(undefined);
+
+    await service.initialize();
+    expect(setupSpy).toHaveBeenCalled();
+  });
+
+  describe('setupHiddenGitRepository', () => {
+    const historyDir = path.join(mockProjectRoot, historyDirName);
+    const repoDir = path.join(historyDir, 'repository');
+    const hiddenGitIgnorePath = path.join(repoDir, '.gitignore');
+    const visibleGitIgnorePath = path.join(mockProjectRoot, '.gitignore');
+
+    it('should create history and repository directories', async () => {
+      const service = new GitService(mockProjectRoot);
+      await service.setupHiddenGitRepository();
+      expect(hoistedMockMkdir).toHaveBeenCalledWith(repoDir, {
+        recursive: true,
+      });
+    });
+
+    it('should initialize git repo in historyDir if not already initialized', async () => {
+      hoistedMockCheckIsRepo.mockResolvedValue(false);
+      const service = new GitService(mockProjectRoot);
+      await service.setupHiddenGitRepository();
+      expect(hoistedMockSimpleGit).toHaveBeenCalledWith(repoDir);
+      expect(hoistedMockInit).toHaveBeenCalled();
+    });
+
+    it('should not initialize git repo if already initialized', async () => {
+      hoistedMockCheckIsRepo.mockResolvedValue(true);
+      const service = new GitService(mockProjectRoot);
+      await service.setupHiddenGitRepository();
+      expect(hoistedMockInit).not.toHaveBeenCalled();
+    });
+
+    it('should copy .gitignore from projectRoot if it exists', async () => {
+      const gitignoreContent = `node_modules/\n.env`;
+      hoistedMockReadFile.mockImplementation(async (filePath) => {
+        if (filePath === visibleGitIgnorePath) {
+          return gitignoreContent;
+        }
+        return '';
+      });
+      const service = new GitService(mockProjectRoot);
+      await service.setupHiddenGitRepository();
+      expect(hoistedMockReadFile).toHaveBeenCalledWith(
+        visibleGitIgnorePath,
+        'utf-8',
+      );
+      expect(hoistedMockWriteFile).toHaveBeenCalledWith(
+        hiddenGitIgnorePath,
+        gitignoreContent,
+      );
+    });
+
+    it('should throw an error if reading projectRoot .gitignore fails with other errors', async () => {
+      const readError = new Error('Read permission denied');
+      hoistedMockReadFile.mockImplementation(async (filePath) => {
+        if (filePath === visibleGitIgnorePath) {
+          throw readError;
+        }
+        return '';
+      });
+      hoistedMockIsNodeError.mockImplementation(
+        (e: unknown): e is NodeJS.ErrnoException =>
+          e === readError &&
+          e instanceof Error &&
+          (e as NodeJS.ErrnoException).code !== 'ENOENT',
+      );
+
+      const service = new GitService(mockProjectRoot);
+      await expect(service.setupHiddenGitRepository()).rejects.toThrow(
+        'Read permission denied',
+      );
+    });
+
+    it('should add historyDirName to projectRoot .gitignore if not present', async () => {
+      const initialGitignoreContent = 'node_modules/';
+      hoistedMockReadFile.mockImplementation(async (filePath) => {
+        if (filePath === visibleGitIgnorePath) {
+          return initialGitignoreContent;
+        }
+        return '';
+      });
+      const service = new GitService(mockProjectRoot);
+      await service.setupHiddenGitRepository();
+      const expectedContent = `${initialGitignoreContent}\n# Gemini CLI history directory\n${historyDirName}\n`;
+      expect(hoistedMockWriteFile).toHaveBeenCalledWith(
+        visibleGitIgnorePath,
+        expectedContent,
+      );
+    });
+
+    it('should make an initial commit if no commits exist in history repo', async () => {
+      hoistedMockRaw.mockResolvedValue('');
+      const service = new GitService(mockProjectRoot);
+      await service.setupHiddenGitRepository();
+      expect(hoistedMockAdd).toHaveBeenCalledWith(hiddenGitIgnorePath);
+      expect(hoistedMockCommit).toHaveBeenCalledWith('Initial commit');
+    });
+
+    it('should not make an initial commit if commits already exist', async () => {
+      hoistedMockRaw.mockResolvedValue('test-commit');
+      const service = new GitService(mockProjectRoot);
+      await service.setupHiddenGitRepository();
+      expect(hoistedMockAdd).not.toHaveBeenCalled();
+      expect(hoistedMockCommit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { isNodeError } from '../utils/errors.js';
+import { isGitRepository } from '../utils/gitUtils.js';
+import { exec } from 'node:child_process';
+import { simpleGit, SimpleGit, CheckRepoActions } from 'simple-git';
+
+export const historyDirName = '.gemini_cli_history';
+
+export class GitService {
+  private projectRoot: string;
+
+  constructor(projectRoot: string) {
+    this.projectRoot = path.resolve(projectRoot);
+    if (!isGitRepository(this.projectRoot)) {
+      throw new Error('GitService requires a Git repository');
+    }
+  }
+
+  async initialize(): Promise<void> {
+    const gitAvailable = await this.verifyGitAvailability();
+    if (!gitAvailable) {
+      throw new Error('GitService requires Git to be installed');
+    }
+    this.setupHiddenGitRepository();
+  }
+
+  verifyGitAvailability(): Promise<boolean> {
+    return new Promise((resolve) => {
+      exec('git --version', (error) => {
+        if (error) {
+          resolve(false);
+        } else {
+          resolve(true);
+        }
+      });
+    });
+  }
+
+  /**
+   * Creates a hidden git repository in the project root.
+   * The Git repository is used to support checkpointing.
+   */
+  async setupHiddenGitRepository() {
+    const historyDir = path.join(this.projectRoot, historyDirName);
+    const repoDir = path.join(historyDir, 'repository');
+
+    await fs.mkdir(repoDir, { recursive: true });
+    const repoInstance: SimpleGit = simpleGit(repoDir);
+    const isRepoDefined = await repoInstance.checkIsRepo(
+      CheckRepoActions.IS_REPO_ROOT,
+    );
+    if (!isRepoDefined) {
+      await repoInstance.init();
+    }
+
+    const visibileGitIgnorePath = path.join(this.projectRoot, '.gitignore');
+    const hiddenGitIgnorePath = path.join(repoDir, '.gitignore');
+
+    let visibileGitIgnoreContent = ``;
+    try {
+      visibileGitIgnoreContent = await fs.readFile(
+        visibileGitIgnorePath,
+        'utf-8',
+      );
+    } catch (error) {
+      if (isNodeError(error) && error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+
+    await fs.writeFile(hiddenGitIgnorePath, visibileGitIgnoreContent);
+
+    if (!visibileGitIgnoreContent.includes(historyDirName)) {
+      const updatedContent = `${visibileGitIgnoreContent}\n# Gemini CLI history directory\n${historyDirName}\n`;
+      await fs.writeFile(visibileGitIgnorePath, updatedContent);
+    }
+
+    const commit = await repoInstance.raw([
+      'rev-list',
+      '--all',
+      '--max-count=1',
+    ]);
+    if (!commit) {
+      await repoInstance.add(hiddenGitIgnorePath);
+
+      await repoInstance.commit('Initial commit');
+    }
+  }
+}


### PR DESCRIPTION
Adds a GitService for creating a hidden Git repository in the user's project that will be managed by the CLI. The hidden Git repository is operated against using `simple-git` operations. Git commits to the hidden repository will be used by the CLI to capture file edits and restore previous state.

While under development, I am keeping this functionality behind a cli flag. Once stable and complete, I will remove it or at the least default to true.

This PR provides the setup for the GitService, the full feature is becoming a larger change so breaking this into working, reviewable components.