### PR TITLE
Update memory and context summary UI for multiple context filenames

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -260,7 +260,7 @@ describe('App UI', () => {
 
   it('should display custom contextFileName in footer when set and count is 1', async () => {
     mockSettings = createMockSettings({
-      contextFileName: 'AGENTS.MD',
+      contextFileName: 'AGENTS.md',
       theme: 'Default',
     });
     mockConfig.getGeminiMdFileCount.mockReturnValue(1);
@@ -275,12 +275,12 @@ describe('App UI', () => {
     );
     currentUnmount = unmount;
     await Promise.resolve();
-    expect(lastFrame()).toContain('Using 1 AGENTS.MD file');
+    expect(lastFrame()).toContain('Using 1 AGENTS.md file');
   });
 
-  it('should display the first custom contextFileName when an array is provided', async () => {
+  it('should display a generic message when multiple context files with different names are provided', async () => {
     mockSettings = createMockSettings({
-      contextFileName: ['AGENTS.MD', 'CONTEXT.MD'],
+      contextFileName: ['AGENTS.md', 'CONTEXT.md'],
       theme: 'Default',
     });
     mockConfig.getGeminiMdFileCount.mockReturnValue(2);
@@ -295,7 +295,7 @@ describe('App UI', () => {
     );
     currentUnmount = unmount;
     await Promise.resolve();
-    expect(lastFrame()).toContain('Using 2 AGENTS.MD files');
+    expect(lastFrame()).toContain('Using 2 context files');
   });
 
   it('should display custom contextFileName with plural when set and count is > 1', async () => {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -168,7 +168,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     addItem(
       {
         type: MessageType.INFO,
-        text: 'Refreshing hierarchical memory (GEMINI.md files)...',
+        text: 'Refreshing hierarchical memory (GEMINI.md or other context files)...',
       },
       Date.now(),
     );
@@ -213,6 +213,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     pendingHistoryItems: pendingSlashCommandHistoryItems,
   } = useSlashCommandProcessor(
     config,
+    settings,
     history,
     addItem,
     clearItems,

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
@@ -28,12 +28,16 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
     return <Text> </Text>; // Render an empty space to reserve height
   }
 
-  const geminiMdText =
-    geminiMdFileCount > 0
-      ? `${geminiMdFileCount} ${contextFileNames[0]} file${
-          geminiMdFileCount > 1 ? 's' : ''
-        }`
-      : '';
+  const geminiMdText = (() => {
+    if (geminiMdFileCount === 0) {
+      return '';
+    }
+    const allNamesTheSame = new Set(contextFileNames).size < 2;
+    const name = allNamesTheSame ? contextFileNames[0] : 'context';
+    return `${geminiMdFileCount} ${name} file${
+      geminiMdFileCount > 1 ? 's' : ''
+    }`;
+  })();
 
   const mcpText =
     mcpServerCount > 0

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -62,14 +62,15 @@ import {
 } from './slashCommandProcessor.js';
 import { MessageType } from '../types.js';
 import {
-  type Config,
-  MCPServerStatus,
-  getMCPServerStatus,
+  Config,
   MCPDiscoveryState,
+  MCPServerStatus,
   getMCPDiscoveryState,
+  getMCPServerStatus,
   GeminiClient,
 } from '@gemini-cli/core';
 import { useSessionStats } from '../contexts/SessionContext.js';
+import { LoadedSettings } from '../../config/settings.js';
 
 vi.mock('@gemini-code/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@gemini-code/core')>();
@@ -161,10 +162,16 @@ describe('useSlashCommandProcessor', () => {
     process.env = { ...globalThis.process.env };
   });
 
-  const getProcessorHook = (showToolDescriptions: boolean = false) =>
-    renderHook(() =>
+  const getProcessorHook = (showToolDescriptions: boolean = false) => {
+    const settings = {
+      merged: {
+        contextFileName: 'GEMINI.md',
+      },
+    } as LoadedSettings;
+    return renderHook(() =>
       useSlashCommandProcessor(
         mockConfig,
+        settings,
         [],
         mockAddItem,
         mockClearItems,
@@ -181,6 +188,7 @@ describe('useSlashCommandProcessor', () => {
         mockSetQuittingMessages,
       ),
     );
+  };
 
   const getProcessor = (showToolDescriptions: boolean = false) =>
     getProcessorHook(showToolDescriptions).result.current;
@@ -253,7 +261,11 @@ describe('useSlashCommandProcessor', () => {
       });
       expect(
         ShowMemoryCommandModule.createShowMemoryAction,
-      ).toHaveBeenCalledWith(mockConfig, expect.any(Function));
+      ).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(Object),
+        expect.any(Function),
+      );
       expect(mockReturnedShowAction).toHaveBeenCalled();
       expect(commandResult).toBe(true);
     });

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -32,6 +32,7 @@ import { createShowMemoryAction } from './useShowMemoryCommand.js';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 import { formatDuration, formatMemoryUsage } from '../utils/formatters.js';
 import { getCliVersion } from '../../utils/version.js';
+import { LoadedSettings } from '../../config/settings.js';
 
 export interface SlashCommandActionReturn {
   shouldScheduleTool?: boolean;
@@ -60,6 +61,7 @@ export interface SlashCommand {
  */
 export const useSlashCommandProcessor = (
   config: Config | null,
+  settings: LoadedSettings,
   history: HistoryItem[],
   addItem: UseHistoryManagerReturn['addItem'],
   clearItems: UseHistoryManagerReturn['clearItems'],
@@ -135,9 +137,9 @@ export const useSlashCommandProcessor = (
   );
 
   const showMemoryAction = useCallback(async () => {
-    const actionFn = createShowMemoryAction(config, addMessage);
+    const actionFn = createShowMemoryAction(config, settings, addMessage);
     await actionFn();
-  }, [config, addMessage]);
+  }, [config, settings, addMessage]);
 
   const addMemoryAction = useCallback(
     (

--- a/packages/cli/src/ui/hooks/useShowMemoryCommand.ts
+++ b/packages/cli/src/ui/hooks/useShowMemoryCommand.ts
@@ -6,9 +6,11 @@
 
 import { Message, MessageType } from '../types.js';
 import { Config } from '@gemini-cli/core';
+import { LoadedSettings } from '../../config/settings.js';
 
 export function createShowMemoryAction(
   config: Config | null,
+  settings: LoadedSettings,
   addMessage: (message: Message) => void,
 ) {
   return async () => {
@@ -29,18 +31,26 @@ export function createShowMemoryAction(
 
     const currentMemory = config.getUserMemory();
     const fileCount = config.getGeminiMdFileCount();
+    const contextFileName = settings.merged.contextFileName;
+    const contextFileNames = Array.isArray(contextFileName)
+      ? contextFileName
+      : [contextFileName];
 
     if (debugMode) {
       console.log(
         `[DEBUG] Showing memory. Content from config.getUserMemory() (first 200 chars): ${currentMemory.substring(0, 200)}...`,
       );
-      console.log(`[DEBUG] Number of GEMINI.md files loaded: ${fileCount}`);
+      console.log(`[DEBUG] Number of context files loaded: ${fileCount}`);
     }
 
     if (fileCount > 0) {
+      const allNamesTheSame = new Set(contextFileNames).size < 2;
+      const name = allNamesTheSame ? contextFileNames[0] : 'context';
       addMessage({
         type: MessageType.INFO,
-        content: `Loaded memory from ${fileCount} GEMINI.md file(s).`,
+        content: `Loaded memory from ${fileCount} ${name} file${
+          fileCount > 1 ? 's' : ''
+        }.`,
         timestamp: new Date(),
       });
     }
@@ -48,7 +58,7 @@ export function createShowMemoryAction(
     if (currentMemory && currentMemory.trim().length > 0) {
       addMessage({
         type: MessageType.INFO,
-        content: `Current combined GEMINI.md memory content:\n\`\`\`markdown\n${currentMemory}\n\`\`\``,
+        content: `Current combined memory content:\n\`\`\`markdown\n${currentMemory}\n\`\`\``,
         timestamp: new Date(),
       });
     } else {
@@ -56,8 +66,8 @@ export function createShowMemoryAction(
         type: MessageType.INFO,
         content:
           fileCount > 0
-            ? 'Hierarchical memory (GEMINI.md) is loaded but content is empty.'
-            : 'No hierarchical memory (GEMINI.md) is currently loaded.',
+            ? 'Hierarchical memory (GEMINI.md or other context files) is loaded but content is empty.'
+            : 'No hierarchical memory (GEMINI.md or other context files) is currently loaded.',
         timestamp: new Date(),
       });
     }


### PR DESCRIPTION
## TLDR

Updates the UI to not always refer to context filenames as GEMINI.md when the config supports multiple filenames.

## Dive Deeper

When using this config: 

```
  contextFileName": ["GEMINI.md", "AGENTS.md" ],
```

The UI now uses strings like `Using 2 context files` or `Loaded memory from 2 context files.` instead of `Using 2 GEMINI.md files` or `Loaded memory from 2 GEMINI.md file(s).`.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1280 