### PR TITLE
fix(ui): adjust dark theme for pure black terminals

### DIFF
--- a/packages/cli/src/ui/themes/ansi.ts
+++ b/packages/cli/src/ui/themes/ansi.ts
@@ -8,7 +8,7 @@ import { type ColorsTheme, Theme } from './theme.js';
 
 const ansiColors: ColorsTheme = {
   type: 'dark',
-  Background: 'black',
+  Background: '#010101',
   Foreground: 'white',
   LightBlue: 'bluebright',
   AccentBlue: '#0000FF',
@@ -30,7 +30,7 @@ export const ANSI: Theme = new Theme(
       display: 'block',
       overflowX: 'auto',
       padding: '0.5em',
-      background: 'black', // Mapped from #1E1E1E
+      background: '#010101', // Mapped from #1E1E1E
       color: 'white', // Mapped from #DCDCDC
     },
     'hljs-keyword': {

--- a/packages/cli/src/ui/themes/theme.ts
+++ b/packages/cli/src/ui/themes/theme.ts
@@ -58,7 +58,7 @@ export const darkTheme: ColorsTheme = {
 
 export const ansiTheme: ColorsTheme = {
   type: 'ansi',
-  Background: 'black',
+  Background: '#010101',
   Foreground: 'white',
   LightBlue: 'blue',
   AccentBlue: 'blue',


### PR DESCRIPTION
## fix(ui): Adjust dark theme for pure black terminals

**Closes:** https://github.com/google-gemini/gemini-cli/issues/2963#issuecomment-3027399182

### Problem

When using a terminal with a pure black background (`#000000`), certain text rendered by the CLI becomes invisible when the `ANSI` theme is active. This occurs because the theme also uses a pure black background, causing any black-colored text to blend in completely.

### Solution

This commit addresses the issue by subtly adjusting the background color of the `ANSI` theme from pure black to a very dark gray (`#010101`). This ensures a slight contrast, making black text visible even on pure black terminal backgrounds without noticeably changing the theme's overall appearance.

The change was applied to:
- `packages/cli/src/ui/themes/ansi.ts`
- `packages/cli/src/ui/themes/theme.ts`

### How to Test

To verify the fix, please follow these steps:

1.  Configure your terminal emulator to use a pure black (`#000000`) background color.
2.  Run the Gemini CLI.
3.  Activate the `ANSI` theme.
4.  Execute a command or trigger an output that is known to render some text in black.
5.  **Expected Result:** The black text should now be clearly visible against the new dark gray background.

#### Testing Matrix

| OS      | Terminal         | Theme | Background | Expected Result   |
| :------ | :--------------- | :---- | :--------- | :---------------- |
| macOS   | iTerm2 / Terminal | ANSI  | `#000000`  | Text is visible   |
| Windows | Windows Terminal | ANSI  | `#000000`  | Text is visible   |
| Linux   | GNOME Terminal   | ANSI  | `#000000`  | Text is visible   |
