### PR TITLE
feat: support GOOGLE_CLOUD_PROJECT_ID fallback (fixes #2262)

### DIFF
--- a/docs/get-started/authentication.md
+++ b/docs/get-started/authentication.md
@@ -39,7 +39,7 @@ If you are running Gemini CLI on your local machine, the simplest method is logg
 
    > **Note:** This method requires a web browser on a machine that can communicate with the terminal running the CLI (e.g., your local machine). The browser will be redirected to a `localhost` URL that the CLI listens on during setup.
 
-#### (Optional) Set your GOOGLE_CLOUD_PROJECT
+#### (Optional) Set your Google Cloud Project
 
 When you log in using a Google account, you may be prompted to select a `GOOGLE_CLOUD_PROJECT`.
 
@@ -57,11 +57,15 @@ If you fall into one of these categories, you must:
 2.  [Enable the Gemini for Cloud API](https://cloud.google.com/gemini/docs/discover/set-up-gemini#enable-api).
 3.  [Configure necessary IAM access permissions](https://cloud.google.com/gemini/docs/discover/set-up-gemini#grant-iam).
 
-To set the project ID, export the `GOOGLE_CLOUD_PROJECT` environment variable:
+To set the project ID, you can export either the `GOOGLE_CLOUD_PROJECT` or `GOOGLE_CLOUD_PROJECT_ID` environment variable. The CLI checks for `GOOGLE_CLOUD_PROJECT` first, then falls back to `GOOGLE_CLOUD_PROJECT_ID` :
 
 ```bash
 # Replace YOUR_PROJECT_ID with your actual Google Cloud Project ID
+# Using the standard variable:
 export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"
+
+# Or, using the fallback variable:
+export GOOGLE_CLOUD_PROJECT_ID="YOUR_PROJECT_ID"
 ```
 
 To make this setting persistent, see [Persisting Environment Variables](#persisting-environment-variables).
@@ -92,12 +96,13 @@ If you intend to use Google Cloud's Vertex AI platform, you have several authent
 
 #### First: Set required environment variables
 
-Regardless of your method of authentication, you'll typically need to set the following variables: `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`.
+Regardless of your method of authentication, you'll typically need to set the following variables: `GOOGLE_CLOUD_PROJECT` (or `GOOGLE_CLOUD_PROJECT_ID`) and `GOOGLE_CLOUD_LOCATION`.
 
 To set these variables:
 
 ```bash
 # Replace with your project ID and desired location (e.g., us-central1)
+# You can use GOOGLE_CLOUD_PROJECT_ID as a fallback for GOOGLE_CLOUD_PROJECT
 export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"
 export GOOGLE_CLOUD_LOCATION="YOUR_PROJECT_LOCATION"
 ```
@@ -121,7 +126,7 @@ unset GOOGLE_API_KEY GEMINI_API_KEY
 
     See [Set up Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc) for details.
 
-3.  Ensure `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` are set.
+3.  Ensure `GOOGLE_CLOUD_PROJECT` (or `GOOGLE_CLOUD_PROJECT_ID`) and `GOOGLE_CLOUD_LOCATION` are set.
 
 #### B. Vertex AI - Service Account JSON key
 
@@ -141,7 +146,7 @@ unset GOOGLE_API_KEY GEMINI_API_KEY
     export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/keyfile.json"
     ```
 
-3.  Ensure `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` are set.
+3.  Ensure `GOOGLE_CLOUD_PROJECT` (or `GOOGLE_CLOUD_PROJECT_ID`) and `GOOGLE_CLOUD_LOCATION` are set.
 
 > **Warning:** Protect your service account key file as it provides access to your resources.
 
@@ -197,7 +202,7 @@ If you have not already logged in with an authentication credential (such as a G
 2.  **Vertex AI:**
     - Set `GOOGLE_GENAI_USE_VERTEXAI=true`.
     - **With Google Cloud API Key:** Set `GOOGLE_API_KEY`.
-    - **With ADC:** Ensure ADC is configured (e.g., via a service account with `GOOGLE_APPLICATION_CREDENTIALS`) and set `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`.
+    - **With ADC:** Ensure ADC is configured (e.g., via a service account with `GOOGLE_APPLICATION_CREDENTIALS`) and set `GOOGLE_CLOUD_PROJECT` (or `GOOGLE_CLOUD_PROJECT_ID`) and `GOOGLE_CLOUD_LOCATION`.
 
 The CLI will exit with an error in non-interactive mode if no suitable environment variables are found.
 

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -17,7 +17,7 @@ import type { OAuth2Client } from 'google-auth-library';
 export class ProjectIdRequiredError extends Error {
   constructor() {
     super(
-      'This account requires setting the GOOGLE_CLOUD_PROJECT env var. See https://goo.gle/gemini-cli-auth-docs#workspace-gca',
+      'This account requires setting the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID env var. See https://goo.gle/gemini-cli-auth-docs#workspace-gca',
     );
   }
 }
@@ -33,7 +33,10 @@ export interface UserData {
  * @returns the user's actual project id
  */
 export async function setupUser(client: OAuth2Client): Promise<UserData> {
-  const projectId = process.env['GOOGLE_CLOUD_PROJECT'] || undefined;
+  const projectId =
+    process.env['GOOGLE_CLOUD_PROJECT'] ||
+    process.env['GOOGLE_CLOUD_PROJECT_ID'] ||
+    undefined;
   const caServer = new CodeAssistServer(client, projectId, {}, '', undefined);
   const coreClientMetadata: ClientMetadata = {
     ideType: 'IDE_UNSPECIFIED',

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -61,7 +61,10 @@ export function createContentGeneratorConfig(
 ): ContentGeneratorConfig {
   const geminiApiKey = process.env['GEMINI_API_KEY'] || undefined;
   const googleApiKey = process.env['GOOGLE_API_KEY'] || undefined;
-  const googleCloudProject = process.env['GOOGLE_CLOUD_PROJECT'] || undefined;
+  const googleCloudProject =
+    process.env['GOOGLE_CLOUD_PROJECT'] ||
+    process.env['GOOGLE_CLOUD_PROJECT_ID'] ||
+    undefined;
   const googleCloudLocation = process.env['GOOGLE_CLOUD_LOCATION'] || undefined;
 
   const contentGeneratorConfig: ContentGeneratorConfig = {


### PR DESCRIPTION
This pull request enhances environment variable handling by introducing support for the GOOGLE_CLOUD_PROJECT_ID environment variable as a fallback to the existing GOOGLE_CLOUD_PROJECT variable.

### What this fixes
Previously, the Gemini CLI only accepted GOOGLE_CLOUD_PROJECT for Google Cloud project identification. However, some users (especially those following other GCP tools or documentation) use GOOGLE_CLOUD_PROJECT_ID instead. This mismatch caused confusion and authentication issues, as highlighted in issue #2262.

### What this PR does
- Updates all relevant code paths to check both GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_PROJECT_ID, defaulting to the first available.
- Ensures backward compatibility with existing users while supporting an alternative common variable name.
- Improves robustness and reduces potential user misconfiguration when authenticating with Google Cloud.

### Affected files
- `slashCommandProcessor.ts`
- `setup.ts`
- `contentGenerator.ts`

### Impact
This small but important enhancement increases flexibility and improves developer experience without introducing breaking changes.

Fixes: #2262
