### PR TITLE
Prevent hard crashing on update notifier fail.

### DIFF
--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -9,27 +9,32 @@ import { readPackageUp } from 'read-package-up';
 import process from 'node:process';
 
 export async function checkForUpdates(): Promise<string | null> {
-  // read-package-up looks for the closest package.json from cwd
-  const pkgResult = await readPackageUp({ cwd: process.cwd() });
-  if (!pkgResult) {
+  try {
+    // read-package-up looks for the closest package.json from cwd
+    const pkgResult = await readPackageUp({ cwd: process.cwd() });
+    if (!pkgResult) {
+      return null;
+    }
+
+    const { packageJson } = pkgResult;
+    const notifier = updateNotifier({
+      pkg: {
+        name: packageJson.name,
+        version: packageJson.version,
+      },
+      // check every time
+      updateCheckInterval: 0,
+      // allow notifier to run in scripts
+      shouldNotifyInNpmScript: true,
+    });
+
+    if (notifier.update) {
+      return `Gemini CLI update available! ${notifier.update.current} → ${notifier.update.latest}\nRun npm install -g ${packageJson.name} to update`;
+    }
+
+    return null;
+  } catch (e) {
+    console.warn('Failed to check for updates: ' + e);
     return null;
   }
-
-  const { packageJson } = pkgResult;
-  const notifier = updateNotifier({
-    pkg: {
-      name: packageJson.name,
-      version: packageJson.version,
-    },
-    // check every time
-    updateCheckInterval: 0,
-    // allow notifier to run in scripts
-    shouldNotifyInNpmScript: true,
-  });
-
-  if (notifier.update) {
-    return `Gemini CLI update available! ${notifier.update.current} → ${notifier.update.latest}\nRun npm install -g ${packageJson.name} to update`;
-  }
-
-  return null;
 }


### PR DESCRIPTION
## TLDR

- Turns out some `early-access` folks were exploding their apps on startup due to the update notifier running and throwing: https://b.corp.google.com/issues/425992897

This is a try catch only to suppress errors.

/cc @eddie-santos it looks like this is getting hit a lot, we'll need to dig deeper