### PR TITLE
Initialize geminiClient in noninteractive mode

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -169,9 +169,11 @@ async function loadNonInteractiveConfig(
     ...settings.merged,
     excludeTools: newExcludeTools,
   };
-  return await loadCliConfig(
+  const newConfig = await loadCliConfig(
     nonInteractiveSettings,
     extensions,
     config.getSessionId(),
   );
+  await newConfig.getGeminiClient().initialize();
+  return newConfig;
 }


### PR DESCRIPTION
## TLDR

PR1196 changed the gemini client to require initialization. This fixes interactive mode by initializing the gemini client used there.

## Dive Deeper

The initialize function was introduced because there was some async work that couldn't be done in the non async constructor.

## Reviewer Test Plan

execute `npm start -- --prompt "What is the capital of France?"`

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | X  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs


