### PR TITLE
Change sandbox default

### DIFF
--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -33,13 +33,13 @@ function getSandboxCommand(
   // note environment variable takes precedence over argument (from command line or settings)
   sandbox = process.env.GEMINI_SANDBOX?.toLowerCase().trim() ?? sandbox;
   if (sandbox === '1' || sandbox === 'true') sandbox = true;
-  else if (sandbox === '0' || sandbox === 'false') sandbox = false;
+  else if (sandbox === '0' || sandbox === 'false' || !sandbox) sandbox = false;
 
   if (sandbox === false) {
     return '';
   }
 
-  if (typeof sandbox === 'string' && sandbox !== '') {
+  if (typeof sandbox === 'string' && sandbox) {
     if (!isSandboxCommand(sandbox)) {
       console.error(
         `ERROR: invalid sandbox command '${sandbox}'. Must be one of ${VALID_SANDBOX_COMMANDS.join(


### PR DESCRIPTION
## TLDR

- Users can still pass -s to get MacOS seatbelt support or configure docker/podman.

## Dive Deeper

This change is driven by the default expectations of users for things to work out of the box and when they don't that sandboxing isn't always obvious how to resolve the problem

## Reviewer Test Plan

Boot Gemini CLI as-is.

## Testing Matrix


|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ✅   | ❓  | ❓  |
| Podman   | ✅   | -   | -   |
| Seatbelt | ✅  | -   | -   |
