### PR TITLE
Ensure telemetry events are flushed immediately

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -289,6 +289,7 @@ describe('useGeminiStream', () => {
       getCheckpointingEnabled: vi.fn(() => false),
       getGeminiClient: mockGetGeminiClient,
       getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
       addHistory: vi.fn(),
     } as unknown as Config;
     mockOnDebugMessage = vi.fn();

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -49,6 +49,7 @@ const mockConfig = {
   getToolRegistry: vi.fn(() => mockToolRegistry as unknown as ToolRegistry),
   getApprovalMode: vi.fn(() => ApprovalMode.DEFAULT),
   getUsageStatisticsEnabled: () => true,
+  getDebugMode: () => false,
 };
 
 const mockTool: Tool = {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -78,7 +78,8 @@ describe('CoreToolScheduler', () => {
     const mockConfig = {
       getSessionId: () => 'test-session-id',
       getUsageStatisticsEnabled: () => true,
-    } as Config;
+      getDebugMode: () => false,
+    } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
       config: mockConfig,

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -28,6 +28,7 @@ const mockConfig = {
   getSessionId: () => 'test-session-id',
   getTelemetryLogPromptsEnabled: () => true,
   getUsageStatisticsEnabled: () => true,
+  getDebugMode: () => false,
 } as unknown as Config;
 
 describe('GeminiChat', () => {

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -19,6 +19,7 @@ import { Part, Type } from '@google/genai';
 const mockConfig = {
   getSessionId: () => 'test-session-id',
   getUsageStatisticsEnabled: () => true,
+  getDebugMode: () => false,
 } as unknown as Config;
 
 describe('executeToolCall', () => {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -249,7 +249,7 @@ export class ClearcutLogger {
     );
 
     this.enqueueLogEvent(this.createLogEvent(new_prompt_event_name, data));
-    this.flushIfNeeded();
+    this.flushToClearcut();
   }
 
   logToolCallEvent(event: ToolCallEvent): void {
@@ -278,7 +278,7 @@ export class ClearcutLogger {
     );
 
     this.enqueueLogEvent(this.createLogEvent(tool_call_event_name, data));
-    this.flushIfNeeded();
+    this.flushToClearcut();
   }
 
   logApiRequestEvent(event: ApiRequestEvent): void {
@@ -287,7 +287,7 @@ export class ClearcutLogger {
     data.set(EventMetadataKey.GEMINI_CLI_API_REQUEST_MODEL, event.model);
 
     this.enqueueLogEvent(this.createLogEvent(api_request_event_name, data));
-    this.flushIfNeeded();
+    this.flushToClearcut();
   }
 
   logApiResponseEvent(event: ApiResponseEvent): void {
@@ -328,7 +328,7 @@ export class ClearcutLogger {
     );
 
     this.enqueueLogEvent(this.createLogEvent(api_response_event_name, data));
-    this.flushIfNeeded();
+    this.flushToClearcut();
   }
 
   logApiErrorEvent(event: ApiErrorEvent): void {
@@ -349,7 +349,7 @@ export class ClearcutLogger {
     );
 
     this.enqueueLogEvent(this.createLogEvent(api_error_event_name, data));
-    this.flushIfNeeded();
+    this.flushToClearcut();
   }
 
   logEndSessionEvent(event: EndSessionEvent): void {


### PR DESCRIPTION
The previous implementation used `flushIfNeeded` to batch most telemetry events, but it was not reliably sending them, leading to data loss. Notably, the `startSession` event, which already used `flushToClearcut`, was working correctly, indicating an issue with the batching logic itself.

This change replaces all calls to `flushIfNeeded` with `flushToClearcut` to align all event logging with the working `startSession` implementation and ensure that events are sent immediately. This prioritizes the reliability of data collection over network efficiency.

This is a temporary solution to prevent further data loss. The underlying issue with the batching mechanism in `flushIfNeeded` should be investigated and fixed in the future, at which point this change can be reverted.