### PR TITLE
Issue #2713 Line number rendered in the output code box is preventing…

### DIFF
--- a/packages/cli/src/ui/utils/CodeColorizer.tsx
+++ b/packages/cli/src/ui/utils/CodeColorizer.tsx
@@ -158,7 +158,6 @@ export function colorizeCode(
       error,
     );
     // Fallback to plain text with default color on error
-    // Also display line numbers in fallback
     const lines = codeToHighlight.split('\n');
     const padWidth = String(lines.length).length; // Calculate padding width based on number of lines
     return (
@@ -169,9 +168,6 @@ export function colorizeCode(
       >
         {lines.map((line, index) => (
           <Box key={index}>
-            <Text color={activeTheme.defaultColor}>
-              {`${String(index + 1).padStart(padWidth, ' ')} `}
-            </Text>
             <Text color={activeTheme.colors.Gray}>{line}</Text>
           </Box>
         ))}

--- a/packages/cli/src/ui/utils/CodeColorizer.tsx
+++ b/packages/cli/src/ui/utils/CodeColorizer.tsx
@@ -144,9 +144,6 @@ export function colorizeCode(
           const contentToRender = renderedNode !== null ? renderedNode : line;
           return (
             <Box key={index}>
-              <Text color={activeTheme.colors.Gray}>
-                {`${String(index + 1 + hiddenLinesCount).padStart(padWidth, ' ')} `}
-              </Text>
               <Text color={activeTheme.defaultColor} wrap="wrap">
                 {contentToRender}
               </Text>


### PR DESCRIPTION
… users to leverage it effectively

## TLDR

There are line numbers rendered in the multi-line code block which prevents one to run it in the bash terminal

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

Tried with different scenarios.

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | Y  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Closes https://github.com/google-gemini/gemini-cli/issues/2713
<!-- Add links to any gh issues or other external bugs --->
