### PR TITLE
Update authentication.md

### DIFF
--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -27,11 +27,11 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
     - Use this option to log in with the **Google Workspace Accounts**. This is a paid service for businesses and organizations that provides a suite of productivity tools, including a custom email domain (e.g. your-name@your-company.com), enhanced security features, and administrative controls. These accounts are often managed by an employer or school.
       - Google Workspace Account must first configure a Google Cloud Project Id to use, [enable the Gemini for Cloud API](https://cloud.google.com/gemini/docs/discover/set-up-gemini#enable-api) and [configure access permissions](https://cloud.google.com/gemini/docs/discover/set-up-gemini#grant-iam). You can temporarily set the environment variable in your current shell session using the following command:
       ```bash
-      export GOOGLE_CLOUD_PROJECT_ID="YOUR_PROJECT_ID"
+      export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"
       ```
       - For repeated use, you can add the environment variable to your `.env` file (located in the project directory or user home directory) or your shell's configuration file (like `~/.bashrc`, `~/.zshrc`, or `~/.profile`). For example, the following command adds the environment variable to a `~/.bashrc` file:
       ```bash
-      echo 'export GOOGLE_CLOUD_PROJECT_ID="YOUR_PROJECT_ID"' >> ~/.bashrc
+      echo 'export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"' >> ~/.bashrc
       source ~/.bashrc
       ```
     - During startup, Gemini CLI will direct you to a webpage for authentication. Once authenticated, your credentials will be cached locally so the web login can be skipped on subsequent runs.


### PR DESCRIPTION
## TLDR

Docs referenced a non-existing env variable.

## Dive Deeper

Removed the `_ID` suffix.

## Reviewer Test Plan

Set the `GOOGLE_CLOUD_PROJECT_ID` to your GCP project ID, and then try logging in with a Workspace account.
Then change it to a `GOOGLE_CLOUD_PROJECT` and try logging in again.
