### PR TITLE
feat(auth): Enhance OAuth callback for robust Docker support

### DIFF
--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -105,7 +105,7 @@ describe('oauth2', () => {
 
     let capturedPort = 0;
     const mockHttpServer = {
-      listen: vi.fn((port: number, callback?: () => void) => {
+      listen: vi.fn((port: number, _host: string, callback?: () => void) => {
         capturedPort = port;
         if (callback) {
           callback();

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -136,13 +136,33 @@ export async function getOauthClient(
   } else {
     const webLogin = await authWithWeb(client);
 
-    // This does basically nothing, as it isn't show to the user.
     console.log(
       `\n\nCode Assist login required.\n` +
         `Attempting to open authentication page in your browser.\n` +
         `Otherwise navigate to:\n\n${webLogin.authUrl}\n\n`,
     );
-    await open(webLogin.authUrl);
+    try {
+      // Attempt to open the authentication URL in the default browser.
+      // We do not use the `wait` option here because the main script's execution
+      // is already paused by `loginCompletePromise`, which awaits the server callback.
+      const childProcess = await open(webLogin.authUrl);
+
+      // IMPORTANT: Attach an error handler to the returned child process.
+      // Without this, if `open` fails to spawn a process (e.g., `xdg-open` is not found
+      // in a minimal Docker container), it will emit an unhandled 'error' event,
+      // causing the entire Node.js process to crash.
+      childProcess.on('error', (_) => {
+        console.error(
+          'Failed to open browser automatically. Please open the URL manually:',
+        );
+        console.error(webLogin.authUrl);
+      });
+    } catch (err) {
+      console.error(
+        'An unexpected error occurred while trying to open the browser:',
+        err,
+      );
+    }
     console.log('Waiting for authentication...');
 
     await webLogin.loginCompletePromise;
@@ -199,6 +219,12 @@ async function authWithUserCode(client: OAuth2Client): Promise<boolean> {
 
 async function authWithWeb(client: OAuth2Client): Promise<OauthWebLogin> {
   const port = await getAvailablePort();
+  // The hostname used for the HTTP server binding (e.g., '0.0.0.0' in Docker).
+  const host = process.env.OAUTH_CALLBACK_HOST || 'localhost';
+  // The `redirectUri` sent to Google's authorization server MUST use a loopback IP literal
+  // (i.e., 'localhost' or '127.0.0.1'). This is a strict security policy for credentials of
+  // type 'Desktop app' or 'Web application' (when using loopback flow) to mitigate
+  // authorization code interception attacks.
   const redirectUri = `http://localhost:${port}/oauth2callback`;
   const state = crypto.randomBytes(32).toString('hex');
   const authUrl = client.generateAuthUrl({
@@ -256,7 +282,7 @@ async function authWithWeb(client: OAuth2Client): Promise<OauthWebLogin> {
         server.close();
       }
     });
-    server.listen(port);
+    server.listen(port, host);
   });
 
   return {
@@ -269,6 +295,16 @@ export function getAvailablePort(): Promise<number> {
   return new Promise((resolve, reject) => {
     let port = 0;
     try {
+      const portStr = process.env.OAUTH_CALLBACK_PORT;
+      if (portStr) {
+        port = parseInt(portStr, 10);
+        if (isNaN(port) || port <= 0 || port > 65535) {
+          return reject(
+            new Error(`Invalid value for OAUTH_CALLBACK_PORT: "${portStr}"`),
+          );
+        }
+        return resolve(port);
+      }
       const server = net.createServer();
       server.listen(0, () => {
         const address = server.address()! as net.AddressInfo;


### PR DESCRIPTION
## TLDR

This pull request improves the OAuth 2.0 authentication flow to make it fully compatible with containerized environments like Docker. It introduces two new environment variables, `OAUTH_CALLBACK_PORT` and `OAUTH_CALLBACK_HOST`, to decouple the server's listening address from the `redirect_uri` sent to Google.

## Dive Deeper
### The Problem

When running `gemini auth login` inside a Docker container, the OAuth flow fails. This is due to a fundamental conflict:

1.  **Google's Requirement**: For security, Google's OAuth server requires the `redirect_uri` to use a loopback address (e.g., `http://localhost:PORT`).
2.  **Docker's Networking**: For a service inside a container to be accessible from the host machine via port mapping, it must listen on `0.0.0.0`, not `localhost`.

The previous implementation used the same host for both constructing the `redirect_uri` and binding the local server, making it impossible to satisfy both conditions simultaneously in Docker.

### The Solution

This PR resolves the conflict by introducing two distinct configurations:

-   `OAUTH_CALLBACK_HOST`: Specifies the IP address for the internal HTTP server to **listen on**. This should be set to `0.0.0.0` when running in Docker.
-   `OAUTH_CALLBACK_PORT`: Specifies a fixed port for both listening and for the `redirect_uri`.

The `redirect_uri` is now always constructed with `localhost`, satisfying Google's security policy, while the server correctly binds to `0.0.0.0` to work with Docker's port mapping.

### How to Use in Docker

This change enables a seamless, one-time login workflow using Docker Compose.

**`docker-compose.yml`:**
```yaml
version: "3.9"

services:
  login:
    image: node:lts
    command: >
      sh -c "
        if [ -f /root/.gemini/oauth_creds.json ]; then
          echo '✅ Credentials already exist.';
        else
          echo '-> Starting interactive login...';
          npx @google/gemini-cli@latest --debug
        fi
      "
    working_dir: /root
    volumes:
      - ./.gemini:/root/.gemini
    ports:
      - "8766:8766" # Map host port to container port
    environment:
      - OAUTH_CALLBACK_PORT=8766
      - OAUTH_CALLBACK_HOST=0.0.0.0
```

**Usage:**
1. Run the one-time, interactive login command:
   ```bash
   docker-compose run --rm --service-ports login
   ```
2. Follow the on-screen instructions to authenticate in your browser.
3. The `oauth_creds.json` file will be created and persisted in the local `./.gemini` directory, ready for use by other services.

### Linked Issues

- Resolves #2040
