### PR TITLE
fix: `TypeError: Cannot read properties of undefined (reading 'authType')`

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -212,7 +212,7 @@ export async function main() {
     'event.timestamp': new Date().toISOString(),
     prompt: input,
     prompt_id,
-    auth_type: config.getContentGeneratorConfig().authType!,
+    auth_type: config.getContentGeneratorConfig()?.authType,
     prompt_length: input.length,
   });
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -160,7 +160,7 @@ export async function runNonInteractive(
     console.error(
       parseAndFormatApiError(
         error,
-        config.getContentGeneratorConfig().authType,
+        config.getContentGeneratorConfig()?.authType,
       ),
     );
     process.exit(1);

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -226,7 +226,7 @@ export const useGeminiStream = (
           new UserPromptEvent(
             trimmedQuery.length,
             prompt_id,
-            config.getContentGeneratorConfig().authType!,
+            config.getContentGeneratorConfig()?.authType,
             trimmedQuery,
           ),
         );
@@ -408,7 +408,7 @@ export const useGeminiStream = (
           type: MessageType.ERROR,
           text: parseAndFormatApiError(
             eventValue.error,
-            config.getContentGeneratorConfig().authType,
+            config.getContentGeneratorConfig()?.authType,
             undefined,
             config.getModel(),
             DEFAULT_GEMINI_FLASH_MODEL,
@@ -588,7 +588,7 @@ export const useGeminiStream = (
               type: MessageType.ERROR,
               text: parseAndFormatApiError(
                 getErrorMessage(error) || 'Unknown error',
-                config.getContentGeneratorConfig().authType,
+                config.getContentGeneratorConfig()?.authType,
                 undefined,
                 config.getModel(),
                 DEFAULT_GEMINI_FLASH_MODEL,

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -172,7 +172,7 @@ export class GeminiChat {
         this.config.getModel(),
         durationMs,
         prompt_id,
-        this.config.getContentGeneratorConfig().authType!,
+        this.config.getContentGeneratorConfig()?.authType,
         usageMetadata,
         responseText,
       ),
@@ -194,7 +194,7 @@ export class GeminiChat {
         errorMessage,
         durationMs,
         prompt_id,
-        this.config.getContentGeneratorConfig().authType!,
+        this.config.getContentGeneratorConfig()?.authType,
         errorType,
       ),
     );

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -96,13 +96,13 @@ export class UserPromptEvent {
   'event.timestamp': string; // ISO 8601
   prompt_length: number;
   prompt_id: string;
-  auth_type: string;
+  auth_type?: string;
   prompt?: string;
 
   constructor(
     prompt_length: number,
     prompt_Id: string,
-    auth_type: string,
+    auth_type?: string,
     prompt?: string,
   ) {
     this['event.name'] = 'user_prompt';
@@ -167,14 +167,14 @@ export class ApiErrorEvent {
   status_code?: number | string;
   duration_ms: number;
   prompt_id: string;
-  auth_type: string;
+  auth_type?: string;
 
   constructor(
     model: string,
     error: string,
     duration_ms: number,
     prompt_id: string,
-    auth_type: string,
+    auth_type?: string,
     error_type?: string,
     status_code?: number | string,
   ) {
@@ -205,13 +205,13 @@ export class ApiResponseEvent {
   total_token_count: number;
   response_text?: string;
   prompt_id: string;
-  auth_type: string;
+  auth_type?: string;
 
   constructor(
     model: string,
     duration_ms: number,
     prompt_id: string,
-    auth_type: string,
+    auth_type?: string,
     usage_data?: GenerateContentResponseUsageMetadata,
     response_text?: string,
     error?: string,


### PR DESCRIPTION
## TLDR

This PR fixes a panic that occurs when authType is not defined in the configuration. It makes the auth_type property optional in telemetry events and uses optional
  chaining (?.) when accessing it to prevent crashes.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Fixes #3913
<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
