### PR TITLE
Bug/1369 at command recursive search

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -210,10 +210,10 @@ export async function handleAtCommand({
       resolvedSuccessfully = true;
     } catch (error) {
       if (isNodeError(error) && error.code === 'ENOENT') {
-        onDebugMessage(
-          `Path ${pathName} not found directly, attempting glob search.`,
-        );
-        if (globTool) {
+        if (config.getEnableRecursiveFileSearch() && globTool) {
+          onDebugMessage(
+            `Path ${pathName} not found directly, attempting glob search.`,
+          );
           try {
             const globResult = await globTool.execute(
               { pattern: `**/*${pathName}*`, path: config.getTargetDir() },


### PR DESCRIPTION
## TLDR

Fix the @ command processor to not perform a recursive (glob) search when the setting disables it. The original implementation missed this spot.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1369 