### PR TITLE
Re-enable backticks in shell tool usage.

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -350,17 +350,14 @@ describe('ShellTool', () => {
     expect(result.allowed).toBe(true);
   });
 
-  it('should block a command with command substitution using backticks', async () => {
+  it('should allow a command with command substitution using backticks', async () => {
     const config = {
       getCoreTools: () => ['run_shell_command(echo)'],
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
     const result = shellTool.isCommandAllowed('echo `rm -rf /`');
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      'Command substitution using backticks is not allowed for security reasons',
-    );
+    expect(result.allowed).toBe(true);
   });
 
   it('should block a command with command substitution using $()', async () => {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -123,13 +123,6 @@ Process Group PGID: Process group started or \`(none)\``,
           'Command substitution using $() is not allowed for security reasons',
       };
     }
-    if (command.includes('`')) {
-      return {
-        allowed: false,
-        reason:
-          'Command substitution using backticks is not allowed for security reasons',
-      };
-    }
 
     const SHELL_TOOL_NAMES = [ShellTool.name, ShellTool.Name];
 


### PR DESCRIPTION
## TLDR

This pull request re-enables the use of backticks in shell commands. This was done to allow for inline markdown in commit messages, which was previously being blocked. This change reverts a precautionary measure that was in place.

## Dive Deeper

The `isCommandAllowed` method in `@packages/core/src/tools/shell.ts` was modified to no longer block backticks. The associated test was also updated to reflect this change. This is a calculated risk to improve developer experience.

## Reviewer Test Plan

1.  Pull down the branch.
2.  Run `npm install`.
3.  Run `npm run test` and see that all tests pass.
4.  Attempt to ask GC to run the `run_shell_command` tool with a command that includes backticks, for example: `git commit -m "feat: a commit with \`backticks\`"`
5.  Verify that the command is successful.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ✅  | ❓  | ❓  |
| Podman   | ✅  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

Fixes #3358
