### PR TITLE
Fix: Enable run_shell_command in non-interactive mode

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -28,7 +28,6 @@ import {
   ApprovalMode,
   Config,
   EditTool,
-  ShellTool,
   WriteFileTool,
   sessionId,
   logUserPrompt,
@@ -243,11 +242,7 @@ async function loadNonInteractiveConfig(
   if (config.getApprovalMode() !== ApprovalMode.YOLO) {
     // Everything is not allowed, ensure that only read-only tools are configured.
     const existingExcludeTools = settings.merged.excludeTools || [];
-    const interactiveTools = [
-      ShellTool.Name,
-      EditTool.Name,
-      WriteFileTool.Name,
-    ];
+    const interactiveTools = [EditTool.Name, WriteFileTool.Name];
 
     const newExcludeTools = [
       ...new Set([...existingExcludeTools, ...interactiveTools]),


### PR DESCRIPTION
The `run_shell_command` tool was unintentionally excluded in non-interactive mode, leading to "tool not found" errors. This commit removes `ShellTool.Name` from the `interactiveTools` exclusion list in `packages/cli/src/gemini.tsx`, allowing it to be used in non-YOLO approval modes.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
