### PR TITLE
Move the shell history our of the project .gemini to the home dir

### DIFF
--- a/packages/cli/src/ui/hooks/useShellHistory.ts
+++ b/packages/cli/src/ui/hooks/useShellHistory.ts
@@ -7,14 +7,13 @@
 import { useState, useEffect, useCallback } from 'react';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { isNodeError } from '@gemini-cli/core';
+import { isNodeError, getProjectTempDir } from '@gemini-cli/core';
 
-const HISTORY_DIR = '.gemini';
 const HISTORY_FILE = 'shell_history';
 const MAX_HISTORY_LENGTH = 100;
 
 async function getHistoryFilePath(projectRoot: string): Promise<string> {
-  const historyDir = path.join(projectRoot, HISTORY_DIR);
+  const historyDir = getProjectTempDir(projectRoot);
   return path.join(historyDir, HISTORY_FILE);
 }
 

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -5,13 +5,10 @@
  */
 
 import path from 'node:path';
-import os from 'node:os';
-import crypto from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { Content } from '@google/genai';
+import { getProjectTempDir } from '../utils/paths.js';
 
-const GEMINI_DIR = '.gemini';
-const TMP_DIR_NAME = 'tmp';
 const LOG_FILE_NAME = 'logs.json';
 const CHECKPOINT_FILE_NAME = 'checkpoint.json';
 
@@ -99,17 +96,7 @@ export class Logger {
       return;
     }
 
-    const projectHash = crypto
-      .createHash('sha256')
-      .update(process.cwd())
-      .digest('hex');
-
-    this.geminiDir = path.join(
-      os.homedir(),
-      GEMINI_DIR,
-      TMP_DIR_NAME,
-      projectHash,
-    );
+    this.geminiDir = getProjectTempDir(process.cwd());
     this.logFilePath = path.join(this.geminiDir, LOG_FILE_NAME);
     this.checkpointFilePath = path.join(this.geminiDir, CHECKPOINT_FILE_NAME);
 

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -7,11 +7,11 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import * as crypto from 'crypto';
 import { isNodeError } from '../utils/errors.js';
 import { isGitRepository } from '../utils/gitUtils.js';
 import { exec } from 'node:child_process';
 import { simpleGit, SimpleGit, CheckRepoActions } from 'simple-git';
+import { getProjectHash, GEMINI_DIR } from '../utils/paths.js';
 
 export class GitService {
   private projectRoot: string;
@@ -21,11 +21,8 @@ export class GitService {
   }
 
   private getHistoryDir(): string {
-    const hash = crypto
-      .createHash('sha256')
-      .update(this.projectRoot)
-      .digest('hex');
-    return path.join(os.homedir(), '.gemini', 'history', hash);
+    const hash = getProjectHash(this.projectRoot);
+    return path.join(os.homedir(), GEMINI_DIR, 'history', hash);
   }
 
   async initialize(): Promise<void> {

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -6,6 +6,10 @@
 
 import path from 'node:path';
 import os from 'os';
+import * as crypto from 'crypto';
+
+export const GEMINI_DIR = '.gemini';
+const TMP_DIR_NAME = 'tmp';
 
 /**
  * Replaces the home directory with a tilde.
@@ -133,4 +137,23 @@ export function escapePath(filePath: string): string {
  */
 export function unescapePath(filePath: string): string {
   return filePath.replace(/\\ /g, ' ');
+}
+
+/**
+ * Generates a unique hash for a project based on its root path.
+ * @param projectRoot The absolute path to the project's root directory.
+ * @returns A SHA256 hash of the project root path.
+ */
+export function getProjectHash(projectRoot: string): string {
+  return crypto.createHash('sha256').update(projectRoot).digest('hex');
+}
+
+/**
+ * Generates a unique temporary directory path for a project.
+ * @param projectRoot The absolute path to the project's root directory.
+ * @returns The path to the project's temporary directory.
+ */
+export function getProjectTempDir(projectRoot: string): string {
+  const hash = getProjectHash(projectRoot);
+  return path.join(os.homedir(), GEMINI_DIR, TMP_DIR_NAME, hash);
 }


### PR DESCRIPTION
This moves the shell_history file out of the project root .gemini folder to the tmp directory that exists under the home directory. It moves the history to a project specific folder which adds support for project scoped command histories.