### PR TITLE
Support configuring GEMINI_BASE_URL

### DIFF
--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -76,7 +76,6 @@ export async function createContentGeneratorConfig(
       contentGeneratorConfig.apiKey,
       contentGeneratorConfig.model,
     );
-
     return contentGeneratorConfig;
   }
 
@@ -107,6 +106,7 @@ export async function createContentGenerator(
     headers: {
       'User-Agent': `GeminiCLI/${version} (${process.platform}; ${process.arch})`,
     },
+    baseUrl: process.env.GEMINI_BASE_URL,
   };
   if (config.authType === AuthType.LOGIN_WITH_GOOGLE_PERSONAL) {
     return createCodeAssistContentGenerator(httpOptions, config.authType);

--- a/packages/core/src/core/modelCheck.ts
+++ b/packages/core/src/core/modelCheck.ts
@@ -28,14 +28,15 @@ export async function getEffectiveModel(
 
   const modelToTest = DEFAULT_GEMINI_MODEL;
   const fallbackModel = DEFAULT_GEMINI_FLASH_MODEL;
-  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${modelToTest}:generateContent?key=${apiKey}`;
+  const baseUrl = process.env.GEMINI_BASE_URL || 'https://generativelanguage.googleapis.com';
+  const endpoint = `${baseUrl}/v1beta/models/${modelToTest}:generateContent`;
   const body = JSON.stringify({
     contents: [{ parts: [{ text: 'test' }] }],
     generationConfig: {
       maxOutputTokens: 1,
       temperature: 0,
       topK: 1,
-      thinkingConfig: { thinkingBudget: 0, includeThoughts: false },
+      thinkingConfig: { thinkingBudget: 256, includeThoughts: false },
     },
   });
 
@@ -45,7 +46,7 @@ export async function getEffectiveModel(
   try {
     const response = await fetch(endpoint, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'x-goog-api-key': `${apiKey}` },
       body,
       signal: controller.signal,
     });


### PR DESCRIPTION
## TLDR

Support configuring GEMINI_BASE_URL for Gemini CLI

## Dive Deeper

- Allow configuring GEMINI_BASE_URL as sys env
- Pass API key via header, instead of query param
- Fix a bug in thinkingConfig in the test request. (`thinkingBudget` needs to be larger than 128)

## Reviewer Test Plan

- Add GEMINI_BASE_URL in `.env` file and run Gemini CLI

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
