### PR TITLE
Add descriptive text to Google login option to indicate that user can also use the Gemini Code Assist extension in the IDE

### DIFF
--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -30,7 +30,7 @@ export function AuthDialog({
   );
   const items = [
     {
-      label: 'Login with Google',
+      label: 'Login with Google - and get Gemini Code Assist in your IDEs (free with personal Gmail accounts)',
       value: AuthType.LOGIN_WITH_GOOGLE_PERSONAL,
     },
     { label: 'Gemini API Key (AI Studio)', value: AuthType.USE_GEMINI },


### PR DESCRIPTION
Adds more context to the 'Login with Google' authentication option to clarify the benefits and availability of Gemini Code Assist for personal accounts.
