### PR TITLE
feat: provide feedback on /clear command (#1541)

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -229,6 +229,11 @@ export const useSlashCommandProcessor = (
           await config?.getGeminiClient()?.resetChat();
           console.clear();
           refreshStatic();
+          addMessage({
+            type: MessageType.INFO,
+            content: 'Screen cleared. Model context has been reset.',
+            timestamp: new Date(),
+          });
         },
       },
       {


### PR DESCRIPTION
## TLDR

Adds a confirmation message to the `/clear` command. This provides clear feedback to the user that the model's context has been successfully reset, addressing the confusion noted in #1541.

## Dive Deeper

The `/clear` command was already correctly resetting the chat session on the backend. However, the UI provided no feedback for this action, leading users to believe the context was not cleared.

This PR resolves the issue by adding an informational message that is displayed to the user immediately after the command executes. The change is a simple call to `addMessage` within the `/clear` command's action in `packages/cli/src/ui/hooks/slashCommandProcessor.ts`, confirming the operation was successful. This is a minimal, UI-only change that directly resolves the user's issue.

## Reviewer Test Plan

To validate this change:

1.  Pull the branch and run the CLI (`npm run start`).
2.  Start a conversation, for example: `What is the capital of France?`
3.  After the model replies, execute the `/clear` command.
4.  **Verify:** The screen clears and a new message appears: `Screen cleared. Model context has been reset.`
5.  **Verify Context Reset:** Ask a follow-up question that relies on the previous context, such as: `What is its population?`. The model should not know you are asking about France, confirming the context has been reset.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

*(Note: Tested on macOS. Other platforms should be unaffected as this is a platform-agnostic UI change.)*

## Linked issues / bugs

Fixes #1541 
