### PR TITLE
Fix: Correct closing tag in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,4 +24,4 @@
 
 ## Linked issues / bugs
 
-<!-- Add links to any gh issues or other external bugs --->
+<!-- Add links to any gh issues or other external bugs -->


### PR DESCRIPTION
## TLDR

Fixes an incorrect closing tag in the pull request template.

## Dive Deeper

The HTML comment closing tag was `--->`, which is invalid. This has been corrected to `-->`.

## Reviewer Test Plan

N/A

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2754
