### PR TITLE
feat: Only show ctrl-s when idle

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:integration:sandbox:docker": "GEMINI_SANDBOX=docker node integration-tests/run-tests.js",
     "test:integration:sandbox:podman": "GEMINI_SANDBOX=podman node integration-tests/run-tests.js",
     "start": "node scripts/start.js",
-    "debug": "cross-env DEBUG=1 node scripts/start.js",
+    "debug": "cross-env DEBUG=1 node --inspect-brk scripts/start.js",
     "lint:fix": "eslint . --fix && eslint integration-tests --fix",
     "lint": "eslint . --ext .ts,.tsx && eslint integration-tests",
     "typecheck": "npm run typecheck --workspaces --if-present",

--- a/packages/cli/src/ui/components/ShowMoreLines.tsx
+++ b/packages/cli/src/ui/components/ShowMoreLines.tsx
@@ -6,6 +6,8 @@
 
 import { Box, Text } from 'ink';
 import { useOverflowState } from '../contexts/OverflowContext.js';
+import { useStreamingContext } from '../contexts/StreamingContext.js';
+import { StreamingState } from '../types.js';
 import { Colors } from '../colors.js';
 
 interface ShowMoreLinesProps {
@@ -14,11 +16,16 @@ interface ShowMoreLinesProps {
 
 export const ShowMoreLines = ({ constrainHeight }: ShowMoreLinesProps) => {
   const overflowState = useOverflowState();
+  const streamingState = useStreamingContext();
 
   if (
     overflowState === undefined ||
     overflowState.overflowingIds.size === 0 ||
-    !constrainHeight
+    !constrainHeight ||
+    !(
+      streamingState === StreamingState.Idle ||
+      streamingState === StreamingState.WaitingForConfirmation
+    )
   ) {
     return null;
   }
@@ -26,7 +33,7 @@ export const ShowMoreLines = ({ constrainHeight }: ShowMoreLinesProps) => {
   return (
     <Box>
       <Text color={Colors.Gray} wrap="truncate">
-        Press Ctrl-S to show more lines
+        Press ctrl-s to show more lines
       </Text>
     </Box>
   );


### PR DESCRIPTION
## TLDR

- Lowercase ctrl-s to be consistent with the rest of the codebase.
- Do not show the indicator if we're in the middle of streaming content. It should only show when we're idle or awaiting a confirmation.

Flow: https://screencast.googleplex.com/cast/NTIyNTUxMjAzMjAxMDI0MHxlMWU0MDk5MC1kYw

FYI @jacob314 

## Dive Deeper

- We shouldn't be showing `ctrl + s` hot key while streaming, we don't want to encourage that flow because if we do then we're basically encouraging flickering.

## Reviewer Test Plan

See video

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ✅   | ❓  | ❓  |
| Docker   | ✅    | ❓  | ❓  |
| Podman   | ✅    | -   | -   |
| Seatbelt | ✅   | -   | -   |
