### PR TITLE
Add a command line option to enable and list extensions

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -311,6 +311,12 @@ Arguments passed directly when running the CLI can override other configurations
   - Enables logging of prompts for telemetry. See [telemetry](../telemetry.md) for more information.
 - **`--checkpointing`**:
   - Enables [checkpointing](./commands.md#checkpointing-commands).
+- **`--extensions <extension_name ...>`** (**`-e <extension_name ...>`**):
+  - Specifies a list of extensions to use for the session. If not provided, all available extensions are used.
+  - Use the special term `gemini -e none` to disable all extensions.
+  - Example: `gemini -e my-extension -e my-other-extension`
+- **`--list-extensions`** (**`-l`**):
+  - Lists all available extensions and exits.
 - **`--version`**:
   - Displays the version of the CLI.
 

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -555,3 +555,44 @@ describe('loadCliConfig with allowed-mcp-server-names', () => {
     expect(config.getMcpServers()).toEqual(baseSettings.mcpServers);
   });
 });
+
+describe('loadCliConfig extensions', () => {
+  const originalArgv = process.argv;
+  const originalEnv = { ...process.env };
+
+  const mockExtensions: Extension[] = [
+    {
+      config: { name: 'ext1', version: '1.0.0' },
+      contextFiles: ['/path/to/ext1.md'],
+    },
+    {
+      config: { name: 'ext2', version: '1.0.0' },
+      contextFiles: ['/path/to/ext2.md'],
+    },
+  ];
+
+  it('should not filter extensions if --extensions flag is not used', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings: Settings = {};
+    const config = await loadCliConfig(
+      settings,
+      mockExtensions,
+      'test-session',
+    );
+    expect(config.getExtensionContextFilePaths()).toEqual([
+      '/path/to/ext1.md',
+      '/path/to/ext2.md',
+    ]);
+  });
+
+  it('should filter extensions if --extensions flag is used', async () => {
+    process.argv = ['node', 'script.js', '--extensions', 'ext1'];
+    const settings: Settings = {};
+    const config = await loadCliConfig(
+      settings,
+      mockExtensions,
+      'test-session',
+    );
+    expect(config.getExtensionContextFilePaths()).toEqual(['/path/to/ext1.md']);
+  });
+});

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -557,9 +557,6 @@ describe('loadCliConfig with allowed-mcp-server-names', () => {
 });
 
 describe('loadCliConfig extensions', () => {
-  const originalArgv = process.argv;
-  const originalEnv = { ...process.env };
-
   const mockExtensions: Extension[] = [
     {
       config: { name: 'ext1', version: '1.0.0' },

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -49,7 +49,7 @@ interface CliArgs {
   telemetryOtlpEndpoint: string | undefined;
   telemetryLogPrompts: boolean | undefined;
   'allowed-mcp-server-names': string | undefined;
-  extensions: string | undefined;
+  extensions: string[] | undefined;
   'list-extensions': boolean | undefined;
 }
 
@@ -137,9 +137,10 @@ async function parseArguments(): Promise<CliArgs> {
     })
     .option('extensions', {
       alias: 'e',
-      type: 'string',
+      type: 'array',
+      string: true,
       description:
-        'Comma-separated list of extensions to use. If not provided, all extensions are used.',
+        'A list of extensions to use. If not provided, all extensions are used.',
     })
     .option('list-extensions', {
       alias: 'l',
@@ -187,8 +188,7 @@ export async function loadCliConfig(
   const argv = await parseArguments();
   const debugMode = argv.debug || false;
 
-  const enabledExtensions =
-    argv.extensions?.split(',').map((e) => e.trim()) || [];
+  const enabledExtensions = argv.extensions?.map((e) => e.trim()) || [];
 
   let activeExtensions;
   try {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -303,6 +303,10 @@ export async function loadCliConfig(
     model: argv.model!,
     extensionContextFilePaths,
     listExtensions: argv['list-extensions'] || false,
+    activeExtensions: activeExtensions.map((e) => ({
+      name: e.config.name,
+      version: e.config.version,
+    })),
   });
 }
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -49,7 +49,7 @@ interface CliArgs {
   telemetryOtlpEndpoint: string | undefined;
   telemetryLogPrompts: boolean | undefined;
   'allowed-mcp-server-names': string | undefined;
-  'disable-extensions': string | undefined;
+  extensions: string | undefined;
   'list-extensions': boolean | undefined;
 }
 
@@ -135,10 +135,11 @@ async function parseArguments(): Promise<CliArgs> {
       type: 'string',
       description: 'Allowed MCP server names',
     })
-    .option('disable-extensions', {
+    .option('extensions', {
       alias: 'e',
       type: 'string',
-      description: 'Comma-separated list of extensions to disable.',
+      description:
+        'Comma-separated list of extensions to use. If not provided, all extensions are used.',
     })
     .option('list-extensions', {
       alias: 'l',
@@ -186,12 +187,15 @@ export async function loadCliConfig(
   const argv = await parseArguments();
   const debugMode = argv.debug || false;
 
-  const disabledExtensions =
-    argv['disable-extensions']?.split(',').map((e) => e.trim().toLowerCase()) ||
-    [];
-  const activeExtensions = extensions.filter(
-    (e) => !disabledExtensions.includes(e.config.name.toLowerCase()),
-  );
+  const enabledExtensions =
+    argv.extensions?.split(',').map((e) => e.trim().toLowerCase()) || [];
+
+  const activeExtensions =
+    enabledExtensions.length > 0
+      ? extensions.filter((e) =>
+          enabledExtensions.includes(e.config.name.toLowerCase()),
+        )
+      : extensions;
 
   // Set the context filename in the server's memoryTool module BEFORE loading memory
   // TODO(b/343434939): This is a bit of a hack. The contextFileName should ideally be passed

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -188,29 +188,10 @@ export async function loadCliConfig(
   const argv = await parseArguments();
   const debugMode = argv.debug || false;
 
-  const enabledExtensions = argv.extensions?.map((e) => e.trim()) || [];
-
-  let activeExtensions;
-  try {
-    activeExtensions = filterActiveExtensions(extensions, enabledExtensions);
-  } catch (e) {
-    console.error((e as Error).message);
-    process.exit(1);
-  }
-
-  if (enabledExtensions.length > 0) {
-    const activeNames = new Set(
-      activeExtensions.map((e) => e.config.name.toLowerCase()),
-    );
-    for (const extension of extensions) {
-      const status = activeNames.has(extension.config.name.toLowerCase())
-        ? 'Activated'
-        : 'Disabled';
-      console.log(
-        `${status} extension: ${extension.config.name} (version: ${extension.config.version})`,
-      );
-    }
-  }
+  const activeExtensions = filterActiveExtensions(
+    extensions,
+    argv.extensions || [],
+  );
 
   // Set the context filename in the server's memoryTool module BEFORE loading memory
   // TODO(b/343434939): This is a bit of a hack. The contextFileName should ideally be passed

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -50,6 +50,7 @@ interface CliArgs {
   telemetryLogPrompts: boolean | undefined;
   'allowed-mcp-server-names': string | undefined;
   'disable-extensions': string | undefined;
+  'list-extensions': boolean | undefined;
 }
 
 async function parseArguments(): Promise<CliArgs> {
@@ -139,6 +140,11 @@ async function parseArguments(): Promise<CliArgs> {
       type: 'string',
       description: 'Comma-separated list of extensions to disable.',
     })
+    .option('list-extensions', {
+      alias: 'l',
+      type: 'boolean',
+      description: 'List all available extensions and exit.',
+    })
     .version(await getCliVersion()) // This will enable the --version flag based on package.json
     .alias('v', 'version')
     .help()
@@ -181,7 +187,8 @@ export async function loadCliConfig(
   const debugMode = argv.debug || false;
 
   const disabledExtensions =
-    argv['disable-extensions']?.split(',').map((e) => e.trim().toLowerCase()) || [];
+    argv['disable-extensions']?.split(',').map((e) => e.trim().toLowerCase()) ||
+    [];
   const activeExtensions = extensions.filter(
     (e) => !disabledExtensions.includes(e.config.name.toLowerCase()),
   );
@@ -276,6 +283,7 @@ export async function loadCliConfig(
     bugCommand: settings.bugCommand,
     model: argv.model!,
     extensionContextFilePaths,
+    listExtensions: argv['list-extensions'] || false,
   });
 }
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -198,6 +198,26 @@ export async function loadCliConfig(
       : extensions;
 
   if (argv.extensions) {
+    const lowerCaseEnabledExtensions = enabledExtensions.map((e) =>
+      e.toLowerCase(),
+    );
+    if (
+      lowerCaseEnabledExtensions.length === 1 &&
+      lowerCaseEnabledExtensions[0] === 'none'
+    ) {
+      activeExtensions.length = 0;
+    } else {
+      const activeNames = new Set(
+        activeExtensions.map((e) => e.config.name.toLowerCase()),
+      );
+      for (const requestedExtension of lowerCaseEnabledExtensions) {
+        if (!activeNames.has(requestedExtension)) {
+          console.error(`Extension not found: ${requestedExtension}`);
+          process.exit(1);
+        }
+      }
+    }
+
     const activeNames = new Set(
       activeExtensions.map((e) => e.config.name.toLowerCase()),
     );

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -20,7 +20,7 @@ import {
 } from '@google/gemini-cli-core';
 import { Settings } from './settings.js';
 
-import { Extension } from './extension.js';
+import { Extension, filterActiveExtensions } from './extension.js';
 import { getCliVersion } from '../utils/version.js';
 import { loadSandboxConfig } from './sandboxConfig.js';
 
@@ -188,47 +188,14 @@ export async function loadCliConfig(
   const debugMode = argv.debug || false;
 
   const enabledExtensions =
-    argv.extensions?.split(',').map((e) => e.trim().toLowerCase()) || [];
+    argv.extensions?.split(',').map((e) => e.trim()) || [];
 
-  const activeExtensions =
-    enabledExtensions.length > 0
-      ? extensions.filter((e) =>
-          enabledExtensions.includes(e.config.name.toLowerCase()),
-        )
-      : extensions;
-
-  if (argv.extensions) {
-    const lowerCaseEnabledExtensions = enabledExtensions.map((e) =>
-      e.toLowerCase(),
-    );
-    if (
-      lowerCaseEnabledExtensions.length === 1 &&
-      lowerCaseEnabledExtensions[0] === 'none'
-    ) {
-      activeExtensions.length = 0;
-    } else {
-      const activeNames = new Set(
-        activeExtensions.map((e) => e.config.name.toLowerCase()),
-      );
-      for (const requestedExtension of lowerCaseEnabledExtensions) {
-        if (!activeNames.has(requestedExtension)) {
-          console.error(`Extension not found: ${requestedExtension}`);
-          process.exit(1);
-        }
-      }
-    }
-
-    const activeNames = new Set(
-      activeExtensions.map((e) => e.config.name.toLowerCase()),
-    );
-    for (const extension of extensions) {
-      const status = activeNames.has(extension.config.name.toLowerCase())
-        ? 'Activated'
-        : 'Disabled';
-      console.log(
-        `${status} extension: ${extension.config.name} (version: ${extension.config.version})`,
-      );
-    }
+  let activeExtensions;
+  try {
+    activeExtensions = filterActiveExtensions(extensions, enabledExtensions);
+  } catch (e) {
+    console.error((e as Error).message);
+    process.exit(1);
   }
 
   // Set the context filename in the server's memoryTool module BEFORE loading memory

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -197,6 +197,20 @@ export async function loadCliConfig(
         )
       : extensions;
 
+  if (argv.extensions) {
+    const activeNames = new Set(
+      activeExtensions.map((e) => e.config.name.toLowerCase()),
+    );
+    for (const extension of extensions) {
+      const status = activeNames.has(extension.config.name.toLowerCase())
+        ? 'Activated'
+        : 'Disabled';
+      console.log(
+        `${status} extension: ${extension.config.name} (version: ${extension.config.version})`,
+      );
+    }
+  }
+
   // Set the context filename in the server's memoryTool module BEFORE loading memory
   // TODO(b/343434939): This is a bit of a hack. The contextFileName should ideally be passed
   // directly to the Config constructor in core, and have core handle setGeminiMdFilename.

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -198,6 +198,20 @@ export async function loadCliConfig(
     process.exit(1);
   }
 
+  if (enabledExtensions.length > 0) {
+    const activeNames = new Set(
+      activeExtensions.map((e) => e.config.name.toLowerCase()),
+    );
+    for (const extension of extensions) {
+      const status = activeNames.has(extension.config.name.toLowerCase())
+        ? 'Activated'
+        : 'Disabled';
+      console.log(
+        `${status} extension: ${extension.config.name} (version: ${extension.config.version})`,
+      );
+    }
+  }
+
   // Set the context filename in the server's memoryTool module BEFORE loading memory
   // TODO(b/343434939): This is a bit of a hack. The contextFileName should ideally be passed
   // directly to the Config constructor in core, and have core handle setGeminiMdFilename.

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -50,7 +50,7 @@ interface CliArgs {
   telemetryLogPrompts: boolean | undefined;
   'allowed-mcp-server-names': string | undefined;
   extensions: string[] | undefined;
-  'list-extensions': boolean | undefined;
+  listExtensions: boolean | undefined;
 }
 
 async function parseArguments(): Promise<CliArgs> {
@@ -302,7 +302,7 @@ export async function loadCliConfig(
     bugCommand: settings.bugCommand,
     model: argv.model!,
     extensionContextFilePaths,
-    listExtensions: argv['list-extensions'] || false,
+    listExtensions: argv.listExtensions || false,
     activeExtensions: activeExtensions.map((e) => ({
       name: e.config.name,
       version: e.config.version,

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import {
   EXTENSIONS_CONFIG_FILENAME,
   EXTENSIONS_DIRECTORY_NAME,
+  filterActiveExtensions,
   loadExtensions,
 } from './extension.js';
 
@@ -82,6 +83,46 @@ describe('loadExtensions', () => {
     expect(ext1?.contextFiles).toEqual([
       path.join(workspaceExtensionsDir, 'ext1', 'my-context-file.md'),
     ]);
+  });
+});
+
+describe('filterActiveExtensions', () => {
+  const extensions = [
+    { config: { name: 'ext1', version: '1.0.0' }, contextFiles: [] },
+    { config: { name: 'ext2', version: '1.0.0' }, contextFiles: [] },
+    { config: { name: 'ext3', version: '1.0.0' }, contextFiles: [] },
+  ];
+
+  it('should return all extensions if no enabled extensions are provided', () => {
+    const activeExtensions = filterActiveExtensions(extensions, []);
+    expect(activeExtensions).toHaveLength(3);
+  });
+
+  it('should return only the enabled extensions', () => {
+    const activeExtensions = filterActiveExtensions(extensions, [
+      'ext1',
+      'ext3',
+    ]);
+    expect(activeExtensions).toHaveLength(2);
+    expect(activeExtensions.some((e) => e.config.name === 'ext1')).toBe(true);
+    expect(activeExtensions.some((e) => e.config.name === 'ext3')).toBe(true);
+  });
+
+  it('should return no extensions when "none" is provided', () => {
+    const activeExtensions = filterActiveExtensions(extensions, ['none']);
+    expect(activeExtensions).toHaveLength(0);
+  });
+
+  it('should handle case-insensitivity', () => {
+    const activeExtensions = filterActiveExtensions(extensions, ['EXT1']);
+    expect(activeExtensions).toHaveLength(1);
+    expect(activeExtensions[0].config.name).toBe('ext1');
+  });
+
+  it('should throw an error for unknown extensions', () => {
+    expect(() => filterActiveExtensions(extensions, ['ext4'])).toThrow(
+      'Extension not found: ext4',
+    );
   });
 });
 

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -119,10 +119,11 @@ describe('filterActiveExtensions', () => {
     expect(activeExtensions[0].config.name).toBe('ext1');
   });
 
-  it('should throw an error for unknown extensions', () => {
-    expect(() => filterActiveExtensions(extensions, ['ext4'])).toThrow(
-      'Extension not found: ext4',
-    );
+  it('should log an error for unknown extensions', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    filterActiveExtensions(extensions, ['ext4']);
+    expect(consoleSpy).toHaveBeenCalledWith('Extension not found: ext4');
+    consoleSpy.mockRestore();
   });
 });
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -114,3 +114,49 @@ function getContextFileNames(config: ExtensionConfig): string[] {
   }
   return config.contextFileName;
 }
+
+export function filterActiveExtensions(
+  extensions: Extension[],
+  enabledExtensions: string[],
+): Extension[] {
+  const lowerCaseEnabledExtensions = enabledExtensions.map((e) =>
+    e.toLowerCase(),
+  );
+  const activeExtensions =
+    enabledExtensions.length > 0
+      ? extensions.filter((e) =>
+          lowerCaseEnabledExtensions.includes(e.config.name.toLowerCase()),
+        )
+      : extensions;
+
+  if (enabledExtensions.length > 0) {
+    if (
+      lowerCaseEnabledExtensions.length === 1 &&
+      lowerCaseEnabledExtensions[0] === 'none'
+    ) {
+      activeExtensions.length = 0;
+    } else {
+      const activeNames = new Set(
+        activeExtensions.map((e) => e.config.name.toLowerCase()),
+      );
+      for (const requestedExtension of lowerCaseEnabledExtensions) {
+        if (!activeNames.has(requestedExtension)) {
+          throw new Error(`Extension not found: ${requestedExtension}`);
+        }
+      }
+    }
+
+    const activeNames = new Set(
+      activeExtensions.map((e) => e.config.name.toLowerCase()),
+    );
+    for (const extension of extensions) {
+      const status = activeNames.has(extension.config.name.toLowerCase())
+        ? 'Activated'
+        : 'Disabled';
+      console.log(
+        `${status} extension: ${extension.config.name} (version: ${extension.config.version})`,
+      );
+    }
+  }
+  return activeExtensions;
+}

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -145,18 +145,6 @@ export function filterActiveExtensions(
         }
       }
     }
-
-    const activeNames = new Set(
-      activeExtensions.map((e) => e.config.name.toLowerCase()),
-    );
-    for (const extension of extensions) {
-      const status = activeNames.has(extension.config.name.toLowerCase())
-        ? 'Activated'
-        : 'Disabled';
-      console.log(
-        `${status} extension: ${extension.config.name} (version: ${extension.config.version})`,
-      );
-    }
   }
   return activeExtensions;
 }

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -126,9 +126,6 @@ export function filterActiveExtensions(
   const lowerCaseEnabledExtensions = enabledExtensionNames.map((e) =>
     e.toLowerCase(),
   );
-  const activeExtensions = extensions.filter((e) =>
-    lowerCaseEnabledExtensions.includes(e.config.name.toLowerCase()),
-  );
 
   if (
     lowerCaseEnabledExtensions.length === 1 &&
@@ -137,13 +134,18 @@ export function filterActiveExtensions(
     return [];
   }
 
-  const activeNames = new Set(
-    activeExtensions.map((e) => e.config.name.toLowerCase()),
+  const extensionMap = new Map(
+    extensions.map((e) => [e.config.name.toLowerCase(), e]),
   );
-  for (const requestedExtension of lowerCaseEnabledExtensions) {
-    if (!activeNames.has(requestedExtension)) {
-      throw new Error(`Extension not found: ${requestedExtension}`);
+
+  const activeExtensions: Extension[] = [];
+  for (const requestedName of lowerCaseEnabledExtensions) {
+    const extension = extensionMap.get(requestedName);
+    if (!extension) {
+      throw new Error(`Extension not found: ${requestedName}`);
     }
+    activeExtensions.push(extension);
   }
+
   return activeExtensions;
 }

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -134,15 +134,15 @@ export function filterActiveExtensions(
     lowerCaseEnabledExtensions.length === 1 &&
     lowerCaseEnabledExtensions[0] === 'none'
   ) {
-    activeExtensions.length = 0;
-  } else {
-    const activeNames = new Set(
-      activeExtensions.map((e) => e.config.name.toLowerCase()),
-    );
-    for (const requestedExtension of lowerCaseEnabledExtensions) {
-      if (!activeNames.has(requestedExtension)) {
-        throw new Error(`Extension not found: ${requestedExtension}`);
-      }
+    return [];
+  }
+
+  const activeNames = new Set(
+    activeExtensions.map((e) => e.config.name.toLowerCase()),
+  );
+  for (const requestedExtension of lowerCaseEnabledExtensions) {
+    if (!activeNames.has(requestedExtension)) {
+      throw new Error(`Extension not found: ${requestedExtension}`);
     }
   }
   return activeExtensions;

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -117,32 +117,31 @@ function getContextFileNames(config: ExtensionConfig): string[] {
 
 export function filterActiveExtensions(
   extensions: Extension[],
-  enabledExtensions: string[],
+  enabledExtensionNames: string[],
 ): Extension[] {
-  const lowerCaseEnabledExtensions = enabledExtensions.map((e) =>
+  if (enabledExtensionNames.length === 0) {
+    return extensions;
+  }
+
+  const lowerCaseEnabledExtensions = enabledExtensionNames.map((e) =>
     e.toLowerCase(),
   );
-  const activeExtensions =
-    enabledExtensions.length > 0
-      ? extensions.filter((e) =>
-          lowerCaseEnabledExtensions.includes(e.config.name.toLowerCase()),
-        )
-      : extensions;
+  const activeExtensions = extensions.filter((e) =>
+    lowerCaseEnabledExtensions.includes(e.config.name.toLowerCase()),
+  );
 
-  if (enabledExtensions.length > 0) {
-    if (
-      lowerCaseEnabledExtensions.length === 1 &&
-      lowerCaseEnabledExtensions[0] === 'none'
-    ) {
-      activeExtensions.length = 0;
-    } else {
-      const activeNames = new Set(
-        activeExtensions.map((e) => e.config.name.toLowerCase()),
-      );
-      for (const requestedExtension of lowerCaseEnabledExtensions) {
-        if (!activeNames.has(requestedExtension)) {
-          throw new Error(`Extension not found: ${requestedExtension}`);
-        }
+  if (
+    lowerCaseEnabledExtensions.length === 1 &&
+    lowerCaseEnabledExtensions[0] === 'none'
+  ) {
+    activeExtensions.length = 0;
+  } else {
+    const activeNames = new Set(
+      activeExtensions.map((e) => e.config.name.toLowerCase()),
+    );
+    for (const requestedExtension of lowerCaseEnabledExtensions) {
+      if (!activeNames.has(requestedExtension)) {
+        throw new Error(`Extension not found: ${requestedExtension}`);
       }
     }
   }

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -103,6 +103,14 @@ export async function main() {
   const extensions = loadExtensions(workspaceRoot);
   const config = await loadCliConfig(settings.merged, extensions, sessionId);
 
+  if (config.getListExtensions()) {
+    console.log('Installed extensions:');
+    for (const extension of extensions) {
+      console.log(`- ${extension.config.name}`);
+    }
+    process.exit(0);
+  }
+
   // Set a default auth type if one isn't set for a couple of known cases.
   if (!settings.merged.selectedAuthType) {
     if (process.env.GEMINI_API_KEY) {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -509,8 +509,10 @@ export const useSlashCommandProcessor = (
 
           let message = 'Active extensions:\n\n';
           for (const ext of activeExtensions) {
-            message += `  - ${ext.name} (v${ext.version})\n`;
+            message += `  - \u001b[36m${ext.name} (v${ext.version})\u001b[0m\n`;
           }
+          // Make sure to reset any ANSI formatting at the end to prevent it from affecting the terminal
+          message += '\u001b[0m';
 
           addMessage({
             type: MessageType.INFO,

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -494,6 +494,32 @@ export const useSlashCommandProcessor = (
         },
       },
       {
+        name: 'extensions',
+        description: 'list active extensions',
+        action: async () => {
+          const activeExtensions = config?.getActiveExtensions();
+          if (!activeExtensions || activeExtensions.length === 0) {
+            addMessage({
+              type: MessageType.INFO,
+              content: 'No active extensions.',
+              timestamp: new Date(),
+            });
+            return;
+          }
+
+          let message = 'Active extensions:\n\n';
+          for (const ext of activeExtensions) {
+            message += `  - ${ext.name} (v${ext.version})\n`;
+          }
+
+          addMessage({
+            type: MessageType.INFO,
+            content: message,
+            timestamp: new Date(),
+          });
+        },
+      },
+      {
         name: 'tools',
         description: 'list available Gemini CLI tools',
         action: async (_mainCommand, _subCommand, _args) => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -133,6 +133,7 @@ export interface ConfigParameters {
   bugCommand?: BugCommandSettings;
   model: string;
   extensionContextFilePaths?: string[];
+  listExtensions?: boolean;
 }
 
 export class Config {
@@ -172,6 +173,7 @@ export class Config {
   private readonly model: string;
   private readonly extensionContextFilePaths: string[];
   private modelSwitchedDuringSession: boolean = false;
+  private readonly listExtensions: boolean;
   flashFallbackHandler?: FlashFallbackHandler;
 
   constructor(params: ConfigParameters) {
@@ -214,6 +216,7 @@ export class Config {
     this.bugCommand = params.bugCommand;
     this.model = params.model;
     this.extensionContextFilePaths = params.extensionContextFilePaths ?? [];
+    this.listExtensions = params.listExtensions ?? false;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -444,6 +447,10 @@ export class Config {
 
   getExtensionContextFilePaths(): string[] {
     return this.extensionContextFilePaths;
+  }
+
+  getListExtensions(): boolean {
+    return this.listExtensions;
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -66,6 +66,11 @@ export interface TelemetrySettings {
   logPrompts?: boolean;
 }
 
+export interface ActiveExtension {
+  name: string;
+  version: string;
+}
+
 export class MCPServerConfig {
   constructor(
     // For stdio transport
@@ -134,6 +139,7 @@ export interface ConfigParameters {
   model: string;
   extensionContextFilePaths?: string[];
   listExtensions?: boolean;
+  activeExtensions?: ActiveExtension[];
 }
 
 export class Config {
@@ -174,6 +180,7 @@ export class Config {
   private readonly extensionContextFilePaths: string[];
   private modelSwitchedDuringSession: boolean = false;
   private readonly listExtensions: boolean;
+  private readonly _activeExtensions: ActiveExtension[];
   flashFallbackHandler?: FlashFallbackHandler;
 
   constructor(params: ConfigParameters) {
@@ -217,6 +224,7 @@ export class Config {
     this.model = params.model;
     this.extensionContextFilePaths = params.extensionContextFilePaths ?? [];
     this.listExtensions = params.listExtensions ?? false;
+    this._activeExtensions = params.activeExtensions ?? [];
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -451,6 +459,10 @@ export class Config {
 
   getListExtensions(): boolean {
     return this.listExtensions;
+  }
+
+  getActiveExtensions(): ActiveExtension[] {
+    return this._activeExtensions;
   }
 
   async getGitService(): Promise<GitService> {


### PR DESCRIPTION
## TLDR

Adds two command line options, --list-extensions to list all installed extensions, and --extensions to provide an exclusive list of extensions to load.

## Dive Deeper

Some extensions are only useful in certain contexts. This change provides two new command line options, one --list-extensions that lists each extension and version and exits. The other, --extensions, provides a comma-separated list of extension names. All other extensions are disabled. A special name "none" requests that no extensions are loaded.

## Reviewer Test Plan

Please try with various extensions as you have them. Right now I am assuming all extensions have single-word names, another option is that we add a way for extensions to provide a 'short name'. Right now we are not validating that extensions have unique names, which may be a problem?

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1467.