### PR TITLE
feat(core): respect .gitignore in glob tool

### DIFF
--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -173,7 +173,9 @@ describe('GlobTool', () => {
       // Check that the ignored file is not in the output
       expect(result.llmContent).not.toContain('ignored.log');
       // Check that the message indicates a file was ignored
-      expect(result.llmContent).toContain('(1 additional files were git-ignored)');
+      expect(result.llmContent).toContain(
+        '(1 additional files were git-ignored)',
+      );
     });
 
     it('should correctly sort files by modification time (newest first)', async () => {


### PR DESCRIPTION
The glob tool now respects the .gitignore file when searching for files. This ensures that ignored files are not included in the search results.

- Added a  parameter to the  tool.
- The  is now used to filter out git-ignored files.
- Added a test to verify that git-ignored files are excluded.