### PR TITLE
fix: Correct grep.ts typo matche(s) to match(es)

### DIFF
--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -122,7 +122,7 @@ describe('GrepTool', () => {
       expect(result.llmContent).toContain('L2: second line with world');
       expect(result.llmContent).toContain('File: sub/fileC.txt');
       expect(result.llmContent).toContain('L1: another world in sub dir');
-      expect(result.returnDisplay).toBe('Found 3 matche(s)');
+      expect(result.returnDisplay).toBe('Found 3 match(es)');
     });
 
     it('should find matches in a specific path', async () => {
@@ -133,7 +133,7 @@ describe('GrepTool', () => {
       );
       expect(result.llmContent).toContain('File: fileC.txt'); // Path relative to 'sub'
       expect(result.llmContent).toContain('L1: another world in sub dir');
-      expect(result.returnDisplay).toBe('Found 1 matche(s)');
+      expect(result.returnDisplay).toBe('Found 1 match(es)');
     });
 
     it('should find matches with an include glob', async () => {
@@ -146,7 +146,7 @@ describe('GrepTool', () => {
       expect(result.llmContent).toContain(
         'L2: function baz() { return "hello"; }',
       );
-      expect(result.returnDisplay).toBe('Found 1 matche(s)');
+      expect(result.returnDisplay).toBe('Found 1 match(es)');
     });
 
     it('should find matches with an include glob and path', async () => {
@@ -165,7 +165,7 @@ describe('GrepTool', () => {
       );
       expect(result.llmContent).toContain('File: another.js');
       expect(result.llmContent).toContain('L1: const greeting = "hello";');
-      expect(result.returnDisplay).toBe('Found 1 matche(s)');
+      expect(result.returnDisplay).toBe('Found 1 match(es)');
     });
 
     it('should return "No matches found" when pattern does not exist', async () => {

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -226,7 +226,7 @@ export class GrepTool extends BaseTool<GrepToolParams, ToolResult> {
 
       return {
         llmContent: llmContent.trim(),
-        returnDisplay: `Found ${matches.length} matche(s)`,
+        returnDisplay: `Found ${matches.length} match(es)`,
       };
     } catch (error) {
       console.error(`Error during GrepLogic execution: ${error}`);


### PR DESCRIPTION
## TLDR

Fixes typo in grep.ts

## Dive Deeper

grep.ts currently has inconsistent usage of match(es) and matche(s). llmContent is using match(es) and returnDisplay matche(s). I believe the latter to be grammatically incorrect and so this has been corrected in this commit.

## Reviewer Test Plan

Validate tests and corrected output

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ✅  |
| npx      | ❓  | ✅  | ✅  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Fixes https://github.com/google-gemini/gemini-cli/issues/2403

