### PR TITLE
Clear out untracked files when restoring a checkpoint

### DIFF
--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -110,5 +110,7 @@ export class GitService {
   async restoreProjectFromSnapshot(commitHash: string): Promise<void> {
     const repo = this.shadowGitRepository;
     await repo.raw(['restore', '--source', commitHash, '.']);
+    // Removes any untracked files that were introduced post snapshot.
+    await repo.clean('f', ['-d']);
   }
 }


### PR DESCRIPTION
This addresses a bug where a new file that was written by the Write tool would not be removed when restoring a checkpoint to the time right before that file was created. This clears out any untracked files when restoring a checkpoint, resetting the working tree to how it was at that moment. 


1. Run the cli with checkpoints enabled `npm run start -- --checkpoint`
2. Trigger a file write tool call. Example prompt "Write Foo.md. The content should be a poem"
3. After the tool has run, use the `/restore` command to view available checkpoints.
4. Call the `/restore` command with a checkpoint name.
5. The recently added `Foo.md` should be removed and conversation state should be reset to right before the Write File tool was run. 


