### PR TITLE
feat: Add custom URL support for the /bug command

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -44,6 +44,18 @@ When you create a `.gemini/settings.json` file for project-specific settings, or
   - **Default:** `GEMINI.md`
   - **Example:** `"contextFileName": "AGENTS.md"`
 
+- **`bugCommand`** (object, optional):
+
+  - **Description:** Overrides the default URL for the `/bug` command.
+  - **Properties:**
+    - **`urlTemplate`** (string, required): A URL that can contain `{title}` and `{body}` placeholders.
+  - **Example:**
+    ```json
+    "bugCommand": {
+      "urlTemplate": "https://bug.example.com/new?title={title}&body={body}"
+    }
+    ```
+
 - **`fileFiltering`** (object, optional):
 
   - **Description:** Controls git-aware file filtering behavior for @ commands and file discovery tools.

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -211,6 +211,7 @@ export async function loadCliConfig(
     telemetryOtlpEndpoint:
       process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? settings.telemetryOtlpEndpoint,
     fileDiscoveryService: fileService,
+    bugCommand: settings.bugCommand,
   });
 }
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -7,7 +7,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { homedir } from 'os';
-import { MCPServerConfig, getErrorMessage } from '@gemini-cli/core';
+import {
+  MCPServerConfig,
+  getErrorMessage,
+  BugCommandSettings,
+} from '@gemini-cli/core';
 import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
 import { DefaultDark } from '../ui/themes/default.js';
@@ -40,6 +44,7 @@ export interface Settings {
   telemetry?: boolean;
   telemetryOtlpEndpoint?: string;
   preferredEditor?: string;
+  bugCommand?: BugCommandSettings;
 
   // Git-aware file filtering settings
   fileFiltering?: {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -512,13 +512,14 @@ Add any other context about the problem here.
 `;
 
           let bugReportUrl =
-            'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.md';
-          if (bugDescription) {
-            const encodedArgs = encodeURIComponent(bugDescription);
-            bugReportUrl += `&title=${encodedArgs}`;
+            'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.md&title={title}&body={body}';
+          const bugCommand = config?.getBugCommand();
+          if (bugCommand?.urlTemplate) {
+            bugReportUrl = bugCommand.urlTemplate;
           }
-          const encodedBody = encodeURIComponent(diagnosticInfo);
-          bugReportUrl += `&body=${encodedBody}`;
+          bugReportUrl = bugReportUrl
+            .replace('{title}', encodeURIComponent(bugDescription))
+            .replace('{body}', encodeURIComponent(diagnosticInfo));
 
           addMessage({
             type: MessageType.INFO,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -36,6 +36,10 @@ export interface AccessibilitySettings {
   disableLoadingPhrases?: boolean;
 }
 
+export interface BugCommandSettings {
+  urlTemplate: string;
+}
+
 export class MCPServerConfig {
   constructor(
     // For stdio transport
@@ -87,6 +91,7 @@ export interface ConfigParameters {
   proxy?: string;
   cwd: string;
   fileDiscoveryService?: FileDiscoveryService;
+  bugCommand?: BugCommandSettings;
 }
 
 export class Config {
@@ -121,6 +126,7 @@ export class Config {
   private readonly checkpoint: boolean;
   private readonly proxy: string | undefined;
   private readonly cwd: string;
+  private readonly bugCommand: BugCommandSettings | undefined;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -154,6 +160,7 @@ export class Config {
     this.proxy = params.proxy;
     this.cwd = params.cwd ?? process.cwd();
     this.fileDiscoveryService = params.fileDiscoveryService ?? null;
+    this.bugCommand = params.bugCommand;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -307,6 +314,10 @@ export class Config {
 
   getWorkingDir(): string {
     return this.cwd;
+  }
+
+  getBugCommand(): BugCommandSettings | undefined {
+    return this.bugCommand;
   }
 
   async getFileService(): Promise<FileDiscoveryService> {


### PR DESCRIPTION
This change introduces a new setting, `bugCommand.urlTemplate`, which allows users to define a custom URL for the `/bug` command.

This is useful for teams that use a bug tracker other than GitHub, as it allows them to integrate their own bug reporting workflow directly into the CLI.

The `urlTemplate` supports `{title}` and `{body}` placeholders, which are replaced with the bug title and diagnostic information respectively.

bug: b/424052604