### PR TITLE
Quota error

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -14,6 +14,7 @@ import {
   ToolRegistry,
   AccessibilitySettings,
   SandboxConfig,
+  FlashFallbackHandler,
 } from '@google/gemini-cli-core';
 import { LoadedSettings, SettingsFile, Settings } from '../config/settings.js';
 import process from 'node:process';
@@ -67,6 +68,7 @@ interface MockServerConfig {
   getAccessibility: Mock<() => AccessibilitySettings>;
   getProjectRoot: Mock<() => string | undefined>;
   getAllGeminiMdFilenames: Mock<() => string[]>;
+  setFlashFallbackHandler: Mock<(handler: FlashFallbackHandler) => void>;
 }
 
 // Mock @google/gemini-cli-core and its Config class
@@ -145,6 +147,8 @@ vi.mock('./hooks/useGeminiStream', () => ({
     submitQuery: vi.fn(),
     initError: null,
     pendingHistoryItems: [],
+    history: [],
+    setHistory: vi.fn(),
   })),
 }));
 

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -75,7 +75,7 @@ import { PrivacyNotice } from './privacy/PrivacyNotice.js';
 
 const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
 
-interface AppProps {
+export interface AppProps {
   config: Config;
   settings: LoadedSettings;
   startupWarnings?: string[];
@@ -243,14 +243,24 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     const flashFallbackHandler = async (
       currentModel: string,
       fallbackModel: string,
+      error?: Error,
     ): Promise<boolean> => {
+      let message: string;
+
+      if (error?.message?.includes('quota')) {
+        message = `⚡ You've reached your daily quota for ${currentModel}. Automatically switching to ${fallbackModel} for the remainder of this session. 
+        ⚡ ${currentModel} is currently limited during preview. Daily quotas reset at midnight Pacific time (UTC-8)`;
+      } else {
+        message = `⚡ Slow response times detected due to rate limiting.
+        ⚡ Automatically switching from ${currentModel} to ${fallbackModel} for faster responses for the remainder of this session.`;
+      }
+
       // Add message to UI history
       addItem(
         {
           type: MessageType.INFO,
-          text: `⚡ Slow response times detected. Automatically switching from ${currentModel} to ${fallbackModel} for faster responses for the remainder of this session.
-⚡ To avoid this you can either upgrade to Standard tier. See: https://goo.gle/set-up-gemini-code-assist
-⚡ Or you can utilize a Gemini API Key. See: https://goo.gle/gemini-cli-docs-auth#gemini-api-key
+          text: `${message}
+⚡ For additional quota you can utilize a Gemini or Vertex API Key. See: https://goo.gle/gemini-cli-docs-auth
 ⚡ You can switch authentication methods by typing /auth`,
         },
         Date.now(),

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -95,6 +95,7 @@ export interface SandboxConfig {
 export type FlashFallbackHandler = (
   currentModel: string,
   fallbackModel: string,
+  error?: Error,
 ) => Promise<boolean>;
 
 export interface ConfigParameters {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -191,7 +191,10 @@ export class GeminiChat {
    * Handles fallback to Flash model when persistent 429 errors occur for OAuth users.
    * Uses a fallback handler if provided by the config, otherwise returns null.
    */
-  private async handleFlashFallback(authType?: string): Promise<string | null> {
+  private async handleFlashFallback(
+    authType?: string,
+    error?: Error,
+  ): Promise<string | null> {
     // Only handle fallback for OAuth users
     if (authType !== AuthType.LOGIN_WITH_GOOGLE) {
       return null;
@@ -209,7 +212,11 @@ export class GeminiChat {
     const fallbackHandler = this.config.flashFallbackHandler;
     if (typeof fallbackHandler === 'function') {
       try {
-        const accepted = await fallbackHandler(currentModel, fallbackModel);
+        const accepted = await fallbackHandler(
+          currentModel,
+          fallbackModel,
+          error,
+        );
         if (accepted) {
           this.config.setModel(fallbackModel);
           return fallbackModel;
@@ -270,8 +277,8 @@ export class GeminiChat {
           }
           return false;
         },
-        onPersistent429: async (authType?: string) =>
-          await this.handleFlashFallback(authType),
+        onPersistent429: async (authType?: string, error?: Error) =>
+          await this.handleFlashFallback(authType, error),
         authType: this.config.getContentGeneratorConfig()?.authType,
       });
       const durationMs = Date.now() - startTime;
@@ -367,8 +374,8 @@ export class GeminiChat {
           }
           return false; // Don't retry other errors by default
         },
-        onPersistent429: async (authType?: string) =>
-          await this.handleFlashFallback(authType),
+        onPersistent429: async (authType?: string, error?: Error) =>
+          await this.handleFlashFallback(authType, error),
         authType: this.config.getContentGeneratorConfig()?.authType,
       });
 

--- a/packages/core/src/utils/flashFallback.integration.test.ts
+++ b/packages/core/src/utils/flashFallback.integration.test.ts
@@ -6,13 +6,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Config } from '../config/config.js';
-import {
-  setSimulate429,
-  disableSimulationAfterFallback,
-  shouldSimulate429,
-  createSimulated429Error,
-  resetRequestCounter,
-} from './testUtils.js';
+import { createSimulated429Error, resetRequestCounter } from './testUtils.js';
 import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { retryWithBackoff } from './retry.js';
 import { AuthType } from '../core/contentGenerator.js';
@@ -29,24 +23,20 @@ describe('Flash Fallback Integration', () => {
       model: 'gemini-2.5-pro',
     });
 
-    // Reset simulation state for each test
-    setSimulate429(false);
     resetRequestCounter();
   });
 
   it('should automatically accept fallback', async () => {
-    // Set up a minimal flash fallback handler for testing
     const flashFallbackHandler = async (): Promise<boolean> => true;
 
     config.setFlashFallbackHandler(flashFallbackHandler);
 
-    // Call the handler directly to test
     const result = await config.flashFallbackHandler!(
       'gemini-2.5-pro',
       DEFAULT_GEMINI_FLASH_MODEL,
+      undefined,
     );
 
-    // Verify it automatically accepts
     expect(result).toBe(true);
   });
 
@@ -54,90 +44,53 @@ describe('Flash Fallback Integration', () => {
     let fallbackCalled = false;
     let fallbackModel = '';
 
-    // Mock function that simulates exactly 2 429 errors, then succeeds after fallback
     const mockApiCall = vi
       .fn()
       .mockRejectedValueOnce(createSimulated429Error())
       .mockRejectedValueOnce(createSimulated429Error())
       .mockResolvedValueOnce('success after fallback');
 
-    // Mock fallback handler
-    const mockFallbackHandler = vi.fn(async (_authType?: string) => {
-      fallbackCalled = true;
-      fallbackModel = DEFAULT_GEMINI_FLASH_MODEL;
-      return fallbackModel;
-    });
+    const mockFallbackHandler = vi.fn(
+      async (_authType?: string, _error?: Error) => {
+        fallbackCalled = true;
+        fallbackModel = DEFAULT_GEMINI_FLASH_MODEL;
+        return fallbackModel;
+      },
+    );
 
-    // Test with OAuth personal auth type, with maxAttempts = 2 to ensure fallback triggers
     const result = await retryWithBackoff(mockApiCall, {
       maxAttempts: 2,
       initialDelayMs: 1,
       maxDelayMs: 10,
-      shouldRetry: (error: Error) => {
-        const status = (error as Error & { status?: number }).status;
-        return status === 429;
-      },
       onPersistent429: mockFallbackHandler,
       authType: AuthType.LOGIN_WITH_GOOGLE,
     });
 
-    // Verify fallback was triggered
     expect(fallbackCalled).toBe(true);
     expect(fallbackModel).toBe(DEFAULT_GEMINI_FLASH_MODEL);
     expect(mockFallbackHandler).toHaveBeenCalledWith(
       AuthType.LOGIN_WITH_GOOGLE,
+      expect.any(Error),
     );
     expect(result).toBe('success after fallback');
-    // Should have: 2 failures, then fallback triggered, then 1 success after retry reset
+    // 2 failures, then fallback triggered, then 1 success after retry reset
     expect(mockApiCall).toHaveBeenCalledTimes(3);
   });
 
   it('should not trigger fallback for API key users', async () => {
-    let fallbackCalled = false;
-
-    // Mock function that simulates 429 errors
+    const mockFallbackHandler = vi.fn();
     const mockApiCall = vi.fn().mockRejectedValue(createSimulated429Error());
 
-    // Mock fallback handler
-    const mockFallbackHandler = vi.fn(async () => {
-      fallbackCalled = true;
-      return DEFAULT_GEMINI_FLASH_MODEL;
-    });
-
-    // Test with API key auth type - should not trigger fallback
-    try {
-      await retryWithBackoff(mockApiCall, {
+    await expect(
+      retryWithBackoff(mockApiCall, {
         maxAttempts: 5,
         initialDelayMs: 10,
         maxDelayMs: 100,
-        shouldRetry: (error: Error) => {
-          const status = (error as Error & { status?: number }).status;
-          return status === 429;
-        },
         onPersistent429: mockFallbackHandler,
         authType: AuthType.USE_GEMINI, // API key auth type
-      });
-    } catch (error) {
-      // Expected to throw after max attempts
-      expect((error as Error).message).toContain('Rate limit exceeded');
-    }
+      }),
+    ).rejects.toThrow('Rate limit exceeded');
 
-    // Verify fallback was NOT triggered for API key users
-    expect(fallbackCalled).toBe(false);
     expect(mockFallbackHandler).not.toHaveBeenCalled();
-  });
-
-  it('should properly disable simulation state after fallback', () => {
-    // Enable simulation
-    setSimulate429(true);
-
-    // Verify simulation is enabled
-    expect(shouldSimulate429()).toBe(true);
-
-    // Disable simulation after fallback
-    disableSimulationAfterFallback();
-
-    // Verify simulation is now disabled
-    expect(shouldSimulate429()).toBe(false);
   });
 });


### PR DESCRIPTION
## TLDR

Clarify in the fallback behavior when this is because of quota, and when this is because of rate limiting

## Dive Deeper

429 errors are used in both situations. We were doing a retry, and then essentially displaying a message about slow responses.

However when people have hit their daily quota this fallback will be consistent on every run of the CLI and it has led to numerous issues.

A fair amount of this change relates to plumbing through the error so that the message contents can be checked at the key fallback message generation moment.

## Reviewer Test Plan

The tests gemini helped revise seem a bit convoluted in places. but I've manually carefully reviewed the core logic and it looks correct. 
## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

resolves #2909


