### PR TITLE
add new flag, --mcp-server-dev that ignores any mcp name restrictions imposed by --allowed-mcp-server-names

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -558,6 +558,18 @@ describe('loadCliConfig with allowed-mcp-server-names', () => {
     const config = await loadCliConfig(baseSettings, [], 'test-session');
     expect(config.getMcpServers()).toEqual({});
   });
+
+  it('should allow all MCP servers when mcp-server-dev is true, even if allowed-mcp-server-names is set', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--mcp-server-dev',
+      '--allowed-mcp-server-names',
+      'server1',
+    ];
+    const config = await loadCliConfig(baseSettings, [], 'test-session');
+    expect(config.getMcpServers()).toEqual(baseSettings.mcpServers);
+  });
 });
 
 describe('loadCliConfig extensions', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -53,6 +53,7 @@ interface CliArgs {
   allowedMcpServerNames: string[] | undefined;
   extensions: string[] | undefined;
   listExtensions: boolean | undefined;
+  mcpServerDev: boolean | undefined;
 }
 
 async function parseArguments(): Promise<CliArgs> {
@@ -155,6 +156,7 @@ async function parseArguments(): Promise<CliArgs> {
       type: 'array',
       string: true,
       description: 'Allowed MCP server names',
+      hidden: true,
     })
     .option('extensions', {
       alias: 'e',
@@ -167,6 +169,12 @@ async function parseArguments(): Promise<CliArgs> {
       alias: 'l',
       type: 'boolean',
       description: 'List all available extensions and exit.',
+    })
+    .option('mcp-server-dev', {
+      type: 'boolean',
+      description: 'Allow all MCP server names (for development)',
+      default: false,
+      hidden: true,
     })
     .version(await getCliVersion()) // This will enable the --version flag based on package.json
     .alias('v', 'version')
@@ -247,7 +255,9 @@ export async function loadCliConfig(
   let mcpServers = mergeMcpServers(settings, activeExtensions);
   const excludeTools = mergeExcludeTools(settings, activeExtensions);
 
-  if (argv.allowedMcpServerNames) {
+  if (argv.mcpServerDev) {
+    // Allow all servers in dev mode, do nothing.
+  } else if (argv.allowedMcpServerNames) {
     const allowedNames = new Set(argv.allowedMcpServerNames.filter(Boolean));
     if (allowedNames.size > 0) {
       mcpServers = Object.fromEntries(


### PR DESCRIPTION
## TLDR

Allows all mcp servers (an override) during the session. Intended for MCP server developers needing to work around allowlist restrictions.

## Dive Deeper

We're using a wrapper that hard-codes a list to --allowed-mcp-server-names, so this flag exists to allow users the ability to temporarily override that otherwise hard-coded setting. 

## Reviewer Test Plan

Not much I think, test coverage looks good.

## Testing Matrix

NA

## Linked issues / bugs

b/428217139 - bug discusses an override flag.