### PR TITLE
Hide MCP stderr output by default, show only with DEBUG_SHOW_MCP_LOGS

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -270,6 +270,9 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
   - `<profile_name>`: Uses a custom profile. To define a custom profile, create a file named `sandbox-macos-<profile_name>.sb` in your project's `.gemini/` directory (e.g., `my-project/.gemini/sandbox-macos-custom.sb`).
 - **`DEBUG` or `DEBUG_MODE`** (often used by underlying libraries or the CLI itself):
   - Set to `true` or `1` to enable verbose debug logging, which can be helpful for troubleshooting.
+- **`DEBUG_SHOW_MCP_LOGS`**:
+  - Set to `true` to display MCP server stderr output. By default, MCP server error logs are hidden unless this is enabled.
+  - Example: `export DEBUG_SHOW_MCP_LOGS=true`
 - **`NO_COLOR`**:
   - Set to any value to disable all color output in the CLI.
 - **`CLI_TITLE`**:

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -275,7 +275,7 @@ async function connectAndDiscover(
         const stderrStr = data.toString();
         // Filter out verbose INFO logs from some MCP servers
         if (!stderrStr.includes('] INFO')) {
-          console.debug(`MCP STDERR (${mcpServerName}):`, stderrStr);
+          console.error(`MCP STDERR (${mcpServerName}):`, stderrStr);
         }
       }
     });

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -271,10 +271,12 @@ async function connectAndDiscover(
 
   if (transport instanceof StdioClientTransport && transport.stderr) {
     transport.stderr.on('data', (data) => {
-      const stderrStr = data.toString();
-      // Filter out verbose INFO logs from some MCP servers
-      if (!stderrStr.includes('] INFO')) {
-        console.debug(`MCP STDERR (${mcpServerName}):`, stderrStr);
+      if (process.env.DEBUG_SHOW_MCP_LOGS === 'true') {
+        const stderrStr = data.toString();
+        // Filter out verbose INFO logs from some MCP servers
+        if (!stderrStr.includes('] INFO')) {
+          console.debug(`MCP STDERR (${mcpServerName}):`, stderrStr);
+        }
       }
     });
   }


### PR DESCRIPTION
…=true

- Modified mcp-client.ts to check DEBUG_SHOW_MCP_LOGS environment variable before logging MCP stderr messages
- Updated configuration.md to document the new DEBUG_SHOW_MCP_LOGS environment variable
- This prevents MCP server logs from cluttering the CLI output unless explicitly enabled for debugging

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

This PR hides MCP server stderr output by default to reduce console clutter. MCP stderr messages are now only displayed when the DEBUG_SHOW_MCP_LOGS=true environment variable is set. This improves the user experience by showing only relevant Gemini responses unless debugging is needed.


## Dive Deeper

<!-- more thoughts and in depth discussion here -->


  Currently, when MCP servers are configured in gemini-cli, their stderr output (connection logs, debug messages) is displayed before Gemini's actual response, creating unnecessary noise for users. For example:

```
  $ gemini -p hello
  MCP STDERR (context7-mcp): 2025-07-03T16:03:59.628Z [Runner] Connecting to server...
  MCP STDERR (mcp-sequentialthinking-tools): 2025-07-03T16:03:59.547Z [Runner] Connecting...
  [more MCP logs...]

  Hello! How can I help you today?
```

  This change:
  - Wraps the MCP stderr logging in a conditional check for DEBUG_SHOW_MCP_LOGS
  - Maintains the existing filtering of verbose INFO logs
  - Documents the new environment variable in the configuration guide
  - Preserves the ability to see MCP logs when debugging is needed


## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

1. Setup: Ensure you have MCP servers configured in your settings.json
  2. Test default behavior (logs hidden):
  npm run bundle
  node bundle/gemini.js -p "hello"
    - Verify only Gemini's response is shown, no MCP stderr messages
  3. Test debug mode (logs shown):
  DEBUG_SHOW_MCP_LOGS=true node bundle/gemini.js -p "hello"
    - Verify MCP stderr messages appear before Gemini's response
  4. Verify documentation:
    - Check docs/cli/configuration.md for the new DEBUG_SHOW_MCP_LOGS environment variable documentation

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

I couldn't test this directly because gemini-cli kept timing out at the 'Waiting for auth' step. I'm submitting the PR anyway, as I believe these changes won't affect runtime behavior.

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

https://github.com/google-gemini/gemini-cli/issues/3148
