### PR TITLE
Bump @google/genai dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -889,9 +889,9 @@
       "link": true
     },
     "node_modules/@google/genai": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.3.0.tgz",
-      "integrity": "sha512-rrMzAELX4P902FUpuWy/W3NcQ7L3q/qtCzfCmGVqIce8yWpptTF9hkKsw744tvZpwqhuzD0URibcJA95wd8QFA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.4.0.tgz",
+      "integrity": "sha512-u9LQZbWBhqaaLelCcYsxMNDTeW12jzNwGkI/eqUeMG/iB1gJBu56LCxrFJ/hkHeZQgPg+j1pckBLZS/dnOh+Bw==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.14.2",
@@ -10397,7 +10397,7 @@
       "name": "@gemini-cli/core",
       "version": "0.1.0",
       "dependencies": {
-        "@google/genai": "^1.0.1",
+        "@google/genai": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.11.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,20 +21,20 @@
     "dist"
   ],
   "dependencies": {
-    "@google/genai": "^1.0.1",
+    "@google/genai": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.11.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.52.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.52.0",
+    "@opentelemetry/instrumentation-http": "^0.52.0",
+    "@opentelemetry/sdk-node": "^0.52.0",
     "diff": "^7.0.0",
     "dotenv": "^16.4.7",
     "fast-glob": "^3.3.3",
     "minimatch": "^10.0.0",
     "shell-quote": "^1.8.2",
-    "strip-ansi": "^7.1.0",
-    "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/sdk-node": "^0.52.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.52.0",
-    "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.52.0",
-    "@opentelemetry/instrumentation-http": "^0.52.0"
+    "strip-ansi": "^7.1.0"
   },
   "devDependencies": {
     "@types/diff": "^7.0.2",


### PR DESCRIPTION
The current version (`1.1.0`), does not have to up-to-date type definitions for `UsageMetadata` in the response from the model. Due to this, the response token count is returned but requires unsafe type assumptions. 

In general, if there are no immediate concerns with this bump, it should help keep this dependency clean for better maintainability. 

This bumps the version to `1.4.0`

**Note about commit**: The update function auto rearranged the other dependencies for better readability. There should be no actual change to those versions.