### PR TITLE
Ignore dot files on @-completion.

### DIFF
--- a/packages/cli/src/ui/hooks/useCompletion.integration.test.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.integration.test.ts
@@ -241,7 +241,7 @@ describe('useCompletion git-aware filtering integration', () => {
 
     expect(mockFileDiscoveryService.glob).toHaveBeenCalledWith('**/s*', {
       cwd: testCwd,
-      dot: true,
+      dot: false,
     });
     expect(fs.readdir).not.toHaveBeenCalled(); // Ensure glob is used instead of readdir
     expect(result.current.suggestions).toEqual([

--- a/packages/cli/src/ui/hooks/useCompletion.integration.test.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.integration.test.ts
@@ -249,4 +249,32 @@ describe('useCompletion git-aware filtering integration', () => {
       { label: 'src/index.ts', value: 'src/index.ts' },
     ]);
   });
+
+  it('should include dotfiles in glob search when input starts with a dot', async () => {
+    const globResults = [
+      `${testCwd}/.env`,
+      `${testCwd}/.gitignore`,
+      `${testCwd}/src/index.ts`,
+    ];
+    mockFileDiscoveryService.glob.mockResolvedValue(globResults);
+
+    const { result } = renderHook(() =>
+      useCompletion('@.', testCwd, true, slashCommands, mockConfig),
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    });
+
+    expect(mockFileDiscoveryService.glob).toHaveBeenCalledWith('**/.*', {
+      cwd: testCwd,
+      dot: true,
+    });
+    expect(fs.readdir).not.toHaveBeenCalled();
+    expect(result.current.suggestions).toEqual([
+      { label: '.env', value: '.env' },
+      { label: '.gitignore', value: '.gitignore' },
+      { label: 'src/index.ts', value: 'src/index.ts' },
+    ]);
+  });
 });

--- a/packages/cli/src/ui/hooks/useCompletion.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.ts
@@ -210,6 +210,11 @@ export function useCompletion(
             path.join(startDir, entry.name),
           );
 
+          // Conditionally ignore dotfiles
+          if (!searchPrefix.startsWith('.') && entry.name.startsWith('.')) {
+            continue;
+          }
+
           // Check if this entry should be ignored by git-aware filtering
           if (
             fileDiscovery &&
@@ -260,7 +265,7 @@ export function useCompletion(
       const globPattern = `**/${searchPrefix}*`;
       const files = await fileDiscoveryService.glob(globPattern, {
         cwd,
-        dot: true,
+        dot: searchPrefix.startsWith('.'),
       });
 
       const suggestions: Suggestion[] = files
@@ -309,6 +314,10 @@ export function useCompletion(
           // Filter entries using git-aware filtering
           const filteredEntries = [];
           for (const entry of entries) {
+            // Conditionally ignore dotfiles
+            if (!prefix.startsWith('.') && entry.name.startsWith('.')) {
+              continue;
+            }
             if (!entry.name.toLowerCase().startsWith(lowerPrefix)) continue;
 
             const relativePath = path.relative(


### PR DESCRIPTION
This change elides dot files in two places:

- When typing `@` and returning the current directory contents.
- When typing `@{search prefix}` and filtering all files.

It does display . files if the user explicitly prefixes the search string with a `.`.

Fixes issue #977.