### PR TITLE
fix(auth): prevent re-triggering Google login after ESC cancellation

### DIFF
--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -52,8 +52,8 @@ export function AuthDialog({
 
   useInput((_input, key) => {
     if (key.escape) {
-      if (settings.merged.selectedAuthType === undefined) {
-        // Prevent exiting if no auth method is set
+      if (settings.merged.selectedAuthType === undefined || errorMessage) {
+        // Prevent exiting if no auth method is set or there's an error message
         setErrorMessage(
           'You must select an auth method to proceed. Press Ctrl+C twice to exit.',
         );


### PR DESCRIPTION
## TLDR

Fixed authentication dialog ESC key handling issues including Google login re-triggering and infinite retry loops. Implemented deferred auth settings persistence to preserve user configuration during cancellations, and enhanced error message handling to prevent ESC exit when errors are present.

## Dive Deeper

Multiple ESC key handling issues were identified and resolved:

1. **Auth cancellation bug**: When user cancels Google authentication with ESC, subsequent ESC presses would incorrectly re-trigger the auth flow instead of showing proper error message.

2. **Configuration corruption**: The original approach of immediately saving selectedAuthType would break users' existing auth configurations in their settings.json when authentication fails or gets cancelled.

3. **Infinite retry loops**: When authentication fails with errors (e.g., missing environment variables), pressing ESC would cause infinite loops between "Waiting for auth" and error dialog.

The solution implements a **deferred authentication pattern** with the following improvements:

- **Pending Auth Selection**: Introduced `pendingAuthSelection` state to track auth choices without immediately persisting them to settings
- **Deferred Persistence**: Auth settings are now only saved after successful authentication, preventing configuration corruption during failures/cancellations
- **Enhanced ESC Handling**: ESC exit is blocked when error messages are present (`|| errorMessage` condition), requiring users to resolve issues before proceeding
- **Automatic Retry**: Existing saved auth methods are automatically loaded as pending selections for seamless re-authentication

## Reviewer Test Plan

### Test Case 1: Auth Cancellation (Updated)
1. Select "Login with Google" in the auth dialog
2. Wait for "Waiting for auth..." message to appear
3. Press ESC to cancel authentication
4. Verify you return to the auth dialog with your original settings intact
5. Press ESC again
6. Verify it shows "You must select an auth method to proceed" error message instead of re-opening Google login

### Test Case 2: Configuration Preservation (Enhanced)
1. Ensure you have selectedAuthType configured in .gemini/settings.json
2. Follow Test Case 1 steps but let authentication fail
3. Verify your settings.json still contains the original selectedAuthType (not the failed attempt)
4. Restart the application and verify auto-authentication still works with your saved settings

### Test Case 3: Error Message Handling (Enhanced)
1. Select "Login with Google" but ensure you have an account that will cause auth errors (e.g., missing GOOGLE_CLOUD_PROJECT)
2. Complete authentication but let it fail with error message
3. Press ESC in the auth dialog with error message displayed
4. Verify it shows "You must select an auth method to proceed" instead of creating infinite retry loop
5. Verify no invalid auth settings were saved to your configuration

### Test Case 4: Deferred Persistence (New)
1. Start with no saved auth configuration
2. Select an auth method and intentionally cause authentication to fail
3. Verify no auth settings were written to settings.json
4. Select the same auth method and complete authentication successfully
5. Verify auth settings are now properly saved to settings.json

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/gemini-cli/issues/1735#issuecomment-3009993820