### PR TITLE
Display privacy notice after changing auth type

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -64,6 +64,9 @@ export interface Settings {
   // UI setting. Does not display the ANSI-controlled terminal title.
   hideWindowTitle?: boolean;
 
+  // Whether or not the user has seen the privacy notice.
+  hasSeenPrivacyNotice?: boolean;
+
   // Add other settings here.
 }
 

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -168,6 +168,20 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     }
   }, [settings.merged.selectedAuthType, openAuthDialog, setAuthError]);
 
+  useEffect(() => {
+    if (
+      !isAuthDialogOpen &&
+      settings.merged.selectedAuthType &&
+      !settings.merged.hasSeenPrivacyNotice
+    ) {
+      setShowPrivacyNotice(true);
+    }
+  }, [
+    isAuthDialogOpen,
+    settings.merged.selectedAuthType,
+    settings.merged.hasSeenPrivacyNotice,
+  ]);
+
   const {
     isEditorDialogOpen,
     openEditorDialog,
@@ -723,6 +737,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
             <PrivacyNotice
               onExit={() => setShowPrivacyNotice(false)}
               config={config}
+              settings={settings}
             />
           ) : (
             <>

--- a/packages/cli/src/ui/hooks/useAuthCommand.ts
+++ b/packages/cli/src/ui/hooks/useAuthCommand.ts
@@ -61,6 +61,7 @@ export const useAuthCommand = (
       if (authMethod) {
         await clearCachedCredentialFile();
         settings.setValue(scope, 'selectedAuthType', authMethod);
+        settings.setValue(scope, 'hasSeenPrivacyNotice', undefined);
       }
       setIsAuthDialogOpen(false);
       setAuthError(null);

--- a/packages/cli/src/ui/privacy/CloudPaidPrivacyNotice.tsx
+++ b/packages/cli/src/ui/privacy/CloudPaidPrivacyNotice.tsx
@@ -23,7 +23,7 @@ export const CloudPaidPrivacyNotice = ({
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Text bold color={Colors.AccentPurple}>
-        Vertex AI Notice
+        Google Cloud Notice
       </Text>
       <Newline />
       <Text>

--- a/packages/cli/src/ui/privacy/PrivacyNotice.tsx
+++ b/packages/cli/src/ui/privacy/PrivacyNotice.tsx
@@ -9,18 +9,21 @@ import { type Config, AuthType } from '@google/gemini-cli-core';
 import { GeminiPrivacyNotice } from './GeminiPrivacyNotice.js';
 import { CloudPaidPrivacyNotice } from './CloudPaidPrivacyNotice.js';
 import { CloudFreePrivacyNotice } from './CloudFreePrivacyNotice.js';
+import { useEffect } from 'react';
+import { LoadedSettings, SettingScope } from '../../config/settings.js';
 
 interface PrivacyNoticeProps {
   onExit: () => void;
   config: Config;
+  settings: LoadedSettings;
 }
 
 const PrivacyNoticeText = ({
-  config,
   onExit,
+  config,
 }: {
-  config: Config;
   onExit: () => void;
+  config: Config;
 }) => {
   const authType = config.getContentGeneratorConfig()?.authType;
 
@@ -35,8 +38,18 @@ const PrivacyNoticeText = ({
   }
 };
 
-export const PrivacyNotice = ({ onExit, config }: PrivacyNoticeProps) => (
-  <Box borderStyle="round" padding={1} flexDirection="column">
-    <PrivacyNoticeText config={config} onExit={onExit} />
-  </Box>
-);
+export const PrivacyNotice = ({
+  onExit,
+  config,
+  settings,
+}: PrivacyNoticeProps) => {
+  useEffect(() => {
+    settings.setValue(SettingScope.User, 'hasSeenPrivacyNotice', 'true');
+  }, [settings]);
+
+  return (
+    <Box borderStyle="round" padding={1} flexDirection="column">
+      <PrivacyNoticeText config={config} onExit={onExit} />
+    </Box>
+  );
+};


### PR DESCRIPTION
## TLDR

Currently we only show the privacy notice if the user calls the `/privacy` command. This also displays it after the user successfully auths with a different auth type.

## Reviewer Test Plan

Try the three different auth types.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | x  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/gemini-cli/issues/2287
