### PR TITLE
bug: Fix modify edit

### DIFF
--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -467,10 +467,12 @@ Expectation for required parameters:
         }
       },
       createUpdatedParams: (
+        oldContent: string,
         modifiedProposedContent: string,
         originalParams: EditToolParams,
       ): EditToolParams => ({
         ...originalParams,
+        old_string: oldContent,
         new_string: modifiedProposedContent,
       }),
     };

--- a/packages/core/src/tools/modifiable-tool.test.ts
+++ b/packages/core/src/tools/modifiable-tool.test.ts
@@ -74,9 +74,10 @@ describe('modifyWithEditor', () => {
       getProposedContent: vi.fn().mockResolvedValue(proposedContent),
       createUpdatedParams: vi
         .fn()
-        .mockImplementation((modifiedContent, originalParams) => ({
+        .mockImplementation((oldContent, modifiedContent, originalParams) => ({
           ...originalParams,
           modifiedContent,
+          oldContent,
         })),
     };
 
@@ -153,6 +154,7 @@ describe('modifyWithEditor', () => {
       );
 
       expect(mockModifyContext.createUpdatedParams).toHaveBeenCalledWith(
+        currentContent,
         modifiedContent,
         mockParams,
       );
@@ -183,6 +185,7 @@ describe('modifyWithEditor', () => {
         updatedParams: {
           ...mockParams,
           modifiedContent,
+          oldContent: currentContent,
         },
         updatedDiff: 'mock diff content',
       });

--- a/packages/core/src/tools/modifiable-tool.ts
+++ b/packages/core/src/tools/modifiable-tool.ts
@@ -29,6 +29,7 @@ export interface ModifyContext<ToolParams> {
   getProposedContent: (params: ToolParams) => Promise<string>;
 
   createUpdatedParams: (
+    oldContent: string,
     modifiedProposedContent: string,
     originalParams: ToolParams,
   ) => ToolParams;
@@ -98,6 +99,7 @@ function getUpdatedParams<ToolParams>(
   }
 
   const updatedParams = modifyContext.createUpdatedParams(
+    oldContent,
     newContent,
     originalParams,
   );

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -389,6 +389,7 @@ export class WriteFileTool
         return correctedContentResult.correctedContent;
       },
       createUpdatedParams: (
+        _oldContent: string,
         modifiedProposedContent: string,
         originalParams: WriteFileToolParams,
       ) => ({


### PR DESCRIPTION
#1044 introduced a a bug to the "modify flow" in the edit tool by appending the entire file's content to itself if the user goes through the modify flow and execute the tool.

This fix is verified to fix the issue by testing manually.