### PR TITLE
remove annoying deprecation warning due to version mistmatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "shell-quote": "^1.8.3"
-      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },
@@ -783,9 +780,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
-      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -798,9 +795,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
-      "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -858,9 +855,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.29.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
-      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
+      "integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4684,19 +4681,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.29.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
-      "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.1.tgz",
+      "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.1",
-        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.0",
         "@eslint/core": "^0.14.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.29.0",
+        "@eslint/js": "9.30.1",
         "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -11410,7 +11407,7 @@
         "ignore": "^7.0.0",
         "micromatch": "^4.0.8",
         "open": "^10.1.2",
-        "shell-quote": "^1.8.2",
+        "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
         "undici": "^7.10.0",

--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
     "typescript-eslint": "^8.30.1",
     "vitest": "^3.2.4",
     "yargs": "^17.7.2"
+  },
+  "overrides": {
+    "punycode": "^2.3.1"
   }
 }


### PR DESCRIPTION
 This change resolves the following deprecation warning that appears during npm operations:
``` 
[DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
```
The warning is silenced by adding an  `overrides` field to the root  `package.json` to ensure a consistent version of
     `punycode` is used throughout the dependency tree.