### PR TITLE
Add @file command support for non-interactive cli input (#3311)

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -20,6 +20,8 @@ import {
 } from '@google/genai';
 
 import { parseAndFormatApiError } from './ui/utils/errorParsing.js';
+import { handleAtCommand } from './ui/hooks/atCommandProcessor.js';
+import { isAtCommand } from './ui/utils/commandUtils.js';
 
 function getResponseText(response: GenerateContentResponse): string | null {
   if (response.candidates && response.candidates.length > 0) {
@@ -60,7 +62,25 @@ export async function runNonInteractive(
 
   const chat = await geminiClient.getChat();
   const abortController = new AbortController();
-  let currentMessages: Content[] = [{ role: 'user', parts: [{ text: input }] }];
+  
+  // Process @file commands if present
+  let processedInput: string | any = input;
+  if (isAtCommand(input)) {
+    const atCommandResult = await handleAtCommand({
+      query: input,
+      config,
+      addItem: () => Date.now(), // Non-interactive mode doesn't need history, return timestamp as ID
+      onDebugMessage: () => {}, // Non-interactive mode doesn't need debug messages
+      messageId: Date.now(),
+      signal: abortController.signal,
+    });
+    
+    if (atCommandResult.processedQuery) {
+      processedInput = atCommandResult.processedQuery;
+    }
+  }
+  
+  let currentMessages: Content[] = [{ role: 'user', parts: typeof processedInput === 'string' ? [{ text: processedInput }] : processedInput }];
 
   try {
     while (true) {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -63,7 +63,7 @@ export async function runNonInteractive(
 
   const chat = await geminiClient.getChat();
   const abortController = new AbortController();
-  
+
   // Process @file commands if present
   let processedInput: string | PartListUnion = input;
   if (isAtCommand(input)) {
@@ -75,22 +75,28 @@ export async function runNonInteractive(
       messageId: Date.now(),
       signal: abortController.signal,
     });
-    
+
     if (atCommandResult.processedQuery) {
       processedInput = atCommandResult.processedQuery;
     }
   }
-  
+
   // Convert processedInput to Part[]
   let parts: Part[];
   if (typeof processedInput === 'string') {
     parts = [{ text: processedInput }];
   } else if (Array.isArray(processedInput)) {
-    parts = processedInput.map(p => typeof p === 'string' ? { text: p } : p);
+    parts = processedInput.map((p) =>
+      typeof p === 'string' ? { text: p } : p,
+    );
   } else {
-    parts = [typeof processedInput === 'string' ? { text: processedInput } : processedInput];
+    parts = [
+      typeof processedInput === 'string'
+        ? { text: processedInput }
+        : processedInput,
+    ];
   }
-  
+
   let currentMessages: Content[] = [{ role: 'user', parts }];
 
   try {


### PR DESCRIPTION
## TLDR

This PR adds `@file` command support to non-interactive (piped) input mode. Previously, `@file` commands only worked in interactive mode, forcing users to rely on slower tool calls in pipeline workflows. Now both modes provide consistent file reference functionality.

## Dive Deeper

The existing `@file` command implementation in `atCommandProcessor.ts` was only integrated into the interactive UI flow via `useGeminiStream.ts`. Non-interactive mode (`nonInteractiveCli.ts`) processed piped input directly without checking for `@file` commands.

This creates a significant UX inconsistency:
- **Interactive**: `@scripts/start.js` → instant file content inclusion
- **Non-interactive**: `@scripts/start.js` → treated as literal text, requiring tool calls

The fix integrates the existing `handleAtCommand` logic into `runNonInteractive` before message construction. This reuses all existing functionality (path resolution, glob patterns, escaped spaces, error handling) without code duplication.

**Key design decisions:**
- Reuse existing `handleAtCommand` function with minimal stub callbacks
- Process `@file` commands before creating the initial message
- Maintain backward compatibility for non-`@file` inputs
- Handle both string and PartListUnion return types from the processor

## Reviewer Test Plan

1. **Build and test the changes:**
   ```bash
   npm run build
   ```

2. **Test non-interactive @file functionality:**
   ```bash
   # Single file reference
   echo "Explain this code @scripts/start.js" | npm start -p
   
   # Multiple file references  
   echo "Compare @package.json @packages/cli/package.json" | npm start -p
   
   # Mixed content
   echo "Review the following files for security issues: @src/*.ts" | npm start -p
   
   # Directory reference
   echo "Summarize the code structure @src/" | npm start -p
   ```

3. **Verify interactive mode still works:**
   ```bash
   npm start
   # Then in interactive mode: "Explain @scripts/start.js"
   ```

4. **Test error handling:**
   ```bash
   echo "Read this file @nonexistent.txt" | npm start -p
   ```

**Expected behavior:**
- File content should be included in the initial context
- No additional tool calls for file reading
- Consistent behavior between interactive and non-interactive modes

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

*Tested on macOS with `npm run` - other platforms need validation*

## Linked issues / bugs

This PR addresses a feature gap where `@file` commands work inconsistently across CLI modes, impacting user experience and workflow automation capabilities.