### PR TITLE
fix: temporarily disable thinking for gemini-2.5-flash-lite-preview-06-17

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -41,6 +41,9 @@ import { ProxyAgent, setGlobalDispatcher } from 'undici';
 import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 
 function isThinkingSupported(model: string) {
+  // TODO: This is a temporary workaround for Github Issue #1953
+  // There should be a more robust way to determine if thinking is supported.
+  if (model === 'gemini-2.5-flash-lite-preview-06-17') return false;
   if (model.startsWith('gemini-2.5')) return true;
   return false;
 }


### PR DESCRIPTION
## TLDR

This PR disables the "thinking" feature for the `gemini-2.5-flash-lite-preview-06-17` model to resolve an API error. This is a temporary workaround until the underlying model issue is fixed.

## Dive Deeper

The `gemini-2.5-flash-lite-preview-06-17` model was returning an error: `Unable to submit request because Thinking_config.include_thoughts is only enabled when thinking is enabled.` This error occurs because while models in the `gemini-2.5` family generally support the "thinking" feature, this specific `flash-lite-preview` version has an issue where it incorrectly reports that thinking is not enabled when the `Thinking_config.include_thoughts` parameter is included in the request. The CLI was sending this parameter based on the model name, which triggered the bug in the model's API.

This change introduces a temporary workaround by explicitly disabling the "thinking" feature for the `gemini-2.5-flash-lite-preview-06-17` model in the CLI. This prevents the problematic parameter from being sent, thus avoiding the API error. A more permanent solution would involve a fix in the model itself, but this change provides an immediate resolution for users of the CLI.

This change explicitly disables the feature for this specific model in the CLI configuration, preventing the erroneous parameter from being sent.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

1.  Run the CLI with the affected model:
    ```bash
    gemini -m gemini-2.5-flash-lite-preview-06-17 -p "hello"
    ```
2.  **Before this change:** The command would fail with the API error.
3.  **After this change:** The command should now succeed and return a valid response from the model.
4.  Verify that other models are unaffected:
    ```bash
    gemini -m gemini-2.5-flash -p "do you have thinking enabled?"
    ```
    This should continue to work as expected (and probably tell about its internal thinking process).

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅ |
| npx      | ❓  | ❓  | ✅ |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->

Fixes #1953