### PR TITLE
feat: Add client-initiated tool call handling

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -89,6 +89,7 @@ export async function runNonInteractive(
             callId,
             name: fc.name as string,
             args: (fc.args ?? {}) as Record<string, unknown>,
+            isClientInitiated: false,
           };
 
           const toolResponse = await executeToolCall(

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -362,6 +362,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     shellModeActive,
     getPreferredEditor,
     onAuthError,
+    performMemoryRefresh,
   );
   pendingHistoryItems.push(...pendingGeminiHistoryItems);
   const { elapsedTime, currentLoadingPhrase } =

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -389,6 +389,7 @@ describe('useGeminiStream', () => {
           >,
           shellModeActive: false,
           loadedSettings: mockLoadedSettings,
+          toolCalls: initialToolCalls,
         },
       },
     );
@@ -404,7 +405,12 @@ describe('useGeminiStream', () => {
   it('should not submit tool responses if not all tool calls are completed', () => {
     const toolCalls: TrackedToolCall[] = [
       {
-        request: { callId: 'call1', name: 'tool1', args: {} },
+        request: {
+          callId: 'call1',
+          name: 'tool1',
+          args: {},
+          isClientInitiated: false,
+        },
         status: 'success',
         responseSubmittedToGemini: false,
         response: {
@@ -452,133 +458,136 @@ describe('useGeminiStream', () => {
     const toolCall2ResponseParts: PartListUnion = [
       { text: 'tool 2 final response' },
     ];
-
-    // Simplified toolCalls to ensure the filter logic is the focus
-    const simplifiedToolCalls: TrackedToolCall[] = [
+    const completedToolCalls: TrackedToolCall[] = [
       {
-        request: { callId: 'call1', name: 'tool1', args: {} },
+        request: {
+          callId: 'call1',
+          name: 'tool1',
+          args: {},
+          isClientInitiated: false,
+        },
         status: 'success',
         responseSubmittedToGemini: false,
-        response: {
-          callId: 'call1',
-          responseParts: toolCall1ResponseParts,
-          error: undefined,
-          resultDisplay: 'Tool 1 success display',
-        },
-        tool: {
-          name: 'tool1',
-          description: 'desc',
-          getDescription: vi.fn(),
-        } as any,
-        startTime: Date.now(),
-        endTime: Date.now(),
+        response: { callId: 'call1', responseParts: toolCall1ResponseParts },
       } as TrackedCompletedToolCall,
       {
-        request: { callId: 'call2', name: 'tool2', args: {} },
-        status: 'cancelled',
-        responseSubmittedToGemini: false,
-        response: {
+        request: {
           callId: 'call2',
-          responseParts: toolCall2ResponseParts,
-          error: undefined,
-          resultDisplay: 'Tool 2 cancelled display',
-        },
-        tool: {
           name: 'tool2',
-          description: 'desc',
-          getDescription: vi.fn(),
-        } as any,
-        startTime: Date.now(),
-        endTime: Date.now(),
-        reason: 'test cancellation',
-      } as TrackedCancelledToolCall,
+          args: {},
+          isClientInitiated: false,
+        },
+        status: 'error',
+        responseSubmittedToGemini: false,
+        response: { callId: 'call2', responseParts: toolCall2ResponseParts },
+      } as TrackedCompletedToolCall, // Treat error as a form of completion for submission
     ];
 
-    const {
-      rerender,
+    // 1. On the first render, there are no tool calls.
+    mockUseReactToolScheduler.mockReturnValue([
+      [],
+      mockScheduleToolCalls,
       mockMarkToolsAsSubmitted,
-      mockSendMessageStream: localMockSendMessageStream,
-      client,
-    } = renderTestHook(simplifiedToolCalls);
+    ]);
+    const { rerender } = renderHook(() =>
+      useGeminiStream(
+        new MockedGeminiClientClass(mockConfig),
+        [],
+        mockAddItem,
+        mockSetShowHelp,
+        mockConfig,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+      ),
+    );
 
+    // 2. Before the second render, change the mock to return the completed tools.
+    mockUseReactToolScheduler.mockReturnValue([
+      completedToolCalls,
+      mockScheduleToolCalls,
+      mockMarkToolsAsSubmitted,
+    ]);
+
+    // 3. Trigger a re-render. The hook will now receive the completed tools, causing the effect to run.
     act(() => {
-      rerender({
-        client,
-        history: [],
-        addItem: mockAddItem,
-        setShowHelp: mockSetShowHelp,
-        config: mockConfig,
-        onDebugMessage: mockOnDebugMessage,
-        handleSlashCommand:
-          mockHandleSlashCommand as unknown as typeof mockHandleSlashCommand,
-        shellModeActive: false,
-        loadedSettings: mockLoadedSettings,
-      });
+      rerender();
     });
 
     await waitFor(() => {
-      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledTimes(0);
-      expect(localMockSendMessageStream).toHaveBeenCalledTimes(0);
+      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledTimes(1);
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
     });
 
     const expectedMergedResponse = mergePartListUnions([
       toolCall1ResponseParts,
       toolCall2ResponseParts,
     ]);
-    expect(localMockSendMessageStream).toHaveBeenCalledWith(
+    expect(mockSendMessageStream).toHaveBeenCalledWith(
       expectedMergedResponse,
       expect.any(AbortSignal),
     );
   });
 
   it('should handle all tool calls being cancelled', async () => {
-    const toolCalls: TrackedToolCall[] = [
+    const cancelledToolCalls: TrackedToolCall[] = [
       {
-        request: { callId: '1', name: 'testTool', args: {} },
-        status: 'cancelled',
-        response: {
+        request: {
           callId: '1',
-          responseParts: [{ text: 'cancelled' }],
-          error: undefined,
-          resultDisplay: 'Tool 1 cancelled display',
-        },
-        responseSubmittedToGemini: false,
-        tool: {
           name: 'testTool',
-          description: 'desc',
-          getDescription: vi.fn(),
-        } as any,
-      },
+          args: {},
+          isClientInitiated: false,
+        },
+        status: 'cancelled',
+        response: { callId: '1', responseParts: [{ text: 'cancelled' }] },
+        responseSubmittedToGemini: false,
+      } as TrackedCancelledToolCall,
     ];
-
     const client = new MockedGeminiClientClass(mockConfig);
-    const { mockMarkToolsAsSubmitted, rerender } = renderTestHook(
-      toolCalls,
-      client,
+
+    // 1. First render: no tool calls.
+    mockUseReactToolScheduler.mockReturnValue([
+      [],
+      mockScheduleToolCalls,
+      mockMarkToolsAsSubmitted,
+    ]);
+    const { rerender } = renderHook(() =>
+      useGeminiStream(
+        client,
+        [],
+        mockAddItem,
+        mockSetShowHelp,
+        mockConfig,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+      ),
     );
 
+    // 2. Second render: tool calls are now cancelled.
+    mockUseReactToolScheduler.mockReturnValue([
+      cancelledToolCalls,
+      mockScheduleToolCalls,
+      mockMarkToolsAsSubmitted,
+    ]);
+
+    // 3. Trigger the re-render.
     act(() => {
-      rerender({
-        client,
-        history: [],
-        addItem: mockAddItem,
-        setShowHelp: mockSetShowHelp,
-        config: mockConfig,
-        onDebugMessage: mockOnDebugMessage,
-        handleSlashCommand:
-          mockHandleSlashCommand as unknown as typeof mockHandleSlashCommand,
-        shellModeActive: false,
-        loadedSettings: mockLoadedSettings,
-      });
+      rerender();
     });
 
     await waitFor(() => {
-      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledTimes(0);
-      expect(client.addHistory).toHaveBeenCalledTimes(2);
+      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith(['1']);
       expect(client.addHistory).toHaveBeenCalledWith({
         role: 'user',
         parts: [{ text: 'cancelled' }],
       });
+      // Ensure we do NOT call back to the API
+      expect(mockSendMessageStream).not.toHaveBeenCalled();
     });
   });
 
@@ -708,7 +717,6 @@ describe('useGeminiStream', () => {
         loadedSettings: mockLoadedSettings,
         // This is the key part of the test: update the toolCalls array
         // to simulate the tool finishing.
-        // @ts-expect-error - we are adding a property to the props object
         toolCalls: completedToolCalls,
       });
     });
@@ -872,6 +880,89 @@ describe('useGeminiStream', () => {
 
       // Nothing should happen because the state is not `Responding`
       expect(abortSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Client-Initiated Tool Calls', () => {
+    it('should execute a client-initiated tool without sending a response to Gemini', async () => {
+      const clientToolRequest = {
+        shouldScheduleTool: true,
+        toolName: 'save_memory',
+        toolArgs: { fact: 'test fact' },
+      };
+      mockHandleSlashCommand.mockResolvedValue(clientToolRequest);
+
+      const completedToolCall: TrackedCompletedToolCall = {
+        request: {
+          callId: 'client-call-1',
+          name: clientToolRequest.toolName,
+          args: clientToolRequest.toolArgs,
+          isClientInitiated: true,
+        },
+        status: 'success',
+        responseSubmittedToGemini: false,
+        response: {
+          callId: 'client-call-1',
+          responseParts: [{ text: 'Memory saved' }],
+          resultDisplay: 'Success: Memory saved',
+          error: undefined,
+        },
+        tool: {
+          name: clientToolRequest.toolName,
+          description: 'Saves memory',
+          getDescription: vi.fn(),
+        } as any,
+      };
+
+      // 1. Initial render state: no tool calls
+      mockUseReactToolScheduler.mockReturnValue([
+        [],
+        mockScheduleToolCalls,
+        mockMarkToolsAsSubmitted,
+      ]);
+
+      const { result, rerender } = renderHook(() =>
+        useGeminiStream(
+          new MockedGeminiClientClass(mockConfig),
+          [],
+          mockAddItem,
+          mockSetShowHelp,
+          mockConfig,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+        ),
+      );
+
+      // --- User runs the slash command ---
+      await act(async () => {
+        await result.current.submitQuery('/memory add "test fact"');
+      });
+
+      // The command handler schedules the tool. Now we simulate the tool completing.
+      // 2. Before the next render, set the mock to return the completed tool.
+      mockUseReactToolScheduler.mockReturnValue([
+        [completedToolCall],
+        mockScheduleToolCalls,
+        mockMarkToolsAsSubmitted,
+      ]);
+
+      // 3. Trigger a re-render to process the completed tool.
+      act(() => {
+        rerender();
+      });
+
+      // --- Assert the outcome ---
+      await waitFor(() => {
+        // The tool should be marked as submitted locally
+        expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith([
+          'client-call-1',
+        ]);
+        // Crucially, no message should be sent to the Gemini API
+        expect(mockSendMessageStream).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -88,7 +88,12 @@ describe('CoreToolScheduler', () => {
     });
 
     const abortController = new AbortController();
-    const request = { callId: '1', name: 'mockTool', args: {} };
+    const request = {
+      callId: '1',
+      name: 'mockTool',
+      args: {},
+      isClientInitiated: false,
+    };
 
     abortController.abort();
     await scheduler.schedule([request], abortController.signal);

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -62,6 +62,7 @@ describe('executeToolCall', () => {
       callId: 'call1',
       name: 'testTool',
       args: { param1: 'value1' },
+      isClientInitiated: false,
     };
     const toolResult: ToolResult = {
       llmContent: 'Tool executed successfully',
@@ -99,6 +100,7 @@ describe('executeToolCall', () => {
       callId: 'call2',
       name: 'nonExistentTool',
       args: {},
+      isClientInitiated: false,
     };
     vi.mocked(mockToolRegistry.getTool).mockReturnValue(undefined);
 
@@ -133,6 +135,7 @@ describe('executeToolCall', () => {
       callId: 'call3',
       name: 'testTool',
       args: { param1: 'value1' },
+      isClientInitiated: false,
     };
     const executionError = new Error('Tool execution failed');
     vi.mocked(mockToolRegistry.getTool).mockReturnValue(mockTool);
@@ -164,6 +167,7 @@ describe('executeToolCall', () => {
       callId: 'call4',
       name: 'testTool',
       args: { param1: 'value1' },
+      isClientInitiated: false,
     };
     const cancellationError = new Error('Operation cancelled');
     vi.mocked(mockToolRegistry.getTool).mockReturnValue(mockTool);
@@ -206,6 +210,7 @@ describe('executeToolCall', () => {
       callId: 'call5',
       name: 'testTool',
       args: {},
+      isClientInitiated: false,
     };
     const imageDataPart: Part = {
       inlineData: { mimeType: 'image/png', data: 'base64data' },

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -132,8 +132,13 @@ describe('Turn', () => {
       const mockResponseStream = (async function* () {
         yield {
           functionCalls: [
-            { id: 'fc1', name: 'tool1', args: { arg1: 'val1' } },
-            { name: 'tool2', args: { arg2: 'val2' } }, // No ID
+            {
+              id: 'fc1',
+              name: 'tool1',
+              args: { arg1: 'val1' },
+              isClientInitiated: false,
+            },
+            { name: 'tool2', args: { arg2: 'val2' }, isClientInitiated: false }, // No ID
           ],
         } as unknown as GenerateContentResponse;
       })();
@@ -156,6 +161,7 @@ describe('Turn', () => {
           callId: 'fc1',
           name: 'tool1',
           args: { arg1: 'val1' },
+          isClientInitiated: false,
         }),
       );
       expect(turn.pendingToolCalls[0]).toEqual(event1.value);
@@ -163,7 +169,11 @@ describe('Turn', () => {
       const event2 = events[1] as ServerGeminiToolCallRequestEvent;
       expect(event2.type).toBe(GeminiEventType.ToolCallRequest);
       expect(event2.value).toEqual(
-        expect.objectContaining({ name: 'tool2', args: { arg2: 'val2' } }),
+        expect.objectContaining({
+          name: 'tool2',
+          args: { arg2: 'val2' },
+          isClientInitiated: false,
+        }),
       );
       expect(event2.value.callId).toEqual(
         expect.stringMatching(/^tool2-\d{13}-\w{10,}$/),
@@ -301,6 +311,7 @@ describe('Turn', () => {
           callId: 'fc1',
           name: 'undefined_tool_name',
           args: { arg1: 'val1' },
+          isClientInitiated: false,
         }),
       );
       expect(turn.pendingToolCalls[0]).toEqual(event1.value);
@@ -308,7 +319,12 @@ describe('Turn', () => {
       const event2 = events[1] as ServerGeminiToolCallRequestEvent;
       expect(event2.type).toBe(GeminiEventType.ToolCallRequest);
       expect(event2.value).toEqual(
-        expect.objectContaining({ callId: 'fc2', name: 'tool2', args: {} }),
+        expect.objectContaining({
+          callId: 'fc2',
+          name: 'tool2',
+          args: {},
+          isClientInitiated: false,
+        }),
       );
       expect(turn.pendingToolCalls[1]).toEqual(event2.value);
 
@@ -319,6 +335,7 @@ describe('Turn', () => {
           callId: 'fc3',
           name: 'undefined_tool_name',
           args: {},
+          isClientInitiated: false,
         }),
       );
       expect(turn.pendingToolCalls[2]).toEqual(event3.value);


### PR DESCRIPTION
## TLDR

This change fixes two critical bugs related to tool-calling and state management:

1.  **Crashing on Client-Side Tools**: Resolves a `400 INVALID_ARGUMENT` crash when using client-side commands like `/memory add` by preventing the client from sending a tool response for a tool the API did not request.
2.  **Stale Memory State**: Fixes a bug where newly added memories were not immediately reflected in the UI. The fix ensures that the application's memory is refreshed automatically after a memory-saving operation, providing immediate feedback to the user.

## Dive Deeper

### 1. Crashing on Client-Side Tools

The root cause of the crash was that the client was sending a `functionResponse` to the Gemini API for a tool call that was initiated locally by the user (e.g., via a slash command). The Gemini API requires a strict 1:1 mapping where it only accepts a `functionResponse` for a `functionCall` it explicitly issued in the preceding turn.

This fix introduces a mandatory `isClientInitiated: boolean` flag to the `ToolCallRequestInfo` interface to solve this problem at the data-structure level:

*   **Mandatory Flag**: Every tool call request must now be explicitly marked as either originating from the client (`true`) or from the model (`false`). This provides compile-time safety, preventing this bug from recurring.
*   **Conditional Logic**: The `useGeminiStream` hook now inspects this flag on all completed tool calls.
    *   If `isClientInitiated` is `true`, the hook finalizes the tool's lifecycle purely on the client-side and, crucially, **does not** send any response to the Gemini API.
    *   If `isClientInitiated` is `false`, the existing logic proceeds as expected, sending the tool's output back to the model for further processing.
*   **Safe Invocation**: All tool call creation sites have been updated to set this flag correctly, ensuring a clear distinction between the two types of tool invocations throughout the application.

### 2. Stale Memory State

Previously, when a user added a new memory using the `/memory add` command or by asking the model to remember something, the underlying `GEMINI.md` file was updated, but the application's in-memory representation of that file was not. This meant that subsequent commands, like `/memory show`, would display stale data until the application was restarted.

This fix introduces a robust refresh mechanism to solve this problem:

*   **Automatic Refresh**: The `useGeminiStream` hook now calls the `performMemoryRefresh` function whenever a `save_memory` tool call completes successfully, regardless of whether it was initiated by the user or the model.
*   **Idempotent Effect**: The refresh logic is designed to be idempotent by tracking which tool calls have already been processed. This prevents unnecessary refreshes and ensures that the operation is efficient and reliable, even across component re-renders.

## Reviewer Test Plan

To validate this change, please test the following scenarios:

1.  **Client-Initiated Tool Call (The Fix)**:
    *   Run the command: `/memory add "my favorite color is blue"`
    *   **Expected Behavior**: The command executes successfully, a confirmation appears, and the CLI returns to an idle state without crashing. There should be no `400 INVALID_ARGUMENT` error.

2.  **Stale Memory State (The Fix)**:
    *   Run the command: `/memory add "my dog's name is fido"`
    *   Immediately run: `/memory show`
    *   **Expected Behavior**: The output of `/memory show` should immediately include "my dog's name is fido".

3.  **Model-Initiated Tool Call (Regression Test)**:
    *   Ask a question that requires a tool, such as: `"Can you remember that my favorite bird is a duck."`
    *   Immediately run: `/memory show`
    *   **Expected Behavior**: The model should request the memory tool, the tool should execute, and the result should be sent back to the model. The model should then use the tool's output to answer tell you it will remember that. The entire flow should complete without errors, and the new memory should appear in the output of `/memory show`.

4.  **Standard Chat (Regression Test)**:
    *   Have a simple conversation with the model without using tools.
    *   **Expected Behavior**: The conversation should proceed normally with no change in behavior.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs
Closes [b/426844709](https://b.corp.google.com/issues/426844709)