### PR TITLE
Do not render mcp responses as markdown

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -44,6 +44,9 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
       )
     : undefined;
 
+  // Long tool call response in MarkdownDisplay doesn't repect availableTerminalHeight properly,
+  // we're forcing it to not render as markdown when the response is too long, it will fallback
+  // to render as plain text, which is contained within the terminal using MaxSizedBox
   if (availableHeight) {
     renderOutputAsMarkdown = false;
   }

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -44,7 +44,6 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
       )
     : undefined;
 
-  // TODO: Fix markdown display to respect max height
   if (availableHeight) {
     renderOutputAsMarkdown = false;
   }

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -44,6 +44,11 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
       )
     : undefined;
 
+  // TODO: Fix markdown display to respect max height
+  if (availableHeight) {
+    renderOutputAsMarkdown = false;
+  }
+
   const childWidth = terminalWidth - 3; // account for padding.
 
   return (


### PR DESCRIPTION
## TLDR

Fallback to render large tool call responses in plain text instead of markdown.

## Dive Deeper

Markdown display inside a ToolMessage doesn't respect availableTerminalHeight, causing flickering when streaming large contents. The implementation of  MardownDisplay is complicated, the safest way to avoid flickering before launch is to render as plaintext, which is height-constrained by a MaxSizedBox.

## Reviewer Test Plan

Connect to an MCP server to stream large content. Verify the content is contained within a terminal-fitting box with the top lines hidden.

(A simple example is use Github MCP server to list commits in a public repo)

Also verify short markdown still gets displayed properly as markdown.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

N/A
