### PR TITLE
Fix double "esc" bug in Auth dialog

### DIFF
--- a/packages/cli/src/ui/components/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.test.tsx
@@ -45,9 +45,7 @@ describe('AuthDialog', () => {
     const onSelect = vi.fn();
     const settings: LoadedSettings = new LoadedSettings(
       {
-        settings: {
-          selectedAuthType: undefined,
-        },
+        settings: {},
         path: '',
       },
       {
@@ -70,6 +68,40 @@ describe('AuthDialog', () => {
     expect(lastFrame()).toContain(
       'You must select an auth method to proceed. Press Ctrl+C twice to exit.',
     );
+    expect(onSelect).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should not exit if there is already an error message', async () => {
+    const onSelect = vi.fn();
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: {},
+        path: '',
+      },
+      {
+        settings: {},
+        path: '',
+      },
+      [],
+    );
+
+    const { lastFrame, stdin, unmount } = render(
+      <AuthDialog
+        onSelect={onSelect}
+        settings={settings}
+        initialErrorMessage="Initial error"
+      />,
+    );
+    await wait();
+
+    expect(lastFrame()).toContain('Initial error');
+
+    // Simulate pressing escape key
+    stdin.write('\u001b'); // ESC key
+    await wait();
+
+    // Should not call onSelect
     expect(onSelect).not.toHaveBeenCalled();
     unmount();
   });

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -66,6 +66,11 @@ export function AuthDialog({
 
   useInput((_input, key) => {
     if (key.escape) {
+      // Prevent exit if there is an error message.
+      // This means they user is not authenticated yet.
+      if (errorMessage) {
+        return;
+      }
       if (settings.merged.selectedAuthType === undefined) {
         // Prevent exiting if no auth method is set
         setErrorMessage(


### PR DESCRIPTION
## TLDR

Previously, if the user ran into an error while authing, hitting escape would exit the screen, and then immediately send them back to the auth dialog. This was fine except when using "Login with Google" since users did not expect hitting esc would cause us to retry logging in.

## Reviewer Test Plan

choose "login with Google" and don't login through the webpage. Instead, hit esc to exit, then hit esc again and verify that the browser is not reopened.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1735 