### PR TITLE
Use 2-space indent for saved checkpoint files (#1152)

### DIFF
--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -253,7 +253,7 @@ export class Logger {
     }
     const path = this._checkpointPath(tag);
     try {
-      await fs.writeFile(path, JSON.stringify(conversation, null), 'utf-8');
+      await fs.writeFile(path, JSON.stringify(conversation, null, 2), 'utf-8');
     } catch (error) {
       console.error('Error writing to checkpoint file:', error);
     }


### PR DESCRIPTION
Improve ease of reading/sharing checkpoint files. Cherry-picking a change from the old main branch.