### PR TITLE
Polish Theme Dialog

### DIFF
--- a/packages/cli/src/ui/components/Header.tsx
+++ b/packages/cli/src/ui/components/Header.tsx
@@ -30,17 +30,22 @@ export const Header: React.FC<HeaderProps> = ({
       terminalWidth >= widthOfLongLogo ? longAsciiLogo : shortAsciiLogo;
   }
 
+  const artWidth = getAsciiArtWidth(displayTitle);
+
   return (
-    <>
-      <Box marginBottom={1} alignItems="flex-start">
-        {Colors.GradientColors ? (
-          <Gradient colors={Colors.GradientColors}>
-            <Text>{displayTitle}</Text>
-          </Gradient>
-        ) : (
+    <Box
+      marginBottom={1}
+      alignItems="flex-start"
+      width={artWidth}
+      flexShrink={0}
+    >
+      {Colors.GradientColors ? (
+        <Gradient colors={Colors.GradientColors}>
           <Text>{displayTitle}</Text>
-        )}
-      </Box>
-    </>
+        </Gradient>
+      ) : (
+        <Text>{displayTitle}</Text>
+      )}
+    </Box>
   );
 };

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { Text } from 'ink';
+import { Text, Box } from 'ink';
 import SelectInput, {
   type ItemProps as InkSelectItemProps,
   type IndicatorProps as InkSelectIndicatorProps,
@@ -78,12 +78,11 @@ export function RadioButtonSelect<T>({
     isSelected = false,
   }: InkSelectIndicatorProps): React.JSX.Element {
     return (
-      <Text
-        color={isSelected ? Colors.AccentGreen : Colors.Foreground}
-        wrap="truncate"
-      >
-        {isSelected ? '● ' : '○ '}
-      </Text>
+      <Box minWidth={2} flexShrink={0}>
+        <Text color={isSelected ? Colors.AccentGreen : Colors.Foreground}>
+          {isSelected ? '●' : '○'}
+        </Text>
+      </Box>
     );
   }
 


### PR DESCRIPTION
This fixes https://github.com/google-gemini/gemini-cli/issues/1347 for all reason terminal widths and heights.

* The theme dialog now displays fully on screen at the default Mac terminal size and slightly smaller screens. This important for the first run experience where the theme dialog is shown.

Video:
https://screencast.googleplex.com/cast/NjYzMjE4NDYwODcxODg0OHw4MGFkZTFiNC1mZQ

Before:
<img width="491" alt="Screenshot 2025-06-23 at 4 07 36 PM" src="https://github.com/user-attachments/assets/84060488-55bb-4370-8276-7970a54a4b3b" />

After:
<img width="486" alt="Screenshot 2025-06-23 at 4 06 47 PM" src="https://github.com/user-attachments/assets/bd243eb9-6b3d-4ab5-8222-7308b1b77179" />

 
This required making the theme dialog UI adaptive as we have a lot of themes. 
The theme dialog now removes the 1 line of vertical padding above and bellow the dialog when there isn't enough space.
The theme dialog now hides the "Apply to" section of the dialog automatically when there isn't enough space.
A bunch of tweaking to the wrapping logic including ensuring all content is wrappable so the sizes are predictable.

Fixed a long standing issue where the space in a radio button between the selection indicator and the text would be removed if the radio button had to have its text truncated.
This issue occurs at wider screen widths but the narrow screen width makes it very obvious
Before:
![Screenshot 2025-06-23 at 2 28 20 PM](https://github.com/user-attachments/assets/1334f6b8-9d8c-402d-9618-15354a694341)

After:
![Screenshot 2025-06-23 at 2 27 47 PM](https://github.com/user-attachments/assets/230dff4c-6561-48e5-a619-bbe0c89522fa)


Tossed in minor polish so that the Gemini Logo renders without extra line breaks (the terminal may still add extra line breaks).
This makes rendering better when the Gemini CLI terminal goes to a narrow width to a wider width.
