### PR TITLE
chore: update @google/genai to version 1.9.0 and adopt JSON schema processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -930,15 +930,13 @@
       "link": true
     },
     "node_modules/@google/genai": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.8.0.tgz",
-      "integrity": "sha512-n3KiMFesQCy2R9iSdBIuJ0JWYQ1HZBJJkmt4PPZMGZKvlgHhBAGw1kUMyX+vsAIzprN3lK45DI755lm70wPOOg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.9.0.tgz",
+      "integrity": "sha512-w9P93OXKPMs9H1mfAx9+p3zJqQGrWBGdvK/SVc7cLZEXNHr/3+vW2eif7ZShA6wU24rNLn9z9MK2vQFUvNRI2Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.14.2",
-        "ws": "^8.18.0",
-        "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.22.4"
+        "ws": "^8.18.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -11913,7 +11911,7 @@
       "name": "@google/gemini-cli-core",
       "version": "0.1.12",
       "dependencies": {
-        "@google/genai": "1.8.0",
+        "@google/genai": "1.9.0",
         "@modelcontextprotocol/sdk": "^1.11.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "dependencies": {
-    "@google/genai": "1.8.0",
+    "@google/genai": "1.9.0",
     "@modelcontextprotocol/sdk": "^1.11.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",


### PR DESCRIPTION


## TLDR

This PR upgrades the @google/genai package from 1.8.0 to 1.9.0.
This update introduced a breaking change in how JSON schemas for tool parameters are processed. To address this, we've added corresponding logic to
mcp-client.ts.
Specifically, schema transformation logic that was removed from @google/genai has been ported into mcp-client.ts to ensure that tool discovery from MCP
servers continues to function correctly.

## Dive Deeper

Previously, schema transformations were handled internally by the SDK. As of v1.9.0, this responsibility has shifted to the caller.
To adapt to this change, we have ported two internal functions, processJsonSchema and flattenTypeArrayToAnyOf, from the @google/genai source code (_transformers.ts)
into our packages/core/src/tools/mcp-client.ts.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Fundamental solution of #3834 , #3780
- Resolves #2553
