### PR TITLE
feat: Add `modelFallbackStrategy` field to control model fallback behavior when requests encounter 429 errors

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -185,6 +185,18 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     "hideTips": true
     ```
 
+- **`modelFallbackStrategy`** (string):
+  - **Description:** Controls the behavior when the defaulte "pro" model is rate-limited (HTTP 429 error). This allows the CLI to temporarily switch to a faster fallback model (e.g., from a Pro model to Flash) for the remainder of the session, preventing workflow interruptions.
+  - **Default:** `"auto"`
+  - **Values:**
+    - `"auto"`: Automatically switches to the fallback model and displays an informational message explaining the change.
+    - `"ask"`: Displays an interactive prompt asking for your confirmation before switching to the fallback model.
+    - `"never"`: Disables the model fallback feature entirely. Errors from the primary model will be displayed directly without attempting a fallback.
+  - **Example:**
+    ```json
+    "modelFallbackStrategy": "ask"
+    ```
+
 ### Example `settings.json`:
 
 ```json
@@ -209,7 +221,8 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     "logPrompts": true
   },
   "usageStatisticsEnabled": true,
-  "hideTips": false
+  "hideTips": false,
+  "modelFallbackStrategy": "auto"
 }
 ```
 

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -38,9 +38,9 @@ You can find the token limits for each model in the [Google AI documentation](ht
 
 ## Model fallback
 
-Gemini CLI includes a model fallback mechanism to ensure that you can continue to use the CLI even if the default "pro" model is rate-limited.
+To ensure that you can continue to use the CLI even if the default "pro" model is rate-limited, Gemini CLI will automatically fall back to the "flash" model for the remainder of the session.
 
-If you are using the default "pro" model and the CLI detects that you are being rate-limited, it automatically switches to the "flash" model for the current session. This allows you to continue working without interruption.
+This default behavior can be adjusted via the `modelFallbackStrategy` setting. For more details, see the [`modelFallbackStrategy` setting](../cli/configuration.md#modelfallbackstrategy) in the CLI Configuration documentation.
 
 ## File discovery service
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -245,6 +245,7 @@ export async function loadCliConfig(
     bugCommand: settings.bugCommand,
     model: argv.model!,
     extensionContextFilePaths,
+    modelFallbackStrategy: settings.modelFallbackStrategy || 'auto',
   });
 }
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -64,6 +64,7 @@ export interface Settings {
   // UI setting. Does not display the ANSI-controlled terminal title.
   hideWindowTitle?: boolean;
   hideTips?: boolean;
+  modelFallbackStrategy?: 'auto' | 'ask' | 'never';
 
   // Add other settings here.
 }

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -67,6 +67,7 @@ interface MockServerConfig {
   getAccessibility: Mock<() => AccessibilitySettings>;
   getProjectRoot: Mock<() => string | undefined>;
   getAllGeminiMdFilenames: Mock<() => string[]>;
+  getModelFallbackStrategy: Mock<() => 'auto' | 'ask' | 'never'>;
 }
 
 // Mock @google/gemini-cli-core and its Config class
@@ -128,6 +129,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
         getCheckpointingEnabled: vi.fn(() => opts.checkpointing ?? true),
         getAllGeminiMdFilenames: vi.fn(() => ['GEMINI.md']),
         setFlashFallbackHandler: vi.fn(),
+        getModelFallbackStrategy: vi.fn(() => 'auto'),
       };
     });
   return {

--- a/packages/cli/src/ui/components/FallbackConfirmationDialog.tsx
+++ b/packages/cli/src/ui/components/FallbackConfirmationDialog.tsx
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Text, useInput } from 'ink';
+import figures from 'figures';
+import { Colors } from '../colors.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+
+interface Props {
+  currentModel: string;
+  fallbackModel: string;
+  onSelect: (confirmed: boolean) => void;
+}
+
+export function FallbackConfirmationDialog({ currentModel, fallbackModel, onSelect }: Props) {
+  useInput((_input, key) => {
+    if (key.escape) {
+      onSelect(false);
+    }
+  });
+
+  const items = [
+    { label: `Yes, switch to Flash model (${fallbackModel})`, value: true },
+    { label: `No, wait for current model (${currentModel})`, value: false },
+  ];
+
+  return (
+    <Box borderStyle="round" borderColor={Colors.Gray} padding={1} flexDirection="column">
+      <Box>
+        <Text color={Colors.AccentYellow}>{figures.warning} </Text>
+        <Text>Model <Text bold>{currentModel}</Text> is currently busy.</Text>
+      </Box>
+      <Text>Would you like to temporarily switch to <Text bold>{fallbackModel}</Text> to continue?</Text>
+      <Box marginTop={1}>
+        <RadioButtonSelect<boolean>
+          items={items}
+          onSelect={(value) => onSelect(value)}
+          isFocused={true}
+        />
+      </Box>
+       <Box marginTop={1}>
+         <Text color={Colors.Gray}>(Use Enter to select, Esc to cancel)</Text>
+       </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/FallbackConfirmationDialog.tsx
+++ b/packages/cli/src/ui/components/FallbackConfirmationDialog.tsx
@@ -37,7 +37,7 @@ export function FallbackConfirmationDialog({ currentModel, fallbackModel, onSele
       <Box marginTop={1}>
         <RadioButtonSelect<boolean>
           items={items}
-          onSelect={(value) => onSelect(value)}
+          onSelect={onSelect}
           isFocused={true}
         />
       </Box>

--- a/packages/cli/src/ui/hooks/useFallbackDialog.ts
+++ b/packages/cli/src/ui/hooks/useFallbackDialog.ts
@@ -15,9 +15,15 @@ interface ConfirmationState {
 export const useFallbackDialog = () => {
   const [dialogState, setDialogState] = useState<ConfirmationState | null>(null);
 
-  const requestConfirmation = useCallback((fallbackModel: string): Promise<boolean> => new Promise<boolean>((resolve) => {
+  const requestConfirmation = useCallback((fallbackModel: string): Promise<boolean> => {
+    if (dialogState) {
+      // A confirmation is already in progress, so we deny this new request to fallback.
+      return Promise.resolve(false);
+    }
+    return new Promise<boolean>((resolve) => {
       setDialogState({ model: fallbackModel, resolver: resolve });
-    }), []);
+    });
+  }, [dialogState]);
 
   const handleSelection = useCallback((confirmed: boolean) => {
     if (dialogState) {

--- a/packages/cli/src/ui/hooks/useFallbackDialog.ts
+++ b/packages/cli/src/ui/hooks/useFallbackDialog.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useCallback } from 'react';
+
+// A type to hold the state for the confirmation promise
+interface ConfirmationState {
+  model: string;
+  resolver: (confirmed: boolean) => void;
+}
+
+export const useFallbackDialog = () => {
+  const [dialogState, setDialogState] = useState<ConfirmationState | null>(null);
+
+  const requestConfirmation = useCallback((fallbackModel: string): Promise<boolean> => new Promise<boolean>((resolve) => {
+      setDialogState({ model: fallbackModel, resolver: resolve });
+    }), []);
+
+  const handleSelection = useCallback((confirmed: boolean) => {
+    if (dialogState) {
+      dialogState.resolver(confirmed);
+      setDialogState(null); // Close dialog and clear state
+    }
+  }, [dialogState]);
+
+  return {
+    isFallbackDialogOpen: dialogState !== null,
+    fallbackModel: dialogState?.model,
+    requestFallbackConfirmation: requestConfirmation,
+    handleFallbackSelection: handleSelection,
+  };
+};

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -130,6 +130,7 @@ export interface ConfigParameters {
   bugCommand?: BugCommandSettings;
   model: string;
   extensionContextFilePaths?: string[];
+  modelFallbackStrategy?: 'auto' | 'ask' | 'never';
 }
 
 export class Config {
@@ -168,6 +169,7 @@ export class Config {
   private readonly bugCommand: BugCommandSettings | undefined;
   private readonly model: string;
   private readonly extensionContextFilePaths: string[];
+  private readonly modelFallbackStrategy: 'auto' | 'ask' | 'never';
   private modelSwitchedDuringSession: boolean = false;
   flashFallbackHandler?: FlashFallbackHandler;
 
@@ -211,6 +213,7 @@ export class Config {
     this.bugCommand = params.bugCommand;
     this.model = params.model;
     this.extensionContextFilePaths = params.extensionContextFilePaths ?? [];
+    this.modelFallbackStrategy = params.modelFallbackStrategy ?? 'auto';
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -290,6 +293,11 @@ export class Config {
   setFlashFallbackHandler(handler: FlashFallbackHandler): void {
     this.flashFallbackHandler = handler;
   }
+
+  getModelFallbackStrategy(): 'auto' | 'ask' | 'never' {
+    return this.modelFallbackStrategy;
+  }
+
 
   getEmbeddingModel(): string {
     return this.embeddingModel;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -508,7 +508,7 @@ export class GeminiClient {
       return null;
     }
 
-    const currentModel = this.model;
+    const currentModel = this.config.getModel();
     const fallbackModel = DEFAULT_GEMINI_FLASH_MODEL;
 
     // Don't fallback if already using Flash model


### PR DESCRIPTION
## TLDR

Add the `modelFallbackStrategy` field in the settings to control the model fallback behavior when a request encounters a 429 rate limit.

## Dive Deeper

### Current Situation
Sometimes, requests to access AI may encounter a 429 error, and at this time, the CLI will automatically switch the `gemini-2.5-pro` model to `gemini-2.5-flash`

### Change 
1. Added the `modelFallbackStrategy` field to `setting`, with optional values of `auto | ask | never`. This field controls whether the model falls back when a 429 error occurs.
2. `auto` is the default value. When set to `auto`, the CLI's behavior is consistent with the current state.
3. When the value is `ask`, if a 429 error occurs, the CLI will display a selector, allowing the user to choose whether to switch to a faster model. If the user chooses not to switch models, the selector will still be displayed if a 429 error occurs again later.
4. When the value is `never`, no fallback will occur even if a 429 error occurs.
<img width="650" alt="image" src="https://github.com/user-attachments/assets/a1e8c6f0-6718-44a9-a0db-10c91e9a3948" />


## Reviewer Test Plan

Testing requires simulating situations where 429 errors occur during requests. This can be done by modifying the `shouldRetry` and `onPersistent429` functions.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

   https://github.com/google-gemini/gemini-cli/issues/2208  https://github.com/google-gemini/gemini-cli/issues/2247  https://github.com/google-gemini/gemini-cli/issues/2325
   