### PR TITLE
Fix seatbelt sandboxing when GEMINI_SANDBOX="" and starting with -s

### DIFF
--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -36,7 +36,12 @@ function getSandboxCommand(
   }
 
   // note environment variable takes precedence over argument (from command line or settings)
-  sandbox = process.env.GEMINI_SANDBOX?.toLowerCase().trim() ?? sandbox;
+  const environmentConfiguredSandbox =
+    process.env.GEMINI_SANDBOX?.toLowerCase().trim() ?? '';
+  sandbox =
+    environmentConfiguredSandbox?.length > 0
+      ? environmentConfiguredSandbox
+      : sandbox;
   if (sandbox === '1' || sandbox === 'true') sandbox = true;
   else if (sandbox === '0' || sandbox === 'false' || !sandbox) sandbox = false;
 


### PR DESCRIPTION
## TLDR

- Prior to this having an empty sandbox env variable and booting with `-s` would result in no sandbox starting.
This screenshot (near the end) when I claer the environment variable is using this fix, without this fix the seatbelt invocation would have booted into no sandbox: https://screencast.googleplex.com/cast/NDcwMDM1NzM4ODE0MDU0NHxhZTMwYmUxMC05Mw

## Reviewer Test Plan

```
export GEMINI_SANDBOX=""
gemini -s

// Expected that you're booted into MacOS seatbelt
```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅ | ❓  | ❓  |
| Docker   | ✅   | ❓  | ❓  |
| Podman   | ✅   | -   | -   |
| Seatbelt | ✅  | -   | -   |
