### PR TITLE
fix: read package.json relative to __dirname

### DIFF
--- a/packages/cli/src/utils/package.ts
+++ b/packages/cli/src/utils/package.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  readPackageUp,
+  type PackageJson as BasePackageJson,
+} from 'read-package-up';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+export type PackageJson = BasePackageJson & {
+  config?: {
+    sandboxImageUri?: string;
+  };
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let packageJson: PackageJson | undefined;
+
+export async function getPackageJson(): Promise<PackageJson | undefined> {
+  if (packageJson) {
+    return packageJson;
+  }
+
+  const result = await readPackageUp({ cwd: __dirname });
+  if (!result) {
+    // TODO: Maybe bubble this up as an error.
+    return;
+  }
+
+  packageJson = result.packageJson;
+  return packageJson;
+}

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -10,7 +10,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { quote } from 'shell-quote';
-import { readPackageUp } from 'read-package-up';
+import { getPackageJson } from './package.js';
 import commandExists from 'command-exists';
 import {
   USER_SETTINGS_DIR,
@@ -102,13 +102,10 @@ async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
 async function getSandboxImageName(
   isCustomProjectSandbox: boolean,
 ): Promise<string> {
-  const packageJsonResult = await readPackageUp();
-  const packageJsonConfig = packageJsonResult?.packageJson.config as
-    | { sandboxImageUri?: string }
-    | undefined;
+  const packageJson = await getPackageJson();
   return (
     process.env.GEMINI_SANDBOX_IMAGE ??
-    packageJsonConfig?.sandboxImageUri ??
+    packageJson?.config?.sandboxImageUri ??
     (isCustomProjectSandbox
       ? LOCAL_DEV_SANDBOX_IMAGE_NAME + '-' + path.basename(path.resolve())
       : LOCAL_DEV_SANDBOX_IMAGE_NAME)


### PR DESCRIPTION
BUG=b/424271369
DIFFBASE=#1020

Cause of bug: `readPackageUp` traverses up the directory tree looking for a package.json, starting from the current working directory. But the production installed `gemini` cli app uses a symlink to a global `node_modules` folder outside of the current working directory. Therefore, the app was unable to find the deployed package.json and consequently the associated sandbox image name. 

Fix: provide `readPackageUp` with the app's `__dirname` (the location that the app _binary_ is stored). also moved this logic to its own module to encapsulate the expected typings on the returned packageJson object.