### PR TITLE
feat(cli): add `proxy` in settings and args and support `all_proxy`.

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -185,6 +185,11 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     "hideTips": true
     ```
 
+- **`proxy`** (string):
+  - **Description:** Sets the proxy server to use for all outbound HTTP/HTTPS requests.
+  - **Default:** `null`
+  - **Example:** `"proxy": "socks5://localhost:1080"`
+
 ### Example `settings.json`:
 
 ```json

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -319,6 +319,10 @@ Arguments passed directly when running the CLI can override other configurations
 - **`--version`**:
   - Displays the version of the CLI.
 
+- **`--proxy <proxy_url>`**:
+  - **Description:** Sets the proxy server to use for all outbound HTTP/HTTPS requests.
+  - **Example:** `npm start -- --proxy socks5://localhost:1080`
+
 ## Context Files (Hierarchical Instructional Context)
 
 While not strictly configuration for the CLI's _behavior_, context files (defaulting to `GEMINI.md` but configurable via the `contextFileName` setting) are crucial for configuring the _instructional context_ (also referred to as "memory") provided to the Gemini model. This powerful feature allows you to give project-specific instructions, coding style guides, or any relevant background information to the AI, making its responses more tailored and accurate to your needs. The CLI includes UI elements, such as an indicator in the footer showing the number of loaded context files, to keep you informed about the active context.

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -252,6 +252,7 @@ describe('loadCliConfig proxy', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    process.env = {};
     vi.stubEnv('GEMINI_API_KEY', 'test-api-key');
   });
 
@@ -330,6 +331,13 @@ describe('loadCliConfig proxy', () => {
     const settings: Settings = { proxy: 'http://settings.example.com' };
     const config = await loadCliConfig(settings, [], 'test-session');
     expect(config.getProxy()).toBe('http://cli.example.com');
+  });
+
+  it('should allow overriding with an empty string from CLI', async () => {
+    process.argv = ['node', 'script.js', '--proxy', ''];
+    const settings: Settings = { proxy: 'http://settings.example.com' };
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getProxy()).toBe('');
   });
 });
 

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -330,6 +330,14 @@ describe('loadCliConfig proxy', () => {
     const config = await loadCliConfig(settings, [], 'test-session');
     expect(config.getProxy()).toBe('http://settings.example.com');
   });
+
+  it('should prioritize CLI flag over settings and env vars', async () => {
+    process.argv = ['node', 'script.js', '--proxy', 'http://cli.example.com'];
+    process.env.HTTPS_PROXY = 'http://https.example.com';
+    const settings: Settings = { proxy: 'http://settings.example.com' };
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getProxy()).toBe('http://cli.example.com');
+  });
 });
 
 describe('Hierarchical Memory Loading (config.ts) - Placeholder Suite', () => {

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -246,6 +246,92 @@ describe('loadCliConfig telemetry', () => {
   });
 });
 
+describe('loadCliConfig proxy', () => {
+  const originalArgv = process.argv;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    process.env.GEMINI_API_KEY = 'test-api-key'; // Ensure API key is set for tests
+    delete process.env.HTTPS_PROXY;
+    delete process.env.https_proxy;
+    delete process.env.HTTP_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.ALL_PROXY;
+    delete process.env.all_proxy;
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('should use proxy from settings', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings: Settings = { proxy: 'http://settings.example.com' };
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getProxy()).toBe('http://settings.example.com');
+  });
+
+  it('should use proxy from HTTPS_PROXY env var', async () => {
+    process.argv = ['node', 'script.js'];
+    process.env.HTTPS_PROXY = 'http://https.example.com';
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getProxy()).toBe('http://https.example.com');
+  });
+
+  it('should use proxy from https_proxy env var', async () => {
+    process.argv = ['node', 'script.js'];
+    process.env.https_proxy = 'http://https_lower.example.com';
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getProxy()).toBe('http://https_lower.example.com');
+  });
+
+  it('should use proxy from HTTP_PROXY env var', async () => {
+    process.argv = ['node', 'script.js'];
+    process.env.HTTP_PROXY = 'http://http.example.com';
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getProxy()).toBe('http://http.example.com');
+  });
+
+  it('should use proxy from http_proxy env var', async () => {
+    process.argv = ['node', 'script.js'];
+    process.env.http_proxy = 'http://http_lower.example.com';
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getProxy()).toBe('http://http_lower.example.com');
+  });
+
+  it('should use proxy from ALL_PROXY env var', async () => {
+    process.argv = ['node', 'script.js'];
+    process.env.ALL_PROXY = 'http://all.example.com';
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getProxy()).toBe('http://all.example.com');
+  });
+
+  it('should use proxy from all_proxy env var', async () => {
+    process.argv = ['node', 'script.js'];
+    process.env.all_proxy = 'http://all_lower.example.com';
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getProxy()).toBe('http://all_lower.example.com');
+  });
+
+  it('should prioritize settings over env vars', async () => {
+    process.argv = ['node', 'script.js'];
+    process.env.HTTPS_PROXY = 'http://https.example.com';
+    const settings: Settings = { proxy: 'http://settings.example.com' };
+    const config = await loadCliConfig(settings, [], 'test-session');
+    expect(config.getProxy()).toBe('http://settings.example.com');
+  });
+});
+
 describe('Hierarchical Memory Loading (config.ts) - Placeholder Suite', () => {
   beforeEach(() => {
     vi.resetAllMocks();

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -252,8 +252,11 @@ describe('loadCliConfig proxy', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
-    process.env = {};
     vi.stubEnv('GEMINI_API_KEY', 'test-api-key');
+    vi.stubEnv('HTTPS_PROXY', '');
+    vi.stubEnv('https_proxy', '');
+    vi.stubEnv('HTTP_PROXY', '');
+    vi.stubEnv('http_proxy', '');
   });
 
   afterEach(() => {

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -248,23 +248,16 @@ describe('loadCliConfig telemetry', () => {
 
 describe('loadCliConfig proxy', () => {
   const originalArgv = process.argv;
-  const originalEnv = { ...process.env };
 
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
-    process.env.GEMINI_API_KEY = 'test-api-key'; // Ensure API key is set for tests
-    delete process.env.HTTPS_PROXY;
-    delete process.env.https_proxy;
-    delete process.env.HTTP_PROXY;
-    delete process.env.http_proxy;
-    delete process.env.ALL_PROXY;
-    delete process.env.all_proxy;
+    vi.stubEnv('GEMINI_API_KEY', 'test-api-key');
   });
 
   afterEach(() => {
     process.argv = originalArgv;
-    process.env = originalEnv;
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -277,7 +270,7 @@ describe('loadCliConfig proxy', () => {
 
   it('should use proxy from HTTPS_PROXY env var', async () => {
     process.argv = ['node', 'script.js'];
-    process.env.HTTPS_PROXY = 'http://https.example.com';
+    vi.stubEnv('HTTPS_PROXY', 'http://https.example.com');
     const settings: Settings = {};
     const config = await loadCliConfig(settings, [], 'test-session');
     expect(config.getProxy()).toBe('http://https.example.com');
@@ -285,7 +278,7 @@ describe('loadCliConfig proxy', () => {
 
   it('should use proxy from https_proxy env var', async () => {
     process.argv = ['node', 'script.js'];
-    process.env.https_proxy = 'http://https_lower.example.com';
+    vi.stubEnv('https_proxy', 'http://https_lower.example.com');
     const settings: Settings = {};
     const config = await loadCliConfig(settings, [], 'test-session');
     expect(config.getProxy()).toBe('http://https_lower.example.com');
@@ -293,7 +286,7 @@ describe('loadCliConfig proxy', () => {
 
   it('should use proxy from HTTP_PROXY env var', async () => {
     process.argv = ['node', 'script.js'];
-    process.env.HTTP_PROXY = 'http://http.example.com';
+    vi.stubEnv('HTTP_PROXY', 'http://http.example.com');
     const settings: Settings = {};
     const config = await loadCliConfig(settings, [], 'test-session');
     expect(config.getProxy()).toBe('http://http.example.com');
@@ -301,7 +294,7 @@ describe('loadCliConfig proxy', () => {
 
   it('should use proxy from http_proxy env var', async () => {
     process.argv = ['node', 'script.js'];
-    process.env.http_proxy = 'http://http_lower.example.com';
+    vi.stubEnv('http_proxy', 'http://http_lower.example.com');
     const settings: Settings = {};
     const config = await loadCliConfig(settings, [], 'test-session');
     expect(config.getProxy()).toBe('http://http_lower.example.com');
@@ -309,7 +302,7 @@ describe('loadCliConfig proxy', () => {
 
   it('should use proxy from ALL_PROXY env var', async () => {
     process.argv = ['node', 'script.js'];
-    process.env.ALL_PROXY = 'http://all.example.com';
+    vi.stubEnv('ALL_PROXY', 'http://all.example.com');
     const settings: Settings = {};
     const config = await loadCliConfig(settings, [], 'test-session');
     expect(config.getProxy()).toBe('http://all.example.com');
@@ -317,7 +310,7 @@ describe('loadCliConfig proxy', () => {
 
   it('should use proxy from all_proxy env var', async () => {
     process.argv = ['node', 'script.js'];
-    process.env.all_proxy = 'http://all_lower.example.com';
+    vi.stubEnv('all_proxy', 'http://all_lower.example.com');
     const settings: Settings = {};
     const config = await loadCliConfig(settings, [], 'test-session');
     expect(config.getProxy()).toBe('http://all_lower.example.com');
@@ -325,7 +318,7 @@ describe('loadCliConfig proxy', () => {
 
   it('should prioritize settings over env vars', async () => {
     process.argv = ['node', 'script.js'];
-    process.env.HTTPS_PROXY = 'http://https.example.com';
+    vi.stubEnv('HTTPS_PROXY', 'http://https.example.com');
     const settings: Settings = { proxy: 'http://settings.example.com' };
     const config = await loadCliConfig(settings, [], 'test-session');
     expect(config.getProxy()).toBe('http://settings.example.com');
@@ -333,7 +326,7 @@ describe('loadCliConfig proxy', () => {
 
   it('should prioritize CLI flag over settings and env vars', async () => {
     process.argv = ['node', 'script.js', '--proxy', 'http://cli.example.com'];
-    process.env.HTTPS_PROXY = 'http://https.example.com';
+    vi.stubEnv('HTTPS_PROXY', 'http://https.example.com');
     const settings: Settings = { proxy: 'http://settings.example.com' };
     const config = await loadCliConfig(settings, [], 'test-session');
     expect(config.getProxy()).toBe('http://cli.example.com');

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -257,6 +257,8 @@ describe('loadCliConfig proxy', () => {
     vi.stubEnv('https_proxy', '');
     vi.stubEnv('HTTP_PROXY', '');
     vi.stubEnv('http_proxy', '');
+    vi.stubEnv('ALL_PROXY', '');
+    vi.stubEnv('all_proxy', '');
   });
 
   afterEach(() => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -53,6 +53,7 @@ interface CliArgs {
   telemetryTarget: string | undefined;
   telemetryOtlpEndpoint: string | undefined;
   telemetryLogPrompts: boolean | undefined;
+  proxy: string | undefined;
 }
 
 async function parseArguments(): Promise<CliArgs> {
@@ -127,6 +128,10 @@ async function parseArguments(): Promise<CliArgs> {
       type: 'boolean',
       description: 'Enables checkpointing of file edits',
       default: false,
+    })
+    .option('proxy', {
+      type: 'string',
+      description: 'Proxy server to use for all outbound requests.',
     })
     .version(await getCliVersion()) // This will enable the --version flag based on package.json
     .alias('v', 'version')
@@ -236,6 +241,7 @@ export async function loadCliConfig(
     },
     checkpointing: argv.checkpointing || settings.checkpointing?.enabled,
     proxy:
+      argv.proxy ||
       settings.proxy ||
       process.env.HTTPS_PROXY ||
       process.env.https_proxy ||

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -241,14 +241,14 @@ export async function loadCliConfig(
     },
     checkpointing: argv.checkpointing || settings.checkpointing?.enabled,
     proxy:
-      argv.proxy ||
-      settings.proxy ||
-      process.env.HTTPS_PROXY ||
-      process.env.https_proxy ||
-      process.env.HTTP_PROXY ||
-      process.env.http_proxy ||
-      process.env.ALL_PROXY ||
-      process.env.all_proxy,
+      argv.proxy ??
+      settings.proxy ??
+      (process.env.HTTPS_PROXY ||
+        process.env.https_proxy ||
+        process.env.HTTP_PROXY ||
+        process.env.http_proxy ||
+        process.env.ALL_PROXY ||
+        process.env.all_proxy),
     cwd: process.cwd(),
     fileDiscoveryService: fileService,
     bugCommand: settings.bugCommand,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -236,10 +236,13 @@ export async function loadCliConfig(
     },
     checkpointing: argv.checkpointing || settings.checkpointing?.enabled,
     proxy:
+      settings.proxy ||
       process.env.HTTPS_PROXY ||
       process.env.https_proxy ||
       process.env.HTTP_PROXY ||
-      process.env.http_proxy,
+      process.env.http_proxy ||
+      process.env.ALL_PROXY ||
+      process.env.all_proxy,
     cwd: process.cwd(),
     fileDiscoveryService: fileService,
     bugCommand: settings.bugCommand,

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -54,6 +54,7 @@ export interface Settings {
   bugCommand?: BugCommandSettings;
   checkpointing?: CheckpointingSettings;
   autoConfigureMaxOldSpaceSize?: boolean;
+  proxy?: string;
 
   // Git-aware file filtering settings
   fileFiltering?: {


### PR DESCRIPTION
## TLDR

Currently, the proxy is only from environment `https_proxy` and `http_proxy`. It could not set by settings or args, and it did not support env from `all_proxy`.



## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/gemini-cli/issues/1412
https://github.com/google-gemini/gemini-cli/issues/2636

