### PR TITLE
feat: align cli argv, settings.json, and GEMINI_SANDBOX envvar

### DIFF
--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -4,92 +4,123 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SandboxConfig } from '@gemini-cli/core';
+import { SandboxConfig, SUPPORTED_SANDBOX_COMMANDS } from '@gemini-cli/core';
 import commandExists from 'command-exists';
-import * as os from 'node:os';
+import { platform } from 'node:os';
 import { getPackageJson } from '../utils/package.js';
 import { Settings } from './settings.js';
 
 // This is a stripped-down version of the CliArgs interface from config.ts
 // to avoid circular dependencies.
 interface SandboxCliArgs {
-  sandbox?: boolean | string;
+  sandbox?: SandboxOption;
   'sandbox-image'?: string;
 }
 
-const VALID_SANDBOX_COMMANDS: ReadonlyArray<SandboxConfig['command']> = [
-  'docker',
-  'podman',
-  'sandbox-exec',
-];
+export const SANDBOX_LEGACY_OPTIONS = ['0', 'false', '1', 'true'] as const; // kept for backwards compatibility
+export type SandboxLegacyOption =
+  typeof SANDBOX_LEGACY_OPTIONS extends ReadonlyArray<infer T> ? T : never;
 
-function isSandboxCommand(value: string): value is SandboxConfig['command'] {
-  return (VALID_SANDBOX_COMMANDS as readonly string[]).includes(value);
+export const SANDBOX_OPTIONS = [
+  // TODO: phase out '0', '1', 'false', and 'true' entirely
+  ...SANDBOX_LEGACY_OPTIONS,
+  'auto',
+  'none',
+  ...SUPPORTED_SANDBOX_COMMANDS,
+] as const;
+export type SandboxOption =
+  typeof SANDBOX_OPTIONS extends ReadonlyArray<infer T> ? T : never;
+function isValidSandboxOption(str: string): str is SandboxOption {
+  return !!SANDBOX_OPTIONS.find((s) => s === str);
 }
 
 function getSandboxCommand(
-  sandbox?: boolean | string,
-): SandboxConfig['command'] | '' {
-  // If the SANDBOX env var is set, we're already inside the sandbox.
-  if (process.env.SANDBOX) {
-    return '';
-  }
-
-  // note environment variable takes precedence over argument (from command line or settings)
-  sandbox = process.env.GEMINI_SANDBOX?.toLowerCase().trim() ?? sandbox;
-  if (sandbox === '1' || sandbox === 'true') sandbox = true;
-  else if (sandbox === '0' || sandbox === 'false' || !sandbox) sandbox = false;
-
-  if (sandbox === false) {
-    return '';
-  }
-
-  if (typeof sandbox === 'string' && sandbox) {
-    if (!isSandboxCommand(sandbox)) {
-      console.error(
-        `ERROR: invalid sandbox command '${sandbox}'. Must be one of ${VALID_SANDBOX_COMMANDS.join(
-          ', ',
-        )}`,
-      );
-      process.exit(1);
-    }
-    // confirm that specfied command exists
-    if (commandExists.sync(sandbox)) {
+  sandbox: SandboxOption,
+): SandboxConfig['command'] | undefined {
+  switch (sandbox) {
+    case 'none':
+    case '0':
+    case 'false':
+      return undefined;
+    case 'docker':
+    case 'podman':
+    case 'sandbox-exec':
+      if (!commandExists.sync(sandbox)) {
+        throw new Error(
+          `provided sandbox command '${sandbox}' was not found on the device`,
+        );
+      }
       return sandbox;
+    case 'auto':
+    case '1':
+    case 'true': {
+      // look for seatbelt, docker, or podman, in that order
+      // for container-based sandboxing, require sandbox to be enabled explicitly
+      if (platform() === 'darwin' && commandExists.sync('sandbox-exec')) {
+        return 'sandbox-exec';
+      } else if (commandExists.sync('docker')) {
+        return 'docker';
+      } else if (commandExists.sync('podman')) {
+        return 'podman';
+      }
+      throw new Error(
+        `Unable to automatically detect the sandbox container command. Options include ${SUPPORTED_SANDBOX_COMMANDS};
+          install docker or podman or specify command with --sandbox CLI arg, GEMINI_SANDBOX env var, or .gemini/settings.json`,
+      );
     }
-    console.error(
-      `ERROR: missing sandbox command '${sandbox}' (from GEMINI_SANDBOX)`,
+    default: {
+      // throws transpiler error if all cases aren't considered
+      const exhaustiveCheck: never = sandbox;
+      return exhaustiveCheck;
+    }
+  }
+}
+
+// defines order of precedence for sandbox selection
+function pickSandboxOption(
+  settings: Settings,
+  argv: SandboxCliArgs,
+): string | undefined {
+  if (argv.sandbox) {
+    console.log(`Using sandbox value from --sandbox '${argv.sandbox}'.`);
+    return argv.sandbox;
+  }
+  // warn if we detect any unsupported settings/envvar values
+  if (settings.sandbox) {
+    console.log(
+      `Using sandbox field in .gemini/settings.json '${settings.sandbox}'.`,
     );
-    process.exit(1);
+    return settings.sandbox;
   }
-
-  // look for seatbelt, docker, or podman, in that order
-  // for container-based sandboxing, require sandbox to be enabled explicitly
-  if (os.platform() === 'darwin' && commandExists.sync('sandbox-exec')) {
-    return 'sandbox-exec';
-  } else if (commandExists.sync('docker') && sandbox === true) {
-    return 'docker';
-  } else if (commandExists.sync('podman') && sandbox === true) {
-    return 'podman';
-  }
-
-  // throw an error if user requested sandbox but no command was found
-  if (sandbox === true) {
-    console.error(
-      'ERROR: GEMINI_SANDBOX is true but failed to determine command for sandbox; ' +
-        'install docker or podman or specify command in GEMINI_SANDBOX',
+  if (process.env.GEMINI_SANDBOX) {
+    console.log(
+      `Using sandbox value from 'GEMINI_SANDBOX' env var '${process.env.GEMINI_SANDBOX}'.`,
     );
-    process.exit(1);
+    return process.env.GEMINI_SANDBOX;
   }
-
-  return '';
+  return undefined;
 }
 
 export async function loadSandboxConfig(
   settings: Settings,
   argv: SandboxCliArgs,
 ): Promise<SandboxConfig | undefined> {
-  const sandboxOption = argv.sandbox ?? settings.sandbox;
+  // If the SANDBOX env var is set, we're already inside the sandbox.
+  if (process.env.SANDBOX) {
+    return undefined;
+  }
+
+  // coallesce all provided options
+  const sandboxOption = pickSandboxOption(settings, argv);
+  if (!sandboxOption) {
+    return undefined;
+  }
+  if (!isValidSandboxOption(sandboxOption)) {
+    throw new Error(
+      `invalid sandbox command '${sandboxOption}'. Must be one of ${SANDBOX_OPTIONS}`,
+    );
+  }
+
   const command = getSandboxCommand(sandboxOption);
 
   const packageJson = await getPackageJson();

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -34,7 +34,7 @@ export interface AccessibilitySettings {
 export interface Settings {
   theme?: string;
   selectedAuthType?: AuthType;
-  sandbox?: boolean | string;
+  sandbox?: string;
   coreTools?: string[];
   excludeTools?: string[];
   toolDiscoveryCommand?: string;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -77,8 +77,17 @@ export class MCPServerConfig {
   ) {}
 }
 
+export const SUPPORTED_SANDBOX_COMMANDS = [
+  'docker',
+  'podman',
+  'sandbox-exec',
+] as const;
+
+export type SupportedSandboxCommand =
+  (typeof SUPPORTED_SANDBOX_COMMANDS)[number];
+
 export interface SandboxConfig {
-  command: 'docker' | 'podman' | 'sandbox-exec';
+  command: SupportedSandboxCommand;
   image: string;
 }
 

--- a/scripts/sandbox_command.js
+++ b/scripts/sandbox_command.js
@@ -84,7 +84,7 @@ const commandExists = (cmd) => {
 };
 
 let command = '';
-if (['1', 'true'].includes(geminiSandbox)) {
+if (['1', 'true', 'auto'].includes(geminiSandbox)) {
   if (commandExists('docker')) {
     command = 'docker';
   } else if (commandExists('podman')) {
@@ -95,7 +95,7 @@ if (['1', 'true'].includes(geminiSandbox)) {
     );
     process.exit(1);
   }
-} else if (geminiSandbox && !['0', 'false'].includes(geminiSandbox)) {
+} else if (geminiSandbox && !['0', 'false', 'none'].includes(geminiSandbox)) {
   if (commandExists(geminiSandbox)) {
     command = geminiSandbox;
   } else {


### PR DESCRIPTION
CHILD=#1267
DEMO=http://screen/9nG8XAvWzpks6Ei

## TLDR

Aligns the accepted values for sandbox configuration between the 3 supported sources:

- CLI args
- .gemini/settings.json
- environment variables

Adds extra build-time type guards to ensure strings provided from these sources are all valid values (see DEMO above)

## Deeper Dive

This change adds stronger types, extra validation, and error messages when coalescing these sandbox configuration sources. They also bring the CLI arg up to parity with the settings and envvar options (previously the CLI arg only accepted booleans).

This also adds the extra options `auto` and `none` to _eventually_ replace `0`, `1`, `true`, and `false`. These new values are more explicit about the intended behavior. 

> NOTE: checking this in to the `main` branch for now to avoid friction and breakages in `release`. We can cherry-pick if needed or deemed valuable enough. 

> NOTE: tests and documentation are added in a followup PR (see child) to keep this diff small and more reviewer-friendly

### Detailed Changes

   * `packages/core/src/config/config.ts`: This file introduces the `SupportedSandboxCommand` type, which is a union of the supported sandbox command [literals](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types). This adds a layer of [build-time type safety](http://screen/9nG8XAvWzpks6Ei) by ensuring that only valid commands can be used in the SandboxConfig.

   * `packages/cli/src/config/config.ts`: This file was updated to improve type safety by using the new `SandboxOption` and `SandboxLegacyOption` types for the `--sandbox` CLI argument. This ensures that only valid sandbox options can be provided on the command line.

   * `packages/cli/src/config/sandboxConfig.ts`: This file was refactored to introduce more robust type checking for sandbox configurations. It now defines and uses the `SandboxOption` and `SandboxLegacyOption` types to validate sandbox settings from all sources (CLI, settings.json, environment variables). It also performs necessary type guards to ensure generic `string` types from environment variables and settings.jsons can be cast to the more strict [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types) `SandboxOption`.

   * `packages/cli/src/config/settings.ts`: The sandbox property in the Settings interface was changed from `boolean | string` to just string.

   * `scripts/sandbox_command.js`: This script was updated to align with the new sandbox options. It now correctly handles the 'auto' and 'none' options, making the script's behavior consistent with the new configuration options.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ✅   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ✅   | ❓  | ✅   |
| Podman   | ✅   | -   | ✅    |
| Seatbelt | ✅   | -   | -   |

