### PR TITLE
feat(auth): handle auth flow errors gracefully

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -587,11 +587,6 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
             </Box>
           ) : isAuthDialogOpen ? (
             <Box flexDirection="column">
-              {authError && (
-                <Box marginBottom={1}>
-                  <Text color={Colors.AccentRed}>{authError}</Text>
-                </Box>
-              )}
               <AuthDialog
                 onSelect={handleAuthSelect}
                 onHighlight={handleAuthHighlight}

--- a/packages/cli/src/ui/hooks/useAuthCommand.ts
+++ b/packages/cli/src/ui/hooks/useAuthCommand.ts
@@ -6,7 +6,12 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { LoadedSettings, SettingScope } from '../../config/settings.js';
-import { AuthType, Config, clearCachedCredentialFile } from '@gemini-cli/core';
+import {
+  AuthType,
+  Config,
+  clearCachedCredentialFile,
+  getErrorMessage,
+} from '@gemini-cli/core';
 
 async function performAuthFlow(authMethod: AuthType, config: Config) {
   await config.refreshAuth(authMethod);
@@ -22,15 +27,35 @@ export const useAuthCommand = (
     settings.merged.selectedAuthType === undefined,
   );
 
-  useEffect(() => {
-    if (!isAuthDialogOpen) {
-      performAuthFlow(settings.merged.selectedAuthType as AuthType, config);
-    }
-  }, [isAuthDialogOpen, settings, config]);
-
   const openAuthDialog = useCallback(() => {
     setIsAuthDialogOpen(true);
   }, []);
+
+  useEffect(() => {
+    const authFlow = async () => {
+      if (isAuthDialogOpen || !settings.merged.selectedAuthType) {
+        return;
+      }
+
+      try {
+        await performAuthFlow(
+          settings.merged.selectedAuthType as AuthType,
+          config,
+        );
+      } catch (e) {
+        const errorMessage =
+          settings.merged.selectedAuthType ===
+          AuthType.LOGIN_WITH_GOOGLE_PERSONAL
+            ? `Failed to login. Ensure your Google account is not an enterprise account.
+Message: ${getErrorMessage(e)}`
+            : `Failed to login. Message: ${getErrorMessage(e)}`;
+        setAuthError(errorMessage);
+        openAuthDialog();
+      }
+    };
+
+    void authFlow();
+  }, [isAuthDialogOpen, settings, config, setAuthError, openAuthDialog]);
 
   const handleAuthSelect = useCallback(
     async (authMethod: string | undefined, scope: SettingScope) => {


### PR DESCRIPTION
## TLDR
- Catches exceptions during the authentication flow.
- Displays a user-friendly error message in the UI instead of crashing the application.
    - Special cases login with Google so that we return a graceful error message.
- Fixes a flaky test in  to ensure deterministic behavior.

![image](https://github.com/user-attachments/assets/96ca1654-6585-4663-9862-d1dedd709ba2)


## Reviewer Test Plan

Login with your Google account  BUT pick your enterprise work account -> fail

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ✅   | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅   | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
