### PR TITLE
Use full terminal width for `--help`

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -56,7 +56,7 @@ interface CliArgs {
 }
 
 async function parseArguments(): Promise<CliArgs> {
-  const argv = await yargs(hideBin(process.argv))
+  const yargsInstance = await yargs(hideBin(process.argv))
     .scriptName('gemini')
     .usage(
       '$0 [options]',
@@ -171,9 +171,11 @@ async function parseArguments(): Promise<CliArgs> {
     .alias('v', 'version')
     .help()
     .alias('h', 'help')
-    .strict().argv;
+    .strict();
 
-  return argv;
+  yargsInstance.wrap(yargsInstance.terminalWidth());
+
+  return yargsInstance.argv;
 }
 
 // This function is now a thin wrapper around the server's implementation.

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -56,7 +56,7 @@ interface CliArgs {
 }
 
 async function parseArguments(): Promise<CliArgs> {
-  const yargsInstance = await yargs(hideBin(process.argv))
+  const yargsInstance = yargs(hideBin(process.argv))
     .scriptName('gemini')
     .usage(
       '$0 [options]',


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

Uses `yargsInstance.terminalWidth()` to auto-adjust the `--help` output to the available terminal width.

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

Fixes #3514
