### PR TITLE
Add --allowed_mcp_server_names flag

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -53,6 +53,7 @@ interface CliArgs {
   telemetryTarget: string | undefined;
   telemetryOtlpEndpoint: string | undefined;
   telemetryLogPrompts: boolean | undefined;
+  allowed_mcp_server_names: string | undefined;
 }
 
 async function parseArguments(): Promise<CliArgs> {
@@ -128,6 +129,10 @@ async function parseArguments(): Promise<CliArgs> {
       description: 'Enables checkpointing of file edits',
       default: false,
     })
+    .option('allowed_mcp_server_names', {
+      type: 'string',
+      description: 'Allowed MCP server names',
+    })
     .version(await getCliVersion()) // This will enable the --version flag based on package.json
     .alias('v', 'version')
     .help()
@@ -193,8 +198,21 @@ export async function loadCliConfig(
     extensionContextFilePaths,
   );
 
-  const mcpServers = mergeMcpServers(settings, extensions);
+  let mcpServers = mergeMcpServers(settings, extensions);
   const excludeTools = mergeExcludeTools(settings, extensions);
+
+  if (argv.allowed_mcp_server_names) {
+    const allowedNames = new Set(
+      argv.allowed_mcp_server_names.split(',').filter(Boolean),
+    );
+    if (allowedNames.size > 0) {
+      mcpServers = Object.fromEntries(
+        Object.entries(mcpServers).filter(([key]) => allowedNames.has(key)),
+      );
+    } else {
+      mcpServers = {};
+    }
+  }
 
   const sandboxConfig = await loadSandboxConfig(settings, argv);
 


### PR DESCRIPTION
## TLDR

This commit introduces a new command-line flag, --allowed_mcp_server_names, to the Gemini CLI. This flag allows users to specify a comma-delimited list of allowed MCP server names.

If the flag is not provided, all configured MCP servers are used. If the flag is provided with a non-empty list, only the MCP servers with names in the list will be used. All other MCP servers will be ignored. This provides a mechanism to selectively enable MCP servers for a given CLI invocation.


## Dive Deeper

See discussion in b/428217139.

## Reviewer Test Plan

N/A

## Testing Matrix

Test coverage in config.test.ts seems sufficient

## Linked issues / bugs

b/428217139