### PR TITLE
feat: Open MCP docs if no MCPs are configured

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -291,11 +291,21 @@ export const useSlashCommandProcessor = (
           const serverNames = Object.keys(mcpServers);
 
           if (serverNames.length === 0) {
-            addMessage({
-              type: MessageType.INFO,
-              content: 'No MCP servers configured.',
-              timestamp: new Date(),
-            });
+            const docsUrl = 'https://goo.gle/gemini-cli-docs-mcp';
+            if (process.env.SANDBOX && process.env.SANDBOX !== 'sandbox-exec') {
+              addMessage({
+                type: MessageType.INFO,
+                content: `No MCP servers configured. Please open the following URL in your browser to view documentation:\n${docsUrl}`,
+                timestamp: new Date(),
+              });
+            } else {
+              addMessage({
+                type: MessageType.INFO,
+                content: `No MCP servers configured. Opening documentation in your browser: ${docsUrl}`,
+                timestamp: new Date(),
+              });
+              await open(docsUrl);
+            }
             return;
           }
 


### PR DESCRIPTION
## TLDR

- If a user types /mcp and there are no MCPs configured, open the MCP docs
- Follows a similar pattern to the /docs slash command for launching a browser

Fixes https://b.corp.google.com/issues/426671777

Flow: https://screencast.googleplex.com/cast/NjE1MzYwODA5MjQ1MDgxNnxmZTQ5MGU2Yi03MQ

## Dive Deeper

We weren't guiding users on how to configure MCP servers when none were configured.

## Reviewer Test Plan

Type /mcp without any configured

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ✅   | ❓  | ❓  |
| Docker   | ✅   | ❓  | ❓  |
| Podman   | ✅   | -   | -   |
| Seatbelt | ✅   | -   | -   |

## Linked issues / bugs

https://b.corp.google.com/issues/426671777
