### PR TITLE
Use EnvHttpProxyAgent to make sure proxy setting from env is correctly used

### DIFF
--- a/packages/a2a-server/src/testing_utils.ts
+++ b/packages/a2a-server/src/testing_utils.ts
@@ -37,6 +37,7 @@ export function createMockConfig(
     setFlashFallbackHandler: vi.fn(),
     initialize: vi.fn().mockResolvedValue(undefined),
     getProxy: vi.fn().mockReturnValue(undefined),
+    getUseEnvProxy: vi.fn().mockReturnValue(false),
     getHistory: vi.fn().mockReturnValue([]),
     getEmbeddingModel: vi.fn().mockReturnValue('text-embedding-004'),
     getSessionId: vi.fn().mockReturnValue('test-session-id'),

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -346,6 +346,22 @@ describe('loadCliConfig', () => {
     expect(config.getShowMemoryUsage()).toBe(true);
   });
 
+  it('should set useEnvProxy flag from settings', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments({} as Settings);
+    const settings: Settings = { general: { useEnvProxy: true } };
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.getUseEnvProxy()).toBe(true);
+  });
+
+  it('should set useEnvProxy flag default false', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments({} as Settings);
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.getUseEnvProxy()).toBe(false);
+  });
+
   describe('Proxy configuration', () => {
     const originalProxyEnv: { [key: string]: string | undefined } = {};
     const proxyEnvVars = [

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -599,6 +599,7 @@ export async function loadCliConfig(
       process.env['https_proxy'] ||
       process.env['HTTP_PROXY'] ||
       process.env['http_proxy'],
+    useEnvProxy: settings.general?.useEnvProxy,
     cwd,
     fileDiscoveryService: fileService,
     bugCommand: settings.advanced?.bugCommand,

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -304,5 +304,27 @@ describe('SettingsSchema', () => {
         SETTINGS_SCHEMA.general.properties.debugKeystrokeLogging.description,
       ).toBe('Enable debug logging of keystrokes to the console.');
     });
+
+    it('should have useEnvProxy setting in schema', () => {
+      expect(SETTINGS_SCHEMA.general.properties.useEnvProxy).toBeDefined();
+      expect(SETTINGS_SCHEMA.general.properties.useEnvProxy.type).toBe(
+        'boolean',
+      );
+      expect(SETTINGS_SCHEMA.general.properties.useEnvProxy.category).toBe(
+        'General',
+      );
+      expect(SETTINGS_SCHEMA.general.properties.useEnvProxy.default).toBe(
+        false,
+      );
+      expect(
+        SETTINGS_SCHEMA.general.properties.useEnvProxy.requiresRestart,
+      ).toBe(true);
+      expect(SETTINGS_SCHEMA.general.properties.useEnvProxy.showInDialog).toBe(
+        true,
+      );
+      expect(SETTINGS_SCHEMA.general.properties.useEnvProxy.description).toBe(
+        'Use proxy settings from environment variables such as `https_proxy` and `no_proxy`.',
+      );
+    });
   });
 });

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -135,6 +135,16 @@ export const SETTINGS_SCHEMA = {
         description: 'Enable debug logging of keystrokes to the console.',
         showInDialog: true,
       },
+      useEnvProxy: {
+        type: 'boolean',
+        label: 'Use proxy settings from environment variables',
+        category: 'General',
+        requiresRestart: true,
+        default: false,
+        description:
+          'Use proxy settings from environment variables such as `https_proxy` and `no_proxy`.',
+        showInDialog: true,
+      },
     },
   },
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -184,6 +184,7 @@ export interface ConfigParameters {
   };
   checkpointing?: boolean;
   proxy?: string;
+  useEnvProxy?: boolean;
   cwd: string;
   fileDiscoveryService?: FileDiscoveryService;
   includeDirectories?: string[];
@@ -251,6 +252,7 @@ export class Config {
   private gitService: GitService | undefined = undefined;
   private readonly checkpointing: boolean;
   private readonly proxy: string | undefined;
+  private readonly useEnvProxy: boolean = false;
   private readonly cwd: string;
   private readonly bugCommand: BugCommandSettings | undefined;
   private readonly model: string;
@@ -334,6 +336,7 @@ export class Config {
     };
     this.checkpointing = params.checkpointing ?? false;
     this.proxy = params.proxy;
+    this.useEnvProxy = params.useEnvProxy ?? false;
     this.cwd = params.cwd ?? process.cwd();
     this.fileDiscoveryService = params.fileDiscoveryService ?? null;
     this.bugCommand = params.bugCommand;
@@ -663,6 +666,10 @@ export class Config {
 
   getProxy(): string | undefined {
     return this.proxy;
+  }
+
+  getUseEnvProxy(): boolean {
+    return this.useEnvProxy;
   }
 
   getWorkingDir(): string {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -48,6 +48,7 @@ import { setSimulate429 } from '../utils/testUtils.js';
 import { tokenLimit } from './tokenLimits.js';
 import { ideContext } from '../ide/ideContext.js';
 import { ClearcutLogger } from '../telemetry/clearcut-logger/clearcut-logger.js';
+import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
 
 // --- Mocks ---
 const mockChatCreateFn = vi.fn();
@@ -95,6 +96,7 @@ vi.mock('../telemetry/index.js', () => ({
   logApiError: vi.fn(),
 }));
 vi.mock('../ide/ideContext.js');
+vi.mock('undici');
 
 /**
  * Array.fromAsync ponyfill, which will be available in es 2024.
@@ -261,6 +263,7 @@ describe('Gemini Client (client.ts)', () => {
       getFullContext: vi.fn().mockReturnValue(false),
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
       getProxy: vi.fn().mockReturnValue(undefined),
+      getUseEnvProxy: vi.fn().mockReturnValue(true),
       getWorkingDir: vi.fn().mockReturnValue('/test/dir'),
       getFileService: vi.fn().mockReturnValue(fileService),
       getMaxSessionTurns: vi.fn().mockReturnValue(0),
@@ -2448,6 +2451,14 @@ ${JSON.stringify(
       client.setHistory(historyWithThoughts, { stripThoughts: false });
 
       expect(mockChat.setHistory).toHaveBeenCalledWith(historyWithThoughts);
+    });
+  });
+
+  describe('useEnvProxy', () => {
+    it('should use EnvProxyAgent when flag is on', () => {
+      expect(setGlobalDispatcher).toHaveBeenCalledExactlyOnceWith(
+        expect.any(EnvHttpProxyAgent),
+      );
     });
   });
 });

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -35,7 +35,7 @@ import type {
   ContentGeneratorConfig,
 } from './contentGenerator.js';
 import { AuthType, createContentGenerator } from './contentGenerator.js';
-import { ProxyAgent, setGlobalDispatcher } from 'undici';
+import { EnvHttpProxyAgent, ProxyAgent, setGlobalDispatcher } from 'undici';
 import {
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_THINKING_MODE,
@@ -134,7 +134,9 @@ export class GeminiClient {
   private hasFailedCompressionAttempt = false;
 
   constructor(private readonly config: Config) {
-    if (config.getProxy()) {
+    if (config.getUseEnvProxy()) {
+      setGlobalDispatcher(new EnvHttpProxyAgent());
+    } else if (config.getProxy()) {
       setGlobalDispatcher(new ProxyAgent(config.getProxy() as string));
     }
 

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -459,6 +459,7 @@ describe('loggers', () => {
       getSessionId: () => 'test-session-id',
       getTargetDir: () => 'target-dir',
       getProxy: () => 'http://test.proxy.com:8080',
+      getUseEnvProxy: () => false,
       getContentGeneratorConfig: () =>
         ({ model: 'test-model' }) as ContentGeneratorConfig,
       getModel: () => 'test-model',


### PR DESCRIPTION
## TLDR

Use the undici [EnvHttpProxyAgent](https://github.com/nodejs/undici/blob/main/docs/docs/api/EnvHttpProxyAgent.md) to make sure http_proxy, https_proxy and no_proxy in the environment is used.

## Dive Deeper

Currently we manually fetched the `https?_proxy` env variable and set the proxy, other envs such as `no_proxy` and  is not 

## Reviewer Test Plan

Please add the following to the `settings.json`.

```
{
  "general": {
    "useEnvProxy": true
  }
}
```

Then set the environment variables to make sure it work. For example, if we use:
```
export no_proxy=127.0.0.1
export https_proxy=http://some.proxy.server
```
gemini cli should use the https proxy to call gemini api but use no proxy to call local mcp server.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | :heavy_plus_sign:   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #3340