### PR TITLE
Add support for showing descriptions of CLI tools

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -61,6 +61,13 @@ Slash commands provide meta-level control over the CLI itself. They can typicall
 
   - **Description:** Displays a list of all the tools that are currently available to the model.
   - **Action:** Outputs a list of the available tools.
+  - **Sub-commands:**
+    - **`desc`** or **`descriptions`**:
+      - **Description:** Shows detailed descriptions of each tool.
+      - **Action:** Displays each tool's name with its full description as provided to the model.
+    - **`nodesc`** or **`nodescriptions`**:
+      - **Description:** Hides tool descriptions, showing only the tool names.
+      - **Action:** Displays a compact list with only tool names.
 
 - **`/compress`**
 

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -625,6 +625,41 @@ Add any other context about the problem here.
       expect(message).toContain('No tools available');
       expect(commandResult).toBe(true);
     });
+
+    it('should display tool descriptions when /tools desc is used', async () => {
+      const mockTools = [
+        {
+          name: 'tool1',
+          displayName: 'Tool1',
+          description: 'Description for Tool1',
+        },
+        {
+          name: 'tool2',
+          displayName: 'Tool2',
+          description: 'Description for Tool2',
+        },
+      ];
+
+      mockConfig = {
+        ...mockConfig,
+        getToolRegistry: vi.fn().mockResolvedValue({
+          getAllTools: vi.fn().mockReturnValue(mockTools),
+        }),
+      } as unknown as Config;
+
+      const { handleSlashCommand } = getProcessor();
+      let commandResult: SlashCommandActionReturn | boolean = false;
+      await act(async () => {
+        commandResult = await handleSlashCommand('/tools desc');
+      });
+
+      const message = mockAddItem.mock.calls[1][0].text;
+      expect(message).toContain('\u001b[36mTool1\u001b[0m');
+      expect(message).toContain('Description for Tool1');
+      expect(message).toContain('\u001b[36mTool2\u001b[0m');
+      expect(message).toContain('Description for Tool2');
+      expect(commandResult).toBe(true);
+    });
   });
 
   describe('/mcp command', () => {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -595,14 +595,9 @@ Add any other context about the problem here.
       });
 
       // Should only show tool1 and tool2, not the MCP tools
-      expect(mockAddItem).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          type: MessageType.INFO,
-          text: 'Available Gemini CLI tools:\n\nTool1\nTool2',
-        }),
-        expect.any(Number),
-      );
+      const message = mockAddItem.mock.calls[1][0].text;
+      expect(message).toContain('\u001b[36mTool1\u001b[0m');
+      expect(message).toContain('\u001b[36mTool2\u001b[0m');
       expect(commandResult).toBe(true);
     });
 
@@ -626,14 +621,8 @@ Add any other context about the problem here.
         commandResult = await handleSlashCommand('/tools');
       });
 
-      expect(mockAddItem).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          type: MessageType.INFO,
-          text: 'Available Gemini CLI tools:\n\n',
-        }),
-        expect.any(Number),
-      );
+      const message = mockAddItem.mock.calls[1][0].text;
+      expect(message).toContain('No tools available');
       expect(commandResult).toBe(true);
     });
   });


### PR DESCRIPTION
Adds an option to `/tools` (`/tools desc`) that shows the description provided to the model for each CLI tool. Fixes #1051 