### PR TITLE
Docs: Further clarify and cross ref login related behaviors

### DIFF
--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -74,6 +74,7 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
           echo 'export GOOGLE_GENAI_USE_VERTEXAI=true' >> ~/.bashrc
           source ~/.bashrc
           ```
+How you authenticate to the CLI determines your [quotas and costs](../quota-and-pricing.md) in using the CLI and which [Terms of Service and Privacy Policies](../tos-privacy.md) apply
 
 ### Persisting Environment Variables with `.env` Files
 

--- a/docs/quota-and-pricing.md
+++ b/docs/quota-and-pricing.md
@@ -1,12 +1,12 @@
 # Gemini CLI: Quotas and Pricing
 
-Your Gemini CLI quotas and pricing depends on the type of account you use to authenticate with Google. Additionally, both quotas and pricing may may be calculated differently based on the model version, requests, and tokens used. A summary of model usage is available through the `/stats` command and presented on exit at the end of a session. See [privacy and terms](./tos-privacy.md) for details on Privacy policy and Terms of Service. Note: published prices are list price; additional negotiated commercial discounting may apply.
+Your Gemini CLI quotas and pricing depends on the type of account you use to [authenticate](./cli/authentication.md) with Google. Additionally, both quotas and pricing may may be calculated differently based on the model version, requests, and tokens used. A summary of model usage is available through the `/stats` command and presented on exit at the end of a session. See [privacy and terms](./tos-privacy.md) for details on Privacy policy and Terms of Service. Note: published prices are list price; additional negotiated commercial discounting may apply.
 
 This article outlines the specific quotas and pricing applicable to the Gemini CLI when using different authentication methods.
 
 ## 1. Log in with Google (Gemini Code Assist Free Tier)
 
-For users who authenticate by using their Google account to access Gemini Code Assist for individuals:
+For users who authenticate by using their personal gmail account to access [Gemini Code Assist for individuals](https://developers.google.com/gemini-code-assist/resources/faqs):
 
 - **Quota:**
   - 60 requests per minute
@@ -14,7 +14,9 @@ For users who authenticate by using their Google account to access Gemini Code A
   - Token usage is not applicable
 - **Cost:** Free
 - **Details:** [Gemini Code Assist Quotas](https://developers.google.com/gemini-code-assist/resources/quotas#quotas-for-agent-mode-gemini-cli)
-- **Notes:** A specific quota for different models is not specified; model fallback may occur to preserve shared experience quality.
+- **Notes:**
+  - Specific quota for different models is not specified; model fallback may occur to preserve shared experience quality.
+  - A gmail account may be qualified as a non-free tier account and require a Google Cloud Project unders several scenarios, see the details in the [authentication documentation](./cli/authentication.md#workspace-gca)
 
 ## 2. Gemini API Key (Unpaid)
 
@@ -35,15 +37,15 @@ If you are using a Gemini API key with a paid plan:
 - **Cost:** Varies by pricing tier and model/token usage.
 - **Details:** [Gemini API Rate Limits](https://ai.google.dev/gemini-api/docs/rate-limits), [Gemini API Pricing](https://ai.google.dev/gemini-api/docs/pricing)
 
-## 4. Login with Google (for Workspace or Licensed Code Assist users)
+## 4. Login with Google (Gemini Code Assist)
 
-For users of Standard or Enterprise editions of Gemini Code Assist, quotas and pricing are based on a fixed price subscription with assigned license seats:
+For users with Google Workspace accounts (using licensed or unlicensed Standard or Enterprise editions of Gemini Code Assist), quotas and pricing are based on a fixed price subscription with assigned license seats:
 
 - **Standard Tier:**
   - **Quota:** 120 requests per minute, 1500 per day
 - **Enterprise Tier:**
   - **Quota:** 120 requests per minute, 2000 per day
-- **Cost:** Fixed price included with your Gemini for Google Workspace or Gemini Code Assist subscription.
+- **Cost:** Fixed price included with your Gemini Code Assist subscription.
 - **Details:** [Gemini Code Assist Quotas](https://developers.google.com/gemini-code-assist/resources/quotas#quotas-for-agent-mode-gemini-cli), [Gemini Code Assist Pricing](https://cloud.google.com/products/gemini/pricing)
 - **Notes:**
   - Specific quota for different models is not specified; model fallback may occur to preserve shared experience quality.

--- a/docs/quota-and-pricing.md
+++ b/docs/quota-and-pricing.md
@@ -1,6 +1,6 @@
 # Gemini CLI: Quotas and Pricing
 
-Your Gemini CLI quotas and pricing depends on the type of account you use to [authenticate](./cli/authentication.md) with Google. Additionally, both quotas and pricing may may be calculated differently based on the model version, requests, and tokens used. A summary of model usage is available through the `/stats` command and presented on exit at the end of a session. See [privacy and terms](./tos-privacy.md) for details on Privacy policy and Terms of Service. Note: published prices are list price; additional negotiated commercial discounting may apply.
+Your Gemini CLI quotas and pricing depends on the type of account you use to [authenticate](./cli/authentication.md) with Google. Additionally, both quotas and pricing may be calculated differently based on the model version, requests, and tokens used. A summary of model usage is available through the `/stats` command and presented on exit at the end of a session. See [privacy and terms](./tos-privacy.md) for details on Privacy policy and Terms of Service. Note: published prices are list price; additional negotiated commercial discounting may apply.
 
 This article outlines the specific quotas and pricing applicable to the Gemini CLI when using different authentication methods.
 
@@ -17,6 +17,7 @@ For users who authenticate by using their personal gmail account to access [Gemi
 - **Notes:**
   - Specific quota for different models is not specified; model fallback may occur to preserve shared experience quality.
   - A gmail account may be qualified as a non-free tier account and require a Google Cloud Project unders several scenarios, see the details in the [authentication documentation](./cli/authentication.md#workspace-gca)
+  - Daily quota limits reset at midnight Pacific Time (UTC-8).
 
 ## 2. Gemini API Key (Unpaid)
 
@@ -50,6 +51,8 @@ For users with Google Workspace accounts (using licensed or unlicensed Standard 
 - **Notes:**
   - Specific quota for different models is not specified; model fallback may occur to preserve shared experience quality.
   - Members of the Google Developer Program may have Gemini Code Assist licenses through their membership.
+  - Daily quota limits reset at midnight Pacific Time (UTC-8).
+
 
 ## 5. Vertex AI (Express Mode)
 

--- a/docs/tos-privacy.md
+++ b/docs/tos-privacy.md
@@ -1,6 +1,6 @@
 # Gemini CLI: Terms of Service and Privacy Notice
 
-Gemini CLI is an open-source tool that lets you interact with Google's powerful language models directly from your command-line interface. The Terms of Service and Privacy notices that apply to your usage of Gemini CLI depend on the type of account you use to authenticate with Google. See [quota and pricing](./quota-and-pricing.md) for details on the quota and pricing details that apply to your usage of Gemini CLI.
+Gemini CLI is an open-source tool that lets you interact with Google's powerful language models directly from your command-line interface. The Terms of Service and Privacy notices that apply to your usage of Gemini CLI depend on the type of account you use to [authenticate](./cli/authentication.md) with Google. See [quota and pricing](./quota-and-pricing.md) for details on the quota and pricing details that apply to your usage of Gemini CLI.
 
 This article outlines the specific terms and privacy policies applicable for different auth methods.
 


### PR DESCRIPTION
cross refernce three related docs

clarify the free-tier conditions on costs page as it was no longer on the auth page

remove errant reference to Gemini for Workspace
