### PR TITLE
Indent subcommands in help output

### DIFF
--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -78,8 +78,8 @@ export const Help: React.FC<Help> = ({ commands }) => (
           {command.subCommands &&
             command.subCommands.map((subCommand) => (
               <Text key={subCommand.name} color={Colors.Foreground}>
-                <Text> </Text>
                 <Text bold color={Colors.AccentPurple}>
+                  {'   '}
                   {subCommand.name}
                 </Text>
                 {subCommand.description && ' - ' + subCommand.description}


### PR DESCRIPTION
## TLDR

indent subcommands in help output

## Dive Deeper
Before:
```
│ Commands:
│  /clear - clear the screen and conversation history
│  /help - for help on gemini-cli
│  /memory - Commands for interacting with memory.
│  show - Show the current memory contents.
│  add - Add content to the memory.
│  refresh - Refresh the memory from the source.
│  /docs - open full Gemini CLI documentation in your browser
│  /theme - change the theme
│  /auth - change the auth method
```
After:
```
│ Commands:
│  /clear - clear the screen and conversation history
│  /help - for help on gemini-cli
│  /memory - Commands for interacting with memory.
│    show - Show the current memory contents.
│    add - Add content to the memory.
│    refresh - Refresh the memory from the source.
│  /docs - open full Gemini CLI documentation in your browser
│  /theme - change the theme
│  /auth - change the auth method
```

## Reviewer Test Plan

run /help

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
