### PR TITLE
feat: Add modus-operandi-tinted theme

### DIFF
--- a/packages/cli/src/ui/themes/modus-operandi-tinted.ts
+++ b/packages/cli/src/ui/themes/modus-operandi-tinted.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Theme, modusOperandiTintedTheme } from './theme.js';
+
+export const ModusOperandiTinted: Theme = new Theme(
+  'Modus Operandi Tinted',
+  'modus-operandi-tinted',
+  {
+    hljs: {
+      display: 'block',
+      overflowX: 'auto',
+      padding: '0.5em',
+      background: modusOperandiTintedTheme.Background,
+      color: modusOperandiTintedTheme.Foreground,
+    },
+    'hljs-comment': {
+      color: modusOperandiTintedTheme.Comment,
+      fontStyle: 'italic',
+    },
+    'hljs-quote': {
+      color: modusOperandiTintedTheme.AccentCyan,
+      fontStyle: 'italic',
+    },
+    'hljs-string': {
+      color: modusOperandiTintedTheme.AccentGreen,
+    },
+    'hljs-constant': {
+      color: modusOperandiTintedTheme.AccentCyan,
+    },
+    'hljs-number': {
+      color: modusOperandiTintedTheme.AccentPurple,
+    },
+    'hljs-keyword': {
+      color: modusOperandiTintedTheme.AccentYellow,
+    },
+    'hljs-selector-tag': {
+      color: modusOperandiTintedTheme.AccentYellow,
+    },
+    'hljs-attribute': {
+      color: modusOperandiTintedTheme.AccentYellow,
+    },
+    'hljs-variable': {
+      color: modusOperandiTintedTheme.Foreground,
+    },
+    'hljs-variable.language': {
+      color: modusOperandiTintedTheme.LightBlue,
+      fontStyle: 'italic',
+    },
+    'hljs-title': {
+      color: modusOperandiTintedTheme.AccentBlue,
+    },
+    'hljs-section': {
+      color: modusOperandiTintedTheme.AccentGreen,
+      fontWeight: 'bold',
+    },
+    'hljs-type': {
+      color: modusOperandiTintedTheme.LightBlue,
+    },
+    'hljs-class .hljs-title': {
+      color: modusOperandiTintedTheme.AccentBlue,
+    },
+    'hljs-tag': {
+      color: modusOperandiTintedTheme.LightBlue,
+    },
+    'hljs-name': {
+      color: modusOperandiTintedTheme.AccentBlue,
+    },
+    'hljs-builtin-name': {
+      color: modusOperandiTintedTheme.AccentYellow,
+    },
+    'hljs-meta': {
+      color: modusOperandiTintedTheme.AccentYellow,
+    },
+    'hljs-symbol': {
+      color: modusOperandiTintedTheme.AccentRed,
+    },
+    'hljs-bullet': {
+      color: modusOperandiTintedTheme.AccentYellow,
+    },
+    'hljs-regexp': {
+      color: modusOperandiTintedTheme.AccentCyan,
+    },
+    'hljs-link': {
+      color: modusOperandiTintedTheme.LightBlue,
+    },
+    'hljs-deletion': {
+      color: modusOperandiTintedTheme.AccentRed,
+    },
+    'hljs-addition': {
+      color: modusOperandiTintedTheme.AccentGreen,
+    },
+    'hljs-emphasis': {
+      fontStyle: 'italic',
+    },
+    'hljs-strong': {
+      fontWeight: 'bold',
+    },
+    'hljs-literal': {
+      color: modusOperandiTintedTheme.AccentCyan,
+    },
+    'hljs-built_in': {
+      color: modusOperandiTintedTheme.AccentRed,
+    },
+    'hljs-doctag': {
+      color: modusOperandiTintedTheme.AccentRed,
+    },
+    'hljs-template-variable': {
+      color: modusOperandiTintedTheme.AccentCyan,
+    },
+    'hljs-selector-id': {
+      color: modusOperandiTintedTheme.AccentRed,
+    },
+  },
+  modusOperandiTintedTheme,
+);

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -18,6 +18,7 @@ import { Theme, ThemeType } from './theme.js';
 import { ANSI } from './ansi.js';
 import { ANSILight } from './ansi-light.js';
 import { NoColorTheme } from './no-color.js';
+import { ModusOperandiTinted } from './modus-operandi-tinted.js';
 import process from 'node:process';
 
 export interface ThemeDisplay {
@@ -45,6 +46,7 @@ class ThemeManager {
       XCode,
       ANSI,
       ANSILight,
+      ModusOperandiTinted,
     ];
     this.activeTheme = DEFAULT_THEME;
   }

--- a/packages/cli/src/ui/themes/theme.ts
+++ b/packages/cli/src/ui/themes/theme.ts
@@ -6,7 +6,7 @@
 
 import type { CSSProperties } from 'react';
 
-export type ThemeType = 'light' | 'dark' | 'ansi';
+export type ThemeType = 'light' | 'dark' | 'ansi' | 'modus-operandi-tinted';
 
 export interface ColorsTheme {
   type: ThemeType;
@@ -69,6 +69,21 @@ export const ansiTheme: ColorsTheme = {
   AccentRed: 'red',
   Comment: 'gray',
   Gray: 'gray',
+};
+
+export const modusOperandiTintedTheme: ColorsTheme = {
+  type: 'modus-operandi-tinted',
+  Background: '#fbf7f0',
+  Foreground: '#000000',
+  LightBlue: '#0031a9',
+  AccentBlue: '#0031a9',
+  AccentPurple: '#731f71',
+  AccentCyan: '#005f5f',
+  AccentGreen: '#005e00',
+  AccentYellow: '#725500',
+  AccentRed: '#a60000',
+  Comment: '#595959',
+  Gray: '#595959',
 };
 
 export class Theme {


### PR DESCRIPTION
This pull request introduces the new `modus-operandi-tinted` theme, expanding the available theme options for users.

## Description

The `modus-operandi-tinted` theme is a variant of the main Modus Operandi light theme. It is designed to be highly accessible while offering a warmer, more comfortable viewing experience.

### Key Benefits:

*   **Reduced Intensity**: The theme uses a light ocher background instead of pure white, which can reduce eye strain for some users, especially during prolonged use.
*   **Enhanced Readability**: Like all Modus themes, it conforms to the WCAG AAA standard for color contrast, ensuring a minimum 7:1 contrast ratio between text and background colors. This makes it highly readable for a wide range of users, including those with visual impairments.
*   **Pleasant Aesthetics**: The tinted background and carefully selected color palette provide a warmer, earthy feel, offering a visually pleasing alternative to standard high-contrast themes.
*   **Color-Deficiency Friendly**: The Modus themes are designed with color-deficient users in mind, with variants available for deuteranopia and tritanopia.

This new theme provides users with more choice and a more comfortable, accessible, and visually appealing CLI experience.