### PR TITLE
fix: Update Help shortcut label to Ctrl+Enter for new line to match InputPrompt behavior

### DIFF
--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -97,7 +97,7 @@ export const Help: React.FC<Help> = ({ commands }) => (
     </Text>
     <Text color={Colors.Foreground}>
       <Text bold color={Colors.AccentPurple}>
-        Ctrl+Enter
+        Ctrl/Cmd+Enter
       </Text>{' '}
       - New line
     </Text>

--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -97,7 +97,7 @@ export const Help: React.FC<Help> = ({ commands }) => (
     </Text>
     <Text color={Colors.Foreground}>
       <Text bold color={Colors.AccentPurple}>
-        Shift+Enter
+        Ctrl+Enter
       </Text>{' '}
       - New line
     </Text>


### PR DESCRIPTION
## TLDR

This pull request corrects the keyboard shortcut label for inserting a new line in the Help screen from "Shift+Enter" to "Ctrl+Enter".  
This change aligns the Help text with the actual behavior in the InputPrompt component, where "Ctrl+Enter" is used for line breaks.

```
// packages/cli/src/ui/components/InputPrompt.tsx 
// line 293

if (key.name === 'return') {
        const [row, col] = buffer.cursor;
        const line = buffer.lines[row];
        const charBefore = col > 0 ? cpSlice(line, col - 1, col) : '';
        if (key.ctrl || key.meta || charBefore === '\\' || key.paste) {
          // Ctrl+Enter or escaped newline
          if (charBefore === '\\') {
            buffer.backspace();
          }
          buffer.newline();
        } else {
          // Enter for submit
          if (query.trim()) {
            handleSubmitAndClear(query);
          }
        }
        return;
      }
```

## Dive Deeper

- Only the user-facing label in `Help.tsx` was changed; no logic or functionality was modified.
- The update ensures consistency between the Help UI and the actual shortcut implemented in the InputPrompt code.
- This helps prevent confusion for users regarding keyboard shortcuts.

## Reviewer Test Plan

- Run the CLI and open the Help screen.
- Confirm that the shortcut for "New line" now displays as "Ctrl+Enter" instead of "Shift+Enter".
- Optionally, test the input prompt to verify that "Ctrl+Enter" inserts a new line as described.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ✅  | ❓  | ❓  |
| Podman   | ✅  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
Fixes #2588