### PR TITLE
fix: use correct directory for update checks

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -22,6 +22,7 @@ esbuild
     platform: 'node',
     format: 'esm',
     define: {
+      'process.env.CLI_NAME': JSON.stringify(pkg.name),
       'process.env.CLI_VERSION': JSON.stringify(pkg.version),
     },
     banner: {

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -22,7 +22,6 @@ esbuild
     platform: 'node',
     format: 'esm',
     define: {
-      'process.env.CLI_NAME': JSON.stringify(pkg.name),
       'process.env.CLI_VERSION': JSON.stringify(pkg.version),
     },
     banner: {

--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -5,22 +5,17 @@
  */
 
 import updateNotifier from 'update-notifier';
-import { readPackageUp } from 'read-package-up';
 import process from 'node:process';
 
 export async function checkForUpdates(): Promise<string | null> {
   try {
-    // read-package-up looks for the closest package.json from cwd
-    const pkgResult = await readPackageUp({ cwd: process.cwd() });
-    if (!pkgResult) {
+    if (!process.env.CLI_NAME || !process.env.CLI_VERSION) {
       return null;
     }
-
-    const { packageJson } = pkgResult;
     const notifier = updateNotifier({
       pkg: {
-        name: packageJson.name,
-        version: packageJson.version,
+        name: process.env.CLI_NAME,
+        version: process.env.CLI_VERSION,
       },
       // check every time
       updateCheckInterval: 0,
@@ -29,7 +24,7 @@ export async function checkForUpdates(): Promise<string | null> {
     });
 
     if (notifier.update) {
-      return `Gemini CLI update available! ${notifier.update.current} → ${notifier.update.latest}\nRun npm install -g ${packageJson.name} to update`;
+      return `Gemini CLI update available! ${notifier.update.current} → ${notifier.update.latest}\nRun npm install -g ${process.env.CLI_NAME} to update`;
     }
 
     return null;

--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -5,17 +5,21 @@
  */
 
 import updateNotifier from 'update-notifier';
-import process from 'node:process';
+import { readPackageUp } from 'read-package-up';
 
 export async function checkForUpdates(): Promise<string | null> {
   try {
-    if (!process.env.CLI_NAME || !process.env.CLI_VERSION) {
+    // read-package-up looks for the closest package.json from cwd
+    const pkgResult = await readPackageUp({ cwd: __dirname });
+    if (!pkgResult) {
       return null;
     }
+
+    const { packageJson } = pkgResult;
     const notifier = updateNotifier({
       pkg: {
-        name: process.env.CLI_NAME,
-        version: process.env.CLI_VERSION,
+        name: packageJson.name,
+        version: packageJson.version,
       },
       // check every time
       updateCheckInterval: 0,
@@ -24,7 +28,7 @@ export async function checkForUpdates(): Promise<string | null> {
     });
 
     if (notifier.update) {
-      return `Gemini CLI update available! ${notifier.update.current} → ${notifier.update.latest}\nRun npm install -g ${process.env.CLI_NAME} to update`;
+      return `Gemini CLI update available! ${notifier.update.current} → ${notifier.update.latest}\nRun npm install -g ${packageJson.name} to update`;
     }
 
     return null;


### PR DESCRIPTION
The update notifier was incorrectly checking for updates to the `@gemini-cli/cli` package, and it was relying on the `package.json` of the user`s current working directory, which is not reliable for a globally installed tool.

This change modifies the build process to inject the top-level package name and version into the bundle. The update checker now uses these build-time variables, ensuring it always checks for the correct package (`gemini-cli`) and its version.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
