### PR TITLE
Fixed Checkpointing docs for enabling checkpointing using settings.json

### DIFF
--- a/docs/checkpointing.md
+++ b/docs/checkpointing.md
@@ -38,10 +38,8 @@ Add the following key to your `settings.json`:
 
 ```json
 {
-  "features": {
-    "checkpointing": {
-      "enabled": true
-    }
+  "checkpointing": {
+    "enabled": true
   }
 }
 ```


### PR DESCRIPTION
## TLDR

The previous docs had incorrect details for enabling checkpointing via the settings.json file. This now has the correct version.

## Dive Deeper

The current docks wrap the needed setting in a "features" object, but instead it just needs to be

`"checkpointing": { "enabled": true }`

at the root level.
