### PR TITLE
Use 2-space indent for saved checkpoint files

### DIFF
--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -252,7 +252,7 @@ export class Logger {
     }
     const path = this._checkpointPath(tag);
     try {
-      await fs.writeFile(path, JSON.stringify(conversation, null), 'utf-8');
+      await fs.writeFile(path, JSON.stringify(conversation, null, 2), 'utf-8');
     } catch (error) {
       console.error('Error writing to checkpoint file:', error);
     }


### PR DESCRIPTION
## TLDR

Updates the saved checkpoint writer to use 2-space indentation.

## Dive Deeper

I find the checkpoint files most useful for debugging tool output, having the checkpoint files be easier to read in a terminal is helpful for debugging.

## Linked issues / bugs

Fixes #1150 