### PR TITLE
Plumb extension context filenames through for /memory refresh

### DIFF
--- a/packages/cli/src/config/config.integration.test.ts
+++ b/packages/cli/src/config/config.integration.test.ts
@@ -210,4 +210,34 @@ describe('Configuration Integration Tests', () => {
       expect(config.getCheckpointingEnabled()).toBe(true);
     });
   });
+
+  describe('Extension Context Files', () => {
+    it('should have an empty array for extension context files by default', () => {
+      const configParams: ConfigParameters = {
+        cwd: '/tmp',
+        contentGeneratorConfig: TEST_CONTENT_GENERATOR_CONFIG,
+        embeddingModel: 'test-embedding-model',
+        sandbox: false,
+        targetDir: tempDir,
+        debugMode: false,
+      };
+      const config = new Config(configParams);
+      expect(config.getExtensionContextFilePaths()).toEqual([]);
+    });
+
+    it('should correctly store and return extension context file paths', () => {
+      const contextFiles = ['/path/to/file1.txt', '/path/to/file2.js'];
+      const configParams: ConfigParameters = {
+        cwd: '/tmp',
+        contentGeneratorConfig: TEST_CONTENT_GENERATOR_CONFIG,
+        embeddingModel: 'test-embedding-model',
+        sandbox: false,
+        targetDir: tempDir,
+        debugMode: false,
+        extensionContextFilePaths: contextFiles,
+      };
+      const config = new Config(configParams);
+      expect(config.getExtensionContextFilePaths()).toEqual(contextFiles);
+    });
+  });
 });

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -244,6 +244,7 @@ export async function loadCliConfig(
     fileDiscoveryService: fileService,
     bugCommand: settings.bugCommand,
     model: argv.model!,
+    extensionContextFilePaths,
   });
 }
 

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -183,6 +183,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
         process.cwd(),
         config.getDebugMode(),
         config.getFileService(),
+        config.getExtensionContextFilePaths(),
       );
       config.setUserMemory(memoryContent);
       config.setGeminiMdFileCount(fileCount);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -118,6 +118,7 @@ export interface ConfigParameters {
   bugCommand?: BugCommandSettings;
   model: string;
   disableDataCollection?: boolean;
+  extensionContextFilePaths?: string[];
 }
 
 export class Config {
@@ -155,6 +156,7 @@ export class Config {
   private readonly bugCommand: BugCommandSettings | undefined;
   private readonly model: string;
   private readonly disableDataCollection: boolean;
+  private readonly extensionContextFilePaths: string[];
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -196,6 +198,7 @@ export class Config {
     this.model = params.model;
     this.disableDataCollection =
       params.telemetry?.disableDataCollection ?? true;
+    this.extensionContextFilePaths = params.extensionContextFilePaths ?? [];
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -385,6 +388,10 @@ export class Config {
 
   getDisableDataCollection(): boolean {
     return this.disableDataCollection;
+  }
+
+  getExtensionContextFilePaths(): string[] {
+    return this.extensionContextFilePaths;
   }
 
   async getGitService(): Promise<GitService> {


### PR DESCRIPTION
## TLDR

When performing a /memory refresh we did not pass through any context filenames provided by extensions. This change simply passes the data through.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1311 