### PR TITLE
Remove warnings for old env var names.

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -9,8 +9,7 @@ import { render } from 'ink';
 import { AppWrapper } from './ui/App.js';
 import { loadCliConfig } from './config/config.js';
 import { readStdin } from './utils/readStdin.js';
-import { fileURLToPath } from 'node:url';
-import { dirname, basename } from 'node:path';
+import { basename } from 'node:path';
 import { sandbox_command, start_sandbox } from './utils/sandbox.js';
 import { LoadedSettings, loadSettings } from './config/settings.js';
 import { themeManager } from './ui/themes/theme-manager.js';
@@ -34,32 +33,10 @@ import {
   WriteFileTool,
 } from '@gemini-cli/core';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
 export async function main() {
   const workspaceRoot = process.cwd();
   const settings = loadSettings(workspaceRoot);
   setWindowTitle(basename(workspaceRoot), settings);
-
-  // warn about deprecated environment variables
-  if (process.env.GEMINI_CODE_MODEL) {
-    console.warn('GEMINI_CODE_MODEL is deprecated. Use GEMINI_MODEL instead.');
-    process.env.GEMINI_MODEL = process.env.GEMINI_CODE_MODEL;
-  }
-  if (process.env.GEMINI_CODE_SANDBOX) {
-    console.warn(
-      'GEMINI_CODE_SANDBOX is deprecated. Use GEMINI_SANDBOX instead.',
-    );
-    process.env.GEMINI_SANDBOX = process.env.GEMINI_CODE_SANDBOX;
-  }
-  if (process.env.GEMINI_CODE_SANDBOX_IMAGE) {
-    console.warn(
-      'GEMINI_CODE_SANDBOX_IMAGE is deprecated. Use GEMINI_SANDBOX_IMAGE_NAME instead.',
-    );
-    process.env.GEMINI_SANDBOX_IMAGE_NAME =
-      process.env.GEMINI_CODE_SANDBOX_IMAGE; // Corrected to GEMINI_SANDBOX_IMAGE_NAME
-  }
 
   const geminiIgnorePatterns = loadGeminiIgnorePatterns(workspaceRoot);
 

--- a/scripts/sandbox_command.js
+++ b/scripts/sandbox_command.js
@@ -63,13 +63,6 @@ if (!geminiSandbox) {
   geminiSandbox = process.env.GEMINI_SANDBOX;
 }
 
-if (process.env.GEMINI_CODE_SANDBOX) {
-  console.warn(
-    'WARNING: GEMINI_CODE_SANDBOX is deprecated. Use GEMINI_SANDBOX instead.',
-  );
-  geminiSandbox = process.env.GEMINI_CODE_SANDBOX;
-}
-
 geminiSandbox = (geminiSandbox || '').toLowerCase();
 
 const commandExists = (cmd) => {


### PR DESCRIPTION
Developers have had a week to get used to the new names. And we don't want these sticking around for the release.