### PR TITLE
Revert "Add support for local logging per session (#936)"

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -398,46 +398,22 @@ export const useGeminiStream = (
             break;
           case ServerGeminiEventType.ToolCallRequest:
             toolCallRequests.push(event.value);
-            await logger?.logMessage(
-              MessageSenderType.TOOL_REQUEST,
-              JSON.stringify(event.value.args),
-            );
             break;
           case ServerGeminiEventType.UserCancelled:
             handleUserCancelledEvent(userMessageTimestamp);
             break;
           case ServerGeminiEventType.Error:
             handleErrorEvent(event.value, userMessageTimestamp);
-            await logger?.logMessage(
-              MessageSenderType.SERVER_ERROR,
-              JSON.stringify(event.value),
-            );
             break;
           case ServerGeminiEventType.ChatCompressed:
             handleChatCompressionEvent();
-            await logger?.logMessage(
-              MessageSenderType.SYSTEM,
-              'Compressing Chat',
-            );
             break;
           case ServerGeminiEventType.UsageMetadata:
             addUsage(event.value);
-            await logger?.logMessage(
-              MessageSenderType.SYSTEM,
-              'Usage Metadata: ' + JSON.stringify(event.value),
-            );
             break;
           case ServerGeminiEventType.ToolCallConfirmation:
-            await logger?.logMessage(
-              MessageSenderType.SYSTEM,
-              JSON.stringify(event.value),
-            );
-            break;
           case ServerGeminiEventType.ToolCallResponse:
-            await logger?.logMessage(
-              MessageSenderType.SYSTEM,
-              JSON.stringify(event.value),
-            );
+            // do nothing
             break;
           default: {
             // enforces exhaustive switch-case
@@ -446,7 +422,6 @@ export const useGeminiStream = (
           }
         }
       }
-      await logger?.logMessage(MessageSenderType.SYSTEM, geminiMessageBuffer);
       if (toolCallRequests.length > 0) {
         scheduleToolCalls(toolCallRequests, signal);
       }
@@ -459,7 +434,6 @@ export const useGeminiStream = (
       scheduleToolCalls,
       handleChatCompressionEvent,
       addUsage,
-      logger,
     ],
   );
 

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -9,14 +9,11 @@ import { promises as fs } from 'node:fs';
 import { Content } from '@google/genai';
 
 const GEMINI_DIR = '.gemini';
-const LOG_FILE_NAME_PREFIX = 'logs';
+const LOG_FILE_NAME = 'logs.json';
 const CHECKPOINT_FILE_NAME = 'checkpoint.json';
 
 export enum MessageSenderType {
   USER = 'user',
-  SYSTEM = 'system',
-  TOOL_REQUEST = 'tool_request',
-  SERVER_ERROR = 'server_error',
 }
 
 export interface LogEntry {
@@ -38,10 +35,6 @@ export class Logger {
 
   constructor(sessionId: string) {
     this.sessionId = sessionId;
-  }
-
-  getLogFilePath(): string | undefined {
-    return this.logFilePath;
   }
 
   private async _readLogFile(): Promise<LogEntry[]> {
@@ -103,10 +96,7 @@ export class Logger {
       return;
     }
     this.geminiDir = path.resolve(process.cwd(), GEMINI_DIR);
-    this.logFilePath = path.join(
-      this.geminiDir,
-      `${LOG_FILE_NAME_PREFIX}-${this.sessionId}.json`,
-    );
+    this.logFilePath = path.join(this.geminiDir, LOG_FILE_NAME);
     this.checkpointFilePath = path.join(this.geminiDir, CHECKPOINT_FILE_NAME);
 
     try {


### PR DESCRIPTION
This reverts commit 2dc79b3bd0f020ede1a923a9c8311058a23977b0.

We are storing previous session history in a file called logs.json and there is no other state related to these messages.  We need to now store local logs in another file to avoid breaking this feature.