### PR TITLE
chore(gha): pin issue triage workflow to a specific commit

### DIFF
--- a/.github/workflows/gemini-issue-triage.yml
+++ b/.github/workflows/gemini-issue-triage.yml
@@ -28,7 +28,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Run Gemini Issue Triage
-        uses: google-gemini/gemini-cli-action@main
+        uses: google-gemini/gemini-cli-action@238438ee44e83c7f97a1a9bb61e62853cebe9767
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         with:


### PR DESCRIPTION
This allows us to easily make changes to the action without impacting the triage workflow
