### PR TITLE
Centralize session ID generation and propagation

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -120,6 +120,7 @@ export async function loadCliConfig(
   settings: Settings,
   extensions: ExtensionConfig[],
   geminiIgnorePatterns: string[],
+  sessionId: string,
 ): Promise<Config> {
   loadEnvironment();
 
@@ -148,6 +149,7 @@ export async function loadCliConfig(
   const mcpServers = mergeMcpServers(settings, extensions);
 
   return new Config({
+    sessionId,
     contentGeneratorConfig,
     embeddingModel: DEFAULT_GEMINI_EMBEDDING_MODEL,
     sandbox: argv.sandbox ?? settings.sandbox,

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -31,6 +31,7 @@ import {
   WebFetchTool,
   WebSearchTool,
   WriteFileTool,
+  sessionId,
 } from '@gemini-cli/core';
 
 export async function main() {
@@ -57,6 +58,7 @@ export async function main() {
     settings.merged,
     extensions,
     geminiIgnorePatterns,
+    sessionId,
   );
 
   // Initialize centralized FileDiscoveryService
@@ -180,5 +182,6 @@ async function loadNonInteractiveConfig(
     nonInteractiveSettings,
     extensions,
     config.getGeminiIgnorePatterns(),
+    config.getSessionId(),
   );
 }

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -190,6 +190,7 @@ describe('App UI', () => {
       userMemory: '',
       geminiMdFileCount: 0,
       showMemoryUsage: false,
+      sessionId: 'test-session-id',
       // Provide other required fields for ConfigParameters if necessary
     }) as unknown as MockServerConfig;
 

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -493,7 +493,7 @@ Add any other context about the problem here.
         description: 'save conversation checkpoint. Usage: /save [tag]',
         action: async (_mainCommand, subCommand, _args) => {
           const tag = (subCommand || '').trim();
-          const logger = new Logger();
+          const logger = new Logger(config?.getSessionId() || '');
           await logger.initialize();
           const chat = await config?.getGeminiClient()?.getChat();
           const history = chat?.getHistory() || [];
@@ -519,7 +519,7 @@ Add any other context about the problem here.
           'resume from conversation checkpoint. Usage: /resume [tag]',
         action: async (_mainCommand, subCommand, _args) => {
           const tag = (subCommand || '').trim();
-          const logger = new Logger();
+          const logger = new Logger(config?.getSessionId() || '');
           await logger.initialize();
           const conversation = await logger.loadCheckpoint(tag);
           if (conversation.length === 0) {

--- a/packages/cli/src/ui/hooks/useLogger.ts
+++ b/packages/cli/src/ui/hooks/useLogger.ts
@@ -5,6 +5,7 @@
  */
 
 import { useState, useEffect } from 'react';
+import { sessionId } from '@gemini-cli/core';
 import { Logger } from '@gemini-cli/core';
 
 /**
@@ -14,7 +15,7 @@ export const useLogger = () => {
   const [logger, setLogger] = useState<Logger | null>(null);
 
   useEffect(() => {
-    const newLogger = new Logger();
+    const newLogger = new Logger(sessionId);
     /**
      * Start async initialization, no need to await. Using await slows down the
      * time from launch to see the gemini-cli prompt and it's better to not save

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -49,6 +49,7 @@ describe('Server Config (config.ts)', () => {
   const USER_MEMORY = 'Test User Memory';
   const TELEMETRY = false;
   const EMBEDDING_MODEL = 'gemini-embedding';
+  const SESSION_ID = 'test-session-id';
   const baseParams: ConfigParameters = {
     contentGeneratorConfig: {
       apiKey: API_KEY,
@@ -62,6 +63,7 @@ describe('Server Config (config.ts)', () => {
     fullContext: FULL_CONTEXT,
     userMemory: USER_MEMORY,
     telemetry: TELEMETRY,
+    sessionId: SESSION_ID,
   };
 
   beforeEach(() => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -55,6 +55,7 @@ export class MCPServerConfig {
 }
 
 export interface ConfigParameters {
+  sessionId: string;
   contentGeneratorConfig: ContentGeneratorConfig;
   embeddingModel: string;
   sandbox?: boolean | string;
@@ -83,6 +84,7 @@ export interface ConfigParameters {
 
 export class Config {
   private toolRegistry: Promise<ToolRegistry>;
+  private readonly sessionId: string;
   private readonly contentGeneratorConfig: ContentGeneratorConfig;
   private readonly embeddingModel: string;
   private readonly sandbox: boolean | string | undefined;
@@ -111,6 +113,7 @@ export class Config {
   private fileDiscoveryService: FileDiscoveryService | null = null;
 
   constructor(params: ConfigParameters) {
+    this.sessionId = params.sessionId;
     this.contentGeneratorConfig = params.contentGeneratorConfig;
     this.embeddingModel = params.embeddingModel;
     this.sandbox = params.sandbox;
@@ -153,6 +156,10 @@ export class Config {
     if (this.telemetry) {
       initializeTelemetry(this);
     }
+  }
+
+  getSessionId(): string {
+    return this.sessionId;
   }
 
   getContentGeneratorConfig(): ContentGeneratorConfig {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -108,6 +108,7 @@ describe('Gemini Client (client.ts)', () => {
         getUserAgent: vi.fn().mockReturnValue('test-agent'),
         getUserMemory: vi.fn().mockReturnValue(''),
         getFullContext: vi.fn().mockReturnValue(false),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       };
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return mock as any;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -162,6 +162,7 @@ export class GeminiClient {
       return new GeminiChat(
         await this.contentGenerator,
         this.model,
+        this.config.getSessionId(),
         {
           systemInstruction,
           ...this.generateContentConfig,

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -21,11 +21,12 @@ describe('GeminiChat', () => {
   let chat: GeminiChat;
   const model = 'gemini-pro';
   const config: GenerateContentConfig = {};
+  const sessionId = 'test-session-id';
 
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset history for each test by creating a new instance
-    chat = new GeminiChat(mockModelsModule, model, config, []);
+    chat = new GeminiChat(mockModelsModule, model, sessionId, config, []);
   });
 
   afterEach(() => {
@@ -120,7 +121,7 @@ describe('GeminiChat', () => {
       chat.recordHistory(userInput, newModelOutput); // userInput here is for the *next* turn, but history is already primed
 
       // Reset and set up a more realistic scenario for merging with existing history
-      chat = new GeminiChat(mockModelsModule, model, config, []);
+      chat = new GeminiChat(mockModelsModule, model, sessionId, config, []);
       const firstUserInput: Content = {
         role: 'user',
         parts: [{ text: 'First user input' }],
@@ -163,7 +164,7 @@ describe('GeminiChat', () => {
         role: 'model',
         parts: [{ text: 'Initial model answer.' }],
       };
-      chat = new GeminiChat(mockModelsModule, model, config, [
+      chat = new GeminiChat(mockModelsModule, model, sessionId, config, [
         initialUser,
         initialModel,
       ]);

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -18,6 +18,7 @@ import {
 import { retryWithBackoff } from '../utils/retry.js';
 import { isFunctionResponse } from '../utils/messageInspectors.js';
 import { ContentGenerator } from './contentGenerator.js';
+import { Logger } from './logger.js';
 
 /**
  * Returns true if the response is valid, false otherwise.
@@ -117,14 +118,17 @@ export class GeminiChat {
   // A promise to represent the current state of the message being sent to the
   // model.
   private sendPromise: Promise<void> = Promise.resolve();
+  private logger: Logger;
 
   constructor(
     private readonly contentGenerator: ContentGenerator,
     private readonly model: string,
+    sessionId: string,
     private readonly config: GenerateContentConfig = {},
     private history: Content[] = [],
   ) {
     validateHistory(history);
+    this.logger = new Logger(sessionId);
   }
 
   /**

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -17,7 +17,7 @@ export enum MessageSenderType {
 }
 
 export interface LogEntry {
-  sessionId: number;
+  sessionId: string;
   messageId: number;
   timestamp: string;
   type: MessageSenderType;
@@ -28,12 +28,14 @@ export class Logger {
   private geminiDir: string | undefined;
   private logFilePath: string | undefined;
   private checkpointFilePath: string | undefined;
-  private sessionId: number | undefined;
+  private sessionId: string | undefined;
   private messageId = 0; // Instance-specific counter for the next messageId
   private initialized = false;
   private logs: LogEntry[] = []; // In-memory cache, ideally reflects the last known state of the file
 
-  constructor() {}
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+  }
 
   private async _readLogFile(): Promise<LogEntry[]> {
     if (!this.logFilePath) {
@@ -51,7 +53,7 @@ export class Logger {
       }
       return parsedLogs.filter(
         (entry) =>
-          typeof entry.sessionId === 'number' &&
+          typeof entry.sessionId === 'string' &&
           typeof entry.messageId === 'number' &&
           typeof entry.timestamp === 'string' &&
           typeof entry.type === 'string' &&
@@ -93,7 +95,6 @@ export class Logger {
     if (this.initialized) {
       return;
     }
-    this.sessionId = Math.floor(Date.now() / 1000);
     this.geminiDir = path.resolve(process.cwd(), GEMINI_DIR);
     this.logFilePath = path.join(this.geminiDir, LOG_FILE_NAME);
     this.checkpointFilePath = path.join(this.geminiDir, CHECKPOINT_FILE_NAME);
@@ -195,11 +196,9 @@ export class Logger {
     return this.logs
       .filter((entry) => entry.type === MessageSenderType.USER)
       .sort((a, b) => {
-        if (b.sessionId !== a.sessionId) return b.sessionId - a.sessionId;
         const dateA = new Date(a.timestamp).getTime();
         const dateB = new Date(b.timestamp).getTime();
-        if (dateB !== dateA) return dateB - dateA;
-        return b.messageId - a.messageId;
+        return dateB - dateA;
       })
       .map((entry) => entry.message);
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,3 +51,4 @@ export * from './tools/mcp-tool.js';
 
 // Export telemetry functions
 export * from './telemetry/index.js';
+export { sessionId } from './utils/session.js';

--- a/packages/core/src/telemetry/constants.ts
+++ b/packages/core/src/telemetry/constants.ts
@@ -4,10 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { randomUUID } from 'crypto';
-
 export const SERVICE_NAME = 'gemini-cli';
-export const sessionId = randomUUID();
 
 export const EVENT_USER_PROMPT = 'gemini_code.user_prompt';
 export const EVENT_TOOL_CALL = 'gemini_code.tool_call';

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -28,4 +28,3 @@ export {
 } from './types.js';
 export { SpanStatusCode, ValueType } from '@opentelemetry/api';
 export { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-export { sessionId } from './constants.js';

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -26,7 +26,7 @@ import {
 } from '@opentelemetry/sdk-metrics';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { Config } from '../config/config.js';
-import { SERVICE_NAME, sessionId } from './constants.js';
+import { SERVICE_NAME } from './constants.js';
 import { initializeMetrics } from './metrics.js';
 import { logCliConfiguration } from './loggers.js';
 
@@ -68,7 +68,7 @@ export function initializeTelemetry(config: Config): void {
   const resource = new Resource({
     [SemanticResourceAttributes.SERVICE_NAME]: SERVICE_NAME,
     [SemanticResourceAttributes.SERVICE_VERSION]: process.version,
-    'session.id': sessionId,
+    'session.id': config.getSessionId(),
   });
 
   const otlpEndpoint = config.getTelemetryOtlpEndpoint();

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -136,6 +136,7 @@ const baseConfigParams: ConfigParameters = {
   userMemory: '',
   geminiMdFileCount: 0,
   approvalMode: ApprovalMode.DEFAULT,
+  sessionId: 'test-session-id',
 };
 
 describe('ToolRegistry', () => {

--- a/packages/core/src/utils/nextSpeakerChecker.test.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.test.ts
@@ -71,6 +71,7 @@ describe('checkNextSpeaker', () => {
     chatInstance = new GeminiChat(
       mockModelsInstance, // This is the instance returned by mockGoogleGenAIInstance.getGenerativeModel
       'gemini-pro', // model name
+      'test-session-id',
       {},
       [], // initial history
     );

--- a/packages/core/src/utils/session.ts
+++ b/packages/core/src/utils/session.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomUUID } from 'crypto';
+
+export const sessionId = randomUUID();


### PR DESCRIPTION
This change refactors how session IDs are generated and used throughout the application to ensure consistency. Previously, different parts of the application could generate their own session identifiers, making it difficult to trace a single user session through various systems.

This refactoring introduces a single, unified sessionId at application startup and propagates it through the system via the main configuration object. The sessionId is generated internally for each session and is not a user-configurable setting.

Fixes #928

Epic: #750 