### PR TITLE
fix(workflows): use preview release gemini-cli in triage workflows

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -28,11 +28,8 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Install dependencies
-        run: npm install
-
       - name: Run Gemini Issue Triage
-        uses: google-gemini/gemini-cli-action@1efc0bac9e0b2da6c6cab95df513324d8dfc2a79
+        uses: google-gemini/gemini-cli-action@111dadaecabd309baba60f56f2b520c52c0f9a47
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
@@ -40,7 +37,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPOSITORY: ${{ github.repository }}
         with:
-          version: main
+          version: 0.1.8-rc.0
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OTLP_GCP_WIF_PROVIDER: ${{ secrets.OTLP_GCP_WIF_PROVIDER }}
           OTLP_GCP_SERVICE_ACCOUNT: ${{ secrets.OTLP_GCP_SERVICE_ACCOUNT }}
@@ -54,28 +51,16 @@ jobs:
               ],
             }
           prompt: |
-            You are an issue triage assistant for GitHub issues.
-            Your task is to analyze the issue and apply appropriate labels from the repository's list of available labels.
+            You are an issue triage assistant. Analyze the current GitHub issue and apply the most appropriate existing labels.
 
-            **IMPORTANT: Your only action should be to apply labels. Do not post any comments or modify any code.**
+            Steps:
+            1. Run: `gh label list --limit 100` to get all available labels.
+            2. Review the issue title and body provided in the environment variables.
+            3. Select the most relevant labels from the existing labels, focusing on kind/*, area/*, and priority/*.
+            4. Apply the selected labels to this issue using: `gh issue edit ISSUE_NUMBER --add-label "label1,label2"`
 
-            **Triage Workflow:**
-
-            1. **Fetch Available Labels:**
-               Execute: `gh label list`
-
-            2. **Get Issue Information:**
-               The issue details are available in environment variables:
-               - Repository: $REPOSITORY
-               - Issue Number: $ISSUE_NUMBER
-               - Issue Title: $ISSUE_TITLE
-               - Issue Body: $ISSUE_BODY
-
-            3. **Analyze and Apply Labels:**
-               Based on the issue title and body, determine appropriate labels and apply them using:
-               `gh issue edit $ISSUE_NUMBER --add-label "label1,label2"`
-
-            **Guidelines:**
-            - Only use labels that exist in the repository
-            - Do not add comments to the issue
-            - Common label patterns: kind/bug, kind/enhancement, kind/documentation, area/*, priority/*
+            Guidelines:
+            - Only use labels that already exist in the repository.
+            - Do not add comments or modify the issue content.
+            - Triage only the current issue.
+            - Assign all applicable kind/*, area/*, and priority/* labels based on the issue content.

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -36,18 +36,15 @@ jobs:
           ISSUES=$(echo "$NO_LABEL_ISSUES" "$NEEDS_TRIAGE_ISSUES" | jq -c -s 'add | unique_by(.number)')
           echo "issues_to_triage=$ISSUES" >> "$GITHUB_OUTPUT"
 
-      - name: Install dependencies
-        run: npm install
-
       - name: Run Gemini Issue Triage
         if: steps.find_issues.outputs.issues_to_triage != '[]'
-        uses: google-gemini/gemini-cli-action@1efc0bac9e0b2da6c6cab95df513324d8dfc2a79
+        uses: google-gemini/gemini-cli-action@111dadaecabd309baba60f56f2b520c52c0f9a47
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           ISSUES_TO_TRIAGE: ${{ steps.find_issues.outputs.issues_to_triage }}
           REPOSITORY: ${{ github.repository }}
         with:
-          version: main
+          version: 0.1.8-rc.0
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OTLP_GCP_WIF_PROVIDER: ${{ secrets.OTLP_GCP_WIF_PROVIDER }}
           OTLP_GCP_SERVICE_ACCOUNT: ${{ secrets.OTLP_GCP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
this allows us to test out the command settings in triage workflows 

we don't want to build from main, we want to rely on the gemini cli action
