### PR TITLE
Docs: Add link links to tools/index.md.

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -8,13 +8,13 @@ In the context of the Gemini CLI, tools are specific functions or modules that t
 
 The core component (`packages/core`) manages these tools, presents their definitions (schemas) to the Gemini model, executes them when requested, and returns the results to the model for further processing into a user-facing response.
 
-These tools provide the following capabilities: 
+These tools provide the following capabilities:
 
-* **Access local information:** Tools allow Gemini to access your local file system, read file contents, list directories, etc.
-* **Execute commands:** With tools like `run_shell_command`, Gemini can run shell commands (with appropriate safety measures and user confirmation).
-* **Interact with the web:** Tools can fetch content from URLs.
-* **Take actions:** Tools can modify files, write new files, or perform other actions on your system (again, typically with safeguards).
-* **Ground responses:** By using tools to fetch real-time or specific local data, Gemini's responses can be more accurate, relevant, and grounded in your actual context.
+- **Access local information:** Tools allow Gemini to access your local file system, read file contents, list directories, etc.
+- **Execute commands:** With tools like `run_shell_command`, Gemini can run shell commands (with appropriate safety measures and user confirmation).
+- **Interact with the web:** Tools can fetch content from URLs.
+- **Take actions:** Tools can modify files, write new files, or perform other actions on your system (again, typically with safeguards).
+- **Ground responses:** By using tools to fetch real-time or specific local data, Gemini's responses can be more accurate, relevant, and grounded in your actual context.
 
 ## How to use Gemini CLI tools
 
@@ -34,8 +34,8 @@ You will typically see messages in the CLI indicating when a tool is being calle
 
 Many tools, especially those that can modify your file system or execute commands (`write_file`, `edit`, `run_shell_command`), are designed with safety in mind. The Gemini CLI will typically:
 
-* **Require confirmation:** Prompt you before executing potentially sensitive operations, showing you what action is about to be taken.
-* **Utilize sandboxing:** All tools are subject to restrictions enforced by sandboxing (see [README](../../README.md#sandboxing)). This means that when operating in a sandbox, any tools (including MCP servers) you wish to use must be available _inside_ the sandbox environment. For example, to run an MCP server through `npx`, the `npx` executable must be installed within the sandbox's Docker image or be available in the `sandbox-exec` environment.
+- **Require confirmation:** Prompt you before executing potentially sensitive operations, showing you what action is about to be taken.
+- **Utilize sandboxing:** All tools are subject to restrictions enforced by sandboxing (see [README](../../README.md#sandboxing)). This means that when operating in a sandbox, any tools (including MCP servers) you wish to use must be available _inside_ the sandbox environment. For example, to run an MCP server through `npx`, the `npx` executable must be installed within the sandbox's Docker image or be available in the `sandbox-exec` environment.
 
 It's important to always review confirmation prompts carefully before allowing a tool to proceed.
 
@@ -43,14 +43,14 @@ It's important to always review confirmation prompts carefully before allowing a
 
 Gemini CLI's built-in tools can be broadly categorized as follows:
 
-* **[File System Tools](./file-system.md):** For interacting with files and directories (reading, writing, listing, searching, etc.).
-* **[Shell Tool](./shell.md) (`run_shell_command`):** For executing shell commands.
-* **[Web Fetch Tool](./web-fetch.md) (`web_fetch`):** For retrieving content from URLs.
-* **[Web Search Tool](./web-search.md) (`web_search`):** For searching the web.
-* **[Multi-File Read Tool](./multi-file.md) (`read_many_files`):** A specialized tool for reading content from multiple files or directories, often used by the `@` command.
-* **[Memory Tool](./memory.md) (`save_memory`):** For saving and recalling information across sessions.
+- **[File System Tools](./file-system.md):** For interacting with files and directories (reading, writing, listing, searching, etc.).
+- **[Shell Tool](./shell.md) (`run_shell_command`):** For executing shell commands.
+- **[Web Fetch Tool](./web-fetch.md) (`web_fetch`):** For retrieving content from URLs.
+- **[Web Search Tool](./web-search.md) (`web_search`):** For searching the web.
+- **[Multi-File Read Tool](./multi-file.md) (`read_many_files`):** A specialized tool for reading content from multiple files or directories, often used by the `@` command.
+- **[Memory Tool](./memory.md) (`save_memory`):** For saving and recalling information across sessions.
 
 Additionally, these tools incorporate:
 
-* **[MCP servers](./mcp-server.md)**: MCP servers act as a bridge between the Gemini model and your local environment or other services like APIs.
-* **[Sandboxing](../sandbox.md)**: Sandboxing isolates the model and its changes from your environment to reduce potenital risk.
+- **[MCP servers](./mcp-server.md)**: MCP servers act as a bridge between the Gemini model and your local environment or other services like APIs.
+- **[Sandboxing](../sandbox.md)**: Sandboxing isolates the model and its changes from your environment to reduce potenital risk.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,22 +1,24 @@
-# Gemini CLI Tools: Overview
+# Gemini CLI tools
 
-The Gemini CLI is equipped with a powerful set of built-in tools that the Gemini model can utilize to interact with your local environment, access information, and perform actions. These tools significantly enhance the CLI's capabilities, allowing it to go beyond text generation and assist with a wide range of tasks.
+The Gemini CLI includes built-in tools that the Gemini model uses to interact with your local environment, access information, and perform actions. These tools enhance the CLI's capabilities, enabling it to go beyond text generation and assist with a wide range of tasks.
 
-## What are Tools?
+## Overview of Gemini CLI tools
 
 In the context of the Gemini CLI, tools are specific functions or modules that the Gemini model can request to be executed. For example, if you ask Gemini to "Summarize the contents of `my_document.txt`," the model will likely identify the need to read that file and will request the execution of the `read_file` tool.
 
 The core component (`packages/core`) manages these tools, presents their definitions (schemas) to the Gemini model, executes them when requested, and returns the results to the model for further processing into a user-facing response.
 
-## Why are Tools Important?
+These tools provide the following capabilities: 
 
-- **Access to Local Information:** Tools allow Gemini to access your local file system, read file contents, list directories, etc.
-- **Execution of Commands:** With tools like `run_shell_command`, Gemini can run shell commands (with appropriate safety measures and user confirmation).
-- **Interaction with the Web:** Tools can fetch content from URLs.
-- **Action Taking:** Tools can modify files, write new files, or perform other actions on your system (again, typically with safeguards).
-- **Grounding Responses:** By using tools to fetch real-time or specific local data, Gemini's responses can be more accurate, relevant, and grounded in your actual context.
+* **Access local information:** Tools allow Gemini to access your local file system, read file contents, list directories, etc.
+* **Execute commands:** With tools like `run_shell_command`, Gemini can run shell commands (with appropriate safety measures and user confirmation).
+* **Interact with the web:** Tools can fetch content from URLs.
+* **Take actions:** Tools can modify files, write new files, or perform other actions on your system (again, typically with safeguards).
+* **Ground responses:** By using tools to fetch real-time or specific local data, Gemini's responses can be more accurate, relevant, and grounded in your actual context.
 
-## How Tools are Used
+## How to use Gemini CLI tools
+
+To use Gemini CLI tools, provide a prompt to the Gemini CLI. The process works as follows:
 
 1.  You provide a prompt to the Gemini CLI.
 2.  The CLI sends the prompt to the core.
@@ -28,24 +30,27 @@ The core component (`packages/core`) manages these tools, presents their definit
 
 You will typically see messages in the CLI indicating when a tool is being called and whether it succeeded or failed.
 
-## Security and Confirmation
+## Security and confirmation
 
 Many tools, especially those that can modify your file system or execute commands (`write_file`, `edit`, `run_shell_command`), are designed with safety in mind. The Gemini CLI will typically:
 
-- **Require Confirmation:** Prompt you before executing potentially sensitive operations, showing you what action is about to be taken.
-- **Utilize Sandboxing:** All tools are subject to restrictions enforced by sandboxing (see [README](../../README.md#sandboxing)). This means that when operating in a sandbox, any tools (including MCP servers) you wish to use must be available _inside_ the sandbox environment. For example, to run an MCP server through `npx`, the `npx` executable must be installed within the sandbox's Docker image or be available in the `sandbox-exec` environment.
+* **Require confirmation:** Prompt you before executing potentially sensitive operations, showing you what action is about to be taken.
+* **Utilize sandboxing:** All tools are subject to restrictions enforced by sandboxing (see [README](../../README.md#sandboxing)). This means that when operating in a sandbox, any tools (including MCP servers) you wish to use must be available _inside_ the sandbox environment. For example, to run an MCP server through `npx`, the `npx` executable must be installed within the sandbox's Docker image or be available in the `sandbox-exec` environment.
 
 It's important to always review confirmation prompts carefully before allowing a tool to proceed.
 
-## Categories of Built-in Tools
+## Learn more about Gemini CLI's tools
 
-The built-in tools can be broadly categorized as follows:
+Gemini CLI's built-in tools can be broadly categorized as follows:
 
-- **[File System Tools](./file-system.md):** For interacting with files and directories (reading, writing, listing, searching, etc.).
-- **[Shell Tool](./shell.md):** For executing shell commands.
-- **[Web Fetch Tool](./web-fetch.md):** For retrieving content from URLs.
-- **[Web Search Tool](./web-search.md):** For searching the web.
-- **[Multi-File Read Tool](./multi-file.md):** A specialized tool for reading content from multiple files or directories, often used by the `@` command.
-- **[Memory Tool](./memory.md):** For saving and recalling information across sessions.
+* **[File System Tools](./file-system.md):** For interacting with files and directories (reading, writing, listing, searching, etc.).
+* **[Shell Tool](./shell.md) (`run_shell_command`):** For executing shell commands.
+* **[Web Fetch Tool](./web-fetch.md) (`web_fetch`):** For retrieving content from URLs.
+* **[Web Search Tool](./web-search.md) (`web_search`):** For searching the web.
+* **[Multi-File Read Tool](./multi-file.md) (`read_many_files`):** A specialized tool for reading content from multiple files or directories, often used by the `@` command.
+* **[Memory Tool](./memory.md) (`save_memory`):** For saving and recalling information across sessions.
 
-Understanding the available tools and how they work will help you make the most effective use of the Gemini CLI.
+Additionally, these tools incorporate:
+
+* **[MCP servers](./mcp-server.md)**: MCP servers act as a bridge between the Gemini model and your local environment or other services like APIs.
+* **[Sandboxing](../sandbox.md)**: Sandboxing isolates the model and its changes from your environment to reduce potenital risk.


### PR DESCRIPTION
## TLDR

Add links to MCP server documentation and sandbox documentation. 

## Dive Deeper

Adds links to MCP server documentation and sandbox documentation.

Tweaks index for style.