### PR TITLE
chore: bump to 0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@google/gemini-cli",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "workspaces": [
         "packages/*"
       ],
@@ -11193,7 +11193,7 @@
     },
     "packages/cli": {
       "name": "@google/gemini-cli",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@google/gemini-cli-core": "*",
         "@types/update-notifier": "^6.0.8",
@@ -11371,7 +11371,7 @@
     },
     "packages/core": {
       "name": "@google/gemini-cli-core",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@google/genai": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@google/gemini-cli",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "workspaces": [
         "packages/*"
       ],
@@ -11193,7 +11193,7 @@
     },
     "packages/cli": {
       "name": "@google/gemini-cli",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@google/gemini-cli-core": "*",
         "@types/update-notifier": "^6.0.8",
@@ -11371,7 +11371,7 @@
     },
     "packages/core": {
       "name": "@google/gemini-cli-core",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@google/genai": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "engines": {
     "node": ">=18.0.0"
   },
@@ -10,7 +10,7 @@
   ],
   "repository": "google-gemini/gemini-cli",
   "config": {
-    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.6"
+    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.7"
   },
   "scripts": {
     "generate": "node scripts/generate-git-commit-info.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "engines": {
     "node": ">=18.0.0"
   },
@@ -10,7 +10,7 @@
   ],
   "repository": "google-gemini/gemini-cli",
   "config": {
-    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.5"
+    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.6"
   },
   "scripts": {
     "generate": "node scripts/generate-git-commit-info.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Gemini CLI",
   "repository": "google-gemini/gemini-cli",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Gemini CLI",
   "repository": "google-gemini/gemini-cli",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli-core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Gemini CLI Server",
   "repository": "google-gemini/gemini-cli",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli-core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Gemini CLI Server",
   "repository": "google-gemini/gemini-cli",
   "type": "module",


### PR DESCRIPTION
there was a sandbox bug in 0.1.6. Pushed 0.1.7 and am fast-forwarding the repo to 0.1.8.