### PR TITLE
Fix typo and add tests for auth validation.

### DIFF
--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AuthType } from '@google/gemini-cli-core';
+import { vi } from 'vitest';
+import { validateAuthMethod } from './auth.js';
+
+vi.mock('./settings.js', () => ({
+  loadEnvironment: vi.fn(),
+}));
+
+describe('validateAuthMethod', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = {};
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should return null for LOGIN_WITH_GOOGLE', () => {
+    expect(validateAuthMethod(AuthType.LOGIN_WITH_GOOGLE)).toBeNull();
+  });
+
+  it('should return null for CLOUD_SHELL', () => {
+    expect(validateAuthMethod(AuthType.CLOUD_SHELL)).toBeNull();
+  });
+
+  describe('USE_GEMINI', () => {
+    it('should return null if GEMINI_API_KEY is set', () => {
+      process.env.GEMINI_API_KEY = 'test-key';
+      expect(validateAuthMethod(AuthType.USE_GEMINI)).toBeNull();
+    });
+
+    it('should return an error message if GEMINI_API_KEY is not set', () => {
+      expect(validateAuthMethod(AuthType.USE_GEMINI)).toBe(
+        'GEMINI_API_KEY environment variable not found. Add that to your .env and try again, no reload needed!',
+      );
+    });
+  });
+
+  describe('USE_VERTEX_AI', () => {
+    it('should return null if GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION are set', () => {
+      process.env.GOOGLE_CLOUD_PROJECT = 'test-project';
+      process.env.GOOGLE_CLOUD_LOCATION = 'test-location';
+      expect(validateAuthMethod(AuthType.USE_VERTEX_AI)).toBeNull();
+    });
+
+    it('should return null if GOOGLE_API_KEY is set', () => {
+      process.env.GOOGLE_API_KEY = 'test-api-key';
+      expect(validateAuthMethod(AuthType.USE_VERTEX_AI)).toBeNull();
+    });
+
+    it('should return an error message if no required environment variables are set', () => {
+      expect(validateAuthMethod(AuthType.USE_VERTEX_AI)).toBe(
+        'Must specify GOOGLE_GENAI_USE_VERTEXAI=true and either:\n' +
+          '• GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION environment variables.\n' +
+          '• GOOGLE_API_KEY environment variable (if using express mode).\n' +
+          'Update your .env and try again, no reload needed!',
+      );
+    });
+  });
+
+  it('should return an error message for an invalid auth method', () => {
+    expect(validateAuthMethod('invalid-method')).toBe(
+      'Invalid auth method selected.',
+    );
+  });
+});

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -9,7 +9,10 @@ import { loadEnvironment } from './settings.js';
 
 export const validateAuthMethod = (authMethod: string): string | null => {
   loadEnvironment();
-  if (authMethod === AuthType.LOGIN_WITH_GOOGLE || AuthType.CLOUD_SHELL) {
+  if (
+    authMethod === AuthType.LOGIN_WITH_GOOGLE ||
+    authMethod === AuthType.CLOUD_SHELL
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## TLDR

Fixes typo in https://github.com/google-gemini/gemini-cli/pull/3070 that was skipping auth validation.

## Dive Deeper

Also added tests so we'll catch this in the future.

## Reviewer Test Plan

Try to use "Gemini API Key" without an env set and verify that it shows you an error.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
