### PR TITLE
fix(cli): ensure config is initialized in non-interactive mode

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -257,6 +257,9 @@ export class Config {
   }
 
   async refreshAuth(authMethod: AuthType) {
+    if (!this.toolRegistry) {
+      await this.initialize();
+    }
     this.contentGeneratorConfig = await createContentGeneratorConfig(
       this.model,
       authMethod,


### PR DESCRIPTION
In non-interactive mode, it was possible for `refreshAuth` to be called on a `Config` object that had not been initialized. This would cause a crash because the `toolRegistry` was not available. This change ensures that the `Config` object is initialized within `refreshAuth` if it has not been already.