### PR TITLE
Added obfuscated google account ID to clearcut log messages

### DIFF
--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getOauthClient, getCachedGaiaId } from './oauth2.js';
+import { getOauthClient, getCachedGoogleAccountId } from './oauth2.js';
 import { OAuth2Client } from 'google-auth-library';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -73,7 +73,7 @@ describe('oauth2', () => {
     // Mock the UserInfo API response
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
-      json: vi.fn().mockResolvedValue({ id: 'test-gaia-id-123' }),
+      json: vi.fn().mockResolvedValue({ id: 'test-google-account-id-123' }),
     } as unknown as Response);
 
     let requestCallback!: http.RequestListener<
@@ -140,13 +140,17 @@ describe('oauth2', () => {
     const tokenData = JSON.parse(fs.readFileSync(tokenPath, 'utf-8'));
     expect(tokenData).toEqual(mockTokens);
 
-    // Verify GAIA ID was cached
-    const gaiaIdPath = path.join(tempHomeDir, '.gemini', 'gaia_id');
-    expect(fs.existsSync(gaiaIdPath)).toBe(true);
-    const cachedGaiaId = fs.readFileSync(gaiaIdPath, 'utf-8');
-    expect(cachedGaiaId).toBe('test-gaia-id-123');
+    // Verify Google Account ID was cached
+    const googleAccountIdPath = path.join(
+      tempHomeDir,
+      '.gemini',
+      'google_account_id',
+    );
+    expect(fs.existsSync(googleAccountIdPath)).toBe(true);
+    const cachedGoogleAccountId = fs.readFileSync(googleAccountIdPath, 'utf-8');
+    expect(cachedGoogleAccountId).toBe('test-google-account-id-123');
 
-    // Verify the getCachedGaiaId function works
-    expect(getCachedGaiaId()).toBe('test-gaia-id-123');
+    // Verify the getCachedGoogleAccountId function works
+    expect(getCachedGoogleAccountId()).toBe('test-google-account-id-123');
   });
 });

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -55,7 +55,9 @@ describe('oauth2', () => {
     const mockGenerateAuthUrl = vi.fn().mockReturnValue(mockAuthUrl);
     const mockGetToken = vi.fn().mockResolvedValue({ tokens: mockTokens });
     const mockSetCredentials = vi.fn();
-    const mockGetAccessToken = vi.fn().mockResolvedValue({ token: 'mock-access-token' });
+    const mockGetAccessToken = vi
+      .fn()
+      .mockResolvedValue({ token: 'mock-access-token' });
     const mockOAuth2Client = {
       generateAuthUrl: mockGenerateAuthUrl,
       getToken: mockGetToken,
@@ -67,7 +69,7 @@ describe('oauth2', () => {
 
     vi.spyOn(crypto, 'randomBytes').mockReturnValue(mockState as never);
     vi.mocked(open).mockImplementation(async () => ({}) as never);
-    
+
     // Mock the UserInfo API response
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getOauthClient } from './oauth2.js';
+import { getOauthClient, getCachedGaiaId } from './oauth2.js';
 import { OAuth2Client } from 'google-auth-library';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -26,6 +26,9 @@ vi.mock('google-auth-library');
 vi.mock('http');
 vi.mock('open');
 vi.mock('crypto');
+
+// Mock fetch globally
+global.fetch = vi.fn();
 
 describe('oauth2', () => {
   let tempHomeDir: string;
@@ -52,16 +55,24 @@ describe('oauth2', () => {
     const mockGenerateAuthUrl = vi.fn().mockReturnValue(mockAuthUrl);
     const mockGetToken = vi.fn().mockResolvedValue({ tokens: mockTokens });
     const mockSetCredentials = vi.fn();
+    const mockGetAccessToken = vi.fn().mockResolvedValue({ token: 'mock-access-token' });
     const mockOAuth2Client = {
       generateAuthUrl: mockGenerateAuthUrl,
       getToken: mockGetToken,
       setCredentials: mockSetCredentials,
+      getAccessToken: mockGetAccessToken,
       credentials: mockTokens,
     } as unknown as OAuth2Client;
     vi.mocked(OAuth2Client).mockImplementation(() => mockOAuth2Client);
 
     vi.spyOn(crypto, 'randomBytes').mockReturnValue(mockState as never);
     vi.mocked(open).mockImplementation(async () => ({}) as never);
+    
+    // Mock the UserInfo API response
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ id: 'test-gaia-id-123' }),
+    } as unknown as Response);
 
     let requestCallback!: http.RequestListener<
       typeof http.IncomingMessage,
@@ -126,5 +137,14 @@ describe('oauth2', () => {
     const tokenPath = path.join(tempHomeDir, '.gemini', 'oauth_creds.json');
     const tokenData = JSON.parse(fs.readFileSync(tokenPath, 'utf-8'));
     expect(tokenData).toEqual(mockTokens);
+
+    // Verify GAIA ID was cached
+    const gaiaIdPath = path.join(tempHomeDir, '.gemini', 'gaia_id');
+    expect(fs.existsSync(gaiaIdPath)).toBe(true);
+    const cachedGaiaId = fs.readFileSync(gaiaIdPath, 'utf-8');
+    expect(cachedGaiaId).toBe('test-gaia-id-123');
+
+    // Verify the getCachedGaiaId function works
+    expect(getCachedGaiaId()).toBe('test-gaia-id-123');
   });
 });

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -41,7 +41,7 @@ const SIGN_IN_FAILURE_URL =
 
 const GEMINI_DIR = '.gemini';
 const CREDENTIAL_FILENAME = 'oauth_creds.json';
-const GAIA_ID_FILENAME = 'gaia_id';
+const GOOGLE_ACCOUNT_ID_FILENAME = 'google_account_id';
 
 /**
  * An Authentication URL for updating the credentials of a Oauth2Client
@@ -61,16 +61,16 @@ export async function getOauthClient(): Promise<OAuth2Client> {
 
   if (await loadCachedCredentials(client)) {
     // Found valid cached credentials.
-    // Check if we need to retrieve GAIA ID
-    if (!getCachedGaiaId()) {
+    // Check if we need to retrieve Google Account ID
+    if (!getCachedGoogleAccountId()) {
       try {
-        const gaiaId = await getGaiaId(client);
-        if (gaiaId) {
-          await cacheGaiaId(gaiaId);
+        const googleAccountId = await getGoogleAccountId(client);
+        if (googleAccountId) {
+          await cacheGoogleAccountId(googleAccountId);
         }
       } catch (error) {
         console.error(
-          'Failed to retrieve GAIA ID for existing credentials:',
+          'Failed to retrieve Google Account ID for existing credentials:',
           error,
         );
         // Continue with existing auth flow
@@ -132,18 +132,18 @@ async function authWithWeb(client: OAuth2Client): Promise<OauthWebLogin> {
           client.setCredentials(tokens);
           await cacheCredentials(client.credentials);
 
-          // Retrieve and cache GAIA ID during authentication
+          // Retrieve and cache Google Account ID during authentication
           try {
-            const gaiaId = await getGaiaId(client);
-            if (gaiaId) {
-              await cacheGaiaId(gaiaId);
+            const googleAccountId = await getGoogleAccountId(client);
+            if (googleAccountId) {
+              await cacheGoogleAccountId(googleAccountId);
             }
           } catch (error) {
             console.error(
-              'Failed to retrieve GAIA ID during authentication:',
+              'Failed to retrieve Google Account ID during authentication:',
               error,
             );
-            // Don't fail the auth flow if GAIA ID retrieval fails
+            // Don't fail the auth flow if Google Account ID retrieval fails
           }
 
           res.writeHead(HTTP_REDIRECT, { Location: SIGN_IN_SUCCESS_URL });
@@ -223,19 +223,19 @@ function getCachedCredentialPath(): string {
   return path.join(os.homedir(), GEMINI_DIR, CREDENTIAL_FILENAME);
 }
 
-function getGaiaIdCachePath(): string {
-  return path.join(os.homedir(), GEMINI_DIR, GAIA_ID_FILENAME);
+function getGoogleAccountIdCachePath(): string {
+  return path.join(os.homedir(), GEMINI_DIR, GOOGLE_ACCOUNT_ID_FILENAME);
 }
 
-async function cacheGaiaId(gaiaId: string): Promise<void> {
-  const filePath = getGaiaIdCachePath();
+async function cacheGoogleAccountId(googleAccountId: string): Promise<void> {
+  const filePath = getGoogleAccountIdCachePath();
   await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, gaiaId, 'utf-8');
+  await fs.writeFile(filePath, googleAccountId, 'utf-8');
 }
 
-export function getCachedGaiaId(): string | null {
+export function getCachedGoogleAccountId(): string | null {
   try {
-    const filePath = getGaiaIdCachePath();
+    const filePath = getGoogleAccountIdCachePath();
     // eslint-disable-next-line @typescript-eslint/no-require-imports, no-restricted-syntax
     const fs_sync = require('fs');
     if (fs_sync.existsSync(filePath)) {
@@ -250,19 +250,21 @@ export function getCachedGaiaId(): string | null {
 export async function clearCachedCredentialFile() {
   try {
     await fs.rm(getCachedCredentialPath(), { force: true });
-    // Clear the GAIA ID cache when credentials are cleared
-    await fs.rm(getGaiaIdCachePath(), { force: true });
+    // Clear the Google Account ID cache when credentials are cleared
+    await fs.rm(getGoogleAccountIdCachePath(), { force: true });
   } catch (_) {
     /* empty */
   }
 }
 
 /**
- * Retrieves the authenticated user's GAIA ID from Google's UserInfo API.
+ * Retrieves the authenticated user's Google Account ID from Google's UserInfo API.
  * @param client - The authenticated OAuth2Client
- * @returns The user's GAIA ID (Google Account ID) or null if not available
+ * @returns The user's Google Account ID or null if not available
  */
-export async function getGaiaId(client: OAuth2Client): Promise<string | null> {
+export async function getGoogleAccountId(
+  client: OAuth2Client,
+): Promise<string | null> {
   try {
     const { token } = await client.getAccessToken();
     if (!token) {
@@ -290,7 +292,7 @@ export async function getGaiaId(client: OAuth2Client): Promise<string | null> {
     const userInfo = await response.json();
     return userInfo.id || null;
   } catch (error) {
-    console.error('Error retrieving GAIA ID:', error);
+    console.error('Error retrieving Google Account ID:', error);
     return null;
   }
 }

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -249,9 +249,9 @@ export function getCachedGaiaId(): string | null {
 
 export async function clearCachedCredentialFile() {
   try {
-    await fs.rm(getCachedCredentialPath());
+    await fs.rm(getCachedCredentialPath(), { force: true });
     // Clear the GAIA ID cache when credentials are cleared
-    await fs.rm(getGaiaIdCachePath());
+    await fs.rm(getGaiaIdCachePath(), { force: true });
   } catch (_) {
     /* empty */
   }

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -17,7 +17,8 @@ import {
 } from '../types.js';
 import { EventMetadataKey } from './event-metadata-key.js';
 import { Config } from '../../config/config.js';
-import { getPersistentUserId } from '../../utils/user_id.js';
+import { getInstallationId } from '../../utils/user_id.js';
+import { getObfuscatedGaiaId } from '../../utils/user_id.js';
 
 const start_session_event_name = 'start_session';
 const new_prompt_event_name = 'new_prompt';
@@ -69,7 +70,8 @@ export class ClearcutLogger {
       console_type: 'GEMINI_CLI',
       application: 102,
       event_name: name,
-      client_install_id: getPersistentUserId(),
+      obfuscated_gaia_id: getObfuscatedGaiaId(),
+      client_install_id: getInstallationId(),
       event_metadata: [data] as object[],
     };
   }

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -18,7 +18,7 @@ import {
 import { EventMetadataKey } from './event-metadata-key.js';
 import { Config } from '../../config/config.js';
 import { getInstallationId } from '../../utils/user_id.js';
-import { getObfuscatedGaiaId } from '../../utils/user_id.js';
+import { getObfuscatedGoogleAccountId } from '../../utils/user_id.js';
 
 const start_session_event_name = 'start_session';
 const new_prompt_event_name = 'new_prompt';
@@ -70,7 +70,7 @@ export class ClearcutLogger {
       console_type: 'GEMINI_CLI',
       application: 102,
       event_name: name,
-      obfuscated_gaia_id: getObfuscatedGaiaId(),
+      obfuscated_google_account_id: getObfuscatedGoogleAccountId(),
       client_install_id: getInstallationId(),
       event_metadata: [data] as object[],
     };

--- a/packages/core/src/utils/user_id.test.ts
+++ b/packages/core/src/utils/user_id.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { getInstallationId, getObfuscatedGaiaId } from './user_id.js';
+import { getInstallationId, getObfuscatedGoogleAccountId } from './user_id.js';
 
 describe('user_id', () => {
   describe('getInstallationId', () => {
@@ -22,27 +22,27 @@ describe('user_id', () => {
     });
   });
 
-  describe('getObfuscatedGaiaId', () => {
+  describe('getObfuscatedGoogleAccountId', () => {
     it('should return a non-empty string', () => {
-      const result = getObfuscatedGaiaId();
+      const result = getObfuscatedGoogleAccountId();
 
       expect(result).toBeDefined();
       expect(typeof result).toBe('string');
       expect(result.length).toBeGreaterThan(0);
 
       // Should be consistent on subsequent calls
-      const secondCall = getObfuscatedGaiaId();
+      const secondCall = getObfuscatedGoogleAccountId();
       expect(secondCall).toBe(result);
     });
 
-    it('should return the same as installation ID when no GAIA ID is cached', () => {
-      // In a clean test environment, there should be no cached GAIA ID
-      // so getObfuscatedGaiaId should fall back to installation ID
-      const gaiaIdResult = getObfuscatedGaiaId();
+    it('should return the same as installation ID when no Google Account ID is cached', () => {
+      // In a clean test environment, there should be no cached Google Account ID
+      // so getObfuscatedGoogleAccountId should fall back to installation ID
+      const googleAccountIdResult = getObfuscatedGoogleAccountId();
       const installationIdResult = getInstallationId();
 
-      // They should be the same when no GAIA ID is cached
-      expect(gaiaIdResult).toBe(installationIdResult);
+      // They should be the same when no Google Account ID is cached
+      expect(googleAccountIdResult).toBe(installationIdResult);
     });
   });
 });

--- a/packages/core/src/utils/user_id.test.ts
+++ b/packages/core/src/utils/user_id.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getInstallationId, getObfuscatedGaiaId } from './user_id.js';
+
+describe('user_id', () => {
+  describe('getInstallationId', () => {
+    it('should return a valid UUID format string', () => {
+      const installationId = getInstallationId();
+      
+      expect(installationId).toBeDefined();
+      expect(typeof installationId).toBe('string');
+      expect(installationId.length).toBeGreaterThan(0);
+      
+      // Should return the same ID on subsequent calls (consistent)
+      const secondCall = getInstallationId();
+      expect(secondCall).toBe(installationId);
+    });
+  });
+
+  describe('getObfuscatedGaiaId', () => {
+    it('should return a non-empty string', () => {
+      const result = getObfuscatedGaiaId();
+      
+      expect(result).toBeDefined();
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+      
+      // Should be consistent on subsequent calls
+      const secondCall = getObfuscatedGaiaId();
+      expect(secondCall).toBe(result);
+    });
+
+    it('should return the same as installation ID when no GAIA ID is cached', () => {
+      // In a clean test environment, there should be no cached GAIA ID
+      // so getObfuscatedGaiaId should fall back to installation ID
+      const gaiaIdResult = getObfuscatedGaiaId();
+      const installationIdResult = getInstallationId();
+      
+      // They should be the same when no GAIA ID is cached
+      expect(gaiaIdResult).toBe(installationIdResult);
+    });
+  });
+});

--- a/packages/core/src/utils/user_id.test.ts
+++ b/packages/core/src/utils/user_id.test.ts
@@ -11,11 +11,11 @@ describe('user_id', () => {
   describe('getInstallationId', () => {
     it('should return a valid UUID format string', () => {
       const installationId = getInstallationId();
-      
+
       expect(installationId).toBeDefined();
       expect(typeof installationId).toBe('string');
       expect(installationId.length).toBeGreaterThan(0);
-      
+
       // Should return the same ID on subsequent calls (consistent)
       const secondCall = getInstallationId();
       expect(secondCall).toBe(installationId);
@@ -25,11 +25,11 @@ describe('user_id', () => {
   describe('getObfuscatedGaiaId', () => {
     it('should return a non-empty string', () => {
       const result = getObfuscatedGaiaId();
-      
+
       expect(result).toBeDefined();
       expect(typeof result).toBe('string');
       expect(result.length).toBeGreaterThan(0);
-      
+
       // Should be consistent on subsequent calls
       const secondCall = getObfuscatedGaiaId();
       expect(secondCall).toBe(result);
@@ -40,7 +40,7 @@ describe('user_id', () => {
       // so getObfuscatedGaiaId should fall back to installation ID
       const gaiaIdResult = getObfuscatedGaiaId();
       const installationIdResult = getInstallationId();
-      
+
       // They should be the same when no GAIA ID is cached
       expect(gaiaIdResult).toBe(installationIdResult);
     });

--- a/packages/core/src/utils/user_id.ts
+++ b/packages/core/src/utils/user_id.ts
@@ -76,22 +76,6 @@ export function getObfuscatedGaiaId(): string {
     // If there's any error accessing GAIA ID, fall back to installation ID
   }
 
-  // Fall back to installation ID
-  try {
-    ensureGeminiDirExists();
-    let userId = readInstallationIdFromFile();
-
-    if (!userId) {
-      userId = randomUUID();
-      writeInstallationIdToFile(userId);
-    }
-
-    return userId;
-  } catch (error) {
-    console.error(
-      'Error accessing unique user ID file, generating ephemeral ID:',
-      error,
-    );
-    return '123456789';
-  }
+  // Fall back to installation ID when no GAIA ID is cached or on error
+  return getInstallationId();
 }

--- a/packages/core/src/utils/user_id.ts
+++ b/packages/core/src/utils/user_id.ts
@@ -58,24 +58,24 @@ export function getInstallationId(): string {
 }
 
 /**
- * Retrieves the obfuscated GAIA ID for the currently authenticated user.
- * When OAuth is available, returns the user's cached GAIA ID. Otherwise, returns the installation ID.
- * @returns A string ID for the user (GAIA ID if available, otherwise installation ID).
+ * Retrieves the obfuscated Google Account ID for the currently authenticated user.
+ * When OAuth is available, returns the user's cached Google Account ID. Otherwise, returns the installation ID.
+ * @returns A string ID for the user (Google Account ID if available, otherwise installation ID).
  */
-export function getObfuscatedGaiaId(): string {
-  // Try to get cached GAIA ID first
+export function getObfuscatedGoogleAccountId(): string {
+  // Try to get cached Google Account ID first
   try {
     // Dynamically import to avoid circular dependencies
     // eslint-disable-next-line @typescript-eslint/no-require-imports, no-restricted-syntax
-    const { getCachedGaiaId } = require('../code_assist/oauth2.js');
-    const gaiaId = getCachedGaiaId();
-    if (gaiaId) {
-      return gaiaId;
+    const { getCachedGoogleAccountId } = require('../code_assist/oauth2.js');
+    const googleAccountId = getCachedGoogleAccountId();
+    if (googleAccountId) {
+      return googleAccountId;
     }
   } catch (_error) {
-    // If there's any error accessing GAIA ID, fall back to installation ID
+    // If there's any error accessing Google Account ID, fall back to installation ID
   }
 
-  // Fall back to installation ID when no GAIA ID is cached or on error
+  // Fall back to installation ID when no Google Account ID is cached or on error
   return getInstallationId();
 }


### PR DESCRIPTION
Modified OAuth authentication to store an obfuscated Google Account ID for all OAuth users. This ID will be passed to Clearcut logs in order to help us determine total number of users using the product. Data is fully anonymized and protected under the terms of service. 

NOTE: Users can opt out of any anonymized logging by modifying ~/.gemini/settings.json and setting usageStatisticsEnabled to false, i.e.:

```
 {
    "usageStatisticsEnabled": false
  }
```
