### PR TITLE
Show stderr output from mcp servers in debug mode

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -166,6 +166,7 @@ describe('discoverMcpTools', () => {
       mockConfig.getMcpServers() ?? {},
       mockConfig.getMcpServerCommand(),
       mockToolRegistry as any,
+      false,
     );
     expect(mockConfig.getMcpServers).toHaveBeenCalledTimes(1);
     expect(mockConfig.getMcpServerCommand).toHaveBeenCalledTimes(1);
@@ -196,6 +197,7 @@ describe('discoverMcpTools', () => {
       mockConfig.getMcpServers() ?? {},
       mockConfig.getMcpServerCommand(),
       mockToolRegistry as any,
+      false,
     );
 
     expect(parse).toHaveBeenCalledWith(commandString, process.env);
@@ -243,6 +245,7 @@ describe('discoverMcpTools', () => {
       mockConfig.getMcpServers() ?? {},
       mockConfig.getMcpServerCommand(),
       mockToolRegistry as any,
+      false,
     );
 
     expect(StdioClientTransport).toHaveBeenCalledWith({
@@ -282,6 +285,7 @@ describe('discoverMcpTools', () => {
       mockConfig.getMcpServers() ?? {},
       mockConfig.getMcpServerCommand(),
       mockToolRegistry as any,
+      false,
     );
 
     expect(SSEClientTransport).toHaveBeenCalledWith(
@@ -325,6 +329,7 @@ describe('discoverMcpTools', () => {
         mockConfig.getMcpServers() ?? {},
         mockConfig.getMcpServerCommand(),
         mockToolRegistry as any,
+        false,
       );
 
       return { serverConfig };
@@ -388,6 +393,7 @@ describe('discoverMcpTools', () => {
       mockConfig.getMcpServers() ?? {},
       mockConfig.getMcpServerCommand(),
       mockToolRegistry as any,
+      false,
     );
 
     expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
@@ -431,6 +437,7 @@ describe('discoverMcpTools', () => {
         mockConfig.getMcpServers() ?? {},
         mockConfig.getMcpServerCommand(),
         mockToolRegistry as any,
+        false,
       );
 
       return { serverConfig };
@@ -542,6 +549,7 @@ describe('discoverMcpTools', () => {
       mockConfig.getMcpServers() ?? {},
       mockConfig.getMcpServerCommand(),
       mockToolRegistry as any,
+      false,
     );
 
     expect(mockToolRegistry.registerTool).toHaveBeenCalledTimes(3);
@@ -610,6 +618,7 @@ describe('discoverMcpTools', () => {
       mockConfig.getMcpServers() ?? {},
       mockConfig.getMcpServerCommand(),
       mockToolRegistry as any,
+      false,
     );
 
     expect(mockToolRegistry.registerTool).toHaveBeenCalledTimes(1);
@@ -644,6 +653,7 @@ describe('discoverMcpTools', () => {
         mockConfig.getMcpServers() ?? {},
         mockConfig.getMcpServerCommand(),
         mockToolRegistry as any,
+        false,
       ),
     ).rejects.toThrow('Parsing failed');
     expect(mockToolRegistry.registerTool).not.toHaveBeenCalled();
@@ -658,6 +668,7 @@ describe('discoverMcpTools', () => {
       mockConfig.getMcpServers() ?? {},
       mockConfig.getMcpServerCommand(),
       mockToolRegistry as any,
+      false,
     );
 
     expect(console.error).toHaveBeenCalledWith(
@@ -683,6 +694,7 @@ describe('discoverMcpTools', () => {
       mockConfig.getMcpServers() ?? {},
       mockConfig.getMcpServerCommand(),
       mockToolRegistry as any,
+      false,
     );
 
     expect(console.error).toHaveBeenCalledWith(
@@ -708,6 +720,7 @@ describe('discoverMcpTools', () => {
       mockConfig.getMcpServers() ?? {},
       mockConfig.getMcpServerCommand(),
       mockToolRegistry as any,
+      false,
     );
 
     expect(console.error).toHaveBeenCalledWith(
@@ -732,6 +745,7 @@ describe('discoverMcpTools', () => {
       mockConfig.getMcpServers() ?? {},
       mockConfig.getMcpServerCommand(),
       mockToolRegistry as any,
+      false,
     );
 
     const clientInstances = vi.mocked(Client).mock.results;
@@ -782,6 +796,7 @@ describe('discoverMcpTools', () => {
         mockConfig.getMcpServers() ?? {},
         mockConfig.getMcpServerCommand(),
         mockToolRegistry as any,
+        false,
       );
 
       expect(mockToolRegistry.registerTool).toHaveBeenCalledTimes(2);
@@ -809,6 +824,7 @@ describe('discoverMcpTools', () => {
         mockConfig.getMcpServers() ?? {},
         mockConfig.getMcpServerCommand(),
         mockToolRegistry as any,
+        false,
       );
 
       expect(mockToolRegistry.registerTool).toHaveBeenCalledTimes(2);
@@ -835,6 +851,7 @@ describe('discoverMcpTools', () => {
         mockConfig.getMcpServers() ?? {},
         mockConfig.getMcpServerCommand(),
         mockToolRegistry as any,
+        false,
       );
 
       expect(mockToolRegistry.registerTool).toHaveBeenCalledTimes(1);

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -127,6 +127,7 @@ export async function discoverMcpTools(
   mcpServers: Record<string, MCPServerConfig>,
   mcpServerCommand: string | undefined,
   toolRegistry: ToolRegistry,
+  debugMode: boolean,
 ): Promise<void> {
   // Set discovery state to in progress
   mcpDiscoveryState = MCPDiscoveryState.IN_PROGRESS;
@@ -147,7 +148,12 @@ export async function discoverMcpTools(
 
     const discoveryPromises = Object.entries(mcpServers).map(
       ([mcpServerName, mcpServerConfig]) =>
-        connectAndDiscover(mcpServerName, mcpServerConfig, toolRegistry),
+        connectAndDiscover(
+          mcpServerName,
+          mcpServerConfig,
+          toolRegistry,
+          debugMode,
+        ),
     );
     await Promise.all(discoveryPromises);
 
@@ -174,6 +180,7 @@ async function connectAndDiscover(
   mcpServerName: string,
   mcpServerConfig: MCPServerConfig,
   toolRegistry: ToolRegistry,
+  debugMode: boolean,
 ): Promise<void> {
   // Initialize the server status as connecting
   updateMCPServerStatus(mcpServerName, MCPServerStatus.CONNECTING);
@@ -221,6 +228,13 @@ async function connectAndDiscover(
     // Update status to disconnected
     updateMCPServerStatus(mcpServerName, MCPServerStatus.DISCONNECTED);
     return;
+  }
+
+  if (debugMode && transport instanceof StdioClientTransport && transport.stderr) {
+    transport.stderr.on('data', (data) => {
+      const stderrStr = data.toString();
+      console.debug(`[DEBUG] [MCP STDERR (${mcpServerName})]: `, stderrStr);
+    });
   }
 
   const mcpClient = new Client({

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -236,7 +236,7 @@ async function connectAndDiscover(
     transport.stderr
   ) {
     transport.stderr.on('data', (data) => {
-      const stderrStr = data.toString();
+      const stderrStr = data.toString().trim();
       console.debug(`[DEBUG] [MCP STDERR (${mcpServerName})]: `, stderrStr);
     });
   }

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -230,7 +230,11 @@ async function connectAndDiscover(
     return;
   }
 
-  if (debugMode && transport instanceof StdioClientTransport && transport.stderr) {
+  if (
+    debugMode &&
+    transport instanceof StdioClientTransport &&
+    transport.stderr
+  ) {
     transport.stderr.on('data', (data) => {
       const stderrStr = data.toString();
       console.debug(`[DEBUG] [MCP STDERR (${mcpServerName})]: `, stderrStr);

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -297,6 +297,7 @@ describe('ToolRegistry', () => {
         mcpServerConfigVal,
         undefined,
         toolRegistry,
+        false,
       );
     });
 
@@ -318,6 +319,7 @@ describe('ToolRegistry', () => {
         mcpServerConfigVal,
         undefined,
         toolRegistry,
+        false,
       );
     });
   });

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -164,6 +164,7 @@ export class ToolRegistry {
       this.config.getMcpServers() ?? {},
       this.config.getMcpServerCommand(),
       this,
+      this.config.getDebugMode(),
     );
   }
 


### PR DESCRIPTION
## TLDR

This change adds back in emitting stderr from MCP tools when in debug mode.

## Dive Deeper

Commit 166f5eaa66b0a643b2d998f8813eb7aac89f2108 dropped stderr output from MCP tools because it was too noisy - this change adds it back when debug mode (`-d` or `--debug`) is enabled.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #4042