### PR TITLE
feat: add /model command for manual model selection

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -18,6 +18,8 @@ import {
   MCPServerStatus,
   getMCPDiscoveryState,
   getMCPServerStatus,
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_GEMINI_FLASH_MODEL,
 } from '@google/gemini-cli-core';
 import { useSessionStats } from '../contexts/SessionContext.js';
 import {
@@ -589,6 +591,62 @@ export const useSlashCommandProcessor = (
         name: 'corgi',
         action: (_mainCommand, _subCommand, _args) => {
           toggleCorgiMode();
+        },
+      },
+      {
+        name: 'model',
+        description: `change the model. Usage: /model [${DEFAULT_GEMINI_MODEL}|${DEFAULT_GEMINI_FLASH_MODEL}]`,
+        action: (_mainCommand, subCommand, _args) => {
+          if (!config) {
+            addMessage({
+              type: MessageType.ERROR,
+              content: 'Configuration not available',
+              timestamp: new Date(),
+            });
+            return;
+          }
+
+          const currentModel = config.getModel();
+          
+          if (!subCommand) {
+            addMessage({
+              type: MessageType.INFO,
+              content: `Current model: ${currentModel}`,
+              timestamp: new Date(),
+            });
+            return;
+          }
+
+          // Normalize the input
+          const normalizedModel = subCommand.toLowerCase();
+          const validModels = [DEFAULT_GEMINI_MODEL, DEFAULT_GEMINI_FLASH_MODEL];
+          
+          if (!validModels.includes(normalizedModel)) {
+            addMessage({
+              type: MessageType.ERROR,
+              content: `Invalid model: ${subCommand}\nValid options: ${validModels.join(', ')}`,
+              timestamp: new Date(),
+            });
+            return;
+          }
+
+          if (normalizedModel === currentModel) {
+            addMessage({
+              type: MessageType.INFO,
+              content: `Already using ${currentModel}`,
+              timestamp: new Date(),
+            });
+            return;
+          }
+
+          config.setModel(normalizedModel);
+          
+          // Provide feedback similar to the automatic switching message
+          addMessage({
+            type: MessageType.INFO,
+            content: `Switched from ${currentModel} to ${normalizedModel}`,
+            timestamp: new Date(),
+          });
         },
       },
       {


### PR DESCRIPTION
## TLDR

  Add /model slash command to allow users to manually switch between gemini-2.5-pro and gemini-2.5-flash models during an interactive session. This gives users control over model selection without restarting the CLI, complementing the existing --model  flag which only sets the initial model.

## Dive Deeper

  Currently, users face two limitations with model selection:
  1. The --model CLI flag only sets the model at startup
  2. Automatic fallback to Flash only triggers after hitting rate limits with error messages

  This change addresses user feedback requesting more control over model selection by adding a /model command that:
  - Shows the current model when typed without arguments
  - Allows switching between Pro and Flash models on demand
  - Validates input and provides clear error messages
  - Uses the same Config.setModel() API as the automatic fallback mechanism

  The implementation imports model constants from @google/gemini-cli-core for consistency and follows existing slash command patterns in the codebase. The command appears automatically in the /help menu.

## Reviewer Test Plan

  1. Build and run the CLI:
  npm install
  npm run build
  npm start
  2. Test the /model command:
    - Type /model - should show current model (default: gemini-2.5-pro)
    - Type /model gemini-2.5-flash - should switch to Flash model
    - Type /model gemini-2.5-pro - should switch back to Pro model
    - Type /model invalid-model - should show error with valid options
    - Type /model gemini-2.5-flash when already on Flash - should show "Already using" message
  3. Test interaction with --model flag:
  npm start -- --model gemini-2.5-flash
    - Type /model - should show gemini-2.5-flash as current
    - Switch models and verify the change persists for the session
  4. Test with rate limiting (if you have a rate-limited account):
    - Use Pro model until hitting rate limits
    - Use /model gemini-2.5-flash to manually switch before automatic fallback
    - Verify you can continue working without hitting limits

## Testing Matrix


|          | 🍏  | 🪟  | 🐧  |
|----------|-----|-----|-----|
| npm run  | ✅   | ❓   | ✅   |
| npx      | ✅   | ❓   | ✅   |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Note: Tested on Linux and MacOS. The change is platform-agnostic (pure TypeScript) so should work identically on all platforms.

## Linked issues / bugs

  N/A - This is a feature enhancement based on user feedback about model selection flexibility.
