### PR TITLE
Fix a circular dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "@google/gemini-cli": "^0.1.1"
-      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,5 @@
     "typescript-eslint": "^8.30.1",
     "yargs": "^17.7.2"
   },
-  "dependencies": {
-    "@google/gemini-cli": "^0.1.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
## TLDR

This PR removes a circular dependency from the root package.json.

## Dive Deeper

The root package.json for this monorepo contained `@google/gemini-cli": "^0.1.1` within its `dependencies` block. This is an anti-pattern that can cause several problems:
- Confusing Dependency Resolution: npm might fetch and install an older, published version of the CLI into the node_modules directory, even though the latest source code is present in the workspace.
- Bloat: It adds an unnecessary package to `node_modules`.
- Potential for Bugs: Scripts could inadvertently use the installed older version instead of the local workspace code, leading to confusing behavior where local changes don't seem to apply.

By removing this entry, we ensure that the project relies solely on the local workspace packages, simplifying the dependency graph and making the build process more reliable and predictable.

## Reviewer Test Plan
Running `npm run preflight` yields the following results:

 Test Files  44 passed (44)
      Tests  633 passed (633)
   Start at  12:32:12
   Duration  4.82s (transform 10.36s, setup 1.60s, collect 39.14s, tests 3.78s, environment 17ms, prepare 8.57s)


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
