### PR TITLE
Rename AuthType LOGIN_WITH_GOOGLE_PERSONAL -> LOGIN_WITH_GOOGLE

### DIFF
--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -9,7 +9,7 @@ import { loadEnvironment } from './config.js';
 
 export const validateAuthMethod = (authMethod: string): string | null => {
   loadEnvironment();
-  if (authMethod === AuthType.LOGIN_WITH_GOOGLE_PERSONAL) {
+  if (authMethod === AuthType.LOGIN_WITH_GOOGLE) {
     return null;
   }
 

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -27,10 +27,7 @@ export function AuthDialog({
     initialErrorMessage || null,
   );
   const items = [
-    {
-      label: 'Login with Google',
-      value: AuthType.LOGIN_WITH_GOOGLE_PERSONAL,
-    },
+    { label: 'Login with Google', value: AuthType.LOGIN_WITH_GOOGLE },
     { label: 'Gemini API Key (AI Studio)', value: AuthType.USE_GEMINI },
     { label: 'Vertex AI', value: AuthType.USE_VERTEX_AI },
   ];

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1009,7 +1009,7 @@ describe('useGeminiStream', () => {
     it('should call parseAndFormatApiError with the correct authType on stream initialization failure', async () => {
       // 1. Setup
       const mockError = new Error('Rate limit exceeded');
-      const mockAuthType = AuthType.LOGIN_WITH_GOOGLE_PERSONAL;
+      const mockAuthType = AuthType.LOGIN_WITH_GOOGLE;
       mockParseAndFormatApiError.mockClear();
       mockSendMessageStream.mockReturnValue(
         (async function* () {

--- a/packages/cli/src/ui/privacy/PrivacyNotice.tsx
+++ b/packages/cli/src/ui/privacy/PrivacyNotice.tsx
@@ -29,7 +29,7 @@ const PrivacyNoticeText = ({
       return <GeminiPrivacyNotice onExit={onExit} />;
     case AuthType.USE_VERTEX_AI:
       return <CloudPaidPrivacyNotice onExit={onExit} />;
-    case AuthType.LOGIN_WITH_GOOGLE_PERSONAL:
+    case AuthType.LOGIN_WITH_GOOGLE:
     default:
       return <CloudFreePrivacyNotice config={config} onExit={onExit} />;
   }

--- a/packages/cli/src/ui/utils/errorParsing.test.ts
+++ b/packages/cli/src/ui/utils/errorParsing.test.ts
@@ -34,7 +34,7 @@ describe('parseAndFormatApiError', () => {
       'got status: 429 Too Many Requests. {"error":{"code":429,"message":"Rate limit exceeded","status":"RESOURCE_EXHAUSTED"}}';
     const result = parseAndFormatApiError(
       errorMessage,
-      AuthType.LOGIN_WITH_GOOGLE_PERSONAL,
+      AuthType.LOGIN_WITH_GOOGLE,
     );
     expect(result).toContain('[API Error: Rate limit exceeded');
     expect(result).toContain(enterpriseMessage);

--- a/packages/cli/src/ui/utils/errorParsing.ts
+++ b/packages/cli/src/ui/utils/errorParsing.ts
@@ -45,7 +45,7 @@ function isStructuredError(error: unknown): error is StructuredError {
 
 function getRateLimitMessage(authType?: AuthType): string {
   switch (authType) {
-    case AuthType.LOGIN_WITH_GOOGLE_PERSONAL:
+    case AuthType.LOGIN_WITH_GOOGLE:
       return RATE_LIMIT_ERROR_MESSAGE_GOOGLE;
     case AuthType.USE_GEMINI:
       return RATE_LIMIT_ERROR_MESSAGE_USE_GEMINI;

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -13,7 +13,7 @@ export async function createCodeAssistContentGenerator(
   httpOptions: HttpOptions,
   authType: AuthType,
 ): Promise<ContentGenerator> {
-  if (authType === AuthType.LOGIN_WITH_GOOGLE_PERSONAL) {
+  if (authType === AuthType.LOGIN_WITH_GOOGLE) {
     const authClient = await getOauthClient();
     const projectId = await setupUser(authClient);
     return new CodeAssistServer(authClient, projectId, httpOptions);

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -504,7 +504,7 @@ export class GeminiClient {
    */
   private async handleFlashFallback(authType?: string): Promise<string | null> {
     // Only handle fallback for OAuth users
-    if (authType !== AuthType.LOGIN_WITH_GOOGLE_PERSONAL) {
+    if (authType !== AuthType.LOGIN_WITH_GOOGLE) {
       return null;
     }
 

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -20,7 +20,7 @@ describe('contentGenerator', () => {
     );
     const generator = await createContentGenerator({
       model: 'test-model',
-      authType: AuthType.LOGIN_WITH_GOOGLE_PERSONAL,
+      authType: AuthType.LOGIN_WITH_GOOGLE,
     });
     expect(createCodeAssistContentGenerator).toHaveBeenCalled();
     expect(generator).toBe(mockGenerator);

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -35,7 +35,7 @@ export interface ContentGenerator {
 }
 
 export enum AuthType {
-  LOGIN_WITH_GOOGLE_PERSONAL = 'oauth-personal',
+  LOGIN_WITH_GOOGLE = 'oauth-personal',
   USE_GEMINI = 'gemini-api-key',
   USE_VERTEX_AI = 'vertex-ai',
 }
@@ -66,7 +66,7 @@ export async function createContentGeneratorConfig(
   };
 
   // if we are using google auth nothing else to validate for now
-  if (authType === AuthType.LOGIN_WITH_GOOGLE_PERSONAL) {
+  if (authType === AuthType.LOGIN_WITH_GOOGLE) {
     return contentGeneratorConfig;
   }
 
@@ -108,7 +108,7 @@ export async function createContentGenerator(
       'User-Agent': `GeminiCLI/${version} (${process.platform}; ${process.arch})`,
     },
   };
-  if (config.authType === AuthType.LOGIN_WITH_GOOGLE_PERSONAL) {
+  if (config.authType === AuthType.LOGIN_WITH_GOOGLE) {
     return createCodeAssistContentGenerator(httpOptions, config.authType);
   }
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -197,7 +197,7 @@ export class GeminiChat {
    */
   private async handleFlashFallback(authType?: string): Promise<string | null> {
     // Only handle fallback for OAuth users
-    if (authType !== AuthType.LOGIN_WITH_GOOGLE_PERSONAL) {
+    if (authType !== AuthType.LOGIN_WITH_GOOGLE) {
       return null;
     }
 

--- a/packages/core/src/utils/flashFallback.integration.test.ts
+++ b/packages/core/src/utils/flashFallback.integration.test.ts
@@ -78,14 +78,14 @@ describe('Flash Fallback Integration', () => {
         return status === 429;
       },
       onPersistent429: mockFallbackHandler,
-      authType: AuthType.LOGIN_WITH_GOOGLE_PERSONAL,
+      authType: AuthType.LOGIN_WITH_GOOGLE,
     });
 
     // Verify fallback was triggered
     expect(fallbackCalled).toBe(true);
     expect(fallbackModel).toBe(DEFAULT_GEMINI_FLASH_MODEL);
     expect(mockFallbackHandler).toHaveBeenCalledWith(
-      AuthType.LOGIN_WITH_GOOGLE_PERSONAL,
+      AuthType.LOGIN_WITH_GOOGLE,
     );
     expect(result).toBe('success after fallback');
     // Should have: 2 failures, then fallback triggered, then 1 success after retry reset

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -97,7 +97,7 @@ export async function retryWithBackoff<T>(
       if (
         consecutive429Count >= 2 &&
         onPersistent429 &&
-        authType === AuthType.LOGIN_WITH_GOOGLE_PERSONAL
+        authType === AuthType.LOGIN_WITH_GOOGLE
       ) {
         try {
           const fallbackModel = await onPersistent429(authType);


### PR DESCRIPTION
## TLDR

Pure refactor.

## Dive Deeper

We used to have LOGIN_WITH_GOOGLE_WORKSPACE but we got rid of that and folded it into this option.


## Linked issues / bugs

https://github.com/google-gemini/gemini-cli/issues/1649
