### PR TITLE
Introduce a screenshot tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   psmisc \
   lsof \
   socat \
+  imagemagick \
   ca-certificates \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -2315,6 +2315,16 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/screenshot-desktop": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@types/screenshot-desktop/-/screenshot-desktop-1.12.3.tgz",
+      "integrity": "sha512-b1BoY60eEUwXgAE4le7gQFf78RWQxveF/ZKW5Ifh1+M4byPiyp3kP4qStVL+2pwrwaaJyN8qzeaczSDfz2WOPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/shell-quote": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.5.tgz",
@@ -3210,7 +3220,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3625,7 +3634,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -5183,6 +5191,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5818,6 +5832,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -7244,7 +7269,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -7257,7 +7281,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7270,6 +7293,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/module-details-from-path": {
@@ -7742,6 +7777,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -8290,6 +8334,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.41.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.1.tgz",
@@ -8490,6 +8568,21 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/screenshot-desktop": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/screenshot-desktop/-/screenshot-desktop-1.15.1.tgz",
+      "integrity": "sha512-4j9bDZSFnkRqH53bAw5W+ZhdGKiTUcUDohO6NZjL6QSC/6AXbhUqJ9YXygjHrYcSOUD4IcLty6uQ1ES7PSsomg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/bencevans"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "temp": "^0.9.4"
       }
     },
     "node_modules/selderee": {
@@ -9164,6 +9257,19 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/temp": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/test-exclude": {
       "version": "7.0.1",
@@ -11005,6 +11111,7 @@
         "ignore": "^7.0.0",
         "micromatch": "^4.0.8",
         "open": "^10.1.2",
+        "screenshot-desktop": "^1.12.3",
         "shell-quote": "^1.8.2",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
@@ -11016,6 +11123,7 @@
         "@types/dotenv": "^6.1.1",
         "@types/micromatch": "^4.0.8",
         "@types/minimatch": "^5.1.2",
+        "@types/screenshot-desktop": "^1.12.3",
         "@types/ws": "^8.5.10",
         "typescript": "^5.3.3",
         "vitest": "^3.1.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,8 @@
     "simple-git": "^3.28.0",
     "strip-ansi": "^7.1.0",
     "undici": "^7.10.0",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "screenshot-desktop": "^1.12.3"
   },
   "devDependencies": {
     "@types/diff": "^7.0.2",
@@ -52,7 +53,8 @@
     "@types/minimatch": "^5.1.2",
     "@types/ws": "^8.5.10",
     "typescript": "^5.3.3",
-    "vitest": "^3.1.1"
+    "vitest": "^3.1.1",
+    "@types/screenshot-desktop": "^1.12.3"
   },
   "engines": {
     "node": ">=18"

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -19,6 +19,7 @@ import { WebFetchTool } from '../tools/web-fetch.js';
 import { ReadManyFilesTool } from '../tools/read-many-files.js';
 import { MemoryTool, setGeminiMdFilename } from '../tools/memoryTool.js';
 import { WebSearchTool } from '../tools/web-search.js';
+import { ScreenshotTool } from '../tools/screenshot.js';
 import { GeminiClient } from '../core/client.js';
 import { GEMINI_CONFIG_DIR as GEMINI_DIR } from '../tools/memoryTool.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
@@ -364,6 +365,7 @@ export function createToolRegistry(config: Config): Promise<ToolRegistry> {
   registerCoreTool(ShellTool, config);
   registerCoreTool(MemoryTool);
   registerCoreTool(WebSearchTool, config);
+  registerCoreTool(ScreenshotTool, config);
   return (async () => {
     await registry.discoverTools();
     return registry;

--- a/packages/core/src/tools/screenshot.ts
+++ b/packages/core/src/tools/screenshot.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseTool,
+  ToolCallConfirmationDetails,
+  ToolResult,
+  ToolConfirmationOutcome,
+} from './tools.js';
+import screenshot from 'screenshot-desktop';
+import { Blob, Part } from '@google/genai';
+import { Config, ApprovalMode } from '../config/config.js';
+
+const screenshotToolDescription = `Takes a screenshot of user screen.
+It allows model to be able to see the user's screen. Without this tool,
+model cannot access to user's screen visually.
+This tool is useful in cases such as:
+- What the model can visually see on their screen.
+- Asking about desktop applications visible on the user screen.
+- Helping users with UIs, e.g. providing usability tips and assistence.
+- Turning visual artifacts into text, e.g. describing an image.`;
+
+/**
+ * Represents a tool that can "take a screenshot" of the current CLI output.
+ * Since a true graphical screenshot is not possible in this environment,
+ * this tool will return a textual representation or description of the CLI state.
+ */
+export class ScreenshotTool extends BaseTool<unknown, ToolResult> {
+  constructor(private readonly config: Config) {
+    super('screenshot', 'Screenshot', screenshotToolDescription, {
+      properties: {
+        screenshots: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Required. An array of screenshots of user displays. User may have one or more displays.',
+        },
+      },
+      required: ['screenshots'],
+      type: 'object',
+    });
+  }
+
+  override async shouldConfirmExecute(): Promise<
+    ToolCallConfirmationDetails | false
+  > {
+    // TODO(jbd): Don't allow execution before confirmation.
+    if (this.config.getApprovalMode() === ApprovalMode.AUTO_EDIT) {
+      return false;
+    }
+    const confirmationDetails: ToolCallConfirmationDetails = {
+      type: 'info',
+      title: `Confirm Screenshot`,
+      prompt: '',
+      onConfirm: async (outcome: ToolConfirmationOutcome) => {
+        if (outcome === ToolConfirmationOutcome.ProceedAlways) {
+          this.config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+        }
+      },
+    };
+    return confirmationDetails;
+  }
+
+  override async execute(): Promise<ToolResult> {
+    const screenshotContent = 'Screenshot captured.';
+    const screenshots: Part[] = await capture();
+    return {
+      llmContent: screenshots,
+      returnDisplay: screenshotContent,
+    };
+  }
+}
+
+async function capture(): Promise<Part[]> {
+  try {
+    const displays = await screenshot.listDisplays();
+
+    if (displays.length === 0) {
+      throw new Error('No displays found.');
+    }
+    const parts = [];
+    for (const display of displays) {
+      const { id } = display;
+      const imgBuffer = await screenshot({ screen: id, format: 'png' });
+      const blob: Blob = {
+        mimeType: 'image/png',
+        data: imgBuffer.toString('base64'),
+      };
+      const part: Part = { inlineData: blob };
+      parts.push(part);
+    }
+    return parts;
+  } catch (error) {
+    throw new Error('An error occurred while taking screenshots:' + error);
+  }
+}


### PR DESCRIPTION
This tool allows Gemini CLI to capture the displays of the user when user asks for the CLI to gather visual input.

```
> hello, can you see my screen and describe what you see?

 ╭──────────────────────────╮
 │ ✔  Screenshot {}         │
 │                          │
 │    Screenshot captured.  │
 ╰──────────────────────────╯

✦ The screenshot displays a macOS desktop environment featuring two primary applications: a VS Code window
  and an iTerm2 terminal.

  In the VS Code window, the "Source Control" panel is visible, indicating pending changes and a commit
  history. The main editor area shows a TypeScript file, tool-registry.ts, with code related to
  DiscoveredTool and ToolRegistry classes. The status bar at the bottom indicates the current git branch
  as "screenshot" and mentions "MacOS Seatbelt (permissive-open)".

  The iTerm2 terminal window shows command-line activity. It displays the gemini-cli project on the
  "screenshot" git branch. Recent commands include git amend, a failed git push origin screenshot due to
  an incorrect command, and npm run start. The output of npm run start shows build status checks, API key
  confirmations, and a large ASCII art "GEMINI" logo. Below the logo, there are tips for getting started
  and the ongoing conversation with me, including my previous response and the output of the screenshot()
  tool call.
```