### PR TITLE
Fix duplicate startSession logs and duplicate logging events over the wire

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -169,7 +169,7 @@ export async function loadCliConfig(
   loadEnvironment();
 
   const argv = await parseArguments();
-  const debugMode = argv.debug || false;
+  const debugMode = argv.debug || true;
 
   // Set the context filename in the server's memoryTool module BEFORE loading memory
   // TODO(b/343434939): This is a bit of a hack. The contextFileName should ideally be passed
@@ -227,7 +227,7 @@ export async function loadCliConfig(
         settings.telemetry?.otlpEndpoint,
       logPrompts: argv.telemetryLogPrompts ?? settings.telemetry?.logPrompts,
       usageStatisticsEnabled:
-        settings.telemetry?.usageStatisticsEnabled ?? true,
+      settings.telemetry?.usageStatisticsEnabled ?? true,
     },
     // Git-aware file filtering settings
     fileFiltering: {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -169,7 +169,7 @@ export async function loadCliConfig(
   loadEnvironment();
 
   const argv = await parseArguments();
-  const debugMode = argv.debug || true;
+  const debugMode = argv.debug || false;
 
   // Set the context filename in the server's memoryTool module BEFORE loading memory
   // TODO(b/343434939): This is a bit of a hack. The contextFileName should ideally be passed
@@ -227,7 +227,7 @@ export async function loadCliConfig(
         settings.telemetry?.otlpEndpoint,
       logPrompts: argv.telemetryLogPrompts ?? settings.telemetry?.logPrompts,
       usageStatisticsEnabled:
-      settings.telemetry?.usageStatisticsEnabled ?? true,
+        settings.telemetry?.usageStatisticsEnabled ?? true,
     },
     // Git-aware file filtering settings
     fileFiltering: {

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -115,7 +115,6 @@ export function initializeTelemetry(config: Config): void {
     console.log('OpenTelemetry SDK started successfully.');
     telemetryInitialized = true;
     initializeMetrics(config);
-    logCliConfiguration(config, new StartSessionEvent(config));
   } catch (error) {
     console.error('Error starting OpenTelemetry SDK:', error);
   }

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -28,8 +28,6 @@ import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { Config } from '../config/config.js';
 import { SERVICE_NAME } from './constants.js';
 import { initializeMetrics } from './metrics.js';
-import { logCliConfiguration } from './loggers.js';
-import { StartSessionEvent } from './types.js';
 import { ClearcutLogger } from './clearcut-logger/clearcut-logger.js';
 
 // For troubleshooting, set the log level to DiagLogLevel.DEBUG

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -12,12 +12,9 @@ import {
 } from './sdk.js';
 import { Config } from '../config/config.js';
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import * as loggers from './loggers.js';
-import { StartSessionEvent } from './types.js';
 
 vi.mock('@opentelemetry/sdk-node');
 vi.mock('../config/config.js');
-vi.mock('./loggers.js');
 
 describe('telemetry', () => {
   let mockConfig: Config;
@@ -38,8 +35,6 @@ describe('telemetry', () => {
       'http://localhost:4317',
     );
     vi.spyOn(mockConfig, 'getSessionId').mockReturnValue('test-session-id');
-    vi.spyOn(loggers, 'logCliConfiguration').mockImplementation(() => {});
-
     mockNodeSdk = {
       start: vi.fn(),
       shutdown: vi.fn().mockResolvedValue(undefined),
@@ -56,11 +51,8 @@ describe('telemetry', () => {
 
   it('should initialize the telemetry service', () => {
     initializeTelemetry(mockConfig);
-    const event = new StartSessionEvent(mockConfig);
-
     expect(NodeSDK).toHaveBeenCalled();
     expect(mockNodeSdk.start).toHaveBeenCalled();
-    expect(loggers.logCliConfiguration).toHaveBeenCalledWith(mockConfig, event);
   });
 
   it('should shutdown the telemetry service', async () => {


### PR DESCRIPTION
## TLDR

Duplicate start session logs were showing up in addition to event logs not being cleared after being sent. 

## Dive Deeper

Two issues were identified:
1. we were initializing clearcut logging in config.ts and sdk.ts. We should skip sdk.ts cause that is part of telemetry initialization and does not depend on the usageStatisticsEnabled flag.
2. The events queue was being cleared only after returning from the server. This meant if events were sent in quick succession they would be duplicates of them in the event queue. Created a temporary event queue for enabling us to send and restore events based on the success/error state of the response. 


## Reviewer Test Plan

* Start the cli in debug mode and see clearcut logs being streamed to the console.

## Testing Matrix


|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | Y  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs


