### PR TITLE
style: Format execution time as minutes, seconds

### DIFF
--- a/packages/cli/src/ui/components/LoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.test.tsx
@@ -63,7 +63,7 @@ describe('<LoadingIndicator />', () => {
     const output = lastFrame();
     expect(output).toContain('MockRespondingSpinner');
     expect(output).toContain('Loading...');
-    expect(output).toContain('(esc to cancel, 5s)');
+    expect(output).toContain('(esc to cancel, 5.0s)');
   });
 
   it('should render spinner (static), phrase but no time/cancel when streamingState is WaitingForConfirmation', () => {
@@ -79,7 +79,7 @@ describe('<LoadingIndicator />', () => {
     expect(output).toContain('⠏'); // Static char for WaitingForConfirmation
     expect(output).toContain('Confirm action');
     expect(output).not.toContain('(esc to cancel)');
-    expect(output).not.toContain(', 10s');
+    expect(output).not.toContain(', 10.0s');
   });
 
   it('should display the currentLoadingPhrase correctly', () => {
@@ -103,7 +103,7 @@ describe('<LoadingIndicator />', () => {
       <LoadingIndicator {...props} />,
       StreamingState.Responding,
     );
-    expect(lastFrame()).toContain('(esc to cancel, 8s)');
+    expect(lastFrame()).toContain('(esc to cancel, 8.0s)');
   });
 
   it('should render rightContent when provided', () => {
@@ -134,7 +134,7 @@ describe('<LoadingIndicator />', () => {
     let output = lastFrame();
     expect(output).toContain('MockRespondingSpinner');
     expect(output).toContain('Now Responding');
-    expect(output).toContain('(esc to cancel, 2s)');
+    expect(output).toContain('(esc to cancel, 2.0s)');
 
     // Transition to WaitingForConfirmation
     rerender(
@@ -149,7 +149,7 @@ describe('<LoadingIndicator />', () => {
     expect(output).toContain('⠏');
     expect(output).toContain('Please Confirm');
     expect(output).not.toContain('(esc to cancel)');
-    expect(output).not.toContain(', 15s');
+    expect(output).not.toContain(', 15.0s');
 
     // Transition back to Idle
     rerender(

--- a/packages/cli/src/ui/components/LoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.test.tsx
@@ -63,7 +63,7 @@ describe('<LoadingIndicator />', () => {
     const output = lastFrame();
     expect(output).toContain('MockRespondingSpinner');
     expect(output).toContain('Loading...');
-    expect(output).toContain('(esc to cancel, 5.0s)');
+    expect(output).toContain('(esc to cancel, 5s)');
   });
 
   it('should render spinner (static), phrase but no time/cancel when streamingState is WaitingForConfirmation', () => {
@@ -79,7 +79,7 @@ describe('<LoadingIndicator />', () => {
     expect(output).toContain('⠏'); // Static char for WaitingForConfirmation
     expect(output).toContain('Confirm action');
     expect(output).not.toContain('(esc to cancel)');
-    expect(output).not.toContain(', 10.0s');
+    expect(output).not.toContain(', 10s');
   });
 
   it('should display the currentLoadingPhrase correctly', () => {
@@ -97,13 +97,25 @@ describe('<LoadingIndicator />', () => {
   it('should display the elapsedTime correctly when Responding', () => {
     const props = {
       currentLoadingPhrase: 'Working...',
-      elapsedTime: 8,
+      elapsedTime: 60,
     };
     const { lastFrame } = renderWithContext(
       <LoadingIndicator {...props} />,
       StreamingState.Responding,
     );
-    expect(lastFrame()).toContain('(esc to cancel, 8.0s)');
+    expect(lastFrame()).toContain('(esc to cancel, 1m)');
+  });
+
+  it('should display the elapsedTime correctly in human-readable format', () => {
+    const props = {
+      currentLoadingPhrase: 'Working...',
+      elapsedTime: 125,
+    };
+    const { lastFrame } = renderWithContext(
+      <LoadingIndicator {...props} />,
+      StreamingState.Responding,
+    );
+    expect(lastFrame()).toContain('(esc to cancel, 2m 5s)');
   });
 
   it('should render rightContent when provided', () => {
@@ -134,7 +146,7 @@ describe('<LoadingIndicator />', () => {
     let output = lastFrame();
     expect(output).toContain('MockRespondingSpinner');
     expect(output).toContain('Now Responding');
-    expect(output).toContain('(esc to cancel, 2.0s)');
+    expect(output).toContain('(esc to cancel, 2s)');
 
     // Transition to WaitingForConfirmation
     rerender(
@@ -149,7 +161,7 @@ describe('<LoadingIndicator />', () => {
     expect(output).toContain('⠏');
     expect(output).toContain('Please Confirm');
     expect(output).not.toContain('(esc to cancel)');
-    expect(output).not.toContain(', 15.0s');
+    expect(output).not.toContain(', 15s');
 
     // Transition back to Idle
     rerender(

--- a/packages/cli/src/ui/components/LoadingIndicator.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.tsx
@@ -51,7 +51,7 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
         <Text color={Colors.Gray}>
           {streamingState === StreamingState.WaitingForConfirmation
             ? ''
-            : ` (esc to cancel, ${formatDuration(elapsedTime * 1000)})`}
+            : ` (esc to cancel, ${elapsedTime < 60 ? `${elapsedTime}s` : formatDuration(elapsedTime * 1000)})`}
         </Text>
         <Box flexGrow={1}>{/* Spacer */}</Box>
         {rightContent && <Box>{rightContent}</Box>}

--- a/packages/cli/src/ui/components/LoadingIndicator.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.tsx
@@ -11,6 +11,7 @@ import { Colors } from '../colors.js';
 import { useStreamingContext } from '../contexts/StreamingContext.js';
 import { StreamingState } from '../types.js';
 import { GeminiRespondingSpinner } from './GeminiRespondingSpinner.js';
+import { formatDuration } from '../utils/formatters.js';
 
 interface LoadingIndicatorProps {
   currentLoadingPhrase?: string;
@@ -50,7 +51,7 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
         <Text color={Colors.Gray}>
           {streamingState === StreamingState.WaitingForConfirmation
             ? ''
-            : ` (esc to cancel, ${elapsedTime}s)`}
+            : ` (esc to cancel, ${formatDuration(elapsedTime * 1000)})`}
         </Text>
         <Box flexGrow={1}>{/* Spacer */}</Box>
         {rightContent && <Box>{rightContent}</Box>}


### PR DESCRIPTION
## TLDR

Improves execution time formatting in the LoadingIndicator component by replacing the basic "Xs" format with human-readable duration formatting (e.g., "1m 30s", "2h 5m"). 

## Dive Deeper

The LoadingIndicator component currently displays elapsed time in a very basic format: `(esc to cancel, 42s)`. This change leverages the existing `formatDuration` utility function that's already used throughout the stats displays to provide consistent, human-readable time formatting.

**Changes made:**
- Modified LoadingIndicator.tsx to use `formatDuration(elapsedTime * 1000)` instead of `${elapsedTime}s`
- Added import for `formatDuration` from the formatters utility
- Maintains consistency with other time displays in the application (StatsDisplay, SessionSummaryDisplay, etc.)

**Examples of the improvement:**
- Before: `(esc to cancel, 125s)`
- After: `(esc to cancel, 2m 5s)`

## Reviewer Test Plan

To validate this change:

1. **Pull and run the code**: `npm run start`
2. **Test real-time formatting**: Ask the AI a complex question that takes >60 seconds to respond
3. **Observe the loading indicator**: Verify it shows properly formatted time (e.g., "1m 30s" instead of "90s")

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ✅ | ✅ |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
#2703 
