### PR TITLE
fix: update code assist server url to point to prod

### DIFF
--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -40,7 +40,7 @@ export interface HttpOptions {
 // TODO: Use production endpoint once it supports our methods.
 export const CODE_ASSIST_ENDPOINT =
   process.env.CODE_ASSIST_ENDPOINT ??
-  'https://staging-cloudcode-pa.sandbox.googleapis.com';
+  'https://cloudcode-pa.googleapis.com';
 export const CODE_ASSIST_API_VERSION = 'v1internal';
 
 export class CodeAssistServer implements ContentGenerator {


### PR DESCRIPTION
## TLDR

The client currently points to staging, this PR updates it to point to prod.

## Reviewer Test Plan

- `export GEMINI_CODE_ASSIST=true`
- `export GOOGLE_CLOUD_PROJECT=${VALID_GCP_PROJECT}`
- `npm run  build && npm run start`
- Use as normal!

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

#1165 
