### PR TITLE
Enable environment variable substitution in settings (useful for MCP servers)

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -23,6 +23,8 @@ The Gemini CLI uses `settings.json` files for persistent configuration. There ar
   - **Location:** `.gemini/settings.json` within your project's root directory.
   - **Scope:** Applies only when running Gemini CLI from that specific project. Project settings override User settings.
 
+**Note on Environment Variables in Settings:** String values within your `settings.json` files can reference environment variables using either `$VAR_NAME` or `${VAR_NAME}` syntax. These variables will be automatically resolved when the settings are loaded. For example, if you have an environment variable `MY_API_TOKEN`, you could use it in `settings.json` like this: `"apiKey": "$MY_API_TOKEN"`.
+
 ### The `.gemini` Directory in Your Project
 
 When you create a `.gemini/settings.json` file for project-specific settings, or when the system needs to store project-specific information, this `.gemini` directory is used.
@@ -145,7 +147,14 @@ When you create a `.gemini/settings.json` file for project-specific settings, or
         "command": "node",
         "args": ["mcp_server.js"],
         "cwd": "./mcp_tools/node"
-      }
+      },
+      "myDockerServer": {
+        "command": "docker",
+        "args": ["run", "i", "--rm", "-e", "API_KEY", "ghcr.io/foo/bar"],
+        "env": {
+          "API_KEY": "$MY_API_TOKEN"
+        }
+      },
     }
     ```
   - **`mcpServerCommand`** (string, advanced, **deprecated**):

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -533,6 +533,30 @@ describe('Settings Loading and Merging', () => {
       delete process.env.MY_ENV_STRING;
       delete process.env.MY_ENV_STRING_NESTED;
     });
+
+    it('should resolve multiple concatenated environment variables in a single string value', () => {
+      process.env.TEST_HOST = 'myhost';
+      process.env.TEST_PORT = '9090';
+      const userSettingsContent = {
+        serverAddress: '${TEST_HOST}:${TEST_PORT}/api',
+      };
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      expect(settings.user.settings.serverAddress).toBe('myhost:9090/api');
+
+      delete process.env.TEST_HOST;
+      delete process.env.TEST_PORT;
+    });
   });
 
   describe('LoadedSettings class', () => {

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -110,6 +110,15 @@ function resolveEnvVarsInString(value: string): string {
 }
 
 function resolveEnvVarsInObject<T>(obj: T): T {
+  if (
+    obj === null ||
+    obj === undefined ||
+    typeof obj === 'boolean' ||
+    typeof obj === 'number'
+  ) {
+    return obj;
+  }
+
   if (typeof obj === 'string') {
     return resolveEnvVarsInString(obj) as unknown as T;
   }
@@ -118,7 +127,7 @@ function resolveEnvVarsInObject<T>(obj: T): T {
     return obj.map((item) => resolveEnvVarsInObject(item)) as unknown as T;
   }
 
-  if (obj && typeof obj === 'object') {
+  if (typeof obj === 'object') {
     const newObj = { ...obj } as T;
     for (const key in newObj) {
       if (Object.prototype.hasOwnProperty.call(newObj, key)) {


### PR DESCRIPTION
This commit introduces the ability to use system environment variables within the settings files (e.g., `settings.json`). Users can now reference environment variables using the `${VAR_NAME}` syntax.

This enhancement improves security and flexibility, particularly for configurations like MCP server settings, which often require sensitive tokens.

Previously, to configure an MCP server, a token might be directly embedded:
```json
"mcpServers": {
  "github": {
    "env": {
      "GITHUB_PERSONAL_ACCESS_TOKEN": "pat_abc123"
    }
  }
}
```

With this change, the same configuration can securely reference an environment variable:
```json
"mcpServers": {
  "github": {
    "env": {
      "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
    }
  }
}
```

This allows users to avoid storing secrets directly in configuration files.

Close https://github.com/google-gemini/gemini-cli/issues/791