### PR TITLE
fix version release for Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM docker.io/library/node:20-slim
 
 ARG SANDBOX_NAME="gemini-cli-sandbox"
+ARG CLI_VERSION_ARG
 ENV SANDBOX="$SANDBOX_NAME"
+ENV CLI_VERSION=$CLI_VERSION_ARG
 
 # install minimal set of packages, then clean up
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -5,9 +5,14 @@
  */
 
 import esbuild from 'esbuild';
-import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 
-const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+const pkg = require(path.resolve(__dirname, 'package.json'));
 
 esbuild
   .build({

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -23,6 +23,7 @@ import {
 import { Settings } from './settings.js';
 import { getEffectiveModel } from '../utils/modelCheck.js';
 import { Extension } from './extension.js';
+import { getCliVersion } from '../utils/version.js';
 import * as dotenv from 'dotenv';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -122,7 +123,8 @@ async function parseArguments(): Promise<CliArgs> {
       description: 'Enables checkpointing of file edits',
       default: false,
     })
-    .version(process.env.CLI_VERSION || '0.0.0') // This will enable the --version flag based on package.json
+    .version(getCliVersion()) // This will enable the --version flag based on package.json
+    .alias('v', 'version')
     .help()
     .alias('h', 'help')
     .strict().argv;

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -109,8 +109,14 @@ function buildImage(imageName, dockerfile) {
       ? `${sandboxCommand} build --authfile=<(echo '{}')`
       : `${sandboxCommand} --config=".docker" buildx build`;
 
+  const npmPackageVersion = JSON.parse(
+    readFileSync(join(process.cwd(), 'package.json'), 'utf-8'),
+  ).version;
+
   execSync(
-    `${buildCommand} ${process.env.BUILD_SANDBOX_FLAGS || ''} -f "${dockerfile}" -t "${imageName}" .`,
+    `${buildCommand} ${
+      process.env.BUILD_SANDBOX_FLAGS || ''
+    } --build-arg CLI_VERSION_ARG=${npmPackageVersion} -f "${dockerfile}" -t "${imageName}" .`,
     { stdio: buildStdout, shell: '/bin/bash' },
   );
   console.log(`built ${imageName}`);


### PR DESCRIPTION
## TLDR

Fix for https://github.com/google-gemini/gemini-cli/issues/607. The Dockerfile build wasn't correctly setting the version.


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ✅  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/gemini-cli/issues/607
