### PR TITLE
refactor: consolidate container image tag source of truth to cli package.json

### DIFF
--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -85,18 +85,13 @@ export async function loadSandboxConfig(
   argv: SandboxCliArgs,
 ): Promise<SandboxConfig | undefined> {
   const sandboxOption = argv.sandbox ?? settings.sandbox;
-  const sandboxCommand = getSandboxCommand(sandboxOption);
-  if (!sandboxCommand) {
-    return undefined;
-  }
+  const command = getSandboxCommand(sandboxOption);
 
   const packageJson = await getPackageJson();
-  return {
-    command: sandboxCommand,
-    image:
-      argv['sandbox-image'] ??
-      process.env.GEMINI_SANDBOX_IMAGE ??
-      packageJson?.config?.sandboxImageUri ??
-      'gemini-cli-sandbox',
-  };
+  const image =
+    argv['sandbox-image'] ??
+    process.env.GEMINI_SANDBOX_IMAGE ??
+    packageJson?.config?.sandboxImageUri;
+
+  return command && image ? { command, image } : undefined;
 }


### PR DESCRIPTION
Consolidating to a single source of truth for the target sandbox image name. This should hopefully reduce confusion around which image we should be hopping into. 

## Details

* `packages/cli/src/config/sandboxConfig.ts`
  The sandbox configuration logic is updated to require an explicit image URI, removing the hardcoded fallback. The function now returns a valid configuration only if both a sandbox command and an image are explicitly defined.

* `scripts/build_sandbox.js`
  This build script is updated to read the base sandbox image URI directly from the CLI's package.json. This change ensures the script builds the image using the same tag that the application expects, making the package configuration the single source of truth.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ✅  |
| npx      | ❓  | ❓  | ✅  |
| Docker   | ❓  | ❓  | ✅   |
| Podman   | ✅   | -   | -   |
| Seatbelt | ✅   | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other extenral bugs --->
