### PR TITLE
fix(cli): Group cancelled tool call responses to prevent API errors

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -636,20 +636,20 @@ export const useGeminiStream = (
           const responsesToAdd = geminiTools.flatMap(
             (toolCall) => toolCall.response.responseParts,
           );
+          const combinedParts: Part[] = [];
           for (const response of responsesToAdd) {
-            let parts: Part[];
             if (Array.isArray(response)) {
-              parts = response;
+              combinedParts.push(...response);
             } else if (typeof response === 'string') {
-              parts = [{ text: response }];
+              combinedParts.push({ text: response });
             } else {
-              parts = [response];
+              combinedParts.push(response);
             }
-            geminiClient.addHistory({
-              role: 'user',
-              parts,
-            });
           }
+          geminiClient.addHistory({
+            role: 'user',
+            parts: combinedParts,
+          });
         }
 
         const callIdsToMarkAsSubmitted = geminiTools.map(


### PR DESCRIPTION
## TLDR

- When the model requests multiple tool calls in a single turn and they are all cancelled, the client was sending a separate `functionResponse` for each cancellation.
- This violates the Gemini API's expectation that all responses for a single multi-tool-call request be bundled in a single user turn, leading to a 400 Bad Request error.
- This change corrects the behavior by grouping all `functionResponse` parts from the cancelled tools into a single user message before adding it to the history.

This pull request fixes a bug where the client would send individual responses for multiple cancelled tool calls, leading to a `400 Bad Request` from the Gemini API. The fix ensures that all cancelled tool call responses from a single model turn are grouped into a single user message.

## Dive Deeper

The root cause of the issue was in `packages/cli/src/ui/hooks/useGeminiStream.ts`. When multiple tool calls from a single model request were cancelled, the `handleCompletedTools` function would iterate over the cancelled tools and call `geminiClient.addHistory` for each one. This resulted in multiple user messages being sent to the Gemini API, which is not the expected behavior.

The fix involves collecting all the `functionResponse` parts from the cancelled tool calls into a single array and then making a single call to `geminiClient.addHistory`. This ensures that the Gemini API receives a single user message with all the cancelled tool call responses, which is the correct behavior.

A new test case has been added to `packages/cli/src/ui/hooks/useGeminiStream.test.tsx` to cover this specific scenario and prevent future regressions.

## Reviewer Test Plan

To test this change, a reviewer can manually trigger a scenario where multiple tool calls are cancelled.

1.  Run the CLI.
2.  Enter a prompt that will trigger multiple tool calls, for example: `Write a 3 paragraph cat poem. Write each paragraph to Foo.md, Bar.md and Baz.md. Do all 3 tool calls using parallel tool calls`
3.  When the confirmation prompt for the tool calls appears, cancel all of them.
4.  Type "hello" and ensure you get a response without an error

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ✅   | ❓  | ❓  |
| Podman   | ✅   | -   | -   |
| Seatbelt | ✅   | -   | -   |

## Linked issues / bugs

Fixes #3131

