### PR TITLE
Add a local telemetry launcher

### DIFF
--- a/docs/core/telemetry.md
+++ b/docs/core/telemetry.md
@@ -53,15 +53,7 @@ mkdir .gemini/otel
 ### Local (Automated Script)
 
 For the most straightforward local setup, use the `scripts/local_telemetry.js` script. This script automates the entire process of setting up a local telemetry pipeline, including configuring the necessary settings in your `.gemini/settings.json` file.
-
-**1. Prerequisites**
-
-Before running the script, ensure you have the following binaries installed and available in your system's `PATH`:
-
-- `otelcol-contrib`: The OpenTelemetry Collector.
-- `jaeger`: The Jaeger UI for viewing traces (version 2.7.0+ recommended).
-
-**2. How to Use It**
+The script installs `otelcol-contrib` (The OpenTelemetry Collector) and `jaeger` (The Jaeger UI for viewing traces). To use it:
 
 1.  **Run the Script**:
     Execute the script from the root of the repository:
@@ -72,9 +64,11 @@ Before running the script, ensure you have the following binaries installed and 
 
     The script will:
 
+    - Download Jaeger and OTEL if needed.
     - Start a local Jaeger instance.
     - Start an OTEL collector configured to receive data from the Gemini CLI.
     - Automatically enable telemetry in your workspace settings.
+    - On exit, disable telemetry.
 
 2.  **View Traces**:
     Open your web browser and navigate to **http://localhost:16686** to access the Jaeger UI. Here you can inspect detailed traces of Gemini CLI operations.

--- a/docs/core/telemetry.md
+++ b/docs/core/telemetry.md
@@ -50,10 +50,44 @@ Learn more about OTEL exporter standard configuration in [documentation][otel-co
 mkdir .gemini/otel
 ```
 
-### Local
+### Local (Automated Script)
 
-This is the simplest way to inspect events, metrics, and traces without any external tools.
-This setup prints all telemetry from the Gemini CLI to your terminal using a local collector.
+For the most straightforward local setup, use the `scripts/local_telemetry.js` script. This script automates the entire process of setting up a local telemetry pipeline, including configuring the necessary settings in your `.gemini/settings.json` file.
+
+**1. Prerequisites**
+
+Before running the script, ensure you have the following binaries installed and available in your system's `PATH`:
+
+- `otelcol-contrib`: The OpenTelemetry Collector.
+- `jaeger`: The Jaeger UI for viewing traces (version 2.7.0+ recommended).
+
+**2. How to Use It**
+
+1.  **Run the Script**:
+    Execute the script from the root of the repository:
+
+    ```bash
+    ./scripts/local_telemetry.js
+    ```
+
+    The script will:
+
+    - Start a local Jaeger instance.
+    - Start an OTEL collector configured to receive data from the Gemini CLI.
+    - Automatically enable telemetry in your workspace settings.
+
+2.  **View Traces**:
+    Open your web browser and navigate to **http://localhost:16686** to access the Jaeger UI. Here you can inspect detailed traces of Gemini CLI operations.
+
+3.  **Inspect Logs and Metrics**:
+    The script redirects the OTEL collector's output (which includes logs and metrics) to `.gemini/otel/collector.log`. You can monitor this file to see the raw telemetry data:
+    ```bash
+    tail -f .gemini/otel/collector.log
+    ```
+4.  **Stop the Services**:
+    Press `Ctrl+C` in the terminal where the script is running to stop the OTEL Collector and Jaeger services.
+
+### Local (Manual Setup)
 
 **1. Create a Configuration File**
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -159,9 +159,20 @@ export default tseslint.config(
     files: ['./scripts/**/*.js', 'esbuild.config.js'],
     languageOptions: {
       globals: {
+        ...globals.node,
         process: 'readonly',
         console: 'readonly',
       },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
     },
   },
   // Prettier config must be last

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -208,7 +208,8 @@ export async function loadCliConfig(
       process.env.HTTP_PROXY ||
       process.env.http_proxy,
     cwd: process.cwd(),
-    telemetryOtlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+    telemetryOtlpEndpoint:
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? settings.telemetryOtlpEndpoint,
     fileDiscoveryService: fileService,
   });
 }

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -38,6 +38,7 @@ export interface Settings {
   contextFileName?: string | string[];
   accessibility?: AccessibilitySettings;
   telemetry?: boolean;
+  telemetryOtlpEndpoint?: string;
   preferredEditor?: string;
 
   // Git-aware file filtering settings

--- a/scripts/local_telemetry.js
+++ b/scripts/local_telemetry.js
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+import path from 'path';
+import fs from 'fs';
+import net from 'net';
+import { spawn, execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const GEMINI_DIR = path.join(ROOT_DIR, '.gemini');
+const OTEL_DIR = path.join(GEMINI_DIR, 'otel');
+const OTEL_CONFIG_FILE = path.join(OTEL_DIR, 'collector-local.yaml');
+const OTEL_LOG_FILE = path.join(OTEL_DIR, 'collector.log');
+const JAEGER_LOG_FILE = path.join(OTEL_DIR, 'jaeger.log');
+const JAEGER_PORT = 16686;
+const WORKSPACE_SETTINGS_FILE = path.join(GEMINI_DIR, 'settings.json');
+const USER_SETTINGS_FILE = path.join(
+  process.env.HOME,
+  '.gemini',
+  'settings.json',
+);
+
+// This configuration is for the primary otelcol-contrib instance.
+// It receives from the CLI on 4317, exports traces to Jaeger on 14317,
+// and sends metrics/logs to the debug log.
+const OTEL_CONFIG_CONTENT = `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "localhost:4317"
+processors:
+  batch:
+    timeout: 1s
+exporters:
+  otlp:
+    endpoint: "localhost:14317"
+    tls:
+      insecure: true
+  debug:
+    verbosity: detailed
+service:
+  telemetry:
+    logs:
+      level: "debug"
+    metrics:
+      level: "none"
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+`;
+
+function fileExists(filePath) {
+  return fs.existsSync(filePath);
+}
+
+function readJsonFile(filePath) {
+  if (!fileExists(filePath)) {
+    return {};
+  }
+  const content = fs.readFileSync(filePath, 'utf-8');
+  return JSON.parse(content);
+}
+
+function writeJsonFile(filePath, data) {
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+function checkForBinary(binaryName) {
+  try {
+    execSync(`which ${binaryName}`, { stdio: 'ignore' });
+    return true;
+  } catch (error) {
+    console.error(
+      `🛑 Error: ${binaryName} not found in your PATH. Please install it.`,
+    );
+    return false;
+  }
+}
+
+function waitForPort(port, timeout = 5000) {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+    const tryConnect = () => {
+      const socket = new net.Socket();
+      socket.once('connect', () => {
+        socket.end();
+        resolve();
+      });
+      socket.once('error', (err) => {
+        if (Date.now() - startTime > timeout) {
+          reject(new Error(`Timeout waiting for port ${port} to open.`));
+        } else {
+          setTimeout(tryConnect, 500);
+        }
+      });
+      socket.connect(port, 'localhost');
+    };
+    tryConnect();
+  });
+}
+
+async function main() {
+  // 1. Check for required binaries
+  if (!checkForBinary('otelcol-contrib')) process.exit(1);
+  if (!checkForBinary('jaeger')) process.exit(1);
+
+  // 2. Kill any existing processes to ensure a clean start.
+  console.log('🧹 Cleaning up old processes and logs...');
+  try {
+    execSync('pkill -f "otelcol-contrib"');
+    console.log('✅ Stopped existing otelcol-contrib process.');
+  } catch (e) {} // eslint-disable-line no-empty
+  try {
+    execSync('pkill -f "jaeger"');
+    console.log('✅ Stopped existing jaeger process.');
+  } catch (e) {} // eslint-disable-line no-empty
+  try {
+    fs.unlinkSync(OTEL_LOG_FILE);
+    console.log('✅ Deleted old collector log.');
+  } catch (e) {
+    if (e.code !== 'ENOENT') console.error(e);
+  }
+  try {
+    fs.unlinkSync(JAEGER_LOG_FILE);
+    console.log('✅ Deleted old jaeger log.');
+  } catch (e) {
+    if (e.code !== 'ENOENT') console.error(e);
+  }
+
+  let jaegerProcess, collectorProcess;
+  let jaegerLogFd, collectorLogFd;
+
+  const cleanup = () => {
+    console.log('\n👋 Shutting down...');
+    [jaegerProcess, collectorProcess].forEach((proc) => {
+      if (proc && proc.pid) {
+        try {
+          console.log(`🛑 Stopping ${proc.spawnargs[0]} (PID: ${proc.pid})...`);
+          // Use SIGTERM for a graceful shutdown
+          process.kill(proc.pid, 'SIGTERM');
+          console.log(`✅ ${proc.spawnargs[0]} stopped.`);
+        } catch (e) {
+          // It's okay if the process is already gone.
+          if (e.code !== 'ESRCH')
+            console.error(`Error stopping ${proc.spawnargs[0]}: ${e.message}`);
+        }
+      }
+    });
+    [jaegerLogFd, collectorLogFd].forEach((fd) => {
+      if (fd)
+        try {
+          fs.closeSync(fd);
+        } catch (e) {} // eslint-disable-line no-empty
+    });
+  };
+
+  process.on('exit', cleanup);
+  process.on('SIGINT', () => process.exit(0));
+  process.on('SIGTERM', () => process.exit(0));
+  process.on('uncaughtException', (err) => {
+    console.error('Uncaught Exception:', err);
+    process.exit(1);
+  });
+
+  if (!fileExists(OTEL_DIR)) fs.mkdirSync(OTEL_DIR, { recursive: true });
+  fs.writeFileSync(OTEL_CONFIG_FILE, OTEL_CONFIG_CONTENT);
+  console.log('📄 Wrote OTEL collector config.');
+
+  const workspaceSettings = readJsonFile(WORKSPACE_SETTINGS_FILE);
+  let settingsModified = false;
+
+  if (workspaceSettings.telemetry !== true) {
+    workspaceSettings.telemetry = true;
+    settingsModified = true;
+    console.log('⚙️  Enabled telemetry in workspace settings.');
+  }
+
+  if (workspaceSettings.sandbox !== false) {
+    workspaceSettings.sandbox = false;
+    settingsModified = true;
+    console.log('✅ Disabled sandbox mode for telemetry.');
+  }
+
+  if (workspaceSettings.telemetryOtlpEndpoint !== 'http://localhost:4317') {
+    workspaceSettings.telemetryOtlpEndpoint = 'http://localhost:4317';
+    settingsModified = true;
+    console.log('🔧 Set telemetry endpoint to http://localhost:4317.');
+  }
+
+  if (settingsModified) {
+    writeJsonFile(WORKSPACE_SETTINGS_FILE, workspaceSettings);
+    console.log('✅ Workspace settings updated.');
+  } else {
+    console.log('✅ Telemetry is already configured correctly.');
+  }
+
+  // Start Jaeger
+  console.log(`🚀 Starting Jaeger service... Logs: ${JAEGER_LOG_FILE}`);
+  jaegerLogFd = fs.openSync(JAEGER_LOG_FILE, 'a');
+  // The collector is on 4317, so we move jaeger to 14317.
+  jaegerProcess = spawn(
+    'jaeger',
+    ['--set=receivers.otlp.protocols.grpc.endpoint=localhost:14317'],
+    { stdio: ['ignore', jaegerLogFd, jaegerLogFd] },
+  );
+  console.log(`⏳ Waiting for Jaeger to start (PID: ${jaegerProcess.pid})...`);
+
+  try {
+    await waitForPort(JAEGER_PORT);
+    console.log(
+      `✅ Jaeger started successfully. UI: http://localhost:${JAEGER_PORT}`,
+    );
+  } catch (error) {
+    console.error(`🛑 Error: Jaeger failed to start on port ${JAEGER_PORT}.`);
+    if (jaegerProcess && jaegerProcess.pid) {
+      process.kill(jaegerProcess.pid, 'SIGKILL');
+    }
+    if (fileExists(JAEGER_LOG_FILE)) {
+      console.error('📄 Jaeger Log Output:');
+      console.error(fs.readFileSync(JAEGER_LOG_FILE, 'utf-8'));
+    }
+    process.exit(1);
+  }
+
+  // Start the primary OTEL collector
+  console.log(`🚀 Starting OTEL collector... Logs: ${OTEL_LOG_FILE}`);
+  collectorLogFd = fs.openSync(OTEL_LOG_FILE, 'a');
+  collectorProcess = spawn('otelcol-contrib', ['--config', OTEL_CONFIG_FILE], {
+    stdio: ['ignore', collectorLogFd, collectorLogFd],
+  });
+  console.log(
+    `⏳ Waiting for OTEL collector to start (PID: ${collectorProcess.pid})...`,
+  );
+
+  try {
+    await waitForPort(4317);
+    console.log(`✅ OTEL collector started successfully.`);
+  } catch (error) {
+    console.error(`🛑 Error: OTEL collector failed to start on port 4317.`);
+    if (collectorProcess && collectorProcess.pid) {
+      process.kill(collectorProcess.pid, 'SIGKILL');
+    }
+    if (fileExists(OTEL_LOG_FILE)) {
+      console.error('📄 OTEL Collector Log Output:');
+      console.error(fs.readFileSync(OTEL_LOG_FILE, 'utf-8'));
+    }
+    process.exit(1);
+  }
+
+  [jaegerProcess, collectorProcess].forEach((proc) => {
+    proc.on('error', (err) => {
+      console.error(`${proc.spawnargs[0]} process error:`, err);
+      process.exit(1);
+    });
+  });
+
+  console.log(
+    '\n✨ Local telemetry environment is running. Press Ctrl+C to exit.',
+  );
+}
+
+main();

--- a/scripts/local_telemetry.js
+++ b/scripts/local_telemetry.js
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import path from 'path';
 import fs from 'fs';
 import net from 'net';
@@ -16,11 +23,6 @@ const OTEL_LOG_FILE = path.join(OTEL_DIR, 'collector.log');
 const JAEGER_LOG_FILE = path.join(OTEL_DIR, 'jaeger.log');
 const JAEGER_PORT = 16686;
 const WORKSPACE_SETTINGS_FILE = path.join(GEMINI_DIR, 'settings.json');
-const USER_SETTINGS_FILE = path.join(
-  process.env.HOME,
-  '.gemini',
-  'settings.json',
-);
 
 // This configuration is for the primary otelcol-contrib instance.
 // It receives from the CLI on 4317, exports traces to Jaeger on 14317,
@@ -82,7 +84,7 @@ function checkForBinary(binaryName) {
   try {
     execSync(`which ${binaryName}`, { stdio: 'ignore' });
     return true;
-  } catch (error) {
+  } catch (_) {
     console.error(
       `🛑 Error: ${binaryName} not found in your PATH. Please install it.`,
     );
@@ -99,7 +101,7 @@ function waitForPort(port, timeout = 5000) {
         socket.end();
         resolve();
       });
-      socket.once('error', (err) => {
+      socket.once('error', (_) => {
         if (Date.now() - startTime > timeout) {
           reject(new Error(`Timeout waiting for port ${port} to open.`));
         } else {
@@ -122,11 +124,11 @@ async function main() {
   try {
     execSync('pkill -f "otelcol-contrib"');
     console.log('✅ Stopped existing otelcol-contrib process.');
-  } catch (e) {} // eslint-disable-line no-empty
+  } catch (_e) {} // eslint-disable-line no-empty
   try {
     execSync('pkill -f "jaeger"');
     console.log('✅ Stopped existing jaeger process.');
-  } catch (e) {} // eslint-disable-line no-empty
+  } catch (_e) {} // eslint-disable-line no-empty
   try {
     fs.unlinkSync(OTEL_LOG_FILE);
     console.log('✅ Deleted old collector log.');
@@ -163,7 +165,7 @@ async function main() {
       if (fd)
         try {
           fs.closeSync(fd);
-        } catch (e) {} // eslint-disable-line no-empty
+        } catch (_) {} // eslint-disable-line no-empty
     });
   };
 
@@ -223,7 +225,7 @@ async function main() {
     console.log(
       `✅ Jaeger started successfully. UI: http://localhost:${JAEGER_PORT}`,
     );
-  } catch (error) {
+  } catch (_) {
     console.error(`🛑 Error: Jaeger failed to start on port ${JAEGER_PORT}.`);
     if (jaegerProcess && jaegerProcess.pid) {
       process.kill(jaegerProcess.pid, 'SIGKILL');
@@ -248,7 +250,7 @@ async function main() {
   try {
     await waitForPort(4317);
     console.log(`✅ OTEL collector started successfully.`);
-  } catch (error) {
+  } catch (_) {
     console.error(`🛑 Error: OTEL collector failed to start on port 4317.`);
     if (collectorProcess && collectorProcess.pid) {
       process.kill(collectorProcess.pid, 'SIGKILL');

--- a/scripts/local_telemetry.js
+++ b/scripts/local_telemetry.js
@@ -190,9 +190,7 @@ async function ensureBinary(
       );
     }
   } else {
-    release = getJson(
-      `https://api.github.com/repos/${repo}/releases/latest`,
-    );
+    release = getJson(`https://api.github.com/repos/${repo}/releases/latest`);
     const version = release.tag_name.startsWith('v')
       ? release.tag_name.substring(1)
       : release.tag_name;

--- a/scripts/local_telemetry.js
+++ b/scripts/local_telemetry.js
@@ -347,6 +347,15 @@ async function main() {
 
   const cleanup = () => {
     console.log('\n👋 Shutting down...');
+
+    // Restore original settings
+    const finalSettings = readJsonFile(WORKSPACE_SETTINGS_FILE);
+    delete finalSettings.telemetry;
+    delete finalSettings.telemetryOtlpEndpoint;
+    finalSettings.sandbox = originalSandboxSetting;
+    writeJsonFile(WORKSPACE_SETTINGS_FILE, finalSettings);
+    console.log('✅ Restored original telemetry and sandbox settings.');
+
     [jaegerProcess, collectorProcess].forEach((proc) => {
       if (proc && proc.pid) {
         try {
@@ -382,6 +391,7 @@ async function main() {
   console.log('📄 Wrote OTEL collector config.');
 
   const workspaceSettings = readJsonFile(WORKSPACE_SETTINGS_FILE);
+  const originalSandboxSetting = workspaceSettings.sandbox;
   let settingsModified = false;
 
   if (workspaceSettings.telemetry !== true) {
@@ -393,7 +403,7 @@ async function main() {
   if (workspaceSettings.sandbox !== false) {
     workspaceSettings.sandbox = false;
     settingsModified = true;
-    console.log('✅ Disabled sandbox mode for telemetry.');
+    console.log('✅ Disabled sandbox mode for local telemetry.');
   }
 
   if (workspaceSettings.telemetryOtlpEndpoint !== 'http://localhost:4317') {

--- a/scripts/local_telemetry.js
+++ b/scripts/local_telemetry.js
@@ -358,15 +358,16 @@ async function main() {
 
     [jaegerProcess, collectorProcess].forEach((proc) => {
       if (proc && proc.pid) {
+        const name = path.basename(proc.spawnfile);
         try {
-          console.log(`🛑 Stopping ${proc.spawnargs[0]} (PID: ${proc.pid})...`);
+          console.log(`🛑 Stopping ${name} (PID: ${proc.pid})...`);
           // Use SIGTERM for a graceful shutdown
           process.kill(proc.pid, 'SIGTERM');
-          console.log(`✅ ${proc.spawnargs[0]} stopped.`);
+          console.log(`✅ ${name} stopped.`);
         } catch (e) {
           // It's okay if the process is already gone.
           if (e.code !== 'ESRCH')
-            console.error(`Error stopping ${proc.spawnargs[0]}: ${e.message}`);
+            console.error(`Error stopping ${name}: ${e.message}`);
         }
       }
     });


### PR DESCRIPTION
Script downloads and runs the necessary tools for telemetry.

```
% ./scripts/local_telemetry.js
✅ otelcol-contrib already exists at /Users/keir/wrk/gemini-cli/.gemini/otel/bin/otelcol-contrib
✅ jaeger already exists at /Users/keir/wrk/gemini-cli/.gemini/otel/bin/jaeger
🧹 Cleaning up old processes and logs...
✅ Deleted old collector log.
✅ Deleted old jaeger log.
📄 Wrote OTEL collector config.
⚙️  Enabled telemetry in workspace settings.
🔧 Set telemetry endpoint to http://localhost:4317.
✅ Workspace settings updated.
🚀 Starting Jaeger service... Logs: /Users/keir/wrk/gemini-cli/.gemini/otel/jaeger.log
⏳ Waiting for Jaeger to start (PID: 30953)...
✅ Jaeger started successfully.
🚀 Starting OTEL collector... Logs: /Users/keir/wrk/gemini-cli/.gemini/otel/collector.log
⏳ Waiting for OTEL collector to start (PID: 30954)...
✅ OTEL collector started successfully.

✨ Local telemetry environment is running.

🔎 View traces in the Jaeger UI: http://localhost:16686

Press Ctrl+C to exit.
^C
👋 Shutting down...
✅ Restored original telemetry and sandbox settings.
🛑 Stopping jaeger (PID: 30953)...
✅ jaeger stopped.
🛑 Stopping otelcol-contrib (PID: 30954)...
✅ otelcol-contrib stopped.
```