### PR TITLE
fix: Use Email for Clearcut Logging and Refactor User Info Fetching

### DIFF
--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -61,30 +61,11 @@ describe('oauth2', () => {
     const mockGetAccessToken = vi
       .fn()
       .mockResolvedValue({ token: 'mock-access-token' });
-    const mockRefreshAccessToken = vi.fn().mockImplementation((callback) => {
-      // Mock the callback-style refreshAccessToken method
-      const mockTokensWithIdToken = {
-        access_token: 'test-access-token',
-        refresh_token: 'test-refresh-token',
-        id_token:
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LWdvb2dsZS1hY2NvdW50LWlkLTEyMyJ9.signature', // Mock JWT with sub: test-google-account-id-123
-      };
-      callback(null, mockTokensWithIdToken);
-    });
-    const mockVerifyIdToken = vi.fn().mockResolvedValue({
-      getPayload: () => ({
-        sub: 'test-google-account-id-123',
-        aud: 'test-audience',
-        iss: 'https://accounts.google.com',
-      }),
-    });
     const mockOAuth2Client = {
       generateAuthUrl: mockGenerateAuthUrl,
       getToken: mockGetToken,
       setCredentials: mockSetCredentials,
       getAccessToken: mockGetAccessToken,
-      refreshAccessToken: mockRefreshAccessToken,
-      verifyIdToken: mockVerifyIdToken,
       credentials: mockTokens,
       on: vi.fn(),
     } as unknown as OAuth2Client;

--- a/packages/core/src/utils/user_id.test.ts
+++ b/packages/core/src/utils/user_id.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { getInstallationId, getGoogleAccountId } from './user_id.js';
+import { getInstallationId, getGoogleAccountEmail } from './user_id.js';
 
 describe('user_id', () => {
   describe('getInstallationId', () => {
@@ -22,30 +22,24 @@ describe('user_id', () => {
     });
   });
 
-  describe('getGoogleAccountId', () => {
-    it('should return a non-empty string', async () => {
-      const result = await getGoogleAccountId();
+  describe('getGoogleAccountEmail', () => {
+    it('should return a non-empty string', () => {
+      const result = getGoogleAccountEmail();
 
       expect(result).toBeDefined();
       expect(typeof result).toBe('string');
 
       // Should be consistent on subsequent calls
-      const secondCall = await getGoogleAccountId();
+      const secondCall = getGoogleAccountEmail();
       expect(secondCall).toBe(result);
     });
 
-    it('should return empty string when no Google Account ID is cached, or a valid ID when cached', async () => {
-      // The function can return either an empty string (if no cached ID) or a valid Google Account ID (if cached)
-      const googleAccountIdResult = await getGoogleAccountId();
+    it('should return empty string when no Google Account email is cached', () => {
+      // In a clean test environment, there should be no cached Google Account email
+      const googleAccountEmailResult = getGoogleAccountEmail();
 
-      expect(googleAccountIdResult).toBeDefined();
-      expect(typeof googleAccountIdResult).toBe('string');
-
-      // Should be either empty string or a numeric string (Google Account ID)
-      if (googleAccountIdResult !== '') {
-        // If we have a cached ID, it should be a numeric string
-        expect(googleAccountIdResult).toMatch(/^\d+$/);
-      }
+      // They should be the same when no Google Account email is cached
+      expect(googleAccountEmailResult).toBe('');
     });
   });
 });

--- a/packages/core/src/utils/user_id.ts
+++ b/packages/core/src/utils/user_id.ts
@@ -8,7 +8,10 @@ import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
+import { createRequire } from 'module';
 import { GEMINI_DIR } from './paths.js';
+
+const require = createRequire(import.meta.url);
 
 const homeDir = os.homedir() ?? '';
 const geminiDir = path.join(homeDir, GEMINI_DIR);
@@ -58,24 +61,23 @@ export function getInstallationId(): string {
 }
 
 /**
- * Retrieves the obfuscated Google Account ID for the currently authenticated user.
- * When OAuth is available, returns the user's cached Google Account ID. Otherwise, returns the installation ID.
- * @returns A string ID for the user (Google Account ID if available, otherwise installation ID).
+ * Retrieves the email for the currently authenticated user.
+ * When OAuth is available, returns the user's cached email. Otherwise, returns an empty string.
+ * @returns A string email for the user (Google Account email if available, otherwise empty string).
  */
-export async function getGoogleAccountId(): Promise<string> {
-  // Try to get cached Google Account ID first
+export function getGoogleAccountEmail(): string {
+  // Try to get cached Google Account email first
   try {
-    // Dynamic import to avoid circular dependencies
-    const { getCachedGoogleAccountId } = await import(
-      '../code_assist/oauth2.js'
-    );
-    const googleAccountId = getCachedGoogleAccountId();
-    if (googleAccountId) {
-      return googleAccountId;
+    // Dynamically import to avoid circular dependencies
+    // eslint-disable-next-line no-restricted-syntax
+    const { getCachedGoogleAccountEmail } = require('../code_assist/oauth2.js');
+    const googleAccountEmail = getCachedGoogleAccountEmail();
+    if (googleAccountEmail) {
+      return googleAccountEmail;
     }
   } catch (error) {
-    // If there's any error accessing Google Account ID, just return empty string
-    console.debug('Could not get cached Google Account ID:', error);
+    // If there's any error accessing Google Account email, just return empty string
+    console.debug('Could not get cached Google Account email:', error);
   }
 
   return '';


### PR DESCRIPTION
This PR addresses an issue with our Clearcut logging by replacing the previously used Google Account ID with the user's email. This change aligns with standard practices (see http://go/cloudmill-1p-oss-instrumentation#define-sessionable-id) which should also work for clearcut to automatically delete the email field and populate the obscured_gaia_id.

### Key Changes:

*   **Updated Clearcut Logging:**
    *   The `ClearcutLogger` now sends the user's email (`client_email`) instead of the installation ID or a numeric Google Account ID.
    *   This ensures that logs are associated with a recognizable user identity when available.
    *   Logging falls back to `client_install_id` if the email is not available.

*   **Refactored User Information Fetching:**
    *   The logic for retrieving user information has been updated to use the `googleapis.com/oauth2/v2/userinfo` endpoint.
    *   This replaces the previous method of decoding the `id_token` to get the `sub` claim.
    *   The new approach fetches both the user's email and their Google Account ID, caching them for future use.

*   **Cached Credentials:**
    *   The user's email is now cached locally, similar to how the Google Account ID was previously handled.
    *   The `getGoogleAccountEmail()` utility function provides a consistent way to access the cached email.

*   **Error Handling and Dependencies:**
    *   Removed `id_token` verification logic that is no longer needed.
    *   Simplified promise handling and error logging around the flushing of telemetry data.
    *   Switched to using `require` for dynamic imports to avoid circular dependency issues.

Fixes #3149