### PR TITLE
bug: fix cancel after a tool has been used

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -92,6 +92,7 @@ export const useGeminiStream = (
 ) => {
   const [initError, setInitError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const turnCancelledRef = useRef(false);
   const [isResponding, setIsResponding] = useState<boolean>(false);
   const [thought, setThought] = useState<ThoughtSummary | null>(null);
   const [pendingHistoryItemRef, setPendingHistoryItem] =
@@ -168,15 +169,25 @@ export const useGeminiStream = (
     return StreamingState.Idle;
   }, [isResponding, toolCalls]);
 
-  useEffect(() => {
-    if (streamingState === StreamingState.Idle) {
-      abortControllerRef.current = null;
-    }
-  }, [streamingState]);
-
   useInput((_input, key) => {
-    if (streamingState !== StreamingState.Idle && key.escape) {
+    if (streamingState === StreamingState.Responding && key.escape) {
+      if (turnCancelledRef.current) {
+        return;
+      }
+      turnCancelledRef.current = true;
       abortControllerRef.current?.abort();
+      if (pendingHistoryItemRef.current) {
+        addItem(pendingHistoryItemRef.current, Date.now());
+      }
+      addItem(
+        {
+          type: MessageType.INFO,
+          text: 'Request cancelled.',
+        },
+        Date.now(),
+      );
+      setPendingHistoryItem(null);
+      setIsResponding(false);
     }
   });
 
@@ -189,6 +200,9 @@ export const useGeminiStream = (
       queryToSend: PartListUnion | null;
       shouldProceed: boolean;
     }> => {
+      if (turnCancelledRef.current) {
+        return { queryToSend: null, shouldProceed: false };
+      }
       if (typeof query === 'string' && query.trim().length === 0) {
         return { queryToSend: null, shouldProceed: false };
       }
@@ -285,6 +299,10 @@ export const useGeminiStream = (
       currentGeminiMessageBuffer: string,
       userMessageTimestamp: number,
     ): string => {
+      if (turnCancelledRef.current) {
+        // Prevents additional output after a user initiated cancel.
+        return '';
+      }
       let newGeminiMessageBuffer = currentGeminiMessageBuffer + eventValue;
       if (
         pendingHistoryItemRef.current?.type !== 'gemini' &&
@@ -335,6 +353,9 @@ export const useGeminiStream = (
 
   const handleUserCancelledEvent = useCallback(
     (userMessageTimestamp: number) => {
+      if (turnCancelledRef.current) {
+        return;
+      }
       if (pendingHistoryItemRef.current) {
         if (pendingHistoryItemRef.current.type === 'tool_group') {
           const updatedTools = pendingHistoryItemRef.current.tools.map(
@@ -469,6 +490,7 @@ export const useGeminiStream = (
 
       abortControllerRef.current = new AbortController();
       const abortSignal = abortControllerRef.current.signal;
+      turnCancelledRef.current = false;
 
       const { queryToSend, shouldProceed } = await prepareQueryForGemini(
         query,


### PR DESCRIPTION
## TLDR

This change introduces the ability for a user to cancel a Gemini request mid-stream, even during tool calls. Pressing the `escape` key will now immediately terminate the request, stop any further processing, and return the CLI to an idle state. This prevents users from getting stuck in long-running or looping tool calls they did not intend.

## Dive Deeper

The core of this change is the introduction of a `turnCancelledRef` within the `useGeminiStream` hook. Here's how it works:

1.  **Cancellation Signal**: The `useInput` hook now listens for the `escape` key. When pressed during a `Responding` state, it sets `turnCancelledRef.current` to `true` and calls `abort()` on the `AbortController`.

2.  **Halting Execution**: Several key functions within the stream processing pipeline (`prepareQueryForGemini`, `handleContentEvent`, `handleUserCancelledEvent`) now check the value of `turnCancelledRef.current` at their entry point. If it's `true`, they immediately exit, preventing any further API calls, tool executions, or state updates.

3.  **State Management**: Upon cancellation, the hook immediately adds a "Request cancelled." message to the history, finalizes any pending history items, and resets the `streamingState` to `Idle`.

This implementation ensures that the cancellation is respected at multiple points in the execution flow, providing a robust way to stop the agent without having to kill the entire session. The accompanying tests in `useGeminiStream.test.tsx` validate this new cancellation logic, including edge cases where cancellation should not occur (e.g., when a tool call is not in a cancellable state).

## Reviewer Test Plan

To validate this change, you can test the following scenarios:

1.  **Simple Cancellation**:
    *   Start a long query that will take some time to respond (e.g., "write me a long story about a robot").
    *   While the response is streaming in, press the `escape` key.
    *   **Expected Behavior**: The stream should immediately stop, a "Request cancelled." message should appear, and you should be able to enter a new prompt.

2.  **Tool Call Cancellation**:
    *   Execute a prompt that you know will trigger a tool call (e.g., a file search or a web search).
    *   As soon as the tool call begins (you'll see the tool execution in the UI), press the `escape` key.
    *   **Expected Behavior**: The tool call should be aborted, and the agent should not proceed with the rest of its plan. The UI should return to an idle state.

43  **No Cancellation when Idle**:
    *   When the CLI is idle and waiting for input, press the `escape` key.
    *   **Expected Behavior**: Nothing should happen. The cancellation logic should only trigger when the agent is actively responding or executing a tool.


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs
[b/425920902](https://b.corp.google.com/issues/425920902)
[b/423607627](https://b.corp.google.com/issues/423607627)
[b/425195827](https://b.corp.google.com/issues/425195827)
[b/426696316](https://b.corp.google.com/issues/426696316)
