### PR TITLE
feat(core): support .aiexclude and refactor file filtering

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -46,17 +46,15 @@ When you create a `.gemini/settings.json` file for project-specific settings, or
 
 - **`fileFiltering`** (object, optional):
 
-  - **Description:** Controls git-aware file filtering behavior for @ commands and file discovery tools.
+  - **Description:** Controls file filtering behavior for @ commands and file discovery tools.
   - **Properties:**
     - **`respectGitIgnore`** (boolean, default: `true`): Whether to respect .gitignore patterns when discovering files. When enabled, git-ignored files (like `node_modules/`, `dist/`, `.env`) are automatically excluded from @ commands and file listing operations.
-    - **`customIgnorePatterns`** (array of strings, default: `[]`): Additional patterns to ignore beyond git-ignored files. Useful for excluding specific directories or file types.
-    - **`allowBuildArtifacts`** (boolean, default: `false`): Whether to include build artifacts and generated files in file discovery operations.
+    - **`respectAIExclude`** (boolean, default: `true`): Whether to respect .aiexclude patterns when discovering files.
   - **Example:**
     ```json
     "fileFiltering": {
       "respectGitIgnore": true,
-      "customIgnorePatterns": ["temp/", "*.log"],
-      "allowBuildArtifacts": false
+      "respectAIExclude": true,
     }
     ```
 
@@ -215,6 +213,24 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
   - Set to any value to disable all color output in the CLI.
 - **`CLI_TITLE`**:
   - Set to a string to customize the title of the CLI.
+
+Additionally, file filtering patterns are sourced from the following files:
+
+- .geminiignore at the root of the workspace.
+- .gitignore at the root of the workspace if enabled (see fileFiltering in settings).
+- .aiexclude at the root of the workspace if enabled (see fileFiltering in settings).
+
+The .geminiignore file follows a format similar to .gitignore:
+
+- Each line specifies a glob pattern.
+- Lines are trimmed of leading and trailing whitespace.
+- Blank lines (after trimming) are ignored.
+- Lines starting with a pound sign (#) (after trimming) are treated as comments and ignored.
+- Patterns are case-sensitive and follow standard glob syntax.
+- If a # character appears elsewhere in a line (not at the start after trimming), it is considered part of the glob pattern.
+
+The .aiexclude file follows the format defined in
+https://cloud.google.com/gemini/docs/codeassist/create-aiexclude-file#write_an_aiexclude_file
 
 ## 3. Command-Line Arguments
 

--- a/packages/cli/src/config/config.integration.test.ts
+++ b/packages/cli/src/config/config.integration.test.ts
@@ -59,13 +59,13 @@ describe('Configuration Integration Tests', () => {
         targetDir: tempDir,
         debugMode: false,
         fileFilteringRespectGitIgnore: undefined, // Should default to true
-        fileFilteringAllowBuildArtifacts: undefined, // Should default to false
+        fileFilteringRespectAIExclude: undefined, // Should default to true
       };
 
       const config = new Config(configParams);
 
       expect(config.getFileFilteringRespectGitIgnore()).toBe(true);
-      expect(config.getFileFilteringAllowBuildArtifacts()).toBe(false);
+      expect(config.getFileFilteringRespectAIExclude()).toBe(true);
     });
 
     it('should load custom file filtering settings from configuration', async () => {
@@ -76,13 +76,13 @@ describe('Configuration Integration Tests', () => {
         targetDir: tempDir,
         debugMode: false,
         fileFilteringRespectGitIgnore: false,
-        fileFilteringAllowBuildArtifacts: true,
+        fileFilteringRespectAIExclude: false,
       };
 
       const config = new Config(configParams);
 
       expect(config.getFileFilteringRespectGitIgnore()).toBe(false);
-      expect(config.getFileFilteringAllowBuildArtifacts()).toBe(true);
+      expect(config.getFileFilteringRespectAIExclude()).toBe(false);
     });
 
     it('should merge user and workspace file filtering settings', async () => {
@@ -93,13 +93,13 @@ describe('Configuration Integration Tests', () => {
         targetDir: tempDir,
         debugMode: false,
         fileFilteringRespectGitIgnore: true,
-        fileFilteringAllowBuildArtifacts: true,
+        fileFilteringRespectAIExclude: true,
       };
 
       const config = new Config(configParams);
 
-      expect(config.getFileFilteringAllowBuildArtifacts()).toBe(true);
       expect(config.getFileFilteringRespectGitIgnore()).toBe(true);
+      expect(config.getFileFilteringRespectAIExclude()).toBe(true);
     });
   });
 
@@ -112,16 +112,14 @@ describe('Configuration Integration Tests', () => {
         targetDir: tempDir,
         debugMode: false,
         fileFilteringRespectGitIgnore: false,
-        fileFilteringAllowBuildArtifacts: undefined, // Should default to false
+        fileFilteringRespectAIExclude: false,
       };
 
       const config = new Config(configParams);
 
       // Specified settings should be applied
       expect(config.getFileFilteringRespectGitIgnore()).toBe(false);
-
-      // Missing settings should use defaults
-      expect(config.getFileFilteringAllowBuildArtifacts()).toBe(false);
+      expect(config.getFileFilteringRespectAIExclude()).toBe(false);
     });
 
     it('should handle empty configuration objects gracefully', async () => {
@@ -132,14 +130,14 @@ describe('Configuration Integration Tests', () => {
         targetDir: tempDir,
         debugMode: false,
         fileFilteringRespectGitIgnore: undefined,
-        fileFilteringAllowBuildArtifacts: undefined,
+        fileFilteringRespectAIExclude: undefined,
       };
 
       const config = new Config(configParams);
 
       // All settings should use defaults
       expect(config.getFileFilteringRespectGitIgnore()).toBe(true);
-      expect(config.getFileFilteringAllowBuildArtifacts()).toBe(false);
+      expect(config.getFileFilteringRespectAIExclude()).toBe(true);
     });
 
     it('should handle missing configuration sections gracefully', async () => {
@@ -156,7 +154,7 @@ describe('Configuration Integration Tests', () => {
 
       // All git-aware settings should use defaults
       expect(config.getFileFilteringRespectGitIgnore()).toBe(true);
-      expect(config.getFileFilteringAllowBuildArtifacts()).toBe(false);
+      expect(config.getFileFilteringRespectAIExclude()).toBe(true);
     });
   });
 
@@ -169,29 +167,13 @@ describe('Configuration Integration Tests', () => {
         targetDir: tempDir,
         debugMode: false,
         fileFilteringRespectGitIgnore: true,
-        fileFilteringAllowBuildArtifacts: false,
+        fileFilteringRespectAIExclude: true,
       };
 
       const config = new Config(configParams);
 
       expect(config.getFileFilteringRespectGitIgnore()).toBe(true);
-      expect(config.getFileFilteringAllowBuildArtifacts()).toBe(false);
-    });
-
-    it('should handle a development-focused configuration', async () => {
-      const configParams: ConfigParameters = {
-        contentGeneratorConfig: TEST_CONTENT_GENERATOR_CONFIG,
-        embeddingModel: 'test-embedding-model',
-        sandbox: false,
-        targetDir: tempDir,
-        debugMode: false,
-        fileFilteringRespectGitIgnore: true,
-        fileFilteringAllowBuildArtifacts: true,
-      };
-
-      const config = new Config(configParams);
-
-      expect(config.getFileFilteringAllowBuildArtifacts()).toBe(true);
+      expect(config.getFileFilteringRespectAIExclude()).toBe(true);
     });
 
     it('should handle a CI/CD environment configuration', async () => {
@@ -202,13 +184,13 @@ describe('Configuration Integration Tests', () => {
         targetDir: tempDir,
         debugMode: false,
         fileFilteringRespectGitIgnore: false, // CI might need to see all files
-        fileFilteringAllowBuildArtifacts: true,
+        fileFilteringRespectAIExclude: false, // CI might need to see all files
       };
 
       const config = new Config(configParams);
 
       expect(config.getFileFilteringRespectGitIgnore()).toBe(false);
-      expect(config.getFileFilteringAllowBuildArtifacts()).toBe(true);
+      expect(config.getFileFilteringRespectAIExclude()).toBe(false);
     });
   });
 });

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -193,8 +193,7 @@ export async function loadCliConfig(
         : (settings.telemetry ?? false),
     // Git-aware file filtering settings
     fileFilteringRespectGitIgnore: settings.fileFiltering?.respectGitIgnore,
-    fileFilteringAllowBuildArtifacts:
-      settings.fileFiltering?.allowBuildArtifacts,
+    fileFilteringRespectAIExclude: settings.fileFiltering?.respectAIExclude,
     checkpoint: argv.checkpoint,
   });
 }

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -43,7 +43,7 @@ export interface Settings {
   // Git-aware file filtering settings
   fileFiltering?: {
     respectGitIgnore?: boolean;
-    allowBuildArtifacts?: boolean;
+    respectAIExclude?: boolean;
   };
 
   // UI setting. Does not display the ANSI-controlled terminal title.

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -21,7 +21,7 @@ const mockConfig = {
   isSandboxed: vi.fn(() => false),
   getFileService: vi.fn(),
   getFileFilteringRespectGitIgnore: vi.fn(() => true),
-  getFileFilteringAllowBuildArtifacts: vi.fn(() => false),
+  getFileFilteringRespectAIExclude: vi.fn(() => true),
 } as unknown as Config;
 
 const mockReadManyFilesExecute = vi.fn();
@@ -92,7 +92,7 @@ describe('handleAtCommand', () => {
       initialize: vi.fn(),
       shouldIgnoreFile: vi.fn(() => false),
       filterFiles: vi.fn((files) => files),
-      getIgnoreInfo: vi.fn(() => ({ gitIgnored: [], customIgnored: [] })),
+      getIgnoreInfo: vi.fn(() => ({ gitIgnored: [] })),
       isGitRepository: vi.fn(() => true),
     };
     vi.mocked(FileDiscoveryService).mockImplementation(
@@ -173,7 +173,7 @@ ${fileContent}`,
       125,
     );
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      { paths: [filePath], respectGitIgnore: true },
+      { paths: [filePath], respectGitIgnore: true, respectAIExclude: true },
       abortController.signal,
     );
     expect(mockAddItem).toHaveBeenCalledWith(
@@ -221,7 +221,7 @@ ${fileContent}`,
       126,
     );
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      { paths: [resolvedGlob], respectGitIgnore: true },
+      { paths: [resolvedGlob], respectGitIgnore: true, respectAIExclude: true },
       abortController.signal,
     );
     expect(mockOnDebugMessage).toHaveBeenCalledWith(
@@ -325,7 +325,11 @@ ${fileContent}`,
       signal: abortController.signal,
     });
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      { paths: [unescapedPath], respectGitIgnore: true },
+      {
+        paths: [unescapedPath],
+        respectGitIgnore: true,
+        respectAIExclude: true,
+      },
       abortController.signal,
     );
   });
@@ -355,7 +359,7 @@ ${content2}`,
       signal: abortController.signal,
     });
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      { paths: [file1, file2], respectGitIgnore: true },
+      { paths: [file1, file2], respectGitIgnore: true, respectAIExclude: true },
       abortController.signal,
     );
     expect(result.processedQuery).toEqual([
@@ -398,7 +402,7 @@ ${content2}`,
       signal: abortController.signal,
     });
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      { paths: [file1, file2], respectGitIgnore: true },
+      { paths: [file1, file2], respectGitIgnore: true, respectAIExclude: true },
       abortController.signal,
     );
     expect(result.processedQuery).toEqual([
@@ -464,7 +468,11 @@ ${content2}`,
     });
 
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      { paths: [file1, resolvedFile2], respectGitIgnore: true },
+      {
+        paths: [file1, resolvedFile2],
+        respectGitIgnore: true,
+        respectAIExclude: true,
+      },
       abortController.signal,
     );
     expect(result.processedQuery).toEqual([
@@ -568,7 +576,7 @@ ${fileContent}`,
       // If the mock is simpler, it might use queryPath if stat(queryPath) succeeds.
       // The most important part is that *some* version of the path that leads to the content is used.
       // Let's assume it uses the path from the query if stat confirms it exists (even if different case on disk)
-      { paths: [queryPath], respectGitIgnore: true },
+      { paths: [queryPath], respectGitIgnore: true, respectAIExclude: true },
       abortController.signal,
     );
     expect(mockAddItem).toHaveBeenCalledWith(
@@ -611,10 +619,10 @@ ${fileContent}`,
         gitIgnoredFile,
       );
       expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        `Path ${gitIgnoredFile} is git-ignored and will be skipped.`,
+        `Path ${gitIgnoredFile} is ignored and will be skipped.`,
       );
       expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        'Ignored 1 git-ignored files: node_modules/package.json',
+        'Ignored 1 patterns-ignored files: node_modules/package.json',
       );
       expect(mockReadManyFilesExecute).not.toHaveBeenCalled();
       expect(result.processedQuery).toEqual([{ text: query }]);
@@ -647,7 +655,7 @@ ${fileContent}`,
         validFile,
       );
       expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-        { paths: [validFile], respectGitIgnore: true },
+        { paths: [validFile], respectGitIgnore: true, respectAIExclude: true },
         abortController.signal,
       );
       expect(result.processedQuery).toEqual([
@@ -692,13 +700,13 @@ ${fileContent}`,
         gitIgnoredFile,
       );
       expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        `Path ${gitIgnoredFile} is git-ignored and will be skipped.`,
+        `Path ${gitIgnoredFile} is ignored and will be skipped.`,
       );
       expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        'Ignored 1 git-ignored files: .env',
+        'Ignored 1 patterns-ignored files: .env',
       );
       expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-        { paths: [validFile], respectGitIgnore: true },
+        { paths: [validFile], respectGitIgnore: true, respectAIExclude: true },
         abortController.signal,
       );
       expect(result.processedQuery).toEqual([
@@ -730,10 +738,134 @@ ${fileContent}`,
         gitFile,
       );
       expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        `Path ${gitFile} is git-ignored and will be skipped.`,
+        `Path ${gitFile} is ignored and will be skipped.`,
       );
       expect(mockReadManyFilesExecute).not.toHaveBeenCalled();
       expect(result.processedQuery).toEqual([{ text: query }]);
+      expect(result.shouldProceed).toBe(true);
+    });
+  });
+
+  describe('aiexclude-aware filtering', () => {
+    it('should skip aiexcluded files in @ commands', async () => {
+      const excludedFile = 'foo.ts';
+      const query = `@${excludedFile}`;
+
+      // Mock the file discovery service to report this file as aiexcluded
+      mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
+        (path: string) => path === excludedFile,
+      );
+
+      const result = await handleAtCommand({
+        query,
+        config: mockConfig,
+        addItem: mockAddItem,
+        onDebugMessage: mockOnDebugMessage,
+        messageId: 200,
+        signal: abortController.signal,
+      });
+
+      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
+        excludedFile,
+      );
+      expect(mockOnDebugMessage).toHaveBeenCalledWith(
+        `Path ${excludedFile} is ignored and will be skipped.`,
+      );
+      expect(mockOnDebugMessage).toHaveBeenCalledWith(
+        'Ignored 1 patterns-ignored files: foo.ts',
+      );
+      expect(mockReadManyFilesExecute).not.toHaveBeenCalled();
+      expect(result.processedQuery).toEqual([{ text: query }]);
+      expect(result.shouldProceed).toBe(true);
+    });
+
+    it('should process non-aiexcluded files normally', async () => {
+      const validFile = 'src/index.ts';
+      const query = `@${validFile}`;
+      const fileContent = 'console.log("Hello world");';
+
+      mockFileDiscoveryService.shouldIgnoreFile.mockReturnValue(false);
+      mockReadManyFilesExecute.mockResolvedValue({
+        llmContent: `
+--- ${validFile} ---
+${fileContent}`,
+        returnDisplay: 'Read 1 file.',
+      });
+
+      const result = await handleAtCommand({
+        query,
+        config: mockConfig,
+        addItem: mockAddItem,
+        onDebugMessage: mockOnDebugMessage,
+        messageId: 201,
+        signal: abortController.signal,
+      });
+
+      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
+        validFile,
+      );
+      expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
+        { paths: [validFile], respectGitIgnore: true, respectAIExclude: true },
+        abortController.signal,
+      );
+      expect(result.processedQuery).toEqual([
+        { text: `@${validFile}` },
+        { text: '\n--- Content from referenced files ---' },
+        { text: `\nContent from @${validFile}:\n` },
+        { text: fileContent },
+        { text: '\n--- End of content ---' },
+      ]);
+      expect(result.shouldProceed).toBe(true);
+    });
+
+    it('should handle mixed aiexcluded and valid files', async () => {
+      const validFile = 'README.md';
+      const excludedFile = '.env';
+      const query = `@${validFile} @${excludedFile}`;
+      const fileContent = '# Project README';
+
+      mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
+        (path: string) => path === excludedFile,
+      );
+      mockReadManyFilesExecute.mockResolvedValue({
+        llmContent: `
+--- ${validFile} ---
+${fileContent}`,
+        returnDisplay: 'Read 1 file.',
+      });
+
+      const result = await handleAtCommand({
+        query,
+        config: mockConfig,
+        addItem: mockAddItem,
+        onDebugMessage: mockOnDebugMessage,
+        messageId: 202,
+        signal: abortController.signal,
+      });
+
+      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
+        validFile,
+      );
+      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
+        excludedFile,
+      );
+      expect(mockOnDebugMessage).toHaveBeenCalledWith(
+        `Path ${excludedFile} is ignored and will be skipped.`,
+      );
+      expect(mockOnDebugMessage).toHaveBeenCalledWith(
+        'Ignored 1 patterns-ignored files: .env',
+      );
+      expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
+        { paths: [validFile], respectGitIgnore: true, respectAIExclude: true },
+        abortController.signal,
+      );
+      expect(result.processedQuery).toEqual([
+        { text: `@${validFile} @${excludedFile}` },
+        { text: '\n--- Content from referenced files ---' },
+        { text: `\nContent from @${validFile}:\n` },
+        { text: fileContent },
+        { text: '\n--- End of content ---' },
+      ]);
       expect(result.shouldProceed).toBe(true);
     });
   });

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -137,6 +137,8 @@ export async function handleAtCommand({
   // Get centralized file discovery service
   const fileDiscovery = await config.getFileService();
   const respectGitIgnore = config.getFileFilteringRespectGitIgnore();
+  const respectAIExclude = config.getFileFilteringRespectAIExclude();
+  const respectIgnore = respectGitIgnore || respectAIExclude;
 
   const pathSpecsToRead: string[] = [];
   const atPathToResolvedSpecMap = new Map<string, string>();
@@ -181,10 +183,10 @@ export async function handleAtCommand({
       return { processedQuery: null, shouldProceed: false };
     }
 
-    // Check if path should be ignored by git
+    // Check if path should be ignored
     if (fileDiscovery.shouldIgnoreFile(pathName)) {
-      const reason = respectGitIgnore
-        ? 'git-ignored and will be skipped'
+      const reason = respectIgnore
+        ? 'ignored and will be skipped'
         : 'ignored by custom patterns';
       onDebugMessage(`Path ${pathName} is ${reason}.`);
       ignoredPaths.push(pathName);
@@ -322,7 +324,7 @@ export async function handleAtCommand({
 
   // Inform user about ignored paths
   if (ignoredPaths.length > 0) {
-    const ignoreType = respectGitIgnore ? 'git-ignored' : 'custom-ignored';
+    const ignoreType = respectIgnore ? 'patterns-ignored' : 'custom-ignored';
     onDebugMessage(
       `Ignored ${ignoredPaths.length} ${ignoreType} files: ${ignoredPaths.join(', ')}`,
     );
@@ -350,6 +352,7 @@ export async function handleAtCommand({
   const toolArgs = {
     paths: pathSpecsToRead,
     respectGitIgnore, // Use configuration setting
+    respectAIExclude, // Use configuration setting
   };
   let toolCallDisplay: IndividualToolCallDisplay;
 

--- a/packages/cli/src/ui/hooks/useCompletion.integration.test.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.integration.test.ts
@@ -41,13 +41,13 @@ describe('useCompletion git-aware filtering integration', () => {
       initialize: vi.fn(),
       shouldIgnoreFile: vi.fn(),
       filterFiles: vi.fn(),
-      getIgnoreInfo: vi.fn(() => ({ gitIgnored: [], customIgnored: [] })),
       glob: vi.fn().mockResolvedValue([]),
+      getIgnoreInfo: vi.fn(() => ({ gitIgnored: [] })),
     };
 
     mockConfig = {
       getFileFilteringRespectGitIgnore: vi.fn(() => true),
-      getFileFilteringAllowBuildArtifacts: vi.fn(() => false),
+      getFileFilteringRespectAIExclude: vi.fn(() => true),
       getFileService: vi.fn().mockResolvedValue(mockFileDiscoveryService),
     };
 

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -105,18 +105,18 @@ describe('Server Config (config.ts)', () => {
   it('should set default file filtering settings when not provided', () => {
     const config = new Config(baseParams);
     expect(config.getFileFilteringRespectGitIgnore()).toBe(true);
-    expect(config.getFileFilteringAllowBuildArtifacts()).toBe(false);
+    expect(config.getFileFilteringRespectAIExclude()).toBe(true);
   });
 
   it('should set custom file filtering settings when provided', () => {
     const paramsWithFileFiltering: ConfigParameters = {
       ...baseParams,
       fileFilteringRespectGitIgnore: false,
-      fileFilteringAllowBuildArtifacts: true,
+      fileFilteringRespectAIExclude: false,
     };
     const config = new Config(paramsWithFileFiltering);
     expect(config.getFileFilteringRespectGitIgnore()).toBe(false);
-    expect(config.getFileFilteringAllowBuildArtifacts()).toBe(true);
+    expect(config.getFileFilteringRespectAIExclude()).toBe(false);
   });
 
   it('Config constructor should set telemetry to true when provided as true', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -80,7 +80,7 @@ export interface ConfigParameters {
   telemetry?: boolean;
   telemetryLogUserPromptsEnabled?: boolean;
   fileFilteringRespectGitIgnore?: boolean;
-  fileFilteringAllowBuildArtifacts?: boolean;
+  fileFilteringRespectAIExclude?: boolean;
   checkpoint?: boolean;
 }
 
@@ -111,7 +111,7 @@ export class Config {
   private readonly geminiClient: GeminiClient;
   private readonly geminiIgnorePatterns: string[] = [];
   private readonly fileFilteringRespectGitIgnore: boolean;
-  private readonly fileFilteringAllowBuildArtifacts: boolean;
+  private readonly fileFilteringRespectAIExclude: boolean;
   private fileDiscoveryService: FileDiscoveryService | null = null;
   private gitService: GitService | undefined = undefined;
   private readonly checkpoint: boolean;
@@ -143,8 +143,8 @@ export class Config {
       process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? 'http://localhost:4317';
     this.fileFilteringRespectGitIgnore =
       params.fileFilteringRespectGitIgnore ?? true;
-    this.fileFilteringAllowBuildArtifacts =
-      params.fileFilteringAllowBuildArtifacts ?? false;
+    this.fileFilteringRespectAIExclude =
+      params.fileFilteringRespectAIExclude ?? true;
     this.checkpoint = params.checkpoint ?? false;
 
     if (params.contextFileName) {
@@ -289,8 +289,8 @@ export class Config {
     return this.fileFilteringRespectGitIgnore;
   }
 
-  getFileFilteringAllowBuildArtifacts(): boolean {
-    return this.fileFilteringAllowBuildArtifacts;
+  getFileFilteringRespectAIExclude(): boolean {
+    return this.fileFilteringRespectAIExclude;
   }
 
   getCheckpointEnabled(): boolean {
@@ -302,7 +302,7 @@ export class Config {
       this.fileDiscoveryService = new FileDiscoveryService(this.targetDir);
       await this.fileDiscoveryService.initialize({
         respectGitIgnore: this.fileFilteringRespectGitIgnore,
-        includeBuildArtifacts: this.fileFilteringAllowBuildArtifacts,
+        respectAIExclude: this.fileFilteringRespectAIExclude,
       });
     }
     return this.fileDiscoveryService;

--- a/packages/core/src/services/fileDiscoveryService.ts
+++ b/packages/core/src/services/fileDiscoveryService.ts
@@ -4,19 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GitIgnoreParser, GitIgnoreFilter } from '../utils/gitIgnoreParser.js';
+import { GitIgnoreParser } from '../utils/gitIgnoreParser.js';
+import { AIExcludeParser } from '../utils/aiExcludeParser.js';
+import { IgnoreFilter } from '../utils/ignoreFilter.js';
 import { isGitRepository } from '../utils/gitUtils.js';
+import { makeRelative } from '../utils/paths.js';
 import * as path from 'path';
 import fg from 'fast-glob';
+import micromatch from 'micromatch';
 
 export interface FileDiscoveryOptions {
   respectGitIgnore?: boolean;
+  respectAIExclude?: boolean;
+  geminiIgnorePatterns?: string[];
   includeBuildArtifacts?: boolean;
   isGitRepo?: boolean;
 }
 
 export class FileDiscoveryService {
-  private gitIgnoreFilter: GitIgnoreFilter | null = null;
+  private gitIgnoreFilter: IgnoreFilter | null = null;
+  private aiExcludeFilter: IgnoreFilter | null = null;
+  private geminiIgnorePatterns: string[] = [];
   private projectRoot: string;
 
   constructor(projectRoot: string) {
@@ -26,11 +34,19 @@ export class FileDiscoveryService {
   async initialize(options: FileDiscoveryOptions = {}): Promise<void> {
     const isGitRepo = options.isGitRepo ?? isGitRepository(this.projectRoot);
 
+    if (options.respectAIExclude !== false) {
+      const parser = new AIExcludeParser(this.projectRoot);
+      await parser.initialize();
+      this.aiExcludeFilter = parser;
+    }
+
     if (options.respectGitIgnore !== false && isGitRepo) {
       const parser = new GitIgnoreParser(this.projectRoot);
       await parser.initialize();
       this.gitIgnoreFilter = parser;
     }
+
+    this.geminiIgnorePatterns = options.geminiIgnorePatterns ?? [];
   }
 
   async glob(
@@ -45,18 +61,33 @@ export class FileDiscoveryService {
   }
 
   /**
-   * Filters a list of file paths based on git ignore rules
+   * Filters a list of file paths based on ignore rules
    */
   filterFiles(
     filePaths: string[],
     options: FileDiscoveryOptions = {},
   ): string[] {
     return filePaths.filter((filePath) => {
+      if (this.geminiIgnoreMatch(filePath, options.geminiIgnorePatterns)) {
+        return false;
+      }
+
+      // aiexclude takes precedence over gitignore
+      // see https://cloud.google.com/gemini/docs/codeassist/create-aiexclude-file#write_an_aiexclude_file
+      if (
+        options.respectAIExclude !== false &&
+        this.aiExcludeFilter?.isIgnored(filePath)
+      ) {
+        return false;
+      }
+
       // Always respect git ignore unless explicitly disabled
-      if (options.respectGitIgnore !== false && this.gitIgnoreFilter) {
-        if (this.gitIgnoreFilter.isIgnored(filePath)) {
-          return false;
-        }
+      if (
+        this.isGitRepository(options) &&
+        options.respectGitIgnore !== false &&
+        this.gitIgnoreFilter?.isIgnored(filePath)
+      ) {
+        return false;
       }
 
       return true;
@@ -70,14 +101,27 @@ export class FileDiscoveryService {
     filePath: string,
     options: FileDiscoveryOptions = {},
   ): boolean {
-    const isGitRepo = options.isGitRepo ?? isGitRepository(this.projectRoot);
-    if (
-      options.respectGitIgnore !== false &&
-      isGitRepo &&
-      this.gitIgnoreFilter
-    ) {
-      return this.gitIgnoreFilter.isIgnored(filePath);
+    if (this.geminiIgnoreMatch(filePath, options.geminiIgnorePatterns)) {
+      return true;
     }
+
+    // aiexclude takes precedence over gitignore
+    // see https://cloud.google.com/gemini/docs/codeassist/create-aiexclude-file#write_an_aiexclude_file
+    if (
+      options.respectAIExclude !== false &&
+      this.aiExcludeFilter?.isIgnored(filePath)
+    ) {
+      return true;
+    }
+
+    if (
+      this.isGitRepository(options) &&
+      options.respectGitIgnore !== false &&
+      this.gitIgnoreFilter?.isIgnored(filePath)
+    ) {
+      return true;
+    }
+
     return false;
   }
 
@@ -86,5 +130,17 @@ export class FileDiscoveryService {
    */
   isGitRepository(options: FileDiscoveryOptions = {}): boolean {
     return options.isGitRepo ?? isGitRepository(this.projectRoot);
+  }
+
+  /**
+   * Returns true if the filePath matches any glob pattern in geminiIgnorePatterns
+   */
+  geminiIgnoreMatch(filePath: string, patterns?: string[]): boolean {
+    const allPatterns = (this.geminiIgnorePatterns ?? []).concat(
+      patterns ?? [],
+    );
+    const relativePath = makeRelative(filePath, this.projectRoot);
+    const isMatch = micromatch.isMatch(relativePath, allPatterns);
+    return isMatch;
   }
 }

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -54,7 +54,7 @@ describe('loggers', () => {
         }),
         getTelemetryLogUserPromptsEnabled: () => true,
         getFileFilteringRespectGitIgnore: () => true,
-        getFileFilteringAllowBuildArtifacts: () => false,
+        getFileFilteringRespectAIExclude: () => true,
         getDebugMode: () => true,
         getMcpServers: () => ({
           'test-server': {
@@ -82,7 +82,7 @@ describe('loggers', () => {
           code_assist_enabled: false,
           log_user_prompts_enabled: true,
           file_filtering_respect_git_ignore: true,
-          file_filtering_allow_build_artifacts: false,
+          file_filtering_respect_ai_exclude: true,
           debug_mode: true,
           mcp_servers: 'test-server',
         },

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -61,8 +61,8 @@ export function logCliConfiguration(config: Config): void {
     log_user_prompts_enabled: config.getTelemetryLogUserPromptsEnabled(),
     file_filtering_respect_git_ignore:
       config.getFileFilteringRespectGitIgnore(),
-    file_filtering_allow_build_artifacts:
-      config.getFileFilteringAllowBuildArtifacts(),
+    file_filtering_respect_ai_exclude:
+      config.getFileFilteringRespectAIExclude(),
     debug_mode: config.getDebugMode(),
     mcp_servers: mcpServers ? Object.keys(mcpServers).join(',') : '',
   };

--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -22,12 +22,14 @@ describe('GlobTool', () => {
   const mockConfig = {
     getFileService: async () => {
       const service = new FileDiscoveryService(tempRootDir);
-      await service.initialize({ respectGitIgnore: true });
+      await service.initialize({
+        respectGitIgnore: true,
+        respectAIExclude: true,
+      });
       return service;
     },
     getFileFilteringRespectGitIgnore: () => true,
-    getFileFilteringCustomIgnorePatterns: () => [],
-    getFileFilteringAllowBuildArtifacts: () => false,
+    getFileFilteringRespectAIExclude: () => true,
   } as Partial<Config> as Config;
 
   beforeEach(async () => {

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -14,6 +14,7 @@ import { BaseTool, ToolResult } from './tools.js';
 import { SchemaValidator } from '../utils/schemaValidator.js';
 import { makeRelative, shortenPath } from '../utils/paths.js';
 import { getErrorMessage, isNodeError } from '../utils/errors.js';
+import { isGitRepository } from '../utils/gitUtils.js';
 
 // --- Interfaces ---
 
@@ -262,47 +263,6 @@ export class GrepTool extends BaseTool<GrepToolParams, ToolResult> {
   }
 
   /**
-   * Checks if a directory or its parent directories contain a .git folder.
-   * @param {string} dirPath Absolute path to the directory to check.
-   * @returns {Promise<boolean>} True if it's a Git repository, false otherwise.
-   */
-  private async isGitRepository(dirPath: string): Promise<boolean> {
-    let currentPath = path.resolve(dirPath);
-    const root = path.parse(currentPath).root;
-
-    try {
-      while (true) {
-        const gitPath = path.join(currentPath, '.git');
-        try {
-          const stats = await fsPromises.stat(gitPath);
-          if (stats.isDirectory() || stats.isFile()) {
-            return true;
-          }
-          // If .git exists but isn't a file/dir, something is weird, return false
-          return false;
-        } catch (error: unknown) {
-          if (!isNodeError(error) || error.code !== 'ENOENT') {
-            console.debug(
-              `Error checking for .git in ${currentPath}: ${error}`,
-            );
-            return false;
-          }
-        }
-
-        if (currentPath === root) {
-          break;
-        }
-        currentPath = path.dirname(currentPath);
-      }
-    } catch (error: unknown) {
-      console.debug(
-        `Error traversing directory structure upwards from ${dirPath}: ${getErrorMessage(error)}`,
-      );
-    }
-    return false;
-  }
-
-  /**
    * Parses the standard output of grep-like commands (git grep, system grep).
    * Expects format: filePath:lineNumber:lineContent
    * Handles colons within file paths and line content correctly.
@@ -388,7 +348,7 @@ export class GrepTool extends BaseTool<GrepToolParams, ToolResult> {
 
     try {
       // --- Strategy 1: git grep ---
-      const isGit = await this.isGitRepository(absolutePath);
+      const isGit = await isGitRepository(absolutePath);
       const gitAvailable = isGit && (await this.isCommandAvailable('git'));
 
       if (gitAvailable) {

--- a/packages/core/src/tools/read-many-files.test.ts
+++ b/packages/core/src/tools/read-many-files.test.ts
@@ -25,12 +25,14 @@ describe('ReadManyFilesTool', () => {
   const mockConfig = {
     getFileService: async () => {
       const service = new FileDiscoveryService(tempRootDir);
-      await service.initialize({ respectGitIgnore: true });
+      await service.initialize({
+        respectGitIgnore: true,
+        respectAIExclude: true,
+      });
       return service;
     },
     getFileFilteringRespectGitIgnore: () => true,
-    getFileFilteringCustomIgnorePatterns: () => [],
-    getFileFilteringAllowBuildArtifacts: () => false,
+    getFileFilteringRespectAIExclude: () => true,
     getGeminiIgnorePatterns: () => ['**/foo.bar', 'foo.baz', 'foo.*'],
   } as Partial<Config> as Config;
 

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -60,6 +60,11 @@ export interface ReadManyFilesParams {
    * Optional. Whether to respect .gitignore patterns. Defaults to true.
    */
   respect_git_ignore?: boolean;
+
+  /**
+   * Optional. Whether to respect .aiexclude patterns. Defaults to true.
+   */
+  respect_ai_exclude?: boolean;
 }
 
 /**
@@ -171,6 +176,12 @@ export class ReadManyFilesTool extends BaseTool<
             'Optional. Whether to respect .gitignore patterns when discovering files. Only available in git repositories. Defaults to true.',
           default: true,
         },
+        respect_ai_exclude: {
+          type: 'boolean',
+          description:
+            'Optional. Whether to respect .aiexclude patterns when discovering files. Defaults to true.',
+          default: true,
+        },
       },
       required: ['paths'],
     };
@@ -265,6 +276,13 @@ Use this tool when the user's query implies needing the content of several files
       }
     }
 
+    if (params.respect_git_ignore) {
+      excludeDesc += ` Additional files may be excluded based on .gitignore.`;
+    }
+    if (params.respect_ai_exclude) {
+      excludeDesc += ` Additional files may be excluded based on .aiexclude.`;
+    }
+
     return `Will attempt to read and concatenate files ${pathDesc}. ${excludeDesc}. File encoding: ${DEFAULT_ENCODING}. Separator: "${DEFAULT_OUTPUT_SEPARATOR_FORMAT.replace('{filePath}', 'path/to/file.ext')}".`;
   }
 
@@ -286,10 +304,14 @@ Use this tool when the user's query implies needing the content of several files
       exclude = [],
       useDefaultExcludes = true,
       respect_git_ignore = true,
+      respect_ai_exclude = true,
     } = params;
 
     const respectGitIgnore =
       respect_git_ignore ?? this.config.getFileFilteringRespectGitIgnore();
+    const respectAIExclude =
+      respect_ai_exclude ?? this.config.getFileFilteringRespectAIExclude();
+    const respectIgnore = respectGitIgnore || respectAIExclude;
 
     // Get centralized file discovery service
     const fileDiscovery = await this.config.getFileService();
@@ -328,20 +350,20 @@ Use this tool when the user's query implies needing the content of several files
         caseSensitiveMatch: false,
       });
 
-      // Apply git-aware filtering if enabled and in git repository
-      const filteredEntries =
-        respectGitIgnore && fileDiscovery.isGitRepository()
-          ? fileDiscovery
-              .filterFiles(
-                entries.map((p) => path.relative(toolBaseDir, p)),
-                {
-                  respectGitIgnore,
-                },
-              )
-              .map((p) => path.resolve(toolBaseDir, p))
-          : entries;
+      // Apply filtering if enabled
+      const filteredEntries = respectIgnore
+        ? fileDiscovery
+            .filterFiles(
+              entries.map((p) => path.relative(toolBaseDir, p)),
+              {
+                respectGitIgnore,
+                respectAIExclude,
+              },
+            )
+            .map((p) => path.resolve(toolBaseDir, p))
+        : entries;
 
-      let gitIgnoredCount = 0;
+      let ignoredCount = 0;
       for (const absoluteFilePath of entries) {
         // Security check: ensure the glob library didn't return something outside targetDir.
         if (!absoluteFilePath.startsWith(toolBaseDir)) {
@@ -352,26 +374,22 @@ Use this tool when the user's query implies needing the content of several files
           continue;
         }
 
-        // Check if this file was filtered out by git ignore
-        if (
-          respectGitIgnore &&
-          fileDiscovery.isGitRepository() &&
-          !filteredEntries.includes(absoluteFilePath)
-        ) {
-          gitIgnoredCount++;
+        // Check if this file was filtered out
+        if (respectIgnore && !filteredEntries.includes(absoluteFilePath)) {
+          ignoredCount++;
           continue;
         }
 
         filesToConsider.add(absoluteFilePath);
       }
 
-      // Add info about git-ignored files if any were filtered
-      if (gitIgnoredCount > 0) {
-        const reason = respectGitIgnore
-          ? 'git-ignored'
+      // Add info about ignored files if any were filtered
+      if (ignoredCount > 0) {
+        const reason = respectIgnore
+          ? 'ignored'
           : 'filtered by custom ignore patterns';
         skippedFiles.push({
-          path: `${gitIgnoredCount} file(s)`,
+          path: `${ignoredCount} file(s)`,
           reason,
         });
       }

--- a/packages/core/src/utils/aiExcludeParser.test.ts
+++ b/packages/core/src/utils/aiExcludeParser.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { AIExcludeParser } from './aiExcludeParser.js';
+
+// Mock fs module
+vi.mock('fs/promises');
+
+describe('AIExcludeParser', () => {
+  let parser: AIExcludeParser;
+  const mockProjectRoot = '/test/project';
+  const aiexcludeContent = `
+apikeys.txt
+*.key
+/secrets.txt
+
+my/sensitive/dir/
+
+foo/*
+!foo/bar.txt
+
+`;
+
+  beforeEach(() => {
+    parser = new AIExcludeParser(mockProjectRoot);
+    // Reset mocks before each test
+    vi.mocked(fs.readFile).mockClear();
+    vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT')); // Default to no file
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('initialization', () => {
+    it('should initialize without errors when no .gitignore exists', async () => {
+      await expect(parser.initialize()).resolves.not.toThrow();
+    });
+
+    it('should load .aiexlucde patterns when file exists', async () => {
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(aiexcludeContent)
+        .mockRejectedValue(new Error('ENOENT'));
+
+      await parser.initialize();
+
+      expect(parser.getIngoredPatterns().length).toBe(7); // .aiexclude is always ignored.
+    });
+  });
+
+  describe('isIgnored', () => {
+    beforeEach(async () => {
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(aiexcludeContent)
+        .mockRejectedValue(new Error('ENOENT'));
+      await parser.initialize();
+    });
+
+    it('should always ignore .aiexclude files', () => {
+      expect(parser.isIgnored('.aiexclude')).toBe(true);
+      expect(parser.isIgnored('./bar/.aiexclude')).toBe(true);
+      expect(
+        parser.isIgnored(path.join(mockProjectRoot, './bar/.aiexclude')),
+      ).toBe(true);
+    });
+
+    it('should ignore files matching patterns', () => {
+      expect(parser.isIgnored('apikeys.txt')).toBe(true);
+      expect(parser.isIgnored('bar/apikeys.txt')).toBe(true);
+      expect(parser.isIgnored('bar/baz/apikeys.txt')).toBe(true);
+      expect(parser.isIgnored('my.key')).toBe(true);
+      expect(parser.isIgnored('bar/their.key')).toBe(true);
+      expect(parser.isIgnored('bar/baz/the.key')).toBe(true);
+      expect(parser.isIgnored('secrets.txt')).toBe(true);
+      expect(parser.isIgnored('bar/secrets.txt')).toBe(false);
+      expect(parser.isIgnored('bar/baz/secrets.txt')).toBe(false);
+      expect(parser.isIgnored('my/sensitive/dir/file')).toBe(true);
+      expect(parser.isIgnored('my/sensitive/dir/foo/secrets.txt')).toBe(true);
+      expect(parser.isIgnored('foo/file.txt')).toBe(true);
+      expect(parser.isIgnored('foo/bar/file.txt')).toBe(true);
+      expect(parser.isIgnored('foo/bar.txt')).toBe(false);
+    });
+
+    it('should not ignore files that do not match patterns', () => {
+      expect(parser.isIgnored('src/index.ts')).toBe(false);
+      expect(parser.isIgnored('README.md')).toBe(false);
+    });
+
+    it('should handle absolute paths correctly', () => {
+      const absolutePath = path.join(mockProjectRoot, 'bar', 'apikeys.txt');
+      expect(parser.isIgnored(absolutePath)).toBe(true);
+    });
+
+    it('should handle paths outside project root by not ignoring them', () => {
+      const outsidePath = path.resolve(mockProjectRoot, '../other/file.txt');
+      expect(parser.isIgnored(outsidePath)).toBe(false);
+    });
+
+    it('should handle relative paths correctly', () => {
+      expect(parser.isIgnored('bar/apikeys.txt')).toBe(true);
+      expect(parser.isIgnored('../some/other/file.txt')).toBe(false);
+    });
+
+    it('should normalize path separators on Windows', () => {
+      expect(parser.isIgnored('bar\\apikeys.txt')).toBe(true);
+    });
+  });
+
+  describe('getIgnoredPatterns', () => {
+    it('should return the raw patterns added', async () => {
+      vi.mocked(fs.readFile).mockResolvedValueOnce('apikeys.txt\n\nmy.key');
+
+      await parser.initialize();
+      expect(parser.getIngoredPatterns()).toEqual([
+        '.aiexclude',
+        'apikeys.txt',
+        'my.key',
+      ]);
+    });
+  });
+});

--- a/packages/core/src/utils/aiExcludeParser.ts
+++ b/packages/core/src/utils/aiExcludeParser.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import ignore, { Ignore } from 'ignore';
+import { IgnoreFilter } from './ignoreFilter.js';
+import { normalizeFilePath } from './fileUtils.js';
+
+export class AIExcludeParser implements IgnoreFilter {
+  private ig: Ignore = ignore();
+  private aiExcludeRoot: string;
+  private _patterns: string[] = [];
+
+  constructor(aiExcludeRoot: string) {
+    this.aiExcludeRoot = path.resolve(aiExcludeRoot);
+  }
+
+  async initialize(): Promise<void> {
+    this._patterns.push('.aiexclude');
+
+    try {
+      const content = await fs.readFile(
+        path.join(this.aiExcludeRoot, '.aiexclude'),
+        'utf-8',
+      );
+      const loaded = content
+        .split('\n')
+        .map((p) => p.trim())
+        .filter((p) => p !== '');
+      this._patterns.push(...loaded);
+      this.ig.add(this._patterns);
+    } catch (_error) {
+      // File doesn't exist or can't be read, continue silently
+    }
+  }
+
+  isIgnored(filePath: string): boolean {
+    const normalizedPath = normalizeFilePath(this.aiExcludeRoot, filePath);
+
+    if (normalizedPath === '' || normalizedPath.startsWith('..')) {
+      return false;
+    }
+
+    const ignored = this.ig.ignores(normalizedPath);
+    return ignored;
+  }
+
+  getIngoredPatterns(): string[] {
+    return this._patterns;
+  }
+}

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -278,3 +278,26 @@ export async function processSingleFileContent(
     };
   }
 }
+
+/**
+ * Returns filePath as a relative path to parent with forward slashes instead of backslashes if any.
+ * The returned path may be empty, includes backtracking (..), or relative to parent without the leading ./ if any.
+ * The returned path is effectively what is needed to traverse from parent to filePath.
+ *   - If both args are relative, they are assumed to be siblings in the working directory (the result is always filePath as is).
+ *   - If parent is relative and filePath is absolute, the result is relative to path.join(process.cwd(), parent).
+ *   - If both args are absolute, the result includes backtracking to the first shared ancestor.
+ * @param parent: parent file path to normalize against.
+ * @param filePath: the file path to normalize.
+ * @returns a normalized file path.
+ */
+export function normalizeFilePath(parent: string, filePath: string): string {
+  const relativePath = path.isAbsolute(filePath)
+    ? path.relative(parent, filePath)
+    : filePath;
+
+  let normalizedPath = relativePath.replace(/\\/g, '/');
+  if (normalizedPath.startsWith('./')) {
+    normalizedPath = normalizedPath.substring(2);
+  }
+  return normalizedPath;
+}

--- a/packages/core/src/utils/getFolderStructure.test.ts
+++ b/packages/core/src/utils/getFolderStructure.test.ts
@@ -5,12 +5,21 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  Mock,
+  Mocked,
+} from 'vitest';
 import fsPromises from 'fs/promises';
 import { Dirent as FSDirent } from 'fs';
 import * as nodePath from 'path';
 import { getFolderStructure } from './getFolderStructure.js';
-import * as gitUtils from './gitUtils.js';
+import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 
 vi.mock('path', async (importOriginal) => {
   const original = (await importOriginal()) as typeof nodePath;
@@ -22,7 +31,7 @@ vi.mock('path', async (importOriginal) => {
 });
 
 vi.mock('fs/promises');
-vi.mock('./gitUtils.js');
+vi.mock('../services/fileDiscoveryService.js');
 
 // Import 'path' again here, it will be the mocked version
 import * as path from 'path';
@@ -42,9 +51,11 @@ const createDirent = (name: string, type: 'file' | 'dir'): FSDirent => ({
 });
 
 describe('getFolderStructure', () => {
+  let mockFileService: Mocked<FileDiscoveryService>;
   beforeEach(() => {
-    vi.resetAllMocks();
-
+    mockFileService = {
+      shouldIgnoreFile: vi.fn(),
+    } as unknown as Mocked<FileDiscoveryService>;
     // path.resolve is now a vi.fn() due to the top-level vi.mock.
     // We ensure its implementation is set for each test (or rely on the one from vi.mock).
     // vi.resetAllMocks() clears call history but not the implementation set by vi.fn() in vi.mock.
@@ -68,6 +79,8 @@ describe('getFolderStructure', () => {
         );
       },
     );
+
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
@@ -133,28 +146,13 @@ Showing up to 200 items (files + folders).
     expect(structure.trim()).toBe(expected.trim());
   });
 
-  it('should ignore folders specified in ignoredFolders (default)', async () => {
-    const structure = await getFolderStructure('/testroot');
-    const expected = `
-Showing up to 200 items (files + folders). Folders or files indicated with ... contain more items not shown, were ignored, or the display limit (200 items) was reached.
-
-/testroot/
-├───.hiddenfile
-├───file1.txt
-├───emptyFolder/
-├───node_modules/...
-└───subfolderA/
-    ├───fileA1.ts
-    ├───fileA2.js
-    └───subfolderB/
-        └───fileB1.md
-`.trim();
-    expect(structure.trim()).toBe(expected);
-  });
-
-  it('should ignore folders specified in custom ignoredFolders', async () => {
+  it('should ignore ignored folders', async () => {
+    mockFileService.shouldIgnoreFile = vi.fn(
+      (filePath) =>
+        filePath.includes('subfolderA') || filePath.includes('node_modules'),
+    );
     const structure = await getFolderStructure('/testroot', {
-      ignoredFolders: new Set(['subfolderA', 'node_modules']),
+      fileService: mockFileService,
     });
     const expected = `
 Showing up to 200 items (files + folders). Folders or files indicated with ... contain more items not shown, were ignored, or the display limit (200 items) was reached.
@@ -165,20 +163,6 @@ Showing up to 200 items (files + folders). Folders or files indicated with ... c
 ├───emptyFolder/
 ├───node_modules/...
 └───subfolderA/...
-`.trim();
-    expect(structure.trim()).toBe(expected);
-  });
-
-  it('should filter files by fileIncludePattern', async () => {
-    const structure = await getFolderStructure('/testroot/subfolderA', {
-      fileIncludePattern: /\.ts$/,
-    });
-    const expected = `
-Showing up to 200 items (files + folders).
-
-/testroot/subfolderA/
-├───fileA1.ts
-└───subfolderB/
 `.trim();
     expect(structure.trim()).toBe(expected);
   });
@@ -277,63 +261,5 @@ Showing up to 3 items (files + folders).
         └───level3/
 `.trim();
     expect(structure.trim()).toBe(expected);
-  });
-});
-
-describe('getFolderStructure gitignore', () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-    (path.resolve as Mock).mockImplementation((str: string) => str);
-
-    (fsPromises.readdir as Mock).mockImplementation(async (p) => {
-      const path = p.toString();
-      if (path === '/test/project') {
-        return [
-          createDirent('file1.txt', 'file'),
-          createDirent('node_modules', 'dir'),
-          createDirent('ignored.txt', 'file'),
-          createDirent('.gemini', 'dir'),
-        ] as any;
-      }
-      if (path === '/test/project/node_modules') {
-        return [createDirent('some-package', 'dir')] as any;
-      }
-      if (path === '/test/project/.gemini') {
-        return [
-          createDirent('config.yaml', 'file'),
-          createDirent('logs.json', 'file'),
-        ] as any;
-      }
-      return [];
-    });
-
-    (fsPromises.readFile as Mock).mockImplementation(async (p) => {
-      const path = p.toString();
-      if (path === '/test/project/.gitignore') {
-        return 'ignored.txt\nnode_modules/\n.gemini/\n!/.gemini/config.yaml';
-      }
-      return '';
-    });
-
-    vi.mocked(gitUtils.isGitRepository).mockReturnValue(true);
-  });
-
-  it('should ignore files and folders specified in .gitignore', async () => {
-    const structure = await getFolderStructure('/test/project', {
-      projectRoot: '/test/project',
-    });
-    expect(structure).not.toContain('ignored.txt');
-    expect(structure).toContain('node_modules/...');
-    expect(structure).not.toContain('logs.json');
-  });
-
-  it('should not ignore files if respectGitIgnore is false', async () => {
-    const structure = await getFolderStructure('/test/project', {
-      projectRoot: '/test/project',
-      respectGitIgnore: false,
-    });
-    expect(structure).toContain('ignored.txt');
-    // node_modules is still ignored by default
-    expect(structure).toContain('node_modules/...');
   });
 });

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -6,14 +6,12 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import ignore, { type Ignore } from 'ignore';
+import ignore, { Ignore } from 'ignore';
+import { IgnoreFilter } from './ignoreFilter.js';
 import { isGitRepository } from './gitUtils.js';
+import { normalizeFilePath } from './fileUtils.js';
 
-export interface GitIgnoreFilter {
-  isIgnored(filePath: string): boolean;
-}
-
-export class GitIgnoreParser implements GitIgnoreFilter {
+export class GitIgnoreParser implements IgnoreFilter {
   private projectRoot: string;
   private isGitRepo: boolean = false;
   private ig: Ignore = ignore();
@@ -54,17 +52,9 @@ export class GitIgnoreParser implements GitIgnoreFilter {
       return false;
     }
 
-    const relativePath = path.isAbsolute(filePath)
-      ? path.relative(this.projectRoot, filePath)
-      : filePath;
-
-    if (relativePath === '' || relativePath.startsWith('..')) {
+    const normalizedPath = normalizeFilePath(this.projectRoot, filePath);
+    if (normalizedPath === '' || normalizedPath.startsWith('..')) {
       return false;
-    }
-
-    let normalizedPath = relativePath.replace(/\\/g, '/');
-    if (normalizedPath.startsWith('./')) {
-      normalizedPath = normalizedPath.substring(2);
     }
 
     const ignored = this.ig.ignores(normalizedPath);

--- a/packages/core/src/utils/ignoreFilter.ts
+++ b/packages/core/src/utils/ignoreFilter.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface IgnoreFilter {
+  isIgnored(filePath: string): boolean;
+}

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -9,6 +9,7 @@ import * as fsSync from 'fs';
 import * as path from 'path';
 import { homedir } from 'os';
 import { bfsFileSearch } from './bfsFileSearch.js';
+import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import {
   GEMINI_CONFIG_DIR,
   getCurrentGeminiMdFilename,
@@ -175,12 +176,15 @@ async function getGeminiMdFilePathsInternal(
   }
   paths.push(...upwardPaths);
 
+  const fileService = new FileDiscoveryService(projectRoot || resolvedCwd);
+  await fileService.initialize({
+    respectGitIgnore: true,
+  });
   const downwardPaths = await bfsFileSearch(resolvedCwd, {
     fileName: getCurrentGeminiMdFilename(),
     maxDirs: MAX_DIRECTORIES_TO_SCAN_FOR_MEMORY,
     debug: debugMode,
-    respectGitIgnore: true,
-    projectRoot: projectRoot || resolvedCwd,
+    fileService,
   });
   downwardPaths.sort(); // Sort for consistent ordering, though hierarchy might be more complex
   if (debugMode && downwardPaths.length > 0)

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -103,8 +103,8 @@ export function makeRelative(
   targetPath: string,
   rootDirectory: string,
 ): string {
-  const resolvedTargetPath = path.resolve(targetPath);
   const resolvedRootDirectory = path.resolve(rootDirectory);
+  const resolvedTargetPath = path.resolve(resolvedRootDirectory, targetPath);
 
   const relativePath = path.relative(resolvedRootDirectory, resolvedTargetPath);
 


### PR DESCRIPTION
File filtering is centralized in `FileDiscoveryService` and controlled by the following sources:
- .geminiignore which defines glob patterns to be excluded from
  listings.
- .gitignore for git repositories.
- .aiexclude for AI specific exclusions.

Other custom settings for exclusions are removed, including
`customIgnorePatterns` and `allowBuildArtifacts`, which were noops as of
this.

Fixes #653 