### PR TITLE
Rename `disableDataCollection` to `usageStatisticsEnabled `

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -226,7 +226,8 @@ export async function loadCliConfig(
         process.env.OTEL_EXPORTER_OTLP_ENDPOINT ??
         settings.telemetry?.otlpEndpoint,
       logPrompts: argv.telemetryLogPrompts ?? settings.telemetry?.logPrompts,
-      disableDataCollection: settings.telemetry?.disableDataCollection ?? false,
+      usageStatisticsEnabled:
+        settings.telemetry?.usageStatisticsEnabled ?? true,
     },
     // Git-aware file filtering settings
     fileFiltering: {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -288,7 +288,7 @@ describe('useGeminiStream', () => {
       getProjectRoot: vi.fn(() => '/test/dir'),
       getCheckpointingEnabled: vi.fn(() => false),
       getGeminiClient: mockGetGeminiClient,
-      getDisableDataCollection: () => false,
+      getUsageStatisticsEnabled: () => true,
       addHistory: vi.fn(),
     } as unknown as Config;
     mockOnDebugMessage = vi.fn();

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -48,7 +48,7 @@ const mockToolRegistry = {
 const mockConfig = {
   getToolRegistry: vi.fn(() => mockToolRegistry as unknown as ToolRegistry),
   getApprovalMode: vi.fn(() => ApprovalMode.DEFAULT),
-  getDisableDataCollection: () => false,
+  getUsageStatisticsEnabled: () => true,
 };
 
 const mockTool: Tool = {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -57,7 +57,7 @@ export interface TelemetrySettings {
   target?: TelemetryTarget;
   otlpEndpoint?: string;
   logPrompts?: boolean;
-  disableDataCollection?: boolean;
+  usageStatisticsEnabled?: boolean;
 }
 
 export class MCPServerConfig {
@@ -181,7 +181,7 @@ export class Config {
       target: params.telemetry?.target ?? DEFAULT_TELEMETRY_TARGET,
       otlpEndpoint: params.telemetry?.otlpEndpoint ?? DEFAULT_OTLP_ENDPOINT,
       logPrompts: params.telemetry?.logPrompts ?? true,
-      disableDataCollection: params.telemetry?.disableDataCollection ?? false,
+      usageStatisticsEnabled: params.telemetry?.usageStatisticsEnabled ?? true,
     };
 
     this.fileFiltering = {
@@ -205,7 +205,7 @@ export class Config {
       initializeTelemetry(this);
     }
 
-    if (!this.getDisableDataCollection()) {
+    if (this.getUsageStatisticsEnabled()) {
       ClearcutLogger.getInstance(this)?.logStartSessionEvent(
         new StartSessionEvent(this),
       );
@@ -385,8 +385,8 @@ export class Config {
     return this.fileDiscoveryService;
   }
 
-  getDisableDataCollection(): boolean {
-    return this.telemetrySettings.disableDataCollection ?? false;
+  getUsageStatisticsEnabled(): boolean {
+    return this.telemetrySettings.usageStatisticsEnabled ?? true;
   }
 
   getExtensionContextFilePaths(): string[] {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -77,7 +77,7 @@ describe('CoreToolScheduler', () => {
 
     const mockConfig = {
       getSessionId: () => 'test-session-id',
-      getDisableDataCollection: () => false,
+      getUsageStatisticsEnabled: () => true,
     } as Config;
 
     const scheduler = new CoreToolScheduler({

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -27,7 +27,7 @@ const mockModelsModule = {
 const mockConfig = {
   getSessionId: () => 'test-session-id',
   getTelemetryLogPromptsEnabled: () => true,
-  getDisableDataCollection: () => false,
+  getUsageStatisticsEnabled: () => true,
 } as unknown as Config;
 
 describe('GeminiChat', () => {

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -18,7 +18,7 @@ import { Part, Type } from '@google/genai';
 
 const mockConfig = {
   getSessionId: () => 'test-session-id',
-  getDisableDataCollection: () => false,
+  getUsageStatisticsEnabled: () => true,
 } as unknown as Config;
 
 describe('executeToolCall', () => {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -46,7 +46,7 @@ export class ClearcutLogger {
   }
 
   static getInstance(config?: Config): ClearcutLogger | undefined {
-    if (config === undefined || config?.getDisableDataCollection())
+    if (config === undefined || !config?.getUsageStatisticsEnabled())
       return undefined;
     if (!ClearcutLogger.instance) {
       ClearcutLogger.instance = new ClearcutLogger(config);

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -71,7 +71,7 @@ describe('loggers', () => {
           authType: AuthType.USE_VERTEX_AI,
         }),
         getTelemetryEnabled: () => true,
-        getDisableDataCollection: () => false,
+        getUsageStatisticsEnabled: () => true,
         getTelemetryLogPromptsEnabled: () => true,
         getFileFilteringRespectGitIgnore: () => true,
         getFileFilteringAllowBuildArtifacts: () => false,
@@ -116,7 +116,7 @@ describe('loggers', () => {
       getSessionId: () => 'test-session-id',
       getTelemetryEnabled: () => true,
       getTelemetryLogPromptsEnabled: () => true,
-      getDisableDataCollection: () => false,
+      getUsageStatisticsEnabled: () => true,
     } as unknown as Config;
 
     it('should log a user prompt', () => {
@@ -142,7 +142,7 @@ describe('loggers', () => {
         getTelemetryEnabled: () => true,
         getTelemetryLogPromptsEnabled: () => false,
         getTargetDir: () => 'target-dir',
-        getDisableDataCollection: () => false,
+        getUsageStatisticsEnabled: () => true,
       } as unknown as Config;
       const event = new UserPromptEvent(11, 'test-prompt');
 
@@ -164,7 +164,7 @@ describe('loggers', () => {
     const mockConfig = {
       getSessionId: () => 'test-session-id',
       getTargetDir: () => 'target-dir',
-      getDisableDataCollection: () => false,
+      getUsageStatisticsEnabled: () => true,
       getTelemetryEnabled: () => true,
       getTelemetryLogPromptsEnabled: () => true,
     } as Config;
@@ -270,7 +270,7 @@ describe('loggers', () => {
     const mockConfig = {
       getSessionId: () => 'test-session-id',
       getTargetDir: () => 'target-dir',
-      getDisableDataCollection: () => false,
+      getUsageStatisticsEnabled: () => true,
       getTelemetryEnabled: () => true,
       getTelemetryLogPromptsEnabled: () => true,
     } as Config;
@@ -347,7 +347,7 @@ describe('loggers', () => {
       getSessionId: () => 'test-session-id',
       getTargetDir: () => 'target-dir',
       getGeminiClient: () => mockGeminiClient,
-      getDisableDataCollection: () => false,
+      getUsageStatisticsEnabled: () => true,
       getTelemetryEnabled: () => true,
       getTelemetryLogPromptsEnabled: () => true,
     } as Config;


### PR DESCRIPTION
Renames the `disableDataCollection` flag to the more intuitive and positive `usageStatisticsEnabled`.

1. Changing from `disable` to `enabled` improves code clarity by avoiding double negatives (`disableDataCollection: false`) and making the purpose of the flag more direct. The logic has been inverted wherever the flag is used to accommodate the new naming convention.

2. Using `enabled` as a suffix instead of a prefix follows a common convention that improves readability. 
- A condition like `if (usageStatisticsEnabled)` reads like a natural language sentence ("if usage statistics is enabled"), which reduces cognitive load.
- Distinguishes the boolean flag (representing a state) from potential functions that would perform an action (e.g., `enableUsageStatistics()` or `disableUsageStatistics()`), avoiding ambiguity between checking a value and calling a function.

3. Changing from "data collection" to "usage statistics" clarifies the scope and purpose of the data.

#750
