### PR TITLE
Add the current auth method and GCP Project config to the about message

### DIFF
--- a/packages/cli/src/ui/components/AboutBox.tsx
+++ b/packages/cli/src/ui/components/AboutBox.tsx
@@ -98,7 +98,9 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
         </Text>
       </Box>
       <Box>
-        <Text>{selectedAuthType}</Text>
+        <Text>
+          {selectedAuthType.startsWith('oauth') ? 'OAuth' : selectedAuthType}
+        </Text>
       </Box>
     </Box>
     {gcpProject && (

--- a/packages/cli/src/ui/components/AboutBox.tsx
+++ b/packages/cli/src/ui/components/AboutBox.tsx
@@ -14,6 +14,8 @@ interface AboutBoxProps {
   osVersion: string;
   sandboxEnv: string;
   modelVersion: string;
+  selectedAuthType: string;
+  gcpProject: string;
 }
 
 export const AboutBox: React.FC<AboutBoxProps> = ({
@@ -21,6 +23,8 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
   osVersion,
   sandboxEnv,
   modelVersion,
+  selectedAuthType,
+  gcpProject,
 }) => (
   <Box
     borderStyle="round"
@@ -87,5 +91,27 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
         <Text>{osVersion}</Text>
       </Box>
     </Box>
+    <Box flexDirection="row">
+      <Box width="35%">
+        <Text bold color={Colors.LightBlue}>
+          Auth Method
+        </Text>
+      </Box>
+      <Box>
+        <Text>{selectedAuthType}</Text>
+      </Box>
+    </Box>
+    {gcpProject && (
+      <Box flexDirection="row">
+        <Box width="35%">
+          <Text bold color={Colors.LightBlue}>
+            GCP Project
+          </Text>
+        </Box>
+        <Box>
+          <Text>{gcpProject}</Text>
+        </Box>
+      </Box>
+    )}
   </Box>
 );

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -67,6 +67,8 @@ describe('<HistoryItemDisplay />', () => {
       osVersion: 'test-os',
       sandboxEnv: 'test-env',
       modelVersion: 'test-model',
+      selectedAuthType: 'test-auth',
+      gcpProject: 'test-project',
     };
     const { lastFrame } = render(
       <HistoryItemDisplay {...baseItem} item={item} />,

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -65,6 +65,8 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
         osVersion={item.osVersion}
         sandboxEnv={item.sandboxEnv}
         modelVersion={item.modelVersion}
+        selectedAuthType={item.selectedAuthType}
+        gcpProject={item.gcpProject}
       />
     )}
     {item.type === 'stats' && (

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -336,6 +336,89 @@ describe('useSlashCommandProcessor', () => {
     });
   });
 
+  describe('/about command', () => {
+    it('should show the about box with all details including auth and project', async () => {
+      // Arrange
+      mockGetCliVersionFn.mockResolvedValue('test-version');
+      process.env.SANDBOX = 'gemini-sandbox';
+      process.env.GOOGLE_CLOUD_PROJECT = 'test-gcp-project';
+      vi.mocked(mockConfig.getModel).mockReturnValue('test-model-from-config');
+
+      const settings = {
+        merged: {
+          selectedAuthType: 'test-auth-type',
+          contextFileName: 'GEMINI.md',
+        },
+      } as LoadedSettings;
+
+      const { result } = renderHook(() =>
+        useSlashCommandProcessor(
+          mockConfig,
+          settings,
+          [],
+          mockAddItem,
+          mockClearItems,
+          mockLoadHistory,
+          mockRefreshStatic,
+          mockSetShowHelp,
+          mockOnDebugMessage,
+          mockOpenThemeDialog,
+          mockOpenAuthDialog,
+          mockOpenEditorDialog,
+          mockPerformMemoryRefresh,
+          mockCorgiMode,
+          false,
+          mockSetQuittingMessages,
+        ),
+      );
+
+      // Act
+      await act(async () => {
+        await result.current.handleSlashCommand('/about');
+      });
+
+      // Assert
+      expect(mockAddItem).toHaveBeenCalledTimes(2); // user message + about message
+      expect(mockAddItem).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          type: 'about',
+          cliVersion: 'test-version',
+          osVersion: 'test-platform',
+          sandboxEnv: 'gemini-sandbox',
+          modelVersion: 'test-model-from-config',
+          selectedAuthType: 'test-auth-type',
+          gcpProject: 'test-gcp-project',
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should show sandbox-exec profile when applicable', async () => {
+      // Arrange
+      mockGetCliVersionFn.mockResolvedValue('test-version');
+      process.env.SANDBOX = 'sandbox-exec';
+      process.env.SEATBELT_PROFILE = 'test-profile';
+      vi.mocked(mockConfig.getModel).mockReturnValue('test-model-from-config');
+
+      const { result } = getProcessorHook();
+
+      // Act
+      await act(async () => {
+        await result.current.handleSlashCommand('/about');
+      });
+
+      // Assert
+      expect(mockAddItem).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          sandboxEnv: 'sandbox-exec (test-profile)',
+        }),
+        expect.any(Number),
+      );
+    });
+  });
+
   describe('Other commands', () => {
     it('/help should open help and return true', async () => {
       const { handleSlashCommand } = getProcessor();

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -103,6 +103,8 @@ export const useSlashCommandProcessor = (
           osVersion: message.osVersion,
           sandboxEnv: message.sandboxEnv,
           modelVersion: message.modelVersion,
+          selectedAuthType: message.selectedAuthType,
+          gcpProject: message.gcpProject,
         };
       } else if (message.type === MessageType.STATS) {
         historyItemContent = {
@@ -588,6 +590,8 @@ export const useSlashCommandProcessor = (
           }
           const modelVersion = config?.getModel() || 'Unknown';
           const cliVersion = await getCliVersion();
+          const selectedAuthType = settings.merged.selectedAuthType || '';
+          const gcpProject = process.env.GOOGLE_CLOUD_PROJECT || '';
           addMessage({
             type: MessageType.ABOUT,
             timestamp: new Date(),
@@ -595,6 +599,8 @@ export const useSlashCommandProcessor = (
             osVersion,
             sandboxEnv,
             modelVersion,
+            selectedAuthType,
+            gcpProject,
           });
         },
       },
@@ -991,6 +997,7 @@ export const useSlashCommandProcessor = (
     toggleCorgiMode,
     savedChatTags,
     config,
+    settings,
     showToolDescriptions,
     session,
     gitService,

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -94,6 +94,8 @@ export type HistoryItemAbout = HistoryItemBase & {
   osVersion: string;
   sandboxEnv: string;
   modelVersion: string;
+  selectedAuthType: string;
+  gcpProject: string;
 };
 
 export type HistoryItemStats = HistoryItemBase & {
@@ -169,6 +171,8 @@ export type Message =
       osVersion: string;
       sandboxEnv: string;
       modelVersion: string;
+      selectedAuthType: string;
+      gcpProject: string;
       content?: string; // Optional content, not really used for ABOUT
     }
   | {


### PR DESCRIPTION
## TLDR

Add two more rows to the about information, to help people better understand their current configuration

## Dive Deeper

Currently the only way to know what auth method you are using is to choose to re-auth.

When there are competing .env files and locally set environment, sometimes it is unclear if the GCP project is set

![Screenshot 2025-06-26 at 9 52 45 PM](https://github.com/user-attachments/assets/f0a0d465-fd86-490c-af43-ad5e3ce328d4)


## Reviewer Test Plan

try the /about command with several different auth options

## Testing Matrix

I've tested this with all three primary auth methods. The GCP project is only displayed when set.

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅   | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

fixes #1992
