### PR TITLE
fix login for when GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -340,9 +340,7 @@ export function getAvailablePort(): Promise<number> {
 
 async function loadCachedCredentials(client: OAuth2Client): Promise<boolean> {
   try {
-    const keyFile =
-      process.env.GOOGLE_APPLICATION_CREDENTIALS || getCachedCredentialPath();
-
+    const keyFile = getCachedCredentialPath();
     const creds = await fs.readFile(keyFile, 'utf-8');
     client.setCredentials(JSON.parse(creds));
 
@@ -370,7 +368,7 @@ async function cacheCredentials(credentials: Credentials) {
 }
 
 function getCachedCredentialPath(): string {
-  return path.join(os.homedir(), GEMINI_DIR, CREDENTIAL_FILENAME);
+  return process.env.GOOGLE_APPLICATION_CREDENTIALS || path.join(os.homedir(), GEMINI_DIR, CREDENTIAL_FILENAME);
 }
 
 export async function clearCachedCredentialFile() {

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -368,7 +368,10 @@ async function cacheCredentials(credentials: Credentials) {
 }
 
 function getCachedCredentialPath(): string {
-  return process.env.GOOGLE_APPLICATION_CREDENTIALS || path.join(os.homedir(), GEMINI_DIR, CREDENTIAL_FILENAME);
+  return (
+    process.env.GOOGLE_APPLICATION_CREDENTIALS ||
+    path.join(os.homedir(), GEMINI_DIR, CREDENTIAL_FILENAME)
+  );
 }
 
 export async function clearCachedCredentialFile() {


### PR DESCRIPTION
## TLDR
Login for personal account is broken. I log in already, i use and exit the app. then the next time i need to login again, this makes me sed

## Dive Deeper
When `GOOGLE_APPLICATION_CREDENTIALS` is set, we load credentials from it, but in the caching we are not writing to it, instead we are writing into the default `~/.gemini/oauth_creds.json`. 

## Reviewer Test Plan
- set `GOOGLE_APPLICATION_CREDENTIALS` then try the login flow for google personal account
- without the fix, you will end up logging in over and over
- with the fix, the creds will be saved and you just need to login one time

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

 fixes #2429
