### PR TITLE
Move the logs.json to a project specific user home dir

### DIFF
--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -5,10 +5,13 @@
  */
 
 import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { Content } from '@google/genai';
 
 const GEMINI_DIR = '.gemini';
+const TMP_DIR_NAME = 'tmp';
 const LOG_FILE_NAME = 'logs.json';
 const CHECKPOINT_FILE_NAME = 'checkpoint.json';
 
@@ -95,7 +98,18 @@ export class Logger {
     if (this.initialized) {
       return;
     }
-    this.geminiDir = path.resolve(process.cwd(), GEMINI_DIR);
+
+    const projectHash = crypto
+      .createHash('sha256')
+      .update(process.cwd())
+      .digest('hex');
+
+    this.geminiDir = path.join(
+      os.homedir(),
+      GEMINI_DIR,
+      TMP_DIR_NAME,
+      projectHash,
+    );
     this.logFilePath = path.join(this.geminiDir, LOG_FILE_NAME);
     this.checkpointFilePath = path.join(this.geminiDir, CHECKPOINT_FILE_NAME);
 


### PR DESCRIPTION
Moves the logs.json file from being written to the `.gemini` folder in the user's project to the home directory. There will be other follow up PRs to move other features that are writing to the project level .gemini folder. Everything that the user may want to eventually clear is being grouped under a tmp folder. An example path `/Users/my-user/.gemini/tmp/<project-hash>/logs.json