### PR TITLE
refactor: Use default centralized Flash & Pro models everywhere

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -15,6 +15,8 @@ import {
   ApprovalMode,
   ContentGeneratorConfig,
   GEMINI_CONFIG_DIR as GEMINI_DIR,
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_GEMINI_EMBEDDING_MODEL,
 } from '@gemini-cli/core';
 import { Settings } from './settings.js';
 import { getEffectiveModel } from '../utils/modelCheck.js';
@@ -33,10 +35,6 @@ const logger = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: (...args: any[]) => console.error('[ERROR]', ...args),
 };
-
-export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro-preview-06-05';
-export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash-preview-05-20';
-export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';
 
 interface CliArgs {
   model: string | undefined;

--- a/packages/cli/src/utils/modelCheck.test.ts
+++ b/packages/cli/src/utils/modelCheck.test.ts
@@ -9,7 +9,7 @@ import { getEffectiveModel } from './modelCheck.js';
 import {
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
-} from '../config/config.js';
+} from '@gemini-cli/core';
 
 // Mock global fetch
 global.fetch = vi.fn();

--- a/packages/cli/src/utils/modelCheck.ts
+++ b/packages/cli/src/utils/modelCheck.ts
@@ -7,7 +7,7 @@
 import {
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
-} from '../config/config.js';
+} from '@gemini-cli/core';
 
 /**
  * Checks if the default "pro" model is rate-limited and returns a fallback "flash"

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -5,3 +5,8 @@
  */
 
 export * from './src/index.js';
+export {
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_GEMINI_FLASH_MODEL,
+  DEFAULT_GEMINI_EMBEDDING_MODEL,
+} from './src/config/models.js';

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -24,6 +24,7 @@ import { GEMINI_CONFIG_DIR as GEMINI_DIR } from '../tools/memoryTool.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { GitService } from '../services/gitService.js';
 import { initializeTelemetry } from '../telemetry/index.js';
+import { DEFAULT_GEMINI_EMBEDDING_MODEL } from './models.js';
 
 export enum ApprovalMode {
   DEFAULT = 'default',
@@ -55,7 +56,7 @@ export class MCPServerConfig {
 export interface ConfigParameters {
   sessionId: string;
   contentGeneratorConfig: ContentGeneratorConfig;
-  embeddingModel: string;
+  embeddingModel?: string;
   sandbox?: boolean | string;
   targetDir: string;
   debugMode: boolean;
@@ -121,7 +122,8 @@ export class Config {
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
     this.contentGeneratorConfig = params.contentGeneratorConfig;
-    this.embeddingModel = params.embeddingModel;
+    this.embeddingModel =
+      params.embeddingModel ?? DEFAULT_GEMINI_EMBEDDING_MODEL;
     this.sandbox = params.sandbox;
     this.targetDir = path.resolve(params.targetDir);
     this.debugMode = params.debugMode;

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro-preview-06-05';
+export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash-preview-05-20';
+export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -18,6 +18,7 @@ import { GeminiChat } from './geminiChat.js';
 import { Config } from '../config/config.js';
 import { Turn } from './turn.js';
 import { getCoreSystemPrompt } from './prompts.js';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 
 // --- Mocks ---
 const mockChatCreateFn = vi.fn();
@@ -295,7 +296,7 @@ describe('Gemini Client (client.ts)', () => {
       await client.generateJson(contents, schema, abortSignal);
 
       expect(mockGenerateContentFn).toHaveBeenCalledWith({
-        model: 'gemini-2.0-flash',
+        model: DEFAULT_GEMINI_FLASH_MODEL,
         config: {
           abortSignal,
           systemInstruction: getCoreSystemPrompt(''),

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -31,6 +31,7 @@ import {
   createContentGenerator,
 } from './contentGenerator.js';
 import { ProxyAgent, setGlobalDispatcher } from 'undici';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 
 export class GeminiClient {
   private chat: Promise<GeminiChat>;
@@ -215,7 +216,7 @@ export class GeminiClient {
     contents: Content[],
     schema: SchemaUnion,
     abortSignal: AbortSignal,
-    model: string = 'gemini-2.0-flash',
+    model: string = DEFAULT_GEMINI_FLASH_MODEL,
     config: GenerateContentConfig = {},
   ): Promise<Record<string, unknown>> {
     const cg = await this.contentGenerator;

--- a/packages/core/src/utils/editCorrector.ts
+++ b/packages/core/src/utils/editCorrector.ts
@@ -13,8 +13,9 @@ import {
 import { GeminiClient } from '../core/client.js';
 import { EditToolParams } from '../tools/edit.js';
 import { LruCache } from './LruCache.js';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 
-const EditModel = 'gemini-2.5-flash-preview-04-17';
+const EditModel = DEFAULT_GEMINI_FLASH_MODEL;
 const EditConfig: GenerateContentConfig = {
   thinkingConfig: {
     thinkingBudget: 0,


### PR DESCRIPTION
- Move default model names to a new file in packages/core
- Update references to use the new centralized location
- This makes model configuration more consistent and easier to manage.
- Remove gemini-2.0-flash usage in favor of 2.5-flash (not supported on Titan)

Fixes https://b.corp.google.com/issues/424624952