### PR TITLE
default non interactive commands to gemini flash and suppress logs on 429

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -205,6 +205,13 @@ export async function main() {
     settings,
   );
 
+  // Set up Flash fallback handler for non-interactive mode
+  const flashFallbackHandler = async (): Promise<boolean> => {
+    console.log('⚡ Slow response times detected. Automatically switching to Flash model for faster responses.');
+    return true;
+  };
+  nonInteractiveConfig.setFlashFallbackHandler(flashFallbackHandler);
+
   await runNonInteractive(nonInteractiveConfig, input);
   process.exit(0);
 }


### PR DESCRIPTION
A better user experience when users run out of gemini 2.5 pro and use non interactive mode, rather than just throwing an error and not having a fallback flash model

<img width="1044" alt="image" src="https://github.com/user-attachments/assets/e8fffac1-9fac-4119-8c06-d61a1c69714e" />


## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

[2305](https://github.com/google-gemini/gemini-cli/issues/2305
)

<!-- Add links to any gh issues or other external bugs --->
