### PR TITLE
Added sandbox error hint when MCP servers fail to launch in sandbox mode

### DIFF
--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -223,10 +223,13 @@ async function connectAndDiscover(
       // Exclude args and env which may contain sensitive data
     };
 
-    console.error(
+    let errorString =
       `failed to start or connect to MCP server '${mcpServerName}' ` +
-        `${JSON.stringify(safeConfig)}; \n${error}`,
-    );
+      `${JSON.stringify(safeConfig)}; \n${error}`;
+    if (process.env.SANDBOX) {
+      errorString += `\nMake sure it is available in the sandbox`;
+    }
+    console.error(errorString);
     // Update status to disconnected
     updateMCPServerStatus(mcpServerName, MCPServerStatus.DISCONNECTED);
     return;


### PR DESCRIPTION
Adding extra error context when sandbox is enabled and MCP servers fail.

As a user I had half-expected the MCP tools to automatically be plumbed into a sandbox, so this extra hint just makes it a bit clearer to users when they first see the failure.