### PR TITLE
Fix: Make video and audio file reading actually work

### DIFF
--- a/diagnose-mime.cjs
+++ b/diagnose-mime.cjs
@@ -1,0 +1,11 @@
+// This is the correct code for a file named diagnose-mime.cjs
+const mime = require('mime-types');
+
+console.log('--- Mime-types Diagnosis ---');
+const extensions = ['.mp4', '.mov', '.mp3', '.wav', '.ts', '.js', '.png', '.pdf'];
+
+extensions.forEach(ext => {
+    const lookupResult = mime.lookup(ext);
+    console.log(`mime.lookup('${ext}') -> '${lookupResult}' (Type: ${typeof lookupResult})`);
+});
+console.log('--- End of Diagnosis ---');

--- a/docs/tools/file-system.md
+++ b/docs/tools/file-system.md
@@ -35,11 +35,12 @@ The Gemini CLI provides a comprehensive suite of tools for interacting with the 
   - `limit` (number, optional): For text files, the maximum number of lines to read. If omitted, reads a default maximum (e.g., 2000 lines) or the entire file if feasible.
 - **Behavior:**
   - For text files: Returns the content. If `offset` and `limit` are used, returns only that slice of lines. Indicates if content was truncated due to line limits or line length limits.
-  - For image and PDF files: Returns the file content as a base64-encoded data structure suitable for model consumption.
+  - For image, video and PDF files: Returns the file content as a base64-encoded data structure suitable for model consumption.
   - For other binary files: Attempts to identify and skip them, returning a message indicating it's a generic binary file.
 - **Output:** (`llmContent`):
   - For text files: The file content, potentially prefixed with a truncation message (e.g., `[File content truncated: showing lines 1-100 of 500 total lines...]\nActual file content...`).
   - For image/PDF files: An object containing `inlineData` with `mimeType` and base64 `data` (e.g., `{ inlineData: { mimeType: 'image/png', data: 'base64encodedstring' } }`).
+  - For video files: An object containing `inlineData` with `mimeType` and base64 `data` (e.g., `{ inlineData: { mimeType: 'video/mp4', data: 'base64encodedstring' } }`).
   - For other binary files: A message like `Cannot display content of binary file: /path/to/data.bin`.
 - **Confirmation:** No.
 

--- a/docs/tools/file-system.md
+++ b/docs/tools/file-system.md
@@ -24,7 +24,7 @@ The Gemini CLI provides a comprehensive suite of tools for interacting with the 
 
 ## 2. `read_file` (ReadFile)
 
-`read_file` reads and returns the content of a specified file. This tool handles text, images (PNG, JPG, GIF, WEBP, SVG, BMP), and PDF files. For text files, it can read specific line ranges. Other binary file types are generally skipped.
+`read_file` reads and returns the content of a specified file. This tool handles text, image, PDF, audio, and video files. For text files, it can read specific line ranges.
 
 - **Tool name:** `read_file`
 - **Display name:** ReadFile

--- a/docs/tools/multi-file.md
+++ b/docs/tools/multi-file.md
@@ -7,7 +7,7 @@ This document describes the `read_many_files` tool for the Gemini CLI.
 Use `read_many_files` to read content from multiple files specified by paths or glob patterns. The behavior of this tool depends on the provided files:
 
 - For text files, this tool concatenates their content into a single string.
-- For image (e.g., PNG, JPEG) and PDF files, it reads and returns them as base64-encoded data, provided they are explicitly requested by name or extension.
+- For image (e.g., PNG, JPEG), PDF, audio (MP3, WAV), and video (MP4, MOV) files, it reads and returns them as base64-encoded data, provided they are explicitly requested by name or extension.
 
 `read_many_files` can be used to perform tasks such as getting an overview of a codebase, finding where specific functionality is implemented, reviewing documentation, or gathering context from multiple configuration files.
 
@@ -59,7 +59,7 @@ read_many_files(paths=["**/*.js"], include=["**/*.test.js", "images/**/*.jpg"], 
 ## Important notes
 
 - **Binary file handling:**
-  - **Image/PDF files:** The tool can read common image types (PNG, JPEG, etc.) and PDF files, returning them as base64 encoded data. These files _must_ be explicitly targeted by the `paths` or `include` patterns (e.g., by specifying the exact filename like `image.png` or a pattern like `*.jpeg`).
+  - **Image/PDF/Audio/Video files:** The tool can read common image types (PNG, JPEG, etc.), PDF, audio (mp3, wav), and video (mp4, mov) files, returning them as base64 encoded data. These files _must_ be explicitly targeted by the `paths` or `include` patterns (e.g., by specifying the exact filename like `video.mp4` or a pattern like `*.mov`).
   - **Other binary files:** The tool attempts to detect and skip other types of binary files by examining their initial content for null bytes. The tool excludes these files from its output.
 - **Performance:** Reading a very large number of files or very large individual files can be resource-intensive.
 - **Path specificity:** Ensure paths and glob patterns are correctly specified relative to the tool's target directory. For image/PDF files, ensure the patterns are specific enough to include them.

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -109,6 +109,25 @@ describe('handleAtCommand', () => {
     abortController.abort();
   });
 
+  it('should pass through query if no @ command is present', async () => {
+    const query = 'regular user query';
+    const result = await handleAtCommand({
+      query,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 123,
+      signal: abortController.signal,
+    });
+    expect(mockAddItem).toHaveBeenCalledWith(
+      { type: 'user', text: query },
+      123,
+    );
+    expect(result.processedQuery).toEqual([{ text: query }]);
+    expect(result.shouldProceed).toBe(true);
+    expect(mockReadManyFilesExecute).not.toHaveBeenCalled();
+  });
+
   it('should try to read a file even if it is invalid, letting the tool handle the error', async () => {
     const query = 'Check @nonexistent.txt and @ also';
     vi.mocked(fsPromises.stat).mockRejectedValue(

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -271,6 +271,15 @@ export async function handleAtCommand({
       pathSpecsToRead.push(currentPathSpec);
       atPathToResolvedSpecMap.set(originalAtPath, currentPathSpec);
       contentLabelsForDisplay.push(pathName);
+    } else {
+      // If stat and glob failed, trust the user and pass the path to the tool anyway.
+      // The tool itself is robust enough to handle read errors.
+      onDebugMessage(
+        `Could not resolve path "${pathName}" directly, but will attempt to read it as-is.`,
+      );
+      pathSpecsToRead.push(pathName);
+      atPathToResolvedSpecMap.set(originalAtPath, pathName);
+      contentLabelsForDisplay.push(pathName);
     }
   }
 

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -247,5 +247,29 @@ describe('ReadFileTool', () => {
       expect(result.returnDisplay).toContain('foo.bar');
       expect(result.returnDisplay).not.toContain('foo.baz');
     });
+
+    it('should return success result for a video file', async () => {
+      const filePath = path.join(tempRootDir, 'video.mp4');
+      const videoData = {
+        inlineData: { mimeType: 'video/mp4', data: 'base64...' },
+      };
+      const params: ReadFileToolParams = { absolute_path: filePath };
+      mockProcessSingleFileContent.mockResolvedValue({
+        llmContent: videoData,
+        returnDisplay: `Read video file: ${path.basename(filePath)}`,
+      });
+
+      const result = await tool.execute(params, abortSignal);
+      expect(mockProcessSingleFileContent).toHaveBeenCalledWith(
+        filePath,
+        tempRootDir,
+        undefined,
+        undefined,
+      );
+      expect(result.llmContent).toEqual(videoData);
+      expect(result.returnDisplay).toBe(
+        `Read video file: ${path.basename(filePath)}`,
+      );
+    });
   });
 });

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -53,7 +53,7 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
     super(
       ReadFileTool.Name,
       'ReadFile',
-      'Reads and returns the content of a specified file from the local filesystem. Handles text, images (PNG, JPG, GIF, WEBP, SVG, BMP), and PDF files. For text files, it can read specific line ranges.',
+      'Reads and returns the content of a specified file from the local filesystem. Handles text, image, PDF, audio, and video files. For text files, it can read specific line ranges.',
       {
         properties: {
           absolute_path: {

--- a/packages/core/src/tools/read-many-files.test.ts
+++ b/packages/core/src/tools/read-many-files.test.ts
@@ -399,5 +399,22 @@ describe('ReadManyFilesTool', () => {
       expect(result.returnDisplay).not.toContain('foo.quux');
       expect(result.returnDisplay).toContain('bar.ts');
     });
+
+    it('should include video files as inlineData parts', async () => {
+      createBinaryFile('clip.mp4', Buffer.from('VIDEO'));
+      const params = { paths: ['*.mp4'] };
+      const result = await tool.execute(params, new AbortController().signal);
+      expect(result.llmContent).toEqual([
+        {
+          inlineData: {
+            data: Buffer.from('VIDEO').toString('base64'),
+            mimeType: 'video/mp4',
+          },
+        },
+      ]);
+      expect(result.returnDisplay).toContain(
+        'Successfully read and concatenated content from **1 file(s)**',
+      );
+    });
   });
 });

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -193,7 +193,7 @@ export class ReadManyFilesTool extends BaseTool<
     super(
       ReadManyFilesTool.Name,
       'ReadManyFiles',
-      `Reads content from multiple files specified by paths or glob patterns within a configured target directory. For text files, it concatenates their content into a single string. It is primarily designed for text-based files. However, it can also process image (e.g., .png, .jpg) and PDF (.pdf) files if their file names or extensions are explicitly included in the 'paths' argument. For these explicitly requested non-text files, their data is read and included in a format suitable for model consumption (e.g., base64 encoded).
+      `Reads content from multiple files specified by paths or glob patterns within a configured target directory. For text files, it concatenates their content into a single string. It is primarily designed for text-based files. However, it can also process image (e.g., .png, .jpg), PDF (.pdf), audio (.mp3, .wav), and video (.mp4, .mov) files if their file names or extensions are explicitly included in the 'paths' argument. For these explicitly requested non-text files, their data is read and included in a format suitable for model consumption (e.g., base64 encoded).
 
 This tool is useful when you need to understand or analyze a collection of files, such as:
 - Getting an overview of a codebase or parts of it (e.g., all TypeScript files in the 'src' directory).
@@ -356,24 +356,25 @@ Use this tool when the user's query implies needing the content of several files
 
       const fileType = detectFileType(filePath);
 
-      if (fileType === 'image' || fileType === 'pdf') {
-        const fileExtension = path.extname(filePath).toLowerCase();
-        const fileNameWithoutExtension = path.basename(filePath, fileExtension);
-        const requestedExplicitly = inputPatterns.some(
-          (pattern: string) =>
-            pattern.toLowerCase().includes(fileExtension) ||
-            pattern.includes(fileNameWithoutExtension),
-        );
-
-        if (!requestedExplicitly) {
-          skippedFiles.push({
-            path: relativePathForDisplay,
-            reason:
-              'asset file (image/pdf) was not explicitly requested by name or extension',
-          });
-          continue;
-        }
-      }
+      // This block is to be deleted as it incorrectly filters out audio/video.
+      // if (fileType === 'image' || fileType === 'pdf') {
+      //   const fileExtension = path.extname(filePath).toLowerCase();
+      //   const fileNameWithoutExtension = path.basename(filePath, fileExtension);
+      //   const requestedExplicitly = inputPatterns.some(
+      //     (pattern: string) =>
+      //       pattern.toLowerCase().includes(fileExtension) ||
+      //       pattern.includes(fileNameWithoutExtension),
+      //   );
+      //
+      //   if (!requestedExplicitly) {
+      //     skippedFiles.push({
+      //       path: relativePathForDisplay,
+      //       reason:
+      //         'asset file (image/pdf) was not explicitly requested by name or extension',
+      //     });
+      //     continue;
+      //   }
+      // }
 
       // Use processSingleFileContent for all file types now
       const fileReadResult = await processSingleFileContent(

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -356,25 +356,23 @@ Use this tool when the user's query implies needing the content of several files
 
       const fileType = detectFileType(filePath);
 
-      // This block is to be deleted as it incorrectly filters out audio/video.
-      // if (fileType === 'image' || fileType === 'pdf') {
-      //   const fileExtension = path.extname(filePath).toLowerCase();
-      //   const fileNameWithoutExtension = path.basename(filePath, fileExtension);
-      //   const requestedExplicitly = inputPatterns.some(
-      //     (pattern: string) =>
-      //       pattern.toLowerCase().includes(fileExtension) ||
-      //       pattern.includes(fileNameWithoutExtension),
-      //   );
-      //
-      //   if (!requestedExplicitly) {
-      //     skippedFiles.push({
-      //       path: relativePathForDisplay,
-      //       reason:
-      //         'asset file (image/pdf) was not explicitly requested by name or extension',
-      //     });
-      //     continue;
-      //   }
-      // }
+      const assetTypes = ['image', 'pdf', 'audio', 'video'];
+      if (assetTypes.includes(fileType)) {
+        const fileExtension = path.extname(filePath).toLowerCase();
+        const fileNameWithoutExtension = path.basename(filePath, fileExtension);
+        const requestedExplicitly = inputPatterns.some(
+          (pattern: string) =>
+            pattern.toLowerCase().includes(fileExtension) ||
+            pattern.includes(fileNameWithoutExtension),
+        );
+        if (!requestedExplicitly) {
+          skippedFiles.push({
+            path: relativePathForDisplay,
+            reason: `asset file (${fileType}) was not explicitly requested by name or extension`,
+          });
+          continue;
+        }
+      }
 
       // Use processSingleFileContent for all file types now
       const fileReadResult = await processSingleFileContent(

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -356,25 +356,24 @@ Use this tool when the user's query implies needing the content of several files
 
       const fileType = detectFileType(filePath);
 
-      // This block is to be deleted as it incorrectly filters out audio/video.
-      // if (fileType === 'image' || fileType === 'pdf') {
-      //   const fileExtension = path.extname(filePath).toLowerCase();
-      //   const fileNameWithoutExtension = path.basename(filePath, fileExtension);
-      //   const requestedExplicitly = inputPatterns.some(
-      //     (pattern: string) =>
-      //       pattern.toLowerCase().includes(fileExtension) ||
-      //       pattern.includes(fileNameWithoutExtension),
-      //   );
-      //
-      //   if (!requestedExplicitly) {
-      //     skippedFiles.push({
-      //       path: relativePathForDisplay,
-      //       reason:
-      //         'asset file (image/pdf) was not explicitly requested by name or extension',
-      //     });
-      //     continue;
-      //   }
-      // }
+      const assetTypes = ['image', 'pdf', 'audio', 'video'];
+      if (assetTypes.includes(fileType)) {
+        const fileExtension = path.extname(filePath).toLowerCase();
+        const fileNameWithoutExtension = path.basename(filePath, fileExtension);
+        const requestedExplicitly = inputPatterns.some(
+          (pattern: string) =>
+            pattern.toLowerCase().includes(fileExtension) ||
+            pattern.includes(fileNameWithoutExtension),
+        );
+
+        if (!requestedExplicitly) {
+          skippedFiles.push({
+            path: relativePathForDisplay,
+            reason: `asset file (${fileType}) was not explicitly requested by name or extension`,
+          });
+          continue;
+        }
+      }
 
       // Use processSingleFileContent for all file types now
       const fileReadResult = await processSingleFileContent(

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -255,6 +255,7 @@ export async function processSingleFileContent(
           returnDisplay: `Skipped binary file: ${relativePathForDisplay}`,
         };
       }
+      case 'svg':
       case 'text': {
         const content = await fs.promises.readFile(filePath, 'utf8');
         const lines = content.split('\n');

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -115,11 +115,15 @@ export function isBinaryFile(filePath: string): boolean {
  */
 export function detectFileType(
   filePath: string,
-): 'text' | 'image' | 'pdf' | 'audio' | 'video' | 'binary' {
+): 'text' | 'image' | 'pdf' | 'audio' | 'video' | 'binary' | 'svg'{
   const ext = path.extname(filePath).toLowerCase();
 
   if (ext === '.ts') {
     return 'text';
+  }
+
+  if (ext === '.svg') {
+    return 'svg';
   }
 
   const lookedUpMimeType = getSpecificMimeType(filePath); // Returns false if not found, or the mime type string


### PR DESCRIPTION
## TLDR

This PR fixes a bug so the CLI can *actually* read video and audio files. 

Another change (#3380) updated the instructions to say this was possible, but the code itself was still broken. This PR fixes the code so it works as expected.

## Dive Deeper

**The Problem:**

On some computers (like mine), the tool we use to identify file types gets it wrong.
*   It labeled `.mp4` video files with the wrong tag (`application/mp4` instead of `video/mp4`), so the Gemini API would reject them.
*   It labeled `.ts` code files as videos, which is a big mistake.

**The Fix:**

Instead of fully trusting that tool, I made our code smarter:
1.  I created a simple list inside our code that has the **correct** tags for important files like `.mp4`, `.mov`, `.mp3`, and `.wav`.
2.  Our code now checks this list **first** before asking the old tool. This guarantees the right tag is always used for media files.
3.  I made sure the special rule for TypeScript files still works, so they are not mistaken for videos.


## Reviewer Test Plan

To make sure this works, you can:

1.  Get the code from this branch.
2.  Find a short `.mp4` video on your computer.
3.  Run this command: `gemini "Tell me what this video is about: @your_video_name.mp4"`. 
4. You can also do it now **without** the @ symbol, simply telling it to go find that video in the folder and it still works without pointing directly.
5.  **It should now work!** The CLI should process the video without errors.
6.  To make sure I didn't break anything, also test a code file: `gemini "What is this code file? @packages/core/src/utils/fileUtils.ts"`
7.  **It should still work correctly** and treat it as a text file.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  |  ✅ |
| npx      | ❓  | ❓  |  ✅ |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3379
