### PR TITLE
feat: add /model command to change the model in slash command processor

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,9 @@
     "typescript-eslint": "^8.30.1",
     "vitest": "^3.2.4",
     "yargs": "^17.7.2"
+  },
+  "dependencies": {
+    "@iarna/toml": "^2.2.5",
+    "chardet": "^2.1.0"
   }
 }

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -23,6 +23,7 @@ import { ideCommand } from '../ui/commands/ideCommand.js';
 import { initCommand } from '../ui/commands/initCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
+import { modelCommand } from '../ui/commands/modelCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
@@ -63,6 +64,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       initCommand,
       mcpCommand,
       memoryCommand,
+      modelCommand,
       privacyCommand,
       quitCommand,
       restoreCommand(this.config),

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -16,80 +16,200 @@ describe('modelCommand', () => {
     mockContext = createMockCommandContext();
   });
 
-  it('should change the model and return success message', () => {
-    if (!modelCommand.action) {
-      throw new Error('The model command must have an action.');
-    }
+  describe('main command behavior', () => {
+    it('should show list of models when no arguments are provided', () => {
+      if (!modelCommand.action) {
+        throw new Error('The model command must have an action.');
+      }
 
-    const setModelSpy = vi.fn();
-    mockContext.services.config = {
-      ...mockContext.services.config,
-      setModel: setModelSpy,
-    } as any;
+      const getModelSpy = vi.fn(() => 'gemini-2.5-pro');
+      mockContext.services.config = {
+        ...mockContext.services.config,
+        getModel: getModelSpy,
+      } as any;
 
-    const newModel = 'new-model-name';
-    const result = modelCommand.action(mockContext, newModel);
+      const result = modelCommand.action(mockContext, '');
 
-    expect(setModelSpy).toHaveBeenCalledWith(newModel);
-    expect(result).toEqual({
-      type: 'message',
-      messageType: 'info',
-      content: `Model changed to ${newModel}`,
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining('Available Gemini models:'),
+      });
+      expect((result as any).content).toContain('gemini-2.5-pro (current)');
+      expect((result as any).content).toContain('gemini-2.5-flash');
+      expect((result as any).content).toContain('[thinking]');
+      expect((result as any).content).toContain('Supports thinking capability');
+      // flash-lite should not have [thinking] indicator
+      expect((result as any).content).toContain('gemini-2.5-flash-lite');
+      expect((result as any).content).not.toContain('gemini-2.5-flash-lite [thinking]');
+    });
+
+    it('should show list of models when "list" argument is provided', () => {
+      if (!modelCommand.action) {
+        throw new Error('The model command must have an action.');
+      }
+
+      const getModelSpy = vi.fn(() => 'gemini-2.5-flash');
+      mockContext.services.config = {
+        ...mockContext.services.config,
+        getModel: getModelSpy,
+      } as any;
+
+      const result = modelCommand.action(mockContext, 'list');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining('Available Gemini models:'),
+      });
+      expect((result as any).content).toContain('gemini-2.5-flash (current)');
+      expect((result as any).content).toContain('[thinking]');
+      // flash-lite should not have [thinking] indicator
+      expect((result as any).content).not.toContain('gemini-2.5-flash-lite [thinking]');
+    });
+
+    it('should change the model when a valid model name is provided directly', () => {
+      if (!modelCommand.action) {
+        throw new Error('The model command must have an action.');
+      }
+
+      const setModelSpy = vi.fn();
+      mockContext.services.config = {
+        ...mockContext.services.config,
+        setModel: setModelSpy,
+      } as any;
+
+      const newModel = 'gemini-2.5-flash';
+      const result = modelCommand.action(mockContext, newModel);
+
+      expect(setModelSpy).toHaveBeenCalledWith(newModel);
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: `Model changed to \u001b[36m${newModel}\u001b[0m`,
+      });
+    });
+
+    it('should return error for invalid model name', () => {
+      if (!modelCommand.action) {
+        throw new Error('The model command must have an action.');
+      }
+
+      const result = modelCommand.action(mockContext, 'invalid-model');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Unknown model: invalid-model\n\nUse /model list to see available models',
+      });
+    });
+
+    it('should show thinking capability and descriptions in model list', () => {
+      if (!modelCommand.action) {
+        throw new Error('The model command must have an action.');
+      }
+
+      const getModelSpy = vi.fn(() => 'gemini-2.5-pro');
+      mockContext.services.config = {
+        ...mockContext.services.config,
+        getModel: getModelSpy,
+      } as any;
+
+      const result = modelCommand.action(mockContext, '');
+
+      expect((result as any).content).toContain('Most capable model with thinking support');
+      expect((result as any).content).toContain('Fast model with thinking support');
+      expect((result as any).content).toContain('Lightweight model (limited thinking support)');
+      expect((result as any).content).toContain('[thinking] = Supports thinking capability');
     });
   });
 
-  it('should change the model with spaces in the name and return success message', () => {
-    if (!modelCommand.action) {
-      throw new Error('The model command must have an action.');
-    }
+  describe('subcommands', () => {
+    it('should have list and set subcommands', () => {
+      expect(modelCommand.subCommands).toHaveLength(2);
+      expect(modelCommand.subCommands?.[0].name).toBe('list');
+      expect(modelCommand.subCommands?.[1].name).toBe('set');
+    });
 
-    const setModelSpy = vi.fn();
-    mockContext.services.config = {
-      ...mockContext.services.config,
-      setModel: setModelSpy,
-    } as any;
+    it('should handle set subcommand with valid model', () => {
+      const setSubCommand = modelCommand.subCommands?.find(cmd => cmd.name === 'set');
+      if (!setSubCommand?.action) {
+        throw new Error('The set subcommand must have an action.');
+      }
 
-    const newModel = 'my custom model';
-    const result = modelCommand.action(mockContext, newModel);
+      const setModelSpy = vi.fn();
+      mockContext.services.config = {
+        ...mockContext.services.config,
+        setModel: setModelSpy,
+      } as any;
 
-    expect(setModelSpy).toHaveBeenCalledWith(newModel);
-    expect(result).toEqual({
-      type: 'message',
-      messageType: 'info',
-      content: `Model changed to ${newModel}`,
+      const result = setSubCommand.action(mockContext, 'gemini-2.5-pro');
+
+      expect(setModelSpy).toHaveBeenCalledWith('gemini-2.5-pro');
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'Model changed to \u001b[36mgemini-2.5-pro\u001b[0m',
+      });
+    });
+
+    it('should handle set subcommand with no arguments', () => {
+      const setSubCommand = modelCommand.subCommands?.find(cmd => cmd.name === 'set');
+      if (!setSubCommand?.action) {
+        throw new Error('The set subcommand must have an action.');
+      }
+
+      const result = setSubCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Usage: /model set <model-name>\n\nUse /model list to see available models',
+      });
     });
   });
 
-  it('should return error message when no model name is provided', () => {
-    if (!modelCommand.action) {
-      throw new Error('The model command must have an action.');
-    }
+  describe('completion', () => {
+    it('should provide model name completion', async () => {
+      if (!modelCommand.completion) {
+        throw new Error('The model command must have completion.');
+      }
 
-    const result = modelCommand.action(mockContext, '');
-
-    expect(result).toEqual({
-      type: 'message',
-      messageType: 'error',
-      content: 'Usage: /model <model-name>',
+      const completions = await modelCommand.completion(mockContext, 'gemini-2.5');
+      
+      expect(completions).toContain('gemini-2.5-pro');
+      expect(completions).toContain('gemini-2.5-flash');
+      expect(completions).toContain('gemini-2.5-flash-lite');
     });
-  });
 
-  it('should return error message when only whitespace is provided', () => {
-    if (!modelCommand.action) {
-      throw new Error('The model command must have an action.');
-    }
+    it('should filter completions based on partial input', async () => {
+      if (!modelCommand.completion) {
+        throw new Error('The model command must have completion.');
+      }
 
-    const result = modelCommand.action(mockContext, '   ');
+      const completions = await modelCommand.completion(mockContext, 'gemini-2.5-f');
+      
+      expect(completions).toContain('gemini-2.5-flash');
+      expect(completions).toContain('gemini-2.5-flash-lite');
+      expect(completions).not.toContain('gemini-2.5-pro');
+    });
 
-    expect(result).toEqual({
-      type: 'message',
-      messageType: 'error',
-      content: 'Usage: /model <model-name>',
+    it('set subcommand should provide model name completion', async () => {
+      const setSubCommand = modelCommand.subCommands?.find(cmd => cmd.name === 'set');
+      if (!setSubCommand?.completion) {
+        throw new Error('The set subcommand must have completion.');
+      }
+
+      const completions = await setSubCommand.completion(mockContext, 'gemini-2.5');
+      
+      expect(completions).toContain('gemini-2.5-pro');
+      expect(completions).toContain('gemini-2.5-flash');
+      expect(completions).toContain('gemini-2.5-flash-lite');
     });
   });
 
   it('should have the correct name and description', () => {
     expect(modelCommand.name).toBe('model');
-    expect(modelCommand.description).toBe('change the model. Usage: /model <model-name>');
+    expect(modelCommand.description).toBe('Manage the active Gemini model');
   });
 });

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { modelCommand } from './modelCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+
+describe('modelCommand', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext();
+  });
+
+  it('should change the model and return success message', () => {
+    if (!modelCommand.action) {
+      throw new Error('The model command must have an action.');
+    }
+
+    const setModelSpy = vi.fn();
+    mockContext.services.config = {
+      ...mockContext.services.config,
+      setModel: setModelSpy,
+    } as any;
+
+    const newModel = 'new-model-name';
+    const result = modelCommand.action(mockContext, newModel);
+
+    expect(setModelSpy).toHaveBeenCalledWith(newModel);
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: `Model changed to ${newModel}`,
+    });
+  });
+
+  it('should change the model with spaces in the name and return success message', () => {
+    if (!modelCommand.action) {
+      throw new Error('The model command must have an action.');
+    }
+
+    const setModelSpy = vi.fn();
+    mockContext.services.config = {
+      ...mockContext.services.config,
+      setModel: setModelSpy,
+    } as any;
+
+    const newModel = 'my custom model';
+    const result = modelCommand.action(mockContext, newModel);
+
+    expect(setModelSpy).toHaveBeenCalledWith(newModel);
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: `Model changed to ${newModel}`,
+    });
+  });
+
+  it('should return error message when no model name is provided', () => {
+    if (!modelCommand.action) {
+      throw new Error('The model command must have an action.');
+    }
+
+    const result = modelCommand.action(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Usage: /model <model-name>',
+    });
+  });
+
+  it('should return error message when only whitespace is provided', () => {
+    if (!modelCommand.action) {
+      throw new Error('The model command must have an action.');
+    }
+
+    const result = modelCommand.action(mockContext, '   ');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Usage: /model <model-name>',
+    });
+  });
+
+  it('should have the correct name and description', () => {
+    expect(modelCommand.name).toBe('model');
+    expect(modelCommand.description).toBe('change the model. Usage: /model <model-name>');
+  });
+});

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -6,18 +6,93 @@
 
 import { CommandKind, MessageActionReturn, SlashCommand } from './types.js';
 
-export const modelCommand: SlashCommand = {
-  name: 'model',
-  description: 'change the model. Usage: /model <model-name>',
+// Available Gemini models with their capabilities
+interface ModelInfo {
+  name: string;
+  supportsThinking: boolean;
+  description?: string;
+}
+
+const AVAILABLE_MODELS: readonly ModelInfo[] = [
+  {
+    name: 'gemini-2.5-pro',
+    supportsThinking: true,
+    description: 'Most capable model with thinking support',
+  },
+  {
+    name: 'gemini-2.5-flash',
+    supportsThinking: true,
+    description: 'Fast model with thinking support',
+  },
+  {
+    name: 'gemini-2.5-flash-lite',
+    supportsThinking: false,
+    description: 'Lightweight model (limited thinking support)',
+  },
+] as const;
+
+// Helper to get just the model names for validation and completion
+const MODEL_NAMES = AVAILABLE_MODELS.map(model => model.name);
+
+const listCommand: SlashCommand = {
+  name: 'list',
+  description: 'List available Gemini models',
   kind: CommandKind.BUILT_IN,
-  action: (context, args): MessageActionReturn | void => {
+  action: (context): MessageActionReturn => {
+    const currentModel = context.services.config?.getModel() || 'unknown';
+    
+    let message = 'Available Gemini models:\n\n';
+    
+    for (const model of AVAILABLE_MODELS) {
+      const isCurrentModel = model.name === currentModel;
+      const marker = isCurrentModel ? '\u001b[32m● \u001b[0m' : '  ';
+      const modelDisplay = isCurrentModel 
+        ? `\u001b[32m${model.name} (current)\u001b[0m`
+        : `\u001b[36m${model.name}\u001b[0m`;
+      
+      const thinkingIndicator = model.supportsThinking 
+        ? '\u001b[90m [thinking]\u001b[0m' 
+        : '';
+      
+      const description = model.description 
+        ? `\u001b[90m - ${model.description}\u001b[0m`
+        : '';
+      
+      message += `${marker}${modelDisplay}${thinkingIndicator}${description}\n`;
+    }
+    
+    message += '\n\u001b[90mUse /model <model-name> to switch models\u001b[0m';
+    message += '\n\u001b[90m[thinking] = Supports thinking capability\u001b[0m';
+    
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: message,
+    };
+  },
+};
+
+const setCommand: SlashCommand = {
+  name: 'set',
+  description: 'Set the active model. Usage: /model set <model-name>',
+  kind: CommandKind.BUILT_IN,
+  action: (context, args): MessageActionReturn => {
     const model = args.trim();
     
     if (!model) {
       return {
         type: 'message',
         messageType: 'error',
-        content: 'Usage: /model <model-name>',
+        content: 'Usage: /model set <model-name>\n\nUse /model list to see available models',
+      };
+    }
+
+    // Check if the model is in our known list
+    if (!MODEL_NAMES.includes(model)) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Unknown model: ${model}\n\nUse /model list to see available models`,
       };
     }
 
@@ -26,7 +101,80 @@ export const modelCommand: SlashCommand = {
     return {
       type: 'message',
       messageType: 'info',
-      content: `Model changed to ${model}`,
+      content: `Model changed to \u001b[36m${model}\u001b[0m`,
     };
   },
+  completion: async (_context, partialArg) => MODEL_NAMES.filter(model => 
+      model.toLowerCase().startsWith(partialArg.toLowerCase())
+    ),
+};
+
+export const modelCommand: SlashCommand = {
+  name: 'model',
+  description: 'Manage the active Gemini model',
+  kind: CommandKind.BUILT_IN,
+  action: (context, args): MessageActionReturn => {
+    const trimmedArgs = args.trim();
+    
+    // If no arguments or "list", show available models
+    if (!trimmedArgs || trimmedArgs === 'list') {
+      const currentModel = context.services.config?.getModel() || 'unknown';
+      
+      let message = 'Available Gemini models:\n\n';
+      
+      for (const model of AVAILABLE_MODELS) {
+        const isCurrentModel = model.name === currentModel;
+        const marker = isCurrentModel ? '\u001b[32m● \u001b[0m' : '  ';
+        const modelDisplay = isCurrentModel 
+          ? `\u001b[32m${model.name} (current)\u001b[0m`
+          : `\u001b[36m${model.name}\u001b[0m`;
+        
+        const thinkingIndicator = model.supportsThinking 
+          ? '\u001b[90m [thinking]\u001b[0m' 
+          : '';
+        
+        const description = model.description 
+          ? `\u001b[90m - ${model.description}\u001b[0m`
+          : '';
+        
+        message += `${marker}${modelDisplay}${thinkingIndicator}${description}\n`;
+      }
+      
+      message += '\n\u001b[90mUse /model <model-name> to switch models\u001b[0m';
+      message += '\n\u001b[90m[thinking] = Supports thinking capability\u001b[0m';
+      
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: message,
+      };
+    }
+    
+    // If a model name is provided directly, treat it as "set <model>"
+    const model = trimmedArgs;
+    
+    // Check if the model is in our known list
+    if (!MODEL_NAMES.includes(model)) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Unknown model: ${model}\n\nUse /model list to see available models`,
+      };
+    }
+
+    context.services.config?.setModel(model);
+    
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: `Model changed to \u001b[36m${model}\u001b[0m`,
+    };
+  },
+  completion: async (context, partialArg) => 
+    // Provide model name completion for direct usage
+     MODEL_NAMES.filter(model => 
+      model.toLowerCase().startsWith(partialArg.toLowerCase())
+    )
+  ,
+  subCommands: [listCommand, setCommand],
 };

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommandKind, MessageActionReturn, SlashCommand } from './types.js';
+
+export const modelCommand: SlashCommand = {
+  name: 'model',
+  description: 'change the model. Usage: /model <model-name>',
+  kind: CommandKind.BUILT_IN,
+  action: (context, args): MessageActionReturn | void => {
+    const model = args.trim();
+    
+    if (!model) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Usage: /model <model-name>',
+      };
+    }
+
+    context.services.config?.setModel(model);
+    
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: `Model changed to ${model}`,
+    };
+  },
+};


### PR DESCRIPTION
## TLDR

This pull request introduces a new slash command, /model <model-name>, which allows users to switch the underlying Gemini model on-the-fly during a chat session. This provides greater flexibility for users who may want to leverage different models for different tasks without restarting the CLI.

## Dive Deeper
  The implementation for this feature involved the following key changes:
   1. Slash Command Definition (`packages/cli/src/ui/hooks/slashCommandProcessor.ts`):
       * A new SlashCommand object was added to the slashCommands array.
       * The action for the /model command was implemented to parse the desired model name from the user's input.
       * It calls the config.setModel() method to update the application's configuration with the new model.
       * An informational message is displayed to the user to confirm that the model has been successfully changed.
       
   2. Configuration Update (`packages/core/src/config/config.ts`):
       * The Config class already had a setModel method, which is now being utilized by the new slash command. This method updates the contentGeneratorConfig and sets a flag to indicate that the model was switched during the session. This ensures that all subsequent API requests from the GeminiClient will use the newly specified model.

   3. Testing (`packages/cli/src/ui/hooks/slashCommandProcessor.test.ts`):
       * A new test case was added to verify the functionality of the /model command.
       * The test ensures that the setModel method is called with the correct model name and that the appropriate confirmation message is displayed to the user.
       * The mock Config object in the test suite was updated to include a mock setModel function to allow for proper testing.

  This approach ensures that the new functionality is well-integrated into the existing command processing and configuration management systems of the Gemini CLI.

## Reviewer Test Plan
  To validate this change, reviewers can perform the following steps:
   1. Pull and build the changes:
   ```bash
   git pull && npm install && npm run build
   ```
   2. Start the Gemini CLI:
   ```bash
   npm start
   ```

   3. Check the initial model: Observe the model name displayed in the footer of the CLI.
   4. Change the model: Type /model <new-model-name> (e.g., /model gemini-1.5-flash) and press Enter.
   5. Verify the change:
       * Confirm that an informational message appears, indicating that the model has been changed.
       * Check the footer to ensure that the new model name is now displayed.
   6. Test the new model: Send a few prompts to the CLI and verify that the responses are being generated by the new model. You can also use the /about command to see the currently active model.
   8. Run the tests:
   ```bash
    npm run test:ci
   ```
      All tests, including the new test for the /model command, should pass.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ✅  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs
- Resolves #3328
