### PR TITLE
refactor: rename allowed_mcp_server_names to allowed-mcp-server-names

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -179,3 +179,7 @@ Design for a good user experience - Provide clear, minimal, and non-blocking UI 
 ## Comments policy
 
 Only write high-value comments if at all. Avoid talking to the user through comments.
+
+## General style requirements
+
+Use hyphens instead of underscores in flag names (e.g. `my-flag` instead of `my_flag`).

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -479,7 +479,7 @@ describe('mergeExcludeTools', () => {
   });
 });
 
-describe('loadCliConfig with allowed_mcp_server_names', () => {
+describe('loadCliConfig with allowed-mcp-server-names', () => {
   const originalArgv = process.argv;
   const originalEnv = { ...process.env };
 
@@ -513,7 +513,7 @@ describe('loadCliConfig with allowed_mcp_server_names', () => {
     process.argv = [
       'node',
       'script.js',
-      '--allowed_mcp_server_names',
+      '--allowed-mcp-server-names',
       'server1',
     ];
     const config = await loadCliConfig(baseSettings, [], 'test-session');
@@ -526,7 +526,7 @@ describe('loadCliConfig with allowed_mcp_server_names', () => {
     process.argv = [
       'node',
       'script.js',
-      '--allowed_mcp_server_names',
+      '--allowed-mcp-server-names',
       'server1,server3',
     ];
     const config = await loadCliConfig(baseSettings, [], 'test-session');
@@ -540,7 +540,7 @@ describe('loadCliConfig with allowed_mcp_server_names', () => {
     process.argv = [
       'node',
       'script.js',
-      '--allowed_mcp_server_names',
+      '--allowed-mcp-server-names',
       'server1,server4',
     ];
     const config = await loadCliConfig(baseSettings, [], 'test-session');
@@ -550,7 +550,7 @@ describe('loadCliConfig with allowed_mcp_server_names', () => {
   });
 
   it('should allow all MCP servers if the flag is an empty string', async () => {
-    process.argv = ['node', 'script.js', '--allowed_mcp_server_names', ''];
+    process.argv = ['node', 'script.js', '--allowed-mcp-server-names', ''];
     const config = await loadCliConfig(baseSettings, [], 'test-session');
     expect(config.getMcpServers()).toEqual(baseSettings.mcpServers);
   });

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -48,7 +48,7 @@ interface CliArgs {
   telemetryTarget: string | undefined;
   telemetryOtlpEndpoint: string | undefined;
   telemetryLogPrompts: boolean | undefined;
-  allowed_mcp_server_names: string | undefined;
+  'allowed-mcp-server-names': string | undefined;
 }
 
 async function parseArguments(): Promise<CliArgs> {
@@ -124,7 +124,7 @@ async function parseArguments(): Promise<CliArgs> {
       description: 'Enables checkpointing of file edits',
       default: false,
     })
-    .option('allowed_mcp_server_names', {
+    .option('allowed-mcp-server-names', {
       type: 'string',
       description: 'Allowed MCP server names',
     })
@@ -194,9 +194,9 @@ export async function loadCliConfig(
   let mcpServers = mergeMcpServers(settings, extensions);
   const excludeTools = mergeExcludeTools(settings, extensions);
 
-  if (argv.allowed_mcp_server_names) {
+  if (argv['allowed-mcp-server-names']) {
     const allowedNames = new Set(
-      argv.allowed_mcp_server_names.split(',').filter(Boolean),
+      argv['allowed-mcp-server-names'].split(',').filter(Boolean),
     );
     if (allowedNames.size > 0) {
       mcpServers = Object.fromEntries(


### PR DESCRIPTION
Just what it says in the title - renaming the flag for consistency. 

Also, added a section to GEMINI.md on style and included a bit about using hyphens instead of underscores. 