### PR TITLE
Fix remaining path parameter naming inconsistencies

### DIFF
--- a/docs/tools/file-system.md
+++ b/docs/tools/file-system.md
@@ -11,7 +11,7 @@ All file system tools operate within a `rootDirectory` (usually the current work
 - **File:** `ls.ts`
 - **Description:** Lists the names of files and subdirectories directly within a specified directory path. It can optionally ignore entries matching provided glob patterns.
 - **Parameters:**
-  - `path` (string, required): The absolute path to the directory to list.
+  - `absolute_path` (string, required): The absolute path to the directory to list.
   - `ignore` (array of strings, optional): A list of glob patterns to exclude from the listing (e.g., `["*.log", ".git"]`).
   - `respect_git_ignore` (boolean, optional): Whether to respect .gitignore patterns when listing files. Defaults to true.
 - **Behavior:**
@@ -28,7 +28,7 @@ All file system tools operate within a `rootDirectory` (usually the current work
 - **File:** `read-file.ts`
 - **Description:** Reads and returns the content of a specified file. Handles text, images (PNG, JPG, GIF, WEBP, SVG, BMP), and PDF files. For text files, it can read specific line ranges. Other binary file types are generally skipped.
 - **Parameters:**
-  - `path` (string, required): The absolute path to the file to read.
+  - `absolute_path` (string, required): The absolute path to the file to read.
   - `offset` (number, optional): For text files, the 0-based line number to start reading from. Requires `limit` to be set.
   - `limit` (number, optional): For text files, the maximum number of lines to read. If omitted, reads a default maximum (e.g., 2000 lines) or the entire file if feasible.
 - **Behavior:**
@@ -48,7 +48,7 @@ All file system tools operate within a `rootDirectory` (usually the current work
 - **File:** `write-file.ts`
 - **Description:** Writes content to a specified file. If the file exists, it will be overwritten. If it doesn't exist, it (and any necessary parent directories) will be created.
 - **Parameters:**
-  - `file_path` (string, required): The absolute path to the file to write to.
+  - `absolute_path` (string, required): The absolute path to the file to write to.
   - `content` (string, required): The content to write into the file.
 - **Behavior:**
   - Writes the provided `content` to the `file_path`.
@@ -64,7 +64,7 @@ All file system tools operate within a `rootDirectory` (usually the current work
 - **Description:** Efficiently finds files matching specific glob patterns (e.g., `src/**/*.ts`, `*.md`), returning absolute paths sorted by modification time (newest first).
 - **Parameters:**
   - `pattern` (string, required): The glob pattern to match against (e.g., `"*.py"`, `"src/**/*.js"`).
-  - `path` (string, optional): The absolute path to the directory to search within. If omitted, searches the tool's root directory.
+  - `absolute_path` (string, optional): The absolute path to the directory to search within. If omitted, searches the tool's root directory.
   - `case_sensitive` (boolean, optional): Whether the search should be case-sensitive. Defaults to false.
   - `respect_git_ignore` (boolean, optional): Whether to respect .gitignore patterns when finding files. Defaults to true.
 - **Behavior:**
@@ -82,7 +82,7 @@ All file system tools operate within a `rootDirectory` (usually the current work
 - **Description:** Searches for a regular expression pattern within the content of files in a specified directory. Can filter files by a glob pattern. Returns the lines containing matches, along with their file paths and line numbers.
 - **Parameters:**
   - `pattern` (string, required): The regular expression (regex) to search for (e.g., `"function\s+myFunction"`).
-  - `path` (string, optional): The absolute path to the directory to search within. Defaults to the current working directory.
+  - `absolute_path` (string, optional): The absolute path to the directory to search within. Defaults to the current working directory.
   - `include` (string, optional): A glob pattern to filter which files are searched (e.g., `"*.js"`, `"src/**/*.{ts,tsx}"`). If omitted, searches most files (respecting common ignores).
 - **Behavior:**
   - Uses `git grep` if available in a Git repository for speed, otherwise falls back to system `grep` or a JavaScript-based search.
@@ -108,8 +108,8 @@ All file system tools operate within a `rootDirectory` (usually the current work
 - **File:** `edit.ts`
 - **Description:** Replaces text within a file. By default, replaces a single occurrence, but can replace multiple occurrences when `expected_replacements` is specified. This tool is designed for precise, targeted changes and requires significant context around the `old_string` to ensure it modifies the correct location.
 - **Parameters:**
-  - `file_path` (string, required): The absolute path to the file to modify.
-  - `old_string` (string, required): The exact literal text to replace. **CRITICAL:** This string must uniquely identify the single instance to change. It should include at least 3 lines of context _before_ and _after_ the target text, matching whitespace and indentation precisely. If `old_string` is empty, the tool attempts to create a new file at `file_path` with `new_string` as content.
+  - `absolute_path` (string, required): The absolute path to the file to modify.
+  - `old_string` (string, required): The exact literal text to replace. **CRITICAL:** This string must uniquely identify the single instance to change. It should include at least 3 lines of context _before_ and _after_ the target text, matching whitespace and indentation precisely. If `old_string` is empty, the tool attempts to create a new file at `absolute_path` with `new_string` as content.
   - `new_string` (string, required): The exact literal text to replace `old_string` with.
   - `expected_replacements` (number, optional): The number of occurrences to replace. Defaults to 1.
 - **Behavior:**

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -92,7 +92,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for absolute_path '/path/to/current/dir']
 </example>
 
 <example>
@@ -104,12 +104,12 @@ model: [tool_call: run_shell_command for 'node server.js &' because it must run 
 user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
 model: Okay, I can refactor 'src/auth.py'.
 First, I'll analyze the code and check for a test safety net before planning any changes.
-[tool_call: glob for path 'tests/test_auth.py']
-[tool_call: read_file for absolute_path '/path/to/tests/test_auth.py']
+[tool_call: glob for pattern 'tests/test_auth.py' absolute_path '/path/to/project']
+[tool_call: read_file for absolute_path '/path/to/project/tests/test_auth.py']
 (After analysis)
 Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
 I'll also confirm 'requests' is a dependency.
-[tool_call: read_file for absolute_path '/path/to/requirements.txt']
+[tool_call: read_file for absolute_path '/path/to/project/requirements.txt']
 (After analysis)
 Looks good, 'requests' is available.
 
@@ -139,7 +139,7 @@ model: I can run \`rm -rf ./temp\`. This will permanently delete the directory a
 user: Write tests for someFile.ts
 model:
 Okay, I can write those tests. First, I'll read \`someFile.ts\` to understand its functionality.
-[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown]
+[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown, e.g. [tool_call: glob for pattern '**/someFile.ts' absolute_path '/path/to/project']]
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_many_files for paths ['**/*.test.ts', 'src/**/*.spec.ts'] assuming someFile.ts is in the src directory]
 (After reviewing existing tests and the file content)
@@ -287,7 +287,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for absolute_path '/path/to/current/dir']
 </example>
 
 <example>
@@ -299,12 +299,12 @@ model: [tool_call: run_shell_command for 'node server.js &' because it must run 
 user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
 model: Okay, I can refactor 'src/auth.py'.
 First, I'll analyze the code and check for a test safety net before planning any changes.
-[tool_call: glob for path 'tests/test_auth.py']
-[tool_call: read_file for absolute_path '/path/to/tests/test_auth.py']
+[tool_call: glob for pattern 'tests/test_auth.py' absolute_path '/path/to/project']
+[tool_call: read_file for absolute_path '/path/to/project/tests/test_auth.py']
 (After analysis)
 Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
 I'll also confirm 'requests' is a dependency.
-[tool_call: read_file for absolute_path '/path/to/requirements.txt']
+[tool_call: read_file for absolute_path '/path/to/project/requirements.txt']
 (After analysis)
 Looks good, 'requests' is available.
 
@@ -334,7 +334,7 @@ model: I can run \`rm -rf ./temp\`. This will permanently delete the directory a
 user: Write tests for someFile.ts
 model:
 Okay, I can write those tests. First, I'll read \`someFile.ts\` to understand its functionality.
-[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown]
+[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown, e.g. [tool_call: glob for pattern '**/someFile.ts' absolute_path '/path/to/project']]
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_many_files for paths ['**/*.test.ts', 'src/**/*.spec.ts'] assuming someFile.ts is in the src directory]
 (After reviewing existing tests and the file content)
@@ -462,7 +462,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for absolute_path '/path/to/current/dir']
 </example>
 
 <example>
@@ -474,12 +474,12 @@ model: [tool_call: run_shell_command for 'node server.js &' because it must run 
 user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
 model: Okay, I can refactor 'src/auth.py'.
 First, I'll analyze the code and check for a test safety net before planning any changes.
-[tool_call: glob for path 'tests/test_auth.py']
-[tool_call: read_file for absolute_path '/path/to/tests/test_auth.py']
+[tool_call: glob for pattern 'tests/test_auth.py' absolute_path '/path/to/project']
+[tool_call: read_file for absolute_path '/path/to/project/tests/test_auth.py']
 (After analysis)
 Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
 I'll also confirm 'requests' is a dependency.
-[tool_call: read_file for absolute_path '/path/to/requirements.txt']
+[tool_call: read_file for absolute_path '/path/to/project/requirements.txt']
 (After analysis)
 Looks good, 'requests' is available.
 
@@ -509,7 +509,7 @@ model: I can run \`rm -rf ./temp\`. This will permanently delete the directory a
 user: Write tests for someFile.ts
 model:
 Okay, I can write those tests. First, I'll read \`someFile.ts\` to understand its functionality.
-[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown]
+[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown, e.g. [tool_call: glob for pattern '**/someFile.ts' absolute_path '/path/to/project']]
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_many_files for paths ['**/*.test.ts', 'src/**/*.spec.ts'] assuming someFile.ts is in the src directory]
 (After reviewing existing tests and the file content)
@@ -637,7 +637,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for absolute_path '/path/to/current/dir']
 </example>
 
 <example>
@@ -649,12 +649,12 @@ model: [tool_call: run_shell_command for 'node server.js &' because it must run 
 user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
 model: Okay, I can refactor 'src/auth.py'.
 First, I'll analyze the code and check for a test safety net before planning any changes.
-[tool_call: glob for path 'tests/test_auth.py']
-[tool_call: read_file for absolute_path '/path/to/tests/test_auth.py']
+[tool_call: glob for pattern 'tests/test_auth.py' absolute_path '/path/to/project']
+[tool_call: read_file for absolute_path '/path/to/project/tests/test_auth.py']
 (After analysis)
 Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
 I'll also confirm 'requests' is a dependency.
-[tool_call: read_file for absolute_path '/path/to/requirements.txt']
+[tool_call: read_file for absolute_path '/path/to/project/requirements.txt']
 (After analysis)
 Looks good, 'requests' is available.
 
@@ -684,7 +684,7 @@ model: I can run \`rm -rf ./temp\`. This will permanently delete the directory a
 user: Write tests for someFile.ts
 model:
 Okay, I can write those tests. First, I'll read \`someFile.ts\` to understand its functionality.
-[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown]
+[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown, e.g. [tool_call: glob for pattern '**/someFile.ts' absolute_path '/path/to/project']]
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_many_files for paths ['**/*.test.ts', 'src/**/*.spec.ts'] assuming someFile.ts is in the src directory]
 (After reviewing existing tests and the file content)
@@ -812,7 +812,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for absolute_path '/path/to/current/dir']
 </example>
 
 <example>
@@ -824,12 +824,12 @@ model: [tool_call: run_shell_command for 'node server.js &' because it must run 
 user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
 model: Okay, I can refactor 'src/auth.py'.
 First, I'll analyze the code and check for a test safety net before planning any changes.
-[tool_call: glob for path 'tests/test_auth.py']
-[tool_call: read_file for absolute_path '/path/to/tests/test_auth.py']
+[tool_call: glob for pattern 'tests/test_auth.py' absolute_path '/path/to/project']
+[tool_call: read_file for absolute_path '/path/to/project/tests/test_auth.py']
 (After analysis)
 Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
 I'll also confirm 'requests' is a dependency.
-[tool_call: read_file for absolute_path '/path/to/requirements.txt']
+[tool_call: read_file for absolute_path '/path/to/project/requirements.txt']
 (After analysis)
 Looks good, 'requests' is available.
 
@@ -859,7 +859,7 @@ model: I can run \`rm -rf ./temp\`. This will permanently delete the directory a
 user: Write tests for someFile.ts
 model:
 Okay, I can write those tests. First, I'll read \`someFile.ts\` to understand its functionality.
-[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown]
+[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown, e.g. [tool_call: glob for pattern '**/someFile.ts' absolute_path '/path/to/project']]
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_many_files for paths ['**/*.test.ts', 'src/**/*.spec.ts'] assuming someFile.ts is in the src directory]
 (After reviewing existing tests and the file content)
@@ -987,7 +987,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for absolute_path '/path/to/current/dir']
 </example>
 
 <example>
@@ -999,12 +999,12 @@ model: [tool_call: run_shell_command for 'node server.js &' because it must run 
 user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
 model: Okay, I can refactor 'src/auth.py'.
 First, I'll analyze the code and check for a test safety net before planning any changes.
-[tool_call: glob for path 'tests/test_auth.py']
-[tool_call: read_file for absolute_path '/path/to/tests/test_auth.py']
+[tool_call: glob for pattern 'tests/test_auth.py' absolute_path '/path/to/project']
+[tool_call: read_file for absolute_path '/path/to/project/tests/test_auth.py']
 (After analysis)
 Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
 I'll also confirm 'requests' is a dependency.
-[tool_call: read_file for absolute_path '/path/to/requirements.txt']
+[tool_call: read_file for absolute_path '/path/to/project/requirements.txt']
 (After analysis)
 Looks good, 'requests' is available.
 
@@ -1034,7 +1034,7 @@ model: I can run \`rm -rf ./temp\`. This will permanently delete the directory a
 user: Write tests for someFile.ts
 model:
 Okay, I can write those tests. First, I'll read \`someFile.ts\` to understand its functionality.
-[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown]
+[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown, e.g. [tool_call: glob for pattern '**/someFile.ts' absolute_path '/path/to/project']]
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_many_files for paths ['**/*.test.ts', 'src/**/*.spec.ts'] assuming someFile.ts is in the src directory]
 (After reviewing existing tests and the file content)
@@ -1162,7 +1162,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for absolute_path '/path/to/current/dir']
 </example>
 
 <example>
@@ -1174,12 +1174,12 @@ model: [tool_call: run_shell_command for 'node server.js &' because it must run 
 user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
 model: Okay, I can refactor 'src/auth.py'.
 First, I'll analyze the code and check for a test safety net before planning any changes.
-[tool_call: glob for path 'tests/test_auth.py']
-[tool_call: read_file for absolute_path '/path/to/tests/test_auth.py']
+[tool_call: glob for pattern 'tests/test_auth.py' absolute_path '/path/to/project']
+[tool_call: read_file for absolute_path '/path/to/project/tests/test_auth.py']
 (After analysis)
 Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
 I'll also confirm 'requests' is a dependency.
-[tool_call: read_file for absolute_path '/path/to/requirements.txt']
+[tool_call: read_file for absolute_path '/path/to/project/requirements.txt']
 (After analysis)
 Looks good, 'requests' is available.
 
@@ -1209,7 +1209,7 @@ model: I can run \`rm -rf ./temp\`. This will permanently delete the directory a
 user: Write tests for someFile.ts
 model:
 Okay, I can write those tests. First, I'll read \`someFile.ts\` to understand its functionality.
-[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown]
+[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown, e.g. [tool_call: glob for pattern '**/someFile.ts' absolute_path '/path/to/project']]
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_many_files for paths ['**/*.test.ts', 'src/**/*.spec.ts'] assuming someFile.ts is in the src directory]
 (After reviewing existing tests and the file content)
@@ -1337,7 +1337,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for absolute_path '/path/to/current/dir']
 </example>
 
 <example>
@@ -1349,12 +1349,12 @@ model: [tool_call: run_shell_command for 'node server.js &' because it must run 
 user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
 model: Okay, I can refactor 'src/auth.py'.
 First, I'll analyze the code and check for a test safety net before planning any changes.
-[tool_call: glob for path 'tests/test_auth.py']
-[tool_call: read_file for absolute_path '/path/to/tests/test_auth.py']
+[tool_call: glob for pattern 'tests/test_auth.py' absolute_path '/path/to/project']
+[tool_call: read_file for absolute_path '/path/to/project/tests/test_auth.py']
 (After analysis)
 Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
 I'll also confirm 'requests' is a dependency.
-[tool_call: read_file for absolute_path '/path/to/requirements.txt']
+[tool_call: read_file for absolute_path '/path/to/project/requirements.txt']
 (After analysis)
 Looks good, 'requests' is available.
 
@@ -1384,7 +1384,7 @@ model: I can run \`rm -rf ./temp\`. This will permanently delete the directory a
 user: Write tests for someFile.ts
 model:
 Okay, I can write those tests. First, I'll read \`someFile.ts\` to understand its functionality.
-[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown]
+[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown, e.g. [tool_call: glob for pattern '**/someFile.ts' absolute_path '/path/to/project']]
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_many_files for paths ['**/*.test.ts', 'src/**/*.spec.ts'] assuming someFile.ts is in the src directory]
 (After reviewing existing tests and the file content)
@@ -1512,7 +1512,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for absolute_path '/path/to/current/dir']
 </example>
 
 <example>
@@ -1524,12 +1524,12 @@ model: [tool_call: run_shell_command for 'node server.js &' because it must run 
 user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
 model: Okay, I can refactor 'src/auth.py'.
 First, I'll analyze the code and check for a test safety net before planning any changes.
-[tool_call: glob for path 'tests/test_auth.py']
-[tool_call: read_file for absolute_path '/path/to/tests/test_auth.py']
+[tool_call: glob for pattern 'tests/test_auth.py' absolute_path '/path/to/project']
+[tool_call: read_file for absolute_path '/path/to/project/tests/test_auth.py']
 (After analysis)
 Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
 I'll also confirm 'requests' is a dependency.
-[tool_call: read_file for absolute_path '/path/to/requirements.txt']
+[tool_call: read_file for absolute_path '/path/to/project/requirements.txt']
 (After analysis)
 Looks good, 'requests' is available.
 
@@ -1559,7 +1559,7 @@ model: I can run \`rm -rf ./temp\`. This will permanently delete the directory a
 user: Write tests for someFile.ts
 model:
 Okay, I can write those tests. First, I'll read \`someFile.ts\` to understand its functionality.
-[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown]
+[tool_call: read_file for absolute_path '/path/to/someFile.ts' or use glob to find \`someFile.ts\` if its location is unknown, e.g. [tool_call: glob for pattern '**/someFile.ts' absolute_path '/path/to/project']]
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_many_files for paths ['**/*.test.ts', 'src/**/*.spec.ts'] assuming someFile.ts is in the src directory]
 (After reviewing existing tests and the file content)

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -166,7 +166,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: ${LSTool.Name} for path '.']
+model: [tool_call: ${LSTool.Name} for absolute_path '/path/to/current/dir']
 </example>
 
 <example>
@@ -178,12 +178,12 @@ model: [tool_call: ${ShellTool.Name} for 'node server.js &' because it must run 
 user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
 model: Okay, I can refactor 'src/auth.py'.
 First, I'll analyze the code and check for a test safety net before planning any changes.
-[tool_call: ${GlobTool.Name} for path 'tests/test_auth.py']
-[tool_call: ${ReadFileTool.Name} for absolute_path '/path/to/tests/test_auth.py']
+[tool_call: ${GlobTool.Name} for pattern 'tests/test_auth.py' absolute_path '/path/to/project']
+[tool_call: ${ReadFileTool.Name} for absolute_path '/path/to/project/tests/test_auth.py']
 (After analysis)
 Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
 I'll also confirm 'requests' is a dependency.
-[tool_call: ${ReadFileTool.Name} for absolute_path '/path/to/requirements.txt']
+[tool_call: ${ReadFileTool.Name} for absolute_path '/path/to/project/requirements.txt']
 (After analysis)
 Looks good, 'requests' is available.
 
@@ -218,7 +218,7 @@ model: I can run \`rm -rf ./temp\`. This will permanently delete the directory a
 user: Write tests for someFile.ts
 model:
 Okay, I can write those tests. First, I'll read \`someFile.ts\` to understand its functionality.
-[tool_call: ${ReadFileTool.Name} for absolute_path '/path/to/someFile.ts' or use ${GlobTool.Name} to find \`someFile.ts\` if its location is unknown]
+[tool_call: ${ReadFileTool.Name} for absolute_path '/path/to/someFile.ts' or use ${GlobTool.Name} to find \`someFile.ts\` if its location is unknown, e.g. [tool_call: ${GlobTool.Name} for pattern '**/someFile.ts' absolute_path '/path/to/project']]
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: ${ReadManyFilesTool.Name} for paths ['**/*.test.ts', 'src/**/*.spec.ts'] assuming someFile.ts is in the src directory]
 (After reviewing existing tests and the file content)

--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -192,7 +192,7 @@ describe('EditTool', () => {
   describe('validateToolParams', () => {
     it('should return null for valid params', () => {
       const params: EditToolParams = {
-        file_path: path.join(rootDir, 'test.txt'),
+        absolute_path: path.join(rootDir, 'test.txt'),
         old_string: 'old',
         new_string: 'new',
       };
@@ -201,7 +201,7 @@ describe('EditTool', () => {
 
     it('should return error for relative path', () => {
       const params: EditToolParams = {
-        file_path: 'test.txt',
+        absolute_path: 'test.txt',
         old_string: 'old',
         new_string: 'new',
       };
@@ -212,7 +212,7 @@ describe('EditTool', () => {
 
     it('should return error for path outside root', () => {
       const params: EditToolParams = {
-        file_path: path.join(tempDir, 'outside-root.txt'),
+        absolute_path: path.join(tempDir, 'outside-root.txt'),
         old_string: 'old',
         new_string: 'new',
       };
@@ -232,7 +232,7 @@ describe('EditTool', () => {
 
     it('should return false if params are invalid', async () => {
       const params: EditToolParams = {
-        file_path: 'relative.txt',
+        absolute_path: 'relative.txt',
         old_string: 'old',
         new_string: 'new',
       };
@@ -244,7 +244,7 @@ describe('EditTool', () => {
     it('should request confirmation for valid edit', async () => {
       fs.writeFileSync(filePath, 'some old content here');
       const params: EditToolParams = {
-        file_path: filePath,
+        absolute_path: filePath,
         old_string: 'old',
         new_string: 'new',
       };
@@ -266,7 +266,7 @@ describe('EditTool', () => {
     it('should return false if old_string is not found (ensureCorrectEdit returns 0)', async () => {
       fs.writeFileSync(filePath, 'some content here');
       const params: EditToolParams = {
-        file_path: filePath,
+        absolute_path: filePath,
         old_string: 'not_found',
         new_string: 'new',
       };
@@ -279,7 +279,7 @@ describe('EditTool', () => {
     it('should return false if multiple occurrences of old_string are found (ensureCorrectEdit returns > 1)', async () => {
       fs.writeFileSync(filePath, 'old old content here');
       const params: EditToolParams = {
-        file_path: filePath,
+        absolute_path: filePath,
         old_string: 'old',
         new_string: 'new',
       };
@@ -293,7 +293,7 @@ describe('EditTool', () => {
       const newFileName = 'new_file.txt';
       const newFilePath = path.join(rootDir, newFileName);
       const params: EditToolParams = {
-        file_path: newFilePath,
+        absolute_path: newFilePath,
         old_string: '',
         new_string: 'new file content',
       };
@@ -325,7 +325,7 @@ describe('EditTool', () => {
 
       fs.writeFileSync(filePath, originalContent);
       const params: EditToolParams = {
-        file_path: filePath,
+        absolute_path: filePath,
         old_string: originalOldString,
         new_string: originalNewString,
       };
@@ -342,7 +342,7 @@ describe('EditTool', () => {
           expect(client).toBe((tool as any).client);
           return {
             params: {
-              file_path: filePath,
+              absolute_path: filePath,
               old_string: correctedOldString,
               new_string: correctedNewString,
             },
@@ -402,7 +402,7 @@ describe('EditTool', () => {
 
     it('should return error if params are invalid', async () => {
       const params: EditToolParams = {
-        file_path: 'relative.txt',
+        absolute_path: 'relative.txt',
         old_string: 'old',
         new_string: 'new',
       };
@@ -416,7 +416,7 @@ describe('EditTool', () => {
       const newContent = 'This is some new text.'; // old -> new
       fs.writeFileSync(filePath, initialContent, 'utf8');
       const params: EditToolParams = {
-        file_path: filePath,
+        absolute_path: filePath,
         old_string: 'old',
         new_string: 'new',
       };
@@ -445,7 +445,7 @@ describe('EditTool', () => {
       const newFilePath = path.join(rootDir, newFileName);
       const fileContent = 'Content for the new file.';
       const params: EditToolParams = {
-        file_path: newFilePath,
+        absolute_path: newFilePath,
         old_string: '',
         new_string: fileContent,
       };
@@ -464,7 +464,7 @@ describe('EditTool', () => {
     it('should return error if old_string is not found in file', async () => {
       fs.writeFileSync(filePath, 'Some content.', 'utf8');
       const params: EditToolParams = {
-        file_path: filePath,
+        absolute_path: filePath,
         old_string: 'nonexistent',
         new_string: 'replacement',
       };
@@ -481,7 +481,7 @@ describe('EditTool', () => {
     it('should return error if multiple occurrences of old_string are found', async () => {
       fs.writeFileSync(filePath, 'multiple old old strings', 'utf8');
       const params: EditToolParams = {
-        file_path: filePath,
+        absolute_path: filePath,
         old_string: 'old',
         new_string: 'new',
       };
@@ -498,7 +498,7 @@ describe('EditTool', () => {
     it('should successfully replace multiple occurrences when expected_replacements specified', async () => {
       fs.writeFileSync(filePath, 'old text old text old text', 'utf8');
       const params: EditToolParams = {
-        file_path: filePath,
+        absolute_path: filePath,
         old_string: 'old',
         new_string: 'new',
         expected_replacements: 3,
@@ -524,7 +524,7 @@ describe('EditTool', () => {
     it('should return error if expected_replacements does not match actual occurrences', async () => {
       fs.writeFileSync(filePath, 'old text old text', 'utf8');
       const params: EditToolParams = {
-        file_path: filePath,
+        absolute_path: filePath,
         old_string: 'old',
         new_string: 'new',
         expected_replacements: 3, // Expecting 3 but only 2 exist
@@ -541,7 +541,7 @@ describe('EditTool', () => {
     it('should return error if trying to create a file that already exists (empty old_string)', async () => {
       fs.writeFileSync(filePath, 'Existing content', 'utf8');
       const params: EditToolParams = {
-        file_path: filePath,
+        absolute_path: filePath,
         old_string: '',
         new_string: 'new content',
       };
@@ -555,7 +555,7 @@ describe('EditTool', () => {
     it('should return error if old_string and new_string are identical', async () => {
       fs.writeFileSync(filePath, 'Some content.', 'utf8');
       const params: EditToolParams = {
-        file_path: filePath,
+        absolute_path: filePath,
         old_string: 'Some content.',
         new_string: 'Some content.',
       };
@@ -573,7 +573,7 @@ describe('EditTool', () => {
     it('should return "No file changes to..." if old_string and new_string are the same', () => {
       const testFileName = 'test.txt';
       const params: EditToolParams = {
-        file_path: path.join(rootDir, testFileName),
+        absolute_path: path.join(rootDir, testFileName),
         old_string: 'identical_string',
         new_string: 'identical_string',
       };
@@ -586,7 +586,7 @@ describe('EditTool', () => {
     it('should return a snippet of old and new strings if they are different', () => {
       const testFileName = 'test.txt';
       const params: EditToolParams = {
-        file_path: path.join(rootDir, testFileName),
+        absolute_path: path.join(rootDir, testFileName),
         old_string: 'this is the old string value',
         new_string: 'this is the new string value',
       };
@@ -600,7 +600,7 @@ describe('EditTool', () => {
     it('should handle very short strings correctly in the description', () => {
       const testFileName = 'short.txt';
       const params: EditToolParams = {
-        file_path: path.join(rootDir, testFileName),
+        absolute_path: path.join(rootDir, testFileName),
         old_string: 'old',
         new_string: 'new',
       };
@@ -610,7 +610,7 @@ describe('EditTool', () => {
     it('should truncate long strings in the description', () => {
       const testFileName = 'long.txt';
       const params: EditToolParams = {
-        file_path: path.join(rootDir, testFileName),
+        absolute_path: path.join(rootDir, testFileName),
         old_string:
           'this is a very long old string that will definitely be truncated',
         new_string:

--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -110,7 +110,7 @@ describe('GlobTool', () => {
     });
 
     it('should find files in a specified relative path (relative to rootDir)', async () => {
-      const params: GlobToolParams = { pattern: '*.md', path: 'sub' };
+      const params: GlobToolParams = { pattern: '*.md', absolute_path: 'sub' };
       const result = await globTool.execute(params, abortSignal);
       expect(result.llmContent).toContain('Found 2 file(s)');
       expect(result.llmContent).toContain(
@@ -164,14 +164,14 @@ describe('GlobTool', () => {
     });
 
     it('should return null for valid parameters (pattern and path)', () => {
-      const params: GlobToolParams = { pattern: '*.js', path: 'sub' };
+      const params: GlobToolParams = { pattern: '*.js', absolute_path: 'sub' };
       expect(globTool.validateToolParams(params)).toBeNull();
     });
 
     it('should return null for valid parameters (pattern, path, and case_sensitive)', () => {
       const params: GlobToolParams = {
         pattern: '*.js',
-        path: 'sub',
+        absolute_path: 'sub',
         case_sensitive: true,
       };
       expect(globTool.validateToolParams(params)).toBeNull();
@@ -179,7 +179,7 @@ describe('GlobTool', () => {
 
     it('should return error if pattern is missing (schema validation)', () => {
       // Need to correctly define this as an object without pattern
-      const params = { path: '.' };
+      const params = { absolute_path: '.' };
       // @ts-expect-error - We're intentionally creating invalid params for testing
       expect(globTool.validateToolParams(params)).toContain(
         'Parameters failed schema validation',
@@ -203,7 +203,7 @@ describe('GlobTool', () => {
     it('should return error if path is provided but is not a string (schema validation)', () => {
       const params = {
         pattern: '*.ts',
-        path: 123,
+        absolute_path: 123,
       };
       // @ts-expect-error - We're intentionally creating invalid params for testing
       expect(globTool.validateToolParams(params)).toContain(
@@ -226,12 +226,12 @@ describe('GlobTool', () => {
       // Create a globTool instance specifically for this test, with a deeper root
       const deeperRootDir = path.join(tempRootDir, 'sub');
       const specificGlobTool = new GlobTool(deeperRootDir, mockConfig);
-      // const params: GlobToolParams = { pattern: '*.txt', path: '..' }; // This line is unused and will be removed.
+      // const params: GlobToolParams = { pattern: '*.txt', absolute_path: '..' }; // This line is unused and will be removed.
       // This should be fine as tempRootDir is still within the original tempRootDir (the parent of deeperRootDir)
       // Let's try to go further up.
       const paramsOutside: GlobToolParams = {
         pattern: '*.txt',
-        path: '../../../../../../../../../../tmp',
+        absolute_path: '../../../../../../../../../../tmp',
       }; // Definitely outside
       expect(specificGlobTool.validateToolParams(paramsOutside)).toContain(
         "resolves outside the tool's root directory",
@@ -241,7 +241,7 @@ describe('GlobTool', () => {
     it('should return error if specified search path does not exist', async () => {
       const params: GlobToolParams = {
         pattern: '*.txt',
-        path: 'nonexistent_subdir',
+        absolute_path: 'nonexistent_subdir',
       };
       expect(globTool.validateToolParams(params)).toContain(
         'Search path does not exist',
@@ -249,7 +249,7 @@ describe('GlobTool', () => {
     });
 
     it('should return error if specified search path is a file, not a directory', async () => {
-      const params: GlobToolParams = { pattern: '*.txt', path: 'fileA.txt' };
+      const params: GlobToolParams = { pattern: '*.txt', absolute_path: 'fileA.txt' };
       expect(globTool.validateToolParams(params)).toContain(
         'Search path is not a directory',
       );

--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -249,7 +249,10 @@ describe('GlobTool', () => {
     });
 
     it('should return error if specified search path is a file, not a directory', async () => {
-      const params: GlobToolParams = { pattern: '*.txt', absolute_path: 'fileA.txt' };
+      const params: GlobToolParams = {
+        pattern: '*.txt',
+        absolute_path: 'fileA.txt',
+      };
       expect(globTool.validateToolParams(params)).toContain(
         'Search path is not a directory',
       );

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -60,7 +60,7 @@ export interface GlobToolParams {
   /**
    * The directory to search in (optional, defaults to current directory)
    */
-  path?: string;
+  absolute_path?: string;
 
   /**
    * Whether the search should be case-sensitive (optional, defaults to false)
@@ -97,7 +97,7 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
               "The glob pattern to match against (e.g., '**/*.py', 'docs/*.md').",
             type: 'string',
           },
-          path: {
+          absolute_path: {
             description:
               'Optional: The absolute path to the directory to search within. If omitted, searches the root directory.',
             type: 'string',
@@ -153,7 +153,7 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
 
     const searchDirAbsolute = path.resolve(
       this.rootDirectory,
-      params.path || '.',
+      params.absolute_path || '.',
     );
 
     if (!this.isWithinRoot(searchDirAbsolute)) {
@@ -188,8 +188,8 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
    */
   getDescription(params: GlobToolParams): string {
     let description = `'${params.pattern}'`;
-    if (params.path) {
-      const searchDir = path.resolve(this.rootDirectory, params.path || '.');
+    if (params.absolute_path) {
+      const searchDir = path.resolve(this.rootDirectory, params.absolute_path || '.');
       const relativePath = makeRelative(searchDir, this.rootDirectory);
       description += ` within ${shortenPath(relativePath)}`;
     }
@@ -214,7 +214,7 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
     try {
       const searchDirAbsolute = path.resolve(
         this.rootDirectory,
-        params.path || '.',
+        params.absolute_path || '.',
       );
 
       // Get centralized file discovery service

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -189,7 +189,10 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
   getDescription(params: GlobToolParams): string {
     let description = `'${params.pattern}'`;
     if (params.absolute_path) {
-      const searchDir = path.resolve(this.rootDirectory, params.absolute_path || '.');
+      const searchDir = path.resolve(
+        this.rootDirectory,
+        params.absolute_path || '.',
+      );
       const relativePath = makeRelative(searchDir, this.rootDirectory);
       description += ` within ${shortenPath(relativePath)}`;
     }

--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -65,21 +65,21 @@ describe('GrepTool', () => {
     });
 
     it('should return null for valid params (pattern and path)', () => {
-      const params: GrepToolParams = { pattern: 'hello', path: '.' };
+      const params: GrepToolParams = { pattern: 'hello', absolute_path: '.' };
       expect(grepTool.validateToolParams(params)).toBeNull();
     });
 
     it('should return null for valid params (pattern, path, and include)', () => {
       const params: GrepToolParams = {
         pattern: 'hello',
-        path: '.',
+        absolute_path: '.',
         include: '*.txt',
       };
       expect(grepTool.validateToolParams(params)).toBeNull();
     });
 
     it('should return error if pattern is missing', () => {
-      const params = { path: '.' } as unknown as GrepToolParams;
+      const params = { absolute_path: '.' } as unknown as GrepToolParams;
       expect(grepTool.validateToolParams(params)).toContain(
         'Parameters failed schema validation',
       );
@@ -93,7 +93,7 @@ describe('GrepTool', () => {
     });
 
     it('should return error if path does not exist', () => {
-      const params: GrepToolParams = { pattern: 'hello', path: 'nonexistent' };
+      const params: GrepToolParams = { pattern: 'hello', absolute_path: 'nonexistent' };
       // Check for the core error message, as the full path might vary
       expect(grepTool.validateToolParams(params)).toContain(
         'Failed to access path stats for',
@@ -103,7 +103,7 @@ describe('GrepTool', () => {
 
     it('should return error if path is a file, not a directory', async () => {
       const filePath = path.join(tempRootDir, 'fileA.txt');
-      const params: GrepToolParams = { pattern: 'hello', path: filePath };
+      const params: GrepToolParams = { pattern: 'hello', absolute_path: filePath };
       expect(grepTool.validateToolParams(params)).toContain(
         `Path is not a directory: ${filePath}`,
       );
@@ -126,7 +126,7 @@ describe('GrepTool', () => {
     });
 
     it('should find matches in a specific path', async () => {
-      const params: GrepToolParams = { pattern: 'world', path: 'sub' };
+      const params: GrepToolParams = { pattern: 'world', absolute_path: 'sub' };
       const result = await grepTool.execute(params, abortSignal);
       expect(result.llmContent).toContain(
         'Found 1 match(es) for pattern "world" in path "sub"',
@@ -156,7 +156,7 @@ describe('GrepTool', () => {
       );
       const params: GrepToolParams = {
         pattern: 'hello',
-        path: 'sub',
+        absolute_path: 'sub',
         include: '*.js',
       };
       const result = await grepTool.execute(params, abortSignal);
@@ -202,7 +202,7 @@ describe('GrepTool', () => {
     });
 
     it('should return an error if params are invalid', async () => {
-      const params = { path: '.' } as unknown as GrepToolParams; // Invalid: pattern missing
+      const params = { absolute_path: '.' } as unknown as GrepToolParams; // Invalid: pattern missing
       const result = await grepTool.execute(params, abortSignal);
       expect(result.llmContent).toContain(
         'Error: Invalid parameters provided. Reason: Parameters failed schema validation',
@@ -230,7 +230,7 @@ describe('GrepTool', () => {
     it('should generate correct description with pattern and path', () => {
       const params: GrepToolParams = {
         pattern: 'testPattern',
-        path: 'src/app',
+        absolute_path: 'src/app',
       };
       // The path will be relative to the tempRootDir, so we check for containment.
       expect(grepTool.getDescription(params)).toContain("'testPattern' within");
@@ -241,7 +241,7 @@ describe('GrepTool', () => {
       const params: GrepToolParams = {
         pattern: 'testPattern',
         include: '*.ts',
-        path: 'src/app',
+        absolute_path: 'src/app',
       };
       expect(grepTool.getDescription(params)).toContain(
         "'testPattern' in *.ts within",
@@ -250,7 +250,7 @@ describe('GrepTool', () => {
     });
 
     it('should use ./ for root path in description', () => {
-      const params: GrepToolParams = { pattern: 'testPattern', path: '.' };
+      const params: GrepToolParams = { pattern: 'testPattern', absolute_path: '.' };
       expect(grepTool.getDescription(params)).toBe("'testPattern' within ./");
     });
   });

--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -93,7 +93,10 @@ describe('GrepTool', () => {
     });
 
     it('should return error if path does not exist', () => {
-      const params: GrepToolParams = { pattern: 'hello', absolute_path: 'nonexistent' };
+      const params: GrepToolParams = {
+        pattern: 'hello',
+        absolute_path: 'nonexistent',
+      };
       // Check for the core error message, as the full path might vary
       expect(grepTool.validateToolParams(params)).toContain(
         'Failed to access path stats for',
@@ -103,7 +106,10 @@ describe('GrepTool', () => {
 
     it('should return error if path is a file, not a directory', async () => {
       const filePath = path.join(tempRootDir, 'fileA.txt');
-      const params: GrepToolParams = { pattern: 'hello', absolute_path: filePath };
+      const params: GrepToolParams = {
+        pattern: 'hello',
+        absolute_path: filePath,
+      };
       expect(grepTool.validateToolParams(params)).toContain(
         `Path is not a directory: ${filePath}`,
       );
@@ -250,7 +256,10 @@ describe('GrepTool', () => {
     });
 
     it('should use ./ for root path in description', () => {
-      const params: GrepToolParams = { pattern: 'testPattern', absolute_path: '.' };
+      const params: GrepToolParams = {
+        pattern: 'testPattern',
+        absolute_path: '.',
+      };
       expect(grepTool.getDescription(params)).toBe("'testPattern' within ./");
     });
   });

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -30,7 +30,7 @@ export interface GrepToolParams {
   /**
    * The directory to search in (optional, defaults to current directory relative to root)
    */
-  path?: string;
+  absolute_path?: string;
 
   /**
    * File pattern to include in the search (e.g. "*.js", "*.{ts,tsx}")
@@ -71,7 +71,7 @@ export class GrepTool extends BaseTool<GrepToolParams, ToolResult> {
               "The regular expression (regex) pattern to search for within file contents (e.g., 'function\\s+myFunction', 'import\\s+\\{.*\\}\\s+from\\s+.*').",
             type: 'string',
           },
-          path: {
+          absolute_path: {
             description:
               'Optional: The absolute path to the directory to search within. If omitted, searches the current working directory.',
             type: 'string',
@@ -152,7 +152,7 @@ export class GrepTool extends BaseTool<GrepToolParams, ToolResult> {
     }
 
     try {
-      this.resolveAndValidatePath(params.path);
+      this.resolveAndValidatePath(params.absolute_path);
     } catch (error) {
       return getErrorMessage(error);
     }
@@ -181,8 +181,8 @@ export class GrepTool extends BaseTool<GrepToolParams, ToolResult> {
 
     let searchDirAbs: string;
     try {
-      searchDirAbs = this.resolveAndValidatePath(params.path);
-      const searchDirDisplay = params.path || '.';
+      searchDirAbs = this.resolveAndValidatePath(params.absolute_path);
+      const searchDirDisplay = params.absolute_path || '.';
 
       const matches: GrepMatch[] = await this.performGrepSearch({
         pattern: params.pattern,
@@ -322,9 +322,9 @@ export class GrepTool extends BaseTool<GrepToolParams, ToolResult> {
     if (params.include) {
       description += ` in ${params.include}`;
     }
-    if (params.path) {
-      const resolvedPath = path.resolve(this.rootDirectory, params.path);
-      if (resolvedPath === this.rootDirectory || params.path === '.') {
+    if (params.absolute_path) {
+      const resolvedPath = path.resolve(this.rootDirectory, params.absolute_path);
+      if (resolvedPath === this.rootDirectory || params.absolute_path === '.') {
         description += ` within ./`;
       } else {
         const relativePath = makeRelative(resolvedPath, this.rootDirectory);

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -323,7 +323,10 @@ export class GrepTool extends BaseTool<GrepToolParams, ToolResult> {
       description += ` in ${params.include}`;
     }
     if (params.absolute_path) {
-      const resolvedPath = path.resolve(this.rootDirectory, params.absolute_path);
+      const resolvedPath = path.resolve(
+        this.rootDirectory,
+        params.absolute_path,
+      );
       if (resolvedPath === this.rootDirectory || params.absolute_path === '.') {
         description += ` within ./`;
       } else {

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -157,14 +157,14 @@ describe('WriteFileTool', () => {
   describe('validateToolParams', () => {
     it('should return null for valid absolute path within root', () => {
       const params = {
-        file_path: path.join(rootDir, 'test.txt'),
+        absolute_path: path.join(rootDir, 'test.txt'),
         content: 'hello',
       };
       expect(tool.validateToolParams(params)).toBeNull();
     });
 
     it('should return error for relative path', () => {
-      const params = { file_path: 'test.txt', content: 'hello' };
+      const params = { absolute_path: 'test.txt', content: 'hello' };
       expect(tool.validateToolParams(params)).toMatch(
         /File path must be absolute/,
       );
@@ -173,7 +173,7 @@ describe('WriteFileTool', () => {
     it('should return error for path outside root', () => {
       const outsidePath = path.resolve(tempDir, 'outside-root.txt');
       const params = {
-        file_path: outsidePath,
+        absolute_path: outsidePath,
         content: 'hello',
       };
       expect(tool.validateToolParams(params)).toMatch(
@@ -185,7 +185,7 @@ describe('WriteFileTool', () => {
       const dirAsFilePath = path.join(rootDir, 'a_directory');
       fs.mkdirSync(dirAsFilePath);
       const params = {
-        file_path: dirAsFilePath,
+        absolute_path: dirAsFilePath,
         content: 'hello',
       };
       expect(tool.validateToolParams(params)).toMatch(
@@ -233,7 +233,7 @@ describe('WriteFileTool', () => {
       // Ensure this mock is active and returns the correct structure
       mockEnsureCorrectEdit.mockResolvedValue({
         params: {
-          file_path: filePath,
+          absolute_path: filePath,
           old_string: originalContent,
           new_string: correctedProposedContent,
         },
@@ -252,7 +252,7 @@ describe('WriteFileTool', () => {
         {
           old_string: originalContent,
           new_string: proposedContent,
-          file_path: filePath,
+          absolute_path: filePath,
         },
         mockGeminiClientInstance,
         abortSignal,
@@ -302,21 +302,21 @@ describe('WriteFileTool', () => {
   describe('shouldConfirmExecute', () => {
     const abortSignal = new AbortController().signal;
     it('should return false if params are invalid (relative path)', async () => {
-      const params = { file_path: 'relative.txt', content: 'test' };
+      const params = { absolute_path: 'relative.txt', content: 'test' };
       const confirmation = await tool.shouldConfirmExecute(params, abortSignal);
       expect(confirmation).toBe(false);
     });
 
     it('should return false if params are invalid (outside root)', async () => {
       const outsidePath = path.resolve(tempDir, 'outside-root.txt');
-      const params = { file_path: outsidePath, content: 'test' };
+      const params = { absolute_path: outsidePath, content: 'test' };
       const confirmation = await tool.shouldConfirmExecute(params, abortSignal);
       expect(confirmation).toBe(false);
     });
 
     it('should return false if _getCorrectedFileContent returns an error', async () => {
       const filePath = path.join(rootDir, 'confirm_error_file.txt');
-      const params = { file_path: filePath, content: 'test content' };
+      const params = { absolute_path: filePath, content: 'test content' };
       fs.writeFileSync(filePath, 'original', { mode: 0o000 });
 
       const readError = new Error('Simulated read error for confirmation');
@@ -338,7 +338,7 @@ describe('WriteFileTool', () => {
       const correctedContent = 'Corrected new content for confirmation.';
       mockEnsureCorrectFileContent.mockResolvedValue(correctedContent); // Ensure this mock is active
 
-      const params = { file_path: filePath, content: proposedContent };
+      const params = { absolute_path: filePath, content: proposedContent };
       const confirmation = (await tool.shouldConfirmExecute(
         params,
         abortSignal,
@@ -374,14 +374,14 @@ describe('WriteFileTool', () => {
 
       mockEnsureCorrectEdit.mockResolvedValue({
         params: {
-          file_path: filePath,
+          absolute_path: filePath,
           old_string: originalContent,
           new_string: correctedProposedContent,
         },
         occurrences: 1,
       });
 
-      const params = { file_path: filePath, content: proposedContent };
+      const params = { absolute_path: filePath, content: proposedContent };
       const confirmation = (await tool.shouldConfirmExecute(
         params,
         abortSignal,
@@ -392,7 +392,7 @@ describe('WriteFileTool', () => {
         {
           old_string: originalContent,
           new_string: proposedContent,
-          file_path: filePath,
+          absolute_path: filePath,
         },
         mockGeminiClientInstance,
         abortSignal,
@@ -413,7 +413,7 @@ describe('WriteFileTool', () => {
   describe('execute', () => {
     const abortSignal = new AbortController().signal;
     it('should return error if params are invalid (relative path)', async () => {
-      const params = { file_path: 'relative.txt', content: 'test' };
+      const params = { absolute_path: 'relative.txt', content: 'test' };
       const result = await tool.execute(params, abortSignal);
       expect(result.llmContent).toMatch(/Error: Invalid parameters provided/);
       expect(result.returnDisplay).toMatch(/Error: File path must be absolute/);
@@ -421,7 +421,7 @@ describe('WriteFileTool', () => {
 
     it('should return error if params are invalid (path outside root)', async () => {
       const outsidePath = path.resolve(tempDir, 'outside-root.txt');
-      const params = { file_path: outsidePath, content: 'test' };
+      const params = { absolute_path: outsidePath, content: 'test' };
       const result = await tool.execute(params, abortSignal);
       expect(result.llmContent).toMatch(/Error: Invalid parameters provided/);
       expect(result.returnDisplay).toMatch(
@@ -431,7 +431,7 @@ describe('WriteFileTool', () => {
 
     it('should return error if _getCorrectedFileContent returns an error during execute', async () => {
       const filePath = path.join(rootDir, 'execute_error_file.txt');
-      const params = { file_path: filePath, content: 'test content' };
+      const params = { absolute_path: filePath, content: 'test content' };
       fs.writeFileSync(filePath, 'original', { mode: 0o000 });
 
       const readError = new Error('Simulated read error for execute');
@@ -456,7 +456,7 @@ describe('WriteFileTool', () => {
       const correctedContent = 'Corrected new content for execute.';
       mockEnsureCorrectFileContent.mockResolvedValue(correctedContent);
 
-      const params = { file_path: filePath, content: proposedContent };
+      const params = { absolute_path: filePath, content: proposedContent };
 
       const confirmDetails = await tool.shouldConfirmExecute(
         params,
@@ -503,14 +503,14 @@ describe('WriteFileTool', () => {
 
       mockEnsureCorrectEdit.mockResolvedValue({
         params: {
-          file_path: filePath,
+          absolute_path: filePath,
           old_string: initialContent,
           new_string: correctedProposedContent,
         },
         occurrences: 1,
       });
 
-      const params = { file_path: filePath, content: proposedContent };
+      const params = { absolute_path: filePath, content: proposedContent };
 
       const confirmDetails = await tool.shouldConfirmExecute(
         params,
@@ -527,7 +527,7 @@ describe('WriteFileTool', () => {
         {
           old_string: initialContent,
           new_string: proposedContent,
-          file_path: filePath,
+          absolute_path: filePath,
         },
         mockGeminiClientInstance,
         abortSignal,
@@ -550,7 +550,7 @@ describe('WriteFileTool', () => {
       const content = 'Content in new directory';
       mockEnsureCorrectFileContent.mockResolvedValue(content); // Ensure this mock is active
 
-      const params = { file_path: filePath, content };
+      const params = { absolute_path: filePath, content };
       // Simulate confirmation if your logic requires it before execute, or remove if not needed for this path
       const confirmDetails = await tool.shouldConfirmExecute(
         params,

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -350,7 +350,7 @@ export class WriteFileTool
         {
           old_string: originalContent, // Treat entire current content as old_string
           new_string: proposedContent,
-          file_path: filePath,
+          absolute_path: filePath,
         },
         this.client,
         abortSignal,

--- a/packages/core/src/utils/editCorrector.test.ts
+++ b/packages/core/src/utils/editCorrector.test.ts
@@ -229,7 +229,7 @@ describe('editCorrector', () => {
       it('Test 1.1: old_string (no literal \\), new_string (escaped by Gemini) -> new_string unescaped', async () => {
         const currentContent = 'This is a test string to find me.';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'find me',
           new_string: 'replace with \\"this\\"',
         };
@@ -250,7 +250,7 @@ describe('editCorrector', () => {
       it('Test 1.2: old_string (no literal \\), new_string (correctly formatted) -> new_string unchanged', async () => {
         const currentContent = 'This is a test string to find me.';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'find me',
           new_string: 'replace with this',
         };
@@ -268,7 +268,7 @@ describe('editCorrector', () => {
       it('Test 1.3: old_string (with literal \\), new_string (escaped by Gemini) -> new_string unchanged (still escaped)', async () => {
         const currentContent = 'This is a test string to find\\me.';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'find\\me',
           new_string: 'replace with \\"this\\"',
         };
@@ -289,7 +289,7 @@ describe('editCorrector', () => {
       it('Test 1.4: old_string (with literal \\), new_string (correctly formatted) -> new_string unchanged', async () => {
         const currentContent = 'This is a test string to find\\me.';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'find\\me',
           new_string: 'replace with this',
         };
@@ -310,7 +310,7 @@ describe('editCorrector', () => {
       it('Test 2.1: old_string (over-escaped, no intended literal \\), new_string (escaped by Gemini) -> new_string unescaped', async () => {
         const currentContent = 'This is a test string to find "me".';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'find \\"me\\"',
           new_string: 'replace with \\"this\\"',
         };
@@ -329,7 +329,7 @@ describe('editCorrector', () => {
       it('Test 2.2: old_string (over-escaped, no intended literal \\), new_string (correctly formatted) -> new_string unescaped (harmlessly)', async () => {
         const currentContent = 'This is a test string to find "me".';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'find \\"me\\"',
           new_string: 'replace with this',
         };
@@ -347,7 +347,7 @@ describe('editCorrector', () => {
       it('Test 2.3: old_string (over-escaped, with intended literal \\), new_string (simple) -> new_string corrected', async () => {
         const currentContent = 'This is a test string to find \\me.';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'find \\\\me',
           new_string: 'replace with foobar',
         };
@@ -368,7 +368,7 @@ describe('editCorrector', () => {
       it('Test 3.1: old_string (no literal \\), new_string (escaped by Gemini), LLM re-escapes new_string -> final new_string is double unescaped', async () => {
         const currentContent = 'This is a test string to corrected find me.';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'find me',
           new_string: 'replace with \\\\"this\\\\"',
         };
@@ -388,7 +388,7 @@ describe('editCorrector', () => {
       it('Test 3.2: old_string (with literal \\), new_string (escaped by Gemini), LLM re-escapes new_string -> final new_string is unescaped once', async () => {
         const currentContent = 'This is a test string to corrected find me.';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'find\\me',
           new_string: 'replace with \\\\"this\\\\"',
         };
@@ -410,7 +410,7 @@ describe('editCorrector', () => {
       it('Test 3.3: old_string needs LLM, new_string is fine -> old_string corrected, new_string original', async () => {
         const currentContent = 'This is a test string to be corrected.';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'fiiind me',
           new_string: 'replace with "this"',
         };
@@ -430,7 +430,7 @@ describe('editCorrector', () => {
       it('Test 3.4: LLM correction path, correctNewString returns the originalNewString it was passed (which was unescaped) -> final new_string is unescaped', async () => {
         const currentContent = 'This is a test string to corrected find me.';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'find me',
           new_string: 'replace with \\\\"this\\\\"',
         };
@@ -454,7 +454,7 @@ describe('editCorrector', () => {
       it('Test 4.1: No version of old_string (original, unescaped, LLM-corrected) matches -> returns original params, 0 occurrences', async () => {
         const currentContent = 'This content has nothing to find.';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'nonexistent string',
           new_string: 'some new string',
         };
@@ -473,7 +473,7 @@ describe('editCorrector', () => {
         const currentContent =
           'This content has find "me" and also find "me" again.';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'find "me"',
           new_string: 'some new string',
         };
@@ -493,7 +493,7 @@ describe('editCorrector', () => {
       it('Test 5.1: old_string needs LLM to become currentContent, new_string also needs correction', async () => {
         const currentContent = 'const x = "a\\nbc\\\\"def\\\\"';
         const originalParams = {
-          file_path: '/test/file.txt',
+          absolute_path: '/test/file.txt',
           old_string: 'const x = \\\\"a\\\\nbc\\\\\\\\"def\\\\\\\\"',
           new_string: 'const y = \\\\"new\\\\nval\\\\\\\\"content\\\\\\\\"',
         };

--- a/packages/core/src/utils/editCorrector.ts
+++ b/packages/core/src/utils/editCorrector.ts
@@ -36,7 +36,7 @@ const fileContentCorrectionCache = new LruCache<string, string>(MAX_CACHE_SIZE);
  * Defines the structure of the parameters within CorrectedEditResult
  */
 interface CorrectedEditParams {
-  file_path: string;
+  absolute_path: string;
   old_string: string;
   new_string: string;
 }
@@ -199,7 +199,7 @@ export async function ensureCorrectEdit(
   // Final result construction
   const result: CorrectedEditResult = {
     params: {
-      file_path: originalParams.file_path,
+      absolute_path: originalParams.absolute_path,
       old_string: finalOldString,
       new_string: finalNewString,
     },


### PR DESCRIPTION
## TLDR

#1057 renamed ReadFile parameters to get the model to more frequently use an absolute path. This PR finishes the job with the other commands.

## Testing

Tested each command and had the model recite its tool definitions.