### PR TITLE
fix(tool-scheduler): Correctly pipe cancellation signal to tool calls

### DIFF
--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -32,8 +32,8 @@ import {
 
 export type ScheduleFn = (
   request: ToolCallRequestInfo | ToolCallRequestInfo[],
+  signal: AbortSignal,
 ) => void;
-export type CancelFn = (reason?: string) => void;
 export type MarkToolsAsSubmittedFn = (callIds: string[]) => void;
 
 export type TrackedScheduledToolCall = ScheduledToolCall & {
@@ -69,7 +69,7 @@ export function useReactToolScheduler(
   setPendingHistoryItem: React.Dispatch<
     React.SetStateAction<HistoryItemWithoutId | null>
   >,
-): [TrackedToolCall[], ScheduleFn, CancelFn, MarkToolsAsSubmittedFn] {
+): [TrackedToolCall[], ScheduleFn, MarkToolsAsSubmittedFn] {
   const [toolCallsForDisplay, setToolCallsForDisplay] = useState<
     TrackedToolCall[]
   >([]);
@@ -172,15 +172,11 @@ export function useReactToolScheduler(
   );
 
   const schedule: ScheduleFn = useCallback(
-    async (request: ToolCallRequestInfo | ToolCallRequestInfo[]) => {
-      scheduler.schedule(request);
-    },
-    [scheduler],
-  );
-
-  const cancel: CancelFn = useCallback(
-    (reason: string = 'unspecified') => {
-      scheduler.cancelAll(reason);
+    async (
+      request: ToolCallRequestInfo | ToolCallRequestInfo[],
+      signal: AbortSignal,
+    ) => {
+      scheduler.schedule(request, signal);
     },
     [scheduler],
   );
@@ -198,7 +194,7 @@ export function useReactToolScheduler(
     [],
   );
 
-  return [toolCallsForDisplay, schedule, cancel, markToolsAsSubmitted];
+  return [toolCallsForDisplay, schedule, markToolsAsSubmitted];
 }
 
 /**

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -137,7 +137,7 @@ describe('useReactToolScheduler in YOLO Mode', () => {
     };
 
     act(() => {
-      schedule(request);
+      schedule(request, new AbortController().signal);
     });
 
     await act(async () => {
@@ -290,7 +290,7 @@ describe('useReactToolScheduler', () => {
     };
 
     act(() => {
-      schedule(request);
+      schedule(request, new AbortController().signal);
     });
     await act(async () => {
       await vi.runAllTimersAsync();
@@ -337,7 +337,7 @@ describe('useReactToolScheduler', () => {
     };
 
     act(() => {
-      schedule(request);
+      schedule(request, new AbortController().signal);
     });
     await act(async () => {
       await vi.runAllTimersAsync();
@@ -374,7 +374,7 @@ describe('useReactToolScheduler', () => {
     };
 
     act(() => {
-      schedule(request);
+      schedule(request, new AbortController().signal);
     });
     await act(async () => {
       await vi.runAllTimersAsync();
@@ -410,7 +410,7 @@ describe('useReactToolScheduler', () => {
     };
 
     act(() => {
-      schedule(request);
+      schedule(request, new AbortController().signal);
     });
     await act(async () => {
       await vi.runAllTimersAsync();
@@ -451,7 +451,7 @@ describe('useReactToolScheduler', () => {
     };
 
     act(() => {
-      schedule(request);
+      schedule(request, new AbortController().signal);
     });
     await act(async () => {
       await vi.runAllTimersAsync();
@@ -507,7 +507,7 @@ describe('useReactToolScheduler', () => {
     };
 
     act(() => {
-      schedule(request);
+      schedule(request, new AbortController().signal);
     });
     await act(async () => {
       await vi.runAllTimersAsync();
@@ -579,7 +579,7 @@ describe('useReactToolScheduler', () => {
     };
 
     act(() => {
-      schedule(request);
+      schedule(request, new AbortController().signal);
     });
     await act(async () => {
       await vi.runAllTimersAsync();
@@ -634,102 +634,6 @@ describe('useReactToolScheduler', () => {
     expect(result.current[0]).toEqual([]);
   });
 
-  it.skip('should cancel tool calls before execution (e.g. when status is scheduled)', async () => {
-    mockToolRegistry.getTool.mockReturnValue(mockTool);
-    (mockTool.shouldConfirmExecute as Mock).mockResolvedValue(null);
-    (mockTool.execute as Mock).mockReturnValue(new Promise(() => {}));
-
-    const { result } = renderScheduler();
-    const schedule = result.current[1];
-    const cancel = result.current[2];
-    const request: ToolCallRequestInfo = {
-      callId: 'cancelCall',
-      name: 'mockTool',
-      args: {},
-    };
-
-    act(() => {
-      schedule(request);
-    });
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
-
-    act(() => {
-      cancel();
-    });
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
-
-    expect(onComplete).toHaveBeenCalledWith([
-      expect.objectContaining({
-        status: 'cancelled',
-        request,
-        response: expect.objectContaining({
-          responseParts: expect.arrayContaining([
-            expect.objectContaining({
-              functionResponse: expect.objectContaining({
-                response: expect.objectContaining({
-                  error:
-                    '[Operation Cancelled] Reason: User cancelled before execution',
-                }),
-              }),
-            }),
-          ]),
-        }),
-      }),
-    ]);
-    expect(mockTool.execute).not.toHaveBeenCalled();
-    expect(result.current[0]).toEqual([]);
-  });
-
-  it.skip('should cancel tool calls that are awaiting approval', async () => {
-    mockToolRegistry.getTool.mockReturnValue(mockToolRequiresConfirmation);
-    const { result } = renderScheduler();
-    const schedule = result.current[1];
-    const cancelFn = result.current[2];
-    const request: ToolCallRequestInfo = {
-      callId: 'cancelApprovalCall',
-      name: 'mockToolRequiresConfirmation',
-      args: {},
-    };
-
-    act(() => {
-      schedule(request);
-    });
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
-
-    act(() => {
-      cancelFn();
-    });
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
-
-    expect(onComplete).toHaveBeenCalledWith([
-      expect.objectContaining({
-        status: 'cancelled',
-        request,
-        response: expect.objectContaining({
-          responseParts: expect.arrayContaining([
-            expect.objectContaining({
-              functionResponse: expect.objectContaining({
-                response: expect.objectContaining({
-                  error:
-                    '[Operation Cancelled] Reason: User cancelled during approval',
-                }),
-              }),
-            }),
-          ]),
-        }),
-      }),
-    ]);
-    expect(result.current[0]).toEqual([]);
-  });
-
   it('should schedule and execute multiple tool calls', async () => {
     const tool1 = {
       ...mockTool,
@@ -766,7 +670,7 @@ describe('useReactToolScheduler', () => {
     ];
 
     act(() => {
-      schedule(requests);
+      schedule(requests, new AbortController().signal);
     });
     await act(async () => {
       await vi.runAllTimersAsync();
@@ -848,13 +752,13 @@ describe('useReactToolScheduler', () => {
     };
 
     act(() => {
-      schedule(request1);
+      schedule(request1, new AbortController().signal);
     });
     await act(async () => {
       await vi.runAllTimersAsync();
     });
 
-    expect(() => schedule(request2)).toThrow(
+    expect(() => schedule(request2, new AbortController().signal)).toThrow(
       'Cannot schedule tool calls while other tool calls are running',
     );
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -162,6 +162,13 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
       };
     }
 
+    if (abortSignal.aborted) {
+      return {
+        llmContent: 'Command was cancelled by user before it could start.',
+        returnDisplay: 'Command cancelled by user.',
+      };
+    }
+
     // wrap command to append subprocess pids (via pgrep) to temporary file
     const tempFileName = `shell_pgrep_${crypto.randomBytes(6).toString('hex')}.tmp`;
     const tempFilePath = path.join(os.tmpdir(), tempFileName);


### PR DESCRIPTION
- This change refactors the `CoreToolScheduler` to correctly handle and propagate the `AbortSignal`.
- The scheduler now stores the signal provided in the `schedule` method and uses it throughout the tool call lifecycle, including in the `handleConfirmationResponse` and `attemptExecutionOfScheduledCalls` methods. This ensures that the original cancellation signal from the UI is always used.
- The `useGeminiStream` hook is updated to correctly manage the `AbortController` lifecycle, ensuring it persists as long as a tool is executing.
- An early exit is added to the `ShellTool` to prevent execution if the signal is already aborted.

This resolves an issue where user-initiated cancellations were not being propagated to in-flight tool executions.

Fixes https://b.corp.google.com/issues/421970025