### PR TITLE
Make checkpoints configurable in settings.json

### DIFF
--- a/packages/cli/src/config/config.integration.test.ts
+++ b/packages/cli/src/config/config.integration.test.ts
@@ -186,4 +186,22 @@ describe('Configuration Integration Tests', () => {
       expect(config.getFileFilteringRespectGitIgnore()).toBe(false);
     });
   });
+
+  describe('Checkpointing Configuration', () => {
+    it('should enable checkpointing when the setting is true', async () => {
+      const configParams: ConfigParameters = {
+        cwd: '/tmp',
+        contentGeneratorConfig: TEST_CONTENT_GENERATOR_CONFIG,
+        embeddingModel: 'test-embedding-model',
+        sandbox: false,
+        targetDir: tempDir,
+        debugMode: false,
+        checkpointing: true,
+      };
+
+      const config = new Config(configParams);
+
+      expect(config.getCheckpointingEnabled()).toBe(true);
+    });
+  });
 });

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -49,7 +49,7 @@ interface CliArgs {
   show_memory_usage: boolean | undefined;
   yolo: boolean | undefined;
   telemetry: boolean | undefined;
-  checkpoint: boolean | undefined;
+  checkpointing: boolean | undefined;
   telemetryTarget: string | undefined;
   telemetryOtlpEndpoint: string | undefined;
   telemetryLogPrompts: boolean | undefined;
@@ -122,7 +122,7 @@ async function parseArguments(): Promise<CliArgs> {
       description:
         'Enable or disable logging of user prompts for telemetry. Overrides settings files.',
     })
-    .option('checkpoint', {
+    .option('checkpointing', {
       alias: 'c',
       type: 'boolean',
       description: 'Enables checkpointing of file edits',
@@ -229,7 +229,7 @@ export async function loadCliConfig(
     },
     // Git-aware file filtering settings
     fileFilteringRespectGitIgnore: settings.fileFiltering?.respectGitIgnore,
-    checkpoint: argv.checkpoint,
+    checkpointing: argv.checkpointing || settings.checkpointing?.enabled,
     proxy:
       process.env.HTTPS_PROXY ||
       process.env.https_proxy ||

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -27,6 +27,10 @@ export enum SettingScope {
   Workspace = 'Workspace',
 }
 
+export interface CheckpointingSettings {
+  enabled?: boolean;
+}
+
 export interface AccessibilitySettings {
   disableLoadingPhrases?: boolean;
 }
@@ -47,6 +51,7 @@ export interface Settings {
   telemetry?: TelemetrySettings;
   preferredEditor?: string;
   bugCommand?: BugCommandSettings;
+  checkpointing?: CheckpointingSettings;
 
   // Git-aware file filtering settings
   fileFiltering?: {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -51,7 +51,7 @@ export async function main() {
 
   // Initialize centralized FileDiscoveryService
   config.getFileService();
-  if (config.getCheckpointEnabled()) {
+  if (config.getCheckpointingEnabled()) {
     try {
       await config.getGitService();
     } catch {

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -123,7 +123,7 @@ vi.mock('@gemini-cli/core', async (importOriginal) => {
         getAccessibility: vi.fn(() => opts.accessibility ?? {}),
         getProjectRoot: vi.fn(() => opts.projectRoot),
         getGeminiClient: vi.fn(() => ({})),
-        getCheckpointEnabled: vi.fn(() => opts.checkpoint ?? true),
+        getCheckpointingEnabled: vi.fn(() => opts.checkpointing ?? true),
         getAllGeminiMdFilenames: vi.fn(() => ['GEMINI.md']),
       };
     });

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -135,7 +135,7 @@ describe('useSlashCommandProcessor', () => {
       getSandbox: vi.fn(() => 'test-sandbox'),
       getModel: vi.fn(() => 'test-model'),
       getProjectRoot: vi.fn(() => '/test/dir'),
-      getCheckpointEnabled: vi.fn(() => true),
+      getCheckpointingEnabled: vi.fn(() => true),
       getBugCommand: vi.fn(() => undefined),
     } as unknown as Config;
     mockCorgiMode = vi.fn();

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -647,7 +647,7 @@ Add any other context about the problem here.
         description:
           'resume from conversation checkpoint. Usage: /resume [tag]',
         completion: async () => {
-          const geminiDir = config?.getGeminiDir();
+          const geminiDir = config?.getProjectTempDir();
           if (!geminiDir) {
             return [];
           }
@@ -805,14 +805,14 @@ Add any other context about the problem here.
       },
     ];
 
-    if (config?.getCheckpointEnabled()) {
+    if (config?.getCheckpointingEnabled()) {
       commands.push({
         name: 'restore',
         description:
           'restore a tool call. This will reset the conversation and file history to the state it was in when the tool call was suggested',
         action: async (_mainCommand, subCommand, _args) => {
-          const checkpointDir = config?.getGeminiDir()
-            ? path.join(config.getGeminiDir(), 'checkpoints')
+          const checkpointDir = config?.getProjectTempDir()
+            ? path.join(config.getProjectTempDir(), 'checkpoints')
             : undefined;
 
           if (!checkpointDir) {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -280,7 +280,7 @@ describe('useGeminiStream', () => {
         () => ({ getToolSchemaList: vi.fn(() => []) }) as any,
       ),
       getProjectRoot: vi.fn(() => '/test/dir'),
-      getCheckpointEnabled: vi.fn(() => false),
+      getCheckpointingEnabled: vi.fn(() => false),
       getGeminiClient: mockGetGeminiClient,
       addHistory: vi.fn(),
     } as unknown as Config;

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -638,7 +638,7 @@ export const useGeminiStream = (
 
   useEffect(() => {
     const saveRestorableToolCalls = async () => {
-      if (!config.getCheckpointEnabled()) {
+      if (!config.getCheckpointingEnabled()) {
         return;
       }
       const restorableToolCalls = toolCalls.filter(
@@ -649,8 +649,8 @@ export const useGeminiStream = (
       );
 
       if (restorableToolCalls.length > 0) {
-        const checkpointDir = config.getGeminiDir()
-          ? path.join(config.getGeminiDir(), 'checkpoints')
+        const checkpointDir = config.getProjectTempDir()
+          ? path.join(config.getProjectTempDir(), 'checkpoints')
           : undefined;
 
         if (!checkpointDir) {

--- a/packages/cli/src/utils/cleanup.ts
+++ b/packages/cli/src/utils/cleanup.ts
@@ -6,10 +6,11 @@
 
 import { promises as fs } from 'fs';
 import { join } from 'path';
+import { getProjectTempDir } from '@gemini-cli/core';
 
 export async function cleanupCheckpoints() {
-  const geminiDir = join(process.cwd(), '.gemini');
-  const checkpointsDir = join(geminiDir, 'checkpoints');
+  const tempDir = getProjectTempDir(process.cwd());
+  const checkpointsDir = join(tempDir, 'checkpoints');
   try {
     await fs.rm(checkpointsDir, { recursive: true, force: true });
   } catch {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -27,6 +27,7 @@ import { GeminiClient } from '../core/client.js';
 import { GEMINI_CONFIG_DIR as GEMINI_DIR } from '../tools/memoryTool.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { GitService } from '../services/gitService.js';
+import { getProjectTempDir } from '../utils/paths.js';
 import {
   initializeTelemetry,
   DEFAULT_TELEMETRY_TARGET,
@@ -104,7 +105,7 @@ export interface ConfigParameters {
   accessibility?: AccessibilitySettings;
   telemetry?: TelemetrySettings;
   fileFilteringRespectGitIgnore?: boolean;
-  checkpoint?: boolean;
+  checkpointing?: boolean;
   proxy?: string;
   cwd: string;
   fileDiscoveryService?: FileDiscoveryService;
@@ -138,7 +139,7 @@ export class Config {
   private readonly fileFilteringRespectGitIgnore: boolean;
   private fileDiscoveryService: FileDiscoveryService | null = null;
   private gitService: GitService | undefined = undefined;
-  private readonly checkpoint: boolean;
+  private readonly checkpointing: boolean;
   private readonly proxy: string | undefined;
   private readonly cwd: string;
   private readonly bugCommand: BugCommandSettings | undefined;
@@ -173,7 +174,7 @@ export class Config {
 
     this.fileFilteringRespectGitIgnore =
       params.fileFilteringRespectGitIgnore ?? true;
-    this.checkpoint = params.checkpoint ?? false;
+    this.checkpointing = params.checkpointing ?? false;
     this.proxy = params.proxy;
     this.cwd = params.cwd ?? process.cwd();
     this.fileDiscoveryService = params.fileDiscoveryService ?? null;
@@ -325,12 +326,16 @@ export class Config {
     return path.join(this.targetDir, GEMINI_DIR);
   }
 
+  getProjectTempDir(): string {
+    return getProjectTempDir(this.getProjectRoot());
+  }
+
   getFileFilteringRespectGitIgnore(): boolean {
     return this.fileFilteringRespectGitIgnore;
   }
 
-  getCheckpointEnabled(): boolean {
-    return this.checkpoint;
+  getCheckpointingEnabled(): boolean {
+    return this.checkpointing;
   }
 
   getProxy(): string | undefined {


### PR DESCRIPTION
This pull request introduces two improvements to checkpointing:

**Checkpointing can now be enabled through the settings.json file**

This allows the checkpoint feature to be enabled in the settings.json. Example
```
{
  "theme": "Dracula",
  "checkpointing": { "enabled": true }
}
```
If omitted and the checkpoint flag is not set to true, the feature will continue to default to off. 

**Checkpoints are now stored in the project hashed tmp folder**

This brings checkpointing in line with other temporary files.