### PR TITLE
Don't exclude config.test.ts.

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -34,31 +34,6 @@ vi.mock('@gemini-cli/core', async () => {
   return {
     ...actualServer,
     loadEnvironment: vi.fn(),
-    Config: vi.fn((params) => ({
-      // Mock the config object and its methods
-      getApiKey: () => params.contentGeneratorConfig.apiKey,
-      getModel: () => params.contentGeneratorConfig.model,
-      getSandbox: () => params.sandbox,
-      getTargetDir: () => params.targetDir,
-      getDebugMode: () => params.debugMode,
-      getQuestion: () => params.question,
-      getFullContext: () => params.fullContext,
-      getCoreTools: () => params.coreTools,
-      getExcludeTools: () => params.excludeTools,
-      getToolDiscoveryCommand: () => params.toolDiscoveryCommand,
-      getToolCallCommand: () => params.toolCallCommand,
-      getMcpServerCommand: () => params.mcpServerCommand,
-      getMcpServers: () => params.mcpServers,
-      getUserAgent: () => params.userAgent,
-      getUserMemory: () => params.userMemory,
-      getGeminiMdFileCount: () => params.geminiMdFileCount,
-      getVertexAI: () => params.contentGeneratorConfig.vertexai,
-      getShowMemoryUsage: () => params.showMemoryUsage, // Added for the test
-      getTelemetry: () => params.telemetry,
-      // Add any other methods that are called on the config object
-      setUserMemory: vi.fn(),
-      setGeminiMdFileCount: vi.fn(),
-    })),
     loadServerHierarchicalMemory: vi.fn((cwd, debug, extensionPaths) =>
       Promise.resolve({
         memoryContent: extensionPaths?.join(',') || '',
@@ -87,28 +62,28 @@ describe('loadCliConfig', () => {
   it('should set showMemoryUsage to true when --memory flag is present', async () => {
     process.argv = ['node', 'script.js', '--show_memory_usage'];
     const settings: Settings = {};
-    const config = await loadCliConfig(settings, []);
+    const config = await loadCliConfig(settings, [], [], 'test-session');
     expect(config.getShowMemoryUsage()).toBe(true);
   });
 
   it('should set showMemoryUsage to false when --memory flag is not present', async () => {
     process.argv = ['node', 'script.js'];
     const settings: Settings = {};
-    const config = await loadCliConfig(settings, []);
+    const config = await loadCliConfig(settings, [], [], 'test-session');
     expect(config.getShowMemoryUsage()).toBe(false);
   });
 
   it('should set showMemoryUsage to false by default from settings if CLI flag is not present', async () => {
     process.argv = ['node', 'script.js'];
     const settings: Settings = { showMemoryUsage: false };
-    const config = await loadCliConfig(settings, []);
+    const config = await loadCliConfig(settings, [], [], 'test-session');
     expect(config.getShowMemoryUsage()).toBe(false);
   });
 
   it('should prioritize CLI flag over settings for showMemoryUsage (CLI true, settings false)', async () => {
     process.argv = ['node', 'script.js', '--show_memory_usage'];
     const settings: Settings = { showMemoryUsage: false };
-    const config = await loadCliConfig(settings, []);
+    const config = await loadCliConfig(settings, [], [], 'test-session');
     expect(config.getShowMemoryUsage()).toBe(true);
   });
 });
@@ -132,50 +107,50 @@ describe('loadCliConfig telemetry', () => {
   it('should set telemetry to false by default when no flag or setting is present', async () => {
     process.argv = ['node', 'script.js'];
     const settings: Settings = {};
-    const config = await loadCliConfig(settings, []);
-    expect(config.getTelemetry()).toBe(false);
+    const config = await loadCliConfig(settings, [], [], 'test-session');
+    expect(config.getTelemetryEnabled()).toBe(false);
   });
 
   it('should set telemetry to true when --telemetry flag is present', async () => {
     process.argv = ['node', 'script.js', '--telemetry'];
     const settings: Settings = {};
-    const config = await loadCliConfig(settings, []);
-    expect(config.getTelemetry()).toBe(true);
+    const config = await loadCliConfig(settings, [], [], 'test-session');
+    expect(config.getTelemetryEnabled()).toBe(true);
   });
 
   it('should set telemetry to false when --no-telemetry flag is present', async () => {
     process.argv = ['node', 'script.js', '--no-telemetry'];
     const settings: Settings = {};
-    const config = await loadCliConfig(settings, []);
-    expect(config.getTelemetry()).toBe(false);
+    const config = await loadCliConfig(settings, [], [], 'test-session');
+    expect(config.getTelemetryEnabled()).toBe(false);
   });
 
   it('should use telemetry value from settings if CLI flag is not present (settings true)', async () => {
     process.argv = ['node', 'script.js'];
     const settings: Settings = { telemetry: true };
-    const config = await loadCliConfig(settings, []);
-    expect(config.getTelemetry()).toBe(true);
+    const config = await loadCliConfig(settings, [], [], 'test-session');
+    expect(config.getTelemetryEnabled()).toBe(true);
   });
 
   it('should use telemetry value from settings if CLI flag is not present (settings false)', async () => {
     process.argv = ['node', 'script.js'];
     const settings: Settings = { telemetry: false };
-    const config = await loadCliConfig(settings, []);
-    expect(config.getTelemetry()).toBe(false);
+    const config = await loadCliConfig(settings, [], [], 'test-session');
+    expect(config.getTelemetryEnabled()).toBe(false);
   });
 
   it('should prioritize --telemetry CLI flag (true) over settings (false)', async () => {
     process.argv = ['node', 'script.js', '--telemetry'];
     const settings: Settings = { telemetry: false };
-    const config = await loadCliConfig(settings, []);
-    expect(config.getTelemetry()).toBe(true);
+    const config = await loadCliConfig(settings, [], [], 'test-session');
+    expect(config.getTelemetryEnabled()).toBe(true);
   });
 
   it('should prioritize --no-telemetry CLI flag (false) over settings (true)', async () => {
     process.argv = ['node', 'script.js', '--no-telemetry'];
     const settings: Settings = { telemetry: true };
-    const config = await loadCliConfig(settings, []);
-    expect(config.getTelemetry()).toBe(false);
+    const config = await loadCliConfig(settings, [], [], 'test-session');
+    expect(config.getTelemetryEnabled()).toBe(false);
   });
 });
 
@@ -198,8 +173,8 @@ describe('API Key Handling', () => {
     delete process.env.GOOGLE_API_KEY;
 
     const settings: Settings = {};
-    const result = await loadCliConfig(settings, []);
-    expect(result.getApiKey()).toBe('gemini-key');
+    const result = await loadCliConfig(settings, [], [], 'test-session');
+    expect(result.getContentGeneratorConfig().apiKey).toBe('gemini-key');
   });
 
   it('should use GOOGLE_API_KEY and warn when both GOOGLE_API_KEY and GEMINI_API_KEY are set', async () => {
@@ -211,13 +186,13 @@ describe('API Key Handling', () => {
     process.env.GOOGLE_API_KEY = 'google-key';
 
     const settings: Settings = {};
-    const result = await loadCliConfig(settings, []);
+    const result = await loadCliConfig(settings, [], [], 'test-session');
 
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       '[WARN]',
       'Both GEMINI_API_KEY and GOOGLE_API_KEY are set. Using GOOGLE_API_KEY.',
     );
-    expect(result.getApiKey()).toBe('google-key');
+    expect(result.getContentGeneratorConfig().apiKey).toBe('google-key');
   });
 });
 

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -9,6 +9,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)', 'config.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**', '**/cypress/**'],
     environment: 'jsdom',
     globals: true,
     reporters: ['default', 'junit'],


### PR DESCRIPTION
By default vitests skips files with "config" in the name. I fixed that and also fixed the errors that had built up in the test.