### PR TITLE
fix: remove unnecessary @gemini-code/core mock from slashCommandProcessor test

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -71,15 +71,6 @@ import {
 } from '@google/gemini-cli-core';
 import { useSessionStats } from '../contexts/SessionContext.js';
 import { LoadedSettings } from '../../config/settings.js';
-
-vi.mock('@gemini-code/core', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@gemini-code/core')>();
-  return {
-    ...actual,
-    GitService: vi.fn(),
-  };
-});
-
 import * as ShowMemoryCommandModule from './useShowMemoryCommand.js';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 


### PR DESCRIPTION
## TLDR

Remove an unnecessary mock for `@gemini-code/core` from the slashCommandProcessor test file. This mock was not being used and had an incorrect package name.

## Dive Deeper

The removed mock had two issues:
1. **Incorrect package name**: The mock was for `@gemini-code/core` but the actual package name used in the project is `@google/gemini-cli-core`
2. **Unused mock**: The `GitService` being mocked was not actually used anywhere in the test file

  This cleanup helps maintain test code quality by removing unnecessary and potentially confusing code.
## Reviewer Test Plan

To validate this change:
Run the test suite to ensure all tests still pass:
 ```bash
 cd packages/cli && npm test -- src/ui/hooks/slashCommandProcessor.test.ts
 ```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A - This is a code cleanup task
