### PR TITLE
Fix bad request in model check

### DIFF
--- a/packages/core/src/core/modelCheck.ts
+++ b/packages/core/src/core/modelCheck.ts
@@ -35,7 +35,7 @@ export async function getEffectiveModel(
       maxOutputTokens: 1,
       temperature: 0,
       topK: 1,
-      thinkingConfig: { thinkingBudget: 0, includeThoughts: false },
+      thinkingConfig: { thinkingBudget: 128, includeThoughts: false },
     },
   });
 


### PR DESCRIPTION
## TLDR

Set thinking budget in model check request to 128 (minimum allowed).

## Dive Deeper

When ``thinkingBudget`` is set to 0, test requests consistently result in a "400 Bad Request" error. This indicates that the model's intended fallback to "flash" functionality never worked during auth.

According to https://ai.google.dev/gemini-api/docs/thinking#set-budget, it is not possible to disable thinking and the minimum budget is 128.

### Before
![image](https://github.com/user-attachments/assets/257e85f3-8eae-4f03-bb37-8fd8ee3b20ab)


### After
![image](https://github.com/user-attachments/assets/ad71ddf8-23a7-4961-bcb8-9f7c5427e480)

## Reviewer Test Plan

Test with an free-tier API key that is already rate-limited. 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs
N/A
