### PR TITLE
Adds the user's active file in the IDE to the footer

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -868,7 +868,7 @@ describe('loadCliConfig ideMode', () => {
     expect(config.getIdeMode()).toBe(false);
   });
 
-  it('should add __ide_server when ideMode is true', async () => {
+  it('should add _ide_server when ideMode is true', async () => {
     process.argv = ['node', 'script.js', '--ide-mode'];
     const argv = await parseArguments();
     process.env.TERM_PROGRAM = 'vscode';

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -18,6 +18,7 @@ import {
   FileDiscoveryService,
   TelemetryTarget,
   MCPServerConfig,
+  IDE_SERVER_NAME,
 } from '@google/gemini-cli-core';
 import { Settings } from './settings.js';
 
@@ -285,13 +286,13 @@ export async function loadCliConfig(
   }
 
   if (ideMode) {
-    mcpServers['_ide_server'] = new MCPServerConfig(
+    mcpServers[IDE_SERVER_NAME] = new MCPServerConfig(
       undefined, // command
       undefined, // args
       undefined, // env
       undefined, // cwd
       undefined, // url
-      'http://localhost:3000/mcp', // httpUrl
+      'http://localhost:52232/mcp', // httpUrl
       undefined, // headers
       undefined, // tcp
       undefined, // timeout

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -292,7 +292,7 @@ export async function loadCliConfig(
       undefined, // env
       undefined, // cwd
       undefined, // url
-      'http://localhost:52232/mcp', // httpUrl
+      'http://localhost:3000/mcp', // httpUrl
       undefined, // headers
       undefined, // tcp
       undefined, // timeout

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -54,6 +54,13 @@ export const Footer: React.FC<FooterProps> = ({
   );
 
   useEffect(() => {
+    const updateActiveFile = () => {
+      const currentActiveFile = ideContext.getActiveFileContext();
+      setActiveFile(currentActiveFile);
+    };
+
+    updateActiveFile();
+
     const unsubscribe = ideContext.subscribeToActiveFile(setActiveFile);
     return () => {
       unsubscribe();
@@ -83,10 +90,10 @@ export const Footer: React.FC<FooterProps> = ({
               {shortenPath(tildeifyPath(activeFile.filePath), 70)}
             </Text>
             {activeFile.cursor && (
-                <Text color={Colors.Gray}>
-                  :{activeFile.cursor.line}:{activeFile.cursor.character}
-                </Text>
-              )}
+              <Text color={Colors.Gray}>
+                :{activeFile.cursor.line}:{activeFile.cursor.character}
+              </Text>
+            )}
           </Text>
         )}
         {debugMode && (

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -11,7 +11,7 @@ import {
   shortenPath,
   tildeifyPath,
   tokenLimit,
-  subscribeToActiveFile,
+  ideContext,
   ActiveFile,
 } from '@google/gemini-cli-core';
 import { ConsoleSummaryDisplay } from './ConsoleSummaryDisplay.js';
@@ -54,7 +54,7 @@ export const Footer: React.FC<FooterProps> = ({
   );
 
   useEffect(() => {
-    const unsubscribe = subscribeToActiveFile(setActiveFile);
+    const unsubscribe = ideContext.subscribeToActiveFile(setActiveFile);
     return () => {
       unsubscribe();
     };

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -4,10 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 import { Colors } from '../colors.js';
-import { shortenPath, tildeifyPath, tokenLimit } from '@google/gemini-cli-core';
+import {
+  shortenPath,
+  tildeifyPath,
+  tokenLimit,
+  subscribeToActiveFile,
+  ActiveFile,
+} from '@google/gemini-cli-core';
 import { ConsoleSummaryDisplay } from './ConsoleSummaryDisplay.js';
 import process from 'node:process';
 import Gradient from 'ink-gradient';
@@ -43,6 +49,17 @@ export const Footer: React.FC<FooterProps> = ({
   const limit = tokenLimit(model);
   const percentage = promptTokenCount / limit;
 
+  const [activeFile, setActiveFile] = useState<ActiveFile | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    const unsubscribe = subscribeToActiveFile(setActiveFile);
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
   return (
     <Box marginTop={1} justifyContent="space-between" width="100%">
       <Box>
@@ -57,6 +74,21 @@ export const Footer: React.FC<FooterProps> = ({
           <Text color={Colors.LightBlue}>
             {shortenPath(tildeifyPath(targetDir), 70)}
             {branchName && <Text color={Colors.Gray}> ({branchName}*)</Text>}
+          </Text>
+        )}
+        {activeFile && activeFile.filePath && (
+          <Text>
+            <Text color={Colors.Gray}> | </Text>
+            <Text color={Colors.LightBlue}>
+              {shortenPath(tildeifyPath(activeFile.filePath), 70)}
+            </Text>
+            {activeFile.cursor &&
+              activeFile.cursor.line > 0 &&
+              activeFile.cursor.character > 0 && (
+                <Text color={Colors.Gray}>
+                  :{activeFile.cursor.line}:{activeFile.cursor.character}
+                </Text>
+              )}
           </Text>
         )}
         {debugMode && (

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -82,9 +82,7 @@ export const Footer: React.FC<FooterProps> = ({
             <Text color={Colors.LightBlue}>
               {shortenPath(tildeifyPath(activeFile.filePath), 70)}
             </Text>
-            {activeFile.cursor &&
-              activeFile.cursor.line > 0 &&
-              activeFile.cursor.character > 0 && (
+            {activeFile.cursor && (
                 <Text color={Colors.Gray}>
                   :{activeFile.cursor.line}:{activeFile.cursor.character}
                 </Text>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export * from './utils/quotaErrorDetection.js';
 // Export services
 export * from './services/fileDiscoveryService.js';
 export * from './services/gitService.js';
+export * from './services/ideContext.js';
 
 // Export base tool definitions
 export * from './tools/tools.js';

--- a/packages/core/src/services/ideContext.test.ts
+++ b/packages/core/src/services/ideContext.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  setActiveFileContext,
+  getActiveFileContext,
+  resetActiveFileContext,
+  subscribeToActiveFile,
+} from './ideContext.js';
+
+describe('ideContext - Active File', () => {
+  beforeEach(() => {
+    resetActiveFileContext(); // Ensure a clean slate for each test
+  });
+
+  it('should return undefined initially for active file context', () => {
+    expect(getActiveFileContext()).toBeUndefined();
+  });
+
+  it('should set and retrieve the active file context', () => {
+    const testFile = {
+      filePath: '/path/to/test/file.ts',
+      cursor: { line: 5, character: 10 },
+    };
+
+    setActiveFileContext(testFile);
+
+    const activeFile = getActiveFileContext();
+    expect(activeFile).toEqual(testFile);
+  });
+
+  it('should update the active file context when called multiple times', () => {
+    const firstFile = {
+      filePath: '/path/to/first.js',
+      cursor: { line: 1, character: 1 },
+    };
+    setActiveFileContext(firstFile);
+
+    const secondFile = {
+      filePath: '/path/to/second.py',
+      cursor: { line: 20, character: 30 },
+    };
+    setActiveFileContext(secondFile);
+
+    const activeFile = getActiveFileContext();
+    expect(activeFile).toEqual(secondFile);
+  });
+
+  it('should handle empty string for file path', () => {
+    const testFile = {
+      filePath: '',
+      cursor: { line: 0, character: 0 },
+    };
+    setActiveFileContext(testFile);
+    expect(getActiveFileContext()).toEqual(testFile);
+  });
+
+  it('should notify subscribers when active file context changes', () => {
+    const subscriber1 = vi.fn();
+    const subscriber2 = vi.fn();
+
+    subscribeToActiveFile(subscriber1);
+    subscribeToActiveFile(subscriber2);
+
+    const testFile = {
+      filePath: '/path/to/subscribed.ts',
+      cursor: { line: 15, character: 25 },
+    };
+    setActiveFileContext(testFile);
+
+    expect(subscriber1).toHaveBeenCalledTimes(1);
+    expect(subscriber1).toHaveBeenCalledWith(testFile);
+    expect(subscriber2).toHaveBeenCalledTimes(1);
+    expect(subscriber2).toHaveBeenCalledWith(testFile);
+
+    // Test with another update
+    const newFile = {
+      filePath: '/path/to/new.js',
+      cursor: { line: 1, character: 1 },
+    };
+    setActiveFileContext(newFile);
+
+    expect(subscriber1).toHaveBeenCalledTimes(2);
+    expect(subscriber1).toHaveBeenCalledWith(newFile);
+    expect(subscriber2).toHaveBeenCalledTimes(2);
+    expect(subscriber2).toHaveBeenCalledWith(newFile);
+  });
+
+  it('should stop notifying a subscriber after unsubscribe', () => {
+    const subscriber1 = vi.fn();
+    const subscriber2 = vi.fn();
+
+    const unsubscribe1 = subscribeToActiveFile(subscriber1);
+    subscribeToActiveFile(subscriber2);
+
+    setActiveFileContext({
+      filePath: '/path/to/file1.txt',
+      cursor: { line: 1, character: 1 },
+    });
+    expect(subscriber1).toHaveBeenCalledTimes(1);
+    expect(subscriber2).toHaveBeenCalledTimes(1);
+
+    unsubscribe1();
+
+    setActiveFileContext({
+      filePath: '/path/to/file2.txt',
+      cursor: { line: 2, character: 2 },
+    });
+    expect(subscriber1).toHaveBeenCalledTimes(1); // Should not be called again
+    expect(subscriber2).toHaveBeenCalledTimes(2);
+  });
+
+  it('should clear all subscribers on resetActiveFileContext', () => {
+    const subscriber1 = vi.fn();
+    const subscriber2 = vi.fn();
+
+    subscribeToActiveFile(subscriber1);
+    subscribeToActiveFile(subscriber2);
+
+    setActiveFileContext({
+      filePath: '/path/to/file1.txt',
+      cursor: { line: 1, character: 1 },
+    });
+    expect(subscriber1).toHaveBeenCalledTimes(1);
+    expect(subscriber2).toHaveBeenCalledTimes(1);
+
+    resetActiveFileContext();
+
+    setActiveFileContext({
+      filePath: '/path/to/file2.txt',
+      cursor: { line: 2, character: 2 },
+    });
+    expect(subscriber1).toHaveBeenCalledTimes(1); // Should not be called again
+    expect(subscriber2).toHaveBeenCalledTimes(1); // Should not be called again
+  });
+});

--- a/packages/core/src/services/ideContext.test.ts
+++ b/packages/core/src/services/ideContext.test.ts
@@ -111,4 +111,15 @@ describe('ideContext - Active File', () => {
     expect(subscriber1).toHaveBeenCalledTimes(1); // Should not be called again
     expect(subscriber2).toHaveBeenCalledTimes(2);
   });
+
+  it('should allow the cursor to be optional', () => {
+    const testFile = {
+      filePath: '/path/to/test/file.ts',
+    };
+
+    ideContext.setActiveFileContext(testFile);
+
+    const activeFile = ideContext.getActiveFileContext();
+    expect(activeFile).toEqual(testFile);
+  });
 });

--- a/packages/core/src/services/ideContext.ts
+++ b/packages/core/src/services/ideContext.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 /**
  * The reserved server name for the IDE's MCP server.
  */
-export const IDE_SERVER_NAME = '__ide_server';
+export const IDE_SERVER_NAME = '_ide_server';
 
 /**
  * Zod schema for validating a cursor position.

--- a/packages/core/src/services/ideContext.ts
+++ b/packages/core/src/services/ideContext.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod';
+
+export const IDE_SERVER_NAME = '_ide_server';
+
+const CursorSchema = z.object({
+  line: z.number(),
+  character: z.number(),
+});
+
+const ActiveFileSchema = z.object({
+  filePath: z.string(),
+  cursor: CursorSchema,
+});
+export type ActiveFile = z.infer<typeof ActiveFileSchema>;
+
+export const ActiveFileNotificationSchema = z.object({
+  method: z.literal('ide/activeFileChanged'),
+  params: ActiveFileSchema,
+});
+
+type ActiveFileSubscriber = (activeFile: ActiveFile | undefined) => void;
+
+let activeFileContext: ActiveFile | undefined = undefined;
+const subscribers = new Set<ActiveFileSubscriber>();
+
+/**
+ * Notifies all registered subscribers about the current active file context.
+ */
+function notifySubscribers(): void {
+  for (const subscriber of subscribers) {
+    subscriber(activeFileContext);
+  }
+}
+
+/**
+ * Sets the active file context and notifies all registered subscribers of the change.
+ * @param newActiveFile The new active file context from the IDE.
+ */
+export function setActiveFileContext(newActiveFile: ActiveFile): void {
+  activeFileContext = newActiveFile;
+  notifySubscribers();
+}
+
+/**
+ * Retrieves the current active file context.
+ * @returns The `ActiveFile` object if a file is active, otherwise `undefined`.
+ */
+export function getActiveFileContext(): ActiveFile | undefined {
+  return activeFileContext;
+}
+
+/**
+ * Subscribes to changes in the active file context.
+ *
+ * When the active file context changes, the provided `subscriber` function will be called.
+ * Note: The subscriber is not called with the current value upon subscription.
+ *
+ * @param subscriber The function to be called when the active file context changes.
+ * @returns A function that, when called, will unsubscribe the provided subscriber.
+ */
+export function subscribeToActiveFile(
+  subscriber: ActiveFileSubscriber,
+): () => void {
+  subscribers.add(subscriber);
+  return () => {
+    subscribers.delete(subscriber);
+  };
+}
+
+/**
+ * Resets the active file context to `undefined` and clears all subscribers.
+ * This is primarily exposed for testing purposes to ensure a clean state.
+ */
+export function resetActiveFileContext(): void {
+  activeFileContext = undefined;
+  subscribers.clear();
+}

--- a/packages/core/src/services/ideContext.ts
+++ b/packages/core/src/services/ideContext.ts
@@ -25,7 +25,7 @@ export type Cursor = z.infer<typeof CursorSchema>;
  */
 export const ActiveFileSchema = z.object({
   filePath: z.string(),
-  cursor: CursorSchema,
+  cursor: CursorSchema.optional(),
 });
 export type ActiveFile = z.infer<typeof ActiveFileSchema>;
 
@@ -85,9 +85,7 @@ export function createIdeContextStore() {
    * @param subscriber The function to be called when the active file context changes.
    * @returns A function that, when called, will unsubscribe the provided subscriber.
    */
-  function subscribeToActiveFile(
-    subscriber: ActiveFileSubscriber,
-  ): () => void {
+  function subscribeToActiveFile(subscriber: ActiveFileSubscriber): () => void {
     subscribers.add(subscriber);
     return () => {
       subscribers.delete(subscriber);

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -19,6 +19,11 @@ import { MCPServerConfig } from '../config/config.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import { Type, mcpToTool } from '@google/genai';
 import { sanitizeParameters, ToolRegistry } from './tool-registry.js';
+import {
+  ActiveFileNotificationSchema,
+  IDE_SERVER_NAME,
+  setActiveFileContext,
+} from '../services/ideContext.js';
 
 export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
 
@@ -293,6 +298,15 @@ async function connectAndDiscover(
     // Update status to disconnected on error
     updateMCPServerStatus(mcpServerName, MCPServerStatus.DISCONNECTED);
   };
+
+  if (mcpServerName == IDE_SERVER_NAME) {
+    mcpClient.setNotificationHandler(
+      ActiveFileNotificationSchema,
+      (notification) => {
+        setActiveFileContext(notification.params);
+      },
+    );
+  }
 
   try {
     const mcpCallableTool = mcpToTool(mcpClient);

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -216,7 +216,7 @@ export async function connectAndDiscover(
         updateMCPServerStatus(mcpServerName, MCPServerStatus.DISCONNECTED);
       };
 
-      if (mcpServerName == IDE_SERVER_NAME) {
+      if (mcpServerName === IDE_SERVER_NAME) {
         mcpClient.setNotificationHandler(
           ActiveFileNotificationSchema,
           (notification) => {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -22,7 +22,7 @@ import { sanitizeParameters, ToolRegistry } from './tool-registry.js';
 import {
   ActiveFileNotificationSchema,
   IDE_SERVER_NAME,
-  setActiveFileContext,
+  ideContext,
 } from '../services/ideContext.js';
 
 export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
@@ -303,7 +303,7 @@ async function connectAndDiscover(
     mcpClient.setNotificationHandler(
       ActiveFileNotificationSchema,
       (notification) => {
-        setActiveFileContext(notification.params);
+        ideContext.setActiveFileContext(notification.params);
       },
     );
   }


### PR DESCRIPTION
## TLDR

Adds the user's active file in the IDE to the footer if IDE mode is active.

## Dive Deeper
* Updates mcp-client to add a notification handler for the _ide_server that triggers whenever the extension detects the active file changing
* Propagating this context to the system prompt will be done in a follow-up
* Displays the current active file in the footer:
<img width="1170" height="116" alt="Screenshot 2025-07-14 at 4 10 56 PM" src="https://github.com/user-attachments/assets/89a8d1e0-c77e-4517-b0ff-3295b526775f" />

## Reviewer Test Plan
- Build companion VS code extension using https://github.com/google-gemini/gemini-cli/pull/4147
- Run gemini-cli w/ --ide-mode
- Change file in VS code 
- Updated file name should show up in the UI

## Linked issues / bugs
Resolves #4138