### PR TITLE
Migrate Gemini CLI Action workflows to Direct WIF authentication

### DIFF
--- a/.github/workflows/community-report.yml
+++ b/.github/workflows/community-report.yml
@@ -162,14 +162,13 @@ jobs:
 
       - name: 🤖 Get Insights from Report
         if: steps.report.outputs.report_body != ''
-        uses: google-gemini/gemini-cli-action@41c0f1b3cbd1a0b284251bd1aac034edd07a3a2f
+        uses: google-gemini/gemini-cli-action@df3f890f003d28c60a2a09d2c29e0126e4d1e2ff
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         with:
           version: 0.1.8-rc.0
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OTLP_GCP_WIF_PROVIDER: ${{ secrets.OTLP_GCP_WIF_PROVIDER }}
-          OTLP_GCP_SERVICE_ACCOUNT: ${{ secrets.OTLP_GCP_SERVICE_ACCOUNT }}
           OTLP_GOOGLE_CLOUD_PROJECT: ${{ secrets.OTLP_GOOGLE_CLOUD_PROJECT }}
           settings_json: |
             {

--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -24,14 +24,13 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Run Gemini Issue Triage
-        uses: google-gemini/gemini-cli-action@41c0f1b3cbd1a0b284251bd1aac034edd07a3a2f
+        uses: google-gemini/gemini-cli-action@df3f890f003d28c60a2a09d2c29e0126e4d1e2ff
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         with:
           version: 0.1.8-rc.0
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OTLP_GCP_WIF_PROVIDER: ${{ secrets.OTLP_GCP_WIF_PROVIDER }}
-          OTLP_GCP_SERVICE_ACCOUNT: ${{ secrets.OTLP_GCP_SERVICE_ACCOUNT }}
           OTLP_GOOGLE_CLOUD_PROJECT: ${{ secrets.OTLP_GOOGLE_CLOUD_PROJECT }}
           settings_json: |
             {
@@ -39,7 +38,12 @@ jobs:
                 "run_shell_command(gh label list)",
                 "run_shell_command(gh issue edit)",
                 "run_shell_command(gh issue list)"
-              ]
+              ],
+              "telemetry": {
+                "enabled": true,
+                "target": "gcp"
+              },
+              "sandbox": false
             }
           prompt: |
             You are an issue triage assistant. Analyze the current GitHub issue and apply the most appropriate existing labels.

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -38,30 +38,33 @@ jobs:
           echo "📝 Setting output for GitHub Actions..."
           echo "issues_to_triage=$ISSUES" >> "$GITHUB_OUTPUT"
 
-          echo "💾 Writing issues to temporary file for Gemini CLI..."
-          echo "$ISSUES" > /tmp/issues_to_triage.json
-
           echo "✅ Found $(echo "$ISSUES" | jq 'length') issues to triage! 🎯"
 
       - name: Run Gemini Issue Triage
         if: steps.find_issues.outputs.issues_to_triage != '[]'
-        uses: google-gemini/gemini-cli-action@41c0f1b3cbd1a0b284251bd1aac034edd07a3a2f
+        uses: google-gemini/gemini-cli-action@df3f890f003d28c60a2a09d2c29e0126e4d1e2ff
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          ISSUES_TO_TRIAGE: ${{ steps.find_issues.outputs.issues_to_triage }}
+          REPOSITORY: ${{ github.repository }}
         with:
           version: 0.1.8-rc.0
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OTLP_GCP_WIF_PROVIDER: ${{ secrets.OTLP_GCP_WIF_PROVIDER }}
-          OTLP_GCP_SERVICE_ACCOUNT: ${{ secrets.OTLP_GCP_SERVICE_ACCOUNT }}
           OTLP_GOOGLE_CLOUD_PROJECT: ${{ secrets.OTLP_GOOGLE_CLOUD_PROJECT }}
           settings_json: |
             {
               "coreTools": [
+                "run_shell_command(echo)",
                 "run_shell_command(gh label list)",
                 "run_shell_command(gh issue edit)",
-                "run_shell_command(gh issue list)",
-                "run_shell_command(cat /tmp/issues_to_triage.json)"
-              ]
+                "run_shell_command(gh issue list)"
+              ],
+              "telemetry": {
+                "enabled": true,
+                "target": "gcp"
+              },
+              "sandbox": false
             }
           prompt: |
             You are an issue triage assistant. Analyze issues and apply appropriate labels ONE AT A TIME.
@@ -70,7 +73,7 @@ jobs:
 
             Steps:
             1. Run: `gh label list --repo ${{ github.repository }} --limit 100` to see available labels
-            2. Run: `cat /tmp/issues_to_triage.json` to get the issues that need triaging
+            2. Check environment variable for issues to triage: $ISSUES_TO_TRIAGE (JSON array of issues)
             3. Parse the JSON array from step 2 and for EACH INDIVIDUAL issue, apply appropriate labels using separate commands:
                - `gh issue edit ISSUE_NUMBER --repo ${{ github.repository }} --add-label "label1"`
                - `gh issue edit ISSUE_NUMBER --repo ${{ github.repository }} --add-label "label2"`


### PR DESCRIPTION
- Use Direct WIF which is the recommended option (over service accounts)
- Remove OTLP_GCP_SERVICE_ACCOUNT references across all workflows
- Update gemini-cli-action to latest version (df3f890f)
- Add telemetry configuration with GCP target for Gemini CLI bot
- Improve issue triage workflow to use environment variables instead of temp files

https://github.com/google-github-actions/auth?tab=readme-ov-file#direct-wif