### PR TITLE
feat: Add Ctrl+n/p for suggestion navigation

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -212,11 +212,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       if (completion.showSuggestions) {
-        if (key.name === 'up') {
+        if (key.name === 'up' || (key.ctrl && key.name === 'p')) {
           completion.navigateUp();
           return;
         }
-        if (key.name === 'down') {
+        if (key.name === 'down' || (key.ctrl && key.name === 'n')) {
           completion.navigateDown();
           return;
         }


### PR DESCRIPTION
This change adds support for navigating command suggestions using Ctrl+n (next) and Ctrl+p (previous) in addition to the arrow keys.

This improves the user experience for developers who are accustomed to these common keybindings from other CLI tools.


