### PR TITLE
Decouple telemetry project ID configuration

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -216,9 +216,12 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
   - Example: `export GOOGLE_API_KEY="YOUR_GOOGLE_API_ KEY"`.
 - **`GOOGLE_CLOUD_PROJECT`**:
   - Your Google Cloud Project ID.
-  - Required for using Code Assist, Telemetry or Vertex AI.
+  - Required for using Code Assist or Vertex AI.
   - If using Vertex AI, ensure you have the necessary permissions and set the `GOOGLE_GENAI_USE_VERTEXAI=true` environment variable.
   - Example: `export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"`.
+- **`OTLP_GOOGLE_CLOUD_PROJECT`**:
+  - Your Google Cloud Project ID for Telemetry in Google Cloud
+  - Example: `export OTLP_GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"`.
 - **`GOOGLE_CLOUD_LOCATION`**:
   - Your Google Cloud Project Location (e.g., us-central1).
   - Required for using Vertex AI in non express mode.

--- a/docs/core/telemetry.md
+++ b/docs/core/telemetry.md
@@ -136,7 +136,7 @@ Use the `npm run telemetry -- --target=gcp` command which automates setting up a
     - Ensure you have a Google Cloud Project ID.
     - Export the `GOOGLE_CLOUD_PROJECT` environment variable to make it available to the OTEL collector.
       ```bash
-      export GOOGLE_CLOUD_PROJECT="your-project-id"
+      export OTLP_GOOGLE_CLOUD_PROJECT="your-project-id"
       ```
     - Authenticate with Google Cloud (e.g., run `gcloud auth application-default login` or ensure `GOOGLE_APPLICATION_CREDENTIALS` is set).
     - Ensure your account/service account has the necessary roles: "Cloud Trace Agent", "Monitoring Metric Writer", and "Logs Writer".

--- a/scripts/telemetry_gcp.js
+++ b/scripts/telemetry_gcp.js
@@ -78,18 +78,18 @@ async function main() {
     originalSandboxSetting,
   );
 
-  const projectId = process.env.GOOGLE_CLOUD_PROJECT;
+  const projectId = process.env.OTLP_GOOGLE_CLOUD_PROJECT;
   if (!projectId) {
     console.error(
-      '🛑 Error: GOOGLE_CLOUD_PROJECT environment variable is not exported.',
+      '🛑 Error: OTLP_GOOGLE_CLOUD_PROJECT environment variable is not exported.',
     );
     console.log(
       '   Please set it to your Google Cloud Project ID and try again.',
     );
-    console.log('   `export GOOGLE_CLOUD_PROJECT=your-project-id`');
+    console.log('   `export OTLP_GOOGLE_CLOUD_PROJECT=your-project-id`');
     process.exit(1);
   }
-  console.log(`✅ Using Google Cloud Project ID: ${projectId}`);
+  console.log(`✅ Using OTLP Google Cloud Project ID: ${projectId}`);
 
   console.log('\n🔑 Please ensure you are authenticated with Google Cloud:');
   console.log(


### PR DESCRIPTION
#750 

Renames project ID for telemetry from `GOOGLE_CLOUD_PROJECT` to `OTLP_GOOGLE_CLOUD_PROJECT`.

This change allows for a separate Google Cloud Project to be used for telemetry data, distinct from the project used for other services like Vertex AI or Code Assist. This enhances clarity and flexibility in project configuration.

---
```shell
$ npm run telemetry -- --target=gcp

> gemini-cli@0.1.0 telemetry
> node scripts/telemetry.js --target=gcp

⚙️  Using command-line target: gcp
🚀 Running telemetry script for target: gcp.
✨ Starting Local Telemetry Exporter for Google Cloud ✨
⚙️  Enabled telemetry in workspace settings.
🔧 Set telemetry OTLP endpoint to http://localhost:4317.
🎯 Set telemetry target to gcp.
✅ Workspace settings updated.
✅ Using OTLP Google Cloud Project ID: foo-bar

🔑 Please ensure you are authenticated with Google Cloud:
  - Run `gcloud auth application-default login` OR ensure `GOOGLE_APPLICATION_CREDENTIALS` environment variable points to a valid service account key.
  - The account needs "Cloud Trace Agent", "Monitoring Metric Writer", and "Logs Writer" roles.
✅ otelcol-contrib already exists at /Users/jerop/github/gemini-cli/.gemini/otel/bin/otelcol-contrib
🧹 Cleaning up old processes and logs...
✅ Stopped existing otelcol-contrib process.
✅ Deleted old GCP collector log.
📄 Wrote OTEL collector config to /Users/jerop/github/gemini-cli/.gemini/otel/collector-gcp.yaml
🚀 Starting OTEL collector for GCP... Logs: /Users/jerop/github/gemini-cli/.gemini/otel/collector-gcp.log
⏳ Waiting for OTEL collector to start (PID: 15488)...
✅ OTEL collector started successfully on port 4317.

✨ Local OTEL collector for GCP is running.

🚀 To send telemetry, run the Gemini CLI in a separate terminal window.

📄 Collector logs are being written to: /Users/jerop/github/gemini-cli/.gemini/otel/collector-gcp.log

📊 View your telemetry data in Google Cloud Console:
   - Logs: https://console.cloud.google.com/logs/query;query=logName%3D%22projects%2Ffoo-bar%2Flogs%2Fgemini_cli%22?project=foo-bar
   - Metrics: https://console.cloud.google.com/monitoring/metrics-explorer?project=foo-bar
   - Traces: https://console.cloud.google.com/traces/list?project=foo-bar

Press Ctrl+C to exit.
^C
👋 Shutting down...
⚙️  Disabled telemetry in workspace settings.
🔧 Cleared telemetry OTLP endpoint.
🎯 Cleared telemetry target.
✅ Workspace settings updated.
🛑 Stopping otelcol-contrib (PID: 15488)...
✅ otelcol-contrib stopped.
```