### PR TITLE
fix: respect env variables in .env for settings.json variable substitution

### DIFF
--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -5,7 +5,7 @@
  */
 
 import { AuthType } from '@google/gemini-cli-core';
-import { loadEnvironment } from './config.js';
+import { loadEnvironment } from './settings.js';
 
 export const validateAuthMethod = (authMethod: string): string | null => {
   loadEnvironment();

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -13,7 +13,6 @@ import {
   setGeminiMdFilename as setServerGeminiMdFilename,
   getCurrentGeminiMdFilename,
   ApprovalMode,
-  GEMINI_CONFIG_DIR as GEMINI_DIR,
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   FileDiscoveryService,
@@ -23,10 +22,6 @@ import { Settings } from './settings.js';
 
 import { Extension } from './extension.js';
 import { getCliVersion } from '../utils/version.js';
-import * as dotenv from 'dotenv';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as os from 'node:os';
 import { loadSandboxConfig } from './sandboxConfig.js';
 
 // Simple console logger for now - replace with actual logger if available
@@ -276,40 +271,4 @@ function mergeExcludeTools(
     }
   }
   return [...allExcludeTools];
-}
-
-function findEnvFile(startDir: string): string | null {
-  let currentDir = path.resolve(startDir);
-  while (true) {
-    // prefer gemini-specific .env under GEMINI_DIR
-    const geminiEnvPath = path.join(currentDir, GEMINI_DIR, '.env');
-    if (fs.existsSync(geminiEnvPath)) {
-      return geminiEnvPath;
-    }
-    const envPath = path.join(currentDir, '.env');
-    if (fs.existsSync(envPath)) {
-      return envPath;
-    }
-    const parentDir = path.dirname(currentDir);
-    if (parentDir === currentDir || !parentDir) {
-      // check .env under home as fallback, again preferring gemini-specific .env
-      const homeGeminiEnvPath = path.join(os.homedir(), GEMINI_DIR, '.env');
-      if (fs.existsSync(homeGeminiEnvPath)) {
-        return homeGeminiEnvPath;
-      }
-      const homeEnvPath = path.join(os.homedir(), '.env');
-      if (fs.existsSync(homeEnvPath)) {
-        return homeEnvPath;
-      }
-      return null;
-    }
-    currentDir = parentDir;
-  }
-}
-
-export function loadEnvironment(): void {
-  const envFilePath = findEnvFile(process.cwd());
-  if (envFilePath) {
-    dotenv.config({ path: envFilePath, quiet: true });
-  }
 }

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -166,8 +166,6 @@ export async function loadCliConfig(
   extensions: Extension[],
   sessionId: string,
 ): Promise<Config> {
-  loadEnvironment();
-
   const argv = await parseArguments();
   const debugMode = argv.debug || false;
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -7,8 +7,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { homedir } from 'os';
+import * as dotenv from 'dotenv';
 import {
   MCPServerConfig,
+  GEMINI_CONFIG_DIR as GEMINI_DIR,
   getErrorMessage,
   BugCommandSettings,
   TelemetrySettings,
@@ -170,6 +172,42 @@ function resolveEnvVarsInObject<T>(obj: T): T {
   }
 
   return obj;
+}
+
+function findEnvFile(startDir: string): string | null {
+  let currentDir = path.resolve(startDir);
+  while (true) {
+    // prefer gemini-specific .env under GEMINI_DIR
+    const geminiEnvPath = path.join(currentDir, GEMINI_DIR, '.env');
+    if (fs.existsSync(geminiEnvPath)) {
+      return geminiEnvPath;
+    }
+    const envPath = path.join(currentDir, '.env');
+    if (fs.existsSync(envPath)) {
+      return envPath;
+    }
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir || !parentDir) {
+      // check .env under home as fallback, again preferring gemini-specific .env
+      const homeGeminiEnvPath = path.join(homedir(), GEMINI_DIR, '.env');
+      if (fs.existsSync(homeGeminiEnvPath)) {
+        return homeGeminiEnvPath;
+      }
+      const homeEnvPath = path.join(homedir(), '.env');
+      if (fs.existsSync(homeEnvPath)) {
+        return homeEnvPath;
+      }
+      return null;
+    }
+    currentDir = parentDir;
+  }
+}
+
+export function loadEnvironment(): void {
+  const envFilePath = findEnvFile(process.cwd());
+  if (envFilePath) {
+    dotenv.config({ path: envFilePath, quiet: true });
+  }
 }
 
 /**

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -215,6 +215,7 @@ export function loadEnvironment(): void {
  * Project settings override user settings.
  */
 export function loadSettings(workspaceDir: string): LoadedSettings {
+  loadEnvironment();
   let userSettings: Settings = {};
   let workspaceSettings: Settings = {};
   const settingsErrors: SettingsError[] = [];

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { render } from 'ink';
 import { AppWrapper } from './ui/App.js';
-import { loadCliConfig, loadEnvironment } from './config/config.js';
+import { loadCliConfig } from './config/config.js';
 import { readStdin } from './utils/readStdin.js';
 import { basename } from 'node:path';
 import v8 from 'node:v8';
@@ -16,6 +16,7 @@ import { spawn } from 'node:child_process';
 import { start_sandbox } from './utils/sandbox.js';
 import {
   LoadedSettings,
+  loadEnvironment,
   loadSettings,
   SettingScope,
   USER_SETTINGS_PATH,

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -16,7 +16,6 @@ import { spawn } from 'node:child_process';
 import { start_sandbox } from './utils/sandbox.js';
 import {
   LoadedSettings,
-  loadEnvironment,
   loadSettings,
   SettingScope,
   USER_SETTINGS_PATH,
@@ -85,7 +84,6 @@ async function relaunchWithAdditionalArgs(additionalArgs: string[]) {
 }
 
 export async function main() {
-  loadEnvironment();
   const workspaceRoot = process.cwd();
   const settings = loadSettings(workspaceRoot);
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { render } from 'ink';
 import { AppWrapper } from './ui/App.js';
-import { loadCliConfig } from './config/config.js';
+import { loadCliConfig, loadEnvironment } from './config/config.js';
 import { readStdin } from './utils/readStdin.js';
 import { basename } from 'node:path';
 import v8 from 'node:v8';
@@ -84,6 +84,7 @@ async function relaunchWithAdditionalArgs(additionalArgs: string[]) {
 }
 
 export async function main() {
+  loadEnvironment();
   const workspaceRoot = process.cwd();
   const settings = loadSettings(workspaceRoot);
 


### PR DESCRIPTION
## TLDR

Moving `loadEnvironment` into `loadSettings` so that `.env` variables are loaded prior to variable substitution on `settings.json` 😄 


## Dive Deeper

<!-- more thoughts and in depth discussion here -->

Variable substitution for environment variables in `.env` files currently does not work because of the existing order of operations that Gemini CLI loads with (`loadSettings --> loadExtensions --> loadCLIConfig`). 

https://github.com/google-gemini/gemini-cli/blob/39d4095a4c0f3478235aa0c80c94586b9e2662c2/packages/cli/src/gemini.tsx#L88-L104

Loading environment variables from `.env` file is being done in `loadCLIConfig` which occurs after `settings.json` has been loaded. This means `.env` variables are not being respected during variable substitution for the `settings.json`.

https://github.com/google-gemini/gemini-cli/blob/39d4095a4c0f3478235aa0c80c94586b9e2662c2/packages/cli/src/config/config.ts#L164-L169

This PR moves `loadEnvironment` into `loadSettings` which allows `.env` variables to be loaded in prior to settings so that variable substitution works with `.env` variables in `settings.json`.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

Use below `settings.json`:

```json
{
    "mcpServers": {
      "github": {
        "httpUrl": "https://api.githubcopilot.com/mcp",
        "headers": {
          "Authorization": "Bearer ${GITHUB_PAT}"
        }
      }
    }
}
```

Create a `.env` file with `GITHUB_PAT`.

```
GITHUB_PAT=<YOUR_GITHUB_PAT>
```

Test Gemini CLI on main or latest release:

You will see it fails to read `.env` var and results in poorly formatted auth header.

![image](https://github.com/user-attachments/assets/39cf2af6-6e96-4bd3-8968-7bc64e6bfd6b)

Checkout the feature branch and run Gemini CLI:

You will see that all is successful and MCP server is  configured properly due to variable substitution.

![image](https://github.com/user-attachments/assets/59433723-deb8-4222-971d-47d3605568f4)

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|            | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Fixes #2836 
Fixes #1269

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
