### PR TITLE
[Feat] Allow setting `baseUrl` to use gemini-cli with LiteLLM Proxy 

### DIFF
--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -113,10 +113,12 @@ export async function createContentGenerator(
   config: ContentGeneratorConfig,
 ): Promise<ContentGenerator> {
   const version = process.env.CLI_VERSION || process.version;
+  const baseUrl = process.env.BASE_URL;
   const httpOptions = {
     headers: {
       'User-Agent': `GeminiCLI/${version} (${process.platform}; ${process.arch})`,
     },
+    ...(baseUrl && { baseURL: baseUrl }),
   };
   if (
     config.authType === AuthType.LOGIN_WITH_GOOGLE_PERSONAL ||

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -118,7 +118,7 @@ export async function createContentGenerator(
     headers: {
       'User-Agent': `GeminiCLI/${version} (${process.platform}; ${process.arch})`,
     },
-    ...(baseUrl && { baseURL: baseUrl }),
+    ...(baseUrl && { baseUrl: baseUrl }),
   };
   if (
     config.authType === AuthType.LOGIN_WITH_GOOGLE_PERSONAL ||


### PR DESCRIPTION
## [Feat] Allow setting `baseUrl` to use gemini-cli with LiteLLM Proxy 

This is a small PR to allow pointing gemini-cli to a baseUrl to use with other gateways like LiteLLM. Other coding tools like [claude code allow using LiteLLM Proxy in this manner too](https://docs.anthropic.com/en/docs/claude-code/llm-gateway)

I'm the maintainer of [LiteLLM](https://github.com/BerriAI/litellm) and we'd love to announce day-0 support for using LiteLLM with gemini-cli 

As you can see our users already have started asking for this 

<img width="552" alt="Screenshot 2025-06-25 at 8 39 50 AM" src="https://github.com/user-attachments/assets/0f2cbe5d-2a25-4e47-a0ce-92b4a42d48b7" />


Closes https://github.com/google-gemini/gemini-cli/issues/1457

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs



<!-- Add links to any gh issues or other external bugs --->
