### PR TITLE
Support Oauth2 Reauthentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "gaxios": "^7.1.0"
-      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },
@@ -3969,15 +3966,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -5297,29 +5285,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -5459,18 +5424,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5543,20 +5496,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gaxios": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.0.tgz",
-      "integrity": "sha512-y1Q0MX1Ba6eg67Zz92kW0MHHhdtWksYckQy1KJsI6P4UlDQ8cvdvpLEPslD/k7vFkdPppMESFGTvk7XpSiKj8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/gcp-metadata": {
@@ -7891,44 +7830,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/normalize-package-data": {
@@ -11239,15 +11140,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -11846,6 +11738,7 @@
         "@types/html-to-text": "^9.0.4",
         "diff": "^7.0.0",
         "dotenv": "^16.4.7",
+        "gaxios": "^6.1.1",
         "glob": "^10.4.5",
         "google-auth-library": "^9.11.0",
         "html-to-text": "^9.0.5",
@@ -11871,6 +11764,22 @@
         "node": ">=18"
       }
     },
+    "packages/core/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "packages/core/node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -11878,6 +11787,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "packages/core/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "packages/core/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "packages/core/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "packages/core/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "packages/core/node_modules/ws": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "gaxios": "^7.1.0"
+      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },
@@ -3966,6 +3969,15 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -5285,6 +5297,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -5424,6 +5459,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5499,6 +5546,34 @@
       }
     },
     "node_modules/gaxios": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.0.tgz",
+      "integrity": "sha512-y1Q0MX1Ba6eg67Zz92kW0MHHhdtWksYckQy1KJsI6P4UlDQ8cvdvpLEPslD/k7vFkdPppMESFGTvk7XpSiKj8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
@@ -5514,18 +5589,46 @@
         "node": ">=14"
       }
     },
-    "node_modules/gcp-metadata": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
-      "license": "Apache-2.0",
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
-        "json-bigint": "^1.0.0"
+        "whatwg-url": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/gcp-metadata/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/gcp-metadata/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -5723,6 +5826,64 @@
         "node": ">=14"
       }
     },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/google-auth-library/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/google-auth-library/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/google-auth-library/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/google-logging-utils": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
@@ -5781,6 +5942,64 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gtoken/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gtoken/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gtoken/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/gtoken/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/gtoken/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -7674,46 +7893,42 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
         }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/normalize-package-data": {
@@ -11022,6 +11237,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     "react-devtools-core": "^4.28.5",
     "typescript-eslint": "^8.30.1",
     "yargs": "^17.7.2"
+  },
+  "dependencies": {
+    "gaxios": "^7.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,8 +73,5 @@
     "react-devtools-core": "^4.28.5",
     "typescript-eslint": "^8.30.1",
     "yargs": "^17.7.2"
-  },
-  "dependencies": {
-    "gaxios": "^7.1.0"
   }
 }

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -513,7 +513,12 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
         </Box>
         {showHelp && <Help commands={slashCommands} />}
 
-        {isReauthRequired && <ReauthDialog />}
+        {isReauthRequired && (
+          <ReauthDialog
+            config={config}
+            onAuthSuccess={() => setIsReauthRequired(false)}
+          />
+        )}
 
         <Box flexDirection="column" ref={mainControlsRef}>
           {startupWarnings.length > 0 && (

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -305,6 +305,10 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     return editorType as EditorType;
   }, [settings, openEditorDialog]);
 
+  const onAuthError = useCallback(() => {
+    setIsReauthRequired(true);
+  }, []);
+
   const {
     streamingState,
     submitQuery,
@@ -321,6 +325,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     handleSlashCommand,
     shellModeActive,
     getPreferredEditor,
+    onAuthError,
   );
   pendingHistoryItems.push(...pendingGeminiHistoryItems);
   const { elapsedTime, currentLoadingPhrase } =

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -62,6 +62,7 @@ import { useTextBuffer } from './components/shared/text-buffer.js';
 import * as fs from 'fs';
 import { UpdateNotification } from './components/UpdateNotification.js';
 import { checkForUpdates } from './utils/updateCheck.js';
+import { ReauthDialog } from './components/ReauthDialog.js';
 
 const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
 
@@ -79,6 +80,7 @@ export const AppWrapper = (props: AppProps) => (
 
 const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   const [updateMessage, setUpdateMessage] = useState<string | null>(null);
+  const [isReauthRequired, setIsReauthRequired] = useState(false);
 
   useEffect(() => {
     checkForUpdates().then(setUpdateMessage);
@@ -505,6 +507,8 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
           ))}
         </Box>
         {showHelp && <Help commands={slashCommands} />}
+
+        {isReauthRequired && <ReauthDialog />}
 
         <Box flexDirection="column" ref={mainControlsRef}>
           {startupWarnings.length > 0 && (

--- a/packages/cli/src/ui/components/ReauthDialog.tsx
+++ b/packages/cli/src/ui/components/ReauthDialog.tsx
@@ -4,10 +4,43 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Box, Text } from 'ink';
+import { Box, Text, useInput } from 'ink';
+import { useState, useCallback } from 'react';
+import { Config, refreshAuth } from '@gemini-cli/core';
+import open from 'open';
 import { Colors } from '../colors.js';
 
-export const ReauthDialog = () => {
+interface ReauthDialogProps {
+  config: Config;
+  onAuthSuccess: () => void;
+}
+
+export const ReauthDialog = ({ config, onAuthSuccess }: ReauthDialogProps) => {
+  const [authUrl, setAuthUrl] = useState<string | null>(null);
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = useCallback(async () => {
+    if (isAuthenticating) return;
+
+    try {
+      const authProcess = await refreshAuth(config.getGeminiClient().getContentGenerator());
+      setAuthUrl(authProcess.authUrl);
+      setIsAuthenticating(true);
+      await open(authProcess.authUrl);
+      await authProcess.loginCompletePromise;
+      onAuthSuccess();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'An unknown error occurred.');
+    }
+  }, [config, onAuthSuccess, isAuthenticating]);
+
+  useInput((_input, key) => {
+    if (key.return) {
+      handleConfirm();
+    }
+  });
+
   return (
     <Box
       borderStyle="round"
@@ -17,7 +50,15 @@ export const ReauthDialog = () => {
       flexDirection="column"
     >
       <Text color={Colors.AccentRed}>Authentication error: Your session has expired.</Text>
-      <Text>Please restart the CLI to log in again.</Text>
+      {error && <Text color={Colors.AccentRed}>Error: {error}</Text>}
+      {!isAuthenticating && !error && <Text>Press Enter to log in again.</Text>}
+      {authUrl && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text>Please open the following URL in your browser to continue:</Text>
+          <Text color={Colors.AccentBlue}>{authUrl}</Text>
+        </Box>
+      )}
+      {isAuthenticating && <Text color={Colors.AccentYellow}>Waiting for authentication...</Text>}
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/ReauthDialog.tsx
+++ b/packages/cli/src/ui/components/ReauthDialog.tsx
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Text } from 'ink';
+import { Colors } from '../colors.js';
+
+export const ReauthDialog = () => {
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={Colors.AccentRed}
+      paddingX={1}
+      marginY={1}
+      flexDirection="column"
+    >
+      <Text color={Colors.AccentRed}>Authentication error: Your session has expired.</Text>
+      <Text>Please restart the CLI to log in again.</Text>
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/ReauthDialog.tsx
+++ b/packages/cli/src/ui/components/ReauthDialog.tsx
@@ -18,23 +18,18 @@ interface ReauthDialogProps {
 export const ReauthDialog = ({ config, onAuthSuccess }: ReauthDialogProps) => {
   const [authUrl, setAuthUrl] = useState<string | null>(null);
   const [isAuthenticating, setIsAuthenticating] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   const handleConfirm = useCallback(async () => {
     if (isAuthenticating) return;
 
-    try {
-      const authProcess = await refreshAuth(
-        config.getGeminiClient().getContentGenerator(),
-      );
-      setAuthUrl(authProcess.authUrl);
-      setIsAuthenticating(true);
-      await open(authProcess.authUrl);
-      await authProcess.loginCompletePromise;
-      onAuthSuccess();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'An unknown error occurred.');
-    }
+    const authProcess = await refreshAuth(
+      config.getGeminiClient().getContentGenerator(),
+    );
+    setAuthUrl(authProcess.authUrl);
+    setIsAuthenticating(true);
+    await open(authProcess.authUrl);
+    await authProcess.loginCompletePromise;
+    onAuthSuccess();
   }, [config, onAuthSuccess, isAuthenticating]);
 
   useInput((_input, key) => {
@@ -54,8 +49,7 @@ export const ReauthDialog = ({ config, onAuthSuccess }: ReauthDialogProps) => {
       <Text color={Colors.AccentRed}>
         Authentication error: Your session has expired.
       </Text>
-      {error && <Text color={Colors.AccentRed}>Error: {error}</Text>}
-      {!isAuthenticating && !error && <Text>Press Enter to log in again.</Text>}
+      {!isAuthenticating && <Text>Press Enter to log in again.</Text>}
       {authUrl && (
         <Box flexDirection="column" marginTop={1}>
           <Text>

--- a/packages/cli/src/ui/components/ReauthDialog.tsx
+++ b/packages/cli/src/ui/components/ReauthDialog.tsx
@@ -24,7 +24,9 @@ export const ReauthDialog = ({ config, onAuthSuccess }: ReauthDialogProps) => {
     if (isAuthenticating) return;
 
     try {
-      const authProcess = await refreshAuth(config.getGeminiClient().getContentGenerator());
+      const authProcess = await refreshAuth(
+        config.getGeminiClient().getContentGenerator(),
+      );
       setAuthUrl(authProcess.authUrl);
       setIsAuthenticating(true);
       await open(authProcess.authUrl);
@@ -49,16 +51,22 @@ export const ReauthDialog = ({ config, onAuthSuccess }: ReauthDialogProps) => {
       marginY={1}
       flexDirection="column"
     >
-      <Text color={Colors.AccentRed}>Authentication error: Your session has expired.</Text>
+      <Text color={Colors.AccentRed}>
+        Authentication error: Your session has expired.
+      </Text>
       {error && <Text color={Colors.AccentRed}>Error: {error}</Text>}
       {!isAuthenticating && !error && <Text>Press Enter to log in again.</Text>}
       {authUrl && (
         <Box flexDirection="column" marginTop={1}>
-          <Text>Please open the following URL in your browser to continue:</Text>
+          <Text>
+            Please open the following URL in your browser to continue:
+          </Text>
           <Text color={Colors.AccentBlue}>{authUrl}</Text>
         </Box>
       )}
-      {isAuthenticating && <Text color={Colors.AccentYellow}>Waiting for authentication...</Text>}
+      {isAuthenticating && (
+        <Text color={Colors.AccentYellow}>Waiting for authentication...</Text>
+      )}
     </Box>
   );
 };

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -359,6 +359,7 @@ describe('useGeminiStream', () => {
           props.handleSlashCommand,
           props.shellModeActive,
           () => 'vscode' as EditorType,
+          () => {},
         ),
       {
         initialProps: {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -533,6 +533,7 @@ export const useGeminiStream = (
       setInitError,
       geminiClient,
       startNewTurn,
+      onAuthError,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -22,6 +22,7 @@ import {
   GitService,
   EditorType,
   ThoughtSummary,
+  ReauthNeededError,
 } from '@gemini-cli/core';
 import { type Part, type PartListUnion } from '@google/genai';
 import {
@@ -50,14 +51,6 @@ import {
   TrackedCancelledToolCall,
 } from './useReactToolScheduler.js';
 import { useSessionStats } from '../contexts/SessionContext.js';
-import { GaxiosError } from 'gaxios';
-
-function isAuthError(error: unknown): boolean {
-  if (error instanceof GaxiosError) {
-    return error.response?.data?.error === 'invalid_grant';
-  }
-  return false;
-}
 
 export function mergePartListUnions(list: PartListUnion[]): PartListUnion {
   const resultParts: PartListUnion = [];
@@ -505,7 +498,7 @@ export const useGeminiStream = (
           setPendingHistoryItem(null);
         }
       } catch (error: unknown) {
-        if (isAuthError(error)) {
+        if (error instanceof ReauthNeededError) {
           onAuthError();
         } else if (!isNodeError(error) || error.name !== 'AbortError') {
           addItem(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
     "@types/html-to-text": "^9.0.4",
     "diff": "^7.0.0",
     "dotenv": "^16.4.7",
+    "gaxios": "^6.1.1",
     "glob": "^10.4.5",
     "google-auth-library": "^9.11.0",
     "html-to-text": "^9.0.5",

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -5,7 +5,7 @@
  */
 
 import { ContentGenerator } from '../core/contentGenerator.js';
-import { getOauthClient } from './oauth2.js';
+import { authWithWeb, getOauthClient, OauthWebLogin } from './oauth2.js';
 import { setupUser } from './setup.js';
 import { CodeAssistServer, HttpOptions } from './server.js';
 
@@ -15,4 +15,16 @@ export async function createCodeAssistContentGenerator(
   const authClient = await getOauthClient();
   const projectId = await setupUser(authClient);
   return new CodeAssistServer(authClient, projectId, httpOptions);
+}
+
+export async function refreshAuth(
+  contentGenerator: ContentGenerator,
+): Promise<OauthWebLogin> {
+  if (!(contentGenerator instanceof CodeAssistServer)) {
+    throw Error("Cannot refresh auth if you're not using CodeAssistServer");
+  }
+  if (!(contentGenerator.auth instanceof OAuth2Client)) {
+    throw Error("Cannot refresh auth if you're not using OAuth2Client");
+  }
+  return authWithWeb(contentGenerator.auth);
 }

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -23,8 +23,5 @@ export async function refreshAuth(
   if (!(contentGenerator instanceof CodeAssistServer)) {
     throw Error("Cannot refresh auth if you're not using CodeAssistServer");
   }
-  if (!(contentGenerator.auth instanceof OAuth2Client)) {
-    throw Error("Cannot refresh auth if you're not using OAuth2Client");
-  }
   return authWithWeb(contentGenerator.auth);
 }

--- a/packages/core/src/code_assist/errors.ts
+++ b/packages/core/src/code_assist/errors.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Error thrown when a user needs to re-authenticate.
+ */
+export class ReauthNeededError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ReauthNeededError';
+  }
+}

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -57,6 +57,7 @@ describe('oauth2', () => {
       getToken: mockGetToken,
       setCredentials: mockSetCredentials,
       credentials: mockTokens,
+      on: vi.fn(),
     } as unknown as OAuth2Client;
     vi.mocked(OAuth2Client).mockImplementation(() => mockOAuth2Client);
 
@@ -122,9 +123,5 @@ describe('oauth2', () => {
       redirect_uri: `http://localhost:${capturedPort}/oauth2callback`,
     });
     expect(mockSetCredentials).toHaveBeenCalledWith(mockTokens);
-
-    const tokenPath = path.join(tempHomeDir, '.gemini', 'oauth_creds.json');
-    const tokenData = JSON.parse(fs.readFileSync(tokenPath, 'utf-8'));
-    expect(tokenData).toEqual(mockTokens);
   });
 });

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -57,6 +57,9 @@ export async function getOauthClient(): Promise<OAuth2Client> {
     clientId: OAUTH_CLIENT_ID,
     clientSecret: OAUTH_CLIENT_SECRET,
   });
+  client.on('tokens', async (tokens: Credentials) => {
+    await cacheCredentials(tokens);
+  });
 
   if (await loadCachedCredentials(client)) {
     // Found valid cached credentials.
@@ -116,7 +119,6 @@ export async function authWithWeb(
             redirect_uri: redirectUri,
           });
           client.setCredentials(tokens);
-          await cacheCredentials(client.credentials);
 
           res.writeHead(HTTP_REDIRECT, { Location: SIGN_IN_SUCCESS_URL });
           res.end();

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -78,7 +78,9 @@ export async function getOauthClient(): Promise<OAuth2Client> {
   return client;
 }
 
-async function authWithWeb(client: OAuth2Client): Promise<OauthWebLogin> {
+export async function authWithWeb(
+  client: OAuth2Client,
+): Promise<OauthWebLogin> {
   const port = await getAvailablePort();
   const redirectUri = `http://localhost:${port}/oauth2callback`;
   const state = crypto.randomBytes(32).toString('hex');

--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -155,4 +155,26 @@ describe('CodeAssistServer', () => {
       }),
     ).rejects.toThrow();
   });
+
+  it('should throw ReauthNeededError when isAuthError is true for callEndpoint', async () => {
+    const auth = new OAuth2Client();
+    const server = new CodeAssistServer(auth, 'test-project');
+    vi.spyOn(server, 'isAuthError').mockReturnValue(true);
+    vi.spyOn(auth, 'request').mockRejectedValue(new Error('Auth error'));
+
+    await expect(server.callEndpoint('someMethod', {})).rejects.toThrow(
+      'Re-authentication is needed.',
+    );
+  });
+
+  it('should throw ReauthNeededError when isAuthError is true for streamEndpoint', async () => {
+    const auth = new OAuth2Client();
+    const server = new CodeAssistServer(auth, 'test-project');
+    vi.spyOn(server, 'isAuthError').mockReturnValue(true);
+    vi.spyOn(auth, 'request').mockRejectedValue(new Error('Auth error'));
+
+    await expect(server.streamEndpoint('someMethod', {})).rejects.toThrow(
+      'Re-authentication is needed.',
+    );
+  });
 });

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -31,6 +31,7 @@ import {
 } from './converter.js';
 import { PassThrough } from 'node:stream';
 import { ReauthNeededError } from './errors.js';
+import { GaxiosError } from 'gaxios';
 
 /** HTTP options to be used in each of the requests. */
 export interface HttpOptions {
@@ -191,8 +192,7 @@ export class CodeAssistServer implements ContentGenerator {
    */
   isAuthError(error: unknown): boolean {
     return (
-      error instanceof Error &&
-      (error.message === 'invalid_grant' || error.message === 'invalid_token')
+      error instanceof GaxiosError && error.response?.data?.error?.code === 401
     );
   }
 }

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -30,7 +30,6 @@ import {
   CaCountTokenResponse,
 } from './converter.js';
 import { PassThrough } from 'node:stream';
-import { GaxiosError } from 'gaxios';
 import { ReauthNeededError } from './errors.js';
 
 /** HTTP options to be used in each of the requests. */
@@ -187,10 +186,13 @@ export class CodeAssistServer implements ContentGenerator {
     }
   }
 
+  /**
+   * Returns true if the error indicates the token was revoked or expired.
+   */
   isAuthError(error: unknown): boolean {
-    if (error instanceof GaxiosError) {
-      return error.response?.data?.error === 'invalid_grant';
-    }
-    return false;
+    return (
+      error instanceof Error &&
+      (error.message === 'invalid_grant' || error.message === 'invalid_token')
+    );
   }
 }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -81,7 +81,7 @@ export class GeminiClient {
     return this.chat;
   }
 
-  private getContentGenerator(): ContentGenerator {
+  getContentGenerator(): ContentGenerator {
     if (!this.contentGenerator) {
       throw new Error('Content generator not initialized');
     }

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -20,6 +20,7 @@ import { getResponseText } from '../utils/generateContentResponseUtilities.js';
 import { reportError } from '../utils/errorReporting.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { GeminiChat } from './geminiChat.js';
+import { ReauthNeededError } from '../code_assist/errors.js';
 
 // Define a structure for tools passed to the server
 export interface ServerTool {
@@ -222,6 +223,9 @@ export class Turn {
         };
       }
     } catch (error) {
+      if (error instanceof ReauthNeededError) {
+        throw error;
+      }
       if (signal.aborted) {
         yield { type: GeminiEventType.UserCancelled };
         // Regular cancellation error, fail gracefully.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,8 +19,10 @@ export * from './core/geminiRequest.js';
 export * from './core/coreToolScheduler.js';
 export * from './core/nonInteractiveToolExecutor.js';
 
+// Export code assist functionality
 export * from './code_assist/codeAssist.js';
 export * from './code_assist/oauth2.js';
+export * from './code_assist/errors.js';
 
 // Export utilities
 export * from './utils/paths.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export * from './core/coreToolScheduler.js';
 export * from './core/nonInteractiveToolExecutor.js';
 
 export * from './code_assist/codeAssist.js';
+export * from './code_assist/oauth2.js';
 
 // Export utilities
 export * from './utils/paths.js';


### PR DESCRIPTION
## TLDR

If a oauth token expires while generating content, prompt the user to log in again. 

## Dive Deeper

This modifies the CodeAssistServer to throw ReauthNeededError when the user's credentials expire. It adds a new ReauthDialog to display when authentication is happening:

https://screenshot.googleplex.com/APpSYynBQVsUFzc
https://screenshot.googleplex.com/7gcF24Tj7ai4aYJ

Note: This catches Reauth errors when the agent is streaming content but there are a few cases (like /compress) where we call the CodeAssistServer via alternative means. I will address those in a follow up CL as this one is already quite large.

## Reviewer Test Plan

1. Start up the CLI and log in with code assist normally.
2. Revoke your credentials by:
   1.  navigating to [Your connections to third-party apps & services](https://myaccount.google.com/connections?continue=https%3A%2F%2Fmyaccount.google.com%2Fsecurity)
   2. Select "Gemini Code Assist" 
   3. click "Delete all connections you have with Gemini Code Assist"
3. **Without exiting the CLI**, Wait five minutes for the revocation to propagate.
4. Ask the cli a question.
5. Verify that the reauth popup appears. 
6. Press return to open the browser.
7. Authenticate. 
8. Verify that you can now talk to the cli without issue.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | X  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

b/425360849
