### PR TITLE
feat: add GitHub Action wrapper for Gemini CLI (fixes #2055)

### DIFF
--- a/.github/actions/gemini-cli/action.yml
+++ b/.github/actions/gemini-cli/action.yml
@@ -1,0 +1,10 @@
+name: 'Gemini CLI Action'
+description: 'Run Gemini CLI in GitHub Actions'
+author: 'Gosling-dude'
+runs:
+  using: 'node16'
+  main: 'entrypoint.js'
+inputs:
+  args:
+    description: 'Arguments to pass to Gemini CLI'
+    required: true

--- a/.github/actions/gemini-cli/action.yml
+++ b/.github/actions/gemini-cli/action.yml
@@ -2,7 +2,7 @@ name: 'Gemini CLI Action'
 description: 'Run Gemini CLI in GitHub Actions'
 author: 'Gosling-dude'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'entrypoint.js'
 inputs:
   args:

--- a/.github/actions/gemini-cli/entrypoint.js
+++ b/.github/actions/gemini-cli/entrypoint.js
@@ -1,10 +1,13 @@
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 try {
-  const args = process.env.INPUT_ARGS;
-  const output = execSync(`npx gemini ${args}`, { stdio: 'inherit' });
-  console.log(output.toString());
+  // Split INPUT_ARGS into an array (simple whitespace split)
+  const args = process.env.INPUT_ARGS || '';
+  const commandArgs = args.trim() ? args.split(/\s+/) : [];
+
+  // Invoke `npx gemini` with execFileSync to avoid shell injection
+  execFileSync('npx', ['gemini', ...commandArgs], { stdio: 'inherit' });
 } catch (error) {
-  console.error('Error running Gemini CLI:', error);
-  process.exit(1);
+  console.error(`Error running Gemini CLI: ${error.message}`);
+  process.exit(error.status || 1);
 }

--- a/.github/actions/gemini-cli/entrypoint.js
+++ b/.github/actions/gemini-cli/entrypoint.js
@@ -1,0 +1,10 @@
+const { execSync } = require('child_process');
+
+try {
+  const args = process.env.INPUT_ARGS;
+  const output = execSync(`npx gemini ${args}`, { stdio: 'inherit' });
+  console.log(output.toString());
+} catch (error) {
+  console.error('Error running Gemini CLI:', error);
+  process.exit(1);
+}

--- a/.github/actions/gemini-cli/package.json
+++ b/.github/actions/gemini-cli/package.json
@@ -1,5 +1,4 @@
 {
   "name": "gemini-cli-action",
-  "main": "entrypoint.js",
-  "type": "module"
+  "main": "entrypoint.js"
 }

--- a/.github/actions/gemini-cli/package.json
+++ b/.github/actions/gemini-cli/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "gemini-cli-action",
+  "main": "entrypoint.js",
+  "type": "module"
+}


### PR DESCRIPTION
### Summary

This PR adds a reusable GitHub Action that wraps the Gemini CLI, enabling developers to run Gemini commands directly within GitHub Actions workflows.

### What it does

- Adds a custom action under `.github/actions/gemini-cli`
- Uses a Node-based entrypoint to execute `npx gemini <args>`
- Accepts `args` as an input to run arbitrary Gemini CLI commands

### Why this is useful

Many developers use GitHub Actions for CI/CD. This addition makes it easier to:
- Integrate Gemini CLI into automated pipelines
- Run commands like `gemini help`, `gemini generate`, etc. during CI runs
- Improve dev tooling workflows without needing manual setup

### Example usage

```yaml
- name: Run Gemini CLI
  uses: ./.github/actions/gemini-cli
  with:
    args: 'help'
