### PR TITLE
feat: Display initial token usage metrics in /stats

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -48,7 +48,7 @@ import {
 } from '@gemini-cli/core';
 import { useLogger } from './hooks/useLogger.js';
 import { StreamingContext } from './contexts/StreamingContext.js';
-import { SessionProvider } from './contexts/SessionContext.js';
+import { SessionStatsProvider } from './contexts/SessionContext.js';
 import { useGitBranchName } from './hooks/useGitBranchName.js';
 
 const CTRL_C_PROMPT_DURATION_MS = 1000;
@@ -60,9 +60,9 @@ interface AppProps {
 }
 
 export const AppWrapper = (props: AppProps) => (
-  <SessionProvider>
+  <SessionStatsProvider>
     <App {...props} />
-  </SessionProvider>
+  </SessionStatsProvider>
 );
 
 const App = ({ config, settings, startupWarnings = [] }: AppProps) => {

--- a/packages/cli/src/ui/contexts/SessionContext.test.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.test.tsx
@@ -4,26 +4,181 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { type MutableRefObject } from 'react';
 import { render } from 'ink-testing-library';
-import { Text } from 'ink';
-import { SessionProvider, useSession } from './SessionContext.js';
-import { describe, it, expect } from 'vitest';
+import { act } from 'react-dom/test-utils';
+import { SessionStatsProvider, useSessionStats } from './SessionContext.js';
+import { describe, it, expect, vi } from 'vitest';
+import { GenerateContentResponseUsageMetadata } from '@google/genai';
 
-const TestComponent = () => {
-  const { startTime } = useSession();
-  return <Text>{startTime.toISOString()}</Text>;
+// Mock data that simulates what the Gemini API would return.
+const mockMetadata1: GenerateContentResponseUsageMetadata = {
+  promptTokenCount: 100,
+  candidatesTokenCount: 200,
+  totalTokenCount: 300,
+  cachedContentTokenCount: 50,
+  toolUsePromptTokenCount: 10,
+  thoughtsTokenCount: 20,
 };
 
-describe('SessionContext', () => {
-  it('should provide a start time', () => {
-    const { lastFrame } = render(
-      <SessionProvider>
-        <TestComponent />
-      </SessionProvider>,
+const mockMetadata2: GenerateContentResponseUsageMetadata = {
+  promptTokenCount: 10,
+  candidatesTokenCount: 20,
+  totalTokenCount: 30,
+  cachedContentTokenCount: 5,
+  toolUsePromptTokenCount: 1,
+  thoughtsTokenCount: 2,
+};
+
+/**
+ * A test harness component that uses the hook and exposes the context value
+ * via a mutable ref. This allows us to interact with the context's functions
+ * and assert against its state directly in our tests.
+ */
+const TestHarness = ({
+  contextRef,
+}: {
+  contextRef: MutableRefObject<ReturnType<typeof useSessionStats> | undefined>;
+}) => {
+  contextRef.current = useSessionStats();
+  return null;
+};
+
+describe('SessionStatsContext', () => {
+  it('should provide the correct initial state', () => {
+    const contextRef: MutableRefObject<
+      ReturnType<typeof useSessionStats> | undefined
+    > = { current: undefined };
+
+    render(
+      <SessionStatsProvider>
+        <TestHarness contextRef={contextRef} />
+      </SessionStatsProvider>,
     );
 
-    const frameText = lastFrame();
-    // Check if the output is a valid ISO string, which confirms it's a Date object.
-    expect(new Date(frameText!).toString()).not.toBe('Invalid Date');
+    const stats = contextRef.current?.stats;
+
+    expect(stats?.sessionStartTime).toBeInstanceOf(Date);
+    expect(stats?.lastTurn).toBeNull();
+    expect(stats?.cumulative.turnCount).toBe(0);
+    expect(stats?.cumulative.totalTokenCount).toBe(0);
+    expect(stats?.cumulative.promptTokenCount).toBe(0);
+  });
+
+  it('should increment turnCount when startNewTurn is called', () => {
+    const contextRef: MutableRefObject<
+      ReturnType<typeof useSessionStats> | undefined
+    > = { current: undefined };
+
+    render(
+      <SessionStatsProvider>
+        <TestHarness contextRef={contextRef} />
+      </SessionStatsProvider>,
+    );
+
+    act(() => {
+      contextRef.current?.startNewTurn();
+    });
+
+    const stats = contextRef.current?.stats;
+    expect(stats?.cumulative.turnCount).toBe(1);
+    // Ensure token counts are unaffected
+    expect(stats?.cumulative.totalTokenCount).toBe(0);
+  });
+
+  it('should aggregate token usage correctly when addUsage is called', () => {
+    const contextRef: MutableRefObject<
+      ReturnType<typeof useSessionStats> | undefined
+    > = { current: undefined };
+
+    render(
+      <SessionStatsProvider>
+        <TestHarness contextRef={contextRef} />
+      </SessionStatsProvider>,
+    );
+
+    act(() => {
+      contextRef.current?.addUsage(mockMetadata1);
+    });
+
+    const stats = contextRef.current?.stats;
+
+    // Check that token counts are updated
+    expect(stats?.cumulative.totalTokenCount).toBe(
+      mockMetadata1.totalTokenCount ?? 0,
+    );
+    expect(stats?.cumulative.promptTokenCount).toBe(
+      mockMetadata1.promptTokenCount ?? 0,
+    );
+
+    // Check that turn count is NOT incremented
+    expect(stats?.cumulative.turnCount).toBe(0);
+
+    // Check that lastTurn is updated
+    expect(stats?.lastTurn?.metadata).toEqual(mockMetadata1);
+  });
+
+  it('should correctly track a full logical turn with multiple API calls', () => {
+    const contextRef: MutableRefObject<
+      ReturnType<typeof useSessionStats> | undefined
+    > = { current: undefined };
+
+    render(
+      <SessionStatsProvider>
+        <TestHarness contextRef={contextRef} />
+      </SessionStatsProvider>,
+    );
+
+    // 1. User starts a new turn
+    act(() => {
+      contextRef.current?.startNewTurn();
+    });
+
+    // 2. First API call (e.g., prompt with a tool request)
+    act(() => {
+      contextRef.current?.addUsage(mockMetadata1);
+    });
+
+    // 3. Second API call (e.g., sending tool response back)
+    act(() => {
+      contextRef.current?.addUsage(mockMetadata2);
+    });
+
+    const stats = contextRef.current?.stats;
+
+    // Turn count should only be 1
+    expect(stats?.cumulative.turnCount).toBe(1);
+
+    // These fields should be the SUM of both calls
+    expect(stats?.cumulative.totalTokenCount).toBe(330); // 300 + 30
+    expect(stats?.cumulative.candidatesTokenCount).toBe(220); // 200 + 20
+    expect(stats?.cumulative.thoughtsTokenCount).toBe(22); // 20 + 2
+
+    // These fields should ONLY be from the FIRST call, because isNewTurnForAggregation was true
+    expect(stats?.cumulative.promptTokenCount).toBe(100);
+    expect(stats?.cumulative.cachedContentTokenCount).toBe(50);
+    expect(stats?.cumulative.toolUsePromptTokenCount).toBe(10);
+
+    // Last turn should hold the metadata from the most recent call
+    expect(stats?.lastTurn?.metadata).toEqual(mockMetadata2);
+  });
+
+  it('should throw an error when useSessionStats is used outside of a provider', () => {
+    // Suppress the expected console error during this test.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const contextRef = { current: undefined };
+
+    // We expect rendering to fail, which React will catch and log as an error.
+    render(<TestHarness contextRef={contextRef} />);
+
+    // Assert that the first argument of the first call to console.error
+    // contains the expected message. This is more robust than checking
+    // the exact arguments, which can be affected by React/JSDOM internals.
+    expect(errorSpy.mock.calls[0][0]).toContain(
+      'useSessionStats must be used within a SessionStatsProvider',
+    );
+
+    errorSpy.mockRestore();
   });
 });

--- a/packages/cli/src/ui/contexts/SessionContext.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.tsx
@@ -4,35 +4,140 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { createContext, useContext, useState, useMemo } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  useCallback,
+} from 'react';
 
-interface SessionContextType {
-  startTime: Date;
+import { type GenerateContentResponseUsageMetadata } from '@google/genai';
+
+// --- Interface Definitions ---
+
+interface CumulativeStats {
+  turnCount: number;
+  promptTokenCount: number;
+  candidatesTokenCount: number;
+  totalTokenCount: number;
+  cachedContentTokenCount: number;
+  toolUsePromptTokenCount: number;
+  thoughtsTokenCount: number;
 }
 
-const SessionContext = createContext<SessionContextType | null>(null);
+interface LastTurnStats {
+  metadata: GenerateContentResponseUsageMetadata;
+  // TODO(abhipatel12): Add apiTime, etc. here in a future step.
+}
 
-export const SessionProvider: React.FC<{ children: React.ReactNode }> = ({
+interface SessionStatsState {
+  sessionStartTime: Date;
+  cumulative: CumulativeStats;
+  lastTurn: LastTurnStats | null;
+  isNewTurnForAggregation: boolean;
+}
+
+// Defines the final "value" of our context, including the state
+// and the functions to update it.
+interface SessionStatsContextValue {
+  stats: SessionStatsState;
+  startNewTurn: () => void;
+  addUsage: (metadata: GenerateContentResponseUsageMetadata) => void;
+}
+
+// --- Context Definition ---
+
+const SessionStatsContext = createContext<SessionStatsContextValue | undefined>(
+  undefined,
+);
+
+// --- Provider Component ---
+
+export const SessionStatsProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [startTime] = useState(new Date());
+  const [stats, setStats] = useState<SessionStatsState>({
+    sessionStartTime: new Date(),
+    cumulative: {
+      turnCount: 0,
+      promptTokenCount: 0,
+      candidatesTokenCount: 0,
+      totalTokenCount: 0,
+      cachedContentTokenCount: 0,
+      toolUsePromptTokenCount: 0,
+      thoughtsTokenCount: 0,
+    },
+    lastTurn: null,
+    isNewTurnForAggregation: true,
+  });
+
+  // A single, internal worker function to handle all metadata aggregation.
+  const aggregateTokens = useCallback(
+    (metadata: GenerateContentResponseUsageMetadata) => {
+      setStats((prevState) => {
+        const { isNewTurnForAggregation } = prevState;
+        const newCumulative = { ...prevState.cumulative };
+
+        newCumulative.candidatesTokenCount +=
+          metadata.candidatesTokenCount ?? 0;
+        newCumulative.thoughtsTokenCount += metadata.thoughtsTokenCount ?? 0;
+        newCumulative.totalTokenCount += metadata.totalTokenCount ?? 0;
+
+        if (isNewTurnForAggregation) {
+          newCumulative.promptTokenCount += metadata.promptTokenCount ?? 0;
+          newCumulative.cachedContentTokenCount +=
+            metadata.cachedContentTokenCount ?? 0;
+          newCumulative.toolUsePromptTokenCount +=
+            metadata.toolUsePromptTokenCount ?? 0;
+        }
+
+        return {
+          ...prevState,
+          cumulative: newCumulative,
+          lastTurn: { metadata },
+          isNewTurnForAggregation: false,
+        };
+      });
+    },
+    [],
+  );
+
+  const startNewTurn = useCallback(() => {
+    setStats((prevState) => ({
+      ...prevState,
+      cumulative: {
+        ...prevState.cumulative,
+        turnCount: prevState.cumulative.turnCount + 1,
+      },
+      isNewTurnForAggregation: true,
+    }));
+  }, []);
 
   const value = useMemo(
     () => ({
-      startTime,
+      stats,
+      startNewTurn,
+      addUsage: aggregateTokens,
     }),
-    [startTime],
+    [stats, startNewTurn, aggregateTokens],
   );
 
   return (
-    <SessionContext.Provider value={value}>{children}</SessionContext.Provider>
+    <SessionStatsContext.Provider value={value}>
+      {children}
+    </SessionStatsContext.Provider>
   );
 };
 
-export const useSession = () => {
-  const context = useContext(SessionContext);
-  if (!context) {
-    throw new Error('useSession must be used within a SessionProvider');
+// --- Consumer Hook ---
+
+export const useSessionStats = () => {
+  const context = useContext(SessionStatsContext);
+  if (context === undefined) {
+    throw new Error(
+      'useSessionStats must be used within a SessionStatsProvider',
+    );
   }
   return context;
 };

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -61,13 +61,13 @@ import {
   MCPServerStatus,
   getMCPServerStatus,
 } from '@gemini-cli/core';
-import { useSession } from '../contexts/SessionContext.js';
+import { useSessionStats } from '../contexts/SessionContext.js';
 
 import * as ShowMemoryCommandModule from './useShowMemoryCommand.js';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 
 vi.mock('../contexts/SessionContext.js', () => ({
-  useSession: vi.fn(),
+  useSessionStats: vi.fn(),
 }));
 
 vi.mock('./useShowMemoryCommand.js', () => ({
@@ -89,7 +89,7 @@ describe('useSlashCommandProcessor', () => {
   let mockPerformMemoryRefresh: ReturnType<typeof vi.fn>;
   let mockConfig: Config;
   let mockCorgiMode: ReturnType<typeof vi.fn>;
-  const mockUseSession = useSession as Mock;
+  const mockUseSessionStats = useSessionStats as Mock;
 
   beforeEach(() => {
     mockAddItem = vi.fn();
@@ -105,8 +105,19 @@ describe('useSlashCommandProcessor', () => {
       getModel: vi.fn(() => 'test-model'),
     } as unknown as Config;
     mockCorgiMode = vi.fn();
-    mockUseSession.mockReturnValue({
-      startTime: new Date('2025-01-01T00:00:00.000Z'),
+    mockUseSessionStats.mockReturnValue({
+      stats: {
+        sessionStartTime: new Date('2025-01-01T00:00:00.000Z'),
+        cumulative: {
+          turnCount: 0,
+          promptTokenCount: 0,
+          candidatesTokenCount: 0,
+          totalTokenCount: 0,
+          cachedContentTokenCount: 0,
+          toolUsePromptTokenCount: 0,
+          thoughtsTokenCount: 0,
+        },
+      },
     });
 
     (open as Mock).mockClear();
@@ -240,29 +251,50 @@ describe('useSlashCommandProcessor', () => {
   });
 
   describe('/stats command', () => {
-    it('should show the session duration', async () => {
-      const { handleSlashCommand } = getProcessor();
-      let commandResult: SlashCommandActionReturn | boolean = false;
-
-      // Mock current time
-      const mockDate = new Date('2025-01-01T00:01:05.000Z');
-      vi.setSystemTime(mockDate);
-
-      await act(async () => {
-        commandResult = handleSlashCommand('/stats');
+    it('should show detailed session statistics', async () => {
+      // Arrange
+      mockUseSessionStats.mockReturnValue({
+        stats: {
+          sessionStartTime: new Date('2025-01-01T00:00:00.000Z'),
+          cumulative: {
+            totalTokenCount: 900,
+            promptTokenCount: 200,
+            candidatesTokenCount: 700,
+            cachedContentTokenCount: 100,
+            turnCount: 1,
+            toolUsePromptTokenCount: 0,
+            thoughtsTokenCount: 0,
+          },
+        },
       });
 
+      const { handleSlashCommand } = getProcessor();
+      const mockDate = new Date('2025-01-01T01:02:03.000Z'); // 1h 2m 3s duration
+      vi.setSystemTime(mockDate);
+
+      // Act
+      await act(async () => {
+        handleSlashCommand('/stats');
+      });
+
+      // Assert
+      const expectedContent = [
+        `Session Duration: 1h 2m 3s`,
+        `Total Tokens:     900`,
+        `Input Tokens:     200`,
+        `Output Tokens:    700`,
+        `Cache Efficiency: 50.00% (100 tokens from cache)`,
+      ].join('\n');
+
       expect(mockAddItem).toHaveBeenNthCalledWith(
-        2,
+        2, // Called after the user message
         expect.objectContaining({
           type: MessageType.INFO,
-          text: 'Session duration: 1m 5s',
+          text: expectedContent,
         }),
         expect.any(Number),
       );
-      expect(commandResult).toBe(true);
 
-      // Restore system time
       vi.useRealTimers();
     });
   });

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -259,11 +259,11 @@ describe('useSlashCommandProcessor', () => {
           cumulative: {
             totalTokenCount: 900,
             promptTokenCount: 200,
-            candidatesTokenCount: 700,
+            candidatesTokenCount: 400,
             cachedContentTokenCount: 100,
             turnCount: 1,
-            toolUsePromptTokenCount: 0,
-            thoughtsTokenCount: 0,
+            toolUsePromptTokenCount: 50,
+            thoughtsTokenCount: 150,
           },
         },
       });
@@ -279,11 +279,16 @@ describe('useSlashCommandProcessor', () => {
 
       // Assert
       const expectedContent = [
-        `Session Duration: 1h 2m 3s`,
-        `Total Tokens:     900`,
-        `Input Tokens:     200`,
-        `Output Tokens:    700`,
-        `Cache Efficiency: 50.00% (100 tokens from cache)`,
+        `  ⎿ Total duration (wall): 1h 2m 3s`,
+        `    Total Token usage:`,
+        `         Turns: 1`,
+        `         Total: 900`,
+        `             ├─ Input: 200`,
+        `             ├─ Output: 400`,
+        `             ├─ Cached: 100`,
+        `             └─ Overhead: 200`,
+        `                  ├─ Model thoughts: 150`,
+        `                  └─ Tool-use prompts: 50`,
       ].join('\n');
 
       expect(mockAddItem).toHaveBeenNthCalledWith(

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -162,21 +162,20 @@ export const useSlashCommandProcessor = (
             .filter(Boolean)
             .join(' ');
 
-          const cacheEfficiency =
-            cumulative.promptTokenCount > 0
-              ? (
-                  (cumulative.cachedContentTokenCount /
-                    cumulative.promptTokenCount) *
-                  100
-                ).toFixed(2)
-              : '0.00';
+          const overheadTotal =
+            cumulative.thoughtsTokenCount + cumulative.toolUsePromptTokenCount;
 
           const statsContent = [
-            `Session Duration: ${durationString}`,
-            `Total Tokens:     ${cumulative.totalTokenCount.toLocaleString()}`,
-            `Input Tokens:     ${cumulative.promptTokenCount.toLocaleString()}`,
-            `Output Tokens:    ${cumulative.candidatesTokenCount.toLocaleString()}`,
-            `Cache Efficiency: ${cacheEfficiency}% (${cumulative.cachedContentTokenCount.toLocaleString()} tokens from cache)`,
+            `  ⎿ Total duration (wall): ${durationString}`,
+            `    Total Token usage:`,
+            `         Turns: ${cumulative.turnCount.toLocaleString()}`,
+            `         Total: ${cumulative.totalTokenCount.toLocaleString()}`,
+            `             ├─ Input: ${cumulative.promptTokenCount.toLocaleString()}`,
+            `             ├─ Output: ${cumulative.candidatesTokenCount.toLocaleString()}`,
+            `             ├─ Cached: ${cumulative.cachedContentTokenCount.toLocaleString()}`,
+            `             └─ Overhead: ${overheadTotal.toLocaleString()}`,
+            `                  ├─ Model thoughts: ${cumulative.thoughtsTokenCount.toLocaleString()}`,
+            `                  └─ Tool-use prompts: ${cumulative.toolUsePromptTokenCount.toLocaleString()}`,
           ].join('\n');
 
           addMessage({

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -174,9 +174,10 @@ export class GeminiClient {
     request: PartListUnion,
     signal: AbortSignal,
     turns: number = this.MAX_TURNS,
-  ): AsyncGenerator<ServerGeminiStreamEvent> {
+  ): AsyncGenerator<ServerGeminiStreamEvent, Turn> {
     if (!turns) {
-      return;
+      const chat = await this.chat;
+      return new Turn(chat);
     }
 
     const compressed = await this.tryCompressChat();
@@ -193,9 +194,12 @@ export class GeminiClient {
       const nextSpeakerCheck = await checkNextSpeaker(chat, this, signal);
       if (nextSpeakerCheck?.next_speaker === 'model') {
         const nextRequest = [{ text: 'Please continue.' }];
+        // This recursive call's events will be yielded out, but the final
+        // turn object will be from the top-level call.
         yield* this.sendMessageStream(nextRequest, signal, turns - 1);
       }
     }
+    return turn;
   }
 
   private _logApiRequest(model: string, inputTokenCount: number): void {
@@ -423,6 +427,10 @@ export class GeminiClient {
         });
 
       const result = await retryWithBackoff(apiCall);
+      console.log(
+        'Raw API Response in client.ts:',
+        JSON.stringify(result, null, 2),
+      );
       const durationMs = Date.now() - startTime;
       this._logApiResponse(modelToUse, durationMs, attempt, result);
       return result;

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -10,8 +10,14 @@ import {
   GeminiEventType,
   ServerGeminiToolCallRequestEvent,
   ServerGeminiErrorEvent,
+  ServerGeminiUsageMetadataEvent,
 } from './turn.js';
-import { GenerateContentResponse, Part, Content } from '@google/genai';
+import {
+  GenerateContentResponse,
+  Part,
+  Content,
+  GenerateContentResponseUsageMetadata,
+} from '@google/genai';
 import { reportError } from '../utils/errorReporting.js';
 import { GeminiChat } from './geminiChat.js';
 
@@ -48,6 +54,24 @@ describe('Turn', () => {
     getHistory: typeof mockGetHistory;
   };
   let mockChatInstance: MockedChatInstance;
+
+  const mockMetadata1: GenerateContentResponseUsageMetadata = {
+    promptTokenCount: 10,
+    candidatesTokenCount: 20,
+    totalTokenCount: 30,
+    cachedContentTokenCount: 5,
+    toolUsePromptTokenCount: 2,
+    thoughtsTokenCount: 3,
+  };
+
+  const mockMetadata2: GenerateContentResponseUsageMetadata = {
+    promptTokenCount: 100,
+    candidatesTokenCount: 200,
+    totalTokenCount: 300,
+    cachedContentTokenCount: 50,
+    toolUsePromptTokenCount: 20,
+    thoughtsTokenCount: 30,
+  };
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -96,6 +120,7 @@ describe('Turn', () => {
         message: reqParts,
         config: { abortSignal: expect.any(AbortSignal) },
       });
+
       expect(events).toEqual([
         { type: GeminiEventType.Content, value: 'Hello' },
         { type: GeminiEventType.Content, value: ' world' },
@@ -208,6 +233,41 @@ describe('Turn', () => {
       );
     });
 
+    it('should yield the last UsageMetadata event from the stream', async () => {
+      const mockResponseStream = (async function* () {
+        yield {
+          candidates: [{ content: { parts: [{ text: 'First response' }] } }],
+          usageMetadata: mockMetadata1,
+        } as unknown as GenerateContentResponse;
+        yield {
+          functionCalls: [{ name: 'aTool' }],
+          usageMetadata: mockMetadata2,
+        } as unknown as GenerateContentResponse;
+      })();
+      mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+      const events = [];
+      const reqParts: Part[] = [{ text: 'Test metadata' }];
+      for await (const event of turn.run(
+        reqParts,
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+
+      // There should be a content event, a tool call, and our metadata event
+      expect(events.length).toBe(3);
+
+      const metadataEvent = events[2] as ServerGeminiUsageMetadataEvent;
+      expect(metadataEvent.type).toBe(GeminiEventType.UsageMetadata);
+
+      // The value should be the *last* metadata object received.
+      expect(metadataEvent.value).toEqual(mockMetadata2);
+
+      // Also check the public getter
+      expect(turn.getUsageMetadata()).toEqual(mockMetadata2);
+    });
+
     it('should handle function calls with undefined name or args', async () => {
       const mockResponseStream = (async function* () {
         yield {
@@ -219,7 +279,6 @@ describe('Turn', () => {
         } as unknown as GenerateContentResponse;
       })();
       mockSendMessageStream.mockResolvedValue(mockResponseStream);
-
       const events = [];
       const reqParts: Part[] = [{ text: 'Test undefined tool parts' }];
       for await (const event of turn.run(


### PR DESCRIPTION
**Issue:** Continues work to address #811
**Related PR:** #854 

### Overview

This PR updates the `/stats` feature in the CLI to contain more information from the `UsageData` in API responses from Gemini. The ultimate goal is to provide users with valuable insights into their token usage, performance, and overall interaction during a session.

### Scope of this Initial Commit

This is the first in a chain of commits for this feature. The changes included here are strictly foundational and focus on setting up the necessary state management pattern.

-   **Updates to stats available in SessionContext:** `SessionContext now contains Gemini API `UsageMetadata` for cumulative and last turn metrics. This gives us an in-depth idea about how token input, output, tool usage, think, modalities, etc. 
-   **/stats update:** Currently prints out some metrics like total tokens, input tokens, output tokens, and cache efficiency in addition to session duration. These are not set in stone and may be changed. This was just to add a proof of concept.

**Current State of `/stats`:**

<img width="1234" alt="Screenshot 2025-06-09 at 5 21 23 PM" src="https://github.com/user-attachments/assets/4bb1e4b3-c150-445b-9709-18a820521541" />

### Next Steps (in follow-up PRs)
-   [ ] Develop the UI component to render the formatted `/stats` output.
-   [ ] Add client-side logic to track API time per turn (and possibly total)
-   [ ] Implement the on-exit summary display