### PR TITLE
Fix noisy tests

### DIFF
--- a/packages/cli/src/ui/hooks/useLoadingIndicator.test.ts
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.test.ts
@@ -16,12 +16,11 @@ import {
 describe('useLoadingIndicator', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.clearAllMocks();
   });
 
   afterEach(() => {
-    vi.runOnlyPendingTimers();
     vi.useRealTimers(); // Restore real timers after each test
+    act(() => vi.runOnlyPendingTimers);
   });
 
   it('should initialize with default values when Idle', () => {


### PR DESCRIPTION
Removes 344 lines of output from tests! This was causing tearing, jank, and flickering for me.