### PR TITLE
feat: allow command-specific restrictions for ShellTool

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -65,14 +65,17 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     ```
 
 - **`coreTools`** (array of strings):
-  - **Description:** Allows you to specify a list of core tool names that should be made available to the model. This can be used to restrict the set of built-in tools. See [Built-in Tools](../core/tools-api.md#built-in-tools) for a list of core tools.
+  - **Description:** Allows you to specify a list of core tool names that should be made available to the model. This can be used to restrict the set of built-in tools. See [Built-in Tools](../core/tools-api.md#built-in-tools) for a list of core tools. You can also specify command-specific restrictions for tools that support it, like the `ShellTool`. For example, `"coreTools": ["ShellTool(ls -l)"]` will only allow the `ls -l` command to be executed.
   - **Default:** All tools available for use by the Gemini model.
-  - **Example:** `"coreTools": ["ReadFileTool", "GlobTool", "SearchText"]`.
+  - **Example:** `"coreTools": ["ReadFileTool", "GlobTool", "ShellTool(ls)"]`.
 
 - **`excludeTools`** (array of strings):
-  - **Description:** Allows you to specify a list of core tool names that should be excluded from the model. A tool listed in both `excludeTools` and `coreTools` is excluded.
+  - **Description:** Allows you to specify a list of core tool names that should be excluded from the model. A tool listed in both `excludeTools` and `coreTools` is excluded. You can also specify command-specific restrictions for tools that support it, like the `ShellTool`. For example, `"excludeTools": ["ShellTool(rm -rf)"]` will block the `rm -rf` command.
   - **Default**: No tools excluded.
   - **Example:** `"excludeTools": ["run_shell_command", "findFiles"]`.
+  - **Security Note:** Command-specific restrictions in
+    `excludeTools` for `run_shell_command` are based on simple string matching and can be easily bypassed. This feature is **not a security mechanism** and should not be relied upon to safely execute untrusted code. It is recommended to use `coreTools` to explicitly select commands
+    that can be executed.
 
 - **`autoAccept`** (boolean):
   - **Description:** Controls whether the CLI automatically accepts and executes tool calls that are considered safe (e.g., read-only operations) without explicit user confirmation. If set to `true`, the CLI will bypass the confirmation prompt for tools deemed safe.

--- a/docs/tools/shell.md
+++ b/docs/tools/shell.md
@@ -59,3 +59,23 @@ run_shell_command(command="npm run dev &", description="Start development server
 - **Interactive commands:** Avoid commands that require interactive user input, as this can cause the tool to hang. Use non-interactive flags if available (e.g., `npm init -y`).
 - **Error handling:** Check the `Stderr`, `Error`, and `Exit Code` fields to determine if a command executed successfully.
 - **Background processes:** When a command is run in the background with `&`, the tool will return immediately and the process will continue to run in the background. The `Background PIDs` field will contain the process ID of the background process.
+
+## Command Restrictions
+
+You can restrict the commands that can be executed by the `run_shell_command` tool by using the `coreTools` and `excludeTools` settings in your configuration file.
+
+- `coreTools`: If you want to restrict the `run_shell_command` tool to a specific set of commands, you can add entries to the `coreTools` list in the format `ShellTool(<command>)`. For example, `"coreTools": ["ShellTool(ls -l)"]` will only allow the `ls -l` command to be executed.
+- `excludeTools`: If you want to block specific commands, you can add entries to the `excludeTools` list in the format `ShellTool(<command>)`. For example, `"excludeTools": ["ShellTool(rm -rf /)"]` will block the `rm -rf /` command.
+
+Example:
+
+```json
+{
+  "coreTools": ["ShellTool(ls -l)", "ShellTool(git status)"],
+  "excludeTools": ["ShellTool(rm -rf /)"]
+}
+```
+
+**Security Note:** Command-specific restrictions in
+`excludeTools` for `run_shell_command` are based on simple string matching and can be easily bypassed. This feature is **not a security mechanism** and should not be relied upon to safely execute untrusted code. It is recommended to use `coreTools` to explicitly select commands
+that can be executed.

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect, describe, it } from 'vitest';
+import { ShellTool } from './shell.js';
+import { Config } from '../config/config.js';
+
+describe('ShellTool', () => {
+  it('should allow a command if no restrictions are provided', async () => {
+    const config = {
+      getCoreTools: () => undefined,
+      getExcludeTools: () => undefined,
+    } as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('ls -l');
+    expect(isAllowed).toBe(true);
+  });
+
+  it('should allow a command if it is in the allowed list', async () => {
+    const config = {
+      getCoreTools: () => ['ShellTool(ls -l)'],
+      getExcludeTools: () => undefined,
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('ls -l');
+    expect(isAllowed).toBe(true);
+  });
+
+  it('should block a command if it is not in the allowed list', async () => {
+    const config = {
+      getCoreTools: () => ['ShellTool(ls -l)'],
+      getExcludeTools: () => undefined,
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('rm -rf /');
+    expect(isAllowed).toBe(false);
+  });
+
+  it('should block a command if it is in the blocked list', async () => {
+    const config = {
+      getCoreTools: () => undefined,
+      getExcludeTools: () => ['ShellTool(rm -rf /)'],
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('rm -rf /');
+    expect(isAllowed).toBe(false);
+  });
+
+  it('should allow a command if it is not in the blocked list', async () => {
+    const config = {
+      getCoreTools: () => undefined,
+      getExcludeTools: () => ['ShellTool(rm -rf /)'],
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('ls -l');
+    expect(isAllowed).toBe(true);
+  });
+
+  it('should block a command if it is in both the allowed and blocked lists', async () => {
+    const config = {
+      getCoreTools: () => ['ShellTool(rm -rf /)'],
+      getExcludeTools: () => ['ShellTool(rm -rf /)'],
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('rm -rf /');
+    expect(isAllowed).toBe(false);
+  });
+
+  it('should allow any command when ShellTool is in coreTools without specific commands', async () => {
+    const config = {
+      getCoreTools: () => ['ShellTool'],
+      getExcludeTools: () => [],
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('any command');
+    expect(isAllowed).toBe(true);
+  });
+
+  it('should block any command when ShellTool is in excludeTools without specific commands', async () => {
+    const config = {
+      getCoreTools: () => [],
+      getExcludeTools: () => ['ShellTool'],
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('any command');
+    expect(isAllowed).toBe(false);
+  });
+
+  it('should allow a command if it is in the allowed list using the public-facing name', async () => {
+    const config = {
+      getCoreTools: () => ['run_shell_command(ls -l)'],
+      getExcludeTools: () => undefined,
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('ls -l');
+    expect(isAllowed).toBe(true);
+  });
+
+  it('should block a command if it is in the blocked list using the public-facing name', async () => {
+    const config = {
+      getCoreTools: () => undefined,
+      getExcludeTools: () => ['run_shell_command(rm -rf /)'],
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('rm -rf /');
+    expect(isAllowed).toBe(false);
+  });
+
+  it('should block any command when ShellTool is in excludeTools using the public-facing name', async () => {
+    const config = {
+      getCoreTools: () => [],
+      getExcludeTools: () => ['run_shell_command'],
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('any command');
+    expect(isAllowed).toBe(false);
+  });
+
+  it('should block any command if coreTools contains an empty ShellTool command list using the public-facing name', async () => {
+    const config = {
+      getCoreTools: () => ['run_shell_command()'],
+      getExcludeTools: () => [],
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('any command');
+    expect(isAllowed).toBe(false);
+  });
+
+  it('should block any command if coreTools contains an empty ShellTool command list', async () => {
+    const config = {
+      getCoreTools: () => ['ShellTool()'],
+      getExcludeTools: () => [],
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed('any command');
+    expect(isAllowed).toBe(false);
+  });
+
+  it('should block a command with extra whitespace if it is in the blocked list', async () => {
+    const config = {
+      getCoreTools: () => undefined,
+      getExcludeTools: () => ['ShellTool(rm -rf /)'],
+    } as unknown as Config;
+    const shellTool = new ShellTool(config);
+    const isAllowed = shellTool.isCommandAllowed(' rm  -rf  / ');
+    expect(isAllowed).toBe(false);
+  });
+});

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -98,7 +98,57 @@ Process Group PGID: Process group started or \`(none)\``,
       .pop(); // take last part and return command root (or undefined if previous line was empty)
   }
 
+  isCommandAllowed(command: string): boolean {
+    const normalize = (cmd: string) => cmd.trim().replace(/\s+/g, ' ');
+
+    const extractCommands = (tools: string[]): string[] =>
+      tools.flatMap((tool) => {
+        if (tool.startsWith(`${ShellTool.name}(`) && tool.endsWith(')')) {
+          return [normalize(tool.slice(ShellTool.name.length + 1, -1))];
+        } else if (
+          tool.startsWith(`${ShellTool.Name}(`) &&
+          tool.endsWith(')')
+        ) {
+          return [normalize(tool.slice(ShellTool.Name.length + 1, -1))];
+        }
+        return [];
+      });
+
+    const coreTools = this.config.getCoreTools() || [];
+    const excludeTools = this.config.getExcludeTools() || [];
+
+    if (
+      excludeTools.includes(ShellTool.name) ||
+      excludeTools.includes(ShellTool.Name)
+    ) {
+      return false;
+    }
+
+    const blockedCommands = extractCommands(excludeTools);
+    const normalizedCommand = normalize(command);
+
+    if (blockedCommands.includes(normalizedCommand)) {
+      return false;
+    }
+
+    const hasShellToolInCoreTools = coreTools.some(
+      (tool) =>
+        (tool.startsWith(`${ShellTool.name}(`) && tool.endsWith(')')) ||
+        (tool.startsWith(`${ShellTool.Name}(`) && tool.endsWith(')')),
+    );
+
+    if (hasShellToolInCoreTools) {
+      const allowedCommands = extractCommands(coreTools);
+      return allowedCommands.includes(normalizedCommand);
+    }
+
+    return true;
+  }
+
   validateToolParams(params: ShellToolParams): string | null {
+    if (!this.isCommandAllowed(params.command)) {
+      return `Command is not allowed: ${params.command}`;
+    }
     if (
       !SchemaValidator.validate(
         this.parameterSchema as Record<string, unknown>,


### PR DESCRIPTION
This change introduces the ability to specify allowed and blocked commands for the `ShellTool` using the `coreTools` and `excludeTools` settings. This provides more granular control over the available tools, without having to disable the entire `ShellTool`.

The following changes are included:

- The `isCommandAllowed` method in `ShellTool` now checks for command-specific restrictions in the `coreTools` and `excludeTools` settings.
- The `createToolRegistry` function now correctly registers the `ShellTool` when command-specific restrictions are present.
- The documentation has been updated to reflect the new implementation.

This change is backward compatible. If no command-specific restrictions are provided, the `ShellTool` will behave as it did before.

---
**Allow-listing**
Users can restrict ShellTool to a specific set of commands in coreTools. If tool-specific rules exist, only the commands in that list are permitted.

```json
// To allow only "gh label list" and "gh issue edit"

{
  "coreTools": [
    "ReadFileTool",
    "ShellTool(gh label list)",
    "ShellTool(gh issue edit)"
  ]
}
```

**Block-listing**
Users can disallow specific commands in excludeTools. Note that restricting specific commands relies on specific string matching. It is recommended to explicitly set allowed commands instead of restricting them.

```json
// To allow ShellTool but block "rm" and "git commit"

{
  "coreTools": [
    "ShellTool"
  ],
  "excludeTools": [
    "ShellTool(rm -rf /)",
    "ShellTool(git commit)"
  ]
}
```

**Precedence**
The excludeTools setting always takes precedence. If a command is present in both lists, it will be excluded.

```json
// "git push" is blocked
{
  "coreTools": [
     "ShellTool(git push)"
  ],
  "excludeTools": [
     "ShellTool(git push)"
  ]
}
```