### PR TITLE
Modify /save and /restore to be sessions specific.

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -382,22 +382,46 @@ export const useGeminiStream = (
             break;
           case ServerGeminiEventType.ToolCallRequest:
             toolCallRequests.push(event.value);
+            await logger?.logMessage(
+              MessageSenderType.TOOL_REQUEST,
+              JSON.stringify(event.value.args),
+            );
             break;
           case ServerGeminiEventType.UserCancelled:
             handleUserCancelledEvent(userMessageTimestamp);
             break;
           case ServerGeminiEventType.Error:
             handleErrorEvent(event.value, userMessageTimestamp);
+            await logger?.logMessage(
+              MessageSenderType.SERVER_ERROR,
+              JSON.stringify(event.value),
+            );
             break;
           case ServerGeminiEventType.ChatCompressed:
             handleChatCompressionEvent();
+            await logger?.logMessage(
+              MessageSenderType.SYSTEM,
+              'Compressing Chat',
+            );
             break;
           case ServerGeminiEventType.UsageMetadata:
             addUsage(event.value);
+            await logger?.logMessage(
+              MessageSenderType.SYSTEM,
+              'Usage Metadata: ' + JSON.stringify(event.value),
+            );
             break;
           case ServerGeminiEventType.ToolCallConfirmation:
+            await logger?.logMessage(
+              MessageSenderType.SYSTEM,
+              JSON.stringify(event.value),
+            );
+            break;
           case ServerGeminiEventType.ToolCallResponse:
-            // do nothing
+            await logger?.logMessage(
+              MessageSenderType.SYSTEM,
+              JSON.stringify(event.value),
+            );
             break;
           default: {
             // enforces exhaustive switch-case
@@ -406,6 +430,7 @@ export const useGeminiStream = (
           }
         }
       }
+      await logger?.logMessage(MessageSenderType.SYSTEM, geminiMessageBuffer);
       if (toolCallRequests.length > 0) {
         scheduleToolCalls(toolCallRequests, signal);
       }

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -9,11 +9,14 @@ import { promises as fs } from 'node:fs';
 import { Content } from '@google/genai';
 
 const GEMINI_DIR = '.gemini';
-const LOG_FILE_NAME = 'logs.json';
-const CHECKPOINT_FILE_NAME = 'checkpoint.json';
+const LOG_FILE_NAME_PREFIX = 'logs';
+const CHECKPOINT_FILE_NAME = 'checkpoint';
 
 export enum MessageSenderType {
   USER = 'user',
+  SYSTEM = 'system',
+  TOOL_REQUEST = 'tool_request',
+  SERVER_ERROR = 'server_error',
 }
 
 export interface LogEntry {
@@ -96,7 +99,10 @@ export class Logger {
       return;
     }
     this.geminiDir = path.resolve(process.cwd(), GEMINI_DIR);
-    this.logFilePath = path.join(this.geminiDir, LOG_FILE_NAME);
+    this.logFilePath = path.join(
+      this.geminiDir,
+      `${LOG_FILE_NAME_PREFIX}-${this.sessionId}.json`,
+    );
     this.checkpointFilePath = path.join(this.geminiDir, CHECKPOINT_FILE_NAME);
 
     try {

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -10,7 +10,7 @@ import { Content } from '@google/genai';
 
 const GEMINI_DIR = '.gemini';
 const LOG_FILE_NAME_PREFIX = 'logs';
-const CHECKPOINT_FILE_NAME = 'checkpoint';
+const CHECKPOINT_FILE_NAME = 'checkpoint.json';
 
 export enum MessageSenderType {
   USER = 'user',


### PR DESCRIPTION
* We want to save and restore sessions
* These should be tied to checkpoints which is work in progress
* Each Content item should be associated with a message, role and optional checkpoint information

(still fixing tests but wanted to put this out there to start discussing this feature.)