### PR TITLE
fix: Correct pluralization of the number of occurrences in `EditTool` tool errors

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -486,10 +486,10 @@ describe('EditTool', () => {
       // The default mockEnsureCorrectEdit will return 2 occurrences for 'old'
       const result = await tool.execute(params, new AbortController().signal);
       expect(result.llmContent).toMatch(
-        /Expected 1 occurrences but found 2 for old_string in file/,
+        /Expected 1 occurrence but found 2 for old_string in file/,
       );
       expect(result.returnDisplay).toMatch(
-        /Failed to edit, expected 1 occurrence\(s\) but found 2/,
+        /Failed to edit, expected 1 occurrence but found 2/,
       );
     });
 
@@ -532,7 +532,7 @@ describe('EditTool', () => {
         /Expected 3 occurrences but found 2 for old_string in file/,
       );
       expect(result.returnDisplay).toMatch(
-        /Failed to edit, expected 3 occurrence\(s\) but found 2/,
+        /Failed to edit, expected 3 occurrences but found 2/,
       );
     });
 

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -250,9 +250,11 @@ Expectation for required parameters:
           raw: `Failed to edit, 0 occurrences found for old_string in ${params.file_path}. No edits made. The exact text in old_string was not found. Ensure you're not escaping content incorrectly and check whitespace, indentation, and context. Use ${ReadFileTool.Name} tool to verify.`,
         };
       } else if (occurrences !== expectedReplacements) {
+        const occurenceTerm = expectedReplacements === 1 ? 'occurrence' : 'occurrences';
+
         error = {
-          display: `Failed to edit, expected ${expectedReplacements} occurrence(s) but found ${occurrences}.`,
-          raw: `Failed to edit, Expected ${expectedReplacements} occurrences but found ${occurrences} for old_string in file: ${params.file_path}`,
+          display: `Failed to edit, expected ${expectedReplacements} ${occurenceTerm} but found ${occurrences}.`,
+          raw: `Failed to edit, Expected ${expectedReplacements} ${occurenceTerm} but found ${occurrences} for old_string in file: ${params.file_path}`,
         };
       }
     } else {

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -250,7 +250,8 @@ Expectation for required parameters:
           raw: `Failed to edit, 0 occurrences found for old_string in ${params.file_path}. No edits made. The exact text in old_string was not found. Ensure you're not escaping content incorrectly and check whitespace, indentation, and context. Use ${ReadFileTool.Name} tool to verify.`,
         };
       } else if (occurrences !== expectedReplacements) {
-        const occurenceTerm = expectedReplacements === 1 ? 'occurrence' : 'occurrences';
+        const occurenceTerm =
+          expectedReplacements === 1 ? 'occurrence' : 'occurrences';
 
         error = {
           display: `Failed to edit, expected ${expectedReplacements} ${occurenceTerm} but found ${occurrences}.`,


### PR DESCRIPTION
## TLDR

Currently, errors returned by the edit tool (aka `replace`) - both the message for the LLM and the message to be displayed to the user - use incorrect pluralization, always saying "occurrences" even when there is only 1 occurrences.

This fixes it to use correct English pluralization.

## Dive Deeper

N/A

## Reviewer Test Plan

_Frankly, I'm not sure how to stimulate incorrect use of the edit tool!_

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
