### PR TITLE
Remove #early-access from npx references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ release:
 	npm run publish:release
 
 run-npx:
-	npx https://github.com/google-gemini/gemini-cli#early-access
+	npx https://github.com/google-gemini/gemini-cli
 
 create-alias:
 	scripts/create_alias.sh

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the Gemini CLI tool.
 1. [Install Node 18+](https://nodejs.org/en/download).
 2. [Get an API key from Google AI Studio](https://aistudio.google.com/apikey).
 3. Set the API key in your shell using the following command, replacing `YOUR_API_KEY` with the API key you obtained: `export GEMINI_API_KEY="YOUR_API_KEY"`.
-4. Run the Gemini CLI from your shell using the following command: `npx https://github.com/google-gemini/gemini-cli#early-access`
+4. Run the Gemini CLI from your shell using the following command: `npx https://github.com/google-gemini/gemini-cli`
 5. Enjoy.
 
 ## Examples


### PR DESCRIPTION
## TLDR

old: `npx https://github.com/google-gemini/gemini-cli#early-access`
new: `npx https://github.com/google-gemini/gemini-cli`

## Reviewer Test Plan

execute `make run-npx` and verify that the CLI starts up correctly.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | x  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

b/426299059
