### PR TITLE
Prod: Integration Tests Main Only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,9 +4,7 @@ name: E2E Tests
 
 on:
   push:
-    branches: [main, release]
-  pull_request:
-    branches: [main, release]
+    branches: [main]
   merge_group:
 
 jobs:


### PR DESCRIPTION
## TLDR

Make integration tests not run or required for pull requests.

## Dive Deeper

Our e2e tests are currently flaky and experiencing permissions issues for forked users. This is a temp change to only run on pushes to main. Follow up work will be needed to ensure these work long term.