### PR TITLE
Add Ctrl+n and Ctrl+p shortcuts to navigate input suggestions

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -212,11 +212,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       if (completion.showSuggestions) {
-        if (key.name === 'up') {
+        if (key.name === 'up' || (key.ctrl && key.name === 'p')) {
           completion.navigateUp();
           return;
         }
-        if (key.name === 'down') {
+        if (key.name === 'down' || (key.ctrl && key.name === 'n')) {
           completion.navigateDown();
           return;
         }


### PR DESCRIPTION
## TLDR

In many applications or IDEs, `Ctrl+n` and `Ctrl+p` are commonly used shortcuts for navigating up and down in suggestion lists.

## Dive Deeper

## Reviewer Test Plan

Type `@` or `/` to trigger the suggestion list, then press `Ctrl+n` or `Ctrl+p` to navigate up and down.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ✅  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

