### PR TITLE
fix: proxy settings

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -240,13 +240,13 @@ export class Config {
     // the previous session's model (which might be Flash)
     this.contentGeneratorConfig = undefined!;
 
+    const gc = new GeminiClient(this);
     const contentConfig = await createContentGeneratorConfig(
       modelToUse,
       authMethod,
       this,
     );
 
-    const gc = new GeminiClient(this);
     this.geminiClient = gc;
     this.toolRegistry = await createToolRegistry(this);
     await gc.initialize(contentConfig);


### PR DESCRIPTION
## TLDR
This PR fixes http proxy settings.

## Dive Deeper

In the constructor of GeminiClient, the http proxy is set:
https://github.com/google-gemini/gemini-cli/blob/21cfe9f6801f286dda6d51d2886e27bd67bd5fa4/packages/core/src/core/client.ts#L61

Moving the instance creation of `GeminiClient` before `await createContentGeneratorConfig()` would help setup the proxy before any http requests are made.