### PR TITLE
Special case mime type for ts file.

### DIFF
--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -196,6 +196,11 @@ describe('fileUtils', () => {
       vi.restoreAllMocks(); // Restore spies on actualNodeFs
     });
 
+    it('should detect typescript type by extension (ts)', () => {
+      expect(detectFileType('file.ts')).toBe('text');
+      expect(detectFileType('file.test.ts')).toBe('text');
+    });
+
     it('should detect image type by extension (png)', () => {
       mockMimeLookup.mockReturnValueOnce('image/png');
       expect(detectFileType('file.png')).toBe('image');

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -100,8 +100,14 @@ export function detectFileType(
   filePath: string,
 ): 'text' | 'image' | 'pdf' | 'audio' | 'video' | 'binary' {
   const ext = path.extname(filePath).toLowerCase();
-  const lookedUpMimeType = mime.lookup(filePath); // Returns false if not found, or the mime type string
 
+  // The mimetype for "ts" is MPEG transport stream (a video format) but we want
+  // to assume these are typescript files instead.
+  if (ext === '.ts') {
+    return 'text';
+  }
+
+  const lookedUpMimeType = mime.lookup(filePath); // Returns false if not found, or the mime type string
   if (lookedUpMimeType) {
     if (lookedUpMimeType.startsWith('image/')) {
       return 'image';


### PR DESCRIPTION
## TLDR

the mime type library categorizes *.ts as a video format. We want to assume it's typescript instead. This avoids 500 errors when trying to read these files.

## Dive Deeper

This issue was introduced several days ago with https://github.com/google-gemini/gemini-cli/pull/2556

## Reviewer Test Plan

Ask GC to edit a ts file.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs


