### PR TITLE
Cache oauth credentials more effciently

### DIFF
--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -17,9 +17,9 @@ export async function createCodeAssistContentGenerator(
     authType === AuthType.LOGIN_WITH_GOOGLE_ENTERPRISE ||
     authType === AuthType.LOGIN_WITH_GOOGLE_PERSONAL
   ) {
-    const authClient = await getOauthClient();
-    const projectId = await setupUser(authClient);
-    return new CodeAssistServer(authClient, projectId, httpOptions);
+    const client = await getOauthClient();
+    const projectId = await setupUser(client);
+    return new CodeAssistServer(client, projectId, httpOptions);
   }
 
   throw new Error(`Unsupported authType: ${authType}`);

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -57,6 +57,7 @@ describe('oauth2', () => {
       getToken: mockGetToken,
       setCredentials: mockSetCredentials,
       credentials: mockTokens,
+      on: vi.fn(),
     } as unknown as OAuth2Client;
     vi.mocked(OAuth2Client).mockImplementation(() => mockOAuth2Client);
 
@@ -122,9 +123,5 @@ describe('oauth2', () => {
       redirect_uri: `http://localhost:${capturedPort}/oauth2callback`,
     });
     expect(mockSetCredentials).toHaveBeenCalledWith(mockTokens);
-
-    const tokenPath = path.join(tempHomeDir, '.gemini', 'oauth_creds.json');
-    const tokenData = JSON.parse(fs.readFileSync(tokenPath, 'utf-8'));
-    expect(tokenData).toEqual(mockTokens);
   });
 });

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -57,6 +57,9 @@ export async function getOauthClient(): Promise<OAuth2Client> {
     clientId: OAUTH_CLIENT_ID,
     clientSecret: OAUTH_CLIENT_SECRET,
   });
+  client.on('tokens', async (tokens: Credentials) => {
+    await cacheCredentials(tokens);
+  });
 
   if (await loadCachedCredentials(client)) {
     // Found valid cached credentials.

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthClient } from 'google-auth-library';
+import { OAuth2Client } from 'google-auth-library';
 import {
   LoadCodeAssistResponse,
   LoadCodeAssistRequest,
@@ -45,7 +45,7 @@ export const CODE_ASSIST_API_VERSION = 'v1internal';
 
 export class CodeAssistServer implements ContentGenerator {
   constructor(
-    readonly auth: AuthClient,
+    readonly client: OAuth2Client,
     readonly projectId?: string,
     readonly httpOptions: HttpOptions = {},
   ) {}
@@ -113,7 +113,7 @@ export class CodeAssistServer implements ContentGenerator {
     req: object,
     signal?: AbortSignal,
   ): Promise<T> {
-    const res = await this.auth.request({
+    const res = await this.client.request({
       url: `${CODE_ASSIST_ENDPOINT}/${CODE_ASSIST_API_VERSION}:${method}`,
       method: 'POST',
       headers: {
@@ -132,7 +132,7 @@ export class CodeAssistServer implements ContentGenerator {
     req: object,
     signal?: AbortSignal,
   ): Promise<AsyncGenerator<T>> {
-    const res = await this.auth.request({
+    const res = await this.client.request({
       url: `${CODE_ASSIST_ENDPOINT}/${CODE_ASSIST_API_VERSION}:${method}`,
       method: 'POST',
       params: {

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -13,9 +13,9 @@ import { OAuth2Client } from 'google-auth-library';
  * @param projectId the user's project id, if any
  * @returns the user's actual project id
  */
-export async function setupUser(authClient: OAuth2Client): Promise<string> {
+export async function setupUser(client: OAuth2Client): Promise<string> {
   const projectId = process.env.GOOGLE_CLOUD_PROJECT;
-  const caServer = new CodeAssistServer(authClient, projectId);
+  const caServer = new CodeAssistServer(client, projectId);
 
   const clientMetadata: ClientMetadata = {
     ideType: 'IDE_UNSPECIFIED',


### PR DESCRIPTION
## TLDR

Changes the oauth client to cache credentials anytime that change, not just after the web login.

## Dive Deeper

Right now we only cache the oauth credentials when you do the web login. But we occasionally refresh the auth token in the background (this is handled transparently by the Oauth client). when that happens we ought to persist it to update the cache. Honestly it would have no user visible effects other than start up being slightly faster since it doesn't have to fetch fresh auth tokens on startup.

## Reviewer Test Plan

1. Delete cached credentials: `rm ~/.gemini/oauth_creds.json`
2. Start up CLI and Log in with Code Assist.
3. Verify that the credentials file is recreated.
4. Shut down CLI
5. Modify oauth_creds.json to set  `"expiry_date": 0,`
6. Start up CLI
7. Verify that the credentials file is updated. 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | X  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/gemini-cli/issues/1237
