### PR TITLE
Fix Patch for grep.test.ts

### DIFF
--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -234,7 +234,9 @@ describe('GrepTool', () => {
       };
       // The path will be relative to the tempRootDir, so we check for containment.
       expect(grepTool.getDescription(params)).toContain("'testPattern' within");
-      expect(grepTool.getDescription(params)).toContain('src/app');
+      expect(grepTool.getDescription(params)).toContain(
+        path.join('src', 'app'),
+      );
     });
 
     it('should generate correct description with pattern, include, and path', () => {


### PR DESCRIPTION
## TLDR

Fixes a failing test in grep.test.ts on Windows caused by hardcoded forward slashes (/) in path assertions. The test now uses path.join() to ensure platform-independent path matching.

## Dive Deeper

In src/tools/grep.test.ts, update this failing test:

🔍 Before (Line ~236–237):
expect(grepTool.getDescription(params)).toContain('src/app');
✅ After:
expect(grepTool.getDescription(params)).toContain(path.join('src', 'app'));

## Reviewer Test Plan

1. Pull this branch
2. Use npm run preflight
3. The test should pass consistently across platforms by handling OS-specific path separators correctly, such as using path.join() or path.normalize() in test assertions.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |


Fixes #3743