### PR TITLE
robustness in handling stream data

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -108,7 +108,7 @@ export class ClearcutLogger {
       };
       const bufs: Buffer[] = [];
       const req = https.request(options, (res) => {
-        res.on('data', (buf) => bufs.push(buf));
+        res.on('data', (buf) => bufs.push(Buffer.from(buf)));
         res.on('end', () => {
           resolve(Buffer.concat(bufs));
         });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -112,6 +112,14 @@ export class ClearcutLogger {
         res.on('end', () => {
           resolve(Buffer.concat(bufs));
         });
+        res.on('error', (e) => {
+          if (this.config?.getDebugMode()) {
+            console.log('Clearcut response stream error: ', e);
+          }
+          // Add the events back to the front of the queue to be retried.
+          this.events.unshift(...eventsToSend);
+          reject(e);
+        });
       });
       req.on('error', (e) => {
         if (this.config?.getDebugMode()) {


### PR DESCRIPTION
## TLDR

Improved the robustness of data collection within the ClearcutLogger by explicitly converting incoming data chunks from https.request to Buffer instances. This ensures consistency and prevents potential type-related errors when concatenating buffers received from the network stream.

## Dive Deeper

The change bufs.push(Buffer.from(buf)) in clearcut-logger.ts explicitly creates a new Buffer instance from each incoming data chunk. This explicit copying is a crucial and recommended practice for ensuring data integrity when collecting stream chunks in Node.js (as the original buffers might be reused by the runtime, leading to data corruption if not copied).


