### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+indent_size = 2
+max_line_length = 80
+
+[Makefile]
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
## TLDR

Add an `.editorconfig` file so that all contributors' code editors will automatically conform to the existing whitespace style, even before prettier is run.

## Dive Deeper

Using editorconfig is standard best practice, especially on popular FOSS repos which have a large number of contributors using a diverse range of IDEs and other editors (including web-based IDEs).  Prettier even [takes default settings from an `.editorconfig` file if it's present](https://prettier.io/docs/configuration#editorconfig).

See https://editorconfig.org/ for more details.

## Reviewer Test Plan

- Check out this PR branch in your local working tree.
- Open any of [the editors with built-in editorconfig
  support](https://editorconfig.org/#pre-installed), or ensure that you have
  [the necessary plugin](https://editorconfig.org/#editor-plugins) installed
  (e.g. for VS code or Cursor use [this
  extension](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)).
- As an experiment, set the editor's default indentation to something other
  than 2 columns, and/or line wrap to something other than 80 columns.
- Load a Typescript file from this repo.
- Observe that the editor auto-configures to match the existing repository
  style.  For example indentation will auto-configure to 2 columns within the
  gemini-cli regardless of the global setting, and similarly for line wrapping
  which will match `printWidth` being set to 80 in `.prettierrc.json`.

## Testing Matrix

Normal testing matrix does not apply, but this has been tested in Cursor and emacs.

## Linked issues / bugs

None - found no prior references to editorconfig anywhere in the repo / issues / PRs, and felt it was overkill to create an issue for such a simple change as it can simply be discussed in the PR.