### PR TITLE
fix(checkpoint): Prevent silent failure and enable for non-Git projects

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -259,11 +259,7 @@ export class Config {
     // Initialize centralized FileDiscoveryService
     this.getFileService();
     if (this.getCheckpointingEnabled()) {
-      try {
-        await this.getGitService();
-      } catch {
-        // For now swallow the error, later log it.
-      }
+      await this.getGitService();
     }
     this.toolRegistry = await this.createToolRegistry();
   }

--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -161,7 +161,7 @@ describe('GitService', () => {
       });
       const service = new GitService(mockProjectRoot);
       await expect(service.initialize()).rejects.toThrow(
-        'GitService requires Git to be installed',
+        'Checkpointing is enabled, but Git is not installed. Please install Git or disable checkpointing to continue.',
       );
     });
 

--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -154,14 +154,6 @@ describe('GitService', () => {
   });
 
   describe('initialize', () => {
-    it('should throw an error if projectRoot is not a Git repository', async () => {
-      hoistedIsGitRepositoryMock.mockReturnValue(false);
-      const service = new GitService(mockProjectRoot);
-      await expect(service.initialize()).rejects.toThrow(
-        'GitService requires a Git repository',
-      );
-    });
-
     it('should throw an error if Git is not available', async () => {
       hoistedMockExec.mockImplementation((command, callback) => {
         callback(new Error('git not found'));

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -8,7 +8,6 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { isNodeError } from '../utils/errors.js';
-import { isGitRepository } from '../utils/gitUtils.js';
 import { exec } from 'node:child_process';
 import { simpleGit, SimpleGit, CheckRepoActions } from 'simple-git';
 import { getProjectHash, GEMINI_DIR } from '../utils/paths.js';
@@ -26,9 +25,6 @@ export class GitService {
   }
 
   async initialize(): Promise<void> {
-    if (!isGitRepository(this.projectRoot)) {
-      throw new Error('GitService requires a Git repository');
-    }
     const gitAvailable = await this.verifyGitAvailability();
     if (!gitAvailable) {
       throw new Error('GitService requires Git to be installed');

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -27,7 +27,9 @@ export class GitService {
   async initialize(): Promise<void> {
     const gitAvailable = await this.verifyGitAvailability();
     if (!gitAvailable) {
-      throw new Error('GitService requires Git to be installed');
+      throw new Error(
+        'Checkpointing is enabled, but Git is not installed. Please install Git or disable checkpointing to continue.',
+      );
     }
     this.setupShadowGitRepository();
   }


### PR DESCRIPTION
## TLDR

This PR fixes two critical issues with the checkpointing feature:
1.  It allows checkpointing to function correctly in projects that do not use Git for version control (e.g., Mercurial).
2.  It ensures the CLI fails immediately on startup if checkpointing is enabled but Git is not installed, preventing a dangerous silent failure.

## Dive Deeper

A user reported that checkpointing was not working in their project, which uses Mercurial (hg). Looking into this revealed that the `GitService` performed a check (`isGitRepository`) to ensure the user's project was a Git repository before it would initialize. This check was unnecessary, as the checkpointing feature uses its own self-contained, shadow Git repository for managing snapshots. The user's choice of version control system should not affect it.

While investigating, I also uncovered a more severe issue. The error thrown when `GitService` failed to initialize (either from the `isGitRepository` check or from Git not being installed at all) was being silently swallowed within the `Config.initialize()` method. This meant a user could enable checkpointing, but if they weren't in a Git repo or didn't have Git installed, the feature would silently disable itself. The user would be led to believe their files were being safely checkpointed when they were not, which could lead to data loss.

This PR addresses both problems by:
1.  Removing the `isGitRepository` check from `gitService.ts`, decoupling the feature from the user's project-level version control.
2.  Removing the `try...catch` block in `config.ts` that was swallowing the initialization error.

Now, checkpointing will work for any project, but if the underlying `git` dependency is not met, the application will fail hard on startup, clearly informing the user of the requirement.

## Reviewer Test Plan

To validate these changes, please perform the following tests:

### 1. Verify Checkpointing Works in a Mercurial (hg) Project

*Prerequisite: You must have Mercurial installed (`brew install hg` or equivalent).*

1.  Create a new directory and initialize a Mercurial repository:
    ```bash
    mkdir hg-test-project && cd hg-test-project
    hg init
    ```
2.  Create a test file and commit it:
    ```bash
    echo "hello world" > my_file.txt
    hg add my_file.txt
    hg commit -m "Initial commit"
    ```
3.  Start the CLI with checkpointing enabled: `gemini --checkpointing`
4.  In the CLI, ask the agent to modify the file: `please change the content of my_file.txt to "hello universe"`
5.  Approve the `write_file` tool call when it is proposed.
6.  Verify that a checkpoint was created by running the `/restore` command. You should see a checkpoint file listed. This confirms the feature now works in a non-Git version-controlled project.
7.  After restoring (optional), you can run `hg status` to see that the file has been reverted to its original state.

### 2. Verify Hard Failure When Git is Not Installed

This is best tested by temporarily making `git` unavailable.

1.  Temporarily rename your `git` executable or modify your system's `PATH` to exclude the directory containing `git`.
2.  From within any directory (Git or non-Git), start the CLI with checkpointing enabled: `gemini --checkpointing`
3.  **Expected Result:** The CLI should immediately exit with an error, displaying a message similar to `Checkpointing is enabled, but Git is not installed. Please install Git or disable checkpointing to continue.`. This confirms the silent failure has been fixed.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |
