### PR TITLE
/save and /resume for checkpointing conversations

### DIFF
--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -131,7 +131,7 @@ export enum MessageType {
   USER = 'user',
   ABOUT = 'about',
   STATS = 'stats',
-  // Add GEMINI if needed by other commands
+  GEMINI = 'gemini',
 }
 
 // Simplified message structure for internal feedback


### PR DESCRIPTION
this should be extended to support `/save <ID>` and `/resume <ID>` as well as keeping a <LAST> conversation by default all of that in a follow up PR.


![Screenshot 2025-06-10 at 3 36 36 PM](https://github.com/user-attachments/assets/3fbafa53-0a55-4421-854a-6031bbd8236b)
After /resume
![Screenshot 2025-06-10 at 3 36 53 PM](https://github.com/user-attachments/assets/a77c55b5-b963-4af2-bf44-481a7ca93555)
