### PR TITLE
Fix so that pressing ctrl-s a second time toggles off constrain height mode

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -294,11 +294,13 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   );
 
   useInput((input: string, key: InkKeyType) => {
+    let enteringConstrainHeightMode = false;
     if (!constrainHeight) {
       // Automatically re-enter constrain height mode if the user types
       // anything. When constrainHeight==false, the user will experience
       // significant flickering so it is best to disable it immediately when
       // the user starts interacting with the app.
+      enteringConstrainHeightMode = true;
       setConstrainHeight(true);
 
       // If our pending history item happens to exceed the terminal height we will most likely need to refresh
@@ -334,7 +336,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
         return;
       }
       handleExit(ctrlDPressedOnce, setCtrlDPressedOnce, ctrlDTimerRef);
-    } else if (key.ctrl && input === 's') {
+    } else if (key.ctrl && input === 's' && !enteringConstrainHeightMode) {
       setConstrainHeight(false);
     }
   });


### PR DESCRIPTION
Previously pressing ctrl-S twice would do nothing as constrain height mode would be automatically disabled then reenabled.