### PR TITLE
chore: remove unused ink-text-input dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6384,47 +6384,6 @@
         }
       }
     },
-    "node_modules/ink-text-input": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
-      "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "type-fest": "^4.18.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "ink": ">=5",
-        "react": ">=18"
-      }
-    },
-    "node_modules/ink-text-input/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ink-text-input/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ink/node_modules/ansi-styles": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
@@ -11334,7 +11293,6 @@
         "ink-link": "^4.1.0",
         "ink-select-input": "^6.2.0",
         "ink-spinner": "^5.0.0",
-        "ink-text-input": "^6.0.0",
         "lowlight": "^3.3.0",
         "mime-types": "^3.0.1",
         "open": "^10.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,6 @@
     "ink-link": "^4.1.0",
     "ink-select-input": "^6.2.0",
     "ink-spinner": "^5.0.0",
-    "ink-text-input": "^6.0.0",
     "lowlight": "^3.3.0",
     "mime-types": "^3.0.1",
     "open": "^10.1.2",


### PR DESCRIPTION
## TLDR

This PR removes the unused `ink-text-input` dependency from `packages/cli/package.json`. The package was replaced with a custom `MultilineTextEditor` implementation in May 2025 but was never removed from dependencies.

## Dive Deeper

The `ink-text-input` package was replaced by `MultilineTextEditor` in commit e2c3611c.

## Reviewer Test Plan

1. Run `npm install` and `npm run build`
2. Test text input in the CLI (`npm start`):

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A
