### PR TITLE
Fix CODE_ASSIST_ENDPOINT env var.

### DIFF
--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -35,14 +35,14 @@ describe('CodeAssistServer', () => {
         ],
       },
     };
-    vi.spyOn(server, 'callEndpoint').mockResolvedValue(mockResponse);
+    vi.spyOn(server, 'requestPost').mockResolvedValue(mockResponse);
 
     const response = await server.generateContent({
       model: 'test-model',
       contents: [{ role: 'user', parts: [{ text: 'request' }] }],
     });
 
-    expect(server.callEndpoint).toHaveBeenCalledWith(
+    expect(server.requestPost).toHaveBeenCalledWith(
       'generateContent',
       expect.any(Object),
       undefined,
@@ -72,7 +72,7 @@ describe('CodeAssistServer', () => {
         },
       };
     })();
-    vi.spyOn(server, 'streamEndpoint').mockResolvedValue(mockResponse);
+    vi.spyOn(server, 'requestStreamingPost').mockResolvedValue(mockResponse);
 
     const stream = await server.generateContentStream({
       model: 'test-model',
@@ -80,7 +80,7 @@ describe('CodeAssistServer', () => {
     });
 
     for await (const res of stream) {
-      expect(server.streamEndpoint).toHaveBeenCalledWith(
+      expect(server.requestStreamingPost).toHaveBeenCalledWith(
         'streamGenerateContent',
         expect.any(Object),
         undefined,
@@ -96,7 +96,7 @@ describe('CodeAssistServer', () => {
       name: 'operations/123',
       done: true,
     };
-    vi.spyOn(server, 'callEndpoint').mockResolvedValue(mockResponse);
+    vi.spyOn(server, 'requestPost').mockResolvedValue(mockResponse);
 
     const response = await server.onboardUser({
       tierId: 'test-tier',
@@ -104,7 +104,7 @@ describe('CodeAssistServer', () => {
       metadata: {},
     });
 
-    expect(server.callEndpoint).toHaveBeenCalledWith(
+    expect(server.requestPost).toHaveBeenCalledWith(
       'onboardUser',
       expect.any(Object),
     );
@@ -117,13 +117,13 @@ describe('CodeAssistServer', () => {
     const mockResponse = {
       // TODO: Add mock response
     };
-    vi.spyOn(server, 'callEndpoint').mockResolvedValue(mockResponse);
+    vi.spyOn(server, 'requestPost').mockResolvedValue(mockResponse);
 
     const response = await server.loadCodeAssist({
       metadata: {},
     });
 
-    expect(server.callEndpoint).toHaveBeenCalledWith(
+    expect(server.requestPost).toHaveBeenCalledWith(
       'loadCodeAssist',
       expect.any(Object),
     );
@@ -136,7 +136,7 @@ describe('CodeAssistServer', () => {
     const mockResponse = {
       totalTokens: 100,
     };
-    vi.spyOn(server, 'callEndpoint').mockResolvedValue(mockResponse);
+    vi.spyOn(server, 'requestPost').mockResolvedValue(mockResponse);
 
     const response = await server.countTokens({
       model: 'test-model',


### PR DESCRIPTION
## TLDR

setting CODE_ASSIST_ENDPOINT in .env files stopped working, probably because recent changes moved up when this static var is loaded to before the .env file is loaded. This moves the calculation back so to after the .env files are applied. But it also just makes a little more sense this way.

## Reviewer Test Plan

Set CODE_ASSIST_ENDPOINT in an .env files and verify that it works. (for example, by pointing it to http://derp.com/ and verifying that the CLI blows up during start up).

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | x  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

cherrypick of https://github.com/google-gemini/gemini-cli/pull/1265 on the old main branch
