### PR TITLE
Concise tool call display

### DIFF
--- a/docs/tool-ux.md
+++ b/docs/tool-ux.md
@@ -1,0 +1,133 @@
+# Tool Call Display UX Specification
+
+This document outlines the user experience (UX) and rendering logic for displaying tool calls in the Gemini CLI. The goal is to create a clear, intuitive, and visually cohesive representation of tool execution that accurately reflects the conversational flow between the user, the model, and the tools.
+
+## Guiding Principles
+
+- **Clarity:** The display should make it obvious what tools are being executed, in what order, and whether they succeeded or failed.
+- **Cohesion:** Related tool calls, even across multiple conversational turns, should be grouped together visually to represent a single logical operation.
+- **Context:** The rendering should reflect the context in which the tools were called (e.g., initiated by the model after a remark vs. initiated directly after a user prompt).
+
+## Core Scenarios
+
+### 1. Tool Calls Following Model Output
+
+When the model makes a remark and then executes one or more tools, the tool calls are visually connected to the model's output. This shows they are part of a continuous thought process.
+
+**Example: A two-tool chain after a remark.**
+
+```
+> I'm testing tool call rendering. Please say a pithy remark, then run two
+  chained tool calls: first, glob for a markdown file, and second, read a
+  file of your choice. Afterwards, make a sassy remark about the file you read.
+
+✦ Alright, let's kick the tires on this thing.
+  ├── ✔ FindFiles '**/*.md' - Found 30 matching file(s)
+  ╰── ✔ ReadFile README.md
+
+✦ Ah, a README.md file. The humble greeting card of every repository. This one
+  seems to have all its papers in order. How... quaint.
+```
+
+**Example: A three-tool chain after a remark.**
+
+```
+> Nice! Now for something similar, but with three steps. Please say a pithy
+  remark, then run the following chained tool calls:
+  1. Glob to find a random markdown file.
+  2. Run the shell command 'ls -l | head -3'.
+  3. Read a file of your choice.
+  Finally, make a sassy remark about the shell command.
+
+✦ Alright, a three-part combo. Let's see if I can do this without tripping
+  over my own digital feet.
+  ├── ✔ FindFiles '**/*.md' - Found 30 matching file(s)
+  ├── ✔ Shell ls -l | head -3
+  ╰─�� ✔ ReadFile docs/cli/commands.md
+
+✦ Ah, ls -l | head -3. A classic "I want to see what's in here, but not,
+  you know, all of it." It's the digital equivalent of peeking through the
+  blinds. A little bit of information, a whole lot of plausible deniability.
+```
+
+### 2. Tool Calls Immediately After User Input
+
+When tool calls are executed immediately after a user's prompt without any preceding model output, the rendering changes to signify a new, distinct block of action initiated by the user's request.
+
+**Example: A three-tool chain.**
+
+```
+> This is looking great. Now, please run the same three tool calls as before,
+  but do so immediately without any introductory remark. Please keep the final
+  pithy comment.
+
+  ┌── ✔ FindFiles '**/*.md' - Found 30 matching file(s)
+  ├── ✔ Shell ls -l | head -3
+  ╰── ✔ ReadFile CONTRIBUTING.md
+
+✦ Ah, ls -l | head -3. A classic "I want to see what's in here, but not,
+  you know, all of it." It's the digital equivalent of peeking through the
+  blinds. A little bit of information, a whole lot of plausible deniability.
+```
+
+## Edge Cases and Special Scenarios
+
+### 1. Multi-Turn Tool Calls
+
+A critical feature of the UX is its ability to handle tool calls that occur across multiple conversational turns. If the model executes a tool, thinks, and then executes another, the UI must render this as a single, continuous chain.
+
+This involves the UI re-rendering the previous tool call to connect it to the new one, forming a cohesive group that accurately represents the model's logical process, even though it spanned multiple turns.
+
+**Example:**
+
+```
+> I'm testing how multi-turn tool calls are rendered. Please perform the
+  following actions in sequence, with a pause for thought between each:
+  1. Read the contents of a file of your choice.
+  2. Read the contents of a second, different file.
+  3. Read the contents of a third file.
+  After completing all three reads, please list the basenames of the three files.
+
+  ┌── ✔ ReadFile README.md
+  ├── ✔ ReadFile LICENSE
+  ╰── ✔ ReadFile package.json
+
+✦ README.md, LICENSE, package.json
+```
+
+### 2. Error Reporting
+
+Error messages are displayed inline with the tool chain, clearly indicating which tool failed without disrupting the overall structure.
+
+**Example: Long error message.**
+
+A longer, multi-line error is displayed on subsequent lines, indented to remain visually associated with the failed tool call. The `│` character maintains the chain's vertical line.
+
+```
+> I'm testing error rendering. Please immediately perform the following
+  chained tool calls:
+  1. Glob to find a random markdown file.
+  2. Attempt to read the non-existent file "fake.txt".
+  3. Read a file of your choice.
+  Afterwards, please provide a pithy remark.
+
+  ┌── ✔ FindFiles '**/*.md' - Found 30 matching file(s)
+  ├── ✘ ReadFile fake.txt
+  │     File path must be absolute, but was relative: fake.txt. You must
+  │     provide an absolute path.
+  ╰── ✔ ReadFile README.md
+```
+
+**Example: Short error message.**
+
+A short, single-line error is displayed on the same line as the failed tool call for conciseness.
+
+```
+> Now, please perform a three-step tool chain. First, find all markdown
+  files. Second, attempt to read the non-existent file "/foobar.txt".
+  Third, read an existing file of your choice.
+
+  ┌── ✔ FindFiles '**/*.md' - Found 30 matching file(s)
+  ├── ✘ ReadFile /foobar.txt - File not found
+  ╰── ✔ ReadFile README.md
+```

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -232,6 +232,7 @@ export async function loadCliConfig(
     cwd: process.cwd(),
     fileDiscoveryService: fileService,
     bugCommand: settings.bugCommand,
+    toolCallDisplay: settings.toolCallDisplay,
   });
 }
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -55,6 +55,7 @@ export interface Settings {
   hideWindowTitle?: boolean;
 
   // Add other settings here.
+  toolCallDisplay?: 'box' | 'line';
 }
 
 export interface SettingsError {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -429,11 +429,12 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   if (quittingMessages) {
     return (
       <Box flexDirection="column" marginBottom={1}>
-        {quittingMessages.map((item) => (
+        {quittingMessages.map((item, i) => (
           <HistoryItemDisplay
             key={item.id}
             availableTerminalHeight={availableTerminalHeight}
             item={item}
+            previousItem={quittingMessages[i - 1]}
             isPending={false}
             config={config}
           />
@@ -463,13 +464,15 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
               <Header terminalWidth={terminalWidth} />
               <Tips config={config} />
             </Box>,
-            ...history.map((h) => (
+            ...history.map((h, i) => (
               <HistoryItemDisplay
                 availableTerminalHeight={availableTerminalHeight}
                 key={h.id}
                 item={h}
+                previousItem={history[i - 1]}
                 isPending={false}
                 config={config}
+                isLastContent={i === history.length - 1}
               />
             )),
           ]}
@@ -477,18 +480,26 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
           {(item) => item}
         </Static>
         <Box ref={pendingHistoryItemRef}>
-          {pendingHistoryItems.map((item, i) => (
-            <HistoryItemDisplay
-              key={i}
-              availableTerminalHeight={availableTerminalHeight}
-              // TODO(taehykim): It seems like references to ids aren't necessary in
-              // HistoryItemDisplay. Refactor later. Use a fake id for now.
-              item={{ ...item, id: 0 }}
-              isPending={true}
-              config={config}
-              isFocused={!isEditorDialogOpen}
-            />
-          ))}
+          {pendingHistoryItems.map((item, i) => {
+            const previousItem =
+              i === 0
+                ? history[history.length - 1]
+                : pendingHistoryItems[i - 1];
+            return (
+              <HistoryItemDisplay
+                key={i}
+                availableTerminalHeight={availableTerminalHeight}
+                // TODO(taehykim): It seems like references to ids aren't necessary in
+                // HistoryItemDisplay. Refactor later. Use a fake id for now.
+                item={{ ...item, id: 0 }}
+                previousItem={previousItem}
+                isPending={true}
+                config={config}
+                isFocused={!isEditorDialogOpen}
+                isLastContent={i === pendingHistoryItems.length - 1}
+              />
+            );
+          })}
         </Box>
         {showHelp && <Help commands={slashCommands} />}
 

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -470,9 +470,9 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
                 key={h.id}
                 item={h}
                 previousItem={history[i - 1]}
+                nextItem={history[i + 1]}
                 isPending={false}
                 config={config}
-                isLastContent={i === history.length - 1}
               />
             )),
           ]}
@@ -485,6 +485,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
               i === 0
                 ? history[history.length - 1]
                 : pendingHistoryItems[i - 1];
+            const nextItem = pendingHistoryItems[i + 1];
             return (
               <HistoryItemDisplay
                 key={i}
@@ -493,10 +494,10 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
                 // HistoryItemDisplay. Refactor later. Use a fake id for now.
                 item={{ ...item, id: 0 }}
                 previousItem={previousItem}
+                nextItem={nextItem}
                 isPending={true}
                 config={config}
                 isFocused={!isEditorDialogOpen}
-                isLastContent={i === pendingHistoryItems.length - 1}
               />
             );
           })}

--- a/packages/cli/src/ui/colors.ts
+++ b/packages/cli/src/ui/colors.ts
@@ -44,6 +44,9 @@ export const Colors: ColorsTheme = {
   get Gray() {
     return themeManager.getActiveTheme().colors.Gray;
   },
+  get ToolPrefix() {
+    return themeManager.getActiveTheme().colors.Gray;
+  },
   get GradientColors() {
     return themeManager.getActiveTheme().colors.GradientColors;
   },

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import type { HistoryItem } from '../types.js';
+import type { HistoryItem, HistoryItemWithoutId } from '../types.js';
 import { UserMessage } from './messages/UserMessage.js';
 import { UserShellMessage } from './messages/UserShellMessage.js';
 import { GeminiMessage } from './messages/GeminiMessage.js';
@@ -22,68 +22,81 @@ import { Config } from '@gemini-cli/core';
 
 interface HistoryItemDisplayProps {
   item: HistoryItem;
+  previousItem?: HistoryItem | HistoryItemWithoutId;
   availableTerminalHeight: number;
   isPending: boolean;
   config?: Config;
   isFocused?: boolean;
+  isLastContent?: boolean;
 }
 
 export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
   item,
+  previousItem,
   availableTerminalHeight,
   isPending,
   config,
   isFocused = true,
-}) => (
-  <Box flexDirection="column" key={item.id}>
-    {/* Render standard message types */}
-    {item.type === 'user' && <UserMessage text={item.text} />}
-    {item.type === 'user_shell' && <UserShellMessage text={item.text} />}
-    {item.type === 'gemini' && (
-      <GeminiMessage
-        text={item.text}
-        isPending={isPending}
-        availableTerminalHeight={availableTerminalHeight}
-      />
-    )}
-    {item.type === 'gemini_content' && (
-      <GeminiMessageContent
-        text={item.text}
-        isPending={isPending}
-        availableTerminalHeight={availableTerminalHeight}
-      />
-    )}
-    {item.type === 'info' && <InfoMessage text={item.text} />}
-    {item.type === 'error' && <ErrorMessage text={item.text} />}
-    {item.type === 'about' && (
-      <AboutBox
-        cliVersion={item.cliVersion}
-        osVersion={item.osVersion}
-        sandboxEnv={item.sandboxEnv}
-        modelVersion={item.modelVersion}
-      />
-    )}
-    {item.type === 'stats' && (
-      <StatsDisplay
-        stats={item.stats}
-        lastTurnStats={item.lastTurnStats}
-        duration={item.duration}
-      />
-    )}
-    {item.type === 'quit' && (
-      <SessionSummaryDisplay stats={item.stats} duration={item.duration} />
-    )}
-    {item.type === 'tool_group' && (
-      <ToolGroupMessage
-        toolCalls={item.tools}
-        groupId={item.id}
-        availableTerminalHeight={availableTerminalHeight}
-        config={config}
-        isFocused={isFocused}
-      />
-    )}
-    {item.type === 'compression' && (
-      <CompressionMessage compression={item.compression} />
-    )}
-  </Box>
-);
+  isLastContent = false,
+}) => {
+  const isFirstContent =
+    !previousItem ||
+    previousItem.type === 'user' ||
+    previousItem.type === 'user_shell';
+
+  return (
+    <Box flexDirection="column" key={item.id}>
+      {/* Render standard message types */}
+      {item.type === 'user' && <UserMessage text={item.text} />}
+      {item.type === 'user_shell' && <UserShellMessage text={item.text} />}
+      {item.type === 'gemini' && (
+        <GeminiMessage
+          text={item.text}
+          isPending={isPending}
+          availableTerminalHeight={availableTerminalHeight}
+        />
+      )}
+      {item.type === 'gemini_content' && (
+        <GeminiMessageContent
+          text={item.text}
+          isPending={isPending}
+          availableTerminalHeight={availableTerminalHeight}
+        />
+      )}
+      {item.type === 'info' && <InfoMessage text={item.text} />}
+      {item.type === 'error' && <ErrorMessage text={item.text} />}
+      {item.type === 'about' && (
+        <AboutBox
+          cliVersion={item.cliVersion}
+          osVersion={item.osVersion}
+          sandboxEnv={item.sandboxEnv}
+          modelVersion={item.modelVersion}
+        />
+      )}
+      {item.type === 'stats' && (
+        <StatsDisplay
+          stats={item.stats}
+          lastTurnStats={item.lastTurnStats}
+          duration={item.duration}
+        />
+      )}
+      {item.type === 'quit' && (
+        <SessionSummaryDisplay stats={item.stats} duration={item.duration} />
+      )}
+      {item.type === 'tool_group' && (
+        <ToolGroupMessage
+          toolCalls={item.tools}
+          groupId={item.id}
+          availableTerminalHeight={availableTerminalHeight}
+          config={config}
+          isFocused={isFocused}
+          isFirstContent={isFirstContent}
+          isLastContent={isLastContent}
+        />
+      )}
+      {item.type === 'compression' && (
+        <CompressionMessage compression={item.compression} />
+      )}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -23,29 +23,36 @@ import { Config } from '@gemini-cli/core';
 interface HistoryItemDisplayProps {
   item: HistoryItem;
   previousItem?: HistoryItem | HistoryItemWithoutId;
+  nextItem?: HistoryItem | HistoryItemWithoutId;
   availableTerminalHeight: number;
   isPending: boolean;
   config?: Config;
   isFocused?: boolean;
-  isLastContent?: boolean;
 }
 
 export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
   item,
   previousItem,
+  nextItem,
   availableTerminalHeight,
   isPending,
   config,
   isFocused = true,
-  isLastContent = false,
 }) => {
   const isFirstContent =
     !previousItem ||
     previousItem.type === 'user' ||
     previousItem.type === 'user_shell';
 
+  const isFollowedByToolGroup = nextItem?.type === 'tool_group';
+
+  const suppressMargin =
+    (item.type === 'tool_group' && isFirstContent) ||
+    (item.type === 'tool_group' && previousItem?.type === 'tool_group') ||
+    (item.type === 'tool_group' && previousItem?.type === 'gemini');
+
   return (
-    <Box flexDirection="column" key={item.id}>
+    <Box flexDirection="column" key={item.id} marginTop={suppressMargin ? 0 : 1}>
       {/* Render standard message types */}
       {item.type === 'user' && <UserMessage text={item.text} />}
       {item.type === 'user_shell' && <UserShellMessage text={item.text} />}
@@ -54,6 +61,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           text={item.text}
           isPending={isPending}
           availableTerminalHeight={availableTerminalHeight}
+          isFollowedByToolGroup={isFollowedByToolGroup}
         />
       )}
       {item.type === 'gemini_content' && (
@@ -61,6 +69,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           text={item.text}
           isPending={isPending}
           availableTerminalHeight={availableTerminalHeight}
+          isFollowedByToolGroup={isFollowedByToolGroup}
         />
       )}
       {item.type === 'info' && <InfoMessage text={item.text} />}
@@ -91,7 +100,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           config={config}
           isFocused={isFocused}
           isFirstContent={isFirstContent}
-          isLastContent={isLastContent}
+          isFollowedByToolGroup={isFollowedByToolGroup}
         />
       )}
       {item.type === 'compression' && (

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -21,9 +21,8 @@ import { SessionSummaryDisplay } from './SessionSummaryDisplay.js';
 import { Config } from '@gemini-cli/core';
 
 interface HistoryItemDisplayProps {
-  item: HistoryItem;
+  item: HistoryItem | HistoryItemWithoutId;
   previousItem?: HistoryItem | HistoryItemWithoutId;
-  nextItem?: HistoryItem | HistoryItemWithoutId;
   availableTerminalHeight: number;
   isPending: boolean;
   config?: Config;
@@ -33,7 +32,6 @@ interface HistoryItemDisplayProps {
 export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
   item,
   previousItem,
-  nextItem,
   availableTerminalHeight,
   isPending,
   config,
@@ -44,15 +42,19 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
     previousItem.type === 'user' ||
     previousItem.type === 'user_shell';
 
-  const isFollowedByToolGroup = nextItem?.type === 'tool_group';
-
   const suppressMargin =
     (item.type === 'tool_group' && isFirstContent) ||
     (item.type === 'tool_group' && previousItem?.type === 'tool_group') ||
     (item.type === 'tool_group' && previousItem?.type === 'gemini');
 
+  const itemId = 'id' in item ? item.id : undefined;
+
   return (
-    <Box flexDirection="column" key={item.id} marginTop={suppressMargin ? 0 : 1}>
+    <Box
+      flexDirection="column"
+      key={itemId}
+      marginTop={suppressMargin ? 0 : 1}
+    >
       {/* Render standard message types */}
       {item.type === 'user' && <UserMessage text={item.text} />}
       {item.type === 'user_shell' && <UserShellMessage text={item.text} />}
@@ -61,7 +63,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           text={item.text}
           isPending={isPending}
           availableTerminalHeight={availableTerminalHeight}
-          isFollowedByToolGroup={isFollowedByToolGroup}
+          isFollowedByToolGroup={false}
         />
       )}
       {item.type === 'gemini_content' && (
@@ -69,7 +71,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           text={item.text}
           isPending={isPending}
           availableTerminalHeight={availableTerminalHeight}
-          isFollowedByToolGroup={isFollowedByToolGroup}
+          isFollowedByToolGroup={false}
         />
       )}
       {item.type === 'info' && <InfoMessage text={item.text} />}
@@ -95,12 +97,11 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
       {item.type === 'tool_group' && (
         <ToolGroupMessage
           toolCalls={item.tools}
-          groupId={item.id}
+          groupId={itemId}
           availableTerminalHeight={availableTerminalHeight}
           config={config}
           isFocused={isFocused}
           isFirstContent={isFirstContent}
-          isFollowedByToolGroup={isFollowedByToolGroup}
         />
       )}
       {item.type === 'compression' && (

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -23,6 +23,7 @@ import { Config } from '@gemini-cli/core';
 interface HistoryItemDisplayProps {
   item: HistoryItem | HistoryItemWithoutId;
   previousItem?: HistoryItem | HistoryItemWithoutId;
+  nextItem?: HistoryItem | HistoryItemWithoutId;
   availableTerminalHeight: number;
   isPending: boolean;
   config?: Config;
@@ -32,6 +33,7 @@ interface HistoryItemDisplayProps {
 export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
   item,
   previousItem,
+  nextItem,
   availableTerminalHeight,
   isPending,
   config,
@@ -41,6 +43,8 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
     !previousItem ||
     previousItem.type === 'user' ||
     previousItem.type === 'user_shell';
+
+  const isFollowedByToolGroup = nextItem?.type === 'tool_group';
 
   const suppressMargin =
     (item.type === 'tool_group' && isFirstContent) ||
@@ -63,7 +67,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           text={item.text}
           isPending={isPending}
           availableTerminalHeight={availableTerminalHeight}
-          isFollowedByToolGroup={false}
+          isFollowedByToolGroup={isFollowedByToolGroup}
         />
       )}
       {item.type === 'gemini_content' && (
@@ -71,7 +75,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           text={item.text}
           isPending={isPending}
           availableTerminalHeight={availableTerminalHeight}
-          isFollowedByToolGroup={false}
+          isFollowedByToolGroup={isFollowedByToolGroup}
         />
       )}
       {item.type === 'info' && <InfoMessage text={item.text} />}
@@ -102,6 +106,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           config={config}
           isFocused={isFocused}
           isFirstContent={isFirstContent}
+          isFollowedByToolGroup={isFollowedByToolGroup}
         />
       )}
       {item.type === 'compression' && (

--- a/packages/cli/src/ui/components/messages/GeminiMessage.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessage.tsx
@@ -13,6 +13,7 @@ interface GeminiMessageProps {
   text: string;
   isPending: boolean;
   availableTerminalHeight: number;
+  isFollowedByToolGroup?: boolean;
 }
 
 export const GeminiMessage: React.FC<GeminiMessageProps> = ({
@@ -20,6 +21,10 @@ export const GeminiMessage: React.FC<GeminiMessageProps> = ({
   isPending,
   availableTerminalHeight,
 }) => {
+  if (!text && !isPending) {
+    return null;
+  }
+
   const prefix = '✦ ';
   const prefixWidth = prefix.length;
 

--- a/packages/cli/src/ui/components/messages/GeminiMessageContent.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessageContent.tsx
@@ -12,6 +12,7 @@ interface GeminiMessageContentProps {
   text: string;
   isPending: boolean;
   availableTerminalHeight: number;
+  isFollowedByToolGroup?: boolean;
 }
 
 /*
@@ -24,12 +25,21 @@ export const GeminiMessageContent: React.FC<GeminiMessageContentProps> = ({
   text,
   isPending,
   availableTerminalHeight,
+  isFollowedByToolGroup = false,
 }) => {
+  if (!text && !isPending) {
+    return null;
+  }
+
   const originalPrefix = '✦ ';
   const prefixWidth = originalPrefix.length;
 
   return (
-    <Box flexDirection="column" paddingLeft={prefixWidth}>
+    <Box
+      flexDirection="column"
+      paddingLeft={prefixWidth}
+      marginBottom={isFollowedByToolGroup || isPending ? 0 : 1}
+    >
       <MarkdownDisplay
         text={text}
         isPending={isPending}

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useMemo } from 'react';
-import { Box } from 'ink';
+import { Box, Text } from 'ink';
 import { IndividualToolCallDisplay, ToolCallStatus } from '../../types.js';
 import { ToolMessage } from './ToolMessage.js';
 import { ToolConfirmationMessage } from './ToolConfirmationMessage.js';
@@ -48,28 +48,41 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     return (
       <Box flexDirection="column" marginLeft={1}>
         {toolCalls.map((tool, index) => {
-          const isFirstToolInGroup = index === 0;
+          const isLastInChain = index === toolCalls.length - 1;
+
+          let prefix: string;
+          if (toolCalls.length === 1) {
+            prefix = isFirstContent ? '─── ' : '╰── ';
+          } else {
+            if (index === 0) {
+              prefix = isFirstContent ? '┌── ' : '├── ';
+            } else if (isLastInChain) {
+              prefix = '╰── ';
+            } else {
+              prefix = '├── ';
+            }
+          }
+
+          const errorLinePrefix = isLastInChain ? '       ' : '│      ';
+
           return (
             <Box key={tool.callId} flexDirection="column" minHeight={1}>
-              <Box flexDirection="row" alignItems="center">
-                <ToolMessage
-                  callId={tool.callId}
-                  name={tool.name}
-                  description={tool.description}
-                  resultDisplay={tool.resultDisplay}
-                  status={tool.status}
-                  confirmationDetails={tool.confirmationDetails}
-                  availableTerminalHeight={
-                    availableTerminalHeight - staticHeight
-                  }
-                  emphasis={'medium'}
-                  renderOutputAsMarkdown={tool.renderOutputAsMarkdown}
-                  displayMode="line"
-                  isFirstContent={isFirstContent && isFirstToolInGroup}
-                  index={index}
-                  total={toolCalls.length}
-                />
-              </Box>
+              <ToolMessage
+                prefix={prefix}
+                errorLinePrefix={errorLinePrefix}
+                callId={tool.callId}
+                name={tool.name}
+                description={tool.description}
+                resultDisplay={tool.resultDisplay}
+                status={tool.status}
+                confirmationDetails={tool.confirmationDetails}
+                availableTerminalHeight={
+                  availableTerminalHeight - staticHeight
+                }
+                emphasis={'medium'}
+                renderOutputAsMarkdown={tool.renderOutputAsMarkdown}
+                displayMode="line"
+              />
             </Box>
           );
         })}
@@ -99,6 +112,8 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
           <Box key={tool.callId} flexDirection="column" minHeight={1}>
             <Box flexDirection="row" alignItems="center">
               <ToolMessage
+                prefix=""
+                errorLinePrefix=""
                 callId={tool.callId}
                 name={tool.name}
                 description={tool.description}

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -19,6 +19,7 @@ interface ToolGroupMessageProps {
   config?: Config;
   isFocused?: boolean;
   isFirstContent?: boolean;
+  isFollowedByToolGroup?: boolean;
 }
 
 // Main component renders the border and maps the tools using ToolMessage
@@ -28,6 +29,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   config,
   isFocused = true,
   isFirstContent = false,
+  isFollowedByToolGroup = false,
 }) => {
   const hasPending = !toolCalls.every(
     (t) => t.status === ToolCallStatus.Success,
@@ -47,16 +49,28 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     return (
       <Box flexDirection="column" marginLeft={2}>
         {toolCalls.map((tool, index) => {
-          const isLastInChain = index === toolCalls.length - 1;
-          const isSingleTool = toolCalls.length === 1;
+          const isLastInGroup = index === toolCalls.length - 1;
+          const isLastInChain = isLastInGroup && !isFollowedByToolGroup;
 
           let prefix: string;
-          if (isSingleTool) {
-            prefix = isFirstContent ? '─── ' : '╰── ';
-          } else if (index === 0) {
-            prefix = isFirstContent ? '┌── ' : '├── ';
+          if (toolCalls.length === 1) {
+            // This group has only one tool.
+            if (isFirstContent) {
+              // This is the very first item after a user prompt.
+              prefix = isFollowedByToolGroup ? '┌── ' : '─── ';
+            } else {
+              // This is a single tool that follows another item.
+              prefix = isLastInChain ? '╰── ' : '├── ';
+            }
           } else {
-            prefix = isLastInChain ? '╰── ' : '├── ';
+            // This group has multiple tools.
+            if (index === 0) {
+              // First tool in the group.
+              prefix = isFirstContent ? '┌── ' : '├── ';
+            } else {
+              // Subsequent tool in the group.
+              prefix = isLastInChain ? '╰── ' : '├── ';
+            }
           }
 
           const errorLinePrefix = isLastInChain ? '      ' : '│     ';

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -47,7 +47,8 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   if (config?.getToolCallDisplay() === 'line' && !toolAwaitingApproval) {
     return (
       <Box flexDirection="column" marginLeft={1}>
-        {toolCalls.map((tool) => {
+        {toolCalls.map((tool, index) => {
+          const isFirstToolInGroup = index === 0;
           return (
             <Box key={tool.callId} flexDirection="column" minHeight={1}>
               <Box flexDirection="row" alignItems="center">
@@ -64,7 +65,9 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
                   emphasis={'medium'}
                   renderOutputAsMarkdown={tool.renderOutputAsMarkdown}
                   displayMode="line"
-                  isFirstContent={isFirstContent}
+                  isFirstContent={isFirstContent && isFirstToolInGroup}
+                  index={index}
+                  total={toolCalls.length}
                 />
               </Box>
             </Box>

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -19,7 +19,7 @@ interface ToolGroupMessageProps {
   config?: Config;
   isFocused?: boolean;
   isFirstContent?: boolean;
-  isLastContent?: boolean;
+  isFollowedByToolGroup?: boolean;
 }
 
 // Main component renders the border and maps the tools using ToolMessage
@@ -29,7 +29,6 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   config,
   isFocused = true,
   isFirstContent = false,
-  isLastContent = false,
 }) => {
   const hasPending = !toolCalls.every(
     (t) => t.status === ToolCallStatus.Success,
@@ -47,11 +46,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
 
   if (config?.getToolCallDisplay() === 'line' && !toolAwaitingApproval) {
     return (
-      <Box
-        flexDirection="column"
-        marginLeft={1}
-        marginBottom={isLastContent ? 0 : 1}
-      >
+      <Box flexDirection="column" marginLeft={1}>
         {toolCalls.map((tool) => {
           return (
             <Box key={tool.callId} flexDirection="column" minHeight={1}>
@@ -93,7 +88,6 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
       marginLeft={1}
       borderDimColor={hasPending}
       borderColor={borderColor}
-      marginBottom={isLastContent ? 0 : 1}
     >
       {toolCalls.map((tool) => {
         const isConfirming =

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -46,8 +46,9 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
 
   if (config?.getToolCallDisplay() === 'line' && !toolAwaitingApproval) {
     return (
-      <Box flexDirection="column" marginLeft={1}>
+      <Box flexDirection="column" marginLeft={2}>
         {toolCalls.map((tool, index) => {
+          const isFirstToolInGroup = index === 0;
           const isLastInChain = index === toolCalls.length - 1;
 
           let prefix: string;
@@ -63,7 +64,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
             }
           }
 
-          const errorLinePrefix = isLastInChain ? '       ' : '│      ';
+          const errorLinePrefix = isLastInChain ? '      ' : '│     ';
 
           return (
             <Box key={tool.callId} flexDirection="column" minHeight={1}>

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -18,6 +18,8 @@ interface ToolGroupMessageProps {
   availableTerminalHeight: number;
   config?: Config;
   isFocused?: boolean;
+  isFirstContent?: boolean;
+  isLastContent?: boolean;
 }
 
 // Main component renders the border and maps the tools using ToolMessage
@@ -26,6 +28,8 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   availableTerminalHeight,
   config,
   isFocused = true,
+  isFirstContent = false,
+  isLastContent = false,
 }) => {
   const hasPending = !toolCalls.every(
     (t) => t.status === ToolCallStatus.Success,
@@ -41,6 +45,40 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     [toolCalls],
   );
 
+  if (config?.getToolCallDisplay() === 'line' && !toolAwaitingApproval) {
+    return (
+      <Box
+        flexDirection="column"
+        marginLeft={1}
+        marginBottom={isLastContent ? 0 : 1}
+      >
+        {toolCalls.map((tool) => {
+          return (
+            <Box key={tool.callId} flexDirection="column" minHeight={1}>
+              <Box flexDirection="row" alignItems="center">
+                <ToolMessage
+                  callId={tool.callId}
+                  name={tool.name}
+                  description={tool.description}
+                  resultDisplay={tool.resultDisplay}
+                  status={tool.status}
+                  confirmationDetails={tool.confirmationDetails}
+                  availableTerminalHeight={
+                    availableTerminalHeight - staticHeight
+                  }
+                  emphasis={'medium'}
+                  renderOutputAsMarkdown={tool.renderOutputAsMarkdown}
+                  displayMode="line"
+                  isFirstContent={isFirstContent}
+                />
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+    );
+  }
+
   return (
     <Box
       flexDirection="column"
@@ -55,10 +93,11 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
       marginLeft={1}
       borderDimColor={hasPending}
       borderColor={borderColor}
-      marginBottom={1}
+      marginBottom={isLastContent ? 0 : 1}
     >
       {toolCalls.map((tool) => {
-        const isConfirming = toolAwaitingApproval?.callId === tool.callId;
+        const isConfirming =
+          !!toolAwaitingApproval && toolAwaitingApproval.callId === tool.callId;
         return (
           <Box key={tool.callId} flexDirection="column" minHeight={1}>
             <Box flexDirection="row" alignItems="center">

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -13,13 +13,12 @@ import { Colors } from '../../colors.js';
 import { Config } from '@gemini-cli/core';
 
 interface ToolGroupMessageProps {
-  groupId: number;
+  groupId?: number;
   toolCalls: IndividualToolCallDisplay[];
   availableTerminalHeight: number;
   config?: Config;
   isFocused?: boolean;
   isFirstContent?: boolean;
-  isFollowedByToolGroup?: boolean;
 }
 
 // Main component renders the border and maps the tools using ToolMessage
@@ -48,20 +47,16 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     return (
       <Box flexDirection="column" marginLeft={2}>
         {toolCalls.map((tool, index) => {
-          const isFirstToolInGroup = index === 0;
           const isLastInChain = index === toolCalls.length - 1;
+          const isSingleTool = toolCalls.length === 1;
 
           let prefix: string;
-          if (toolCalls.length === 1) {
+          if (isSingleTool) {
             prefix = isFirstContent ? '─── ' : '╰── ';
+          } else if (index === 0) {
+            prefix = isFirstContent ? '┌── ' : '├── ';
           } else {
-            if (index === 0) {
-              prefix = isFirstContent ? '┌── ' : '├── ';
-            } else if (isLastInChain) {
-              prefix = '╰── ';
-            } else {
-              prefix = '├── ';
-            }
+            prefix = isLastInChain ? '╰── ' : '├── ';
           }
 
           const errorLinePrefix = isLastInChain ? '      ' : '│     ';

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -57,29 +57,31 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
             // This group has only one tool.
             if (isFirstContent) {
               // This is the very first item after a user prompt.
-              prefix = isFollowedByToolGroup ? '┌── ' : '─── ';
+              prefix = isFollowedByToolGroup ? '╭─ ' : '── ';
             } else {
               // This is a single tool that follows another item.
-              prefix = isLastInChain ? '╰── ' : '├── ';
+              prefix = isLastInChain ? '╰─ ' : '├─ ';
             }
           } else {
             // This group has multiple tools.
             if (index === 0) {
               // First tool in the group.
-              prefix = isFirstContent ? '┌── ' : '├── ';
+              prefix = isFirstContent ? '╭─ ' : '├─ ';
             } else {
               // Subsequent tool in the group.
-              prefix = isLastInChain ? '╰── ' : '├── ';
+              prefix = isLastInChain ? '╰─ ' : '├─ ';
             }
           }
 
-          const errorLinePrefix = isLastInChain ? '      ' : '│     ';
+          const errorLinePrefix = isLastInChain ? '     ' : '│    ';
 
           return (
             <Box key={tool.callId} flexDirection="column" minHeight={1}>
               <ToolMessage
-                prefix={prefix}
-                errorLinePrefix={errorLinePrefix}
+                prefix={<Text color={Colors.ToolPrefix}>{prefix}</Text>}
+                errorLinePrefix={
+                  <Text color={Colors.ToolPrefix}>{errorLinePrefix}</Text>
+                }
                 callId={tool.callId}
                 name={tool.name}
                 description={tool.description}

--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -55,6 +55,8 @@ const renderWithContext = (
 
 describe('<ToolMessage />', () => {
   const baseProps: ToolMessageProps = {
+    prefix: '├─',
+    errorLinePrefix: '│ ',
     callId: 'tool-123',
     name: 'test-tool',
     description: 'A tool for testing',

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -21,8 +21,8 @@ const MIN_LINES_HIDDEN = 3; // hide at least this many lines (or don't hide any)
 export type TextEmphasis = 'high' | 'medium' | 'low';
 
 export interface ToolMessageProps extends IndividualToolCallDisplay {
-  prefix: string;
-  errorLinePrefix: string;
+  prefix: React.ReactNode;
+  errorLinePrefix: React.ReactNode;
   availableTerminalHeight: number;
   emphasis?: TextEmphasis;
   renderOutputAsMarkdown?: boolean;
@@ -107,7 +107,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
           resultIsString &&
           !resultIsShortString && (
             <Box width="100%" flexDirection="row">
-              <Text color={Colors.AccentRed}>{errorLinePrefix}</Text>
+              {errorLinePrefix}
               <Box>
                 <Text color={Colors.AccentRed}>{resultDisplay}</Text>
               </Box>
@@ -253,7 +253,7 @@ const TrailingIndicator: React.FC = () => (
 
 type LineToolStatusIndicatorProps = {
   status: ToolCallStatus;
-  prefix: string;
+  prefix: React.ReactNode;
 };
 
 const LineToolStatusIndicator: React.FC<LineToolStatusIndicatorProps> = ({

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -21,16 +21,17 @@ const MIN_LINES_HIDDEN = 3; // hide at least this many lines (or don't hide any)
 export type TextEmphasis = 'high' | 'medium' | 'low';
 
 export interface ToolMessageProps extends IndividualToolCallDisplay {
+  prefix: string;
+  errorLinePrefix: string;
   availableTerminalHeight: number;
   emphasis?: TextEmphasis;
   renderOutputAsMarkdown?: boolean;
   displayMode?: 'box' | 'line';
-  isFirstContent?: boolean;
-  index?: number;
-  total?: number;
 }
 
 export const ToolMessage: React.FC<ToolMessageProps> = ({
+  prefix,
+  errorLinePrefix,
   name,
   description,
   resultDisplay,
@@ -39,9 +40,6 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   emphasis = 'medium',
   renderOutputAsMarkdown = true,
   displayMode = 'box',
-  isFirstContent = false,
-  index = 0,
-  total = 1,
 }) => {
   const resultIsString =
     typeof resultDisplay === 'string' && resultDisplay.trim().length > 0;
@@ -78,18 +76,10 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
       resultDisplay.length < 80 &&
       !resultDisplay.includes('\n');
 
-    const isLastInChain = index === total - 1;
-    const errorLinePrefix = isLastInChain ? '    ' : '│   ';
-
     return (
-      <Box paddingX={1} paddingY={0} flexDirection="column">
+      <Box paddingY={0} flexDirection="column">
         <Box minHeight={1}>
-          <LineToolStatusIndicator
-            status={status}
-            isFirstContent={isFirstContent}
-            index={index}
-            total={total}
-          />
+          <LineToolStatusIndicator status={status} prefix={prefix} />
           <ToolInfo
             name={name}
             status={status}
@@ -263,32 +253,15 @@ const TrailingIndicator: React.FC = () => (
 
 type LineToolStatusIndicatorProps = {
   status: ToolCallStatus;
-  isFirstContent: boolean;
-  index: number;
-  total: number;
+  prefix: string;
 };
 
 const LineToolStatusIndicator: React.FC<LineToolStatusIndicatorProps> = ({
   status,
-  isFirstContent,
-  index,
-  total,
+  prefix,
 }) => {
-  let prefix: string;
-  if (total === 1) {
-    prefix = isFirstContent ? '─── ' : '╰── ';
-  } else {
-    if (index === 0) {
-      prefix = isFirstContent ? '┌── ' : '├── ';
-    } else if (index === total - 1) {
-      prefix = '╰── ';
-    } else {
-      prefix = '├── ';
-    }
-  }
-
   return (
-    <Box minWidth={STATUS_INDICATOR_WIDTH}>
+    <Box>
       {status === ToolCallStatus.Pending && (
         <Text color={Colors.AccentGreen}>{prefix}o </Text>
       )}
@@ -314,10 +287,11 @@ const LineToolStatusIndicator: React.FC<LineToolStatusIndicatorProps> = ({
       )}
       {status === ToolCallStatus.Error && (
         <Text color={Colors.AccentRed} bold>
-          {prefix}✘{' '}
+          {prefix}✘{'  '}
         </Text>
       )}
     </Box>
   );
 };
+
 

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -26,6 +26,8 @@ export interface ToolMessageProps extends IndividualToolCallDisplay {
   renderOutputAsMarkdown?: boolean;
   displayMode?: 'box' | 'line';
   isFirstContent?: boolean;
+  index?: number;
+  total?: number;
 }
 
 export const ToolMessage: React.FC<ToolMessageProps> = ({
@@ -38,6 +40,8 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   renderOutputAsMarkdown = true,
   displayMode = 'box',
   isFirstContent = false,
+  index = 0,
+  total = 1,
 }) => {
   const resultIsString =
     typeof resultDisplay === 'string' && resultDisplay.trim().length > 0;
@@ -74,12 +78,22 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
       resultDisplay.length < 80 &&
       !resultDisplay.includes('\n');
 
+    const isLastInChain = index === total - 1;
+    let errorLinePrefix;
+    if (isFirstContent) {
+      errorLinePrefix = isLastInChain ? '    ' : '│   ';
+    } else {
+      errorLinePrefix = isLastInChain ? '   ' : '│  ';
+    }
+
     return (
       <Box paddingX={1} paddingY={0} flexDirection="column">
         <Box minHeight={1}>
           <LineToolStatusIndicator
             status={status}
             isFirstContent={isFirstContent}
+            index={index}
+            total={total}
           />
           <ToolInfo
             name={name}
@@ -107,8 +121,15 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
         {status === ToolCallStatus.Error &&
           resultIsString &&
           !resultIsShortString && (
-            <Box paddingLeft={isFirstContent ? 3 : 5} width="100%">
-              <Text color={Colors.AccentRed}>{resultDisplay}</Text>
+            <Box
+              paddingLeft={isFirstContent ? 0 : 1}
+              width="100%"
+              flexDirection="row"
+            >
+              <Text color={Colors.AccentRed}>{errorLinePrefix}</Text>
+              <Box>
+                <Text color={Colors.AccentRed}>{resultDisplay}</Text>
+              </Box>
             </Box>
           )}
       </Box>
@@ -252,13 +273,28 @@ const TrailingIndicator: React.FC = () => (
 type LineToolStatusIndicatorProps = {
   status: ToolCallStatus;
   isFirstContent: boolean;
+  index: number;
+  total: number;
 };
 
 const LineToolStatusIndicator: React.FC<LineToolStatusIndicatorProps> = ({
   status,
   isFirstContent,
+  index,
+  total,
 }) => {
-  const prefix = isFirstContent ? '─── ' : '╰── ';
+  let prefix: string;
+  if (total === 1) {
+    prefix = isFirstContent ? '─── ' : '╰── ';
+  } else {
+    if (index === 0) {
+      prefix = isFirstContent ? '┌── ' : '├── ';
+    } else if (index === total - 1) {
+      prefix = '╰── ';
+    } else {
+      prefix = '├── ';
+    }
+  }
 
   return (
     <Box minWidth={STATUS_INDICATOR_WIDTH + (isFirstContent ? 0 : 2)}>

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -275,19 +275,19 @@ const LineToolStatusIndicator: React.FC<LineToolStatusIndicatorProps> = ({
         </Text>
       )}
       {status === ToolCallStatus.Success && (
-        <Text color={Colors.AccentGreen}>{prefix}✔ </Text>
+        <Text color={Colors.AccentGreen}>{prefix}✔</Text>
       )}
       {status === ToolCallStatus.Confirming && (
         <Text color={Colors.AccentYellow}>{prefix}? </Text>
       )}
       {status === ToolCallStatus.Canceled && (
         <Text color={Colors.AccentYellow} bold>
-          {prefix}-{' '}
+          {prefix}✘{' '}
         </Text>
       )}
       {status === ToolCallStatus.Error && (
         <Text color={Colors.AccentRed} bold>
-          {prefix}✘{'  '}
+          {prefix}✘{' '}
         </Text>
       )}
     </Box>

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -79,12 +79,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
       !resultDisplay.includes('\n');
 
     const isLastInChain = index === total - 1;
-    let errorLinePrefix;
-    if (isFirstContent) {
-      errorLinePrefix = isLastInChain ? '    ' : '│   ';
-    } else {
-      errorLinePrefix = isLastInChain ? '   ' : '│  ';
-    }
+    const errorLinePrefix = isLastInChain ? '    ' : '│   ';
 
     return (
       <Box paddingX={1} paddingY={0} flexDirection="column">
@@ -121,11 +116,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
         {status === ToolCallStatus.Error &&
           resultIsString &&
           !resultIsShortString && (
-            <Box
-              paddingLeft={isFirstContent ? 0 : 1}
-              width="100%"
-              flexDirection="row"
-            >
+            <Box width="100%" flexDirection="row">
               <Text color={Colors.AccentRed}>{errorLinePrefix}</Text>
               <Box>
                 <Text color={Colors.AccentRed}>{resultDisplay}</Text>
@@ -297,7 +288,7 @@ const LineToolStatusIndicator: React.FC<LineToolStatusIndicatorProps> = ({
   }
 
   return (
-    <Box minWidth={STATUS_INDICATOR_WIDTH + (isFirstContent ? 0 : 2)}>
+    <Box minWidth={STATUS_INDICATOR_WIDTH}>
       {status === ToolCallStatus.Pending && (
         <Text color={Colors.AccentGreen}>{prefix}o </Text>
       )}

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -329,9 +329,7 @@ export const useGeminiStream = (
         if (pendingHistoryItemRef.current.type === 'tool_group') {
           const updatedTools = pendingHistoryItemRef.current.tools.map(
             (tool) =>
-              tool.status === ToolCallStatus.Pending ||
-              tool.status === ToolCallStatus.Confirming ||
-              tool.status === ToolCallStatus.Executing
+              tool.status === ToolCallStatus.Confirming
                 ? { ...tool, status: ToolCallStatus.Canceled }
                 : tool,
           );

--- a/packages/cli/src/ui/themes/ansi-light.ts
+++ b/packages/cli/src/ui/themes/ansi-light.ts
@@ -19,6 +19,7 @@ const ansiLightColors: ColorsTheme = {
   AccentRed: 'red',
   Comment: 'gray',
   Gray: 'gray',
+  ToolPrefix: 'gray',
   GradientColors: ['blue', 'green'],
 };
 

--- a/packages/cli/src/ui/themes/ansi.ts
+++ b/packages/cli/src/ui/themes/ansi.ts
@@ -19,6 +19,7 @@ const ansiColors: ColorsTheme = {
   AccentRed: 'red',
   Comment: 'gray',
   Gray: 'gray',
+  ToolPrefix: 'gray',
   GradientColors: ['cyan', 'green'],
 };
 

--- a/packages/cli/src/ui/themes/atom-one-dark.ts
+++ b/packages/cli/src/ui/themes/atom-one-dark.ts
@@ -19,6 +19,7 @@ const atomOneDarkColors: ColorsTheme = {
   AccentRed: '#e06c75',
   Comment: '#5c6370',
   Gray: '#5c6370',
+  ToolPrefix: '#5c6370',
   GradientColors: ['#61aeee', '#98c379'],
 };
 

--- a/packages/cli/src/ui/themes/ayu-light.ts
+++ b/packages/cli/src/ui/themes/ayu-light.ts
@@ -19,6 +19,7 @@ const ayuLightColors: ColorsTheme = {
   AccentRed: '#f07171',
   Comment: '#ABADB1',
   Gray: '#CCCFD3',
+  ToolPrefix: '#CCCFD3',
   GradientColors: ['#399ee6', '#86b300'],
 };
 

--- a/packages/cli/src/ui/themes/ayu.ts
+++ b/packages/cli/src/ui/themes/ayu.ts
@@ -18,7 +18,8 @@ const ayuDarkColors: ColorsTheme = {
   AccentYellow: '#FFB454',
   AccentRed: '#F26D78',
   Comment: '#646A71',
-  Gray: '##3D4149',
+  Gray: '#3D4149',
+  ToolPrefix: '#3D4149',
   GradientColors: ['#FFB454', '#F26D78'],
 };
 

--- a/packages/cli/src/ui/themes/dracula.ts
+++ b/packages/cli/src/ui/themes/dracula.ts
@@ -19,6 +19,7 @@ const draculaColors: ColorsTheme = {
   AccentRed: '#ff5555',
   Comment: '#6272a4',
   Gray: '#6272a4',
+  ToolPrefix: '#6272a4',
   GradientColors: ['#ff79c6', '#8be9fd'],
 };
 

--- a/packages/cli/src/ui/themes/github-dark.ts
+++ b/packages/cli/src/ui/themes/github-dark.ts
@@ -19,6 +19,7 @@ const githubDarkColors: ColorsTheme = {
   AccentRed: '#F97583',
   Comment: '#6A737D',
   Gray: '#6A737D',
+  ToolPrefix: '#6A737D',
   GradientColors: ['#79B8FF', '#85E89D'],
 };
 

--- a/packages/cli/src/ui/themes/github-light.ts
+++ b/packages/cli/src/ui/themes/github-light.ts
@@ -19,6 +19,7 @@ const githubLightColors: ColorsTheme = {
   AccentRed: '#d14',
   Comment: '#998',
   Gray: '#999',
+  ToolPrefix: '#999',
   GradientColors: ['#458', '#008080'],
 };
 

--- a/packages/cli/src/ui/themes/googlecode.ts
+++ b/packages/cli/src/ui/themes/googlecode.ts
@@ -19,6 +19,7 @@ const googleCodeColors: ColorsTheme = {
   AccentRed: '#800',
   Comment: '#5f6368',
   Gray: lightTheme.Gray,
+  ToolPrefix: lightTheme.Gray,
   GradientColors: ['#066', '#606'],
 };
 

--- a/packages/cli/src/ui/themes/no-color.ts
+++ b/packages/cli/src/ui/themes/no-color.ts
@@ -19,6 +19,7 @@ const noColorColorsTheme: ColorsTheme = {
   AccentRed: '',
   Comment: '',
   Gray: '',
+  ToolPrefix: '',
 };
 
 export const NoColorTheme: Theme = new Theme(

--- a/packages/cli/src/ui/themes/theme.ts
+++ b/packages/cli/src/ui/themes/theme.ts
@@ -21,6 +21,7 @@ export interface ColorsTheme {
   AccentRed: string;
   Comment: string;
   Gray: string;
+  ToolPrefix: string;
   GradientColors?: string[];
 }
 
@@ -37,6 +38,7 @@ export const lightTheme: ColorsTheme = {
   AccentRed: '#DD4C4C',
   Comment: '#008000',
   Gray: '#B7BECC',
+  ToolPrefix: '#B7BECC',
   GradientColors: ['#4796E4', '#847ACE', '#C3677F'],
 };
 
@@ -53,6 +55,7 @@ export const darkTheme: ColorsTheme = {
   AccentRed: '#F38BA8',
   Comment: '#6C7086',
   Gray: '#6C7086',
+  ToolPrefix: '#6C7086',
   GradientColors: ['#4796E4', '#847ACE', '#C3677F'],
 };
 
@@ -69,6 +72,7 @@ export const ansiTheme: ColorsTheme = {
   AccentRed: 'red',
   Comment: 'gray',
   Gray: 'gray',
+  ToolPrefix: 'gray',
 };
 
 export class Theme {

--- a/packages/cli/src/ui/themes/xcode.ts
+++ b/packages/cli/src/ui/themes/xcode.ts
@@ -19,6 +19,7 @@ const xcodeColors: ColorsTheme = {
   AccentRed: '#c41a16',
   Comment: '#007400',
   Gray: '#c0c0c0',
+  ToolPrefix: '#c0c0c0',
   GradientColors: ['#1c00cf', '#007400'],
 };
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -101,6 +101,7 @@ export interface ConfigParameters {
   cwd: string;
   fileDiscoveryService?: FileDiscoveryService;
   bugCommand?: BugCommandSettings;
+  toolCallDisplay?: 'box' | 'line';
 }
 
 export class Config {
@@ -133,6 +134,7 @@ export class Config {
   private readonly proxy: string | undefined;
   private readonly cwd: string;
   private readonly bugCommand: BugCommandSettings | undefined;
+  private readonly toolCallDisplay: 'box' | 'line';
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -169,6 +171,7 @@ export class Config {
     this.cwd = params.cwd ?? process.cwd();
     this.fileDiscoveryService = params.fileDiscoveryService ?? null;
     this.bugCommand = params.bugCommand;
+    this.toolCallDisplay = params.toolCallDisplay ?? 'box';
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -323,6 +326,10 @@ export class Config {
 
   getBugCommand(): BugCommandSettings | undefined {
     return this.bugCommand;
+  }
+
+  getToolCallDisplay(): 'box' | 'line' {
+    return this.toolCallDisplay;
   }
 
   getFileService(): FileDiscoveryService {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -425,6 +425,8 @@ export class CoreToolScheduler {
       (reqInfo): ToolCall => {
         const toolInstance = toolRegistry.getTool(reqInfo.name);
         if (!toolInstance) {
+          reqInfo.displayName = reqInfo.name;
+          reqInfo.description = JSON.stringify(reqInfo.args);
           return {
             status: 'error',
             request: reqInfo,
@@ -435,6 +437,10 @@ export class CoreToolScheduler {
             durationMs: 0,
           };
         }
+
+        reqInfo.displayName = toolInstance.displayName;
+        reqInfo.description = toolInstance.getDescription(reqInfo.args);
+
         return {
           status: 'validating',
           request: reqInfo,
@@ -605,6 +611,18 @@ export class CoreToolScheduler {
                 callId,
                 'cancelled',
                 'User cancelled tool execution.',
+              );
+              return;
+            }
+
+            if (toolResult.isError) {
+              this.setStatusInternal(
+                callId,
+                'error',
+                createErrorResponse(
+                  scheduledCall.request,
+                  new Error(toolResult.returnDisplay as string),
+                ),
               );
               return;
             }

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -54,6 +54,8 @@ export interface GeminiErrorEventValue {
 export interface ToolCallRequestInfo {
   callId: string;
   name: string;
+  displayName?: string;
+  description?: string;
   args: Record<string, unknown>;
 }
 

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -128,6 +128,7 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
       return {
         llmContent: `Error: Invalid parameters provided. Reason: ${validationError}`,
         returnDisplay: validationError,
+        isError: true,
       };
     }
 
@@ -142,6 +143,7 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
       return {
         llmContent: result.error, // The detailed error for LLM
         returnDisplay: result.returnDisplay, // User-friendly error
+        isError: true,
       };
     }
 

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -187,6 +187,7 @@ export interface ToolResult {
    * For now, we keep it as the core logic in ReadFileTool currently produces it.
    */
   returnDisplay: ToolResultDisplay;
+  isError?: boolean;
 }
 
 export type ToolResultDisplay = string | FileDiff;


### PR DESCRIPTION
## TLDR

- Switch tool call rendering to a single line where possible, with box rendering characters.
- Render tool call failures

This is not ready for merging. If there is interest in this alternate display approach, it can get cleaned up, tests fixed, etc.

## Dive Deeper

The current tool call rendering uses many lines of the terminal. Those lines push off important code, LLM, and user text that is useful when iterating.

## Reviewer Test Plan

Needs to be put together, but in short try a bunch of tool calling, including chains of tool calls, with some failing, some passing, some cancelled.

## Testing Matrix

For now, only tested locally on mac; not yet ready for merging.

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |