### PR TITLE
Don't enforce leading slash since that's not true on Windows

### DIFF
--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -74,7 +74,7 @@ describe('ReadFileTool', () => {
     it('should return error for relative path', () => {
       const params: ReadFileToolParams = { absolute_path: 'test.txt' };
       expect(tool.validateToolParams(params)).toBe(
-        `params/absolute_path must match pattern "^/"`,
+        `File path must be absolute, but was relative: test.txt. You must provide an absolute path.`,
       );
     });
 
@@ -144,10 +144,10 @@ describe('ReadFileTool', () => {
       const params: ReadFileToolParams = { absolute_path: 'relative/path.txt' };
       const result = await tool.execute(params, abortSignal);
       expect(result.llmContent).toBe(
-        'Error: Invalid parameters provided. Reason: params/absolute_path must match pattern "^/"',
+        'Error: Invalid parameters provided. Reason: File path must be absolute, but was relative: relative/path.txt. You must provide an absolute path.',
       );
       expect(result.returnDisplay).toBe(
-        'params/absolute_path must match pattern "^/"',
+        'File path must be absolute, but was relative: relative/path.txt. You must provide an absolute path.',
       );
     });
 

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -60,7 +60,6 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
             description:
               "The absolute path to the file to read (e.g., '/home/user/project/file.txt'). Relative paths are not supported. You must provide an absolute path.",
             type: Type.STRING,
-            pattern: '^/',
           },
           offset: {
             description:


### PR DESCRIPTION
## TLDR

Don't enforce leading slashes in path names.

## Dive Deeper

When we merged https://github.com/google-gemini/gemini-cli/pull/2881 this pattern started getting enforced.

## Reviewer Test Plan

Try reading a file in windows.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3525