### PR TITLE
Migrate /privacy to new architecture

### DIFF
--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -12,6 +12,7 @@ import { helpCommand } from '../ui/commands/helpCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
 import { authCommand } from '../ui/commands/authCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
+import { privacyCommand } from '../ui/commands/privacyCommand.js';
 
 // Mock the command modules to isolate the service from the command implementations.
 vi.mock('../ui/commands/memoryCommand.js', () => ({
@@ -28,6 +29,9 @@ vi.mock('../ui/commands/authCommand.js', () => ({
 }));
 vi.mock('../ui/commands/themeCommand.js', () => ({
   themeCommand: { name: 'theme', description: 'Mock Theme' },
+}));
+vi.mock('../ui/commands/privacyCommand.js', () => ({
+  privacyCommand: { name: 'privacy', description: 'Mock Privacy' },
 }));
 
 describe('CommandService', () => {
@@ -54,7 +58,7 @@ describe('CommandService', () => {
         const tree = commandService.getCommands();
 
         // Post-condition assertions
-        expect(tree.length).toBe(5);
+        expect(tree.length).toBe(6);
 
         const commandNames = tree.map((cmd) => cmd.name);
         expect(commandNames).toContain('auth');
@@ -62,19 +66,20 @@ describe('CommandService', () => {
         expect(commandNames).toContain('help');
         expect(commandNames).toContain('clear');
         expect(commandNames).toContain('theme');
+        expect(commandNames).toContain('privacy');
       });
 
       it('should overwrite any existing commands when called again', async () => {
         // Load once
         await commandService.loadCommands();
-        expect(commandService.getCommands().length).toBe(5);
+        expect(commandService.getCommands().length).toBe(6);
 
         // Load again
         await commandService.loadCommands();
         const tree = commandService.getCommands();
 
         // Should not append, but overwrite
-        expect(tree.length).toBe(5);
+        expect(tree.length).toBe(6);
       });
     });
 
@@ -86,12 +91,13 @@ describe('CommandService', () => {
         await commandService.loadCommands();
 
         const loadedTree = commandService.getCommands();
-        expect(loadedTree.length).toBe(5);
+        expect(loadedTree.length).toBe(6);
         expect(loadedTree).toEqual([
           authCommand,
           clearCommand,
           helpCommand,
           memoryCommand,
+          privacyCommand,
           themeCommand,
         ]);
       });

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -10,12 +10,14 @@ import { helpCommand } from '../ui/commands/helpCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
 import { authCommand } from '../ui/commands/authCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
+import { privacyCommand } from '../ui/commands/privacyCommand.js';
 
 const loadBuiltInCommands = async (): Promise<SlashCommand[]> => [
   authCommand,
   clearCommand,
   helpCommand,
   memoryCommand,
+  privacyCommand,
   themeCommand,
 ];
 

--- a/packages/cli/src/ui/commands/privacyCommand.test.ts
+++ b/packages/cli/src/ui/commands/privacyCommand.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { privacyCommand } from './privacyCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+
+describe('privacyCommand', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext();
+  });
+
+  it('should return a dialog action to open the privacy dialog', () => {
+    // Ensure the command has an action to test.
+    if (!privacyCommand.action) {
+      throw new Error('The privacy command must have an action.');
+    }
+
+    const result = privacyCommand.action(mockContext, '');
+
+    // Assert that the action returns the correct object to trigger the privacy dialog.
+    expect(result).toEqual({
+      type: 'dialog',
+      dialog: 'privacy',
+    });
+  });
+
+  it('should have the correct name and description', () => {
+    expect(privacyCommand.name).toBe('privacy');
+    expect(privacyCommand.description).toBe('display the privacy notice');
+  });
+});

--- a/packages/cli/src/ui/commands/privacyCommand.ts
+++ b/packages/cli/src/ui/commands/privacyCommand.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OpenDialogActionReturn, SlashCommand } from './types.js';
+
+export const privacyCommand: SlashCommand = {
+  name: 'privacy',
+  description: 'display the privacy notice',
+  action: (): OpenDialogActionReturn => ({
+    type: 'dialog',
+    dialog: 'privacy',
+  }),
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -66,7 +66,7 @@ export interface MessageActionReturn {
 export interface OpenDialogActionReturn {
   type: 'dialog';
   // TODO: Add 'theme' | 'auth' | 'editor' | 'privacy' as migration happens.
-  dialog: 'help' | 'auth' | 'theme';
+  dialog: 'help' | 'auth' | 'theme' | 'privacy';
 }
 
 export type SlashCommandActionReturn =

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -248,11 +248,6 @@ export const useSlashCommandProcessor = (
         action: (_mainCommand, _subCommand, _args) => openEditorDialog(),
       },
       {
-        name: 'privacy',
-        description: 'display the privacy notice',
-        action: (_mainCommand, _subCommand, _args) => openPrivacyNotice(),
-      },
-      {
         name: 'stats',
         altName: 'usage',
         description: 'check session stats. Usage: /stats [model|tools]',
@@ -1023,7 +1018,6 @@ export const useSlashCommandProcessor = (
   }, [
     addMessage,
     openEditorDialog,
-    openPrivacyNotice,
     toggleCorgiMode,
     savedChatTags,
     config,
@@ -1125,6 +1119,9 @@ export const useSlashCommandProcessor = (
                   case 'theme':
                     openThemeDialog();
                     return { type: 'handled' };
+                  case 'privacy':
+                    openPrivacyNotice();
+                    return { type: 'handled' };
                   default: {
                     const unhandled: never = result.dialog;
                     throw new Error(
@@ -1208,6 +1205,7 @@ export const useSlashCommandProcessor = (
       commandContext,
       addMessage,
       openThemeDialog,
+      openPrivacyNotice,
     ],
   );
 


### PR DESCRIPTION
## TLDR

This pull request migrates the `/privacy` slash command from its legacy, inline implementation into a modern, standalone command file. This change aligns the command with the project's established architectural pattern, improving modularity and maintainability. A dedicated test file has also been added to ensure the command is properly covered.

## Dive Deeper

The primary motivation for this refactoring was to continue the effort of breaking down the monolithic `slashCommandProcessor.ts` into smaller, more manageable units. By moving the `/privacy` command into its own file (`packages/cli/src/ui/commands/privacyCommand.ts`), we adhere to the convention set by other commands like `/theme` and `/help`.

Key changes include:
- **`privacyCommand.ts`**: A new file defining the command's name, description, and action, which returns a `dialog` type to open the privacy notice.
- **`privacyCommand.test.ts`**: A new Vitest test file that verifies the command's properties and ensures its action returns the correct dialog action object.
- **`CommandService.ts`**: Updated to import and register the new `privacyCommand`.
- **`CommandService.test.ts`**: The corresponding test file was updated to reflect the inclusion of the new command.
- **`types.ts`**: The `OpenDialogActionReturn` type was extended to include `'privacy'` as a valid dialog option.
- **`slashCommandProcessor.ts`**: The old, inline implementation of the `/privacy` command was removed. The hook's dependencies were also updated to resolve ESLint warnings that arose from the refactoring.

This effort contributes to a cleaner, more scalable command architecture.

## Reviewer Test Plan

To validate these changes, please follow these steps:

1.  Pull down the branch and run `npm install` to ensure all dependencies are up to date.
2.  Run the full preflight check with `npm run preflight` and confirm that all tests, linting, and build steps pass successfully.
3.  Start the Gemini CLI by running `npm start`.
4.  At the prompt, type the command `/privacy` and press Enter.
5.  **Expected Result**: The application should open the privacy notice dialog, confirming that the new command is correctly wired up and functional.
6.  You can also run the specific test file to ensure it passes: `npm run test -w packages/cli privacyCommand.test.ts`.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |  ✅ | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅❓  | -   | -   |
