### PR TITLE
migrate /editor slash command to new system

### DIFF
--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -10,10 +10,13 @@ import { type SlashCommand } from '../ui/commands/types.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
-
+import { editorCommand } from '../ui/commands/editorCommand.js';
 // Mock the command modules to isolate the service from the command implementations.
 vi.mock('../ui/commands/memoryCommand.js', () => ({
   memoryCommand: { name: 'memory', description: 'Mock Memory' },
+}));
+vi.mock('../ui/commands/editorCommand.js', () => ({
+  editorCommand: { name: 'editor', description: 'Mock editor' },
 }));
 vi.mock('../ui/commands/helpCommand.js', () => ({
   helpCommand: { name: 'help', description: 'Mock Help' },
@@ -46,10 +49,11 @@ describe('CommandService', () => {
         const tree = commandService.getCommands();
 
         // Post-condition assertions
-        expect(tree.length).toBe(3);
+        expect(tree.length).toBe(4);
 
         const commandNames = tree.map((cmd) => cmd.name);
         expect(commandNames).toContain('memory');
+        expect(commandNames).toContain('editor');
         expect(commandNames).toContain('help');
         expect(commandNames).toContain('clear');
       });
@@ -57,14 +61,14 @@ describe('CommandService', () => {
       it('should overwrite any existing commands when called again', async () => {
         // Load once
         await commandService.loadCommands();
-        expect(commandService.getCommands().length).toBe(3);
+        expect(commandService.getCommands().length).toBe(4);
 
         // Load again
         await commandService.loadCommands();
         const tree = commandService.getCommands();
 
         // Should not append, but overwrite
-        expect(tree.length).toBe(3);
+        expect(tree.length).toBe(4);
       });
     });
 
@@ -76,8 +80,13 @@ describe('CommandService', () => {
         await commandService.loadCommands();
 
         const loadedTree = commandService.getCommands();
-        expect(loadedTree.length).toBe(3);
-        expect(loadedTree).toEqual([clearCommand, helpCommand, memoryCommand]);
+        expect(loadedTree.length).toBe(4);
+        expect(loadedTree).toEqual([
+          clearCommand,
+          editorCommand,
+          helpCommand,
+          memoryCommand,
+        ]);
       });
     });
   });

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -8,9 +8,11 @@ import { SlashCommand } from '../ui/commands/types.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
+import { editorCommand } from '../ui/commands/editorCommand.js';
 
 const loadBuiltInCommands = async (): Promise<SlashCommand[]> => [
   clearCommand,
+  editorCommand,
   helpCommand,
   memoryCommand,
 ];

--- a/packages/cli/src/ui/commands/editorCommand.test.ts
+++ b/packages/cli/src/ui/commands/editorCommand.test.ts
@@ -9,14 +9,14 @@ import { editorCommand } from './editorCommand.js';
 import { type CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 
-describe('authCommand', () => {
+describe('editorCommand', () => {
   let mockContext: CommandContext;
 
   beforeEach(() => {
     mockContext = createMockCommandContext();
   });
 
-  it('should return a dialog action to open the auth dialog', () => {
+  it('should return a dialog action to open the editor dialog', () => {
     if (!editorCommand.action) {
       throw new Error('The editor command must have an action.');
     }

--- a/packages/cli/src/ui/commands/editorCommand.test.ts
+++ b/packages/cli/src/ui/commands/editorCommand.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { editorCommand } from './editorCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+
+describe('authCommand', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext();
+  });
+
+  it('should return a dialog action to open the auth dialog', () => {
+    if (!editorCommand.action) {
+      throw new Error('The editor command must have an action.');
+    }
+
+    const result = editorCommand.action(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'dialog',
+      dialog: 'editor',
+    });
+  });
+
+  it('should have the correct name and description', () => {
+    expect(editorCommand.name).toBe('editor');
+    expect(editorCommand.description).toBe('set external editor preference');
+  });
+});

--- a/packages/cli/src/ui/commands/editorCommand.ts
+++ b/packages/cli/src/ui/commands/editorCommand.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OpenDialogActionReturn, SlashCommand } from './types.js';
+
+export const editorCommand: SlashCommand = {
+  name: 'editor',
+  description: 'set external editor preference',
+  action: (_context, _args): OpenDialogActionReturn => ({
+    type: 'dialog',
+    dialog: 'editor',
+  }),
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -66,7 +66,7 @@ export interface MessageActionReturn {
 export interface OpenDialogActionReturn {
   type: 'dialog';
   // TODO: Add 'theme' | 'auth' | 'editor' | 'privacy' as migration happens.
-  dialog: 'help';
+  dialog: 'help' | 'editor';
 }
 
 export type SlashCommandActionReturn =

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -65,7 +65,7 @@ export interface MessageActionReturn {
  */
 export interface OpenDialogActionReturn {
   type: 'dialog';
-  // TODO: Add 'theme' | 'auth' | 'editor' | 'privacy' as migration happens.
+  // TODO: Add 'theme' | 'auth' | 'privacy' as migration happens.
   dialog: 'help' | 'editor';
 }
 

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -255,11 +255,6 @@ export const useSlashCommandProcessor = (
         action: (_mainCommand, _subCommand, _args) => openAuthDialog(),
       },
       {
-        name: 'editor',
-        description: 'set external editor preference',
-        action: (_mainCommand, _subCommand, _args) => openEditorDialog(),
-      },
-      {
         name: 'privacy',
         description: 'display the privacy notice',
         action: (_mainCommand, _subCommand, _args) => openPrivacyNotice(),
@@ -1036,7 +1031,6 @@ export const useSlashCommandProcessor = (
     addMessage,
     openThemeDialog,
     openAuthDialog,
-    openEditorDialog,
     openPrivacyNotice,
     toggleCorgiMode,
     savedChatTags,
@@ -1130,6 +1124,9 @@ export const useSlashCommandProcessor = (
                 return { type: 'handled' };
               case 'dialog':
                 switch (result.dialog) {
+                  case 'editor':
+                    openEditorDialog();
+                    return { type: 'handled' };
                   case 'help':
                     setShowHelp(true);
                     return { type: 'handled' };
@@ -1214,6 +1211,7 @@ export const useSlashCommandProcessor = (
       legacyCommands,
       commandContext,
       addMessage,
+      openEditorDialog,
     ],
   );
 


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->
Migrates the /editor command to the new architecture

## Dive Deeper

<!-- more thoughts and in depth discussion here -->
The new architecture uses CommandService with modular commands, the /editor command should be migrated

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

Pull the code
`gemini`
`/editor`
It should show a menu where you can select your preferred editor

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
