### PR TITLE
feat(core): Add support for custom Gemini base URL

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -244,6 +244,7 @@ export async function loadCliConfig(
     fileDiscoveryService: fileService,
     bugCommand: settings.bugCommand,
     model: argv.model!,
+    baseUrl: process.env.GEMINI_BASE_URL,
     extensionContextFilePaths,
   });
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -125,6 +125,7 @@ export interface ConfigParameters {
   fileDiscoveryService?: FileDiscoveryService;
   bugCommand?: BugCommandSettings;
   model: string;
+  baseUrl?: string;
   extensionContextFilePaths?: string[];
 }
 
@@ -163,6 +164,7 @@ export class Config {
   private readonly cwd: string;
   private readonly bugCommand: BugCommandSettings | undefined;
   private readonly model: string;
+  private readonly baseUrl: string | undefined;
   private readonly extensionContextFilePaths: string[];
   private modelSwitchedDuringSession: boolean = false;
   flashFallbackHandler?: FlashFallbackHandler;
@@ -206,6 +208,7 @@ export class Config {
     this.fileDiscoveryService = params.fileDiscoveryService ?? null;
     this.bugCommand = params.bugCommand;
     this.model = params.model;
+    this.baseUrl = params.baseUrl;
     this.extensionContextFilePaths = params.extensionContextFilePaths ?? [];
 
     if (params.contextFileName) {
@@ -243,7 +246,10 @@ export class Config {
     const contentConfig = await createContentGeneratorConfig(
       modelToUse,
       authMethod,
-      this,
+      {
+        getModel: this.getModel.bind(this),
+        getBaseUrl: this.getBaseUrl.bind(this),
+      },
     );
 
     const gc = new GeminiClient(this);
@@ -264,6 +270,10 @@ export class Config {
 
   getContentGeneratorConfig(): ContentGeneratorConfig {
     return this.contentGeneratorConfig;
+  }
+
+  getBaseUrl(): string | undefined {
+    return this.baseUrl;
   }
 
   getModel(): string {

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -43,6 +43,7 @@ export enum AuthType {
 export type ContentGeneratorConfig = {
   model: string;
   apiKey?: string;
+  baseUrl?: string;
   vertexai?: boolean;
   authType?: AuthType | undefined;
 };
@@ -50,12 +51,13 @@ export type ContentGeneratorConfig = {
 export async function createContentGeneratorConfig(
   model: string | undefined,
   authType: AuthType | undefined,
-  config?: { getModel?: () => string },
+  config?: { getModel?: () => string; getBaseUrl?: () => string | undefined },
 ): Promise<ContentGeneratorConfig> {
   const geminiApiKey = process.env.GEMINI_API_KEY;
   const googleApiKey = process.env.GOOGLE_API_KEY;
   const googleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
   const googleCloudLocation = process.env.GOOGLE_CLOUD_LOCATION;
+  const baseUrl = config?.getBaseUrl?.();
 
   // Use runtime model from config if available, otherwise fallback to parameter or default
   const effectiveModel = config?.getModel?.() || model || DEFAULT_GEMINI_MODEL;
@@ -63,6 +65,7 @@ export async function createContentGeneratorConfig(
   const contentGeneratorConfig: ContentGeneratorConfig = {
     model: effectiveModel,
     authType,
+    baseUrl,
   };
 
   // if we are using google auth nothing else to validate for now
@@ -74,7 +77,7 @@ export async function createContentGeneratorConfig(
   if (authType === AuthType.USE_GEMINI && geminiApiKey) {
     contentGeneratorConfig.apiKey = geminiApiKey;
     contentGeneratorConfig.model = await getEffectiveModel(
-      contentGeneratorConfig.apiKey,
+      contentGeneratorConfig.apiKey ?? '',
       contentGeneratorConfig.model,
     );
 
@@ -90,7 +93,7 @@ export async function createContentGeneratorConfig(
     contentGeneratorConfig.apiKey = googleApiKey;
     contentGeneratorConfig.vertexai = true;
     contentGeneratorConfig.model = await getEffectiveModel(
-      contentGeneratorConfig.apiKey,
+      contentGeneratorConfig.apiKey ?? '',
       contentGeneratorConfig.model,
     );
 
@@ -120,7 +123,10 @@ export async function createContentGenerator(
     const googleGenAI = new GoogleGenAI({
       apiKey: config.apiKey === '' ? undefined : config.apiKey,
       vertexai: config.vertexai,
-      httpOptions,
+      httpOptions: {
+        ...httpOptions,
+        baseUrl: config.baseUrl,
+      },
     });
 
     return googleGenAI.models;


### PR DESCRIPTION
This commit introduces the ability to specify a custom base URL for the Gemini API, allowing users to connect to alternative endpoints.

The `GEMINI_BASE_URL` environment variable is now read from the CLI configuration and passed through the core config to the `GoogleGenAI` client. This provides flexibility for users who need to route API requests through a proxy or connect to a self-hosted model.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | :heavy_check_mark:   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
