### PR TITLE
feat: consolidate sandbox configurations into a single object

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -28,6 +28,7 @@ import * as dotenv from 'dotenv';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { loadSandboxConfig } from './sandboxConfig.js';
 
 // Simple console logger for now - replace with actual logger if available
 const logger = {
@@ -42,6 +43,7 @@ const logger = {
 interface CliArgs {
   model: string | undefined;
   sandbox: boolean | string | undefined;
+  'sandbox-image': string | undefined;
   debug: boolean | undefined;
   prompt: string | undefined;
   all_files: boolean | undefined;
@@ -71,6 +73,10 @@ async function parseArguments(): Promise<CliArgs> {
       alias: 's',
       type: 'boolean',
       description: 'Run in sandbox?',
+    })
+    .option('sandbox-image', {
+      type: 'string',
+      description: 'Sandbox image URI.',
     })
     .option('debug', {
       alias: 'd',
@@ -192,11 +198,13 @@ export async function loadCliConfig(
 
   const mcpServers = mergeMcpServers(settings, extensions);
 
+  const sandboxConfig = await loadSandboxConfig(settings, argv);
+
   return new Config({
     sessionId,
     contentGeneratorConfig,
     embeddingModel: DEFAULT_GEMINI_EMBEDDING_MODEL,
-    sandbox: argv.sandbox ?? settings.sandbox,
+    sandbox: sandboxConfig,
     targetDir: process.cwd(),
     debugMode,
     question: argv.prompt || '',

--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SandboxConfig } from '@gemini-cli/core';
+import commandExists from 'command-exists';
+import * as os from 'node:os';
+import { getPackageJson } from '../utils/package.js';
+import { Settings } from './settings.js';
+
+// This is a stripped-down version of the CliArgs interface from config.ts
+// to avoid circular dependencies.
+interface SandboxCliArgs {
+  sandbox?: boolean | string;
+  'sandbox-image'?: string;
+}
+
+const VALID_SANDBOX_COMMANDS: ReadonlyArray<SandboxConfig['command']> = [
+  'docker',
+  'podman',
+  'sandbox-exec',
+];
+
+function isSandboxCommand(value: string): value is SandboxConfig['command'] {
+  return (VALID_SANDBOX_COMMANDS as readonly string[]).includes(value);
+}
+
+function getSandboxCommand(
+  sandbox?: boolean | string,
+): SandboxConfig['command'] | '' {
+  // note environment variable takes precedence over argument (from command line or settings)
+  sandbox = process.env.GEMINI_SANDBOX?.toLowerCase().trim() ?? sandbox;
+  if (sandbox === '1' || sandbox === 'true') sandbox = true;
+  else if (sandbox === '0' || sandbox === 'false') sandbox = false;
+
+  if (sandbox === false) {
+    return '';
+  }
+
+  if (typeof sandbox === 'string' && sandbox !== '') {
+    if (!isSandboxCommand(sandbox)) {
+      console.error(
+        `ERROR: invalid sandbox command '${sandbox}'. Must be one of ${VALID_SANDBOX_COMMANDS.join(
+          ', ',
+        )}`,
+      );
+      process.exit(1);
+    }
+    // confirm that specfied command exists
+    if (commandExists.sync(sandbox)) {
+      return sandbox;
+    }
+    console.error(
+      `ERROR: missing sandbox command '${sandbox}' (from GEMINI_SANDBOX)`,
+    );
+    process.exit(1);
+  }
+
+  // look for seatbelt, docker, or podman, in that order
+  // for container-based sandboxing, require sandbox to be enabled explicitly
+  if (os.platform() === 'darwin' && commandExists.sync('sandbox-exec')) {
+    return 'sandbox-exec';
+  } else if (commandExists.sync('docker') && sandbox === true) {
+    return 'docker';
+  } else if (commandExists.sync('podman') && sandbox === true) {
+    return 'podman';
+  }
+
+  // throw an error if user requested sandbox but no command was found
+  if (sandbox === true) {
+    console.error(
+      'ERROR: GEMINI_SANDBOX is true but failed to determine command for sandbox; ' +
+        'install docker or podman or specify command in GEMINI_SANDBOX',
+    );
+    process.exit(1);
+  }
+
+  return '';
+}
+
+export async function loadSandboxConfig(
+  settings: Settings,
+  argv: SandboxCliArgs,
+): Promise<SandboxConfig | undefined> {
+  const sandboxOption = argv.sandbox ?? settings.sandbox;
+  const sandboxCommand = getSandboxCommand(sandboxOption);
+  if (!sandboxCommand) {
+    return undefined;
+  }
+
+  const packageJson = await getPackageJson();
+  return {
+    command: sandboxCommand,
+    image:
+      argv['sandbox-image'] ??
+      process.env.GEMINI_SANDBOX_IMAGE ??
+      packageJson?.config?.sandboxImageUri ??
+      'gemini-cli-sandbox',
+  };
+}

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -10,7 +10,7 @@ import { AppWrapper } from './ui/App.js';
 import { loadCliConfig } from './config/config.js';
 import { readStdin } from './utils/readStdin.js';
 import { basename } from 'node:path';
-import { sandbox_command, start_sandbox } from './utils/sandbox.js';
+import { start_sandbox } from './utils/sandbox.js';
 import { LoadedSettings, loadSettings } from './config/settings.js';
 import { themeManager } from './ui/themes/theme-manager.js';
 import { getStartupWarnings } from './utils/startupWarnings.js';
@@ -72,9 +72,9 @@ export async function main() {
 
   // hop into sandbox if we are outside and sandboxing is enabled
   if (!process.env.SANDBOX) {
-    const sandbox = sandbox_command(config.getSandbox());
-    if (sandbox) {
-      await start_sandbox(sandbox);
+    const sandboxConfig = config.getSandbox();
+    if (sandboxConfig) {
+      await start_sandbox(sandboxConfig);
       process.exit(0);
     }
   }

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -13,6 +13,7 @@ import {
   ApprovalMode,
   ToolRegistry,
   AccessibilitySettings,
+  SandboxConfig,
 } from '@gemini-cli/core';
 import { LoadedSettings, SettingsFile, Settings } from '../config/settings.js';
 import process from 'node:process';
@@ -21,7 +22,7 @@ import process from 'node:process';
 interface MockServerConfig {
   apiKey: string;
   model: string;
-  sandbox: boolean | string;
+  sandbox?: SandboxConfig;
   targetDir: string;
   debugMode: boolean;
   question?: string;
@@ -42,7 +43,7 @@ interface MockServerConfig {
 
   getApiKey: Mock<() => string>;
   getModel: Mock<() => string>;
-  getSandbox: Mock<() => boolean | string>;
+  getSandbox: Mock<() => SandboxConfig | undefined>;
   getTargetDir: Mock<() => string>;
   getToolRegistry: Mock<() => ToolRegistry>; // Use imported ToolRegistry type
   getDebugMode: Mock<() => boolean>;
@@ -78,7 +79,7 @@ vi.mock('@gemini-cli/core', async (importOriginal) => {
       return {
         apiKey: opts.apiKey || 'test-key',
         model: opts.model || 'test-model-in-mock-factory',
-        sandbox: typeof opts.sandbox === 'boolean' ? opts.sandbox : false,
+        sandbox: opts.sandbox,
         targetDir: opts.targetDir || '/test/dir',
         debugMode: opts.debugMode || false,
         question: opts.question,
@@ -99,9 +100,7 @@ vi.mock('@gemini-cli/core', async (importOriginal) => {
 
         getApiKey: vi.fn(() => opts.apiKey || 'test-key'),
         getModel: vi.fn(() => opts.model || 'test-model-in-mock-factory'),
-        getSandbox: vi.fn(() =>
-          typeof opts.sandbox === 'boolean' ? opts.sandbox : false,
-        ),
+        getSandbox: vi.fn(() => opts.sandbox),
         getTargetDir: vi.fn(() => opts.targetDir || '/test/dir'),
         getToolRegistry: vi.fn(() => ({}) as ToolRegistry), // Simple mock
         getDebugMode: vi.fn(() => opts.debugMode || false),
@@ -190,7 +189,7 @@ describe('App UI', () => {
         model: 'test-model',
       },
       embeddingModel: 'test-embedding-model',
-      sandbox: false,
+      sandbox: undefined,
       targetDir: '/test/dir',
       debugMode: false,
       userMemory: '',

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Config, ConfigParameters } from './config.js';
+import { Config, ConfigParameters, SandboxConfig } from './config.js';
 import * as path from 'path';
 import { setGeminiMdFilename as mockSetGeminiMdFilename } from '../tools/memoryTool.js';
 import {
@@ -53,7 +53,10 @@ vi.mock('../telemetry/index.js', async (importOriginal) => {
 describe('Server Config (config.ts)', () => {
   const API_KEY = 'server-api-key';
   const MODEL = 'gemini-pro';
-  const SANDBOX = false;
+  const SANDBOX: SandboxConfig = {
+    command: 'docker',
+    image: 'gemini-cli-sandbox',
+  };
   const TARGET_DIR = '/path/to/target';
   const DEBUG_MODE = false;
   const QUESTION = 'test question';

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -73,11 +73,16 @@ export class MCPServerConfig {
   ) {}
 }
 
+export interface SandboxConfig {
+  command: 'docker' | 'podman' | 'sandbox-exec';
+  image: string;
+}
+
 export interface ConfigParameters {
   sessionId: string;
   contentGeneratorConfig: ContentGeneratorConfig;
   embeddingModel?: string;
-  sandbox?: boolean | string;
+  sandbox?: SandboxConfig;
   targetDir: string;
   debugMode: boolean;
   question?: string;
@@ -108,7 +113,7 @@ export class Config {
   private readonly sessionId: string;
   private readonly contentGeneratorConfig: ContentGeneratorConfig;
   private readonly embeddingModel: string;
-  private readonly sandbox: boolean | string | undefined;
+  private readonly sandbox: SandboxConfig | undefined;
   private readonly targetDir: string;
   private readonly debugMode: boolean;
   private readonly question: string | undefined;
@@ -198,7 +203,7 @@ export class Config {
     return this.embeddingModel;
   }
 
-  getSandbox(): boolean | string | undefined {
+  getSandbox(): SandboxConfig | undefined {
     return this.sandbox;
   }
 

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -79,8 +79,7 @@ export function logCliConfiguration(config: Config): void {
     'event.timestamp': new Date().toISOString(),
     model: config.getModel(),
     embedding_model: config.getEmbeddingModel(),
-    sandbox_enabled:
-      typeof config.getSandbox() === 'string' ? true : config.getSandbox(),
+    sandbox_enabled: !!config.getSandbox(),
     core_tools_enabled: (config.getCoreTools() ?? []).join(','),
     approval_mode: config.getApprovalMode(),
     api_key_enabled: !!generatorConfig.apiKey,

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -131,7 +131,7 @@ const baseConfigParams: ConfigParameters = {
     vertexai: false,
   },
   embeddingModel: 'test-embedding-model',
-  sandbox: false,
+  sandbox: undefined,
   targetDir: '/test/dir',
   debugMode: false,
   userMemory: '',


### PR DESCRIPTION
## TLDR

This commit adds a --sandbox-image CLI argument and a sandboxImage settings option to allow users to specify the sandbox image.

This hopefully makes is more clear when sandboxing is on or off, particularly which factors (eg env vars, settings file) to verify when one wants to toggle it on/off.

## Dive Deeper

   * `packages/cli/src/config/sandboxConfig.ts` (New File)
      This new file introduces the `loadSandboxConfig` function, which now contains all the logic for determining the sandbox command and image URI. It consolidates checks for settings, command-line arguments, environment variables, and available system commands.


   * `packages/cli/src/config/config.ts`
      The main configuration file is simplified by removing the inline sandbox logic and instead calling the new `loadSandboxConfig` function. It also adds the `--sandbox-image` command-line option to allow users to specify a custom sandbox image.


   * `packages/cli/src/utils/sandbox.ts`
      This utility is refactored to work with the new `SandboxConfig` object instead of a simple string or boolean. The now-redundant
  `sandbox_command` function has been removed as its logic was moved to the new config file.


   * `packages/cli/src/gemini.tsx`
      This is the entry point that consumes the new configuration. It is updated to retrieve the SandboxConfig object and pass it to the `start_sandbox` function.


   * `packages/cli/src/ui/App.test.tsx`
      The test mocks for the configuration object are updated to reflect the new data structure. The sandbox property is now an object of type `SandboxConfig` rather than a primitive type.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ✅  | ❓  | ✅   |
| Docker   | -  | ❓  | ✅  |
| Podman   | ✅   | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

BUG=b/424619542
