### PR TITLE
Telemetry onboarding dialog

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -21,6 +21,7 @@ import { useTerminalSize } from './hooks/useTerminalSize.js';
 import { useGeminiStream } from './hooks/useGeminiStream.js';
 import { useLoadingIndicator } from './hooks/useLoadingIndicator.js';
 import { useThemeCommand } from './hooks/useThemeCommand.js';
+import { useUsageStatsNotificationCommand } from './hooks/useUsageStatsNotificationCommand.js';
 import { useAuthCommand } from './hooks/useAuthCommand.js';
 import { useEditorSettings } from './hooks/useEditorSettings.js';
 import { useSlashCommandProcessor } from './hooks/slashCommandProcessor.js';
@@ -32,6 +33,7 @@ import { AutoAcceptIndicator } from './components/AutoAcceptIndicator.js';
 import { ShellModeIndicator } from './components/ShellModeIndicator.js';
 import { InputPrompt } from './components/InputPrompt.js';
 import { Footer } from './components/Footer.js';
+import { UsageStatsNotificationDialog } from './components/UsageStatsNotificationDialog.js';
 import { ThemeDialog } from './components/ThemeDialog.js';
 import { AuthDialog } from './components/AuthDialog.js';
 import { AuthInProgress } from './components/AuthInProgress.js';
@@ -133,6 +135,16 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     [consoleMessages],
   );
 
+  const [showTelemetryOnboarding, setShowTelemetryOnboarding] = useState<boolean>(
+    settings.user.settings.usageStatisticsEnabled === undefined,
+  );
+
+  const {
+    isUsageStatsNotificationDialogOpen,
+    openUsageStatsNotificationDialog,
+    handleUsageStatsNotificationOptionSelect
+  } = useUsageStatsNotificationCommand(settings);
+
   const {
     isThemeDialogOpen,
     openThemeDialog,
@@ -228,6 +240,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     refreshStatic,
     setShowHelp,
     setDebugMessage,
+    openUsageStatsNotificationDialog,
     openThemeDialog,
     openAuthDialog,
     openEditorDialog,
@@ -620,8 +633,13 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
               ))}
             </Box>
           )}
-
-          {isThemeDialogOpen ? (
+          {
+          isUsageStatsNotificationDialogOpen ? (
+        <UsageStatsNotificationDialog
+          onSelect={handleUsageStatsNotificationOptionSelect}
+          settings={settings}
+        />
+      ) : isThemeDialogOpen ? (
             <Box flexDirection="column">
               {themeError && (
                 <Box marginBottom={1}>

--- a/packages/cli/src/ui/components/UsageStatsNotificationDialog.tsx
+++ b/packages/cli/src/ui/components/UsageStatsNotificationDialog.tsx
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { Box, Text } from 'ink';
+import { RadioButtonSelect, type RadioSelectItem } from './shared/RadioButtonSelect.js';
+import { Colors } from '../colors.js';
+import { LoadedSettings, SettingScope } from '../../config/settings.js';
+
+interface UsageStatsNotificationDialogProps {
+    onSelect: (value: string, scope: SettingScope) => void;
+    settings: LoadedSettings;
+}
+
+const DIALOG_CHOICES: RadioSelectItem<string>[] = [
+    {
+        label: 'Acknowledge',
+        value: 'acknowledge',
+    },
+    {
+        label: 'Disable usage statistics',
+        value: 'disable',
+    },
+];
+
+export function UsageStatsNotificationDialog({ onSelect, settings }: UsageStatsNotificationDialogProps): React.JSX.Element {
+    const [selectedScope, setSelectedScope] = useState<SettingScope>(
+        SettingScope.User,
+      );
+
+    const handleOptionSelect = (optionName: string) => {
+        onSelect(optionName, selectedScope);
+    };
+
+    return (
+        <Box borderStyle="round"
+          borderColor={Colors.Gray}
+          flexDirection="column"
+          padding={1}
+          width="100%">
+            <Text>
+                To help improve Gemini CLI, we collect anonymized usage statistics.
+            </Text>
+            <Text>
+                You can change this setting at any time by invoking /toggleUsageStatistics within Gemini CLI 
+                or by changing the value of "usageStatisticsEnabled" in your ~/.gemini/settings.json file.
+            </Text>
+            <RadioButtonSelect
+                items={DIALOG_CHOICES}
+                onSelect={handleOptionSelect}
+            />
+        </Box>
+    );
+}

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -69,6 +69,7 @@ export const useSlashCommandProcessor = (
   refreshStatic: () => void,
   setShowHelp: React.Dispatch<React.SetStateAction<boolean>>,
   onDebugMessage: (message: string) => void,
+  openUsageStatsNotificationDialog: () => void,
   openThemeDialog: () => void,
   openAuthDialog: () => void,
   openEditorDialog: () => void,
@@ -229,6 +230,13 @@ export const useSlashCommandProcessor = (
           await config?.getGeminiClient()?.resetChat();
           console.clear();
           refreshStatic();
+        },
+      },
+      {
+        name: 'toggleUsageStats',
+        description: 'enable or disable usage statistics collection',
+        action: (_mainCommand, _subCommand, _args) => {
+          openUsageStatsNotificationDialog();
         },
       },
       {
@@ -983,6 +991,7 @@ Add any other context about the problem here.
     onDebugMessage,
     setShowHelp,
     refreshStatic,
+    openUsageStatsNotificationDialog,
     openThemeDialog,
     openAuthDialog,
     openEditorDialog,

--- a/packages/cli/src/ui/hooks/useUsageStatsNotificationCommand.ts
+++ b/packages/cli/src/ui/hooks/useUsageStatsNotificationCommand.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useCallback } from 'react';
+import { LoadedSettings, SettingScope } from '../../config/settings.js';
+
+interface UseUsageStatsNotificationCommandReturn {
+  isUsageStatsNotificationDialogOpen: boolean;
+  openUsageStatsNotificationDialog: () => void;
+  handleUsageStatsNotificationOptionSelect: (
+    optionName: string | undefined,
+    scope: SettingScope,
+  ) => void;
+}
+
+export const useUsageStatsNotificationCommand = (
+  loadedSettings: LoadedSettings,
+): UseUsageStatsNotificationCommandReturn => {
+  const usageStatsEnabled = loadedSettings.merged.usageStatisticsEnabled;
+
+  // Initial state: Open dialog if no theme is set in either user or workspace settings
+  const [isUsageStatsNotificationDialogOpen, setIsUsageStatsNotificationDialogOpen] = useState(
+    usageStatsEnabled === undefined,
+  );
+
+  const openUsageStatsNotificationDialog = useCallback(() => {
+    setIsUsageStatsNotificationDialogOpen(true);
+  }, []);
+
+  const handleUsageStatsNotificationOptionSelect = useCallback(
+    (optionName: string | undefined, scope: SettingScope) => {
+      try {
+        loadedSettings.setValue(scope, 'theme', optionName); // Update the merged settings
+      } finally {
+        setIsUsageStatsNotificationDialogOpen(false); // Close the dialog
+      }
+    },
+    [loadedSettings],
+  );
+
+  return {
+    isUsageStatsNotificationDialogOpen,
+    openUsageStatsNotificationDialog,
+    handleUsageStatsNotificationOptionSelect,
+  };
+};


### PR DESCRIPTION
## TLDR

Added a one-time dialog to notify users about collection of usage statistics and enable them to opt out.

## Dive Deeper

Also added a /toggleUsageStats command to make it easy for users to change this setting at any time.

## Reviewer Test Plan

Run the CLI, use the dialog to make a selection, and verify that doing so updates the value of "usageStatisticsEnabled" in your ~/.gemini/settings.json file.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

b/424466618