### PR TITLE
feat: Implement get_active_application_info for Windows

### DIFF
--- a/ActiveWindowInfo/ActiveWindowInfo.csproj
+++ b/ActiveWindowInfo/ActiveWindowInfo.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework> <!-- Or any other appropriate .NET version -->
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>ActiveWindowInfo</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/ActiveWindowInfo/Program.cs
+++ b/ActiveWindowInfo/Program.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Diagnostics;
+using System.ComponentModel;
+using System.IO;
+
+public class ActiveWindowInfo
+{
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr OpenProcess(uint processAccess, bool bInheritHandle, uint processId);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool QueryFullProcessImageName(IntPtr hProcess, uint dwFlags, StringBuilder lpExeName, ref uint lpdwSize);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
+    private const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+
+    public static void Main(string[] args)
+    {
+        IntPtr hWnd = GetForegroundWindow();
+        if (hWnd == IntPtr.Zero)
+        {
+            Console.Error.WriteLine("Error: Could not get foreground window.");
+            return;
+        }
+
+        StringBuilder windowTitle = new StringBuilder(256);
+        if (GetWindowText(hWnd, windowTitle, windowTitle.Capacity) == 0)
+        {
+            // Error or empty title, proceed with empty title
+        }
+
+        uint processId;
+        GetWindowThreadProcessId(hWnd, out processId);
+        if (processId == 0)
+        {
+            Console.Error.WriteLine("Error: Could not get process ID.");
+            return;
+        }
+
+        string executablePath = GetProcessExecutablePath(processId);
+
+        Console.WriteLine($"{{\"title\":\"{JsonEscape(windowTitle.ToString())}\",\"pid\":{processId},\"executablePath\":\"{JsonEscape(executablePath)}\"}}");
+    }
+
+    private static string GetProcessExecutablePath(uint processId)
+    {
+        IntPtr hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processId);
+        if (hProcess == IntPtr.Zero)
+        {
+            // Cannot open process (e.g. access denied)
+            return "N/A";
+        }
+
+        try
+        {
+            StringBuilder exePath = new StringBuilder(1024);
+            uint size = (uint)exePath.Capacity;
+            if (QueryFullProcessImageName(hProcess, 0, exePath, ref size))
+            {
+                return exePath.ToString();
+            }
+            else
+            {
+                 // Could not query process image name
+                return "N/A";
+            }
+        }
+        finally
+        {
+            CloseHandle(hProcess);
+        }
+    }
+
+    private static string JsonEscape(string str)
+    {
+        if (string.IsNullOrEmpty(str))
+        {
+            return string.Empty;
+        }
+        return str.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    }
+}

--- a/docs/tools/get-active-application-info.md
+++ b/docs/tools/get-active-application-info.md
@@ -1,0 +1,54 @@
+# Get Active Application Info Tool
+
+The `getActiveApplicationInfo` tool retrieves information about the currently active (foreground) application window on the user's desktop.
+
+## Functionality
+
+This tool provides the following details for the active window:
+
+-   **Window Title:** The title text of the foreground window.
+-   **Process ID (PID):** The ID of the process that owns the window.
+-   **Executable Path:** The full file system path to the executable file of the process.
+
+## Platform Specificity
+
+**This tool is Windows-specific.** It relies on Windows APIs to gather the required information and will not function on other operating systems (e.g., macOS, Linux). Attempting to use it on a non-Windows platform will result in an error.
+
+## Use Cases
+
+-   Identifying the application the user is currently interacting with.
+-   Debugging or logging application context.
+-   Integrating with other tools that might need to know the foreground application details on Windows.
+
+## Parameters
+
+This tool takes no parameters.
+
+## Output Structure (JSON)
+
+The tool outputs a JSON object with the following structure:
+
+```json
+{
+  "pid": 1234,
+  "title": "Example Window Title - Notepad",
+  "executablePath": "C:\\Windows\\System32\\notepad.exe"
+}
+```
+
+## Implementation Details
+
+The Node.js tool (`GetActiveApplicationInfoTool`) internally calls a compiled C# utility (`ActiveWindowInfo.exe`). This native utility uses Windows APIs such as `GetForegroundWindow`, `GetWindowTextW`, `GetWindowThreadProcessId`, `OpenProcess`, and `QueryFullProcessImageNameW` to fetch the application details. The C# utility then outputs this information as a JSON string to its standard output, which is captured and parsed by the Node.js tool.
+
+## Build and Packaging
+
+The `ActiveWindowInfo.exe` utility must be compiled from its C# source and be available at a path accessible by the Gemini CLI during runtime. The exact packaging and distribution mechanism will ensure this utility is correctly located. Currently, it's expected to be found relative to the `get-active-application-info.ts` tool file, but this might be subject to change based on the final build process.
+If the utility is not found, the tool will fail with an error indicating that `ActiveWindowInfo.exe` could not be started.
+
+## Error Handling
+
+-   If run on a non-Windows system, an error is thrown.
+-   If the native utility (`ActiveWindowInfo.exe`) cannot be spawned (e.g., not found, permissions issue), an error is thrown.
+-   If the native utility exits with a non-zero status code, an error is thrown, including any error messages from the utility's stderr.
+-   If the output from the native utility is not valid JSON, an error is thrown.
+-   If the tool execution is aborted via an `AbortSignal`, an error is thrown.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -49,8 +49,17 @@ Gemini CLI's built-in tools can be broadly categorized as follows:
 - **[Web Search Tool](./web-search.md) (`web_search`):** For searching the web.
 - **[Multi-File Read Tool](./multi-file.md) (`read_many_files`):** A specialized tool for reading content from multiple files or directories, often used by the `@` command.
 - **[Memory Tool](./memory.md) (`save_memory`):** For saving and recalling information across sessions.
+- **[Platform-Specific Tools](#platform-specific-tools):** Tools that are designed to work on a particular operating system.
 
 Additionally, these tools incorporate:
 
 - **[MCP servers](./mcp-server.md)**: MCP servers act as a bridge between the Gemini model and your local environment or other services like APIs.
 - **[Sandboxing](../sandbox.md)**: Sandboxing isolates the model and its changes from your environment to reduce potential risk.
+
+---
+
+### Platform-Specific Tools
+
+Some tools are designed to work only on specific operating systems due to their reliance on platform-dependent APIs or functionalities.
+
+*   **[`getActiveApplicationInfo`](./get-active-application-info.md):** (Windows-specific) Retrieves information about the currently active application window.

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -27,6 +27,7 @@ import {
   GEMINI_CONFIG_DIR as GEMINI_DIR,
 } from '../tools/memoryTool.js';
 import { WebSearchTool } from '../tools/web-search.js';
+import { GetActiveApplicationInfoTool } from '../tools/get-active-application-info.js';
 import { GeminiClient } from '../core/client.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { GitService } from '../services/gitService.js';
@@ -499,6 +500,7 @@ export function createToolRegistry(config: Config): Promise<ToolRegistry> {
   registerCoreTool(ShellTool, config);
   registerCoreTool(MemoryTool);
   registerCoreTool(WebSearchTool, config);
+  registerCoreTool(GetActiveApplicationInfoTool);
   return (async () => {
     await registry.discoverTools();
     return registry;

--- a/packages/core/src/tools/get-active-application-info.test.ts
+++ b/packages/core/src/tools/get-active-application-info.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { GetActiveApplicationInfoTool } from './get-active-application-info';
+import * as child_process from 'child_process';
+
+// Mock child_process
+vi.mock('child_process');
+
+describe('GetActiveApplicationInfoTool', () => {
+  let tool: GetActiveApplicationInfoTool;
+  let mockSpawn: any;
+  let mockProcess: any;
+
+  beforeEach(() => {
+    tool = new GetActiveApplicationInfoTool();
+    mockProcess = {
+      stdout: { on: vi.fn(), removeAllListeners: vi.fn() },
+      stderr: { on: vi.fn(), removeAllListeners: vi.fn() },
+      on: vi.fn(),
+      removeAllListeners: vi.fn(),
+      kill: vi.fn(),
+    };
+    mockSpawn = vi.spyOn(child_process, 'spawn').mockReturnValue(mockProcess);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should correctly initialize', () => {
+    expect(tool.name).toBe('getActiveApplicationInfo');
+    expect(tool.description).toContain('Windows-specific');
+    expect(tool.schema.parameters).toEqual({}); // No parameters
+  });
+
+  it('should throw an error if not on Windows', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'darwin', writable: true });
+
+    await expect(tool.execute({}, new AbortController().signal)).rejects.toThrow(
+      'GetActiveApplicationInfoTool is only supported on Windows.',
+    );
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform }); // Restore platform
+  });
+
+  it('should execute and parse valid JSON output on Windows', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', writable: true });
+
+    const mockOutput = {
+      pid: 1234,
+      title: 'Test Window',
+      executablePath: 'C:\\test\\app.exe',
+    };
+    const expectedLlmContent = `Active application: Test Window (PID: 1234, Path: C:\\test\\app.exe)`;
+    const expectedReturnDisplay = `Active Window:\nTitle: Test Window\nPID: 1234\nExecutable Path: C:\\test\\app.exe`;
+
+    // Simulate successful process execution
+    mockProcess.on.mockImplementation((event: string, callback: Function) => {
+      if (event === 'close') {
+        // Simulate stdout data before close
+        mockProcess.stdout.on.mock.calls.find((call: any) => call[0] === 'data')?.[1](JSON.stringify(mockOutput));
+        callback(0); // Success code
+      }
+      return mockProcess;
+    });
+
+    const result = await tool.execute({}, new AbortController().signal);
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      expect.stringContaining('ActiveWindowInfo.exe'),
+      [],
+      expect.any(Object),
+    );
+    expect(result.pid).toBe(mockOutput.pid);
+    expect(result.title).toBe(mockOutput.title);
+    expect(result.executablePath).toBe(mockOutput.executablePath);
+    expect(result.llmContent).toBe(expectedLlmContent);
+    expect(result.returnDisplay).toBe(expectedReturnDisplay);
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('should handle JSON parsing errors', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', writable: true });
+
+    // Simulate process with invalid JSON output
+    mockProcess.on.mockImplementation((event: string, callback: Function) => {
+      if (event === 'close') {
+        mockProcess.stdout.on.mock.calls.find((call: any) => call[0] === 'data')?.[1]('invalid json');
+        callback(0); // Success code, but bad output
+      }
+      return mockProcess;
+    });
+
+    await expect(tool.execute({}, new AbortController().signal)).rejects.toThrow(
+      /Error parsing JSON output: Unexpected token i in JSON at position 0\nOutput: invalid json/,
+    );
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('should handle process error (e.g., non-zero exit code)', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', writable: true });
+
+    // Simulate process error
+    mockProcess.on.mockImplementation((event: string, callback: Function) => {
+      if (event === 'close') {
+        mockProcess.stderr.on.mock.calls.find((call: any) => call[0] === 'data')?.[1]('Some error');
+        callback(1); // Error code
+      }
+      return mockProcess;
+    });
+
+    await expect(tool.execute({}, new AbortController().signal)).rejects.toThrow(
+      'ActiveWindowInfo.exe exited with code 1: Some error',
+    );
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+   it('should handle spawn error (e.g., file not found)', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', writable: true });
+
+    mockSpawn.mockImplementation(() => {
+      // Simulate the 'error' event being emitted by the spawned process object
+      const fakeProcess = {
+        stdout: { on: vi.fn(), removeAllListeners: vi.fn() },
+        stderr: { on: vi.fn(), removeAllListeners: vi.fn() },
+        on: (event: string, cb: (err?: Error) => void) => {
+          if (event === 'error') {
+            cb(new Error('ENOENT: spawn EACCES'));
+          }
+        },
+        removeAllListeners: vi.fn(),
+        kill: vi.fn(),
+      };
+      // Ensure the 'on' method is chainable or returns the object
+      fakeProcess.on = fakeProcess.on.bind(fakeProcess);
+      return fakeProcess as any;
+    });
+
+
+    await expect(tool.execute({}, new AbortController().signal)).rejects.toThrow(
+      /Failed to start ActiveWindowInfo.exe: ENOENT: spawn EACCES. Ensure the utility is compiled and at the correct path: .*ActiveWindowInfo.exe/,
+    );
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('should be aborted if signal is aborted', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', writable: true });
+    const controller = new AbortController();
+
+    mockProcess.on.mockImplementation((event: string, callback: Function) => {
+      if (event === 'close') {
+        // Simulate abortion before close is called
+        controller.abort();
+        callback(0); // Success code
+      }
+      return mockProcess;
+    });
+
+    await expect(tool.execute({}, controller.signal)).rejects.toThrow(
+        'Tool execution was aborted.'
+    );
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('validateToolParams should return null as there are no params', () => {
+    expect(tool.validateToolParams({})).toBeNull();
+  });
+
+  it('getDescription should return the correct description string', () => {
+    expect(tool.getDescription({})).toBe('Gets information about the currently active application window on Windows.');
+  });
+
+});

--- a/packages/core/src/tools/get-active-application-info.ts
+++ b/packages/core/src/tools/get-active-application-info.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as child_process from 'child_process';
+import * as path from 'path';
+import {
+  BaseTool,
+  GetActiveApplicationInfoParams,
+  GetActiveApplicationInfoResult,
+  ToolResult,
+} from './tools'; // Adjust path as necessary
+
+// TODO: Determine the final path for the compiled utility
+const ACTIVE_WINDOW_INFO_EXE_PATH = path.join(
+  __dirname,
+  '..', // Adjust based on final location relative to this file
+  '..',
+  '..',
+  '..',
+  'ActiveWindowInfo', // Assuming it's in a sibling directory at the root for now
+  'bin', // Standard output for .NET builds
+  'Debug', // Or Release
+  'net6.0', // Or other target framework
+  'ActiveWindowInfo.exe',
+);
+
+export class GetActiveApplicationInfoTool extends BaseTool<
+  GetActiveApplicationInfoParams,
+  GetActiveApplicationInfoResult
+> {
+  constructor() {
+    super(
+      'getActiveApplicationInfo',
+      'Get Active Application Info',
+      'Retrieves information (PID, title, executable path) about the currently active application window. This tool is Windows-specific.',
+      {}, // No parameters
+      false, // isOutputMarkdown
+      false, // canUpdateOutput
+    );
+  }
+
+  validateToolParams(
+    params: GetActiveApplicationInfoParams,
+  ): string | null {
+    // No parameters to validate
+    return null;
+  }
+
+  getDescription(params: GetActiveApplicationInfoParams): string {
+    return 'Gets information about the currently active application window on Windows.';
+  }
+
+  async execute(
+    params: GetActiveApplicationInfoParams,
+    signal: AbortSignal,
+  ): Promise<GetActiveApplicationInfoResult> {
+    if (process.platform !== 'win32') {
+      throw new Error(
+        'GetActiveApplicationInfoTool is only supported on Windows.',
+      );
+    }
+
+    return new Promise<GetActiveApplicationInfoResult>((resolve, reject) => {
+      const process = child_process.spawn(ACTIVE_WINDOW_INFO_EXE_PATH, [], {
+        signal,
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      process.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      process.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      process.on('close', (code) => {
+        if (signal.aborted) {
+          return reject(new Error('Tool execution was aborted.'));
+        }
+        if (code !== 0) {
+          return reject(
+            new Error(
+              `ActiveWindowInfo.exe exited with code ${code}: ${stderr}`,
+            ),
+          );
+        }
+
+        try {
+          const resultData = JSON.parse(stdout);
+          // Ensure the result conforms to the interface, though the C# app should guarantee this
+          const result: GetActiveApplicationInfoResult = {
+            pid: resultData.pid,
+            title: resultData.title,
+            executablePath: resultData.executablePath,
+            llmContent: `Active application: ${resultData.title} (PID: ${resultData.pid}, Path: ${resultData.executablePath})`,
+            returnDisplay: `Active Window:\nTitle: ${resultData.title}\nPID: ${resultData.pid}\nExecutable Path: ${resultData.executablePath}`,
+          };
+          resolve(result);
+        } catch (e: any) {
+          reject(new Error(`Error parsing JSON output: ${e.message}\nOutput: ${stdout}`));
+        }
+      });
+
+      process.on('error', (err) => {
+        // e.g., EACCES or ENOENT
+        reject(
+          new Error(
+            `Failed to start ActiveWindowInfo.exe: ${err.message}. Ensure the utility is compiled and at the correct path: ${ACTIVE_WINDOW_INFO_EXE_PATH}`,
+          ),
+        );
+      });
+    });
+  }
+}

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -244,3 +244,13 @@ export enum ToolConfirmationOutcome {
   ModifyWithEditor = 'modify_with_editor',
   Cancel = 'cancel',
 }
+
+export interface GetActiveApplicationInfoParams {
+  // No parameters needed for this tool
+}
+
+export interface GetActiveApplicationInfoResult extends ToolResult {
+  pid: number;
+  title: string;
+  executablePath: string;
+}


### PR DESCRIPTION
Adds a new tool to retrieve active application information (PID, title, executable path) on Windows.

- Defines TypeScript interfaces for the tool.
- Implements a C# utility (ActiveWindowInfo.exe) to fetch data using Windows APIs.
- Creates GetActiveApplicationInfoTool class in Node.js to spawn the C# utility and parse its JSON output.
- Registers the tool in the application's configuration.
- Adds unit tests for the Node.js tool.
- Includes documentation for the new tool, highlighting its Windows-specific nature.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
