### PR TITLE
fix(help): update new line shortcut to ⌥+Return for Mac users (#1699)

### DIFF
--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -97,9 +97,9 @@ export const Help: React.FC<Help> = ({ commands }) => (
     </Text>
     <Text color={Colors.Foreground}>
       <Text bold color={Colors.AccentPurple}>
-        Shift+Enter
+        {process.platform === 'darwin' ? '⌥+Return' : 'Shift+Enter'}
       </Text>{' '}
-      - New line
+      - New line (on Mac: Option+Return, on other platforms: Shift+Enter)
     </Text>
     <Text color={Colors.Foreground}>
       <Text bold color={Colors.AccentPurple}>


### PR DESCRIPTION
Clarifies in the help text that on Mac, the correct shortcut for inserting a new line is Option+Return (⌥+Return), while on other platforms it is Shift+Enter. This addresses confusion for Mac users and matches actual behavior.

Fixes #1699

## TLDR

Updates the in-app help text to show ⌥+Return as the new line shortcut for Mac users, instead of Shift+Enter.

## Dive Deeper

Previously, the help text always displayed Shift+Enter for a new line, which does not work on Mac. This change detects the platform and displays the correct shortcut, improving usability for Mac users.

## Reviewer Test Plan

- Open the help screen in the CLI on Mac and non-Mac platforms.
- Verify that Mac users see ⌥+Return for new line, and other platforms see Shift+Enter.
- Try entering a new line using the displayed shortcut to confirm it works as described.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ✅  | ✅  |
| npx      | ✅  | ✅  | ✅  |
| Docker   | ✅  | ✅  | ✅  |
| Podman   | ✅  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

Fixes #1699

---