### PR TITLE
Fix a heading issue for Authentication Setup doc

### DIFF
--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -1,4 +1,4 @@
-## Authentication Setup
+# Authentication Setup
 
 The Gemini CLI requires you to authenticate with Google's AI services. On initial startup you'll need to configure **one** of the following authentication methods:
 


### PR DESCRIPTION
## TLDR

The Authentication Setup doc contains a wrong H1 heading. I just fixed it.

