### PR TITLE
Bug fix telemetry token count

### DIFF
--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -30,15 +30,15 @@ export function AuthDialog({
   );
   const allAuthItems = [
     {
-      label: 'Login with Google Personal Account',
+      label: 'Login with Google',
       value: AuthType.LOGIN_WITH_GOOGLE_PERSONAL,
     },
     { label: 'Gemini API Key', value: AuthType.USE_GEMINI },
     {
-      label: 'Login with GCP Project and Google Work Account',
+      label: 'Login with Google Work',
       value: AuthType.LOGIN_WITH_GOOGLE_ENTERPRISE,
     },
-    { label: 'Vertex AI', value: AuthType.USE_VERTEX_AI },
+    { label: 'Vertex API Key', value: AuthType.USE_VERTEX_AI },
   ];
 
   const isSelectedAuthInMore = allAuthItems

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -28,7 +28,7 @@ export function AuthDialog({
   const [errorMessage, setErrorMessage] = useState<string | null>(
     initialErrorMessage || null,
   );
-  const authItems = [
+  const allAuthItems = [
     {
       label: 'Login with Google Personal Account',
       value: AuthType.LOGIN_WITH_GOOGLE_PERSONAL,
@@ -41,7 +41,20 @@ export function AuthDialog({
     { label: 'Vertex AI', value: AuthType.USE_VERTEX_AI },
   ];
 
-  let initialAuthIndex = authItems.findIndex(
+  const isSelectedAuthInMore = allAuthItems
+    .slice(2)
+    .some((item) => item.value === settings.merged.selectedAuthType);
+
+  const [showAll, setShowAll] = useState(isSelectedAuthInMore);
+
+  const initialAuthItems = [
+    ...allAuthItems.slice(0, 2),
+    { label: 'More...', value: 'more' },
+  ];
+
+  const items = showAll ? allAuthItems : initialAuthItems;
+
+  let initialAuthIndex = items.findIndex(
     (item) => item.value === settings.merged.selectedAuthType,
   );
 
@@ -50,6 +63,10 @@ export function AuthDialog({
   }
 
   const handleAuthSelect = (authMethod: string) => {
+    if (authMethod === 'more') {
+      setShowAll(true);
+      return;
+    }
     const error = validateAuthMethod(authMethod);
     if (error) {
       setErrorMessage(error);
@@ -75,7 +92,7 @@ export function AuthDialog({
     >
       <Text bold>Select Auth Method</Text>
       <RadioButtonSelect
-        items={authItems}
+        items={items}
         initialIndex={initialAuthIndex}
         onSelect={handleAuthSelect}
         onHighlight={onHighlight}

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -155,7 +155,12 @@ export const useGeminiStream = (
         (tc) =>
           tc.status === 'executing' ||
           tc.status === 'scheduled' ||
-          tc.status === 'validating',
+          tc.status === 'validating' ||
+          ((tc.status === 'success' ||
+            tc.status === 'error' ||
+            tc.status === 'cancelled') &&
+            !(tc as TrackedCompletedToolCall | TrackedCancelledToolCall)
+              .responseSubmittedToGemini),
       )
     ) {
       return StreamingState.Responding;
@@ -453,8 +458,9 @@ export const useGeminiStream = (
   const submitQuery = useCallback(
     async (query: PartListUnion, options?: { isContinuation: boolean }) => {
       if (
-        streamingState === StreamingState.Responding ||
-        streamingState === StreamingState.WaitingForConfirmation
+        (streamingState === StreamingState.Responding ||
+          streamingState === StreamingState.WaitingForConfirmation) &&
+        !options?.isContinuation
       )
         return;
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -113,7 +113,7 @@ export interface ConfigParameters {
 }
 
 export class Config {
-  private toolRegistry: Promise<ToolRegistry>;
+  private toolRegistry!: ToolRegistry;
   private readonly sessionId: string;
   private contentGeneratorConfig!: ContentGeneratorConfig;
   private readonly embeddingModel: string;
@@ -184,8 +184,6 @@ export class Config {
       setGeminiMdFilename(params.contextFileName);
     }
 
-    this.toolRegistry = createToolRegistry(this);
-
     if (this.telemetrySettings.enabled) {
       initializeTelemetry(this);
     }
@@ -198,10 +196,10 @@ export class Config {
     );
 
     const gc = new GeminiClient(this);
-    await gc.initialize(contentConfig);
-
-    this.contentGeneratorConfig = contentConfig;
     this.geminiClient = gc;
+    this.toolRegistry = await createToolRegistry(this);
+    await gc.initialize(contentConfig);
+    this.contentGeneratorConfig = contentConfig;
   }
 
   getSessionId(): string {
@@ -232,8 +230,8 @@ export class Config {
     return this.targetDir;
   }
 
-  async getToolRegistry(): Promise<ToolRegistry> {
-    return this.toolRegistry;
+  getToolRegistry(): Promise<ToolRegistry> {
+    return Promise.resolve(this.toolRegistry);
   }
 
   getDebugMode(): boolean {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -24,7 +24,7 @@ import {
   logApiRequest,
   logApiResponse,
   logApiError,
-  combinedUsageMetadata,
+  getFinalUsageMetadata,
 } from '../telemetry/loggers.js';
 import {
   getStructuredResponse,
@@ -444,7 +444,7 @@ export class GeminiChat {
       const fullText = getStructuredResponseFromParts(allParts);
       await this._logApiResponse(
         durationMs,
-        combinedUsageMetadata(chunks),
+        getFinalUsageMetadata(chunks),
         fullText,
       );
     }

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -25,7 +25,7 @@ export {
   logApiRequest,
   logApiError,
   logApiResponse,
-  combinedUsageMetadata,
+  getFinalUsageMetadata,
 } from './loggers.js';
 export {
   UserPromptEvent,

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -20,10 +20,12 @@ import {
   logUserPrompt,
   logToolCall,
   ToolCallDecision,
+  getFinalUsageMetadata,
 } from './loggers.js';
 import * as metrics from './metrics.js';
 import * as sdk from './sdk.js';
 import { vi, describe, beforeEach, it, expect } from 'vitest';
+import { GenerateContentResponse } from '@google/genai';
 
 vi.mock('@gemini-cli/cli/dist/src/utils/version', () => ({
   getCliVersion: () => 'test-version',
@@ -518,5 +520,76 @@ describe('loggers', () => {
         undefined,
       );
     });
+  });
+});
+
+describe('getFinalUsageMetadata', () => {
+  const createMockResponse = (
+    usageMetadata?: GenerateContentResponse['usageMetadata'],
+  ): GenerateContentResponse => ({
+      text: () => '',
+      data: () => ({}) as Record<string, unknown>,
+      functionCalls: () => [],
+      executableCode: () => [],
+      codeExecutionResult: () => [],
+      usageMetadata,
+    } as unknown as GenerateContentResponse);
+
+  it('should return the usageMetadata from the last chunk that has it', () => {
+    const chunks: GenerateContentResponse[] = [
+      createMockResponse({
+        promptTokenCount: 10,
+        candidatesTokenCount: 20,
+        totalTokenCount: 30,
+      }),
+      createMockResponse(),
+      createMockResponse({
+        promptTokenCount: 15,
+        candidatesTokenCount: 25,
+        totalTokenCount: 40,
+      }),
+      createMockResponse(),
+    ];
+
+    const result = getFinalUsageMetadata(chunks);
+    expect(result).toEqual({
+      promptTokenCount: 15,
+      candidatesTokenCount: 25,
+      totalTokenCount: 40,
+    });
+  });
+
+  it('should return undefined if no chunks have usageMetadata', () => {
+    const chunks: GenerateContentResponse[] = [
+      createMockResponse(),
+      createMockResponse(),
+      createMockResponse(),
+    ];
+
+    const result = getFinalUsageMetadata(chunks);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return the metadata from the only chunk if it has it', () => {
+    const chunks: GenerateContentResponse[] = [
+      createMockResponse({
+        promptTokenCount: 1,
+        candidatesTokenCount: 2,
+        totalTokenCount: 3,
+      }),
+    ];
+
+    const result = getFinalUsageMetadata(chunks);
+    expect(result).toEqual({
+      promptTokenCount: 1,
+      candidatesTokenCount: 2,
+      totalTokenCount: 3,
+    });
+  });
+
+  it('should return undefined for an empty array of chunks', () => {
+    const chunks: GenerateContentResponse[] = [];
+    const result = getFinalUsageMetadata(chunks);
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -288,42 +288,14 @@ export function logApiResponse(
   recordTokenUsageMetrics(config, event.model, event.tool_token_count, 'tool');
 }
 
-export function combinedUsageMetadata(
+export function getFinalUsageMetadata(
   chunks: GenerateContentResponse[],
-): GenerateContentResponseUsageMetadata {
-  const metadataKeys: Array<keyof GenerateContentResponseUsageMetadata> = [
-    'promptTokenCount',
-    'candidatesTokenCount',
-    'cachedContentTokenCount',
-    'thoughtsTokenCount',
-    'toolUsePromptTokenCount',
-    'totalTokenCount',
-  ];
+): GenerateContentResponseUsageMetadata | undefined {
+  //
+  const lastChunkWithMetadata = chunks
+    .slice()
+    .reverse()
+    .find((chunk) => chunk.usageMetadata);
 
-  const totals: Record<keyof GenerateContentResponseUsageMetadata, number> = {
-    promptTokenCount: 0,
-    candidatesTokenCount: 0,
-    cachedContentTokenCount: 0,
-    thoughtsTokenCount: 0,
-    toolUsePromptTokenCount: 0,
-    totalTokenCount: 0,
-    cacheTokensDetails: 0,
-    candidatesTokensDetails: 0,
-    promptTokensDetails: 0,
-    toolUsePromptTokensDetails: 0,
-    trafficType: 0,
-  };
-
-  for (const chunk of chunks) {
-    if (chunk.usageMetadata) {
-      for (const key of metadataKeys) {
-        const chunkValue = chunk.usageMetadata[key];
-        if (typeof chunkValue === 'number') {
-          totals[key] += chunkValue;
-        }
-      }
-    }
-  }
-
-  return totals as unknown as GenerateContentResponseUsageMetadata;
+  return lastChunkWithMetadata?.usageMetadata;
 }

--- a/scripts/telemetry_utils.js
+++ b/scripts/telemetry_utils.js
@@ -12,15 +12,31 @@ import net from 'net';
 import os from 'os';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
+import crypto from 'node:crypto';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-export const ROOT_DIR = path.resolve(__dirname, '..');
-export const GEMINI_DIR = path.join(ROOT_DIR, '.gemini');
-export const OTEL_DIR = path.join(GEMINI_DIR, 'otel');
+const projectRoot = path.resolve(__dirname, '..');
+const projectHash = crypto
+  .createHash('sha256')
+  .update(projectRoot)
+  .digest('hex');
+
+// User-level .gemini directory in home
+const USER_GEMINI_DIR = path.join(os.homedir(), '.gemini');
+// Project-level .gemini directory in the workspace
+const WORKSPACE_GEMINI_DIR = path.join(projectRoot, '.gemini');
+
+// Telemetry artifacts are stored in a hashed directory under the user's ~/.gemini/tmp
+export const OTEL_DIR = path.join(USER_GEMINI_DIR, 'tmp', projectHash, 'otel');
 export const BIN_DIR = path.join(OTEL_DIR, 'bin');
-export const WORKSPACE_SETTINGS_FILE = path.join(GEMINI_DIR, 'settings.json');
+
+// Workspace settings remain in the project's .gemini directory
+export const WORKSPACE_SETTINGS_FILE = path.join(
+  WORKSPACE_GEMINI_DIR,
+  'settings.json',
+);
 
 export function getJson(url) {
   const tmpFile = path.join(


### PR DESCRIPTION
## TLDR

This pull request fixes a bug in the telemetry system where token usage for streaming responses was calculated incorrectly. It changes the logic to correctly use the `usageMetadata` from the final chunk of the response, which contains the accurate total, instead of summing the metadata from all intermediate chunks.

## Dive Deeper

The `getFinalUsageMetadata` function in `packages/core/src/telemetry/loggers.ts` was previously iterating over every chunk in a streaming `GenerateContentResponse` and summing the token counts. This resulted in significantly inflated and inaccurate token usage metrics being reported.

The fix refactors this function to find the *last* chunk in the response array that contains a `usageMetadata` object and use that object as the single source of truth for the token counts. This aligns with the intended behavior of the Gemini API, which provides the final, complete usage statistics in the last message of a stream.

## Reviewer Test Plan

The validation for this change is primarily covered by unit tests.

1.  **Review the Code:**
    *   Inspect the change in `packages/core/src/telemetry/loggers.ts` to see the updated `getFinalUsageMetadata` function.
    *   Review the new unit tests in `packages/core/src/telemetry/loggers.test.ts` under the `describe('getFinalUsageMetadata', ...)` block.

2.  **Run Tests:**
    *   Pull down the branch and run the tests for the `core` package to ensure they all pass.
    *   Execute the following command from the root of the project:
        ```bash
        npm test -w packages/core loggers.test.ts
        ```
    *   Confirm that the new tests pass, validating the logic under various conditions (e.g., metadata in the last chunk, an intermediate chunk, or no chunks).


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

