### PR TITLE
Have @ pass through images and other Part objects

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -240,8 +240,12 @@ describe('handleAtCommand', () => {
     // If it were to return actual image Part, the test and handling would be different.
     // Current implementation of read_many_files for images returns base64 in text.
     const imageFileTextContent = '[base64 image data for path/to/image.png]';
+    const imagePart = {
+      mimeType: 'image/png',
+      inlineData: imageFileTextContent,
+    };
     mockReadManyFilesExecute.mockResolvedValue({
-      llmContent: [`--- ${imagePath} ---\n\n${imageFileTextContent}\n\n`],
+      llmContent: [imagePart],
       returnDisplay: 'Read 1 image.',
     });
 
@@ -256,8 +260,7 @@ describe('handleAtCommand', () => {
     expect(result.processedQuery).toEqual([
       { text: `@${imagePath}` },
       { text: '\n--- Content from referenced files ---' },
-      { text: `\nContent from @${imagePath}:\n` },
-      { text: imageFileTextContent },
+      imagePart,
       { text: '\n--- End of content ---' },
     ]);
     expect(result.shouldProceed).toBe(true);

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -381,7 +381,12 @@ export async function handleAtCommand({
               text: `\nContent from @${filePathSpecInContent}:\n`,
             });
             processedQueryParts.push({ text: fileActualContent });
+          } else {
+            processedQueryParts.push({ text: part });
           }
+        } else {
+          // part is a Part object.
+          processedQueryParts.push(part);
         }
       }
       processedQueryParts.push({ text: '\n--- End of content ---' });


### PR DESCRIPTION
![Screenshot 2025-06-12 at 3 33 43 PM](https://github.com/user-attachments/assets/00e79163-8c99-49c8-a542-003620a9cc58)
