### PR TITLE
Use Env Var directly instead of through GoogleAuth()

### DIFF
--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GoogleAuth, AuthClient } from 'google-auth-library';
 import { ContentGenerator } from '../core/contentGenerator.js';
 import { getOauthClient } from './oauth2.js';
 import { setupUser } from './setup.js';
@@ -13,17 +12,7 @@ import { CodeAssistServer, HttpOptions } from './server.js';
 export async function createCodeAssistContentGenerator(
   httpOptions: HttpOptions,
 ): Promise<ContentGenerator> {
-  const authClient = await getAuthClient();
+  const authClient = await getOauthClient();
   const projectId = await setupUser(authClient);
   return new CodeAssistServer(authClient, projectId, httpOptions);
-}
-
-async function getAuthClient(): Promise<AuthClient> {
-  try {
-    // Try for Application Default Credentials.
-    return await new GoogleAuth().getClient();
-  } catch (_) {
-    // No Application Default Credentials so try Oauth.
-    return await getOauthClient();
-  }
 }

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthClient } from 'google-auth-library';
+import { OAuth2Client } from 'google-auth-library';
 import {
   LoadCodeAssistResponse,
   LoadCodeAssistRequest,
@@ -45,7 +45,7 @@ export const CODE_ASSIST_API_VERSION = 'v1internal';
 
 export class CodeAssistServer implements ContentGenerator {
   constructor(
-    readonly auth: AuthClient,
+    readonly auth: OAuth2Client,
     readonly projectId?: string,
     readonly httpOptions: HttpOptions = {},
   ) {}

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -6,14 +6,14 @@
 
 import { ClientMetadata, OnboardUserRequest } from './types.js';
 import { CodeAssistServer } from './server.js';
-import { AuthClient } from 'google-auth-library';
+import { OAuth2Client } from 'google-auth-library';
 
 /**
  *
  * @param projectId the user's project id, if any
  * @returns the user's actual project id
  */
-export async function setupUser(authClient: AuthClient): Promise<string> {
+export async function setupUser(authClient: OAuth2Client): Promise<string> {
   const projectId = process.env.GOOGLE_CLOUD_PROJECT;
   const caServer = new CodeAssistServer(authClient, projectId);
 


### PR DESCRIPTION
## TLDR

To let the vscode plugin provide its own credentials we want to support the GOOGLE_APPLICATION_CREDENTIALS env var. GoogleAuth() does that but it also picks up the application default credentials which is not what we want. So just support that env var directly.


## Reviewer Test Plan

After logging in with Code Assist normally exit gemini cli. Rename your credential file at `/Users/your_home_dir/.gemini/oauth_creds.json` to `oauth_creds_alt.json`. Then set your env var to point to the renamed file:

`export GOOGLE_APPLICATION_CREDENTIALS=/Users/your_home_dir/.gemini/oauth_creds_alt.json`

Then start up Gemini CLI and verify that it does not ask you to log in again since it finds your creds at the alternative location.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | X  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

b/425360849
