### PR TITLE
feat: Allow setting path for config directory via environment variable

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -18,7 +18,9 @@ import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
 import { DefaultDark } from '../ui/themes/default.js';
 
-export const SETTINGS_DIRECTORY_NAME = '.gemini';
+const GEMINI_CONFIG_DIR_ENV_VAR = 'GEMINI_CONFIG_DIR';
+export const SETTINGS_DIRECTORY_NAME =
+  process.env[GEMINI_CONFIG_DIR_ENV_VAR] || '.gemini';
 export const USER_SETTINGS_DIR = path.join(homedir(), SETTINGS_DIRECTORY_NAME);
 export const USER_SETTINGS_PATH = path.join(USER_SETTINGS_DIR, 'settings.json');
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -13,14 +13,13 @@ import {
   BugCommandSettings,
   TelemetrySettings,
   AuthType,
+  GEMINI_DIR,
 } from '@google/gemini-cli-core';
 import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
 import { DefaultDark } from '../ui/themes/default.js';
 
-const GEMINI_CONFIG_DIR_ENV_VAR = 'GEMINI_CONFIG_DIR';
-export const SETTINGS_DIRECTORY_NAME =
-  process.env[GEMINI_CONFIG_DIR_ENV_VAR] || '.gemini';
+export const SETTINGS_DIRECTORY_NAME = GEMINI_DIR;
 export const USER_SETTINGS_DIR = path.join(homedir(), SETTINGS_DIRECTORY_NAME);
 export const USER_SETTINGS_PATH = path.join(USER_SETTINGS_DIR, 'settings.json');
 

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     outputFile: {
       junit: 'junit.xml',
     },
+    setupFiles: ['./vitest.setup.ts'],
     coverage: {
       enabled: true,
       provider: 'v8',

--- a/packages/cli/vitest.setup.ts
+++ b/packages/cli/vitest.setup.ts
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { setSimulate429 } from './src/utils/testUtils.js';
-
 // Unset the GEMINI_CONFIG_DIR environment variable before tests run.
 // This ensures that tests use the default config directory.
 process.env.GEMINI_CONFIG_DIR = '';
-
-// Disable 429 simulation globally for all tests
-setSimulate429(false);

--- a/packages/cli/vitest.setup.ts
+++ b/packages/cli/vitest.setup.ts
@@ -6,4 +6,4 @@
 
 // Unset the GEMINI_CONFIG_DIR environment variable before tests run.
 // This ensures that tests use the default config directory.
-process.env.GEMINI_CONFIG_DIR = '';
+delete process.env.GEMINI_CONFIG_DIR;

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -39,8 +39,7 @@ const SIGN_IN_SUCCESS_URL =
 const SIGN_IN_FAILURE_URL =
   'https://developers.google.com/gemini-code-assist/auth_failure_gemini';
 
-const GEMINI_CONFIG_DIR_ENV_VAR = 'GEMINI_CONFIG_DIR';
-const GEMINI_DIR = process.env[GEMINI_CONFIG_DIR_ENV_VAR] || '.gemini';
+import { GEMINI_DIR } from '../utils/paths.js';
 const CREDENTIAL_FILENAME = 'oauth_creds.json';
 const GOOGLE_ACCOUNT_ID_FILENAME = 'google_account_id';
 

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -39,7 +39,8 @@ const SIGN_IN_SUCCESS_URL =
 const SIGN_IN_FAILURE_URL =
   'https://developers.google.com/gemini-code-assist/auth_failure_gemini';
 
-const GEMINI_DIR = '.gemini';
+const GEMINI_CONFIG_DIR_ENV_VAR = 'GEMINI_CONFIG_DIR';
+const GEMINI_DIR = process.env[GEMINI_CONFIG_DIR_ENV_VAR] || '.gemini';
 const CREDENTIAL_FILENAME = 'oauth_creds.json';
 const GOOGLE_ACCOUNT_ID_FILENAME = 'google_account_id';
 

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 import os from 'os';
 import * as crypto from 'crypto';
 
-export const GEMINI_CONFIG_DIR_ENV_VAR = 'GEMINI_CONFIG_DIR';
+const GEMINI_CONFIG_DIR_ENV_VAR = 'GEMINI_CONFIG_DIR';
 export const GEMINI_DIR = process.env[GEMINI_CONFIG_DIR_ENV_VAR] || '.gemini';
 const TMP_DIR_NAME = 'tmp';
 

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -8,7 +8,8 @@ import path from 'node:path';
 import os from 'os';
 import * as crypto from 'crypto';
 
-export const GEMINI_DIR = '.gemini';
+export const GEMINI_CONFIG_DIR_ENV_VAR = 'GEMINI_CONFIG_DIR';
+export const GEMINI_DIR = process.env[GEMINI_CONFIG_DIR_ENV_VAR] || '.gemini';
 const TMP_DIR_NAME = 'tmp';
 
 /**

--- a/packages/core/test-setup.ts
+++ b/packages/core/test-setup.ts
@@ -8,7 +8,7 @@ import { setSimulate429 } from './src/utils/testUtils.js';
 
 // Unset the GEMINI_CONFIG_DIR environment variable before tests run.
 // This ensures that tests use the default config directory.
-process.env.GEMINI_CONFIG_DIR = '';
+delete process.env.GEMINI_CONFIG_DIR;
 
 // Disable 429 simulation globally for all tests
 setSimulate429(false);


### PR DESCRIPTION
## TLDR

This change introduces the ability to configure the Gemini CLI config directory
using the `GEMINI_CONFIG_DIR` environment variable.

## Dive Deeper

Previously, the Gemini CLI hardcoded the configuration directory to ".gemini" within the user's home directory. This change externalizes that path, allowing users to specify an alternative location by setting the `GEMINI_CONFIG_DIR` environment variable. If the environment variable is not set, the CLI will gracefully fall back to the default ".gemini" directory.


To ensure that our tests are robust and not affected by any lingering environment variables from the test runner's environment, I've updated the Vitest setup files for both the cli and core packages. These setup files now explicitly unset GEMINI_CONFIG_DIR before any tests are executed, guaranteeing that tests always run with the default configuration directory behavior.


## Reviewer Test Plan

Verify `GEMINI_CONFIG_DIR` functionality:
* Default behavior: Run the CLI without setting `GEMINI_CONFIG_DIR`. Verify that configuration files (e.g., settings.json, oauth_creds.json) are created and read from the default
         "~/.gemini" directory within your home directory.
* Custom path: Set the `GEMINI_CONFIG_DIR` environment variable to a custom, non-existent path (e.g., export GEMINI_CONFIG_DIR=".config/.gemini"). Run the CLI. Verify that the
         configuration files are now created and read from this custom path.
* Unset after custom path: Unset the `GEMINI_CONFIG_DIR` environment variable. Run the CLI again. Verify that it reverts to using the default "~/.gemini" directory.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |


Closes #2815
