### PR TITLE
Docs: update docs to clarify the differences between Google account login o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This repository contains the Gemini CLI tool.
    npx https://github.com/google-gemini/gemini-cli
    ```
 
-3. **Authenticate:** When prompted, sign in with your Google account. This will grant you up to 60 model requests per minute and 1,000 model requests per day using Gemini 2.5 Pro.
+3. **Pick a color theme**
+4. **Authenticate:** When prompted, sign in with your gmail account. This will grant you up to 60 model requests per minute and 1,000 model requests per day using Gemini 2.5 Pro.
 
 You are now ready to use the Gemini CLI!
 
@@ -30,7 +31,7 @@ If you need to use a specific model or require a higher request capacity, you ca
    export GEMINI_API_KEY="YOUR_API_KEY"
    ```
 
-For other authentication methods, see the [authentication](./docs/cli/authentication.md) guide.
+For other authentication methods, including Google Workspace accounts, see the [authentication](./docs/cli/authentication.md) guide.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains the Gemini CLI tool.
    ```
 
 3. **Pick a color theme**
-4. **Authenticate:** When prompted, sign in with your gmail account. This will grant you up to 60 model requests per minute and 1,000 model requests per day using Gemini 2.5 Pro.
+4. **Authenticate:** When prompted, sign in with your personal Google account. This will grant you up to 60 model requests per minute and 1,000 model requests per day using Gemini 2.5 Pro.
 
 You are now ready to use the Gemini CLI!
 

--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -4,7 +4,7 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
 
 1.  **Login with Google (Gemini Code Assist):**
 
-    - Use this option to log in with the standard, free account you use for services like Gmail, Google Photos, and Google Drive for personal use (e.g. your-name@gmail.com).
+    - Use this option to log in with the standard, personal account you use for services like Gmail, Google Photos, and Google Drive for personal use (e.g. your-name@gmail.com).
     - During initial startup, Gemini CLI will direct you to a webpage for authentication. Once authenticated, your credentials will be cached locally so the web login can be skipped on subsequent runs.
     - Note that the web login must be done in a browser that can communicate with the machine Gemini CLI is being run from. (Specifically, the browser will be redirected to a localhost url that Gemini CLI will be listening on).
 
@@ -25,7 +25,7 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
 3.  **Login with Google Workspace**
 
     - Use this option to log in with the **Google Workspace Accounts**. This is a paid service for businesses and organizations that provides a suite of productivity tools, including a custom email domain (e.g. your-name@your-company.com), enhanced security features, and administrative controls. These accounts are often managed by an employer or school.
-      - Google Workspace Account must configure a Google Cloud Project Id to use. You can temporarily set the environment variable in your current shell session using the following command:
+      - Google Workspace Account must first configure a Google Cloud Project Id to use, [enable the Gemini for Cloud API](https://cloud.google.com/gemini/docs/discover/set-up-gemini#enable-api) and [configure access permissions](https://cloud.google.com/gemini/docs/discover/set-up-gemini#grant-iam). You can temporarily set the environment variable in your current shell session using the following command:
       ```bash
       export GOOGLE_CLOUD_PROJECT_ID="YOUR_PROJECT_ID"
       ```


### PR DESCRIPTION


## TLDR

The different account types for Google login are clarified. The distinction is more personal (gmail) and work more than free/paid. Also, to use a workspace account, further API enablement and Permission setup steps are needed beyond just providing a project ID.


