### PR TITLE
Add NO_BROWSER environment variable to trigger offline oauth flow

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -317,6 +317,7 @@ export async function loadCliConfig(
       name: e.config.name,
       version: e.config.version,
     })),
+    noBrowser: !!process.env.NO_BROWSER,
   });
 }
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -172,10 +172,7 @@ export async function main() {
     config.getNoBrowser()
   ) {
     // Do oauth before app renders to make copying the link possible.
-    await getOauthClient(
-      settings.merged.selectedAuthType,
-      config.getNoBrowser(),
-    );
+    await getOauthClient(settings.merged.selectedAuthType, config);
   }
 
   let input = config.getQuestion();

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -35,6 +35,7 @@ import {
   sessionId,
   logUserPrompt,
   AuthType,
+  getOauthClient,
 } from '@google/gemini-cli-core';
 import { validateAuthMethod } from './config/auth.js';
 import { setMaxSizedBoxDebugging } from './ui/components/shared/MaxSizedBox.js';
@@ -165,6 +166,18 @@ export async function main() {
       }
     }
   }
+
+  if (
+    settings.merged.selectedAuthType === AuthType.LOGIN_WITH_GOOGLE &&
+    config.getNoBrowser()
+  ) {
+    // Do oauth before app renders to make copying the link possible.
+    await getOauthClient(
+      settings.merged.selectedAuthType,
+      config.getNoBrowser(),
+    );
+  }
+
   let input = config.getQuestion();
   const startupWarnings = [
     ...(await getStartupWarnings()),

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -728,13 +728,29 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
               />
             </Box>
           ) : isAuthenticating ? (
-            <AuthInProgress
-              onTimeout={() => {
-                setAuthError('Authentication timed out. Please try again.');
-                cancelAuthentication();
-                openAuthDialog();
-              }}
-            />
+            <>
+              <AuthInProgress
+                onTimeout={() => {
+                  setAuthError('Authentication timed out. Please try again.');
+                  cancelAuthentication();
+                  openAuthDialog();
+                }}
+              />
+              {showErrorDetails && (
+                <OverflowProvider>
+                  <Box flexDirection="column">
+                    <DetailedMessagesDisplay
+                      messages={filteredConsoleMessages}
+                      maxHeight={
+                        constrainHeight ? debugConsoleMaxHeight : undefined
+                      }
+                      width={inputWidth}
+                    />
+                    <ShowMoreLines constrainHeight={constrainHeight} />
+                  </Box>
+                </OverflowProvider>
+              )}
+            </>
           ) : isAuthDialogOpen ? (
             <Box flexDirection="column">
               <AuthDialog

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -12,13 +12,14 @@ import { CodeAssistServer, HttpOptions } from './server.js';
 export async function createCodeAssistContentGenerator(
   httpOptions: HttpOptions,
   authType: AuthType,
+  noBrowser: boolean,
   sessionId?: string,
 ): Promise<ContentGenerator> {
   if (
     authType === AuthType.LOGIN_WITH_GOOGLE ||
     authType === AuthType.CLOUD_SHELL
   ) {
-    const authClient = await getOauthClient(authType);
+    const authClient = await getOauthClient(authType, noBrowser);
     const projectId = await setupUser(authClient);
     return new CodeAssistServer(authClient, projectId, httpOptions, sessionId);
   }

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -8,18 +8,19 @@ import { AuthType, ContentGenerator } from '../core/contentGenerator.js';
 import { getOauthClient } from './oauth2.js';
 import { setupUser } from './setup.js';
 import { CodeAssistServer, HttpOptions } from './server.js';
+import { Config } from '../config/config.js';
 
 export async function createCodeAssistContentGenerator(
   httpOptions: HttpOptions,
   authType: AuthType,
-  noBrowser: boolean,
+  config: Config,
   sessionId?: string,
 ): Promise<ContentGenerator> {
   if (
     authType === AuthType.LOGIN_WITH_GOOGLE ||
     authType === AuthType.CLOUD_SHELL
   ) {
-    const authClient = await getOauthClient(authType, noBrowser);
+    const authClient = await getOauthClient(authType, config);
     const projectId = await setupUser(authClient);
     return new CodeAssistServer(authClient, projectId, httpOptions, sessionId);
   }

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -14,6 +14,7 @@ import open from 'open';
 import crypto from 'crypto';
 import * as os from 'os';
 import { AuthType } from '../core/contentGenerator.js';
+import { Config } from '../config/config.js';
 
 vi.mock('os', async (importOriginal) => {
   const os = await importOriginal<typeof import('os')>();
@@ -27,6 +28,10 @@ vi.mock('google-auth-library');
 vi.mock('http');
 vi.mock('open');
 vi.mock('crypto');
+
+const mockConfig = {
+  getNoBrowser: () => false,
+} as unknown as Config;
 
 // Mock fetch globally
 global.fetch = vi.fn();
@@ -136,8 +141,10 @@ describe('oauth2', () => {
       return mockHttpServer as unknown as http.Server;
     });
 
-    const noBrowser = false;
-    const clientPromise = getOauthClient(AuthType.LOGIN_WITH_GOOGLE, noBrowser);
+    const clientPromise = getOauthClient(
+      AuthType.LOGIN_WITH_GOOGLE,
+      mockConfig,
+    );
 
     // wait for server to start listening.
     await serverListeningPromise;
@@ -179,7 +186,6 @@ describe('oauth2', () => {
   describe('in Cloud Shell', () => {
     const mockGetAccessToken = vi.fn();
     let mockComputeClient: Compute;
-    const noBrowser = false;
 
     beforeEach(() => {
       vi.spyOn(os, 'homedir').mockReturnValue('/user/home');
@@ -216,7 +222,7 @@ describe('oauth2', () => {
         () => mockClient as unknown as OAuth2Client,
       );
 
-      await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, noBrowser);
+      await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfig);
 
       expect(fs.promises.readFile).toHaveBeenCalledWith(
         '/user/home/.gemini/oauth_creds.json',
@@ -229,7 +235,7 @@ describe('oauth2', () => {
     });
 
     it('should use Compute to get a client if no cached credentials exist', async () => {
-      await getOauthClient(AuthType.CLOUD_SHELL, noBrowser);
+      await getOauthClient(AuthType.CLOUD_SHELL, mockConfig);
 
       expect(Compute).toHaveBeenCalledWith({});
       expect(mockGetAccessToken).toHaveBeenCalled();
@@ -240,13 +246,13 @@ describe('oauth2', () => {
       mockComputeClient.credentials = newCredentials;
       mockGetAccessToken.mockResolvedValue({ token: 'new-adc-token' });
 
-      await getOauthClient(AuthType.CLOUD_SHELL, noBrowser);
+      await getOauthClient(AuthType.CLOUD_SHELL, mockConfig);
 
       expect(fs.promises.writeFile).not.toHaveBeenCalled();
     });
 
     it('should return the Compute client on successful ADC authentication', async () => {
-      const client = await getOauthClient(AuthType.CLOUD_SHELL, noBrowser);
+      const client = await getOauthClient(AuthType.CLOUD_SHELL, mockConfig);
       expect(client).toBe(mockComputeClient);
     });
 
@@ -255,7 +261,7 @@ describe('oauth2', () => {
       mockGetAccessToken.mockRejectedValue(testError);
 
       await expect(
-        getOauthClient(AuthType.CLOUD_SHELL, noBrowser),
+        getOauthClient(AuthType.CLOUD_SHELL, mockConfig),
       ).rejects.toThrow(
         'Could not authenticate using Cloud Shell credentials. Please select a different authentication method or ensure you are in a properly configured environment. Error: ADC Failed',
       );

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -136,7 +136,8 @@ describe('oauth2', () => {
       return mockHttpServer as unknown as http.Server;
     });
 
-    const clientPromise = getOauthClient(AuthType.LOGIN_WITH_GOOGLE);
+    const noBrowser = false;
+    const clientPromise = getOauthClient(AuthType.LOGIN_WITH_GOOGLE, noBrowser);
 
     // wait for server to start listening.
     await serverListeningPromise;
@@ -178,6 +179,7 @@ describe('oauth2', () => {
   describe('in Cloud Shell', () => {
     const mockGetAccessToken = vi.fn();
     let mockComputeClient: Compute;
+    const noBrowser = false;
 
     beforeEach(() => {
       vi.spyOn(os, 'homedir').mockReturnValue('/user/home');
@@ -214,7 +216,7 @@ describe('oauth2', () => {
         () => mockClient as unknown as OAuth2Client,
       );
 
-      await getOauthClient(AuthType.LOGIN_WITH_GOOGLE);
+      await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, noBrowser);
 
       expect(fs.promises.readFile).toHaveBeenCalledWith(
         '/user/home/.gemini/oauth_creds.json',
@@ -227,7 +229,7 @@ describe('oauth2', () => {
     });
 
     it('should use Compute to get a client if no cached credentials exist', async () => {
-      await getOauthClient(AuthType.CLOUD_SHELL);
+      await getOauthClient(AuthType.CLOUD_SHELL, noBrowser);
 
       expect(Compute).toHaveBeenCalledWith({});
       expect(mockGetAccessToken).toHaveBeenCalled();
@@ -238,13 +240,13 @@ describe('oauth2', () => {
       mockComputeClient.credentials = newCredentials;
       mockGetAccessToken.mockResolvedValue({ token: 'new-adc-token' });
 
-      await getOauthClient(AuthType.CLOUD_SHELL);
+      await getOauthClient(AuthType.CLOUD_SHELL, noBrowser);
 
       expect(fs.promises.writeFile).not.toHaveBeenCalled();
     });
 
     it('should return the Compute client on successful ADC authentication', async () => {
-      const client = await getOauthClient(AuthType.CLOUD_SHELL);
+      const client = await getOauthClient(AuthType.CLOUD_SHELL, noBrowser);
       expect(client).toBe(mockComputeClient);
     });
 
@@ -252,7 +254,9 @@ describe('oauth2', () => {
       const testError = new Error('ADC Failed');
       mockGetAccessToken.mockRejectedValue(testError);
 
-      await expect(getOauthClient(AuthType.CLOUD_SHELL)).rejects.toThrow(
+      await expect(
+        getOauthClient(AuthType.CLOUD_SHELL, noBrowser),
+      ).rejects.toThrow(
         'Could not authenticate using Cloud Shell credentials. Please select a different authentication method or ensure you are in a properly configured environment. Error: ADC Failed',
       );
     });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -141,6 +141,7 @@ export interface ConfigParameters {
   extensionContextFilePaths?: string[];
   listExtensions?: boolean;
   activeExtensions?: ActiveExtension[];
+  noBrowser?: boolean;
 }
 
 export class Config {
@@ -179,6 +180,7 @@ export class Config {
   private readonly bugCommand: BugCommandSettings | undefined;
   private readonly model: string;
   private readonly extensionContextFilePaths: string[];
+  private readonly noBrowser: boolean;
   private modelSwitchedDuringSession: boolean = false;
   private readonly listExtensions: boolean;
   private readonly _activeExtensions: ActiveExtension[];
@@ -227,6 +229,7 @@ export class Config {
     this.extensionContextFilePaths = params.extensionContextFilePaths ?? [];
     this.listExtensions = params.listExtensions ?? false;
     this._activeExtensions = params.activeExtensions ?? [];
+    this.noBrowser = params.noBrowser ?? false;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -473,6 +476,10 @@ export class Config {
 
   getActiveExtensions(): ActiveExtension[] {
     return this._activeExtensions;
+  }
+
+  getNoBrowser(): boolean {
+    return this.noBrowser;
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -180,6 +180,7 @@ describe('Gemini Client (client.ts)', () => {
         getFileService: vi.fn().mockReturnValue(fileService),
         getQuotaErrorOccurred: vi.fn().mockReturnValue(false),
         setQuotaErrorOccurred: vi.fn(),
+        getNoBrowser: vi.fn().mockReturnValue(false),
       };
       return mock as unknown as Config;
     });

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -109,6 +109,7 @@ export class GeminiClient {
   async initialize(contentGeneratorConfig: ContentGeneratorConfig) {
     this.contentGenerator = await createContentGenerator(
       contentGeneratorConfig,
+      this.config.getNoBrowser(),
       this.config.getSessionId(),
     );
     this.chat = await this.startChat();

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -109,7 +109,7 @@ export class GeminiClient {
   async initialize(contentGeneratorConfig: ContentGeneratorConfig) {
     this.contentGenerator = await createContentGenerator(
       contentGeneratorConfig,
-      this.config.getNoBrowser(),
+      this.config,
       this.config.getSessionId(),
     );
     this.chat = await this.startChat();

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -12,9 +12,12 @@ import {
 } from './contentGenerator.js';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import { GoogleGenAI } from '@google/genai';
+import { Config } from '../config/config.js';
 
 vi.mock('../code_assist/codeAssist.js');
 vi.mock('@google/genai');
+
+const mockConfig = {} as unknown as Config;
 
 describe('createContentGenerator', () => {
   it('should create a CodeAssistContentGenerator', async () => {
@@ -22,10 +25,13 @@ describe('createContentGenerator', () => {
     vi.mocked(createCodeAssistContentGenerator).mockResolvedValue(
       mockGenerator as never,
     );
-    const generator = await createContentGenerator({
-      model: 'test-model',
-      authType: AuthType.LOGIN_WITH_GOOGLE,
-    });
+    const generator = await createContentGenerator(
+      {
+        model: 'test-model',
+        authType: AuthType.LOGIN_WITH_GOOGLE,
+      },
+      mockConfig,
+    );
     expect(createCodeAssistContentGenerator).toHaveBeenCalled();
     expect(generator).toBe(mockGenerator);
   });
@@ -35,11 +41,14 @@ describe('createContentGenerator', () => {
       models: {},
     } as unknown;
     vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
-    const generator = await createContentGenerator({
-      model: 'test-model',
-      apiKey: 'test-api-key',
-      authType: AuthType.USE_GEMINI,
-    });
+    const generator = await createContentGenerator(
+      {
+        model: 'test-model',
+        apiKey: 'test-api-key',
+        authType: AuthType.USE_GEMINI,
+      },
+      mockConfig,
+    );
     expect(GoogleGenAI).toHaveBeenCalledWith({
       apiKey: 'test-api-key',
       vertexai: undefined,

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -15,6 +15,7 @@ import {
 } from '@google/genai';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
+import { Config } from '../config/config.js';
 import { getEffectiveModel } from './modelCheck.js';
 
 /**
@@ -99,7 +100,7 @@ export async function createContentGeneratorConfig(
 
 export async function createContentGenerator(
   config: ContentGeneratorConfig,
-  noBrowser: boolean = false,
+  gcConfig: Config,
   sessionId?: string,
 ): Promise<ContentGenerator> {
   const version = process.env.CLI_VERSION || process.version;
@@ -115,7 +116,7 @@ export async function createContentGenerator(
     return createCodeAssistContentGenerator(
       httpOptions,
       config.authType,
-      noBrowser,
+      gcConfig,
       sessionId,
     );
   }

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -99,6 +99,7 @@ export async function createContentGeneratorConfig(
 
 export async function createContentGenerator(
   config: ContentGeneratorConfig,
+  noBrowser: boolean = false,
   sessionId?: string,
 ): Promise<ContentGenerator> {
   const version = process.env.CLI_VERSION || process.version;
@@ -114,6 +115,7 @@ export async function createContentGenerator(
     return createCodeAssistContentGenerator(
       httpOptions,
       config.authType,
+      noBrowser,
       sessionId,
     );
   }


### PR DESCRIPTION
If this flag is

1. auth runs before the app starts which helps with copying output.
2. The normal `open(url)` is replaced with `console.log(url)` and `code = readline()`
3. A configurable number of retries are attempted if the code doesn't validate.

This allows people in ssh and other headless environments to perform authentication.