### PR TITLE
Update Readme to call out gemini command after npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ With the Gemini CLI you can:
 2. **Run the CLI:** Execute the following command in your terminal:
 
    ```bash
-   npx https://github.com/google-gemini/gemini-cli
+   $ npx https://github.com/google-gemini/gemini-cli
    ```
 
    Or install it with:
 
    ```bash
-   npm install -g @google/gemini-cli
+   $ npm install -g @google/gemini-cli
+   $ gemini
    ```
 
 3. **Pick a color theme**

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ With the Gemini CLI you can:
 2. **Run the CLI:** Execute the following command in your terminal:
 
    ```bash
-   $ npx https://github.com/google-gemini/gemini-cli
+   npx https://github.com/google-gemini/gemini-cli
    ```
 
    Or install it with:
 
    ```bash
-   $ npm install -g @google/gemini-cli
-   $ gemini
+   npm install -g @google/gemini-cli
+   gemini
    ```
 
 3. **Pick a color theme**
@@ -58,17 +58,17 @@ Once the CLI is running, you can start interacting with Gemini from your shell.
 You can start a project from a new directory:
 
 ```sh
-$ cd new-project/
-$ gemini
+cd new-project/
+gemini
 > Write me a Gemini Discord bot that answers questions using a FAQ.md file I will provide
 ```
 
 Or work with an existing project:
 
 ```sh
-$ git clone https://github.com/google-gemini/gemini-cli
-$ cd gemini-cli
-$ gemini
+git clone https://github.com/google-gemini/gemini-cli
+cd gemini-cli
+gemini
 > Give me a summary of all of the changes that went in yesterday
 ```
 


### PR DESCRIPTION
fix npm install directions

## TLDR

Fixes the readme so after npm install there is the command to start gemini.

## Dive Deeper

The TLDR is the thing.

## Reviewer Test Plan

They should have a fresh install of this and make sure that the two steps are needed.

## Testing Matrix

Not applicable.

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
