### PR TITLE
feat(cli): enhance toCodePoints to prevent potential unicode 14 errors

### DIFF
--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isBinary } from './textUtils';
+import { isBinary, toCodePoints } from './textUtils.js';
 
 describe('textUtils', () => {
   describe('isBinary', () => {
@@ -36,6 +36,19 @@ describe('textUtils', () => {
         Buffer.from([0x00]),
       ]);
       expect(isBinary(longBufferWithNullByteAtEnd, 512)).toBe(false);
+    });
+  });
+
+  describe('toCodePoints', () => {
+    it('should correctly split a string into code points', () => {
+      expect(toCodePoints('abc')).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should handle emoji and surrogate pairs correctly', () => {
+      // Emoji with surrogate pairs
+      expect(toCodePoints('😀')).toHaveLength(1);
+      // Family emoji is composed of multiple code points
+      expect(toCodePoints('👨‍👩‍👧‍👦')).toHaveLength(1);
     });
   });
 });

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -53,6 +53,10 @@ export function isBinary(
  * ---------------------------------------------------------------------- */
 
 export function toCodePoints(str: string): string[] {
+  if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
+    const seg = new Intl.Segmenter();
+    return [...seg.segment(str)].map((seg) => seg.segment);
+  }
   // [...str] or Array.from both iterate by UTF‑32 code point, handling
   // surrogate pairs correctly.
   return Array.from(str);

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "jsx": "react-jsx",
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["node", "vitest/globals"]
   },
   "include": [


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

Array.from may fail when handling certain characters newly added in Unicode 14. Where possible, it seems better to use Intl.Segmenter for more reliable processing.

![image](https://github.com/user-attachments/assets/864a9c48-f6f3-4e6a-b540-6412257597fa)


I noticed that the lib option in tsconfig varies across different project folders, using different ES versions. Is this intentional, and should we align them for consistency? 🤔

![image](https://github.com/user-attachments/assets/ac048a3a-04bd-455a-8aa9-f8cc4d7117e8)



## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
