### PR TITLE
CCPA Count Token support

### DIFF
--- a/packages/core/src/code_assist/converter.test.ts
+++ b/packages/core/src/code_assist/converter.test.ts
@@ -6,9 +6,9 @@
 
 import { describe, it, expect } from 'vitest';
 import {
-  toCodeAssistRequest,
-  fromCodeAsistResponse,
-  CodeAssistResponse,
+  toGenerateContentRequest,
+  fromGenerateContentResponse,
+  CaGenerateContentResponse,
 } from './converter.js';
 import {
   GenerateContentParameters,
@@ -24,7 +24,7 @@ describe('converter', () => {
         model: 'gemini-pro',
         contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
       };
-      const codeAssistReq = toCodeAssistRequest(genaiReq, 'my-project');
+      const codeAssistReq = toGenerateContentRequest(genaiReq, 'my-project');
       expect(codeAssistReq).toEqual({
         model: 'gemini-pro',
         project: 'my-project',
@@ -46,7 +46,7 @@ describe('converter', () => {
         model: 'gemini-pro',
         contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
       };
-      const codeAssistReq = toCodeAssistRequest(genaiReq);
+      const codeAssistReq = toGenerateContentRequest(genaiReq);
       expect(codeAssistReq).toEqual({
         model: 'gemini-pro',
         project: undefined,
@@ -68,7 +68,7 @@ describe('converter', () => {
         model: 'gemini-pro',
         contents: 'Hello',
       };
-      const codeAssistReq = toCodeAssistRequest(genaiReq);
+      const codeAssistReq = toGenerateContentRequest(genaiReq);
       expect(codeAssistReq.request.contents).toEqual([
         { role: 'user', parts: [{ text: 'Hello' }] },
       ]);
@@ -79,7 +79,7 @@ describe('converter', () => {
         model: 'gemini-pro',
         contents: [{ text: 'Hello' }, { text: 'World' }],
       };
-      const codeAssistReq = toCodeAssistRequest(genaiReq);
+      const codeAssistReq = toGenerateContentRequest(genaiReq);
       expect(codeAssistReq.request.contents).toEqual([
         { role: 'user', parts: [{ text: 'Hello' }] },
         { role: 'user', parts: [{ text: 'World' }] },
@@ -94,7 +94,7 @@ describe('converter', () => {
           systemInstruction: 'You are a helpful assistant.',
         },
       };
-      const codeAssistReq = toCodeAssistRequest(genaiReq);
+      const codeAssistReq = toGenerateContentRequest(genaiReq);
       expect(codeAssistReq.request.systemInstruction).toEqual({
         role: 'user',
         parts: [{ text: 'You are a helpful assistant.' }],
@@ -110,7 +110,7 @@ describe('converter', () => {
           topK: 40,
         },
       };
-      const codeAssistReq = toCodeAssistRequest(genaiReq);
+      const codeAssistReq = toGenerateContentRequest(genaiReq);
       expect(codeAssistReq.request.generationConfig).toEqual({
         temperature: 0.8,
         topK: 40,
@@ -136,7 +136,7 @@ describe('converter', () => {
           responseMimeType: 'application/json',
         },
       };
-      const codeAssistReq = toCodeAssistRequest(genaiReq);
+      const codeAssistReq = toGenerateContentRequest(genaiReq);
       expect(codeAssistReq.request.generationConfig).toEqual({
         temperature: 0.1,
         topP: 0.2,
@@ -156,7 +156,7 @@ describe('converter', () => {
 
   describe('fromCodeAssistResponse', () => {
     it('should convert a simple response', () => {
-      const codeAssistRes: CodeAssistResponse = {
+      const codeAssistRes: CaGenerateContentResponse = {
         response: {
           candidates: [
             {
@@ -171,13 +171,13 @@ describe('converter', () => {
           ],
         },
       };
-      const genaiRes = fromCodeAsistResponse(codeAssistRes);
+      const genaiRes = fromGenerateContentResponse(codeAssistRes);
       expect(genaiRes).toBeInstanceOf(GenerateContentResponse);
       expect(genaiRes.candidates).toEqual(codeAssistRes.response.candidates);
     });
 
     it('should handle prompt feedback and usage metadata', () => {
-      const codeAssistRes: CodeAssistResponse = {
+      const codeAssistRes: CaGenerateContentResponse = {
         response: {
           candidates: [],
           promptFeedback: {
@@ -191,7 +191,7 @@ describe('converter', () => {
           },
         },
       };
-      const genaiRes = fromCodeAsistResponse(codeAssistRes);
+      const genaiRes = fromGenerateContentResponse(codeAssistRes);
       expect(genaiRes.promptFeedback).toEqual(
         codeAssistRes.response.promptFeedback,
       );
@@ -201,7 +201,7 @@ describe('converter', () => {
     });
 
     it('should handle automatic function calling history', () => {
-      const codeAssistRes: CodeAssistResponse = {
+      const codeAssistRes: CaGenerateContentResponse = {
         response: {
           candidates: [],
           automaticFunctionCallingHistory: [
@@ -221,7 +221,7 @@ describe('converter', () => {
           ],
         },
       };
-      const genaiRes = fromCodeAsistResponse(codeAssistRes);
+      const genaiRes = fromGenerateContentResponse(codeAssistRes);
       expect(genaiRes.automaticFunctionCallingHistory).toEqual(
         codeAssistRes.response.automaticFunctionCallingHistory,
       );

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -48,7 +48,6 @@ describe('oauth2', () => {
       access_token: 'test-access-token',
       refresh_token: 'test-refresh-token',
     };
-    const mockScopes = ['https://www.googleapis.com/auth/cloud-platform'];
 
     const mockGenerateAuthUrl = vi.fn().mockReturnValue(mockAuthUrl);
     const mockGetToken = vi.fn().mockResolvedValue({ tokens: mockTokens });
@@ -97,7 +96,7 @@ describe('oauth2', () => {
       return mockHttpServer as unknown as http.Server;
     });
 
-    const clientPromise = getOauthClient(mockScopes);
+    const clientPromise = getOauthClient();
 
     // wait for server to start listening.
     await serverListeningPromise;

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -48,6 +48,7 @@ describe('oauth2', () => {
       access_token: 'test-access-token',
       refresh_token: 'test-refresh-token',
     };
+    const mockScopes = ['https://www.googleapis.com/auth/cloud-platform'];
 
     const mockGenerateAuthUrl = vi.fn().mockReturnValue(mockAuthUrl);
     const mockGetToken = vi.fn().mockResolvedValue({ tokens: mockTokens });
@@ -96,7 +97,7 @@ describe('oauth2', () => {
       return mockHttpServer as unknown as http.Server;
     });
 
-    const clientPromise = getOauthClient();
+    const clientPromise = getOauthClient(mockScopes);
 
     // wait for server to start listening.
     await serverListeningPromise;

--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -133,11 +133,16 @@ describe('CodeAssistServer', () => {
   it('should return 0 for countTokens', async () => {
     const auth = new OAuth2Client();
     const server = new CodeAssistServer(auth, 'test-project');
+    const mockResponse = {
+      totalTokens: 100,
+    };
+    vi.spyOn(server, 'callEndpoint').mockResolvedValue(mockResponse);
+
     const response = await server.countTokens({
       model: 'test-model',
       contents: [{ role: 'user', parts: [{ text: 'request' }] }],
     });
-    expect(response.totalTokens).toBe(0);
+    expect(response.totalTokens).toBe(100);
   });
 
   it('should throw an error for embedContent', async () => {


### PR DESCRIPTION
## TLDR

CCPA didn't support CountToken until earlier today (in staging). This adds code to actually call CCPA. 

## Dive Deeper

This is used in the /compress command.

## Reviewer Test Plan

Set up Code Assist (GEMINI_CODE_ASSIST=true ,GOOGLE_CLOUD_PROJECT=aipp-internal-testing) and execute the /compress command. Previously, with Code Assist this would return "✕ Failed to compress chat history." Now it should return something like "Chat history compressed from 2156 to 167 tokens."

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | X  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

b/425360849
