### PR TITLE
fix: render markdown formatting in table cells

### DIFF
--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -232,6 +232,75 @@ But there's no separator line
       const { lastFrame } = renderNarrow();
       expect(lastFrame()).not.toBe('');
     });
+
+    it('should render inline formatting in table cells', () => {
+      const tableWithFormatting = `
+| Characteristic | \`execSync\` (Old Way) | \`spawn\` (New Way in PR) |
+|----------------|---------------------|------------------------|
+| **Execution** | Synchronous (blocks everything) | Asynchronous (non-blocking) |
+| **Security** | **Vulnerable to shell injection** | **Safe from shell injection** |
+| *Use Case* | Simple commands with \`small\` output | Long-running processes |
+`;
+
+      const { lastFrame } = render(
+        <MarkdownDisplay
+          text={tableWithFormatting}
+          isPending={false}
+          terminalWidth={120}
+        />,
+      );
+
+      const output = lastFrame();
+      
+      // Should render table structure
+      expect(output).toContain('Characteristic');
+      expect(output).toContain('execSync');
+      expect(output).toContain('spawn');
+      
+      // Should render content without markdown syntax
+      expect(output).toContain('Execution');
+      expect(output).toContain('Security');
+      expect(output).toContain('Use Case');
+      expect(output).toContain('Vulnerable to shell injection');
+      expect(output).toContain('Safe from shell injection');
+      expect(output).toContain('small');
+      
+      // Should NOT contain raw markdown syntax
+      expect(output).not.toContain('**Execution**');
+      expect(output).not.toContain('`execSync`');
+      expect(output).not.toContain('*Use Case*');
+    });
+
+    it('should handle complex nested formatting in tables', () => {
+      const complexTable = `
+| Command | Description | Example |
+|---------|-------------|---------|
+| \`git status\` | Shows **current** repository status | \`git status --short\` |
+| \`npm install\` | Installs *all* dependencies | **\`npm install --save-dev\`** |
+`;
+
+      const { lastFrame } = render(
+        <MarkdownDisplay
+          text={complexTable}
+          isPending={false}
+          terminalWidth={120}
+        />,
+      );
+
+      const output = lastFrame();
+      
+      // Check content is rendered
+      expect(output).toContain('git status');
+      expect(output).toContain('current');
+      expect(output).toContain('npm install');
+      expect(output).toContain('all');
+      expect(output).toContain('npm install --save-dev');
+      
+      // Should NOT contain raw markdown
+      expect(output).not.toContain('**current**');
+      expect(output).not.toContain('*all*');
+      expect(output).not.toContain('**`npm install --save-dev`**');
+    });
   });
 
   describe('Existing Functionality', () => {

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -53,8 +53,8 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   let codeBlockLang: string | null = null;
   let codeBlockFence = '';
   let inTable = false;
-  let tableRows: string[][] = [];
-  let tableHeaders: string[] = [];
+  let tableRows: React.ReactNode[][] = [];
+  let tableHeaders: React.ReactNode[] = [];
 
   lines.forEach((line, index) => {
     const key = `line-${index}`;
@@ -105,7 +105,9 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         lines[index + 1].match(tableSeparatorRegex)
       ) {
         inTable = true;
-        tableHeaders = tableRowMatch[1].split('|').map((cell) => cell.trim());
+        tableHeaders = tableRowMatch[1].split('|').map((cell) => (
+          <RenderInline text={cell.trim()} />
+        ));
         tableRows = [];
       } else {
         // Not a table, treat as regular text
@@ -121,10 +123,12 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
       // Skip separator line - already handled
     } else if (inTable && tableRowMatch) {
       // Add table row
-      const cells = tableRowMatch[1].split('|').map((cell) => cell.trim());
+      const cells = tableRowMatch[1].split('|').map((cell) => (
+        <RenderInline text={cell.trim()} />
+      ));
       // Ensure row has same column count as headers
       while (cells.length < tableHeaders.length) {
-        cells.push('');
+        cells.push(<RenderInline text="" />);
       }
       if (cells.length > tableHeaders.length) {
         cells.length = tableHeaders.length;
@@ -522,8 +526,8 @@ const RenderListItemInternal: React.FC<RenderListItemProps> = ({
 const RenderListItem = React.memo(RenderListItemInternal);
 
 interface RenderTableProps {
-  headers: string[];
-  rows: string[][];
+  headers: React.ReactNode[];
+  rows: React.ReactNode[][];
   terminalWidth: number;
 }
 


### PR DESCRIPTION

  **⚠️ EXPERIMENTAL PR - NOT FOR MERGE ⚠️**

  This PR was created by Claude Code as part of an experiment comparing different AI coding
  assistants. At least a Gemini CLI PR will follow, potentially a GitHub Copilot one as well.
  This is for informational purposes only - feel free to ignore or close.

  This issue was selected after seeing this Bluesky post:
  https://bsky.app/profile/ntaylormullen.bsky.social/post/3ltahic7f6s27

  The PR is part of an upcoming talk comparing agentic coding tools.
  
  See session log [here](https://trecker.dev/skorfmann/coding-agents/coding_sessions/1)

  ---

  Previously, table cells would display raw markdown syntax like **bold** or `code` instead of
  rendering them properly. This fix processes table headers and cells through the RenderInline
  component to ensure all inline markdown formatting is properly rendered.

  - Modified TableRenderer to accept React nodes instead of strings
  - Updated MarkdownDisplay to process cells with RenderInline
  - Added comprehensive tests for inline formatting in tables

  Fixes issue where markdown-to-terminal renderer doesn't correctly process nested formatting
  elements inside table headers or rows.

  ## TLDR

  This PR fixes the rendering of markdown formatting (bold, inline code, italics, etc.) inside
  table cells. Previously, the raw markdown syntax was displayed instead of being properly
  formatted.

  ## Dive Deeper

  The issue was that table cells were being passed as plain strings to the TableRenderer
  component, bypassing the markdown parsing logic. The solution involves:

  1. **TableRenderer changes**: Modified to accept `React.ReactNode[]` instead of `string[]` for
   headers and rows, allowing it to render pre-formatted content
  2. **MarkdownDisplay changes**: Now processes each table cell through the `RenderInline`
  component before passing to TableRenderer
  3. **Text length calculation**: Added a helper function to calculate text length from React
  nodes for proper column width calculations

  The fix maintains backward compatibility and doesn't affect table structure or alignment.

  ## Reviewer Test Plan

  1. Create a markdown file with tables containing inline formatting:
  ```markdown
  | Feature | **Bold Text** | `Inline Code` |
  |---------|---------------|---------------|
  | Example | **Important** | `console.log()` |
```

  2. Run the tests: cd packages/cli && npm test -- src/ui/utils/MarkdownDisplay.test.tsx
  3. The table should render with proper formatting (bold text appears bold, inline code styled
  appropriately) instead of showing raw markdown syntax
  4. Test edge cases like nested formatting: **bold code** or mixed formatting in cells

  Testing Matrix

  |          | 🍏  | 🪟  | 🐧  |
  |----------|-----|-----|-----|
  | npm run  | ✅   | ❓   | ❓   |
  | npx      | ❓   | ❓   | ❓   |
  | Docker   | ❓   | ❓   | ❓   |
  | Podman   | ❓   | -   | -   |
  | Seatbelt | ❓   | -   | -   |

  Linked issues / bugs

  Fixes #3331
