### PR TITLE
Add file operation telemetry

### DIFF
--- a/docs/core/telemetry.md
+++ b/docs/core/telemetry.md
@@ -273,6 +273,15 @@ These are numerical measurements of behavior over time.
     - `model`
 
 - `gemini_cli.token.usage` (Counter, Int): Counts the number of tokens used.
+
   - **Attributes**:
     - `model`
     - `type` (string: "input", "output", "thought", "cache", or "tool")
+
+- `gemini_cli.file.operation.count` (Counter, Int): Counts file operations.
+
+  - **Attributes**:
+    - `operation` (string: "create", "read", "update"): The type of file operation.
+    - `lines` (optional, Int): Number of lines in the file.
+    - `mimetype` (optional, string): Mimetype of the file.
+    - `extension` (optional, string): File extension of the file.

--- a/packages/core/src/telemetry/constants.ts
+++ b/packages/core/src/telemetry/constants.ts
@@ -19,3 +19,4 @@ export const METRIC_API_REQUEST_COUNT = 'gemini_cli.api.request.count';
 export const METRIC_API_REQUEST_LATENCY = 'gemini_cli.api.request.latency';
 export const METRIC_TOKEN_USAGE = 'gemini_cli.token.usage';
 export const METRIC_SESSION_COUNT = 'gemini_cli.session.count';
+export const METRIC_FILE_OPERATION_COUNT = 'gemini_cli.file.operation.count';

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -14,9 +14,14 @@ import {
   detectFileType,
   processSingleFileContent,
   DEFAULT_ENCODING,
+  getSpecificMimeType,
 } from '../utils/fileUtils.js';
 import { PartListUnion } from '@google/genai';
 import { Config } from '../config/config.js';
+import {
+  recordFileOperationMetric,
+  FileOperation,
+} from '../telemetry/metrics.js';
 
 /**
  * Parameters for the ReadManyFilesTool.
@@ -420,6 +425,18 @@ Use this tool when the user's query implies needing the content of several files
           contentParts.push(fileReadResult.llmContent); // This is a Part for image/pdf
         }
         processedFilesRelativePaths.push(relativePathForDisplay);
+        const lines =
+          typeof fileReadResult.llmContent === 'string'
+            ? fileReadResult.llmContent.split('\n').length
+            : undefined;
+        const mimetype = getSpecificMimeType(filePath);
+        recordFileOperationMetric(
+          this.config,
+          FileOperation.READ,
+          lines,
+          mimetype,
+          path.extname(filePath),
+        );
       }
     }
 

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -17,6 +17,16 @@ const MAX_LINE_LENGTH_TEXT_FILE = 2000;
 export const DEFAULT_ENCODING: BufferEncoding = 'utf-8';
 
 /**
+ * Looks up the specific MIME type for a file path.
+ * @param filePath Path to the file.
+ * @returns The specific MIME type string (e.g., 'text/python', 'application/javascript') or undefined if not found or ambiguous.
+ */
+export function getSpecificMimeType(filePath: string): string | undefined {
+  const lookedUpMime = mime.lookup(filePath);
+  return typeof lookedUpMime === 'string' ? lookedUpMime : undefined;
+}
+
+/**
  * Checks if a path is within a given root directory.
  * @param pathToCheck The absolute path to check.
  * @param rootDirectory The absolute root directory.


### PR DESCRIPTION
Introduces telemetry for file create, read, and update operations.

This change adds the `gemini_cli.file.operation.count` metric, recorded by the `read-file`, `read-many-files`, and `write-file` tools.

The metric includes the following attributes:
    - `operation` (string: `create`, `read`, `update`): The type of file operation.
    - `lines` (optional, Int): Number of lines in the file.
    - `mimetype` (optional, string): Mimetype of the file.
    - `extension` (optional, string): File extension of the file.

Here is a stacked bar chart of file operations by extension (`js`, `ts`, `md`):
![image](https://github.com/user-attachments/assets/3e8f8ea9-6155-4186-863c-075cc47647c5)

Here is a stacked bar chart of file operations by type (`create`, `read`, `update`):
![image](https://github.com/user-attachments/assets/3fcf491d-31d0-4ba8-80e6-7fd2bd9c7c27)

#750 

cc @allenhutchison as discussed 