### PR TITLE
Update README.md: Set the API Key in the env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The Gemini API provides a free tier with [100 requests per day](https://ai.googl
    Alternatively, to make the variable persistent across sessions, add it to a `~/.env` file in your home directory:
    ```bash
    GEMINI_API_KEY="YOUR_API_KEY"
+   ```
 
 For other authentication methods, including Google Workspace accounts, see the [authentication](./docs/cli/authentication.md) guide.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ The Gemini API provides a free tier with [100 requests per day](https://ai.googl
    export GEMINI_API_KEY="YOUR_API_KEY"
    ```
 
-3. (Optionally) Upgrade your Gemini API project to a paid plan on the API key page (will automatically unlock [Tier 1 rate limits](https://ai.google.dev/gemini-api/docs/rate-limits#tier-1))
+   Or set the environment variable to `~/.env` file:
+   ```bash
+   GEMINI_API_KEY="YOUR_API_KEY"
+   ```
+
+4. (Optionally) Upgrade your Gemini API project to a paid plan on the API key page (will automatically unlock [Tier 1 rate limits](https://ai.google.dev/gemini-api/docs/rate-limits#tier-1))
 
 For other authentication methods, including Google Workspace accounts, see the [authentication](./docs/cli/authentication.md) guide.
 

--- a/README.md
+++ b/README.md
@@ -49,12 +49,9 @@ The Gemini API provides a free tier with [100 requests per day](https://ai.googl
    export GEMINI_API_KEY="YOUR_API_KEY"
    ```
 
-   Or set the environment variable to `~/.env` file:
+   Alternatively, to make the variable persistent across sessions, add it to a `~/.env` file in your home directory:
    ```bash
    GEMINI_API_KEY="YOUR_API_KEY"
-   ```
-
-4. (Optionally) Upgrade your Gemini API project to a paid plan on the API key page (will automatically unlock [Tier 1 rate limits](https://ai.google.dev/gemini-api/docs/rate-limits#tier-1))
 
 For other authentication methods, including Google Workspace accounts, see the [authentication](./docs/cli/authentication.md) guide.
 


### PR DESCRIPTION
For the inital setup, gemeni-cli detects the enviorment variable in the `~/.env` file so it's worth mentioning.