### PR TITLE
Stop matching numbers in error messages if it is not required.

### DIFF
--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -157,7 +157,24 @@ describe('retryWithBackoff', () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it('should respect maxDelayMs', async () => {
+  it('should not retry on 500 error if only checking message', async () => {
+      const mockFn = vi.fn(async () => {
+        const error = new Error('Internal Server Error') as any;
+        error.status = 500;
+        throw error;
+      });
+
+      const promise = retryWithBackoff(mockFn, {
+        maxAttempts: 2,
+        initialDelayMs: 10,
+        shouldRetry: (err: Error) => err.message.includes('429'),
+      });
+
+      await expect(promise).rejects.toThrow('Internal Server Error');
+      expect(mockFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should respect maxDelayMs', async () => {
     const mockFn = createFailingFunction(3);
     const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
 

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -36,10 +36,6 @@ function defaultShouldRetry(error: Error | unknown): boolean {
       return true;
     }
   }
-  if (error instanceof Error && error.message) {
-    if (error.message.includes('429')) return true;
-    if (error.message.match(/5\d{2}/)) return true;
-  }
   return false;
 }
 


### PR DESCRIPTION
For discussion. Need to verify whether we have errors that lack a status field. As @bbiggs pointed out, the regex matches for 3 digit numbers aren't safe as they false positive on errors for the token limit being exceeded as those messages include the token count and the typical 7 digit number often has a 5 followed by a 2 digits. If we need to include status, we should exactly match message text that indicates the number is an error code.