### PR TITLE
Provide a clear, user-friendly error message when the CLI attempts to connect to an MCP server that requires OAuth2.x authentication.

### DIFF
--- a/.github/workflows/gemini-scheduled-pr-triage.yml
+++ b/.github/workflows/gemini-scheduled-pr-triage.yml
@@ -1,5 +1,7 @@
 name: Gemini Scheduled PR Triage 🚀
-
+env:
+  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+  
 on:
   schedule:
     - cron: '*/15 * * * *' # Runs every 15 minutes

--- a/package.json
+++ b/package.json
@@ -89,5 +89,6 @@
     "typescript-eslint": "^8.30.1",
     "vitest": "^3.2.4",
     "yargs": "^17.7.2"
-  }
+  },
+  "dependencies": {}
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -454,7 +454,7 @@ export class Config {
   }
 }
 
-export function createToolRegistry(config: Config): Promise<ToolRegistry> {
+export async function createToolRegistry(config: Config): Promise<ToolRegistry> {
   const registry = new ToolRegistry(config);
   const targetDir = config.getTargetDir();
 
@@ -499,10 +499,8 @@ export function createToolRegistry(config: Config): Promise<ToolRegistry> {
   registerCoreTool(ShellTool, config);
   registerCoreTool(MemoryTool);
   registerCoreTool(WebSearchTool, config);
-  return (async () => {
-    await registry.discoverTools();
-    return registry;
-  })();
+  await registry.discoverTools();
+  return registry;
 }
 
 // Export model constants for use in CLI

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -385,6 +385,18 @@ describe('discoverMcpTools', () => {
         {},
       );
     });
+
+    it('should pass oauth token when provided', async () => {
+      const headers = {
+        Authorization: 'Bearer test-token',
+      };
+      const { serverConfig } = await setupHttpTest(headers);
+
+      expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
+        new URL(serverConfig.httpUrl!),
+        { requestInit: { headers } },
+      );
+    });
   });
 
   it('should prefix tool names if multiple MCP servers are configured', async () => {

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -646,6 +646,29 @@ describe('discoverMcpTools', () => {
     expect(mockToolRegistry.registerTool).not.toHaveBeenCalled();
   });
 
+  it('should throw a specific error for 401 Unauthorized', async () => {
+    const serverConfig: MCPServerConfig = {
+      httpUrl: 'http://localhost:4001/mcp',
+    };
+    mockConfig.getMcpServers.mockReturnValue({
+      'unauthorized-server': serverConfig,
+    });
+    vi.mocked(Client.prototype.connect).mockRejectedValue(
+      new Error('Request failed with status 401'),
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      discoverMcpTools(
+        mockConfig.getMcpServers() ?? {},
+        mockConfig.getMcpServerCommand(),
+        mockToolRegistry as any,
+      ),
+    ).rejects.toThrow(
+      "The MCP server at 'http://localhost:4001/mcp' requires OAuth2.x authentication, which is not yet fully supported by the Gemini CLI. As a temporary workaround, you can manually provide a bearer token. Please see PR #2477 for more details.",
+    );
+  });
+
   it('should assign mcpClient.onerror handler', async () => {
     const serverConfig: MCPServerConfig = { command: './mcp-onerror' };
     mockConfig.getMcpServers.mockReturnValue({

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -256,14 +256,13 @@ async function connectAndDiscover(
     // Update status to disconnected
     updateMCPServerStatus(mcpServerName, MCPServerStatus.DISCONNECTED);
     // Check for OAuth2.x authentication error
-// Check for OAuth2.x authentication error more robustly.
-// The `error` is of type `unknown` in a catch block, so we first check if it's an Error instance.
-if (error instanceof Error && error.message.includes('401')) {
-  const origin = mcpServerConfig.httpUrl || mcpServerConfig.url;
-  throw new Error(
-    `The MCP server at '${origin}' requires OAuth2.x authentication, which is not yet fully supported by the Gemini CLI. As a temporary workaround, you can manually provide a bearer token. Please see PR #2477 for more details.`,
-  );
-}
+    // Check for OAuth2.x authentication error more robustly.
+    if (error instanceof Error && error.message.includes('401')) {
+      const origin = mcpServerConfig.httpUrl || mcpServerConfig.url;
+      throw new Error(
+        `The MCP server at '${origin}' requires OAuth2.x authentication, which is not yet fully supported by the Gemini CLI. As a temporary workaround, you can manually provide a bearer token. Please see PR #2477 for more details.`,
+      );
+    }
     return;
   }
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -256,13 +256,14 @@ async function connectAndDiscover(
     // Update status to disconnected
     updateMCPServerStatus(mcpServerName, MCPServerStatus.DISCONNECTED);
     // Check for OAuth2.x authentication error
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((error as any).toString().includes('401')) {
-      const origin = mcpServerConfig.httpUrl || mcpServerConfig.url;
-      throw new Error(
-        `The MCP server at '${origin}' requires OAuth2.x authentication, which is not yet fully supported by the Gemini CLI. As a temporary workaround, you can manually provide a bearer token. Please see PR #2477 for more details.`,
-      );
-    }
+// Check for OAuth2.x authentication error more robustly.
+// The `error` is of type `unknown` in a catch block, so we first check if it's an Error instance.
+if (error instanceof Error && error.message.includes('401')) {
+  const origin = mcpServerConfig.httpUrl || mcpServerConfig.url;
+  throw new Error(
+    `The MCP server at '${origin}' requires OAuth2.x authentication, which is not yet fully supported by the Gemini CLI. As a temporary workaround, you can manually provide a bearer token. Please see PR #2477 for more details.`,
+  );
+}
     return;
   }
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -255,6 +255,14 @@ async function connectAndDiscover(
     console.error(errorString);
     // Update status to disconnected
     updateMCPServerStatus(mcpServerName, MCPServerStatus.DISCONNECTED);
+    // Check for OAuth2.x authentication error
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((error as any).toString().includes('401')) {
+      const origin = mcpServerConfig.httpUrl || mcpServerConfig.url;
+      throw new Error(
+        `The MCP server at '${origin}' requires OAuth2.x authentication, which is not yet fully supported by the Gemini CLI. As a temporary workaround, you can manually provide a bearer token. Please see PR #2477 for more details.`,
+      );
+    }
     return;
   }
 


### PR DESCRIPTION
 ## TLDR
 
This pull request addresses issue #2173 by providing a clear, user-friendly error message when the CLI attempts to connect to an MCP server that requires OAuth2.x authentication. 
Instead of a generic 401 error, the user is now informed about the authentication requirement and pointed to a temporary workaround.
In addition, we add new test to verify that when an Authorization header is provided]
(https://github.com/google-gemini/gemini-cli/commit/8305242c3edafcb044571e35b37b24028c0b4b47)
 
## Dive Deeper
Previously, when a user configured an MCP server that was protected by OAuth2.x, the connection would fail with a generic HTTP 401 Unauthorized error, leaving the user unsure of how to proceed.

This change intercepts that specific 401 error within the MCP client's connection logic. It then throws a new, more informative error that explicitly states:
1.  The server requires OAuth2.x authentication.
2.  Full OAuth2.x support is not yet implemented in the CLI.
3.  A temporary workaround is available by manually providing a bearer token in the configuration, with a reference to PR #2477 for details.

This serves as an stop-gap measure to improve user experience while the full OAuth 2.1 Authorization Code Flow is being developed.
## Reviewer Test Plan
To validate this change, you can run the newly added unit test which simulates this exact scenario.
1.  Navigate to the `packages/core` directory.
2.  Run the tests for `mcp-client.test.ts`:

      npm test -- src/tools/mcp-client.test.ts


3.  Verify that the test named `"should throw a specific error for 401 Unauthorized"` passes. This test mocks a 401 response from an MCP server and asserts that the correct, user-friendly error message is thrown.
## Testing Matrix
|          |   |   |   |
| -------- | --- | --- | --- |
| npm run  | ✅  |   |   |
| npx      | ❓  |   |   |
| Docker   | ❓  |   |   |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Addresses #2173