### PR TITLE
fallback to gemini_api_key

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,8 @@
       "skipFiles": ["<node_internals>/**"],
       "cwd": "${workspaceFolder}",
       "env": {
-        "GEMINI_SANDBOX": "false"
+        "GEMINI_SANDBOX": "false",
+        "GEMINI_API_KEY": "testkey"
       }
     },
     {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -34,6 +34,11 @@ export async function main() {
   const workspaceRoot = process.cwd();
   const settings = loadSettings(workspaceRoot);
 
+  // set default fallback to gemini api key
+  settings.merged.selectedAuthType ||= process.env.GEMINI_API_KEY
+    ? AuthType.USE_GEMINI
+    : undefined;
+
   await cleanupCheckpoints();
   if (settings.errors.length > 0) {
     for (const error of settings.errors) {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -57,7 +57,7 @@ export async function main() {
   // set default fallback to gemini api key
   // this has to go after load cli becuase thats where the env is set
   if (!settings.merged.selectedAuthType && process.env.GEMINI_API_KEY) {
-    settings.setValue(SettingScope.User, 'selectedAuthType', 'gemini-api-key');
+    settings.setValue(SettingScope.User, 'selectedAuthType', AuthType.USE_GEMINI);
   }
 
   setMaxSizedBoxDebugging(config.getDebugMode());

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -57,7 +57,11 @@ export async function main() {
   // set default fallback to gemini api key
   // this has to go after load cli becuase thats where the env is set
   if (!settings.merged.selectedAuthType && process.env.GEMINI_API_KEY) {
-    settings.setValue(SettingScope.User, 'selectedAuthType', AuthType.USE_GEMINI);
+    settings.setValue(
+      SettingScope.User,
+      'selectedAuthType',
+      AuthType.USE_GEMINI,
+    );
   }
 
   setMaxSizedBoxDebugging(config.getDebugMode());


### PR DESCRIPTION
## TLDR

For users with gemini_api_key set this defaults to that. /auth can still be used to change.

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
