### PR TITLE
Fix CODE_ASSIST_ENDPOINT env var loading

### DIFF
--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -39,7 +39,6 @@ export interface HttpOptions {
 
 // TODO: Use production endpoint once it supports our methods.
 export const CODE_ASSIST_ENDPOINT =
-  process.env.CODE_ASSIST_ENDPOINT ??
   'https://staging-cloudcode-pa.sandbox.googleapis.com';
 export const CODE_ASSIST_API_VERSION = 'v1internal';
 
@@ -114,7 +113,7 @@ export class CodeAssistServer implements ContentGenerator {
     signal?: AbortSignal,
   ): Promise<T> {
     const res = await this.client.request({
-      url: `${CODE_ASSIST_ENDPOINT}/${CODE_ASSIST_API_VERSION}:${method}`,
+      url: this.getMethodUrl(method),
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -133,7 +132,7 @@ export class CodeAssistServer implements ContentGenerator {
     signal?: AbortSignal,
   ): Promise<AsyncGenerator<T>> {
     const res = await this.client.request({
-      url: `${CODE_ASSIST_ENDPOINT}/${CODE_ASSIST_API_VERSION}:${method}`,
+      url: this.getMethodUrl(method),
       method: 'POST',
       params: {
         alt: 'sse',
@@ -169,5 +168,10 @@ export class CodeAssistServer implements ContentGenerator {
         }
       }
     })();
+  }
+
+  getMethodUrl(method: string): string {
+    const endpoint = process.env.CODE_ASSIST_ENDPOINT ?? CODE_ASSIST_ENDPOINT;
+    return `${endpoint}/${CODE_ASSIST_API_VERSION}:${method}`;
   }
 }


### PR DESCRIPTION
## TLDR

setting CODE_ASSIST_ENDPOINT in .env files stopped working, probably because recent changes moved up when this static var is loaded to before the .env file is loaded. This moves the calculation back so to after the .env files are applied. But it also just makes a little more sense this way.


## Reviewer Test Plan

Set CODE_ASSIST_ENDPOINT in an .env files and verify that it works. (for example, by pointing it to http://derp.com and verifying that the CLI blows up during start up).

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | X  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

