### PR TITLE
feat(auth): improve init auth flow

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -127,6 +127,8 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   const [ctrlDPressedOnce, setCtrlDPressedOnce] = useState(false);
   const ctrlDTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [constrainHeight, setConstrainHeight] = useState<boolean>(true);
+  const [isInitialAuthResolved, setIsInitialAuthResolved] =
+    useState<boolean>(false);
 
   const errorCount = useMemo(
     () => consoleMessages.filter((msg) => msg.type === 'error').length,
@@ -155,7 +157,11 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
       if (error) {
         setAuthError(error);
         openAuthDialog();
+      } else {
+        setIsInitialAuthResolved(true);
       }
+    } else {
+      openAuthDialog();
     }
   }, [settings.merged.selectedAuthType, openAuthDialog, setAuthError]);
 
@@ -658,6 +664,8 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
                 onHighlight={handleAuthHighlight}
                 settings={settings}
                 initialErrorMessage={authError}
+                isInitialAuth={!isInitialAuthResolved}
+                onExit={() => process.exit(0)}
               />
             </Box>
           ) : isEditorDialogOpen ? (

--- a/packages/cli/src/ui/components/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.test.tsx
@@ -8,6 +8,13 @@ import { render } from 'ink-testing-library';
 import { AuthDialog } from './AuthDialog.js';
 import { LoadedSettings } from '../../config/settings.js';
 import { AuthType } from '@gemini-cli/core';
+import { useInput } from 'ink';
+import { vi } from 'vitest';
+
+vi.mock('ink', async (importOriginal) => {
+  const actualInkModule = (await importOriginal()) as object;
+  return { ...actualInkModule, useInput: vi.fn() };
+});
 
 describe('AuthDialog', () => {
   it('should show an error if the initial auth type is invalid', () => {
@@ -31,11 +38,196 @@ describe('AuthDialog', () => {
         onHighlight={() => {}}
         settings={settings}
         initialErrorMessage="GEMINI_API_KEY  environment variable not found"
+        isInitialAuth={true}
+        onExit={() => {}}
       />,
     );
 
     expect(lastFrame()).toContain(
       'GEMINI_API_KEY  environment variable not found',
     );
+  });
+
+  it('should call onExit when isInitialAuth is true and escape is pressed', () => {
+    const onExit = vi.fn();
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: {},
+        path: '',
+      },
+      {
+        settings: {},
+        path: '',
+      },
+      [],
+    );
+
+    let useInputCallback: (
+      input: string,
+      key: { escape: boolean },
+    ) => void = () => {};
+    (useInput as ReturnType<typeof vi.fn>).mockImplementation((callback) => {
+      useInputCallback = callback;
+    });
+
+    const { unmount } = render(
+      <AuthDialog
+        onSelect={() => {}}
+        onHighlight={() => {}}
+        settings={settings}
+        isInitialAuth={true}
+        onExit={onExit}
+      />,
+    );
+
+    useInputCallback('', { escape: true });
+    expect(onExit).toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should call onSelect with undefined when isInitialAuth is false and escape is pressed', () => {
+    const onSelect = vi.fn();
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: {},
+        path: '',
+      },
+      {
+        settings: {},
+        path: '',
+      },
+      [],
+    );
+
+    let useInputCallback: (
+      input: string,
+      key: { escape: boolean },
+    ) => void = () => {};
+    (useInput as ReturnType<typeof vi.fn>).mockImplementation((callback) => {
+      useInputCallback = callback;
+    });
+
+    const { unmount } = render(
+      <AuthDialog
+        onSelect={onSelect}
+        onHighlight={() => {}}
+        settings={settings}
+        isInitialAuth={false}
+        onExit={() => {}}
+      />,
+    );
+
+    useInputCallback('', { escape: true });
+    expect(onSelect).toHaveBeenCalledWith(undefined, 'User');
+    unmount();
+  });
+
+  describe('Snapshots', () => {
+    it('should render correctly for initial auth', () => {
+      const settings: LoadedSettings = new LoadedSettings(
+        {
+          settings: {},
+          path: '',
+        },
+        {
+          settings: {},
+          path: '',
+        },
+        [],
+      );
+
+      const { lastFrame } = render(
+        <AuthDialog
+          onSelect={() => {}}
+          onHighlight={() => {}}
+          settings={settings}
+          isInitialAuth={true}
+          onExit={() => {}}
+        />,
+      );
+
+      expect(lastFrame()).toMatchSnapshot();
+    });
+
+    it('should render correctly for user-initiated auth', () => {
+      const settings: LoadedSettings = new LoadedSettings(
+        {
+          settings: {},
+          path: '',
+        },
+        {
+          settings: {},
+          path: '',
+        },
+        [],
+      );
+
+      const { lastFrame } = render(
+        <AuthDialog
+          onSelect={() => {}}
+          onHighlight={() => {}}
+          settings={settings}
+          isInitialAuth={false}
+          onExit={() => {}}
+        />,
+      );
+
+      expect(lastFrame()).toMatchSnapshot();
+    });
+
+    it('should render correctly with an error message', () => {
+      const settings: LoadedSettings = new LoadedSettings(
+        {
+          settings: {},
+          path: '',
+        },
+        {
+          settings: {},
+          path: '',
+        },
+        [],
+      );
+
+      const { lastFrame } = render(
+        <AuthDialog
+          onSelect={() => {}}
+          onHighlight={() => {}}
+          settings={settings}
+          isInitialAuth={false}
+          onExit={() => {}}
+          initialErrorMessage="Something went wrong"
+        />,
+      );
+
+      expect(lastFrame()).toMatchSnapshot();
+    });
+
+    it('should render all options when an advanced option is pre-selected', () => {
+      const settings: LoadedSettings = new LoadedSettings(
+        {
+          settings: {
+            selectedAuthType: AuthType.USE_VERTEX_AI,
+          },
+          path: '',
+        },
+        {
+          settings: {},
+          path: '',
+        },
+        [],
+      );
+
+      const { lastFrame } = render(
+        <AuthDialog
+          onSelect={() => {}}
+          onHighlight={() => {}}
+          settings={settings}
+          isInitialAuth={false}
+          onExit={() => {}}
+        />,
+      );
+
+      expect(lastFrame()).toMatchSnapshot();
+    });
   });
 });

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -17,6 +17,8 @@ interface AuthDialogProps {
   onHighlight: (authMethod: string | undefined) => void;
   settings: LoadedSettings;
   initialErrorMessage?: string | null;
+  isInitialAuth: boolean;
+  onExit: () => void;
 }
 
 export function AuthDialog({
@@ -24,6 +26,8 @@ export function AuthDialog({
   onHighlight,
   settings,
   initialErrorMessage,
+  isInitialAuth,
+  onExit,
 }: AuthDialogProps): React.JSX.Element {
   const [errorMessage, setErrorMessage] = useState<string | null>(
     initialErrorMessage || null,
@@ -78,7 +82,11 @@ export function AuthDialog({
 
   useInput((_input, key) => {
     if (key.escape) {
-      onSelect(undefined, SettingScope.User);
+      if (isInitialAuth) {
+        onExit();
+      } else {
+        onSelect(undefined, SettingScope.User);
+      }
     }
   });
 
@@ -104,7 +112,10 @@ export function AuthDialog({
         </Box>
       )}
       <Box marginTop={1}>
-        <Text color={Colors.Gray}>(Use Enter to select)</Text>
+        <Text color={Colors.Gray}>
+          (Use Enter to select,{' '}
+          {isInitialAuth ? 'esc to quit' : 'esc to cancel'})
+        </Text>
       </Box>
     </Box>
   );

--- a/packages/cli/src/ui/components/__snapshots__/AuthDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/AuthDialog.test.tsx.snap
@@ -1,0 +1,56 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthDialog > Snapshots > should render all options when an advanced option is pre-selected 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                  │
+│ Select Auth Method                                                                               │
+│ ○ Login with Google                                                                              │
+│ ○ Gemini API Key                                                                                 │
+│ ○ Login with Google Work                                                                         │
+│ ● Vertex API Key                                                                                 │
+│                                                                                                  │
+│ (Use Enter to select, esc to cancel)                                                             │
+│                                                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`AuthDialog > Snapshots > should render correctly for initial auth 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                  │
+│ Select Auth Method                                                                               │
+│ ● Login with Google                                                                              │
+│ ○ Gemini API Key                                                                                 │
+│ ○ More...                                                                                        │
+│                                                                                                  │
+│ (Use Enter to select, esc to quit)                                                               │
+│                                                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`AuthDialog > Snapshots > should render correctly for user-initiated auth 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                  │
+│ Select Auth Method                                                                               │
+│ ● Login with Google                                                                              │
+│ ○ Gemini API Key                                                                                 │
+│ ○ More...                                                                                        │
+│                                                                                                  │
+│ (Use Enter to select, esc to cancel)                                                             │
+│                                                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`AuthDialog > Snapshots > should render correctly with an error message 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                  │
+│ Select Auth Method                                                                               │
+│ ● Login with Google                                                                              │
+│ ○ Gemini API Key                                                                                 │
+│ ○ More...                                                                                        │
+│                                                                                                  │
+│ Something went wrong                                                                             │
+│                                                                                                  │
+│ (Use Enter to select, esc to cancel)                                                             │
+│                                                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;

--- a/packages/cli/src/ui/hooks/useAuthCommand.test.ts
+++ b/packages/cli/src/ui/hooks/useAuthCommand.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAuthCommand } from './useAuthCommand.js';
+import {
+  LoadedSettings,
+  SettingScope,
+  type Settings,
+  type SettingsFile,
+} from '../../config/settings.js';
+import { AuthType, Config, clearCachedCredentialFile } from '@gemini-cli/core';
+
+// Mock dependencies with side-effects
+vi.mock('@gemini-cli/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@gemini-cli/core')>();
+  return {
+    ...actual,
+    clearCachedCredentialFile: vi.fn(),
+  };
+});
+
+// Mock the saveSettings function to prevent file system writes during tests.
+vi.mock('../../config/settings.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../config/settings.js')>();
+  return {
+    ...actual,
+    saveSettings: vi.fn(),
+  };
+});
+
+describe('useAuthCommand', () => {
+  let mockConfig: Config;
+  let mockSetAuthError: ReturnType<typeof vi.fn>;
+
+  // Helper function to create a real LoadedSettings instance for tests.
+  // This avoids the type errors from using a plain object mock.
+  const createMockSettings = (
+    initialSettings: Settings = {},
+  ): LoadedSettings => {
+    const user: SettingsFile = { path: 'user.json', settings: {} };
+    const workspace: SettingsFile = {
+      path: 'workspace.json',
+      settings: initialSettings,
+    };
+    return new LoadedSettings(user, workspace, []);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSetAuthError = vi.fn();
+    mockConfig = {
+      refreshAuth: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Config;
+  });
+
+  it('should initialize with the auth dialog open if no auth type is selected', () => {
+    // Setup: Create settings with no `selectedAuthType`.
+    const mockSettings = createMockSettings({});
+
+    const { result } = renderHook(() =>
+      useAuthCommand(mockSettings, mockSetAuthError, mockConfig),
+    );
+
+    expect(result.current.isAuthDialogOpen).toBe(true);
+  });
+
+  it('should initialize with the auth dialog closed if an auth type is already selected', () => {
+    // Setup: Create settings with `selectedAuthType` present.
+    const mockSettings = createMockSettings({
+      selectedAuthType: AuthType.USE_GEMINI,
+    });
+
+    const { result } = renderHook(() =>
+      useAuthCommand(mockSettings, mockSetAuthError, mockConfig),
+    );
+
+    expect(result.current.isAuthDialogOpen).toBe(false);
+  });
+
+  describe('handleAuthSelect', () => {
+    it('should set auth type and clear credentials when a method is selected', async () => {
+      const mockSettings = createMockSettings();
+
+      const setValueSpy = vi
+        .spyOn(mockSettings, 'setValue')
+        .mockImplementation(() => {});
+
+      const { result } = renderHook(() =>
+        useAuthCommand(mockSettings, mockSetAuthError, mockConfig),
+      );
+      const authMethod = AuthType.USE_GEMINI;
+      const scope = SettingScope.User;
+
+      await act(async () => {
+        await result.current.handleAuthSelect(authMethod, scope);
+      });
+
+      expect(clearCachedCredentialFile).toHaveBeenCalledTimes(1);
+      expect(setValueSpy).toHaveBeenCalledWith(
+        scope,
+        'selectedAuthType',
+        authMethod,
+      );
+      expect(result.current.isAuthDialogOpen).toBe(false);
+      expect(mockSetAuthError).toHaveBeenCalledWith(null);
+    });
+
+    it('should just close the dialog if no method is selected (e.g., escape)', async () => {
+      const mockSettings = createMockSettings();
+      const setValueSpy = vi.spyOn(mockSettings, 'setValue');
+
+      const { result } = renderHook(() =>
+        useAuthCommand(mockSettings, mockSetAuthError, mockConfig),
+      );
+
+      await act(async () => {
+        await result.current.handleAuthSelect(undefined, SettingScope.User);
+      });
+
+      expect(clearCachedCredentialFile).not.toHaveBeenCalled();
+      expect(setValueSpy).not.toHaveBeenCalled();
+      expect(result.current.isAuthDialogOpen).toBe(false);
+    });
+  });
+
+  describe('closeAuthDialog', () => {
+    it('should close the dialog when called', () => {
+      const mockSettings = createMockSettings({}); // Start with dialog open
+      const { result } = renderHook(() =>
+        useAuthCommand(mockSettings, mockSetAuthError, mockConfig),
+      );
+      expect(result.current.isAuthDialogOpen).toBe(true);
+
+      act(() => {
+        result.current.closeAuthDialog();
+      });
+
+      expect(result.current.isAuthDialogOpen).toBe(false);
+    });
+  });
+
+  describe('Automatic Authentication (useEffect)', () => {
+    it('should not attempt to authenticate if the dialog is open', () => {
+      const mockSettings = createMockSettings({
+        selectedAuthType: AuthType.USE_GEMINI,
+      });
+      const { result } = renderHook(() =>
+        useAuthCommand(mockSettings, mockSetAuthError, mockConfig),
+      );
+
+      vi.mocked(mockConfig.refreshAuth).mockClear();
+
+      act(() => {
+        result.current.openAuthDialog();
+      });
+
+      expect(mockConfig.refreshAuth).not.toHaveBeenCalled();
+    });
+
+    it('should set an error and reopen the dialog if authentication fails', async () => {
+      const errorMessage = 'Authentication failed';
+      vi.mocked(mockConfig.refreshAuth).mockRejectedValue(
+        new Error(errorMessage),
+      );
+      const mockSettings = createMockSettings({
+        selectedAuthType: AuthType.LOGIN_WITH_GOOGLE_PERSONAL,
+      });
+
+      const { result } = renderHook(() =>
+        useAuthCommand(mockSettings, mockSetAuthError, mockConfig),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isAuthDialogOpen).toBe(true);
+      });
+
+      expect(mockSetAuthError).toHaveBeenCalledWith(
+        expect.stringContaining(errorMessage),
+      );
+      expect(result.current.isAuthenticating).toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/ui/hooks/useAuthCommand.ts
+++ b/packages/cli/src/ui/hooks/useAuthCommand.ts
@@ -82,6 +82,10 @@ Message: ${getErrorMessage(e)}`
     setIsAuthenticating(false);
   }, []);
 
+  const closeAuthDialog = useCallback(() => {
+    setIsAuthDialogOpen(false);
+  }, []);
+
   return {
     isAuthDialogOpen,
     openAuthDialog,
@@ -89,5 +93,6 @@ Message: ${getErrorMessage(e)}`
     handleAuthHighlight,
     isAuthenticating,
     cancelAuthentication,
+    closeAuthDialog,
   };
 };


### PR DESCRIPTION
## TLDR

This change improves the user experience of the authentication flow by providing different exit behaviors for the initial authentication and user-initiated authentication. It also adds more robust testing for the authentication components.

1.  **Differentiated Exit Behavior**: The `AuthDialog` now has a different exit behavior depending on whether it is being displayed for the initial authentication or a user-initiated authentication. If it is the initial authentication, pressing `esc` will exit the CLI. If it is a user-initiated authentication, pressing `esc` will simply close the dialog.
2.  **Context-Aware Hint**: The `AuthDialog` now displays a hint to the user about what pressing `esc` will do. The hint is context-aware and will display "esc to quit" for the initial authentication and "esc to cancel" for a user-initiated authentication.
3.  **Improved Testing**: The tests for the `AuthDialog` have been improved to cover the new exit behavior and to use snapshot testing to ensure the UI remains consistent across changes.

## Dive Deeper

### 1. Differentiated Exit Behavior

The root cause of the confusing user experience was that the `AuthDialog` had the same exit behavior for both the initial authentication and a user-initiated authentication. This was fixed by introducing a new state variable, `isInitialAuthResolved`, to the `App` component. This variable is used to determine whether the `AuthDialog` is being displayed for the initial authentication or a user-initiated authentication.

### 2. Context-Aware Hint

The `AuthDialog` now displays a hint to the user about what pressing `esc` will do. The hint is context-aware and will display "esc to quit" for the initial authentication and "esc to cancel" for a user-initiated authentication. This was implemented by adding a new `Text` component to the `AuthDialog` that displays the appropriate hint based on the `isInitialAuth` prop.

### 3. Improved Testing

The tests for the `AuthDialog` have been improved to cover the new exit behavior and to use snapshot testing to ensure the UI remains consistent across changes. The tests now use a mocked `useInput` hook to simulate the escape key press and verify that the correct exit behavior is triggered.

## Reviewer Test Plan

To validate this change, please test the following scenarios:

1.  **Initial Auth (The Fix)**:
    *   Run the CLI without a valid authentication method configured.
        * Using `rm ../../.gemini/oauth_creds.json` and `rm ../../.gemini/settings.json` worked for me.
    *   **Expected Behavior**: The `AuthDialog` should be displayed. Pressing `esc` should exit the CLI.

2.  **User-Initiated Auth (The Fix)**:
    *   Run the CLI with a valid authentication method configured.
    *   Run the `/auth` command.
    *   **Expected Behavior**: The `AuthDialog` should be displayed. Pressing `esc` should close the dialog and return you to the input prompt.

3.  **Standard Chat (Regression Test)**:
    *   Have a simple conversation with the model without using tools.
    *   **Expected Behavior**: The conversation should proceed normally with no change in behavior.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs
Closes [b/426635736](https://b.corp.google.com/issues/426635736)