### PR TITLE
Support autocompletion for checkpoints

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -810,6 +810,22 @@ Add any other context about the problem here.
         name: 'restore',
         description:
           'restore a tool call. This will reset the conversation and file history to the state it was in when the tool call was suggested',
+        completion: async () => {
+          const checkpointDir = config?.getProjectTempDir()
+            ? path.join(config.getProjectTempDir(), 'checkpoints')
+            : undefined;
+          if (!checkpointDir) {
+            return [];
+          }
+          try {
+            const files = await fs.readdir(checkpointDir);
+            return files
+              .filter((file) => file.endsWith('.json'))
+              .map((file) => file.replace('.json', ''));
+          } catch (_err) {
+            return [];
+          }
+        },
         action: async (_mainCommand, subCommand, _args) => {
           const checkpointDir = config?.getProjectTempDir()
             ? path.join(config.getProjectTempDir(), 'checkpoints')


### PR DESCRIPTION
This small change adds autocomplete support to the restore command in order to make it easier to select a checkpoint. As long as one file write or replace has occurred, typing `/restore` brings up a list of checkpoints that can be selected from with the keyboard.

Note the command for restore is behind a flag. Run `npm run start -- -c` or update settings.json to include 
```
{
  "checkpointing": {
    "enabled": true
  }
}
```