### PR TITLE
telemetry: expand cli configuration event

### DIFF
--- a/docs/core/telemetry.md
+++ b/docs/core/telemetry.md
@@ -262,13 +262,18 @@ These are timestamped records of specific events.
 
   - **Attributes**:
     - `model` (string)
+    - `embedding_model` (string)
     - `sandbox_enabled` (boolean)
     - `core_tools_enabled` (string)
     - `approval_mode` (string)
+    - `api_key_enabled` (boolean)
     - `vertex_ai_enabled` (boolean)
+    - `code_assist_enabled` (boolean)
     - `log_user_prompts_enabled` (boolean)
     - `file_filtering_respect_git_ignore` (boolean)
     - `file_filtering_allow_build_artifacts` (boolean)
+    - `debug_mode` (boolean)
+    - `mcp_servers` (string)
 
 - `gemini_cli.user_prompt`: Fired when a user submits a prompt.
 

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -43,21 +43,28 @@ function getCommonAttributes(config: Config): LogAttributes {
 export function logCliConfiguration(config: Config): void {
   if (!isTelemetrySdkInitialized()) return;
 
+  const generatorConfig = config.getContentGeneratorConfig();
+  const mcpServers = config.getMcpServers();
   const attributes: LogAttributes = {
     ...getCommonAttributes(config),
     'event.name': EVENT_CLI_CONFIG,
     'event.timestamp': new Date().toISOString(),
     model: config.getModel(),
+    embedding_model: config.getEmbeddingModel(),
     sandbox_enabled:
       typeof config.getSandbox() === 'string' ? true : config.getSandbox(),
     core_tools_enabled: (config.getCoreTools() ?? []).join(','),
     approval_mode: config.getApprovalMode(),
-    vertex_ai_enabled: !!config.getContentGeneratorConfig().vertexai,
+    api_key_enabled: !!generatorConfig.apiKey,
+    vertex_ai_enabled: !!generatorConfig.vertexai,
+    code_assist_enabled: !!generatorConfig.codeAssist,
     log_user_prompts_enabled: config.getTelemetryLogUserPromptsEnabled(),
     file_filtering_respect_git_ignore:
       config.getFileFilteringRespectGitIgnore(),
     file_filtering_allow_build_artifacts:
       config.getFileFilteringAllowBuildArtifacts(),
+    debug_mode: config.getDebugMode(),
+    mcp_servers: mcpServers ? Object.keys(mcpServers).join(',') : '',
   };
   const logger = logs.getLogger(SERVICE_NAME);
   const logRecord: LogRecord = {


### PR DESCRIPTION
Adds the following attributes to the  event:
- `embedding_model`
- `api_key_enabled`
- `code_assist_enabled`
- `vertex_enabled`
- `debug_mode`
- `mcp_servers`

This additional data will provide more insight into user configurations.

Example event in GCP logs explorer:
![image](https://github.com/user-attachments/assets/a5c9628e-8da4-489d-a678-5f926d606722)

#750 
