### PR TITLE
Add support for logging unique user ids for telemetry

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -226,6 +226,8 @@ export async function loadCliConfig(
         process.env.OTEL_EXPORTER_OTLP_ENDPOINT ??
         settings.telemetry?.otlpEndpoint,
       logPrompts: argv.telemetryLogPrompts ?? settings.telemetry?.logPrompts,
+      disableDataCollection:
+        settings.telemetry?.disableDataCollection ?? true,
     },
     // Git-aware file filtering settings
     fileFilteringRespectGitIgnore: settings.fileFiltering?.respectGitIgnore,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -28,7 +28,6 @@ import { GEMINI_CONFIG_DIR as GEMINI_DIR } from '../tools/memoryTool.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { GitService } from '../services/gitService.js';
 import { getProjectTempDir } from '../utils/paths.js';
-import { getPersistentUserId } from '../utils/user_id.js';
 import {
   initializeTelemetry,
   shutdownTelemetry,
@@ -59,6 +58,7 @@ export interface TelemetrySettings {
   target?: TelemetryTarget;
   otlpEndpoint?: string;
   logPrompts?: boolean;
+  disableDataCollection?: boolean;
 }
 
 export class MCPServerConfig {
@@ -115,7 +115,6 @@ export interface ConfigParameters {
   fileDiscoveryService?: FileDiscoveryService;
   bugCommand?: BugCommandSettings;
   model: string;
-  disableDataCollection?: boolean;
 }
 
 export class Config {
@@ -150,7 +149,6 @@ export class Config {
   private readonly bugCommand: BugCommandSettings | undefined;
   private readonly model: string;
   private readonly disableDataCollection: boolean = true;
-  private readonly userId: string;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -187,8 +185,8 @@ export class Config {
     this.fileDiscoveryService = params.fileDiscoveryService ?? null;
     this.bugCommand = params.bugCommand;
     this.model = params.model;
-    this.disableDataCollection = params.disableDataCollection ?? true;
-    this.userId = getPersistentUserId();
+    this.disableDataCollection =
+      params.telemetry?.disableDataCollection ?? true;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -355,10 +353,6 @@ export class Config {
 
   getProxy(): string | undefined {
     return this.proxy;
-  }
-
-  getUserId(): string {
-    return this.userId;
   }
 
   getWorkingDir(): string {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -28,13 +28,15 @@ import { GEMINI_CONFIG_DIR as GEMINI_DIR } from '../tools/memoryTool.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { GitService } from '../services/gitService.js';
 import { getProjectTempDir } from '../utils/paths.js';
+import { getPersistentUserId } from '../utils/user_id.js';
 import {
   initializeTelemetry,
+  shutdownTelemetry,
   DEFAULT_TELEMETRY_TARGET,
   DEFAULT_OTLP_ENDPOINT,
   TelemetryTarget,
-  StartSessionEvent,
 } from '../telemetry/index.js';
+import { StartSessionEvent } from '../telemetry/types.js';
 import { DEFAULT_GEMINI_EMBEDDING_MODEL } from './models.js';
 import { ClearcutLogger } from '../telemetry/clearcut-logger/clearcut-logger.js';
 
@@ -148,6 +150,7 @@ export class Config {
   private readonly bugCommand: BugCommandSettings | undefined;
   private readonly model: string;
   private readonly disableDataCollection: boolean = true;
+  private readonly userId: string;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -185,6 +188,7 @@ export class Config {
     this.bugCommand = params.bugCommand;
     this.model = params.model;
     this.disableDataCollection = params.disableDataCollection ?? true;
+    this.userId = getPersistentUserId();
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -351,6 +355,10 @@ export class Config {
 
   getProxy(): string | undefined {
     return this.proxy;
+  }
+
+  getUserId(): string {
+    return this.userId;
   }
 
   getWorkingDir(): string {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -30,12 +30,11 @@ import { GitService } from '../services/gitService.js';
 import { getProjectTempDir } from '../utils/paths.js';
 import {
   initializeTelemetry,
-  shutdownTelemetry,
   DEFAULT_TELEMETRY_TARGET,
   DEFAULT_OTLP_ENDPOINT,
   TelemetryTarget,
+  StartSessionEvent,
 } from '../telemetry/index.js';
-import { StartSessionEvent } from '../telemetry/types.js';
 import { DEFAULT_GEMINI_EMBEDDING_MODEL } from './models.js';
 import { ClearcutLogger } from '../telemetry/clearcut-logger/clearcut-logger.js';
 
@@ -115,6 +114,7 @@ export interface ConfigParameters {
   fileDiscoveryService?: FileDiscoveryService;
   bugCommand?: BugCommandSettings;
   model: string;
+  disableDataCollection?: boolean;
 }
 
 export class Config {
@@ -148,7 +148,7 @@ export class Config {
   private readonly cwd: string;
   private readonly bugCommand: BugCommandSettings | undefined;
   private readonly model: string;
-  private readonly disableDataCollection: boolean = true;
+  private readonly disableDataCollection: boolean;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -17,6 +17,7 @@ import {
 } from '../types.js';
 import { EventMetadataKey } from './event-metadata-key.js';
 import { Config } from '../../config/config.js';
+import { getPersistentUserId } from '../../utils/user_id.js';
 
 const start_session_event_name = 'start_session';
 const new_prompt_event_name = 'new_prompt';
@@ -67,6 +68,7 @@ export class ClearcutLogger {
     return {
       Application: 'GEMINI_CLI',
       event_name: name,
+      client_install_id: getPersistentUserId(),
       event_metadata: [data] as object[],
     };
   }

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -71,6 +71,7 @@ export function initializeTelemetry(config: Config): void {
     [SemanticResourceAttributes.SERVICE_NAME]: SERVICE_NAME,
     [SemanticResourceAttributes.SERVICE_VERSION]: process.version,
     'session.id': config.getSessionId(),
+    'user.id': config.getUserId(),
   });
 
   const otlpEndpoint = config.getTelemetryOtlpEndpoint();

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -71,7 +71,6 @@ export function initializeTelemetry(config: Config): void {
     [SemanticResourceAttributes.SERVICE_NAME]: SERVICE_NAME,
     [SemanticResourceAttributes.SERVICE_VERSION]: process.version,
     'session.id': config.getSessionId(),
-    'user.id': config.getUserId(),
   });
 
   const otlpEndpoint = config.getTelemetryOtlpEndpoint();

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -48,7 +48,7 @@ export class StartSessionEvent {
   telemetry_enabled: boolean;
   telemetry_log_user_prompts_enabled: boolean;
   file_filtering_respect_git_ignore: boolean;
-  user_id: string;
+
 
   constructor(config: Config) {
     const generatorConfig = config.getContentGeneratorConfig();
@@ -77,7 +77,6 @@ export class StartSessionEvent {
       config.getTelemetryLogPromptsEnabled();
     this.file_filtering_respect_git_ignore =
       config.getFileFilteringRespectGitIgnore();
-    this.user_id = config.getUserId();
   }
 }
 
@@ -85,13 +84,11 @@ export class EndSessionEvent {
   'event.name': 'end_session';
   'event.timestamp': string; // ISO 8601
   session_id?: string;
-  user_id?: string;
 
   constructor(config?: Config) {
     this['event.name'] = 'end_session';
     this['event.timestamp'] = new Date().toISOString();
     this.session_id = config?.getSessionId();
-    this.user_id = config?.getUserId();
   }
 }
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -48,6 +48,7 @@ export class StartSessionEvent {
   telemetry_enabled: boolean;
   telemetry_log_user_prompts_enabled: boolean;
   file_filtering_respect_git_ignore: boolean;
+  user_id: string;
 
   constructor(config: Config) {
     const generatorConfig = config.getContentGeneratorConfig();
@@ -76,6 +77,7 @@ export class StartSessionEvent {
       config.getTelemetryLogPromptsEnabled();
     this.file_filtering_respect_git_ignore =
       config.getFileFilteringRespectGitIgnore();
+    this.user_id = config.getUserId();
   }
 }
 
@@ -83,11 +85,13 @@ export class EndSessionEvent {
   'event.name': 'end_session';
   'event.timestamp': string; // ISO 8601
   session_id?: string;
+  user_id?: string;
 
   constructor(config?: Config) {
     this['event.name'] = 'end_session';
     this['event.timestamp'] = new Date().toISOString();
     this.session_id = config?.getSessionId();
+    this.user_id = config?.getUserId();
   }
 }
 

--- a/packages/core/src/utils/user_id.ts
+++ b/packages/core/src/utils/user_id.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+
+const geminiDir = path.join(os.homedir(), '.gemini');
+const userIdFile = path.join(geminiDir, 'user_id');
+
+function ensureGeminiDirExists() {
+  if (!fs.existsSync(geminiDir)) {
+    fs.mkdirSync(geminiDir, { recursive: true });
+  }
+}
+
+function readUserIdFromFile(): string | null {
+  if (fs.existsSync(userIdFile)) {
+    const userId = fs.readFileSync(userIdFile, 'utf-8').trim();
+    return userId || null;
+  }
+  return null;
+}
+
+function writeUserIdToFile(userId: string) {
+  fs.writeFileSync(userIdFile, userId, 'utf-8');
+}
+
+/**
+ * Retrieves the persistent user ID from a file, creating it if it doesn't exist.
+ * This ID is used for unique user tracking in telemetry.
+ * @returns A UUID string for the user.
+ */
+export function getPersistentUserId(): string {
+  try {
+    ensureGeminiDirExists();
+    let userId = readUserIdFromFile();
+
+    if (!userId) {
+      userId = randomUUID();
+      writeUserIdToFile(userId);
+    }
+
+    return userId;
+  } catch (error) {
+    // In case of any error (e.g., permissions),
+    // generate a UUID for the session but don't persist it.
+    console.error('Error accessing persistent user ID file, generating ephemeral ID:', error);
+    return "123456789";
+  }
+}

--- a/packages/core/src/utils/user_id.ts
+++ b/packages/core/src/utils/user_id.ts
@@ -8,8 +8,9 @@ import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
+import { GEMINI_DIR } from './paths.js';
 
-const geminiDir = path.join(os.homedir(), '.gemini');
+const geminiDir = path.join(os.homedir(), GEMINI_DIR);
 const userIdFile = path.join(geminiDir, 'user_id');
 
 function ensureGeminiDirExists() {

--- a/packages/core/src/utils/user_id.ts
+++ b/packages/core/src/utils/user_id.ts
@@ -32,7 +32,7 @@ function writeUserIdToFile(userId: string) {
 
 /**
  * Retrieves the persistent user ID from a file, creating it if it doesn't exist.
- * This ID is used for unique user tracking in telemetry.
+ * This ID is used for unique user tracking.
  * @returns A UUID string for the user.
  */
 export function getPersistentUserId(): string {
@@ -47,8 +47,6 @@ export function getPersistentUserId(): string {
 
     return userId;
   } catch (error) {
-    // In case of any error (e.g., permissions),
-    // generate a UUID for the session but don't persist it.
     console.error('Error accessing persistent user ID file, generating ephemeral ID:', error);
     return "123456789";
   }


### PR DESCRIPTION
* Based off clearcut-logging
* Added unique user ids by storing a UUID in the user's home directory.
* Add support for setting the disable property in the settings file