### PR TITLE
Updated auth message for `NO_BROWSER` mode.

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -131,6 +131,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
         setFlashFallbackHandler: vi.fn(),
         getSessionId: vi.fn(() => 'test-session-id'),
         getUserTier: vi.fn().mockResolvedValue(undefined),
+        setSetAuthMessage: vi.fn(),
       };
     });
   return {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -124,6 +124,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   const [showHelp, setShowHelp] = useState<boolean>(false);
   const [themeError, setThemeError] = useState<string | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
+  const [authMessage, setAuthMessage] = useState<string | null>(null);
   const [editorError, setEditorError] = useState<string | null>(null);
   const [footerHeight, setFooterHeight] = useState<number>(0);
   const [corgiMode, setCorgiMode] = useState(false);
@@ -168,6 +169,12 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     isAuthenticating,
     cancelAuthentication,
   } = useAuthCommand(settings, setAuthError, config);
+
+  useEffect(() => {
+    if (config) {
+      config.setSetAuthMessage(setAuthMessage);
+    }
+  }, [config]);
 
   useEffect(() => {
     if (settings.merged.selectedAuthType) {
@@ -764,6 +771,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
           ) : isAuthenticating ? (
             <>
               <AuthInProgress
+                authMessage={authMessage}
                 onTimeout={() => {
                   setAuthError('Authentication timed out. Please try again.');
                   cancelAuthentication();

--- a/packages/cli/src/ui/components/AuthInProgress.tsx
+++ b/packages/cli/src/ui/components/AuthInProgress.tsx
@@ -11,10 +11,12 @@ import { Colors } from '../colors.js';
 
 interface AuthInProgressProps {
   onTimeout: () => void;
+  authMessage: string | null;
 }
 
 export function AuthInProgress({
   onTimeout,
+  authMessage,
 }: AuthInProgressProps): React.JSX.Element {
   const [timedOut, setTimedOut] = useState(false);
 
@@ -48,7 +50,8 @@ export function AuthInProgress({
       ) : (
         <Box>
           <Text>
-            <Spinner type="dots" /> Waiting for auth... (Press ESC to cancel)
+            <Spinner type="dots" />{' '}
+            {authMessage || 'Waiting for auth... (Press ESC to cancel)'}
           </Text>
         </Box>
       )}

--- a/packages/cli/src/ui/hooks/useAuthCommand.ts
+++ b/packages/cli/src/ui/hooks/useAuthCommand.ts
@@ -36,6 +36,9 @@ export const useAuthCommand = (
       }
 
       try {
+        config.getSetAuthMessage()?.(
+          'Waiting for auth... (Press ESC to cancel)',
+        );
         setIsAuthenticating(true);
         await config.refreshAuth(authType);
         console.log(`Authenticated via "${authType}".`);

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -34,6 +34,7 @@ vi.mock('node:readline');
 
 const mockConfig = {
   getNoBrowser: () => false,
+  getSetAuthMessage: () => vi.fn(),
 } as unknown as Config;
 
 // Mock fetch globally
@@ -175,6 +176,7 @@ describe('oauth2', () => {
   it('should perform login with user code', async () => {
     const mockConfigWithNoBrowser = {
       getNoBrowser: () => true,
+      getSetAuthMessage: () => vi.fn(),
     } as unknown as Config;
 
     const mockCodeVerifier = {

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -119,6 +119,9 @@ export async function getOauthClient(
   }
 
   if (config.getNoBrowser()) {
+    config.getSetAuthMessage()?.(
+      'Restart gemmini-cli to enter manual authorization code. (Press ESC to cancel)',
+    );
     let success = false;
     const maxRetries = 2;
     for (let i = 0; !success && i < maxRetries; i++) {
@@ -130,11 +133,14 @@ export async function getOauthClient(
         );
       }
     }
+    config.getSetAuthMessage()?.('Authentication complete.');
     if (!success) {
       process.exit(1);
     }
   } else {
     const webLogin = await authWithWeb(client);
+    const authMessage = 'Waiting for authentication from browser...';
+    config.getSetAuthMessage()?.(authMessage);
 
     // This does basically nothing, as it isn't show to the user.
     console.log(
@@ -143,7 +149,7 @@ export async function getOauthClient(
         `Otherwise navigate to:\n\n${webLogin.authUrl}\n\n`,
     );
     await open(webLogin.authUrl);
-    console.log('Waiting for authentication...');
+    console.log(authMessage);
 
     await webLogin.loginCompletePromise;
   }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -144,6 +144,7 @@ export interface ConfigParameters {
   listExtensions?: boolean;
   activeExtensions?: ActiveExtension[];
   noBrowser?: boolean;
+  setAuthMessage?: (message: string | null) => void;
 }
 
 export class Config {
@@ -189,6 +190,7 @@ export class Config {
   private readonly _activeExtensions: ActiveExtension[];
   flashFallbackHandler?: FlashFallbackHandler;
   private quotaErrorOccurred: boolean = false;
+  private setAuthMessage?: (message: string | null) => void;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -234,6 +236,7 @@ export class Config {
     this.listExtensions = params.listExtensions ?? false;
     this._activeExtensions = params.activeExtensions ?? [];
     this.noBrowser = params.noBrowser ?? false;
+    this.setAuthMessage = params.setAuthMessage;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -269,6 +272,7 @@ export class Config {
     this.contentGeneratorConfig = await createContentGeneratorConfig(
       this.model,
       authMethod,
+      this,
     );
 
     this.geminiClient = new GeminiClient(this);
@@ -496,6 +500,14 @@ export class Config {
 
   getNoBrowser(): boolean {
     return this.noBrowser;
+  }
+
+  setSetAuthMessage(setAuthMessage?: (message: string | null) => void) {
+    this.setAuthMessage = setAuthMessage;
+  }
+
+  getSetAuthMessage(): ((message: string | null) => void) | undefined {
+    return this.setAuthMessage;
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -82,6 +82,7 @@ describe('createContentGeneratorConfig', () => {
     const config = await createContentGeneratorConfig(
       undefined,
       AuthType.USE_GEMINI,
+      mockConfig,
     );
     expect(config.apiKey).toBe('env-gemini-key');
     expect(config.vertexai).toBe(false);
@@ -92,6 +93,7 @@ describe('createContentGeneratorConfig', () => {
     const config = await createContentGeneratorConfig(
       undefined,
       AuthType.USE_GEMINI,
+      mockConfig,
     );
     expect(config.apiKey).toBeUndefined();
     expect(config.vertexai).toBeUndefined();
@@ -102,6 +104,7 @@ describe('createContentGeneratorConfig', () => {
     const config = await createContentGeneratorConfig(
       undefined,
       AuthType.USE_VERTEX_AI,
+      mockConfig,
     );
     expect(config.apiKey).toBe('env-google-key');
     expect(config.vertexai).toBe(true);
@@ -113,6 +116,7 @@ describe('createContentGeneratorConfig', () => {
     const config = await createContentGeneratorConfig(
       undefined,
       AuthType.USE_VERTEX_AI,
+      mockConfig,
     );
     expect(config.vertexai).toBe(true);
     expect(config.apiKey).toBeUndefined();
@@ -125,6 +129,7 @@ describe('createContentGeneratorConfig', () => {
     const config = await createContentGeneratorConfig(
       undefined,
       AuthType.USE_VERTEX_AI,
+      mockConfig,
     );
     expect(config.apiKey).toBeUndefined();
     expect(config.vertexai).toBeUndefined();

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -50,11 +50,13 @@ export type ContentGeneratorConfig = {
   apiKey?: string;
   vertexai?: boolean;
   authType?: AuthType | undefined;
+  config?: Config;
 };
 
 export async function createContentGeneratorConfig(
   model: string | undefined,
   authType: AuthType | undefined,
+  config: Config,
 ): Promise<ContentGeneratorConfig> {
   const geminiApiKey = process.env.GEMINI_API_KEY || undefined;
   const googleApiKey = process.env.GOOGLE_API_KEY || undefined;
@@ -67,6 +69,7 @@ export async function createContentGeneratorConfig(
   const contentGeneratorConfig: ContentGeneratorConfig = {
     model: effectiveModel,
     authType,
+    config,
   };
 
   // If we are using Google auth or we are in Cloud Shell, there is nothing else to validate for now


### PR DESCRIPTION
Improvement to the `NO_BROWSER` mode. If you don't have `settings.json` then we run `/auth` at startup you select "Log in with Google" and we prompt you to restart gemini-cli (which gets you a clickable / copy-able link with good UI for inputting the received auth code.

Longer term we should handle this all in the `/auth` flow but getting URLs to display well has proven very difficult so this is a nice Quality-of-life improvement till then.