### PR TITLE
Scotdensmore/first run auth fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,9 +12,9 @@
       "runtimeArgs": ["run", "start"],
       "skipFiles": ["<node_internals>/**"],
       "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
       "env": {
-        "GEMINI_SANDBOX": "false",
-        "GEMINI_API_KEY": "testkey"
+        "GEMINI_SANDBOX": "false"
       }
     },
     {

--- a/packages/cli/src/ui/components/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.test.tsx
@@ -5,11 +5,14 @@
  */
 
 import { render } from 'ink-testing-library';
+import { describe, it, expect, vi } from 'vitest';
 import { AuthDialog } from './AuthDialog.js';
-import { LoadedSettings } from '../../config/settings.js';
+import { LoadedSettings, SettingScope } from '../../config/settings.js';
 import { AuthType } from '@gemini-cli/core';
 
 describe('AuthDialog', () => {
+  const wait = (ms = 50) => new Promise((resolve) => setTimeout(resolve, ms));
+
   it('should show an error if the initial auth type is invalid', () => {
     const settings: LoadedSettings = new LoadedSettings(
       {
@@ -37,5 +40,76 @@ describe('AuthDialog', () => {
     expect(lastFrame()).toContain(
       'GEMINI_API_KEY  environment variable not found',
     );
+  });
+
+  it('should prevent exiting when no auth method is selected and show error message', async () => {
+    const onSelect = vi.fn();
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: {
+          selectedAuthType: undefined,
+        },
+        path: '',
+      },
+      {
+        settings: {},
+        path: '',
+      },
+      [],
+    );
+
+    const { lastFrame, stdin, unmount } = render(
+      <AuthDialog
+        onSelect={onSelect}
+        onHighlight={() => {}}
+        settings={settings}
+      />,
+    );
+    await wait();
+
+    // Simulate pressing escape key
+    stdin.write('\u001b'); // ESC key
+    await wait();
+
+    // Should show error message instead of calling onSelect
+    expect(lastFrame()).toContain(
+      'You must select an auth method to proceed. Press Ctrl+C twice to exit.',
+    );
+    expect(onSelect).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should allow exiting when auth method is already selected', async () => {
+    const onSelect = vi.fn();
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: {
+          selectedAuthType: AuthType.USE_GEMINI,
+        },
+        path: '',
+      },
+      {
+        settings: {},
+        path: '',
+      },
+      [],
+    );
+
+    const { stdin, unmount } = render(
+      <AuthDialog
+        onSelect={onSelect}
+        onHighlight={() => {}}
+        settings={settings}
+      />,
+    );
+    await wait();
+
+    // Simulate pressing escape key
+    stdin.write('\u001b'); // ESC key
+    await wait();
+
+    // Should call onSelect with undefined to exit
+    expect(onSelect).toHaveBeenCalledWith(undefined, SettingScope.User);
+    unmount();
   });
 });

--- a/packages/cli/src/ui/components/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.test.tsx
@@ -5,14 +5,11 @@
  */
 
 import { render } from 'ink-testing-library';
-import { describe, it, expect, vi } from 'vitest';
 import { AuthDialog } from './AuthDialog.js';
-import { LoadedSettings, SettingScope } from '../../config/settings.js';
+import { LoadedSettings } from '../../config/settings.js';
 import { AuthType } from '@gemini-cli/core';
 
 describe('AuthDialog', () => {
-  const wait = (ms = 50) => new Promise((resolve) => setTimeout(resolve, ms));
-
   it('should show an error if the initial auth type is invalid', () => {
     const settings: LoadedSettings = new LoadedSettings(
       {
@@ -40,76 +37,5 @@ describe('AuthDialog', () => {
     expect(lastFrame()).toContain(
       'GEMINI_API_KEY  environment variable not found',
     );
-  });
-
-  it('should prevent exiting when no auth method is selected and show error message', async () => {
-    const onSelect = vi.fn();
-    const settings: LoadedSettings = new LoadedSettings(
-      {
-        settings: {
-          selectedAuthType: undefined,
-        },
-        path: '',
-      },
-      {
-        settings: {},
-        path: '',
-      },
-      [],
-    );
-
-    const { lastFrame, stdin, unmount } = render(
-      <AuthDialog
-        onSelect={onSelect}
-        onHighlight={() => {}}
-        settings={settings}
-      />,
-    );
-    await wait();
-
-    // Simulate pressing escape key
-    stdin.write('\u001b'); // ESC key
-    await wait();
-
-    // Should show error message instead of calling onSelect
-    expect(lastFrame()).toContain(
-      'You must select an auth method to proceed. Press Ctrl+C twice to exit.',
-    );
-    expect(onSelect).not.toHaveBeenCalled();
-    unmount();
-  });
-
-  it('should allow exiting when auth method is already selected', async () => {
-    const onSelect = vi.fn();
-    const settings: LoadedSettings = new LoadedSettings(
-      {
-        settings: {
-          selectedAuthType: AuthType.USE_GEMINI,
-        },
-        path: '',
-      },
-      {
-        settings: {},
-        path: '',
-      },
-      [],
-    );
-
-    const { stdin, unmount } = render(
-      <AuthDialog
-        onSelect={onSelect}
-        onHighlight={() => {}}
-        settings={settings}
-      />,
-    );
-    await wait();
-
-    // Simulate pressing escape key
-    stdin.write('\u001b'); // ESC key
-    await wait();
-
-    // Should call onSelect with undefined to exit
-    expect(onSelect).toHaveBeenCalledWith(undefined, SettingScope.User);
-    unmount();
   });
 });

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -78,6 +78,13 @@ export function AuthDialog({
 
   useInput((_input, key) => {
     if (key.escape) {
+      if (settings.merged.selectedAuthType === undefined) {
+        // Prevent exiting if no auth method is set
+        setErrorMessage(
+          'You must select an auth method to proceed. Press Ctrl+C twice to exit.',
+        );
+        return;
+      }
       onSelect(undefined, SettingScope.User);
     }
   });

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -80,7 +80,9 @@ export function AuthDialog({
     if (key.escape) {
       if (settings.merged.selectedAuthType === undefined) {
         // Prevent exiting if no auth method is set
-        setErrorMessage('You must select an auth method to proceed. Press Ctrl+C twice to exit.');
+        setErrorMessage(
+          'You must select an auth method to proceed. Press Ctrl+C twice to exit.',
+        );
         return;
       }
       onSelect(undefined, SettingScope.User);

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -78,6 +78,11 @@ export function AuthDialog({
 
   useInput((_input, key) => {
     if (key.escape) {
+      if (settings.merged.selectedAuthType === undefined) {
+        // Prevent exiting if no auth method is set
+        setErrorMessage('You must select an auth method to proceed. Press Ctrl+C twice to exit.');
+        return;
+      }
       onSelect(undefined, SettingScope.User);
     }
   });

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -80,9 +80,7 @@ export function AuthDialog({
     if (key.escape) {
       if (settings.merged.selectedAuthType === undefined) {
         // Prevent exiting if no auth method is set
-        setErrorMessage(
-          'You must select an auth method to proceed. Press Ctrl+C twice to exit.',
-        );
+        setErrorMessage('You must select an auth method to proceed. Press Ctrl+C twice to exit.');
         return;
       }
       onSelect(undefined, SettingScope.User);


### PR DESCRIPTION
## TLDR

Improved the initial authentication flow by preventing the user from closing the auth dialog without selecting an authentication method. Also removed a hardcoded GEMINI_API_KEY from the VS Code launch configuration.


## Dive Deeper

The user either enters a auth type on first run or has to quit.

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓ | ❓  | ❓  |
| Podman   | x  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes 426635736.
