### PR TITLE
fix: always confirm dangerous shell commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,9 @@
         "react-devtools-core": "^4.28.5",
         "typescript-eslint": "^8.30.1",
         "yargs": "^17.7.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -29,6 +29,16 @@ import { spawn } from 'child_process';
 
 const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 
+const DANGEROUS_COMMAND_PATTERNS = [
+  /^git\s+checkout\b/,
+  /^git\s+reset\b/,
+  /^git\s+clean\b/,
+  /^rm\b/,
+  /^mv\b/,
+  /^dd\b/,
+  // Add more as needed
+];
+
 export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
   static Name: string = 'run_shell_command';
   private whitelist: Set<string> = new Set();
@@ -121,6 +131,12 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
     return null;
   }
 
+  isDangerousCommand(command: string): boolean {
+    return DANGEROUS_COMMAND_PATTERNS.some((pattern) =>
+      pattern.test(command.trim()),
+    );
+  }
+
   async shouldConfirmExecute(
     params: ShellToolParams,
     _abortSignal: AbortSignal,
@@ -129,6 +145,17 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
       return false; // skip confirmation, execute call will fail immediately
     }
     const rootCommand = this.getCommandRoot(params.command)!; // must be non-empty string post-validation
+
+    if (this.isDangerousCommand(params.command)) {
+      return {
+        type: 'exec',
+        title: 'Dangerous Command Confirmation',
+        command: params.command,
+        rootCommand,
+        onConfirm: async (_outcome) => {},
+      };
+    }
+
     if (this.whitelist.has(rootCommand)) {
       return false; // already approved and whitelisted
     }


### PR DESCRIPTION
## Problem
Previously, the CLI would execute potentially destructive shell commands such as git checkout, git reset, or rm without always prompting the user for confirmation. Once a root command (like git) was whitelisted, all subcommands—including dangerous ones—could be executed without further checks. This could lead to accidental data loss, as reported in Issue #1938 

## Solution
This PR introduces stricter confirmation logic for dangerous shell commands:
- A list of dangerous command patterns (e.g., git checkout, git reset, rm, mv, dd, etc.) is now maintained.
- Any command matching a dangerous pattern will always prompt the user for explicit confirmation, regardless of previous approvals or whitelisting.
- Whitelisting is still supported for non-dangerous commands, so safe commands (like ls or echo) can be approved for repeated use without further prompts.
- The confirmation dialog for dangerous commands is clearly labeled to indicate the risk.
