### PR TITLE
Simplify Error handling in Code Assist onboarding

### DIFF
--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -7,7 +7,6 @@
 import { ClientMetadata, OnboardUserRequest } from './types.js';
 import { CodeAssistServer } from './server.js';
 import { OAuth2Client } from 'google-auth-library';
-import { GaxiosError } from 'gaxios';
 import { clearCachedCredentials } from './oauth2.js';
 
 /**
@@ -53,17 +52,12 @@ export async function setupUser(
 
     return lroRes.response?.cloudaicompanionProject?.id || '';
   } catch (e) {
-    if (e instanceof GaxiosError) {
-      const detail = e.response?.data?.error?.details[0].detail;
-      if (detail && detail.includes('projectID is empty')) {
-        await clearCachedCredentials();
-        console.log(
-          '\n\nEnterprise users must specify GOOGLE_CLOUD_PROJECT ' +
-            'in your environment variables or .env file.\n\n',
-        );
-        process.exit(1);
-      }
-    }
+    await clearCachedCredentials();
+    console.log(
+      '\n\nError onboarding with Code Assist.\n' +
+        'Enterprise users must specify GOOGLE_CLOUD_PROJECT ' +
+        'in their environment variables or .env file.\n\n',
+    );
     throw e;
   }
 }


### PR DESCRIPTION
## TLDR

Always suggest setting GOOGLE_CLOUD_PROJECT when Code Assist onboarding fails.

## Dive Deeper

We used to only suggest this when the error had a specific message in it, but CCPA no longer seems to be returning that message. Instead it now just says "Request contains an invalid argument". So I changed the logic to always suggest setting the project id since that's the problem 99% of the time.

## Reviewer Test Plan

Set GEMINI_CODE_ASSIST=true and GOOGLE_CLOUD_PROJECT unset, and log in with your google.com email. 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | x  | -   | -   |

## Linked issues / bugs

b/425360849
