### PR TITLE
Use yargs array type for the allowedMcpServerNames flag instead of processing the list directly ourselves.

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -527,7 +527,9 @@ describe('loadCliConfig with allowed-mcp-server-names', () => {
       'node',
       'script.js',
       '--allowed-mcp-server-names',
-      'server1,server3',
+      'server1',
+      '--allowed-mcp-server-names',
+      'server3',
     ];
     const config = await loadCliConfig(baseSettings, [], 'test-session');
     expect(config.getMcpServers()).toEqual({
@@ -541,7 +543,9 @@ describe('loadCliConfig with allowed-mcp-server-names', () => {
       'node',
       'script.js',
       '--allowed-mcp-server-names',
-      'server1,server4',
+      'server1',
+      '--allowed-mcp-server-names',
+      'server4',
     ];
     const config = await loadCliConfig(baseSettings, [], 'test-session');
     expect(config.getMcpServers()).toEqual({
@@ -549,10 +553,10 @@ describe('loadCliConfig with allowed-mcp-server-names', () => {
     });
   });
 
-  it('should allow all MCP servers if the flag is an empty string', async () => {
+  it('should allow no MCP servers if the flag is provided but empty', async () => {
     process.argv = ['node', 'script.js', '--allowed-mcp-server-names', ''];
     const config = await loadCliConfig(baseSettings, [], 'test-session');
-    expect(config.getMcpServers()).toEqual(baseSettings.mcpServers);
+    expect(config.getMcpServers()).toEqual({});
   });
 });
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -50,7 +50,7 @@ interface CliArgs {
   telemetryTarget: string | undefined;
   telemetryOtlpEndpoint: string | undefined;
   telemetryLogPrompts: boolean | undefined;
-  allowedMcpServerNames: string | undefined;
+  allowedMcpServerNames: string[] | undefined;
   extensions: string[] | undefined;
   listExtensions: boolean | undefined;
 }
@@ -152,7 +152,8 @@ async function parseArguments(): Promise<CliArgs> {
       default: false,
     })
     .option('allowed-mcp-server-names', {
-      type: 'string',
+      type: 'array',
+      string: true,
       description: 'Allowed MCP server names',
     })
     .option('extensions', {
@@ -245,9 +246,7 @@ export async function loadCliConfig(
   const excludeTools = mergeExcludeTools(settings, activeExtensions);
 
   if (argv.allowedMcpServerNames) {
-    const allowedNames = new Set(
-      argv.allowedMcpServerNames.split(',').filter(Boolean),
-    );
+    const allowedNames = new Set(argv.allowedMcpServerNames.filter(Boolean));
     if (allowedNames.size > 0) {
       mcpServers = Object.fromEntries(
         Object.entries(mcpServers).filter(([key]) => allowedNames.has(key)),


### PR DESCRIPTION
## TLDR

Use yargs array type for the allowedMcpServerNames flag instead of processing the list directly ourselves.

## Dive Deeper

Just a cleanup (suggested by @bbiggs)

## Reviewer Test Plan

Unit test coverage is sufficient.

## Testing Matrix

No idea if this works on windows.

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Just a cleanup.