### PR TITLE
fix: add repository field to package.jsons

### DIFF
--- a/.gcp/release.yaml
+++ b/.gcp/release.yaml
@@ -41,9 +41,9 @@ steps:
 
   # Step 6: Prepare CLI package.json for publishing
   - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
-    id: 'Prepare @google/gemini-cli package.json and readme'
+    id: 'Prepare @google/gemini-cli and @google/gemini-cli-core packages'
     entrypoint: 'npm'
-    args: ['run', 'prepare:cli-packagejson']
+    args: ['run', 'prepare:packages']
     env:
       - 'GEMINI_SANDBOX=$_CONTAINER_TOOL'
       - 'SANDBOX_IMAGE_REGISTRY=$_SANDBOX_IMAGE_REGISTRY'
@@ -70,6 +70,9 @@ steps:
       - 'SANDBOX_IMAGE_NAME=$_SANDBOX_IMAGE_NAME'
 
   # Pre-Step 9: authenticate to our intermediate npm registry
+  # NOTE: when running locally, run this instead (from the `packages/core` directory):
+  #   - `npm login --registry https://wombat-dressing-room.appspot.com`
+  #   - use a 24hr token
   - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
     id: 'Setup @google/gemini-cli-core auth token for publishing'
     entrypoint: 'bash'
@@ -97,6 +100,9 @@ steps:
       - 'SANDBOX_IMAGE_NAME=$_SANDBOX_IMAGE_NAME'
 
   # Pre-Step 10: authenticate to our intermediate npm registry
+  # NOTE: when running locally, run this instead (from the `packages/cli` directory)
+  #   - `npm login --registry https://wombat-dressing-room.appspot.com`
+  #   - use a 24hr token
   - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
     id: 'Setup @google/gemini-cli auth token for publishing'
     entrypoint: 'bash'

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,9 @@
         "react-devtools-core": "^4.28.5",
         "typescript-eslint": "^8.30.1",
         "yargs": "^17.7.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "build:packages": "npm run build:core && npm run build:cli",
     "build:sandbox:fast": "node scripts/build_sandbox.js --skip-npm-install-build",
     "prepare:cli-packagejson": "node scripts/prepare-cli-packagejson.js",
+    "prepare:packages": "node scripts/prepare-cli-packagejson.js && node scripts/prepare-core-package.js",
     "publish:sandbox": "node scripts/publish-sandbox.js",
     "publish:npm": "npm publish --workspaces ${NPM_PUBLISH_TAG:+--tag=$NPM_PUBLISH_TAG} ${NPM_DRY_RUN:+--dry-run}",
     "publish:release": "npm run build:packages && npm run prepare:cli-packagejson && npm run build:sandbox:fast && npm run publish:sandbox && npm run publish:npm",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,7 @@
   "name": "@google/gemini-cli",
   "version": "0.1.5",
   "description": "Gemini CLI",
+  "repository": "google-gemini/gemini-cli",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -25,7 +26,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.1"
+    "sandboxImageUri": "gemini-cli-sandbox"
   },
   "dependencies": {
     "@google/gemini-cli-core": "*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@google/gemini-cli-core",
   "version": "0.1.5",
   "description": "Gemini CLI Server",
+  "repository": "google-gemini/gemini-cli",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/prepare-cli-packagejson.js
+++ b/scripts/prepare-cli-packagejson.js
@@ -74,3 +74,15 @@ try {
   console.error('Error copying README.md:', err);
   process.exit(1);
 }
+
+// Copy README.md to packages/cli
+const rootLicensePath = path.resolve(__dirname, '../LICENSE');
+const cliLicensePath = path.resolve(__dirname, '../packages/cli/LICENSE');
+
+try {
+  fs.copyFileSync(rootLicensePath, cliLicensePath);
+  console.log('Copied root LICENSE to packages/cli/');
+} catch (err) {
+  console.error('Error copying LICENSE:', err);
+  process.exit(1);
+}

--- a/scripts/prepare-core-package.js
+++ b/scripts/prepare-core-package.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// ES module equivalent of __dirname
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Copy README.md to packages/core
+const rootReadmePath = path.resolve(__dirname, '../README.md');
+const coreReadmePath = path.resolve(__dirname, '../packages/core/README.md');
+
+try {
+  fs.copyFileSync(rootReadmePath, coreReadmePath);
+  console.log('Copied root README.md to packages/core/');
+} catch (err) {
+  console.error('Error copying README.md:', err);
+  process.exit(1);
+}
+
+// Copy README.md to packages/cli
+const rootLicensePath = path.resolve(__dirname, '../LICENSE');
+const coreLicensePath = path.resolve(__dirname, '../packages/core/LICENSE');
+
+try {
+  fs.copyFileSync(rootLicensePath, coreLicensePath);
+  console.log('Copied root LICENSE to packages/core/');
+} catch (err) {
+  console.error('Error copying LICENSE:', err);
+  process.exit(1);
+}


### PR DESCRIPTION
Our release publishing trigger needs this metadata to be set in the package.jsons. 

Drive by change: point the source `sandboxImageUri` to the image name used for local sandbox development (note, this gets updated to a production sandbox in the release pipeline). Added extra steps to copy README and LICENSE into the core package.