### PR TITLE
Jacob314/auto exit unconstrained height mode

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -294,6 +294,26 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   );
 
   useInput((input: string, key: InkKeyType) => {
+    if (!constrainHeight) {
+      // Automatically re-enter constrain height mode if the user types
+      // anything. When constrainHeight==false, the user will experience
+      // significant flickering so it is best to disable it immediately when
+      // the user starts interacting with the app.
+      setConstrainHeight(true);
+
+      // If our pending history item happens to exceed the terminal height we will most likely need to refresh
+      // our static collection to ensure no duplication or tearing. This is currently working around a core bug
+      // in Ink which we have a PR out to fix: https://github.com/vadimdemedes/ink/pull/717
+      if (pendingHistoryItemRef.current && pendingHistoryItems.length > 0) {
+        const pendingItemDimensions = measureElement(
+          pendingHistoryItemRef.current,
+        );
+        if (pendingItemDimensions.height > availableTerminalHeight) {
+          refreshStatic();
+        }
+      }
+    }
+
     if (key.ctrl && input === 'o') {
       setShowErrorDetails((prev) => !prev);
       refreshStatic();
@@ -315,7 +335,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
       }
       handleExit(ctrlDPressedOnce, setCtrlDPressedOnce, ctrlDTimerRef);
     } else if (key.ctrl && input === 's') {
-      setConstrainHeight((prev) => !prev);
+      setConstrainHeight(false);
     }
   });
 
@@ -522,7 +542,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     );
   }
   const mainAreaWidth = Math.floor(terminalWidth * 0.9);
-  const debugConsoleMaxHeight = Math.max(terminalHeight * 0.2, 5);
+  const debugConsoleMaxHeight = Math.floor(Math.max(terminalHeight * 0.2, 5));
   // Arbitrary threshold to ensure that items in the static area are large
   // enough but not too large to make the terminal hard to use.
   const staticAreaMaxItemHeight = Math.max(terminalHeight * 4, 100);


### PR DESCRIPTION
## TLDR

Unconstrained mode causes flicker so we shouldn't let users accidentally stay in it.
We now exit unconstrained mode automatically on any keystroke.
As a bonus we also apply our hacks to fixup torn terminal output when needed when exiting unconstrained mode.