### PR TITLE
GEMINI_SANDBOX=false should disable seatbelt

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -151,7 +151,7 @@ export async function loadCliConfig(
   return new Config({
     contentGeneratorConfig,
     embeddingModel: DEFAULT_GEMINI_EMBEDDING_MODEL,
-    sandbox: sandbox,
+    sandbox,
     targetDir: process.cwd(),
     debugMode,
     question: argv.prompt || '',

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -143,10 +143,15 @@ export async function loadCliConfig(
 
   const contentGeneratorConfig = await createContentGeneratorConfig(argv);
 
+  let sandbox = argv.sandbox ?? settings.sandbox;
+  if (argv.yolo) {
+    sandbox = false;
+  }
+
   return new Config({
     contentGeneratorConfig,
     embeddingModel: DEFAULT_GEMINI_EMBEDDING_MODEL,
-    sandbox: argv.sandbox ?? settings.sandbox ?? argv.yolo ?? false,
+    sandbox: sandbox,
     targetDir: process.cwd(),
     debugMode,
     question: argv.prompt || '',

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -109,42 +109,44 @@ export function sandbox_command(sandbox?: string | boolean): string {
   if (sandbox === '1' || sandbox === 'true') sandbox = true;
   else if (sandbox === '0' || sandbox === 'false') sandbox = false;
 
-  if (sandbox === true) {
-    // look for docker or podman, in that order
-    if (commandExists.sync('docker')) {
-      return 'docker'; // Set sandbox to 'docker' if found
-    } else if (commandExists.sync('podman')) {
-      return 'podman'; // Set sandbox to 'podman' if found
-    } else {
-      console.error(
-        'ERROR: failed to determine command for sandbox; ' +
-          'install docker or podman or specify command in GEMINI_SANDBOX',
-      );
-      process.exit(1);
-    }
-  } else if (sandbox) {
+  if (sandbox === false) {
+    return '';
+  }
+
+  if (typeof sandbox === 'string') {
     // confirm that specfied command exists
     if (commandExists.sync(sandbox)) {
       return sandbox;
-    } else {
-      console.error(
-        `ERROR: missing sandbox command '${sandbox}' (from GEMINI_SANDBOX)`,
-      );
-      process.exit(1);
     }
-  } else {
-    // if we are on macOS (Darwin) and sandbox-exec is available, use that for minimal sandboxing
-    // unless SEATBELT_PROFILE is set to 'none', which we allow as an escape hatch
-    if (
-      os.platform() === 'darwin' &&
-      commandExists.sync('sandbox-exec') &&
-      process.env.SEATBELT_PROFILE !== 'none'
-    ) {
-      return 'sandbox-exec';
-    }
-
-    return ''; // no sandbox
+    console.error(
+      `ERROR: missing sandbox command '${sandbox}' (from GEMINI_SANDBOX)`,
+    );
+    process.exit(1);
   }
+
+
+  // look for seatbelt, docker, or podman, in that order
+  if (
+    os.platform() === 'darwin' &&
+    commandExists.sync('sandbox-exec') &&
+    process.env.SEATBELT_PROFILE !== 'none'
+  ) {
+    return 'sandbox-exec';
+  } else if (commandExists.sync('docker')) {
+    return 'docker';
+  } else if (commandExists.sync('podman')) {
+    return 'podman';
+  }
+
+  if (sandbox === true) {
+    console.error(
+      'ERROR: GEMINI_SANDBOX is true but failed to determine command for sandbox; ' +
+      'install docker or podman or specify command in GEMINI_SANDBOX',
+    );
+    process.exit(1);
+  }
+
+  return '';
 }
 
 // docker does not allow container names to contain ':' or '/', so we
@@ -303,7 +305,7 @@ export async function start_sandbox(sandbox: string) {
     if (!gcPath.includes('gemini-cli/packages/')) {
       console.error(
         'ERROR: cannot build sandbox using installed gemini binary; ' +
-          'run `npm link ./packages/cli` under gemini-cli repo to switch to linked binary.',
+        'run `npm link ./packages/cli` under gemini-cli repo to switch to linked binary.',
       );
       process.exit(1);
     } else {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -102,7 +102,6 @@ async function getSandboxImageName(
   );
 }
 
-// node.js equivalent of scripts/sandbox_command.sh
 export function sandbox_command(sandbox?: string | boolean): string {
   // note environment variable takes precedence over argument (from command line or settings)
   sandbox = process.env.GEMINI_SANDBOX?.toLowerCase().trim() ?? sandbox;
@@ -113,7 +112,7 @@ export function sandbox_command(sandbox?: string | boolean): string {
     return '';
   }
 
-  if (typeof sandbox === 'string') {
+  if (typeof sandbox === 'string' && sandbox !== '') {
     // confirm that specfied command exists
     if (commandExists.sync(sandbox)) {
       return sandbox;
@@ -124,13 +123,8 @@ export function sandbox_command(sandbox?: string | boolean): string {
     process.exit(1);
   }
 
-
   // look for seatbelt, docker, or podman, in that order
-  if (
-    os.platform() === 'darwin' &&
-    commandExists.sync('sandbox-exec') &&
-    process.env.SEATBELT_PROFILE !== 'none'
-  ) {
+  if (os.platform() === 'darwin' && commandExists.sync('sandbox-exec')) {
     return 'sandbox-exec';
   } else if (commandExists.sync('docker')) {
     return 'docker';
@@ -138,10 +132,11 @@ export function sandbox_command(sandbox?: string | boolean): string {
     return 'podman';
   }
 
+  // throw an error if user requested sandbox but no command was found
   if (sandbox === true) {
     console.error(
       'ERROR: GEMINI_SANDBOX is true but failed to determine command for sandbox; ' +
-      'install docker or podman or specify command in GEMINI_SANDBOX',
+        'install docker or podman or specify command in GEMINI_SANDBOX',
     );
     process.exit(1);
   }
@@ -305,7 +300,7 @@ export async function start_sandbox(sandbox: string) {
     if (!gcPath.includes('gemini-cli/packages/')) {
       console.error(
         'ERROR: cannot build sandbox using installed gemini binary; ' +
-        'run `npm link ./packages/cli` under gemini-cli repo to switch to linked binary.',
+          'run `npm link ./packages/cli` under gemini-cli repo to switch to linked binary.',
       );
       process.exit(1);
     } else {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -57,7 +57,7 @@ export class MCPServerConfig {
 export interface ConfigParameters {
   contentGeneratorConfig: ContentGeneratorConfig;
   embeddingModel: string;
-  sandbox: boolean | string;
+  sandbox?: boolean | string;
   targetDir: string;
   debugMode: boolean;
   question?: string;
@@ -85,7 +85,7 @@ export class Config {
   private toolRegistry: Promise<ToolRegistry>;
   private readonly contentGeneratorConfig: ContentGeneratorConfig;
   private readonly embeddingModel: string;
-  private readonly sandbox: boolean | string;
+  private readonly sandbox: boolean | string | undefined;
   private readonly targetDir: string;
   private readonly debugMode: boolean;
   private readonly question: string | undefined;
@@ -167,7 +167,7 @@ export class Config {
     return this.embeddingModel;
   }
 
-  getSandbox(): boolean | string {
+  getSandbox(): boolean | string | undefined {
     return this.sandbox;
   }
 


### PR DESCRIPTION
Refactors the sandbox configuration and execution logic.

  Key changes:
  - GEMINI_SANDBOX=false now disables all sandboxing
   - The --yolo flag now correctly disables the sandbox.
   - Sandbox command detection is improved, prioritizing sandbox-exec on macOS.
   - The sandbox configuration is now optional in the core config.
