### PR TITLE
fix: remove circular references in core package

### DIFF
--- a/packages/core/src/core/modelCheck.ts
+++ b/packages/core/src/core/modelCheck.ts
@@ -7,7 +7,7 @@
 import {
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
-} from '@gemini-cli/core';
+} from '../config/models.js';
 
 /**
  * Checks if the default "pro" model is rate-limited and returns a fallback "flash"

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthType, ToolConfirmationOutcome } from '../index.js';
+import { ToolConfirmationOutcome } from '../tools/tools.js';
+import { AuthType } from '../core/contentGenerator.js';
 import { logs } from '@opentelemetry/api-logs';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { Config } from '../config/config.js';
@@ -24,14 +25,6 @@ import {
 import * as metrics from './metrics.js';
 import * as sdk from './sdk.js';
 import { vi, describe, beforeEach, it, expect } from 'vitest';
-
-vi.mock('@gemini-cli/cli/dist/src/utils/version', () => ({
-  getCliVersion: () => 'test-version',
-}));
-
-vi.mock('@gemini-cli/cli/dist/src/config/settings', () => ({
-  getTheme: () => 'test-theme',
-}));
 
 describe('loggers', () => {
   const mockLogger = {

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -30,7 +30,7 @@ import {
   recordToolCallMetrics,
 } from './metrics.js';
 import { isTelemetrySdkInitialized } from './sdk.js';
-import { ToolConfirmationOutcome } from '../index.js';
+import { ToolConfirmationOutcome } from '../tools/tools.js';
 import {
   GenerateContentResponse,
   GenerateContentResponseUsageMetadata,


### PR DESCRIPTION
This was causing rebuild errors, eg:

```
 % npm run build

> gemini-cli@0.1.0 build
> node scripts/build.js


> gemini-cli@0.1.0 generate
> node scripts/generate-git-commit-info.js


> @gemini-cli/cli@0.1.0 build
> node ../../scripts/build_package.js

error TS5055: Cannot write file '/usr/local/google/home/brandonkeiji/git/gemini-cli/packages/core/dist/index.d.ts' because it would overwrite input file.

error TS5055: Cannot write file '/usr/local/google/home/brandonkeiji/git/gemini-cli/packages/core/dist/src/code_assist/codeAssist.d.ts' because it would overwrite input file.

...
```

Root Cause:

- on first build `tsc` generates these type declarations
- our tsconfig knows to ignore anything under the `dist/` folder
- we have some imports that self-reference the package
    ```
    // from ./packages/core/src/some-file.ts
    import {} from '@gemini-cli/core' // imports the core package (ie itself)
    ```
- this gets treated as an external package with its own `dist/` folder
- because the import treated the package as external, the `exclude` statement on `dist/` in our tsconfig did not apply, meaning `tsc` tried to take in these type declarations as source files. 
- so when `tsc` tried to overwrite those declarations on a rebuild, we'd see the error above
- **this is why clean builds succeed (ie `npm run clean && npm run build`), but subsequent builds would fail

Long term we should probably make a custom lint rule to prevent a package from importing itself using the `@gemini-cli/*` identifier. For now, just checking this in to unblock people.
