### PR TITLE
fix: use cross-platform rimraf for clean scripts on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "memfs": "^4.17.2",
         "prettier": "^3.5.3",
         "react-devtools-core": "^4.28.5",
+        "rimraf": "^6.0.1",
         "typescript-eslint": "^8.30.1",
         "yargs": "^17.7.2"
       },
@@ -1049,6 +1050,27 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -8777,6 +8799,103 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
     "memfs": "^4.17.2",
     "prettier": "^3.5.3",
     "react-devtools-core": "^4.28.5",
+    "rimraf": "^6.0.1",
     "typescript-eslint": "^8.30.1",
     "yargs": "^17.7.2"
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/build_package.js",
-    "clean": "rm -rf dist",
+    "clean": "npx rimraf dist",
     "start": "node dist/index.js",
     "debug": "node --inspect-brk dist/index.js",
     "lint": "eslint . --ext .ts,.tsx",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node dist/src/index.js",
     "build": "node ../../scripts/build_package.js",
-    "clean": "rm -rf dist",
+    "clean": "npx rimraf dist",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write .",
     "test": "vitest run",


### PR DESCRIPTION
- Replace Unix-specific 'rm -rf dist' with 'npx rimraf dist' in package scripts
- Add rimraf as devDependency for cross-platform file deletion
- Fixes clean script execution failure on Windows systems
- Ensures compatibility across Windows, macOS, and Linux platforms

Fixes clean script errors like:
'rm' is not recognized as an internal or external command

## TLDR

Fixes `npm run clean` failure on Windows by replacing Unix-specific `rm -rf dist` commands with cross-platform `npx rimraf dist` in workspace packages. Adds rimraf as devDependency to ensure compatibility across all platforms.

## Dive Deeper

The issue occurs because the clean scripts in `packages/cli/package.json` and `packages/core/package.json` use `rm -rf dist`, which is a Unix/Linux command that doesn't exist on Windows systems.

**Root cause:**
- Windows Command Prompt and PowerShell don't have the `rm` command
- This causes `npm run clean` to fail with: `'rm' is not recognized as an internal or external command`

**Solution:**
- Replace `rm -rf dist` with `npx rimraf dist` in both packages
- Add `rimraf` as a devDependency in the root package.json
- `rimraf` is the Node.js ecosystem standard for cross-platform file deletion

**Why rimraf:**
- Industry standard for cross-platform file removal in Node.js projects
- Used by many Google and major open source projects
- Zero configuration required
- Consistent behavior across all platforms

## Reviewer Test Plan

1. **Test the fix:**
   ```bash
   npm install
   # Build to create dist directories first
   npm run build
   # Test the clean command (this should work without errors)
   npm run clean
    
   # Verify dist directories are removed
   ls packages/cli/    # should not contain dist/
   ls packages/core/   # should not contain dist/
   ```
2. **Test Full Workflow:**
   ```bash
   # Test complete build-clean-build cycle
   npm run build     # Create dist directories
   npm run clean     # Remove them (should succeed)
   npm run build     # Build again (should work)
   ```
3. **Platform-Specific Testing:**

   - On Windows: Run in both PowerShell and Command Prompt
   - On macOS/Linux: Run in terminal to ensure no regression
   - Verify no error messages like: 'rm' is not recognized as an internal or external command

4. **Workspace Verification:** The clean script runs across all workspaces, so check that:

   - Both packages/cli/dist and packages/core/dist are properly removed
   - No workspace-specific errors occur
   - The main clean script in scripts/clean.js continues to work

**Expected Behavior:**

✅ Clean command completes without errors
✅ All dist directories are removed
✅ Subsequent builds work normally
✅ Works identically across Windows, macOS, and Linux


## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ❓  |
| npx      | ❓  | ✅  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

**Tested on:**
- ✅ Windows 10 with PowerShell - `npm run clean` works correctly
- ❓ macOS (to be tested by reviewers)
- ❓ Linux (to be tested by reviewers)


## Linked issues / bugs

This PR addresses a cross-platform compatibility issue that affects Windows users when trying to run the clean script. No existing GitHub issue was found, but this is a common problem in Node.js monorepos that use Unix-specific commands.
