### PR TITLE
feat: Persist "allow always" settings

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -79,6 +79,40 @@ In addition to a project settings file, a project's `.gemini` directory can cont
   - **Default:** `false`
   - **Example:** `"autoAccept": true`
 
+- **`toolAllowList`** (object):
+
+  - **Description:** Configures tools to automatically execute without requiring user confirmation on each invocation. This setting persists across sessions, allowing you to permanently approve tools you trust. The configuration supports different granularities of trust: full tool approval, or approval for specific commands/entries.
+  - **Default:** Empty
+  - **Properties:**
+    - **Tool-level approval** (boolean): Set a tool name to `true` to always allow that tool without confirmation.
+    - **Entry-level approval** (array of strings): For tools that operate on different commands or entries, specify an array of allowed values:
+      - For `run_shell_command`: List specific command roots (e.g., `["ls", "git", "npm"]`). Note that approval is managed per command root, so allowing `"git"` will permit all git commands like `git status`, `git commit`, etc.
+      - For `mcp`: List specific MCP tools or servers. You can specify either:
+        - Specific tools: `"server.tool"` (e.g., `"weather.get_forecast"`, `"database.query"`) to allow individual tools
+        - Entire servers: `"server"` (e.g., `"weather"`, `"database"`) to allow all tools from that server
+  - **Notes:**
+    - **Automatic updates:** When you select "Yes, allow always" during a tool confirmation prompt, the CLI automatically updates this setting. Manual editing of this configuration is rarely needed, as the interactive prompts handle most use cases.
+      - For MCP tools, you may see two different confirmation options: "Yes, always allow tool '[tool]' from server '[server]'" (adds specific tool like `server.tool`) or "Yes, always allow all tools from server '[server]'" (adds the server name to allow all its tools).
+    - Tool-level approval (`true`) takes precedence over entry-level approval for the same tool.
+  - **Example:**
+
+    ```json
+    "toolAllowList": {
+      "web_fetch": true,
+      "write_file": true,
+      "run_shell_command": [
+        "date",
+        "ls",
+        "git",
+        "npm"
+      ],
+      "mcp": [
+        "weather",
+        "database.query_users"
+      ]
+    }
+    ```
+
 - **`theme`** (string):
   - **Description:** Sets the visual [theme](./themes.md) for Gemini CLI.
   - **Default:** `"Default"`

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -13,6 +13,7 @@ import {
   BugCommandSettings,
   TelemetrySettings,
   AuthType,
+  ToolAllowListConfig,
 } from '@google/gemini-cli-core';
 import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
@@ -63,6 +64,9 @@ export interface Settings {
 
   // UI setting. Does not display the ANSI-controlled terminal title.
   hideWindowTitle?: boolean;
+
+  // Persistence for "allow always" tool confirmations.
+  toolAllowList?: Record<string, ToolAllowListConfig>;
 
   // Add other settings here.
 }
@@ -119,7 +123,11 @@ export class LoadedSettings {
   setValue(
     scope: SettingScope,
     key: keyof Settings,
-    value: string | Record<string, MCPServerConfig> | undefined,
+    value:
+      | string
+      | Record<string, MCPServerConfig>
+      | Record<string, ToolAllowListConfig>
+      | undefined,
   ): void {
     const settingsFile = this.forScope(scope);
     // @ts-expect-error - value can be string | Record<string, MCPServerConfig>

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -99,7 +99,12 @@ export async function main() {
   }
 
   const extensions = loadExtensions(workspaceRoot);
-  const config = await loadCliConfig(settings.merged, extensions, sessionId);
+  const config = await loadCliConfig(
+    settings.merged,
+    extensions,
+    sessionId,
+    settings,
+  );
 
   // set default fallback to gemini api key
   // this has to go after load cli because thats where the env is set

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -485,8 +485,10 @@ export class Config {
 
   setToolAlwaysAllowed(tool: Tool | string): void {
     const toolName = typeof tool === 'string' ? tool : tool.name;
-    this.toolAllowList[toolName] = true;
-    this.settingsCallback?.updateSettings('toolAllowList', this.toolAllowList);
+    if (this.toolAllowList[toolName] !== true) {
+      this.toolAllowList[toolName] = true;
+      this.settingsCallback?.updateSettings('toolAllowList', this.toolAllowList);
+    }
   }
 
   setToolAllowedFor(tool: Tool | string, entry: string): void {
@@ -499,6 +501,8 @@ export class Config {
       toolConfirmationConfig.push(entry);
     } else if (toolConfirmationConfig !== true) {
       this.toolAllowList[toolName] = [entry];
+    } else {
+      return;
     }
     this.settingsCallback?.updateSettings('toolAllowList', this.toolAllowList);
   }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -42,6 +42,8 @@ import {
 import { ClearcutLogger } from '../telemetry/clearcut-logger/clearcut-logger.js';
 import { Tool } from '../tools/tools.js';
 
+const TOOL_ALLOW_LIST_KEY = 'toolAllowList';
+
 export enum ApprovalMode {
   DEFAULT = 'default',
   AUTO_EDIT = 'autoEdit',
@@ -487,7 +489,7 @@ export class Config {
     const toolName = typeof tool === 'string' ? tool : tool.name;
     if (this.toolAllowList[toolName] !== true) {
       this.toolAllowList[toolName] = true;
-      this.settingsCallback?.updateSettings('toolAllowList', this.toolAllowList);
+      this.settingsCallback?.updateSettings(TOOL_ALLOW_LIST_KEY, this.toolAllowList);
     }
   }
 
@@ -504,7 +506,7 @@ export class Config {
     } else {
       return;
     }
-    this.settingsCallback?.updateSettings('toolAllowList', this.toolAllowList);
+    this.settingsCallback?.updateSettings(TOOL_ALLOW_LIST_KEY, this.toolAllowList);
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -294,7 +294,10 @@ Expectation for required parameters:
     params: EditToolParams,
     abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false> {
-    if (this.config.getApprovalMode() === ApprovalMode.AUTO_EDIT) {
+    if (
+      this.config.getApprovalMode() === ApprovalMode.AUTO_EDIT ||
+      this.config.isToolAlwaysAllowed(this)
+    ) {
       return false;
     }
     const validationError = this.validateToolParams(params);
@@ -336,6 +339,7 @@ Expectation for required parameters:
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
           this.config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+          this.config.setToolAlwaysAllowed(this);
         }
       },
     };

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -320,6 +320,7 @@ async function connectAndDiscover(
           funcDecl.description ?? '',
           parameterSchema,
           funcDecl.name,
+          toolRegistry.config,
           mcpServerConfig.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC,
           mcpServerConfig.trust,
         ),

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi, Mock } from 'vitest';
+import { ShellTool } from './shell.js';
+import { Config, ApprovalMode } from '../config/config.js';
+import {
+  ToolConfirmationOutcome,
+  ToolExecuteConfirmationDetails,
+} from './tools.js';
+
+describe('ShellTool', () => {
+  let tool: ShellTool;
+  let mockConfig: Config;
+
+  beforeEach(() => {
+    mockConfig = {
+      getTargetDir: () => '/test/dir',
+      getApprovalMode: vi.fn(),
+      setApprovalMode: vi.fn(),
+      isToolAllowedFor: vi.fn(),
+      setToolAllowedFor: vi.fn(),
+      getDebugMode: () => false,
+      getSandbox: () => undefined,
+      getGeminiClient: vi.fn(),
+      getApiKey: () => 'test-key',
+      getModel: () => 'test-model',
+      getQuestion: () => undefined,
+      getFullContext: () => false,
+      getToolDiscoveryCommand: () => undefined,
+      getToolCallCommand: () => undefined,
+      getMcpServerCommand: () => undefined,
+      getMcpServers: () => undefined,
+      getUserAgent: () => 'test-agent',
+      getUserMemory: () => '',
+      setUserMemory: vi.fn(),
+      getGeminiMdFileCount: () => 0,
+      setGeminiMdFileCount: vi.fn(),
+      getToolRegistry: vi.fn(),
+    } as unknown as Config;
+
+    // Reset mocks before each test
+    (mockConfig.getApprovalMode as Mock).mockClear();
+    (mockConfig.isToolAllowedFor as Mock).mockClear();
+    (mockConfig.setToolAllowedFor as Mock).mockClear();
+    (mockConfig.getApprovalMode as Mock).mockReturnValue(ApprovalMode.DEFAULT);
+    (mockConfig.isToolAllowedFor as Mock).mockReturnValue(false);
+
+    tool = new ShellTool(mockConfig);
+  });
+
+  describe('getCommandRoot', () => {
+    it('should extract command root correctly', () => {
+      expect(tool.getCommandRoot('ls -la')).toBe('ls');
+      expect(tool.getCommandRoot('  npm install  ')).toBe('npm');
+      expect(tool.getCommandRoot('git status && echo done')).toBe('git');
+      expect(tool.getCommandRoot('/usr/bin/python3 script.py')).toBe('python3');
+      expect(tool.getCommandRoot('')).toBe('');
+    });
+  });
+
+  describe('validateToolParams', () => {
+    it('should return error for empty command', () => {
+      const result = tool.validateToolParams({ command: '' });
+      expect(result).toBe('Command cannot be empty.');
+    });
+
+    it('should return null for valid command', () => {
+      const result = tool.validateToolParams({ command: 'ls -la' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('shouldConfirmExecute', () => {
+    it('should return false if validation fails', async () => {
+      const params = { command: '' };
+      const result = await tool.shouldConfirmExecute(
+        params,
+        new AbortController().signal,
+      );
+      expect(result).toBe(false);
+    });
+
+    it('should return false if command is already allowed', async () => {
+      (mockConfig.isToolAllowedFor as Mock).mockReturnValue(true);
+
+      const params = { command: 'ls -la' };
+      const result = await tool.shouldConfirmExecute(
+        params,
+        new AbortController().signal,
+      );
+
+      expect(result).toBe(false);
+      expect(mockConfig.isToolAllowedFor).toHaveBeenCalledWith(tool, 'ls');
+    });
+
+    it('should return confirmation details for unallowed command', async () => {
+      const params = { command: 'git status' };
+      const result = await tool.shouldConfirmExecute(
+        params,
+        new AbortController().signal,
+      );
+
+      expect(result).not.toBe(false);
+      if (result && typeof result === 'object' && result.type === 'exec') {
+        const execResult = result as ToolExecuteConfirmationDetails;
+        expect(execResult.type).toBe('exec');
+        expect(execResult.title).toBe('Confirm Shell Command');
+        expect(execResult.command).toBe('git status');
+        expect(execResult.rootCommand).toBe('git');
+        expect(typeof execResult.onConfirm).toBe('function');
+      }
+    });
+  });
+
+  describe('allow always functionality', () => {
+    it('should call setToolAllowedFor when onConfirm is called with ProceedAlways', async () => {
+      const params = { command: 'npm install' };
+      const confirmation = await tool.shouldConfirmExecute(
+        params,
+        new AbortController().signal,
+      );
+
+      expect(confirmation).not.toBe(false);
+
+      if (
+        confirmation &&
+        typeof confirmation === 'object' &&
+        'onConfirm' in confirmation &&
+        typeof confirmation.onConfirm === 'function'
+      ) {
+        await confirmation.onConfirm(ToolConfirmationOutcome.ProceedAlways);
+        expect(mockConfig.setToolAllowedFor).toHaveBeenCalledWith(tool, 'npm');
+      } else {
+        throw new Error(
+          'Confirmation details or onConfirm not in expected format',
+        );
+      }
+    });
+
+    it('should not call setToolAllowedFor when onConfirm is called with ProceedOnce', async () => {
+      const params = { command: 'git status' };
+      const confirmation = await tool.shouldConfirmExecute(
+        params,
+        new AbortController().signal,
+      );
+
+      expect(confirmation).not.toBe(false);
+
+      if (
+        confirmation &&
+        typeof confirmation === 'object' &&
+        'onConfirm' in confirmation &&
+        typeof confirmation.onConfirm === 'function'
+      ) {
+        await confirmation.onConfirm(ToolConfirmationOutcome.ProceedOnce);
+        expect(mockConfig.setToolAllowedFor).not.toHaveBeenCalled();
+      } else {
+        throw new Error(
+          'Confirmation details or onConfirm not in expected format',
+        );
+      }
+    });
+
+    it('should not add to allowlist when command is already allowed', async () => {
+      (mockConfig.isToolAllowedFor as Mock).mockReturnValue(true);
+
+      const params = { command: 'ls -la' };
+      await tool.shouldConfirmExecute(params, new AbortController().signal);
+
+      expect(mockConfig.setToolAllowedFor).not.toHaveBeenCalled();
+    });
+
+    it('should check allowlist with correct command root', async () => {
+      const params = { command: '/usr/bin/python3 -m pip install package' };
+      await tool.shouldConfirmExecute(params, new AbortController().signal);
+
+      expect(mockConfig.isToolAllowedFor).toHaveBeenCalledWith(tool, 'python3');
+    });
+  });
+
+  describe('getDescription', () => {
+    it('should return command description', () => {
+      const params = { command: 'ls -la' };
+      const result = tool.getDescription(params);
+      expect(result).toBe('ls -la');
+    });
+
+    it('should include directory in description', () => {
+      const params = { command: 'npm install', directory: 'subfolder' };
+      const result = tool.getDescription(params);
+      expect(result).toBe('npm install [in subfolder]');
+    });
+
+    it('should include custom description', () => {
+      const params = { command: 'git commit', description: 'Commit changes' };
+      const result = tool.getDescription(params);
+      expect(result).toBe('git commit (Commit changes)');
+    });
+
+    it('should include both directory and description', () => {
+      const params = {
+        command: 'npm test',
+        directory: 'packages/core',
+        description: 'Run tests for core package',
+      };
+      const result = tool.getDescription(params);
+      expect(result).toBe(
+        'npm test [in packages/core] (Run tests for core package)',
+      );
+    });
+  });
+});

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -31,7 +31,6 @@ const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 
 export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
   static Name: string = 'run_shell_command';
-  private whitelist: Set<string> = new Set();
 
   constructor(private readonly config: Config) {
     super(
@@ -136,7 +135,7 @@ Process Group PGID: Process group started or \`(none)\``,
       return false; // skip confirmation, execute call will fail immediately
     }
     const rootCommand = this.getCommandRoot(params.command)!; // must be non-empty string post-validation
-    if (this.whitelist.has(rootCommand)) {
+    if (this.config.isToolAllowedFor(this, rootCommand)) {
       return false; // already approved and whitelisted
     }
     const confirmationDetails: ToolExecuteConfirmationDetails = {
@@ -146,7 +145,7 @@ Process Group PGID: Process group started or \`(none)\``,
       rootCommand,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
-          this.whitelist.add(rootCommand);
+          this.config.setToolAllowedFor(this, rootCommand);
         }
       },
     };

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -124,7 +124,7 @@ Signal: Signal number or \`(none)\` if no signal was received.
 export class ToolRegistry {
   private tools: Map<string, Tool> = new Map();
   private discovery: Promise<void> | null = null;
-  private config: Config;
+  config: Config;
 
   constructor(config: Config) {
     this.config = config;

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -181,7 +181,10 @@ ${textContent}
   async shouldConfirmExecute(
     params: WebFetchToolParams,
   ): Promise<ToolCallConfirmationDetails | false> {
-    if (this.config.getApprovalMode() === ApprovalMode.AUTO_EDIT) {
+    if (
+      this.config.getApprovalMode() === ApprovalMode.AUTO_EDIT ||
+      this.config.isToolAlwaysAllowed(this)
+    ) {
       return false;
     }
 
@@ -209,6 +212,7 @@ ${textContent}
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
           this.config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+          this.config.setToolAlwaysAllowed(this);
         }
       },
     };

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -162,7 +162,10 @@ export class WriteFileTool
     params: WriteFileToolParams,
     abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false> {
-    if (this.config.getApprovalMode() === ApprovalMode.AUTO_EDIT) {
+    if (
+      this.config.getApprovalMode() === ApprovalMode.AUTO_EDIT ||
+      this.config.isToolAlwaysAllowed(this)
+    ) {
       return false;
     }
 
@@ -206,6 +209,7 @@ export class WriteFileTool
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
           this.config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+          this.config.setToolAlwaysAllowed(this);
         }
       },
     };


### PR DESCRIPTION
## TLDR

This Pull Request adds persistence to the existing "allow always" functionality for tool confirmations via the new `toolAllowList` configuration setting. When users select "Yes, allow always" during tool confirmation prompts, the setting is now automatically saved to the CLI configuration and persists across sessions, eliminating the need for repeated confirmations of trusted tools.

## Dive Deeper

### Key Changes

- **Persistent tool allowlisting**: Extended the existing "allow always" confirmation option to persist across CLI sessions through the new `toolAllowList` configuration setting
- **Granular approval control**: Different tools support different granularities:
  - **Shell commands**: Per command root (e.g., `"git"` allows all git commands)
  - **MCP tools**: Per specific tool (`"server.tool"`) or per entire server (`"server"`)
  - **Other tools**: Full tool approval

### Technical Implementation

- Enhanced existing tool confirmation dialogs to persist "allow always" selections in `toolAllowList`
- Added callback mechanism from CLI config to core server config to enable runtime settings updates

### Test Coverage Additions

- Created `shell.test.ts` (previously missing) with tests for both existing shell tool functionality and new persistence features
- Enhanced existing test files (`edit.test.ts`, `write-file.test.ts`, `web-fetch.test.ts`, `mcp-tool.test.ts`) to cover the new "allow always" persistence behavior

### Question for Reviewers

The codebase contains `setApprovalMode(ApprovalMode.AUTO_EDIT)` calls that I've left untouched. These seem redundant with the new allowlist functionality - should these be removed or do they serve a different purpose?

## Reviewer Test Plan

Test the enhanced "allow always" persistence with these tools:

1. **EditTool**: Try editing files and select "allow always" - verify it persists across sessions
2. **WriteFileTool**: Test file creation/modification with persistent approval
3. **WebFetchTool**: Test web requests with "allow always" option
4. **ShellTool**: Test shell command approval per command root (e.g., allow `git` for all git commands)
5. **DiscoveredMCPTool**: Test both per-tool and per-server approval options

### Test Scenarios

- Start a new CLI session, use a tool, select "allow always"
- Restart CLI and verify the tool no longer prompts for confirmation
- Check that `~/.gemini/settings.json` or `.gemini/settings.json` contains the expected `toolAllowList` entries
- Test both tool-level (`true`) and entry-level (array) configurations
- Verify that tool-level approval takes precedence over entry-level approval

### Documentation Validation

- Review the updated configuration documentation in `docs/cli/configuration.md`
- Verify examples match actual behavior
- Test the interactive confirmation prompts match the documented behavior

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #1215