### PR TITLE
fix(core): Correctly handle chat state on tool call cancellation #2017

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -470,6 +470,54 @@ describe('Gemini Client (client.ts)', () => {
     });
   });
 
+  describe('undoLastModelTurn', () => {
+    it('should remove the last model turn from history, and do nothing otherwise', async () => {
+      // --- Scenario 1: Last turn is from the model ---
+      const historyBeforeModelUndo = await client.getHistory();
+      const lengthBeforeModelUndo = historyBeforeModelUndo.length;
+      expect(lengthBeforeModelUndo).toBeGreaterThan(0);
+      const lastTurnBeforeModelUndo =
+        historyBeforeModelUndo[lengthBeforeModelUndo - 1];
+      expect(lastTurnBeforeModelUndo.role).toBe('model'); // Default setup ends with a model turn
+
+      // Call undoLastModelTurn
+      await client.undoLastModelTurn();
+
+      // Assert the new state
+      const historyAfterModelUndo = await client.getHistory();
+      expect(historyAfterModelUndo.length).toBe(lengthBeforeModelUndo - 1);
+      expect(JSON.stringify(historyAfterModelUndo)).not.toContain(
+        JSON.stringify(lastTurnBeforeModelUndo.parts),
+      );
+      const lastTurnAfterModelUndo =
+        historyAfterModelUndo[historyAfterModelUndo.length - 1];
+      expect(lastTurnAfterModelUndo.role).toBe('user'); // The previous turn should now be the last
+
+      // --- Scenario 2: Last turn is from the user ---
+      const userTurn = {
+        role: 'user',
+        parts: [{ text: 'User says something' }],
+      };
+      await client.addHistory(userTurn);
+      const historyBeforeUserUndo = await client.getHistory();
+      const lengthBeforeUserUndo = historyBeforeUserUndo.length;
+
+      // Call undoLastModelTurn - should do nothing
+      await client.undoLastModelTurn();
+
+      // Assert history is unchanged
+      const historyAfterUserUndo = await client.getHistory();
+      expect(historyAfterUserUndo.length).toBe(lengthBeforeUserUndo);
+      expect(historyAfterUserUndo).toEqual(historyBeforeUserUndo);
+
+      // --- Scenario 3: History is empty ---
+      await client.setHistory([]);
+      await client.undoLastModelTurn();
+      const historyAfterEmptyUndo = await client.getHistory();
+      expect(historyAfterEmptyUndo.length).toBe(0);
+    });
+  });
+
   describe('sendMessageStream', () => {
     it('should return the turn instance after the stream is complete', async () => {
       // Arrange

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -118,15 +118,13 @@ export class GeminiClient {
 
     if (lastTurn?.role === 'model') {
       const newHistory = history.slice(0, -1);
-
-      if (this.contentGenerator) {
-        this.chat = new GeminiChat(
-          this.config,
-          this.contentGenerator,
-          undefined,
-          newHistory,
-        );
-      }
+      const generationConfig = this.chat.getGenerationConfig();
+      this.chat = new GeminiChat(
+        this.config,
+        this.getContentGenerator(),
+        generationConfig,
+        newHistory,
+      );
     }
   }
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -104,6 +104,32 @@ export class GeminiClient {
     this.chat = await this.startChat();
   }
 
+  async undoLastModelTurn(): Promise<void> {
+    if (!this.chat) {
+      return;
+    }
+
+    const history = await this.chat.getHistory();
+    if (history.length === 0) {
+      return;
+    }
+
+    const lastTurn = history[history.length - 1];
+
+    if (lastTurn?.role === 'model') {
+      const newHistory = history.slice(0, -1);
+
+      if (this.contentGenerator) {
+        this.chat = new GeminiChat(
+          this.config,
+          this.contentGenerator,
+          undefined,
+          newHistory,
+        );
+      }
+    }
+  }
+
   private async getEnvironment(): Promise<Part[]> {
     const cwd = this.config.getWorkingDir();
     const today = new Date().toLocaleDateString(undefined, {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -515,6 +515,7 @@ export class CoreToolScheduler {
         'cancelled',
         'User did not allow tool call',
       );
+      await this.config.getGeminiClient().undoLastModelTurn();
     } else if (outcome === ToolConfirmationOutcome.ModifyWithEditor) {
       const waitingToolCall = toolCall as WaitingToolCall;
       if (isModifiableTool(waitingToolCall.tool)) {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -444,6 +444,10 @@ export class GeminiChat {
     this.history = history;
   }
 
+  getGenerationConfig(): GenerateContentConfig {
+    return this.generationConfig;
+  }
+
   getFinalUsageMetadata(
     chunks: GenerateContentResponse[],
   ): GenerateContentResponseUsageMetadata | undefined {
@@ -538,7 +542,7 @@ export class GeminiChat {
       automaticFunctionCallingHistory.length > 0
     ) {
       this.history.push(
-        ...extractCuratedHistory(automaticFunctionCallingHistory),
+        ...extractCuratedHistory(automaticFunctionCallingHistory!),
       );
     } else {
       this.history.push(userInput);


### PR DESCRIPTION
## TLDR

This PR fixes a critical bug (issue #2017) where canceling a tool call would corrupt the chat session, making further interaction impossible without a restart. The fix ensures the chat history is correctly rolled back upon cancellation, restoring the chat to a valid state.

## Dive Deeper

**The Problem:**

The core issue was a state desynchronization between the Gemini CLI client and the backend API. The flow was as follows:
1. The model suggests a tool call, and this suggestion is added to the local chat history.
2. The UI prompts the user for confirmation.
3. The user cancels the execution.
4. **Bug:** The tool call suggestion (the last model turn) was not being removed from the `GeminiClient`'s chat history.
5. On the next user message, the client would send an inconsistent history to the API. The API expected a `tool_response` for the tool call it previously suggested, but since it never received one, it would return an error, effectively breaking the session.

**The Solution:**

This PR introduces a robust mechanism to handle this cancellation flow gracefully:

1.  **`undoLastModelTurn()` in `GeminiClient`:** A new public method, `undoLastModelTurn`, has been added to `packages/core/src/core/client.ts`. This method safely inspects the chat history and, if the last entry is from the `model` (indicating a tool call suggestion), it removes it. This is achieved by re-initializing the chat with a truncated history, which is the correct and safe pattern for updating history with the underlying `@google/genai` library.

2.  **Integration with `CoreToolScheduler`:** The `handleConfirmationResponse` method in `packages/core/src/core/coreToolScheduler.ts` is the natural place to hook into the cancellation event. When the user's response `outcome` is `ToolConfirmationOutcome.Cancel`, the scheduler now calls `await this.config.getGeminiClient().undoLastModelTurn()`. This immediately synchronizes the client's state with the user's action.

3.  **Comprehensive Testing:**
    *   New unit tests were added to `packages/core/src/core/client.test.ts` to validate the behavior of `undoLastModelTurn` in various scenarios (last turn is model, last turn is user, empty history).
    *   New unit tests were added to `packages/core/src/core/coreToolScheduler.test.ts` to specifically verify that `undoLastModelTurn` is called upon cancellation and that the scheduler's final state is correct.
    *   Existing tests that were affected by the changes were updated to ensure the entire test suite remains green.
    *   All `npm run preflight` checks pass 100%, ensuring code quality, formatting, and all tests are successful.

This fix makes the tool interaction much more resilient and improves the overall user experience by preventing unrecoverable session states.

## Reviewer Test Plan

To manually validate the fix:

1.  Check out this branch.
2.  Run `npm install` and `npm run build`.
3.  Start the CLI with `npm start`.
4.  Use a prompt that is likely to trigger a tool call requiring confirmation (e.g., "read the content of `package.json`" or "list the files in the current directory").
5.  When the CLI asks for confirmation to run the tool, select **"No"** to cancel.
6.  **Verification:** Send another message in the chat (e.g., "hello" or "what is 2+2?"). The chat should now respond normally without any errors.
7.  **Contrast:** On the `main` branch, step 6 would fail with an API error, and all subsequent chat attempts in that session would also fail.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ✅  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2017
