### PR TITLE
Update mcp-client.ts to add support for remote MCP servers.

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -71,6 +71,7 @@ export class MCPServerConfig {
     readonly cwd?: string,
     // For sse transport
     readonly url?: string,
+    readonly authorization_token?: string,
     // For streamable http transport
     readonly httpUrl?: string,
     // For websocket transport

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -279,10 +279,10 @@ describe('discoverMcpTools', () => {
     const mockFuncDecl = {
       name: 'authed-tool',
       description: 'An authenticated tool',
-      parameters: { type: 'object' as const, properties: {} },
+      inputSchema: { type: 'object' as const, properties: {} },
     };
-    mockCallableTool.tool.mockResolvedValue({
-      functionDeclarations: [mockFuncDecl],
+    vi.mocked(Client.prototype.listTools).mockResolvedValue({
+      tools: [mockFuncDecl],
     });
 
     mockToolRegistry.getToolsByServer.mockReturnValueOnce([

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -173,7 +173,21 @@ async function connectAndDiscover(
       new URL(mcpServerConfig.httpUrl),
     );
   } else if (mcpServerConfig.url) {
-    transport = new SSEClientTransport(new URL(mcpServerConfig.url));
+    const bearerToken = mcpServerConfig.authorization_token;
+
+    if (!bearerToken) {
+      transport = new SSEClientTransport(new URL(mcpServerConfig.url));
+    } else {
+      const headers = {
+        'Authorization': bearerToken,
+      };
+      transport = new SSEClientTransport(
+        new URL(mcpServerConfig.url),
+        {
+          requestInit: { headers: headers }
+        }
+      );
+    }
   } else if (mcpServerConfig.command) {
     transport = new StdioClientTransport({
       command: mcpServerConfig.command,


### PR DESCRIPTION
Add support for remote MCP servers when the url and authorization_token are provided.

Sample settings.json:
```
{
  "mcpServers": {
    "github": {
      "url": "https://api.githubcopilot.com/mcp/",
      "authorization_token": "Bearer <your GitHub PAT>"
    }
  }
}
```

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
