### PR TITLE
fix(ui): remove extraneous whitespace from startup screen

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -648,6 +648,38 @@ describe('App UI', () => {
     });
   });
 
+  it('should render the initial UI correctly', () => {
+    const { lastFrame, unmount } = render(
+      <App
+        config={mockConfig as unknown as ServerConfig}
+        settings={mockSettings}
+        version={mockVersion}
+      />,
+    );
+    currentUnmount = unmount;
+    expect(lastFrame()).toMatchSnapshot();
+  });
+
+  it('should render correctly with the prompt input box', () => {
+    vi.mocked(useGeminiStream).mockReturnValue({
+      streamingState: StreamingState.Idle,
+      submitQuery: vi.fn(),
+      initError: null,
+      pendingHistoryItems: [],
+      thought: null,
+    });
+
+    const { lastFrame, unmount } = render(
+      <App
+        config={mockConfig as unknown as ServerConfig}
+        settings={mockSettings}
+        version={mockVersion}
+      />,
+    );
+    currentUnmount = unmount;
+    expect(lastFrame()).toMatchSnapshot();
+  });
+
   describe('with initial prompt from --prompt-interactive', () => {
     it('should submit the initial prompt automatically', async () => {
       const mockSubmitQuery = vi.fn();

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -722,7 +722,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
 
   return (
     <StreamingContext.Provider value={streamingState}>
-      <Box flexDirection="column" marginBottom={1} width="90%">
+      <Box flexDirection="column" width="90%">
         {/* Move UpdateNotification outside Static so it can re-render when updateMessage changes */}
         {updateMessage && <UpdateNotification message={updateMessage} />}
 

--- a/packages/cli/src/ui/__snapshots__/App.test.tsx.snap
+++ b/packages/cli/src/ui/__snapshots__/App.test.tsx.snap
@@ -1,0 +1,18 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`App UI > should render correctly with the prompt input box 1`] = `
+"
+
+╭────────────────────────────────────────────────────────────────────────────────────────╮
+│ >   Type your message or @path/to/file                                                 │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+/test/dir                no sandbox (see /docs)                  model (100% context left)"
+`;
+
+exports[`App UI > should render the initial UI correctly 1`] = `
+"
+ I'm Feeling Lucky (esc to cancel, 0s)
+
+
+/test/dir                no sandbox (see /docs)                  model (100% context left)"
+`;

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -46,7 +46,7 @@ export const Footer: React.FC<FooterProps> = ({
   const percentage = promptTokenCount / limit;
 
   return (
-    <Box marginTop={1} justifyContent="space-between" width="100%">
+    <Box justifyContent="space-between" width="100%">
       <Box>
         {vimMode && <Text color={Colors.Gray}>[{vimMode}] </Text>}
         {nightly ? (

--- a/packages/cli/src/ui/components/Header.tsx
+++ b/packages/cli/src/ui/components/Header.tsx
@@ -38,7 +38,6 @@ export const Header: React.FC<HeaderProps> = ({
 
   return (
     <Box
-      marginBottom={1}
       alignItems="flex-start"
       width={artWidth}
       flexShrink={0}

--- a/packages/cli/src/ui/components/Tips.tsx
+++ b/packages/cli/src/ui/components/Tips.tsx
@@ -16,7 +16,7 @@ interface TipsProps {
 export const Tips: React.FC<TipsProps> = ({ config }) => {
   const geminiMdFileCount = config.getGeminiMdFileCount();
   return (
-    <Box flexDirection="column" marginBottom={1}>
+    <Box flexDirection="column">
       <Text color={Colors.Foreground}>Tips for getting started:</Text>
       <Text color={Colors.Foreground}>
         1. Ask questions, edit files, or run commands.


### PR DESCRIPTION
Remove extra whitespace lines from App.tsx

Removes two lines of whitespace that were appearing before and after the "Tips for getting started" section on the CLI startup screen. This was caused by a combination of a leading newline in the ASCII art and extra margins on the Header, Tips, and ContextSummaryDisplay components. This change removes the unnecessary whitespace to tighten up the UI. We accidentally had multiple lines of whitespace
at multiple places in App.tsx.

Adds a snapshot test for the initial rendering of the App.tsx component. This will help to prevent unintentional UI regressions.

With the changes the startup UI now looks like
<img width="936" height="323" alt="Screenshot 2025-07-12 at 12 42 26 PM" src="https://github.com/user-attachments/assets/c2e9010d-e4aa-4b71-9bc7-cb2f600faf48" />

## Linked issues / bugs
- Fixes #3988
