### PR TITLE
Telemetry: Improve clarity of user prompt event

### DIFF
--- a/docs/core/telemetry.md
+++ b/docs/core/telemetry.md
@@ -278,7 +278,7 @@ These are timestamped records of specific events.
 - `gemini_cli.user_prompt`: Fired when a user submits a prompt.
 
   - **Attributes**:
-    - `prompt_char_count`
+    - `prompt_length`
     - `prompt` (except if `log_user_prompts_enabled` is false)
 
 - `gemini_cli.tool_call`: Fired for every function call.

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -188,7 +188,7 @@ export const useGeminiStream = (
         const trimmedQuery = query.trim();
         logUserPrompt(config, {
           prompt: trimmedQuery,
-          prompt_char_count: trimmedQuery.length,
+          prompt_length: trimmedQuery.length,
         });
         onDebugMessage(`User query: '${trimmedQuery}'`);
         await logger?.logMessage(MessageSenderType.USER, trimmedQuery);

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -81,19 +81,21 @@ export function logUserPrompt(
   },
 ): void {
   if (!isTelemetrySdkInitialized()) return;
-  const { prompt, ...restOfEventArgs } = event;
+
   const attributes: LogAttributes = {
     ...getCommonAttributes(config),
-    ...restOfEventArgs,
     'event.name': EVENT_USER_PROMPT,
     'event.timestamp': new Date().toISOString(),
+    prompt_length: event.prompt_length,
   };
+
   if (shouldLogUserPrompts(config)) {
-    attributes.prompt = prompt;
+    attributes.prompt = event.prompt;
   }
+
   const logger = logs.getLogger(SERVICE_NAME);
   const logRecord: LogRecord = {
-    body: `User prompt. Length: ${event.prompt_char_count}`,
+    body: `User prompt. Length: ${event.prompt_length}`,
     attributes,
   };
   logger.emit(logRecord);

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -7,7 +7,7 @@
 export interface UserPromptEvent {
   'event.name': 'user_prompt';
   'event.timestamp': string; // ISO 8601
-  prompt_char_count: number;
+  prompt_length: number;
   prompt?: string;
 }
 


### PR DESCRIPTION
Renames the `prompt_char_count` attribute to `prompt_length` in the user prompt telemetry event for better clarity and consistency.

This also updates the documentation and tests to reflect the new attribute name.

#750 