### PR TITLE
feat: add fuzzy matcher for edit error fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "fuse.js": "^7.1.0"
+      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },
@@ -5441,6 +5444,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gaxios": {

--- a/package.json
+++ b/package.json
@@ -84,5 +84,7 @@
     "typescript-eslint": "^8.30.1",
     "yargs": "^17.7.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "fuse.js": "^7.1.0"
+  }
 }

--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -544,7 +544,9 @@ describe('EditTool', () => {
         new_string: 'new content',
       };
       const result = await tool.execute(params, new AbortController().signal);
-      expect(result.llmContent).toMatch(/File already exists, cannot create/);
+      expect(result.llmContent).toMatch(
+        /You attempted to create a file at .* but it already exists/,
+      );
       expect(result.returnDisplay).toMatch(
         /Attempted to create a file that already exists/,
       );

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -227,7 +227,7 @@ Expectation for required parameters:
       if (fuzzyMatch) {
         return this.createInstructiveFailureMessage(
           fuzzyMatch,
-          correctedEditResult.params.old_string,
+          params.old_string,
         );
       }
       return {

--- a/packages/core/src/utils/fuzzyMatcher.ts
+++ b/packages/core/src/utils/fuzzyMatcher.ts
@@ -1,0 +1,173 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Fuse from 'fuse.js';
+
+/**
+ * Configuration for the fuzzy matching algorithm.
+ * These values are centralized to allow for easy tuning and to provide a clear
+ * explanation of the heuristics used.
+ */
+const FuzzyMatcherConfig = {
+  /**
+   * The minimum number of lines a search chunk should have. This provides a baseline
+   * level of context for small snippets, improving search stability and reducing
+   * false positives for common, short lines of code.
+   */
+  MINIMUM_CHUNK_SIZE: 5,
+
+  /**
+   * The number of extra lines to add to the chunk size beyond the snippet's own
+   * line count. Half of this value is added as context before and after the
+   * snippet's expected location within the chunk, improving disambiguation.
+   * This value should be an even number.
+   */
+  CONTEXT_LINES: 2,
+
+  /**
+   * The Fuse.js threshold for matching. A value of 0.0 requires a perfect match,
+   * while 1.0 would match anything. 0.4 provides a good balance for source code,
+   * tolerating minor typos and whitespace differences without being overly loose.
+   */
+  FUSE_THRESHOLD: 0.4,
+};
+
+/**
+ * Represents a chunk of text used for searching. Includes the content
+ * and its original starting line number for later reconstruction.
+ */
+interface SearchChunk {
+  content: string;
+  startLine: number;
+}
+
+/**
+ * The structured result of a fuzzy match operation.
+ */
+export interface FuzzyMatchResult {
+  /** The best-matching text block found in the source content. */
+  bestMatch: string;
+  /** The starting line number (0-indexed) of the best match in the source. */
+  startLine: number;
+  /** A confidence score from 0 (perfect match) to 1 (complete mismatch). */
+  confidenceScore: number;
+}
+
+/**
+ * Creates an array of overlapping text chunks from a source string.
+ *
+ * Overlapping text chunks are superior for multi-line code blocks as opposed to line-based
+ * searching.
+ *
+ * @param text The full source text content.
+ * @param chunkSize The number of lines in each chunk.
+ * @param stepSize The number of lines to slide the window forward for each new chunk.
+ * @returns An array of SearchChunk objects.
+ */
+function createOverlappingChunks(
+  text: string,
+  chunkSize: number,
+  stepSize: number = 1,
+): SearchChunk[] {
+  const lines = text.split('\n');
+  const chunks: SearchChunk[] = [];
+
+  // If the text is smaller than the chunk size, treat the whole text as a single chunk.
+  if (lines.length <= chunkSize) {
+    if (text.trim() !== '') {
+      chunks.push({ content: text, startLine: 0 });
+    }
+    return chunks;
+  }
+
+  for (let i = 0; i <= lines.length - chunkSize; i += stepSize) {
+    const chunkLines = lines.slice(i, i + chunkSize);
+    chunks.push({
+      content: chunkLines.join('\n'),
+      startLine: i,
+    });
+  }
+
+  return chunks;
+}
+
+/**
+ * Performs a fuzzy search to find the best match for a given snippet within a
+ * larger body of source text.
+ *
+ * @param sourceText The complete content of the file to search within.
+ * @param snippetToFind The text snippet that needs to be found.
+ * @returns A FuzzyMatchResult object if a reasonable match is found, otherwise null.
+ */
+export function findBestFuzzyMatch(
+  sourceText: string,
+  snippetToFind: string,
+): FuzzyMatchResult | null {
+  // Cannot search for or within an empty or whitespace-only string.
+  if (
+    !snippetToFind ||
+    snippetToFind.trim() === '' ||
+    !sourceText ||
+    sourceText.trim() === ''
+  ) {
+    return null;
+  }
+
+  // Determine Optimal Chunk Size
+  // The chunk size should be at least as large as the snippet we're looking for.
+  const snippetLineCount = snippetToFind.split('\n').length;
+
+  // Calculate the chunk size needed to contain the snippet plus surrounding context.
+  const requiredChunkSize = snippetLineCount + FuzzyMatcherConfig.CONTEXT_LINES;
+
+  // The final chunk size is the greater of the required size and the configured minimum.
+  // This ensures stability even for very small snippets.
+  const chunkSize = Math.max(
+    requiredChunkSize,
+    FuzzyMatcherConfig.MINIMUM_CHUNK_SIZE,
+  );
+
+  // Generate Searchable Chunks using a sliding window.
+  const searchChunks = createOverlappingChunks(sourceText, chunkSize);
+  if (searchChunks.length === 0) {
+    return null;
+  }
+
+  // Configure and Execute Fuse.js Search
+  const fuse = new Fuse(searchChunks, {
+    includeScore: true,
+    threshold: FuzzyMatcherConfig.FUSE_THRESHOLD,
+    keys: ['content'],
+    ignoreLocation: true,
+  });
+
+  const searchResults = fuse.search(snippetToFind);
+
+  if (searchResults.length === 0) {
+    return null;
+  }
+
+  // Process and Return the Best Result
+  const bestResult = searchResults[0];
+  const confidenceScore = bestResult.score!; // Fuse.js guarantees a score when includeScore is true.
+
+  // Reconstruct the actual block from the original file content using the
+  // matched chunk's start line and the snippet's line count. This ensures we
+  // return the correctly-sized block, not the entire search chunk.
+  const lines = sourceText.split('\n');
+  const actualBlock = lines
+    .slice(
+      bestResult.item.startLine,
+      bestResult.item.startLine + snippetLineCount,
+    )
+    .join('\n');
+
+  return {
+    bestMatch: actualBlock,
+    startLine: bestResult.item.startLine,
+    confidenceScore,
+  };
+}


### PR DESCRIPTION
## TLDR

This pull request introduces a fuzzy matching fallback mechanism to the `replace` tool. When an edit fails because the provided `old_string` cannot be found exactly, this change allows the tool to search for the *closest* possible match.

If a close match is identified, the tool provides a detailed `diff` back to the agent, instructing it on how to correct the `old_string` for a successful retry. This makes the `replace` tool significantly more resilient to minor inaccuracies in whitespace, indentation, or syntax, reducing agent error loops.

## Goal
This PR is primarily intended to generate discussion and allow for evals/local testing to see if certain edit loops are improved with more instructive errors being returned to the model.

## Dive Deeper

The `replace` tool is fundamental to the agent's ability to modify code, but its requirement for an exact `old_string` match makes it brittle. LLMs can introduce subtle, non-functional differences when quoting blocks of code, causing edits to fail and forcing the agent into a recovery loop of re-reading the file and trying again.

This PR addresses that brittleness by integrating `fuse.js` as a fuzzy search dependency. The core changes are:

1.  **`fuzzyMatcher.ts` Utility**: A new, self-contained utility (`packages/core/src/utils/fuzzyMatcher.ts`) is introduced. It takes source text and a snippet to find, and returns the best-matching block using a sliding-window chunking strategy. This approach is more robust for multi-line code snippets than simple line-by-line comparisons.

2.  **Refactored `edit.ts` Logic**: The validation and execution logic within the `replace` tool has been refactored. When a direct replacement attempt finds 0 occurrences, it now triggers the `findBestFuzzyMatch` function.

3.  **Instructive Failure Messages**: If a fuzzy match is found, a new, highly instructive error message is generated for the agent. This message includes a `diff` between the agent's incorrect `old_string` and the closest match found in the file. This gives the agent direct, actionable feedback to correct its next attempt, breaking the failure loop.

4.  **Improved No-Op Error**: The error message for attempting an empty edit (`old_string: ''`, `new_string: ''`) on an existing file has been improved to better guide the agent away from this anti-pattern.

This change moves the tool from a state of "pass/fail" to a more collaborative "fail with feedback" model, improving the agent's autonomy and task success rate.

## Reviewer Test Plan

To validate these changes, a reviewer should test scenarios where the `replace` tool would have previously failed.

1.  **Pull the branch** and ensure all dependencies are installed (`npm install`).
2.  **Start the CLI** (`npm start`).
3.  **Create a test file**, e.g., `test.js`.

### Test Case 1 - Failures that the edit corrector cannot fix.

-  This is difficult to mock without removing the edit corrector and running it locally as it does attempt to fix certain cases like whitespaces, even using a Flash model in some cases.
- Due to this, this use case is where actual local testing is best utilized. A user should use a locally built version that utilizes edits quite often. In some local testing, some difficulties testing this involved the model deciding to use write file instead.

### Test Case 2: Invalid No-Op Edit

-   **File Content**: Any existing file, like `test.js`.
-   **Prompt**: "In `test.js`, replace `''` with `''`."
-   **Expected Behavior**: The tool should return the new, more descriptive error message explaining that this is an invalid action on an existing file and instructing the agent to re-read the file to check its state.


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |
