### PR TITLE
feat(auth): make terms of service link clickable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "shell-quote": "^1.8.3"
-      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },
@@ -11384,7 +11381,7 @@
         "ignore": "^7.0.0",
         "micromatch": "^4.0.8",
         "open": "^10.1.2",
-        "shell-quote": "^1.8.2",
+        "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
         "undici": "^7.10.0",

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -12,6 +12,8 @@ import { LoadedSettings, SettingScope } from '../../config/settings.js';
 import { AuthType } from '@google/gemini-cli-core';
 import { validateAuthMethod } from '../../config/auth.js';
 
+import Link from 'ink-link';
+
 interface AuthDialogProps {
   onSelect: (authMethod: AuthType | undefined, scope: SettingScope) => void;
   settings: LoadedSettings;
@@ -90,11 +92,9 @@ export function AuthDialog({
         <Text>Terms of Services and Privacy Notice for Gemini CLI</Text>
       </Box>
       <Box marginTop={1}>
-        <Text color={Colors.AccentBlue}>
-          {
-            'https://github.com/google-gemini/gemini-cli/blob/main/docs/tos-privacy.md'
-          }
-        </Text>
+        <Link url="https://github.com/google-gemini/gemini-cli/blob/main/docs/tos-privacy.md">
+          https://github.com/google-gemini/gemini-cli/blob/main/docs/tos-privacy.md
+        </Link>
       </Box>
     </Box>
   );

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -92,7 +92,10 @@ export function AuthDialog({
         <Text>Terms of Services and Privacy Notice for Gemini CLI</Text>
       </Box>
       <Box marginTop={1}>
-        <Link url="https://github.com/google-gemini/gemini-cli/blob/main/docs/tos-privacy.md">
+        <Link
+          url="https://github.com/google-gemini/gemini-cli/blob/main/docs/tos-privacy.md"
+          fallback={false}
+        >
           https://github.com/google-gemini/gemini-cli/blob/main/docs/tos-privacy.md
         </Link>
       </Box>


### PR DESCRIPTION
## TLDR

feat(auth): make terms of service link clickable

## Dive Deeper

This pull request enhances the user experience of the authentication flow by making the Terms of Service link clickable.

Previously, the URL was displayed as plain text. This change replaces the `Text` component with the `Link` component from the `ink-link` library, allowing users to directly open the link from their terminal.

This improves usability and makes it easier for users to access the Terms of Service and Privacy Notice.

## Reviewer Test Plan

1. Pull down this branch.
2. Run `npm install` to install the new `ink-link` dependency.
3. Run the CLI in a way that triggers the authentication dialog (e.g., by running a command that requires authentication without being logged in, or by clearing existing credentials).
4. Verify that the Terms of Service link is now blue (or the accent color of your terminal theme).
5. Cmd+click (or the equivalent for your terminal) on the link.
6. Verify that the link opens the correct URL (`https://github.com/google-gemini/gemini-cli/blob/main/docs/tos-privacy.md`) in your web browser.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅ | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ✅  | ❓  | ❓  |
| Podman   | ✅  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
