### PR TITLE
Added in proper checks for customer tiers in 429/Quota error messaging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ In the PR description, explain the "why" behind your changes and link to the rel
 
 ## Forking
 
-If you are forking the repository you will be able to run the Built, Test and Integration test workflows. However in order to make the integration tests run you'll need to add a [GitHub Repository Secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) with a value of `GEMINI_API_KEY` and set that to a valid API key that you have available. Your key and secret are private to your repo; no one without access can see your key and you cannot see any secrets related to this repo.
+If you are forking the repository you will be able to run the Build, Test and Integration test workflows. However in order to make the integration tests run you'll need to add a [GitHub Repository Secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) with a value of `GEMINI_API_KEY` and set that to a valid API key that you have available. Your key and secret are private to your repo; no one without access can see your key and you cannot see any secrets related to this repo.
 
 Additionally you will need to click on the `Actions` tab and enable workflows for your repository, you'll find it's the large blue button in the center of the screen.
 

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -67,6 +67,8 @@ interface MockServerConfig {
   getAccessibility: Mock<() => AccessibilitySettings>;
   getProjectRoot: Mock<() => string | undefined>;
   getAllGeminiMdFilenames: Mock<() => string[]>;
+  getUserTier: Mock<() => any>;
+  setUserTier: Mock<(userTier: any) => void>;
 }
 
 // Mock @google/gemini-cli-core and its Config class
@@ -129,6 +131,8 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
         getAllGeminiMdFilenames: vi.fn(() => ['GEMINI.md']),
         setFlashFallbackHandler: vi.fn(),
         getSessionId: vi.fn(() => 'test-session-id'),
+        getUserTier: vi.fn(() => undefined),
+        setUserTier: vi.fn(),
       };
     });
   return {
@@ -155,6 +159,8 @@ vi.mock('./hooks/useAuthCommand', () => ({
     openAuthDialog: vi.fn(),
     handleAuthSelect: vi.fn(),
     handleAuthHighlight: vi.fn(),
+    isAuthenticating: false,
+    cancelAuthentication: vi.fn(),
   })),
 }));
 

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -67,8 +67,8 @@ interface MockServerConfig {
   getAccessibility: Mock<() => AccessibilitySettings>;
   getProjectRoot: Mock<() => string | undefined>;
   getAllGeminiMdFilenames: Mock<() => string[]>;
-  getUserTier: Mock<() => any>;
-  setUserTier: Mock<(userTier: any) => void>;
+  getUserTier: Mock<() => string | undefined>;
+  setUserTier: Mock<(userTier: string | undefined) => void>;
 }
 
 // Mock @google/gemini-cli-core and its Config class

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -67,8 +67,7 @@ interface MockServerConfig {
   getAccessibility: Mock<() => AccessibilitySettings>;
   getProjectRoot: Mock<() => string | undefined>;
   getAllGeminiMdFilenames: Mock<() => string[]>;
-  getUserTier: Mock<() => string | undefined>;
-  setUserTier: Mock<(userTier: string | undefined) => void>;
+  getUserTier: Mock<() => Promise<string | undefined>>;
 }
 
 // Mock @google/gemini-cli-core and its Config class
@@ -131,8 +130,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
         getAllGeminiMdFilenames: vi.fn(() => ['GEMINI.md']),
         setFlashFallbackHandler: vi.fn(),
         getSessionId: vi.fn(() => 'test-session-id'),
-        getUserTier: vi.fn(() => undefined),
-        setUserTier: vi.fn(),
+        getUserTier: vi.fn().mockResolvedValue(undefined),
       };
     });
   return {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -179,6 +179,8 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
 
   // User tier detection effect
   useEffect(() => {
+    let isCancelled = false;
+
     const detectUserTier = async () => {
       try {
         // Reset user tier when authentication changes
@@ -210,6 +212,9 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
                   duetProject: codeAssistServer.projectId,
                 },
               });
+
+              if (isCancelled) return;
+
               if (loadRes.currentTier) {
                 setUserTier(loadRes.currentTier.id);
               }
@@ -217,6 +222,7 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
           }
         }
       } catch (error) {
+        if (isCancelled) return;
         // Silently fail - this is not critical functionality
         // We'll default to FREE tier behavior if tier detection fails
         console.debug('User tier detection failed:', error);
@@ -224,6 +230,10 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     };
 
     detectUserTier();
+
+    return () => {
+      isCancelled = true;
+    };
   }, [config, isAuthenticating]);
 
   const {

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -17,6 +17,7 @@ import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
 import { Config } from '../config/config.js';
 import { getEffectiveModel } from './modelCheck.js';
+import { UserTierId } from '../code_assist/types.js';
 
 /**
  * Interface abstracting the core functionalities for generating content and counting tokens.
@@ -33,6 +34,8 @@ export interface ContentGenerator {
   countTokens(request: CountTokensParameters): Promise<CountTokensResponse>;
 
   embedContent(request: EmbedContentParameters): Promise<EmbedContentResponse>;
+
+  getTier?(): Promise<UserTierId | undefined>;
 }
 
 export enum AuthType {


### PR DESCRIPTION
User Tier Detection Implementation

  Added automatic user tier detection for OAuth users to enable personalized quota error messaging:

  - User Tier State Management: Added userTier state to track the current user's subscription tier (FREE, STANDARD, LEGACY)
  - Automatic Tier Detection: Implemented a useEffect hook that automatically detects the user's tier for OAuth users by:
    - Checking if the user is authenticated via Google OAuth (AuthType.LOGIN_WITH_GOOGLE)
    - Calling the CodeAssist API to retrieve the user's current tier information
    - Gracefully handling detection failures with debug logging
  - Authentication State Integration: The tier detection properly integrates with the authentication flow:
    - Runs after authentication is complete (listens to isAuthenticating state)
    - Resets tier information when authentication changes
    - Skips detection during active authentication processes
  - Enhanced Quota Error Messages: The existing Flash fallback handler now uses the detected user tier to show appropriate upgrade suggestions:
    - Paid tier users: Directed to use API keys from AI Studio
    - Free tier users: Shown upgrade options for Code Assist Standard/Enterprise plans

  This enables the CLI to provide more relevant and helpful error messages based on the user's actual subscription status, improving the user experience during quota limit scenarios.

This should resolve issue #3862
