### PR TITLE
Remove unneeded `mockRestore()`s from tests

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -214,8 +214,6 @@ describe('API Key Handling', () => {
       'Both GEMINI_API_KEY and GOOGLE_API_KEY are set. Using GOOGLE_API_KEY.',
     );
     expect(result.getApiKey()).toBe('google-key');
-
-    consoleWarnSpy.mockRestore();
   });
 });
 

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -35,6 +35,7 @@ describe('runNonInteractive', () => {
   let mockProcessExit: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    vi.resetAllMocks();
     mockChat = {
       sendMessageStream: vi.fn(),
     };
@@ -201,7 +202,6 @@ describe('runNonInteractive', () => {
     expect(mockProcessStdoutWrite).toHaveBeenCalledWith(
       'Could not complete request.',
     );
-    consoleErrorSpy.mockRestore();
   });
 
   it('should exit with error if sendMessageStream throws initially', async () => {
@@ -217,6 +217,5 @@ describe('runNonInteractive', () => {
       'Error processing input:',
       apiError,
     );
-    consoleErrorSpy.mockRestore();
   });
 });

--- a/packages/cli/src/utils/loadIgnorePatterns.test.ts
+++ b/packages/cli/src/utils/loadIgnorePatterns.test.ts
@@ -74,8 +74,7 @@ describe('loadGeminiIgnorePatterns', () => {
     if (actualFs.existsSync(tempDir)) {
       actualFs.rmSync(tempDir, { recursive: true, force: true });
     }
-    consoleLogSpy.mockRestore();
-    consoleWarnSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 
   it('should load and parse patterns from .geminiignore, ignoring comments and empty lines', () => {

--- a/packages/core/src/utils/errorReporting.test.ts
+++ b/packages/core/src/utils/errorReporting.test.ts
@@ -29,7 +29,6 @@ describe('reportError', () => {
   });
 
   afterEach(() => {
-    consoleErrorSpy.mockRestore();
     vi.restoreAllMocks();
   });
 

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -176,8 +176,6 @@ describe('retryWithBackoff', () => {
     // The third delay should be capped by maxDelayMs (250ms), accounting for jitter
     expect(delays[2]).toBeGreaterThanOrEqual(250 * 0.7);
     expect(delays[2]).toBeLessThanOrEqual(250 * 1.3);
-
-    setTimeoutSpy.mockRestore();
   });
 
   it('should handle jitter correctly, ensuring varied delays', async () => {
@@ -232,7 +230,5 @@ describe('retryWithBackoff', () => {
       expect(d).toBeGreaterThanOrEqual(100 * 0.7);
       expect(d).toBeLessThanOrEqual(100 * 1.3);
     });
-
-    setTimeoutSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Almost all tests do

```
  beforeEach(async () => {
    vi.resetAllMocks();
  });

  afterEach(async () => {
    vi.restoreAllMocks();
  });
```

so `<object>.mockRestore()` are not needed at the end of tests.