### PR TITLE
Fix batch flush to Clearcut

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -79,7 +79,6 @@ export class ClearcutLogger {
     }
 
     this.flushToClearcut();
-    this.last_flush_time = Date.now();
   }
 
   flushToClearcut(): Promise<LogResponse> {
@@ -121,6 +120,7 @@ export class ClearcutLogger {
     }).then((buf: Buffer) => {
       try {
         this.events.length = 0;
+        this.last_flush_time = Date.now();
         return this.decodeLogResponse(buf) || {};
       } catch (error: unknown) {
         console.error('Error flushing log events:', error);


### PR DESCRIPTION
The `last_flush_time` in the Clearcut logger was being updated before the asynchronous flush operation completed, leading to incorrect flush timing and potential data delivery delays.

This change moves the timestamp update to after the flush promise resolves successfully, ensuring the flush time is only recorded after events are sent to Clearcut.