### PR TITLE
Add error messaging for 429 errors

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -215,8 +215,7 @@ describe('runNonInteractive', () => {
     await runNonInteractive(mockConfig, 'Initial fail');
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Error processing input:',
-      apiError,
+      '[API Error: API connection failed]',
     );
   });
 });

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -19,6 +19,8 @@ import {
   GenerateContentResponse,
 } from '@google/genai';
 
+import { parseAndFormatApiError } from './ui/utils/errorParsing.js';
+
 function getResponseText(response: GenerateContentResponse): string | null {
   if (response.candidates && response.candidates.length > 0) {
     const candidate = response.candidates[0];
@@ -126,7 +128,7 @@ export async function runNonInteractive(
       }
     }
   } catch (error) {
-    console.error('Error processing input:', error);
+    console.error(parseAndFormatApiError(error));
     process.exit(1);
   } finally {
     if (isTelemetrySdkInitialized()) {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -396,7 +396,10 @@ export const useGeminiStream = (
         setPendingHistoryItem(null);
       }
       addItem(
-        { type: MessageType.ERROR, text: `[API Error: ${eventValue.message}]` },
+        {
+          type: MessageType.ERROR,
+          text: parseAndFormatApiError(eventValue.error),
+        },
         userMessageTimestamp,
       );
     },
@@ -530,6 +533,10 @@ export const useGeminiStream = (
           setPendingHistoryItem(null);
         }
       } catch (error: unknown) {
+        console.log(
+          'GEMINI_DEBUG: Caught error in useGeminiStream.ts:',
+          JSON.stringify(error),
+        );
         if (isAuthError(error)) {
           onAuthError();
         } else if (!isNodeError(error) || error.name !== 'AbortError') {

--- a/packages/cli/src/ui/utils/errorParsing.test.ts
+++ b/packages/cli/src/ui/utils/errorParsing.test.ts
@@ -6,29 +6,46 @@
 
 import { describe, it, expect } from 'vitest';
 import { parseAndFormatApiError } from './errorParsing.js';
+import { StructuredError } from '@gemini-cli/core';
 
 describe('parseAndFormatApiError', () => {
+  const rateLimitMessage =
+    'Please wait and try again later. To increase your limits, upgrade to a plan with higher limits, or use /auth to switch to using a paid API key from AI Studio at https://aistudio.google.com/apikey';
+
   it('should format a valid API error JSON', () => {
     const errorMessage =
       'got status: 400 Bad Request. {"error":{"code":400,"message":"API key not valid. Please pass a valid API key.","status":"INVALID_ARGUMENT"}}';
     const expected =
-      'API Error: API key not valid. Please pass a valid API key. (Status: INVALID_ARGUMENT)';
+      '[API Error: API key not valid. Please pass a valid API key. (Status: INVALID_ARGUMENT)]';
+    expect(parseAndFormatApiError(errorMessage)).toBe(expected);
+  });
+
+  it('should format a 429 API error JSON with the custom message', () => {
+    const errorMessage =
+      'got status: 429 Too Many Requests. {"error":{"code":429,"message":"Rate limit exceeded","status":"RESOURCE_EXHAUSTED"}}';
+    const expected = `[API Error: Rate limit exceeded (Status: RESOURCE_EXHAUSTED)]\n${rateLimitMessage}`;
     expect(parseAndFormatApiError(errorMessage)).toBe(expected);
   });
 
   it('should return the original message if it is not a JSON error', () => {
     const errorMessage = 'This is a plain old error message';
-    expect(parseAndFormatApiError(errorMessage)).toBe(errorMessage);
+    expect(parseAndFormatApiError(errorMessage)).toBe(
+      `[API Error: ${errorMessage}]`,
+    );
   });
 
   it('should return the original message for malformed JSON', () => {
     const errorMessage = '[Stream Error: {"error": "malformed}';
-    expect(parseAndFormatApiError(errorMessage)).toBe(errorMessage);
+    expect(parseAndFormatApiError(errorMessage)).toBe(
+      `[API Error: ${errorMessage}]`,
+    );
   });
 
   it('should handle JSON that does not match the ApiError structure', () => {
     const errorMessage = '[Stream Error: {"not_an_error": "some other json"}]';
-    expect(parseAndFormatApiError(errorMessage)).toBe(errorMessage);
+    expect(parseAndFormatApiError(errorMessage)).toBe(
+      `[API Error: ${errorMessage}]`,
+    );
   });
 
   it('should format a nested API error', () => {
@@ -49,8 +66,32 @@ describe('parseAndFormatApiError', () => {
       },
     });
 
-    expect(parseAndFormatApiError(errorMessage)).toBe(
-      "API Error: Gemini 2.5 Pro Preview doesn't have a free quota tier. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. (Status: Too Many Requests)",
-    );
+    const expected = `[API Error: Gemini 2.5 Pro Preview doesn't have a free quota tier. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. (Status: Too Many Requests)]\n${rateLimitMessage}`;
+
+    expect(parseAndFormatApiError(errorMessage)).toBe(expected);
+  });
+
+  it('should format a StructuredError', () => {
+    const error: StructuredError = {
+      message: 'A structured error occurred',
+      status: 500,
+    };
+    const expected = '[API Error: A structured error occurred]';
+    expect(parseAndFormatApiError(error)).toBe(expected);
+  });
+
+  it('should format a 429 StructuredError with the custom message', () => {
+    const error: StructuredError = {
+      message: 'Rate limit exceeded',
+      status: 429,
+    };
+    const expected = `[API Error: Rate limit exceeded]\n${rateLimitMessage}`;
+    expect(parseAndFormatApiError(error)).toBe(expected);
+  });
+
+  it('should handle an unknown error type', () => {
+    const error = 12345;
+    const expected = '[API Error: An unknown error occurred.]';
+    expect(parseAndFormatApiError(error)).toBe(expected);
   });
 });

--- a/packages/cli/src/ui/utils/errorParsing.ts
+++ b/packages/cli/src/ui/utils/errorParsing.ts
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { StructuredError } from '@gemini-cli/core';
+
+const RATE_LIMIT_ERROR_MESSAGE =
+  '\nPlease wait and try again later. To increase your limits, upgrade to a plan with higher limits, or use /auth to switch to using a paid API key from AI Studio at https://aistudio.google.com/apikey';
+
 export interface ApiError {
   error: {
     code: number;
@@ -23,34 +28,57 @@ function isApiError(error: unknown): error is ApiError {
   );
 }
 
-export function parseAndFormatApiError(errorMessage: string): string {
-  // The error message might be prefixed with some text, like "[Stream Error: ...]".
-  // We want to find the start of the JSON object.
-  const jsonStart = errorMessage.indexOf('{');
-  if (jsonStart === -1) {
-    return errorMessage; // Not a JSON error, return as is.
-  }
+function isStructuredError(error: unknown): error is StructuredError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof (error as StructuredError).message === 'string'
+  );
+}
 
-  const jsonString = errorMessage.substring(jsonStart);
-
-  try {
-    const error = JSON.parse(jsonString) as unknown;
-    if (isApiError(error)) {
-      let finalMessage = error.error.message;
-      try {
-        // See if the message is a stringified JSON with another error
-        const nestedError = JSON.parse(finalMessage) as unknown;
-        if (isApiError(nestedError)) {
-          finalMessage = nestedError.error.message;
-        }
-      } catch (_e) {
-        // It's not a nested JSON error, so we just use the message as is.
-      }
-      return `API Error: ${finalMessage} (Status: ${error.error.status})`;
+export function parseAndFormatApiError(error: unknown): string {
+  if (isStructuredError(error)) {
+    let text = `[API Error: ${error.message}]`;
+    if (error.status === 429) {
+      text += RATE_LIMIT_ERROR_MESSAGE;
     }
-  } catch (_e) {
-    // Not a valid JSON, fall through and return the original message.
+    return text;
   }
 
-  return errorMessage;
+  // The error message might be a string containing a JSON object.
+  if (typeof error === 'string') {
+    const jsonStart = error.indexOf('{');
+    if (jsonStart === -1) {
+      return `[API Error: ${error}]`; // Not a JSON error, return as is.
+    }
+
+    const jsonString = error.substring(jsonStart);
+
+    try {
+      const parsedError = JSON.parse(jsonString) as unknown;
+      if (isApiError(parsedError)) {
+        let finalMessage = parsedError.error.message;
+        try {
+          // See if the message is a stringified JSON with another error
+          const nestedError = JSON.parse(finalMessage) as unknown;
+          if (isApiError(nestedError)) {
+            finalMessage = nestedError.error.message;
+          }
+        } catch (_e) {
+          // It's not a nested JSON error, so we just use the message as is.
+        }
+        let text = `[API Error: ${finalMessage} (Status: ${parsedError.error.status})]`;
+        if (parsedError.error.code === 429) {
+          text += RATE_LIMIT_ERROR_MESSAGE;
+        }
+        return text;
+      }
+    } catch (_e) {
+      // Not a valid JSON, fall through and return the original message.
+    }
+    return `[API Error: ${error}]`;
+  }
+
+  return '[API Error: An unknown error occurred.]';
 }

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -233,7 +233,9 @@ describe('Turn', () => {
       expect(events.length).toBe(1);
       const errorEvent = events[0] as ServerGeminiErrorEvent;
       expect(errorEvent.type).toBe(GeminiEventType.Error);
-      expect(errorEvent.value).toEqual({ message: 'API Error' });
+      expect(errorEvent.value).toEqual({
+        error: { message: 'API Error', status: undefined },
+      });
       expect(turn.getDebugResponses().length).toBe(0);
       expect(reportError).toHaveBeenCalledWith(
         error,


### PR DESCRIPTION
## TLDR

This change improves user experience when rate limit errors (429) from the Gemini API were not providing a helpful message to the user. It also improves the overall robustness of the error handling system by introducing a structured error type and ensuring consistent error messages across both interactive and non-interactive modes.

## Dive Deeper

### 1. Unhelpful Rate Limit Errors

Previously, when a user hit a 429 rate limit error, the application would display a unhelpful error message  with a lack of actionable steps. This was because the error handling system discarded the HTTP status code before it reached the UI, preventing any special handling for different error types.

This fix introduces a new `StructuredError` interface to solve this problem at the data-structure level:

*   **Actionable 429 Message**: The parser now explicitly checks for a status of 429 and appends a detailed, helpful message guiding the user on how to resolve the rate limit issue.

    <img width="1173" alt="Screenshot 2025-06-22 at 7 02 25 PM" src="https://github.com/user-attachments/assets/cdf1f7e7-0e3c-4168-b8ec-6c40429baa60" />

*   **Structured Error Event**: The core event stream (`Turn.run`) now catches raw API errors and re-packages them into a `StructuredError` object (`{ message: string, status?: number }`). This preserves the critical HTTP status code while still abstracting away the raw error object from the UI layer.
*   **Centralized Parsing Logic**: A single function, `parseAndFormatApiError`, is now responsible for handling all API errors. It intelligently inspects the error it receives, whether it's the new `StructuredError` or an older string-based JSON error, and formats it appropriately.
*   **Consistent User Experience**: The non-interactive CLI mode has been updated to use the same centralized parsing logic, ensuring users receive the same helpful error message regardless of how they are using the tool.
    
    <img width="1174" alt="Screenshot 2025-06-22 at 7 03 48 PM" src="https://github.com/user-attachments/assets/14bda3d6-cc5c-42fa-851a-70521ac89455" />


### 2. Test Suite Improvements

To ensure the long-term stability of these changes, the test suite has been significantly improved:

*   **Comprehensive Coverage**: New tests have been added to `errorParsing.test.ts` to cover all possible error paths, including the new `StructuredError`, stringified JSON errors, and plain string errors.
*   **Downstream Test Fixes**: All downstream tests that were affected by the new error handling logic have been updated to reflect the new, more robust system.

## Reviewer Test Plan

To validate this change, please test the following scenarios:

1.  **Interactive Mode 429 Error (The Fix)**:
    *   Trigger a 429 error in interactive mode.
    *   **Expected Behavior**: The UI should display the detailed rate limit error message, including the link to AI Studio.

2.  **Non-Interactive Mode 429 Error (The Fix)**:
    *   Trigger a 429 error in non-interactive mode.
    *   **Expected Behavior**: The console output should display the same detailed rate limit error message as the interactive mode.

3.  **Standard API Error (Regression Test)**:
    *   Trigger a different API error (e.g., a 400 Bad Request).
    *   **Expected Behavior**: The application should display a concise, formatted error message (e.g., `[API Error: API key not valid. Please pass a valid API key. (Status: INVALID_ARGUMENT)]`) without the detailed 429 help text.

4.  **Standard Chat (Regression Test)**:
    *   Have a simple conversation with the model without triggering any errors.
    *   **Expected Behavior**: The conversation should proceed normally with no change in behavior.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |
