### PR TITLE
feat: add --interactive flag to force interactive mode

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -247,6 +247,44 @@ describe('loadCliConfig telemetry', () => {
   });
 });
 
+describe('loadCliConfig interactive flag', () => {
+  const originalArgv = process.argv;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue(MOCK_HOME_DIR);
+    process.env.GEMINI_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('should set interactive to true when --interactive flag is present', async () => {
+    process.argv = ['node', 'script.js', '--interactive'];
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getInteractive()).toBe(true);
+  });
+
+  it('should set interactive to true when -i flag is present', async () => {
+    process.argv = ['node', 'script.js', '-i'];
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getInteractive()).toBe(true);
+  });
+
+  it('should set interactive to false when flag is not present', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getInteractive()).toBe(false);
+  });
+});
+
 describe('Hierarchical Memory Loading (config.ts) - Placeholder Suite', () => {
   beforeEach(() => {
     vi.resetAllMocks();

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -59,6 +59,7 @@ interface CliArgs {
   telemetryTarget: string | undefined;
   telemetryOtlpEndpoint: string | undefined;
   telemetryLogPrompts: boolean | undefined;
+  interactive: boolean | undefined;
 }
 
 async function parseArguments(): Promise<CliArgs> {
@@ -137,6 +138,13 @@ async function parseArguments(): Promise<CliArgs> {
       alias: 'c',
       type: 'boolean',
       description: 'Enables checkpointing of file edits',
+      default: false,
+    })
+    .option('interactive', {
+      alias: 'i',
+      type: 'boolean',
+      description:
+        'Forces an interactive session. When used with --prompt, executes the prompt before starting the session.',
       default: false,
     })
     .version(await getCliVersion()) // This will enable the --version flag based on package.json
@@ -255,6 +263,7 @@ export async function loadCliConfig(
     fileDiscoveryService: fileService,
     bugCommand: settings.bugCommand,
     model: argv.model!,
+    interactive: argv.interactive,
   });
 }
 

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -72,6 +72,7 @@ interface AppProps {
   config: Config;
   settings: LoadedSettings;
   startupWarnings?: string[];
+  input?: string;
 }
 
 export const AppWrapper = (props: AppProps) => (
@@ -80,8 +81,9 @@ export const AppWrapper = (props: AppProps) => (
   </SessionStatsProvider>
 );
 
-const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
+const App = ({ config, settings, startupWarnings = [], input }: AppProps) => {
   const [updateMessage, setUpdateMessage] = useState<string | null>(null);
+  const initialPromptSubmitted = useRef(false);
 
   useEffect(() => {
     checkForUpdates().then(setUpdateMessage);
@@ -351,6 +353,14 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     getPreferredEditor,
     onAuthError,
   );
+
+  useEffect(() => {
+    if (input && !initialPromptSubmitted.current) {
+      submitQuery(input);
+      initialPromptSubmitted.current = true;
+    }
+  }, [input, submitQuery]);
+
   pendingHistoryItems.push(...pendingGeminiHistoryItems);
   const { elapsedTime, currentLoadingPhrase } =
     useLoadingIndicator(streamingState);

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -268,4 +268,29 @@ describe('Server Config (config.ts)', () => {
       expect(config.getTelemetryOtlpEndpoint()).toBe(DEFAULT_OTLP_ENDPOINT);
     });
   });
+
+  describe('Interactive Flag', () => {
+    it('should set interactive to true when provided as true', () => {
+      const paramsWithInteractive: ConfigParameters = {
+        ...baseParams,
+        interactive: true,
+      };
+      const config = new Config(paramsWithInteractive);
+      expect(config.getInteractive()).toBe(true);
+    });
+
+    it('should set interactive to false when provided as false', () => {
+      const paramsWithInteractive: ConfigParameters = {
+        ...baseParams,
+        interactive: false,
+      };
+      const config = new Config(paramsWithInteractive);
+      expect(config.getInteractive()).toBe(false);
+    });
+
+    it('should default interactive to false if not provided', () => {
+      const config = new Config(baseParams);
+      expect(config.getInteractive()).toBe(false);
+    });
+  });
 });

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -268,29 +268,4 @@ describe('Server Config (config.ts)', () => {
       expect(config.getTelemetryOtlpEndpoint()).toBe(DEFAULT_OTLP_ENDPOINT);
     });
   });
-
-  describe('Interactive Flag', () => {
-    it('should set interactive to true when provided as true', () => {
-      const paramsWithInteractive: ConfigParameters = {
-        ...baseParams,
-        interactive: true,
-      };
-      const config = new Config(paramsWithInteractive);
-      expect(config.getInteractive()).toBe(true);
-    });
-
-    it('should set interactive to false when provided as false', () => {
-      const paramsWithInteractive: ConfigParameters = {
-        ...baseParams,
-        interactive: false,
-      };
-      const config = new Config(paramsWithInteractive);
-      expect(config.getInteractive()).toBe(false);
-    });
-
-    it('should default interactive to false if not provided', () => {
-      const config = new Config(baseParams);
-      expect(config.getInteractive()).toBe(false);
-    });
-  });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -119,6 +119,7 @@ export interface ConfigParameters {
   fileDiscoveryService?: FileDiscoveryService;
   bugCommand?: BugCommandSettings;
   model: string;
+  interactive?: boolean;
 }
 
 export class Config {
@@ -152,6 +153,7 @@ export class Config {
   private readonly cwd: string;
   private readonly bugCommand: BugCommandSettings | undefined;
   private readonly model: string;
+  private readonly interactive: boolean;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -188,6 +190,7 @@ export class Config {
     this.fileDiscoveryService = params.fileDiscoveryService ?? null;
     this.bugCommand = params.bugCommand;
     this.model = params.model;
+    this.interactive = params.interactive ?? false;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -354,6 +357,10 @@ export class Config {
 
   getBugCommand(): BugCommandSettings | undefined {
     return this.bugCommand;
+  }
+
+  getInteractive(): boolean {
+    return this.interactive;
   }
 
   getFileService(): FileDiscoveryService {


### PR DESCRIPTION
Closed in favor of https://github.com/google-gemini/gemini-cli/pull/1277

## TLDR

This change introduces the "--interactive" (or "-i") flag to force the Gemini CLI into an interactive session, even when an initial prompt is provided. This allows for a seamless transition from a single-shot command to a continued conversation.

## Dive Deeper

When a prompt is provided via `--prompt` (`-p`) or standard input, the CLI typically processes the request and exits. With the new `--interactive` (`-i`) flag, the CLI will execute the initial prompt and then enter an interactive session.

This change also explicitly disallows using the `--interactive` flag when piping from standard input. This is a deliberate design choice, as interactive mode requires a direct connection to the user's terminal (a TTY) to handle keyboard input, which is unavailable when `stdin` is redirected from another process. This restriction prevents crashes and ensures predictable behavior.

### Real-World Examples

- **Python:** The `-i` flag can run an inline command with `-c` and then drop into an interactive session where the state from the command is preserved.

```bash
$ python3 -i -c "print('Hello from inlined script'); x = 10" Hello from inlined script
  >>> x
  10
  >>>
```

- **Node.js:** The `-i` flag forces the REPL to start, even when input is piped from another process, allowing inspection of the result.

```bash
$ node -e "console.log('Hello from inlined script'); x = 10" -i
Welcome to Node.js v22.12.0.
Type ".help" for more information.
> Hello from inlined script
x
10
> x
>
```

- **Docker:** The `-i` flag (combined with `-t` for a TTY) is fundamental for running an interactive shell inside a container.

```bash
$ docker run -it ubuntu bash
root@a1b2c3d4e5f6:/# ls
bin  boot  dev  etc  home  lib ...
root@a1b2c3d4e5f6:/# exit
```

## Reviewer Test Plan

1.  **Verify standard non-interactive behavior:** Run the CLI with a prompt and confirm it exits after providing the answer. 

```bash
$ gemini -p "hello"
Hi there! What can I help you with today?
```

3.  **Verify interactive behavior without a prompt:** Run the CLI with `-i` and confirm it enters an interactive session immediately.

```bash
$ gemini -i

 ███            █████████  ██████████ ██████   ██████ █████ ██████   █████ █████
░░░███         ███░░░░░███░░███░░░░░█░░██████ ██████ ░░███ ░░██████ ░░███ ░░███
  ░░░███      ███     ░░░  ░███  █ ░  ░███░█████░███  ░███  ░███░███ ░███  ░███
    ░░░███   ░███          ░██████    ░███░░███ ░███  ░███  ░███░░███░███  ░███
     ███░    ░███    █████ ░███░░█    ░███ ░░░  ░███  ░███  ░███ ░░██████  ░███
   ███░      ░░███  ░░███  ░███ ░   █ ░███      ░███  ░███  ░███  ░░█████  ░███
 ███░         ░░█████████  ██████████ █████     █████ █████ █████  ░░█████ █████
░░░            ░░░░░░░░░  ░░░░░░░░░░ ░░░░░     ░░░░░ ░░░░░ ░░░░░    ░░░░░ ░░░░░

Using 1 GEMINI.md file and 1 MCP server (ctrl+t to view)
╭──────────────────────────────────────────────────────────────────────╮
│ >   Type your message or @path/to/file                               │  
╰──────────────────────────────────────────────────────────────────────╯
```

5.  **Verify the new core behavior:** Run the CLI with a prompt and the `-i` flag. Confirm it prints the answer to the initial prompt and then remains in an interactive session for follow-up questions.
```bash
$ gemini -p "hello" -i

 ███            █████████  ██████████ ██████   ██████ █████ ██████   █████ █████
░░░███         ███░░░░░███░░███░░░░░█░░██████ ██████ ░░███ ░░██████ ░░███ ░░███
  ░░░███      ███     ░░░  ░███  █ ░  ░███░█████░███  ░███  ░███░███ ░███  ░███
    ░░░███   ░███          ░██████    ░███░░███ ░███  ░███  ░███░░███░███  ░███
     ███░    ░███    █████ ░███░░█    ░███ ░░░  ░███  ░███  ░███ ░░██████  ░███
   ███░      ░░███  ░░███  ░███ ░   █ ░███      ░███  ░███  ░███  ░░█████  ░███
 ███░         ░░█████████  ██████████ █████     █████ █████ █████  ░░█████ █████
░░░            ░░░░░░░░░  ░░░░░░░░░░ ░░░░░     ░░░░░ ░░░░░ ░░░░░    ░░░░░ ░░░░░

> hello

✦ Hi there! How can I help you today?

Using 1 GEMINI.md file and 1 MCP server (ctrl+t to view)
╭──────────────────────────────────────────────────────────────────────╮
│ >   Type your message or @path/to/file                               │  
╰──────────────────────────────────────────────────────────────────────╯
```

7.  **Verify with piped input:**
```bash
$ echo "hello" | gemini -i
Error: The --interactive flag is not supported when piping input from stdin.
```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

b/426596225