### PR TITLE
docs: add 20 language links of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
+<div align="right" >
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="right">
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=en">English</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=zh-CN">简体中文</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=zh-TW">繁體中文</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=ja">日本語</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=ko">한국어</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=hi">हिन्दी</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=th">ไทย</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=fr">Français</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=de">Deutsch</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=es">Español</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=it">Itapano</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=ru">Русский</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=pt">Português</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=nl">Nederlands</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=pl">Polski</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=ar">العربية</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=fa">فارسی</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=tr">Türkçe</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=vi">Tiếng Việt</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=id">Bahasa Indonesia</a></p>
+      </div>
+    </div>
+  </details>
+</div>
+
+
 # Gemini CLI
 
 [![Gemini CLI CI](https://github.com/google-gemini/gemini-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/google-gemini/gemini-cli/actions/workflows/ci.yml)


### PR DESCRIPTION



## TLDR

PR adds 20 languages link to the README and user can easily to access translated READEME.

Page demo https://openaitx.github.io/view.html?user=google-gemini&project=gemini-cli&lang=ja

![Image](https://github.com/user-attachments/assets/4d9e0060-ee40-42b9-9f3f-d5509c58af1f)


## Dive Deeper


## Reviewer Test Plan


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->


## Linked issues / bugs

