### PR TITLE
feat(workflows): add automated and scheduled PR triage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,4 +24,18 @@
 
 ## Linked issues / bugs
 
-<!-- Add links to any gh issues or other external bugs --->
+<!--
+Link to any related issues or bugs.
+
+**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**
+
+- Closes #<issue_number>
+- Fixes #<issue_number>
+- Resolves #<issue_number>
+
+*Example: `Resolves #123`*
+
+**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**
+
+*Example: `This PR makes progress on #456` or `Related to #789`*
+-->

--- a/.github/workflows/gemini-automated-pr-triage.yml
+++ b/.github/workflows/gemini-automated-pr-triage.yml
@@ -1,0 +1,84 @@
+name: Gemini Automated PR Triage 🛳️
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  triage-pr:
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run Gemini PR Triage
+        uses: google-gemini/gemini-cli-action@41c0f1b3cbd1a0b284251bd1aac034edd07a3a2f
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        with:
+          version: 0.1.8-rc.0
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OTLP_GCP_WIF_PROVIDER: ${{ secrets.OTLP_GCP_WIF_PROVIDER }}
+          OTLP_GCP_SERVICE_ACCOUNT: ${{ secrets.OTLP_GCP_SERVICE_ACCOUNT }}
+          OTLP_GOOGLE_CLOUD_PROJECT: ${{ secrets.OTLP_GOOGLE_CLOUD_PROJECT }}
+          settings_json: |
+            {
+              "coreTools": [
+                "run_shell_command(gh pr list)",
+                "run_shell_command(gh pr view)",
+                "run_shell_command(gh pr edit)",
+                "run_shell_command(gh issue view)"
+              ]
+            }
+          prompt: |
+            You are a PR triage assistant. Your task is to ensure every pull request is linked to an issue and to perform a full synchronization of labels from the issue to the PR.
+
+            The current pull request is #${{ github.event.pull_request.number }} in the repository ${{ github.repository }}.
+
+            Follow these steps:
+            1.  **Check for a linked issue in the PR body.**
+                `gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json body -q .body`
+
+            2.  **Scan the body for an issue reference** (e.g., `#123`, `Closes #456`).
+
+            3.  **Process the result:**
+                - If **no issue reference is found**, add the `status/need-issue` label to the PR:
+                  `gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label "status/need-issue"`
+
+                - If **an issue reference is found**, perform a full label synchronization:
+                  a. **Remove the `status/need-issue` label** (if present):
+                     `gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --remove-label "status/need-issue"`
+
+                  b. **Extract the issue number** from the reference.
+
+                  c. **Fetch all labels for the issue** and store them.
+                     `gh issue view <ISSUE_NUMBER> --repo ${{ github.repository }} --json labels`
+
+                  d. **Fetch all labels for the PR** and store them.
+                     `gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json labels`
+
+                  e. **Compare the two sets of labels.**
+                     - Identify labels to **add**: those on the issue but not on the PR.
+                     - Identify labels to **remove**: those on the PR but not on the issue.
+
+                  f. **Execute the synchronization.**
+                     - If there are labels to add, run: `gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label "label1,label2,..."`
+                     - If there are labels to remove, run: `gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --remove-label "label3,label4,..."`
+
+            **Strictly follow these rules:**
+            - Only use the `gh` commands provided.
+            - Do not add any comments to the PR.
+            - The final set of labels on the PR must exactly match the labels on the linked issue.

--- a/.github/workflows/gemini-scheduled-pr-triage.yml
+++ b/.github/workflows/gemini-scheduled-pr-triage.yml
@@ -1,0 +1,87 @@
+name: Gemini Scheduled PR Triage 🚀
+
+on:
+  schedule:
+    - cron: '0 * * * *' # Runs at the beginning of every hour
+  workflow_dispatch: {}
+
+jobs:
+  audit-prs:
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run Gemini Scheduled PR Triage
+        uses: google-gemini/gemini-cli-action@41c0f1b3cbd1a0b284251bd1aac034edd07a3a2f
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        with:
+          version: 0.1.8-rc.0
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OTLP_GCP_WIF_PROVIDER: ${{ secrets.OTLP_GCP_WIF_PROVIDER }}
+          OTLP_GCP_SERVICE_ACCOUNT: ${{ secrets.OTLP_GCP_SERVICE_ACCOUNT }}
+          OTLP_GOOGLE_CLOUD_PROJECT: ${{ secrets.OTLP_GOOGLE_CLOUD_PROJECT }}
+          settings_json: |
+            {
+              "coreTools": [
+                "run_shell_command(gh pr list)",
+                "run_shell_command(gh pr view)",
+                "run_shell_command(gh pr edit)",
+                "run_shell_command(gh issue view)"
+              ]
+            }
+          prompt: |
+            You are a PR auditing assistant. Your task is to scan all open pull requests in the repository and ensure they are correctly triaged by performing a full label synchronization from the linked issue.
+
+            The repository is ${{ github.repository }}.
+
+            Follow these steps for each open pull request:
+            1.  **Get all open pull requests.**
+                `gh pr list --repo ${{ github.repository }} --state open --json number -q '.[].number'`
+
+            2.  **Iterate through each PR number** and perform the following triage steps:
+                a. **Check for a linked issue in the PR body.**
+                   `gh pr view <PR_NUMBER> --repo ${{ github.repository }} --json body -q .body`
+
+                b. **Scan the body for an issue reference** (e.g., `#123`, `Closes #456`).
+
+                c. **Process the result:**
+                   - If **no issue reference is found**, add the `status/need-issue` label to the PR:
+                     `gh pr edit <PR_NUMBER> --repo ${{ github.repository }} --add-label "status/need-issue"`
+
+                   - If **an issue reference is found**, perform a full label synchronization:
+                     i. **Remove the `status/need-issue` label** (if present):
+                        `gh pr edit <PR_NUMBER> --repo ${{ github.repository }} --remove-label "status/need-issue"`
+
+                     ii. **Extract the issue number** from the reference.
+
+                     iii. **Fetch all labels for the issue** and store them.
+                          `gh issue view <ISSUE_NUMBER> --repo ${{ github.repository }} --json labels`
+
+                     iv. **Fetch all labels for the PR** and store them.
+                          `gh pr view <PR_NUMBER> --repo ${{ github.repository }} --json labels`
+
+                     v. **Compare the two sets of labels.**
+                        - Identify labels to **add**: those on the issue but not on the PR.
+                        - Identify labels to **remove**: those on the PR but not on the issue.
+
+                     vi. **Execute the synchronization.**
+                         - If there are labels to add, run: `gh pr edit <PR_NUMBER> --repo ${{ github.repository }} --add-label "label1,label2,..."`
+                         - If there are labels to remove, run: `gh pr edit <PR_NUMBER> --repo ${{ github.repository }} --remove-label "label3,label4,..."`
+
+            **Strictly follow these rules:**
+            - Execute the logic for every open pull request.
+            - Only use the `gh` commands provided.
+            - Do not add any comments.
+            - The final set of labels on each PR must exactly match the labels on its linked issue.


### PR DESCRIPTION
This commit introduces two new workflows to automate pull request triage and auditing.

The "Gemini Automated PR Triage" workflow is triggered on every pull request change. It ensures that every PR is linked to an issue and syncs all labels from the issue to the PR. This provides immediate context to reviewers and ensures consistency.

The "Gemini Scheduled PR Triage" workflow runs hourly to audit all open pull requests, ensuring that any PRs that were missed by the real-time triage are correctly labeled and that all labels are kept in sync with their linked issues.

This also updates the pull request template to provide clear instructions on how to link issues to pull requests.

Fixes https://github.com/google-gemini/gemini-cli/issues/3065

---
See the action acting on itself below:
![image](https://github.com/user-attachments/assets/dc2ea6bf-2be8-4ca9-acab-88d1abe9043d)

