### PR TITLE
feat: add support to remote MCP servers for custom HTTP headers

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -87,6 +87,7 @@ Each server configuration supports the following properties:
 #### Optional
 
 - **`args`** (string[]): Command-line arguments for Stdio transport
+- **`headers`** (object): Custom HTTP headers when using `httpUrl`
 - **`env`** (object): Environment variables for the server process. Values can reference environment variables using `$VAR_NAME` or `${VAR_NAME}` syntax
 - **`cwd`** (string): Working directory for Stdio transport
 - **`timeout`** (number): Request timeout in milliseconds (default: 600,000ms = 10 minutes)
@@ -160,6 +161,24 @@ Each server configuration supports the following properties:
   "mcpServers": {
     "httpServer": {
       "httpUrl": "http://localhost:3000/mcp",
+      "timeout": 5000
+    }
+  }
+}
+```
+
+#### HTTP-based MCP Server with Custom Headers
+
+```json
+{
+  "mcpServers": {
+    "httpServerWithAuth": {
+      "httpUrl": "http://localhost:3000/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-token",
+        "X-Custom-Header": "custom-value",
+        "Content-Type": "application/json"
+      },
       "timeout": 5000
     }
   }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -73,6 +73,7 @@ export class MCPServerConfig {
     readonly url?: string,
     // For streamable http transport
     readonly httpUrl?: string,
+    readonly headers?: Record<string, string>,
     // For websocket transport
     readonly tcp?: string,
     // Common

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -7,7 +7,10 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPClientTransportOptions,
+} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { parse } from 'shell-quote';
 import { MCPServerConfig } from '../config/config.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
@@ -169,8 +172,17 @@ async function connectAndDiscover(
 
   let transport;
   if (mcpServerConfig.httpUrl) {
+    const transportOptions: StreamableHTTPClientTransportOptions = {};
+
+    if (mcpServerConfig.headers) {
+      transportOptions.requestInit = {
+        headers: mcpServerConfig.headers,
+      };
+    }
+
     transport = new StreamableHTTPClientTransport(
       new URL(mcpServerConfig.httpUrl),
+      transportOptions,
     );
   } else if (mcpServerConfig.url) {
     transport = new SSEClientTransport(new URL(mcpServerConfig.url));
@@ -222,10 +234,11 @@ async function connectAndDiscover(
     const safeConfig = {
       command: mcpServerConfig.command,
       url: mcpServerConfig.url,
+      httpUrl: mcpServerConfig.httpUrl,
       cwd: mcpServerConfig.cwd,
       timeout: mcpServerConfig.timeout,
       trust: mcpServerConfig.trust,
-      // Exclude args and env which may contain sensitive data
+      // Exclude args, env, and headers which may contain sensitive data
     };
 
     let errorString =


### PR DESCRIPTION
## TLDR

This allows the GitHub MCP server to work with personal access tokens, for example if you have this in your `~/.gemini/settings.json`:

```json
{
  ...
  "mcpServers": {
    "github": {
      "httpUrl": "https://api.githubcopilot.com/mcp/",
      "headers": {
        "Authorization": "Bearer <INSERT GITHUB ACCESS TOKEN HERE>"
      }
    }
  }
}
```

## Dive Deeper

This doesn't support a full OAuth flow, but at least it makes some MCP servers such as the GitHub one usable.  See #2046 and #2173.

## Reviewer Test Plan

- Create a GitHub personal access token via https://github.com/settings/tokens (classic is probably easier than fine-grained, since there are less things to configure and it applies to any repo you can access through your GitHub account)
- Add it to your `~/.gemini/settings.json` as per above
- Start up a build of gemini-cli with the code from this PR
- The GitHub MCP server should now be active (e.g. press `Ctrl-t` to see tools)
- Ask it to list the latest PRs or something like that
- Observe it fetching data via the `list_pull_requests` tool
- For bonus points, try it from a private repo

## Testing Matrix

(I don't have access to MacOS or Windows, sorry.)

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ✅  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This should be a step in the right direction towards solving OAuth in general, as per:

- #2046
- #2173