### PR TITLE
Convert CCPA requests to proper format

### DIFF
--- a/packages/core/src/code_assist/ccpaServer.ts
+++ b/packages/core/src/code_assist/ccpaServer.ts
@@ -27,7 +27,6 @@ import { PassThrough } from 'node:stream';
 // TODO: Use production endpoint once it supports our methods.
 export const CCPA_ENDPOINT =
   'https://staging-cloudcode-pa.sandbox.googleapis.com';
-// export const CCPA_ENDPOINT = 'http://localhost:9999';
 export const CCPA_API_VERSION = 'v1internal';
 
 export class CcpaServer implements ContentGenerator {

--- a/packages/core/src/code_assist/ccpaServer.ts
+++ b/packages/core/src/code_assist/ccpaServer.ts
@@ -23,6 +23,8 @@ import { Readable } from 'stream';
 import * as readline from 'readline';
 import type { ReadableStream } from 'node:stream/web';
 import { ContentGenerator } from '../core/contentGenerator.js';
+import {toVertexRequest} from './converter.js';
+
 
 // TODO: Use production endpoint once it supports our methods.
 export const CCPA_ENDPOINT =
@@ -40,7 +42,7 @@ export class CcpaServer implements ContentGenerator {
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
     return await this.streamEndpoint<GenerateContentResponse>(
       'streamGenerateContent',
-      req,
+      toVertexRequest(req),
     );
   }
 
@@ -49,7 +51,7 @@ export class CcpaServer implements ContentGenerator {
   ): Promise<GenerateContentResponse> {
     return await this.callEndpoint<GenerateContentResponse>(
       'generateContent',
-      req,
+      toVertexRequest(req),
     );
   }
 

--- a/packages/core/src/code_assist/converter.test.ts
+++ b/packages/core/src/code_assist/converter.test.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toCcpaRequest, fromCcpaResponse, CcpaResponse } from './converter.js';
+import {
+  GenerateContentParameters,
+  GenerateContentResponse,
+  FinishReason,
+  BlockedReason,
+} from '@google/genai';
+
+describe('converter', () => {
+  describe('toCcpaRequest', () => {
+    it('should convert a simple request with project', () => {
+      const genaiReq: GenerateContentParameters = {
+        model: 'gemini-pro',
+        contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
+      };
+      const ccpaReq = toCcpaRequest(genaiReq, 'my-project');
+      expect(ccpaReq).toEqual({
+        model: 'gemini-pro',
+        project: 'my-project',
+        request: {
+          contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
+          systemInstruction: undefined,
+          cachedContent: undefined,
+          tools: undefined,
+          toolConfig: undefined,
+          labels: undefined,
+          safetySettings: undefined,
+          generationConfig: undefined,
+        },
+      });
+    });
+
+    it('should convert a request without a project', () => {
+      const genaiReq: GenerateContentParameters = {
+        model: 'gemini-pro',
+        contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
+      };
+      const ccpaReq = toCcpaRequest(genaiReq);
+      expect(ccpaReq).toEqual({
+        model: 'gemini-pro',
+        project: undefined,
+        request: {
+          contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
+          systemInstruction: undefined,
+          cachedContent: undefined,
+          tools: undefined,
+          toolConfig: undefined,
+          labels: undefined,
+          safetySettings: undefined,
+          generationConfig: undefined,
+        },
+      });
+    });
+
+    it('should handle string content', () => {
+      const genaiReq: GenerateContentParameters = {
+        model: 'gemini-pro',
+        contents: 'Hello',
+      };
+      const ccpaReq = toCcpaRequest(genaiReq);
+      expect(ccpaReq.request.contents).toEqual([
+        { role: 'user', parts: [{ text: 'Hello' }] },
+      ]);
+    });
+
+    it('should handle Part[] content', () => {
+      const genaiReq: GenerateContentParameters = {
+        model: 'gemini-pro',
+        contents: [{ text: 'Hello' }, { text: 'World' }],
+      };
+      const ccpaReq = toCcpaRequest(genaiReq);
+      expect(ccpaReq.request.contents).toEqual([
+        { role: 'user', parts: [{ text: 'Hello' }] },
+        { role: 'user', parts: [{ text: 'World' }] },
+      ]);
+    });
+
+    it('should handle system instructions', () => {
+      const genaiReq: GenerateContentParameters = {
+        model: 'gemini-pro',
+        contents: 'Hello',
+        config: {
+          systemInstruction: 'You are a helpful assistant.',
+        },
+      };
+      const ccpaReq = toCcpaRequest(genaiReq);
+      expect(ccpaReq.request.systemInstruction).toEqual({
+        role: 'user',
+        parts: [{ text: 'You are a helpful assistant.' }],
+      });
+    });
+
+    it('should handle generation config', () => {
+      const genaiReq: GenerateContentParameters = {
+        model: 'gemini-pro',
+        contents: 'Hello',
+        config: {
+          temperature: 0.8,
+          topK: 40,
+        },
+      };
+      const ccpaReq = toCcpaRequest(genaiReq);
+      expect(ccpaReq.request.generationConfig).toEqual({
+        temperature: 0.8,
+        topK: 40,
+      });
+    });
+
+    it('should handle all generation config fields', () => {
+      const genaiReq: GenerateContentParameters = {
+        model: 'gemini-pro',
+        contents: 'Hello',
+        config: {
+          temperature: 0.1,
+          topP: 0.2,
+          topK: 3,
+          candidateCount: 4,
+          maxOutputTokens: 5,
+          stopSequences: ['a'],
+          responseLogprobs: true,
+          logprobs: 6,
+          presencePenalty: 0.7,
+          frequencyPenalty: 0.8,
+          seed: 9,
+          responseMimeType: 'application/json',
+        },
+      };
+      const ccpaReq = toCcpaRequest(genaiReq);
+      expect(ccpaReq.request.generationConfig).toEqual({
+        temperature: 0.1,
+        topP: 0.2,
+        topK: 3,
+        candidateCount: 4,
+        maxOutputTokens: 5,
+        stopSequences: ['a'],
+        responseLogprobs: true,
+        logprobs: 6,
+        presencePenalty: 0.7,
+        frequencyPenalty: 0.8,
+        seed: 9,
+        responseMimeType: 'application/json',
+      });
+    });
+  });
+
+  describe('fromCcpaResponse', () => {
+    it('should convert a simple response', () => {
+      const ccpaRes: CcpaResponse = {
+        response: {
+          candidates: [
+            {
+              index: 0,
+              content: {
+                role: 'model',
+                parts: [{ text: 'Hi there!' }],
+              },
+              finishReason: FinishReason.STOP,
+              safetyRatings: [],
+            },
+          ],
+        },
+      };
+      const genaiRes = fromCcpaResponse(ccpaRes);
+      expect(genaiRes).toBeInstanceOf(GenerateContentResponse);
+      expect(genaiRes.candidates).toEqual(ccpaRes.response.candidates);
+    });
+
+    it('should handle prompt feedback and usage metadata', () => {
+      const ccpaRes: CcpaResponse = {
+        response: {
+          candidates: [],
+          promptFeedback: {
+            blockReason: BlockedReason.SAFETY,
+            safetyRatings: [],
+          },
+          usageMetadata: {
+            promptTokenCount: 10,
+            candidatesTokenCount: 20,
+            totalTokenCount: 30,
+          },
+        },
+      };
+      const genaiRes = fromCcpaResponse(ccpaRes);
+      expect(genaiRes.promptFeedback).toEqual(ccpaRes.response.promptFeedback);
+      expect(genaiRes.usageMetadata).toEqual(ccpaRes.response.usageMetadata);
+    });
+
+    it('should handle automatic function calling history', () => {
+      const ccpaRes: CcpaResponse = {
+        response: {
+          candidates: [],
+          automaticFunctionCallingHistory: [
+            {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'test_function',
+                    args: {
+                      foo: 'bar',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+      const genaiRes = fromCcpaResponse(ccpaRes);
+      expect(genaiRes.automaticFunctionCallingHistory).toEqual(
+        ccpaRes.response.automaticFunctionCallingHistory,
+      );
+    });
+  });
+});

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Content,
+  ContentListUnion,
+  ContentUnion,
+  GenerateContentConfig,
+  GenerateContentParameters,
+  GenerationConfigRoutingConfig,
+  MediaResolution,
+  ModelSelectionConfig,
+  Part,
+  SafetySetting,
+  PartUnion,
+  SchemaUnion,
+  SpeechConfigUnion,
+  ThinkingConfig,
+  ToolListUnion,
+  ToolConfig,
+} from '@google/genai';
+
+declare interface VertexRequest {
+  model: string;
+  contents: Content[];
+  systemInstructions?: Content;
+  cachedContent?: string;
+  tools?: ToolListUnion;
+  toolConfig?: ToolConfig;
+  labels?: Record<string, string>
+  safetySettings?: SafetySetting[];
+  generationConfig: VertexGenerationConfig;
+}
+
+declare interface VertexGenerationConfig {
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  candidateCount?: number;
+  maxOutputTokens?: number;
+  stopSequences?: string[];
+  responseLogprobs?: boolean;
+  logprobs?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  responseMimeType?: string;
+  responseSchema?: SchemaUnion;
+  routingConfig?: GenerationConfigRoutingConfig;
+  modelSelectionConfig?: ModelSelectionConfig;
+  responseModalities?: string[];
+  mediaResolution?: MediaResolution;
+  speechConfig?: SpeechConfigUnion;
+  audioTimestamp?: boolean;
+  thinkingConfig?: ThinkingConfig;
+}
+
+export function toVertexRequest(req: GenerateContentParameters): VertexRequest {
+  return {
+    model: req.model,
+    contents: toVertexContents(req.contents),
+    systemInstructions: maybeToVertexContent(req.config?.systemInstruction),
+    cachedContent: req.config?.cachedContent,
+    tools: req.config?.tools,
+    toolConfig: req.config?.toolConfig,
+    labels: req.config?.labels,
+    safetySettings: req.config?.safetySettings,
+    generationConfig: toVertexGenerationConfig(req.config),
+  };
+}
+
+function toVertexContents(contents: ContentListUnion): Content[] {
+  if (Array.isArray(contents)) {
+    // it's a Content[] or a PartsUnion[]
+    return contents.map(toVertexContent);
+  }
+  // it's a Content or a PartsUnion
+  return [toVertexContent(contents)];
+}
+
+function maybeToVertexContent(content?: ContentUnion): Content | undefined {
+  if (!content) {
+    return undefined;
+  }
+  return toVertexContent(content);
+}
+
+function toVertexContent(content: ContentUnion): Content {
+  if (Array.isArray(content)) {
+    // it's a PartsUnion[]
+    return {
+      role: 'user',
+      parts: toVertexParts(content),
+    };
+  }
+  if (typeof content === 'string') {
+    // it's a string
+    return {
+      role: 'user',
+      parts: [{ text: content }],
+    };
+  }
+  if ('parts' in content) {
+    // it's a Content
+    return content;
+  }
+  // it's a Part
+  return {
+    role: 'user',
+    parts: [content as Part],
+  };
+}
+
+function toVertexParts(parts: PartUnion[]): Part[] {
+  return parts.map(toVertexPart);
+}
+
+function toVertexPart(part: PartUnion): Part {
+  if (typeof part === 'string') {
+    // it's a string
+    return { text: part };
+  }
+  return part;
+}
+
+function toVertexGenerationConfig(
+  config?: GenerateContentConfig,
+): VertexGenerationConfig {
+  if (!config) {
+    return {};
+  }
+  return {
+    temperature: config.temperature,
+    topP: config.topP,
+    topK: config.topK,
+    candidateCount: config.candidateCount,
+    maxOutputTokens: config.maxOutputTokens,
+    stopSequences: config.stopSequences,
+    responseLogprobs: config.responseLogprobs,
+    logprobs: config.logprobs,
+    presencePenalty: config.presencePenalty,
+    frequencyPenalty: config.frequencyPenalty,
+    seed: config.seed,
+    responseMimeType: config.responseMimeType,
+    responseSchema: config.responseSchema,
+    routingConfig: config.routingConfig,
+    modelSelectionConfig: config.modelSelectionConfig,
+    responseModalities: config.responseModalities,
+    mediaResolution: config.mediaResolution,
+    speechConfig: config.speechConfig,
+    audioTimestamp: config.audioTimestamp,
+    thinkingConfig: config.thinkingConfig,
+  };
+}

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -24,9 +24,8 @@ import {
 } from '@google/genai';
 
 declare interface VertexRequest {
-  model: string;
   contents: Content[];
-  systemInstructions?: Content;
+  systemInstruction?: Content;
   cachedContent?: string;
   tools?: ToolListUnion;
   toolConfig?: ToolConfig;
@@ -60,9 +59,8 @@ declare interface VertexGenerationConfig {
 
 export function toVertexRequest(req: GenerateContentParameters): VertexRequest {
   return {
-    model: req.model,
     contents: toVertexContents(req.contents),
-    systemInstructions: maybeToVertexContent(req.config?.systemInstruction),
+    systemInstruction: maybeToVertexContent(req.config?.systemInstruction),
     cachedContent: req.config?.cachedContent,
     tools: req.config?.tools,
     toolConfig: req.config?.toolConfig,

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -10,9 +10,13 @@ import {
   ContentUnion,
   GenerateContentConfig,
   GenerateContentParameters,
+  GenerateContentResponse,
   GenerationConfigRoutingConfig,
   MediaResolution,
+  Candidate,
   ModelSelectionConfig,
+  GenerateContentResponsePromptFeedback,
+  GenerateContentResponseUsageMetadata,
   Part,
   SafetySetting,
   PartUnion,
@@ -56,6 +60,40 @@ declare interface VertexGenerationConfig {
   audioTimestamp?: boolean;
   thinkingConfig?: ThinkingConfig;
 }
+
+declare interface VertexResponse {
+  candidates: Candidate[];
+  automaticFunctionCallingHistory?: Content[];
+  promptFeedback?: GenerateContentResponsePromptFeedback;
+  usageMetadata?: GenerateContentResponseUsageMetadata;
+}
+
+export function toCcpaRequest(req: GenerateContentParameters, project?: string): Object {
+  return {
+    model: req.model,
+    project: project,
+    request: toVertexRequest(req),
+  };
+}
+
+export function fromCcpaResponse(res: Object): GenerateContentResponse {
+  if ('response' in res) {
+    return fromVertexResponse(res.response as Object);
+  }
+  throw new Error("no response field in ccpa response");
+}
+
+
+export function fromVertexResponse(res: Object): GenerateContentResponse {
+  const vres = res as VertexResponse;
+  const resp = new GenerateContentResponse();
+  resp.candidates = vres.candidates;
+  resp.automaticFunctionCallingHistory = vres.automaticFunctionCallingHistory;
+  resp.promptFeedback = vres.promptFeedback;
+  resp.usageMetadata = vres.usageMetadata;
+  return resp;
+}
+
 
 export function toVertexRequest(req: GenerateContentParameters): VertexRequest {
   return {


### PR DESCRIPTION
CCPA uses a different format than GenAi. This adds conversion code to get it to the right format.

Note that this doesn't work against the current ccpa staging server, The changes it needs are in cl/770266927