### PR TITLE
enhance gemini cli to attach a base64 file as an attachment and send it with the next prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:ci": "eslint . --ext .ts,.tsx --max-warnings 0 && eslint integration-tests --max-warnings 0",
     "format": "prettier --write .",
     "typecheck": "npm run typecheck --workspaces --if-present",
-    "preflight": "npm run clean && npm ci && npm run format && npm run lint:ci && npm run build && npm run typecheck && npm run test:ci",
+    "preflight": "npm ci && npm run format && npm run lint:ci && npm run build && npm run typecheck && npm run test:ci && npm run clean",
     "prepare": "npm run bundle",
     "prepare:package": "node scripts/prepare-package.js",
     "release:version": "node scripts/version.js",

--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -11,6 +11,7 @@ import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
+import { pasteCommand } from '../ui/commands/pasteCommand.js';
 
 // Mock the command modules to isolate the service from the command implementations.
 vi.mock('../ui/commands/memoryCommand.js', () => ({
@@ -24,6 +25,9 @@ vi.mock('../ui/commands/clearCommand.js', () => ({
 }));
 vi.mock('../ui/commands/themeCommand.js', () => ({
   themeCommand: { name: 'theme', description: 'Mock Theme' },
+}));
+vi.mock('../ui/commands/pasteCommand.js', () => ({
+  pasteCommand: { name: 'paste', description: 'Mock Paste' },
 }));
 
 describe('CommandService', () => {
@@ -50,26 +54,27 @@ describe('CommandService', () => {
         const tree = commandService.getCommands();
 
         // Post-condition assertions
-        expect(tree.length).toBe(4);
+        expect(tree.length).toBe(5);
 
         const commandNames = tree.map((cmd) => cmd.name);
         expect(commandNames).toContain('memory');
         expect(commandNames).toContain('help');
         expect(commandNames).toContain('clear');
         expect(commandNames).toContain('theme');
+        expect(commandNames).toContain('paste');
       });
 
       it('should overwrite any existing commands when called again', async () => {
         // Load once
         await commandService.loadCommands();
-        expect(commandService.getCommands().length).toBe(4);
+        expect(commandService.getCommands().length).toBe(5);
 
         // Load again
         await commandService.loadCommands();
         const tree = commandService.getCommands();
 
         // Should not append, but overwrite
-        expect(tree.length).toBe(4);
+        expect(tree.length).toBe(5);
       });
     });
 
@@ -81,11 +86,12 @@ describe('CommandService', () => {
         await commandService.loadCommands();
 
         const loadedTree = commandService.getCommands();
-        expect(loadedTree.length).toBe(4);
+        expect(loadedTree.length).toBe(5);
         expect(loadedTree).toEqual([
           clearCommand,
           helpCommand,
           memoryCommand,
+          pasteCommand,
           themeCommand,
         ]);
       });

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -9,11 +9,13 @@ import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
+import { pasteCommand } from '../ui/commands/pasteCommand.js';
 
 const loadBuiltInCommands = async (): Promise<SlashCommand[]> => [
   clearCommand,
   helpCommand,
   memoryCommand,
+  pasteCommand,
   themeCommand,
 ];
 

--- a/packages/cli/src/ui/commands/pasteCommand.test.ts
+++ b/packages/cli/src/ui/commands/pasteCommand.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { pasteCommand } from './pasteCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { CommandContext } from './types.js';
+
+describe('pasteCommand', () => {
+  let context: CommandContext;
+
+  beforeEach(() => {
+    context = createMockCommandContext();
+    // Add the new methods to the mock context
+    context.ui.setInputMode = vi.fn();
+    context.ui.clearPastedContent = vi.fn();
+  });
+
+  it('should set input mode to "paste" when called with no arguments', async () => {
+    const result = await pasteCommand.action(context, '');
+    expect(context.ui.setInputMode).toHaveBeenCalledWith('paste');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Paste your data and press Enter. Press Esc to cancel.',
+    });
+  });
+
+  it('should call clearPastedContent when called with --clear', async () => {
+    const result = await pasteCommand.action(context, ' --clear ');
+    expect(context.ui.clearPastedContent).toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Staged images cleared.',
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/pasteCommand.ts
+++ b/packages/cli/src/ui/commands/pasteCommand.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type SlashCommand, type CommandContext } from './types.js';
+
+export const pasteCommand: SlashCommand = {
+  name: 'paste',
+  description: 'Paste base64 image data. Use --clear to remove staged images.',
+  action: async (context: CommandContext, args: string) => {
+    console.log(`pasteCommand action called with args: "${args}"`);
+    if (args.trim() === '--clear') {
+      console.log('pasteCommand: --clear flag detected');
+      context.ui.clearPastedContent();
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: 'Staged images cleared.',
+      };
+    }
+
+    console.log('pasteCommand: setting input mode to "paste"');
+    context.ui.setInputMode('paste');
+    console.log('pasteCommand: input mode set');
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: 'Paste your data and press Enter. Press Esc to cancel.',
+    };
+  },
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -34,6 +34,8 @@ export interface CommandContext {
      * Sets the transient debug message displayed in the application footer in debug mode.
      */
     setDebugMessage: (message: string) => void;
+    setInputMode: (mode: 'normal' | 'paste') => void;
+    clearPastedContent: () => void;
   };
   // Session-specific data
   session: {

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
@@ -14,6 +14,7 @@ interface ContextSummaryDisplayProps {
   contextFileNames: string[];
   mcpServers?: Record<string, MCPServerConfig>;
   showToolDescriptions?: boolean;
+  pastedImageCount?: number;
 }
 
 export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
@@ -21,12 +22,9 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
   contextFileNames,
   mcpServers,
   showToolDescriptions,
+  pastedImageCount = 0,
 }) => {
   const mcpServerCount = Object.keys(mcpServers || {}).length;
-
-  if (geminiMdFileCount === 0 && mcpServerCount === 0) {
-    return <Text> </Text>; // Render an empty space to reserve height
-  }
 
   const geminiMdText = (() => {
     if (geminiMdFileCount === 0) {
@@ -44,22 +42,25 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
       ? `${mcpServerCount} MCP server${mcpServerCount > 1 ? 's' : ''}`
       : '';
 
-  let summaryText = 'Using ';
-  if (geminiMdText) {
-    summaryText += geminiMdText;
+  const pastedText =
+    pastedImageCount > 0
+      ? `${pastedImageCount} image${pastedImageCount > 1 ? 's' : ''} staged`
+      : '';
+
+  const allParts = [geminiMdText, mcpText, pastedText].filter(Boolean);
+
+  if (allParts.length === 0) {
+    return <Text> </Text>; // Render an empty space to reserve height
   }
-  if (geminiMdText && mcpText) {
-    summaryText += ' and ';
-  }
-  if (mcpText) {
-    summaryText += mcpText;
-    // Add ctrl+t hint when MCP servers are available
-    if (mcpServers && Object.keys(mcpServers).length > 0) {
-      if (showToolDescriptions) {
-        summaryText += ' (ctrl+t to toggle)';
-      } else {
-        summaryText += ' (ctrl+t to view)';
-      }
+
+  let summaryText = 'Using ' + allParts.join(' and ');
+
+  // Add ctrl+t hint when MCP servers are available
+  if (mcpServerCount > 0) {
+    if (showToolDescriptions) {
+      summaryText += ' (ctrl+t to toggle)';
+    } else {
+      summaryText += ' (ctrl+t to view)';
     }
   }
 

--- a/packages/cli/src/ui/components/PasteHandler.tsx
+++ b/packages/cli/src/ui/components/PasteHandler.tsx
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useEffect } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { HistoryItemWithoutId } from '../types.js';
+
+// Helper to remove bracketed paste markers
+const stripBracketedPaste = (text: string) => {
+  const startMarker = '\x1b[200~';
+  const endMarker = '\x1b[201~';
+
+  let processedText = text;
+
+  // The end marker seems to be consistently present with the escape sequence
+  if (processedText.endsWith(endMarker)) {
+    processedText = processedText.slice(0, -endMarker.length);
+  }
+
+  // The start marker sometimes appears without the initial escape sequence
+  if (processedText.startsWith(startMarker)) {
+    processedText = processedText.slice(startMarker.length);
+  } else if (processedText.startsWith('[200~')) {
+    processedText = processedText.slice('[200~'.length);
+  }
+
+  return processedText;
+};
+
+// Helper to check for base64 data URI
+const isBase64DataUri = (text: string) => text.startsWith('data:image/');
+
+// Helper to check for raw base64 JPEG
+const isRawJpeg = (text: string) =>
+  // Basic check for JPEG magic numbers in base64
+  text.startsWith('/9j/');
+
+interface PasteHandlerProps {
+  onPaste: (pastedText: string) => void;
+  onCancel: () => void;
+  addItem: (item: HistoryItemWithoutId, timestamp: number) => void;
+}
+
+export const PasteHandler: React.FC<PasteHandlerProps> = ({
+  onPaste,
+  onCancel,
+  addItem,
+}) => {
+  const [buffer, setBuffer] = useState('');
+
+  useInput((input, key) => {
+    if (key.return) {
+      // Enter key
+      console.log(
+        'PasteHandler: Enter key pressed. Raw buffer:',
+        JSON.stringify(buffer),
+      );
+      // More robustly clean the input, removing any newlines from the paste
+      const cleaned = buffer.replace(/(\r\n|\n|\r)/gm, '');
+      const trimmed = cleaned.trim();
+      console.log('PasteHandler: Buffer trimmed:', JSON.stringify(trimmed));
+      const processedData = stripBracketedPaste(trimmed);
+      console.log(
+        'PasteHandler: Bracketed paste stripped:',
+        JSON.stringify(processedData),
+      );
+
+      if (isBase64DataUri(processedData)) {
+        console.log('PasteHandler: Valid base64 data URI detected.');
+        onPaste(processedData);
+        addItem(
+          {
+            type: 'pasted_image',
+            text: 'Pasted image data received.',
+          },
+          Date.now(),
+        );
+      } else if (isRawJpeg(processedData)) {
+        console.log('PasteHandler: Raw base64 JPEG detected. Adding prefix.');
+        const fullDataUri = `data:image/jpeg;base64,${processedData}`;
+        onPaste(fullDataUri);
+        addItem(
+          {
+            type: 'pasted_image',
+            text: 'Pasted raw JPEG data received and prefixed.',
+          },
+          Date.now(),
+        );
+      } else {
+        console.error(
+          'PasteHandler: Invalid data format. Not a base64 data URI or raw JPEG.',
+        );
+        addItem(
+          {
+            type: 'error',
+            text: 'Error: Pasted data is not a valid base64 image.',
+          },
+          Date.now(),
+        );
+      }
+      onCancel(); // Return to normal mode
+    } else if (key.escape) {
+      // Escape key
+      // Escape key
+      console.log('PasteHandler: Escape key pressed.');
+      onCancel();
+    } else {
+      setBuffer((prev) => prev + input);
+    }
+  });
+
+  useEffect(() => {
+    console.log('PasteHandler: Component mounted.');
+    return () => {
+      console.log('PasteHandler: Component unmounted.');
+    };
+  }, []);
+
+  return (
+    <Box>
+      {buffer.length > 0 ? (
+        <Text>**********</Text>
+      ) : (
+        <Text>Waiting for paste...</Text>
+      )}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -77,6 +77,8 @@ export const useSlashCommandProcessor = (
   showToolDescriptions: boolean = false,
   setQuittingMessages: (message: HistoryItem[]) => void,
   openPrivacyNotice: () => void,
+  setInputMode: (mode: 'normal' | 'paste') => void,
+  clearPastedContent: () => void,
 ) => {
   const session = useSessionStats();
   const [commands, setCommands] = useState<SlashCommand[]>([]);
@@ -169,6 +171,8 @@ export const useSlashCommandProcessor = (
           refreshStatic();
         },
         setDebugMessage: onDebugMessage,
+        setInputMode,
+        clearPastedContent,
       },
       session: {
         stats: session.stats,
@@ -184,6 +188,8 @@ export const useSlashCommandProcessor = (
       refreshStatic,
       session.stats,
       onDebugMessage,
+      setInputMode,
+      clearPastedContent,
     ],
   );
 

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -130,6 +130,11 @@ export type HistoryItemCompression = HistoryItemBase & {
   compression: CompressionProps;
 };
 
+export type HistoryItemPastedImage = HistoryItemBase & {
+  type: 'pasted_image';
+  text: string;
+};
+
 // Using Omit<HistoryItem, 'id'> seems to have some issues with typescript's
 // type inference e.g. historyItem.type === 'tool_group' isn't auto-inferring that
 // 'tools' in historyItem.
@@ -147,7 +152,8 @@ export type HistoryItemWithoutId =
   | HistoryItemModelStats
   | HistoryItemToolStats
   | HistoryItemQuit
-  | HistoryItemCompression;
+  | HistoryItemCompression
+  | HistoryItemPastedImage;
 
 export type HistoryItem = HistoryItemWithoutId & { id: number };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,3 +60,5 @@ export * from './tools/mcp-tool.js';
 // Export telemetry functions
 export * from './telemetry/index.js';
 export { sessionId } from './utils/session.js';
+
+export type { Part } from '@google/genai';


### PR DESCRIPTION
this is related to this issue https://github.com/google-gemini/gemini-cli/issues/3955 

it is hard to use gemini cli on a remote server, especially if you want to give it screenshots of code, etc. now you can create base64 encodings of screenshots, but if you paste it in the cli, it actually eats up the prompt length. it is not treated as a multimodal attachment, even though the gemini api explicitly supports base64 encoded images in the attachments section.

this PR adds a new command /paste. this command is a mode command, so after typing /paste you press enter. and then you paste the base64 encoded image. this is an optimisation feature, since if we dont do this...the screens will keep redrawing on paste and it completely hangs the cli.

you can /paste multiple images (and the cli will visually display the number of images attached) and then you can send the prompt and all the images are sent together. 

this PR also takes care of bracketed paste - some terminals will attach some escape characters as a security feature.