### PR TITLE
Add user-defined commands feature (#805)

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -122,3 +122,110 @@ The `!` prefix provides a powerful way to interact with your system's shell dire
 - **Caution for all `!` usage:** Be mindful of the commands you execute, as they have the same permissions and impact as if you ran them directly in your terminal. The Shell Mode feature does not inherently add extra sandboxing beyond what's already configured for the underlying `run_shell_command` tool.
 
 This integrated shell capability allows for seamless switching between AI-assisted tasks and direct system interaction.
+
+## User-Defined Commands (`/user-`)
+
+The Gemini CLI supports custom user-defined commands that allow you to create personalized shortcuts and workflows. These commands are stored as markdown files in the `.gemini/user-tools/` directories and can be invoked using the `/user-` prefix.
+
+### Creating User Tools
+
+1. **Location:** User tools can be stored in two locations:
+
+   - **Global tools:** `~/.gemini/user-tools/` - Available from any directory
+   - **Workspace tools:** `.gemini/user-tools/` - Relative to your current working directory
+
+   When both locations contain a tool with the same name, the workspace tool takes precedence.
+
+2. **Format:** Each tool is a markdown file (`.md`) with YAML frontmatter.
+3. **Naming:** The filename (without `.md` extension) becomes the tool name.
+
+### User Tool File Structure
+
+```markdown
+---
+description: Brief description of what this tool does
+autoSubmit: false
+---
+
+Your prompt template here. This template will be sent to Gemini as-is,
+along with any additional instructions the user provides when invoking the tool.
+```
+
+**Frontmatter Options:**
+
+- `description`: A brief description shown in autocomplete
+- `autoSubmit`: Set to `true` if the tool should auto-submit when selected from autocomplete (defaults to `false`)
+
+### Example User Tools
+
+**`.gemini/user-tools/git-log.md`**
+
+```markdown
+---
+description: Show git commit history with customizable formatting
+---
+
+Please show the git commit history for this repository. Use `git log` with appropriate formatting options to display:
+
+- Commit hash (abbreviated)
+- Author name and date
+- Commit message
+- Files changed statistics
+
+Make the output clear and easy to read. If the user provides additional instructions (like date ranges, author filters, or specific formatting), incorporate those into the git log command.
+```
+
+**`.gemini/user-tools/find-math-book.md`**
+
+```markdown
+---
+description: Get a random math book recommendation
+---
+
+Please recommend a random mathematics book. Consider various branches of mathematics (algebra, calculus, geometry, topology, number theory, statistics, etc.) and difficulty levels (from popular math to advanced textbooks).
+
+For your recommendation, please provide:
+
+1. Book title and author(s)
+2. What branch of mathematics it covers
+3. The target audience/difficulty level
+4. A brief description of what makes this book interesting or valuable
+5. Why someone might want to read it
+
+If the user provides any preferences or constraints in their additional instructions, take those into account when making your recommendation.
+```
+
+### Using User Tools
+
+- **Invocation:** Use `/user-toolname` followed by any additional instructions or context.
+- **Examples:**
+  - `/user-git-log` - Shows full git history with default formatting
+  - `/user-git-log --since="1 week ago" --author="John"` - Shows commits from last week by John
+  - `/user-git-log last 4 days` - User can use free form text and Gemini will do the right thing and show git log for last four days
+  - `/user-find-math-book` - Gets a random math book recommendation
+  - `/user-find-math-book find me a good topology book` - Gets a recommendation for a topology book
+- **Autocomplete:** Type `/user-` and press Tab to see available user tools.
+
+### Managing User Tools
+
+- **`/reload-user-tools`**
+  - **Description:** Reloads all user tools from both global (`~/.gemini/user-tools/`) and workspace (`.gemini/user-tools/`) directories.
+  - **Action:** Scans both directories and refreshes the available user tools list. Workspace tools take precedence over global tools with the same name.
+  - **Usage:** Run this command after adding, modifying, or removing user tool files.
+
+### How User Tools Work
+
+When you invoke a user tool, the tool's template is sent to Gemini along with any additional instructions you provide. For example:
+
+- `/user-git-log` sends the git-log template to Gemini
+- `/user-git-log last 3 days` sends the template plus "At the time of invoking this tool, the user provided these additional instructions: last 3 days"
+
+This approach allows Gemini to use its judgment to interpret your specific needs while following the general template of the tool.
+
+### Best Practices
+
+- Keep tool names descriptive and use hyphens for multi-word names (e.g., `git-summary`, `code-review`)
+- Provide clear descriptions in the frontmatter for better autocomplete hints
+- Test your tools after creation using the actual command syntax
+- Write clear prompts that explain what the tool does and what information it needs
+- Consider creating tools for repetitive tasks or complex multi-step workflows

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "simple-git": "^3.28.0"
+      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },
@@ -17,6 +20,7 @@
         "@types/micromatch": "^4.0.9",
         "@types/mime-types": "^2.1.4",
         "@types/minimatch": "^5.1.2",
+        "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^3.1.1",
         "cross-env": "^7.0.3",
         "esbuild": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/micromatch": "^4.0.9",
     "@types/mime-types": "^2.1.4",
     "@types/minimatch": "^5.1.2",
+    "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^3.1.1",
     "cross-env": "^7.0.3",
     "esbuild": "^0.25.0",
@@ -66,5 +67,8 @@
     "react-devtools-core": "^4.28.5",
     "typescript-eslint": "^8.30.1",
     "yargs": "^17.7.2"
+  },
+  "dependencies": {
+    "simple-git": "^3.28.0"
   }
 }

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -97,6 +97,9 @@ describe('Settings Loading and Merging', () => {
       expect(settings.workspace.settings).toEqual({});
       expect(settings.merged).toEqual({});
       expect(settings.errors.length).toBe(0);
+      expect(settings.userTools.size).toBe(0);
+      expect(settings.workspaceTools.size).toBe(0);
+      expect(settings.mergedTools.size).toBe(0);
     });
 
     it('should load user settings if only user file exists', () => {

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -11,6 +11,7 @@ import { MCPServerConfig, getErrorMessage } from '@gemini-cli/core';
 import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
 import { DefaultDark } from '../ui/themes/default.js';
+import { UserTool, loadMergedUserTools } from '../utils/userToolsLoader.js';
 
 export const SETTINGS_DIRECTORY_NAME = '.gemini';
 export const USER_SETTINGS_DIR = path.join(homedir(), SETTINGS_DIRECTORY_NAME);
@@ -65,21 +66,33 @@ export class LoadedSettings {
     user: SettingsFile,
     workspace: SettingsFile,
     errors: SettingsError[],
+    userTools: Map<string, UserTool>,
+    workspaceTools: Map<string, UserTool>,
   ) {
     this.user = user;
     this.workspace = workspace;
     this.errors = errors;
+    this.userTools = userTools;
+    this.workspaceTools = workspaceTools;
     this._merged = this.computeMergedSettings();
+    this._mergedTools = this.computeMergedTools();
   }
 
   readonly user: SettingsFile;
   readonly workspace: SettingsFile;
   readonly errors: SettingsError[];
+  readonly userTools: Map<string, UserTool>;
+  readonly workspaceTools: Map<string, UserTool>;
 
   private _merged: Settings;
+  private _mergedTools: Map<string, UserTool>;
 
   get merged(): Settings {
     return this._merged;
+  }
+
+  get mergedTools(): Map<string, UserTool> {
+    return this._mergedTools;
   }
 
   private computeMergedSettings(): Settings {
@@ -87,6 +100,22 @@ export class LoadedSettings {
       ...this.user.settings,
       ...this.workspace.settings,
     };
+  }
+
+  private computeMergedTools(): Map<string, UserTool> {
+    const merged = new Map<string, UserTool>();
+
+    // Add all user tools
+    for (const [name, tool] of this.userTools) {
+      merged.set(name, tool);
+    }
+
+    // Override with workspace tools
+    for (const [name, tool] of this.workspaceTools) {
+      merged.set(name, tool);
+    }
+
+    return merged;
   }
 
   forScope(scope: SettingScope): SettingsFile {
@@ -216,6 +245,14 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
     });
   }
 
+  // Load user tools from both directories
+  const {
+    globalTools,
+    workspaceTools,
+    errors: toolErrors,
+  } = loadMergedUserTools(workspaceDir);
+  settingsErrors.push(...toolErrors);
+
   return new LoadedSettings(
     {
       path: USER_SETTINGS_PATH,
@@ -226,6 +263,8 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
       settings: workspaceSettings,
     },
     settingsErrors,
+    globalTools,
+    workspaceTools,
   );
 }
 

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -110,6 +110,8 @@ describe('gemini.tsx main function', () => {
       userSettingsFile,
       workspaceSettingsFile,
       [settingsError],
+      new Map(),
+      new Map(),
     );
 
     loadSettingsMock.mockReturnValue(mockLoadedSettings);

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -179,7 +179,13 @@ describe('App UI', () => {
       path: '/workspace/.gemini/settings.json',
       settings,
     };
-    return new LoadedSettings(userSettingsFile, workspaceSettingsFile, []);
+    return new LoadedSettings(
+      userSettingsFile,
+      workspaceSettingsFile,
+      [],
+      new Map(),
+      new Map(),
+    );
   };
 
   beforeEach(() => {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -169,22 +169,24 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     }
   }, [config, addItem]);
 
-  const { handleSlashCommand, slashCommands } = useSlashCommandProcessor(
-    config,
-    history,
-    addItem,
-    clearItems,
-    loadHistory,
-    refreshStatic,
-    setShowHelp,
-    setDebugMessage,
-    openThemeDialog,
-    openEditorDialog,
-    performMemoryRefresh,
-    toggleCorgiMode,
-    showToolDescriptions,
-    setQuittingMessages,
-  );
+  const { handleSlashCommand, slashCommands, userTools } =
+    useSlashCommandProcessor(
+      config,
+      history,
+      addItem,
+      clearItems,
+      loadHistory,
+      refreshStatic,
+      setShowHelp,
+      setDebugMessage,
+      openThemeDialog,
+      openEditorDialog,
+      performMemoryRefresh,
+      toggleCorgiMode,
+      showToolDescriptions,
+      setQuittingMessages,
+      settings.mergedTools,
+    );
 
   const { rows: terminalHeight, columns: terminalWidth } = useTerminalSize();
   const { stdin, setRawMode } = useStdin();
@@ -586,6 +588,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
                   onClearScreen={handleClearScreen}
                   config={config}
                   slashCommands={slashCommands}
+                  userTools={userTools}
                   shellModeActive={shellModeActive}
                   setShellModeActive={setShellModeActive}
                 />

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -10,6 +10,7 @@ export interface Suggestion {
   label: string;
   value: string;
   description?: string;
+  autoSubmit?: boolean;
 }
 interface SuggestionsDisplayProps {
   suggestions: Suggestion[];

--- a/packages/cli/src/utils/userToolProcessor.test.ts
+++ b/packages/cli/src/utils/userToolProcessor.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { UserToolProcessor } from './userToolProcessor.js';
+import { UserTool } from './userToolsLoader.js';
+
+describe('UserToolProcessor', () => {
+  describe('processUserToolCommand', () => {
+    it('should process tool without additional instructions', () => {
+      const tool: UserTool = {
+        name: 'test-tool',
+        description: 'Test tool',
+        content: 'This is the tool template.',
+        filePath: '/test/path/test-tool.md',
+      };
+
+      const result = UserToolProcessor.processUserToolCommand(tool, []);
+
+      expect(result).toBe(
+        `[This is the expanded content of the user-defined command '/user-test-tool' - the command has already been processed by the CLI]\n\n` +
+          `This is the tool template.`,
+      );
+    });
+
+    it('should append user instructions when provided', () => {
+      const tool: UserTool = {
+        name: 'git-log',
+        description: 'Show git log',
+        content: 'Please show the git commit history.',
+        filePath: '/test/path/git-log.md',
+      };
+
+      const result = UserToolProcessor.processUserToolCommand(tool, [
+        '--since="1 week ago"',
+        '--author="John"',
+      ]);
+
+      expect(result).toBe(
+        `[This is the expanded content of the user-defined command '/user-git-log' - the command has already been processed by the CLI]\n\n` +
+          `Please show the git commit history.\n\n---\n` +
+          `At the time of invoking this tool, the user provided these additional instructions:\n` +
+          `--since="1 week ago" --author="John"`,
+      );
+    });
+
+    it('should handle empty args array', () => {
+      const tool: UserTool = {
+        name: 'test',
+        description: 'Test',
+        content: 'Content',
+        filePath: '/test/path/test.md',
+      };
+
+      const result = UserToolProcessor.processUserToolCommand(tool, []);
+
+      expect(result).not.toContain('additional instructions');
+    });
+
+    it('should handle args with only whitespace', () => {
+      const tool: UserTool = {
+        name: 'test',
+        description: 'Test',
+        content: 'Content',
+        filePath: '/test/path/test.md',
+      };
+
+      const result = UserToolProcessor.processUserToolCommand(tool, [
+        '  ',
+        '',
+        '   ',
+      ]);
+
+      expect(result).not.toContain('additional instructions');
+    });
+
+    it('should preserve spacing in user instructions', () => {
+      const tool: UserTool = {
+        name: 'test',
+        description: 'Test',
+        content: 'Content',
+        filePath: '/test/path/test.md',
+      };
+
+      const result = UserToolProcessor.processUserToolCommand(tool, [
+        'arg1',
+        'arg2   with   spaces',
+        'arg3',
+      ]);
+
+      expect(result).toContain('arg1 arg2   with   spaces arg3');
+    });
+  });
+});

--- a/packages/cli/src/utils/userToolProcessor.ts
+++ b/packages/cli/src/utils/userToolProcessor.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { UserTool } from './userToolsLoader.js';
+
+export class UserToolProcessor {
+  /**
+   * Process a user tool command and prepare it for execution
+   * @param tool The user tool definition
+   * @param args Arguments passed to the command
+   * @returns The processed prompt to send to Gemini
+   */
+  static processUserToolCommand(tool: UserTool, args: string[]): string {
+    let prompt = `[This is the expanded content of the user-defined command '/user-${tool.name}' - the command has already been processed by the CLI]\n\n`;
+    prompt += tool.content;
+
+    // If user provided any arguments/instructions, append them to the prompt
+    const userInstructions = args.join(' ').trim();
+    if (userInstructions) {
+      prompt += '\n\n---\n';
+      prompt +=
+        'At the time of invoking this tool, the user provided these additional instructions:\n';
+      prompt += userInstructions;
+    }
+
+    return prompt;
+  }
+}

--- a/packages/cli/src/utils/userToolsLoader.test.ts
+++ b/packages/cli/src/utils/userToolsLoader.test.ts
@@ -1,0 +1,401 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Mock fs
+vi.mock('node:fs');
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { UserToolsLoader, loadMergedUserTools } from './userToolsLoader.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('UserToolsLoader', () => {
+  let tempDir: string;
+  let loader: UserToolsLoader;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    tempDir = os.tmpdir();
+    loader = new UserToolsLoader(tempDir);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('loadUserTools', () => {
+    it('should return empty map when directory does not exist', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const tools = loader.loadUserTools();
+
+      expect(tools.size).toBe(0);
+    });
+
+    it('should load valid user tool from markdown file', () => {
+      const toolContent = `---
+description: Test tool description
+---
+
+This is the tool template content.`;
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'test-tool.md',
+      ] as unknown as fs.Dirent[]);
+      vi.mocked(fs.readFileSync).mockReturnValue(toolContent);
+
+      const tools = loader.loadUserTools();
+
+      expect(tools.size).toBe(1);
+      expect(tools.has('test-tool')).toBe(true);
+
+      const tool = tools.get('test-tool');
+      expect(tool).toEqual({
+        name: 'test-tool',
+        description: 'Test tool description',
+        content: 'This is the tool template content.',
+        filePath: path.join(tempDir, '.gemini', 'user-tools', 'test-tool.md'),
+        autoSubmit: false,
+      });
+    });
+
+    it('should load multiple tools', () => {
+      const tool1Content = `---
+description: Tool 1
+---
+Tool 1 content`;
+
+      const tool2Content = `---
+description: Tool 2
+---
+Tool 2 content`;
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'tool1.md',
+        'tool2.md',
+      ] as unknown as fs.Dirent[]);
+      vi.mocked(fs.readFileSync)
+        .mockReturnValueOnce(tool1Content)
+        .mockReturnValueOnce(tool2Content);
+
+      const tools = loader.loadUserTools();
+
+      expect(tools.size).toBe(2);
+      expect(tools.has('tool1')).toBe(true);
+      expect(tools.has('tool2')).toBe(true);
+    });
+
+    it('should ignore non-markdown files', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'tool.md',
+        'readme.txt',
+        'config.json',
+      ] as unknown as fs.Dirent[]);
+      vi.mocked(fs.readFileSync).mockReturnValue(`---
+description: Valid tool
+---
+Content`);
+
+      const tools = loader.loadUserTools();
+
+      expect(tools.size).toBe(1);
+      expect(tools.has('tool')).toBe(true);
+    });
+
+    it('should handle empty frontmatter gracefully', () => {
+      const toolContent = `---
+---
+Just content without metadata`;
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'empty-meta.md',
+      ] as unknown as fs.Dirent[]);
+      vi.mocked(fs.readFileSync).mockReturnValue(toolContent);
+
+      const tools = loader.loadUserTools();
+
+      expect(tools.size).toBe(1);
+      const tool = tools.get('empty-meta');
+      expect(tool).toEqual({
+        name: 'empty-meta',
+        description: 'User-defined tool: empty-meta',
+        content: 'Just content without metadata',
+        filePath: path.join(tempDir, '.gemini', 'user-tools', 'empty-meta.md'),
+        autoSubmit: false,
+      });
+    });
+
+    it('should handle missing frontmatter', () => {
+      const toolContent = `This is just plain content
+without any frontmatter`;
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'no-frontmatter.md',
+      ] as unknown as fs.Dirent[]);
+      vi.mocked(fs.readFileSync).mockReturnValue(toolContent);
+
+      const tools = loader.loadUserTools();
+
+      expect(tools.size).toBe(1);
+      const tool = tools.get('no-frontmatter');
+      expect(tool).toEqual({
+        name: 'no-frontmatter',
+        description: 'User-defined tool: no-frontmatter',
+        content: toolContent,
+        filePath: path.join(
+          tempDir,
+          '.gemini',
+          'user-tools',
+          'no-frontmatter.md',
+        ),
+        autoSubmit: false,
+      });
+    });
+
+    it('should handle file read errors gracefully', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'error-tool.md',
+        'valid-tool.md',
+      ] as unknown as fs.Dirent[]);
+      vi.mocked(fs.readFileSync).mockImplementationOnce(() => {
+        throw new Error('Read error');
+      }).mockReturnValueOnce(`---
+description: Valid tool
+---
+Content`);
+
+      const tools = loader.loadUserTools();
+
+      expect(tools.size).toBe(1);
+      expect(tools.has('valid-tool')).toBe(true);
+      expect(tools.has('error-tool')).toBe(false);
+    });
+
+    it('should trim whitespace from content', () => {
+      const toolContent = `---
+description: Test tool
+---
+
+  
+Content with whitespace  
+
+  `;
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'whitespace.md',
+      ] as unknown as fs.Dirent[]);
+      vi.mocked(fs.readFileSync).mockReturnValue(toolContent);
+
+      const tools = loader.loadUserTools();
+
+      const tool = tools.get('whitespace');
+      expect(tool?.content).toBe('Content with whitespace');
+    });
+
+    it('should parse autoSubmit flag when true', () => {
+      const toolContent = `---
+description: No args tool
+autoSubmit: true
+---
+Tool content`;
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'no-args.md',
+      ] as unknown as fs.Dirent[]);
+      vi.mocked(fs.readFileSync).mockReturnValue(toolContent);
+
+      const tools = loader.loadUserTools();
+
+      const tool = tools.get('no-args');
+      expect(tool?.autoSubmit).toBe(true);
+    });
+
+    it('should default autoSubmit to false when not specified', () => {
+      const toolContent = `---
+description: Regular tool
+---
+Tool content`;
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'regular.md',
+      ] as unknown as fs.Dirent[]);
+      vi.mocked(fs.readFileSync).mockReturnValue(toolContent);
+
+      const tools = loader.loadUserTools();
+
+      const tool = tools.get('regular');
+      expect(tool?.autoSubmit).toBe(false);
+    });
+
+    it('should handle frontmatter with extra whitespace', () => {
+      const toolContent = `  ---  
+description: Tool with spaces
+autoSubmit: true
+  ---  
+Tool content`;
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'whitespace-frontmatter.md',
+      ] as unknown as fs.Dirent[]);
+      vi.mocked(fs.readFileSync).mockReturnValue(toolContent);
+
+      const tools = loader.loadUserTools();
+
+      const tool = tools.get('whitespace-frontmatter');
+      expect(tool?.description).toBe('Tool with spaces');
+      expect(tool?.autoSubmit).toBe(true);
+    });
+
+    it('should skip malformed frontmatter lines', () => {
+      const toolContent = `---
+description: Valid description
+this line has no colon
+malformed line without colon
+autoSubmit: false
+---
+Tool content`;
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'malformed.md',
+      ] as unknown as fs.Dirent[]);
+      vi.mocked(fs.readFileSync).mockReturnValue(toolContent);
+
+      const tools = loader.loadUserTools();
+
+      const tool = tools.get('malformed');
+      expect(tool?.description).toBe('Valid description');
+      expect(tool?.autoSubmit).toBe(false);
+    });
+  });
+});
+
+describe('loadMergedUserTools', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Set NODE_ENV to test to suppress console logs during tests
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should load and merge tools from both global and workspace directories', () => {
+    const homeDir = os.homedir();
+
+    const globalToolContent = `---
+description: Global tool
+---
+Global tool content`;
+
+    const workspaceToolContent = `---
+description: Workspace tool
+---
+Workspace tool content`;
+
+    const overrideToolContent = `---
+description: Override tool from workspace
+---
+Override content`;
+
+    // Mock mkdirSync to prevent directory creation attempts
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+
+    // Setup mocks for file system operations
+    vi.mocked(fs.existsSync).mockImplementation((path) => {
+      const pathStr = path.toString();
+      // Return true for both global and workspace user-tools directories
+      return pathStr.includes('/.gemini/user-tools');
+    });
+
+    vi.mocked(fs.readdirSync).mockImplementation((path) => {
+      const pathStr = path.toString();
+      if (pathStr.includes(`${homeDir}/.gemini/user-tools`)) {
+        // Return file names as strings cast to Dirent array
+        return ['global-tool.md', 'shared-tool.md'] as unknown as fs.Dirent[];
+      } else if (pathStr.includes('/workspace/.gemini/user-tools')) {
+        // Return file names as strings cast to Dirent array
+        return [
+          'workspace-tool.md',
+          'shared-tool.md',
+        ] as unknown as fs.Dirent[];
+      }
+      return [] as unknown as fs.Dirent[];
+    });
+
+    vi.mocked(fs.readFileSync).mockImplementation((path) => {
+      const pathStr = path.toString();
+      if (pathStr.includes('global-tool.md')) {
+        return globalToolContent;
+      } else if (pathStr.includes('workspace-tool.md')) {
+        return workspaceToolContent;
+      } else if (pathStr.includes('shared-tool.md')) {
+        if (pathStr.includes(homeDir)) {
+          return globalToolContent;
+        } else {
+          return overrideToolContent;
+        }
+      }
+      return '';
+    });
+
+    const result = loadMergedUserTools('/workspace');
+
+    // Check global tools
+    expect(result.globalTools.size).toBe(2);
+    expect(result.globalTools.get('global-tool')).toBeTruthy();
+    expect(result.globalTools.get('shared-tool')).toBeTruthy();
+
+    // Check workspace tools
+    expect(result.workspaceTools.size).toBe(2);
+    expect(result.workspaceTools.get('workspace-tool')).toBeTruthy();
+    expect(result.workspaceTools.get('shared-tool')).toBeTruthy();
+
+    // Check merged tools
+    expect(result.mergedTools.size).toBe(3);
+    expect(result.mergedTools.get('global-tool')?.description).toBe(
+      'Global tool',
+    );
+    expect(result.mergedTools.get('workspace-tool')?.description).toBe(
+      'Workspace tool',
+    );
+    expect(result.mergedTools.get('shared-tool')?.description).toBe(
+      'Override tool from workspace',
+    );
+
+    // Check no errors
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should handle errors gracefully when loading fails', () => {
+    // Set up the mock to throw an error when checking existence
+    vi.mocked(fs.existsSync).mockImplementation(() => {
+      throw new Error('File system error');
+    });
+
+    const result = loadMergedUserTools('/workspace');
+
+    // The loadMergedUserTools function catches errors and returns empty maps with error messages
+    expect(result.globalTools.size).toBe(0);
+    expect(result.workspaceTools.size).toBe(0);
+    expect(result.mergedTools.size).toBe(0);
+
+    // No errors are reported because the UserToolsLoader catches and handles them internally
+    expect(result.errors.length).toBe(0);
+  });
+});

--- a/packages/cli/src/utils/userToolsLoader.ts
+++ b/packages/cli/src/utils/userToolsLoader.ts
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { homedir } from 'os';
+
+export interface UserTool {
+  name: string;
+  description: string;
+  content: string;
+  filePath: string;
+  autoSubmit?: boolean;
+}
+
+/**
+ * Load user tools from both global (~/.gemini/user-tools) and workspace directories
+ * Workspace tools take precedence over global tools when names conflict
+ */
+export function loadMergedUserTools(workspaceDir: string): {
+  globalTools: Map<string, UserTool>;
+  workspaceTools: Map<string, UserTool>;
+  mergedTools: Map<string, UserTool>;
+  errors: Array<{ message: string; path: string }>;
+} {
+  const errors: Array<{ message: string; path: string }> = [];
+
+  // Load global user tools
+  let globalTools = new Map<string, UserTool>();
+  try {
+    const globalLoader = new UserToolsLoader(homedir());
+    globalTools = globalLoader.loadUserTools();
+  } catch (error: unknown) {
+    errors.push({
+      message: `Failed to load global user tools: ${error instanceof Error ? error.message : String(error)}`,
+      path: path.join(homedir(), '.gemini', 'user-tools'),
+    });
+  }
+
+  // Load workspace user tools
+  let workspaceTools = new Map<string, UserTool>();
+  try {
+    const workspaceLoader = new UserToolsLoader(workspaceDir);
+    workspaceTools = workspaceLoader.loadUserTools();
+  } catch (error: unknown) {
+    errors.push({
+      message: `Failed to load workspace user tools: ${error instanceof Error ? error.message : String(error)}`,
+      path: path.join(workspaceDir, '.gemini', 'user-tools'),
+    });
+  }
+
+  // Merge tools with workspace taking precedence
+  const mergedTools = new Map<string, UserTool>();
+  for (const [name, tool] of globalTools) {
+    mergedTools.set(name, tool);
+  }
+  for (const [name, tool] of workspaceTools) {
+    mergedTools.set(name, tool);
+  }
+
+  return { globalTools, workspaceTools, mergedTools, errors };
+}
+
+export class UserToolsLoader {
+  private userTools: Map<string, UserTool> = new Map();
+  private userToolsDir: string;
+
+  constructor(targetDir: string) {
+    this.userToolsDir = path.join(targetDir, '.gemini', 'user-tools');
+  }
+
+  /**
+   * Load all user tools from the .gemini/user-tools directory
+   */
+  loadUserTools(): Map<string, UserTool> {
+    const tools = new Map<string, UserTool>();
+
+    try {
+      // Create directory if it doesn't exist
+      if (!fs.existsSync(this.userToolsDir)) {
+        try {
+          fs.mkdirSync(this.userToolsDir, { recursive: true });
+        } catch (mkdirError) {
+          // In test environments or restricted environments, directory creation might fail
+          console.debug('Failed to create user tools directory:', mkdirError);
+        }
+        return tools;
+      }
+    } catch (existsError) {
+      console.debug('Failed to check user tools directory:', existsError);
+      return tools;
+    }
+
+    try {
+      const files = fs.readdirSync(this.userToolsDir);
+      const mdFiles = files.filter((file) => file.endsWith('.md'));
+
+      for (const file of mdFiles) {
+        const filePath = path.join(this.userToolsDir, file);
+        try {
+          const content = fs.readFileSync(filePath, 'utf-8');
+          const toolName = path.basename(file, '.md');
+
+          // Parse the markdown file to extract metadata
+          const tool = this.parseUserTool(toolName, content, filePath);
+          tools.set(toolName, tool);
+        } catch (error) {
+          console.error(`Error loading user tool ${file}:`, error);
+        }
+      }
+    } catch (error) {
+      console.error('Error reading user tools directory:', error);
+    }
+
+    return tools;
+  }
+
+  /**
+   * Parse a user tool markdown file
+   *
+   * Expected frontmatter format:
+   * ---
+   * description: Brief description of what the tool does
+   * autoSubmit: true or false (optional, defaults to false)
+   * ---
+   */
+  private parseUserTool(
+    name: string,
+    content: string,
+    filePath: string,
+  ): UserTool {
+    const lines = content.split('\n');
+    let description = `User-defined tool: ${name}`;
+    let autoSubmit = false;
+    let contentStartIndex = 0;
+
+    // Parse frontmatter if present
+    if (lines[0].trim() === '---') {
+      let inFrontmatter = true;
+      let i = 1;
+      while (i < lines.length && inFrontmatter) {
+        const trimmedLine = lines[i].trim();
+
+        if (trimmedLine === '---') {
+          inFrontmatter = false;
+          contentStartIndex = i + 1;
+        } else if (trimmedLine) {
+          // Skip empty lines in frontmatter
+          const colonIndex = trimmedLine.indexOf(':');
+          if (colonIndex === -1) {
+            // Skip malformed lines
+            console.debug(
+              `Skipping malformed frontmatter line: "${trimmedLine}"`,
+            );
+            i++;
+            continue;
+          }
+
+          const key = trimmedLine.substring(0, colonIndex).trim();
+          const value = trimmedLine.substring(colonIndex + 1).trim();
+
+          if (key === 'description') {
+            description = value;
+          } else if (key === 'autoSubmit') {
+            autoSubmit = value.toLowerCase() === 'true';
+          }
+        }
+        i++;
+      }
+    }
+
+    const actualContent = lines.slice(contentStartIndex).join('\n').trim();
+
+    return {
+      name,
+      description,
+      content: actualContent,
+      filePath,
+      autoSubmit,
+    };
+  }
+
+  /**
+   * Get a specific user tool by name
+   */
+  getUserTool(name: string): UserTool | undefined {
+    return this.userTools.get(name);
+  }
+
+  /**
+   * Get all loaded user tools
+   */
+  getAllUserTools(): UserTool[] {
+    return Array.from(this.userTools.values());
+  }
+
+  /**
+   * Reload user tools from disk
+   */
+  reloadUserTools(): Map<string, UserTool> {
+    return this.loadUserTools();
+  }
+}

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -85,6 +85,7 @@ When asked to refactor code, follow this specialized sequence to ensure safety a
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
+- **User-Defined Commands:** Users can create custom commands with the \`/user-\` prefix (e.g., \`/user-git-summary\`, \`/user-largest-files\`). These are valid commands that execute user-defined templates stored in \`.gemini/user-tools/\`. When you see these commands being used, treat them as valid and process their expanded content accordingly.
 
 
 # Outside of Sandbox
@@ -279,6 +280,7 @@ When asked to refactor code, follow this specialized sequence to ensure safety a
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
+- **User-Defined Commands:** Users can create custom commands with the \`/user-\` prefix (e.g., \`/user-git-summary\`, \`/user-largest-files\`). These are valid commands that execute user-defined templates stored in \`.gemini/user-tools/\`. When you see these commands being used, treat them as valid and process their expanded content accordingly.
 
 
 # Outside of Sandbox
@@ -483,6 +485,7 @@ When asked to refactor code, follow this specialized sequence to ensure safety a
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
+- **User-Defined Commands:** Users can create custom commands with the \`/user-\` prefix (e.g., \`/user-git-summary\`, \`/user-largest-files\`). These are valid commands that execute user-defined templates stored in \`.gemini/user-tools/\`. When you see these commands being used, treat them as valid and process their expanded content accordingly.
 
 
 # Outside of Sandbox
@@ -672,6 +675,7 @@ When asked to refactor code, follow this specialized sequence to ensure safety a
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
+- **User-Defined Commands:** Users can create custom commands with the \`/user-\` prefix (e.g., \`/user-git-summary\`, \`/user-largest-files\`). These are valid commands that execute user-defined templates stored in \`.gemini/user-tools/\`. When you see these commands being used, treat them as valid and process their expanded content accordingly.
 
 
 # Sandbox
@@ -861,6 +865,7 @@ When asked to refactor code, follow this specialized sequence to ensure safety a
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
+- **User-Defined Commands:** Users can create custom commands with the \`/user-\` prefix (e.g., \`/user-git-summary\`, \`/user-largest-files\`). These are valid commands that execute user-defined templates stored in \`.gemini/user-tools/\`. When you see these commands being used, treat them as valid and process their expanded content accordingly.
 
 
 # MacOS Seatbelt
@@ -1050,6 +1055,7 @@ When asked to refactor code, follow this specialized sequence to ensure safety a
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
+- **User-Defined Commands:** Users can create custom commands with the \`/user-\` prefix (e.g., \`/user-git-summary\`, \`/user-largest-files\`). These are valid commands that execute user-defined templates stored in \`.gemini/user-tools/\`. When you see these commands being used, treat them as valid and process their expanded content accordingly.
 
 
 # Outside of Sandbox
@@ -1239,6 +1245,7 @@ When asked to refactor code, follow this specialized sequence to ensure safety a
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
+- **User-Defined Commands:** Users can create custom commands with the \`/user-\` prefix (e.g., \`/user-git-summary\`, \`/user-largest-files\`). These are valid commands that execute user-defined templates stored in \`.gemini/user-tools/\`. When you see these commands being used, treat them as valid and process their expanded content accordingly.
 
 
 # Outside of Sandbox
@@ -1428,6 +1435,7 @@ When asked to refactor code, follow this specialized sequence to ensure safety a
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
+- **User-Defined Commands:** Users can create custom commands with the \`/user-\` prefix (e.g., \`/user-git-summary\`, \`/user-largest-files\`). These are valid commands that execute user-defined templates stored in \`.gemini/user-tools/\`. When you see these commands being used, treat them as valid and process their expanded content accordingly.
 
 
 # Outside of Sandbox
@@ -1617,6 +1625,7 @@ When asked to refactor code, follow this specialized sequence to ensure safety a
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
+- **User-Defined Commands:** Users can create custom commands with the \`/user-\` prefix (e.g., \`/user-git-summary\`, \`/user-largest-files\`). These are valid commands that execute user-defined templates stored in \`.gemini/user-tools/\`. When you see these commands being used, treat them as valid and process their expanded content accordingly.
 
 
 # Outside of Sandbox

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -126,6 +126,7 @@ ${(function () {
 ## Interaction Details
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
+- **User-Defined Commands:** Users can create custom commands with the \`/user-\` prefix (e.g., \`/user-git-summary\`, \`/user-largest-files\`). These are valid commands that execute user-defined templates stored in \`.gemini/user-tools/\`. When you see these commands being used, treat them as valid and process their expanded content accordingly.
 
 ${(function () {
   // Determine sandbox status based on environment variables


### PR DESCRIPTION
Enables users to create custom commands as markdown files in `.gemini/user-tools/` directory. Commands are invoked with `/user-` prefix and support additional parameters.

- Add UserToolsLoader to discover and parse tool markdown files
- Add UserToolProcessor to handle command execution
- Integrate user tools with slash command system and autocomplete
- Add comprehensive test coverage for all components
- Update documentation with examples and usage instructions
- Handle directory creation failures gracefully for restricted environments

Example: Create `.gemini/user-tools/find-math-book.md`:
```markdown
---
description: Get a random math book recommendation
parameters:
---

Please recommend a random mathematics book. Consider various branches of mathematics (algebra, calculus, geometry, topology, number theory, statistics, etc.) and difficulty levels (from popular math to advanced textbooks).

For your recommendation, please provide:
1. Book title and author(s)
2. What branch of mathematics it covers
3. The target audience/difficulty level
4. A brief description of what makes this book interesting or valuable
5. Why someone might want to read it

If the user provides any preferences or constraints in their additional instructions, take those into account when making your recommendation.
```

Then reload tools: `/reload-user-tools`
Run with: `/user-find-math-book` or `/user-find-math-book focusing on topology`