### PR TITLE
refactor(cli): Use excludeTools for non-interactive mode

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -21,15 +21,7 @@ import {
   ApprovalMode,
   Config,
   EditTool,
-  GlobTool,
-  GrepTool,
-  LSTool,
-  MemoryTool,
-  ReadFileTool,
-  ReadManyFilesTool,
   ShellTool,
-  WebFetchTool,
-  WebSearchTool,
   WriteFileTool,
   sessionId,
   logUserPrompt,
@@ -166,28 +158,16 @@ async function loadNonInteractiveConfig(
   }
 
   // Everything is not allowed, ensure that only read-only tools are configured.
-
-  let existingCoreTools = config.getCoreTools();
-  existingCoreTools = existingCoreTools || [
-    ReadFileTool.Name,
-    LSTool.Name,
-    GrepTool.Name,
-    GlobTool.Name,
-    EditTool.Name,
-    WriteFileTool.Name,
-    WebFetchTool.Name,
-    WebSearchTool.Name,
-    ReadManyFilesTool.Name,
-    ShellTool.Name,
-    MemoryTool.Name,
-  ];
+  const existingExcludeTools = settings.merged.excludeTools || [];
   const interactiveTools = [ShellTool.Name, EditTool.Name, WriteFileTool.Name];
-  const nonInteractiveTools = existingCoreTools.filter(
-    (tool) => !interactiveTools.includes(tool),
-  );
+
+  const newExcludeTools = [
+    ...new Set([...existingExcludeTools, ...interactiveTools]),
+  ];
+
   const nonInteractiveSettings = {
     ...settings.merged,
-    coreTools: nonInteractiveTools,
+    excludeTools: newExcludeTools,
   };
   return await loadCliConfig(
     nonInteractiveSettings,

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -427,6 +427,9 @@ Add any other context about the problem here.
     });
 
     it('should use the custom bug command URL from config if available', async () => {
+      process.env.CLI_VERSION = '0.1.0';
+      process.env.SANDBOX = 'sandbox-exec';
+      process.env.SEATBELT_PROFILE = 'permissive-open';
       const bugCommand = {
         urlTemplate:
           'https://custom-bug-tracker.com/new?title={title}&body={body}',
@@ -449,7 +452,7 @@ Add any other context about the problem here.
 *   **CLI Version:** 0.1.0
 *   **Git Commit:** ${GIT_COMMIT_INFO}
 *   **Operating System:** test-platform test-node-version
-*   **Sandbox Environment:** no sandbox
+*   **Sandbox Environment:** sandbox-exec (permissive-open)
 *   **Model Version:** test-model
 *   **Memory Usage:** 11.8 MB
 `;

--- a/packages/cli/src/ui/hooks/usePhraseCycler.test.ts
+++ b/packages/cli/src/ui/hooks/usePhraseCycler.test.ts
@@ -87,7 +87,9 @@ describe('usePhraseCycler', () => {
     expect(result.current).toBe(WITTY_LOADING_PHRASES[0]);
 
     // Set back to active - should pick a random witty phrase
-    rerender({ isActive: true, isWaiting: false });
+    act(() => {
+      rerender({ isActive: true, isWaiting: false });
+    });
     expect(WITTY_LOADING_PHRASES).toContain(result.current);
   });
 


### PR DESCRIPTION
- Migrates the logic for disabling interactive tools in non-interactive mode to use the `excludeTools` setting.
- This corrects the previous implementation that was improperly filtering the `coreTools` list, ensuring that custom tool configurations are not overridden.
- Aligns the non-interactive mode with the intended design for tool exclusion.
- Updates a test case that was affected by the change in configuration loading.

Fixes https://b.corp.google.com/issues/425113548