### PR TITLE
Add Custom Auth type.

### DIFF
--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -34,6 +34,9 @@ export const validateAuthMethod = (authMethod: string): string | null => {
     }
     return null;
   }
+  if (authMethod === AuthType.CUSTOM) {
+    return null;
+  }
 
   return 'Invalid auth method selected.';
 };

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -11,6 +11,7 @@ import process from 'node:process';
 import { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { useStateAndRef } from './useStateAndRef.js';
 import {
+  AuthType,
   Config,
   GitService,
   Logger,
@@ -247,6 +248,15 @@ export const useSlashCommandProcessor = (
         name: 'auth',
         description: 'change the auth method',
         action: (_mainCommand, _subCommand, _args) => {
+          if (settings.merged.selectedAuthType === AuthType.CUSTOM) {
+            addMessage({
+              type: MessageType.ERROR,
+              content:
+                'Cannot open Auth Dialog when using custom auth method. Please modify your settings manually.',
+              timestamp: new Date(),
+            });
+            return;
+          }
           openAuthDialog();
         },
       },

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -38,6 +38,7 @@ export enum AuthType {
   LOGIN_WITH_GOOGLE = 'oauth-personal',
   USE_GEMINI = 'gemini-api-key',
   USE_VERTEX_AI = 'vertex-ai',
+  CUSTOM = 'custom',
 }
 
 export type ContentGeneratorConfig = {
@@ -65,8 +66,7 @@ export async function createContentGeneratorConfig(
     authType,
   };
 
-  // if we are using google auth nothing else to validate for now
-  if (authType === AuthType.LOGIN_WITH_GOOGLE) {
+  if (authType === AuthType.LOGIN_WITH_GOOGLE || authType === AuthType.CUSTOM) {
     return contentGeneratorConfig;
   }
 
@@ -128,6 +128,10 @@ export async function createContentGenerator(
     });
 
     return googleGenAI.models;
+  }
+
+  if (config.authType === AuthType.CUSTOM) {
+    return new GoogleGenAI({ httpOptions }).models;
   }
 
   throw new Error(


### PR DESCRIPTION
## TLDR

This will skip all checks and just use GenAI directly. Disables /auth dialog. Only configurable via manually modifying settings.json.

## Dive Deeper

This will allow users to use any auth system supported by @google/genai. Specifically, we want to support this for running in  Cloud Shell where we want to use the cloud metadata server to authenticate.

## Reviewer Test Plan

Modify settings.json to set `"selectedAuthType": "custom",`. Try logging in using gcloud default application credentials.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

b/429067472
