### PR TITLE
feat(tools): Centralize shell tool summarization

### DIFF
--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -656,39 +656,15 @@ export class CoreToolScheduler {
               return;
             }
 
-            let resultForDisplay: ToolResult = toolResult;
-            let summary: string | undefined;
-            if (scheduledCall.tool.summarizer) {
-              try {
-                const toolSignal = new AbortController();
-                summary = await scheduledCall.tool.summarizer(
-                  toolResult,
-                  this.config.getGeminiClient(),
-                  toolSignal.signal,
-                );
-                if (toolSignal.signal.aborted) {
-                  console.debug('aborted summarizing tool result');
-                  return;
-                }
-                if (scheduledCall.tool?.shouldSummarizeDisplay) {
-                  resultForDisplay = {
-                    ...toolResult,
-                    returnDisplay: summary,
-                  };
-                }
-              } catch (e) {
-                console.error('Error summarizing tool result:', e);
-              }
-            }
             const response = convertToFunctionResponse(
               toolName,
               callId,
-              summary ? [summary] : toolResult.llmContent,
+              toolResult.llmContent,
             );
             const successResponse: ToolCallResponseInfo = {
               callId,
               responseParts: response,
-              resultDisplay: resultForDisplay.returnDisplay,
+              resultDisplay: toolResult.returnDisplay,
               error: undefined,
             };
 

--- a/packages/core/src/core/nonInteractiveToolExecutor.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.ts
@@ -68,17 +68,9 @@ export async function executeToolCall(
       // No live output callback for non-interactive mode
     );
 
-    const tool_output = tool.summarizer
-      ? await tool.summarizer(
-          toolResult,
-          config.getGeminiClient(),
-          effectiveAbortSignal,
-        )
-      : toolResult.llmContent;
+    const tool_output = toolResult.llmContent;
 
-    const tool_display = tool.shouldSummarizeDisplay
-      ? (tool_output as string)
-      : toolResult.returnDisplay;
+    const tool_display = toolResult.returnDisplay;
 
     const durationMs = Date.now() - startTime;
     logToolCall(config, {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect, describe, it } from 'vitest';
+import { expect, describe, it, vi, beforeEach } from 'vitest';
 import { ShellTool } from './shell.js';
 import { Config } from '../config/config.js';
+import * as summarizer from '../utils/summarizer.js';
+import { GeminiClient } from '../core/client.js';
 
 describe('ShellTool', () => {
   it('should allow a command if no restrictions are provided', async () => {
@@ -394,5 +396,37 @@ describe('ShellTool', () => {
     expect(result.reason).toBe(
       "Command 'rm -rf /' is not in the allowed commands list",
     );
+  });
+});
+
+describe('ShellTool Bug Reproduction', () => {
+  let shellTool: ShellTool;
+  let config: Config;
+
+  beforeEach(() => {
+    config = {
+      getCoreTools: () => undefined,
+      getExcludeTools: () => undefined,
+      getDebugMode: () => false,
+      getGeminiClient: () => ({}) as GeminiClient,
+      getTargetDir: () => '.',
+    } as unknown as Config;
+    shellTool = new ShellTool(config);
+  });
+
+  it('should not let the summarizer override the return display', async () => {
+    const summarizeSpy = vi
+      .spyOn(summarizer, 'summarizeToolOutput')
+      .mockResolvedValue('summarized output');
+
+    const abortSignal = new AbortController().signal;
+    const result = await shellTool.execute(
+      { command: 'echo "hello"' },
+      abortSignal,
+    );
+
+    expect(result.returnDisplay).toBe('hello\n');
+    expect(result.llmContent).toBe('summarized output');
+    expect(summarizeSpy).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -27,7 +27,7 @@ export interface ShellToolParams {
   directory?: string;
 }
 import { spawn } from 'child_process';
-import { llmSummarizer } from '../utils/summarizer.js';
+import { summarizeToolOutput } from '../utils/summarizer.js';
 
 const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 
@@ -74,8 +74,6 @@ Process Group PGID: Process group started or \`(none)\``,
       },
       false, // output is not markdown
       true, // output can be updated
-      llmSummarizer,
-      true, // should summarize display output
     );
   }
 
@@ -490,6 +488,16 @@ Process Group PGID: Process group started or \`(none)\``,
         // returnDisplayMessage will remain empty, which is fine.
       }
     }
-    return { llmContent, returnDisplay: returnDisplayMessage };
+
+    const summary = await summarizeToolOutput(
+      llmContent,
+      this.config.getGeminiClient(),
+      abortSignal,
+    );
+
+    return {
+      llmContent: summary,
+      returnDisplay: returnDisplayMessage,
+    };
   }
 }

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -11,7 +11,6 @@ import { spawn } from 'node:child_process';
 import { StringDecoder } from 'node:string_decoder';
 import { discoverMcpTools } from './mcp-client.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
-import { defaultSummarizer } from '../utils/summarizer.js';
 import { parse } from 'shell-quote';
 
 type ToolParams = Record<string, unknown>;
@@ -48,7 +47,6 @@ Signal: Signal number or \`(none)\` if no signal was received.
       parameterSchema,
       false, // isOutputMarkdown
       false, // canUpdateOutput
-      defaultSummarizer,
     );
   }
 

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -5,7 +5,6 @@
  */
 
 import { FunctionDeclaration, PartListUnion, Schema } from '@google/genai';
-import { Summarizer, defaultSummarizer } from '../utils/summarizer.js';
 
 /**
  * Interface representing the base Tool functionality
@@ -43,16 +42,6 @@ export interface Tool<
    * Whether the tool supports live (streaming) output
    */
   canUpdateOutput: boolean;
-
-  /**
-   * A function that summarizes the result of the tool execution.
-   */
-  summarizer?: Summarizer;
-
-  /**
-   * Whether the tool's display output should be summarized
-   */
-  shouldSummarizeDisplay?: boolean;
 
   /**
    * Validates the parameters for the tool
@@ -109,8 +98,6 @@ export abstract class BaseTool<
    * @param isOutputMarkdown Whether the tool's output should be rendered as markdown
    * @param canUpdateOutput Whether the tool supports live (streaming) output
    * @param parameterSchema JSON Schema defining the parameters
-   * @param summarizer Function to summarize the tool's output
-   * @param shouldSummarizeDisplay Whether the tool's display output should be summarized
    */
   constructor(
     readonly name: string,
@@ -119,8 +106,6 @@ export abstract class BaseTool<
     readonly parameterSchema: Schema,
     readonly isOutputMarkdown: boolean = true,
     readonly canUpdateOutput: boolean = false,
-    readonly summarizer: Summarizer = defaultSummarizer,
-    readonly shouldSummarizeDisplay: boolean = false,
   ) {}
 
   /**


### PR DESCRIPTION
## TLDR

This PR centralizes the output summarization logic directly into the ShellTool's `execute` method. This prevents the summarizer from incorrectly overriding the user-facing `returnDisplay` with internal LLM content, ensuring only the actual command output is shown. A regression test is included to verify the fix.

## Dive Deeper

The previous implementation used generic `summarizer` and `shouldSummarizeDisplay` properties on the base tool definition. This approach was too broad and led to the bug where the shell tool's output was being replaced by the summarized version intended for the LLM. By moving the summarization call to be specific to the `llmContent` within the `ShellTool`, we get more precise control over what is displayed to the user and what is sent to the model.

### Before
<img width="1824" height="1976" alt="image" src="https://github.com/user-attachments/assets/444e44b4-7abf-4728-96b1-bb539622b562" />


### After
<img width="1824" height="1976" alt="image" src="https://github.com/user-attachments/assets/db0a69c3-e426-4875-a14b-4631797c3e39" />


## Reviewer Test Plan

1. Pull down this branch.
2. Run the tests for the core package: `npm run test -w @google/gemini-cli-core`
3. Verify that the new test in `packages/core/src/tools/shell.test.ts` passes.
4. Run a command that produces output, e.g. `gemini ls -l`.
5. Verify that the output is clean and does not contain any extra "summarized" text.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ✅  | ❓  | ❓  |
| Podman   | ✅  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

Fixes #4008
