### PR TITLE
Esc to exit privacy screen in error state

### DIFF
--- a/packages/cli/src/ui/privacy/CloudFreePrivacyNotice.tsx
+++ b/packages/cli/src/ui/privacy/CloudFreePrivacyNotice.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Box, Newline, Text } from 'ink';
+import { Box, Newline, Text, useInput } from 'ink';
 import { RadioButtonSelect } from '../components/shared/RadioButtonSelect.js';
 import { usePrivacySettings } from '../hooks/usePrivacySettings.js';
 import { CloudPaidPrivacyNotice } from './CloudPaidPrivacyNotice.js';
@@ -23,15 +23,24 @@ export const CloudFreePrivacyNotice = ({
   const { privacyState, updateDataCollectionOptIn } =
     usePrivacySettings(config);
 
+  useInput((input, key) => {
+    if (privacyState.error && key.escape) {
+      onExit();
+    }
+  });
+
   if (privacyState.isLoading) {
     return <Text color={Colors.Gray}>Loading...</Text>;
   }
 
   if (privacyState.error) {
     return (
-      <Text color={Colors.AccentRed}>
-        Error loading Opt-in settings: {privacyState.error}
-      </Text>
+      <Box flexDirection="column" marginY={1}>
+        <Text color={Colors.AccentRed}>
+          Error loading Opt-in settings: {privacyState.error}
+        </Text>
+        <Text color={Colors.Gray}>Press Esc to exit.</Text>
+      </Box>
     );
   }
 


### PR DESCRIPTION
## TLDR

Allow users to exit the privacy screen by pressing escape when there is an error being displayed.

## Deeper Dive

Anjali is experiencing an issue causing the privacy screen to error out. We don't know if this is effecting many other people, but wether it is or not, when there is an error on the privacy screen people should be able to exit out of the privacy screen without restarting the cli.

## Reviewer Test Plan

Log in with a personal account and turn off your internet connection before executing /privacy

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | x  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs


