### PR TITLE
fix: Correct start script reference in create_alias.sh

### DIFF
--- a/scripts/create_alias.sh
+++ b/scripts/create_alias.sh
@@ -4,7 +4,7 @@
 
 # Determine the project directory
 PROJECT_DIR=$(cd "$(dirname "$0")/.." && pwd)
-ALIAS_COMMAND="alias gemini='$PROJECT_DIR/scripts/start.sh'"
+ALIAS_COMMAND="alias gemini='node $PROJECT_DIR/scripts/start.js'"
 
 # Detect shell and set config file path
 if [[ "$SHELL" == *"/bash" ]]; then


### PR DESCRIPTION
This pull request corrects a bug in the create_alias.sh script where the generated gemini
  alias pointed to a non-existent start.sh file.


  The alias has been updated to correctly execute node scripts/start.js, ensuring that the
  alias works as intended.