### PR TITLE
Auto insert @ when dragging and dropping files.

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'fs';
 import React, { useCallback, useEffect, useState } from 'react';
 import { Text, Box, useInput, useStdin } from 'ink';
 import { Colors } from '../colors.js';
@@ -58,11 +59,20 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const { stdin, setRawMode } = useStdin();
 
+  const isValidPath = useCallback((filePath: string): boolean => {
+    try {
+      return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
+    } catch (_e) {
+      return false;
+    }
+  }, []);
+
   const buffer = useTextBuffer({
     initialText: '',
     viewport: { height, width: effectiveWidth },
     stdin,
     setRawMode,
+    isValidPath,
   });
 
   const completion = useCompletion(

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -11,6 +11,7 @@ import os from 'os';
 import pathMod from 'path';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import stringWidth from 'string-width';
+import { unescapePath } from '@gemini-code/core';
 
 export type Direction =
   | 'left'
@@ -85,6 +86,7 @@ interface UseTextBufferProps {
   stdin?: NodeJS.ReadStream | null; // For external editor
   setRawMode?: (mode: boolean) => void; // For external editor
   onChange?: (text: string) => void; // Callback for when text changes
+  isValidPath: (path: string) => boolean;
 }
 
 interface UndoHistoryEntry {
@@ -392,6 +394,7 @@ export function useTextBuffer({
   stdin,
   setRawMode,
   onChange,
+  isValidPath,
 }: UseTextBufferProps): TextBuffer {
   const [lines, setLines] = useState<string[]>(() => {
     const l = initialText.split('\n');
@@ -561,6 +564,20 @@ export function useTextBuffer({
       }
       dbg('insert', { ch, beforeCursor: [cursorRow, cursorCol] });
       pushUndo();
+
+      if (ch.length > 2) {
+        // Possible drag and drop of a file path.
+        let potentialPath = ch;
+        if (ch.startsWith("'") && ch.endsWith("'")) {
+          potentialPath = ch.slice(1, -1);
+        }
+
+        // Be conservative and only add an @ if the path is valid.
+        if (isValidPath(unescapePath(potentialPath).trim())) {
+          ch = `@${potentialPath}`;
+        }
+      }
+
       setLines((prevLines) => {
         const newLines = [...prevLines];
         const lineContent = currentLine(cursorRow);
@@ -573,7 +590,15 @@ export function useTextBuffer({
       setCursorCol((prev) => prev + cpLen(ch)); // Use cpLen for character length
       setPreferredCol(null);
     },
-    [pushUndo, cursorRow, cursorCol, currentLine, insertStr, setPreferredCol],
+    [
+      pushUndo,
+      cursorRow,
+      cursorCol,
+      currentLine,
+      insertStr,
+      setPreferredCol,
+      isValidPath,
+    ],
   );
 
   const newline = useCallback((): void => {

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -565,15 +565,23 @@ export function useTextBuffer({
       dbg('insert', { ch, beforeCursor: [cursorRow, cursorCol] });
       pushUndo();
 
-      if (ch.length > 2) {
+      // Arbitrary threshold to avoid false positives on normal key presses
+      // while still detecting virtually all reasonable length file paths.
+      const minLengthToInferAsDragDrop = 3;
+      if (ch.length >= minLengthToInferAsDragDrop) {
         // Possible drag and drop of a file path.
         let potentialPath = ch;
-        if (ch.startsWith("'") && ch.endsWith("'")) {
+        if (
+          potentialPath.length > 2 &&
+          potentialPath.startsWith("'") &&
+          potentialPath.endsWith("'")
+        ) {
           potentialPath = ch.slice(1, -1);
         }
 
+        potentialPath = potentialPath.trim();
         // Be conservative and only add an @ if the path is valid.
-        if (isValidPath(unescapePath(potentialPath).trim())) {
+        if (isValidPath(unescapePath(potentialPath))) {
           ch = `@${potentialPath}`;
         }
       }


### PR DESCRIPTION
This change automatically prepends an "@" symbol when a valid file path is dragged and dropped into the input prompt. This provides a more intuitive user experience for referencing files.

  The changes include:
   - Updated InputPrompt.tsx to pass an isValidPath function to the useTextBuffer hook.
   - Modified text-buffer.ts to check for valid file paths on text insertion and prepend "@" accordingly.
   - Added and updated tests in text-buffer.test.ts to cover the new file path handling logic.