### PR TITLE
feat(config): Add fallback support for GOOGLE_CLOUD_PROJECT from settings.json

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -64,6 +64,11 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     }
     ```
 
+- **`gcpProjectId`** (string):
+  - **Description:** Fallback for the `GOOGLE_CLOUD_PROJECT` environment variable used by the CLI for Code Assist and Vertex AI features.
+  - **Default:** Not set.
+  - **Example:** `"gcpProjectId": "my-gcp-project-id"`
+
 - **`coreTools`** (array of strings):
   - **Description:** Allows you to specify a list of core tool names that should be made available to the model. This can be used to restrict the set of built-in tools. See [Built-in Tools](../core/tools-api.md#built-in-tools) for a list of core tools. You can also specify command-specific restrictions for tools that support it, like the `ShellTool`. For example, `"coreTools": ["ShellTool(ls -l)"]` will only allow the `ls -l` command to be executed.
   - **Default:** All tools available for use by the Gemini model.
@@ -249,6 +254,7 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
   - Required for using Code Assist or Vertex AI.
   - If using Vertex AI, ensure you have the necessary permissions and set the `GOOGLE_GENAI_USE_VERTEXAI=true` environment variable.
   - Example: `export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"`.
+  - You can also set this in `~/.gemini/settings.json` using the `gcpProjectId` key as a fallback.
 - **`GOOGLE_APPLICATION_CREDENTIALS`** (string):
   - **Description:** The path to your Google Application Credentials JSON file.
   - **Example:** `export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/credentials.json"`

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -6,9 +6,11 @@
 
 import { AuthType } from '@google/gemini-cli-core';
 import { loadEnvironment } from './config.js';
+import { loadSettings } from './settings.js';
 
 export const validateAuthMethod = (authMethod: string): string | null => {
-  loadEnvironment();
+  const settings = loadSettings(process.cwd());
+  loadEnvironment(settings.merged);
   if (authMethod === AuthType.LOGIN_WITH_GOOGLE_PERSONAL) {
     return null;
   }

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -6,10 +6,12 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as os from 'os';
-import { loadCliConfig } from './config.js';
+import { loadCliConfig, loadEnvironment } from './config.js';
 import { Settings } from './settings.js';
 import { Extension } from './extension.js';
 import * as ServerConfig from '@google/gemini-cli-core';
+import { mkdirSync, rmSync } from 'fs';
+import path from 'path';
 
 vi.mock('os', async (importOriginal) => {
   const actualOs = await importOriginal<typeof os>();
@@ -348,5 +350,50 @@ describe('mergeMcpServers', () => {
     const originalSettings = JSON.parse(JSON.stringify(settings));
     await loadCliConfig(settings, extensions, 'test-session');
     expect(settings).toEqual(originalSettings);
+  });
+});
+
+describe('loadEnvironment', () => {
+  const tempHomeDir = path.join(os.tmpdir(), 'gemini-test-home-env');
+  const settingsDir = path.join(tempHomeDir, '.gemini');
+  const originalGoogleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
+
+  beforeEach(() => {
+    // Mock homedir for this test suite
+    vi.spyOn(os, 'homedir').mockReturnValue(tempHomeDir);
+    mkdirSync(settingsDir, { recursive: true });
+    // Reset env var
+    delete process.env.GOOGLE_CLOUD_PROJECT;
+  });
+
+  afterEach(() => {
+    // Clean up created files and mocks
+    rmSync(tempHomeDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    // Restore env var
+    if (originalGoogleCloudProject !== undefined) {
+      process.env.GOOGLE_CLOUD_PROJECT = originalGoogleCloudProject;
+    } else {
+      delete process.env.GOOGLE_CLOUD_PROJECT;
+    }
+  });
+
+  it('should load GOOGLE_CLOUD_PROJECT from gcpProjectId in settings.json', () => {
+    const settings: Settings = { gcpProjectId: 'project-from-settings' };
+    loadEnvironment(settings);
+    expect(process.env.GOOGLE_CLOUD_PROJECT).toBe('project-from-settings');
+  });
+
+  it('should not override an existing GOOGLE_CLOUD_PROJECT environment variable', () => {
+    process.env.GOOGLE_CLOUD_PROJECT = 'existing-project';
+    const settings: Settings = { gcpProjectId: 'project-from-settings' };
+    loadEnvironment(settings);
+    expect(process.env.GOOGLE_CLOUD_PROJECT).toBe('existing-project');
+  });
+
+  it('should not set GOOGLE_CLOUD_PROJECT if gcpProjectId is not a string', () => {
+    const settings: Settings = { gcpProjectId: 12345 as unknown as string };
+    loadEnvironment(settings);
+    expect(process.env.GOOGLE_CLOUD_PROJECT).toBeUndefined();
   });
 });

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -298,7 +298,11 @@ function findEnvFile(startDir: string): string | null {
 export function loadEnvironment(settings: Settings): void {
   const envFilePath = findEnvFile(process.cwd());
   if (envFilePath) {
-    dotenv.config({ path: envFilePath, quiet: true });
+    try {
+      dotenv.config({ path: envFilePath });
+    } catch (_) {
+      logger.warn('Warning: could not parse .env file at', envFilePath);
+    }
   }
 
   // Fallback to settings.json if GOOGLE_CLOUD_PROJECT is not already set

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -27,6 +27,7 @@ import * as dotenv from 'dotenv';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+
 import { loadSandboxConfig } from './sandboxConfig.js';
 
 // Simple console logger for now - replace with actual logger if available
@@ -166,7 +167,7 @@ export async function loadCliConfig(
   extensions: Extension[],
   sessionId: string,
 ): Promise<Config> {
-  loadEnvironment();
+  loadEnvironment(settings);
 
   const argv = await parseArguments();
   const debugMode = argv.debug || false;
@@ -294,9 +295,19 @@ function findEnvFile(startDir: string): string | null {
   }
 }
 
-export function loadEnvironment(): void {
+export function loadEnvironment(settings: Settings): void {
   const envFilePath = findEnvFile(process.cwd());
   if (envFilePath) {
     dotenv.config({ path: envFilePath, quiet: true });
+  }
+
+  // Fallback to settings.json if GOOGLE_CLOUD_PROJECT is not already set
+  if (!process.env.GOOGLE_CLOUD_PROJECT) {
+    if (typeof settings.gcpProjectId === 'string') {
+      const projectId = settings.gcpProjectId.trim();
+      if (projectId) {
+        process.env.GOOGLE_CLOUD_PROJECT = projectId;
+      }
+    }
   }
 }

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -61,6 +61,8 @@ export interface Settings {
     enableRecursiveFileSearch?: boolean;
   };
 
+  gcpProjectId?: string;
+
   // UI setting. Does not display the ANSI-controlled terminal title.
   hideWindowTitle?: boolean;
   hideTips?: boolean;


### PR DESCRIPTION
## TLDR

Adds a fallback mechanism in `config.ts` to populate `GOOGLE_CLOUD_PROJECT`  from `settings.json` in the hierarchy of `project, user` if not already set in the environment. 

## Dive Deeper

This PR enhances the CLI's configuration system for determining the Google Cloud Project ID. The logic is now handled by the primary settings-loading mechanism, which provides a clear and maintainable approach.

Internally, the system now discovers the gcpProjectId by merging configurations from multiple sources in a specific order of precedence:

   1. Environment Variable: The GOOGLE_CLOUD_PROJECT environment variable
      is checked first and used if set.
   2. Project Settings: If the environment variable is not present, the CLI
       looks for a gcpProjectId in the project-specific
      .gemini/settings.json.
   3. User Settings: If neither of the above is found, it falls back to the
       gcpProjectId in the global ~/.gemini/settings.json.

  This ensures that project-specific settings correctly override global user settings, and standard environment variables always take highest priority, aligning with expected command-line tool behavior.

## Reviewer Test Plan

   1. Ensure GOOGLE_CLOUD_PROJECT is not set in your shell environment or
      any .env file.
   2. Add this to your global settings at ~/.gemini/settings.json:
   ```json
   1     {
   2       "gcpProjectId": "user-project-id"
   3     }
  ```

   3. Run the CLI. The application should use user-project-id.
   4. Now, in a separate project directory, create a local
      .gemini/settings.json with:
   ```json
   1     {
   2       "gcpProjectId": "project-override-id"
   3     }
  ```
   5. Run the CLI from within that project directory. The application
      should now use project-override-id.
   6. Finally, set an environment variable: export 
      GOOGLE_CLOUD_PROJECT=env-var-id.
   7. Run the CLI from any directory. The application should use
      env-var-id, confirming it has the highest precedence.


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅ | ✅ |✅|
| npx      | ✅ | ✅ | ✅ |
| Docker   | ✅ | ✅ | ✅ |
| Podman   | ✅ | -   | -   |
| Seatbelt |✅| -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
Fixes #2262 - "GOOGLE_CLOUD_PROJECT env var"
