### PR TITLE
help: add shift+tab tip

### DIFF
--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -117,6 +117,12 @@ export const Help: React.FC<Help> = ({ commands }) => (
     </Text>
     <Text color={Colors.Foreground}>
       <Text bold color={Colors.AccentPurple}>
+        Shift+Tab
+      </Text>{' '}
+      - Toggle auto-accepting edits
+    </Text>
+    <Text color={Colors.Foreground}>
+      <Text bold color={Colors.AccentPurple}>
         Esc
       </Text>{' '}
       - Cancel operation


### PR DESCRIPTION
## TLDR

Adds a keyboard shortcut hint inside the `/help` menu for shift+tab which is toggling auto-accept edits/

## Quick Look
<img width="1092" alt="Screenshot 2025-07-01 at 4 22 39 PM" src="https://github.com/user-attachments/assets/3a9afde0-0908-46e1-9cd6-8c336a341c36" />


## Reviewer Test Plan

1. Start Gemini CLI
2. Use `/help`
3. See the new `Shift+Tab` hint.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |
