### PR TITLE
Fix: update npx command to correct GitHub repository URL

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -77,7 +77,7 @@ You can run the most recently committed version of Gemini CLI directly from the 
 
 ```bash
 # Execute the CLI directly from the main branch on GitHub
-npx https://github.com/google/gemini-cli
+npx https://github.com/google-gemini/gemini-cli
 ```
 
 ## Deployment architecture


### PR DESCRIPTION
## TLDR

Fix broken npx command with correct GitHub repository URL for gemini-cli installation.

## Dive Deeper

The previous npx command pointed to an non-existent repository path, making it impossible for users to execute the CLI directly from GitHub. Updated to use the correct `google-gemini/gemini-cli` repository URL.