### PR TITLE
Don't print MCP server logs. It's too noisy.

### DIFF
--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -264,16 +264,6 @@ async function connectAndDiscover(
     updateMCPServerStatus(mcpServerName, MCPServerStatus.DISCONNECTED);
   };
 
-  if (transport instanceof StdioClientTransport && transport.stderr) {
-    transport.stderr.on('data', (data) => {
-      const stderrStr = data.toString();
-      // Filter out verbose INFO logs from some MCP servers
-      if (!stderrStr.includes('] INFO')) {
-        console.debug(`MCP STDERR (${mcpServerName}):`, stderrStr);
-      }
-    });
-  }
-
   try {
     const mcpCallableTool = mcpToTool(mcpClient);
     const tool = await mcpCallableTool.tool();


### PR DESCRIPTION
## TLDR

Many MCP servers log start up messages to stderr and it's printing to the screen on startup.

## Dive Deeper

[PR #3484](https://github.com/google-gemini/gemini-cli/pull/3483) moved MCP server startup to before React loads up. This lead to debug messages being logged to the terminal because they're not being caught by the ConsolePatcher (which swallows console.debug unless debug mode is enabled). 

## Reviewer Test Plan

Configure this MCP server and verify that it doesn't log on startup:

```
 "mcpServers": {
    "sequential-thinking": {
      "command": "npx",
      "args": [
        "-y",
        "@modelcontextprotocol/server-sequential-thinking"
      ]
    }
  },
```
Previously it would log "MCP STDERR (sequential-thinking): Sequential Thinking MCP Server running on stdio"

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
