### PR TITLE
Tactical client lifetime fix.

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -113,7 +113,7 @@ export interface ConfigParameters {
 }
 
 export class Config {
-  private toolRegistry: Promise<ToolRegistry>;
+  private toolRegistry!: ToolRegistry;
   private readonly sessionId: string;
   private contentGeneratorConfig!: ContentGeneratorConfig;
   private readonly embeddingModel: string;
@@ -184,8 +184,6 @@ export class Config {
       setGeminiMdFilename(params.contextFileName);
     }
 
-    this.toolRegistry = createToolRegistry(this);
-
     if (this.telemetrySettings.enabled) {
       initializeTelemetry(this);
     }
@@ -198,10 +196,10 @@ export class Config {
     );
 
     const gc = new GeminiClient(this);
-    await gc.initialize(contentConfig);
-
-    this.contentGeneratorConfig = contentConfig;
     this.geminiClient = gc;
+    this.toolRegistry = await createToolRegistry(this);
+    await gc.initialize(contentConfig);
+    this.contentGeneratorConfig = contentConfig;
   }
 
   getSessionId(): string {
@@ -232,8 +230,8 @@ export class Config {
     return this.targetDir;
   }
 
-  async getToolRegistry(): Promise<ToolRegistry> {
-    return this.toolRegistry;
+  getToolRegistry(): Promise<ToolRegistry> {
+    return Promise.resolve(this.toolRegistry);
   }
 
   getDebugMode(): boolean {


### PR DESCRIPTION
## TLDR

This is a tactical fix for the issue which was plagueing our integration tests where they'd occasionally fail with "undefined client" exceptions.

## Dive Deeper

A longer leaded fix is to solidify the lifetime of our client object so that it cannot be called in an invalid state OR immediately explodes.

## Reviewer Test Plan
Normal

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ✅   | ❓  | ❓  |
| Docker   | ✅   | ❓  | ❓  |
| Podman   | ✅   | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
