### PR TITLE
feat(ui): add cursor to empty input prompt

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -39,7 +39,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   onClearScreen,
   config,
   slashCommands,
-  placeholder = 'Type your message or @path/to/file',
+  placeholder = '  Type your message or @path/to/file',
   height = 10,
   focus = true,
   widthFraction,
@@ -349,7 +349,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         </Text>
         <Box flexGrow={1} flexDirection="column">
           {buffer.text.length === 0 && placeholder ? (
-            <Text color={Colors.Gray}>{placeholder}</Text>
+            focus ? (
+              <Text>
+                {chalk.inverse(placeholder.slice(0, 1))}
+                <Text color={Colors.Gray}>{placeholder.slice(1)}</Text>
+              </Text>
+            ) : (
+              <Text color={Colors.Gray}>{placeholder}</Text>
+            )
           ) : (
             linesToRender.map((lineText, visualIdxInRenderedSet) => {
               const cursorVisualRow = cursorVisualRowAbsolute - scrollVisualRow;


### PR DESCRIPTION
Previously, when the input prompt was empty, there was no cursor or visual indication that the component was focused and ready for input. This could be confusing for the user.

<img width="654" alt="Screenshot 2025-06-06 at 11 44 32 AM" src="https://github.com/user-attachments/assets/e886d72c-22bb-4eb8-bee1-1f56fc0ee037" />
