### PR TITLE
Cleanup: Removed duplicate guidelines prompt

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -61,9 +61,3 @@ jobs:
             - Do not add comments or modify the issue content.
             - Triage only the current issue.
             - Assign all applicable kind/*, area/*, and priority/* labels based on the issue content.
-
-            Guidelines:
-            - Only use labels that already exist in the repository.
-            - Do not add comments or modify the issue content.
-            - Triage only the current issue.
-            - Assign all applicable kind/*, area/*, and priority/* labels based on the issue content.


### PR DESCRIPTION
## TLDR
This PR removes the duplicate "Guidelines" section from the prompt block in the Gemini Automated Issue Triage GitHub Actions workflow.

Why:

- Repeating the same guidelines twice does not improve LLM behavior or triage accuracy.
- Keeping the prompt concise helps maintain clarity and reduces noise for the Gemini CLI.
- No functionality is changed just a cleanup to improve maintainability.
