### PR TITLE
feat: Invert scroll arrow default in RadioButtonSelect

### DIFF
--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -203,6 +203,7 @@ export function ThemeDialog({
             onHighlight={onHighlight}
             isFocused={currenFocusedSection === 'theme'}
             maxItemsToShow={8}
+            showScrollArrows={true}
           />
 
           {/* Scope Selection */}
@@ -217,7 +218,6 @@ export function ThemeDialog({
                 onSelect={handleScopeSelect}
                 onHighlight={handleScopeHighlight}
                 isFocused={currenFocusedSection === 'scope'}
-                showScrollArrows={false}
               />
             </Box>
           )}

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -53,7 +53,7 @@ export function RadioButtonSelect<T>({
   onSelect,
   onHighlight,
   isFocused,
-  showScrollArrows = true,
+  showScrollArrows = false,
   maxItemsToShow = 10,
 }: RadioButtonSelectProps<T>): React.JSX.Element {
   const [activeIndex, setActiveIndex] = useState(initialIndex);


### PR DESCRIPTION
## TLDR

This PR inverts the default behavior of the  component to hide scroll arrows by default. They are now explicitly enabled only for the theme selection list, which has many options. This declutters the UI for other radio button selections with fewer items.

## Dive Deeper

The  prop in  now defaults to . The  has been updated to explicitly set this prop to  for the theme list, ensuring the scroll indicators remain visible where they are needed most.

### Before
<img width="1824" height="1976" alt="image" src="https://github.com/user-attachments/assets/5eedb185-0aed-4fa4-b0d1-29855b54905c" />


### After
<img width="1824" height="1976" alt="image" src="https://github.com/user-attachments/assets/7988bddf-ddfd-4f1e-bc4e-9002474d6b29" />


## Reviewer Test Plan

1. Run .
2. Verify that the scroll arrows are visible for the theme selection list.
3. Verify that other radio button selections in the application (if any) do not show scroll arrows by default.

## Testing Matrix

| | 🍏 | 🪟 | 🐧 |
| --- | --- | --- | --- |
| npm run | ✅ | ❓ | ❓ |
| npx | ✅ | ❓ | ❓ |
| Docker | ✅ | ❓ | ❓ |
| Podman | ✅ | - | - |
| Seatbelt | ✅ | - | - |

## Linked issues / bugs

Fixes #4005
