### PR TITLE
feat: Implement selectable agent personas and custom CLI commands

### DIFF
--- a/packages/cli/src/config/personas.json
+++ b/packages/cli/src/config/personas.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "coder",
+    "prompt": "You are an expert software developer. You are helping the user write, debug, and understand code. Provide clear and concise explanations. Output code in markdown code blocks.",
+    "model": "gemini-pro",
+    "tools": ["ReadFileTool", "WriteFileTool", "ShellTool", "EditTool", "GrepTool"],
+    "description": "A persona specialized in coding tasks."
+  },
+  {
+    "name": "writer",
+    "prompt": "You are a professional writer. You are helping the user draft, edit, and revise text. Provide creative and helpful suggestions.",
+    "description": "A persona focused on writing and text generation."
+  },
+  {
+    "name": "researcher",
+    "prompt": "You are a skilled researcher. You are helping the user find and synthesize information from various sources. Provide accurate and well-supported answers.",
+    "tools": ["WebSearchTool", "WebFetchTool"],
+    "description": "A persona designed for research and information gathering."
+  }
+]

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -79,6 +79,7 @@ export interface Settings {
   // UI setting. Does not display the ANSI-controlled terminal title.
   hideWindowTitle?: boolean;
   hideTips?: boolean;
+  selectedPersona?: string;
 
   // Add other settings here.
 }

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -8,11 +8,13 @@ import { SlashCommand } from '../ui/commands/types.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
+import { personaCommand } from '../ui/commands/personaCommand.js';
 
 const loadBuiltInCommands = async (): Promise<SlashCommand[]> => [
   clearCommand,
   helpCommand,
   memoryCommand,
+  personaCommand,
 ];
 
 export class CommandService {

--- a/packages/cli/src/ui/commands/personaCommand.ts
+++ b/packages/cli/src/ui/commands/personaCommand.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MessageType } from '../types.js';
+import { SlashCommand, type CommandContext } from './types.js';
+
+export const personaCommand: SlashCommand = {
+  name: 'persona',
+  description: 'List available personas or select a persona. Usage: /persona [name]',
+  action: async (context: CommandContext, args?: string) => {
+    const { services, ui } = context;
+    const config = services.config;
+    const settings = services.settings;
+
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Config not available.',
+      };
+    }
+
+    const availablePersonas = config.getPersonas();
+
+    if (!args) {
+      // List available personas
+      if (availablePersonas.length === 0) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: 'No personas available. You can define personas in personas.json.',
+        };
+      }
+      let message = 'Available personas:\n';
+      availablePersonas.forEach(p => {
+        message += `  - ${p.name}: ${p.description}\n`;
+      });
+      message += '\nTo select a persona, use: /persona <name>';
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: message,
+      };
+    }
+
+    // Select a persona
+    const personaName = args.trim();
+    const selectedPersona = availablePersonas.find(p => p.name === personaName);
+
+    if (!selectedPersona) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Persona "${personaName}" not found. Use /persona to see available personas.`,
+      };
+    }
+
+    config.setCurrentPersona(selectedPersona);
+    // Persist selection to settings to remember across sessions
+    settings.setValue('selectedPersona', personaName);
+
+
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: `Switched to persona: ${selectedPersona.name}`,
+    };
+  },
+  completion: async (context: CommandContext) => {
+    const config = context.services.config;
+    if (!config) return [];
+    return config.getPersonas().map(p => p.name);
+  }
+};

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -1127,6 +1127,14 @@ export const useSlashCommandProcessor = (
                   },
                   Date.now(),
                 );
+                // If persona was changed, update it in the main config
+                if (commandToExecute.name === 'persona' && result.messageType === 'info' && result.content.startsWith('Switched to persona:')) {
+                  const newPersonaName = result.content.substring('Switched to persona: '.length);
+                  const persona = config?.getPersonas().find(p => p.name === newPersonaName);
+                  if (persona) {
+                    config?.setCurrentPersona(persona);
+                  }
+                }
                 return { type: 'handled' };
               case 'dialog':
                 switch (result.dialog) {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -43,6 +43,14 @@ import {
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
 } from './models.js';
+
+export interface Persona {
+  name: string;
+  prompt: string;
+  model?: string;
+  tools?: string[];
+  description: string;
+}
 import { ClearcutLogger } from '../telemetry/clearcut-logger/clearcut-logger.js';
 
 export enum ApprovalMode {
@@ -141,6 +149,8 @@ export interface ConfigParameters {
   extensionContextFilePaths?: string[];
   listExtensions?: boolean;
   activeExtensions?: ActiveExtension[];
+  personas?: Persona[];
+  currentPersona?: Persona | null;
 }
 
 export class Config {
@@ -182,6 +192,8 @@ export class Config {
   private modelSwitchedDuringSession: boolean = false;
   private readonly listExtensions: boolean;
   private readonly _activeExtensions: ActiveExtension[];
+  private readonly personas: Persona[];
+  private currentPersona: Persona | null;
   flashFallbackHandler?: FlashFallbackHandler;
   private quotaErrorOccurred: boolean = false;
 
@@ -227,6 +239,8 @@ export class Config {
     this.extensionContextFilePaths = params.extensionContextFilePaths ?? [];
     this.listExtensions = params.listExtensions ?? false;
     this._activeExtensions = params.activeExtensions ?? [];
+    this.personas = params.personas ?? [];
+    this.currentPersona = params.currentPersona ?? null;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -473,6 +487,18 @@ export class Config {
 
   getActiveExtensions(): ActiveExtension[] {
     return this._activeExtensions;
+  }
+
+  getPersonas(): Persona[] {
+    return this.personas;
+  }
+
+  getCurrentPersona(): Persona | null {
+    return this.currentPersona;
+  }
+
+  setCurrentPersona(persona: Persona | null): void {
+    this.currentPersona = persona;
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -17,8 +17,20 @@ import { WriteFileTool } from '../tools/write-file.js';
 import process from 'node:process';
 import { isGitRepository } from '../utils/gitUtils.js';
 import { MemoryTool, GEMINI_CONFIG_DIR } from '../tools/memoryTool.js';
+import { Config } from '../config/config.js'; // Import Config
 
-export function getCoreSystemPrompt(userMemory?: string): string {
+export function getCoreSystemPrompt(userMemory?: string, config?: Config): string {
+  const currentPersona = config?.getCurrentPersona();
+  if (currentPersona) {
+    // If a persona is active, its prompt takes precedence
+    const personaPrompt = currentPersona.prompt;
+    const memorySuffix =
+      userMemory && userMemory.trim().length > 0
+        ? `\n\n---\n\n${userMemory.trim()}`
+        : '';
+    return `${personaPrompt}${memorySuffix}`;
+  }
+
   // if GEMINI_SYSTEM_MD is set (and not 0|false), override system prompt from file
   // default path is .gemini/system.md but can be modified via custom path in GEMINI_SYSTEM_MD
   let systemMdEnabled = false;


### PR DESCRIPTION
This change introduces a persona system to the Gemini CLI, allowing you to select different agent behaviors (prompts, models, tools) via CLI arguments or interactive slash commands.

Key features:
- Personas defined in `personas.json`.
- `--persona` CLI argument to select a persona.
- `/persona` slash command to list and select personas.
- Selected persona is persisted in settings.
- Core logic updated to use persona-specific prompts, models, and tools.
- Added `gemini describe-persona` command to display active persona details.
- Includes `implementation_plan.md` detailing the changes.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
