### PR TITLE
fix: improve error message for Google Workspace account login

### DIFF
--- a/packages/cli/src/ui/hooks/useAuthCommand.ts
+++ b/packages/cli/src/ui/hooks/useAuthCommand.ts
@@ -49,8 +49,17 @@ export const useAuthCommand = (
         const errorMessage =
           settings.merged.selectedAuthType ===
           AuthType.LOGIN_WITH_GOOGLE_PERSONAL
-            ? `Failed to login. Ensure your Google account is not a Workspace account.
-Message: ${getErrorMessage(e)}`
+            ? `Failed to login. This error typically occurs when:
+• Your Google account is a Workspace (G Suite) account
+• Your Google account has been used to sign up for Google Cloud
+
+To resolve this:
+1. Use a personal Gmail account instead
+2. Create a new Google account that hasn't been used for Google Cloud
+
+For more information, see: https://developers.google.com/gemini-code-assist/resources/faqs#gcp-project-requirement
+
+Error details: ${getErrorMessage(e)}`
             : `Failed to login. Message: ${getErrorMessage(e)}`;
         setAuthError(errorMessage);
         openAuthDialog();


### PR DESCRIPTION
## Issue

https://github.com/google-gemini/gemini-cli/issues/1432

## Summary
This PR improves the error message displayed when users attempt to login with a Google Workspace account, providing clearer guidance on why the login failed and how to resolve it.

## Changes
- Enhanced error message for `LOGIN_WITH_GOOGLE_PERSONAL` authentication failures
- Added specific reasons why login might fail (Workspace account, Google Cloud usage)
- Provided clear resolution steps (use personal Gmail, create new account)
- Added direct link to official documentation for more details

## Background
The current error message "Failed to login. Ensure your Google account is not a Workspace account" doesn't provide enough context for users to understand:
- Why Workspace accounts can't be used
- That Google Cloud usage also affects account eligibility
- What specific steps they should take to resolve the issue

## Testing

Testing My Google Workspace Account

### 1. Build Status

✅ Successfully built gemini-cli with updated error message

### 2. Error Message Verification

✅ Confirmed the new error message is properly implemented in the compiled JavaScript:
```javascript
`Failed to login. This error typically occurs when:
• Your Google account is a Workspace (G Suite) account
• Your Google account has been used to sign up for Google Cloud

To resolve this:
1. Use a personal Gmail account instead
2. Create a new Google account that hasn't been used for Google Cloud

For more information, see: https://developers.google.com/gemini-code-assist/resources/faqs#gcp-project-requirement

Error details: ${getErrorMessage(e)}`
```

### 3. Non-Interactive Mode Test
When running in non-interactive mode (command line with -p flag), the system shows a different error:
```
Error onboarding with Code Assist.
Google Workspace Account (e.g. your-name@your-company.com) must specify a GOOGLE_CLOUD_PROJECT environment variable.
```

This is expected behavior as the auth dialog (where our improved error would appear) is not triggered in non-interactive mode.

### 4. Interactive Mode
The improved error message will be displayed when:
- User runs `gemini` without flags (interactive mode)
- Auth dialog appears
- User selects "Login with Google (Personal)" 
- Login fails due to Workspace account