### PR TITLE
prompt users to search for existing issues before creating a new one

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,8 @@ labels: ''
 assignees: ''
 ---
 
+<!-- Please search https://github.com/google-gemini/gemini-cli/issues to see if an issue already exists for the bug you encountered. If you find one, please add a comment to the existing issue. -->
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
this will help us reduce duplicate bug reports