### PR TITLE
reuse `GitIgnoreParser` for loading `.geminiignore`

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -41,7 +41,7 @@ export async function main() {
   const settings = loadSettings(workspaceRoot);
   setWindowTitle(basename(workspaceRoot), settings);
 
-  const geminiIgnorePatterns = loadGeminiIgnorePatterns(workspaceRoot);
+  const geminiIgnorePatterns = await loadGeminiIgnorePatterns(workspaceRoot);
   await cleanupCheckpoints();
   if (settings.errors.length > 0) {
     for (const error of settings.errors) {

--- a/packages/cli/src/utils/loadIgnorePatterns.test.ts
+++ b/packages/cli/src/utils/loadIgnorePatterns.test.ts
@@ -42,9 +42,6 @@ describe('loadGeminiIgnorePatterns', () => {
   let consoleLogSpy: Mock<
     (message?: unknown, ...optionalParams: unknown[]) => void
   >;
-  let consoleWarnSpy: Mock<
-    (message?: unknown, ...optionalParams: unknown[]) => void
-  >;
 
   beforeAll(async () => {
     actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
@@ -62,11 +59,6 @@ describe('loadGeminiIgnorePatterns', () => {
       .mockImplementation(() => {}) as Mock<
       (message?: unknown, ...optionalParams: unknown[]) => void
     >;
-    consoleWarnSpy = vi
-      .spyOn(console, 'warn')
-      .mockImplementation(() => {}) as Mock<
-      (message?: unknown, ...optionalParams: unknown[]) => void
-    >;
     mockedFsReadFileSync.mockReset();
   });
 
@@ -77,7 +69,7 @@ describe('loadGeminiIgnorePatterns', () => {
     vi.restoreAllMocks();
   });
 
-  it('should load and parse patterns from .geminiignore, ignoring comments and empty lines', () => {
+  it('should load and parse patterns from .geminiignore, ignoring comments and empty lines', async () => {
     const ignoreContent = [
       '# This is a comment',
       'pattern1',
@@ -90,14 +82,7 @@ describe('loadGeminiIgnorePatterns', () => {
     const ignoreFilePath = path.join(tempDir, '.geminiignore');
     actualFs.writeFileSync(ignoreFilePath, ignoreContent);
 
-    mockedFsReadFileSync.mockImplementation((p: string, encoding: string) => {
-      if (p === ignoreFilePath && encoding === 'utf-8') return ignoreContent;
-      throw new Error(
-        `Mock fs.readFileSync: Unexpected call with path: ${p}, encoding: ${encoding}`,
-      );
-    });
-
-    const patterns = loadGeminiIgnorePatterns(tempDir);
+    const patterns = await loadGeminiIgnorePatterns(tempDir);
 
     expect(patterns).toEqual([
       'pattern1',
@@ -109,39 +94,19 @@ describe('loadGeminiIgnorePatterns', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith(
       expect.stringContaining('Loaded 5 patterns from .geminiignore'),
     );
-    expect(mockedFsReadFileSync).toHaveBeenCalledWith(ignoreFilePath, 'utf-8');
   });
 
-  it('should return an empty array and log info if .geminiignore is not found', () => {
-    const ignoreFilePath = path.join(tempDir, '.geminiignore');
-    mockedFsReadFileSync.mockImplementation((p: string, encoding: string) => {
-      if (p === ignoreFilePath && encoding === 'utf-8') {
-        const error = new Error('File not found') as NodeJS.ErrnoException;
-        error.code = 'ENOENT';
-        throw error;
-      }
-      throw new Error(
-        `Mock fs.readFileSync: Unexpected call with path: ${p}, encoding: ${encoding}`,
-      );
-    });
-
-    const patterns = loadGeminiIgnorePatterns(tempDir);
+  it('should return an empty array and log info if .geminiignore is not found', async () => {
+    const patterns = await loadGeminiIgnorePatterns(tempDir);
     expect(patterns).toEqual([]);
     expect(consoleLogSpy).not.toHaveBeenCalled();
-    expect(mockedFsReadFileSync).toHaveBeenCalledWith(ignoreFilePath, 'utf-8');
   });
 
-  it('should return an empty array if .geminiignore is empty', () => {
+  it('should return an empty array if .geminiignore is empty', async () => {
     const ignoreFilePath = path.join(tempDir, '.geminiignore');
     actualFs.writeFileSync(ignoreFilePath, '');
-    mockedFsReadFileSync.mockImplementation((p: string, encoding: string) => {
-      if (p === ignoreFilePath && encoding === 'utf-8') return ''; // Return string for empty file
-      throw new Error(
-        `Mock fs.readFileSync: Unexpected call with path: ${p}, encoding: ${encoding}`,
-      );
-    });
 
-    const patterns = loadGeminiIgnorePatterns(tempDir);
+    const patterns = await loadGeminiIgnorePatterns(tempDir);
     expect(patterns).toEqual([]);
     expect(consoleLogSpy).not.toHaveBeenCalledWith(
       expect.stringContaining('Loaded 0 patterns from .geminiignore'),
@@ -149,10 +114,9 @@ describe('loadGeminiIgnorePatterns', () => {
     expect(consoleLogSpy).not.toHaveBeenCalledWith(
       expect.stringContaining('No .geminiignore file found'),
     );
-    expect(mockedFsReadFileSync).toHaveBeenCalledWith(ignoreFilePath, 'utf-8');
   });
 
-  it('should return an empty array if .geminiignore contains only comments and empty lines', () => {
+  it('should return an empty array if .geminiignore contains only comments and empty lines', async () => {
     const ignoreContent = [
       '# Comment 1',
       '  # Comment 2 with leading spaces',
@@ -161,14 +125,8 @@ describe('loadGeminiIgnorePatterns', () => {
     ].join('\n');
     const ignoreFilePath = path.join(tempDir, '.geminiignore');
     actualFs.writeFileSync(ignoreFilePath, ignoreContent);
-    mockedFsReadFileSync.mockImplementation((p: string, encoding: string) => {
-      if (p === ignoreFilePath && encoding === 'utf-8') return ignoreContent;
-      throw new Error(
-        `Mock fs.readFileSync: Unexpected call with path: ${p}, encoding: ${encoding}`,
-      );
-    });
 
-    const patterns = loadGeminiIgnorePatterns(tempDir);
+    const patterns = await loadGeminiIgnorePatterns(tempDir);
     expect(patterns).toEqual([]);
     expect(consoleLogSpy).not.toHaveBeenCalledWith(
       expect.stringContaining('Loaded 0 patterns from .geminiignore'),
@@ -176,48 +134,17 @@ describe('loadGeminiIgnorePatterns', () => {
     expect(consoleLogSpy).not.toHaveBeenCalledWith(
       expect.stringContaining('No .geminiignore file found'),
     );
-    expect(mockedFsReadFileSync).toHaveBeenCalledWith(ignoreFilePath, 'utf-8');
   });
 
-  it('should handle read errors (other than ENOENT) and log a warning', () => {
-    const ignoreFilePath = path.join(tempDir, '.geminiignore');
-    mockedFsReadFileSync.mockImplementation((p: string, encoding: string) => {
-      if (p === ignoreFilePath && encoding === 'utf-8') {
-        const error = new Error('Test read error') as NodeJS.ErrnoException;
-        error.code = 'EACCES';
-        throw error;
-      }
-      throw new Error(
-        `Mock fs.readFileSync: Unexpected call with path: ${p}, encoding: ${encoding}`,
-      );
-    });
-
-    const patterns = loadGeminiIgnorePatterns(tempDir);
-    expect(patterns).toEqual([]);
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `[WARN] Could not read .geminiignore file at ${ignoreFilePath}: Test read error`,
-      ),
-    );
-    expect(mockedFsReadFileSync).toHaveBeenCalledWith(ignoreFilePath, 'utf-8');
-  });
-
-  it('should correctly handle patterns with inline comments if not starting with #', () => {
+  it('should correctly handle patterns with inline comments if not starting with #', async () => {
     const ignoreContent = 'src/important # but not this part';
     const ignoreFilePath = path.join(tempDir, '.geminiignore');
     actualFs.writeFileSync(ignoreFilePath, ignoreContent);
-    mockedFsReadFileSync.mockImplementation((p: string, encoding: string) => {
-      if (p === ignoreFilePath && encoding === 'utf-8') return ignoreContent;
-      throw new Error(
-        `Mock fs.readFileSync: Unexpected call with path: ${p}, encoding: ${encoding}`,
-      );
-    });
 
-    const patterns = loadGeminiIgnorePatterns(tempDir);
+    const patterns = await loadGeminiIgnorePatterns(tempDir);
     expect(patterns).toEqual(['src/important # but not this part']);
     expect(consoleLogSpy).toHaveBeenCalledWith(
       expect.stringContaining('Loaded 1 patterns from .geminiignore'),
     );
-    expect(mockedFsReadFileSync).toHaveBeenCalledWith(ignoreFilePath, 'utf-8');
   });
 });

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -17,43 +17,53 @@ export class GitIgnoreParser implements GitIgnoreFilter {
   private projectRoot: string;
   private isGitRepo: boolean = false;
   private ig: Ignore = ignore();
+  private patterns: string[] = [];
 
   constructor(projectRoot: string) {
     this.projectRoot = path.resolve(projectRoot);
   }
 
-  async initialize(): Promise<void> {
+  async initialize(patternsFileName?: string): Promise<void> {
+    const patternFiles = [];
+    if (patternsFileName && patternsFileName !== '') {
+      patternFiles.push(patternsFileName);
+    }
+
     this.isGitRepo = isGitRepository(this.projectRoot);
     if (this.isGitRepo) {
-      const gitIgnoreFiles = [
-        path.join(this.projectRoot, '.gitignore'),
-        path.join(this.projectRoot, '.git', 'info', 'exclude'),
-      ];
+      patternFiles.push('.gitignore');
+      patternFiles.push(path.join('.git', 'info', 'exclude'));
 
       // Always ignore .git directory regardless of .gitignore content
       this.addPatterns(['.git']);
-
-      for (const gitIgnoreFile of gitIgnoreFiles) {
-        try {
-          const content = await fs.readFile(gitIgnoreFile, 'utf-8');
-          const patterns = content.split('\n').map((p) => p.trim());
-          this.addPatterns(patterns);
-        } catch (_error) {
-          // File doesn't exist or can't be read, continue silently
-        }
+    }
+    for (const pf of patternFiles) {
+      try {
+        await this.loadPatterns(pf);
+      } catch (_error) {
+        // File doesn't exist or can't be read, continue silently
       }
     }
   }
 
+  async loadPatterns(patternsFileName: string): Promise<void> {
+    const content = await fs.readFile(
+      path.join(this.projectRoot, patternsFileName),
+      'utf-8',
+    );
+    const patterns = content
+      .split('\n')
+      .map((p) => p.trim())
+      .filter((p) => p !== '' && !p.startsWith('#'));
+    this.addPatterns(patterns);
+  }
+
   private addPatterns(patterns: string[]) {
     this.ig.add(patterns);
+    this.patterns.push(...patterns);
   }
 
   isIgnored(filePath: string): boolean {
-    if (!this.isGitRepo) {
-      return false;
-    }
-
     const relativePath = path.isAbsolute(filePath)
       ? path.relative(this.projectRoot, filePath)
       : filePath;
@@ -67,11 +77,10 @@ export class GitIgnoreParser implements GitIgnoreFilter {
       normalizedPath = normalizedPath.substring(2);
     }
 
-    const ignored = this.ig.ignores(normalizedPath);
-    return ignored;
+    return this.ig.ignores(normalizedPath);
   }
 
-  getGitRepoRoot(): string {
-    return this.projectRoot;
+  getPatterns(): string[] {
+    return this.patterns;
   }
 }


### PR DESCRIPTION
This is an incremental change towards incorporating .geminiignore filtering into `FileDiscoveryService`.