### PR TITLE
Doc: update gemini-cli README.md to require Node.js version 20+

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ With the Gemini CLI you can:
 
 ## Quickstart
 
-1. **Prerequisites:** Ensure you have [Node.js version 18](https://nodejs.org/en/download) or higher installed.
+1. **Prerequisites:** Ensure you have [Node.js version 20](https://nodejs.org/en/download) or higher installed.
 2. **Run the CLI:** Execute the following command in your terminal:
 
    ```bash


### PR DESCRIPTION
## TLDR

gemini-cli requires at leastNode.js version 20. This PR update the README.md accordingly.


## Reviewer Test Plan

`nvm install 20` and `nvm use 20` fixes the issue.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

N/A since this is just a README.md change

## Linked issues / bugs

- Closes #3245
