### PR TITLE
fix: define es module __dirname in updateCheck.ts

### DIFF
--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -6,6 +6,12 @@
 
 import updateNotifier from 'update-notifier';
 import { readPackageUp } from 'read-package-up';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+// ES module equivalent of __dirname
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export async function checkForUpdates(): Promise<string | null> {
   try {


### PR DESCRIPTION
this is a global in some JS variants (CommonJS?), but not in ES modules. So it needs to be explicitly defined