### PR TITLE
fix: add support for proxy in ClearcutLogger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11397,6 +11397,7 @@
         "glob": "^10.4.5",
         "google-auth-library": "^9.11.0",
         "html-to-text": "^9.0.5",
+        "https-proxy-agent": "^7.0.6",
         "ignore": "^7.0.0",
         "micromatch": "^4.0.8",
         "open": "^10.1.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "glob": "^10.4.5",
     "google-auth-library": "^9.11.0",
     "html-to-text": "^9.0.5",
+    "https-proxy-agent": "^7.0.6",
     "ignore": "^7.0.0",
     "micromatch": "^4.0.8",
     "open": "^10.1.2",


### PR DESCRIPTION
## TLDR

When sending requests in ClearcutLogger, it does not apply the proxy from env, which may cause network errors.
![image](https://github.com/user-attachments/assets/f002080d-8d7c-4e72-a52a-fff2b447863a)


## Dive Deeper

The proxy implementation is based on https-proxy-agent.

## Reviewer Test Plan

No special instructions

## Testing Matrix


|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/gemini-cli/issues/1700 This issue's root cause is that when sending requests in ClearcutLogger, the current environment's proxy was not applied, which caused the request to fail. A contributor added a catch to capture this error. The current cli does not automatically exit, but it still displays a network error.
![image](https://github.com/user-attachments/assets/a0163c96-1f1f-41de-91c7-e20c30ee453e)

