### PR TITLE
Jacob314/overflow notification and one MaxSizedBox bug fix

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -68,6 +68,8 @@ import * as fs from 'fs';
 import { UpdateNotification } from './components/UpdateNotification.js';
 import { checkForUpdates } from './utils/updateCheck.js';
 import ansiEscapes from 'ansi-escapes';
+import { OverflowProvider } from './contexts/OverflowContext.js';
+import { ShowMoreLines } from './components/ShowMoreLines.js';
 
 const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
 
@@ -560,23 +562,27 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
         >
           {(item) => item}
         </Static>
-        <Box ref={pendingHistoryItemRef}>
-          {pendingHistoryItems.map((item, i) => (
-            <HistoryItemDisplay
-              key={i}
-              availableTerminalHeight={
-                constrainHeight ? availableTerminalHeight : undefined
-              }
-              terminalWidth={mainAreaWidth}
-              // TODO(taehykim): It seems like references to ids aren't necessary in
-              // HistoryItemDisplay. Refactor later. Use a fake id for now.
-              item={{ ...item, id: 0 }}
-              isPending={true}
-              config={config}
-              isFocused={!isEditorDialogOpen}
-            />
-          ))}
-        </Box>
+        <OverflowProvider>
+          <Box ref={pendingHistoryItemRef} flexDirection="column">
+            {pendingHistoryItems.map((item, i) => (
+              <HistoryItemDisplay
+                key={i}
+                availableTerminalHeight={
+                  constrainHeight ? availableTerminalHeight : undefined
+                }
+                terminalWidth={mainAreaWidth}
+                // TODO(taehykim): It seems like references to ids aren't necessary in
+                // HistoryItemDisplay. Refactor later. Use a fake id for now.
+                item={{ ...item, id: 0 }}
+                isPending={true}
+                config={config}
+                isFocused={!isEditorDialogOpen}
+              />
+            ))}
+            <ShowMoreLines constrainHeight={constrainHeight} />
+          </Box>
+        </OverflowProvider>
+
         {showHelp && <Help commands={slashCommands} />}
 
         <Box flexDirection="column" ref={mainControlsRef}>
@@ -700,13 +706,16 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
               </Box>
 
               {showErrorDetails && (
-                <DetailedMessagesDisplay
-                  messages={filteredConsoleMessages}
-                  maxHeight={
-                    constrainHeight ? debugConsoleMaxHeight : undefined
-                  }
-                  width={inputWidth}
-                />
+                <OverflowProvider>
+                  <DetailedMessagesDisplay
+                    messages={filteredConsoleMessages}
+                    maxHeight={
+                      constrainHeight ? debugConsoleMaxHeight : undefined
+                    }
+                    width={inputWidth}
+                  />
+                  <ShowMoreLines constrainHeight={constrainHeight} />
+                </OverflowProvider>
               )}
 
               {isInputActive && (

--- a/packages/cli/src/ui/components/ShowMoreLines.tsx
+++ b/packages/cli/src/ui/components/ShowMoreLines.tsx
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Text } from 'ink';
+import { useOverflowState } from '../contexts/OverflowContext.js';
+import { Colors } from '../colors.js';
+
+interface ShowMoreLinesProps {
+  constrainHeight: boolean;
+}
+
+export const ShowMoreLines = ({ constrainHeight }: ShowMoreLinesProps) => {
+  const overflowState = useOverflowState();
+
+  if (
+    overflowState === undefined ||
+    overflowState.overflowingIds.size === 0 ||
+    !constrainHeight
+  ) {
+    return null;
+  }
+
+  return (
+    <Box>
+      <Text color={Colors.Gray} wrap="truncate">
+        Press Ctrl-S to show more lines
+      </Text>
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/messages/DiffRenderer.test.tsx
+++ b/packages/cli/src/ui/components/messages/DiffRenderer.test.tsx
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { OverflowProvider } from '../../contexts/OverflowContext.js';
 import { render } from 'ink-testing-library';
 import { DiffRenderer } from './DiffRenderer.js';
 import * as CodeColorizer from '../../utils/CodeColorizer.js';
 import { vi } from 'vitest';
 
-describe('<DiffRenderer />', () => {
+describe('<OverflowProvider><DiffRenderer /></OverflowProvider>', () => {
   const mockColorizeCode = vi.spyOn(CodeColorizer, 'colorizeCode');
 
   beforeEach(() => {
@@ -30,11 +31,13 @@ index 0000000..e69de29
 +print("hello world")
 `;
     render(
-      <DiffRenderer
-        diffContent={newFileDiffContent}
-        filename="test.py"
-        terminalWidth={80}
-      />,
+      <OverflowProvider>
+        <DiffRenderer
+          diffContent={newFileDiffContent}
+          filename="test.py"
+          terminalWidth={80}
+        />
+      </OverflowProvider>,
     );
     expect(mockColorizeCode).toHaveBeenCalledWith(
       'print("hello world")',
@@ -55,11 +58,13 @@ index 0000000..e69de29
 +some content
 `;
     render(
-      <DiffRenderer
-        diffContent={newFileDiffContent}
-        filename="test.unknown"
-        terminalWidth={80}
-      />,
+      <OverflowProvider>
+        <DiffRenderer
+          diffContent={newFileDiffContent}
+          filename="test.unknown"
+          terminalWidth={80}
+        />
+      </OverflowProvider>,
     );
     expect(mockColorizeCode).toHaveBeenCalledWith(
       'some content',
@@ -80,7 +85,9 @@ index 0000000..e69de29
 +some text content
 `;
     render(
-      <DiffRenderer diffContent={newFileDiffContent} terminalWidth={80} />,
+      <OverflowProvider>
+        <DiffRenderer diffContent={newFileDiffContent} terminalWidth={80} />
+      </OverflowProvider>,
     );
     expect(mockColorizeCode).toHaveBeenCalledWith(
       'some text content',
@@ -101,11 +108,13 @@ index 0000001..0000002 100644
 +new line
 `;
     const { lastFrame } = render(
-      <DiffRenderer
-        diffContent={existingFileDiffContent}
-        filename="test.txt"
-        terminalWidth={80}
-      />,
+      <OverflowProvider>
+        <DiffRenderer
+          diffContent={existingFileDiffContent}
+          filename="test.txt"
+          terminalWidth={80}
+        />
+      </OverflowProvider>,
     );
     // colorizeCode is used internally by the line-by-line rendering, not for the whole block
     expect(mockColorizeCode).not.toHaveBeenCalledWith(
@@ -129,11 +138,13 @@ index 1234567..1234567 100644
 +++ b/file.txt
 `;
     const { lastFrame } = render(
-      <DiffRenderer
-        diffContent={noChangeDiff}
-        filename="file.txt"
-        terminalWidth={80}
-      />,
+      <OverflowProvider>
+        <DiffRenderer
+          diffContent={noChangeDiff}
+          filename="file.txt"
+          terminalWidth={80}
+        />
+      </OverflowProvider>,
     );
     expect(lastFrame()).toContain('No changes detected');
     expect(mockColorizeCode).not.toHaveBeenCalled();
@@ -141,7 +152,9 @@ index 1234567..1234567 100644
 
   it('should handle empty diff content', () => {
     const { lastFrame } = render(
-      <DiffRenderer diffContent="" terminalWidth={80} />,
+      <OverflowProvider>
+        <DiffRenderer diffContent="" terminalWidth={80} />
+      </OverflowProvider>,
     );
     expect(lastFrame()).toContain('No diff content');
     expect(mockColorizeCode).not.toHaveBeenCalled();
@@ -162,11 +175,13 @@ index 123..456 100644
  context line 11
 `;
     const { lastFrame } = render(
-      <DiffRenderer
-        diffContent={diffWithGap}
-        filename="file.txt"
-        terminalWidth={80}
-      />,
+      <OverflowProvider>
+        <DiffRenderer
+          diffContent={diffWithGap}
+          filename="file.txt"
+          terminalWidth={80}
+        />
+      </OverflowProvider>,
     );
     const output = lastFrame();
     expect(output).toContain('═'); // Check for the border character used in the gap
@@ -197,11 +212,13 @@ index abc..def 100644
  context line 15
 `;
     const { lastFrame } = render(
-      <DiffRenderer
-        diffContent={diffWithSmallGap}
-        filename="file.txt"
-        terminalWidth={80}
-      />,
+      <OverflowProvider>
+        <DiffRenderer
+          diffContent={diffWithSmallGap}
+          filename="file.txt"
+          terminalWidth={80}
+        />
+      </OverflowProvider>,
     );
     const output = lastFrame();
     expect(output).not.toContain('═'); // Ensure no separator is rendered
@@ -267,12 +284,14 @@ index 123..789 100644
       'with terminalWidth $terminalWidth and height $height',
       ({ terminalWidth, height, expected }) => {
         const { lastFrame } = render(
-          <DiffRenderer
-            diffContent={diffWithMultipleHunks}
-            filename="multi.js"
-            terminalWidth={terminalWidth}
-            availableTerminalHeight={height}
-          />,
+          <OverflowProvider>
+            <DiffRenderer
+              diffContent={diffWithMultipleHunks}
+              filename="multi.js"
+              terminalWidth={terminalWidth}
+              availableTerminalHeight={height}
+            />
+          </OverflowProvider>,
         );
         const output = lastFrame();
         expect(sanitizeOutput(output, terminalWidth)).toEqual(expected);
@@ -297,11 +316,13 @@ fileDiff Index: file.txt
 \\ No newline at end of file  
 `;
     const { lastFrame } = render(
-      <DiffRenderer
-        diffContent={newFileDiff}
-        filename="TEST"
-        terminalWidth={80}
-      />,
+      <OverflowProvider>
+        <DiffRenderer
+          diffContent={newFileDiff}
+          filename="TEST"
+          terminalWidth={80}
+        />
+      </OverflowProvider>,
     );
     const output = lastFrame();
 
@@ -325,11 +346,13 @@ fileDiff Index: Dockerfile
 \\ No newline at end of file  
 `;
     const { lastFrame } = render(
-      <DiffRenderer
-        diffContent={newFileDiff}
-        filename="Dockerfile"
-        terminalWidth={80}
-      />,
+      <OverflowProvider>
+        <DiffRenderer
+          diffContent={newFileDiff}
+          filename="Dockerfile"
+          terminalWidth={80}
+        />
+      </OverflowProvider>,
     );
     const output = lastFrame();
     expect(output).toEqual(`1 FROM node:14

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -77,7 +77,6 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
       marginLeft={1}
       borderDimColor={hasPending}
       borderColor={borderColor}
-      marginBottom={1}
     >
       {toolCalls.map((tool) => {
         const isConfirming = toolAwaitingApproval?.callId === tool.callId;

--- a/packages/cli/src/ui/components/shared/MaxSizedBox.test.tsx
+++ b/packages/cli/src/ui/components/shared/MaxSizedBox.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { render } from 'ink-testing-library';
+import { OverflowProvider } from '../../contexts/OverflowContext.js';
 import { MaxSizedBox, setMaxSizedBoxDebugging } from './MaxSizedBox.js';
 import { Box, Text } from 'ink';
 import { describe, it, expect } from 'vitest';
@@ -18,28 +19,32 @@ describe('<MaxSizedBox />', () => {
 
   it('renders children without truncation when they fit', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={80} maxHeight={10}>
-        <Box>
-          <Text>Hello, World!</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={80} maxHeight={10}>
+          <Box>
+            <Text>Hello, World!</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
     expect(lastFrame()).equals('Hello, World!');
   });
 
   it('hides lines when content exceeds maxHeight', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={80} maxHeight={2}>
-        <Box>
-          <Text>Line 1</Text>
-        </Box>
-        <Box>
-          <Text>Line 2</Text>
-        </Box>
-        <Box>
-          <Text>Line 3</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={80} maxHeight={2}>
+          <Box>
+            <Text>Line 1</Text>
+          </Box>
+          <Box>
+            <Text>Line 2</Text>
+          </Box>
+          <Box>
+            <Text>Line 3</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
     expect(lastFrame()).equals(`... first 2 lines hidden ...
 Line 3`);
@@ -47,17 +52,19 @@ Line 3`);
 
   it('hides lines at the end when content exceeds maxHeight and overflowDirection is bottom', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={80} maxHeight={2} overflowDirection="bottom">
-        <Box>
-          <Text>Line 1</Text>
-        </Box>
-        <Box>
-          <Text>Line 2</Text>
-        </Box>
-        <Box>
-          <Text>Line 3</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={80} maxHeight={2} overflowDirection="bottom">
+          <Box>
+            <Text>Line 1</Text>
+          </Box>
+          <Box>
+            <Text>Line 2</Text>
+          </Box>
+          <Box>
+            <Text>Line 3</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
     expect(lastFrame()).equals(`Line 1
 ... last 2 lines hidden ...`);
@@ -65,11 +72,13 @@ Line 3`);
 
   it('wraps text that exceeds maxWidth', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={10} maxHeight={5}>
-        <Box>
-          <Text wrap="wrap">This is a long line of text</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={10} maxHeight={5}>
+          <Box>
+            <Text wrap="wrap">This is a long line of text</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
 
     expect(lastFrame()).equals(`This is a
@@ -82,19 +91,21 @@ of text`);
 And has a line break.
   Leading spaces preserved.`;
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={20} maxHeight={20}>
-        <Box>
-          <Text>Example</Text>
-        </Box>
-        <Box>
-          <Text>No Wrap: </Text>
-          <Text wrap="wrap">{multilineText}</Text>
-        </Box>
-        <Box>
-          <Text>Longer No Wrap: </Text>
-          <Text wrap="wrap">This part will wrap around.</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={20} maxHeight={20}>
+          <Box>
+            <Text>Example</Text>
+          </Box>
+          <Box>
+            <Text>No Wrap: </Text>
+            <Text wrap="wrap">{multilineText}</Text>
+          </Box>
+          <Box>
+            <Text>Longer No Wrap: </Text>
+            <Text wrap="wrap">This part will wrap around.</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
 
     expect(lastFrame()).equals(
@@ -118,11 +129,13 @@ Longer No Wrap: This
 
   it('handles words longer than maxWidth by splitting them', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={5} maxHeight={5}>
-        <Box>
-          <Text wrap="wrap">Supercalifragilisticexpialidocious</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={5} maxHeight={5}>
+          <Box>
+            <Text wrap="wrap">Supercalifragilisticexpialidocious</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
 
     expect(lastFrame()).equals(`... …
@@ -134,14 +147,16 @@ ious`);
 
   it('does not truncate when maxHeight is undefined', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={80} maxHeight={undefined}>
-        <Box>
-          <Text>Line 1</Text>
-        </Box>
-        <Box>
-          <Text>Line 2</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={80} maxHeight={undefined}>
+          <Box>
+            <Text>Line 1</Text>
+          </Box>
+          <Box>
+            <Text>Line 2</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
     expect(lastFrame()).equals(`Line 1
 Line 2`);
@@ -149,17 +164,19 @@ Line 2`);
 
   it('shows plural "lines" when more than one line is hidden', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={80} maxHeight={2}>
-        <Box>
-          <Text>Line 1</Text>
-        </Box>
-        <Box>
-          <Text>Line 2</Text>
-        </Box>
-        <Box>
-          <Text>Line 3</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={80} maxHeight={2}>
+          <Box>
+            <Text>Line 1</Text>
+          </Box>
+          <Box>
+            <Text>Line 2</Text>
+          </Box>
+          <Box>
+            <Text>Line 3</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
     expect(lastFrame()).equals(`... first 2 lines hidden ...
 Line 3`);
@@ -167,17 +184,19 @@ Line 3`);
 
   it('shows plural "lines" when more than one line is hidden and overflowDirection is bottom', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={80} maxHeight={2} overflowDirection="bottom">
-        <Box>
-          <Text>Line 1</Text>
-        </Box>
-        <Box>
-          <Text>Line 2</Text>
-        </Box>
-        <Box>
-          <Text>Line 3</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={80} maxHeight={2} overflowDirection="bottom">
+          <Box>
+            <Text>Line 1</Text>
+          </Box>
+          <Box>
+            <Text>Line 2</Text>
+          </Box>
+          <Box>
+            <Text>Line 3</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
     expect(lastFrame()).equals(`Line 1
 ... last 2 lines hidden ...`);
@@ -185,7 +204,9 @@ Line 3`);
 
   it('renders an empty box for empty children', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={80} maxHeight={10}></MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={80} maxHeight={10}></MaxSizedBox>
+      </OverflowProvider>,
     );
     // Expect an empty string or a box with nothing in it.
     // Ink renders an empty box as an empty string.
@@ -194,11 +215,13 @@ Line 3`);
 
   it('wraps text with multi-byte unicode characters correctly', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={5} maxHeight={5}>
-        <Box>
-          <Text wrap="wrap">你好世界</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={5} maxHeight={5}>
+          <Box>
+            <Text wrap="wrap">你好世界</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
 
     // "你好" has a visual width of 4. "世界" has a visual width of 4.
@@ -209,11 +232,13 @@ Line 3`);
 
   it('wraps text with multi-byte emoji characters correctly', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={5} maxHeight={5}>
-        <Box>
-          <Text wrap="wrap">🐶🐶🐶🐶🐶</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={5} maxHeight={5}>
+          <Box>
+            <Text wrap="wrap">🐶🐶🐶🐶🐶</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
 
     // Each "🐶" has a visual width of 2.
@@ -225,17 +250,19 @@ Line 3`);
 
   it('accounts for additionalHiddenLinesCount', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={80} maxHeight={2} additionalHiddenLinesCount={5}>
-        <Box>
-          <Text>Line 1</Text>
-        </Box>
-        <Box>
-          <Text>Line 2</Text>
-        </Box>
-        <Box>
-          <Text>Line 3</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={80} maxHeight={2} additionalHiddenLinesCount={5}>
+          <Box>
+            <Text>Line 1</Text>
+          </Box>
+          <Box>
+            <Text>Line 2</Text>
+          </Box>
+          <Box>
+            <Text>Line 3</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
     // 1 line is hidden by overflow, 5 are additionally hidden.
     expect(lastFrame()).equals(`... first 7 lines hidden ...
@@ -244,19 +271,21 @@ Line 3`);
 
   it('handles React.Fragment as a child', () => {
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={80} maxHeight={10}>
-        <>
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={80} maxHeight={10}>
+          <>
+            <Box>
+              <Text>Line 1 from Fragment</Text>
+            </Box>
+            <Box>
+              <Text>Line 2 from Fragment</Text>
+            </Box>
+          </>
           <Box>
-            <Text>Line 1 from Fragment</Text>
+            <Text>Line 3 direct child</Text>
           </Box>
-          <Box>
-            <Text>Line 2 from Fragment</Text>
-          </Box>
-        </>
-        <Box>
-          <Text>Line 3 direct child</Text>
-        </Box>
-      </MaxSizedBox>,
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
     expect(lastFrame()).equals(`Line 1 from Fragment
 Line 2 from Fragment
@@ -270,11 +299,13 @@ Line 3 direct child`);
     ).join('\n');
 
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={80} maxHeight={10}>
-        <Box>
-          <Text>{THIRTY_LINES}</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={80} maxHeight={10}>
+          <Box>
+            <Text>{THIRTY_LINES}</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
 
     const expected = [
@@ -292,11 +323,13 @@ Line 3 direct child`);
     ).join('\n');
 
     const { lastFrame } = render(
-      <MaxSizedBox maxWidth={80} maxHeight={10} overflowDirection="bottom">
-        <Box>
-          <Text>{THIRTY_LINES}</Text>
-        </Box>
-      </MaxSizedBox>,
+      <OverflowProvider>
+        <MaxSizedBox maxWidth={80} maxHeight={10} overflowDirection="bottom">
+          <Box>
+            <Text>{THIRTY_LINES}</Text>
+          </Box>
+        </MaxSizedBox>
+      </OverflowProvider>,
     );
 
     const expected = [

--- a/packages/cli/src/ui/contexts/OverflowContext.tsx
+++ b/packages/cli/src/ui/contexts/OverflowContext.tsx
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useMemo,
+} from 'react';
+
+interface OverflowState {
+  overflowingIds: ReadonlySet<string>;
+}
+
+interface OverflowActions {
+  addOverflowingId: (id: string) => void;
+  removeOverflowingId: (id: string) => void;
+}
+
+const OverflowStateContext = createContext<OverflowState | undefined>(
+  undefined,
+);
+
+const OverflowActionsContext = createContext<OverflowActions | undefined>(
+  undefined,
+);
+
+export const useOverflowState = (): OverflowState | undefined =>
+  useContext(OverflowStateContext);
+
+export const useOverflowActions = (): OverflowActions | undefined =>
+  useContext(OverflowActionsContext);
+
+export const OverflowProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [overflowingIds, setOverflowingIds] = useState(new Set<string>());
+
+  const addOverflowingId = useCallback((id: string) => {
+    setOverflowingIds((prevIds) => {
+      if (prevIds.has(id)) {
+        return prevIds;
+      }
+      const newIds = new Set(prevIds);
+      newIds.add(id);
+      return newIds;
+    });
+  }, []);
+
+  const removeOverflowingId = useCallback((id: string) => {
+    setOverflowingIds((prevIds) => {
+      if (!prevIds.has(id)) {
+        return prevIds;
+      }
+      const newIds = new Set(prevIds);
+      newIds.delete(id);
+      return newIds;
+    });
+  }, []);
+
+  const stateValue = useMemo(
+    () => ({
+      overflowingIds,
+    }),
+    [overflowingIds],
+  );
+
+  const actionsValue = useMemo(
+    () => ({
+      addOverflowingId,
+      removeOverflowingId,
+    }),
+    [addOverflowingId, removeOverflowingId],
+  );
+
+  return (
+    <OverflowStateContext.Provider value={stateValue}>
+      <OverflowActionsContext.Provider value={actionsValue}>
+        {children}
+      </OverflowActionsContext.Provider>
+    </OverflowStateContext.Provider>
+  );
+};

--- a/packages/cli/src/ui/utils/CodeColorizer.tsx
+++ b/packages/cli/src/ui/utils/CodeColorizer.tsx
@@ -16,7 +16,10 @@ import type {
 } from 'hast';
 import { themeManager } from '../themes/theme-manager.js';
 import { Theme } from '../themes/theme.js';
-import { MaxSizedBox } from '../components/shared/MaxSizedBox.js';
+import {
+  MaxSizedBox,
+  MINIMUM_MAX_HEIGHT,
+} from '../components/shared/MaxSizedBox.js';
 
 // Configure themeing and parsing utilities.
 const lowlight = createLowlight(common);
@@ -85,8 +88,6 @@ function renderHastNode(
   return null;
 }
 
-const RESERVED_LINES_FOR_TRUNCATION_MESSAGE = 2;
-
 /**
  * Renders syntax-highlighted code for Ink applications using a selected theme.
  *
@@ -111,11 +112,11 @@ export function colorizeCode(
 
     let hiddenLinesCount = 0;
 
-    // Optimizaiton to avoid highlighting lines that cannot possibly be displayed.
-    if (availableHeight && lines.length > availableHeight) {
-      const sliceIndex =
-        lines.length - availableHeight + RESERVED_LINES_FOR_TRUNCATION_MESSAGE;
-      if (sliceIndex > 0) {
+    // Optimization to avoid highlighting lines that cannot possibly be displayed.
+    if (availableHeight !== undefined) {
+      availableHeight = Math.max(availableHeight, MINIMUM_MAX_HEIGHT);
+      if (lines.length > availableHeight) {
+        const sliceIndex = lines.length - availableHeight;
         hiddenLinesCount = sliceIndex;
         lines = lines.slice(sliceIndex);
       }


### PR DESCRIPTION
## TLDR

This pull request has two commits.
The first changes the UI to show "Press Ctrl-S to show more lines" 

Show grey messages saying 
"Press Ctrl-S to show more lines" 
bellow both boxes in the UI where important content is truncated.

Original UX mock from Miguel:
![image](https://github.com/user-attachments/assets/542b7614-ed55-4635-a12a-0b865082afee)

Screenshot of how it typically shows tool confirmations
![image](https://github.com/user-attachments/assets/cbd15b32-1858-41a0-bd73-b4c851956b7f)

Screenshot showing how this looks for the debug console.
![image](https://github.com/user-attachments/assets/c9abbd56-4132-4a7f-9aad-44bdee75124d)

The second fixes a bug where the optimization to truncate code in CodeColorizer would sometimes truncate all the lines before passing them to MaxSizedBox due to a logic bug. Also added a minimum height to MaxSizedBox to ensure we don't have any cases where were setting MaxSizedBox objects to have too small a height to show some actual text as well as the truncation message.

## Dive Deeper

It is crucial this code doesn't cause infinite re-rendering and in fact Gemini CLIs first implementation of this did.

In the unlikely even that you have confirmation messages for the debug console and the main ui at the same time, we will show the message twice once bellow each box but that is an ok tradeoff to have both messages show more intuitively for the typical cases.

We don't bother showing this for the Theme dialog because while it could truncate, the truncated text barely matters.
