### PR TITLE
Support logging in with application default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,26 @@ The Gemini CLI requires you to authenticate with Google's AI services. You'll ne
 1.  **Gemini Code Assist:**
 
     - To enable this mode you only need set the GEMINI_CODE_ASSIST environment variable to true.
-    - Enterprise users must also provide a GOOGLE_CLOUD_PROJECT environment variable specifying their Google Cloud project.
-      In the following methods, replace `GOOGLE_CLOUD_PROJECT` with the relevant values for your project:
       - You can temporarily set the environment variable in your current shell session using the following command:
         ```bash
         export GEMINI_CODE_ASSIST="true"
-        export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID" // Enterprise users only.
         ```
       - For repeated use, you can add the environment variable to your `.env` file (located in the project directory or user home directory) or your shell's configuration file (like `~/.bashrc`, `~/.zshrc`, or `~/.profile`). For example, the following command adds the environment variable to a `~/.bashrc` file:
         ```bash
         echo 'export GEMINI_CODE_ASSIST="true"' >> ~/.bashrc
-        echo 'export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"' >> ~/.bashrc # Enterprise users only.
         source ~/.bashrc
         ```
+    - There are two types of Google Accounts you might use to try to use Gemini Code Assist:
+      - **Personal Google Account**: This is the standard, free account you use for services like Gmail, Google Photos, and Google Drive for personal use (e.g. your-name@gmail.com).
+      - **Google Workspace Account**: This is a paid service for businesses and organizations that provides a suite of productivity tools, including a custom email domain (e.g. your-name@your-company.com), enhanced security features, and administrative controls. These accounts are often managed by an employer or school.
+        - Google Workspace Account must configure a Google Cloud Project Id to use. This can be done by:
+          - Using gcloud to set `gcloud config set project <your project id>`
+          - Setting the GOOGLE_CLOUD_PROJECT environment variable.
+    - During start up, Gemini CLI will look for cached credentials.
+      - If it finds Application Default Credentials (set up with `gcloud auth application-default login`) it will use them.
+      - Otherwise, if it find unexpired cached Oauth2 credentials it will use them.
+      - Otherwise, it will prompt you to visit a URL to authenticate (using Oauth2). Once authenticated, your Oauth2 credentials will be cached locally. Credentials normally expire after about 20 hours.
+    - Note that the Oauth2 login must be done in a browser that can communicate with the machine Gemini Cli is being run from. (Specifically, the browser will be redirected to a localhost url that Gemini CLI will be listening on).
 
 2.  **Gemini API key:**
 

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -25,12 +25,15 @@ interface ClientAndProjectId {
 export async function createCodeAssistContentGenerator(
   httpOptions: HttpOptions,
 ): Promise<ContentGenerator> {
-  const cp = await getAuthClient();
-  const projectId = await setupUser(cp.client, cp.projectId || process.env.GOOGLE_CLOUD_PROJECT);
+  const cp = await getClientAndProject();
+  const projectId = await setupUser(
+    cp.client,
+    cp.projectId || process.env.GOOGLE_CLOUD_PROJECT,
+  );
   return new CodeAssistServer(cp.client, projectId, httpOptions);
 }
 
-async function getAuthClient(): Promise<ClientAndProjectId> {
+async function getClientAndProject(): Promise<ClientAndProjectId> {
   try {
     return await getGoogleAuthClient(OAUTH_SCOPE);
   } catch (_) {
@@ -47,7 +50,9 @@ async function getAuthClient(): Promise<ClientAndProjectId> {
  * @returns a valid auth client.
  * @throws error if there are no Application Default Credentials.
  */
-async function getGoogleAuthClient(scopes: string[]): Promise<ClientAndProjectId> {
+async function getGoogleAuthClient(
+  scopes: string[],
+): Promise<ClientAndProjectId> {
   const googleAuth = new GoogleAuth({ scopes });
   return {
     client: await googleAuth.getClient(),

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -18,6 +18,7 @@ const OAUTH_SCOPE = [
 ];
 
 interface ClientAndProjectId {
+  type: string;
   client: AuthClient;
   projectId?: string;
 }
@@ -30,6 +31,10 @@ export async function createCodeAssistContentGenerator(
     cp.client,
     cp.projectId || process.env.GOOGLE_CLOUD_PROJECT,
   );
+  console.debug(
+    `Authenticated with Code Assist using ${cp.type}` +
+      ` Credentials and project id: ${projectId}`,
+  );
   return new CodeAssistServer(cp.client, projectId, httpOptions);
 }
 
@@ -40,6 +45,7 @@ async function getClientAndProject(): Promise<ClientAndProjectId> {
     // No Application Default Credentials so try Oauth.
     const oauthClient = await getOauthClient(OAUTH_SCOPE);
     return {
+      type: 'Oauth2',
       client: oauthClient,
       projectId: oauthClient.projectId || undefined,
     };
@@ -55,6 +61,7 @@ async function getGoogleAuthClient(
 ): Promise<ClientAndProjectId> {
   const googleAuth = new GoogleAuth({ scopes });
   return {
+    type: 'Gcloud Application Default',
     client: await googleAuth.getClient(),
     projectId: await googleAuth.getProjectId(),
   };

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -10,7 +10,6 @@ import { getOauthClient } from './oauth2.js';
 import { setupUser } from './setup.js';
 import { CodeAssistServer, HttpOptions } from './server.js';
 
-
 // OAuth Scopes for Cloud Code authorization.
 const OAUTH_SCOPE = [
   'https://www.googleapis.com/auth/cloud-platform',

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -4,18 +4,42 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { GoogleAuth, AuthClient } from 'google-auth-library';
 import { ContentGenerator } from '../core/contentGenerator.js';
 import { getOauthClient } from './oauth2.js';
 import { setupUser } from './setup.js';
 import { CodeAssistServer, HttpOptions } from './server.js';
 
+
+// OAuth Scopes for Cloud Code authorization.
+const OAUTH_SCOPE = [
+  'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/userinfo.email',
+  'https://www.googleapis.com/auth/userinfo.profile',
+];
+
 export async function createCodeAssistContentGenerator(
   httpOptions: HttpOptions,
 ): Promise<ContentGenerator> {
-  const oauth2Client = await getOauthClient();
-  const projectId = await setupUser(
-    oauth2Client,
-    process.env.GOOGLE_CLOUD_PROJECT,
-  );
-  return new CodeAssistServer(oauth2Client, projectId, httpOptions);
+  const authClient = await getAuthClient();
+  const projectId = await setupUser(authClient);
+  return new CodeAssistServer(authClient, projectId, httpOptions);
+}
+
+async function getAuthClient(): Promise<AuthClient> {
+  try {
+    return await getGoogleAuthClient(OAUTH_SCOPE);
+  } catch (_) {
+    // No Application Default Credentials so try Oauth.
+    return await getOauthClient(OAUTH_SCOPE);
+  }
+}
+
+/**
+ * @returns a valid auth client.
+ * @throws error if there are no Application Default Credentials.
+ */
+async function getGoogleAuthClient(scopes: string[]): Promise<AuthClient> {
+  const googleAuth = new GoogleAuth({ scopes });
+  return await googleAuth.getClient();
 }

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -37,8 +37,8 @@ const CREDENTIAL_FILENAME = 'oauth_creds.json';
 
 export async function clearCachedCredentials(): Promise<void> {
   try {
-  await fs.rm(getCachedCredentialPath());
-  } catch(_) {
+    await fs.rm(getCachedCredentialPath());
+  } catch (_) {
     // The file might not be there but that's ok.
   }
 }

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -36,7 +36,11 @@ const GEMINI_DIR = '.gemini';
 const CREDENTIAL_FILENAME = 'oauth_creds.json';
 
 export async function clearCachedCredentials(): Promise<void> {
+  try {
   await fs.rm(getCachedCredentialPath());
+  } catch(_) {
+    // The file might not be there but that's ok.
+  }
 }
 
 export async function getOauthClient(scopes: string[]): Promise<OAuth2Client> {

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OAuth2Client, Credentials, GoogleAuth, AuthClient } from 'google-auth-library';
+import { OAuth2Client, Credentials } from 'google-auth-library';
 import * as http from 'http';
 import url from 'url';
 import crypto from 'crypto';
@@ -39,7 +39,7 @@ export async function clearCachedCredentials(): Promise<void> {
   await fs.rm(getCachedCredentialPath());
 }
 
-export async function getOauthClient(scopes: string[]): Promise<AuthClient> {
+export async function getOauthClient(scopes: string[]): Promise<OAuth2Client> {
   try {
     return await getCachedCredentialClient();
   } catch (_) {
@@ -66,8 +66,8 @@ async function webLoginClient(scopes: string[]): Promise<OAuth2Client> {
     });
     console.log(
       `\n\nCode Assist login required.\n` +
-      `Attempting to open authentication page in your browser.\n` +
-      `Otherwise navigate to:\n\n${authURL}\n\n`,
+        `Attempting to open authentication page in your browser.\n` +
+        `Otherwise navigate to:\n\n${authURL}\n\n`,
     );
     open(authURL);
     console.log('Waiting for authentication...');
@@ -152,10 +152,10 @@ async function getCachedCredentialClient(): Promise<OAuth2Client> {
 
 async function setCachedCredentials(credentials: Credentials) {
   const filePath = getCachedCredentialPath();
-  await fs.mkdir(path.dirname(filePath), { recursive: true, });
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
 
   const credString = JSON.stringify(credentials, null, 2);
-  await fs.writeFile(filePath, credString,);
+  await fs.writeFile(filePath, credString);
 }
 
 function getCachedCredentialPath(): string {

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OAuth2Client } from 'google-auth-library';
+import { AuthClient } from 'google-auth-library';
 import {
   LoadCodeAssistResponse,
   LoadCodeAssistRequest,
@@ -42,10 +42,10 @@ export const CODE_ASSIST_API_VERSION = 'v1internal';
 
 export class CodeAssistServer implements ContentGenerator {
   constructor(
-    readonly auth: OAuth2Client,
+    readonly auth: AuthClient,
     readonly projectId?: string,
     readonly httpOptions: HttpOptions = {},
-  ) {}
+  ) { }
 
   async generateContentStream(
     req: GenerateContentParameters,

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -45,7 +45,7 @@ export class CodeAssistServer implements ContentGenerator {
     readonly auth: AuthClient,
     readonly projectId?: string,
     readonly httpOptions: HttpOptions = {},
-  ) { }
+  ) {}
 
   async generateContentStream(
     req: GenerateContentParameters,

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -8,27 +8,27 @@ import { ClientMetadata, OnboardUserRequest } from './types.js';
 import { CodeAssistServer } from './server.js';
 import { AuthClient } from 'google-auth-library';
 import { clearCachedCredentials } from './oauth2.js';
+import { GaxiosError } from 'gaxios';
+
 
 /**
  *
  * @param projectId the user's project id, if any
  * @returns the user's actual project id
  */
-export async function setupUser(authClient: AuthClient): Promise<string> {
+export async function setupUser(authClient: AuthClient, projectId?: string): Promise<string> {
+  const caServer = new CodeAssistServer(authClient, projectId);
+
   const clientMetadata: ClientMetadata = {
     ideType: 'IDE_UNSPECIFIED',
     platform: 'PLATFORM_UNSPECIFIED',
     pluginType: 'GEMINI',
+    duetProject: projectId,
   };
-  if (process.env.GOOGLE_CLOUD_PROJECT) {
-    clientMetadata.duetProject = process.env.GOOGLE_CLOUD_PROJECT;
-  }
-
-  const caServer = new CodeAssistServer(authClient, clientMetadata.duetProject);
 
   // TODO: Support Free Tier user without projectId.
   const loadRes = await caServer.loadCodeAssist({
-    cloudaicompanionProject: process.env.GOOGLE_CLOUD_PROJECT,
+    cloudaicompanionProject: projectId,
     metadata: clientMetadata,
   });
 
@@ -37,7 +37,7 @@ export async function setupUser(authClient: AuthClient): Promise<string> {
 
   const onboardReq: OnboardUserRequest = {
     tierId: onboardTier,
-    cloudaicompanionProject: loadRes.cloudaicompanionProject || '',
+    cloudaicompanionProject: loadRes.cloudaicompanionProject || projectId || '',
     metadata: clientMetadata,
   };
   try {
@@ -47,14 +47,13 @@ export async function setupUser(authClient: AuthClient): Promise<string> {
       await new Promise((f) => setTimeout(f, 5000));
       lroRes = await caServer.onboardUser(onboardReq);
     }
-
     return lroRes.response?.cloudaicompanionProject?.id || '';
   } catch (e) {
     await clearCachedCredentials();
     console.log(
       '\n\nError onboarding with Code Assist.\n' +
-        'Enterprise users must specify GOOGLE_CLOUD_PROJECT ' +
-        'in their environment variables or .env file.\n\n',
+      'Enterprise users must specify GOOGLE_CLOUD_PROJECT ' +
+      'in their environment variables or .env file.\n\n',
     );
     throw e;
   }

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -53,8 +53,8 @@ export async function setupUser(authClient: AuthClient): Promise<string> {
     await clearCachedCredentials();
     console.log(
       '\n\nError onboarding with Code Assist.\n' +
-      'Enterprise users must specify GOOGLE_CLOUD_PROJECT ' +
-      'in their environment variables or .env file.\n\n',
+        'Enterprise users must specify GOOGLE_CLOUD_PROJECT ' +
+        'in their environment variables or .env file.\n\n',
     );
     throw e;
   }

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -6,7 +6,7 @@
 
 import { ClientMetadata, OnboardUserRequest } from './types.js';
 import { CodeAssistServer } from './server.js';
-import { OAuth2Client } from 'google-auth-library';
+import { AuthClient } from 'google-auth-library';
 import { clearCachedCredentials } from './oauth2.js';
 
 /**
@@ -14,11 +14,7 @@ import { clearCachedCredentials } from './oauth2.js';
  * @param projectId the user's project id, if any
  * @returns the user's actual project id
  */
-export async function setupUser(
-  oAuth2Client: OAuth2Client,
-  projectId?: string,
-): Promise<string> {
-  const caServer = new CodeAssistServer(oAuth2Client, projectId);
+export async function setupUser(authClient: AuthClient): Promise<string> {
   const clientMetadata: ClientMetadata = {
     ideType: 'IDE_UNSPECIFIED',
     platform: 'PLATFORM_UNSPECIFIED',
@@ -27,6 +23,8 @@ export async function setupUser(
   if (process.env.GOOGLE_CLOUD_PROJECT) {
     clientMetadata.duetProject = process.env.GOOGLE_CLOUD_PROJECT;
   }
+
+  const caServer = new CodeAssistServer(authClient, clientMetadata.duetProject);
 
   // TODO: Support Free Tier user without projectId.
   const loadRes = await caServer.loadCodeAssist({
@@ -55,8 +53,8 @@ export async function setupUser(
     await clearCachedCredentials();
     console.log(
       '\n\nError onboarding with Code Assist.\n' +
-        'Enterprise users must specify GOOGLE_CLOUD_PROJECT ' +
-        'in their environment variables or .env file.\n\n',
+      'Enterprise users must specify GOOGLE_CLOUD_PROJECT ' +
+      'in their environment variables or .env file.\n\n',
     );
     throw e;
   }

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -8,15 +8,16 @@ import { ClientMetadata, OnboardUserRequest } from './types.js';
 import { CodeAssistServer } from './server.js';
 import { AuthClient } from 'google-auth-library';
 import { clearCachedCredentials } from './oauth2.js';
-import { GaxiosError } from 'gaxios';
-
 
 /**
  *
  * @param projectId the user's project id, if any
  * @returns the user's actual project id
  */
-export async function setupUser(authClient: AuthClient, projectId?: string): Promise<string> {
+export async function setupUser(
+  authClient: AuthClient,
+  projectId?: string,
+): Promise<string> {
   const caServer = new CodeAssistServer(authClient, projectId);
 
   const clientMetadata: ClientMetadata = {
@@ -52,8 +53,8 @@ export async function setupUser(authClient: AuthClient, projectId?: string): Pro
     await clearCachedCredentials();
     console.log(
       '\n\nError onboarding with Code Assist.\n' +
-      'Enterprise users must specify GOOGLE_CLOUD_PROJECT ' +
-      'in their environment variables or .env file.\n\n',
+        'Enterprise users must specify GOOGLE_CLOUD_PROJECT ' +
+        'in their environment variables or .env file.\n\n',
     );
     throw e;
   }


### PR DESCRIPTION
## TLDR

Previously CCPA would only be supported with Oauth. Now, we also support looking for the gcloud application default credentials (and the project id).

## Dive Deeper

Unlike Oauth, this does not require Dasher users to set the GOOGLE_CLOUD_PROJECT env var.

The verbage about the two kinds of users was pulled from this: https://developers.google.com/gemini-code-assist/resources/faqs#gcp-project-requirement

## Reviewer Test Plan

1. Run this to revoke all your credentials:  `gcloud auth application-default revoke; gcloud auth revoke --all`
2. Remove any oauth credentials you might have: `rm ~/.gemini/oauth_creds.json`
3. Enable Code assist with  'export GEMINI_CODE_ASSIST=true'
4. Start up Gemini CLI and log in with a gmail.com account to verify that Personal accounts work.
5. Shut down the CLI.
6. Log in with gcloud and set the project id: `gcloud auth application-default login; gcloud config set project aipp-internal-testing`
7. Start up Gemini CLI and verify that you are logged in without having to do oauth.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | x  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |  x  | -   | -   |

## Linked issues / bugs

b/425360849
