### PR TITLE
telemetry: include session id in logs and metrics

### DIFF
--- a/docs/core/telemetry.md
+++ b/docs/core/telemetry.md
@@ -252,6 +252,8 @@ Use this method if you prefer not to use Docker.
 
 ## Data Reference: Logs & Metrics
 
+A `sessionId` is included as a common attribute on all logs and metrics.
+
 ### Logs
 
 These are timestamped records of specific events.

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -134,6 +134,7 @@ describe('runNonInteractive', () => {
 
     expect(mockChat.sendMessageStream).toHaveBeenCalledTimes(2);
     expect(mockCoreExecuteToolCall).toHaveBeenCalledWith(
+      mockConfig,
       expect.objectContaining({ callId: 'fc1', name: 'testTool' }),
       mockToolRegistry,
       expect.any(AbortSignal),

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -85,6 +85,7 @@ export async function runNonInteractive(
           };
 
           const toolResponse = await executeToolCall(
+            config,
             requestInfo,
             toolRegistry,
             abortController.signal,

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -122,7 +122,7 @@ export function useReactToolScheduler(
         }
         duration = call.durationMs || 0;
 
-        logToolCall({
+        logToolCall(config, {
           function_name: call.request.name,
           function_args: call.request.args,
           duration_ms: duration,

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -160,9 +160,9 @@ export class GeminiClient {
       const systemInstruction = getCoreSystemPrompt(userMemory);
 
       return new GeminiChat(
+        this.config,
         await this.contentGenerator,
         this.model,
-        this.config.getSessionId(),
         {
           systemInstruction,
           ...this.generateContentConfig,
@@ -214,7 +214,7 @@ export class GeminiClient {
   }
 
   private _logApiRequest(model: string, inputTokenCount: number): void {
-    logApiRequest({
+    logApiRequest(this.config, {
       model,
       input_token_count: inputTokenCount,
       duration_ms: 0, // Duration is not known at request time
@@ -239,7 +239,7 @@ export class GeminiClient {
       responseError = `Finished with reason: ${finishReason}`;
     }
 
-    logApiResponse({
+    logApiResponse(this.config, {
       model,
       duration_ms: durationMs,
       attempt,
@@ -277,7 +277,7 @@ export class GeminiClient {
       }
     }
 
-    logApiError({
+    logApiError(this.config, {
       model,
       error: errorMessage,
       status_code: statusCode,

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Content, Models, GenerateContentConfig, Part } from '@google/genai';
 import { GeminiChat } from './geminiChat.js';
+import { Config } from '../config/config.js';
 
 // Mocks
 const mockModelsModule = {
@@ -17,16 +18,19 @@ const mockModelsModule = {
   batchEmbedContents: vi.fn(),
 } as unknown as Models;
 
+const mockConfig = {
+  getSessionId: () => 'test-session-id',
+} as unknown as Config;
+
 describe('GeminiChat', () => {
   let chat: GeminiChat;
   const model = 'gemini-pro';
   const config: GenerateContentConfig = {};
-  const sessionId = 'test-session-id';
 
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset history for each test by creating a new instance
-    chat = new GeminiChat(mockModelsModule, model, sessionId, config, []);
+    chat = new GeminiChat(mockConfig, mockModelsModule, model, config, []);
   });
 
   afterEach(() => {
@@ -121,7 +125,7 @@ describe('GeminiChat', () => {
       chat.recordHistory(userInput, newModelOutput); // userInput here is for the *next* turn, but history is already primed
 
       // Reset and set up a more realistic scenario for merging with existing history
-      chat = new GeminiChat(mockModelsModule, model, sessionId, config, []);
+      chat = new GeminiChat(mockConfig, mockModelsModule, model, config, []);
       const firstUserInput: Content = {
         role: 'user',
         parts: [{ text: 'First user input' }],
@@ -164,7 +168,7 @@ describe('GeminiChat', () => {
         role: 'model',
         parts: [{ text: 'Initial model answer.' }],
       };
-      chat = new GeminiChat(mockModelsModule, model, sessionId, config, [
+      chat = new GeminiChat(mockConfig, mockModelsModule, model, config, [
         initialUser,
         initialModel,
       ]);

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -18,7 +18,7 @@ import {
 import { retryWithBackoff } from '../utils/retry.js';
 import { isFunctionResponse } from '../utils/messageInspectors.js';
 import { ContentGenerator } from './contentGenerator.js';
-import { Logger } from './logger.js';
+import { Config } from '../config/config.js';
 
 /**
  * Returns true if the response is valid, false otherwise.
@@ -118,17 +118,15 @@ export class GeminiChat {
   // A promise to represent the current state of the message being sent to the
   // model.
   private sendPromise: Promise<void> = Promise.resolve();
-  private logger: Logger;
 
   constructor(
+    private readonly config: Config,
     private readonly contentGenerator: ContentGenerator,
     private readonly model: string,
-    sessionId: string,
-    private readonly config: GenerateContentConfig = {},
+    private readonly generationConfig: GenerateContentConfig = {},
     private history: Content[] = [],
   ) {
     validateHistory(history);
-    this.logger = new Logger(sessionId);
   }
 
   /**
@@ -161,7 +159,7 @@ export class GeminiChat {
       this.contentGenerator.generateContent({
         model: this.model,
         contents: this.getHistory(true).concat(userContent),
-        config: { ...this.config, ...params.config },
+        config: { ...this.generationConfig, ...params.config },
       });
 
     const responsePromise = retryWithBackoff(apiCall);
@@ -230,7 +228,7 @@ export class GeminiChat {
       this.contentGenerator.generateContentStream({
         model: this.model,
         contents: this.getHistory(true).concat(userContent),
-        config: { ...this.config, ...params.config },
+        config: { ...this.generationConfig, ...params.config },
       });
 
     // Note: Retrying streams can be complex. If generateContentStream itself doesn't handle retries

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -12,8 +12,11 @@ import {
   ToolResult,
   Tool,
   ToolCallConfirmationDetails,
+  Config,
 } from '../index.js';
 import { Part, Type } from '@google/genai';
+
+const mockConfig = {} as unknown as Config;
 
 describe('executeToolCall', () => {
   let mockToolRegistry: ToolRegistry;
@@ -68,6 +71,7 @@ describe('executeToolCall', () => {
     vi.mocked(mockTool.execute).mockResolvedValue(toolResult);
 
     const response = await executeToolCall(
+      mockConfig,
       request,
       mockToolRegistry,
       abortController.signal,
@@ -99,6 +103,7 @@ describe('executeToolCall', () => {
     vi.mocked(mockToolRegistry.getTool).mockReturnValue(undefined);
 
     const response = await executeToolCall(
+      mockConfig,
       request,
       mockToolRegistry,
       abortController.signal,
@@ -134,6 +139,7 @@ describe('executeToolCall', () => {
     vi.mocked(mockTool.execute).mockRejectedValue(executionError);
 
     const response = await executeToolCall(
+      mockConfig,
       request,
       mockToolRegistry,
       abortController.signal,
@@ -184,6 +190,7 @@ describe('executeToolCall', () => {
 
     abortController.abort(); // Abort before calling
     const response = await executeToolCall(
+      mockConfig,
       request,
       mockToolRegistry,
       abortController.signal,
@@ -211,6 +218,7 @@ describe('executeToolCall', () => {
     vi.mocked(mockTool.execute).mockResolvedValue(toolResult);
 
     const response = await executeToolCall(
+      mockConfig,
       request,
       mockToolRegistry,
       abortController.signal,

--- a/packages/core/src/core/nonInteractiveToolExecutor.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.ts
@@ -10,6 +10,7 @@ import {
   ToolRegistry,
   ToolResult,
 } from '../index.js';
+import { Config } from '../config/config.js';
 import { convertToFunctionResponse } from './coreToolScheduler.js';
 
 /**
@@ -17,6 +18,7 @@ import { convertToFunctionResponse } from './coreToolScheduler.js';
  * It does not handle confirmations, multiple calls, or live updates.
  */
 export async function executeToolCall(
+  config: Config,
   toolCallRequest: ToolCallRequestInfo,
   toolRegistry: ToolRegistry,
   abortSignal?: AbortSignal,

--- a/packages/core/src/telemetry/metrics.test.ts
+++ b/packages/core/src/telemetry/metrics.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { Counter, Meter, metrics } from '@opentelemetry/api';
 import { initializeMetrics, recordTokenUsageMetrics } from './metrics.js';
+import { Config } from '../config/config.js';
 
 const mockCounter = {
   add: vi.fn(),
@@ -33,51 +34,61 @@ describe('Telemetry Metrics', () => {
   });
 
   describe('recordTokenUsageMetrics', () => {
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+    } as unknown as Config;
+
     it('should not record metrics if not initialized', () => {
-      recordTokenUsageMetrics('gemini-pro', 100, 'input');
+      recordTokenUsageMetrics(mockConfig, 'gemini-pro', 100, 'input');
       expect(mockCounter.add).not.toHaveBeenCalled();
     });
 
     it('should record token usage with the correct attributes', () => {
-      initializeMetrics();
-      recordTokenUsageMetrics('gemini-pro', 100, 'input');
+      initializeMetrics(mockConfig);
+      recordTokenUsageMetrics(mockConfig, 'gemini-pro', 100, 'input');
       expect(mockCounter.add).toHaveBeenCalledWith(100, {
+        'session.id': 'test-session-id',
         model: 'gemini-pro',
         type: 'input',
       });
     });
 
     it('should record token usage for different types', () => {
-      initializeMetrics();
-      recordTokenUsageMetrics('gemini-pro', 50, 'output');
+      initializeMetrics(mockConfig);
+      recordTokenUsageMetrics(mockConfig, 'gemini-pro', 50, 'output');
       expect(mockCounter.add).toHaveBeenCalledWith(50, {
+        'session.id': 'test-session-id',
         model: 'gemini-pro',
         type: 'output',
       });
 
-      recordTokenUsageMetrics('gemini-pro', 25, 'thought');
+      recordTokenUsageMetrics(mockConfig, 'gemini-pro', 25, 'thought');
       expect(mockCounter.add).toHaveBeenCalledWith(25, {
+        'session.id': 'test-session-id',
         model: 'gemini-pro',
         type: 'thought',
       });
 
-      recordTokenUsageMetrics('gemini-pro', 75, 'cache');
+      recordTokenUsageMetrics(mockConfig, 'gemini-pro', 75, 'cache');
       expect(mockCounter.add).toHaveBeenCalledWith(75, {
+        'session.id': 'test-session-id',
         model: 'gemini-pro',
         type: 'cache',
       });
 
-      recordTokenUsageMetrics('gemini-pro', 125, 'tool');
+      recordTokenUsageMetrics(mockConfig, 'gemini-pro', 125, 'tool');
       expect(mockCounter.add).toHaveBeenCalledWith(125, {
+        'session.id': 'test-session-id',
         model: 'gemini-pro',
         type: 'tool',
       });
     });
 
     it('should handle different models', () => {
-      initializeMetrics();
-      recordTokenUsageMetrics('gemini-ultra', 200, 'input');
+      initializeMetrics(mockConfig);
+      recordTokenUsageMetrics(mockConfig, 'gemini-ultra', 200, 'input');
       expect(mockCounter.add).toHaveBeenCalledWith(200, {
+        'session.id': 'test-session-id',
         model: 'gemini-ultra',
         type: 'input',
       });

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -112,7 +112,7 @@ export function initializeTelemetry(config: Config): void {
     sdk.start();
     console.log('OpenTelemetry SDK started successfully.');
     telemetryInitialized = true;
-    initializeMetrics();
+    initializeMetrics(config);
     logCliConfiguration(config);
   } catch (error) {
     console.error('Error starting OpenTelemetry SDK:', error);

--- a/packages/core/src/utils/nextSpeakerChecker.test.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.test.ts
@@ -69,9 +69,9 @@ describe('checkNextSpeaker', () => {
 
     // GeminiChat will receive the mocked instances via the mocked GoogleGenAI constructor
     chatInstance = new GeminiChat(
+      mockConfigInstance,
       mockModelsInstance, // This is the instance returned by mockGoogleGenAIInstance.getGenerativeModel
       'gemini-pro', // model name
-      'test-session-id',
       {},
       [], // initial history
     );


### PR DESCRIPTION
This commit refactors the telemetry system to pass a config object to various logging and metrics functions. This change centralizes configuration management within the telemetry system, making it more modular and easier to maintain. 

The  constructor and various tool execution functions have been updated to accept the  object, which is then passed down to the telemetry functions. This eliminates the need to pass individual configuration values, such as , through multiple layers of the CLI. 

At this point, we use this to include session ID in logs and metrics. We can then expand this to include other common attributes, such as CLI version. 

Here is an an example of filtering logs by session ID in GCP logs explorer:
![image](https://github.com/user-attachments/assets/14a2b841-60c0-4c5c-a5be-d0ccfcc42fd2)

#750 
