### PR TITLE
fix: flicker of StreamingState to Idle when tool finishes (#1190)

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -155,7 +155,12 @@ export const useGeminiStream = (
         (tc) =>
           tc.status === 'executing' ||
           tc.status === 'scheduled' ||
-          tc.status === 'validating',
+          tc.status === 'validating' ||
+          ((tc.status === 'success' ||
+            tc.status === 'error' ||
+            tc.status === 'cancelled') &&
+            !(tc as TrackedCompletedToolCall | TrackedCancelledToolCall)
+              .responseSubmittedToGemini),
       )
     ) {
       return StreamingState.Responding;
@@ -453,8 +458,9 @@ export const useGeminiStream = (
   const submitQuery = useCallback(
     async (query: PartListUnion, options?: { isContinuation: boolean }) => {
       if (
-        streamingState === StreamingState.Responding ||
-        streamingState === StreamingState.WaitingForConfirmation
+        (streamingState === StreamingState.Responding ||
+          streamingState === StreamingState.WaitingForConfirmation) &&
+        !options?.isContinuation
       )
         return;
 


### PR DESCRIPTION
## TLDR

This is a cherry-pick of: https://github.com/google-gemini/gemini-cli/pull/1190

## Dive Deeper

Part of the flicker work. Ran by @jacob314 and friends that this makes sense to include. @asadm fyi

## Reviewer Test Plan

Try out multiple tool calls

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ✅   | ❓  | ❓  |
| Docker   | ✅   | ❓  | ❓  |
| Podman   | ✅   | -   | -   |
| Seatbelt | ✅   | -   | -   |

## Linked issues / bugs

https://b.corp.google.com/issues/422571619
