### PR TITLE
Propagate abort signal to ccpa generateContent.

### DIFF
--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -45,6 +45,7 @@ describe('CodeAssistServer', () => {
     expect(server.callEndpoint).toHaveBeenCalledWith(
       'generateContent',
       expect.any(Object),
+      undefined,
     );
     expect(response.candidates?.[0]?.content?.parts?.[0]?.text).toBe(
       'response',
@@ -82,6 +83,7 @@ describe('CodeAssistServer', () => {
       expect(server.streamEndpoint).toHaveBeenCalledWith(
         'streamGenerateContent',
         expect.any(Object),
+        undefined,
       );
       expect(res.candidates?.[0]?.content?.parts?.[0]?.text).toBe('response');
     }


### PR DESCRIPTION
## TLDR

Allows the user to cancel ccpa generatecontent requests with esc instead of having to wait till they are done.

## Dive Deeper

We do this for non-ccpa so it makes sense to do it here too.

## Reviewer Test Plan

Log in using ccpa. Ask it a question and then immediately hit "esc". You should see it return the prompt immediately.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | X  | -   | -   |

## Linked issues / bugs

b/425360849