### PR TITLE
Bryanmorgan/add mcp description support

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -11,6 +11,19 @@ Slash commands provide meta-level control over the CLI itself. They can typicall
   - **Description:** Displays help information about the Gemini CLI, including available commands and their usage.
   - **Action:** Opens a help dialog or section within the CLI.
 
+- **`/mcp`** (Toggle descriptions: **Ctrl+T**)
+
+  - **Description:** Lists configured Model Context Protocol (MCP) servers and their available tools.
+  - **Action:** Displays a formatted list of MCP servers with connection status indicators, server details, and available tools.
+  - **Sub-commands:**
+    - **`desc`** or **`descriptions`**:
+      - **Description:** Shows detailed descriptions for MCP servers and tools.
+      - **Action:** Displays each tool's name with its full description, formatted for readability.
+    - **`nodesc`** or **`nodescriptions`**:
+      - **Description:** Hides tool descriptions, showing only the tool names.
+      - **Action:** Displays a compact list with only tool names.
+  - **Keyboard Shortcut:** Press **Ctrl+T** at any time to toggle between showing and hiding tool descriptions.
+
 - **`/clear`** (Shortcut: **Ctrl+L**)
 
   - **Description:** Clears the entire terminal screen, including the visible session history and scrollback within the CLI.

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -79,6 +79,7 @@ export const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   const [corgiMode, setCorgiMode] = useState(false);
   const [shellModeActive, setShellModeActive] = useState(false);
   const [showErrorDetails, setShowErrorDetails] = useState<boolean>(false);
+  const [showToolDescriptions, setShowToolDescriptions] = useState<boolean>(false);
   const [ctrlCPressedOnce, setCtrlCPressedOnce] = useState(false);
   const ctrlCTimerRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -90,6 +91,10 @@ export const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   useInput((input: string, key: InkKeyType) => {
     if (key.ctrl && input === 'o') {
       setShowErrorDetails((prev) => !prev);
+      refreshStatic();
+    } else if (key.ctrl && input === 't') {
+      // Toggle showing tool descriptions
+      setShowToolDescriptions((prev) => !prev);
       refreshStatic();
     } else if (key.ctrl && (input === 'c' || input === 'C')) {
       if (ctrlCPressedOnce) {
@@ -190,6 +195,7 @@ export const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     openThemeDialog,
     performMemoryRefresh,
     toggleCorgiMode,
+    showToolDescriptions,
   );
 
   const { streamingState, submitQuery, initError, pendingHistoryItems } =
@@ -422,6 +428,7 @@ export const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
                         getCurrentGeminiMdFilename()
                       }
                       mcpServers={config.getMcpServers()}
+                      showToolDescriptions={showToolDescriptions}
                     />
                   )}
                 </Box>

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -79,7 +79,8 @@ export const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   const [corgiMode, setCorgiMode] = useState(false);
   const [shellModeActive, setShellModeActive] = useState(false);
   const [showErrorDetails, setShowErrorDetails] = useState<boolean>(false);
-  const [showToolDescriptions, setShowToolDescriptions] = useState<boolean>(false);
+  const [showToolDescriptions, setShowToolDescriptions] =
+    useState<boolean>(false);
   const [ctrlCPressedOnce, setCtrlCPressedOnce] = useState(false);
   const ctrlCTimerRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -88,48 +89,6 @@ export const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     [consoleMessages],
   );
 
-  useInput((input: string, key: InkKeyType) => {
-    if (key.ctrl && input === 'o') {
-      setShowErrorDetails((prev) => !prev);
-      refreshStatic();
-    } else if (key.ctrl && input === 't') {
-      // Toggle showing tool descriptions
-      setShowToolDescriptions((prev) => !prev);
-      refreshStatic();
-    } else if (key.ctrl && (input === 'c' || input === 'C')) {
-      if (ctrlCPressedOnce) {
-        if (ctrlCTimerRef.current) {
-          clearTimeout(ctrlCTimerRef.current);
-        }
-        process.exit(0);
-      } else {
-        setCtrlCPressedOnce(true);
-        ctrlCTimerRef.current = setTimeout(() => {
-          setCtrlCPressedOnce(false);
-          ctrlCTimerRef.current = null;
-        }, CTRL_C_PROMPT_DURATION_MS);
-      }
-    }
-  });
-
-  useEffect(
-    () => () => {
-      if (ctrlCTimerRef.current) {
-        clearTimeout(ctrlCTimerRef.current);
-      }
-    },
-    [],
-  );
-
-  useConsolePatcher({
-    onNewMessage: handleNewMessage,
-    debugMode: config.getDebugMode(),
-  });
-
-  const toggleCorgiMode = useCallback(() => {
-    setCorgiMode((prev) => !prev);
-  }, []);
-
   const {
     isThemeDialogOpen,
     openThemeDialog,
@@ -137,11 +96,9 @@ export const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     handleThemeHighlight,
   } = useThemeCommand(settings, setThemeError, addItem);
 
-  useEffect(() => {
-    if (config) {
-      setGeminiMdFileCount(config.getGeminiMdFileCount());
-    }
-  }, [config]);
+  const toggleCorgiMode = useCallback(() => {
+    setCorgiMode((prev) => !prev);
+  }, []);
 
   const performMemoryRefresh = useCallback(async () => {
     addItem(
@@ -197,6 +154,58 @@ export const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     toggleCorgiMode,
     showToolDescriptions,
   );
+
+  useInput((input: string, key: InkKeyType) => {
+    if (key.ctrl && input === 'o') {
+      setShowErrorDetails((prev) => !prev);
+      refreshStatic();
+    } else if (key.ctrl && input === 't') {
+      // Toggle showing tool descriptions
+      const newValue = !showToolDescriptions;
+      setShowToolDescriptions(newValue);
+      refreshStatic();
+
+      // Re-execute the MCP command to show/hide descriptions
+      const mcpServers = config.getMcpServers();
+      if (Object.keys(mcpServers || {}).length > 0) {
+        // Pass description flag based on the new value
+        handleSlashCommand(newValue ? '/mcp desc' : '/mcp nodesc');
+      }
+    } else if (key.ctrl && (input === 'c' || input === 'C')) {
+      if (ctrlCPressedOnce) {
+        if (ctrlCTimerRef.current) {
+          clearTimeout(ctrlCTimerRef.current);
+        }
+        process.exit(0);
+      } else {
+        setCtrlCPressedOnce(true);
+        ctrlCTimerRef.current = setTimeout(() => {
+          setCtrlCPressedOnce(false);
+          ctrlCTimerRef.current = null;
+        }, CTRL_C_PROMPT_DURATION_MS);
+      }
+    }
+  });
+
+  useEffect(
+    () => () => {
+      if (ctrlCTimerRef.current) {
+        clearTimeout(ctrlCTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  useConsolePatcher({
+    onNewMessage: handleNewMessage,
+    debugMode: config.getDebugMode(),
+  });
+
+  useEffect(() => {
+    if (config) {
+      setGeminiMdFileCount(config.getGeminiMdFileCount());
+    }
+  }, [config]);
 
   const { streamingState, submitQuery, initError, pendingHistoryItems } =
     useGeminiStream(

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
@@ -48,10 +48,12 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
   if (mcpText) {
     summaryText += mcpText;
     // Add Ctrl+T hint when MCP servers are available
-    if (showToolDescriptions) {
-      summaryText += ' (Ctrl+T to hide descriptions)';
-    } else {
-      summaryText += ' (Ctrl+T to view descriptions)';
+    if (mcpServers && Object.keys(mcpServers).length > 0) {
+      if (showToolDescriptions) {
+        summaryText += ' (Ctrl+T to hide descriptions)';
+      } else {
+        summaryText += ' (Ctrl+T to view descriptions)';
+      }
     }
   }
 

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
@@ -13,12 +13,14 @@ interface ContextSummaryDisplayProps {
   geminiMdFileCount: number;
   contextFileName: string;
   mcpServers?: Record<string, MCPServerConfig>;
+  showToolDescriptions?: boolean;
 }
 
 export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
   geminiMdFileCount,
   contextFileName,
   mcpServers,
+  showToolDescriptions,
 }) => {
   const mcpServerCount = Object.keys(mcpServers || {}).length;
 
@@ -45,6 +47,12 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
   }
   if (mcpText) {
     summaryText += mcpText;
+    // Add Ctrl+T hint when MCP servers are available
+    if (showToolDescriptions) {
+      summaryText += ' (Ctrl+T to hide descriptions)';
+    } else {
+      summaryText += ' (Ctrl+T to view descriptions)';
+    }
   }
 
   return <Text color={Colors.Gray}>{summaryText}</Text>;

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -572,42 +572,42 @@ Add any other context about the problem here.
       // Check that the message contains details about both servers and their tools
       const message = mockAddItem.mock.calls[1][0].text;
       // Server 1 - Connected (green dot)
-      expect(message).toContain('🟢 server1 (2 tools):');
-      expect(message).toContain('server1_tool1');
-      expect(message).toContain('server1_tool2');
+      expect(message).toContain('🟢 \u001b[1mserver1\u001b[0m (2 tools)');
+      expect(message).toContain('\u001b[36mserver1_tool1\u001b[0m');
+      expect(message).toContain('\u001b[36mserver1_tool2\u001b[0m');
 
       // Server 2 - Connecting (yellow dot)
-      expect(message).toContain('🟡 server2 (1 tools):');
-      expect(message).toContain('server2_tool1');
+      expect(message).toContain('🟡 \u001b[1mserver2\u001b[0m (1 tools)');
+      expect(message).toContain('\u001b[36mserver2_tool1\u001b[0m');
 
       // Server 3 - No status, should default to Disconnected (red dot)
-      expect(message).toContain('🔴 server3 (1 tools):');
-      expect(message).toContain('server3_tool1');
-
-      // Should include Ctrl+T hint
-      expect(message).toContain('Ctrl+T to view descriptions');
+      expect(message).toContain('🔴 \u001b[1mserver3\u001b[0m (1 tools)');
+      expect(message).toContain('\u001b[36mserver3_tool1\u001b[0m');
 
       expect(commandResult).toBe(true);
     });
 
     it('should display tool descriptions when showToolDescriptions is true', async () => {
-      // Mock MCP servers configuration
+      // Mock MCP servers configuration with server description
       const mockMcpServers = {
-        server1: { command: 'cmd1' }
+        server1: {
+          command: 'cmd1',
+          description: 'This is a server description',
+        },
       };
-      
+
       // Setup getMCPServerStatus mock implementation
       vi.mocked(getMCPServerStatus).mockImplementation((serverName) => {
         if (serverName === 'server1') return MCPServerStatus.CONNECTED;
         return MCPServerStatus.DISCONNECTED;
       });
-      
+
       // Mock tools from server with descriptions
       const mockServerTools = [
         { name: 'tool1', description: 'This is tool 1 description' },
-        { name: 'tool2', description: 'This is tool 2 description' }
+        { name: 'tool2', description: 'This is tool 2 description' },
       ];
-      
+
       mockConfig = {
         ...mockConfig,
         getToolRegistry: vi.fn().mockResolvedValue({
@@ -615,13 +615,13 @@ Add any other context about the problem here.
         }),
         getMcpServers: vi.fn().mockReturnValue(mockMcpServers),
       } as unknown as Config;
-      
+
       const { handleSlashCommand } = getProcessor(true);
       let commandResult: SlashCommandActionReturn | boolean = false;
       await act(async () => {
         commandResult = handleSlashCommand('/mcp');
       });
-      
+
       expect(mockAddItem).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
@@ -630,13 +630,25 @@ Add any other context about the problem here.
         }),
         expect.any(Number),
       );
-      
+
       const message = mockAddItem.mock.calls[1][0].text;
-      // Check that tool descriptions are included
-      expect(message).toContain('tool1: This is tool 1 description');
-      expect(message).toContain('tool2: This is tool 2 description');
-      expect(message).toContain('Ctrl+T to hide tool descriptions');
-      
+
+      // Check that server description is included (with ANSI color codes)
+      expect(message).toContain('\u001b[1mserver1\u001b[0m (2 tools)');
+      expect(message).toContain(
+        '\u001b[32mThis is a server description\u001b[0m',
+      );
+
+      // Check that tool descriptions are included (with ANSI color codes)
+      expect(message).toContain('\u001b[36mtool1\u001b[0m');
+      expect(message).toContain(
+        '\u001b[32mThis is tool 1 description\u001b[0m',
+      );
+      expect(message).toContain('\u001b[36mtool2\u001b[0m');
+      expect(message).toContain(
+        '\u001b[32mThis is tool 2 description\u001b[0m',
+      );
+
       expect(commandResult).toBe(true);
     });
 
@@ -690,9 +702,9 @@ Add any other context about the problem here.
 
       // Check that the message contains details about both servers and their tools
       const message = mockAddItem.mock.calls[1][0].text;
-      expect(message).toContain('🟢 server1 (1 tools):');
-      expect(message).toContain('server1_tool1');
-      expect(message).toContain('🔴 server2 (0 tools):');
+      expect(message).toContain('🟢 \u001b[1mserver1\u001b[0m (1 tools)');
+      expect(message).toContain('\u001b[36mserver1_tool1\u001b[0m');
+      expect(message).toContain('🔴 \u001b[1mserver2\u001b[0m (0 tools)');
       expect(message).toContain('No tools available');
 
       expect(commandResult).toBe(true);

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -47,6 +47,7 @@ export const useSlashCommandProcessor = (
   openThemeDialog: () => void,
   performMemoryRefresh: () => Promise<void>,
   toggleCorgiMode: () => void,
+  showToolDescriptions: boolean = false,
 ) => {
   const addMessage = useCallback(
     (message: Message) => {
@@ -187,13 +188,22 @@ export const useSlashCommandProcessor = (
             message += `${statusDot} ${serverName} (${serverTools.length} tools):\n`;
             if (serverTools.length > 0) {
               serverTools.forEach((tool) => {
-                message += `  - ${tool.name}\n`;
+                if (showToolDescriptions && tool.description) {
+                  message += `  - ${tool.name}: ${tool.description}\n`;
+                } else {
+                  message += `  - ${tool.name}\n`;
+                }
               });
             } else {
               message += '  No tools available\n';
             }
             message += '\n';
           }
+          
+          // Add the Ctrl+T hint for viewing/hiding descriptions
+          message += showToolDescriptions ? 
+            'Ctrl+T to hide tool descriptions' : 
+            'Ctrl+T to view tool descriptions';
 
           addMessage({
             type: MessageType.INFO,
@@ -369,6 +379,7 @@ Add any other context about the problem here.
       addMessage,
       toggleCorgiMode,
       config,
+      showToolDescriptions,
     ],
   );
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -49,6 +49,8 @@ export class MCPServerConfig {
     // Common
     readonly timeout?: number,
     readonly trust?: boolean,
+    // Metadata
+    readonly description?: string,
   ) {}
 }
 

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -52,7 +52,7 @@ describe('DiscoveredMCPTool', () => {
   });
 
   describe('constructor', () => {
-    it('should set properties correctly and augment description (non-generic server)', () => {
+    it('should set properties correctly (non-generic server)', () => {
       const tool = new DiscoveredMCPTool(
         mockCallableToolInstance,
         serverName, // serverName is 'mock-mcp-server', not 'mcp'
@@ -64,14 +64,13 @@ describe('DiscoveredMCPTool', () => {
 
       expect(tool.name).toBe(toolNameForModel);
       expect(tool.schema.name).toBe(toolNameForModel);
-      const expectedDescription = `${baseDescription}\n\nThis MCP tool named '${serverToolName}' was discovered from an MCP server.`;
-      expect(tool.schema.description).toBe(expectedDescription);
+      expect(tool.schema.description).toBe(baseDescription);
       expect(tool.schema.parameters).toEqual(inputSchema);
       expect(tool.serverToolName).toBe(serverToolName);
       expect(tool.timeout).toBeUndefined();
     });
 
-    it('should set properties correctly and augment description (generic "mcp" server)', () => {
+    it('should set properties correctly (generic "mcp" server)', () => {
       const genericServerName = 'mcp';
       const tool = new DiscoveredMCPTool(
         mockCallableToolInstance,
@@ -81,8 +80,7 @@ describe('DiscoveredMCPTool', () => {
         inputSchema,
         serverToolName,
       );
-      const expectedDescription = `${baseDescription}\n\nThis MCP tool named '${serverToolName}' was discovered from '${genericServerName}' MCP server.`;
-      expect(tool.schema.description).toBe(expectedDescription);
+      expect(tool.schema.description).toBe(baseDescription);
     });
 
     it('should accept and store a custom timeout', () => {

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -30,17 +30,6 @@ export class DiscoveredMCPTool extends BaseTool<ToolParams, ToolResult> {
     readonly timeout?: number,
     readonly trust?: boolean,
   ) {
-    if (serverName !== 'mcp') {
-      // Add server name if not the generic 'mcp'
-      description += `
-
-This MCP tool named '${serverToolName}' was discovered from an MCP server.`;
-    } else {
-      description += `
-
-This MCP tool named '${serverToolName}' was discovered from '${serverName}' MCP server.`;
-    }
-
     super(
       name,
       name,


### PR DESCRIPTION
The complete /mcp feature now provides:
  - Easy toggling of MCP tool descriptions using Ctrl+T
  - Consistently formatted and colored descriptions (green text for descriptions, cyan for tool names)
  - Proper documentation for users
  - Comprehensive test coverage
  - 
**Details**

1. Initial Implementation of Ctrl+T Toggle

  - Added state variable showToolDescriptions in App.tsx to track visibility of tool descriptions
  - Implemented keyboard event handler for Ctrl+T in App.tsx using Ink's useInput hook
  - Added logic to toggle the state when Ctrl+T is pressed
  - Added code to refresh the static display after toggling
  - Configured the handler to pass /mcp desc or /mcp nodesc command to update the display

  2. Context Summary Display Updates

  - Modified ContextSummaryDisplay.tsx to receive showToolDescriptions prop
  - Added conditional text to display either "(Ctrl+T to view descriptions)" or "(Ctrl+T to hide descriptions)"
  - Positioned the hint after MCP server information in the status line

  3. Slash Command Processor Enhancements

  - Updated useSlashCommandProcessor hook to accept showToolDescriptions parameter
  - Added support for command flags (desc/descriptions and nodesc/nodescriptions)
  - Implemented conditional display of tool descriptions based on flag or state
  - Added formatting with ANSI escape codes for server names (bold) and tool names (cyan)
  - Initially implemented cleanMCPToolDescription function to remove the auto-appended text

  4. Configuration Updates

  - Added description field to MCPServerConfig class in config.ts to support server descriptions

  5. Multi-line Text Formatting

  - Added proper indentation for multi-line descriptions
  - Implemented special handling for empty lines and line breaks
  - Added reset codes at critical points to maintain proper formatting

  6. Improved Color Formatting

  - Added green coloring (\u001b[32m) to ALL lines of tool descriptions
  - Applied color codes to each line individually to handle terminal wrapping
  - Ensured proper reset codes (\u001b[0m) after each line to prevent color bleeding
  - Maintained consistent styling across servers and tools

  7. Test Suite Updates

  - Updated tests in slashCommandProcessor.test.ts to match new formatting with ANSI codes
  - Revised test expectations for the modified description format
  - Updated tests in mcp-tool.test.ts to no longer expect appended text
  - Fixed various test cases to match the new implementation

  8. Documentation

  - Added comprehensive documentation for the /mcp command in commands.md
  - Documented the Ctrl+T keyboard shortcut for toggling descriptions
  - Included information about the /mcp desc and /mcp nodesc sub-commands
  - Followed existing documentation style and formatting

