### PR TITLE
feat: allow customizing project root for VSCode debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,10 @@
       "type": "node",
       "request": "launch",
       "name": "Launch CLI",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "start"],
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["${workspaceFolder}/scripts/start.js"],
       "skipFiles": ["<node_internals>/**"],
+      // You can change the cwd to the root of your project if needed
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",
       "env": {

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -55,7 +55,7 @@ if (process.env.DEBUG && !sandboxCommand) {
   }
 }
 
-nodeArgs.push('./packages/cli');
+nodeArgs.push(`${root}/packages/cli`);
 nodeArgs.push(...process.argv.slice(2));
 
 const env = {

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -55,7 +55,7 @@ if (process.env.DEBUG && !sandboxCommand) {
   }
 }
 
-nodeArgs.push(`${root}/packages/cli`);
+nodeArgs.push(join(root, 'packages', 'cli'));
 nodeArgs.push(...process.argv.slice(2));
 
 const env = {


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

This PR adds support for customizing the project root during VSCode debugging by allowing users to set the cwd field in .vscode/launch.json.

![image](https://github.com/user-attachments/assets/cd804235-58f2-4e5e-991f-09e18a24faa5)

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

- Users can now specify the desired project root for debugging sessions by setting the cwd property in their launch configuration.
- With this change, developers can easily adjust the project root for different debugging scenarios directly in launch.json.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

#3250 

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
