### PR TITLE
Fix doc link in the auth dialog 

### DIFF
--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -6,7 +6,6 @@
 
 import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
-import Link from 'ink-link';
 import { Colors } from '../colors.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import { LoadedSettings, SettingScope } from '../../config/settings.js';
@@ -94,9 +93,14 @@ export function AuthDialog({
         <Text color={Colors.Gray}>(Use Enter to select)</Text>
       </Box>
       <Box marginTop={1}>
-        <Link url="https://github.com/google/gemini-cli/blob/main/docs/tos-privacy.md">
-          <Text>Terms of Services and Privacy Notice for Gemini CLI</Text>
-        </Link>
+        <Text>Terms of Services and Privacy Notice for Gemini CLI</Text>
+      </Box>
+      <Box marginTop={1}>
+        <Text color={Colors.AccentBlue}>
+          {
+            'https://github.com/google-gemini/gemini-cli/blob/main/docs/tos-privacy.md'
+          }
+        </Text>
       </Box>
     </Box>
   );


### PR DESCRIPTION
* Moved to removing hyperlinks since they don't render in all terminals. We need to investigate a better way of displaying this.
* Fixing broken URL link