### PR TITLE
feat(triage): improve automated issue triage workflows

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -23,19 +23,10 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
-
       - name: Run Gemini Issue Triage
-        uses: google-gemini/gemini-cli-action@111dadaecabd309baba60f56f2b520c52c0f9a47
+        uses: google-gemini/gemini-cli-action@41c0f1b3cbd1a0b284251bd1aac034edd07a3a2f
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          REPOSITORY: ${{ github.repository }}
         with:
           version: 0.1.8-rc.0
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -48,16 +39,23 @@ jobs:
                 "run_shell_command(gh label list)",
                 "run_shell_command(gh issue edit)",
                 "run_shell_command(gh issue list)"
-              ],
+              ]
             }
           prompt: |
             You are an issue triage assistant. Analyze the current GitHub issue and apply the most appropriate existing labels.
 
             Steps:
-            1. Run: `gh label list --limit 100` to get all available labels.
+            1. Run: `gh label list --repo ${{ github.repository }} --limit 100` to get all available labels.
             2. Review the issue title and body provided in the environment variables.
             3. Select the most relevant labels from the existing labels, focusing on kind/*, area/*, and priority/*.
-            4. Apply the selected labels to this issue using: `gh issue edit ISSUE_NUMBER --add-label "label1,label2"`
+            4. Apply the selected labels to this issue using: `gh issue edit ${{ github.event.issue.number }} --repo ${{ github.repository }} --add-label "label1,label2"`
+            5. If the issue has a "status/need-triage" label, remove it after applying the appropriate labels: `gh issue edit ${{ github.event.issue.number }} --repo ${{ github.repository }} --remove-label "status/need-triage"`
+
+            Guidelines:
+            - Only use labels that already exist in the repository.
+            - Do not add comments or modify the issue content.
+            - Triage only the current issue.
+            - Assign all applicable kind/*, area/*, and priority/* labels based on the issue content.
 
             Guidelines:
             - Only use labels that already exist in the repository.

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -21,28 +21,33 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
-
       - name: Find untriaged issues
         id: find_issues
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
+          echo "🔍 Finding issues without labels..."
           NO_LABEL_ISSUES=$(gh issue list --repo ${{ github.repository }} --search "is:open is:issue no:label" --json number,title,body)
-          NEEDS_TRIAGE_ISSUES=$(gh issue list --repo ${{ github.repository }} --search "is:open is:issue label:\"status/needs-triage\"" --json number,title,body)
-          ISSUES=$(echo "$NO_LABEL_ISSUES" "$NEEDS_TRIAGE_ISSUES" | jq -c -s 'add | unique_by(.number)')
+
+          echo "🏷️ Finding issues that need triage..."
+          NEED_TRIAGE_ISSUES=$(gh issue list --repo ${{ github.repository }} --search "is:open is:issue label:\"status/need-triage\"" --json number,title,body)
+
+          echo "🔄 Merging and deduplicating issues..."
+          ISSUES=$(echo "$NO_LABEL_ISSUES" "$NEED_TRIAGE_ISSUES" | jq -c -s 'add | unique_by(.number)')
+
+          echo "📝 Setting output for GitHub Actions..."
           echo "issues_to_triage=$ISSUES" >> "$GITHUB_OUTPUT"
+
+          echo "💾 Writing issues to temporary file for Gemini CLI..."
+          echo "$ISSUES" > /tmp/issues_to_triage.json
+
+          echo "✅ Found $(echo "$ISSUES" | jq 'length') issues to triage! 🎯"
 
       - name: Run Gemini Issue Triage
         if: steps.find_issues.outputs.issues_to_triage != '[]'
-        uses: google-gemini/gemini-cli-action@111dadaecabd309baba60f56f2b520c52c0f9a47
+        uses: google-gemini/gemini-cli-action@41c0f1b3cbd1a0b284251bd1aac034edd07a3a2f
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          ISSUES_TO_TRIAGE: ${{ steps.find_issues.outputs.issues_to_triage }}
-          REPOSITORY: ${{ github.repository }}
         with:
           version: 0.1.8-rc.0
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -54,19 +59,38 @@ jobs:
               "coreTools": [
                 "run_shell_command(gh label list)",
                 "run_shell_command(gh issue edit)",
-                "run_shell_command(gh issue list)"
-              ],
+                "run_shell_command(gh issue list)",
+                "run_shell_command(cat /tmp/issues_to_triage.json)"
+              ]
             }
           prompt: |
-            You are an issue triage assistant. Analyze issues and apply appropriate labels.
+            You are an issue triage assistant. Analyze issues and apply appropriate labels ONE AT A TIME.
+
+            Repository: ${{ github.repository }}
 
             Steps:
-            1. Run: `gh label list --limit 100`
-            2. Check environment variable: $ISSUES_TO_TRIAGE (JSON array of issues)
-            3. For each issue, apply labels: `gh issue edit ISSUE_NUMBER --add-label "label1,label2"`
+            1. Run: `gh label list --repo ${{ github.repository }} --limit 100` to see available labels
+            2. Run: `cat /tmp/issues_to_triage.json` to get the issues that need triaging
+            3. Parse the JSON array from step 2 and for EACH INDIVIDUAL issue, apply appropriate labels using separate commands:
+               - `gh issue edit ISSUE_NUMBER --repo ${{ github.repository }} --add-label "label1"`
+               - `gh issue edit ISSUE_NUMBER --repo ${{ github.repository }} --add-label "label2"`
+               - Continue for each label separately
+
+            IMPORTANT: Label each issue individually, one command per issue, one label at a time if needed.
 
             Guidelines:
-            - Only use existing repository labels
-            - Do not add comments
-            - Triage each issue independently
-            - Focus on: kind/*, area/*, priority/* labels
+            - Only use existing repository labels from step 1
+            - Do not add comments to issues
+            - Triage each issue independently based on title and body content
+            - Focus on applying: kind/* (bug/enhancement/documentation), area/* (core/cli/testing/windows), and priority/* labels
+            - If an issue has insufficient information, consider applying "status/need-information"
+            - After applying appropriate labels to an issue, remove the "status/need-triage" label if present: `gh issue edit ISSUE_NUMBER --repo ${{ github.repository }} --remove-label "status/need-triage"`
+            - Execute one `gh issue edit` command per issue, wait for success before proceeding to the next
+
+            Example triage logic:
+            - Issues with "bug", "error", "broken" → kind/bug
+            - Issues with "feature", "enhancement", "improve" → kind/enhancement
+            - Issues about Windows/performance → area/windows, area/performance
+            - Critical bugs → priority/p0, other bugs → priority/p1, enhancements → priority/p2
+
+            Process each issue sequentially and confirm each labeling operation before moving to the next issue.


### PR DESCRIPTION
This commit enhances the GitHub Actions workflows for automated issue triage. The key changes include:
- Bumping the `gemini-cli-action` to the latest version.
- Making all `gh` CLI calls repository-aware by adding the `--repo` flag to prevent errors when the workflows are forked.
- Improving the prompts for the Gemini CLI to be more specific and provide better guidance on how to triage issues.
- In the scheduled triage workflow:
    - Issues are now passed to the Gemini CLI via a temporary file to handle a larger number of issues.
    - The workflow now also triages issues with the "status/needs-triage" label, in addition to issues with no labels.

Successful runs from the branch: https://github.com/google-gemini/gemini-cli/actions/runs/15987526647/job/45094674230

---
![image](https://github.com/user-attachments/assets/4a5f6879-73b6-4bb1-b6a1-0573a51a6d72)
