### PR TITLE
feat(git): Refactor gitignore handling to use `ignore` library instead of `minimatch`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3100,6 +3100,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -10408,7 +10409,7 @@
         "diff": "^7.0.0",
         "dotenv": "^16.4.7",
         "fast-glob": "^3.3.3",
-        "minimatch": "^10.0.0",
+        "ignore": "^7.0.0",
         "shell-quote": "^1.8.2",
         "strip-ansi": "^7.1.0"
       },
@@ -10423,28 +10424,13 @@
         "node": ">=18"
       }
     },
-    "packages/core/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+    "packages/core/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "packages/core/node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
       "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">= 4"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,7 @@
     "diff": "^7.0.0",
     "dotenv": "^16.4.7",
     "fast-glob": "^3.3.3",
-    "minimatch": "^10.0.0",
+    "ignore": "^7.0.0",
     "shell-quote": "^1.8.2",
     "strip-ansi": "^7.1.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/core/src/services/fileDiscoveryService.test.ts
+++ b/packages/core/src/services/fileDiscoveryService.test.ts
@@ -140,33 +140,6 @@ describe('FileDiscoveryService', () => {
     });
   });
 
-  describe('getIgnoreInfo', () => {
-    beforeEach(async () => {
-      await service.initialize();
-    });
-
-    it('should return git ignored patterns', () => {
-      const info = service.getIgnoreInfo();
-
-      expect(info.gitIgnored).toEqual(['.git/**', 'node_modules/**']);
-    });
-
-    it('should return empty arrays when git ignore parser is not initialized', async () => {
-      const uninitializedService = new FileDiscoveryService(mockProjectRoot);
-      const info = uninitializedService.getIgnoreInfo();
-
-      expect(info.gitIgnored).toEqual([]);
-    });
-
-    it('should handle git ignore parser returning null patterns', async () => {
-      mockGitIgnoreParser.getIgnoredPatterns.mockReturnValue([] as string[]);
-
-      const info = service.getIgnoreInfo();
-
-      expect(info.gitIgnored).toEqual([]);
-    });
-  });
-
   describe('isGitRepository', () => {
     it('should return true when isGitRepo is explicitly set to true in options', () => {
       const result = service.isGitRepository({ isGitRepo: true });

--- a/packages/core/src/services/fileDiscoveryService.ts
+++ b/packages/core/src/services/fileDiscoveryService.ts
@@ -52,15 +52,6 @@ export class FileDiscoveryService {
   }
 
   /**
-   * Gets patterns that would be ignored for debugging/transparency
-   */
-  getIgnoreInfo(): { gitIgnored: string[] } {
-    return {
-      gitIgnored: this.gitIgnoreFilter?.getIgnoredPatterns() || [],
-    };
-  }
-
-  /**
    * Checks if a single file should be ignored
    */
   shouldIgnoreFile(


### PR DESCRIPTION
- This commit refactors the `GitIgnoreParser` to use the `ignore` library, which provides a more robust and accurate implementation of gitignore rule parsing.
- The previous implementation, which used `minimatch`, had several limitations and did not fully support all gitignore syntax.
- The `fileDiscoveryService` has been updated to use the new `GitIgnoreParser`, and the `getIgnoreInfo` method has been removed as it is no longer needed.
- Tests have been updated to reflect the new implementation.

Part of https://github.com/google-gemini/gemini-cli/issues/847