### PR TITLE
feat(core): add telemetry for 'turns' in sendMessageStream

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -350,7 +350,7 @@ This is the cursor position in the file:
         // Record telemetry for the turn
         recordTurnMetrics(
           this.config,
-          currentModel,
+          initialModel,
           this.MAX_TURNS - boundedTurns + 1,
           this.MAX_TURNS,
           false, // limit not reached

--- a/packages/core/src/telemetry/constants.ts
+++ b/packages/core/src/telemetry/constants.ts
@@ -21,3 +21,4 @@ export const METRIC_API_REQUEST_LATENCY = 'gemini_cli.api.request.latency';
 export const METRIC_TOKEN_USAGE = 'gemini_cli.token.usage';
 export const METRIC_SESSION_COUNT = 'gemini_cli.session.count';
 export const METRIC_FILE_OPERATION_COUNT = 'gemini_cli.file.operation.count';
+export const METRIC_TURN_COUNT = 'gemini_cli.turn.count';


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->
As written in #3948, added telemetry to the 'turns' variable in the 'sendMessageStream' method within 'packages/core/src/core/client.ts'. This will help us gather data on how often the turn limit is being hit and provide better insights into the conversation flow.

## Dive Deeper

<!-- more thoughts and in depth discussion here -->
This is important to understand and improve the robustness of the client.


## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->
Added the following tests
- Verifies that telemetry is recorded when the conversation reaches the maximum turn limit
- Verifies telemetry is recorded when the conversation ends naturally
- Verifies telemetry is recorded when a turn ends because there are pending tool calls to execute
- Verifies that recursive turns are tracked correctly when the model continues speaking multiple times 

Each test verifies that recordTurnMetrics is called with:
1. config: The configuration object
2. model: The model name (e.g., 'gemini-pro')
3. turns_used: Number of turns used in the conversation
4. max_turns: Maximum allowed turns (100)
5. limit_reached: Boolean indicating if the limit was hit
6. session_turn_count: Total turns in the session

These tests ensure that the telemetry accurately tracks:
- Normal conversation flow
- Recursive model responses
- Tool call interruptions
- Turn limit enforcement

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #3948 
<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
