### PR TITLE
fix: Replace calls with identical old/new are errors

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -551,6 +551,22 @@ describe('EditTool', () => {
         /Attempted to create a file that already exists/,
       );
     });
+
+    it('should return error if old_string and new_string are identical', async () => {
+      fs.writeFileSync(filePath, 'Some content.', 'utf8');
+      const params: EditToolParams = {
+        file_path: filePath,
+        old_string: 'Some content.',
+        new_string: 'Some content.',
+      };
+      const result = await tool.execute(params, new AbortController().signal);
+      expect(result.llmContent).toMatch(
+        /The old_string and new_string parameters were effectively identical/,
+      );
+      expect(result.returnDisplay).toMatch(
+        /The proposed change resulted in no changes to the file./,
+      );
+    });
   });
 
   describe('getDescription', () => {

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -270,6 +270,14 @@ Expectation for required parameters:
       isNewFile,
     );
 
+    // Only check for no-op if no other error has been found.
+    if (!error && !isNewFile && currentContent === newContent) {
+      error = {
+        display: `The proposed change resulted in no changes to the file.`,
+        raw: `The old_string and new_string parameters were effectively identical, resulting in no change to the file.`,
+      };
+    }
+
     return {
       currentContent,
       newContent,


### PR DESCRIPTION
## TLDR

In long sessions, the model often proposes no-op edits. These should not be presented to the user, and instead should error out. For now, this change leaves the "no changes" dialog in the code.

## Dive Deeper

The current behaviour is annoying for users. What should they do when the model proposes a no-edit diff?
