### PR TITLE
`/ide` command placeholder

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -40,6 +40,7 @@ export interface Settings {
   telemetry?: boolean;
   enableModifyWithExternalEditors?: boolean;
   preferredEditor?: string;
+  ide?: IDESettings;
 
   // Git-aware file filtering settings
   fileFiltering?: {
@@ -51,6 +52,23 @@ export interface Settings {
   hideWindowTitle?: boolean;
 
   // Add other settings here.
+  enableIDE?: boolean;
+}
+
+export interface IDECapabilities {
+  // The IDE supports opening a file and selecting a range.
+  openFile?: boolean;
+}
+
+export interface IDESettings {
+  // Path to the IDE binary.
+  path?: string;
+  // The extension is installed.
+  extensionInstalled?: boolean;
+  // The port the MCP server is running on.
+  mcpPort?: number;
+  // The capabilities of the IDE.
+  capabilities?: IDECapabilities;
 }
 
 export interface SettingsError {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -54,6 +54,7 @@ import { useLogger } from './hooks/useLogger.js';
 import { StreamingContext } from './contexts/StreamingContext.js';
 import { SessionStatsProvider } from './contexts/SessionContext.js';
 import { useGitBranchName } from './hooks/useGitBranchName.js';
+import { ConnectIDEDialog } from './components/ConnectIDEDialog.js';
 
 const CTRL_C_PROMPT_DURATION_MS = 1000;
 
@@ -97,7 +98,12 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   const [quittingMessages, setQuittingMessages] = useState<
     HistoryItem[] | null
   >(null);
+  const [isConnectIDEDialogOpen, setIsConnectIDEDialogOpen] = useState(false);
   const ctrlCTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const openConnectIDEDialog = useCallback(() => {
+    setIsConnectIDEDialogOpen(true);
+  }, []);
 
   const errorCount = useMemo(
     () => consoleMessages.filter((msg) => msg.type === 'error').length,
@@ -166,6 +172,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
 
   const { handleSlashCommand, slashCommands } = useSlashCommandProcessor(
     config,
+    settings,
     history,
     addItem,
     clearItems,
@@ -175,6 +182,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     setDebugMessage,
     openThemeDialog,
     openEditorDialog,
+    openConnectIDEDialog,
     performMemoryRefresh,
     toggleCorgiMode,
     showToolDescriptions,
@@ -482,6 +490,8 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
                 onExit={exitEditorDialog}
               />
             </Box>
+          ) : isConnectIDEDialogOpen ? (
+            <ConnectIDEDialog onExit={() => setIsConnectIDEDialogOpen(false)} />
           ) : (
             <>
               <LoadingIndicator

--- a/packages/cli/src/ui/components/ConnectIDEDialog.tsx
+++ b/packages/cli/src/ui/components/ConnectIDEDialog.tsx
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Text, useInput } from 'ink';
+import { useCallback } from 'react';
+import { Colors } from '../colors.js';
+
+interface ConnectIDEDialogProps {
+  onExit: () => void;
+}
+
+export const ConnectIDEDialog = ({ onExit }: ConnectIDEDialogProps) => {
+  useInput(
+    useCallback(() => {
+      onExit();
+    }, [onExit]),
+  );
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={Colors.AccentBlue}
+      paddingX={1}
+      flexDirection="column"
+    >
+      <Box marginBottom={1}>
+        <Text bold>Connect IDE</Text>
+      </Box>
+      <Text>Press any key to exit.</Text>
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -64,6 +64,7 @@ import {
   getMCPDiscoveryState,
 } from '@gemini-cli/core';
 import { useSessionStats } from '../contexts/SessionContext.js';
+import { LoadedSettings } from '../../config/settings.js';
 
 vi.mock('@gemini-code/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@gemini-code/core')>();
@@ -98,6 +99,7 @@ describe('useSlashCommandProcessor', () => {
   let mockOnDebugMessage: ReturnType<typeof vi.fn>;
   let mockOpenThemeDialog: ReturnType<typeof vi.fn>;
   let mockOpenEditorDialog: ReturnType<typeof vi.fn>;
+  let mockOpenConnectIDEDialog: ReturnType<typeof vi.fn>;
   let mockPerformMemoryRefresh: ReturnType<typeof vi.fn>;
   let mockSetQuittingMessages: ReturnType<typeof vi.fn>;
   let mockConfig: Config;
@@ -113,6 +115,7 @@ describe('useSlashCommandProcessor', () => {
     mockOnDebugMessage = vi.fn();
     mockOpenThemeDialog = vi.fn();
     mockOpenEditorDialog = vi.fn();
+    mockOpenConnectIDEDialog = vi.fn();
     mockPerformMemoryRefresh = vi.fn().mockResolvedValue(undefined);
     mockSetQuittingMessages = vi.fn();
     mockConfig = {
@@ -149,6 +152,7 @@ describe('useSlashCommandProcessor', () => {
     const { result } = renderHook(() =>
       useSlashCommandProcessor(
         mockConfig,
+        { merged: { enableIDE: false } } as LoadedSettings,
         [],
         mockAddItem,
         mockClearItems,
@@ -158,6 +162,7 @@ describe('useSlashCommandProcessor', () => {
         mockOnDebugMessage,
         mockOpenThemeDialog,
         mockOpenEditorDialog,
+        mockOpenConnectIDEDialog,
         mockPerformMemoryRefresh,
         mockCorgiMode,
         showToolDescriptions,

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -649,7 +649,7 @@ Add any other context about the problem here.
     if (settings.merged.enableIDE) {
       commands.push({
         name: 'ide',
-        description: 'Connect to a supported IDE',
+        description: 'connect to a supported IDE',
         action: (_mainCommand, _subCommand, _args) => {
           openConnectIDEDialog();
         },

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -29,8 +29,9 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { createShowMemoryAction } from './useShowMemoryCommand.js';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
-import { formatDuration, formatMemoryUsage } from '../utils/formatters.js';
 import { getCliVersion } from '../../utils/version.js';
+import { LoadedSettings } from '../../config/settings.js';
+import { formatDuration, formatMemoryUsage } from '../utils/formatters.js';
 
 export interface SlashCommandActionReturn {
   shouldScheduleTool?: boolean;
@@ -58,6 +59,7 @@ export interface SlashCommand {
  */
 export const useSlashCommandProcessor = (
   config: Config | null,
+  settings: LoadedSettings,
   history: HistoryItem[],
   addItem: UseHistoryManagerReturn['addItem'],
   clearItems: UseHistoryManagerReturn['clearItems'],
@@ -67,6 +69,7 @@ export const useSlashCommandProcessor = (
   onDebugMessage: (message: string) => void,
   openThemeDialog: () => void,
   openEditorDialog: () => void,
+  openConnectIDEDialog: () => void,
   performMemoryRefresh: () => Promise<void>,
   toggleCorgiMode: () => void,
   showToolDescriptions: boolean = false,
@@ -643,6 +646,16 @@ Add any other context about the problem here.
       },
     ];
 
+    if (settings.merged.enableIDE) {
+      commands.push({
+        name: 'ide',
+        description: 'Connect to a supported IDE',
+        action: (_mainCommand, _subCommand, _args) => {
+          openConnectIDEDialog();
+        },
+      });
+    }
+
     if (config?.getCheckpointEnabled()) {
       commands.push({
         name: 'restore',
@@ -754,6 +767,7 @@ Add any other context about the problem here.
     refreshStatic,
     openThemeDialog,
     openEditorDialog,
+    openConnectIDEDialog,
     clearItems,
     performMemoryRefresh,
     showMemoryAction,
@@ -767,6 +781,7 @@ Add any other context about the problem here.
     loadHistory,
     addItem,
     setQuittingMessages,
+    settings.merged.enableIDE,
   ]);
 
   const handleSlashCommand = useCallback(


### PR DESCRIPTION
Implements the slash command that's hidden behind `enableIDE` in `settings.json`.

<img width="587" alt="image" src="https://github.com/user-attachments/assets/aec1fcbb-6719-4c0b-98f7-2860e5c5b74c" />

<img width="584" alt="image" src="https://github.com/user-attachments/assets/ce04fa61-91e2-49c3-bc96-0e3708bfdaf2" />

<img width="581" alt="image" src="https://github.com/user-attachments/assets/b48ba521-4f56-435c-b47b-a54688ae0d67" />


