### PR TITLE
Add multi-line input support with Alt+Enter

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -2,7 +2,14 @@
 
 Gemini CLI supports several built-in commands to help you manage your session, customize the interface, and control its behavior. These commands are prefixed with a forward slash (`/`), an at symbol (`@`), or an exclamation mark (`!`).
 
-## Slash commands (`/`)
+## Keyboard Shortcuts
+
+- **Multi-line Input:**
+  - **Shift+Enter** or **Ctrl+Enter** or **Alt+Enter** (Option+Enter on Mac): Insert a new line without submitting your message
+  - **Enter**: Submit your message
+  - When in multi-line mode, the prompt changes from `>` to `»` to indicate multi-line content
+
+## Slash Commands (`/`)
 
 Slash commands provide meta-level control over the CLI itself.
 
@@ -79,6 +86,24 @@ Slash commands provide meta-level control over the CLI itself.
 - **`/quit`** (or **`/exit`**)
 
   - **Description:** Exit Gemini CLI.
+
+- **`/terminal-setup`**
+  - **Description:** Automatically detects and configures your terminal emulator to work with gemini-cli.
+  - **Action:**
+    - Detects your current terminal emulator
+    - For supported terminals, automatically adds the necessary keybinding configuration
+    - Creates backups of configuration files before modifying them
+    - Reports success or failure with appropriate instructions
+  - **Supported Terminals:**
+    - **Kitty** - Adds keybindings to `~/.config/kitty/kitty.conf`
+    - **Alacritty** - Adds keybindings to `~/.config/alacritty/alacritty.toml` or `.yml`
+    - **Ghostty** - Adds keybindings to `~/.config/ghostty/config`
+    - **URxvt** - Adds keybindings to `~/.Xresources` (requires `xrdb -merge ~/.Xresources`)
+    - **VS Code** - Adds keybindings to VS Code's `keybindings.json`
+    - **Foot** - Works out of the box, no configuration needed
+  - **Notes:**
+    - Most terminals require a restart after configuration
+    - VS Code requires restarting the entire application, not just the terminal
 
 ## Checkpointing Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "html-to-text": "^9.0.5"
+      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     "react-devtools-core": "^4.28.5",
     "typescript-eslint": "^8.30.1",
     "yargs": "^17.7.2"
+  },
+  "dependencies": {
+    "html-to-text": "^9.0.5"
   }
 }

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -9,7 +9,7 @@ import { Box, Text } from 'ink';
 import { Colors } from '../colors.js';
 import { SuggestionsDisplay } from './SuggestionsDisplay.js';
 import { useInputHistory } from '../hooks/useInputHistory.js';
-import { TextBuffer } from './shared/text-buffer.js';
+import { TextBuffer, NEWLINE_INPUT_SEQUENCES } from './shared/text-buffer.js';
 import { cpSlice, cpLen } from '../utils/textUtils.js';
 import chalk from 'chalk';
 import stringWidth from 'string-width';
@@ -273,8 +273,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         console.log('[InputPromptCombined] event', { key });
       }
 
+      const { sequence: input } = key;
       // Ctrl+Enter for newline, Enter for submit
-      if (key.name === 'return') {
+      if (
+        key.name === 'return' &&
+        !key.ctrl &&
+        !key.shift &&
+        !NEWLINE_INPUT_SEQUENCES.includes(input || '')
+      ) {
         const [row, col] = buffer.cursor;
         const line = buffer.lines[row];
         const charBefore = col > 0 ? cpSlice(line, col - 1, col) : '';
@@ -367,7 +373,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         <Text
           color={shellModeActive ? Colors.AccentYellow : Colors.AccentPurple}
         >
-          {shellModeActive ? '! ' : '> '}
+          {shellModeActive ? '! ' : buffer.lines.length > 1 ? '» ' : '> '}
         </Text>
         <Box flexGrow={1} flexDirection="column">
           {buffer.text.length === 0 && placeholder ? (

--- a/packages/cli/src/ui/components/Tips.tsx
+++ b/packages/cli/src/ui/components/Tips.tsx
@@ -24,9 +24,20 @@ export const Tips: React.FC<TipsProps> = ({ config }) => {
       <Text color={Colors.Foreground}>
         2. Be specific for the best results.
       </Text>
+      <Text color={Colors.Foreground}>
+        3. Use{' '}
+        <Text bold color={Colors.AccentPurple}>
+          Alt+Enter
+        </Text>{' '}
+        or{' '}
+        <Text bold color={Colors.AccentPurple}>
+          Shift+Enter
+        </Text>{' '}
+        for multi-line input.
+      </Text>
       {geminiMdFileCount === 0 && (
         <Text color={Colors.Foreground}>
-          3. Create{' '}
+          4. Create{' '}
           <Text bold color={Colors.AccentPurple}>
             GEMINI.md
           </Text>{' '}
@@ -34,7 +45,7 @@ export const Tips: React.FC<TipsProps> = ({ config }) => {
         </Text>
       )}
       <Text color={Colors.Foreground}>
-        {geminiMdFileCount === 0 ? '4.' : '3.'}{' '}
+        {geminiMdFileCount === 0 ? '5.' : '4.'}{' '}
         <Text bold color={Colors.AccentPurple}>
           /help
         </Text>{' '}

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -14,6 +14,19 @@ import stringWidth from 'string-width';
 import { unescapePath } from '@gemini-cli/core';
 import { toCodePoints, cpLen, cpSlice } from '../../utils/textUtils.js';
 
+// Constants for newline input sequences
+export const NEWLINE_INPUT_SEQUENCES = [
+  '\n',
+  '\r\n',
+  '\\\r', // VSCode terminal represents shift + enter this way
+  '[13;2u', // shift-enter kitty (needs-setup)
+  '[13;5u', // ctrl-enter kitty (needs-setup)
+  '[27;2;13~', // shift-enter foot (no-setup)
+  '[27;5;13~', // ctrl-enter foot (no-setup)
+  '\x1b[13;2u', // shift-enter alacritty (needs-setup)
+  '\x1b[13;5u', // ctrl-enter alacritty (needs-setup)
+];
+
 export type Direction =
   | 'left'
   | 'right'
@@ -1242,9 +1255,7 @@ export function useTextBuffer({
 
       if (
         key.name === 'return' ||
-        input === '\r' ||
-        input === '\n' ||
-        input === '\\\r' // VSCode terminal represents shift + enter this way
+        (input && NEWLINE_INPUT_SEQUENCES.includes(input))
       )
         newline();
       else if (key.name === 'left' && !key.meta && !key.ctrl) move('left');

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -33,6 +33,7 @@ import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 import { formatDuration, formatMemoryUsage } from '../utils/formatters.js';
 import { getCliVersion } from '../../utils/version.js';
 import { LoadedSettings } from '../../config/settings.js';
+import { terminalSetup } from '../utils/terminalSetup.js';
 
 export interface SlashCommandActionReturn {
   shouldScheduleTool?: boolean;
@@ -523,6 +524,38 @@ export const useSlashCommandProcessor = (
         name: 'corgi',
         action: (_mainCommand, _subCommand, _args) => {
           toggleCorgiMode();
+        },
+      },
+      {
+        name: 'terminal-setup',
+        description:
+          'configure terminal for Shift+Enter and Ctrl+Enter support',
+        action: async (_mainCommand, _subCommand, _args) => {
+          addMessage({
+            type: MessageType.INFO,
+            content: 'Detecting and configuring terminal...',
+            timestamp: new Date(),
+          });
+
+          const result = await terminalSetup();
+
+          if (result.success) {
+            addMessage({
+              type: MessageType.INFO,
+              content:
+                result.message +
+                (result.requiresRestart
+                  ? '\n\nPlease restart your terminal for changes to take effect.'
+                  : ''),
+              timestamp: new Date(),
+            });
+          } else {
+            addMessage({
+              type: MessageType.ERROR,
+              content: result.message,
+              timestamp: new Date(),
+            });
+          }
         },
       },
       {

--- a/packages/cli/src/ui/utils/terminalSetup.ts
+++ b/packages/cli/src/ui/utils/terminalSetup.ts
@@ -1,0 +1,514 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Terminal setup utility for configuring Shift+Enter and Ctrl+Enter support.
+ *
+ * This module provides automatic detection and configuration of various terminal
+ * emulators to support CSI u format escape sequences for modified Enter keys.
+ *
+ * Supported terminals:
+ * - Kitty: Configures ~/.config/kitty/kitty.conf
+ * - Alacritty: Configures ~/.config/alacritty/alacritty.toml (or .yml)
+ * - Ghostty: Configures ~/.config/ghostty/config
+ * - URxvt: Configures ~/.Xresources
+ * - VS Code: Configures keybindings.json
+ * - Foot: Works out of the box, no configuration needed
+ *
+ * The module sends CSI u format sequences:
+ * - Shift+Enter: \x1b[13;2u
+ * - Ctrl+Enter: \x1b[13;5u
+ */
+
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export interface TerminalSetupResult {
+  success: boolean;
+  message: string;
+  requiresRestart?: boolean;
+}
+
+type SupportedTerminal =
+  | 'kitty'
+  | 'alacritty'
+  | 'ghostty'
+  | 'urxvt'
+  | 'vscode'
+  | 'foot';
+
+// Terminal detection
+async function detectTerminal(): Promise<SupportedTerminal | null> {
+  const termProgram = process.env.TERM_PROGRAM;
+
+  // Check VS Code first
+  if (termProgram === 'vscode' || process.env.VSCODE_GIT_IPC_HANDLE) {
+    return 'vscode';
+  }
+
+  // Check TERM_PROGRAM
+  if (termProgram) {
+    const termLower = termProgram.toLowerCase().replace(/\.app$/, '');
+    if (['kitty', 'alacritty', 'ghostty'].includes(termLower)) {
+      return termLower as SupportedTerminal;
+    }
+  }
+
+  // Check specific env vars
+  if (process.env.ALACRITTY_WINDOW_ID) return 'alacritty';
+  if (process.env.TERM === 'xterm-kitty') return 'kitty';
+  if (
+    process.env.TERM?.startsWith('rxvt-unicode') ||
+    process.env.TERM?.startsWith('urxvt')
+  )
+    return 'urxvt';
+  if (process.env.TERM?.startsWith('foot') || process.env.FOOT_TERM)
+    return 'foot';
+
+  // Check parent process name
+  try {
+    const { stdout } = await execAsync('ps -o comm= -p $PPID');
+    const parentName = stdout.trim();
+
+    if (parentName.includes('kitty')) return 'kitty';
+    if (parentName.includes('alacritty')) return 'alacritty';
+    if (parentName.includes('ghostty')) return 'ghostty';
+    if (parentName.includes('urxvt') || parentName.includes('rxvt-unicode'))
+      return 'urxvt';
+    if (parentName.includes('foot')) return 'foot';
+  } catch (error) {
+    // Continue detection even if process check fails
+    console.debug('Parent process detection failed:', error);
+  }
+
+  return null;
+}
+
+// Backup file helper
+async function backupFile(filePath: string): Promise<void> {
+  try {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const backupPath = `${filePath}.backup.${timestamp}`;
+    await fs.copyFile(filePath, backupPath);
+  } catch (error) {
+    // Log backup errors but continue with operation
+    console.warn(`Failed to create backup of ${filePath}:`, error);
+  }
+}
+
+// Terminal-specific configuration functions
+async function configureKitty(): Promise<TerminalSetupResult> {
+  const configDir = path.join(os.homedir(), '.config', 'kitty');
+  const configFile = path.join(configDir, 'kitty.conf');
+
+  try {
+    await fs.mkdir(configDir, { recursive: true });
+
+    let content = '';
+    try {
+      content = await fs.readFile(configFile, 'utf8');
+      await backupFile(configFile);
+    } catch {
+      // Expected case: File doesn't exist yet (first-time setup)
+      // We intentionally ignore this error and proceed with empty content
+      // The file will be created below with our keybindings
+    }
+
+    const shiftEnterLine = 'map shift+enter send_text all \\x1b[13;2u';
+    const ctrlEnterLine = 'map ctrl+enter send_text all \\x1b[13;5u';
+
+    let modified = false;
+
+    if (!content.includes(shiftEnterLine)) {
+      content += '\n# Gemini CLI keybindings\n' + shiftEnterLine + '\n';
+      modified = true;
+    }
+
+    if (!content.includes(ctrlEnterLine)) {
+      content += ctrlEnterLine + '\n';
+      modified = true;
+    }
+
+    if (modified) {
+      await fs.writeFile(configFile, content);
+      return {
+        success: true,
+        message: `Added Shift+Enter and Ctrl+Enter keybindings to Kitty.\nModified: ${configFile}`,
+        requiresRestart: true,
+      };
+    } else {
+      return {
+        success: true,
+        message: 'Kitty keybindings already configured.',
+      };
+    }
+  } catch (error) {
+    return {
+      success: false,
+      message: `Failed to configure Kitty.\nFile: ${configFile}\nError: ${error}`,
+    };
+  }
+}
+
+async function configureAlacritty(): Promise<TerminalSetupResult> {
+  const configDir = path.join(os.homedir(), '.config', 'alacritty');
+  const tomlFile = path.join(configDir, 'alacritty.toml');
+  const ymlFile = path.join(configDir, 'alacritty.yml');
+
+  try {
+    await fs.mkdir(configDir, { recursive: true });
+
+    // Check which config file exists
+    let configFile = tomlFile;
+    let isToml = true;
+
+    try {
+      await fs.access(tomlFile);
+    } catch {
+      try {
+        await fs.access(ymlFile);
+        configFile = ymlFile;
+        isToml = false;
+      } catch {
+        // Neither exists, use TOML
+      }
+    }
+
+    let content = '';
+    try {
+      content = await fs.readFile(configFile, 'utf8');
+      await backupFile(configFile);
+    } catch {
+      // Expected case: File doesn't exist yet (first-time setup)
+      // We intentionally ignore this error and proceed with empty content
+      // The file will be created below with our keybindings
+    }
+
+    if (isToml) {
+      const tomlBindings = `
+# Gemini CLI keybindings
+[[keyboard.bindings]]
+key = "Return"
+mods = "Shift"
+chars = "\\u001b[13;2u"
+
+[[keyboard.bindings]]
+key = "Return"
+mods = "Control"
+chars = "\\u001b[13;5u"
+`;
+
+      if (
+        !content.includes('\\u001b[13;2u') ||
+        !content.includes('\\u001b[13;5u')
+      ) {
+        content += '\n' + tomlBindings;
+        await fs.writeFile(configFile, content);
+        return {
+          success: true,
+          message: `Added Shift+Enter and Ctrl+Enter keybindings to Alacritty.\nModified: ${configFile}`,
+          requiresRestart: true,
+        };
+      }
+    } else {
+      // YAML format
+      const yamlBindings = `
+# Gemini CLI keybindings
+key_bindings:
+  - { key: Return, mods: Shift, chars: "\\x1b[13;2u" }
+  - { key: Return, mods: Control, chars: "\\x1b[13;5u" }
+`;
+
+      if (
+        !content.includes('\\x1b[13;2u') ||
+        !content.includes('\\x1b[13;5u')
+      ) {
+        content += '\n' + yamlBindings;
+        await fs.writeFile(configFile, content);
+        return {
+          success: true,
+          message: `Added Shift+Enter and Ctrl+Enter keybindings to Alacritty.\nModified: ${configFile}`,
+          requiresRestart: true,
+        };
+      }
+    }
+
+    return {
+      success: true,
+      message: 'Alacritty keybindings already configured.',
+    };
+  } catch (error) {
+    return {
+      success: false,
+      message: `Failed to configure Alacritty.\nFile: ${tomlFile} or ${ymlFile}\nError: ${error}`,
+    };
+  }
+}
+
+async function configureGhostty(): Promise<TerminalSetupResult> {
+  const configDir = path.join(os.homedir(), '.config', 'ghostty');
+  const configFile = path.join(configDir, 'config');
+
+  try {
+    await fs.mkdir(configDir, { recursive: true });
+
+    let content = '';
+    try {
+      content = await fs.readFile(configFile, 'utf8');
+      await backupFile(configFile);
+    } catch {
+      // Expected case: File doesn't exist yet (first-time setup)
+      // We intentionally ignore this error and proceed with empty content
+      // The file will be created below with our keybindings
+    }
+
+    const shiftEnterLine = 'keybind = performable:shift+enter=csi:13;2u';
+    const ctrlEnterLine = 'keybind = performable:ctrl+enter=csi:13;5u';
+
+    let modified = false;
+
+    if (!content.includes('performable:shift+enter=')) {
+      content += '\n# Gemini CLI keybindings\n' + shiftEnterLine + '\n';
+      modified = true;
+    }
+
+    if (!content.includes('performable:ctrl+enter=')) {
+      content += ctrlEnterLine + '\n';
+      modified = true;
+    }
+
+    if (modified) {
+      await fs.writeFile(configFile, content);
+      return {
+        success: true,
+        message: `Added Shift+Enter and Ctrl+Enter keybindings to Ghostty.\nModified: ${configFile}`,
+        requiresRestart: true,
+      };
+    } else {
+      return {
+        success: true,
+        message: 'Ghostty keybindings already configured.',
+      };
+    }
+  } catch (error) {
+    return {
+      success: false,
+      message: `Failed to configure Ghostty.\nFile: ${configFile}\nError: ${error}`,
+    };
+  }
+}
+
+async function configureUrxvt(): Promise<TerminalSetupResult> {
+  const xresourcesFile = path.join(os.homedir(), '.Xresources');
+
+  try {
+    let content = '';
+    try {
+      content = await fs.readFile(xresourcesFile, 'utf8');
+      await backupFile(xresourcesFile);
+    } catch {
+      // Expected case: File doesn't exist yet (first-time setup)
+      // We intentionally ignore this error and proceed with empty content
+      // The file will be created below with our keybindings
+    }
+
+    const shiftEnterLine = 'URxvt.keysym.S-Return:     \\033[13;2u';
+    const ctrlEnterLine = 'URxvt.keysym.C-Return:     \\033[13;5u';
+
+    let modified = false;
+
+    if (!content.includes('URxvt.keysym.S-Return:')) {
+      content +=
+        '\n! Gemini CLI keybindings for URxvt\n' + shiftEnterLine + '\n';
+      modified = true;
+    }
+
+    if (!content.includes('URxvt.keysym.C-Return:')) {
+      content += ctrlEnterLine + '\n';
+      modified = true;
+    }
+
+    if (modified) {
+      await fs.writeFile(xresourcesFile, content);
+      return {
+        success: true,
+        message: `Added Shift+Enter and Ctrl+Enter keybindings to URxvt.\nModified: ${xresourcesFile}\nRun "xrdb -merge ~/.Xresources" to apply.`,
+        requiresRestart: true,
+      };
+    } else {
+      return {
+        success: true,
+        message: 'URxvt keybindings already configured.',
+      };
+    }
+  } catch (error) {
+    return {
+      success: false,
+      message: `Failed to configure URxvt.\nFile: ${xresourcesFile}\nError: ${error}`,
+    };
+  }
+}
+
+async function configureVSCode(): Promise<TerminalSetupResult> {
+  const platform = os.platform();
+  let configDir: string;
+
+  if (platform === 'darwin') {
+    configDir = path.join(
+      os.homedir(),
+      'Library',
+      'Application Support',
+      'Code',
+      'User',
+    );
+  } else {
+    configDir = path.join(os.homedir(), '.config', 'Code', 'User');
+  }
+
+  const keybindingsFile = path.join(configDir, 'keybindings.json');
+
+  try {
+    await fs.mkdir(configDir, { recursive: true });
+
+    let keybindings: unknown[] = [];
+    try {
+      const content = await fs.readFile(keybindingsFile, 'utf8');
+      try {
+        keybindings = JSON.parse(content);
+        if (!Array.isArray(keybindings)) {
+          console.warn(
+            'VS Code keybindings.json is not an array, creating new array',
+          );
+          keybindings = [];
+        }
+      } catch (parseError) {
+        console.warn('Failed to parse VS Code keybindings.json:', parseError);
+        keybindings = [];
+      }
+      await backupFile(keybindingsFile);
+    } catch {
+      // File doesn't exist, will create new one
+    }
+
+    const shiftEnterBinding = {
+      key: 'shift+enter',
+      command: 'workbench.action.terminal.sendSequence',
+      when: 'terminalFocus',
+      args: { text: '\u001b[13;2u' },
+    };
+
+    const ctrlEnterBinding = {
+      key: 'ctrl+enter',
+      command: 'workbench.action.terminal.sendSequence',
+      when: 'terminalFocus',
+      args: { text: '\u001b[13;5u' },
+    };
+
+    // Check if bindings already exist
+    const hasShiftEnter = keybindings.some((kb) => {
+      const binding = kb as { command?: string; args?: { text?: string } };
+      return (
+        binding.command === 'workbench.action.terminal.sendSequence' &&
+        binding.args?.text === '\u001b[13;2u'
+      );
+    });
+
+    const hasCtrlEnter = keybindings.some((kb) => {
+      const binding = kb as { command?: string; args?: { text?: string } };
+      return (
+        binding.command === 'workbench.action.terminal.sendSequence' &&
+        binding.args?.text === '\u001b[13;5u'
+      );
+    });
+
+    if (!hasShiftEnter || !hasCtrlEnter) {
+      if (!hasShiftEnter) keybindings.unshift(shiftEnterBinding);
+      if (!hasCtrlEnter) keybindings.unshift(ctrlEnterBinding);
+
+      await fs.writeFile(keybindingsFile, JSON.stringify(keybindings, null, 4));
+      return {
+        success: true,
+        message: `Added Shift+Enter and Ctrl+Enter keybindings to VS Code.\nModified: ${keybindingsFile}`,
+        requiresRestart: true,
+      };
+    } else {
+      return {
+        success: true,
+        message: 'VS Code keybindings already configured.',
+      };
+    }
+  } catch (error) {
+    return {
+      success: false,
+      message: `Failed to configure VS Code.\nFile: ${keybindingsFile}\nError: ${error}`,
+    };
+  }
+}
+
+async function configureFoot(): Promise<TerminalSetupResult> {
+  return {
+    success: true,
+    message:
+      'Foot terminal works out of the box! No configuration needed.\n' +
+      'Foot already sends the required sequences for Shift+Enter and Ctrl+Enter.',
+  };
+}
+
+/**
+ * Main terminal setup function that detects and configures the current terminal.
+ *
+ * This function:
+ * 1. Detects the current terminal emulator
+ * 2. Applies appropriate configuration for Shift+Enter and Ctrl+Enter support
+ * 3. Creates backups of configuration files before modifying them
+ *
+ * @returns Promise<TerminalSetupResult> Result object with success status and message
+ *
+ * @example
+ * const result = await terminalSetup();
+ * if (result.success) {
+ *   console.log(result.message);
+ *   if (result.requiresRestart) {
+ *     console.log('Please restart your terminal');
+ *   }
+ * }
+ */
+export async function terminalSetup(): Promise<TerminalSetupResult> {
+  const terminal = await detectTerminal();
+
+  if (!terminal) {
+    return {
+      success: false,
+      message:
+        'Could not detect terminal type. Supported terminals: Kitty, Alacritty, Ghostty, URxvt, VS Code, and Foot.',
+    };
+  }
+
+  switch (terminal) {
+    case 'kitty':
+      return configureKitty();
+    case 'alacritty':
+      return configureAlacritty();
+    case 'ghostty':
+      return configureGhostty();
+    case 'urxvt':
+      return configureUrxvt();
+    case 'vscode':
+      return configureVSCode();
+    case 'foot':
+      return configureFoot();
+    default:
+      return {
+        success: false,
+        message: `Terminal "${terminal}" is not supported yet.`,
+      };
+  }
+}


### PR DESCRIPTION
Enable users to compose multi-line messages before submitting. This addresses the need to paste multi-line content or format messages with proper line breaks without immediately sending them.

- Add Alt+Enter (Option+Enter on Mac) keybinding for inserting newlines
- Change prompt from '>' to '»' when buffer contains newlines for visual feedback
- Update documentation with new keyboard shortcut
- Add tip in startup message about multi-line input capability
- Hide autocomplete suggestions when inserting newlines

Alt+Enter was chosen for multi-line input because Shift+Enter doesn't work reliably across different terminal emulators, where many terminals treat it identically to pressing Enter alone.

Commit tested in terminal and VS Code terminal on Mac and Linux.

Fixes #849 