### PR TITLE
feat: add user startup warnings, add home directory check

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -168,7 +168,7 @@ export async function main() {
   let input = config.getQuestion();
   const startupWarnings = [
     ...(await getStartupWarnings()),
-    ...(await getUserStartupWarnings())
+    ...(await getUserStartupWarnings()),
   ];
 
   // Render UI, passing necessary config values. Check that there is no command line question.

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -168,7 +168,7 @@ export async function main() {
   let input = config.getQuestion();
   const startupWarnings = [
     ...(await getStartupWarnings()),
-    ...(await getUserStartupWarnings()),
+    ...(await getUserStartupWarnings(workspaceRoot)),
   ];
 
   // Render UI, passing necessary config values. Check that there is no command line question.

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -166,8 +166,10 @@ export async function main() {
     }
   }
   let input = config.getQuestion();
-  const startupWarnings = await getStartupWarnings();
-  const userWarnings = await getUserStartupWarnings();
+  const startupWarnings = [
+    ...(await getStartupWarnings()),
+    ...(await getUserStartupWarnings())
+  ];
 
   // Render UI, passing necessary config values. Check that there is no command line question.
   if (process.stdin.isTTY && input?.length === 0) {
@@ -178,7 +180,6 @@ export async function main() {
           config={config}
           settings={settings}
           startupWarnings={startupWarnings}
-          userWarnings={userWarnings}
         />
       </React.StrictMode>,
       { exitOnCtrlC: false },

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -22,6 +22,7 @@ import {
 } from './config/settings.js';
 import { themeManager } from './ui/themes/theme-manager.js';
 import { getStartupWarnings } from './utils/startupWarnings.js';
+import { getUserStartupWarnings } from './utils/userStartupWarnings.js';
 import { runNonInteractive } from './nonInteractiveCli.js';
 import { loadExtensions, Extension } from './config/extension.js';
 import { cleanupCheckpoints } from './utils/cleanup.js';
@@ -166,6 +167,7 @@ export async function main() {
   }
   let input = config.getQuestion();
   const startupWarnings = await getStartupWarnings();
+  const userWarnings = await getUserStartupWarnings();
 
   // Render UI, passing necessary config values. Check that there is no command line question.
   if (process.stdin.isTTY && input?.length === 0) {
@@ -176,6 +178,7 @@ export async function main() {
           config={config}
           settings={settings}
           startupWarnings={startupWarnings}
+          userWarnings={userWarnings}
         />
       </React.StrictMode>,
       { exitOnCtrlC: false },

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -79,6 +79,7 @@ interface AppProps {
   config: Config;
   settings: LoadedSettings;
   startupWarnings?: string[];
+  userWarnings?: string[];
 }
 
 export const AppWrapper = (props: AppProps) => (
@@ -87,7 +88,12 @@ export const AppWrapper = (props: AppProps) => (
   </SessionStatsProvider>
 );
 
-const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
+const App = ({
+  config,
+  settings,
+  startupWarnings = [],
+  userWarnings = [],
+}: AppProps) => {
   useBracketedPaste();
   const [updateMessage, setUpdateMessage] = useState<string | null>(null);
   const { stdout } = useStdout();
@@ -636,6 +642,22 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
               flexDirection="column"
             >
               {startupWarnings.map((warning, index) => (
+                <Text key={index} color={Colors.AccentYellow}>
+                  {warning}
+                </Text>
+              ))}
+            </Box>
+          )}
+
+          {userWarnings.length > 0 && (
+            <Box
+              borderStyle="round"
+              borderColor={Colors.AccentYellow}
+              paddingX={1}
+              marginY={1}
+              flexDirection="column"
+            >
+              {userWarnings.map((warning, index) => (
                 <Text key={index} color={Colors.AccentYellow}>
                   {warning}
                 </Text>

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -79,7 +79,6 @@ interface AppProps {
   config: Config;
   settings: LoadedSettings;
   startupWarnings?: string[];
-  userWarnings?: string[];
 }
 
 export const AppWrapper = (props: AppProps) => (
@@ -92,7 +91,6 @@ const App = ({
   config,
   settings,
   startupWarnings = [],
-  userWarnings = [],
 }: AppProps) => {
   useBracketedPaste();
   const [updateMessage, setUpdateMessage] = useState<string | null>(null);
@@ -649,21 +647,7 @@ const App = ({
             </Box>
           )}
 
-          {userWarnings.length > 0 && (
-            <Box
-              borderStyle="round"
-              borderColor={Colors.AccentYellow}
-              paddingX={1}
-              marginY={1}
-              flexDirection="column"
-            >
-              {userWarnings.map((warning, index) => (
-                <Text key={index} color={Colors.AccentYellow}>
-                  {warning}
-                </Text>
-              ))}
-            </Box>
-          )}
+  
 
           {isThemeDialogOpen ? (
             <Box flexDirection="column">

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -87,11 +87,7 @@ export const AppWrapper = (props: AppProps) => (
   </SessionStatsProvider>
 );
 
-const App = ({
-  config,
-  settings,
-  startupWarnings = [],
-}: AppProps) => {
+const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   useBracketedPaste();
   const [updateMessage, setUpdateMessage] = useState<string | null>(null);
   const { stdout } = useStdout();
@@ -646,8 +642,6 @@ const App = ({
               ))}
             </Box>
           )}
-
-  
 
           {isThemeDialogOpen ? (
             <Box flexDirection="column">

--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -41,59 +41,78 @@ describe('getUserStartupWarnings', () => {
   });
 
   it('should return a warning when running in home directory', async () => {
-    vi.mocked(fs.realpath).mockResolvedValueOnce(homeDir);
+    vi.mocked(fs.realpath)
+      .mockResolvedValueOnce(homeDir)  // workspace path resolves to home
+      .mockResolvedValueOnce(homeDir); // home path
 
     const warnings = await getUserStartupWarnings();
 
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain('home directory');
-    expect(fs.realpath).toHaveBeenCalledWith(process.cwd());
+    expect(fs.realpath).toHaveBeenNthCalledWith(1, process.cwd());
+    expect(fs.realpath).toHaveBeenNthCalledWith(2, homeDir);
   });
 
   it('should not return a warning when running in a project directory', async () => {
-    vi.mocked(fs.realpath).mockResolvedValueOnce('/some/project/path');
-
+    // Mock both calls explicitly
+    vi.mocked(fs.realpath)
+      .mockResolvedValueOnce('/some/project/path')  // workspace path
+      .mockResolvedValueOnce('/home/user');         // home path
+      
     const warnings = await getUserStartupWarnings();
-
+    
     expect(warnings).toHaveLength(0);
-    expect(fs.realpath).toHaveBeenCalledWith(process.cwd());
+    expect(fs.realpath).toHaveBeenNthCalledWith(1, process.cwd());
+    expect(fs.realpath).toHaveBeenNthCalledWith(2, '/home/user');
   });
-
   it('should handle errors when checking directory', async () => {
-    vi.mocked(fs.realpath).mockRejectedValueOnce(new Error('FS error'));
+    vi.mocked(fs.realpath)
+      .mockRejectedValueOnce(new Error('FS error'))  // workspace path fails
+      .mockResolvedValueOnce(homeDir);               // home path still succeeds
 
     const warnings = await getUserStartupWarnings();
 
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain('Could not verify');
+    expect(fs.realpath).toHaveBeenNthCalledWith(1, process.cwd());
+    expect(fs.realpath).toHaveBeenNthCalledWith(2, homeDir);
   });
 
   it('should not return a warning when workspaceRoot is provided and not home', async () => {
-    vi.mocked(fs.realpath).mockResolvedValueOnce('/some/project/path');
+    vi.mocked(fs.realpath)
+      .mockResolvedValueOnce('/some/project/path')  // workspace path
+      .mockResolvedValueOnce(homeDir);              // home path
 
     const warnings = await getUserStartupWarnings('/some/project/path');
 
     expect(warnings).toHaveLength(0);
-    expect(fs.realpath).toHaveBeenCalledWith('/some/project/path');
+    expect(fs.realpath).toHaveBeenNthCalledWith(1, '/some/project/path');
+    expect(fs.realpath).toHaveBeenNthCalledWith(2, homeDir);
   });
 
   it('should return a warning when workspaceRoot is home', async () => {
-    vi.mocked(fs.realpath).mockResolvedValueOnce(homeDir);
+    vi.mocked(fs.realpath)
+      .mockResolvedValueOnce(homeDir)  // workspace path (home)
+      .mockResolvedValueOnce(homeDir); // home path
 
     const warnings = await getUserStartupWarnings(homeDir);
 
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain('home directory');
-    expect(fs.realpath).toHaveBeenCalledWith(homeDir);
+    expect(fs.realpath).toHaveBeenNthCalledWith(1, homeDir);
+    expect(fs.realpath).toHaveBeenNthCalledWith(2, homeDir);
   });
 
   it('should handle errors when checking provided workspaceRoot', async () => {
-    vi.mocked(fs.realpath).mockRejectedValueOnce(new Error('FS error'));
+    vi.mocked(fs.realpath)
+      .mockRejectedValueOnce(new Error('FS error'))  // workspace path fails
+      .mockResolvedValueOnce(homeDir);               // home path still succeeds
 
     const warnings = await getUserStartupWarnings('/invalid/path');
 
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain('Could not verify');
-    expect(fs.realpath).toHaveBeenCalledWith('/invalid/path');
+    expect(fs.realpath).toHaveBeenNthCalledWith(1, '/invalid/path');
+    expect(fs.realpath).toHaveBeenNthCalledWith(2, homeDir);
   });
 });

--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -5,114 +5,71 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { PathLike } from 'node:fs';
+import { getUserStartupWarnings } from './userStartupWarnings.js';
+import * as os from 'os';
+import fs from 'fs/promises';
 
+// Mock dependencies
 vi.mock('os', () => ({
-  default: {
-    homedir: vi.fn(),
-  },
+  default: { homedir: vi.fn() },
   homedir: vi.fn(),
 }));
 
 vi.mock('fs/promises', () => ({
-  default: {
-    realpath: vi
-      .fn()
-      .mockImplementation((path: PathLike) => Promise.resolve(path.toString())),
-  },
+  default: { realpath: vi.fn() },
 }));
-
-import { getUserStartupWarnings } from './userStartupWarnings.js';
-import * as os from 'os';
-import fs from 'fs/promises';
 
 describe('getUserStartupWarnings', () => {
   const homeDir = '/home/user';
 
   beforeEach(() => {
     vi.mocked(os.homedir).mockReturnValue(homeDir);
-    vi.mocked(fs.realpath).mockImplementation(async (path: PathLike) =>
-      path.toString(),
-    );
+    vi.mocked(fs.realpath).mockImplementation(async (path) => path.toString());
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should return a warning when running in home directory', async () => {
-    vi.mocked(fs.realpath)
-      .mockResolvedValueOnce(homeDir)
-      .mockResolvedValueOnce(homeDir);
+  describe('home directory check', () => {
+    it('should return a warning when running in home directory', async () => {
+      vi.mocked(fs.realpath)
+        .mockResolvedValueOnce(homeDir)
+        .mockResolvedValueOnce(homeDir);
 
-    const warnings = await getUserStartupWarnings();
+      const warnings = await getUserStartupWarnings();
 
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('home directory');
-    expect(fs.realpath).toHaveBeenNthCalledWith(1, process.cwd());
-    expect(fs.realpath).toHaveBeenNthCalledWith(2, homeDir);
+      expect(warnings).toContainEqual(
+        expect.stringContaining('home directory'),
+      );
+    });
+
+    it('should not return a warning when running in a project directory', async () => {
+      vi.mocked(fs.realpath)
+        .mockResolvedValueOnce('/some/project/path')
+        .mockResolvedValueOnce(homeDir);
+
+      const warnings = await getUserStartupWarnings();
+      expect(warnings).not.toContainEqual(
+        expect.stringContaining('home directory'),
+      );
+    });
+
+    it('should handle errors when checking directory', async () => {
+      vi.mocked(fs.realpath)
+        .mockRejectedValueOnce(new Error('FS error'))
+        .mockResolvedValueOnce(homeDir);
+
+      const warnings = await getUserStartupWarnings();
+      expect(warnings).toContainEqual(
+        expect.stringContaining('Could not verify'),
+      );
+    });
   });
 
-  it('should not return a warning when running in a project directory', async () => {
-    // Mock both calls explicitly
-    vi.mocked(fs.realpath)
-      .mockResolvedValueOnce('/some/project/path') // workspace path
-      .mockResolvedValueOnce('/home/user'); // home path
-
-    const warnings = await getUserStartupWarnings();
-
-    expect(warnings).toHaveLength(0);
-    expect(fs.realpath).toHaveBeenNthCalledWith(1, process.cwd());
-    expect(fs.realpath).toHaveBeenNthCalledWith(2, '/home/user');
-  });
-  it('should handle errors when checking directory', async () => {
-    vi.mocked(fs.realpath)
-      .mockRejectedValueOnce(new Error('FS error'))
-      .mockResolvedValueOnce(homeDir);
-
-    const warnings = await getUserStartupWarnings();
-
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('Could not verify');
-    expect(fs.realpath).toHaveBeenNthCalledWith(1, process.cwd());
-    expect(fs.realpath).toHaveBeenNthCalledWith(2, homeDir);
-  });
-
-  it('should not return a warning when workspaceRoot is provided and not home', async () => {
-    vi.mocked(fs.realpath)
-      .mockResolvedValueOnce('/some/project/path')
-      .mockResolvedValueOnce(homeDir);
-
-    const warnings = await getUserStartupWarnings('/some/project/path');
-
-    expect(warnings).toHaveLength(0);
-    expect(fs.realpath).toHaveBeenNthCalledWith(1, '/some/project/path');
-    expect(fs.realpath).toHaveBeenNthCalledWith(2, homeDir);
-  });
-
-  it('should return a warning when workspaceRoot is home', async () => {
-    vi.mocked(fs.realpath)
-      .mockResolvedValueOnce(homeDir)
-      .mockResolvedValueOnce(homeDir);
-
-    const warnings = await getUserStartupWarnings(homeDir);
-
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('home directory');
-    expect(fs.realpath).toHaveBeenNthCalledWith(1, homeDir);
-    expect(fs.realpath).toHaveBeenNthCalledWith(2, homeDir);
-  });
-
-  it('should handle errors when checking provided workspaceRoot', async () => {
-    vi.mocked(fs.realpath)
-      .mockRejectedValueOnce(new Error('FS error'))
-      .mockResolvedValueOnce(homeDir);
-
-    const warnings = await getUserStartupWarnings('/invalid/path');
-
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('Could not verify');
-    expect(fs.realpath).toHaveBeenNthCalledWith(1, '/invalid/path');
-    expect(fs.realpath).toHaveBeenNthCalledWith(2, homeDir);
-  });
+  // // Example of how to add a new check:
+  // describe('node version check', () => {
+  //   // Tests for node version check would go here
+  //   // This shows how easy it is to add new test sections
+  // });
 });

--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -42,8 +42,8 @@ describe('getUserStartupWarnings', () => {
 
   it('should return a warning when running in home directory', async () => {
     vi.mocked(fs.realpath)
-      .mockResolvedValueOnce(homeDir)  // workspace path resolves to home
-      .mockResolvedValueOnce(homeDir); // home path
+      .mockResolvedValueOnce(homeDir)
+      .mockResolvedValueOnce(homeDir);
 
     const warnings = await getUserStartupWarnings();
 
@@ -56,19 +56,19 @@ describe('getUserStartupWarnings', () => {
   it('should not return a warning when running in a project directory', async () => {
     // Mock both calls explicitly
     vi.mocked(fs.realpath)
-      .mockResolvedValueOnce('/some/project/path')  // workspace path
-      .mockResolvedValueOnce('/home/user');         // home path
-      
+      .mockResolvedValueOnce('/some/project/path') // workspace path
+      .mockResolvedValueOnce('/home/user'); // home path
+
     const warnings = await getUserStartupWarnings();
-    
+
     expect(warnings).toHaveLength(0);
     expect(fs.realpath).toHaveBeenNthCalledWith(1, process.cwd());
     expect(fs.realpath).toHaveBeenNthCalledWith(2, '/home/user');
   });
   it('should handle errors when checking directory', async () => {
     vi.mocked(fs.realpath)
-      .mockRejectedValueOnce(new Error('FS error'))  // workspace path fails
-      .mockResolvedValueOnce(homeDir);               // home path still succeeds
+      .mockRejectedValueOnce(new Error('FS error'))
+      .mockResolvedValueOnce(homeDir);
 
     const warnings = await getUserStartupWarnings();
 
@@ -80,8 +80,8 @@ describe('getUserStartupWarnings', () => {
 
   it('should not return a warning when workspaceRoot is provided and not home', async () => {
     vi.mocked(fs.realpath)
-      .mockResolvedValueOnce('/some/project/path')  // workspace path
-      .mockResolvedValueOnce(homeDir);              // home path
+      .mockResolvedValueOnce('/some/project/path')
+      .mockResolvedValueOnce(homeDir);
 
     const warnings = await getUserStartupWarnings('/some/project/path');
 
@@ -92,8 +92,8 @@ describe('getUserStartupWarnings', () => {
 
   it('should return a warning when workspaceRoot is home', async () => {
     vi.mocked(fs.realpath)
-      .mockResolvedValueOnce(homeDir)  // workspace path (home)
-      .mockResolvedValueOnce(homeDir); // home path
+      .mockResolvedValueOnce(homeDir)
+      .mockResolvedValueOnce(homeDir);
 
     const warnings = await getUserStartupWarnings(homeDir);
 
@@ -105,8 +105,8 @@ describe('getUserStartupWarnings', () => {
 
   it('should handle errors when checking provided workspaceRoot', async () => {
     vi.mocked(fs.realpath)
-      .mockRejectedValueOnce(new Error('FS error'))  // workspace path fails
-      .mockResolvedValueOnce(homeDir);               // home path still succeeds
+      .mockRejectedValueOnce(new Error('FS error'))
+      .mockResolvedValueOnce(homeDir);
 
     const warnings = await getUserStartupWarnings('/invalid/path');
 

--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -4,94 +4,96 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { PathLike } from 'node:fs';
+
+vi.mock('os', () => ({
+  default: {
+    homedir: vi.fn(),
+  },
+  homedir: vi.fn(),
+}));
+
+vi.mock('fs/promises', () => ({
+  default: {
+    realpath: vi
+      .fn()
+      .mockImplementation((path: PathLike) => Promise.resolve(path.toString())),
+  },
+}));
+
 import { getUserStartupWarnings } from './userStartupWarnings.js';
-import * as fs from 'fs/promises';
 import * as os from 'os';
+import fs from 'fs/promises';
 
-vi.mock('fs/promises');
-vi.mock('os');
+describe('getUserStartupWarnings', () => {
+  const homeDir = '/home/user';
 
-describe.skip('getUserStartupWarnings', () => {
   beforeEach(() => {
-    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue(homeDir);
+    vi.mocked(fs.realpath).mockImplementation(async (path: PathLike) =>
+      path.toString(),
+    );
   });
 
-  it('should return a warning if the workspace is the home directory', async () => {
-    const homeDir = '/home/user';
-    vi.mocked(os.homedir).mockReturnValue(homeDir);
-    vi.spyOn(fs, 'realpath').mockResolvedValue(homeDir);
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return a warning when running in home directory', async () => {
+    vi.mocked(fs.realpath).mockResolvedValueOnce(homeDir);
 
     const warnings = await getUserStartupWarnings();
 
-    expect(warnings).toEqual([
-      'You are running Gemini CLI in your home directory. It is recommended to run in a project-specific directory.',
-    ]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('home directory');
     expect(fs.realpath).toHaveBeenCalledWith(process.cwd());
-    expect(fs.realpath).toHaveBeenCalledWith(homeDir);
   });
 
-  it('should return no warnings if the workspace is not the home directory', async () => {
-    const homeDir = '/home/user';
-    const projectDir = '/home/user/project';
-    vi.mocked(os.homedir).mockReturnValue(homeDir);
-    vi.spyOn(fs, 'realpath').mockImplementation(async (path) => {
-      if (path === process.cwd()) {
-        return projectDir;
-      }
-      if (path === homeDir) {
-        return homeDir;
-      }
-      throw new Error(`unexpected path: ${path}`);
-    });
+  it('should not return a warning when running in a project directory', async () => {
+    vi.mocked(fs.realpath).mockResolvedValueOnce('/some/project/path');
 
     const warnings = await getUserStartupWarnings();
 
-    expect(warnings).toEqual([]);
+    expect(warnings).toHaveLength(0);
+    expect(fs.realpath).toHaveBeenCalledWith(process.cwd());
   });
 
-  it('should return a warning if checking the directory fails', async () => {
-    vi.mocked(os.homedir).mockReturnValue('/home/user');
-    vi.spyOn(fs, 'realpath').mockRejectedValue(new Error('Permission denied'));
+  it('should handle errors when checking directory', async () => {
+    vi.mocked(fs.realpath).mockRejectedValueOnce(new Error('FS error'));
 
     const warnings = await getUserStartupWarnings();
 
-    expect(warnings).toEqual([
-      'Could not verify the current directory due to a file system error.',
-    ]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Could not verify');
   });
 
-  it('should return a warning when provided workspaceRoot is the home directory', async () => {
-    const homeDir = '/home/user';
-    const workspaceRoot = '/home/user';
-    vi.mocked(os.homedir).mockReturnValue(homeDir);
-    vi.spyOn(fs, 'realpath').mockResolvedValue(homeDir);
+  it('should not return a warning when workspaceRoot is provided and not home', async () => {
+    vi.mocked(fs.realpath).mockResolvedValueOnce('/some/project/path');
 
-    const warnings = await getUserStartupWarnings(workspaceRoot);
+    const warnings = await getUserStartupWarnings('/some/project/path');
 
-    expect(warnings).toEqual([
-      'You are running Gemini CLI in your home directory. It is recommended to run in a project-specific directory.',
-    ]);
-    expect(fs.realpath).toHaveBeenCalledWith(workspaceRoot);
+    expect(warnings).toHaveLength(0);
+    expect(fs.realpath).toHaveBeenCalledWith('/some/project/path');
+  });
+
+  it('should return a warning when workspaceRoot is home', async () => {
+    vi.mocked(fs.realpath).mockResolvedValueOnce(homeDir);
+
+    const warnings = await getUserStartupWarnings(homeDir);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('home directory');
     expect(fs.realpath).toHaveBeenCalledWith(homeDir);
   });
 
-  it('should return no warnings when provided workspaceRoot is not home', async () => {
-    const homeDir = '/home/user';
-    const workspaceRoot = '/some/other/dir';
-    vi.mocked(os.homedir).mockReturnValue(homeDir);
-    vi.spyOn(fs, 'realpath').mockImplementation(async (path) => {
-      if (path === workspaceRoot) {
-        return workspaceRoot;
-      }
-      if (path === homeDir) {
-        return homeDir;
-      }
-      throw new Error(`unexpected path: ${path}`);
-    });
+  it('should handle errors when checking provided workspaceRoot', async () => {
+    vi.mocked(fs.realpath).mockRejectedValueOnce(new Error('FS error'));
 
-    const warnings = await getUserStartupWarnings(workspaceRoot);
+    const warnings = await getUserStartupWarnings('/invalid/path');
 
-    expect(warnings).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Could not verify');
+    expect(fs.realpath).toHaveBeenCalledWith('/invalid/path');
   });
 });

--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getUserStartupWarnings } from './userStartupWarnings.js';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+
+vi.mock('fs/promises');
+vi.mock('os');
+
+describe.skip('getUserStartupWarnings', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should return a warning if the workspace is the home directory', async () => {
+    const homeDir = '/home/user';
+    vi.mocked(os.homedir).mockReturnValue(homeDir);
+    vi.spyOn(fs, 'realpath').mockResolvedValue(homeDir);
+
+    const warnings = await getUserStartupWarnings();
+
+    expect(warnings).toEqual([
+      'You are running Gemini CLI in your home directory. It is recommended to run in a project-specific directory.',
+    ]);
+    expect(fs.realpath).toHaveBeenCalledWith(process.cwd());
+    expect(fs.realpath).toHaveBeenCalledWith(homeDir);
+  });
+
+  it('should return no warnings if the workspace is not the home directory', async () => {
+    const homeDir = '/home/user';
+    const projectDir = '/home/user/project';
+    vi.mocked(os.homedir).mockReturnValue(homeDir);
+    vi.spyOn(fs, 'realpath').mockImplementation(async (path) => {
+      if (path === process.cwd()) {
+        return projectDir;
+      }
+      if (path === homeDir) {
+        return homeDir;
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const warnings = await getUserStartupWarnings();
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('should return a warning if checking the directory fails', async () => {
+    vi.mocked(os.homedir).mockReturnValue('/home/user');
+    vi.spyOn(fs, 'realpath').mockRejectedValue(new Error('Permission denied'));
+
+    const warnings = await getUserStartupWarnings();
+
+    expect(warnings).toEqual([
+      'Could not verify the current directory due to a file system error.',
+    ]);
+  });
+
+  it('should return a warning when provided workspaceRoot is the home directory', async () => {
+    const homeDir = '/home/user';
+    const workspaceRoot = '/home/user';
+    vi.mocked(os.homedir).mockReturnValue(homeDir);
+    vi.spyOn(fs, 'realpath').mockResolvedValue(homeDir);
+
+    const warnings = await getUserStartupWarnings(workspaceRoot);
+
+    expect(warnings).toEqual([
+      'You are running Gemini CLI in your home directory. It is recommended to run in a project-specific directory.',
+    ]);
+    expect(fs.realpath).toHaveBeenCalledWith(workspaceRoot);
+    expect(fs.realpath).toHaveBeenCalledWith(homeDir);
+  });
+
+  it('should return no warnings when provided workspaceRoot is not home', async () => {
+    const homeDir = '/home/user';
+    const workspaceRoot = '/some/other/dir';
+    vi.mocked(os.homedir).mockReturnValue(homeDir);
+    vi.spyOn(fs, 'realpath').mockImplementation(async (path) => {
+      if (path === workspaceRoot) {
+        return workspaceRoot;
+      }
+      if (path === homeDir) {
+        return homeDir;
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const warnings = await getUserStartupWarnings(workspaceRoot);
+
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -9,7 +9,6 @@ import { getUserStartupWarnings } from './userStartupWarnings.js';
 import * as os from 'os';
 import fs from 'fs/promises';
 
-// Mock dependencies
 vi.mock('os', () => ({
   default: { homedir: vi.fn() },
   homedir: vi.fn(),

--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -37,7 +37,7 @@ describe('getUserStartupWarnings', () => {
         .mockResolvedValueOnce(homeDir)
         .mockResolvedValueOnce(homeDir);
 
-      const warnings = await getUserStartupWarnings();
+      const warnings = await getUserStartupWarnings(homeDir);
 
       expect(warnings).toContainEqual(
         expect.stringContaining('home directory'),
@@ -49,7 +49,7 @@ describe('getUserStartupWarnings', () => {
         .mockResolvedValueOnce('/some/project/path')
         .mockResolvedValueOnce(homeDir);
 
-      const warnings = await getUserStartupWarnings();
+      const warnings = await getUserStartupWarnings('/some/project/path');
       expect(warnings).not.toContainEqual(
         expect.stringContaining('home directory'),
       );
@@ -60,7 +60,7 @@ describe('getUserStartupWarnings', () => {
         .mockRejectedValueOnce(new Error('FS error'))
         .mockResolvedValueOnce(homeDir);
 
-      const warnings = await getUserStartupWarnings();
+      const warnings = await getUserStartupWarnings('/error/path');
       expect(warnings).toContainEqual(
         expect.stringContaining('Could not verify'),
       );

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -9,7 +9,7 @@ import * as os from 'os';
 
 type WarningCheck = {
   id: string;
-  check: (workspaceRoot: string) => Promise<string | null>; // Returns null if no warning
+  check: (workspaceRoot: string) => Promise<string | null>;
 };
 
 // Individual warning checks
@@ -35,7 +35,6 @@ const homeDirectoryCheck: WarningCheck = {
 // All warning checks
 const WARNING_CHECKS: readonly WarningCheck[] = [homeDirectoryCheck];
 
-// Main function
 export async function getUserStartupWarnings(
   workspaceRoot: string,
 ): Promise<string[]> {

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -9,13 +9,13 @@ import * as os from 'os';
 
 type WarningCheck = {
   id: string;
-  check: (workspaceRoot?: string) => Promise<string | null>; // Returns null if no warning
+  check: (workspaceRoot: string) => Promise<string | null>; // Returns null if no warning
 };
 
 // Individual warning checks
 const homeDirectoryCheck: WarningCheck = {
   id: 'home-directory',
-  check: async (workspaceRoot = process.cwd()) => {
+  check: async (workspaceRoot: string) => {
     try {
       const [workspaceRealPath, homeRealPath] = await Promise.all([
         fs.realpath(workspaceRoot),
@@ -37,10 +37,10 @@ const WARNING_CHECKS: readonly WarningCheck[] = [homeDirectoryCheck];
 
 // Main function
 export async function getUserStartupWarnings(
-  workspaceRoot?: string,
+  workspaceRoot: string,
 ): Promise<string[]> {
   const results = await Promise.all(
     WARNING_CHECKS.map((check) => check.check(workspaceRoot)),
   );
-  return results.filter((msg): msg is string => msg !== null);
+  return results.filter((msg) => msg !== null);
 }

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs/promises';
+import * as os from 'os';
+
+type WorkspaceCheckResult = 'IS_HOME' | 'NOT_HOME' | 'CHECK_FAILED';
+
+/**
+ * Checks if the current workspace is the user's home directory.
+ * @param workspaceRoot - The root path of the workspace to check (defaults to process.cwd())
+ * @returns WorkspaceCheckResult - the result of the check
+ */
+async function checkIfWorkspaceIsHome(
+  workspaceRoot: string = process.cwd(),
+): Promise<WorkspaceCheckResult> {
+  try {
+    const [workspaceRealPath, homeRealPath] = await Promise.all([
+      fs.realpath(workspaceRoot),
+      fs.realpath(os.homedir()),
+    ]);
+
+    if (workspaceRealPath === homeRealPath) {
+      return 'IS_HOME';
+    }
+    return 'NOT_HOME';
+  } catch (_err: unknown) {
+    return 'CHECK_FAILED';
+  }
+}
+
+/**
+ * Gathers all user-facing warnings to be displayed on startup.
+ * @param workspaceRoot - The root path of the workspace to check.
+ * @returns A promise that resolves to an array of warning strings.
+ */
+export async function getUserStartupWarnings(
+  workspaceRoot?: string,
+): Promise<string[]> {
+  const warnings: string[] = [];
+
+  // Home directory check
+  switch (await checkIfWorkspaceIsHome(workspaceRoot)) {
+    case 'IS_HOME':
+      warnings.push(
+        'You are running Gemini CLI in your home directory. It is recommended to run in a project-specific directory.',
+      );
+      break;
+    case 'CHECK_FAILED':
+      warnings.push(
+        'Could not verify the current directory due to a file system error.',
+      );
+      break;
+    default:
+      break;
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
## TL;DR

This PR implements a utility function to return startup warnings designed for the user experience. 

One such warning is implemented, it checks if the Gemini CLI is executed from the home directory, addressing part of #2617.


---

## Dive Deeper
`startupWarnings` is currently architected for developer warnings via `npm run start`.  
This can be conflicting for developers trying to add user-facing warnings when getting familiar with the codebase.  
See https://github.com/google-gemini/gemini-cli/pull/2974#issuecomment-3029374119

Therefore, this PR creates `userStartupWarnings.ts` and a corresponding test file. It also adds a home directory warning with respect to #2617.

This separates all future user focused warnings from having to push each warning directly to the startupWarnings array, and allows contributors to test new warnings.

Instead, all developer and user focused startup warnings can be merged before being passed down to App.

#2617 and #2930 show that the inclusion of user-facing warnings may be a recurring request that would benefit from this abstraction. With this PR, contributors can rely on a separation between developer and user warnings, and their tests.

This will be useful for all future developers adding simple startup warnings that should be displayed to the user.

---

## Reviewer Test Plan

**To test development:**

```bash
npm install
npm run start
```

**To test build:**


```bash
npm install
npm run build
npm link .
```
Then enter the home/user directory of your OS and run the linked build.

For example:

```bash
cd home/psinha98
gemini
```

---

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ✅  | ✅  |
| npx      | ✅  | ✅  | ✅  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

---

## Linked Issues 

<!-- Add links to any GitHub issues or external bugs -->
- Fixes #2617 

