### PR TITLE
chore: update package version to 0.1.4

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@google:registry=https://wombat-dressing-room.appspot.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@google/gemini-cli",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "workspaces": [
         "packages/*"
       ],
@@ -11671,9 +11671,9 @@
     },
     "packages/cli": {
       "name": "@google/gemini-cli",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "dependencies": {
-        "@google/gemini-cli-core": "0.1.1",
+        "@google/gemini-cli-core": "*",
         "@types/update-notifier": "^6.0.8",
         "command-exists": "^1.2.9",
         "diff": "^7.0.0",
@@ -11745,7 +11745,7 @@
     },
     "packages/core": {
       "name": "@google/gemini-cli-core",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "dependencies": {
         "@google/genai": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "type": "module",
   "workspaces": [
     "packages/*"
   ],
   "repository": "google-gemini/gemini-cli",
   "config": {
-    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.1"
+    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.4"
   },
   "scripts": {
     "generate": "node scripts/generate-git-commit-info.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "Gemini CLI",
   "type": "module",
   "main": "dist/index.js",
+  "repository": "google-gemini/gemini-cli",
   "bin": {
     "gemini": "dist/index.js"
   },
@@ -25,10 +26,10 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.1"
+    "sandboxImageUri": "gemini-cli-sandbox"
   },
   "dependencies": {
-    "@google/gemini-cli-core": "0.1.1",
+    "@google/gemini-cli-core": "*",
     "@types/update-notifier": "^6.0.8",
     "command-exists": "^1.2.9",
     "diff": "^7.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@google/gemini-cli-core",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "Gemini CLI Server",
   "type": "module",
   "main": "dist/index.js",
+  "repository": "google-gemini/gemini-cli",
   "scripts": {
     "start": "node dist/src/index.js",
     "build": "node ../../scripts/build_package.js",


### PR DESCRIPTION
merge once we've promoted the latest release candidate `0.1.4-rc.0` to the release `0.1.4`.

aligns the source with the latest published version (https://www.npmjs.com/package/@google/gemini-cli)