### PR TITLE
Fix not using flash for next speaker check

### DIFF
--- a/packages/core/src/utils/nextSpeakerChecker.test.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, Mock, afterEach } from 'vitest';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '@google/gemini-cli-core';
 import { Content, GoogleGenAI, Models } from '@google/genai';
 import { GeminiClient } from '../core/client.js';
 import { Config } from '../config/config.js';
@@ -230,5 +231,23 @@ describe('checkNextSpeaker', () => {
       abortSignal,
     );
     expect(result).toBeNull();
+  });
+
+  it('should call generateJson with DEFAULT_GEMINI_FLASH_MODEL', async () => {
+    (chatInstance.getHistory as Mock).mockReturnValue([
+      { role: 'model', parts: [{ text: 'Some model output.' }] },
+    ] as Content[]);
+    const mockApiResponse: NextSpeakerResponse = {
+      reasoning: 'Model made a statement, awaiting user input.',
+      next_speaker: 'user',
+    };
+    (mockGeminiClient.generateJson as Mock).mockResolvedValue(mockApiResponse);
+
+    await checkNextSpeaker(chatInstance, mockGeminiClient, abortSignal);
+
+    expect(mockGeminiClient.generateJson).toHaveBeenCalled();
+    const generateJsonCall = (mockGeminiClient.generateJson as Mock).mock
+      .calls[0];
+    expect(generateJsonCall[3]).toBe(DEFAULT_GEMINI_FLASH_MODEL);
   });
 });

--- a/packages/core/src/utils/nextSpeakerChecker.test.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.test.ts
@@ -5,8 +5,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, Mock, afterEach } from 'vitest';
-import { DEFAULT_GEMINI_FLASH_MODEL } from '@google/gemini-cli-core';
 import { Content, GoogleGenAI, Models } from '@google/genai';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { GeminiClient } from '../core/client.js';
 import { Config } from '../config/config.js';
 import { checkNextSpeaker, NextSpeakerResponse } from './nextSpeakerChecker.js';

--- a/packages/core/src/utils/nextSpeakerChecker.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DEFAULT_GEMINI_FLASH_MODEL } from '@google/gemini-cli-core';
 import { Content, SchemaUnion, Type } from '@google/genai';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { GeminiClient } from '../core/client.js';
 import { GeminiChat } from '../core/geminiChat.js';
 import { isFunctionResponse } from './messageInspectors.js';

--- a/packages/core/src/utils/nextSpeakerChecker.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DEFAULT_GEMINI_FLASH_MODEL } from '@google/gemini-cli-core';
 import { Content, SchemaUnion, Type } from '@google/genai';
 import { GeminiClient } from '../core/client.js';
 import { GeminiChat } from '../core/geminiChat.js';
@@ -131,6 +132,7 @@ export async function checkNextSpeaker(
       contents,
       RESPONSE_SCHEMA,
       abortSignal,
+      DEFAULT_GEMINI_FLASH_MODEL,
     )) as unknown as NextSpeakerResponse;
 
     if (


### PR DESCRIPTION
## TLDR

Specify flash model when calling generateJson in nextSpeakerCheck, as a previous change accidentally removed this feature.

## Dive Deeper

Noticed model hangs at the end of every turn. Analyzed network traffic and found it now uses pro model for next speaker check, but previously it was using flash.

Turns out https://github.com/google-gemini/gemini-cli/pull/3662 removed this default behavior.

Also added a test to ensure this behavior.

## Reviewer Test Plan

Watch how model hangs less at the end of each turn.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs
N/A