### PR TITLE
fix: privacy command becomes unresponsive on error

### DIFF
--- a/packages/cli/src/ui/privacy/CloudFreePrivacyNotice.tsx
+++ b/packages/cli/src/ui/privacy/CloudFreePrivacyNotice.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Box, Newline, Text } from 'ink';
+import { Box, Newline, Text, useInput, Key } from 'ink';
 import { RadioButtonSelect } from '../components/shared/RadioButtonSelect.js';
 import { usePrivacySettings } from '../hooks/usePrivacySettings.js';
 import { CloudPaidPrivacyNotice } from './CloudPaidPrivacyNotice.js';
@@ -23,15 +23,25 @@ export const CloudFreePrivacyNotice = ({
   const { privacyState, updateDataCollectionOptIn } =
     usePrivacySettings(config);
 
+  useInput((_input: string, key: Key) => {
+    if (key.escape) {
+      onExit();
+    }
+  });
+
   if (privacyState.isLoading) {
     return <Text color={Colors.Gray}>Loading...</Text>;
   }
 
   if (privacyState.error) {
     return (
-      <Text color={Colors.AccentRed}>
-        Error loading Opt-in settings: {privacyState.error}
-      </Text>
+      <Box flexDirection="column" marginBottom={1}>
+        <Text color={Colors.AccentRed}>
+          Error loading Opt-in settings: {privacyState.error}
+        </Text>
+        <Newline />
+        <Text color={Colors.Gray}>Press Esc to exit.</Text>
+      </Box>
     );
   }
 

--- a/packages/cli/src/ui/privacy/CloudFreePrivacyNotice.tsx
+++ b/packages/cli/src/ui/privacy/CloudFreePrivacyNotice.tsx
@@ -27,7 +27,7 @@ export const CloudFreePrivacyNotice = ({
     if (key.escape) {
       onExit();
     }
-  });
+  }, { isActive: privacyState.isLoading || !!privacyState.error });
 
   if (privacyState.isLoading) {
     return <Text color={Colors.Gray}>Loading...</Text>;


### PR DESCRIPTION
Introduces useInput to allow users to exit the CloudFreePrivacyNotice screen by pressing the Escape key. Also updates the error UI to inform users they can press Esc to exit when an error occurs.

## TLDR

Fixes a bug where the `/privacy` command freezes when an error occurs (e.g., "User does not have a current tier"), requiring users to force quit with Ctrl+C. This PR adds consistent error handling by allowing users to exit with Escape key, maintaining consistency with other privacy notice components and slash commands.

Note: This is submitted as an obvious bug fix before feedback, as it addresses a critical user experience issue that blocks normal CLI operation.

## Dive Deeper

The issue was introduced in PR #2059 which implemented the `/privacy` command. When `CloudFreePrivacyNotice` encounters an error loading privacy settings, it displays an error message but provides no way for users to exit - no input handling is available, forcing users to kill the process with Ctrl+C.

This behavior is inconsistent with:
- Other privacy notice components (`CloudPaidPrivacyNotice`, `GeminiPrivacyNotice`) which use `useInput` with Escape key handling
- Other slash commands (`/about`, `/theme`, `/auth`, etc.) which handle errors by adding messages to history and returning to input mode

The fix adds `useInput` hook to handle Escape key presses when errors occur, providing a consistent exit mechanism. The implementation follows the same pattern used in other privacy notice components.

Note: The requirement for Escape key interaction is purely for consistency with other commands. If maintainers prefer a different approach (such as automatically returning to input mode), I'm happy to modify the implementation accordingly.

## Reviewer Test Plan

To reproduce the original bug:
1. Set up an environment where privacy settings fail to load (e.g., GWS Enterprise + GCP Project)
2. Run `/privacy` command
3. Observe that CLI becomes unresponsive when error appears
4. Verify that Ctrl+C is the only way to exit

To test the fix:
1. Apply this change
2. Reproduce the same error condition
3. Verify that pressing Escape key exits the privacy notice and returns to normal input mode
4. Test normal privacy notice flow still works when no errors

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2404 
Closes #2407 
