### PR TITLE
fix version set for cli and slash commands

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -5,6 +5,9 @@
  */
 
 import esbuild from 'esbuild';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 esbuild
   .build({
@@ -13,6 +16,9 @@ esbuild
     outfile: 'bundle/gemini.js',
     platform: 'node',
     format: 'esm',
+    define: {
+      'process.env.CLI_VERSION': JSON.stringify(pkg.version),
+    },
     banner: {
       js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url); globalThis.__filename = require('url').fileURLToPath(import.meta.url); globalThis.__dirname = require('path').dirname(globalThis.__filename);`,
     },

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -90,7 +90,7 @@ async function parseArguments(): Promise<CliArgs> {
       type: 'boolean',
       description: 'Enable telemetry?',
     })
-    .version() // This will enable the --version flag based on package.json
+    .version(process.env.CLI_VERSION || '0.0.0') // This will enable the --version flag based on package.json
     .help()
     .alias('h', 'help')
     .strict().argv;

--- a/packages/cli/src/utils/version.ts
+++ b/packages/cli/src/utils/version.ts
@@ -5,5 +5,5 @@
  */
 
 export function getCliVersion(): string {
-  return process.env.CLI_VERSION || process.version;
+  return process.env.CLI_VERSION || "unknown";
 }

--- a/packages/cli/src/utils/version.ts
+++ b/packages/cli/src/utils/version.ts
@@ -5,5 +5,5 @@
  */
 
 export function getCliVersion(): string {
-  return process.env.CLI_VERSION || "unknown";
+  return process.env.CLI_VERSION || 'unknown';
 }

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -19,8 +19,10 @@
 
 import { spawn, execSync } from 'child_process';
 import { join } from 'path';
+import { readFileSync } from 'fs';
 
 const root = join(import.meta.dirname, '..');
+const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'));
 
 // check build status, write warnings to file for app to display if needed
 execSync('node ./scripts/check-build-status.js', {
@@ -54,7 +56,7 @@ nodeArgs.push(...process.argv.slice(2));
 
 const env = {
   ...process.env,
-  CLI_VERSION: 'development',
+  CLI_VERSION: pkg.version,
   DEV: 'true',
 };
 


### PR DESCRIPTION
Fix for https://github.com/google-gemini/gemini-cli/issues/607. It also sets the correct version in the "/about" command. Previously, we were using the version of NPM as the "CLI Version".