### PR TITLE
feat: display commit hash in detached HEAD state

### DIFF
--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -27,7 +27,17 @@ export function useGitBranchName(cwd: string): string | undefined {
           if (branch && branch !== 'HEAD') {
             setBranchName(branch);
           } else {
-            setBranchName(undefined);
+            exec(
+              'git rev-parse --short HEAD',
+              { cwd },
+              (error, stdout, _stderr) => {
+                if (error) {
+                  setBranchName(undefined);
+                  return;
+                }
+                setBranchName(stdout.toString().trim());
+              },
+            );
           }
         },
       ),


### PR DESCRIPTION
When the git repository is in a detached HEAD state, the branch name is displayed as 'HEAD'. This is not very informative. This change modifies the  hook to display the short commit hash instead of 'HEAD' when the repository is in a detached HEAD state.

Fixes #686