### PR TITLE
[DRAFT] refactor: decouple build system scripts from app sandbox config code

### DIFF
--- a/.gcp/dogfood.yaml
+++ b/.gcp/dogfood.yaml
@@ -10,8 +10,15 @@ steps:
     args:
       - -c # Use bash -c to allow for command substitution and string manipulation
       - |
-        npm pkg set config.sandboxRepository="${_SANDBOX_IMAGE_REGISTRY}"
-        echo $(npm pkg get config.sandboxRepository)
+        current_version=$(npm pkg get version | sed 's/"//g')
+        new_version="$${current_version}-$SHORT_SHA"
+        npm pkg set "version=$${new_version}"
+        echo "Set root package.json version to: $${new_version}"
+
+  # Step 3: Run prerelease:dev to update workspace versions and dependencies
+  - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
+    entrypoint: 'npm'
+    args: ['run', 'prerelease:dev'] # This will run prerelease:version and prerelease:deps
 
   # Step 4: Authenticate for Docker and NPM
   - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
@@ -26,30 +33,7 @@ steps:
       - 'GEMINI_SANDBOX=$_CONTAINER_TOOL'
       - 'SANDBOX_IMAGE_REGISTRY=$_SANDBOX_IMAGE_REGISTRY'
       - 'SANDBOX_IMAGE_NAME=$_SANDBOX_IMAGE_NAME'
-
- # Step 6: Update version in root package.json for npm publish
-  - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
-    entrypoint: 'bash'
-    args:
-      - -c # Use bash -c to allow for command substitution and string manipulation
-      - |
-        current_version=$(npm pkg get version | sed 's/"//g')
-        new_version="$${current_version}-$SHORT_SHA"
-        npm pkg set "version=$${new_version}"
-        echo "Set root package.json version to: $${new_version}"
- 
-  # Step 3: Run prerelease:dev to update workspace versions and dependencies
-  - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
-    entrypoint: 'npm'
-    args: ['run', 'prerelease:dev'] # This will run prerelease:version and prerelease:deps
-
- # Step 6: Run the master release script
-  - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
-    entrypoint: 'npm'
-    args: ['run', 'publish:npm']
-    env:
       - 'NPM_PUBLISH_TAG=$_NPM_PUBLISH_TAG'
-
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:sandbox": "node scripts/build_sandbox.js",
     "build:all": "npm run build && npm run build:sandbox",
     "clean": "node scripts/clean.js",
-    "prepare": "npm run bundle",
+    "prepare": "npm run bundle && npm run prepare:root-packagejson",
     "test": "npm run test --workspaces",
     "test:ci": "npm run test:ci --workspaces --if-present",
     "test:e2e": "npm run test:integration:sandbox:none -- --verbose --keep-output",
@@ -35,10 +35,11 @@
     "build:core": "npm run build --workspace packages/core",
     "build:packages": "npm run build:core && npm run build:cli",
     "build:docker": "node scripts/build_sandbox.js -s",
-    "prepare:cli-packagejson": "node scripts/prepare-cli-packagejson.js",
+    "prepare:cli-packagejson": "node scripts/prepare-cli-packagejson.js --target=package",
+    "prepare:repo-packagejson": "node scripts/prepare-cli-packagejson.js --target=repo",
     "publish:sandbox": "node scripts/publish-sandbox.js",
     "publish:npm": "npm publish --workspaces ${NPM_PUBLISH_TAG:+--tag=$NPM_PUBLISH_TAG} ${NPM_DRY_RUN:+--dry-run}",
-    "publish:release": "npm run build:packages && npm run build:docker && npm run publish:sandbox",
+    "publish:release": "npm run build:packages && npm run prepare:cli-packagejson && npm run build:docker && npm run publish:sandbox && npm run publish:npm",
     "telemetry": "node scripts/telemetry.js",
     "start:gcp": "npm run telemetry -- --target=gcp & npm start"
   },
@@ -51,8 +52,7 @@
     "LICENSE"
   ],
   "config": {
-    "sandboxImageUri": "gemini-cli-sandbox",
-    "sandboxRepositoryn": "us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers"
+    "sandboxImageUri": "us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-cli-sandbox"
   },
   "devDependencies": {
     "@types/micromatch": "^4.0.9",

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -22,7 +22,7 @@ import { chmodSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { buildImageName } from '../packages/cli/dist/src/config/sandboxConfig.js';
+import cliPkgJson from '../packages/cli/package.json' with { type: 'json' };
 
 const argv = yargs(hideBin(process.argv))
   .option('s', {
@@ -61,8 +61,7 @@ if (sandboxCommand === 'sandbox-exec') {
 
 console.log(`using ${sandboxCommand} for sandboxing`);
 
-const baseImage = await buildImageName();
-
+const baseImage = cliPkgJson.config.sandboxImageUri;
 const customImage = argv.i;
 const baseDockerfile = 'Dockerfile';
 const customDockerfile = argv.f;
@@ -106,7 +105,7 @@ chmodSync(
   0o755,
 );
 
-const buildStdout = 'inherit';
+const buildStdout = process.env.VERBOSE ? 'inherit' : 'ignore';
 
 function buildImage(imageName, dockerfile) {
   console.log(`building ${imageName} ... (can be slow first time)`);

--- a/scripts/generate-git-commit-info.js
+++ b/scripts/generate-git-commit-info.js
@@ -42,7 +42,7 @@ try {
       encoding: 'utf-8',
     }).trim();
     if (gitStatus) {
-      gitCommitInfo = `${gitHash}`;
+      gitCommitInfo = `${gitHash} (local modifications)`;
     }
   }
 } catch {

--- a/scripts/prepare-cli-packagejson.js
+++ b/scripts/prepare-cli-packagejson.js
@@ -7,26 +7,49 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { execSync } from 'child_process';
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const cliPackageJsonPath = path.resolve(
-  __dirname,
-  '../packages/cli/package.json',
-);
+const argv = yargs(hideBin(process.argv))
+  .option('target', {
+    description: 'The package.json to update.',
+    choices: ['package', 'repo'],
+    demandOption: true,
+  })
+  .help()
+  .alias('help', 'h').argv;
+
+const { target } = argv;
+
+const cliPackageJsonPath =
+  target === 'package'
+    ? path.resolve(__dirname, '../packages/cli/package.json')
+    : path.resolve(__dirname, '../package.json');
 const cliPackageJson = JSON.parse(fs.readFileSync(cliPackageJsonPath, 'utf8'));
 
 // Get version from root package.json (accessible via env var in npm scripts)
-const version = process.env.npm_package_version;
+const baseVersion = process.env.npm_package_version;
+let version = baseVersion;
+
+// For root, append the git commit hash to the version.
+if (target === 'repo') {
+  const shortSha = execSync('git rev-parse --short HEAD').toString().trim();
+  version = `${baseVersion}-${shortSha}`;
+  cliPackageJson.version = version;
+  console.log(`Updated version for root package.json to: ${version}`);
+}
 
 // Get Docker registry and image name directly from PUBLISH_ environment variables.
 // These are expected to be set by the CI/build environment.
 const containerImageRegistry = process.env.SANDBOX_IMAGE_REGISTRY;
 const containerImageName = process.env.SANDBOX_IMAGE_NAME;
 
-if (!version || !containerImageRegistry || !containerImageName) {
+if (!baseVersion || !containerImageRegistry || !containerImageName) {
   console.error(
     'Error: Missing required environment variables. Need: ' +
       'npm_package_version, SANDBOX_IMAGE_REGISTRY, and SANDBOX_IMAGE_NAME.',
@@ -49,7 +72,12 @@ cliPackageJson.config.sandboxImageUri = containerImageUri;
 // Remove 'prepublishOnly' from scripts if it exists
 if (cliPackageJson.scripts && cliPackageJson.scripts.prepublishOnly) {
   delete cliPackageJson.scripts.prepublishOnly;
-  console.log('Removed prepublishOnly script from packages/cli/package.json');
+  console.log(
+    `Removed prepublishOnly script from ${path.relative(
+      process.cwd(),
+      cliPackageJsonPath,
+    )}`,
+  );
 }
 
 fs.writeFileSync(

--- a/scripts/publish-sandbox.js
+++ b/scripts/publish-sandbox.js
@@ -18,13 +18,34 @@
 // limitations under the License.
 
 import { execSync } from 'child_process';
-import { buildImageName } from '../packages/cli/dist/src/config/sandboxConfig.js';
 
 const {
+  SANDBOX_IMAGE_REGISTRY,
+  SANDBOX_IMAGE_NAME,
+  npm_package_version,
   DOCKER_DRY_RUN,
 } = process.env;
 
-const imageUri = await buildImageName()
+if (!SANDBOX_IMAGE_REGISTRY) {
+  console.error(
+    'Error: SANDBOX_IMAGE_REGISTRY environment variable is not set.',
+  );
+  process.exit(1);
+}
+
+if (!SANDBOX_IMAGE_NAME) {
+  console.error('Error: SANDBOX_IMAGE_NAME environment variable is not set.');
+  process.exit(1);
+}
+
+if (!npm_package_version) {
+  console.error(
+    'Error: npm_package_version environment variable is not set (should be run via npm).',
+  );
+  process.exit(1);
+}
+
+const imageUri = `${SANDBOX_IMAGE_REGISTRY}/${SANDBOX_IMAGE_NAME}:${npm_package_version}`;
 
 if (DOCKER_DRY_RUN) {
   console.log(`DRY RUN: Would execute: docker push "${imageUri}"`);


### PR DESCRIPTION
Draft PR/POC into [#npx-sandbox-fix-test2](https://github.com/google-gemini/gemini-cli/tree/npx-sandbox-fix-test2). This adjustment should:

1. reduce the overall [diff](https://github.com/google-gemini/gemini-cli/compare/release...keijibranshi/refactor/npx-sandbox-fix-test2) against `release` (approx. +44 -12),
2. keep changes scoped to the build system and not the app runtime,
3. reduce risk against the npm package and sandbox image publishing steps in ci
