### PR TITLE
feat: add home directory warning

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -9,7 +9,8 @@ import { render } from 'ink';
 import { AppWrapper } from './ui/App.js';
 import { loadCliConfig } from './config/config.js';
 import { readStdin } from './utils/readStdin.js';
-import { basename, relative } from 'node:path';
+import { basename } from 'node:path';
+import fs from 'node:fs';
 import v8 from 'node:v8';
 import os from 'node:os';
 import { spawn } from 'node:child_process';
@@ -167,10 +168,14 @@ export async function main() {
   let input = config.getQuestion();
   const startupWarnings = await getStartupWarnings();
 
-  if (relative(os.homedir(), workspaceRoot) === '') {
-    startupWarnings.push(
-      'You are running Gemini CLI in your home directory. For a better experience, launch it in a project directory instead.',
-    );
+  try {
+    if (fs.realpathSync(workspaceRoot) === fs.realpathSync(os.homedir())) {
+      startupWarnings.push(
+        'You are running Gemini CLI in your home directory. For a better experience, launch it in a project directory instead.',
+      );
+    }
+  } catch (e) {
+    console.error('Error checking workspace root:', e);
   }
 
   // Render UI, passing necessary config values. Check that there is no command line question.

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -167,6 +167,13 @@ export async function main() {
   let input = config.getQuestion();
   const startupWarnings = await getStartupWarnings();
 
+  
+  if (workspaceRoot === os.homedir()) {
+    startupWarnings.push(
+      'You are running Gemini CLI in your home directory. For a better experience, launch it in a project directory instead.',
+    );
+  }
+
   // Render UI, passing necessary config values. Check that there is no command line question.
   if (process.stdin.isTTY && input?.length === 0) {
     setWindowTitle(basename(workspaceRoot), settings);

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -10,7 +10,6 @@ import { AppWrapper } from './ui/App.js';
 import { loadCliConfig } from './config/config.js';
 import { readStdin } from './utils/readStdin.js';
 import { basename } from 'node:path';
-import fs from 'node:fs';
 import v8 from 'node:v8';
 import os from 'node:os';
 import { spawn } from 'node:child_process';
@@ -167,16 +166,6 @@ export async function main() {
   }
   let input = config.getQuestion();
   const startupWarnings = await getStartupWarnings();
-
-  try {
-    if (fs.realpathSync(workspaceRoot) === fs.realpathSync(os.homedir())) {
-      startupWarnings.push(
-        'You are running Gemini CLI in your home directory. For a better experience, launch it in a project directory instead.',
-      );
-    }
-  } catch (e) {
-    console.error('Error checking workspace root:', e);
-  }
 
   // Render UI, passing necessary config values. Check that there is no command line question.
   if (process.stdin.isTTY && input?.length === 0) {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -9,7 +9,7 @@ import { render } from 'ink';
 import { AppWrapper } from './ui/App.js';
 import { loadCliConfig } from './config/config.js';
 import { readStdin } from './utils/readStdin.js';
-import { basename } from 'node:path';
+import { basename, relative } from 'node:path';
 import v8 from 'node:v8';
 import os from 'node:os';
 import { spawn } from 'node:child_process';
@@ -167,8 +167,7 @@ export async function main() {
   let input = config.getQuestion();
   const startupWarnings = await getStartupWarnings();
 
-  
-  if (workspaceRoot === os.homedir()) {
+  if (relative(os.homedir(), workspaceRoot) === '') {
     startupWarnings.push(
       'You are running Gemini CLI in your home directory. For a better experience, launch it in a project directory instead.',
     );

--- a/packages/cli/src/utils/startupWarnings.ts
+++ b/packages/cli/src/utils/startupWarnings.ts
@@ -12,12 +12,32 @@ import { getErrorMessage } from '@google/gemini-cli-core';
 const warningsFilePath = pathJoin(os.tmpdir(), 'gemini-cli-warnings.txt');
 
 export async function getStartupWarnings(): Promise<string[]> {
+  const warnings: string[] = [];
+
+  // Check for home directory usage
+  try {
+    const workspaceRoot = process.cwd();
+    const [workspaceRealPath, homeRealPath] = await Promise.all([
+      fs.realpath(workspaceRoot),
+      fs.realpath(os.homedir()),
+    ]);
+
+    if (workspaceRealPath === homeRealPath) {
+      warnings.push(
+        'You are running Gemini CLI in your home directory. For a better experience, launch it in a project directory instead.',
+      );
+    }
+  } catch (err: unknown) {
+    console.error('Error checking workspace root:', err);
+  }
+
   try {
     await fs.access(warningsFilePath); // Check if file exists
     const warningsContent = await fs.readFile(warningsFilePath, 'utf-8');
-    const warnings = warningsContent
+    const fileWarnings = warningsContent
       .split('\n')
       .filter((line) => line.trim() !== '');
+    warnings.push(...fileWarnings);
     try {
       await fs.unlink(warningsFilePath);
     } catch {
@@ -32,9 +52,12 @@ export async function getStartupWarnings(): Promise<string[]> {
     // To maintain closer parity while making it async, we'll check the error code.
     // ENOENT is "Error NO ENTry" (file not found).
     if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
-      return []; // File not found, no warnings to return.
+      return warnings; // File not found, return any existing warnings.
     }
     // For other errors (permissions, etc.), return the error message.
-    return [`Error checking/reading warnings file: ${getErrorMessage(err)}`];
+    warnings.push(
+      `Error checking/reading warnings file: ${getErrorMessage(err)}`,
+    );
+    return warnings;
   }
 }

--- a/packages/cli/src/utils/startupWarnings.ts
+++ b/packages/cli/src/utils/startupWarnings.ts
@@ -28,7 +28,9 @@ export async function getStartupWarnings(): Promise<string[]> {
       );
     }
   } catch (err: unknown) {
-    console.error('Error checking workspace root:', err);
+    warnings.push(
+      `Warning: Could not check if running in home directory: ${getErrorMessage(err)}`,
+    );
   }
 
   try {


### PR DESCRIPTION
## TLDR

Adds a very basic startup warning if the user is in their home directory
![image](https://github.com/user-attachments/assets/11ef2759-ef31-49b5-9cdb-daa734c21957)


## Dive Deeper

It's an extremely simple warning based on the UX of Claude Code.


## Reviewer Test Plan

Run the build in your home/user directory `os.homedir()` from `node:os`

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ✅| ✅|
| npx      | ✅  | ✅| ✅|
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |



## Linked issues / bugs

addresses allenhutchison's suggestion in #2617

Importantly, a user articulated a negative experience where Gemini deleted their codebase -- irrelevant to whether it was in the `os.homedir()`

I think that there are a few ways to elegantly leverage opt-out non-determinism for scenarios where whitelisted commands may be dangerous due to other circumstances.

Perhaps I can draft a small PR about this matter?

<!-- Add links to any gh issues or other external bugs --->
