### PR TITLE
bug: only show tool tokens if > 0

### DIFF
--- a/packages/cli/src/ui/components/Stats.test.tsx
+++ b/packages/cli/src/ui/components/Stats.test.tsx
@@ -66,6 +66,17 @@ describe('<StatsColumn />', () => {
     );
     expect(lastFrame()).toMatchSnapshot();
   });
+
+  it('hides the tool use row when there are no tool use tokens', () => {
+    const statsWithNoToolUse: FormattedStats = {
+      ...mockStats,
+      toolUseTokens: 0,
+    };
+    const { lastFrame } = render(
+      <StatsColumn title="Test Stats" stats={statsWithNoToolUse} />,
+    );
+    expect(lastFrame()).not.toContain('Tool Use Tokens');
+  });
 });
 
 describe('<DurationColumn />', () => {

--- a/packages/cli/src/ui/components/Stats.tsx
+++ b/packages/cli/src/ui/components/Stats.tsx
@@ -66,10 +66,12 @@ export const StatsColumn: React.FC<{
           label="Output Tokens"
           value={stats.outputTokens.toLocaleString()}
         />
-        <StatRow
-          label="Tool Use Tokens"
-          value={stats.toolUseTokens.toLocaleString()}
-        />
+        {stats.toolUseTokens > 0 && (
+          <StatRow
+            label="Tool Use Tokens"
+            value={stats.toolUseTokens.toLocaleString()}
+          />
+        )}
         <StatRow
           label="Thoughts Tokens"
           value={stats.thoughtsTokens.toLocaleString()}

--- a/packages/cli/src/ui/components/__snapshots__/SessionSummaryDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SessionSummaryDisplay.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`<SessionSummaryDisplay /> > renders zero state correctly 1`] = `
 │                                 │
 │  Input Tokens             0     │
 │  Output Tokens            0     │
-│  Tool Use Tokens          0     │
 │  Thoughts Tokens          0     │
 │  Cached Tokens            0     │
 │  ──────────────────────────     │

--- a/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`<StatsDisplay /> > renders zero state correctly 1`] = `
 │                                                                                                  │
 │  Input Tokens                                0    Input Tokens                                0  │
 │  Output Tokens                               0    Output Tokens                               0  │
-│  Tool Use Tokens                             0    Tool Use Tokens                             0  │
 │  Thoughts Tokens                             0    Thoughts Tokens                             0  │
 │  Cached Tokens                               0    Cached Tokens                               0  │
 │  ─────────────────────────────────────────────    ─────────────────────────────────────────────  │


### PR DESCRIPTION
Currently, it appears that tool usage (it terms of GC) is not adequately portrayed by the tool token count field in the usage metadata  in the response from the Gemini API. 

Thus, even when GC appears to use tools like `readFile` and `writeFile`, the stats shown in `/stats` and `/quit` ALWAYS show `0` for tool token counts. 

This PR adds a conditional that hides this row unless there is something returned in the API response. 

A good followup would be to understand why tools are not being counted here and what we can do to make this a more useful stat for users.