### PR TITLE
Fix delete/backspace mapping in gemini-cli.

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1280,8 +1280,6 @@ export function useTextBuffer({
       else if (key['end']) move('end');
       else if (key['ctrl'] && input === 'e') move('end');
       else if (key['ctrl'] && input === 'w') deleteWordLeft();
-      // Specific multi-byte sequence for forward delete.
-      else if (input === '\x1b[3~') del();
       else if (
         (key['meta'] || key['ctrl'] || key['alt']) &&
         (key['backspace'] || input === '\x7f')
@@ -1289,14 +1287,13 @@ export function useTextBuffer({
         deleteWordLeft();
       else if ((key['meta'] || key['ctrl'] || key['alt']) && key['delete'])
         deleteWordRight();
-      // `key.backspace` is for `\b` (and ctrl+h). `\x7f` is for macOS backspace.
       else if (
         key['backspace'] ||
         input === '\x7f' ||
-        (key['ctrl'] && input === 'h')
+        (key['ctrl'] && input === 'h') ||
+        (key['delete'] && !key['shift'])
       )
         backspace();
-      // `key.delete` is a fallback for other terminals. `ctrl+d` is a standard binding.
       else if (key['delete'] || (key['ctrl'] && input === 'd')) del();
       else if (input && !key['ctrl'] && !key['meta']) {
         insert(input);

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1280,6 +1280,8 @@ export function useTextBuffer({
       else if (key['end']) move('end');
       else if (key['ctrl'] && input === 'e') move('end');
       else if (key['ctrl'] && input === 'w') deleteWordLeft();
+      // Specific multi-byte sequence for forward delete.
+      else if (input === '\x1b[3~') del();
       else if (
         (key['meta'] || key['ctrl'] || key['alt']) &&
         (key['backspace'] || input === '\x7f')
@@ -1287,13 +1289,14 @@ export function useTextBuffer({
         deleteWordLeft();
       else if ((key['meta'] || key['ctrl'] || key['alt']) && key['delete'])
         deleteWordRight();
+      // `key.backspace` is for `\b` (and ctrl+h). `\x7f` is for macOS backspace.
       else if (
         key['backspace'] ||
         input === '\x7f' ||
-        (key['ctrl'] && input === 'h') ||
-        (key['delete'] && !key['shift'])
+        (key['ctrl'] && input === 'h')
       )
         backspace();
+      // `key.delete` is a fallback for other terminals. `ctrl+d` is a standard binding.
       else if (key['delete'] || (key['ctrl'] && input === 'd')) del();
       else if (input && !key['ctrl'] && !key['meta']) {
         insert(input);

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1290,8 +1290,7 @@ export function useTextBuffer({
       else if (
         key['backspace'] ||
         input === '\x7f' ||
-        (key['ctrl'] && input === 'h') ||
-        (key['delete'] && !key['shift'])
+        (key['ctrl'] && input === 'h')
       )
         backspace();
       else if (key['delete'] || (key['ctrl'] && input === 'd')) del();


### PR DESCRIPTION
## TLDR

This PR is one half of the code required to fix the backspace/delete mapping issue raised in #1212.

This half of the change prevents the delete key from functioning as the backspace key. Unfortunately, it also causes the _backspace_ key to stop functioning as a backspace key.

To preserve the expected backspace key behavior, we must also have the other half of this change, which regrettably must be upstreamed into Ink itself. The change on that side is also simple, but must made before this change is complete and can be merged.

To demonstrate, I made a public fork of ink and branched off of the 5.2.1 tag (the same tag this revision of gemini-cli depends on) and make the required updates on this branch:

  https://github.com/dewitt/ink/tree/v5.2.1-backspace-fix

You can test against this by updating the local gemini-cli client to build against the forked repo by patching `package.json` with:

```
diff --git a/packages/cli/package.json b/packages/cli/package.json
index 6caa312f..3470b0e9 100644
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,7 @@
     "dotenv": "^16.4.7",
     "glob": "^10.4.1",
     "highlight.js": "^11.11.1",
-    "ink": "^5.2.0",
+    "ink": "dewitt/ink#v5.2.1-backspace-fix",
     "ink-big-text": "^2.0.0",
     "ink-gradient": "^3.0.0",
     "ink-select-input": "^6.0.0",
```

## Dive Deeper

Please see issue #1212 for the full details.

## Reviewer Test Plan

Testers should first apply the patch to `package.json` above, then:

```
$ npm install 
$ npm run build:all
$ npm start
```

Things to test:

- That `backspace` (`←`) deletes the previous character in Terminal.app with "Delete sends Control-H" turned OFF
- That `backspace` (`←`)' deletes the previous character in Terminal.app with "Delete sends Control-H" turned ON
- That `delete` ('DEL`) deletes the next character 
- That `ctrl-h` deletes the previous character 
- That `ctrl-d` deletes the next character 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes issue #1212.