### PR TITLE
fix(cli): Enable @-file context processing in non-interactive mode

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -25,7 +25,6 @@ vi.mock('@google/gemini-cli-core', async () => {
   };
 });
 
-// FIX: Mock the local modules directly so we can spy on them.
 vi.mock('./ui/utils/commandUtils.js');
 vi.mock('./ui/hooks/atCommandProcessor.js');
 
@@ -303,7 +302,6 @@ describe('runNonInteractive', () => {
 
   describe('@-command processing', () => {
     it('should process an @-command and send the file content to the model', async () => {
-      // FIX: Spy on the imported module object
       const mockIsAtCommand = vi.spyOn(commandUtils, 'isAtCommand');
       const mockHandleAtCommand = vi.spyOn(
         atCommandProcessor,
@@ -347,7 +345,6 @@ describe('runNonInteractive', () => {
     });
 
     it('should handle a normal prompt without calling @-command logic', async () => {
-      // FIX: Spy on the imported module object
       const mockIsAtCommand = vi.spyOn(commandUtils, 'isAtCommand');
       const mockHandleAtCommand = vi.spyOn(
         atCommandProcessor,


### PR DESCRIPTION
## TLDR

This PR fixes a critical bug where file context provided via `@filename` syntax was ignored when running the CLI in non-interactive mode (e.g., using the `-p` or `--prompt` flag). The fix enables feature parity between interactive and non-interactive modes for including local file content in prompts.

## Dive Deeper

**The Problem:**

The logic for parsing `@` commands to include file content was only implemented in the interactive UI hooks. When a user ran a command like `gemini -p "Summarize @README.md"`, the non-interactive execution path was taken, which bypassed this parsing logic.

As a result, the CLI sent the literal string `"Summarize @README.md"` directly to the Gemini API. Since the model has no access to the user's local filesystem, it could not fulfill the request and would typically return an empty response. This caused the CLI to exit without any output, making it appear to hang or fail silently.

**The Solution:**

This change ports the `@` command handling logic to the `runNonInteractive` function in `packages/cli/src/nonInteractiveCli.ts`.

1.  It now uses the `isAtCommand` utility to detect if the input prompt contains a file directive.
2.  If detected, it invokes the existing `handleAtCommand` processor.
3.  This processor reads the local file(s), constructs a `PartListUnion` containing both the user's text and the file content, and passes this complete context to the `sendMessageStream` function.
4.  The test suite for `nonInteractiveCli.ts` has been updated with new tests to cover this functionality and prevent future regressions.

This ensures that both interactive and non-interactive modes handle file context consistently, providing a more reliable and intuitive user experience.

## Reviewer Test Plan

To validate this fix, a reviewer can perform the following steps in their terminal after checking out this branch and running `npm run build`:

1.  **Create a test file:**
    ```bash
    echo "This is a test file for the Gemini CLI." > test.txt
    ```

2.  **Test the fix:** Run a command that previously failed. This command asks the AI to act on the content of the local file.
    ```bash
    gemini -p "Summarize the content of @test.txt"
    ```
    **Expected Outcome:** The command should now succeed and return a summary of the file's content, such as:
    > The file contains the text "This is a test file for the Gemini CLI."

3.  **Test a non-existent file:**
    ```bash
    gemini -p "Summarize @nonexistentfile.txt"
    ```
    **Expected Outcome:** The CLI should handle this gracefully. A debug message will indicate the file was not found, and the prompt sent to the AI will not contain file content. The AI will likely respond that it cannot summarize a file it hasn't been given the content for. This is correct behavior.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  |  |  |


*The fix is in cross-platform Node.js code and has been validated with unit tests. It is expected to work on all systems. Direct validation was performed on macOS (`🍏`).*