### PR TITLE
ci: disable scheduled jobs in forked repo

### DIFF
--- a/.github/workflows/community-report.yml
+++ b/.github/workflows/community-report.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   generate-report:
     name: Generate Report 📝
+    if: ${{ github.repository == 'google-gemini/gemini-cli' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   triage-issue:
     timeout-minutes: 5
+    if: ${{ github.repository == 'google-gemini/gemini-cli' }}
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   triage-issues:
     timeout-minutes: 10
+    if: ${{ github.repository == 'google-gemini/gemini-cli' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/gemini-scheduled-pr-triage.yml
+++ b/.github/workflows/gemini-scheduled-pr-triage.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   audit-prs:
     timeout-minutes: 15
+    if: ${{ github.repository == 'google-gemini/gemini-cli' }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->
there is no need to run all ci tasks as the original task in the scenario of forked repo, so I want to submit the PR, only allow these kinds of ci task work in the original repo.

## Dive Deeper
for some schedule task like:
- Gemini Scheduled PR Triage 🚀
- Gemini Scheduled Issue Triage
- Generate Weekly Community Report 📊
there is no need to run these task periodly in the forked repo, it will turn out too many failed result.


for `Gemini Automated Issue Triage` task, it only make sense in the `google-gemini/gemini-cli` repo. So I want to 
<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
