### PR TITLE
Edit pass of docs/architecture.md 

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,88 +1,56 @@
 # Gemini CLI Architecture Overview
 
-This document provides a high-level overview of the Gemini CLI's architecture. Understanding the main components and their interactions can be helpful for both users and developers.
+This document provides a high-level overview of the Gemini CLI's architecture.
 
-## Core Components
+## Core components
 
-The Gemini CLI is primarily composed of two main packages, along with a suite of tools that the system utilizes:
+The Gemini CLI is primarily composed of two main packages, along with a suite of tools that can be used by the system in the course of handling command-line input:
 
-1.  **CLI Package (`packages/cli`):**
+1.  **CLI package (`packages/cli`):**
 
-    - **Purpose:** This is the user-facing component. It provides the interactive command-line interface (REPL), handles user input, displays output from Gemini, and manages the overall user experience.
-    - **Key Features:**
-      - Input processing (parsing commands, text prompts).
-      - History management.
-      - Display rendering (including Markdown, code highlighting, and tool messages).
-      - [Theme and UI customization](./cli/themes.md).
-      - Communication with the Core package.
-      - Manages user configuration settings specific to the CLI.
+    - **Purpose:** This contains the user-facing portion of the Gemini CLI, such as handling the initial user input, presenting the final output, and managing the overall user experience.
+    - **Key functions contained in the package:**
+      - [Input processing](./cli/commands.md)
+      - History management
+      - Display rendering
+      - [Theme and UI customization](./cli/themes.md)
+      - [CLI configuration settings](./cli/configuration.md)
 
-2.  **Core Package (`packages/core`):**
+2.  **Core package (`packages/core`):**
 
-    - **Purpose:** This acts as the backend for the CLI. It receives requests from the CLI, orchestrates interactions with the Gemini API, and manages the execution of available tools.
-    - **Key Features:**
-      - API client for communicating with the Google Gemini API.
-      - Prompt construction and management.
-      - Tool registration and execution logic.
-      - State management for conversations or sessions.
-      - Manages server-side configuration.
+    - **Purpose:** This acts as the backend for the Gemini CLI. It receives requests sent from `packages/cli`, orchestrates interactions with the Gemini API, and manages the execution of available tools.
+    - **Key functions contained in the package:**
+      - API client for communicating with the Google Gemini API
+      - Prompt construction and managemen
+      - Tool registration and execution logic
+      - State management for conversations or sessions
+      - Server-side configuration
 
 3.  **Tools (`packages/core/src/tools/`):**
     - **Purpose:** These are individual modules that extend the capabilities of the Gemini model, allowing it to interact with the local environment (e.g., file system, shell commands, web fetching).
-    - **Interaction:** The Core package invokes these tools based on requests from the Gemini model. The CLI then displays the results of tool execution.
+    - **Interaction:** `packages/core` invokes these tools based on requests from the Gemini model.
 
 ## Interaction Flow
 
-A typical interaction with the Gemini CLI follows this general flow:
+A typical interaction with the Gemini CLI follows this flow:
 
-1.  **User Input:** The user types a prompt or command into the CLI (`packages/cli`).
-2.  **Request to Core:** The CLI package sends the user's input to the Core package (`packages/core`).
-3.  **Core Processes Request:** The Core package:
+1.  **User input:** The user types a prompt or command into the terminal, which is managed by `packages/cli`.
+2.  **Request to core:** `packages/cli` sends the user's input to `packages/core`.
+3.  **Request processed:** The core package:
     - Constructs an appropriate prompt for the Gemini API, possibly including conversation history and available tool definitions.
     - Sends the prompt to the Gemini API.
-4.  **Gemini API Response:** The Gemini API processes the prompt and returns a response. This response might be a direct answer or a request to use one of the available tools.
-5.  **Tool Execution (if applicable):**
-    - If the Gemini API requests a tool, the Core package prepares to execute it.
-    - **User Confirmation for Potentially Impactful Tools:** If the requested tool can modify the file system (e.g., file edits, writes) or execute shell commands, the CLI (`packages/cli`) displays a confirmation prompt to the user. This prompt details the tool and its arguments, and the user must approve the execution. Read-only operations (e.g., reading files, listing directories) may not always require this explicit confirmation step.
-    - If confirmed (or if confirmation is not required for the specific tool), the Core package identifies and executes the relevant tool (e.g., `read_file`, `run_shell_command`).
-    - The tool performs its action (e.g., reads a file from the disk).
-    - The result of the tool execution is sent back to the Gemini API by the Core.
+4.  **Gemini API response:** The Gemini API processes the prompt and returns a response. This response might be a direct answer or a request to use one of the available tools.
+5.  **Tool execution (if applicable):**
+    - When the Gemini API requests a tool, the core package prepares to execute it.
+    - If the requested tool can modify the file system or execute shell commands, the user is first given details of the tool and its arguments, and the user must approve the execution.
+    - Read-only operations, such as reading files, might not require explicit user confirmation to proceed.
+    - Once confirmed, or if confirmation is not required, the core package executes the relevant action within the relevant tool, and the result is sent back to the Gemini API by the core package.
     - The Gemini API processes the tool result and generates a final response.
-6.  **Response to CLI:** The Core package sends the final response (or intermediate tool messages) back to the CLI package.
-7.  **Display to User:** The CLI package formats and displays the response to the user in the terminal.
-
-## Diagram (Conceptual)
-
-```mermaid
-graph TD
-    User[User via Terminal] -- Input --> CLI[packages/cli]
-    CLI -- Request --> Core[packages/core]
-    Core -- Prompt/ToolInfo --> GeminiAPI[Gemini API]
-    GeminiAPI -- Response/ToolCall --> Core
-    Core -- ToolDetails --> CLI
-    CLI -- UserConfirms --> Core
-    Core -- ExecuteTool --> Tools[Tools e.g., read_file, shell]
-    Tools -- ToolResult --> Core
-    Core -- FinalResponse --> CLI
-    CLI -- Output --> User
-
-    classDef userStyle fill:#FFFFFF,stroke:#333333,stroke-width:2px
-    classDef cliStyle fill:#FBBC05,stroke:#000000,stroke-width:2px
-    classDef coreStyle fill:#34A853,stroke:#000000,stroke-width:2px
-    classDef apiStyle fill:#4285F4,stroke:#3F51B5,stroke-width:2px
-    classDef toolsStyle fill:#EA4335,stroke:#000000,stroke-width:2px
-
-    class User userStyle
-    class CLI cliStyle
-    class Core coreStyle
-    class GeminiAPI apiStyle
-    class Tools toolsStyle
-```
+6.  **Response to CLI:** The core package sends the final response back to the CLI package.
+7.  **Display to user:** The CLI package formats and displays the response to the user in the terminal.
 
 ## Key Design Principles
 
-- **Modularity:** Separating the CLI (frontend) from the Core (backend) allows for independent development and potential future extensions (e.g., different frontends for the same server).
+- **Modularity:** Separating the CLI (frontend) from the Core (backend) allows for independent development and potential future extensions (e.g., different frontends for the same backend).
 - **Extensibility:** The tool system is designed to be extensible, allowing new capabilities to be added.
-- **User Experience:** The CLI focuses on providing a rich and interactive terminal experience.
-
-This overview should provide a foundational understanding of the Gemini CLI's architecture. For more detailed information, refer to the specific documentation for each package and the development guides.
+- **User experience:** The CLI focuses on providing a rich and interactive terminal experience.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ The Gemini CLI is primarily composed of two main packages, along with a suite of
     - **Purpose:** This acts as the backend for the Gemini CLI. It receives requests sent from `packages/cli`, orchestrates interactions with the Gemini API, and manages the execution of available tools.
     - **Key functions contained in the package:**
       - API client for communicating with the Google Gemini API
-      - Prompt construction and managemen
+      - Prompt construction and management
       - Tool registration and execution logic
       - State management for conversations or sessions
       - Server-side configuration


### PR DESCRIPTION
Make a pass through the docs/archtiecture.md file to hopefully improve readability and conciseness.

Notably, I've proposed axing the conceptual diagram, since as currently presented it's not very comprehensible. I think that a diagram could have value here, but it would need a fair amount of tweaking, and I'm not familiar with the syntax being used.