### PR TITLE
fix(core): Improve shell tool reliability and test portability

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -174,8 +174,8 @@ export class Config {
       setGeminiMdFilename(params.contextFileName);
     }
 
-    this.toolRegistry = createToolRegistry(this);
     this.geminiClient = new GeminiClient(this);
+    this.toolRegistry = createToolRegistry(this);
 
     if (this.telemetrySettings.enabled) {
       initializeTelemetry(this);

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getCoreSystemPrompt } from './prompts.js'; // Adjust import path
 import * as process from 'node:process';
+import * as os from 'node:os';
 import { isGitRepository } from '../utils/gitUtils.js';
 
 // Mock tool names if they are dynamically generated or complex
@@ -24,6 +25,9 @@ vi.mock('../tools/shell', () => ({
 vi.mock('../tools/write-file', () => ({
   WriteFileTool: { Name: 'write_file' },
 }));
+vi.mock('node:os', () => ({
+  platform: vi.fn(),
+}));
 vi.mock('../utils/gitUtils', () => ({
   isGitRepository: vi.fn(),
 }));
@@ -35,6 +39,7 @@ describe('Core System Prompt (prompts.ts)', () => {
   beforeEach(() => {
     // Store original value before each test
     originalSandboxEnv = process.env.SANDBOX;
+    vi.mocked(os.platform).mockReturnValue('darwin');
   });
 
   afterEach(() => {


### PR DESCRIPTION
  This pull request addresses two related issues to improve the robustness of the ShellTool and the portability of our test suite. The changes are organized into two distinct, atomic commits for clarity and easier review.


1. Fix: Corrected Temp File Name Handling in ShellTool (Fixes https://github.com/google-gemini/gemini-cli/issues/1035)


  This commit refactors the logic for generating the temporary file path used for pgrep output on non-Windows systems.


   * Before: The temporary file path was being generated multiple times within the same function, which could lead to race conditions or errors in tracking background processes.
   * After: The path is now generated once at the beginning of the function and reused, ensuring the ShellTool reliably captures background PIDs.


2. Test: Made Prompt Tests OS-Agnostic


  This commit resolves a brittle test in prompts.test.ts that would produce different snapshots depending on the host operating system (macOS vs. others).


   * Before: The test snapshot included an OS-specific string ("MacOS Seatbelt"), causing the test to fail on non-macOS environments.
   * After: The os.platform() module is now mocked during the test run. This ensures the generated prompt is consistent, making the test portable and reliable across all development machines
     and CI runners.

3. Initializes the GeminiClient before the ToolRegistry within the Config constructor (fixes https://github.com/google-gemini/gemini-cli/issues/1037).

Previously, the ToolRegistry and its associated tools were created before the GeminiClient instance was ready. This caused tools that depend on the client, such as EditTool, to fail with a TypeError when they attempted to make LLM calls.

 This change ensures that all dependencies are available to the tools at instantiation time, preventing the initialization race condition.