### PR TITLE
Enable clearcut logging by default and fix Start Session event logging

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -226,7 +226,7 @@ export async function loadCliConfig(
         process.env.OTEL_EXPORTER_OTLP_ENDPOINT ??
         settings.telemetry?.otlpEndpoint,
       logPrompts: argv.telemetryLogPrompts ?? settings.telemetry?.logPrompts,
-      disableDataCollection: settings.telemetry?.disableDataCollection ?? true,
+      disableDataCollection: settings.telemetry?.disableDataCollection ?? false,
     },
     // Git-aware file filtering settings
     fileFiltering: {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -117,7 +117,6 @@ export interface ConfigParameters {
   fileDiscoveryService?: FileDiscoveryService;
   bugCommand?: BugCommandSettings;
   model: string;
-  disableDataCollection?: boolean;
 }
 
 export class Config {
@@ -154,7 +153,6 @@ export class Config {
   private readonly cwd: string;
   private readonly bugCommand: BugCommandSettings | undefined;
   private readonly model: string;
-  private readonly disableDataCollection: boolean;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -181,6 +179,7 @@ export class Config {
       target: params.telemetry?.target ?? DEFAULT_TELEMETRY_TARGET,
       otlpEndpoint: params.telemetry?.otlpEndpoint ?? DEFAULT_OTLP_ENDPOINT,
       logPrompts: params.telemetry?.logPrompts ?? true,
+      disableDataCollection: params.telemetry?.disableDataCollection ?? false,
     };
 
     this.fileFiltering = {
@@ -194,8 +193,6 @@ export class Config {
     this.fileDiscoveryService = params.fileDiscoveryService ?? null;
     this.bugCommand = params.bugCommand;
     this.model = params.model;
-    this.disableDataCollection =
-      params.telemetry?.disableDataCollection ?? false;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -205,7 +202,7 @@ export class Config {
       initializeTelemetry(this);
     }
 
-    if (!this.disableDataCollection) {
+    if (!this.telemetrySettings.disableDataCollection) {
       ClearcutLogger.getInstance(this)?.enqueueLogEvent(
         new StartSessionEvent(this),
       );
@@ -384,7 +381,7 @@ export class Config {
   }
 
   getDisableDataCollection(): boolean {
-    return this.disableDataCollection;
+    return this.telemetrySettings.disableDataCollection ?? false;
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -381,19 +381,6 @@ export class Config {
   }
 
   getDisableDataCollection(): boolean {
-    if (this.telemetrySettings === undefined)
-    {
-      throw new Error('telemetry.disableDataCollection is undefined.');
-    }
-    if (this.telemetrySettings.disableDataCollection === undefined) {
-      throw new Error('telemetry.disableDataCollection is undefined.');
-    }
-    if (this.telemetrySettings.disableDataCollection) {
-      throw new Error('telemetry.disableDataCollection is true.');
-    }
-    if (!this.telemetrySettings.disableDataCollection) {
-      throw new Error('telemetry.disableDataCollection is: ' + this.telemetrySettings.disableDataCollection);
-    }
     return this.telemetrySettings.disableDataCollection ?? false;
   }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -391,6 +391,9 @@ export class Config {
     if (this.telemetrySettings.disableDataCollection) {
       throw new Error('telemetry.disableDataCollection is true.');
     }
+    if (!this.telemetrySettings.disableDataCollection) {
+      throw new Error('telemetry.disableDataCollection is: ' + this.telemetrySettings.disableDataCollection);
+    }
     return this.telemetrySettings.disableDataCollection ?? false;
   }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -195,7 +195,7 @@ export class Config {
     this.bugCommand = params.bugCommand;
     this.model = params.model;
     this.disableDataCollection =
-      params.telemetry?.disableDataCollection ?? true;
+      params.telemetry?.disableDataCollection ?? false;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -203,9 +203,11 @@ export class Config {
     }
 
     if (!this.getDisableDataCollection()) {
-      ClearcutLogger.getInstance(this)?.enqueueLogEvent(
+      ClearcutLogger.getInstance(this)?.logStartSessionEvent(
         new StartSessionEvent(this),
       );
+    } else {
+      console.log('Data collection is disabled.');
     }
   }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -381,6 +381,16 @@ export class Config {
   }
 
   getDisableDataCollection(): boolean {
+    if (this.telemetrySettings === undefined)
+    {
+      throw new Error('telemetry.disableDataCollection is undefined.');
+    }
+    if (this.telemetrySettings.disableDataCollection === undefined) {
+      throw new Error('telemetry.disableDataCollection is undefined.');
+    }
+    if (this.telemetrySettings.disableDataCollection) {
+      throw new Error('telemetry.disableDataCollection is true.');
+    }
     return this.telemetrySettings.disableDataCollection ?? false;
   }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -202,7 +202,7 @@ export class Config {
       initializeTelemetry(this);
     }
 
-    if (!this.telemetrySettings.disableDataCollection) {
+    if (!this.getDisableDataCollection()) {
       ClearcutLogger.getInstance(this)?.enqueueLogEvent(
         new StartSessionEvent(this),
       );

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -47,6 +47,10 @@ export class ClearcutLogger {
 
   static getInstance(config?: Config): ClearcutLogger | undefined {
     if (config === undefined || config?.getDisableDataCollection())
+      if (config === undefined) {
+        throw new Error('getInstance returning undefined: config is undefined.');
+      }
+      throw new Error('getInstance returning undefined: data collection is disabled.');
       return undefined;
     if (!ClearcutLogger.instance) {
       ClearcutLogger.instance = new ClearcutLogger(config);
@@ -62,6 +66,7 @@ export class ClearcutLogger {
         source_extension_json: JSON.stringify(event),
       },
     ]);
+    throw new Error('Enqueuing log event.');
   }
 
   createLogEvent(name: string, data: Map<EventMetadataKey, string>): object {
@@ -83,6 +88,7 @@ export class ClearcutLogger {
   }
 
   flushToClearcut(): Promise<LogResponse> {
+    throw new Error('Flushing to Clearcut.');
     return new Promise<Buffer>((resolve, reject) => {
       const request = [
         {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -39,7 +39,7 @@ export class ClearcutLogger {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Clearcut expects this format.
   private readonly events: any = [];
   private last_flush_time: number = Date.now();
-  private flush_interval_ms: number = 100; // Wait at least a minute before flushing events.
+  private flush_interval_ms: number = 1000 * 60; // Wait at least a minute before flushing events.
 
   private constructor(config?: Config) {
     this.config = config;

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -39,7 +39,7 @@ export class ClearcutLogger {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Clearcut expects this format.
   private readonly events: any = [];
   private last_flush_time: number = Date.now();
-  private flush_interval_ms: number = 1000 * 60; // Wait at least a minute before flushing events.
+  private flush_interval_ms: number = 100; // Wait at least a minute before flushing events.
 
   private constructor(config?: Config) {
     this.config = config;

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -68,7 +68,6 @@ export class ClearcutLogger {
         source_extension_json: JSON.stringify(event),
       },
     ]);
-    throw new Error('Enqueuing log event.');
   }
 
   createLogEvent(name: string, data: Map<EventMetadataKey, string>): object {
@@ -90,7 +89,7 @@ export class ClearcutLogger {
   }
 
   flushToClearcut(): Promise<LogResponse> {
-    throw new Error('Flushing to Clearcut.');
+    //throw new Error('Flushing to Clearcut.');
     return new Promise<Buffer>((resolve, reject) => {
       const request = [
         {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -85,6 +85,7 @@ export class ClearcutLogger {
   }
 
   flushToClearcut(): Promise<LogResponse> {
+    throw new Error('Flushing to clearcut.');
     return new Promise<Buffer>((resolve, reject) => {
       const request = [
         {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -85,7 +85,6 @@ export class ClearcutLogger {
   }
 
   flushToClearcut(): Promise<LogResponse> {
-    throw new Error('Flushing to clearcut.');
     return new Promise<Buffer>((resolve, reject) => {
       const request = [
         {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -46,10 +46,8 @@ export class ClearcutLogger {
   }
 
   static getInstance(config?: Config): ClearcutLogger | undefined {
-    if (config === undefined || config?.getDisableDataCollection()) {
+    if (config === undefined || config?.getDisableDataCollection())
       return undefined;
-    }
-
     if (!ClearcutLogger.instance) {
       ClearcutLogger.instance = new ClearcutLogger(config);
     }
@@ -66,7 +64,7 @@ export class ClearcutLogger {
     ]);
   }
 
-  createLogEvent(name: string, data: Map<EventMetadataKey, string>): object {
+  createLogEvent(name: string, data: object): object {
     return {
       Application: 'GEMINI_CLI',
       event_name: name,
@@ -85,6 +83,7 @@ export class ClearcutLogger {
   }
 
   flushToClearcut(): Promise<LogResponse> {
+    console.log('Flushing log events to Clearcut.');
     return new Promise<Buffer>((resolve, reject) => {
       const request = [
         {
@@ -94,6 +93,7 @@ export class ClearcutLogger {
         },
       ];
       const body = JSON.stringify(request);
+      console.log('Clearcut POST request body:', body);
       const options = {
         hostname: 'play.googleapis.com',
         path: '/log',
@@ -108,6 +108,7 @@ export class ClearcutLogger {
         });
       });
       req.on('error', (e) => {
+        console.log('Clearcut POST request error: ', e);
         reject(e);
       });
       req.end(body);
@@ -152,62 +153,83 @@ export class ClearcutLogger {
     if (cont) {
       // We have fallen off the buffer without seeing a terminating byte. The
       // message is corrupted.
-      console.error('Error parsing respone bytes from Clearcut.');
       return undefined;
     }
 
-    return {
+    const returnVal = {
       nextRequestWaitMs: Number(ms),
     };
+    console.log('Clearcut response: ', returnVal);
+    return returnVal;
   }
 
   logStartSessionEvent(event: StartSessionEvent): void {
-    const data: Map<EventMetadataKey, string> = new Map();
-
-    data.set(EventMetadataKey.GEMINI_CLI_START_SESSION_MODEL, event.model);
-    data.set(
-      EventMetadataKey.GEMINI_CLI_START_SESSION_EMBEDDING_MODEL,
-      event.embedding_model,
-    );
-    data.set(
-      EventMetadataKey.GEMINI_CLI_START_SESSION_SANDBOX,
-      event.sandbox_enabled.toString(),
-    );
-    data.set(
-      EventMetadataKey.GEMINI_CLI_START_SESSION_CORE_TOOLS,
-      event.core_tools_enabled,
-    );
-    data.set(
-      EventMetadataKey.GEMINI_CLI_START_SESSION_APPROVAL_MODE,
-      event.approval_mode,
-    );
-    data.set(
-      EventMetadataKey.GEMINI_CLI_START_SESSION_API_KEY_ENABLED,
-      event.api_key_enabled.toString(),
-    );
-    data.set(
-      EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
-      event.vertex_ai_enabled.toString(),
-    );
-    data.set(
-      EventMetadataKey.GEMINI_CLI_START_SESSION_DEBUG_MODE_ENABLED,
-      event.debug_enabled.toString(),
-    );
-    data.set(
-      EventMetadataKey.GEMINI_CLI_START_SESSION_MCP_SERVERS,
-      event.mcp_servers,
-    );
-    data.set(
-      EventMetadataKey.GEMINI_CLI_START_SESSION_TELEMETRY_ENABLED,
-      event.telemetry_enabled.toString(),
-    );
-    data.set(
-      EventMetadataKey.GEMINI_CLI_START_SESSION_TELEMETRY_LOG_USER_PROMPTS_ENABLED,
-      event.telemetry_log_user_prompts_enabled.toString(),
-    );
-
+    const data = [
+      {
+        EventMetadataKey: EventMetadataKey.GEMINI_CLI_START_SESSION_MODEL,
+        value: event.model,
+      },
+      {
+        EventMetadataKey:
+          EventMetadataKey.GEMINI_CLI_START_SESSION_EMBEDDING_MODEL,
+        value: event.embedding_model,
+      },
+      {
+        EventMetadataKey: EventMetadataKey.GEMINI_CLI_START_SESSION_SANDBOX,
+        value: event.sandbox_enabled.toString(),
+      },
+      {
+        EventMetadataKey: EventMetadataKey.GEMINI_CLI_START_SESSION_CORE_TOOLS,
+        value: event.core_tools_enabled,
+      },
+      {
+        EventMetadataKey:
+          EventMetadataKey.GEMINI_CLI_START_SESSION_APPROVAL_MODE,
+        value: event.approval_mode,
+      },
+      {
+        EventMetadataKey:
+          EventMetadataKey.GEMINI_CLI_START_SESSION_API_KEY_ENABLED,
+        value: event.api_key_enabled.toString(),
+      },
+      {
+        EventMetadataKey:
+          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
+        value: event.vertex_ai_enabled.toString(),
+      },
+      {
+        EventMetadataKey:
+          EventMetadataKey.GEMINI_CLI_START_SESSION_DEBUG_MODE_ENABLED,
+        value: event.debug_enabled.toString(),
+      },
+      {
+        EventMetadataKey:
+          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
+        value: event.vertex_ai_enabled.toString(),
+      },
+      {
+        EventMetadataKey: EventMetadataKey.GEMINI_CLI_START_SESSION_MCP_SERVERS,
+        value: event.mcp_servers,
+      },
+      {
+        EventMetadataKey:
+          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
+        value: event.vertex_ai_enabled.toString(),
+      },
+      {
+        EventMetadataKey:
+          EventMetadataKey.GEMINI_CLI_START_SESSION_TELEMETRY_ENABLED,
+        value: event.telemetry_enabled.toString(),
+      },
+      {
+        EventMetadataKey:
+          EventMetadataKey.GEMINI_CLI_START_SESSION_TELEMETRY_LOG_USER_PROMPTS_ENABLED,
+        value: event.telemetry_log_user_prompts_enabled.toString(),
+      },
+    ];
     this.enqueueLogEvent(this.createLogEvent(start_session_event_name, data));
-    this.flushIfNeeded();
+    // Flush start event immediately
+    this.flushToClearcut();
   }
 
   logNewPromptEvent(event: UserPromptEvent): void {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -46,12 +46,14 @@ export class ClearcutLogger {
   }
 
   static getInstance(config?: Config): ClearcutLogger | undefined {
-    if (config === undefined || config?.getDisableDataCollection())
+    if (config === undefined || config?.getDisableDataCollection()) {
       if (config === undefined) {
         throw new Error('getInstance returning undefined: config is undefined.');
       }
       throw new Error('getInstance returning undefined: data collection is disabled.');
       return undefined;
+    }
+
     if (!ClearcutLogger.instance) {
       ClearcutLogger.instance = new ClearcutLogger(config);
     }

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -47,10 +47,6 @@ export class ClearcutLogger {
 
   static getInstance(config?: Config): ClearcutLogger | undefined {
     if (config === undefined || config?.getDisableDataCollection()) {
-      if (config === undefined) {
-        throw new Error('getInstance returning undefined: config is undefined.');
-      }
-      throw new Error('getInstance returning undefined: data collection is disabled.');
       return undefined;
     }
 
@@ -89,7 +85,6 @@ export class ClearcutLogger {
   }
 
   flushToClearcut(): Promise<LogResponse> {
-    //throw new Error('Flushing to Clearcut.');
     return new Promise<Buffer>((resolve, reject) => {
       const request = [
         {
@@ -122,7 +117,6 @@ export class ClearcutLogger {
         return this.decodeLogResponse(buf) || {};
       } catch (error: unknown) {
         console.error('Error flushing log events:', error);
-        throw new Error('Error flushing log events' + error);
         return {};
       }
     });
@@ -158,11 +152,10 @@ export class ClearcutLogger {
     if (cont) {
       // We have fallen off the buffer without seeing a terminating byte. The
       // message is corrupted.
-      throw new Error('Error parsing respone bytes.');
+      console.error('Error parsing respone bytes from Clearcut.');
       return undefined;
     }
 
-    throw new Error('Got response from clearcut: ' + Number(ms).toString());
     return {
       nextRequestWaitMs: Number(ms),
     };

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -115,6 +115,7 @@ export class ClearcutLogger {
         return this.decodeLogResponse(buf) || {};
       } catch (error: unknown) {
         console.error('Error flushing log events:', error);
+        throw new Error('Error flushing log events' + error);
         return {};
       }
     });
@@ -150,8 +151,11 @@ export class ClearcutLogger {
     if (cont) {
       // We have fallen off the buffer without seeing a terminating byte. The
       // message is corrupted.
+      throw new Error('Error parsing respone bytes.');
       return undefined;
     }
+
+    throw new Error('Got response from clearcut: ' + Number(ms).toString());
     return {
       nextRequestWaitMs: Number(ms),
     };


### PR DESCRIPTION
## TLDR

Enabled Clearcut data collection by default. Also fixed a couple of bugs:
- Clearcut logging could not be enabled by setting disableDataCollection to false
- Logging of Session Start events was not getting triggered 

## Dive Deeper

Also cleaned up the settings / config to consolidate on the disableDataCollection setting nested inside of TelemetrySettings.

## Reviewer Test Plan

Run the CLI, enter a prompt, and after a minute, look for an HTTP POST to play.googleapis.com/log

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ✅   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

b/424466618
