### PR TITLE
Auth blocking

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -589,11 +589,13 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
               />
             </Box>
           ) : isAuthenticating ? (
-            <AuthInProgress onTimeout={() => {
-              setAuthError('Authentication timed out. Please try again.');
-              cancelAuthentication();
-              openAuthDialog();
-            }} />
+            <AuthInProgress
+              onTimeout={() => {
+                setAuthError('Authentication timed out. Please try again.');
+                cancelAuthentication();
+                openAuthDialog();
+              }}
+            />
           ) : isAuthDialogOpen ? (
             <Box flexDirection="column">
               <AuthDialog

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -33,6 +33,7 @@ import { InputPrompt } from './components/InputPrompt.js';
 import { Footer } from './components/Footer.js';
 import { ThemeDialog } from './components/ThemeDialog.js';
 import { AuthDialog } from './components/AuthDialog.js';
+import { AuthInProgress } from './components/AuthInProgress.js';
 import { EditorSettingsDialog } from './components/EditorSettingsDialog.js';
 import { Colors } from './colors.js';
 import { Help } from './components/Help.js';
@@ -138,6 +139,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     openAuthDialog,
     handleAuthSelect,
     handleAuthHighlight,
+    isAuthenticating,
   } = useAuthCommand(settings, setAuthError, config);
 
   useEffect(() => {
@@ -585,6 +587,8 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
                 terminalWidth={mainAreaWidth}
               />
             </Box>
+          ) : isAuthenticating ? (
+            <AuthInProgress />
           ) : isAuthDialogOpen ? (
             <Box flexDirection="column">
               <AuthDialog

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -140,6 +140,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     handleAuthSelect,
     handleAuthHighlight,
     isAuthenticating,
+    cancelAuthentication,
   } = useAuthCommand(settings, setAuthError, config);
 
   useEffect(() => {
@@ -588,7 +589,11 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
               />
             </Box>
           ) : isAuthenticating ? (
-            <AuthInProgress />
+            <AuthInProgress onTimeout={() => {
+              setAuthError('Authentication timed out. Please try again.');
+              cancelAuthentication();
+              openAuthDialog();
+            }} />
           ) : isAuthDialogOpen ? (
             <Box flexDirection="column">
               <AuthDialog

--- a/packages/cli/src/ui/components/AuthInProgress.tsx
+++ b/packages/cli/src/ui/components/AuthInProgress.tsx
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { Colors } from '../colors.js';
+
+export function AuthInProgress(): React.JSX.Element {
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={Colors.Gray}
+      flexDirection="column"
+      padding={1}
+      width="100%"
+    >
+      <Text>Waiting for auth...</Text>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/AuthInProgress.tsx
+++ b/packages/cli/src/ui/components/AuthInProgress.tsx
@@ -13,7 +13,9 @@ interface AuthInProgressProps {
   onTimeout: () => void;
 }
 
-export function AuthInProgress({ onTimeout }: AuthInProgressProps): React.JSX.Element {
+export function AuthInProgress({
+  onTimeout,
+}: AuthInProgressProps): React.JSX.Element {
   const [timedOut, setTimedOut] = useState(false);
 
   useEffect(() => {
@@ -34,7 +36,9 @@ export function AuthInProgress({ onTimeout }: AuthInProgressProps): React.JSX.El
       width="100%"
     >
       {timedOut ? (
-        <Text color={Colors.AccentRed}>Authentication timed out. Please try again.</Text>
+        <Text color={Colors.AccentRed}>
+          Authentication timed out. Please try again.
+        </Text>
       ) : (
         <Box>
           <Text>

--- a/packages/cli/src/ui/components/AuthInProgress.tsx
+++ b/packages/cli/src/ui/components/AuthInProgress.tsx
@@ -4,11 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, Text } from 'ink';
+import Spinner from 'ink-spinner';
 import { Colors } from '../colors.js';
 
-export function AuthInProgress(): React.JSX.Element {
+interface AuthInProgressProps {
+  onTimeout: () => void;
+}
+
+export function AuthInProgress({ onTimeout }: AuthInProgressProps): React.JSX.Element {
+  const [timedOut, setTimedOut] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setTimedOut(true);
+      onTimeout();
+    }, 30000);
+
+    return () => clearTimeout(timer);
+  }, [onTimeout]);
+
   return (
     <Box
       borderStyle="round"
@@ -17,7 +33,15 @@ export function AuthInProgress(): React.JSX.Element {
       padding={1}
       width="100%"
     >
-      <Text>Waiting for auth...</Text>
+      {timedOut ? (
+        <Text color={Colors.AccentRed}>Authentication timed out. Please try again.</Text>
+      ) : (
+        <Box>
+          <Text>
+            <Spinner type="dots" /> Waiting for auth...
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/packages/cli/src/ui/hooks/useAuthCommand.ts
+++ b/packages/cli/src/ui/hooks/useAuthCommand.ts
@@ -31,6 +31,8 @@ export const useAuthCommand = (
     setIsAuthDialogOpen(true);
   }, []);
 
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+
   useEffect(() => {
     const authFlow = async () => {
       if (isAuthDialogOpen || !settings.merged.selectedAuthType) {
@@ -38,6 +40,7 @@ export const useAuthCommand = (
       }
 
       try {
+        setIsAuthenticating(true);
         await performAuthFlow(
           settings.merged.selectedAuthType as AuthType,
           config,
@@ -51,6 +54,8 @@ Message: ${getErrorMessage(e)}`
             : `Failed to login. Message: ${getErrorMessage(e)}`;
         setAuthError(errorMessage);
         openAuthDialog();
+      } finally {
+        setIsAuthenticating(false);
       }
     };
 
@@ -78,5 +83,6 @@ Message: ${getErrorMessage(e)}`
     openAuthDialog,
     handleAuthSelect,
     handleAuthHighlight,
+    isAuthenticating,
   };
 };

--- a/packages/cli/src/ui/hooks/useAuthCommand.ts
+++ b/packages/cli/src/ui/hooks/useAuthCommand.ts
@@ -78,11 +78,16 @@ Message: ${getErrorMessage(e)}`
     // For now, we don't do anything on highlight.
   }, []);
 
+  const cancelAuthentication = useCallback(() => {
+    setIsAuthenticating(false);
+  }, []);
+
   return {
     isAuthDialogOpen,
     openAuthDialog,
     handleAuthSelect,
     handleAuthHighlight,
     isAuthenticating,
+    cancelAuthentication,
   };
 };


### PR DESCRIPTION
## TLDR

When we launch the oauth flow, we don't block and users can try and enter text with out a valid api set up

## Dive Deeper

Oauth requires a browser launch and pops up a physical window. depending on system this window can get lost in the background. when that happens the cli keeps taking input and shows `chat not started`. This might not be the only path to gt `chat not started` see #1247 and https://github.com/google-gemini/gemini-cli/pull/1243

## Reviewer Test Plan

1. open the cli
2. /auth
3. select Login with google
4. when the browswer window opens, switch back to the cli
5. verify that you can't enter text

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
