### PR TITLE
fix: regression in completion filtering

### DIFF
--- a/packages/cli/src/ui/hooks/useCompletion.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.ts
@@ -306,6 +306,12 @@ export function useCompletion(
             value: escapePath(relativePath),
           };
         })
+        .filter((s) => {
+          if (fileDiscoveryService) {
+            return !fileDiscoveryService.shouldGitIgnoreFile(s.label); // relative path
+          }
+          return true;
+        })
         .slice(0, maxResults);
 
       return suggestions;


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

Fixes a regression in @ completion where glob results are not filtered.

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

The regression was introduced in a refactoring PR that missed filtering glob results. Existing unit tests did not exercise that particular path.

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->
Previously:
```
Using 1 GEMINI.md file
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ > @client                                                                                                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 node_modules/react-dom/client.js
 node_modules/undici-types/client.d.ts
 node_modules/vite/client.d.ts
 node_modules/@types/react-dom/client.d.ts
 node_modules/undici/types/client-stats.d.ts
 node_modules/undici/types/client.d.ts
 node_modules/vite-node/dist/client.cjs
 node_modules/vite-node/dist/client.d.ts

```

With this PR:
```
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ > @client                                                                                                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 packages/core/src/core/client.test.ts
 packages/core/src/core/client.ts
```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | Y  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | Y  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other extenral bugs --->
