### PR TITLE
Jacob314/max old space

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -53,6 +53,7 @@ export interface Settings {
   preferredEditor?: string;
   bugCommand?: BugCommandSettings;
   checkpointing?: CheckpointingSettings;
+  autoConfigureMaxOldSpaceSize?: boolean;
 
   // Git-aware file filtering settings
   fileFiltering?: {

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -64,6 +64,11 @@ const env = {
   DEV: 'true',
 };
 
+if (process.env.DEBUG) {
+  // If this is not set, the debugger will pause on the outer process rather
+  // than the relauncehd process making it harder to debug.
+  env.GEMINI_CLI_NO_RELAUNCH = 'true';
+}
 const child = spawn('node', nodeArgs, { stdio: 'inherit', env });
 
 child.on('close', (code) => {


### PR DESCRIPTION
## TLDR
This should significantly reduce OOM for users with 8GB+ memory as previously we were using the default
node heap size of 4GB. Now we allow 50% of physical memory or the existing maximum heap size Node was using whichever is larger. As we were already launching a second node process when using a sandbox there is not significant extra overhead associated with configuring that node process to use more memory. When not using a sandbox we do have to open an additional process as it is not possible to change the maximum heap size after a node process is started.

As far as we can tell, Gemini CLI doesn't have large memory leaks but may suffer from memory bloat particularly when dealing with large projects or very long chat conversations. Given this, the best solution is to allow users on powerful machines to use more of their memory as needed.

This option is off by default to minimize risk.

## Linked issues / bugs

[b/426892886](https://b.corp.google.com/426892886)
