### PR TITLE
Fix issues that resulted in Gemini trying to use relative paths where absolute paths were required

### DIFF
--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -13,6 +13,7 @@ exports[`Core System Prompt (prompts.ts) > should append userMemory with separat
 - **Proactiveness:** Fulfill the user's request thoroughly, including reasonable, directly implied follow-up actions.
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
+- **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
 
 # Primary Workflows
@@ -92,7 +93,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for path '/path/to/project']
 </example>
 
 <example>
@@ -132,7 +133,7 @@ All checks passed. This is a stable checkpoint.
 
 <example>
 user: Delete the temp directory.
-model: I can run \`rm -rf ./temp\`. This will permanently delete the directory and all its contents.
+model: I can run \`rm -rf /path/to/project/temp\`. This will permanently delete the directory and all its contents.
 </example>
 
 <example>
@@ -193,6 +194,7 @@ exports[`Core System Prompt (prompts.ts) > should include git instructions when 
 - **Proactiveness:** Fulfill the user's request thoroughly, including reasonable, directly implied follow-up actions.
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
+- **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
 
 # Primary Workflows
@@ -287,7 +289,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for path '/path/to/project']
 </example>
 
 <example>
@@ -327,7 +329,7 @@ Would you like me to write a commit message and commit these changes?
 
 <example>
 user: Delete the temp directory.
-model: I can run \`rm -rf ./temp\`. This will permanently delete the directory and all its contents.
+model: I can run \`rm -rf /path/to/project/temp\`. This will permanently delete the directory and all its contents.
 </example>
 
 <example>
@@ -383,6 +385,7 @@ exports[`Core System Prompt (prompts.ts) > should include non-sandbox instructio
 - **Proactiveness:** Fulfill the user's request thoroughly, including reasonable, directly implied follow-up actions.
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
+- **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
 
 # Primary Workflows
@@ -462,7 +465,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for path '/path/to/project']
 </example>
 
 <example>
@@ -502,7 +505,7 @@ All checks passed. This is a stable checkpoint.
 
 <example>
 user: Delete the temp directory.
-model: I can run \`rm -rf ./temp\`. This will permanently delete the directory and all its contents.
+model: I can run \`rm -rf /path/to/project/temp\`. This will permanently delete the directory and all its contents.
 </example>
 
 <example>
@@ -558,6 +561,7 @@ exports[`Core System Prompt (prompts.ts) > should include sandbox-specific instr
 - **Proactiveness:** Fulfill the user's request thoroughly, including reasonable, directly implied follow-up actions.
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
+- **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
 
 # Primary Workflows
@@ -637,7 +641,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for path '/path/to/project']
 </example>
 
 <example>
@@ -677,7 +681,7 @@ All checks passed. This is a stable checkpoint.
 
 <example>
 user: Delete the temp directory.
-model: I can run \`rm -rf ./temp\`. This will permanently delete the directory and all its contents.
+model: I can run \`rm -rf /path/to/project/temp\`. This will permanently delete the directory and all its contents.
 </example>
 
 <example>
@@ -733,6 +737,7 @@ exports[`Core System Prompt (prompts.ts) > should include seatbelt-specific inst
 - **Proactiveness:** Fulfill the user's request thoroughly, including reasonable, directly implied follow-up actions.
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
+- **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
 
 # Primary Workflows
@@ -812,7 +817,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for path '/path/to/project']
 </example>
 
 <example>
@@ -852,7 +857,7 @@ All checks passed. This is a stable checkpoint.
 
 <example>
 user: Delete the temp directory.
-model: I can run \`rm -rf ./temp\`. This will permanently delete the directory and all its contents.
+model: I can run \`rm -rf /path/to/project/temp\`. This will permanently delete the directory and all its contents.
 </example>
 
 <example>
@@ -908,6 +913,7 @@ exports[`Core System Prompt (prompts.ts) > should not include git instructions w
 - **Proactiveness:** Fulfill the user's request thoroughly, including reasonable, directly implied follow-up actions.
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
+- **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
 
 # Primary Workflows
@@ -987,7 +993,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for path '/path/to/project']
 </example>
 
 <example>
@@ -1027,7 +1033,7 @@ All checks passed. This is a stable checkpoint.
 
 <example>
 user: Delete the temp directory.
-model: I can run \`rm -rf ./temp\`. This will permanently delete the directory and all its contents.
+model: I can run \`rm -rf /path/to/project/temp\`. This will permanently delete the directory and all its contents.
 </example>
 
 <example>
@@ -1083,6 +1089,7 @@ exports[`Core System Prompt (prompts.ts) > should return the base prompt when no
 - **Proactiveness:** Fulfill the user's request thoroughly, including reasonable, directly implied follow-up actions.
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
+- **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
 
 # Primary Workflows
@@ -1162,7 +1169,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for path '/path/to/project']
 </example>
 
 <example>
@@ -1202,7 +1209,7 @@ All checks passed. This is a stable checkpoint.
 
 <example>
 user: Delete the temp directory.
-model: I can run \`rm -rf ./temp\`. This will permanently delete the directory and all its contents.
+model: I can run \`rm -rf /path/to/project/temp\`. This will permanently delete the directory and all its contents.
 </example>
 
 <example>
@@ -1258,6 +1265,7 @@ exports[`Core System Prompt (prompts.ts) > should return the base prompt when us
 - **Proactiveness:** Fulfill the user's request thoroughly, including reasonable, directly implied follow-up actions.
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
+- **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
 
 # Primary Workflows
@@ -1337,7 +1345,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for path '/path/to/project']
 </example>
 
 <example>
@@ -1377,7 +1385,7 @@ All checks passed. This is a stable checkpoint.
 
 <example>
 user: Delete the temp directory.
-model: I can run \`rm -rf ./temp\`. This will permanently delete the directory and all its contents.
+model: I can run \`rm -rf /path/to/project/temp\`. This will permanently delete the directory and all its contents.
 </example>
 
 <example>
@@ -1433,6 +1441,7 @@ exports[`Core System Prompt (prompts.ts) > should return the base prompt when us
 - **Proactiveness:** Fulfill the user's request thoroughly, including reasonable, directly implied follow-up actions.
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
+- **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
 
 # Primary Workflows
@@ -1512,7 +1521,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: list_directory for path '.']
+model: [tool_call: list_directory for path '/path/to/project']
 </example>
 
 <example>
@@ -1552,7 +1561,7 @@ All checks passed. This is a stable checkpoint.
 
 <example>
 user: Delete the temp directory.
-model: I can run \`rm -rf ./temp\`. This will permanently delete the directory and all its contents.
+model: I can run \`rm -rf /path/to/project/temp\`. This will permanently delete the directory and all its contents.
 </example>
 
 <example>

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -22,12 +22,12 @@ export function getCoreSystemPrompt(userMemory?: string): string {
   // if GEMINI_SYSTEM_MD is set (and not 0|false), override system prompt from file
   // default path is .gemini/system.md but can be modified via custom path in GEMINI_SYSTEM_MD
   let systemMdEnabled = false;
-  let systemMdPath = path.join(GEMINI_CONFIG_DIR, 'system.md');
+  let systemMdPath = path.resolve(path.join(GEMINI_CONFIG_DIR, 'system.md'));
   const systemMdVar = process.env.GEMINI_SYSTEM_MD?.toLowerCase();
   if (systemMdVar && !['0', 'false'].includes(systemMdVar)) {
     systemMdEnabled = true; // enable system prompt override
     if (!['1', 'true'].includes(systemMdVar)) {
-      systemMdPath = systemMdVar; // use custom path from GEMINI_SYSTEM_MD
+      systemMdPath = path.resolve(systemMdVar); // use custom path from GEMINI_SYSTEM_MD
     }
     // require file to exist when override is enabled
     if (!fs.existsSync(systemMdPath)) {
@@ -166,7 +166,7 @@ model: true
 
 <example>
 user: list files here.
-model: [tool_call: ${LSTool.Name} for path '.']
+model: [tool_call: ${LSTool.Name} for path '/path/to/project']
 </example>
 
 <example>
@@ -211,7 +211,7 @@ ${(function () {
 
 <example>
 user: Delete the temp directory.
-model: I can run \`rm -rf ./temp\`. This will permanently delete the directory and all its contents.
+model: I can run `rm -rf /path/to/project/temp`. This will permanently delete the directory and all its contents.
 </example>
 
 <example>
@@ -260,7 +260,7 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
     if (['1', 'true'].includes(writeSystemMdVar)) {
       fs.writeFileSync(systemMdPath, basePrompt); // write to default path, can be modified via GEMINI_SYSTEM_MD
     } else {
-      fs.writeFileSync(writeSystemMdVar, basePrompt); // write to custom path from GEMINI_WRITE_SYSTEM_MD
+      fs.writeFileSync(path.resolve(writeSystemMdVar), basePrompt); // write to custom path from GEMINI_WRITE_SYSTEM_MD
     }
   }
 

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -49,6 +49,7 @@ You are an interactive CLI agent specializing in software engineering tasks. You
 - **Proactiveness:** Fulfill the user's request thoroughly, including reasonable, directly implied follow-up actions.
 - **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without confirming with the user. If asked *how* to do something, explain first, don't just do it.
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
+- **Path Construction:** Before using any file system tool (e.g., ${ReadFileTool.Name}' or '${WriteFileTool.Name}'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
 
 # Primary Workflows
@@ -211,7 +212,7 @@ ${(function () {
 
 <example>
 user: Delete the temp directory.
-model: I can run `rm -rf /path/to/project/temp`. This will permanently delete the directory and all its contents.
+model: I can run \`rm -rf /path/to/project/temp\`. This will permanently delete the directory and all its contents.
 </example>
 
 <example>

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -101,11 +101,7 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
 
     const fileService = this.config.getFileService();
     if (fileService.shouldGeminiIgnoreFile(params.absolute_path)) {
-      const relativePath = makeRelative(
-        params.absolute_path,
-        this.rootDirectory,
-      );
-      return `File path '${shortenPath(relativePath)}' is ignored by .geminiignore pattern(s).`;
+      return `File path '${filePath}' is ignored by .geminiignore pattern(s).`;
     }
 
     return null;

--- a/packages/core/src/tools/read-many-files.test.ts
+++ b/packages/core/src/tools/read-many-files.test.ts
@@ -195,8 +195,9 @@ describe('ReadManyFilesTool', () => {
       createFile('file1.txt', 'Content of file1');
       const params = { paths: ['file1.txt'] };
       const result = await tool.execute(params, new AbortController().signal);
+      const expectedPath = path.join(tempRootDir, 'file1.txt');
       expect(result.llmContent).toEqual([
-        '--- file1.txt ---\n\nContent of file1\n\n',
+        `--- ${expectedPath} ---\n\nContent of file1\n\n`,
       ]);
       expect(result.returnDisplay).toContain(
         'Successfully read and concatenated content from **1 file(s)**',
@@ -209,12 +210,16 @@ describe('ReadManyFilesTool', () => {
       const params = { paths: ['file1.txt', 'subdir/file2.js'] };
       const result = await tool.execute(params, new AbortController().signal);
       const content = result.llmContent as string[];
+      const expectedPath1 = path.join(tempRootDir, 'file1.txt');
+      const expectedPath2 = path.join(tempRootDir, 'subdir/file2.js');
       expect(
-        content.some((c) => c.includes('--- file1.txt ---\n\nContent1\n\n')),
+        content.some((c) =>
+          c.includes(`--- ${expectedPath1} ---\n\nContent1\n\n`),
+        ),
       ).toBe(true);
       expect(
         content.some((c) =>
-          c.includes('--- subdir/file2.js ---\n\nContent2\n\n'),
+          c.includes(`--- ${expectedPath2} ---\n\nContent2\n\n`),
         ),
       ).toBe(true);
       expect(result.returnDisplay).toContain(
@@ -229,12 +234,16 @@ describe('ReadManyFilesTool', () => {
       const params = { paths: ['*.txt'] };
       const result = await tool.execute(params, new AbortController().signal);
       const content = result.llmContent as string[];
+      const expectedPath1 = path.join(tempRootDir, 'file.txt');
+      const expectedPath2 = path.join(tempRootDir, 'another.txt');
       expect(
-        content.some((c) => c.includes('--- file.txt ---\n\nText file\n\n')),
+        content.some((c) =>
+          c.includes(`--- ${expectedPath1} ---\n\nText file\n\n`),
+        ),
       ).toBe(true);
       expect(
         content.some((c) =>
-          c.includes('--- another.txt ---\n\nAnother text\n\n'),
+          c.includes(`--- ${expectedPath2} ---\n\nAnother text\n\n`),
         ),
       ).toBe(true);
       expect(content.find((c) => c.includes('sub/data.json'))).toBeUndefined();
@@ -249,7 +258,8 @@ describe('ReadManyFilesTool', () => {
       const params = { paths: ['src/**/*.ts'], exclude: ['**/*.test.ts'] };
       const result = await tool.execute(params, new AbortController().signal);
       const content = result.llmContent as string[];
-      expect(content).toEqual(['--- src/main.ts ---\n\nMain content\n\n']);
+      const expectedPath = path.join(tempRootDir, 'src/main.ts');
+      expect(content).toEqual([`--- ${expectedPath} ---\n\nMain content\n\n`]);
       expect(
         content.find((c) => c.includes('src/main.test.ts')),
       ).toBeUndefined();
@@ -275,7 +285,8 @@ describe('ReadManyFilesTool', () => {
       const params = { paths: ['**/*.js'] };
       const result = await tool.execute(params, new AbortController().signal);
       const content = result.llmContent as string[];
-      expect(content).toEqual(['--- src/app.js ---\n\napp code\n\n']);
+      const expectedPath = path.join(tempRootDir, 'src/app.js');
+      expect(content).toEqual([`--- ${expectedPath} ---\n\napp code\n\n`]);
       expect(
         content.find((c) => c.includes('node_modules/some-lib/index.js')),
       ).toBeUndefined();
@@ -290,13 +301,20 @@ describe('ReadManyFilesTool', () => {
       const params = { paths: ['**/*.js'], useDefaultExcludes: false };
       const result = await tool.execute(params, new AbortController().signal);
       const content = result.llmContent as string[];
+      const expectedPath1 = path.join(
+        tempRootDir,
+        'node_modules/some-lib/index.js',
+      );
+      const expectedPath2 = path.join(tempRootDir, 'src/app.js');
       expect(
         content.some((c) =>
-          c.includes('--- node_modules/some-lib/index.js ---\n\nlib code\n\n'),
+          c.includes(`--- ${expectedPath1} ---\n\nlib code\n\n`),
         ),
       ).toBe(true);
       expect(
-        content.some((c) => c.includes('--- src/app.js ---\n\napp code\n\n')),
+        content.some((c) =>
+          c.includes(`--- ${expectedPath2} ---\n\napp code\n\n`),
+        ),
       ).toBe(true);
       expect(result.returnDisplay).toContain(
         'Successfully read and concatenated content from **2 file(s)**',
@@ -350,9 +368,12 @@ describe('ReadManyFilesTool', () => {
       const params = { paths: ['*'] }; // Generic glob, not specific to .pdf
       const result = await tool.execute(params, new AbortController().signal);
       const content = result.llmContent as string[];
+      const expectedPath = path.join(tempRootDir, 'notes.txt');
       expect(
         content.some(
-          (c) => typeof c === 'string' && c.includes('--- notes.txt ---'),
+          (c) =>
+            typeof c === 'string' &&
+            c.includes(`--- ${expectedPath} ---\n\ntext notes\n\n`),
         ),
       ).toBe(true);
       expect(result.returnDisplay).toContain('**Skipped 1 item(s):**');

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -390,7 +390,7 @@ Use this tool when the user's query implies needing the content of several files
         if (typeof fileReadResult.llmContent === 'string') {
           const separator = DEFAULT_OUTPUT_SEPARATOR_FORMAT.replace(
             '{filePath}',
-            relativePathForDisplay,
+            filePath,
           );
           contentParts.push(`${separator}\n\n${fileReadResult.llmContent}\n\n`);
         } else {


### PR DESCRIPTION
## TLDR

We were leading Gemini astray by examples in our prompt and a bug in read-many-files that told the model relative rather than absolute path names. Unsurprising the model then tried to use relative path names.
I also added a mandate to prompts.ts to convert from relative to absolute paths with an example of what that means.

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

Someone with more context/prompt engineering expertise may have ideas for how to refine the mandate added about file paths. Potentially this could be merged with some of the other mentions of absolute file paths in the prompt but given the struggles with paths I think it could be worth it to over index on this for now.

Fix prompt, read-many-files, and read-file to avoid relative paths
This was resulting the Gemini trying to access files by relative paths
causing wasted Gemini 2.5 pro calls as Gemini would have to course
correct to figure out the absolute path after getting errors when it
used relative paths.

## Reviewer Test Plan

Try some of your favorite prompts that were previously resulting in this frustrating behavior.

A simple prompt that I was that reproduced the issue was 
`Add tests for @packages/cli/src/ui/utils/MarkdownDisplay.tsx`

Example output without my change:
<img width="946" height="940" alt="Screenshot 2025-07-11 at 4 55 13 PM" src="https://github.com/user-attachments/assets/0e170255-9d9f-4ede-9cc2-b4cdff8050c0" />

With my change
<img width="946" height="940" alt="Screenshot 2025-07-11 at 4 55 13 PM" src="https://github.com/user-attachments/assets/0ca033af-1dc9-4a27-961d-dbab9f92a396" />

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

As with any path related issue, it would be good to test this on windows.

## Linked issues / bugs
https://b.corp.google.com/issues/425434634

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
