### PR TITLE
feat(ui): Add "Skip" option when reviewing suggestions interactively

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -118,7 +118,11 @@ export const ToolConfirmationMessage: React.FC<
         label: 'Modify with external editor',
         value: ToolConfirmationOutcome.ModifyWithEditor,
       },
-      { label: 'No (esc)', value: ToolConfirmationOutcome.Cancel },
+      {
+        label: 'No (skip this)',
+        value: ToolConfirmationOutcome.Skip,
+      },
+      { label: 'Cancel all (esc)', value: ToolConfirmationOutcome.Cancel },
     );
     bodyContent = (
       <DiffRenderer
@@ -142,7 +146,11 @@ export const ToolConfirmationMessage: React.FC<
         label: `Yes, allow always "${executionProps.rootCommand} ..."`,
         value: ToolConfirmationOutcome.ProceedAlways,
       },
-      { label: 'No (esc)', value: ToolConfirmationOutcome.Cancel },
+      {
+        label: 'No (skip this)',
+        value: ToolConfirmationOutcome.Skip,
+      },
+      { label: 'Cancel all (esc)', value: ToolConfirmationOutcome.Cancel },
     );
 
     let bodyContentHeight = availableBodyContentHeight();
@@ -179,7 +187,11 @@ export const ToolConfirmationMessage: React.FC<
         label: 'Yes, allow always',
         value: ToolConfirmationOutcome.ProceedAlways,
       },
-      { label: 'No (esc)', value: ToolConfirmationOutcome.Cancel },
+      {
+        label: 'No (skip this)',
+        value: ToolConfirmationOutcome.Skip,
+      },
+      { label: 'Cancel all (esc)', value: ToolConfirmationOutcome.Cancel },
     );
 
     bodyContent = (
@@ -220,7 +232,11 @@ export const ToolConfirmationMessage: React.FC<
         label: `Yes, always allow all tools from server "${mcpProps.serverName}"`,
         value: ToolConfirmationOutcome.ProceedAlwaysServer,
       },
-      { label: 'No (esc)', value: ToolConfirmationOutcome.Cancel },
+      {
+        label: 'No (skip this)',
+        value: ToolConfirmationOutcome.Skip,
+      },
+      { label: 'Cancel all (esc)', value: ToolConfirmationOutcome.Cancel },
     );
   }
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -525,8 +525,16 @@ export class CoreToolScheduler {
       this.setStatusInternal(
         callId,
         'cancelled',
-        'User did not allow tool call',
+        'User cancelled all tool calls',
       );
+    } else if (outcome === ToolConfirmationOutcome.Skip) {
+      // Skip this tool call but continue with others
+      this.setStatusInternal(
+        callId,
+        'cancelled',
+        'User skipped this tool call',
+      );
+      // Important: Don't cancel other pending tool calls
     } else if (outcome === ToolConfirmationOutcome.ModifyWithEditor) {
       const waitingToolCall = toolCall as WaitingToolCall;
       if (isModifiableTool(waitingToolCall.tool)) {

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -242,5 +242,6 @@ export enum ToolConfirmationOutcome {
   ProceedAlwaysServer = 'proceed_always_server',
   ProceedAlwaysTool = 'proceed_always_tool',
   ModifyWithEditor = 'modify_with_editor',
+  Skip = 'skip',
   Cancel = 'cancel',
 }


### PR DESCRIPTION
## TLDR
This PR adds a "Skip" option to the interactive suggestion review process, allowing users to skip individual suggestions without terminating the entire search process.

## Dive Deeper
Currently, when reviewing multiple suggestions interactively, selecting "No (esc)" terminates the entire review process. This forces users to restart if they want to skip just one suggestion.

This PR introduces a separate "Skip" option that only cancels the current suggestion while allowing the review process to continue with the next suggestions.

## Reviewer Test Plan
1. Run `gemini` with a prompt that generates multiple tool calls (e.g., file edits)
2. When prompted for confirmation:
   - Select "No (skip this)" for some suggestions
   - Verify the process continues to the next suggestion
   - Select "Cancel all (esc)" to verify it still terminates the entire process
3. Verify that skipped suggestions show as cancelled while others continue

Example test prompt:
```
gemini "Create three test files: test1.txt with 'Hello', test2.txt with 'World', and test3.txt with 'Gemini'"
```

## Testing Matrix
|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

Tested on macOS with `npm run` and Seatbelt sandbox.

## Linked issues / bugs
- Fixes #1686