### PR TITLE
Centralize Key Binding Logic and Refactor

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -70,6 +70,7 @@ import { checkForUpdates } from './utils/updateCheck.js';
 import ansiEscapes from 'ansi-escapes';
 import { OverflowProvider } from './contexts/OverflowContext.js';
 import { ShowMoreLines } from './components/ShowMoreLines.js';
+import { keyMatchers } from './keyBindings.js';
 
 const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
 
@@ -355,9 +356,9 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
       }
     }
 
-    if (key.ctrl && input === 'o') {
+    if (keyMatchers.showErrorDetails(key, input)) {
       setShowErrorDetails((prev) => !prev);
-    } else if (key.ctrl && input === 't') {
+    } else if (keyMatchers.toggleToolDescriptions(key, input)) {
       const newValue = !showToolDescriptions;
       setShowToolDescriptions(newValue);
 
@@ -365,15 +366,18 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
       if (Object.keys(mcpServers || {}).length > 0) {
         handleSlashCommand(newValue ? '/mcp desc' : '/mcp nodesc');
       }
-    } else if (key.ctrl && (input === 'c' || input === 'C')) {
+    } else if (keyMatchers.quit(key, input)) {
       handleExit(ctrlCPressedOnce, setCtrlCPressedOnce, ctrlCTimerRef);
-    } else if (key.ctrl && (input === 'd' || input === 'D')) {
+    } else if (keyMatchers.exit(key, input)) {
       if (buffer.text.length > 0) {
         // Do nothing if there is text in the input.
         return;
       }
       handleExit(ctrlDPressedOnce, setCtrlDPressedOnce, ctrlDTimerRef);
-    } else if (key.ctrl && input === 's' && !enteringConstrainHeightMode) {
+    } else if (
+      keyMatchers.showMoreLines(key, input) &&
+      !enteringConstrainHeightMode
+    ) {
       setConstrainHeight(false);
     }
   });

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -19,6 +19,7 @@ import { useCompletion } from '../hooks/useCompletion.js';
 import { isAtCommand, isSlashCommand } from '../utils/commandUtils.js';
 import { SlashCommand } from '../hooks/slashCommandProcessor.js';
 import { Config } from '@google/gemini-cli-core';
+import { keyMatchers } from '../keyBindings.js';
 
 export interface InputPromptProps {
   buffer: TextBuffer;
@@ -199,15 +200,15 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
       } else {
         // Keybindings when suggestions are not shown
-        if (key.ctrl && input === 'l') {
+        if (keyMatchers.clearScreen(key, input)) {
           onClearScreen();
           return true;
         }
-        if (key.ctrl && input === 'p') {
+        if (keyMatchers.historyUp(key, input)) {
           inputHistory.navigateUp();
           return true;
         }
-        if (key.ctrl && input === 'n') {
+        if (keyMatchers.historyDown(key, input)) {
           inputHistory.navigateDown();
           return true;
         }
@@ -222,39 +223,39 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       // Ctrl+A (Home)
-      if (key.ctrl && input === 'a') {
+      if (keyMatchers.home(key, input)) {
         buffer.move('home');
         buffer.moveToOffset(0);
         return;
       }
       // Ctrl+E (End)
-      if (key.ctrl && input === 'e') {
+      if (keyMatchers.end(key, input)) {
         buffer.move('end');
         buffer.moveToOffset(cpLen(buffer.text));
         return;
       }
       // Ctrl+L (Clear Screen)
-      if (key.ctrl && input === 'l') {
+      if (keyMatchers.clearScreen(key, input)) {
         onClearScreen();
         return;
       }
       // Ctrl+P (History Up)
-      if (key.ctrl && input === 'p' && !completion.showSuggestions) {
+      if (keyMatchers.historyUp(key, input) && !completion.showSuggestions) {
         inputHistory.navigateUp();
         return;
       }
       // Ctrl+N (History Down)
-      if (key.ctrl && input === 'n' && !completion.showSuggestions) {
+      if (keyMatchers.historyDown(key, input) && !completion.showSuggestions) {
         inputHistory.navigateDown();
         return;
       }
 
       // Core text editing from MultilineTextEditor's useInput
-      if (key.ctrl && input === 'k') {
+      if (keyMatchers.killLineRight(key, input)) {
         buffer.killLineRight();
         return;
       }
-      if (key.ctrl && input === 'u') {
+      if (keyMatchers.killLineLeft(key, input)) {
         buffer.killLineLeft();
         return;
       }

--- a/packages/cli/src/ui/keyBindings.ts
+++ b/packages/cli/src/ui/keyBindings.ts
@@ -1,0 +1,40 @@
+import { Key } from 'ink';
+
+/**
+ * Key matcher function type
+ */
+type KeyMatcher = (key: Key, input: string) => boolean;
+
+/**
+ * interface for key matchers
+ */
+export interface KeyMatchers {
+  readonly [shortcutName: string]: KeyMatcher;
+}
+
+/**
+ * key binding matchers
+ */
+export const keyMatchers: KeyMatchers = {
+  // Cursor movement
+  home: (key, input) => key.ctrl && input === 'a',
+  end: (key, input) => key.ctrl && input === 'e',
+
+  // Text deletion
+  killLineRight: (key, input) => key.ctrl && input === 'k',
+  killLineLeft: (key, input) => key.ctrl && input === 'u',
+
+  // Screen control
+  clearScreen: (key, input) => key.ctrl && input === 'l',
+
+  // History navigation
+  historyUp: (key, input) => key.ctrl && input === 'p',
+  historyDown: (key, input) => key.ctrl && input === 'n',
+
+  // App level bindings
+  showErrorDetails: (key, input) => key.ctrl && input === 'o',
+  toggleToolDescriptions: (key, input) => key.ctrl && input === 't',
+  quit: (key, input) => key.ctrl && (input === 'c' || input === 'C'),
+  exit: (key, input) => key.ctrl && (input === 'd' || input === 'D'),
+  showMoreLines: (key, input) => key.ctrl && input === 's',
+};

--- a/packages/cli/src/ui/keyBindings.ts
+++ b/packages/cli/src/ui/keyBindings.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Key } from 'ink';
 
 /**


### PR DESCRIPTION
## TLDR

Centralized key binding logic into a single place to improve maintainability and consistency. Hardcoded key combinations like `Ctrl+L` and `Ctrl+P` have been moved to the `keyMatchers` object in `keyBindings.ts`. This lays the groundwork for future support for user-defined key bindings.

## Dive Deeper

Previously, key bindings were scattered across different files like `App.tsx` and `InputPrompt.tsx`, making them hard to manage. This change introduces:

- Centralized key binding definitions in `keyBindings.ts` under `keyMatchers`
- Meaningful action names for each key binding (e.g., `showErrorDetails`, `toggleToolDescriptions`)
- Reduced code duplication and increased consistency

A few exceptions remain:
- `Ctrl+X` and `Ctrl+E` interactions with external editors involve complex logic, so the original code is left untouched
- Low-level keys managed by `text-buffer`  are also left unchanged, as improvements have already been made by the gemini-cli team (e.g., handling `del` vs `backspace`)

## Reviewer Test Plan

Confirm that all previous key bindings still work as expected.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  |  O  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
#1950 


This PR presents a sample / illustrative approach to centralizing key bindings.
It’s not meant to dictate the only possible solution—if the original structure (e.g., keeping bindings directly in terminal-style components) was intentionally chosen, please feel free to point that out.