### PR TITLE
docs: update tos docs auth

### DIFF
--- a/docs/tos-privacy.md
+++ b/docs/tos-privacy.md
@@ -4,12 +4,18 @@ Gemini CLI is an open-source tool that allows you to interact with Google's powe
 
 This article outlines the specific terms and privacy policies applicable for different auth methods.
 
-## 1. Login with Google (Gemini Code Assist for [individuals](https://developers.google.com/gemini-code-assist/docs/overview#supported-features-gca))
+## 1. Login with Google (a: Personal Accounts, b: Workspace or Licensed Code Assist Users)
 
-For users who authenticate using their Google account to access Gemini Code Assist for individuals:
+For users who authenticate using their Google account:
 
+### a. Personal Google Accounts (Gemini Code Assist for [individuals](https://developers.google.com/gemini-code-assist/docs/overview#supported-features-gca))
 - Terms of Service: Your use of Gemini CLI is governed by the general [Google Terms of Service](https://policies.google.com/terms?hl=en-US).
 - Privacy Notice: The collection and use of your data are described in the [Gemini Code Assist Privacy Notice for Individuals](https://developers.google.com/gemini-code-assist/resources/privacy-notice-gemini-code-assist-individuals).
+
+### b. Workspace or Licensed Code Assist Users
+For users of Standard or Enterprise [edition](https://cloud.google.com/gemini/docs/codeassist/overview#editions-overview) of Gemini Code Assist:
+- Terms of Service: The [Google Cloud Platform Terms of Service](https://cloud.google.com/terms) govern your use of the service.
+- Privacy Notice: The handling of your data is outlined in the [Gemini Code Assist Privacy Notices](https://developers.google.com/gemini-code-assist/resources/privacy-notices).
 
 ## 2. Gemini API Key (Using Gemini Developer [API](https://ai.google.dev/gemini-api/docs) a: Unpaid Service, b: Paid Service)
 
@@ -18,14 +24,7 @@ If you are using a Gemini API key for authentication, the following terms apply:
 - Terms of Service: Your use is subject to the [Gemini API Terms of Service](https://ai.google.dev/gemini-api/terms). For a. [Unpaid Service](https://ai.google.dev/gemini-api/terms#unpaid-services) or b. [Paid Service](https://ai.google.dev/gemini-api/terms#paid-services)
 - Privacy Notice: Information regarding data handling and privacy is detailed in the general [Google Privacy Policy](https://policies.google.com/privacy).
 
-## 3. Login with Google (for Workspace or Licensed Code Assist users)
-
-For users of Standard or Enterprise [edition](https://cloud.google.com/gemini/docs/codeassist/overview#editions-overview) of Gemini Code Assist :
-
-- Terms of Service: The [Google Cloud Platform Terms of Service](https://cloud.google.com/terms) govern your use of the service.
-- Privacy Notice: The handling of your data is outlined in the [Gemini Code Assist Privacy Notices](https://developers.google.com/gemini-code-assist/resources/privacy-notices).
-
-## 4. Vertex AI (Using Vertex AI Gen [API](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest))
+## 3. Vertex AI (Using Vertex AI Gen [API](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest))
 
 If you are using an API key with a Vertex AI Gen API backend:
 
@@ -42,17 +41,19 @@ You may opt-out from sending Usage Statistics to Google data by following the in
 
 This depends entirely on the type of auth method you use.
 
-- **Auth method 1:** Yes. When you use your personal Google account, the Gemini Code Assist Privacy Notice for Individuals applies. Under this notice, your **prompts, answers, and related code are collected** and may be used to improve Google's products, which includes model training.
+- **Auth method 1a:** Yes. When you use your personal Google account, the Gemini Code Assist Privacy Notice for Individuals applies. Under this notice, your **prompts, answers, and related code are collected** and may be used to improve Google's products, which includes model training.
+- **Auth method 1b:** No. For Workspace or Licensed Code Assist users, your data is governed by the Google Cloud terms, which treat your inputs as confidential. Your code, prompts, and other inputs are **not** used to train models.
 - **Auth method 2a:** Yes, When you use the Gemini API key Gemini API (Unpaid Service) terms apply. Under this notice , your **prompts, answers, and related code are collected** and may be used to improve Google's products, which includes model training.
-- **Auth method 2b, 3 & 4:** No. For these accounts, your data is governed by the Google Cloud or Gemini API (Paid Service) terms, which treat your inputs as confidential. Your code, prompts, and other inputs are **not** used to train models.
+- **Auth method 2b & 3:** No. For these accounts, your data is governed by the Google Cloud or Gemini API (Paid Service) terms, which treat your inputs as confidential. Your code, prompts, and other inputs are **not** used to train models.
 
 ### 2. What are "Usage Statistics" and what does the opt-out control?
 
 The "Usage Statistics" setting is the single control for all optional data collection in the Gemini CLI. The data it collects depends on your account type:
 
-- **Auth method 1:** When enabled, this setting allows Google to collect both anonymous telemetry (like commands run and performance metrics) and **your prompts and answers** for model improvement.
+- **Auth method 1a:** When enabled, this setting allows Google to collect both anonymous telemetry (like commands run and performance metrics) and **your prompts and answers** for model improvement.
+- **Auth method 1b:** This setting only controls the collection of anonymous telemetry. Your prompts and answers are never collected, regardless of this setting.
 - **Auth method 2a:** When enabled, this setting allows Google to collect both anonymous telemetry (like commands run and performance metrics) and **your prompts and answers** for model improvement. When disabled we will use your data as described in the [How Google Uses Your Data](https://ai.google.dev/gemini-api/terms#data-use-unpaid).
 - **Auth method 2b:** This setting only controls the collection of anonymous telemetry. Google logs prompts and responses for a limited period of time, solely for the purpose of detecting violations of the Prohibited Use Policy and any required legal or regulatory disclosures
-- **Auth methods 3 & 4:** This setting only controls the collection of anonymous telemetry. Your prompts and answers are never collected, regardless of this setting.
+- **Auth method 3:** This setting only controls the collection of anonymous telemetry. Your prompts and answers are never collected, regardless of this setting.
 
 You can disable Usage Statistics for any account type by following the instructions in the [Usage Statistics Configuration](./cli/configuration.md#usage-statistics) documentation.


### PR DESCRIPTION
## TLDR

Updates `tos-privacy.md` to reflect the authentication option UI changes introduced in PR https://github.com/google-gemini/gemini-cli/pull/1574. This ensures documentation consistency with the current auth behavior.


## Dive Deeper

PR #1574 simplified the authentication flow by:
- Merging "Login with Google Workspace" into a single "Login with Google" option
- Removing the "More..." expandable option (all auth methods are now always visible)
- Adding conditional error messaging for workspace accounts based on `GOOGLE_CLOUD_PROJECT` configuration

## Reviewer Test Plan

Review the updated `tos-privacy.md` file

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/gemini-cli/pull/1574
