### PR TITLE
Drop file search in completion for simpler and faster path completion

### DIFF
--- a/packages/cli/src/ui/hooks/useCompletion.integration.test.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.integration.test.ts
@@ -10,7 +10,6 @@ import { renderHook, act } from '@testing-library/react';
 import { useCompletion } from './useCompletion.js';
 import * as fs from 'fs/promises';
 import { FileDiscoveryService } from '@gemini-cli/core';
-import { glob } from 'glob';
 
 // Mock dependencies
 vi.mock('fs/promises');
@@ -25,7 +24,6 @@ vi.mock('@gemini-cli/core', async () => {
     getErrorMessage: vi.fn((error) => error.message),
   };
 });
-vi.mock('glob');
 
 describe('useCompletion git-aware filtering integration', () => {
   let mockFileDiscoveryService: Mocked<FileDiscoveryService>;

--- a/packages/cli/src/ui/hooks/useCompletion.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.ts
@@ -7,14 +7,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { glob } from 'glob';
 import {
   isNodeError,
   escapePath,
   unescapePath,
   getErrorMessage,
   Config,
-  FileDiscoveryService,
 } from '@gemini-cli/core';
 import {
   MAX_SUGGESTIONS_TO_SHOW,
@@ -213,110 +211,6 @@ export function useCompletion(
 
     let isMounted = true;
 
-    const findFilesRecursively = async (
-      startDir: string,
-      searchPrefix: string,
-      fileDiscovery: { shouldGitIgnoreFile: (path: string) => boolean } | null,
-      currentRelativePath = '',
-      depth = 0,
-      maxDepth = 10, // Limit recursion depth
-      maxResults = 50, // Limit number of results
-    ): Promise<Suggestion[]> => {
-      if (depth > maxDepth) {
-        return [];
-      }
-
-      const lowerSearchPrefix = searchPrefix.toLowerCase();
-      let foundSuggestions: Suggestion[] = [];
-      try {
-        const entries = await fs.readdir(startDir, { withFileTypes: true });
-        for (const entry of entries) {
-          if (foundSuggestions.length >= maxResults) break;
-
-          const entryPathRelative = path.join(currentRelativePath, entry.name);
-          const entryPathFromRoot = path.relative(
-            cwd,
-            path.join(startDir, entry.name),
-          );
-
-          // Conditionally ignore dotfiles
-          if (!searchPrefix.startsWith('.') && entry.name.startsWith('.')) {
-            continue;
-          }
-
-          // Check if this entry should be ignored by git-aware filtering
-          if (
-            fileDiscovery &&
-            fileDiscovery.shouldGitIgnoreFile(entryPathFromRoot)
-          ) {
-            continue;
-          }
-
-          if (entry.name.toLowerCase().startsWith(lowerSearchPrefix)) {
-            foundSuggestions.push({
-              label: entryPathRelative + (entry.isDirectory() ? '/' : ''),
-              value: escapePath(
-                entryPathRelative + (entry.isDirectory() ? '/' : ''),
-              ),
-            });
-          }
-          if (
-            entry.isDirectory() &&
-            entry.name !== 'node_modules' &&
-            !entry.name.startsWith('.')
-          ) {
-            if (foundSuggestions.length < maxResults) {
-              foundSuggestions = foundSuggestions.concat(
-                await findFilesRecursively(
-                  path.join(startDir, entry.name),
-                  searchPrefix, // Pass original searchPrefix for recursive calls
-                  fileDiscovery,
-                  entryPathRelative,
-                  depth + 1,
-                  maxDepth,
-                  maxResults - foundSuggestions.length,
-                ),
-              );
-            }
-          }
-        }
-      } catch (_err) {
-        // Ignore errors like permission denied or ENOENT during recursive search
-      }
-      return foundSuggestions.slice(0, maxResults);
-    };
-
-    const findFilesWithGlob = async (
-      searchPrefix: string,
-      fileDiscoveryService: FileDiscoveryService,
-      maxResults = 50,
-    ): Promise<Suggestion[]> => {
-      const globPattern = `**/${searchPrefix}*`;
-      const files = await glob(globPattern, {
-        cwd,
-        dot: searchPrefix.startsWith('.'),
-        nocase: true,
-      });
-
-      const suggestions: Suggestion[] = files
-        .map((file: string) => {
-          const relativePath = path.relative(cwd, file);
-          return {
-            label: relativePath,
-            value: escapePath(relativePath),
-          };
-        })
-        .filter((s) => {
-          if (fileDiscoveryService) {
-            return !fileDiscoveryService.shouldGitIgnoreFile(s.label); // relative path
-          }
-          return true;
-        })
-        .slice(0, maxResults);
-
-      return suggestions;
-    };
-
     const fetchSuggestions = async () => {
       setIsLoadingSuggestions(true);
       let fetchedSuggestions: Suggestion[] = [];
@@ -324,58 +218,41 @@ export function useCompletion(
       const fileDiscoveryService = config ? config.getFileService() : null;
 
       try {
-        // If there's no slash, or it's the root, do a recursive search from cwd
-        if (partialPath.indexOf('/') === -1 && prefix) {
-          if (fileDiscoveryService) {
-            fetchedSuggestions = await findFilesWithGlob(
-              prefix,
-              fileDiscoveryService,
-            );
-          } else {
-            fetchedSuggestions = await findFilesRecursively(
-              cwd,
-              prefix,
-              fileDiscoveryService,
-            );
+        const lowerPrefix = prefix.toLowerCase();
+        const entries = await fs.readdir(baseDirAbsolute, {
+          withFileTypes: true,
+        });
+
+        // Filter entries using git-aware filtering
+        const filteredEntries = [];
+        for (const entry of entries) {
+          // Conditionally ignore dotfiles
+          if (!prefix.startsWith('.') && entry.name.startsWith('.')) {
+            continue;
           }
-        } else {
-          // Original behavior: list files in the specific directory
-          const lowerPrefix = prefix.toLowerCase();
-          const entries = await fs.readdir(baseDirAbsolute, {
-            withFileTypes: true,
-          });
+          if (!entry.name.toLowerCase().startsWith(lowerPrefix)) continue;
 
-          // Filter entries using git-aware filtering
-          const filteredEntries = [];
-          for (const entry of entries) {
-            // Conditionally ignore dotfiles
-            if (!prefix.startsWith('.') && entry.name.startsWith('.')) {
-              continue;
-            }
-            if (!entry.name.toLowerCase().startsWith(lowerPrefix)) continue;
-
-            const relativePath = path.relative(
-              cwd,
-              path.join(baseDirAbsolute, entry.name),
-            );
-            if (
-              fileDiscoveryService &&
-              fileDiscoveryService.shouldGitIgnoreFile(relativePath)
-            ) {
-              continue;
-            }
-
-            filteredEntries.push(entry);
+          const relativePath = path.relative(
+            cwd,
+            path.join(baseDirAbsolute, entry.name),
+          );
+          if (
+            fileDiscoveryService &&
+            fileDiscoveryService.shouldGitIgnoreFile(relativePath)
+          ) {
+            continue;
           }
 
-          fetchedSuggestions = filteredEntries.map((entry) => {
-            const label = entry.isDirectory() ? entry.name + '/' : entry.name;
-            return {
-              label,
-              value: escapePath(label), // Value for completion should be just the name part
-            };
-          });
+          filteredEntries.push(entry);
         }
+
+        fetchedSuggestions = filteredEntries.map((entry) => {
+          const label = entry.isDirectory() ? entry.name + '/' : entry.name;
+          return {
+            label,
+            value: escapePath(label), // Value for completion should be just the name part
+          };
+        });
 
         // Sort by depth, then directories first, then alphabetically
         fetchedSuggestions.sort((a, b) => {


### PR DESCRIPTION
## TLDR

When in a remote or large filesystem, doing a recursive glob is very expensive. Drop the feature for a simpler and faster completion.

## Dive Deeper

Currently you can use @-completion to find flies anywhere in the local tree, for example typing in `@useFoo` will search from the current directory for any file called `useFoo` in any subdirectory. When running gemini-cli from a remote filesystem, this can be very expensive and slow. While we could keep the feature or make it optional, this patch opts for just removing the capability for now.

## Reviewer Test Plan

This change should be straightforward as it is just removing a feature, but also possible I broke something! Please actually try this out :)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1285