### PR TITLE
Ability to hide header component

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -185,6 +185,15 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     "hideTips": true
     ```
 
+- **`hideHeader`** (boolean):
+  - **Description:** Enables or disables the Gemini ASCII art in the CLI interface.
+  - **Default:** `false`
+  - **Example:**
+
+    ```json
+    "hideHeader": true
+    ```
+
 ### Example `settings.json`:
 
 ```json
@@ -209,7 +218,8 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     "logPrompts": true
   },
   "usageStatisticsEnabled": true,
-  "hideTips": false
+  "hideTips": false,
+  "hideHeader": false
 }
 ```
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -63,6 +63,7 @@ export interface Settings {
 
   // UI setting. Does not display the ANSI-controlled terminal title.
   hideWindowTitle?: boolean;
+  hideHeader?: boolean;
   hideTips?: boolean;
 
   // Add other settings here.

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -18,6 +18,7 @@ import {
 import { LoadedSettings, SettingsFile, Settings } from '../config/settings.js';
 import process from 'node:process';
 import { Tips } from './components/Tips.js';
+import { Header } from './components/Header.js';
 
 // Define a more complete mock server config based on actual Config
 interface MockServerConfig {
@@ -176,6 +177,10 @@ vi.mock('../config/config.js', async (importOriginal) => {
 
 vi.mock('./components/Tips.js', () => ({
   Tips: vi.fn(() => null),
+}));
+
+vi.mock('./components/Header.js', () => ({
+  Header: vi.fn(() => null),
 }));
 
 describe('App UI', () => {
@@ -410,6 +415,22 @@ describe('App UI', () => {
     currentUnmount = unmount;
     await Promise.resolve();
     expect(vi.mocked(Tips)).not.toHaveBeenCalled();
+  });
+
+  it('should not display Header component when hideHeader is true', async () => {
+    mockSettings = createMockSettings({
+      hideHeader: true,
+    });
+
+    const { unmount } = render(
+      <App
+        config={mockConfig as unknown as ServerConfig}
+        settings={mockSettings}
+      />,
+    );
+    currentUnmount = unmount;
+    await Promise.resolve();
+    expect(vi.mocked(Header)).not.toHaveBeenCalled();
   });
 
   describe('when no theme is set', () => {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -583,7 +583,9 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
           key={staticKey}
           items={[
             <Box flexDirection="column" key="header">
-              <Header terminalWidth={terminalWidth} />
+              {!settings.merged.hideHeader && (
+                <Header terminalWidth={terminalWidth} />
+              )}
               {!settings.merged.hideTips && <Tips config={config} />}
               {updateMessage && <UpdateNotification message={updateMessage} />}
             </Box>,


### PR DESCRIPTION
## TLDR

This will add the ability to hide the header component for the CLI.

## Reviewer Test Plan

1. Change `hideHeader` setting to `true`
2. See that the header component is not rendered.
