### PR TITLE
Add a command line option to disable extensions by name

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -178,7 +178,8 @@ export async function loadCliConfig(
   const debugMode = argv.debug || false;
 
   const disabledExtensions =
-    argv['disable-extensions']?.split(',').map((e) => e.trim().toLowerCase()) || [];
+    argv['disable-extensions']?.split(',').map((e) => e.trim().toLowerCase()) ||
+    [];
   const activeExtensions = extensions.filter(
     (e) => !disabledExtensions.includes(e.config.name.toLowerCase()),
   );


### PR DESCRIPTION
## TLDR

Add a new command line option, -e or --disable-extensions, to provide a comma-separated list of extensions to disable by name.

## Dive Deeper

Some extensions may be more useful to apply contextually depending on the project. This is a first attempt at a command line argument to control what extensions are active, by first providing a list of extensions to disable. An alternate approach may be to list out specific extensions to *enable* instead though, so please give feedback on whether you like this strategy.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1467.