### PR TITLE
docs: add documentation for mcp excludeTools and includeTools

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -116,6 +116,8 @@ In addition to a project settings file, a project's `.gemini` directory can cont
       - `cwd` (string, optional): The working directory in which to start the server.
       - `timeout` (number, optional): Timeout in milliseconds for requests to this MCP server.
       - `trust` (boolean, optional): Trust this server and bypass all tool call confirmations.
+      - `includeTools` (array of strings, optional): List of tool names to include from this MCP server. When specified, only the tools listed here will be available from this server (whitelist behavior). If not specified, all tools from the server are enabled by default.
+      - `excludeTools` (array of strings, optional): List of tool names to exclude from this MCP server. Tools listed here will not be available to the model, even if they are exposed by the server. **Note:** `excludeTools` takes precedence over `includeTools` - if a tool is in both lists, it will be excluded.
   - **Example:**
     ```json
     "mcpServers": {
@@ -123,12 +125,14 @@ In addition to a project settings file, a project's `.gemini` directory can cont
         "command": "python",
         "args": ["mcp_server.py", "--port", "8080"],
         "cwd": "./mcp_tools/python",
-        "timeout": 5000
+        "timeout": 5000,
+        "includeTools": ["safe_tool", "file_reader"],
       },
       "myNodeServer": {
         "command": "node",
         "args": ["mcp_server.js"],
-        "cwd": "./mcp_tools/node"
+        "cwd": "./mcp_tools/node",
+        "excludeTools": ["dangerous_tool", "file_deleter"]
       },
       "myDockerServer": {
         "command": "docker",

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -225,7 +225,7 @@ Upon successful connection:
 
 1. **Tool listing:** The client calls the MCP server's tool listing endpoint
 2. **Schema validation:** Each tool's function declaration is validated
-3. **Tool filtering:** Tools are filtered based on `includeTools` and `excludeTools` configuration:
+3. **Tool filtering:** Tools are filtered based on `includeTools` and `excludeTools` configuration
 4. **Name sanitization:** Tool names are cleaned to meet Gemini API requirements:
    - Invalid characters (non-alphanumeric, underscore, dot, hyphen) are replaced with underscores
    - Names longer than 63 characters are truncated with middle replacement (`___`)

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -92,6 +92,8 @@ Each server configuration supports the following properties:
 - **`cwd`** (string): Working directory for Stdio transport
 - **`timeout`** (number): Request timeout in milliseconds (default: 600,000ms = 10 minutes)
 - **`trust`** (boolean): When `true`, bypasses all tool call confirmations for this server (default: `false`)
+- **`includeTools`** (string[]): List of tool names to include from this MCP server. When specified, only the tools listed here will be available from this server (whitelist behavior). If not specified, all tools from the server are enabled by default.
+- **`excludeTools`** (string[]): List of tool names to exclude from this MCP server. Tools listed here will not be available to the model, even if they are exposed by the server. **Note:** `excludeTools` takes precedence over `includeTools` - if a tool is in both lists, it will be excluded.
 
 ### Example Configurations
 
@@ -185,6 +187,22 @@ Each server configuration supports the following properties:
 }
 ```
 
+#### MCP Server with Tool Filtering
+
+```json
+{
+  "mcpServers": {
+    "filteredServer": {
+      "command": "python",
+      "args": ["-m", "my_mcp_server"],
+      "includeTools": ["safe_tool", "file_reader", "data_processor"],
+      // "excludeTools": ["dangerous_tool", "file_deleter"],
+      "timeout": 30000
+    }
+  }
+}
+```
+
 ## Discovery Process Deep Dive
 
 When the Gemini CLI starts, it performs MCP server discovery through the following detailed process:
@@ -207,7 +225,8 @@ Upon successful connection:
 
 1. **Tool listing:** The client calls the MCP server's tool listing endpoint
 2. **Schema validation:** Each tool's function declaration is validated
-3. **Name sanitization:** Tool names are cleaned to meet Gemini API requirements:
+3. **Tool filtering:** Tools are filtered based on `includeTools` and `excludeTools` configuration:
+4. **Name sanitization:** Tool names are cleaned to meet Gemini API requirements:
    - Invalid characters (non-alphanumeric, underscore, dot, hyphen) are replaced with underscores
    - Names longer than 63 characters are truncated with middle replacement (`___`)
 


### PR DESCRIPTION
## TLDR

This PR clarifies the behavior of `includeTools` and `excludeTools` configuration options for MCP servers in the CLI configuration documentation.


## Dive Deeper

  ### Changes
- **Added `includeTools` description**: Added clarification that it creates a whitelist behavior and that all tools are enabled by default when not specified
- **Added `excludeTools` description**: Added note about precedence - `excludeTools` takes precedence over `includeTools`


  ### Testing
- [x] Documentation changes only - no code changes

## Linked issues / bugs

Documentation for #2976 changes