### PR TITLE
Use AccentBlue: 'blue' in ANSI theme instead of hard-coded #0000FF

### DIFF
--- a/packages/cli/src/ui/themes/ansi.ts
+++ b/packages/cli/src/ui/themes/ansi.ts
@@ -11,7 +11,7 @@ const ansiColors: ColorsTheme = {
   Background: 'black',
   Foreground: 'white',
   LightBlue: 'bluebright',
-  AccentBlue: '#0000FF',
+  AccentBlue: 'blue',
   AccentPurple: 'magenta',
   AccentCyan: 'cyan',
   AccentGreen: 'green',


### PR DESCRIPTION
## TLDR

The hard-coded `#0000FF` for `AccentBlue` is bound to look out of place in terminals providing their own colors (most of them).

This patch fixes that so that `blue` is used instead.

## Dive Deeper

Run this command on your CLI to compare the `blue` used by your terminal vs. the hard-coded `#0000FF` value:

```sh
echo -e "[30mblack[0m (Background)"
echo -e "[37mwhite[0m (Foreground)" 
echo -e "[94mbluebright[0m (LightBlue)"
echo -e "[34mblue[0m (ANSI blue for comparison)"
echo -e "[38;2;0;0;255m#0000FF[0m (AccentBlue - hard-coded)"
echo -e "[35mmagenta[0m (AccentPurple)"
echo -e "[36mcyan[0m (AccentCyan)"
echo -e "[32mgreen[0m (AccentGreen)"
echo -e "[33myellow[0m (AccentYellow)"
echo -e "[31mred[0m (AccentRed)"
echo -e "[90mgray[0m (Comment/Gray)"
```

This is what it looks like on my own terminal:

![image](https://github.com/user-attachments/assets/02209d02-a2da-4ef0-93cb-51fd9b97a0d1)

This is using my own terminal theme:
https://github.com/fnune/standard/blob/main/kitty/standard.dark.conf

## Reviewer Test Plan

```sh
cd packages/cli
npm run start
```

Select the ANSI theme. Comparison:

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ad4ac2f4-11a5-4e30-9137-256703595156) | ![image](https://github.com/user-attachments/assets/a2c2a3dd-a894-44af-94c8-fb6b0cbaf4cf) |

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |