### PR TITLE
feat: Update default Gemini Flash model to 2.5

### DIFF
--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -5,5 +5,5 @@
  */
 
 export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
-export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash-preview-05-20';
+export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
 export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -20,6 +20,7 @@ export function tokenLimit(model: Model): TokenCount {
     case 'gemini-2.5-pro-preview-06-05':
     case 'gemini-2.5-pro':
     case 'gemini-2.5-flash-preview-05-20':
+    case 'gemini-2.5-flash':
     case 'gemini-2.0-flash':
       return 1_048_576;
     case 'gemini-2.0-flash-preview-image-generation':


### PR DESCRIPTION
## TLDR

- Updates the default fallback model for Gemini Flash to `gemini-2.5-flash`.
- Adds the new model to the token limit list.

## Dive Deeper

Unfortunately there's a core model bug that reproduces with the existing gemini-2.5-flash-05-20 model (they're the same thing) as well. This change is mostly about synchronizing the names since they were re-tagged.

## Reviewer Test Plan

Normal flow

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
