### PR TITLE
feat: update default gemini model to GA 2.5 pro

### DIFF
--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro-preview-06-05';
+export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash-preview-05-20';
 export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -18,6 +18,7 @@ export function tokenLimit(model: Model): TokenCount {
     case 'gemini-1.5-flash':
     case 'gemini-2.5-pro-preview-05-06':
     case 'gemini-2.5-pro-preview-06-05':
+    case 'gemini-2.5-pro':
     case 'gemini-2.5-flash-preview-05-20':
     case 'gemini-2.0-flash':
       return 1_048_576;


### PR DESCRIPTION
## TLDR
- Updates the default gemini model to the GA .
- Adds  to the token limits.

## Dive Deeper

Gemini 2.5 Pro GA model was just released. This is a requirement for our final GA launch.

## Reviewer Test Plan

Normal flows. Mine personally is: `Write a 3 paragraph poem about cats, then write a one paragraph summary to Foo.md. Once that's done I'd like you to copy Foo.md to Bar.md. Then as a final request (pre-req work) I need to know the latest stock price of Google.`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

None, probably should have but this was a straightforward change and model upgrade.
