### PR TITLE
Fix typo in README.md regarding Vertex AI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The Gemini API provides a free tier with [100 requests per day](https://ai.googl
 
 ### Use a Vertex AI API key:
 
-The Vertex AI provides [free tier](https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview) using express mode for Gemini 2.5 Pro, control over which model you use, and access to higher rate limits with a billing account:
+The Vertex AI API provides a [free tier](https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview) using express mode for Gemini 2.5 Pro, control over which model you use, and access to higher rate limits with a billing account:
 
 1. Generate a key from [Google Cloud](https://cloud.google.com/vertex-ai/generative-ai/docs/start/api-keys).
 2. Set it as an environment variable in your terminal. Replace `YOUR_API_KEY` with your generated key and set GOOGLE_GENAI_USE_VERTEXAI to true


### PR DESCRIPTION
## TLDR

Fixes a grammar mistake in the README.md file, under the section "Use a Vertex AI API key:"

## Dive Deeper

This changes the first sentence of the following paragraph, which currently reads "The Vertex AI provides free tier" to "The Vertex AI API provides a free tier". 

<img width="1067" height="201" alt="Screenshot 2025-07-10 232954" src="https://github.com/user-attachments/assets/1b07b35f-cd09-4903-a03b-820c9750e848" />

This change makes the above section consistent with the section below.

<img width="1015" height="147" alt="Screenshot 2025-07-10 233552" src="https://github.com/user-attachments/assets/b25c4426-3ccf-456c-b0ea-542ad17702ee" />


## Reviewer Test Plan

Review the README.md file and see if the content renders as intended.


## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

- Fixes #3798 
