### PR TITLE
feat(ui): hide cursor when terminal is unfocused

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -66,6 +66,7 @@ import {
   useSessionStats,
 } from './contexts/SessionContext.js';
 import { useGitBranchName } from './hooks/useGitBranchName.js';
+import { useFocus } from './hooks/useFocus.js';
 import { useBracketedPaste } from './hooks/useBracketedPaste.js';
 import { useTextBuffer } from './components/shared/text-buffer.js';
 import * as fs from 'fs';
@@ -97,6 +98,7 @@ export const AppWrapper = (props: AppProps) => (
 );
 
 const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
+  const isFocused = useFocus();
   useBracketedPaste();
   const [updateMessage, setUpdateMessage] = useState<string | null>(null);
   const { stdout } = useStdout();
@@ -928,6 +930,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
                   commandContext={commandContext}
                   shellModeActive={shellModeActive}
                   setShellModeActive={setShellModeActive}
+                  focus={isFocused}
                 />
               )}
             </>

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -430,7 +430,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 display = display + ' '.repeat(inputWidth - currentVisualWidth);
               }
 
-              if (visualIdxInRenderedSet === cursorVisualRow) {
+              if (focus && visualIdxInRenderedSet === cursorVisualRow) {
                 const relativeVisualColForHighlight = cursorVisualColAbsolute;
 
                 if (relativeVisualColForHighlight >= 0) {

--- a/packages/cli/src/ui/hooks/useFocus.test.ts
+++ b/packages/cli/src/ui/hooks/useFocus.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { EventEmitter } from 'events';
+import { useFocus } from './useFocus.js';
+import { vi } from 'vitest';
+import { useStdin, useStdout } from 'ink';
+
+// Mock the ink hooks
+vi.mock('ink', async (importOriginal) => {
+  const original = await importOriginal<typeof import('ink')>();
+  return {
+    ...original,
+    useStdin: vi.fn(),
+    useStdout: vi.fn(),
+  };
+});
+
+const mockedUseStdin = vi.mocked(useStdin);
+const mockedUseStdout = vi.mocked(useStdout);
+
+describe('useFocus', () => {
+  let stdin: EventEmitter;
+  let stdout: { write: vi.Func };
+
+  beforeEach(() => {
+    stdin = new EventEmitter();
+    stdout = { write: vi.fn() };
+    mockedUseStdin.mockReturnValue({ stdin } as ReturnType<typeof useStdin>);
+    mockedUseStdout.mockReturnValue({ stdout } as unknown as ReturnType<
+      typeof useStdout
+    >);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should initialize with focus and enable focus reporting', () => {
+    const { result } = renderHook(() => useFocus());
+
+    expect(result.current).toBe(true);
+    expect(stdout.write).toHaveBeenCalledWith('\x1b[?1004h');
+  });
+
+  it('should set isFocused to false when a focus-out event is received', () => {
+    const { result } = renderHook(() => useFocus());
+
+    // Initial state is focused
+    expect(result.current).toBe(true);
+
+    // Simulate focus-out event
+    act(() => {
+      stdin.emit('data', Buffer.from('\x1b[O'));
+    });
+
+    // State should now be unfocused
+    expect(result.current).toBe(false);
+  });
+
+  it('should set isFocused to true when a focus-in event is received', () => {
+    const { result } = renderHook(() => useFocus());
+
+    // Simulate focus-out to set initial state to false
+    act(() => {
+      stdin.emit('data', Buffer.from('\x1b[O'));
+    });
+    expect(result.current).toBe(false);
+
+    // Simulate focus-in event
+    act(() => {
+      stdin.emit('data', Buffer.from('\x1b[I'));
+    });
+
+    // State should now be focused
+    expect(result.current).toBe(true);
+  });
+
+  it('should clean up and disable focus reporting on unmount', () => {
+    const { unmount } = renderHook(() => useFocus());
+
+    // Ensure listener was attached
+    expect(stdin.listenerCount('data')).toBe(1);
+
+    unmount();
+
+    // Assert that the cleanup function was called
+    expect(stdout.write).toHaveBeenCalledWith('\x1b[?1004l');
+    expect(stdin.listenerCount('data')).toBe(0);
+  });
+
+  it('should handle multiple focus events correctly', () => {
+    const { result } = renderHook(() => useFocus());
+
+    act(() => {
+      stdin.emit('data', Buffer.from('\x1b[O'));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      stdin.emit('data', Buffer.from('\x1b[O'));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      stdin.emit('data', Buffer.from('\x1b[I'));
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      stdin.emit('data', Buffer.from('\x1b[I'));
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/packages/cli/src/ui/hooks/useFocus.ts
+++ b/packages/cli/src/ui/hooks/useFocus.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useStdin, useStdout } from 'ink';
+import { useEffect, useState } from 'react';
+
+// ANSI escape codes to enable/disable terminal focus reporting
+const ENABLE_FOCUS_REPORTING = '\x1b[?1004h';
+const DISABLE_FOCUS_REPORTING = '\x1b[?1004l';
+
+// ANSI escape codes for focus events
+const FOCUS_IN = '\x1b[I';
+const FOCUS_OUT = '\x1b[O';
+
+export const useFocus = () => {
+  const { stdin } = useStdin();
+  const { stdout } = useStdout();
+  const [isFocused, setIsFocused] = useState(true);
+
+  useEffect(() => {
+    const handleData = (data: Buffer) => {
+      const sequence = data.toString();
+      const lastFocusIn = sequence.lastIndexOf(FOCUS_IN);
+      const lastFocusOut = sequence.lastIndexOf(FOCUS_OUT);
+
+      if (lastFocusIn > lastFocusOut) {
+        setIsFocused(true);
+      } else if (lastFocusOut > lastFocusIn) {
+        setIsFocused(false);
+      }
+    };
+
+    // Enable focus reporting
+    stdout?.write(ENABLE_FOCUS_REPORTING);
+    stdin?.on('data', handleData);
+
+    return () => {
+      // Disable focus reporting on cleanup
+      stdout?.write(DISABLE_FOCUS_REPORTING);
+      stdin?.removeListener('data', handleData);
+    };
+  }, [stdin, stdout]);
+
+  return isFocused;
+};


### PR DESCRIPTION
Introduces a new `useFocus` hook to track terminal focus using ANSI escape codes.

This hook is used in the main `App` component to determine if the terminal window is active. The focus state is then passed to the `InputPrompt` component to conditionally render the cursor, hiding it when the window is not focused.

This improves the user experience by providing a clear visual indicator of the application's focus state.

Fixes #4007

## TLDR

This PR hides the input cursor when the terminal window is not in focus. A new `useFocus` hook has been added to detect the terminal's focus state, and the `InputPrompt` now uses this state to control the cursor's visibility.

## Dive Deeper

The core of this change is the new `useFocus` hook, which enables and disables terminal focus reporting using ANSI escape codes (`CSI ? 1004 h` and `CSI ? 1004
l`). When focus reporting is enabled, the terminal emits specific sequences on `stdin` when its focus state changes:
* `\x1b[I` (or `CSI I`) for focus-in
* `\x1b[O` (or `CSI O`) for focus-out

The hook listens for these sequences and maintains a boolean state (`isFocused`). This state is passed from the main `App` component down to the `InputPrompt`. The `InputPrompt` then uses this boolean to decide whether to render the cursor.

This approach is robust because it relies on a standard terminal feature and avoids trying to infer focus from other, less reliable events. The hook also includes comprehensive tests to ensure it correctly handles events and cleans up its listeners and terminal settings on unmount.

## Reviewer Test Plan

1.  Pull down this branch.
2.  Run `npm install` to ensure all dependencies are up to date.
3.  Start the Gemini CLI by running `npm start`.
4.  **Verify the cursor behavior:**
    * With the terminal window active and focused, you should see the cursor in the input prompt as normal.
    * Click on another window or your desktop to make the terminal lose focus.
    * **Expected result:** The cursor in the input prompt should disappear.
    * Click back into the terminal window to give it focus again.
    * **Expected result:** The cursor should reappear.
5.  Type a command and interact with the CLI to ensure no other functionality has been affected.

## Testing Matrix

|         | Linux | macOS | Windows |
| -------- | :---: | :---: | :-----: |
| npm run  |  ✅   |  ❓   |   ❓    |
| npx      |  ❓   |  ❓   |   ❓    |
| Docker   |  ❓   |  ❓   |   ❓    |
| Podman   |  ❓   |   -   |    -    |
| Seatbelt |  ❓   |   -   |    -    |

## Linked issues / bugs

Fixes #4007

