### PR TITLE
feat: Add /docs command and update UI

### DIFF
--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -74,7 +74,7 @@ export const Footer: React.FC<FooterProps> = ({
           </Text>
         ) : (
           <Text color={Colors.AccentRed}>
-            no sandbox <Text color={Colors.Gray}>(see docs)</Text>
+            no sandbox <Text color={Colors.Gray}>(see /docs)</Text>
           </Text>
         )}
       </Box>

--- a/packages/cli/src/ui/components/Tips.tsx
+++ b/packages/cli/src/ui/components/Tips.tsx
@@ -38,8 +38,7 @@ export const Tips: React.FC<TipsProps> = ({ config }) => {
         <Text bold color={Colors.AccentPurple}>
           /help
         </Text>{' '}
-        for more information. Full documentation can be found at
-        https://github.com/google-gemini/gemini-cli/blob/main/docs/index.md.
+        for more information.
       </Text>
     </Box>
   );

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -183,6 +183,28 @@ export const useSlashCommandProcessor = (
         },
       },
       {
+        name: 'docs',
+        description: 'open full Gemini CLI documentation in your browser',
+        action: async (_mainCommand, _subCommand, _args) => {
+          const docsUrl =
+            'https://github.com/google-gemini/gemini-cli/blob/main/docs/index.md';
+          if (process.env.SANDBOX && process.env.SANDBOX !== 'sandbox-exec') {
+            addMessage({
+              type: MessageType.INFO,
+              content: `Please open the following URL in your browser to view the documentation:\n${docsUrl}`,
+              timestamp: new Date(),
+            });
+          } else {
+            addMessage({
+              type: MessageType.INFO,
+              content: `Opening documentation in your browser: ${docsUrl}`,
+              timestamp: new Date(),
+            });
+            await open(docsUrl);
+          }
+        },
+      },
+      {
         name: 'clear',
         description: 'clear the screen and conversation history',
         action: async (_mainCommand, _subCommand, _args) => {


### PR DESCRIPTION
- Removes the "Full documentation" link from the main page.
- Adds a /docs slash command that opens the documentation in a new browser window.
- Updates the "no sandbox" message to refer to the /docs command.

Flow of no sandbox -> docker -> podman -> seatbelt: https://screencast.googleplex.com/cast/NDcwMDM1NzM4ODE0MDU0NHxhZTMwYmUxMC05Mw

Also listed in `/help`:
![image](https://github.com/user-attachments/assets/e0ca6bba-6a8f-4dc5-9dfd-9636c9ab15d4)
