### PR TITLE
Pure refactor: Consolidate isWithinRoot() function calling.

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -525,7 +525,6 @@ export class Config {
 
   async createToolRegistry(): Promise<ToolRegistry> {
     const registry = new ToolRegistry(this);
-    const targetDir = this.getTargetDir();
 
     // helper to create & register core tools that are enabled
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -560,14 +559,14 @@ export class Config {
       }
     };
 
-    registerCoreTool(LSTool, targetDir, this);
-    registerCoreTool(ReadFileTool, targetDir, this);
-    registerCoreTool(GrepTool, targetDir);
-    registerCoreTool(GlobTool, targetDir, this);
+    registerCoreTool(LSTool, this);
+    registerCoreTool(ReadFileTool, this);
+    registerCoreTool(GrepTool, this);
+    registerCoreTool(GlobTool, this);
     registerCoreTool(EditTool, this);
     registerCoreTool(WriteFileTool, this);
     registerCoreTool(WebFetchTool, this);
-    registerCoreTool(ReadManyFilesTool, targetDir, this);
+    registerCoreTool(ReadManyFilesTool, this);
     registerCoreTool(ShellTool, this);
     registerCoreTool(MemoryTool);
     registerCoreTool(WebSearchTool, this);

--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -22,12 +22,13 @@ describe('GlobTool', () => {
   const mockConfig = {
     getFileService: () => new FileDiscoveryService(tempRootDir),
     getFileFilteringRespectGitIgnore: () => true,
-  } as Partial<Config> as Config;
+    getTargetDir: () => tempRootDir,
+  } as unknown as Config;
 
   beforeEach(async () => {
     // Create a unique root directory for each test run
     tempRootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'glob-tool-root-'));
-    globTool = new GlobTool(tempRootDir, mockConfig);
+    globTool = new GlobTool(mockConfig);
 
     // Create some test files and directories within this root
     // Top-level files
@@ -224,8 +225,8 @@ describe('GlobTool', () => {
 
     it("should return error if search path resolves outside the tool's root directory", () => {
       // Create a globTool instance specifically for this test, with a deeper root
-      const deeperRootDir = path.join(tempRootDir, 'sub');
-      const specificGlobTool = new GlobTool(deeperRootDir, mockConfig);
+      tempRootDir = path.join(tempRootDir, 'sub');
+      const specificGlobTool = new GlobTool(mockConfig);
       // const params: GlobToolParams = { pattern: '*.txt', path: '..' }; // This line is unused and will be removed.
       // This should be fine as tempRootDir is still within the original tempRootDir (the parent of deeperRootDir)
       // Let's try to go further up.

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -11,6 +11,7 @@ import { SchemaValidator } from '../utils/schemaValidator.js';
 import { BaseTool, ToolResult } from './tools.js';
 import { Type } from '@google/genai';
 import { shortenPath, makeRelative } from '../utils/paths.js';
+import { isWithinRoot } from '../utils/fileUtils.js';
 import { Config } from '../config/config.js';
 
 // Subset of 'Path' interface provided by 'glob' that we can implement for testing
@@ -79,14 +80,8 @@ export interface GlobToolParams {
  */
 export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
   static readonly Name = 'glob';
-  /**
-   * Creates a new instance of the GlobLogic
-   * @param rootDirectory Root directory to ground this tool in.
-   */
-  constructor(
-    private rootDirectory: string,
-    private config: Config,
-  ) {
+
+  constructor(private config: Config) {
     super(
       GlobTool.Name,
       'FindFiles',
@@ -118,28 +113,6 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
         type: Type.OBJECT,
       },
     );
-
-    this.rootDirectory = path.resolve(rootDirectory);
-  }
-
-  /**
-   * Checks if a given path is within the root directory bounds.
-   * This security check prevents accessing files outside the designated root directory.
-   *
-   * @param pathToCheck The absolute path to validate
-   * @returns True if the path is within the root directory, false otherwise
-   */
-  private isWithinRoot(pathToCheck: string): boolean {
-    const absolutePathToCheck = path.resolve(pathToCheck);
-    const normalizedPath = path.normalize(absolutePathToCheck);
-    const normalizedRoot = path.normalize(this.rootDirectory);
-    const rootWithSep = normalizedRoot.endsWith(path.sep)
-      ? normalizedRoot
-      : normalizedRoot + path.sep;
-    return (
-      normalizedPath === normalizedRoot ||
-      normalizedPath.startsWith(rootWithSep)
-    );
   }
 
   /**
@@ -152,15 +125,15 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
     }
 
     const searchDirAbsolute = path.resolve(
-      this.rootDirectory,
+      this.config.getTargetDir(),
       params.path || '.',
     );
 
-    if (!this.isWithinRoot(searchDirAbsolute)) {
-      return `Search path ("${searchDirAbsolute}") resolves outside the tool's root directory ("${this.rootDirectory}").`;
+    if (!isWithinRoot(searchDirAbsolute, this.config.getTargetDir())) {
+      return `Search path ("${searchDirAbsolute}") resolves outside the tool's root directory ("${this.config.getTargetDir()}").`;
     }
 
-    const targetDir = searchDirAbsolute || this.rootDirectory;
+    const targetDir = searchDirAbsolute || this.config.getTargetDir();
     try {
       if (!fs.existsSync(targetDir)) {
         return `Search path does not exist ${targetDir}`;
@@ -189,8 +162,11 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
   getDescription(params: GlobToolParams): string {
     let description = `'${params.pattern}'`;
     if (params.path) {
-      const searchDir = path.resolve(this.rootDirectory, params.path || '.');
-      const relativePath = makeRelative(searchDir, this.rootDirectory);
+      const searchDir = path.resolve(
+        this.config.getTargetDir(),
+        params.path || '.',
+      );
+      const relativePath = makeRelative(searchDir, this.config.getTargetDir());
       description += ` within ${shortenPath(relativePath)}`;
     }
     return description;
@@ -213,7 +189,7 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
 
     try {
       const searchDirAbsolute = path.resolve(
-        this.rootDirectory,
+        this.config.getTargetDir(),
         params.path || '.',
       );
 
@@ -241,13 +217,15 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
 
       if (respectGitIgnore) {
         const relativePaths = entries.map((p) =>
-          path.relative(this.rootDirectory, p.fullpath()),
+          path.relative(this.config.getTargetDir(), p.fullpath()),
         );
         const filteredRelativePaths = fileDiscovery.filterFiles(relativePaths, {
           respectGitIgnore,
         });
         const filteredAbsolutePaths = new Set(
-          filteredRelativePaths.map((p) => path.resolve(this.rootDirectory, p)),
+          filteredRelativePaths.map((p) =>
+            path.resolve(this.config.getTargetDir(), p),
+          ),
         );
 
         filteredEntries = entries.filter((entry) =>

--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -9,6 +9,7 @@ import { GrepTool, GrepToolParams } from './grep.js';
 import path from 'path';
 import fs from 'fs/promises';
 import os from 'os';
+import { Config } from '../config/config.js';
 
 // Mock the child_process module to control grep/git grep behavior
 vi.mock('child_process', () => ({
@@ -30,9 +31,13 @@ describe('GrepTool', () => {
   let grepTool: GrepTool;
   const abortSignal = new AbortController().signal;
 
+  const mockConfig = {
+    getTargetDir: () => tempRootDir,
+  } as unknown as Config;
+
   beforeEach(async () => {
     tempRootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'grep-tool-root-'));
-    grepTool = new GrepTool(tempRootDir);
+    grepTool = new GrepTool(mockConfig);
 
     // Create some test files and directories
     await fs.writeFile(

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -11,6 +11,7 @@ import { Type } from '@google/genai';
 import { SchemaValidator } from '../utils/schemaValidator.js';
 import { makeRelative, shortenPath } from '../utils/paths.js';
 import { Config } from '../config/config.js';
+import { isWithinRoot } from '../utils/fileUtils.js';
 
 /**
  * Parameters for the LS tool
@@ -68,14 +69,7 @@ export interface FileEntry {
 export class LSTool extends BaseTool<LSToolParams, ToolResult> {
   static readonly Name = 'list_directory';
 
-  /**
-   * Creates a new instance of the LSLogic
-   * @param rootDirectory Root directory to ground this tool in. All operations will be restricted to this directory.
-   */
-  constructor(
-    private rootDirectory: string,
-    private config: Config,
-  ) {
+  constructor(private config: Config) {
     super(
       LSTool.Name,
       'ReadFolder',
@@ -104,27 +98,6 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
         type: Type.OBJECT,
       },
     );
-
-    // Set the root directory
-    this.rootDirectory = path.resolve(rootDirectory);
-  }
-
-  /**
-   * Checks if a path is within the root directory
-   * @param dirpath The path to check
-   * @returns True if the path is within the root directory, false otherwise
-   */
-  private isWithinRoot(dirpath: string): boolean {
-    const normalizedPath = path.normalize(dirpath);
-    const normalizedRoot = path.normalize(this.rootDirectory);
-    // Ensure the normalizedRoot ends with a path separator for proper path comparison
-    const rootWithSep = normalizedRoot.endsWith(path.sep)
-      ? normalizedRoot
-      : normalizedRoot + path.sep;
-    return (
-      normalizedPath === normalizedRoot ||
-      normalizedPath.startsWith(rootWithSep)
-    );
   }
 
   /**
@@ -140,8 +113,8 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
     if (!path.isAbsolute(params.path)) {
       return `Path must be absolute: ${params.path}`;
     }
-    if (!this.isWithinRoot(params.path)) {
-      return `Path must be within the root directory (${this.rootDirectory}): ${params.path}`;
+    if (!isWithinRoot(params.path, this.config.getTargetDir())) {
+      return `Path must be within the root directory (${this.config.getTargetDir()}): ${params.path}`;
     }
     return null;
   }
@@ -176,7 +149,7 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
    * @returns A string describing the file being read
    */
   getDescription(params: LSToolParams): string {
-    const relativePath = makeRelative(params.path, this.rootDirectory);
+    const relativePath = makeRelative(params.path, this.config.getTargetDir());
     return shortenPath(relativePath);
   }
 
@@ -248,7 +221,10 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
         }
 
         const fullPath = path.join(params.path, file);
-        const relativePath = path.relative(this.rootDirectory, fullPath);
+        const relativePath = path.relative(
+          this.config.getTargetDir(),
+          fullPath,
+        );
 
         // Check if this file should be git-ignored (only in git repositories)
         if (

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -42,8 +42,9 @@ describe('ReadFileTool', () => {
     const fileService = new FileDiscoveryService(tempRootDir);
     const mockConfigInstance = {
       getFileService: () => fileService,
+      getTargetDir: () => tempRootDir,
     } as unknown as Config;
-    tool = new ReadFileTool(tempRootDir, mockConfigInstance);
+    tool = new ReadFileTool(mockConfigInstance);
     mockProcessSingleFileContent.mockReset();
   });
 

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -46,10 +46,7 @@ export interface ReadFileToolParams {
 export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
   static readonly Name: string = 'read_file';
 
-  constructor(
-    private rootDirectory: string,
-    private config: Config,
-  ) {
+  constructor(private config: Config) {
     super(
       ReadFileTool.Name,
       'ReadFile',
@@ -76,7 +73,6 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
         type: Type.OBJECT,
       },
     );
-    this.rootDirectory = path.resolve(rootDirectory);
   }
 
   validateToolParams(params: ReadFileToolParams): string | null {
@@ -89,8 +85,8 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
     if (!path.isAbsolute(filePath)) {
       return `File path must be absolute, but was relative: ${filePath}. You must provide an absolute path.`;
     }
-    if (!isWithinRoot(filePath, this.rootDirectory)) {
-      return `File path must be within the root directory (${this.rootDirectory}): ${filePath}`;
+    if (!isWithinRoot(filePath, this.config.getTargetDir())) {
+      return `File path must be within the root directory (${this.config.getTargetDir()}): ${filePath}`;
     }
     if (params.offset !== undefined && params.offset < 0) {
       return 'Offset must be a non-negative number';
@@ -115,7 +111,10 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
     ) {
       return `Path unavailable`;
     }
-    const relativePath = makeRelative(params.absolute_path, this.rootDirectory);
+    const relativePath = makeRelative(
+      params.absolute_path,
+      this.config.getTargetDir(),
+    );
     return shortenPath(relativePath);
   }
 
@@ -133,7 +132,7 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
 
     const result = await processSingleFileContent(
       params.absolute_path,
-      this.rootDirectory,
+      this.config.getTargetDir(),
       params.offset,
       params.limit,
     );

--- a/packages/core/src/tools/read-many-files.test.ts
+++ b/packages/core/src/tools/read-many-files.test.ts
@@ -59,9 +59,10 @@ describe('ReadManyFilesTool', () => {
     const mockConfig = {
       getFileService: () => fileService,
       getFileFilteringRespectGitIgnore: () => true,
+      getTargetDir: () => tempRootDir,
     } as Partial<Config> as Config;
 
-    tool = new ReadManyFilesTool(tempRootDir, mockConfig);
+    tool = new ReadManyFilesTool(mockConfig);
 
     mockReadFileFn = mockControl.mockReadFile;
     mockReadFileFn.mockReset();

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -36,8 +36,8 @@ export function isWithinRoot(
   pathToCheck: string,
   rootDirectory: string,
 ): boolean {
-  const normalizedPathToCheck = path.normalize(pathToCheck);
-  const normalizedRootDirectory = path.normalize(rootDirectory);
+  const normalizedPathToCheck = path.resolve(pathToCheck);
+  const normalizedRootDirectory = path.resolve(rootDirectory);
 
   // Ensure the rootDirectory path ends with a separator for correct startsWith comparison,
   // unless it's the root path itself (e.g., '/' or 'C:\').


### PR DESCRIPTION
## TLDR

Consolidate multi implementations of isWithinRoot and simplify "rootDirectory" logic which was unnecessarily trying to resolve a path that was already absolute.

## Reviewer Test Plan

Make sure edit tools still work.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Cleans up code that might be touched by #3708