### PR TITLE
Makefile for convenience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+# Makefile for gemini-cli
+
+.PHONY: help install build build-sandbox build-all test lint format preflight clean start debug release run-npx create-alias
+
+help:
+	@echo "Makefile for gemini-cli"
+	@echo ""
+	@echo "Usage:"
+	@echo "  make install          - Install npm dependencies"
+	@echo "  make build            - Build the entire project"
+	@echo "  make build-sandbox    - Build the sandbox container"
+	@echo "  make build-all        - Build the project and the sandbox"
+	@echo "  make test             - Run the test suite"
+	@echo "  make lint             - Lint the code"
+	@echo "  make format           - Format the code"
+	@echo "  make preflight        - Run formatting, linting, and tests"
+	@echo "  make clean            - Remove generated files"
+	@echo "  make start            - Start the Gemini CLI"
+	@echo "  make debug            - Start the Gemini CLI in debug mode"
+	@echo "  make release          - Publish a new release"
+	@echo "  make run-npx          - Run the CLI using npx (for testing the published package)"
+	@echo "  make create-alias     - Create a 'gemini' alias for your shell"
+
+install:
+	npm install
+
+build:
+	npm run build
+
+build-sandbox:
+	npm run build:sandbox
+
+build-all:
+	npm run build:all
+
+test:
+	npm run test
+
+lint:
+	npm run lint
+
+format:
+	npm run format
+
+preflight:
+	npm run preflight
+
+clean:
+	npm run clean
+
+start:
+	npm run start
+
+debug:
+	npm run debug
+
+release:
+	npm run publish:release
+
+run-npx:
+	npx https://github.com/google-gemini/gemini-cli#early-access
+
+create-alias:
+	scripts/create_alias.sh

--- a/scripts/create_alias.sh
+++ b/scripts/create_alias.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This script creates an alias for the Gemini CLI
+
+# Determine the project directory
+PROJECT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+ALIAS_COMMAND="alias gemini='$PROJECT_DIR/scripts/start.sh'"
+
+# Detect shell and set config file path
+if [[ "$SHELL" == *"/bash" ]]; then
+    CONFIG_FILE="$HOME/.bashrc"
+elif [[ "$SHELL" == *"/zsh" ]]; then
+    CONFIG_FILE="$HOME/.zshrc"
+else
+    echo "Unsupported shell. Only bash and zsh are supported."
+    exit 1
+fi
+
+echo "This script will add the following alias to your shell configuration file ($CONFIG_FILE):"
+echo "  $ALIAS_COMMAND"
+echo ""
+
+# Check if the alias already exists
+if grep -q "alias gemini=" "$CONFIG_FILE"; then
+    echo "A 'gemini' alias already exists in $CONFIG_FILE. No changes were made."
+    exit 0
+fi
+
+read -p "Do you want to proceed? (y/n) " -n 1 -r
+echo ""
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "$ALIAS_COMMAND" >> "$CONFIG_FILE"
+    echo ""
+    echo "Alias added to $CONFIG_FILE."
+    echo "Please run 'source $CONFIG_FILE' or open a new terminal to use the 'gemini' command."
+else
+    echo "Aborted. No changes were made."
+fi


### PR DESCRIPTION
 This PR introduces a `Makefile` to streamline common development tasks and adds a script to create a `gemini` shell alias for easier access to the CLI. It also includes a minor typo  fix in the contributing guide.
   
 ### Features
- **Makefile**: A new `Makefile` provides convenient shortcuts for commands like `install`, `build`, `test`, `lint`, `clean`, and `start`. 
-  **Alias Script**: A new script `scripts/create_alias.sh` allows users to create a  `gemini` alias in their shell (`bash` or `zsh`), making it easier to run the CLI from anywhere.

### Fixes
 - **Typo**: Corrects a minor typo in `CONTRIBUTING.md`.