### PR TITLE
feat: add Neovim editor support

### DIFF
--- a/packages/cli/src/ui/editors/editorSettingsManager.ts
+++ b/packages/cli/src/ui/editors/editorSettingsManager.ts
@@ -23,6 +23,7 @@ export const EDITOR_DISPLAY_NAMES: Record<EditorType, string> = {
   windsurf: 'Windsurf',
   cursor: 'Cursor',
   vim: 'Vim',
+  neovim: 'Neovim',
 };
 
 class EditorSettingsManager {
@@ -36,6 +37,7 @@ class EditorSettingsManager {
       'windsurf',
       'cursor',
       'vim',
+      'neovim',
     ];
     this.availableEditors = [
       {

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -60,6 +60,7 @@ describe('editor utils', () => {
       { editor: 'windsurf', command: 'windsurf', win32Command: 'windsurf' },
       { editor: 'cursor', command: 'cursor', win32Command: 'cursor' },
       { editor: 'vim', command: 'vim', win32Command: 'vim' },
+      { editor: 'neovim', command: 'nvim', win32Command: 'nvim' },
       { editor: 'zed', command: 'zed', win32Command: 'zed' },
     ];
 
@@ -165,6 +166,32 @@ describe('editor utils', () => {
       });
     });
 
+    it('should return the correct command for neovim', () => {
+      const command = getDiffCommand('old.txt', 'new.txt', 'neovim');
+      expect(command).toEqual({
+        command: 'nvim',
+        args: [
+          '-d',
+          '-i',
+          'NONE',
+          '-c',
+          'wincmd h | set readonly | wincmd l',
+          '-c',
+          'highlight DiffAdd cterm=bold ctermbg=22 guibg=#005f00 | highlight DiffChange cterm=bold ctermbg=24 guibg=#005f87 | highlight DiffText ctermbg=21 guibg=#0000af | highlight DiffDelete ctermbg=52 guibg=#5f0000',
+          '-c',
+          'set showtabline=2 | set tabline=[Instructions]\\ :wqa(save\\ &\\ quit)\\ \\|\\ i/esc(toggle\\ edit\\ mode)',
+          '-c',
+          'wincmd h | setlocal statusline=OLD\\ FILE',
+          '-c',
+          'wincmd l | setlocal statusline=%#StatusBold#NEW\\ FILE\\ :wqa(save\\ &\\ quit)\\ \\|\\ i/esc(toggle\\ edit\\ mode)',
+          '-c',
+          'autocmd WinClosed * wqa',
+          'old.txt',
+          'new.txt',
+        ],
+      });
+    });
+
     it('should return null for an unsupported editor', () => {
       // @ts-expect-error Testing unsupported editor
       const command = getDiffCommand('old.txt', 'new.txt', 'foobar');
@@ -240,7 +267,7 @@ describe('editor utils', () => {
       });
     }
 
-    const execSyncEditors: EditorType[] = ['vim'];
+    const execSyncEditors: EditorType[] = ['vim', 'neovim'];
     for (const editor of execSyncEditors) {
       it(`should call execSync for ${editor} on non-windows`, async () => {
         Object.defineProperty(process, 'platform', { value: 'linux' });
@@ -291,6 +318,15 @@ describe('editor utils', () => {
 
     it('should allow vim when not in sandbox mode', () => {
       expect(allowEditorTypeInSandbox('vim')).toBe(true);
+    });
+
+    it('should allow neovim in sandbox mode', () => {
+      process.env.SANDBOX = 'sandbox';
+      expect(allowEditorTypeInSandbox('neovim')).toBe(true);
+    });
+
+    it('should allow neovim when not in sandbox mode', () => {
+      expect(allowEditorTypeInSandbox('neovim')).toBe(true);
     });
 
     const guiEditors: EditorType[] = [
@@ -347,6 +383,12 @@ describe('editor utils', () => {
       (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/vim'));
       process.env.SANDBOX = 'sandbox';
       expect(isEditorAvailable('vim')).toBe(true);
+    });
+
+    it('should return true for neovim when installed and in sandbox mode', () => {
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/nvim'));
+      process.env.SANDBOX = 'sandbox';
+      expect(isEditorAvailable('neovim')).toBe(true);
     });
   });
 });

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -140,57 +140,41 @@ describe('editor utils', () => {
       });
     }
 
-    it('should return the correct command for vim', () => {
-      const command = getDiffCommand('old.txt', 'new.txt', 'vim');
-      expect(command).toEqual({
-        command: 'vim',
-        args: [
-          '-d',
-          '-i',
-          'NONE',
-          '-c',
-          'wincmd h | set readonly | wincmd l',
-          '-c',
-          'highlight DiffAdd cterm=bold ctermbg=22 guibg=#005f00 | highlight DiffChange cterm=bold ctermbg=24 guibg=#005f87 | highlight DiffText ctermbg=21 guibg=#0000af | highlight DiffDelete ctermbg=52 guibg=#5f0000',
-          '-c',
-          'set showtabline=2 | set tabline=[Instructions]\\ :wqa(save\\ &\\ quit)\\ \\|\\ i/esc(toggle\\ edit\\ mode)',
-          '-c',
-          'wincmd h | setlocal statusline=OLD\\ FILE',
-          '-c',
-          'wincmd l | setlocal statusline=%#StatusBold#NEW\\ FILE\\ :wqa(save\\ &\\ quit)\\ \\|\\ i/esc(toggle\\ edit\\ mode)',
-          '-c',
-          'autocmd WinClosed * wqa',
-          'old.txt',
-          'new.txt',
-        ],
-      });
-    });
+    const terminalEditors: Array<{
+      editor: EditorType;
+      command: string;
+    }> = [
+      { editor: 'vim', command: 'vim' },
+      { editor: 'neovim', command: 'nvim' },
+    ];
 
-    it('should return the correct command for neovim', () => {
-      const command = getDiffCommand('old.txt', 'new.txt', 'neovim');
-      expect(command).toEqual({
-        command: 'nvim',
-        args: [
-          '-d',
-          '-i',
-          'NONE',
-          '-c',
-          'wincmd h | set readonly | wincmd l',
-          '-c',
-          'highlight DiffAdd cterm=bold ctermbg=22 guibg=#005f00 | highlight DiffChange cterm=bold ctermbg=24 guibg=#005f87 | highlight DiffText ctermbg=21 guibg=#0000af | highlight DiffDelete ctermbg=52 guibg=#5f0000',
-          '-c',
-          'set showtabline=2 | set tabline=[Instructions]\\ :wqa(save\\ &\\ quit)\\ \\|\\ i/esc(toggle\\ edit\\ mode)',
-          '-c',
-          'wincmd h | setlocal statusline=OLD\\ FILE',
-          '-c',
-          'wincmd l | setlocal statusline=%#StatusBold#NEW\\ FILE\\ :wqa(save\\ &\\ quit)\\ \\|\\ i/esc(toggle\\ edit\\ mode)',
-          '-c',
-          'autocmd WinClosed * wqa',
-          'old.txt',
-          'new.txt',
-        ],
+    for (const { editor, command } of terminalEditors) {
+      it(`should return the correct command for ${editor}`, () => {
+        const diffCommand = getDiffCommand('old.txt', 'new.txt', editor);
+        expect(diffCommand).toEqual({
+          command,
+          args: [
+            '-d',
+            '-i',
+            'NONE',
+            '-c',
+            'wincmd h | set readonly | wincmd l',
+            '-c',
+            'highlight DiffAdd cterm=bold ctermbg=22 guibg=#005f00 | highlight DiffChange cterm=bold ctermbg=24 guibg=#005f87 | highlight DiffText ctermbg=21 guibg=#0000af | highlight DiffDelete ctermbg=52 guibg=#5f0000',
+            '-c',
+            'set showtabline=2 | set tabline=[Instructions]\\ :wqa(save\\ &\\ quit)\\ \\|\\ i/esc(toggle\\ edit\\ mode)',
+            '-c',
+            'wincmd h | setlocal statusline=OLD\\ FILE',
+            '-c',
+            'wincmd l | setlocal statusline=%#StatusBold#NEW\\ FILE\\ :wqa(save\\ &\\ quit)\\ \\|\\ i/esc(toggle\\ edit\\ mode)',
+            '-c',
+            'autocmd WinClosed * wqa',
+            'old.txt',
+            'new.txt',
+          ],
+        });
       });
-    });
+    }
 
     it('should return null for an unsupported editor', () => {
       // @ts-expect-error Testing unsupported editor

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -16,9 +16,15 @@ export type EditorType =
   | 'zed';
 
 function isValidEditorType(editor: string): editor is EditorType {
-  return ['vscode', 'vscodium', 'windsurf', 'cursor', 'vim', 'neovim', 'zed'].includes(
-    editor,
-  );
+  return [
+    'vscode',
+    'vscodium',
+    'windsurf',
+    'cursor',
+    'vim',
+    'neovim',
+    'zed',
+  ].includes(editor);
 }
 
 interface DiffCommand {

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -99,36 +99,9 @@ export function getDiffCommand(
     case 'zed':
       return { command, args: ['--wait', '--diff', oldPath, newPath] };
     case 'vim':
-      return {
-        command: 'vim',
-        args: [
-          '-d',
-          // skip viminfo file to avoid E138 errors
-          '-i',
-          'NONE',
-          // make the left window read-only and the right window editable
-          '-c',
-          'wincmd h | set readonly | wincmd l',
-          // set up colors for diffs
-          '-c',
-          'highlight DiffAdd cterm=bold ctermbg=22 guibg=#005f00 | highlight DiffChange cterm=bold ctermbg=24 guibg=#005f87 | highlight DiffText ctermbg=21 guibg=#0000af | highlight DiffDelete ctermbg=52 guibg=#5f0000',
-          // Show helpful messages
-          '-c',
-          'set showtabline=2 | set tabline=[Instructions]\\ :wqa(save\\ &\\ quit)\\ \\|\\ i/esc(toggle\\ edit\\ mode)',
-          '-c',
-          'wincmd h | setlocal statusline=OLD\\ FILE',
-          '-c',
-          'wincmd l | setlocal statusline=%#StatusBold#NEW\\ FILE\\ :wqa(save\\ &\\ quit)\\ \\|\\ i/esc(toggle\\ edit\\ mode)',
-          // Auto close all windows when one is closed
-          '-c',
-          'autocmd WinClosed * wqa',
-          oldPath,
-          newPath,
-        ],
-      };
     case 'neovim':
       return {
-        command: 'nvim',
+        command,
         args: [
           '-d',
           // skip viminfo file to avoid E138 errors


### PR DESCRIPTION
## Summary
This PR adds support for Neovim as a diff editor option in gemini-cli, providing the same functionality as the existing Vim support.

## Changes
- Added 'neovim' to the EditorType type definition
- Added neovim command configuration using 'nvim' command for all platforms
- Implemented getDiffCommand and openDiff support for neovim with the same settings as vim
- Added neovim to the editor settings UI with display name "Neovim"
- Added comprehensive test coverage for all neovim functionality
- Configured neovim to be allowed in sandbox mode (same behavior as vim)

## Notes
Neovim uses the same diff command arguments as Vim since they share compatible command-line interfaces for diff mode.