### PR TITLE
Add a command for starting Gemini CLI with GCP telemetry

### DIFF
--- a/docs/core/telemetry.md
+++ b/docs/core/telemetry.md
@@ -23,6 +23,8 @@ This entire system is built on the **[OpenTelemetry] (OTEL)** standard, allowing
 1.  **View Data:** The script will provide links to view your telemetry data (traces, metrics, logs) in the Google Cloud Console.
 1.  **Details:** Refer to documentation for telemetry in [Google Cloud](#google-cloud).
 
+> **Note:** You can also use `npm run start:gcp` as a shorthand for running the CLI with GCP telemetry.
+
 ### Local Telemetry with Jaeger UI (for Traces)
 
 1.  **Run the Command:** Execute the following command from the project root:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "publish:sandbox": "node scripts/publish-sandbox.js",
     "publish:npm": "npm publish --workspaces ${NPM_PUBLISH_TAG:+--tag=$NPM_PUBLISH_TAG} ${NPM_DRY_RUN:+--dry-run}",
     "publish:release": "npm run build:packages && npm run prepare:cli-packagejson && npm run build:docker && npm run tag:docker && npm run publish:sandbox && npm run publish:npm",
-    "telemetry": "node scripts/telemetry.js"
+    "telemetry": "node scripts/telemetry.js",
+    "start:gcp": "npm run telemetry -- --target=gcp & npm start"
   },
   "bin": {
     "gemini": "bundle/gemini.js"


### PR DESCRIPTION
This command enables starting the application with GCP telemetry:

```shell
npm run start:gcp
```