### PR TITLE
Add new test to verify that when an Authorization header is provided

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -385,6 +385,18 @@ describe('discoverMcpTools', () => {
         {},
       );
     });
+
+    it('should pass oauth token when provided', async () => {
+      const headers = {
+        Authorization: 'Bearer test-token',
+      };
+      const { serverConfig } = await setupHttpTest(headers);
+
+      expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
+        new URL(serverConfig.httpUrl!),
+        { requestInit: { headers } },
+      );
+    });
   });
 
   it('should prefix tool names if multiple MCP servers are configured', async () => {


### PR DESCRIPTION
## TLDR

[Add new test to verify that when an Authorization header is provided]
(https://github.com/google-gemini/gemini-cli/commit/8305242c3edafcb044571e35b37b24028c0b4b47)

## Dive Deeper
Following #2477 

## Reviewer Test Plan
Run all tests

## Testing Matrix
<!-- Before submitting please validate your changes on as many of these options as possible -->

| npm run  preflight
Test Files  48 passed (48)                                                                                                                                                                                                                                                     │
 │          Tests  734 passed (734)                                                                                                                                                                                                                                                   │
 │       Start at  15:31:53                                                                                                                                                                                                                                                           │
 │       Duration  4.32s (transform 15.65s, setup 1.49s, collect 52.00s, tests 3.32s, environment 14ms, prepare 6.50s)

## Linked issues / bugs
