### PR TITLE
Refactor usage statistics to be a top-level setting

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -169,7 +169,6 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     - **`target`** (string): The destination for collected telemetry. Supported values are `local` and `gcp`.
     - **`otlpEndpoint`** (string): The endpoint for the OTLP Exporter.
     - **`logPrompts`** (boolean): Whether or not to include the content of user prompts in the logs.
-    - **`usageStatisticsEnabled`** (boolean): Enables or disables the collection of usage statistics. See [Usage Statistics](#usage-statistics) for more information.
   - **Example:**
     ```json
     "telemetry": {
@@ -178,6 +177,13 @@ In addition to a project settings file, a project's `.gemini` directory can cont
       "otlpEndpoint": "http://localhost:16686",
       "logPrompts": false
     }
+    ```
+- **`usageStatisticsEnabled`** (boolean):
+  - **Description:** Enables or disables the collection of usage statistics. See [Usage Statistics](#usage-statistics) for more information.
+  - **Default:** `true`
+  - **Example:**
+    ```json
+    "usageStatisticsEnabled": false
     ```
 
 ### Example `settings.json`:
@@ -201,9 +207,9 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     "enabled": true,
     "target": "local",
     "otlpEndpoint": "http://localhost:4317",
-    "logPrompts": true,
-    "usageStatisticsEnabled": false
-  }
+    "logPrompts": true
+  },
+  "usageStatisticsEnabled": true
 }
 ```
 
@@ -423,18 +429,6 @@ You can opt out of usage statistics collection at any time by setting the `usage
 
 ```json
 {
-  "telemetry": {
-    "usageStatisticsEnabled": false
-  }
-}
-```
-
-You can also disable all telemetry data collection by setting the `enabled` property to `false`:
-
-```json
-{
-  "telemetry": {
-    "enabled": false
-  }
+  "usageStatisticsEnabled": false
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,6 @@ This documentation is organized into the following sections:
   - **[Telemetry](./telemetry.md):** Overview of telemetry in the CLI.
 - **Core Details:** Documentation for `packages/core`.
   - **[Core Introduction](./core/index.md):** Overview of the core component.
-  - **[Telemetry and Usage Statistics](./core/telemetry.md):** Details on configuring telemetry and usage statistics.
   - **[Tools API](./core/tools-api.md):** Information on how the core manages and exposes tools.
 - **Tools:**
   - **[Tools Overview](./tools/index.md):** Overview of the available tools.

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -226,9 +226,8 @@ export async function loadCliConfig(
         process.env.OTEL_EXPORTER_OTLP_ENDPOINT ??
         settings.telemetry?.otlpEndpoint,
       logPrompts: argv.telemetryLogPrompts ?? settings.telemetry?.logPrompts,
-      usageStatisticsEnabled:
-        settings.telemetry?.usageStatisticsEnabled ?? true,
     },
+    usageStatisticsEnabled: settings.usageStatisticsEnabled ?? true,
     // Git-aware file filtering settings
     fileFiltering: {
       respectGitIgnore: settings.fileFiltering?.respectGitIgnore,

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -49,6 +49,7 @@ export interface Settings {
   contextFileName?: string | string[];
   accessibility?: AccessibilitySettings;
   telemetry?: TelemetrySettings;
+  usageStatisticsEnabled?: boolean;
   preferredEditor?: string;
   bugCommand?: BugCommandSettings;
   checkpointing?: CheckpointingSettings;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -57,7 +57,6 @@ export interface TelemetrySettings {
   target?: TelemetryTarget;
   otlpEndpoint?: string;
   logPrompts?: boolean;
-  usageStatisticsEnabled?: boolean;
 }
 
 export class MCPServerConfig {
@@ -107,6 +106,7 @@ export interface ConfigParameters {
   contextFileName?: string | string[];
   accessibility?: AccessibilitySettings;
   telemetry?: TelemetrySettings;
+  usageStatisticsEnabled?: boolean;
   fileFiltering?: {
     respectGitIgnore?: boolean;
     enableRecursiveFileSearch?: boolean;
@@ -142,6 +142,7 @@ export class Config {
   private readonly showMemoryUsage: boolean;
   private readonly accessibility: AccessibilitySettings;
   private readonly telemetrySettings: TelemetrySettings;
+  private readonly usageStatisticsEnabled: boolean;
   private geminiClient!: GeminiClient;
   private readonly fileFiltering: {
     respectGitIgnore: boolean;
@@ -181,8 +182,8 @@ export class Config {
       target: params.telemetry?.target ?? DEFAULT_TELEMETRY_TARGET,
       otlpEndpoint: params.telemetry?.otlpEndpoint ?? DEFAULT_OTLP_ENDPOINT,
       logPrompts: params.telemetry?.logPrompts ?? true,
-      usageStatisticsEnabled: params.telemetry?.usageStatisticsEnabled ?? true,
     };
+    this.usageStatisticsEnabled = params.usageStatisticsEnabled ?? true;
 
     this.fileFiltering = {
       respectGitIgnore: params.fileFiltering?.respectGitIgnore ?? true,
@@ -386,7 +387,7 @@ export class Config {
   }
 
   getUsageStatisticsEnabled(): boolean {
-    return this.telemetrySettings.usageStatisticsEnabled ?? true;
+    return this.usageStatisticsEnabled;
   }
 
   getExtensionContextFilePaths(): string[] {


### PR DESCRIPTION
This commit refactors the `usageStatisticsEnabled` setting from a sub-property of the `telemetry` configuration to a top-level setting. This change simplifies the configuration by decoupling usage statistics from the telemetry settings.

The documentation has also been updated to reflect this change.

