### PR TITLE
add excludeTools flag to settings.json config

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -64,6 +64,9 @@ When you create a `.gemini/settings.json` file for project-specific settings, or
   - **Description:** Allows you to specify a list of core tool names that should be made available to the model. This can be used to restrict or customize the set of built-in tools.
   - **Example:** `"coreTools": ["ReadFileTool", "GlobTool", "SearchText"]`.
   - **Behavior:** If this setting is provided, only the listed tools will be available for the model to use. If omitted, all default core tools are available. See [Built-in Tools](../core/tools-api.md#built-in-tools) for a list of core tools. You can also specify the alternative internal tool names used by the model, e.g. `read_file`, and you can get a full listing for that by simply asking the model "what tools do you have?".
+- **`excludeTools`** (array of strings, optional):
+  - **Description:** Allows you to specify a list of core tool names that should be excluded from the model.
+  - **Example:** `"excludeTools": ["run_shell_command", "glob"]`.
 - **`autoAccept`** (boolean, optional):
 
   - **Description:** Controls whether the CLI automatically accepts and executes tool calls that are considered safe (e.g., read-only operations) without explicit user confirmation.

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -44,6 +44,7 @@ vi.mock('@gemini-cli/core', async () => {
       getQuestion: () => params.question,
       getFullContext: () => params.fullContext,
       getCoreTools: () => params.coreTools,
+      getExcludeTools: () => params.excludeTools,
       getToolDiscoveryCommand: () => params.toolDiscoveryCommand,
       getToolCallCommand: () => params.toolCallCommand,
       getMcpServerCommand: () => params.mcpServerCommand,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -175,6 +175,7 @@ export async function loadCliConfig(
     question: argv.prompt || '',
     fullContext: argv.all_files || false,
     coreTools: settings.coreTools || undefined,
+    excludeTools: settings.excludeTools || undefined,
     toolDiscoveryCommand: settings.toolDiscoveryCommand,
     toolCallCommand: settings.toolCallCommand,
     mcpServerCommand: settings.mcpServerCommand,

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -29,6 +29,7 @@ export interface Settings {
   theme?: string;
   sandbox?: boolean | string;
   coreTools?: string[];
+  excludeTools?: string[];
   toolDiscoveryCommand?: string;
   toolCallCommand?: string;
   mcpServerCommand?: string;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -65,6 +65,7 @@ export interface ConfigParameters {
   question?: string;
   fullContext?: boolean;
   coreTools?: string[];
+  excludeTools?: string[];
   toolDiscoveryCommand?: string;
   toolCallCommand?: string;
   mcpServerCommand?: string;
@@ -95,6 +96,7 @@ export class Config {
   private readonly question: string | undefined;
   private readonly fullContext: boolean;
   private readonly coreTools: string[] | undefined;
+  private readonly excludeTools: string[] | undefined;
   private readonly toolDiscoveryCommand: string | undefined;
   private readonly toolCallCommand: string | undefined;
   private readonly mcpServerCommand: string | undefined;
@@ -126,6 +128,7 @@ export class Config {
     this.question = params.question;
     this.fullContext = params.fullContext ?? false;
     this.coreTools = params.coreTools;
+    this.excludeTools = params.excludeTools;
     this.toolDiscoveryCommand = params.toolDiscoveryCommand;
     this.toolCallCommand = params.toolCallCommand;
     this.mcpServerCommand = params.mcpServerCommand;
@@ -208,6 +211,10 @@ export class Config {
 
   getCoreTools(): string[] | undefined {
     return this.coreTools;
+  }
+
+  getExcludeTools(): string[] | undefined {
+    return this.excludeTools;
   }
 
   getToolDiscoveryCommand(): string | undefined {
@@ -360,12 +367,22 @@ export function createToolRegistry(config: Config): Promise<ToolRegistry> {
   const tools = config.getCoreTools()
     ? new Set(config.getCoreTools())
     : undefined;
+  const excludeTools = config.getExcludeTools()
+    ? new Set(config.getExcludeTools())
+    : undefined;
 
   // helper to create & register core tools that are enabled
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const registerCoreTool = (ToolClass: any, ...args: unknown[]) => {
     // check both the tool name (.Name) and the class name (.name)
-    if (!tools || tools.has(ToolClass.Name) || tools.has(ToolClass.name)) {
+    if (
+      // coreTools contain tool name
+      (!tools || tools.has(ToolClass.Name) || tools.has(ToolClass.name)) &&
+      // excludeTools don't contain tool name
+      (!excludeTools ||
+        (!excludeTools.has(ToolClass.Name) &&
+          !excludeTools.has(ToolClass.name)))
+    ) {
       registry.registerTool(new ToolClass(...args));
     }
   };


### PR DESCRIPTION
This new flag enables certain tools to be removed based on settings.json config.

For example, we wouldn't want to do `glob` to find files in 1P cases. 