### PR TITLE
Add scrolling to theme dialog

### DIFF
--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -128,7 +128,7 @@ export function ThemeDialog({
   );
 
   const DIALOG_PADDING = 2;
-  const selectThemeHeight = 10;
+  const selectThemeHeight = themeItems.length + 1;
   const SCOPE_SELECTION_HEIGHT = 4; // Height for the scope selection section + margin.
   const SPACE_BETWEEN_THEME_SELECTION_AND_APPLY_TO = 1;
   const TAB_TO_SELECT_HEIGHT = 2;

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -122,7 +122,7 @@ export function ThemeDialog({
   );
 
   const DIALOG_PADDING = 2;
-  const selectThemeHeight = themeItems.length + 1;
+  const selectThemeHeight = 10;
   const SCOPE_SELECTION_HEIGHT = 4; // Height for the scope selection section + margin.
   const SPACE_BETWEEN_THEME_SELECTION_AND_APPLY_TO = 1;
   const TAB_TO_SELECT_HEIGHT = 2;
@@ -196,6 +196,7 @@ export function ThemeDialog({
             onSelect={handleThemeSelect}
             onHighlight={onHighlight}
             isFocused={currenFocusedSection === 'theme'}
+            maxItemsToShow={8}
           />
 
           {/* Scope Selection */}
@@ -210,6 +211,7 @@ export function ThemeDialog({
                 onSelect={handleScopeSelect}
                 onHighlight={handleScopeHighlight}
                 isFocused={currenFocusedSection === 'scope'}
+                showScrollArrows={false}
               />
             </Box>
           )}

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { Colors } from '../colors.js';
 import { themeManager, DEFAULT_THEME } from '../themes/theme-manager.js';
@@ -60,19 +60,25 @@ export function ThemeDialog({
     { label: 'System Settings', value: SettingScope.System },
   ];
 
-  const handleThemeSelect = (themeName: string) => {
-    onSelect(themeName, selectedScope);
-  };
+  const handleThemeSelect = useCallback(
+    (themeName: string) => {
+      onSelect(themeName, selectedScope);
+    },
+    [onSelect, selectedScope],
+  );
 
-  const handleScopeHighlight = (scope: SettingScope) => {
+  const handleScopeHighlight = useCallback((scope: SettingScope) => {
     setSelectedScope(scope);
     setSelectInputKey(Date.now());
-  };
+  }, []);
 
-  const handleScopeSelect = (scope: SettingScope) => {
-    handleScopeHighlight(scope);
-    setFocusedSection('theme'); // Reset focus to theme section
-  };
+  const handleScopeSelect = useCallback(
+    (scope: SettingScope) => {
+      handleScopeHighlight(scope);
+      setFocusedSection('theme'); // Reset focus to theme section
+    },
+    [handleScopeHighlight],
+  );
 
   const [focusedSection, setFocusedSection] = useState<'theme' | 'scope'>(
     'theme',

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -66,7 +66,7 @@ export function RadioButtonSelect<T>({
         onSelect(items[activeIndex]!.value);
       }
     },
-    { isActive: isFocused },
+    { isActive: isFocused && items.length > 0 },
   );
 
   const visibleItems = items.slice(scrollOffset, scrollOffset + maxItemsToShow);

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -86,6 +86,17 @@ export function RadioButtonSelect<T>({
       if (key.return) {
         onSelect(items[activeIndex]!.value);
       }
+
+      // Enable selection directly from number keys.
+      if (/^[1-9]$/.test(input)) {
+        const targetIndex = Number.parseInt(input, 10) - 1;
+        if (targetIndex >= 0 && targetIndex < visibleItems.length) {
+          const selectedItem = visibleItems[targetIndex];
+          if (selectedItem) {
+            onSelect?.(selectedItem.value);
+          }
+        }
+      }
     },
     { isActive: isFocused && items.length > 0 },
   );

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -4,139 +4,122 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { Text, Box } from 'ink';
-import SelectInput, {
-  type ItemProps as InkSelectItemProps,
-  type IndicatorProps as InkSelectIndicatorProps,
-} from 'ink-select-input';
+import React, { useEffect, useState } from 'react';
+import { Text, Box, useInput } from 'ink';
 import { Colors } from '../../colors.js';
 
-/**
- * Represents a single option for the RadioButtonSelect.
- * Requires a label for display and a value to be returned on selection.
- */
 export interface RadioSelectItem<T> {
   label: string;
   value: T;
   disabled?: boolean;
+  themeNameDisplay?: string;
+  themeTypeDisplay?: string;
 }
 
-/**
- * Props for the RadioButtonSelect component.
- * @template T The type of the value associated with each radio item.
- */
 export interface RadioButtonSelectProps<T> {
-  /** An array of items to display as radio options. */
-  items: Array<
-    RadioSelectItem<T> & {
-      themeNameDisplay?: string;
-      themeTypeDisplay?: string;
-    }
-  >;
-
-  /** The initial index selected */
+  items: Array<RadioSelectItem<T>>;
   initialIndex?: number;
-
-  /** Function called when an item is selected. Receives the `value` of the selected item. */
   onSelect: (value: T) => void;
-
-  /** Function called when an item is highlighted. Receives the `value` of the selected item. */
   onHighlight?: (value: T) => void;
-
-  /** Whether this select input is currently focused and should respond to input. */
   isFocused?: boolean;
+  showScrollArrows?: boolean;
+  maxItemsToShow?: number;
 }
 
-/**
- * A specialized SelectInput component styled to look like radio buttons.
- * It uses '◉' for selected and '○' for unselected items.
- *
- * @template T The type of the value associated with each radio item.
- */
 export function RadioButtonSelect<T>({
   items,
-  initialIndex,
+  initialIndex = 0,
   onSelect,
   onHighlight,
-  isFocused, // This prop indicates if the current RadioButtonSelect group is focused
+  isFocused,
+  showScrollArrows = true,
+  maxItemsToShow = 10,
 }: RadioButtonSelectProps<T>): React.JSX.Element {
-  const handleSelect = (item: RadioSelectItem<T>) => {
-    onSelect(item.value);
-  };
-  const handleHighlight = (item: RadioSelectItem<T>) => {
-    if (onHighlight) {
-      onHighlight(item.value);
-    }
-  };
+  const [activeIndex, setActiveIndex] = useState(initialIndex);
+  const [scrollOffset, setScrollOffset] = useState(0);
 
-  /**
-   * Custom indicator component displaying radio button style (◉/○).
-   * Color changes based on whether the item is selected and if its group is focused.
-   */
-  function DynamicRadioIndicator({
-    isSelected = false,
-  }: InkSelectIndicatorProps): React.JSX.Element {
-    return (
-      <Box minWidth={2} flexShrink={0}>
-        <Text color={isSelected ? Colors.AccentGreen : Colors.Foreground}>
-          {isSelected ? '●' : '○'}
-        </Text>
-      </Box>
+  useEffect(() => {
+    const newScrollOffset = Math.max(
+      0,
+      Math.min(activeIndex - maxItemsToShow + 1, items.length - maxItemsToShow),
     );
-  }
-
-  /**
-   * Custom item component for displaying the label.
-   * Color changes based on whether the item is selected and if its group is focused.
-   * Now also handles displaying theme type with custom color.
-   */
-  function CustomThemeItemComponent(
-    props: InkSelectItemProps,
-  ): React.JSX.Element {
-    const { isSelected = false, label } = props;
-    const itemWithThemeProps = props as typeof props & {
-      themeNameDisplay?: string;
-      themeTypeDisplay?: string;
-      disabled?: boolean;
-    };
-
-    let textColor = Colors.Foreground;
-    if (isSelected) {
-      textColor = Colors.AccentGreen;
-    } else if (itemWithThemeProps.disabled === true) {
-      textColor = Colors.Gray;
+    if (activeIndex < scrollOffset) {
+      setScrollOffset(activeIndex);
+    } else if (activeIndex >= scrollOffset + maxItemsToShow) {
+      setScrollOffset(newScrollOffset);
     }
+  }, [activeIndex, items.length, scrollOffset, maxItemsToShow]);
 
-    if (
-      itemWithThemeProps.themeNameDisplay &&
-      itemWithThemeProps.themeTypeDisplay
-    ) {
-      return (
-        <Text color={textColor} wrap="truncate">
-          {itemWithThemeProps.themeNameDisplay}{' '}
-          <Text color={Colors.Gray}>{itemWithThemeProps.themeTypeDisplay}</Text>
-        </Text>
-      );
-    }
+  useInput(
+    (input, key) => {
+      if (key.upArrow) {
+        const newIndex = activeIndex > 0 ? activeIndex - 1 : items.length - 1;
+        setActiveIndex(newIndex);
+        onHighlight?.(items[newIndex]!.value);
+      }
+      if (key.downArrow) {
+        const newIndex = activeIndex < items.length - 1 ? activeIndex + 1 : 0;
+        setActiveIndex(newIndex);
+        onHighlight?.(items[newIndex]!.value);
+      }
+      if (key.return) {
+        onSelect(items[activeIndex]!.value);
+      }
+    },
+    { isActive: isFocused },
+  );
 
-    return (
-      <Text color={textColor} wrap="truncate">
-        {label}
-      </Text>
-    );
-  }
+  const visibleItems = items.slice(scrollOffset, scrollOffset + maxItemsToShow);
 
-  initialIndex = initialIndex ?? 0;
   return (
-    <SelectInput
-      indicatorComponent={DynamicRadioIndicator}
-      itemComponent={CustomThemeItemComponent}
-      items={items}
-      initialIndex={initialIndex}
-      onSelect={handleSelect}
-      onHighlight={handleHighlight}
-      isFocused={isFocused}
-    />
+    <Box flexDirection="column">
+      {showScrollArrows && (
+        <Text color={scrollOffset > 0 ? Colors.Foreground : Colors.Gray}>
+          ▲
+        </Text>
+      )}
+      {visibleItems.map((item, index) => {
+        const itemIndex = scrollOffset + index;
+        const isSelected = activeIndex === itemIndex;
+
+        let textColor = Colors.Foreground;
+        if (isSelected) {
+          textColor = Colors.AccentGreen;
+        } else if (item.disabled) {
+          textColor = Colors.Gray;
+        }
+
+        return (
+          <Box key={item.label}>
+            <Box minWidth={2} flexShrink={0}>
+              <Text color={isSelected ? Colors.AccentGreen : Colors.Foreground}>
+                {isSelected ? '●' : '○'}
+              </Text>
+            </Box>
+            {item.themeNameDisplay && item.themeTypeDisplay ? (
+              <Text color={textColor} wrap="truncate">
+                {item.themeNameDisplay}{' '}
+                <Text color={Colors.Gray}>{item.themeTypeDisplay}</Text>
+              </Text>
+            ) : (
+              <Text color={textColor} wrap="truncate">
+                {item.label}
+              </Text>
+            )}
+          </Box>
+        );
+      })}
+      {showScrollArrows && (
+        <Text
+          color={
+            scrollOffset + maxItemsToShow < items.length
+              ? Colors.Foreground
+              : Colors.Gray
+          }
+        >
+          ▼
+        </Text>
+      )}
+    </Box>
   );
 }

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -8,6 +8,10 @@ import React, { useEffect, useState } from 'react';
 import { Text, Box, useInput } from 'ink';
 import { Colors } from '../../colors.js';
 
+/**
+ * Represents a single option for the RadioButtonSelect.
+ * Requires a label for display and a value to be returned on selection.
+ */
 export interface RadioSelectItem<T> {
   label: string;
   value: T;
@@ -16,16 +20,33 @@ export interface RadioSelectItem<T> {
   themeTypeDisplay?: string;
 }
 
+/**
+ * Props for the RadioButtonSelect component.
+ * @template T The type of the value associated with each radio item.
+ */
 export interface RadioButtonSelectProps<T> {
+  /** An array of items to display as radio options. */
   items: Array<RadioSelectItem<T>>;
+  /** The initial index selected */
   initialIndex?: number;
+  /** Function called when an item is selected. Receives the `value` of the selected item. */
   onSelect: (value: T) => void;
+  /** Function called when an item is highlighted. Receives the `value` of the selected item. */
   onHighlight?: (value: T) => void;
+  /** Whether this select input is currently focused and should respond to input. */
   isFocused?: boolean;
+  /** Whether to show the scroll arrows. */
   showScrollArrows?: boolean;
+  /** The maximum number of items to show at once. */
   maxItemsToShow?: number;
 }
 
+/**
+ * A custom component that displays a list of items with radio buttons,
+ * supporting scrolling and keyboard navigation.
+ *
+ * @template T The type of the value associated with each radio item.
+ */
 export function RadioButtonSelect<T>({
   items,
   initialIndex = 0,

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -73,12 +73,12 @@ export function RadioButtonSelect<T>({
 
   useInput(
     (input, key) => {
-      if (key.upArrow) {
+      if (input === 'k' || key.upArrow) {
         const newIndex = activeIndex > 0 ? activeIndex - 1 : items.length - 1;
         setActiveIndex(newIndex);
         onHighlight?.(items[newIndex]!.value);
       }
-      if (key.downArrow) {
+      if (input === 'j' || key.downArrow) {
         const newIndex = activeIndex < items.length - 1 ? activeIndex + 1 : 0;
         setActiveIndex(newIndex);
         onHighlight?.(items[newIndex]!.value);


### PR DESCRIPTION
## TLDR

Adds scrolling to theme dialog to allow more themes to be shown

## Dive Deeper

https://github.com/user-attachments/assets/22a29b8c-6ca5-43fd-a9bc-5658c1afd312


This copies the same interaction pattern from our suggestions. 

There is a minor screen flicker (current issue #3653) where the screen flickers when navigating through the themes

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3890
