### PR TITLE
feat: Add custom ASCII art config option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "strip-ansi": "^7.1.0"
+      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },
@@ -9582,7 +9585,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -84,5 +84,7 @@
     "typescript-eslint": "^8.30.1",
     "yargs": "^17.7.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "strip-ansi": "^7.1.0"
+  }
 }

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -53,6 +53,7 @@ interface CliArgs {
   telemetryTarget: string | undefined;
   telemetryOtlpEndpoint: string | undefined;
   telemetryLogPrompts: boolean | undefined;
+  'ascii-art': string | undefined;
 }
 
 async function parseArguments(): Promise<CliArgs> {
@@ -127,6 +128,10 @@ async function parseArguments(): Promise<CliArgs> {
       type: 'boolean',
       description: 'Enables checkpointing of file edits',
       default: false,
+    })
+    .option('ascii-art', {
+      type: 'string',
+      description: 'Custom ASCII art to display in the header',
     })
     .version(await getCliVersion()) // This will enable the --version flag based on package.json
     .alias('v', 'version')
@@ -245,6 +250,7 @@ export async function loadCliConfig(
     bugCommand: settings.bugCommand,
     model: argv.model!,
     extensionContextFilePaths,
+    asciiArt: argv['ascii-art'] ?? settings.asciiArt,
   });
 }
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -64,6 +64,7 @@ export interface Settings {
   // UI setting. Does not display the ANSI-controlled terminal title.
   hideWindowTitle?: boolean;
   hideTips?: boolean;
+  asciiArt?: string;
 
   // Add other settings here.
 }

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -67,6 +67,7 @@ interface MockServerConfig {
   getAccessibility: Mock<() => AccessibilitySettings>;
   getProjectRoot: Mock<() => string | undefined>;
   getAllGeminiMdFilenames: Mock<() => string[]>;
+  getAsciiArt: Mock<() => string | undefined>;
 }
 
 // Mock @google/gemini-cli-core and its Config class
@@ -128,6 +129,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
         getCheckpointingEnabled: vi.fn(() => opts.checkpointing ?? true),
         getAllGeminiMdFilenames: vi.fn(() => ['GEMINI.md']),
         setFlashFallbackHandler: vi.fn(),
+        getAsciiArt: vi.fn(() => opts.asciiArt),
       };
     });
   return {
@@ -410,6 +412,22 @@ describe('App UI', () => {
     currentUnmount = unmount;
     await Promise.resolve();
     expect(vi.mocked(Tips)).not.toHaveBeenCalled();
+  });
+
+  it('should display an empty string when customAsciiArt is an empty string', async () => {
+    mockConfig.getAsciiArt.mockReturnValue('');
+
+    const { lastFrame, unmount } = render(
+      <App
+        config={mockConfig as unknown as ServerConfig}
+        settings={mockSettings}
+      />,
+    );
+    currentUnmount = unmount;
+    await Promise.resolve();
+    // Assert that the default ASCII art is NOT present
+    expect(lastFrame()).not.toContain('  ______'); // Part of shortAsciiLogo
+    expect(lastFrame()).not.toContain('  ██████'); // Part of longAsciiLogo
   });
 
   describe('when no theme is set', () => {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -582,7 +582,10 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
           key={staticKey}
           items={[
             <Box flexDirection="column" key="header">
-              <Header terminalWidth={terminalWidth} />
+              <Header
+                terminalWidth={terminalWidth}
+                customAsciiArt={config.getAsciiArt()}
+              />
               {!settings.merged.hideTips && <Tips config={config} />}
               {updateMessage && <UpdateNotification message={updateMessage} />}
             </Box>,

--- a/packages/cli/src/ui/components/Header.tsx
+++ b/packages/cli/src/ui/components/Header.tsx
@@ -23,7 +23,7 @@ export const Header: React.FC<HeaderProps> = ({
   let displayTitle;
   const widthOfLongLogo = getAsciiArtWidth(longAsciiLogo);
 
-  if (customAsciiArt) {
+  if (customAsciiArt !== undefined) {
     displayTitle = customAsciiArt;
   } else {
     displayTitle =

--- a/packages/cli/src/ui/components/Header.tsx
+++ b/packages/cli/src/ui/components/Header.tsx
@@ -10,6 +10,7 @@ import Gradient from 'ink-gradient';
 import { Colors } from '../colors.js';
 import { shortAsciiLogo, longAsciiLogo } from './AsciiArt.js';
 import { getAsciiArtWidth } from '../utils/textUtils.js';
+import stripAnsi from 'strip-ansi';
 
 interface HeaderProps {
   customAsciiArt?: string; // For user-defined ASCII art
@@ -24,7 +25,7 @@ export const Header: React.FC<HeaderProps> = ({
   const widthOfLongLogo = getAsciiArtWidth(longAsciiLogo);
 
   if (customAsciiArt !== undefined) {
-    displayTitle = customAsciiArt;
+    displayTitle = stripAnsi(customAsciiArt);
   } else {
     displayTitle =
       terminalWidth >= widthOfLongLogo ? longAsciiLogo : shortAsciiLogo;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -130,6 +130,7 @@ export interface ConfigParameters {
   bugCommand?: BugCommandSettings;
   model: string;
   extensionContextFilePaths?: string[];
+  asciiArt?: string;
 }
 
 export class Config {
@@ -168,6 +169,7 @@ export class Config {
   private readonly bugCommand: BugCommandSettings | undefined;
   private readonly model: string;
   private readonly extensionContextFilePaths: string[];
+  private readonly asciiArt: string | undefined;
   private modelSwitchedDuringSession: boolean = false;
   flashFallbackHandler?: FlashFallbackHandler;
 
@@ -211,6 +213,7 @@ export class Config {
     this.bugCommand = params.bugCommand;
     this.model = params.model;
     this.extensionContextFilePaths = params.extensionContextFilePaths ?? [];
+    this.asciiArt = params.asciiArt;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -443,6 +446,10 @@ export class Config {
 
   getExtensionContextFilePaths(): string[] {
     return this.extensionContextFilePaths;
+  }
+
+  getAsciiArt(): string | undefined {
+    return this.asciiArt;
   }
 
   async getGitService(): Promise<GitService> {


### PR DESCRIPTION
## TLDR

This commit introduces a new configuration option `--ascii-art` to allow users to specify custom ASCII art to be displayed in the CLI header.

## Reviewer Test Plan

Here's a test plan to verify the changes:

**Test Plan: Custom ASCII Art Option**

1.  **Verify CLI `--ascii-art` flag:**
    *   Run the CLI with a custom ASCII art string: `gemini --ascii-art "HELLO"`
    *   **Expected:** The CLI header should display "HELLO" instead of the default ASCII art.

2.  **Verify `settings.json` `asciiArt` option:**
    *   Create or modify `~/.gemini/settings.json` (or `.gemini/settings.json` in your project root) and add:
        ```json
        {
          "asciiArt": "CUSTOM ART FROM SETTINGS"
        }
        ```
    *   Run the CLI without the `--ascii-art` flag: `gemini`
    *   **Expected:** The CLI header should display "CUSTOM ART FROM SETTINGS".

3.  **Verify empty `asciiArt` string:**
    *   Set `asciiArt` to an empty string in `settings.json`:
        ```json
        {
          "asciiArt": ""
        }
        ```
    *   Run the CLI: `gemini`
    *   **Expected:** No ASCII art should be displayed in the header (it should be blank where the art usually is).

4.  **Verify default ASCII art (no `asciiArt` set):**
    *   Remove the `asciiArt` entry from your `settings.json` (or ensure it's not present).
    *   Run the CLI: `gemini`
    *   **Expected:** The default Gemini ASCII art should be displayed in the header.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
closes #2828 
closes #2360