### PR TITLE
Allow OTLP telemetry export from macOS sandbox

### DIFF
--- a/docs/core/telemetry.md
+++ b/docs/core/telemetry.md
@@ -38,7 +38,7 @@ This entire system is built on the **[OpenTelemetry] (OTEL)** standard, allowing
 
 You can enable telemetry in multiple ways. [Configuration](configuration.md) is primarily managed via the `.gemini/settings.json` file and environment variables, but CLI flags can override these settings for a specific session.
 
-> **A Note on Sandbox Mode:** Telemetry is not compatible with sandbox mode at this time. Turn off sandbox mode before enabling telemetry. Tracked in #894.
+> **A Note on Sandbox Mode:** Telemetry is not compatible with docker/podman sandbox mode at this time - but it works for Seatbelt sandbox mode in MacOS. Tracked in #894.
 
 **Order of Precedence:**
 

--- a/packages/cli/src/utils/sandbox-macos-permissive-closed.sb
+++ b/packages/cli/src/utils/sandbox-macos-permissive-closed.sb
@@ -24,3 +24,5 @@
 
 ;; deny all outbound network traffic
 (deny network-outbound)
+;; Allow outbound traffic on OTLP collector port
+(allow network-outbound (remote tcp "localhost:4317"))

--- a/packages/cli/src/utils/sandbox-macos-permissive-proxied.sb
+++ b/packages/cli/src/utils/sandbox-macos-permissive-proxied.sb
@@ -22,10 +22,12 @@
 (deny network-inbound)
 (allow network-inbound (local ip "localhost:9229"))
 
-;; deny all outbound network traffic EXCEPT through proxy on localhost:8877
+;; deny all outbound network traffic EXCEPT through proxy on localhost:8877 and OTLP collector on localhost:4317
 ;; set `GEMINI_SANDBOX_PROXY_COMMAND=<command>` to run proxy alongside sandbox
 ;; proxy must listen on :::8877 (see scripts/example-proxy.js)
 (deny network-outbound)
 (allow network-outbound (remote tcp "localhost:8877"))
+;; Allow outbound traffic on OTLP collector port
+(allow network-outbound (remote tcp "localhost:4317"))
 
 (allow network-bind (local ip "*:*"))

--- a/packages/cli/src/utils/sandbox-macos-restrictive-closed.sb
+++ b/packages/cli/src/utils/sandbox-macos-restrictive-closed.sb
@@ -85,3 +85,6 @@
 
 ;; allow inbound network traffic on debugger port
 (allow network-inbound (local ip "localhost:9229"))
+
+;; Allow outbound traffic on OTLP collector port
+(allow network-outbound (remote tcp "localhost:4317"))

--- a/packages/cli/src/utils/sandbox-macos-restrictive-proxied.sb
+++ b/packages/cli/src/utils/sandbox-macos-restrictive-proxied.sb
@@ -90,3 +90,5 @@
 ;; set `GEMINI_SANDBOX_PROXY_COMMAND=<command>` to run proxy alongside sandbox
 ;; proxy must listen on :::8877 (see scripts/example-proxy.js)
 (allow network-outbound (remote tcp "localhost:8877"))
+;; Allow outbound traffic on OTLP collector port
+(allow network-outbound (remote tcp "localhost:4317"))


### PR DESCRIPTION
Modifies macOS Seatbelt sandbox profiles (.sb files) to permit outbound network connections to localhost:4317. This enables Gemini CLI to export OTLP telemetry data when running under these sandbox restrictions.

Associated documentation for telemetry in sandbox mode has also been updated to reflect these capabilities and guide users.

This change partially addresses issue #894.

---
![image](https://github.com/user-attachments/assets/66407603-5738-4155-a198-302723a10fe5)

#750 
