### PR TITLE
fix: correct mcp client name and version

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -368,6 +368,7 @@ export async function loadCliConfig(
   cwd: string = process.cwd(),
 ): Promise<Config> {
   const debugMode = isDebugMode(argv);
+  const version = await getCliVersion();
 
   const memoryImportFormat = settings.context?.importFormat || 'tree';
 
@@ -562,6 +563,7 @@ export async function loadCliConfig(
 
   return new Config({
     sessionId,
+    version,
     embeddingModel: DEFAULT_GEMINI_EMBEDDING_MODEL,
     sandbox: sandboxConfig,
     targetDir: cwd,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -574,6 +574,22 @@ describe('Server Config (config.ts)', () => {
     });
   });
 
+  describe('Version Configuration', () => {
+    it('should store and return version when provided', () => {
+      const paramsWithVersion: ConfigParameters = {
+        ...baseParams,
+        version: '2.3.4',
+      };
+      const config = new Config(paramsWithVersion);
+      expect(config.getVersion()).toBe('2.3.4');
+    });
+
+    it('should return undefined when version not provided', () => {
+      const config = new Config(baseParams);
+      expect(config.getVersion()).toBeUndefined();
+    });
+  });
+
   describe('UseModelRouter Configuration', () => {
     it('should default useModelRouter to false when not provided', () => {
       const config = new Config(baseParams);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -214,6 +214,7 @@ export interface SandboxConfig {
 
 export interface ConfigParameters {
   sessionId: string;
+  version?: string;
   embeddingModel?: string;
   sandbox?: SandboxConfig;
   targetDir: string;
@@ -291,6 +292,7 @@ export class Config {
   private promptRegistry!: PromptRegistry;
   private agentRegistry!: AgentRegistry;
   private readonly sessionId: string;
+  private readonly version: string | undefined;
   private fileSystemService: FileSystemService;
   private contentGeneratorConfig!: ContentGeneratorConfig;
   private contentGenerator!: ContentGenerator;
@@ -383,6 +385,7 @@ export class Config {
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
+    this.version = params.version;
     this.embeddingModel =
       params.embeddingModel ?? DEFAULT_GEMINI_EMBEDDING_MODEL;
     this.fileSystemService = new StandardFileSystemService();
@@ -599,6 +602,10 @@ export class Config {
 
   getSessionId(): string {
     return this.sessionId;
+  }
+
+  getVersion(): string | undefined {
+    return this.version;
   }
 
   shouldLoadMemoryFromIncludeDirectories(): boolean {

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -64,7 +64,7 @@ export class McpClientManager {
 
         this.eventEmitter?.emit('mcp-client-update', this.clients);
         try {
-          await client.connect();
+          await client.connect(cliConfig);
           await client.discover(cliConfig);
           this.eventEmitter?.emit('mcp-client-update', this.clients);
         } catch (error) {

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -55,6 +55,46 @@ describe('mcp-client', () => {
   });
 
   describe('McpClient', () => {
+    it('should create client with correct name and version', () => {
+      const mockClient = vi.fn();
+      vi.mocked(ClientLib.Client).mockImplementation(mockClient);
+
+      new McpClient(
+        'test-server',
+        { command: 'test-command' },
+        {} as ToolRegistry,
+        {} as PromptRegistry,
+        {} as WorkspaceContext,
+        false,
+        '2.1.0',
+      );
+
+      expect(mockClient).toHaveBeenCalledWith({
+        name: 'gemini-cli',
+        version: '2.1.0',
+      });
+    });
+
+    it('should use "unknown" version when not provided', () => {
+      const mockClient = vi.fn();
+      vi.mocked(ClientLib.Client).mockImplementation(mockClient);
+
+      new McpClient(
+        'test-server',
+        { command: 'test-command' },
+        {} as ToolRegistry,
+        {} as PromptRegistry,
+        {} as WorkspaceContext,
+        false,
+        undefined,
+      );
+
+      expect(mockClient).toHaveBeenCalledWith({
+        name: 'gemini-cli',
+        version: 'unknown',
+      });
+    });
+
     it('should discover tools', async () => {
       const mockedClient = {
         connect: vi.fn(),
@@ -92,6 +132,7 @@ describe('mcp-client', () => {
         {} as PromptRegistry,
         workspaceContext,
         false,
+        '1.0.0',
       );
       await client.connect();
       await client.discover({} as Config);
@@ -155,6 +196,7 @@ describe('mcp-client', () => {
         {} as PromptRegistry,
         workspaceContext,
         false,
+        '1.0.0',
       );
       await client.connect();
       await client.discover({} as Config);
@@ -195,6 +237,7 @@ describe('mcp-client', () => {
         {} as PromptRegistry,
         workspaceContext,
         false,
+        '1.0.0',
       );
       await client.connect();
       await expect(client.discover({} as Config)).rejects.toThrow(

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -99,7 +99,7 @@ export class McpClient {
   /**
    * Connects to the MCP server.
    */
-  async connect(): Promise<void> {
+  async connect(cliConfig?: Config): Promise<void> {
     if (this.status !== MCPServerStatus.DISCONNECTED) {
       throw new Error(
         `Can only connect when the client is disconnected, current state is ${this.status}`,
@@ -112,6 +112,7 @@ export class McpClient {
         this.serverConfig,
         this.debugMode,
         this.workspaceContext,
+        cliConfig?.getVersion(),
       );
       const originalOnError = this.client.onerror;
       this.client.onerror = (error) => {
@@ -517,6 +518,7 @@ export async function connectAndDiscover(
       mcpServerConfig,
       debugMode,
       workspaceContext,
+      cliConfig.getVersion(),
     );
 
     mcpClient.onerror = (error) => {
@@ -752,10 +754,11 @@ export async function connectToMcpServer(
   mcpServerConfig: MCPServerConfig,
   debugMode: boolean,
   workspaceContext: WorkspaceContext,
+  version?: string,
 ): Promise<Client> {
   const mcpClient = new Client({
-    name: 'gemini-cli-mcp-client',
-    version: '0.0.1',
+    name: 'gemini-cli',
+    version: version || 'unknown',
   });
 
   mcpClient.registerCapabilities({


### PR DESCRIPTION
The mcp client keeps sending the same version 0.0.1 since dawn of time.

This PR, use the package version to give gemini mcp client a version.

