### PR TITLE
Set slice=true on tests to supress output.

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     reporters: ['default', 'junit'],
+    silent: true,
     outputFile: {
       junit: 'junit.xml',
     },

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -9,6 +9,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     reporters: ['default', 'junit'],
+    silent: true,
     outputFile: {
       junit: 'junit.xml',
     },


### PR DESCRIPTION
## TLDR

Silences console.log() output during tests.

## Reviewer Test Plan

run `npm run test`

## Testing Matrix

N/A because it's test only.

