### PR TITLE
Initially hide some Auth options behind "More..."

### DIFF
--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -28,7 +28,7 @@ export function AuthDialog({
   const [errorMessage, setErrorMessage] = useState<string | null>(
     initialErrorMessage || null,
   );
-  const authItems = [
+  const allAuthItems = [
     {
       label: 'Login with Google Personal Account',
       value: AuthType.LOGIN_WITH_GOOGLE_PERSONAL,
@@ -41,7 +41,20 @@ export function AuthDialog({
     { label: 'Vertex AI', value: AuthType.USE_VERTEX_AI },
   ];
 
-  let initialAuthIndex = authItems.findIndex(
+  const isSelectedAuthInMore = allAuthItems
+    .slice(2)
+    .some((item) => item.value === settings.merged.selectedAuthType);
+
+  const [showAll, setShowAll] = useState(isSelectedAuthInMore);
+
+  const initialAuthItems = [
+    ...allAuthItems.slice(0, 2),
+    { label: 'More...', value: 'more' },
+  ];
+
+  const items = showAll ? allAuthItems : initialAuthItems;
+
+  let initialAuthIndex = items.findIndex(
     (item) => item.value === settings.merged.selectedAuthType,
   );
 
@@ -50,6 +63,10 @@ export function AuthDialog({
   }
 
   const handleAuthSelect = (authMethod: string) => {
+    if (authMethod === 'more') {
+      setShowAll(true);
+      return;
+    }
     const error = validateAuthMethod(authMethod);
     if (error) {
       setErrorMessage(error);
@@ -75,7 +92,7 @@ export function AuthDialog({
     >
       <Text bold>Select Auth Method</Text>
       <RadioButtonSelect
-        items={authItems}
+        items={items}
         initialIndex={initialAuthIndex}
         onSelect={handleAuthSelect}
         onHighlight={onHighlight}


### PR DESCRIPTION
## TLDR

Initially hide all but the first two auth options unless the user selects "More..."

## Dive Deeper

With some options hidden: https://screenshot.googleplex.com/9hqTFyKhXgUUbfu
After selecting "More...":https://screenshot.googleplex.com/66k8uZepjim5ouT

## Reviewer Test Plan

1. Test logging in with fresh settings (no settings.json)
2. Test logging in with initially hidden auth options:
  1. change your settings.json to have "selectedAuthType": "vertex-ai"
  2. Verify that when you start up, it does not show "more..." but rather all auth options.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | X  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/gemini-cli/issues/1233
