### PR TITLE
`shift+enter` creates a new line, `enter` still submits the command

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -292,10 +292,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         console.log('[InputPromptCombined] event', { input, key });
       }
 
-      // Ctrl+Enter for newline, Enter for submit
+      // Shift+Enter for newline, Enter for submit
       if (key.return) {
-        if (key.ctrl) {
-          // Ctrl+Enter for newline
+        if (key.shift) {
+          // Shift+Enter for newline
           buffer.newline();
         } else {
           // Enter for submit


### PR DESCRIPTION
For interacting with LLMs, whether through Gemini web app, ChatGPT, Claude Code, etc, `shift+enter` creates a new line and `enter` submits the prompt.

This has been a major pain point, so fixing it here.