### PR TITLE
Remove .gitignore logging from startup.

### DIFF
--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -48,12 +48,6 @@ export class GitIgnoreParser implements GitIgnoreFilter {
       .split('\n')
       .map((p) => p.trim())
       .filter((p) => p !== '' && !p.startsWith('#'));
-    if (patterns.length > 0) {
-      // Log the number of patterns loaded on STDERR so it doesn't clutter the output on STDOUT
-      console.error(
-        `Loaded ${patterns.length} patterns from ${patternsFilePath}`,
-      );
-    }
     this.addPatterns(patterns);
   }
 


### PR DESCRIPTION
- When booting Gemini CLI we'd unnecessarily log git ignore patterns.

## Before
See top line
![image](https://github.com/user-attachments/assets/9b63f86c-eea2-4314-b586-f32e591096a9)


## After
![image](https://github.com/user-attachments/assets/fab87775-bf84-496d-8235-b379ccddb49a)
