### PR TITLE
update `/editor` to new slash command arch

### DIFF
--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, type Mocked } from 'vitest';
 import { CommandService } from './CommandService.js';
 import { type Config } from '@google/gemini-cli-core';
 import { type SlashCommand } from '../ui/commands/types.js';
@@ -73,13 +73,13 @@ vi.mock('../ui/commands/editorCommand.js', () => ({
 }));
 
 describe('CommandService', () => {
-  const subCommandLen = 14;
-  let mockConfig: vi.Mocked<Config>;
+  const subCommandLen = 15;
+  let mockConfig: Mocked<Config>;
 
   beforeEach(() => {
     mockConfig = {
       getIdeMode: vi.fn(),
-    } as unknown as vi.Mocked<Config>;
+    } as unknown as Mocked<Config>;
     vi.mocked(ideCommand).mockReturnValue(null);
   });
 

--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -23,6 +23,7 @@ import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 import { toolsCommand } from '../ui/commands/toolsCommand.js';
 import { compressCommand } from '../ui/commands/compressCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
+import { editorCommand } from '../ui/commands/editorCommand.js';
 
 // Mock the command modules to isolate the service from the command implementations.
 vi.mock('../ui/commands/memoryCommand.js', () => ({
@@ -66,6 +67,9 @@ vi.mock('../ui/commands/compressCommand.js', () => ({
 }));
 vi.mock('../ui/commands/mcpCommand.js', () => ({
   mcpCommand: { name: 'mcp', description: 'Mock MCP' },
+}));
+vi.mock('../ui/commands/editorCommand.js', () => ({
+  editorCommand: { name: 'editor', description: 'Mock Editor' },
 }));
 
 describe('CommandService', () => {
@@ -134,6 +138,7 @@ describe('CommandService', () => {
         expect(tree.length).toBe(subCommandLen + 1);
         const commandNames = tree.map((cmd) => cmd.name);
         expect(commandNames).toContain('ide');
+        expect(commandNames).toContain('editor');
       });
 
       it('should overwrite any existing commands when called again', async () => {
@@ -166,6 +171,7 @@ describe('CommandService', () => {
           clearCommand,
           compressCommand,
           docsCommand,
+          editorCommand,
           extensionsCommand,
           helpCommand,
           mcpCommand,

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -43,7 +43,7 @@ const loadBuiltInCommands = async (
     statsCommand,
     themeCommand,
     toolsCommand,
-];
+  ];
 
   return allCommands.filter(
     (command): command is SlashCommand => command !== null,

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -13,6 +13,7 @@ import { docsCommand } from '../ui/commands/docsCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { authCommand } from '../ui/commands/authCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
+import { editorCommand } from '../ui/commands/editorCommand.js';
 import { chatCommand } from '../ui/commands/chatCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
@@ -32,6 +33,7 @@ const loadBuiltInCommands = async (
     clearCommand,
     compressCommand,
     docsCommand,
+    editorCommand,
     extensionsCommand,
     helpCommand,
     ideCommand(config),
@@ -41,7 +43,7 @@ const loadBuiltInCommands = async (
     statsCommand,
     themeCommand,
     toolsCommand,
-  ];
+];
 
   return allCommands.filter(
     (command): command is SlashCommand => command !== null,

--- a/packages/cli/src/ui/commands/editorCommand.test.ts
+++ b/packages/cli/src/ui/commands/editorCommand.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { editorCommand } from './editorCommand.js';
+// 1. Import the mock context utility
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+
+describe('editorCommand', () => {
+  it('should return a dialog action to open the editor dialog', () => {
+    if (!editorCommand.action) {
+      throw new Error('The editor command must have an action.');
+    }
+    const mockContext = createMockCommandContext();
+    const result = editorCommand.action(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'dialog',
+      dialog: 'editor',
+    });
+  });
+
+  it('should have the correct name and description', () => {
+    expect(editorCommand.name).toBe('editor');
+    expect(editorCommand.description).toBe('set external editor preference');
+  });
+});

--- a/packages/cli/src/ui/commands/editorCommand.ts
+++ b/packages/cli/src/ui/commands/editorCommand.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type OpenDialogActionReturn, type SlashCommand } from './types.js';
+
+export const editorCommand: SlashCommand = {
+  name: 'editor',
+  description: 'set external editor preference',
+  action: (): OpenDialogActionReturn => ({
+    type: 'dialog',
+    dialog: 'editor',
+  }),
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -71,8 +71,7 @@ export interface MessageActionReturn {
  */
 export interface OpenDialogActionReturn {
   type: 'dialog';
-  // TODO: Add 'theme' | 'auth' | 'editor' | 'privacy' as migration happens.
-  dialog: 'help' | 'auth' | 'theme' | 'privacy';
+  dialog: 'help' | 'auth' | 'theme' | 'editor' | 'privacy';
 }
 
 /**

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -206,18 +206,6 @@ describe('useSlashCommandProcessor', () => {
 
   const getProcessor = () => getProcessorHook().result.current;
 
-  describe('Other commands', () => {
-    it('/editor should open editor dialog and return handled', async () => {
-      const { handleSlashCommand } = getProcessor();
-      let commandResult: SlashCommandProcessorResult | false = false;
-      await act(async () => {
-        commandResult = await handleSlashCommand('/editor');
-      });
-      expect(mockOpenEditorDialog).toHaveBeenCalled();
-      expect(commandResult).toEqual({ type: 'handled' });
-    });
-  });
-
   describe('New command registry', () => {
     let ActualCommandService: typeof CommandService;
 

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -200,11 +200,6 @@ export const useSlashCommandProcessor = (
     const commands: LegacySlashCommand[] = [
       // `/help` and `/clear` have been migrated and REMOVED from this list.
       {
-        name: 'editor',
-        description: 'set external editor preference',
-        action: (_mainCommand, _subCommand, _args) => openEditorDialog(),
-      },
-      {
         name: 'corgi',
         action: (_mainCommand, _subCommand, _args) => {
           toggleCorgiMode();
@@ -519,6 +514,9 @@ export const useSlashCommandProcessor = (
                   case 'theme':
                     openThemeDialog();
                     return { type: 'handled' };
+                  case 'editor':
+                    openEditorDialog();
+                    return { type: 'handled' };
                   case 'privacy':
                     openPrivacyNotice();
                     return { type: 'handled' };
@@ -617,6 +615,7 @@ export const useSlashCommandProcessor = (
       addMessage,
       openThemeDialog,
       openPrivacyNotice,
+      openEditorDialog,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -420,7 +420,6 @@ export const useSlashCommandProcessor = (
     return commands;
   }, [
     addMessage,
-    openEditorDialog,
     toggleCorgiMode,
     config,
     session,


### PR DESCRIPTION
## TLDR

Refactored the `/editor` slash command to adhere to a new architecture. Integrating it with the CommandService, and slashCommandProcessor and adding unit test

## Dive Deeper

This pr migrates the legacy slash command `/editor` to the new CommandService Architecture. The command has been refactored to a standalone module and removes it from the legacy handler in slashCommandProcessor.ts

## Reviewer Test Plan

Run `/editor`. The terminal should open the list of editors, allowing the user to select one.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |


<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
