### PR TITLE
refactor: remove docker tagging step from sandbox publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,10 @@
     "build:core": "npm run build --workspace packages/core",
     "build:packages": "npm run build:core && npm run build:cli",
     "build:docker": "node scripts/build_sandbox.js -s",
-    "tag:docker": "docker tag gemini-cli-sandbox ${SANDBOX_IMAGE_REGISTRY:?SANDBOX_IMAGE_REGISTRY not set}/${SANDBOX_IMAGE_NAME:?SANDBOX_IMAGE_NAME not set}:$npm_package_version",
     "prepare:cli-packagejson": "node scripts/prepare-cli-packagejson.js",
     "publish:sandbox": "node scripts/publish-sandbox.js",
     "publish:npm": "npm publish --workspaces ${NPM_PUBLISH_TAG:+--tag=$NPM_PUBLISH_TAG} ${NPM_DRY_RUN:+--dry-run}",
-    "publish:release": "npm run build:packages && npm run prepare:cli-packagejson && npm run build:docker && npm run tag:docker && npm run publish:sandbox && npm run publish:npm",
+    "publish:release": "npm run build:packages && npm run prepare:cli-packagejson && npm run build:docker && npm run publish:sandbox && npm run publish:npm",
     "telemetry": "node scripts/telemetry.js",
     "start:gcp": "npm run telemetry -- --target=gcp & npm start"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,8 +26,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "gemini-cli-sandbox",
-    "sandboximageName": "gemini-cli-sandbox"
+    "sandboxImageUri": "gemini-cli-sandbox"
   },
   "dependencies": {
     "@gemini-cli/core": "file:../core",

--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -91,7 +91,7 @@ export async function loadSandboxConfig(
   const image =
     argv['sandbox-image'] ??
     process.env.GEMINI_SANDBOX_IMAGE ??
-    packageJson?.config?.sandboximageName;
+    packageJson?.config?.sandboxImageUri;
 
   return command && image ? { command, image } : undefined;
 }

--- a/packages/cli/src/utils/package.ts
+++ b/packages/cli/src/utils/package.ts
@@ -14,7 +14,6 @@ import path from 'path';
 export type PackageJson = BasePackageJson & {
   config?: {
     sandboxImageUri?: string;
-    sandboximageName?: string;
   };
 };
 

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -61,7 +61,7 @@ if (sandboxCommand === 'sandbox-exec') {
 
 console.log(`using ${sandboxCommand} for sandboxing`);
 
-const baseImage = cliPkgJson.config.sandboximageName;
+const baseImage = cliPkgJson.config.sandboxImageUri;
 const customImage = argv.i;
 const baseDockerfile = 'Dockerfile';
 const customDockerfile = argv.f;

--- a/scripts/prepare-cli-packagejson.js
+++ b/scripts/prepare-cli-packagejson.js
@@ -45,7 +45,6 @@ if (!cliPackageJson.config) {
   cliPackageJson.config = {};
 }
 cliPackageJson.config.sandboxImageUri = containerImageUri;
-cliPackageJson.config.sandboximageName = containerImageName;
 
 // Remove 'prepublishOnly' from scripts if it exists
 if (cliPackageJson.scripts && cliPackageJson.scripts.prepublishOnly) {


### PR DESCRIPTION
we have two configs for the sandbox image name/uri to build and hop into in the app. this is because our release pipeline builds `gemini-cli-sandbox:latest` then tags it to an official uri `us-west1-docker.pkg.dev/<path>/<to>/<image>:<version-tag>`. When the app runs in production, we check the package.json for the latter to know which sandbox is associated with the installed app. 

The first attempt to consolidate (cc89830b2ab74ec8d4a04e5846c7d3a08bb6d31b) broke our release pipeline which depended on a two-tag docker image flow. we tried to fix by adding a second image uri `gemini-cli-sandbox`, but this ended up overwriting the line that tells the app which _published_ sandbox uri to use as runtume: whttps://github.com/google-gemini/gemini-cli/pull/1219/files#diff-c1caae92aaa6c92f3f8d8cc352e6521e66c9ccb6b0aa0f72c010671cec151d28 updated 

Instead of building an image with one name, then tagging it with another, forcing us to use two image name configs, this PR removes the tagging step and consolidates us back down to one.

## Changes

- 5b0ee1b - removes the image tagging step
- 0f82e58 - reverts the previous release fix so that the prod app points to the published sandboxImageUri

Successful Cloudbuild: https://pantheon.corp.google.com/cloud-build/builds;region=us-west1/3a4fb38b-fea6-4951-90cd-4a25504af0d4?e=13803378&inv=1&invt=Ab0jtQ&mods=-ai_platform_fake_service&project=gemini-code-dev