### PR TITLE
Add Zed Editor to Eidtor List

### DIFF
--- a/packages/cli/src/ui/editors/editorSettingsManager.ts
+++ b/packages/cli/src/ui/editors/editorSettingsManager.ts
@@ -17,6 +17,7 @@ export interface EditorDisplay {
 }
 
 export const EDITOR_DISPLAY_NAMES: Record<EditorType, string> = {
+  zed: 'Zed',
   vscode: 'VS Code',
   windsurf: 'Windsurf',
   cursor: 'Cursor',
@@ -27,7 +28,13 @@ class EditorSettingsManager {
   private readonly availableEditors: EditorDisplay[];
 
   constructor() {
-    const editorTypes: EditorType[] = ['vscode', 'windsurf', 'cursor', 'vim'];
+    const editorTypes: EditorType[] = [
+      'vscode',
+      'windsurf',
+      'cursor',
+      'vim',
+      'zed',
+    ];
     this.availableEditors = [
       {
         name: 'None',

--- a/packages/cli/src/ui/editors/editorSettingsManager.ts
+++ b/packages/cli/src/ui/editors/editorSettingsManager.ts
@@ -29,11 +29,11 @@ class EditorSettingsManager {
 
   constructor() {
     const editorTypes: EditorType[] = [
+      'zed',
       'vscode',
       'windsurf',
       'cursor',
       'vim',
-      'zed',
     ];
     this.availableEditors = [
       {

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -59,6 +59,7 @@ describe('editor utils', () => {
       { editor: 'windsurf', command: 'windsurf', win32Command: 'windsurf' },
       { editor: 'cursor', command: 'cursor', win32Command: 'cursor' },
       { editor: 'vim', command: 'vim', win32Command: 'vim' },
+      { editor: 'zed', command: 'zed', win32Command: 'zed' },
     ];
 
     for (const { editor, command, win32Command } of testCases) {
@@ -129,6 +130,14 @@ describe('editor utils', () => {
       });
     });
 
+    it('should return the correct command for zed', () => {
+      const command = getDiffCommand('old.txt', 'new.txt', 'zed');
+      expect(command).toEqual({
+        command: 'zed',
+        args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+      });
+    });
+
     it('should return the correct command for vim', () => {
       const command = getDiffCommand('old.txt', 'new.txt', 'vim');
       expect(command).toEqual({
@@ -163,55 +172,67 @@ describe('editor utils', () => {
   });
 
   describe('openDiff', () => {
-    it('should call spawn for vscode', async () => {
-      const mockSpawn = {
-        on: vi.fn((event, cb) => {
-          if (event === 'close') {
-            cb(0);
-          }
-        }),
-      };
-      (spawn as Mock).mockReturnValue(mockSpawn);
-      await openDiff('old.txt', 'new.txt', 'vscode');
-      expect(spawn).toHaveBeenCalledWith(
-        'code',
-        ['--wait', '--diff', 'old.txt', 'new.txt'],
-        { stdio: 'inherit' },
-      );
-      expect(mockSpawn.on).toHaveBeenCalledWith('close', expect.any(Function));
-      expect(mockSpawn.on).toHaveBeenCalledWith('error', expect.any(Function));
-    });
+    const spawnEditors: EditorType[] = ['vscode', 'windsurf', 'cursor', 'zed'];
+    for (const editor of spawnEditors) {
+      it(`should call spawn for ${editor}`, async () => {
+        const mockSpawn = {
+          on: vi.fn((event, cb) => {
+            if (event === 'close') {
+              cb(0);
+            }
+          }),
+        };
+        (spawn as Mock).mockReturnValue(mockSpawn);
+        await openDiff('old.txt', 'new.txt', editor);
+        const diffCommand = getDiffCommand('old.txt', 'new.txt', editor)!;
+        expect(spawn).toHaveBeenCalledWith(
+          diffCommand.command,
+          diffCommand.args,
+          {
+            stdio: 'inherit',
+          },
+        );
+        expect(mockSpawn.on).toHaveBeenCalledWith(
+          'close',
+          expect.any(Function),
+        );
+        expect(mockSpawn.on).toHaveBeenCalledWith(
+          'error',
+          expect.any(Function),
+        );
+      });
 
-    it('should reject if spawn for vscode fails', async () => {
-      const mockError = new Error('spawn error');
-      const mockSpawn = {
-        on: vi.fn((event, cb) => {
-          if (event === 'error') {
-            cb(mockError);
-          }
-        }),
-      };
-      (spawn as Mock).mockReturnValue(mockSpawn);
-      await expect(openDiff('old.txt', 'new.txt', 'vscode')).rejects.toThrow(
-        'spawn error',
-      );
-    });
+      it(`should reject if spawn for ${editor} fails`, async () => {
+        const mockError = new Error('spawn error');
+        const mockSpawn = {
+          on: vi.fn((event, cb) => {
+            if (event === 'error') {
+              cb(mockError);
+            }
+          }),
+        };
+        (spawn as Mock).mockReturnValue(mockSpawn);
+        await expect(openDiff('old.txt', 'new.txt', editor)).rejects.toThrow(
+          'spawn error',
+        );
+      });
 
-    it('should reject if vscode exits with non-zero code', async () => {
-      const mockSpawn = {
-        on: vi.fn((event, cb) => {
-          if (event === 'close') {
-            cb(1);
-          }
-        }),
-      };
-      (spawn as Mock).mockReturnValue(mockSpawn);
-      await expect(openDiff('old.txt', 'new.txt', 'vscode')).rejects.toThrow(
-        'VS Code exited with code 1',
-      );
-    });
+      it(`should reject if ${editor} exits with non-zero code`, async () => {
+        const mockSpawn = {
+          on: vi.fn((event, cb) => {
+            if (event === 'close') {
+              cb(1);
+            }
+          }),
+        };
+        (spawn as Mock).mockReturnValue(mockSpawn);
+        await expect(openDiff('old.txt', 'new.txt', editor)).rejects.toThrow(
+          `${editor} exited with code 1`,
+        );
+      });
+    }
 
-    const execSyncEditors: EditorType[] = ['vim', 'windsurf', 'cursor'];
+    const execSyncEditors: EditorType[] = ['vim'];
     for (const editor of execSyncEditors) {
       it(`should call execSync for ${editor} on non-windows`, async () => {
         Object.defineProperty(process, 'platform', { value: 'linux' });
@@ -249,7 +270,7 @@ describe('editor utils', () => {
       // @ts-expect-error Testing unsupported editor
       await openDiff('old.txt', 'new.txt', 'foobar');
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'No diff tool available. Install vim or vscode.',
+        'No diff tool available. Install a supported editor.',
       );
     });
   });
@@ -264,7 +285,7 @@ describe('editor utils', () => {
       expect(allowEditorTypeInSandbox('vim')).toBe(true);
     });
 
-    const guiEditors: EditorType[] = ['vscode', 'windsurf', 'cursor'];
+    const guiEditors: EditorType[] = ['vscode', 'windsurf', 'cursor', 'zed'];
     for (const editor of guiEditors) {
       it(`should not allow ${editor} in sandbox mode`, () => {
         process.env.SANDBOX = 'sandbox';

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -106,37 +106,36 @@ describe('editor utils', () => {
   });
 
   describe('getDiffCommand', () => {
-    it('should return the correct command for vscode', () => {
-      const command = getDiffCommand('old.txt', 'new.txt', 'vscode');
-      expect(command).toEqual({
-        command: 'code',
-        args: ['--wait', '--diff', 'old.txt', 'new.txt'],
-      });
-    });
+    const guiEditors: Array<{
+      editor: EditorType;
+      command: string;
+      win32Command: string;
+    }> = [
+      { editor: 'vscode', command: 'code', win32Command: 'code.cmd' },
+      { editor: 'windsurf', command: 'windsurf', win32Command: 'windsurf' },
+      { editor: 'cursor', command: 'cursor', win32Command: 'cursor' },
+      { editor: 'zed', command: 'zed', win32Command: 'zed' },
+    ];
 
-    it('should return the correct command for windsurf', () => {
-      const command = getDiffCommand('old.txt', 'new.txt', 'windsurf');
-      expect(command).toEqual({
-        command: 'windsurf',
-        args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+    for (const { editor, command, win32Command } of guiEditors) {
+      it(`should return the correct command for ${editor} on non-windows`, () => {
+        Object.defineProperty(process, 'platform', { value: 'linux' });
+        const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
+        expect(diffCommand).toEqual({
+          command,
+          args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+        });
       });
-    });
 
-    it('should return the correct command for cursor', () => {
-      const command = getDiffCommand('old.txt', 'new.txt', 'cursor');
-      expect(command).toEqual({
-        command: 'cursor',
-        args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+      it(`should return the correct command for ${editor} on windows`, () => {
+        Object.defineProperty(process, 'platform', { value: 'win32' });
+        const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
+        expect(diffCommand).toEqual({
+          command: win32Command,
+          args: ['--wait', '--diff', 'old.txt', 'new.txt'],
+        });
       });
-    });
-
-    it('should return the correct command for zed', () => {
-      const command = getDiffCommand('old.txt', 'new.txt', 'zed');
-      expect(command).toEqual({
-        command: 'zed',
-        args: ['--wait', '--diff', 'old.txt', 'new.txt'],
-      });
-    });
+    }
 
     it('should return the correct command for vim', () => {
       const command = getDiffCommand('old.txt', 'new.txt', 'vim');

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -6,10 +6,10 @@
 
 import { execSync, spawn } from 'child_process';
 
-export type EditorType = 'vscode' | 'windsurf' | 'cursor' | 'vim';
+export type EditorType = 'vscode' | 'windsurf' | 'cursor' | 'vim' | 'zed';
 
 function isValidEditorType(editor: string): editor is EditorType {
-  return ['vscode', 'windsurf', 'cursor', 'vim'].includes(editor);
+  return ['vscode', 'windsurf', 'cursor', 'vim', 'zed'].includes(editor);
 }
 
 interface DiffCommand {
@@ -34,6 +34,7 @@ const editorCommands: Record<EditorType, { win32: string; default: string }> = {
   windsurf: { win32: 'windsurf', default: 'windsurf' },
   cursor: { win32: 'cursor', default: 'cursor' },
   vim: { win32: 'vim', default: 'vim' },
+  zed: { win32: 'zed', default: 'zed' },
 };
 
 export function checkHasEditorType(editor: EditorType): boolean {
@@ -45,7 +46,7 @@ export function checkHasEditorType(editor: EditorType): boolean {
 
 export function allowEditorTypeInSandbox(editor: EditorType): boolean {
   const notUsingSandbox = !process.env.SANDBOX;
-  if (['vscode', 'windsurf', 'cursor'].includes(editor)) {
+  if (['vscode', 'windsurf', 'cursor', 'zed'].includes(editor)) {
     return notUsingSandbox;
   }
   return true;
@@ -87,6 +88,11 @@ export function getDiffCommand(
     case 'cursor':
       return {
         command: 'cursor',
+        args: ['--wait', '--diff', oldPath, newPath],
+      };
+    case 'zed':
+      return {
+        command: 'zed',
         args: ['--wait', '--diff', oldPath, newPath],
       };
     case 'vim':
@@ -134,40 +140,50 @@ export async function openDiff(
 ): Promise<void> {
   const diffCommand = getDiffCommand(oldPath, newPath, editor);
   if (!diffCommand) {
-    console.error('No diff tool available. Install vim or vscode.');
+    console.error('No diff tool available. Install a supported editor.');
     return;
   }
 
   try {
-    if (editor === 'vscode') {
-      // Use spawn to avoid blocking the entire process, resolve this function when editor is closed.
-      return new Promise((resolve, reject) => {
-        const process = spawn(diffCommand.command, diffCommand.args, {
+    switch (editor) {
+      case 'vscode':
+      case 'windsurf':
+      case 'cursor':
+      case 'zed':
+        // Use spawn for GUI-based editors to avoid blocking the entire process
+        return new Promise((resolve, reject) => {
+          const childProcess = spawn(diffCommand.command, diffCommand.args, {
+            stdio: 'inherit',
+          });
+
+          childProcess.on('close', (code) => {
+            if (code === 0) {
+              resolve();
+            } else {
+              reject(new Error(`${editor} exited with code ${code}`));
+            }
+          });
+
+          childProcess.on('error', (error) => {
+            reject(error);
+          });
+        });
+
+      case 'vim': {
+        // Use execSync for terminal-based editors
+        const command =
+          process.platform === 'win32'
+            ? `${diffCommand.command} ${diffCommand.args.join(' ')}`
+            : `${diffCommand.command} ${diffCommand.args.map((arg) => `"${arg}"`).join(' ')}`;
+        execSync(command, {
           stdio: 'inherit',
+          encoding: 'utf8',
         });
+        break;
+      }
 
-        process.on('close', (code) => {
-          if (code === 0) {
-            resolve();
-          } else {
-            reject(new Error(`VS Code exited with code ${code}`));
-          }
-        });
-
-        process.on('error', (error) => {
-          reject(error);
-        });
-      });
-    } else {
-      // Use execSync for terminal-based editors like vim
-      const command =
-        process.platform === 'win32'
-          ? `${diffCommand.command} ${diffCommand.args.join(' ')}`
-          : `${diffCommand.command} ${diffCommand.args.map((arg) => `"${arg}"`).join(' ')}`;
-      execSync(command, {
-        stdio: 'inherit',
-        encoding: 'utf8',
-      });
+      default:
+        throw new Error(`Unsupported editor: ${editor}`);
     }
   } catch (error) {
     console.error(error);

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -74,27 +74,18 @@ export function getDiffCommand(
   newPath: string,
   editor: EditorType,
 ): DiffCommand | null {
+  if (!isValidEditorType(editor)) {
+    return null;
+  }
+  const commandConfig = editorCommands[editor];
+  const command =
+    process.platform === 'win32' ? commandConfig.win32 : commandConfig.default;
   switch (editor) {
     case 'vscode':
-      return {
-        command: 'code',
-        args: ['--wait', '--diff', oldPath, newPath],
-      };
     case 'windsurf':
-      return {
-        command: 'windsurf',
-        args: ['--wait', '--diff', oldPath, newPath],
-      };
     case 'cursor':
-      return {
-        command: 'cursor',
-        args: ['--wait', '--diff', oldPath, newPath],
-      };
     case 'zed':
-      return {
-        command: 'zed',
-        args: ['--wait', '--diff', oldPath, newPath],
-      };
+      return { command, args: ['--wait', '--diff', oldPath, newPath] };
     case 'vim':
       return {
         command: 'vim',


### PR DESCRIPTION
## TLDR

Add the Zed Editor to the list of editors. Also fix the gitDiffCommand so it uses the correct platform command.

## Dive Deeper

Added the Zed Editor to the list of supported editor. 

We also had a list of commands by platform but didn't use that to pick the right command based on platform to do a diff. 

## Reviewer Test Plan

Make sure that zed works in diffs and VSCode now works on Windows for diffs.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | x  | ❓  | ❓  |
| Docker   | x  | ❓  | ❓  |
| Podman   | x  | -   | -   |
| Seatbelt | x  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
