### PR TITLE
Bug fix telemetry token count 

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -24,7 +24,7 @@ import {
   logApiRequest,
   logApiResponse,
   logApiError,
-  combinedUsageMetadata,
+  getFinalUsageMetadata,
 } from '../telemetry/loggers.js';
 import {
   getStructuredResponse,
@@ -444,7 +444,7 @@ export class GeminiChat {
       const fullText = getStructuredResponseFromParts(allParts);
       await this._logApiResponse(
         durationMs,
-        combinedUsageMetadata(chunks),
+        getFinalUsageMetadata(chunks),
         fullText,
       );
     }

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -25,7 +25,7 @@ export {
   logApiRequest,
   logApiError,
   logApiResponse,
-  combinedUsageMetadata,
+  getFinalUsageMetadata,
 } from './loggers.js';
 export {
   UserPromptEvent,

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -20,10 +20,12 @@ import {
   logUserPrompt,
   logToolCall,
   ToolCallDecision,
+  getFinalUsageMetadata,
 } from './loggers.js';
 import * as metrics from './metrics.js';
 import * as sdk from './sdk.js';
 import { vi, describe, beforeEach, it, expect } from 'vitest';
+import { GenerateContentResponse } from '@google/genai';
 
 vi.mock('@gemini-cli/cli/dist/src/utils/version', () => ({
   getCliVersion: () => 'test-version',
@@ -518,5 +520,77 @@ describe('loggers', () => {
         undefined,
       );
     });
+  });
+});
+
+describe('getFinalUsageMetadata', () => {
+  const createMockResponse = (
+    usageMetadata?: GenerateContentResponse['usageMetadata'],
+  ): GenerateContentResponse =>
+    ({
+      text: () => '',
+      data: () => ({}) as Record<string, unknown>,
+      functionCalls: () => [],
+      executableCode: () => [],
+      codeExecutionResult: () => [],
+      usageMetadata,
+    }) as unknown as GenerateContentResponse;
+
+  it('should return the usageMetadata from the last chunk that has it', () => {
+    const chunks: GenerateContentResponse[] = [
+      createMockResponse({
+        promptTokenCount: 10,
+        candidatesTokenCount: 20,
+        totalTokenCount: 30,
+      }),
+      createMockResponse(),
+      createMockResponse({
+        promptTokenCount: 15,
+        candidatesTokenCount: 25,
+        totalTokenCount: 40,
+      }),
+      createMockResponse(),
+    ];
+
+    const result = getFinalUsageMetadata(chunks);
+    expect(result).toEqual({
+      promptTokenCount: 15,
+      candidatesTokenCount: 25,
+      totalTokenCount: 40,
+    });
+  });
+
+  it('should return undefined if no chunks have usageMetadata', () => {
+    const chunks: GenerateContentResponse[] = [
+      createMockResponse(),
+      createMockResponse(),
+      createMockResponse(),
+    ];
+
+    const result = getFinalUsageMetadata(chunks);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return the metadata from the only chunk if it has it', () => {
+    const chunks: GenerateContentResponse[] = [
+      createMockResponse({
+        promptTokenCount: 1,
+        candidatesTokenCount: 2,
+        totalTokenCount: 3,
+      }),
+    ];
+
+    const result = getFinalUsageMetadata(chunks);
+    expect(result).toEqual({
+      promptTokenCount: 1,
+      candidatesTokenCount: 2,
+      totalTokenCount: 3,
+    });
+  });
+
+  it('should return undefined for an empty array of chunks', () => {
+    const chunks: GenerateContentResponse[] = [];
+    const result = getFinalUsageMetadata(chunks);
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -288,42 +288,14 @@ export function logApiResponse(
   recordTokenUsageMetrics(config, event.model, event.tool_token_count, 'tool');
 }
 
-export function combinedUsageMetadata(
+export function getFinalUsageMetadata(
   chunks: GenerateContentResponse[],
-): GenerateContentResponseUsageMetadata {
-  const metadataKeys: Array<keyof GenerateContentResponseUsageMetadata> = [
-    'promptTokenCount',
-    'candidatesTokenCount',
-    'cachedContentTokenCount',
-    'thoughtsTokenCount',
-    'toolUsePromptTokenCount',
-    'totalTokenCount',
-  ];
+): GenerateContentResponseUsageMetadata | undefined {
+  //
+  const lastChunkWithMetadata = chunks
+    .slice()
+    .reverse()
+    .find((chunk) => chunk.usageMetadata);
 
-  const totals: Record<keyof GenerateContentResponseUsageMetadata, number> = {
-    promptTokenCount: 0,
-    candidatesTokenCount: 0,
-    cachedContentTokenCount: 0,
-    thoughtsTokenCount: 0,
-    toolUsePromptTokenCount: 0,
-    totalTokenCount: 0,
-    cacheTokensDetails: 0,
-    candidatesTokensDetails: 0,
-    promptTokensDetails: 0,
-    toolUsePromptTokensDetails: 0,
-    trafficType: 0,
-  };
-
-  for (const chunk of chunks) {
-    if (chunk.usageMetadata) {
-      for (const key of metadataKeys) {
-        const chunkValue = chunk.usageMetadata[key];
-        if (typeof chunkValue === 'number') {
-          totals[key] += chunkValue;
-        }
-      }
-    }
-  }
-
-  return totals as unknown as GenerateContentResponseUsageMetadata;
+  return lastChunkWithMetadata?.usageMetadata;
 }

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -291,7 +291,7 @@ export function logApiResponse(
 export function getFinalUsageMetadata(
   chunks: GenerateContentResponse[],
 ): GenerateContentResponseUsageMetadata | undefined {
-  //
+  // Only the last streamed item has the final token count.
   const lastChunkWithMetadata = chunks
     .slice()
     .reverse()


### PR DESCRIPTION
## TLDR

This pull request fixes a bug in the telemetry system where token usage for streaming responses was calculated incorrectly. It changes the logic to correctly use the `usageMetadata` from the final chunk of the response, which contains the accurate total, instead of summing the metadata from all intermediate chunks.

## Dive Deeper

The `getFinalUsageMetadata` function in `packages/core/src/telemetry/loggers.ts` was previously iterating over every chunk in a streaming `GenerateContentResponse` and summing the token counts. This resulted in significantly inflated and inaccurate token usage metrics being reported.

The fix refactors this function to find the *last* chunk in the response array that contains a `usageMetadata` object and use that object as the single source of truth for the token counts. This aligns with the intended behavior of the Gemini API, which provides the final, complete usage statistics in the last message of a stream.

## Reviewer Test Plan

The validation for this change is primarily covered by unit tests.

1.  **Review the Code:**
    *   Inspect the change in `packages/core/src/telemetry/loggers.ts` to see the updated `getFinalUsageMetadata` function.
    *   Review the new unit tests in `packages/core/src/telemetry/loggers.test.ts` under the `describe('getFinalUsageMetadata', ...)` block.

2.  **Run Tests:**
    *   Pull down the branch and run the tests for the `core` package to ensure they all pass.
    *   Execute the following command from the root of the project:
        ```bash
        npm test -w packages/core loggers.test.ts
        ```
    *   Confirm that the new tests pass, validating the logic under various conditions (e.g., metadata in the last chunk, an intermediate chunk, or no chunks).

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

