### PR TITLE
Add tos and privacy links docs for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,6 @@ Use MCP servers to integrate your local system tools with your enterprise collab
 > Organise my PDF invoices by month of expenditure.
 ```
 
-## Gemini APIs
+## Terms of Service and Privacy Notice
 
-This project leverages the Gemini APIs to provide AI capabilities. For details on the terms of service governing the Gemini API, please refer to the terms for the access mechanism you are using:
-
-- [Gemini API key](https://ai.google.dev/gemini-api/terms)
-- [Gemini Code Assist](https://developers.google.com/gemini-code-assist/resources/privacy-notices)
-- [Vertex AI](https://cloud.google.com/terms/service-terms)
+For details on the terms of service and privacy notice applicable to your use of Gemini CLI, see the [Terms of Service and Privacy Notice](./docs/tos-privacy.md).

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -427,6 +427,3 @@ You can opt out of usage statistics collection at any time by setting the `usage
   "usageStatisticsEnabled": false
 }
 ```
-
-**Privacy Policy:**
-Data collected is subject to the [Google Privacy Policy](https://policies.google.com/privacy).

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,5 +32,6 @@ This documentation is organized into the following sections:
   - **[Memory Tool](./tools/memory.md):** Documentation for the `save_memory` tool.
 - **[Contributing & Development Guide](../CONTRIBUTING.md):** Information for contributors and developers, including setup, building, testing, and coding conventions.
 - **[Troubleshooting Guide](./troubleshooting.md):** Find solutions to common problems and FAQs.
+- **[Terms of Service and Privacy Notice](./tos-privacy.md):** Information on the terms of service and privacy notices applicable to your use of Gemini CLI.  
 
 We hope this documentation helps you make the most of the Gemini CLI!

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,6 @@ This documentation is organized into the following sections:
   - **[Memory Tool](./tools/memory.md):** Documentation for the `save_memory` tool.
 - **[Contributing & Development Guide](../CONTRIBUTING.md):** Information for contributors and developers, including setup, building, testing, and coding conventions.
 - **[Troubleshooting Guide](./troubleshooting.md):** Find solutions to common problems and FAQs.
-- **[Terms of Service and Privacy Notice](./tos-privacy.md):** Information on the terms of service and privacy notices applicable to your use of Gemini CLI.  
+- **[Terms of Service and Privacy Notice](./tos-privacy.md):** Information on the terms of service and privacy notices applicable to your use of Gemini CLI.
 
 We hope this documentation helps you make the most of the Gemini CLI!

--- a/docs/tos-privacy.md
+++ b/docs/tos-privacy.md
@@ -1,6 +1,7 @@
 # Gemini CLI: Terms of Service and Privacy Notice
 
-Gemini CLI is an open-source tool that allows you to interact with Google's powerful language models directly from your command-line interface. The terms of service and privacy notices that apply to your usage of Gemini CLI depend on the type of account you use to authenticate with Google
+Gemini CLI is an open-source tool that allows you to interact with Google's powerful language models directly from your command-line interface. The terms of service and privacy notices that apply to your usage of Gemini CLI depend on the type of account you use to authenticate with Google.
+
 This article outlines the specific terms and privacy policies applicable to each account type.
 
 ## Login with Google (Code Assist Free Tier)

--- a/docs/tos-privacy.md
+++ b/docs/tos-privacy.md
@@ -6,21 +6,21 @@ This article outlines the specific terms and privacy policies applicable to each
 ## Login with Google (Code Assist Free Tier)
 
 For users who authenticate using their Google account to access the Code Assist free tier:
-Terms of Service: Your use of Gemini CLI is governed by the general [Google Terms of Service](https://policies.google.com/terms?hl=en-US).
-Privacy Notice: The collection and use of your data are described in the [Gemini Code Assist Privacy Notice for Individuals](https://developers.google.com/gemini-code-assist/resources/privacy-notice-gemini-code-assist-individuals).
-Usage Statistics Opt-Out: You may opt-out from Usage Statistics data by following the instructions available here: Usage Statistics Configuration.
+- Terms of Service: Your use of Gemini CLI is governed by the general [Google Terms of Service](https://policies.google.com/terms?hl=en-US).
+- Privacy Notice: The collection and use of your data are described in the [Gemini Code Assist Privacy Notice for Individuals](https://developers.google.com/gemini-code-assist/resources/privacy-notice-gemini-code-assist-individuals).
+- Usage Statistics Opt-Out: You may opt-out from Usage Statistics data by following the instructions available here: Usage Statistics Configuration.
 
 ## Gemini API key
 
 If you are using a Gemini API key for authentication, the following terms apply:
-Terms of Service: Your use is subject to the [Gemini API Terms of Service](https://ai.google.dev/gemini-api/terms).
-Privacy Notice: Information regarding data handling and privacy is detailed in the general [Google Privacy Policy](https://policies.google.com/privacy).
+- Terms of Service: Your use is subject to the [Gemini API Terms of Service](https://ai.google.dev/gemini-api/terms).
+- Privacy Notice: Information regarding data handling and privacy is detailed in the general [Google Privacy Policy](https://policies.google.com/privacy).
 
 ## Licensed Code Assist Users
 
-For users with a licensed version of Code Assist (e.g., Standard and Enterprise editions):
-Terms of Service: The [Google Cloud Platform Terms of Service](https://cloud.google.com/terms) govern your use of the service.
-Privacy Notice: The handling of your data is outlined in the [Gemini Code Assist Privacy Notices](https://developers.google.com/gemini-code-assist/resources/privacy-notices).
+For users with a licensed version of Code Assist (e.g. Standard and Enterprise editions):
+- Terms of Service: The [Google Cloud Platform Terms of Service](https://cloud.google.com/terms) govern your use of the service.
+- Privacy Notice: The handling of your data is outlined in the [Gemini Code Assist Privacy Notices](https://developers.google.com/gemini-code-assist/resources/privacy-notices).
 
 ## Vertex AI
 

--- a/docs/tos-privacy.md
+++ b/docs/tos-privacy.md
@@ -25,8 +25,8 @@ For users with a licensed version of Code Assist (e.g. Standard and Enterprise e
 ## Vertex AI
 
 For users leveraging Gemini CLI with a Vertex AI backend:
-Terms of Service: Your usage is governed by the [Google Cloud Platform Service Terms](https://cloud.google.com/terms/service-terms/).
-Privacy Notice: The [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice) describes how your data is collected and managed.
+- Terms of Service: Your usage is governed by the [Google Cloud Platform Service Terms](https://cloud.google.com/terms/service-terms/).
+- Privacy Notice: The [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice) describes how your data is collected and managed.
 
 ## Usage Statistics Opt-Out
 

--- a/docs/tos-privacy.md
+++ b/docs/tos-privacy.md
@@ -1,0 +1,33 @@
+# Gemini CLI: Terms of Service and Privacy Notice
+
+Gemini CLI is an open-source tool that allows you to interact with Google's powerful language models directly from your command-line interface. The terms of service and privacy notices that apply to your usage of Gemini CLI depend on the type of account you use to authenticate with Google
+This article outlines the specific terms and privacy policies applicable to each account type.
+
+## Login with Google (Code Assist Free Tier)
+
+For users who authenticate using their Google account to access the Code Assist free tier:
+Terms of Service: Your use of Gemini CLI is governed by the general [Google Terms of Service](https://policies.google.com/terms?hl=en-US).
+Privacy Notice: The collection and use of your data are described in the [Gemini Code Assist Privacy Notice for Individuals](https://developers.google.com/gemini-code-assist/resources/privacy-notice-gemini-code-assist-individuals).
+Usage Statistics Opt-Out: You may opt-out from Usage Statistics data by following the instructions available here: Usage Statistics Configuration.
+
+## Gemini API key
+
+If you are using a Gemini API key for authentication, the following terms apply:
+Terms of Service: Your use is subject to the [Gemini API Terms of Service](https://ai.google.dev/gemini-api/terms).
+Privacy Notice: Information regarding data handling and privacy is detailed in the general [Google Privacy Policy](https://policies.google.com/privacy).
+
+## Licensed Code Assist Users
+
+For users with a licensed version of Code Assist (e.g., Standard and Enterprise editions):
+Terms of Service: The [Google Cloud Platform Terms of Service](https://cloud.google.com/terms) govern your use of the service.
+Privacy Notice: The handling of your data is outlined in the [Gemini Code Assist Privacy Notices](https://developers.google.com/gemini-code-assist/resources/privacy-notices).
+
+## Vertex AI
+
+For users leveraging Gemini CLI with a Vertex AI backend:
+Terms of Service: Your usage is governed by the [Google Cloud Platform Service Terms](https://cloud.google.com/terms/service-terms/).
+Privacy Notice: The [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice) describes how your data is collected and managed.
+
+## Usage Statistics Opt-Out
+
+You may opt-out from sending Usage Statistics to Google data by following the instructions available here: [Usage Statistics Configuration](./cli/configuration.md#usage-statistics).

--- a/docs/tos-privacy.md
+++ b/docs/tos-privacy.md
@@ -7,6 +7,7 @@ This article outlines the specific terms and privacy policies applicable to each
 ## Login with Google (Code Assist Free Tier)
 
 For users who authenticate using their Google account to access the Code Assist free tier:
+
 - Terms of Service: Your use of Gemini CLI is governed by the general [Google Terms of Service](https://policies.google.com/terms?hl=en-US).
 - Privacy Notice: The collection and use of your data are described in the [Gemini Code Assist Privacy Notice for Individuals](https://developers.google.com/gemini-code-assist/resources/privacy-notice-gemini-code-assist-individuals).
 - Usage Statistics Opt-Out: You may opt-out from Usage Statistics data by following the instructions available here: Usage Statistics Configuration.
@@ -14,18 +15,21 @@ For users who authenticate using their Google account to access the Code Assist 
 ## Gemini API key
 
 If you are using a Gemini API key for authentication, the following terms apply:
+
 - Terms of Service: Your use is subject to the [Gemini API Terms of Service](https://ai.google.dev/gemini-api/terms).
 - Privacy Notice: Information regarding data handling and privacy is detailed in the general [Google Privacy Policy](https://policies.google.com/privacy).
 
 ## Licensed Code Assist Users
 
 For users with a licensed version of Code Assist (e.g. Standard and Enterprise editions):
+
 - Terms of Service: The [Google Cloud Platform Terms of Service](https://cloud.google.com/terms) govern your use of the service.
 - Privacy Notice: The handling of your data is outlined in the [Gemini Code Assist Privacy Notices](https://developers.google.com/gemini-code-assist/resources/privacy-notices).
 
 ## Vertex AI
 
 For users leveraging Gemini CLI with a Vertex AI backend:
+
 - Terms of Service: Your usage is governed by the [Google Cloud Platform Service Terms](https://cloud.google.com/terms/service-terms/).
 - Privacy Notice: The [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice) describes how your data is collected and managed.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6250,6 +6250,24 @@
         "ink": ">=4"
       }
     },
+    "node_modules/ink-link": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ink-link/-/ink-link-4.1.0.tgz",
+      "integrity": "sha512-3nNyJXum0FJIKAXBK8qat2jEOM41nJ1J60NRivwgK9Xh92R5UMN/k4vbz0A9xFzhJVrlf4BQEmmxMgXkCE1Jeg==",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "terminal-link": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "peerDependencies": {
+        "ink": ">=4"
+      }
+    },
     "node_modules/ink-select-input": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/ink-select-input/-/ink-select-input-6.2.0.tgz",
@@ -9670,6 +9688,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -9688,6 +9718,46 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/terminal-link": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-3.0.0.tgz",
+      "integrity": "sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==",
+      "dependencies": {
+        "ansi-escapes": "^5.0.0",
+        "supports-hyperlinks": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-link/node_modules/ansi-escapes": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "dependencies": {
+        "type-fest": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-link/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/test-exclude": {
       "version": "7.0.1",
@@ -11613,6 +11683,7 @@
         "ink": "^5.2.0",
         "ink-big-text": "^2.0.0",
         "ink-gradient": "^3.0.0",
+        "ink-link": "^4.0.0",
         "ink-select-input": "^6.0.0",
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "ink-gradient": "^3.0.0",
     "ink-select-input": "^6.0.0",
     "ink-spinner": "^5.0.0",
+    "ink-link": "^4.0.0",
     "ink-text-input": "^6.0.0",
     "lowlight": "^3.3.0",
     "mime-types": "^2.1.4",

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -6,6 +6,7 @@
 
 import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
+import Link from 'ink-link';
 import { Colors } from '../colors.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import { LoadedSettings, SettingScope } from '../../config/settings.js';
@@ -112,6 +113,11 @@ export function AuthDialog({
       )}
       <Box marginTop={1}>
         <Text color={Colors.Gray}>(Use Enter to select)</Text>
+      </Box>
+      <Box marginTop={1}>
+        <Link url="https://github.com/google/gemini-cli/blob/main/docs/tos-privacy.md">
+          <Text>Terms of Services and Privacy Notice for Gemini CLI</Text>
+        </Link>
       </Box>
     </Box>
   );


### PR DESCRIPTION
* Add a page with the tos and privacy docs for different auth options
* Add a link to the page in the auth dialog box
* Remove extraneous link in Usage statistics
