### PR TITLE
feat: Introduce session-based usage statistics

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { render } from 'ink';
-import { App } from './ui/App.js';
+import { AppWrapper } from './ui/App.js';
 import { loadCliConfig } from './config/config.js';
 import { readStdin } from './utils/readStdin.js';
 import { sandbox_command, start_sandbox } from './utils/sandbox.js';
@@ -95,7 +95,7 @@ export async function main() {
   if (process.stdin.isTTY && input?.length === 0) {
     render(
       <React.StrictMode>
-        <App
+        <AppWrapper
           config={config}
           settings={settings}
           startupWarnings={startupWarnings}

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import { render } from 'ink-testing-library';
-import { App } from './App.js';
+import { AppWrapper as App } from './App.js';
 import {
   Config as ServerConfig,
   MCPServerConfig,

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -48,6 +48,7 @@ import {
 } from '@gemini-cli/core';
 import { useLogger } from './hooks/useLogger.js';
 import { StreamingContext } from './contexts/StreamingContext.js';
+import { SessionProvider } from './contexts/SessionContext.js';
 import { useGitBranchName } from './hooks/useGitBranchName.js';
 
 const CTRL_C_PROMPT_DURATION_MS = 1000;
@@ -58,7 +59,13 @@ interface AppProps {
   startupWarnings?: string[];
 }
 
-export const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
+export const AppWrapper = (props: AppProps) => (
+  <SessionProvider>
+    <App {...props} />
+  </SessionProvider>
+);
+
+const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   const { history, addItem, clearItems } = useHistory();
   const {
     consoleMessages,

--- a/packages/cli/src/ui/contexts/SessionContext.test.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import { SessionProvider, useSession } from './SessionContext.js';
+import { describe, it, expect } from 'vitest';
+
+const TestComponent = () => {
+  const { startTime } = useSession();
+  return <Text>{startTime.toISOString()}</Text>;
+};
+
+describe('SessionContext', () => {
+  it('should provide a start time', () => {
+    const { lastFrame } = render(
+      <SessionProvider>
+        <TestComponent />
+      </SessionProvider>,
+    );
+
+    const frameText = lastFrame();
+    // Check if the output is a valid ISO string, which confirms it's a Date object.
+    expect(new Date(frameText!).toString()).not.toBe('Invalid Date');
+  });
+});

--- a/packages/cli/src/ui/contexts/SessionContext.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.tsx
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { createContext, useContext, useState, useMemo } from 'react';
+
+interface SessionContextType {
+  startTime: Date;
+}
+
+const SessionContext = createContext<SessionContextType | null>(null);
+
+export const SessionProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [startTime] = useState(new Date());
+
+  const value = useMemo(
+    () => ({
+      startTime,
+    }),
+    [startTime],
+  );
+
+  return (
+    <SessionContext.Provider value={value}>{children}</SessionContext.Provider>
+  );
+};
+
+export const useSession = () => {
+  const context = useContext(SessionContext);
+  if (!context) {
+    throw new Error('useSession must be used within a SessionProvider');
+  }
+  return context;
+};

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -61,9 +61,14 @@ import {
   MCPServerStatus,
   getMCPServerStatus,
 } from '@gemini-cli/core';
+import { useSession } from '../contexts/SessionContext.js';
 
 import * as ShowMemoryCommandModule from './useShowMemoryCommand.js';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
+
+vi.mock('../contexts/SessionContext.js', () => ({
+  useSession: vi.fn(),
+}));
 
 vi.mock('./useShowMemoryCommand.js', () => ({
   SHOW_MEMORY_COMMAND_NAME: '/memory show',
@@ -84,6 +89,7 @@ describe('useSlashCommandProcessor', () => {
   let mockPerformMemoryRefresh: ReturnType<typeof vi.fn>;
   let mockConfig: Config;
   let mockCorgiMode: ReturnType<typeof vi.fn>;
+  const mockUseSession = useSession as Mock;
 
   beforeEach(() => {
     mockAddItem = vi.fn();
@@ -99,6 +105,9 @@ describe('useSlashCommandProcessor', () => {
       getModel: vi.fn(() => 'test-model'),
     } as unknown as Config;
     mockCorgiMode = vi.fn();
+    mockUseSession.mockReturnValue({
+      startTime: new Date('2025-01-01T00:00:00.000Z'),
+    });
 
     (open as Mock).mockClear();
     mockProcessExit.mockClear();
@@ -227,6 +236,34 @@ describe('useSlashCommandProcessor', () => {
         expect.any(Number),
       );
       expect(commandResult).toBe(true);
+    });
+  });
+
+  describe('/stats command', () => {
+    it('should show the session duration', async () => {
+      const { handleSlashCommand } = getProcessor();
+      let commandResult: SlashCommandActionReturn | boolean = false;
+
+      // Mock current time
+      const mockDate = new Date('2025-01-01T00:01:05.000Z');
+      vi.setSystemTime(mockDate);
+
+      await act(async () => {
+        commandResult = handleSlashCommand('/stats');
+      });
+
+      expect(mockAddItem).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: 'Session duration: 1m 5s',
+        }),
+        expect.any(Number),
+      );
+      expect(commandResult).toBe(true);
+
+      // Restore system time
+      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
**Issue:** Works to address #811

### Overview

This PR introduces a new usage statistics feature in the CLI. The ultimate goal is to provide users with valuable insights into their token usage, performance, and overall interaction during a session.

This will be delivered in two ways:
1.  **On-Demand:** A `/stats` slash command that displays detailed metrics for the current session and the most recent turn.
2.  **On-Exit:** A summary of session usage presented when the user exits the CLI.

This initial commit establishes the core architecture for session state management but does not yet include the final UI or data collection logic.

### Scope of this Initial Commit

This is the first in a chain of commits for this feature. The changes included here are strictly foundational and focus on setting up the necessary state management pattern.

-   **React Context for Session State:** Adds a new `SessionContext`. This provides a centralized, application-wide store for session data, avoiding the need to pass state down through multiple component layers.
-   **Session Provider:** Implements `SessionProvider` which wraps the main `App` component. This ensures that session state is available to the entire component tree.
-   **Initial State Definition:** Defines the basic structure for the session state, starting with a session `startTime`. I will add additional metrics like token counts, performance metrics, and more later in subsequent commits. 

**Current UI:**

<img width="1218" alt="Screenshot 2025-06-08 at 4 38 49 PM" src="https://github.com/user-attachments/assets/db534c4d-354a-468a-9774-1a5af495b7a2" />

### Next Steps (in this PR)

-   [ ] Expand the `SessionContext` to hold all relevant statistical data (such as token counts from the Gemini API, etc.).
-   [ ] Implement the logic to capture `UsageMetadata` from API responses and update the session state.
-   [ ] Develop the UI component to render the formatted `/stats` output.
-   [ ] Add client-side logic to track wall-clock time and API latency per turn.
-   [ ] Implement the on-exit summary display (This can also be made into a separate PR if this one becomes to lengthy).

This PR is a work-in-progress. Please let me know if there is any feedback as I work to add onto this chain!