### PR TITLE
Fixed Google User Id pass to Clearcut

### DIFF
--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -58,11 +58,22 @@ describe('oauth2', () => {
     const mockGetAccessToken = vi
       .fn()
       .mockResolvedValue({ token: 'mock-access-token' });
+    const mockRefreshAccessToken = vi.fn().mockImplementation((callback) => {
+      // Mock the callback-style refreshAccessToken method
+      const mockTokensWithIdToken = {
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        id_token:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LWdvb2dsZS1hY2NvdW50LWlkLTEyMyJ9.signature', // Mock JWT with sub: test-google-account-id-123
+      };
+      callback(null, mockTokensWithIdToken);
+    });
     const mockOAuth2Client = {
       generateAuthUrl: mockGenerateAuthUrl,
       getToken: mockGetToken,
       setCredentials: mockSetCredentials,
       getAccessToken: mockGetAccessToken,
+      refreshAccessToken: mockRefreshAccessToken,
       credentials: mockTokens,
       on: vi.fn(),
     } as unknown as OAuth2Client;

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -68,12 +68,20 @@ describe('oauth2', () => {
       };
       callback(null, mockTokensWithIdToken);
     });
+    const mockVerifyIdToken = vi.fn().mockResolvedValue({
+      getPayload: () => ({
+        sub: 'test-google-account-id-123',
+        aud: 'test-audience',
+        iss: 'https://accounts.google.com',
+      }),
+    });
     const mockOAuth2Client = {
       generateAuthUrl: mockGenerateAuthUrl,
       getToken: mockGetToken,
       setCredentials: mockSetCredentials,
       getAccessToken: mockGetAccessToken,
       refreshAccessToken: mockRefreshAccessToken,
+      verifyIdToken: mockVerifyIdToken,
       credentials: mockTokens,
       on: vi.fn(),
     } as unknown as OAuth2Client;

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -14,13 +14,6 @@ import path from 'node:path';
 import { promises as fs, existsSync, readFileSync } from 'node:fs';
 import * as os from 'os';
 
-interface DecodedIdTokenPayload {
-  sub: string;
-  // Add other fields you might need from the id_token
-  email?: string;
-  name?: string;
-}
-
 //  OAuth Client ID used to initiate OAuth2Client class.
 const OAUTH_CLIENT_ID =
   '681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com';
@@ -305,33 +298,6 @@ export async function getRawGoogleAccountId(
     return payload.sub;
   } catch (error) {
     console.error('Error retrieving or verifying Google Account ID:', error);
-    return null;
-  }
-}
-
-async function extractRawGaiaIdFromIdToken(
-  idToken: string,
-): Promise<string | null> {
-  try {
-    // Split the id_token into header, payload, and signature
-    const parts = idToken.split('.');
-    if (parts.length !== 3) {
-      console.warn('Invalid ID token format');
-      return null;
-    }
-    const payloadBase64 = parts[1];
-
-    // Decode the payload from base64
-    const payload = JSON.parse(
-      Buffer.from(payloadBase64, 'base64').toString('utf-8'),
-    ) as DecodedIdTokenPayload;
-    if (!payload || !payload.sub) {
-      console.warn('Could not extract sub claim from ID token.');
-      return null;
-    }
-    return payload.sub;
-  } catch (error) {
-    console.error('Error decoding ID token:', error);
     return null;
   }
 }

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -18,7 +18,7 @@ import {
 import { EventMetadataKey } from './event-metadata-key.js';
 import { Config } from '../../config/config.js';
 import { getInstallationId } from '../../utils/user_id.js';
-import { getObfuscatedGoogleAccountId } from '../../utils/user_id.js';
+import { getGoogleAccountId } from '../../utils/user_id.js';
 
 const start_session_event_name = 'start_session';
 const new_prompt_event_name = 'new_prompt';
@@ -70,7 +70,6 @@ export class ClearcutLogger {
       console_type: 'GEMINI_CLI',
       application: 102,
       event_name: name,
-      obfuscated_google_account_id: getObfuscatedGoogleAccountId(),
       client_install_id: getInstallationId(),
       event_metadata: [data] as object[],
     };
@@ -81,15 +80,20 @@ export class ClearcutLogger {
       return;
     }
 
-    this.flushToClearcut();
+    // Fire and forget - don't await
+    this.flushToClearcut().catch((error) => {
+      console.debug('Error flushing to Clearcut:', error);
+    });
   }
 
-  flushToClearcut(): Promise<LogResponse> {
+  async flushToClearcut(): Promise<LogResponse> {
     if (this.config?.getDebugMode()) {
       console.log('Flushing log events to Clearcut.');
     }
     const eventsToSend = [...this.events];
     this.events.length = 0;
+
+    const googleAccountId = await getGoogleAccountId();
 
     return new Promise<Buffer>((resolve, reject) => {
       const request = [
@@ -97,6 +101,12 @@ export class ClearcutLogger {
           log_source_name: 'CONCORD',
           request_time_ms: Date.now(),
           log_event: eventsToSend,
+          // Add UserInfo with the raw Gaia ID
+          user_info: googleAccountId
+            ? {
+                UserID: googleAccountId,
+              }
+            : undefined,
         },
       ];
       const body = JSON.stringify(request);
@@ -244,7 +254,9 @@ export class ClearcutLogger {
     ];
     this.enqueueLogEvent(this.createLogEvent(start_session_event_name, data));
     // Flush start event immediately
-    this.flushToClearcut();
+    this.flushToClearcut().catch((error) => {
+      console.debug('Error flushing start session event to Clearcut:', error);
+    });
   }
 
   logNewPromptEvent(event: UserPromptEvent): void {
@@ -256,7 +268,9 @@ export class ClearcutLogger {
     ];
 
     this.enqueueLogEvent(this.createLogEvent(new_prompt_event_name, data));
-    this.flushToClearcut();
+    this.flushToClearcut().catch((error) => {
+      console.debug('Error flushing to Clearcut:', error);
+    });
   }
 
   logToolCallEvent(event: ToolCallEvent): void {
@@ -288,7 +302,9 @@ export class ClearcutLogger {
     ];
 
     this.enqueueLogEvent(this.createLogEvent(tool_call_event_name, data));
-    this.flushToClearcut();
+    this.flushToClearcut().catch((error) => {
+      console.debug('Error flushing to Clearcut:', error);
+    });
   }
 
   logApiRequestEvent(event: ApiRequestEvent): void {
@@ -300,7 +316,9 @@ export class ClearcutLogger {
     ];
 
     this.enqueueLogEvent(this.createLogEvent(api_request_event_name, data));
-    this.flushToClearcut();
+    this.flushToClearcut().catch((error) => {
+      console.debug('Error flushing to Clearcut:', error);
+    });
   }
 
   logApiResponseEvent(event: ApiResponseEvent): void {
@@ -349,7 +367,9 @@ export class ClearcutLogger {
     ];
 
     this.enqueueLogEvent(this.createLogEvent(api_response_event_name, data));
-    this.flushToClearcut();
+    this.flushToClearcut().catch((error) => {
+      console.debug('Error flushing to Clearcut:', error);
+    });
   }
 
   logApiErrorEvent(event: ApiErrorEvent): void {
@@ -373,7 +393,9 @@ export class ClearcutLogger {
     ];
 
     this.enqueueLogEvent(this.createLogEvent(api_error_event_name, data));
-    this.flushToClearcut();
+    this.flushToClearcut().catch((error) => {
+      console.debug('Error flushing to Clearcut:', error);
+    });
   }
 
   logEndSessionEvent(event: EndSessionEvent): void {
@@ -386,7 +408,9 @@ export class ClearcutLogger {
 
     this.enqueueLogEvent(this.createLogEvent(end_session_event_name, data));
     // Flush immediately on session end.
-    this.flushToClearcut();
+    this.flushToClearcut().catch((error) => {
+      console.debug('Error flushing to Clearcut:', error);
+    });
   }
 
   shutdown() {

--- a/packages/core/src/utils/user_id.test.ts
+++ b/packages/core/src/utils/user_id.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { getInstallationId, getObfuscatedGoogleAccountId } from './user_id.js';
+import { getInstallationId, getGoogleAccountId } from './user_id.js';
 
 describe('user_id', () => {
   describe('getInstallationId', () => {
@@ -22,25 +22,30 @@ describe('user_id', () => {
     });
   });
 
-  describe('getObfuscatedGoogleAccountId', () => {
-    it('should return a non-empty string', () => {
-      const result = getObfuscatedGoogleAccountId();
+  describe('getGoogleAccountId', () => {
+    it('should return a non-empty string', async () => {
+      const result = await getGoogleAccountId();
 
       expect(result).toBeDefined();
       expect(typeof result).toBe('string');
 
       // Should be consistent on subsequent calls
-      const secondCall = getObfuscatedGoogleAccountId();
+      const secondCall = await getGoogleAccountId();
       expect(secondCall).toBe(result);
     });
 
-    it('should return empty string when no Google Account ID is cached', () => {
-      // In a clean test environment, there should be no cached Google Account ID
-      // so getObfuscatedGoogleAccountId should fall back to installation ID
-      const googleAccountIdResult = getObfuscatedGoogleAccountId();
+    it('should return empty string when no Google Account ID is cached, or a valid ID when cached', async () => {
+      // The function can return either an empty string (if no cached ID) or a valid Google Account ID (if cached)
+      const googleAccountIdResult = await getGoogleAccountId();
 
-      // They should be the same when no Google Account ID is cached
-      expect(googleAccountIdResult).toBe('');
+      expect(googleAccountIdResult).toBeDefined();
+      expect(typeof googleAccountIdResult).toBe('string');
+
+      // Should be either empty string or a numeric string (Google Account ID)
+      if (googleAccountIdResult !== '') {
+        // If we have a cached ID, it should be a numeric string
+        expect(googleAccountIdResult).toMatch(/^\d+$/);
+      }
     });
   });
 });

--- a/packages/core/src/utils/user_id.ts
+++ b/packages/core/src/utils/user_id.ts
@@ -62,18 +62,20 @@ export function getInstallationId(): string {
  * When OAuth is available, returns the user's cached Google Account ID. Otherwise, returns the installation ID.
  * @returns A string ID for the user (Google Account ID if available, otherwise installation ID).
  */
-export function getObfuscatedGoogleAccountId(): string {
+export async function getGoogleAccountId(): Promise<string> {
   // Try to get cached Google Account ID first
   try {
-    // Dynamically import to avoid circular dependencies
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, no-restricted-syntax
-    const { getCachedGoogleAccountId } = require('../code_assist/oauth2.js');
+    // Dynamic import to avoid circular dependencies
+    const { getCachedGoogleAccountId } = await import(
+      '../code_assist/oauth2.js'
+    );
     const googleAccountId = getCachedGoogleAccountId();
     if (googleAccountId) {
       return googleAccountId;
     }
-  } catch (_error) {
+  } catch (error) {
     // If there's any error accessing Google Account ID, just return empty string
+    console.debug('Could not get cached Google Account ID:', error);
   }
 
   return '';


### PR DESCRIPTION
Previous implementation was setting the wrong field into Clearcut. It turns out that a UserInfo object needs to be populated:

* The UserInfo message within input proto is the standard place to store user-related identifiers.
* The UserID field within UserInfo is specifically designated for the user's Gaia ID.

Note that User ID here is an anonymized numeric ID and not an email or any other identifiable information.

This should correctly result in these identifiers being passed in for logging purposes. 

This PR should resolve issue #3149 