### PR TITLE
Re-enable Gemini Code Assist PR review bot

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,10 +1,10 @@
 have_fun: false
 code_review:
-  disable: true
+  disable: false
   comment_severity_threshold: HIGH
   max_review_comments: -1
   pull_request_opened:
     help: false
-    summary: false
-    code_review: false
+    summary: true
+    code_review: true
 ignore_patterns: []


### PR DESCRIPTION
## TLDR

Re-enable the Gemini Code Assist PR bot. Also enable automatic PR summary and code reviews.

## Dive Deeper

This was disabled in https://github.com/google-gemini/gemini-cli/pull/809.

## Reviewer Test Plan

N/A

## Testing Matrix

N/A

## Linked issues / bugs

N/A