### PR TITLE
Reduce noisy logging for missing .geminiignore file.

### DIFF
--- a/packages/cli/src/utils/loadIgnorePatterns.test.ts
+++ b/packages/cli/src/utils/loadIgnorePatterns.test.ts
@@ -128,9 +128,7 @@ describe('loadGeminiIgnorePatterns', () => {
 
     const patterns = loadGeminiIgnorePatterns(tempDir);
     expect(patterns).toEqual([]);
-    expect(consoleLogSpy).toHaveBeenCalledWith(
-      '[INFO] No .geminiignore file found. Proceeding without custom ignore patterns.',
-    );
+    expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(mockedFsReadFileSync).toHaveBeenCalledWith(ignoreFilePath, 'utf-8');
   });
 

--- a/packages/cli/src/utils/loadIgnorePatterns.ts
+++ b/packages/cli/src/utils/loadIgnorePatterns.ts
@@ -51,9 +51,6 @@ export function loadGeminiIgnorePatterns(workspaceRoot: string): string[] {
     ) {
       if (error.code === 'ENOENT') {
         // .geminiignore not found, which is fine.
-        console.log(
-          '[INFO] No .geminiignore file found. Proceeding without custom ignore patterns.',
-        );
       } else {
         // Other error reading the file (e.g., permissions)
         console.warn(


### PR DESCRIPTION
Remove the unnecessary logging messages when failing to load .geminiignore files, as those are not required.

Addresses issue #792.