### PR TITLE
Adh/issue/1117 headless output

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,9 +4,9 @@ name: E2E Tests
 
 on:
   push:
-    branches: [main, release]
+    branches: [main]
   pull_request:
-    branches: [main, release]
+    branches: [main]
 
 jobs:
   e2e-test:

--- a/commit-message.txt
+++ b/commit-message.txt
@@ -1,0 +1,12 @@
+feat(headless): reduce noise in non-interactive mode
+
+This commit introduces several changes to reduce the amount of noise printed to STDOUT when running in non-interactive (headless) mode.
+
+The following changes have been made:
+
+- **`gemini.tsx`**: The `setWindowTitle` function is now only called when `process.stdin.isTTY` is true, preventing the window title from being set in non-interactive sessions.
+- **`nonInteractiveCli.ts`**: The `getResponseText` function now checks for and filters out "thoughts" from the model's response, so they are not printed to STDOUT.
+- **`sandbox.ts`**: The "using macos seatbelt..." message is now logged to STDERR instead of STDOUT.
+- **`gitIgnoreParser.ts`**: The "Loaded X patterns" message is now logged to STDERR instead of STDOUT.
+
+These changes ensure that the output of the CLI is clean and contains only the model's response when running in non-interactive mode.

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -62,6 +62,10 @@ Slash commands provide meta-level control over the CLI itself.
 
   - **Description:** Replace the entire chat context with a summary. This saves on tokens used for future tasks while retaining a high level summary of what has happened.
 
+- **`/bug`**
+
+  - **Description:** File an issue about Gemini CLI. By default, the issue is filed within the GitHub repository for Gemini CLI. The string you enter after `/bug` will become the headline for the bug being filed. The default `/bug` behavior can be modified using the `bugCommand` setting in your `.gemini/settings.json` files.
+
 ## At commands (`@`)
 
 At commands are used to include the content of files or directories as part of your prompt to Gemini. These commands include git-aware filtering.

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -1,140 +1,113 @@
 # CLI Commands
 
-The Gemini CLI supports several built-in commands to help you manage your session, customize the interface, and control its behavior. These commands are typically prefixed with a forward slash (`/`), an at symbol (`@`), or an exclamation mark (`!`).
+Gemini CLI supports several built-in commands to help you manage your session, customize the interface, and control its behavior. These commands are prefixed with a forward slash (`/`), an at symbol (`@`), or an exclamation mark (`!`).
 
-## Slash Commands (`/`)
+## Slash commands (`/`)
 
-Slash commands provide meta-level control over the CLI itself. They can typically be executed by typing the command and pressing `Enter`.
+Slash commands provide meta-level control over the CLI itself.
 
 - **`/editor`**
 
-  - **Description:** Allows you to configure your external editor for actions such as modifying Gemini's proposed code change.
-  - **Action:** Opens a dialog for selecting supported editors.
+  - **Description:** Open a dialog for selecting supported editors.
 
 - **`/help`** (or **`/?`**)
 
-  - **Description:** Displays help information about the Gemini CLI, including available commands and their usage.
-  - **Action:** Opens a help dialog or section within the CLI.
+  - **Description:** Display help information about the Gemini CLI, including available commands and their usage.
 
-- **`/mcp`** (Toggle descriptions: **Ctrl+T**)
+- **`/mcp`**
 
-  - **Description:** Lists configured Model Context Protocol (MCP) servers and their available tools.
-  - **Action:** Displays a formatted list of MCP servers with connection status indicators, server details, and available tools.
+  - **Description:** List configured Model Context Protocol (MCP) servers, their connection status, server details, and available tools.
   - **Sub-commands:**
     - **`desc`** or **`descriptions`**:
-      - **Description:** Shows detailed descriptions for MCP servers and tools.
-      - **Action:** Displays each tool's name with its full description, formatted for readability.
+      - **Description:** Show detailed descriptions for MCP servers and tools.
     - **`nodesc`** or **`nodescriptions`**:
-      - **Description:** Hides tool descriptions, showing only the tool names.
-      - **Action:** Displays a compact list with only tool names.
+      - **Description:** Hide tool descriptions, showing only the tool names.
     - **`schema`**:
-      - **Description:** Shows full schema of tool parameters.
-      - **Action:** Displays the full JSON schema for the tool's configured parameters.
+      - **Description:** Show the full JSON schema for the tool's configured parameters.
   - **Keyboard Shortcut:** Press **Ctrl+T** at any time to toggle between showing and hiding tool descriptions.
 
-- **`/clear`** (Shortcut: **Ctrl+L**)
+- **`/clear`**
 
-  - **Description:** Clears the entire terminal screen, including the visible session history and scrollback within the CLI.
-  - **Action:** Wipes the terminal display. The underlying session data (for history recall) might be preserved depending on the exact implementation, but the visual display is cleared.
+  - **Description:** Clear the terminal screen, including the visible session history and scrollback within the CLI. The underlying session data (for history recall) might be preserved depending on the exact implementation, but the visual display is cleared.
+  - **Keyboard shortcut:** Press **Ctrl+L** at any time to perform a clear action.
 
 - [**`/theme`**](./themes.md)
 
-  - **Description:** Allows you to change the visual theme of the Gemini CLI.
-  - **Action:** Opens a dialog or prompt to select from available themes.
+  - **Description:** Open a dialog that lets you change the visual theme of Gemini CLI.
 
 - **`/memory`**
 
-  - **Description:** Manages the AI's instructional context (hierarchical memory loaded from `GEMINI.md` files) and allows for adding ad-hoc memory entries.
-  - **Usage:** `/memory <sub_command> [text_for_add]`
+  - **Description:** Manage the AI's instructional context (hierarchical memory loaded from `GEMINI.md` files).
   - **Sub-commands:**
     - **`show`**:
-      - **Description:** Displays the full, concatenated content of the current hierarchical memory that has been loaded from all `GEMINI.md` files. This allows you to inspect the exact instructional context being provided to the Gemini model.
-      - **Action:** Outputs the combined content of all loaded `GEMINI.md` files, including separators that indicate the origin and path of each part of the memory. This is useful for verifying the loading order and final context.
+      - **Description:** Display the full, concatenated content of the current hierarchical memory that has been loaded from all `GEMINI.md` files. This lets you inspect the instructional context being provided to the Gemini model.
     - **`refresh`**:
-      - **Description:** Reloads the hierarchical instructional context (memory) from all `GEMINI.md` files found in the configured locations (global, project/ancestors, and sub-directories). This command updates the AI's understanding based on the latest `GEMINI.md` content.
-      - **Action:** The CLI re-scans for all relevant `GEMINI.md` files and rebuilds its instructional memory. The number of loaded files is typically indicated in the CLI footer.
+      - **Description:** Reload the hierarchical instructional memory from all `GEMINI.md` files found in the configured locations (global, project/ancestors, and sub-directories). This command updates the model with the latest `GEMINI.md` content.
     - **Note:** For more details on how `GEMINI.md` files contribute to hierarchical memory, see the [CLI Configuration documentation](./configuration.md#4-geminimd-files-hierarchical-instructional-context).
 
 - **`/quit`** (or **`/exit`**)
 
-  - **Description:** Exits the Gemini CLI application.
-  - **Action:** Terminates the CLI process.
+  - **Description:** Exit Gemini CLI.
 
-- **`/tools`**
+- [**`/tools`**](../tools/index.md)
 
-  - **Description:** Displays a list of all the tools that are currently available to the model.
-  - **Action:** Outputs a list of the available tools.
+  - **Description:** Display a list of tools that are currently available within Gemini CLI.
   - **Sub-commands:**
     - **`desc`** or **`descriptions`**:
-      - **Description:** Shows detailed descriptions of each tool.
-      - **Action:** Displays each tool's name with its full description as provided to the model.
+      - **Description:** Show detailed descriptions of each tool, including each tool's name with its full description as provided to the model.
     - **`nodesc`** or **`nodescriptions`**:
-      - **Description:** Hides tool descriptions, showing only the tool names.
-      - **Action:** Displays a compact list with only tool names.
+      - **Description:** Hide tool descriptions, showing only the tool names.
 
 - **`/compress`**
 
-  - **Description:** Compresses the current context. This will save on tokens used for future tasks while retaining a high level summary of what has happened.
-  - **Action:** Replaces the entire chat context with a summary.
+  - **Description:** Replace the entire chat context with a summary. This saves on tokens used for future tasks while retaining a high level summary of what has happened.
 
-## At Commands (`@`)
+## At commands (`@`)
 
-At commands are used to quickly include the content of files or directories as part of your prompt to Gemini. These commands now feature git-aware filtering.
+At commands are used to include the content of files or directories as part of your prompt to Gemini. These commands include git-aware filtering.
 
 - **`@<path_to_file_or_directory>`**
 
-  - **Description:** Injects the content of the specified file or files within a directory into your current prompt. This is useful for asking questions about specific code, text, or collections of files.
-  - **Usage:**
+  - **Description:** Inject the content of the specified file or files into your current prompt. This is useful for asking questions about specific code, text, or collections of files.
+  - **Examples:**
     - `@path/to/your/file.txt Explain this text.`
     - `@src/my_project/ Summarize the code in this directory.`
     - `What is this file about? @README.md`
   - **Details:**
     - If a path to a single file is provided, the content of that file is read.
-    - If a path to a directory is provided, the command attempts to read the content of files within that directory (often recursively, like `directory/**`).
+    - If a path to a directory is provided, the command attempts to read the content of files within that directory and any subdirectories.
     - Spaces in paths should be escaped with a backslash (e.g., `@My\ Documents/file.txt`).
-    - The command uses the `read_many_files` tool internally. The content is fetched and then prepended or inserted into your query before being sent to the Gemini model.
-    - The text before and after the `@<path>` part of your query is preserved and sent along with the file content.
-    - **Git-Aware Filtering:** By default, git-ignored files (like `node_modules/`, `dist/`, `.env`, `.git/`) are automatically excluded. This behavior can be configured via the `fileFiltering` settings.
-    - **File Types:** The command is intended for text-based files. While it might attempt to read any file, binary files or very large files might be skipped or truncated by the underlying `read_many_files` tool to ensure performance and relevance. The tool will typically indicate if files were skipped.
-  - **Output:** The CLI will show a tool call message indicating that `read_many_files` was used, along with an improved display message detailing the status (e.g., number of files read, total size) and the path(s) that were processed.
+    - The command uses the `read_many_files` tool internally. The content is fetched and then inserted into your query before being sent to the Gemini model.
+    - **Git-aware filtering:** By default, git-ignored files (like `node_modules/`, `dist/`, `.env`, `.git/`) are excluded. This behavior can be changed via the `fileFiltering` settings.
+    - **File types:** The command is intended for text-based files. While it might attempt to read any file, binary files or very large files might be skipped or truncated by the underlying `read_many_files` tool to ensure performance and relevance. The tool indicates if files were skipped.
+  - **Output:** The CLI will show a tool call message indicating that `read_many_files` was used, along with a message detailing the status and the path(s) that were processed.
 
-- **`@` (Lone At Symbol)**
-  - **Description:** If you type a lone `@` symbol without a path, the entire query (including the `@`) is passed directly to the Gemini model. This might be useful if you are specifically talking _about_ the `@` symbol itself in your prompt.
+- **`@` (Lone at symbol)**
+  - **Description:** If you type a lone `@` symbol without a path, the query is passed as-is to the Gemini model. This might be useful if you are specifically talking _about_ the `@` symbol in your prompt.
 
-### Error Handling for `@` Commands
+### Error handling for `@` commands
 
 - If the path specified after `@` is not found or is invalid, an error message will be displayed, and the query might not be sent to the Gemini model, or it will be sent without the file content.
 - If the `read_many_files` tool encounters an error (e.g., permission issues), this will also be reported.
 
-## Shell Mode & Passthrough Commands (`!`)
+## Shell mode & passthrough commands (`!`)
 
-The `!` prefix provides a powerful way to interact with your system's shell directly from within the Gemini CLI. It allows for both single command execution and a toggleable Shell Mode for a more persistent shell experience.
+The `!` prefix lets you interact with your system's shell directly from within Gemini CLI.
 
 - **`!<shell_command>`**
 
-  - **Description:** Executes the given `<shell_command>` in your system's default shell.
-  - **Usage:**
-    - `!ls -la` (executes `ls -la` and returns to normal CLI mode)
-    - `!git status` (executes `git status` and returns to normal CLI mode)
-  - **Action:** The command following the `!` is passed to the system shell for execution. Standard output and standard error are displayed in the CLI. After execution, the CLI typically returns to its standard conversational mode.
+  - **Description:** Execute the given `<shell_command>` in your system's default shell. Any output or errors from the command are displayed in the terminal.
+  - **Examples:**
+    - `!ls -la` (executes `ls -la` and returns to Gemini CLI)
+    - `!git status` (executes `git status` and returns to Gemini CLI)
 
-- **`!` (Toggle Shell Mode)**
+- **`!` (Toggle shell mode)**
 
-  - **Description:** Typing `!` on its own (without an immediately following command) toggles Shell Mode.
-  - **Action & Behavior:**
-    - **Entering Shell Mode:**
-      - The UI will update, often with different coloring and a "Shell Mode Indicator," to clearly show that Shell Mode is active.
-      - Most slash commands (e.g., `/help`, `/theme`) and AI-powered suggestions are disabled to provide an uninterrupted shell experience.
-      - Any text you type is interpreted directly as a shell command.
-    - **Exiting Shell Mode:**
-      - Typing `!` again while in Shell Mode will toggle it off.
-      - The UI will revert to its standard appearance.
-      - Slash commands and AI suggestions are re-enabled.
-  - **Usage:**
-    - Type `!` and press Enter to enter Shell Mode.
-    - Type your shell commands (e.g., `cd my_project`, `npm run dev`, `cat file.txt`).
-    - Type `!` and press Enter again to exit Shell Mode.
+  - **Description:** Typing `!` on its own toggles shell mode.
+    - **Entering shell mode:**
+      - When active, shell mode uses a different coloring and a "Shell Mode Indicator".
+      - While in shell mode, text you type is interpreted directly as a shell command.
+    - **Exiting shell mode:**
+      - When exited, the UI reverts to its standard appearance and normal Gemini CLI behavior resumes.
 
-- **Caution for all `!` usage:** Be mindful of the commands you execute, as they have the same permissions and impact as if you ran them directly in your terminal. The Shell Mode feature does not inherently add extra sandboxing beyond what's already configured for the underlying `run_shell_command` tool.
-
-This integrated shell capability allows for seamless switching between AI-assisted tasks and direct system interaction.
+- **Caution for all `!` usage:** Commands you execute in shell mode have the same permissions and impact as if you ran them directly in your terminal.

--- a/integration-tests/save_memory.test.js
+++ b/integration-tests/save_memory.test.js
@@ -12,10 +12,12 @@ test('should be able to save to memory', async (t) => {
   const rig = new TestRig();
   rig.setup(t.name);
 
-  const prompt = `remember that my favorite color is  blue.
+  const prompt = `remember that my favorite color is  blue`;
+  await rig.run(prompt);
+  const result = await rig.run(
+    'what is my favorite color? tell me that and surround it with $ symbol',
+  );
 
-  what is my favorite color? tell me that and surround it with $ symbol`;
-  const result = await rig.run(prompt);
-
-  assert.ok(result.toLowerCase().includes('$blue$'));
+  assert.ok(result.toLowerCase().includes('$blue
+));
 });

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -30,7 +30,6 @@ import {
 export async function main() {
   const workspaceRoot = process.cwd();
   const settings = loadSettings(workspaceRoot);
-  setWindowTitle(basename(workspaceRoot), settings);
 
   await cleanupCheckpoints();
   if (settings.errors.length > 0) {
@@ -84,6 +83,7 @@ export async function main() {
 
   // Render UI, passing necessary config values. Check that there is no command line question.
   if (process.stdin.isTTY && input?.length === 0) {
+    setWindowTitle(basename(workspaceRoot), settings);
     render(
       <React.StrictMode>
         <AppWrapper

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -27,6 +27,11 @@ function getResponseText(response: GenerateContentResponse): string | null {
       candidate.content.parts &&
       candidate.content.parts.length > 0
     ) {
+      // We are running in headless mode so we don't need to return thoughts to STDOUT.
+      const thoughtPart = candidate.content.parts[0];
+      if (thoughtPart?.thought) {
+        return null;
+      }
       return candidate.content.parts
         .filter((part) => part.text)
         .map((part) => part.text)

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -148,7 +148,7 @@ vi.mock('./hooks/useGeminiStream', () => ({
 
 vi.mock('./hooks/useLogger', () => ({
   useLogger: vi.fn(() => ({
-    getPreviousUserMessages: vi.fn().mockResolvedValue([]),
+    getPreviousUserMessages: vi.fn().mockReturnValue([]),
   })),
 }));
 

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -340,7 +340,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
 
   useEffect(() => {
     const fetchUserMessages = async () => {
-      const pastMessagesRaw = (await logger?.getPreviousUserMessages()) || []; // Newest first
+      const pastMessagesRaw = logger?.getPreviousUserMessages() || []; // Newest first
 
       const currentSessionUserMessages = history
         .filter(

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -260,6 +260,7 @@ export async function start_sandbox(sandbox: string) {
       );
       process.exit(1);
     }
+    // Log on STDERR so it doesn't clutter the output on STDOUT
     console.error(`using macos seatbelt (profile: ${profile}) ...`);
     // if DEBUG is set, convert to --inspect-brk in NODE_OPTIONS
     const args = [

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -191,7 +191,7 @@ export class Logger {
     }
   }
 
-  async getPreviousUserMessages(): Promise<string[]> {
+  getPreviousUserMessages(): string[] {
     if (!this.initialized) return [];
     return this.logs
       .filter((entry) => entry.type === MessageSenderType.USER)

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -49,7 +49,8 @@ export class GitIgnoreParser implements GitIgnoreFilter {
       .map((p) => p.trim())
       .filter((p) => p !== '' && !p.startsWith('#'));
     if (patterns.length > 0) {
-      console.log(
+      // Log the number of patterns loaded on STDERR so it doesn't clutter the output on STDOUT
+      console.error(
         `Loaded ${patterns.length} patterns from ${patternsFilePath}`,
       );
     }

--- a/scripts/telemetry_utils.js
+++ b/scripts/telemetry_utils.js
@@ -232,7 +232,7 @@ export async function ensureBinary(
       );
     }
 
-    fs.renameSync(foundBinaryPath, executablePath);
+    fs.copyFileSync(foundBinaryPath, executablePath);
 
     if (platform !== 'windows') {
       fs.chmodSync(executablePath, '755');


### PR DESCRIPTION
## TLDR

This commit introduces several changes to reduce the amount of noise printed to STDOUT when running in non-interactive (headless) mode. Addresses #1117 

## Dive Deeper

The following changes have been made:

- **`gemini.tsx`**: The `setWindowTitle` function is now only called when `process.stdin.isTTY` is true, preventing the window title from being set in non-interactive sessions.
- **`nonInteractiveCli.ts`**: The `getResponseText` function now checks for and filters out "thoughts" from the model's response, so they are not printed to STDOUT.
- **`sandbox.ts`**: The "using macos seatbelt..." message is now logged to STDERR instead of STDOUT.
- **`gitIgnoreParser.ts`**: The "Loaded X patterns" message is now logged to STDERR instead of STDOUT.

These changes ensure that the output of the CLI is clean and contains only the model's response when running in non-interactive mode.

## Reviewer Test Plan

`npm run start -- --prompt "Explain this codebase to me" >> text.md` 

Make sure that there are no app status messages or window title characters in text.md

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | +  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | +  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other extenral bugs --->
