### PR TITLE
A couple of these log messages were now showing up every time on app startup

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -83,7 +83,9 @@ export class ClearcutLogger {
   }
 
   flushToClearcut(): Promise<LogResponse> {
-    console.log('Flushing log events to Clearcut.');
+    if (this.config?.getDebugMode()) {
+      console.log('Flushing log events to Clearcut.');
+    }
     return new Promise<Buffer>((resolve, reject) => {
       const request = [
         {
@@ -93,7 +95,9 @@ export class ClearcutLogger {
         },
       ];
       const body = JSON.stringify(request);
-      console.log('Clearcut POST request body:', body);
+      if (this.config?.getDebugMode()) {
+        console.log('Clearcut POST request body:', body);
+      }
       const options = {
         hostname: 'play.googleapis.com',
         path: '/log',
@@ -108,7 +112,9 @@ export class ClearcutLogger {
         });
       });
       req.on('error', (e) => {
-        console.log('Clearcut POST request error: ', e);
+        if (this.config?.getDebugMode()) {
+          console.log('Clearcut POST request error: ', e);
+        }
         reject(e);
       });
       req.end(body);
@@ -159,7 +165,9 @@ export class ClearcutLogger {
     const returnVal = {
       nextRequestWaitMs: Number(ms),
     };
-    console.log('Clearcut response: ', returnVal);
+    if (this.config?.getDebugMode()) {
+      console.log('Clearcut response: ', returnVal);
+    }
     return returnVal;
   }
 


### PR DESCRIPTION
## TLDR

This logging showed up at the top of the app as the logging happens before Ink has started rendering. This logging only seems important when debugging so removed by default.

This became noticeable when https://github.com/google-gemini/gemini-cli/pull/1309 landed.
Repro:
start up Gemini CLI normally
![Screenshot 2025-06-23 at 11 28 40 AM](https://github.com/user-attachments/assets/1bd155d6-62e5-4767-875d-714355840a19)

