### PR TITLE
fix: Prevent infinite loop when building on Windows

### DIFF
--- a/scripts/sandbox_command.js
+++ b/scripts/sandbox_command.js
@@ -48,7 +48,7 @@ if (!geminiSandbox) {
 
 if (!geminiSandbox) {
   let currentDir = process.cwd();
-  while (currentDir !== '/') {
+  while (true) {
     const geminiEnv = join(currentDir, '.gemini', '.env');
     const regularEnv = join(currentDir, '.env');
     if (existsSync(geminiEnv)) {
@@ -58,7 +58,11 @@ if (!geminiSandbox) {
       dotenv.config({ path: regularEnv, quiet: true });
       break;
     }
-    currentDir = dirname(currentDir);
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
   }
   geminiSandbox = process.env.GEMINI_SANDBOX;
 }


### PR DESCRIPTION
## TLDR

This change fixes a potential infinite loop in the `.env` file discovery logic when building on Windows.

## Dive Deeper

The original code used `while (currentDir !== '/')` to terminate the search for an `.env` file at the filesystem root. However, this condition is never met on Windows, causing the while loop to run indefinitely if no `.env` file is found.

The updated code instead checks if the parent directory is the same as the current directory `(parentDir === currentDir)`, which reliably stops the loop on any operating system.

## Reviewer Test Plan

On a Windows machine, navigate to a project directory that does not contain a `.env` file in its path.

Run `npm run build` and verify that it terminates successfully without hanging.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #2084
