### PR TITLE
Fix #2922: Prevent @ concatenation to valid paths in shellmode.

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -310,6 +310,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     stdin,
     setRawMode,
     isValidPath,
+    shellModeActive,
   });
 
   const handleExit = useCallback(

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -439,6 +439,60 @@ describe('useTextBuffer', () => {
     });
   });
 
+  describe('Shell Mode Behavior', () => {
+    it('should not prepend @ to valid file paths when shellModeActive is true', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          viewport,
+          isValidPath: () => true,
+          shellModeActive: true,
+        }),
+      );
+      const filePath = '/path/to/a/valid/file.txt';
+      act(() => result.current.insert(filePath));
+      expect(getBufferState(result).text).toBe(filePath); // No @ prefix
+    });
+
+    it('should not prepend @ to quoted paths when shellModeActive is true', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          viewport,
+          isValidPath: () => true,
+          shellModeActive: true,
+        }),
+      );
+      const quotedFilePath = "'/path/to/a/valid/file.txt'";
+      act(() => result.current.insert(quotedFilePath));
+      expect(getBufferState(result).text).toBe(quotedFilePath); // No @ prefix, keeps quotes
+    });
+
+    it('should behave normally with invalid paths when shellModeActive is true', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          viewport,
+          isValidPath: () => false,
+          shellModeActive: true,
+        }),
+      );
+      const notAPath = 'this is just some text';
+      act(() => result.current.insert(notAPath));
+      expect(getBufferState(result).text).toBe(notAPath);
+    });
+
+    it('should behave normally with short text when shellModeActive is true', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          viewport,
+          isValidPath: () => true,
+          shellModeActive: true,
+        }),
+      );
+      const shortText = 'ls';
+      act(() => result.current.insert(shortText));
+      expect(getBufferState(result).text).toBe(shortText); // No @ prefix for short text
+    });
+  });
+
   describe('Cursor Movement', () => {
     it('move: left/right should work within and across visual lines (due to wrapping)', () => {
       // Text: "long line1next line2" (20 chars)
@@ -722,6 +776,7 @@ describe('useTextBuffer', () => {
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: 'h',
         }),
       );
@@ -731,6 +786,7 @@ describe('useTextBuffer', () => {
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: 'i',
         }),
       );
@@ -747,6 +803,7 @@ describe('useTextBuffer', () => {
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: '\r',
         }),
       );
@@ -768,6 +825,7 @@ describe('useTextBuffer', () => {
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: '\x7f',
         }),
       );
@@ -863,6 +921,7 @@ describe('useTextBuffer', () => {
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: '\x1b[D',
         }),
       ); // cursor [0,1]
@@ -873,6 +932,7 @@ describe('useTextBuffer', () => {
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: '\x1b[C',
         }),
       ); // cursor [0,2]
@@ -887,10 +947,11 @@ describe('useTextBuffer', () => {
       // Simulate pasting by calling handleInput with a string longer than 1 char
       act(() =>
         result.current.handleInput({
-          name: undefined,
+          name: '',
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: textWithAnsi,
         }),
       );
@@ -907,6 +968,7 @@ describe('useTextBuffer', () => {
           ctrl: false,
           meta: false,
           shift: true,
+          paste: false,
           sequence: '\r',
         }),
       ); // Simulates Shift+Enter in VSCode terminal
@@ -1096,10 +1158,11 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
       const textWithAnsi = '\x1B[31mHello\x1B[0m';
       act(() =>
         result.current.handleInput({
-          name: undefined,
+          name: '',
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: textWithAnsi,
         }),
       );
@@ -1113,10 +1176,11 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
       const textWithControlChars = 'H\x07e\x08l\x0Bl\x0Co'; // BELL, BACKSPACE, VT, FF
       act(() =>
         result.current.handleInput({
-          name: undefined,
+          name: '',
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: textWithControlChars,
         }),
       );
@@ -1130,10 +1194,11 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
       const textWithMixed = '\u001B[4mH\u001B[0mello';
       act(() =>
         result.current.handleInput({
-          name: undefined,
+          name: '',
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: textWithMixed,
         }),
       );
@@ -1147,10 +1212,11 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
       const validText = 'Hello World\nThis is a test.';
       act(() =>
         result.current.handleInput({
-          name: undefined,
+          name: '',
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: validText,
         }),
       );
@@ -1164,10 +1230,11 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
       const pastedText = '\u001B[4mPasted\u001B[4m Text';
       act(() =>
         result.current.handleInput({
-          name: undefined,
+          name: '',
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: pastedText,
         }),
       );

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -73,6 +73,7 @@ interface UseTextBufferProps {
   setRawMode?: (mode: boolean) => void; // For external editor
   onChange?: (text: string) => void; // Callback for when text changes
   isValidPath: (path: string) => boolean;
+  shellModeActive?: boolean; // Whether the text buffer is in shell mode
 }
 
 interface UndoHistoryEntry {

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -961,6 +961,7 @@ export function useTextBuffer({
   setRawMode,
   onChange,
   isValidPath,
+  shellModeActive = false,
 }: UseTextBufferProps): TextBuffer {
   const initialState = useMemo((): TextBufferState => {
     const lines = initialText.split('\n');
@@ -1029,7 +1030,7 @@ export function useTextBuffer({
       }
 
       const minLengthToInferAsDragDrop = 3;
-      if (ch.length >= minLengthToInferAsDragDrop) {
+      if (ch.length >= minLengthToInferAsDragDrop && !shellModeActive) {
         let potentialPath = ch;
         if (
           potentialPath.length > 2 &&
@@ -1061,7 +1062,7 @@ export function useTextBuffer({
         dispatch({ type: 'insert', payload: currentText });
       }
     },
-    [isValidPath],
+    [isValidPath, shellModeActive],
   );
 
   const newline = useCallback((): void => {


### PR DESCRIPTION
# TLDR

Fixes incorrect `@` character injection for file paths when shell mode is active. The text buffer now properly respects the `shellModeActive` flag and skips automatic `@` prefixing for drag-and-dropped file paths in shell mode, preventing command corruption when users drag files into the shell prompt.

## Dive Deeper

This PR addresses a bug where the text buffer's drag-and-drop file path detection was incorrectly prefixing file paths with `@` characters even when the user was in shell mode. This caused issues because:

1. **Shell Mode Context**: In shell mode, users expect file paths to be inserted as-is for shell commands (e.g., `ls /path/to/file` not `ls @/path/to/file`)
2. **Drag-and-Drop Detection**: The existing logic detected file paths and automatically added `@` prefixes for the AI assistant context, but this behavior should be disabled in shell mode
3. **Command Corruption**: The unintended `@` prefixes made shell commands invalid and unusable

### Key Changes:

**Core Logic Fix** (text-buffer.ts):
- Added `shellModeActive` parameter to `useTextBuffer` hook (defaults to `false`)
- Modified the `insert` function to skip `@` prefixing when `shellModeActive` is true
- Updated dependency array to include `shellModeActive` for proper re-rendering

**Integration** (App.tsx):
- Passed the existing `shellModeActive` state to the `useTextBuffer` hook

**Test Coverage** (text-buffer.test.ts):
- Added comprehensive test suite for shell mode behavior
- Tests cover valid/invalid paths, quoted paths, and short text scenarios
- Updated existing tests to include missing `paste` parameter for consistency
- Fixed test formatting issues (changed `undefined` to empty string for `name` field)

### Technical Details:

The fix works by checking the `shellModeActive` flag before applying drag-and-drop file path detection:

```typescript
// Before: Always applied @ prefix for valid file paths
if (ch.length >= minLengthToInferAsDragDrop) {
  // ... @ prefix logic
}

// After: Skip @ prefix when in shell mode  
if (ch.length >= minLengthToInferAsDragDrop && !shellModeActive) {
  // ... @ prefix logic only when NOT in shell mode
}
```

## Reviewer Test Plan

### Manual Testing:

1. **Test Normal Mode (@ prefixing should work)**:
   - Ensure shell mode is OFF
   - Drag a file from Finder into the text input
   - Verify the file path gets `@` prefix automatically
   - Verify quoted paths have quotes removed but keep `@` prefix

2. **Test Shell Mode (@ prefixing should be disabled)**:
   - Enable shell mode
   - Drag a file from Finder into the shell prompt
   - Verify the file path is inserted without `@` prefix
   - Verify quoted paths keep their quotes and no `@` prefix
   - Test typing short commands like `ls`, `cd` work normally

3. **Test Edge Cases**:
   - Drag invalid paths (should work the same in both modes)
   - Drag very short text (should not trigger @ logic in either mode)
   - Type normal text vs paste large text blocks

### Automated Testing:

Run the test suite to verify:
```bash
npm test text-buffer.test.ts
```

Key test cases that should pass:
- ✅ Shell mode disables @ prefixing for valid file paths
- ✅ Shell mode preserves quoted file paths without @ prefix  
- ✅ Shell mode works normally with invalid paths and short text
- ✅ Normal mode still correctly applies @ prefixing (regression test)
- ✅ All existing functionality remains intact

### Regression Testing:

Verify that existing drag-and-drop behavior in normal (non-shell) mode continues to work as expected, ensuring this fix doesn't break the AI assistant's file reference functionality.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/gemini-cli/issues/2922