### PR TITLE
Update /tools desc to show the name of each tool as known to the model

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -606,8 +606,8 @@ Add any other context about the problem here.
 
       // Should only show tool1 and tool2, not the MCP tools
       const message = mockAddItem.mock.calls[1][0].text;
-      expect(message).toContain('\u001b[36mTool1\u001b[0m');
-      expect(message).toContain('\u001b[36mTool2\u001b[0m');
+      expect(message).toContain('Tool1');
+      expect(message).toContain('Tool2');
       expect(commandResult).toBe(true);
     });
 
@@ -664,9 +664,9 @@ Add any other context about the problem here.
       });
 
       const message = mockAddItem.mock.calls[1][0].text;
-      expect(message).toContain('\u001b[36mTool1\u001b[0m');
+      expect(message).toContain('Tool1');
       expect(message).toContain('Description for Tool1');
-      expect(message).toContain('\u001b[36mTool2\u001b[0m');
+      expect(message).toContain('Tool2');
       expect(message).toContain('Description for Tool2');
       expect(commandResult).toBe(true);
     });

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -473,25 +473,19 @@ export const useSlashCommandProcessor = (
             geminiTools.forEach((tool) => {
               if (useShowDescriptions && tool.description) {
                 // Format tool name in cyan using simple ANSI cyan color
-                message += `  - \u001b[36m${tool.displayName}\u001b[0m: `;
+                message += `  - \u001b[36m${tool.displayName} (${tool.name})\u001b[0m:\n`;
 
                 // Apply green color to the description text
                 const greenColor = '\u001b[32m';
                 const resetColor = '\u001b[0m';
 
                 // Handle multi-line descriptions by properly indenting and preserving formatting
-                const descLines = tool.description.split('\n');
+                const descLines = tool.description.trim().split('\n');
                 message += `${greenColor}${descLines[0]}${resetColor}\n`;
 
                 // If there are multiple lines, add proper indentation for each line
-                if (descLines.length > 1) {
-                  for (let i = 1; i < descLines.length; i++) {
-                    // Skip empty lines at the end
-                    if (
-                      i === descLines.length - 1 &&
-                      descLines[i].trim() === ''
-                    )
-                      continue;
+                if (descLines) {
+                  for (let i = 0; i < descLines.length; i++) {
                     message += `      ${greenColor}${descLines[i]}${resetColor}\n`;
                   }
                 }

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -481,7 +481,6 @@ export const useSlashCommandProcessor = (
 
                 // Handle multi-line descriptions by properly indenting and preserving formatting
                 const descLines = tool.description.trim().split('\n');
-                message += `${greenColor}${descLines[0]}${resetColor}\n`;
 
                 // If there are multiple lines, add proper indentation for each line
                 if (descLines) {


### PR DESCRIPTION
## TLDR

Update /tools desc to show the name of each tool as known to the model

## Dive Deeper

Adds the name of the tool as known to the model after the display name. Example:

```
    - GoogleSearch (google_web_search):
          Performs a web search using Google Search (via the Gemini API) and returns the results. This tool is useful for finding information on the internet based on a query.
```

## Linked issues / bugs

Fixes #1090