### PR TITLE
chore(deps): Pin @google/genai to 1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11499,7 +11499,7 @@
       "name": "@google/gemini-cli-core",
       "version": "0.1.10",
       "dependencies": {
-        "@google/genai": "^1.8.0",
+        "@google/genai": "1.8.0",
         "@modelcontextprotocol/sdk": "^1.11.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "dependencies": {
-    "@google/genai": "^1.8.0",
+    "@google/genai": "1.8.0",
     "@modelcontextprotocol/sdk": "^1.11.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",


### PR DESCRIPTION
@google/genai@1.9.0 introduces an incompatibility.

## TLDR

This PR pins the @google/genai dependency to the exact version 1.8.0 to prevent a critical issue where all tool schemas registered via MCP become invalid. The ^1.8.0 specifier in package.json currently allows the incompatible v1.9.0 to be installed, which breaks tool function calls.

## Dive Deeper

The gemini-cli currently specifies its dependency on @google/genai as ^1.8.0 in `packages/core/package.json` . This allows npm or yarn to automatically install the latest minor version, which is 1.9.0.

However, @google/genai@1.9.0 introduced a breaking change related to FunctionDeclaration schema conversion, as detailed in [this commit in the googleapis/js-genai repository](https://github.com/googleapis/js-genai/commit/36f6350705ecafc47eaea3f3eecbcc69512edab7#diff-fdde9372aec8593).

This change breaks the logic in the McpClient ([mcp-client.ts#L350](https://github.com/google-gemini/gemini-cli/blob/v0.1.10/packages/core/src/tools/mcp-client.ts#L350), causing it to fail when processing tool arguments. As a result, all tool schemas are incorrectly registered in MCP with a generic {"type": "object", "properties": {}} schema. This effectively makes all tool arguments any and prevents the model from correctly calling tools with parameters.

This PR resolves the issue by pinning the dependency to exactly 1.8.0, ensuring a compatible version is used until the gemini-cli can be updated to support the new schema structure.
## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓   | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
