### PR TITLE
Turn off debug logging of MaxSizedBox errors by default.

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -28,6 +28,7 @@ import {
   AuthType,
 } from '@gemini-cli/core';
 import { validateAuthMethod } from './config/auth.js';
+import { setMaxSizedBoxDebugging } from './ui/components/shared/MaxSizedBox.js';
 
 export async function main() {
   const workspaceRoot = process.cwd();
@@ -48,6 +49,8 @@ export async function main() {
 
   const extensions = loadExtensions(workspaceRoot);
   const config = await loadCliConfig(settings.merged, extensions, sessionId);
+
+  setMaxSizedBoxDebugging(config.getDebugMode());
 
   // Initialize centralized FileDiscoveryService
   config.getFileService();

--- a/packages/cli/src/ui/components/shared/MaxSizedBox.test.tsx
+++ b/packages/cli/src/ui/components/shared/MaxSizedBox.test.tsx
@@ -5,11 +5,17 @@
  */
 
 import { render } from 'ink-testing-library';
-import { MaxSizedBox } from './MaxSizedBox.js';
+import { MaxSizedBox, setMaxSizedBoxDebugging } from './MaxSizedBox.js';
 import { Box, Text } from 'ink';
 import { describe, it, expect } from 'vitest';
 
 describe('<MaxSizedBox />', () => {
+  // Make sure MaxSizedBox logs errors on invalid configurations.
+  // This is useful for debugging issues with the component.
+  // It should be set to false in production for perfornance and to avoid
+  // cluttering the console if there are ignoreable issues.
+  setMaxSizedBoxDebugging(true);
+
   it('renders children without truncation when they fit', () => {
     const { lastFrame } = render(
       <MaxSizedBox maxWidth={80} maxHeight={10}>

--- a/packages/cli/src/ui/components/shared/MaxSizedBox.tsx
+++ b/packages/cli/src/ui/components/shared/MaxSizedBox.tsx
@@ -10,7 +10,11 @@ import stringWidth from 'string-width';
 import { Colors } from '../../colors.js';
 import { toCodePoints } from '../../utils/textUtils.js';
 
-const enableDebugLog = true;
+let enableDebugLog = false;
+
+export function setMaxSizedBoxDebugging(value: boolean) {
+  enableDebugLog = value;
+}
 
 function debugReportError(message: string, element: React.ReactNode) {
   if (!enableDebugLog) return;


### PR DESCRIPTION
Logging is enabled automatically when in debug mode but disabled otherwise.

This would actually be great to land after the next dogfood build so we get one dogfood build where users will see the errors if we happen to have any errors resulting in MaxSizedBox reporting we are passing it invalid elements.