### PR TITLE
feat(prompt): Allow --prompt to accept a file path

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { render } from 'ink';
 import { AppWrapper } from './ui/App.js';
 import { loadCliConfig } from './config/config.js';
+import { resolvePromptFromFile } from './utils/prompt.js';
 import { readStdin } from './utils/readStdin.js';
 import { basename } from 'node:path';
 import { sandbox_command, start_sandbox } from './utils/sandbox.js';
@@ -79,7 +80,7 @@ export async function main() {
     }
   }
 
-  let input = config.getQuestion();
+  let input = resolvePromptFromFile(config.getQuestion() ?? '', workspaceRoot);
   const startupWarnings = await getStartupWarnings();
 
   // Render UI, passing necessary config values. Check that there is no command line question.

--- a/packages/cli/src/utils/prompt.test.ts
+++ b/packages/cli/src/utils/prompt.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { resolvePromptFromFile } from './prompt';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Mock the 'fs' module
+vi.mock('node:fs');
+
+describe('resolvePromptFromFile', () => {
+  const workingDir = '/test/dir';
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.resetAllMocks();
+  });
+
+  it('should return the original string if it is not a file path', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    const prompt = 'This is a normal prompt.';
+    const result = resolvePromptFromFile(prompt, workingDir);
+    expect(result).toBe(prompt);
+    expect(fs.existsSync).toHaveBeenCalledWith(
+      path.resolve(workingDir, prompt),
+    );
+  });
+
+  it('should return the file content if the string is a valid file path', () => {
+    const filePath = 'prompt.txt';
+    const absolutePath = path.resolve(workingDir, filePath);
+    const fileContent = 'This is the content of the file.';
+
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as fs.Stats);
+    vi.mocked(fs.readFileSync).mockReturnValue(fileContent);
+
+    const result = resolvePromptFromFile(filePath, workingDir);
+
+    expect(result).toBe(fileContent);
+    expect(fs.existsSync).toHaveBeenCalledWith(absolutePath);
+    expect(fs.statSync).toHaveBeenCalledWith(absolutePath);
+    expect(fs.readFileSync).toHaveBeenCalledWith(absolutePath, 'utf-8');
+  });
+
+  it('should return the original string if the path exists but is a directory', () => {
+    const dirPath = 'a-directory';
+    const absolutePath = path.resolve(workingDir, dirPath);
+
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => false } as fs.Stats);
+
+    const result = resolvePromptFromFile(dirPath, workingDir);
+
+    expect(result).toBe(dirPath);
+    expect(fs.existsSync).toHaveBeenCalledWith(absolutePath);
+    expect(fs.statSync).toHaveBeenCalledWith(absolutePath);
+    expect(fs.readFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should return the original string if fs.existsSync throws an error', () => {
+    const prompt = 'some/path';
+    vi.mocked(fs.existsSync).mockImplementation(() => {
+      throw new Error('Permission denied');
+    });
+
+    const result = resolvePromptFromFile(prompt, workingDir);
+    expect(result).toBe(prompt);
+  });
+
+  it('should return an empty string if the input is empty', () => {
+    const result = resolvePromptFromFile('', workingDir);
+    expect(result).toBe('');
+    expect(fs.existsSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/utils/prompt.ts
+++ b/packages/cli/src/utils/prompt.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Resolves a prompt. If the input string is a valid path to an existing
+ * file, its content is read and returned. Otherwise, the original string
+ * is returned.
+ *
+ * @param promptOrPath The user-provided string from the --prompt argument.
+ * @param workingDir The current working directory to resolve relative paths from.
+ * @returns The file content if it's a valid path, otherwise the original string.
+ */
+export function resolvePromptFromFile(
+  promptOrPath: string,
+  workingDir: string,
+): string {
+  // An empty string can never be a file, so return early.
+  if (!promptOrPath) {
+    return promptOrPath;
+  }
+
+  try {
+    const potentialPath = path.resolve(workingDir, promptOrPath);
+    // Check if the path exists and is a file.
+    if (fs.existsSync(potentialPath) && fs.statSync(potentialPath).isFile()) {
+      return fs.readFileSync(potentialPath, 'utf-8');
+    }
+  } catch (_e) {
+    // If any fs operation fails (e.g., permission errors),
+    // assume it's not a file path and return the original string.
+    // We can add logging here in the future if needed.
+    return promptOrPath;
+  }
+
+  // If the path doesn't exist or isn't a file, return the original string.
+  return promptOrPath;
+}


### PR DESCRIPTION
This PR implements the feature requested in #1099, allowing the --prompt argument to accept a file path as input.