### PR TITLE
Provide a .gitconfig for shadow repos

### DIFF
--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -188,6 +188,18 @@ describe('GitService', () => {
     const repoDir = path.join(mockHomedir, '.gemini', 'history', mockHash);
     const hiddenGitIgnorePath = path.join(repoDir, '.gitignore');
     const visibleGitIgnorePath = path.join(mockProjectRoot, '.gitignore');
+    const gitConfigPath = path.join(repoDir, '.gitconfig');
+
+    it('should create a .gitconfig file with the correct content', async () => {
+      const service = new GitService(mockProjectRoot);
+      await service.setupShadowGitRepository();
+      const expectedConfigContent =
+        '[user]\n  name = Gemini CLI\n  email = gemini-cli@google.com\n[commit]\n  gpgsign = false\n';
+      expect(hoistedMockWriteFile).toHaveBeenCalledWith(
+        gitConfigPath,
+        expectedConfigContent,
+      );
+    });
 
     it('should create history and repository directories', async () => {
       const service = new GitService(mockProjectRoot);


### PR DESCRIPTION
This writes a .gitconfig to the shadow repos that back checkpointing. It also sets environment variables to prevent shadow repo git operations from trying to load the user's gitconfig.