### PR TITLE
Fix invalid docker command and invalid JSON in the mcpServers example.

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -132,11 +132,11 @@ In addition to a project settings file, a project's `.gemini` directory can cont
       },
       "myDockerServer": {
         "command": "docker",
-        "args": ["run", "i", "--rm", "-e", "API_KEY", "ghcr.io/foo/bar"],
+        "args": ["run", "-i", "--rm", "-e", "API_KEY", "ghcr.io/foo/bar"],
         "env": {
           "API_KEY": "$MY_API_TOKEN"
         }
-      },
+      }
     }
     ```
 


### PR DESCRIPTION
## TLDR

The docker command in https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md?plain=1#L135 is invalid. The mcp server setup with docker would fail and need user's attention to fix.

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

Review the sample with AI, eg,

```
   is this a valid json and valid docker command:  "mcpServers": {
      "myPythonServer": {
        "command": "python",
        "args": ["mcp_server.py", "--port", "8080"],
        "cwd": "./mcp_tools/python",
        "timeout": 5000
      },
      "myNodeServer": {
        "command": "node",
        "args": ["mcp_server.js"],
        "cwd": "./mcp_tools/node"
      },
      "myDockerServer": {
        "command": "docker",
        "args": ["run", "i", "--rm", "-e", "API_KEY", "ghcr.io/foo/bar"],
        "env": {
          "API_KEY": "$MY_API_TOKEN"
        }
      },
    }
```

expected result:
```
The provided text is a valid JSON snippet.

  The Docker command extracted from the JSON is:
  docker run -i --rm -e API_KEY ghcr.io/foo/bar


  This is a syntactically valid Docker command. It will:
   * run: Create and run a new container.
   * -i: Keep STDIN open even if not attached.
   * --rm: Automatically remove the container when it exits.
   * -e API_KEY: Set an environment variable named API_KEY inside the container. The value for API_KEY would
     be passed from the env section of the JSON ($MY_API_TOKEN).
   * ghcr.io/foo/bar: Specify the Docker image to use.
```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Fixes #3670

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**
- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
