### PR TITLE
Remove uses of the spread operator that appear to have caused a maximum call stack size exceeded error

### DIFF
--- a/packages/cli/src/ui/components/shared/MaxSizedBox.tsx
+++ b/packages/cli/src/ui/components/shared/MaxSizedBox.tsx
@@ -408,7 +408,9 @@ function layoutInkElementAsStyledText(
     ) {
       lines.push(currentLine);
     }
-    output.push(...lines);
+    for (const line of lines) {
+      output.push(line);
+    }
     return;
   }
 
@@ -524,5 +526,7 @@ function layoutInkElementAsStyledText(
   if (wrappingPart.length > 0) {
     addWrappingPartToLines();
   }
-  output.push(...lines);
+  for (const line of lines) {
+    output.push(line);
+  }
 }


### PR DESCRIPTION
I would have thought this was just a theoretical stack overflow issue but we have this user report so it appears some users are generating outputs large enough to hit this issue.

https://b.corp.google.com/issues/427533822