### PR TITLE
feat: add eslint rule to catch self-referential package imports

### DIFF
--- a/eslint-rules/no-self-package-import.js
+++ b/eslint-rules/no-self-package-import.js
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Disallows a package from importing itself using its package name.
+ */
+'use strict';
+
+import path from 'node:path';
+import fs from 'node:fs';
+
+/**
+ * Finds the package name by searching for the nearest `package.json` file
+ * in the directory hierarchy, starting from the given file's directory
+ * and moving upwards until the specified root directory is reached.
+ * It reads the `package.json` and extracts the `name` property.
+ *
+ * @requires module:path Node.js path module
+ * @requires module:fs Node.js fs module
+ *
+ * @param {string} filePath - The path (absolute or relative) to a file within the potential package structure.
+ * The search starts from the directory containing this file.
+ * @param {string} root - The absolute path to the root directory of the project/monorepo.
+ * The upward search stops when this directory is reached.
+ * @returns {string | undefined | null} The value of the `name` field from the first `package.json` found.
+ * Returns `undefined` if the `name` field doesn't exist in the found `package.json`.
+ * Returns `null` if no `package.json` is found before reaching the `root` directory.
+ * @throws {Error} Can throw an error if `fs.readFileSync` fails (e.g., permissions) or if `JSON.parse` fails on invalid JSON content.
+ */
+function findPackageName(filePath, root) {
+  let currentDir = path.dirname(path.resolve(filePath));
+  while (currentDir !== root) {
+    const parentDir = path.dirname(currentDir);
+    const packageJsonPath = path.join(currentDir, 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      return pkg.name;
+    }
+
+    // Move up one level
+    currentDir = parentDir;
+    // Safety break if we somehow reached the root directly in the loop condition (less likely with path.resolve)
+    if (path.dirname(currentDir) === currentDir) break;
+  }
+
+  return null; // Not found within the expected structure
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow a package from importing itself.',
+      category: 'Best Practices',
+      recommended: 'error',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          root: {
+            type: 'string',
+            description:
+              'Absolute path to the root of all relevant packages to consider.',
+          },
+        },
+        required: ['root'],
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noSelfPackageImport:
+        "Package '{{packageName}}' should not import itself. Use relative paths for intra-package imports.",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {};
+    const allPackagesRoot = options.root;
+
+    const currentFilePath = context.filename;
+    if (
+      !currentFilePath ||
+      currentFilePath === '<input>' ||
+      currentFilePath === '<text>'
+    ) {
+      // Skip if filename is not available (e.g., linting raw text)
+      return {};
+    }
+
+    const currentPackage = findPackageName(currentFilePath, allPackagesRoot);
+
+    // If the current file isn't inside a package structure, don't apply the rule
+    if (!currentPackage) {
+      return {};
+    }
+
+    return {
+      ImportDeclaration(node) {
+        const importedPath = node.source.value;
+
+        // Only interested in absolute paths that are package names
+        if (
+          !importedPath ||
+          typeof importedPath !== 'string' ||
+          importedPath.startsWith('.')
+        ) {
+          return;
+        }
+
+        if (importedPath === currentPackage) {
+          context.report({
+            node: node.source,
+            messageId: 'noSelfPackageImport',
+            data: {
+              packageName: currentPackage,
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,7 @@ import importPlugin from 'eslint-plugin-import';
 import globals from 'globals';
 import licenseHeader from 'eslint-plugin-license-header';
 import noRelativeCrossPackageImports from './eslint-rules/no-relative-cross-package-imports.js';
+import noSelfPackageImport from './eslint-rules/no-self-package-import.js';
 import path from 'node:path'; // Use node: prefix for built-ins
 import url from 'node:url';
 
@@ -205,12 +206,19 @@ export default tseslint.config(
       custom: {
         rules: {
           'no-relative-cross-package-imports': noRelativeCrossPackageImports,
+          'no-self-package-import': noSelfPackageImport,
         },
       },
     },
     rules: {
       // Enable and configure your custom rule
       'custom/no-relative-cross-package-imports': [
+        'error',
+        {
+          root: path.join(projectRoot, 'packages'),
+        },
+      ],
+      'custom/no-self-package-import': [
         'error',
         {
           root: path.join(projectRoot, 'packages'),


### PR DESCRIPTION
DEMO=http://screen/9zxLYnVR7urXk4g

A followup from #1271. This custom lint rule should (hopefully) catch these sorts of issues. 