### PR TITLE
Move theme discussion from configuration.md to themes.md

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -355,36 +355,3 @@ When `.gemini/sandbox.Dockerfile` exists, you can use `BUILD_SANDBOX` environmen
 ```bash
 BUILD_SANDBOX=1 gemini -s
 ```
-
-## Theming
-
-The Gemini CLI supports theming to customize its color scheme and appearance. Themes define colors for text, backgrounds, syntax highlighting, and other UI elements.
-
-### Available Themes
-
-The CLI comes with a selection of pre-defined themes. As seen in `theme-manager.ts`, these typically include:
-
-- **Dark Themes:**
-  - `AtomOneDark`
-  - `Dracula`
-  - `VS2015` (Default)
-  - `GitHub` (Dark variant usually)
-- **Light Themes:**
-  - `VS` (Visual Studio Light)
-  - `GoogleCode`
-  - `XCode` (Light variant usually)
-- **ANSI:**
-  - `ANSI`: A theme that primarily uses the terminal's native ANSI color capabilities.
-
-_(The exact list and their appearance can be confirmed by running the `/theme` command within the CLI.)_
-
-### Changing Themes
-
-1.  Type the `/theme` command in the CLI.
-2.  A dialog or selection prompt (`ThemeDialog.tsx`) will appear, listing the available themes.
-3.  You can typically navigate (e.g., with arrow keys) and select a theme. Some interfaces might offer a live preview or highlight as you select.
-4.  Confirm your selection (often with Enter) to apply the theme. You can usually cancel out of the selection (e.g., with Escape).
-
-### Theme Persistence
-
-Selected themes are usually saved in the CLI's configuration (see [CLI Configuration](./docs/cli/configuration.md)) so your preference is remembered across sessions.

--- a/docs/cli/themes.md
+++ b/docs/cli/themes.md
@@ -1,6 +1,35 @@
 # Themes
 
-The Gemini CLI supports a variety of themes to customize its appearance. You can change the theme to suit your preferences via the `/theme` command. Below are the available themes:
+Gemini CLI supports a variety of themes to customize its color scheme and appearance. You can change the theme to suit your preferences via the `/theme` command.
+
+## Available Themes
+
+The CLI comes with a selection of pre-defined themes. As seen in `theme-manager.ts`, these typically include:
+
+- **Dark Themes:**
+  - `AtomOneDark`
+  - `Dracula`
+  - `VS2015` (Default)
+  - `GitHub` (Dark variant usually)
+- **Light Themes:**
+  - `VS` (Visual Studio Light)
+  - `GoogleCode`
+  - `XCode` (Light variant usually)
+- **ANSI:**
+  - `ANSI`: A theme that primarily uses the terminal's native ANSI color capabilities.
+
+_(The exact list and their appearance can be confirmed by running the `/theme` command within the CLI.)_
+
+### Changing Themes
+
+1.  Type the `/theme` command in the CLI.
+2.  A dialog or selection prompt (`ThemeDialog.tsx`) will appear, listing the available themes.
+3.  You can typically navigate (e.g., with arrow keys) and select a theme. Some interfaces might offer a live preview or highlight as you select.
+4.  Confirm your selection (often with Enter) to apply the theme. You can usually cancel out of the selection (e.g., with Escape).
+
+### Theme Persistence
+
+Selected themes are usually saved in the CLI's configuration (see [CLI Configuration](./docs/cli/configuration.md)) so your preference is remembered across sessions.
 
 ## Dark Themes
 


### PR DESCRIPTION
##TLDR

This content looks like it is better hosted in the themes.md doc

##Dive Deeper

This is as close as possible to an as-is cut-paste from one file to the other, with the goal of minimizing fine-grained review in this particular PR. I'll take another pass through themes.md specifically to improve the moved content in a follow up PR
