### PR TITLE
mcp-server: Fix debug flag

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -416,7 +416,7 @@ The MCP integration tracks several states:
 
 ### Debugging Tips
 
-1. **Enable debug mode:** Run the CLI with `--debug_mode` for verbose output
+1. **Enable debug mode:** Run the CLI with `--debug` for verbose output
 2. **Check stderr:** MCP server stderr is captured and logged (INFO messages filtered)
 3. **Test isolation:** Test your MCP server independently before integrating
 4. **Incremental setup:** Start with simple tools before adding complex functionality


### PR DESCRIPTION
## TLDR

- Correct debug flag
- When running, `--debug_mode` isn't recognised, but `--debug` is