### PR TITLE
feat(mcp): Add OAuth support for MCP servers

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -168,6 +168,28 @@ Use the `/mcp auth` command to manage OAuth authentication:
 - **`redirectUri`** (string): Custom redirect URI (defaults to `http://localhost:7777/oauth/callback`)
 - **`tokenParamName`** (string): Query parameter name for tokens in SSE URLs
 
+#### Authentication Provider Type
+
+You can specify the authentication provider type using the `authProviderType` property:
+
+- **`authProviderType`** (string): Specifies the authentication provider. Can be one of the following:
+  - **`dynamic_discovery`** (default): The CLI will automatically discover the OAuth configuration from the server.
+  - **`google_credentials`**: The CLI will use the Google Application Default Credentials (ADC) to authenticate with the server. When using this provider, you must specify the required scopes.
+
+```json
+{
+  "mcpServers": {
+    "googleCloudServer": {
+      "httpUrl": "https://my-gcp-service.run.app/mcp",
+      "authProviderType": "google_credentials",
+      "oauth": {
+        "scopes": ["https://www.googleapis.com/auth/userinfo.email"]
+      }
+    }
+  }
+}
+```
+
 #### Token Management
 
 OAuth tokens are automatically:

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -93,6 +93,90 @@ Each server configuration supports the following properties:
 - **`timeout`** (number): Request timeout in milliseconds (default: 600,000ms = 10 minutes)
 - **`trust`** (boolean): When `true`, bypasses all tool call confirmations for this server (default: `false`)
 
+### OAuth Support for Remote MCP Servers
+
+The Gemini CLI supports OAuth 2.0 authentication for remote MCP servers using SSE or HTTP transports. This enables secure access to MCP servers that require authentication.
+
+#### Automatic OAuth Discovery
+
+For servers that support OAuth discovery, you can omit the OAuth configuration and let the CLI discover it automatically:
+
+```json
+{
+  "mcpServers": {
+    "discoveredServer": {
+      "url": "https://api.example.com/sse"
+    }
+  }
+}
+```
+
+The CLI will automatically:
+
+- Detect when a server requires OAuth authentication (401 responses)
+- Discover OAuth endpoints from server metadata
+- Perform dynamic client registration if supported
+- Handle the OAuth flow and token management
+
+#### Authentication Flow
+
+When connecting to an OAuth-enabled server:
+
+1. **Initial connection attempt** fails with 401 Unauthorized
+2. **OAuth discovery** finds authorization and token endpoints
+3. **Browser opens** for user authentication (requires local browser access)
+4. **Authorization code** is exchanged for access tokens
+5. **Tokens are stored** securely for future use
+6. **Connection retry** succeeds with valid tokens
+
+#### Browser Redirect Requirements
+
+**Important:** OAuth authentication requires that your local machine can:
+
+- Open a web browser for authentication
+- Receive redirects on `http://localhost:7777/oauth/callback`
+
+This feature will not work in:
+
+- Headless environments without browser access
+- Remote SSH sessions without X11 forwarding
+- Containerized environments without browser support
+
+#### Managing OAuth Authentication
+
+Use the `/mcp auth` command to manage OAuth authentication:
+
+```bash
+# List servers requiring authentication
+/mcp auth
+
+# Authenticate with a specific server
+/mcp auth serverName
+
+# Re-authenticate if tokens expire
+/mcp auth serverName
+```
+
+#### OAuth Configuration Properties
+
+- **`enabled`** (boolean): Enable OAuth for this server
+- **`clientId`** (string): OAuth client identifier (optional with dynamic registration)
+- **`clientSecret`** (string): OAuth client secret (optional for public clients)
+- **`authorizationUrl`** (string): OAuth authorization endpoint (auto-discovered if omitted)
+- **`tokenUrl`** (string): OAuth token endpoint (auto-discovered if omitted)
+- **`scopes`** (string[]): Required OAuth scopes
+- **`redirectUri`** (string): Custom redirect URI (defaults to `http://localhost:7777/oauth/callback`)
+- **`tokenParamName`** (string): Query parameter name for tokens in SSE URLs
+
+#### Token Management
+
+OAuth tokens are automatically:
+
+- **Stored securely** in `~/.gemini/mcp-oauth-tokens.json`
+- **Refreshed** when expired (if refresh tokens are available)
+- **Validated** before each connection attempt
+- **Cleaned up** when invalid or expired
+
 ### Example Configurations
 
 #### Python MCP Server (Stdio)

--- a/packages/cli/src/ui/commands/mcpCommand.test.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.test.ts
@@ -30,6 +30,13 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     ...actual,
     getMCPServerStatus: vi.fn(),
     getMCPDiscoveryState: vi.fn(),
+    MCPOAuthProvider: {
+      authenticate: vi.fn(),
+    },
+    MCPOAuthTokenStorage: {
+      getToken: vi.fn(),
+      isTokenExpired: vi.fn(),
+    },
   };
 });
 
@@ -750,6 +757,165 @@ describe('mcpCommand', () => {
         expect(message).toContain('server-with-dashes');
         expect(message).toContain('server_with_underscores');
         expect(message).toContain('server.with.dots');
+      }
+    });
+  });
+
+  describe('auth subcommand', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should list OAuth-enabled servers when no server name is provided', async () => {
+      const context = createMockCommandContext({
+        services: {
+          config: {
+            getMcpServers: vi.fn().mockReturnValue({
+              'oauth-server': { oauth: { enabled: true } },
+              'regular-server': {},
+              'another-oauth': { oauth: { enabled: true } },
+            }),
+          },
+        },
+      });
+
+      const authCommand = mcpCommand.subCommands?.find(
+        (cmd) => cmd.name === 'auth',
+      );
+      expect(authCommand).toBeDefined();
+
+      const result = await authCommand!.action!(context, '');
+      expect(isMessageAction(result)).toBe(true);
+      if (isMessageAction(result)) {
+        expect(result.messageType).toBe('info');
+        expect(result.content).toContain('oauth-server');
+        expect(result.content).toContain('another-oauth');
+        expect(result.content).not.toContain('regular-server');
+        expect(result.content).toContain('/mcp auth <server-name>');
+      }
+    });
+
+    it('should show message when no OAuth servers are configured', async () => {
+      const context = createMockCommandContext({
+        services: {
+          config: {
+            getMcpServers: vi.fn().mockReturnValue({
+              'regular-server': {},
+            }),
+          },
+        },
+      });
+
+      const authCommand = mcpCommand.subCommands?.find(
+        (cmd) => cmd.name === 'auth',
+      );
+      const result = await authCommand!.action!(context, '');
+
+      expect(isMessageAction(result)).toBe(true);
+      if (isMessageAction(result)) {
+        expect(result.messageType).toBe('info');
+        expect(result.content).toBe(
+          'No MCP servers configured with OAuth authentication.',
+        );
+      }
+    });
+
+    it('should authenticate with a specific server', async () => {
+      const mockToolRegistry = {
+        discoverToolsForServer: vi.fn(),
+      };
+      const mockGeminiClient = {
+        setTools: vi.fn(),
+      };
+
+      const context = createMockCommandContext({
+        services: {
+          config: {
+            getMcpServers: vi.fn().mockReturnValue({
+              'test-server': {
+                url: 'http://localhost:3000',
+                oauth: { enabled: true },
+              },
+            }),
+            getToolRegistry: vi.fn().mockResolvedValue(mockToolRegistry),
+            getGeminiClient: vi.fn().mockReturnValue(mockGeminiClient),
+          },
+        },
+      });
+
+      const { MCPOAuthProvider } = await import('@google/gemini-cli-core');
+
+      const authCommand = mcpCommand.subCommands?.find(
+        (cmd) => cmd.name === 'auth',
+      );
+      const result = await authCommand!.action!(context, 'test-server');
+
+      expect(MCPOAuthProvider.authenticate).toHaveBeenCalledWith(
+        'test-server',
+        { enabled: true },
+        'http://localhost:3000',
+      );
+      expect(mockToolRegistry.discoverToolsForServer).toHaveBeenCalledWith(
+        'test-server',
+      );
+      expect(mockGeminiClient.setTools).toHaveBeenCalled();
+
+      expect(isMessageAction(result)).toBe(true);
+      if (isMessageAction(result)) {
+        expect(result.messageType).toBe('info');
+        expect(result.content).toContain('Successfully authenticated');
+      }
+    });
+
+    it('should handle authentication errors', async () => {
+      const context = createMockCommandContext({
+        services: {
+          config: {
+            getMcpServers: vi.fn().mockReturnValue({
+              'test-server': { oauth: { enabled: true } },
+            }),
+          },
+        },
+      });
+
+      const { MCPOAuthProvider } = await import('@google/gemini-cli-core');
+      (
+        MCPOAuthProvider.authenticate as ReturnType<typeof vi.fn>
+      ).mockRejectedValue(new Error('Auth failed'));
+
+      const authCommand = mcpCommand.subCommands?.find(
+        (cmd) => cmd.name === 'auth',
+      );
+      const result = await authCommand!.action!(context, 'test-server');
+
+      expect(isMessageAction(result)).toBe(true);
+      if (isMessageAction(result)) {
+        expect(result.messageType).toBe('error');
+        expect(result.content).toContain('Failed to authenticate');
+        expect(result.content).toContain('Auth failed');
+      }
+    });
+
+    it('should handle non-existent server', async () => {
+      const context = createMockCommandContext({
+        services: {
+          config: {
+            getMcpServers: vi.fn().mockReturnValue({
+              'existing-server': {},
+            }),
+          },
+        },
+      });
+
+      const authCommand = mcpCommand.subCommands?.find(
+        (cmd) => cmd.name === 'auth',
+      );
+      const result = await authCommand!.action!(context, 'non-existent');
+
+      expect(isMessageAction(result)).toBe(true);
+      if (isMessageAction(result)) {
+        expect(result.messageType).toBe('error');
+        expect(result.content).toContain("MCP server 'non-existent' not found");
       }
     });
   });

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -8,6 +8,7 @@ import {
   SlashCommand,
   SlashCommandActionReturn,
   CommandContext,
+  MessageActionReturn,
 } from './types.js';
 import {
   DiscoveredMCPTool,
@@ -15,12 +16,16 @@ import {
   getMCPServerStatus,
   MCPDiscoveryState,
   MCPServerStatus,
+  mcpServerRequiresOAuth,
+  getErrorMessage,
 } from '@google/gemini-cli-core';
 import open from 'open';
 
 const COLOR_GREEN = '\u001b[32m';
 const COLOR_YELLOW = '\u001b[33m';
+const COLOR_RED = '\u001b[31m';
 const COLOR_CYAN = '\u001b[36m';
+const COLOR_GREY = '\u001b[90m';
 const RESET_COLOR = '\u001b[0m';
 
 const getMcpStatus = async (
@@ -122,6 +127,31 @@ const getMcpStatus = async (
     // Format server header with bold formatting and status
     message += `${statusIndicator} \u001b[1m${serverName}\u001b[0m - ${statusText}`;
 
+    let needsAuthHint = mcpServerRequiresOAuth.get(serverName) || false;
+    // Add OAuth status if applicable
+    if (server?.oauth?.enabled) {
+      needsAuthHint = true;
+      try {
+        const { MCPOAuthTokenStorage } = await import(
+          '@google/gemini-cli-core'
+        );
+        const hasToken = await MCPOAuthTokenStorage.getToken(serverName);
+        if (hasToken) {
+          const isExpired = MCPOAuthTokenStorage.isTokenExpired(hasToken.token);
+          if (isExpired) {
+            message += ` ${COLOR_YELLOW}(OAuth token expired)${RESET_COLOR}`;
+          } else {
+            message += ` ${COLOR_GREEN}(OAuth authenticated)${RESET_COLOR}`;
+            needsAuthHint = false;
+          }
+        } else {
+          message += ` ${COLOR_RED}(OAuth not authenticated)${RESET_COLOR}`;
+        }
+      } catch (_err) {
+        // If we can't check OAuth status, just continue
+      }
+    }
+
     // Add tool count with conditional messaging
     if (status === MCPServerStatus.CONNECTED) {
       message += ` (${serverTools.length} tools)`;
@@ -185,7 +215,11 @@ const getMcpStatus = async (
         }
       });
     } else {
-      message += '  No tools available\n';
+      message += '  No tools available';
+      if (status === MCPServerStatus.DISCONNECTED && needsAuthHint) {
+        message += ` ${COLOR_GREY}(type: "/mcp auth ${serverName}" to authenticate this server)${RESET_COLOR}`;
+      }
+      message += '\n';
     }
     message += '\n';
   }
@@ -197,6 +231,7 @@ const getMcpStatus = async (
     message += `  • Use ${COLOR_CYAN}/mcp desc${RESET_COLOR} to show server and tool descriptions\n`;
     message += `  • Use ${COLOR_CYAN}/mcp schema${RESET_COLOR} to show tool parameter schemas\n`;
     message += `  • Use ${COLOR_CYAN}/mcp nodesc${RESET_COLOR} to hide descriptions\n`;
+    message += `  • Use ${COLOR_CYAN}/mcp auth <server-name>${RESET_COLOR} to authenticate with OAuth-enabled servers\n`;
     message += `  • Press ${COLOR_CYAN}Ctrl+T${RESET_COLOR} to toggle tool descriptions on/off\n`;
     message += '\n';
   }
@@ -211,9 +246,138 @@ const getMcpStatus = async (
   };
 };
 
-export const mcpCommand: SlashCommand = {
-  name: 'mcp',
-  description: 'list configured MCP servers and tools',
+const authCommand: SlashCommand = {
+  name: 'auth',
+  description: 'Authenticate with an OAuth-enabled MCP server',
+  action: async (
+    context: CommandContext,
+    args: string,
+  ): Promise<MessageActionReturn> => {
+    const serverName = args.trim();
+    const { config } = context.services;
+
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Config not loaded.',
+      };
+    }
+
+    const mcpServers = config.getMcpServers() || {};
+
+    if (!serverName) {
+      // List servers that support OAuth
+      const oauthServers = Object.entries(mcpServers)
+        .filter(([_, server]) => server.oauth?.enabled)
+        .map(([name, _]) => name);
+
+      if (oauthServers.length === 0) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: 'No MCP servers configured with OAuth authentication.',
+        };
+      }
+
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `MCP servers with OAuth authentication:\n${oauthServers.map((s) => `  - ${s}`).join('\n')}\n\nUse /mcp auth <server-name> to authenticate.`,
+      };
+    }
+
+    const server = mcpServers[serverName];
+    if (!server) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `MCP server '${serverName}' not found.`,
+      };
+    }
+
+    // Always attempt OAuth authentication, even if not explicitly configured
+    // The authentication process will discover OAuth requirements automatically
+
+    try {
+      context.ui.addItem(
+        {
+          type: 'info',
+          text: `Starting OAuth authentication for MCP server '${serverName}'...`,
+        },
+        Date.now(),
+      );
+
+      // Import dynamically to avoid circular dependencies
+      const { MCPOAuthProvider } = await import('@google/gemini-cli-core');
+
+      // Create OAuth config for authentication (will be discovered automatically)
+      const oauthConfig = server.oauth || {
+        authorizationUrl: '', // Will be discovered automatically
+        tokenUrl: '', // Will be discovered automatically
+      };
+
+      // Pass the MCP server URL for OAuth discovery
+      const mcpServerUrl = server.httpUrl || server.url;
+      await MCPOAuthProvider.authenticate(
+        serverName,
+        oauthConfig,
+        mcpServerUrl,
+      );
+
+      context.ui.addItem(
+        {
+          type: 'info',
+          text: `✅ Successfully authenticated with MCP server '${serverName}'!`,
+        },
+        Date.now(),
+      );
+
+      // Trigger tool re-discovery to pick up authenticated server
+      const toolRegistry = await config.getToolRegistry();
+      if (toolRegistry) {
+        context.ui.addItem(
+          {
+            type: 'info',
+            text: `Re-discovering tools from '${serverName}'...`,
+          },
+          Date.now(),
+        );
+        await toolRegistry.discoverToolsForServer(serverName);
+      }
+      // Update the client with the new tools
+      const geminiClient = config.getGeminiClient();
+      if (geminiClient) {
+        await geminiClient.setTools();
+      }
+
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `Successfully authenticated and refreshed tools for '${serverName}'.`,
+      };
+    } catch (error) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Failed to authenticate with MCP server '${serverName}': ${getErrorMessage(error)}`,
+      };
+    }
+  },
+  completion: async (context: CommandContext, partialArg: string) => {
+    const { config } = context.services;
+    if (!config) return [];
+
+    const mcpServers = config.getMcpServers() || {};
+    return Object.keys(mcpServers).filter((name) =>
+      name.startsWith(partialArg),
+    );
+  },
+};
+
+const listCommand: SlashCommand = {
+  name: 'list',
+  description: 'List configured MCP servers and tools',
   action: async (context: CommandContext, args: string) => {
     const lowerCaseArgs = args.toLowerCase().split(/\s+/).filter(Boolean);
 
@@ -233,4 +397,15 @@ export const mcpCommand: SlashCommand = {
 
     return getMcpStatus(context, showDescriptions, showSchema, showTips);
   },
+};
+
+export const mcpCommand: SlashCommand = {
+  name: 'mcp',
+  description:
+    'list configured MCP servers and tools, or authenticate with OAuth-enabled servers',
+  subCommands: [listCommand, authCommand],
+  // Default action when no subcommand is provided
+  action: async (context: CommandContext, args: string) =>
+    // If no subcommand, run the list command
+    listCommand.action!(context, args),
 };

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -103,7 +103,13 @@ export class MCPServerConfig {
     readonly excludeTools?: string[],
     // OAuth configuration
     readonly oauth?: MCPOAuthConfig,
+    readonly authProviderType?: AuthProviderType,
   ) {}
+}
+
+export enum AuthProviderType {
+  DYNAMIC_DISCOVERY = 'dynamic_discovery',
+  GOOGLE_CREDENTIALS = 'google_credentials',
 }
 
 export interface SandboxConfig {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -45,6 +45,10 @@ import {
   DEFAULT_GEMINI_FLASH_MODEL,
 } from './models.js';
 import { ClearcutLogger } from '../telemetry/clearcut-logger/clearcut-logger.js';
+import { MCPOAuthConfig } from '../mcp/oauth-provider.js';
+
+// Re-export OAuth config type
+export type { MCPOAuthConfig };
 
 export enum ApprovalMode {
   DEFAULT = 'default',
@@ -97,6 +101,8 @@ export class MCPServerConfig {
     readonly description?: string,
     readonly includeTools?: string[],
     readonly excludeTools?: string[],
+    // OAuth configuration
+    readonly oauth?: MCPOAuthConfig,
   ) {}
 }
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -152,6 +152,13 @@ export class GeminiClient {
     this.getChat().setHistory(history);
   }
 
+  async setTools(): Promise<void> {
+    const toolRegistry = await this.config.getToolRegistry();
+    const toolDeclarations = toolRegistry.getFunctionDeclarations();
+    const tools: Tool[] = [{ functionDeclarations: toolDeclarations }];
+    this.getChat().setTools(tools);
+  }
+
   async resetChat(): Promise<void> {
     this.chat = await this.startChat();
   }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -15,6 +15,7 @@ import {
   createUserContent,
   Part,
   GenerateContentResponseUsageMetadata,
+  Tool,
 } from '@google/genai';
 import { retryWithBackoff } from '../utils/retry.js';
 import { isFunctionResponse } from '../utils/messageInspectors.js';
@@ -496,6 +497,10 @@ export class GeminiChat {
   }
   setHistory(history: Content[]): void {
     this.history = history;
+  }
+
+  setTools(tools: Tool[]): void {
+    this.generationConfig.tools = tools;
   }
 
   getFinalUsageMetadata(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,20 @@ export * from './tools/read-many-files.js';
 export * from './tools/mcp-client.js';
 export * from './tools/mcp-tool.js';
 
+// MCP OAuth
+export { MCPOAuthProvider } from './mcp/oauth-provider.js';
+export {
+  MCPOAuthToken,
+  MCPOAuthCredentials,
+  MCPOAuthTokenStorage,
+} from './mcp/oauth-token-storage.js';
+export type { MCPOAuthConfig } from './mcp/oauth-provider.js';
+export type {
+  OAuthAuthorizationServerMetadata,
+  OAuthProtectedResourceMetadata,
+} from './mcp/oauth-utils.js';
+export { OAuthUtils } from './mcp/oauth-utils.js';
+
 // Export telemetry functions
 export * from './telemetry/index.js';
 export { sessionId } from './utils/session.js';

--- a/packages/core/src/mcp/google-auth-provider.test.ts
+++ b/packages/core/src/mcp/google-auth-provider.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GoogleAuth } from 'google-auth-library';
+import { GoogleCredentialProvider } from './google-auth-provider.js';
+import { vi, describe, beforeEach, it, expect, Mock } from 'vitest';
+import { MCPServerConfig } from '../config/config.js';
+
+vi.mock('google-auth-library');
+
+describe('GoogleCredentialProvider', () => {
+  it('should throw an error if no scopes are provided', () => {
+    expect(() => new GoogleCredentialProvider()).toThrow(
+      'Scopes must be provided in the oauth config for Google Credentials provider',
+    );
+  });
+
+  it('should use scopes from the config if provided', () => {
+    const config = {
+      oauth: {
+        scopes: ['scope1', 'scope2'],
+      },
+    } as MCPServerConfig;
+    new GoogleCredentialProvider(config);
+    expect(GoogleAuth).toHaveBeenCalledWith({
+      scopes: ['scope1', 'scope2'],
+    });
+  });
+
+  describe('with provider instance', () => {
+    let provider: GoogleCredentialProvider;
+
+    beforeEach(() => {
+      const config = {
+        oauth: {
+          scopes: ['scope1', 'scope2'],
+        },
+      } as MCPServerConfig;
+      provider = new GoogleCredentialProvider(config);
+      vi.clearAllMocks();
+    });
+
+    it('should return credentials', async () => {
+      const mockClient = {
+        getAccessToken: vi.fn().mockResolvedValue({ token: 'test-token' }),
+      };
+      (GoogleAuth.prototype.getClient as Mock).mockResolvedValue(mockClient);
+
+      const credentials = await provider.tokens();
+
+      expect(credentials?.access_token).toBe('test-token');
+    });
+
+    it('should return undefined if access token is not available', async () => {
+      const mockClient = {
+        getAccessToken: vi.fn().mockResolvedValue({ token: null }),
+      };
+      (GoogleAuth.prototype.getClient as Mock).mockResolvedValue(mockClient);
+
+      const credentials = await provider.tokens();
+      expect(credentials).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/mcp/google-auth-provider.ts
+++ b/packages/core/src/mcp/google-auth-provider.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+import {
+  OAuthClientInformation,
+  OAuthClientInformationFull,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import { GoogleAuth } from 'google-auth-library';
+import { MCPServerConfig } from '../config/config.js';
+
+export class GoogleCredentialProvider implements OAuthClientProvider {
+  private readonly auth: GoogleAuth;
+
+  // Properties required by OAuthClientProvider, with no-op values
+  readonly redirectUrl = '';
+  readonly clientMetadata: OAuthClientMetadata = {
+    client_name: 'Gemini CLI (Google ADC)',
+    redirect_uris: [],
+    grant_types: [],
+    response_types: [],
+    token_endpoint_auth_method: 'none',
+  };
+  private _clientInformation?: OAuthClientInformationFull;
+
+  constructor(private readonly config?: MCPServerConfig) {
+    const scopes = this.config?.oauth?.scopes;
+    if (!scopes || scopes.length === 0) {
+      throw new Error(
+        'Scopes must be provided in the oauth config for Google Credentials provider',
+      );
+    }
+    this.auth = new GoogleAuth({
+      scopes,
+    });
+  }
+
+  clientInformation(): OAuthClientInformation | undefined {
+    return this._clientInformation;
+  }
+
+  saveClientInformation(clientInformation: OAuthClientInformationFull): void {
+    this._clientInformation = clientInformation;
+  }
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    const client = await this.auth.getClient();
+    const accessTokenResponse = await client.getAccessToken();
+
+    if (!accessTokenResponse.token) {
+      console.error('Failed to get access token from Google ADC');
+      return undefined;
+    }
+
+    const tokens: OAuthTokens = {
+      access_token: accessTokenResponse.token,
+      token_type: 'Bearer',
+    };
+    return tokens;
+  }
+
+  saveTokens(_tokens: OAuthTokens): void {
+    // No-op, ADC manages tokens.
+  }
+
+  redirectToAuthorization(_authorizationUrl: URL): void {
+    // No-op
+  }
+
+  saveCodeVerifier(_codeVerifier: string): void {
+    // No-op
+  }
+
+  codeVerifier(): string {
+    // No-op
+    return '';
+  }
+}

--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -1,0 +1,720 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as http from 'node:http';
+import * as crypto from 'node:crypto';
+import open from 'open';
+import {
+  MCPOAuthProvider,
+  MCPOAuthConfig,
+  OAuthTokenResponse,
+  OAuthClientRegistrationResponse,
+} from './oauth-provider.js';
+import { MCPOAuthTokenStorage, MCPOAuthToken } from './oauth-token-storage.js';
+
+// Mock dependencies
+vi.mock('open');
+vi.mock('node:crypto');
+vi.mock('./oauth-token-storage.js');
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Define a reusable mock server with .listen, .close, and .on methods
+const mockHttpServer = {
+  listen: vi.fn(),
+  close: vi.fn(),
+  on: vi.fn(),
+};
+vi.mock('node:http', () => ({
+  createServer: vi.fn(() => mockHttpServer),
+}));
+
+describe('MCPOAuthProvider', () => {
+  const mockConfig: MCPOAuthConfig = {
+    enabled: true,
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    authorizationUrl: 'https://auth.example.com/authorize',
+    tokenUrl: 'https://auth.example.com/token',
+    scopes: ['read', 'write'],
+    redirectUri: 'http://localhost:7777/oauth/callback',
+  };
+
+  const mockToken: MCPOAuthToken = {
+    accessToken: 'access_token_123',
+    refreshToken: 'refresh_token_456',
+    tokenType: 'Bearer',
+    scope: 'read write',
+    expiresAt: Date.now() + 3600000,
+  };
+
+  const mockTokenResponse: OAuthTokenResponse = {
+    access_token: 'access_token_123',
+    token_type: 'Bearer',
+    expires_in: 3600,
+    refresh_token: 'refresh_token_456',
+    scope: 'read write',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Mock crypto functions
+    vi.mocked(crypto.randomBytes).mockImplementation((size: number) => {
+      if (size === 32) return Buffer.from('code_verifier_mock_32_bytes_long');
+      if (size === 16) return Buffer.from('state_mock_16_by');
+      return Buffer.alloc(size);
+    });
+
+    vi.mocked(crypto.createHash).mockReturnValue({
+      update: vi.fn().mockReturnThis(),
+      digest: vi.fn().mockReturnValue('code_challenge_mock'),
+    } as unknown as crypto.Hash);
+
+    // Mock randomBytes to return predictable values for state
+    vi.mocked(crypto.randomBytes).mockImplementation((size) => {
+      if (size === 32) {
+        return Buffer.from('mock_code_verifier_32_bytes_long_string');
+      } else if (size === 16) {
+        return Buffer.from('mock_state_16_bytes');
+      }
+      return Buffer.alloc(size);
+    });
+
+    // Mock token storage
+    vi.mocked(MCPOAuthTokenStorage.saveToken).mockResolvedValue(undefined);
+    vi.mocked(MCPOAuthTokenStorage.getToken).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('authenticate', () => {
+    it('should perform complete OAuth flow with PKCE', async () => {
+      // Mock HTTP server callback
+      let callbackHandler: unknown;
+      vi.mocked(http.createServer).mockImplementation((handler) => {
+        callbackHandler = handler;
+        return mockHttpServer as unknown as http.Server;
+      });
+
+      mockHttpServer.listen.mockImplementation((port, callback) => {
+        callback?.();
+        // Simulate OAuth callback
+        setTimeout(() => {
+          const mockReq = {
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+          };
+          const mockRes = {
+            writeHead: vi.fn(),
+            end: vi.fn(),
+          };
+          (callbackHandler as (req: unknown, res: unknown) => void)(
+            mockReq,
+            mockRes,
+          );
+        }, 10);
+      });
+
+      // Mock token exchange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse),
+      });
+
+      const result = await MCPOAuthProvider.authenticate(
+        'test-server',
+        mockConfig,
+      );
+
+      expect(result).toEqual({
+        accessToken: 'access_token_123',
+        refreshToken: 'refresh_token_456',
+        tokenType: 'Bearer',
+        scope: 'read write',
+        expiresAt: expect.any(Number),
+      });
+
+      expect(open).toHaveBeenCalledWith(expect.stringContaining('authorize'));
+      expect(MCPOAuthTokenStorage.saveToken).toHaveBeenCalledWith(
+        'test-server',
+        expect.objectContaining({ accessToken: 'access_token_123' }),
+        'test-client-id',
+        'https://auth.example.com/token',
+      );
+    });
+
+    it('should handle OAuth discovery when no authorization URL provided', async () => {
+      // Use a mutable config object
+      const configWithoutAuth: MCPOAuthConfig = { ...mockConfig };
+      delete configWithoutAuth.authorizationUrl;
+      delete configWithoutAuth.tokenUrl;
+
+      const mockResourceMetadata = {
+        authorization_servers: ['https://discovered.auth.com'],
+      };
+
+      const mockAuthServerMetadata = {
+        authorization_endpoint: 'https://discovered.auth.com/authorize',
+        token_endpoint: 'https://discovered.auth.com/token',
+        scopes_supported: ['read', 'write'],
+      };
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockResourceMetadata),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockAuthServerMetadata),
+        });
+
+      // Patch config after discovery
+      configWithoutAuth.authorizationUrl =
+        mockAuthServerMetadata.authorization_endpoint;
+      configWithoutAuth.tokenUrl = mockAuthServerMetadata.token_endpoint;
+      configWithoutAuth.scopes = mockAuthServerMetadata.scopes_supported;
+
+      // Setup callback handler
+      let callbackHandler: unknown;
+      vi.mocked(http.createServer).mockImplementation((handler) => {
+        callbackHandler = handler;
+        return mockHttpServer as unknown as http.Server;
+      });
+
+      mockHttpServer.listen.mockImplementation((port, callback) => {
+        callback?.();
+        setTimeout(() => {
+          const mockReq = {
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+          };
+          const mockRes = {
+            writeHead: vi.fn(),
+            end: vi.fn(),
+          };
+          (callbackHandler as (req: unknown, res: unknown) => void)(
+            mockReq,
+            mockRes,
+          );
+        }, 10);
+      });
+
+      // Mock token exchange with discovered endpoint
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse),
+      });
+
+      const result = await MCPOAuthProvider.authenticate(
+        'test-server',
+        configWithoutAuth,
+        'https://api.example.com',
+      );
+
+      expect(result).toBeDefined();
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://discovered.auth.com/token',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        }),
+      );
+    });
+
+    it('should perform dynamic client registration when no client ID provided', async () => {
+      const configWithoutClient = { ...mockConfig };
+      delete configWithoutClient.clientId;
+
+      const mockRegistrationResponse: OAuthClientRegistrationResponse = {
+        client_id: 'dynamic_client_id',
+        client_secret: 'dynamic_client_secret',
+        redirect_uris: ['http://localhost:7777/oauth/callback'],
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+      };
+
+      const mockAuthServerMetadata = {
+        authorization_endpoint: 'https://auth.example.com/authorize',
+        token_endpoint: 'https://auth.example.com/token',
+        registration_endpoint: 'https://auth.example.com/register',
+      };
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockAuthServerMetadata),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockRegistrationResponse),
+        });
+
+      // Setup callback handler
+      let callbackHandler: unknown;
+      vi.mocked(http.createServer).mockImplementation((handler) => {
+        callbackHandler = handler;
+        return mockHttpServer as unknown as http.Server;
+      });
+
+      mockHttpServer.listen.mockImplementation((port, callback) => {
+        callback?.();
+        setTimeout(() => {
+          const mockReq = {
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+          };
+          const mockRes = {
+            writeHead: vi.fn(),
+            end: vi.fn(),
+          };
+          (callbackHandler as (req: unknown, res: unknown) => void)(
+            mockReq,
+            mockRes,
+          );
+        }, 10);
+      });
+
+      // Mock token exchange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse),
+      });
+
+      const result = await MCPOAuthProvider.authenticate(
+        'test-server',
+        configWithoutClient,
+      );
+
+      expect(result).toBeDefined();
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://auth.example.com/register',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    it('should handle OAuth callback errors', async () => {
+      let callbackHandler: unknown;
+      vi.mocked(http.createServer).mockImplementation((handler) => {
+        callbackHandler = handler;
+        return mockHttpServer as unknown as http.Server;
+      });
+
+      mockHttpServer.listen.mockImplementation((port, callback) => {
+        callback?.();
+        setTimeout(() => {
+          const mockReq = {
+            url: '/oauth/callback?error=access_denied&error_description=User%20denied%20access',
+          };
+          const mockRes = {
+            writeHead: vi.fn(),
+            end: vi.fn(),
+          };
+          (callbackHandler as (req: unknown, res: unknown) => void)(
+            mockReq,
+            mockRes,
+          );
+        }, 10);
+      });
+
+      await expect(
+        MCPOAuthProvider.authenticate('test-server', mockConfig),
+      ).rejects.toThrow('OAuth error: access_denied');
+    });
+
+    it('should handle state mismatch in callback', async () => {
+      let callbackHandler: unknown;
+      vi.mocked(http.createServer).mockImplementation((handler) => {
+        callbackHandler = handler;
+        return mockHttpServer as unknown as http.Server;
+      });
+
+      mockHttpServer.listen.mockImplementation((port, callback) => {
+        callback?.();
+        setTimeout(() => {
+          const mockReq = {
+            url: '/oauth/callback?code=auth_code_123&state=wrong_state',
+          };
+          const mockRes = {
+            writeHead: vi.fn(),
+            end: vi.fn(),
+          };
+          (callbackHandler as (req: unknown, res: unknown) => void)(
+            mockReq,
+            mockRes,
+          );
+        }, 10);
+      });
+
+      await expect(
+        MCPOAuthProvider.authenticate('test-server', mockConfig),
+      ).rejects.toThrow('State mismatch - possible CSRF attack');
+    });
+
+    it('should handle token exchange failure', async () => {
+      let callbackHandler: unknown;
+      vi.mocked(http.createServer).mockImplementation((handler) => {
+        callbackHandler = handler;
+        return mockHttpServer as unknown as http.Server;
+      });
+
+      mockHttpServer.listen.mockImplementation((port, callback) => {
+        callback?.();
+        setTimeout(() => {
+          const mockReq = {
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+          };
+          const mockRes = {
+            writeHead: vi.fn(),
+            end: vi.fn(),
+          };
+          (callbackHandler as (req: unknown, res: unknown) => void)(
+            mockReq,
+            mockRes,
+          );
+        }, 10);
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve('Invalid grant'),
+      });
+
+      await expect(
+        MCPOAuthProvider.authenticate('test-server', mockConfig),
+      ).rejects.toThrow('Token exchange failed: 400 - Invalid grant');
+    });
+
+    it('should handle callback timeout', async () => {
+      vi.mocked(http.createServer).mockImplementation(
+        () => mockHttpServer as unknown as http.Server,
+      );
+
+      mockHttpServer.listen.mockImplementation((port, callback) => {
+        callback?.();
+        // Don't trigger callback - simulate timeout
+      });
+
+      // Mock setTimeout to trigger timeout immediately
+      const originalSetTimeout = global.setTimeout;
+      global.setTimeout = vi.fn((callback, delay) => {
+        if (delay === 5 * 60 * 1000) {
+          // 5 minute timeout
+          callback();
+        }
+        return originalSetTimeout(callback, 0);
+      }) as unknown as typeof setTimeout;
+
+      await expect(
+        MCPOAuthProvider.authenticate('test-server', mockConfig),
+      ).rejects.toThrow('OAuth callback timeout');
+
+      global.setTimeout = originalSetTimeout;
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    it('should refresh token successfully', async () => {
+      const refreshResponse = {
+        access_token: 'new_access_token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        refresh_token: 'new_refresh_token',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(refreshResponse),
+      });
+
+      const result = await MCPOAuthProvider.refreshAccessToken(
+        mockConfig,
+        'old_refresh_token',
+        'https://auth.example.com/token',
+      );
+
+      expect(result).toEqual(refreshResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://auth.example.com/token',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: expect.stringContaining('grant_type=refresh_token'),
+        }),
+      );
+    });
+
+    it('should include client secret in refresh request when available', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse),
+      });
+
+      await MCPOAuthProvider.refreshAccessToken(
+        mockConfig,
+        'refresh_token',
+        'https://auth.example.com/token',
+      );
+
+      const fetchCall = mockFetch.mock.calls[0];
+      expect(fetchCall[1].body).toContain('client_secret=test-client-secret');
+    });
+
+    it('should handle refresh token failure', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve('Invalid refresh token'),
+      });
+
+      await expect(
+        MCPOAuthProvider.refreshAccessToken(
+          mockConfig,
+          'invalid_refresh_token',
+          'https://auth.example.com/token',
+        ),
+      ).rejects.toThrow('Token refresh failed: 400 - Invalid refresh token');
+    });
+  });
+
+  describe('getValidToken', () => {
+    it('should return valid token when not expired', async () => {
+      const validCredentials = {
+        serverName: 'test-server',
+        token: mockToken,
+        clientId: 'test-client-id',
+        tokenUrl: 'https://auth.example.com/token',
+        updatedAt: Date.now(),
+      };
+
+      vi.mocked(MCPOAuthTokenStorage.getToken).mockResolvedValue(
+        validCredentials,
+      );
+      vi.mocked(MCPOAuthTokenStorage.isTokenExpired).mockReturnValue(false);
+
+      const result = await MCPOAuthProvider.getValidToken(
+        'test-server',
+        mockConfig,
+      );
+
+      expect(result).toBe('access_token_123');
+    });
+
+    it('should refresh expired token and return new token', async () => {
+      const expiredCredentials = {
+        serverName: 'test-server',
+        token: { ...mockToken, expiresAt: Date.now() - 3600000 },
+        clientId: 'test-client-id',
+        tokenUrl: 'https://auth.example.com/token',
+        updatedAt: Date.now(),
+      };
+
+      vi.mocked(MCPOAuthTokenStorage.getToken).mockResolvedValue(
+        expiredCredentials,
+      );
+      vi.mocked(MCPOAuthTokenStorage.isTokenExpired).mockReturnValue(true);
+
+      const refreshResponse = {
+        access_token: 'new_access_token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        refresh_token: 'new_refresh_token',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(refreshResponse),
+      });
+
+      const result = await MCPOAuthProvider.getValidToken(
+        'test-server',
+        mockConfig,
+      );
+
+      expect(result).toBe('new_access_token');
+      expect(MCPOAuthTokenStorage.saveToken).toHaveBeenCalledWith(
+        'test-server',
+        expect.objectContaining({ accessToken: 'new_access_token' }),
+        'test-client-id',
+        'https://auth.example.com/token',
+      );
+    });
+
+    it('should return null when no credentials exist', async () => {
+      vi.mocked(MCPOAuthTokenStorage.getToken).mockResolvedValue(null);
+
+      const result = await MCPOAuthProvider.getValidToken(
+        'test-server',
+        mockConfig,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle refresh failure and remove invalid token', async () => {
+      const expiredCredentials = {
+        serverName: 'test-server',
+        token: { ...mockToken, expiresAt: Date.now() - 3600000 },
+        clientId: 'test-client-id',
+        tokenUrl: 'https://auth.example.com/token',
+        updatedAt: Date.now(),
+      };
+
+      vi.mocked(MCPOAuthTokenStorage.getToken).mockResolvedValue(
+        expiredCredentials,
+      );
+      vi.mocked(MCPOAuthTokenStorage.isTokenExpired).mockReturnValue(true);
+      vi.mocked(MCPOAuthTokenStorage.removeToken).mockResolvedValue(undefined);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve('Invalid refresh token'),
+      });
+
+      const result = await MCPOAuthProvider.getValidToken(
+        'test-server',
+        mockConfig,
+      );
+
+      expect(result).toBeNull();
+      expect(MCPOAuthTokenStorage.removeToken).toHaveBeenCalledWith(
+        'test-server',
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to refresh token'),
+      );
+    });
+
+    it('should return null for token without refresh capability', async () => {
+      const tokenWithoutRefresh = {
+        serverName: 'test-server',
+        token: {
+          ...mockToken,
+          refreshToken: undefined,
+          expiresAt: Date.now() - 3600000,
+        },
+        clientId: 'test-client-id',
+        tokenUrl: 'https://auth.example.com/token',
+        updatedAt: Date.now(),
+      };
+
+      vi.mocked(MCPOAuthTokenStorage.getToken).mockResolvedValue(
+        tokenWithoutRefresh,
+      );
+      vi.mocked(MCPOAuthTokenStorage.isTokenExpired).mockReturnValue(true);
+
+      const result = await MCPOAuthProvider.getValidToken(
+        'test-server',
+        mockConfig,
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('PKCE parameter generation', () => {
+    it('should generate valid PKCE parameters', async () => {
+      // Test is implicit in the authenticate flow tests, but we can verify
+      // the crypto mocks are called correctly
+      let callbackHandler: unknown;
+      vi.mocked(http.createServer).mockImplementation((handler) => {
+        callbackHandler = handler;
+        return mockHttpServer as unknown as http.Server;
+      });
+
+      mockHttpServer.listen.mockImplementation((port, callback) => {
+        callback?.();
+        setTimeout(() => {
+          const mockReq = {
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+          };
+          const mockRes = {
+            writeHead: vi.fn(),
+            end: vi.fn(),
+          };
+          (callbackHandler as (req: unknown, res: unknown) => void)(
+            mockReq,
+            mockRes,
+          );
+        }, 10);
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse),
+      });
+
+      await MCPOAuthProvider.authenticate('test-server', mockConfig);
+
+      expect(crypto.randomBytes).toHaveBeenCalledWith(32); // code verifier
+      expect(crypto.randomBytes).toHaveBeenCalledWith(16); // state
+      expect(crypto.createHash).toHaveBeenCalledWith('sha256');
+    });
+  });
+
+  describe('Authorization URL building', () => {
+    it('should build correct authorization URL with all parameters', async () => {
+      // Mock to capture the URL that would be opened
+      let capturedUrl: string;
+      vi.mocked(open).mockImplementation((url) => {
+        capturedUrl = url;
+        // Return a minimal mock ChildProcess
+        return Promise.resolve({
+          pid: 1234,
+        } as unknown as import('child_process').ChildProcess);
+      });
+
+      let callbackHandler: unknown;
+      vi.mocked(http.createServer).mockImplementation((handler) => {
+        callbackHandler = handler;
+        return mockHttpServer as unknown as http.Server;
+      });
+
+      mockHttpServer.listen.mockImplementation((port, callback) => {
+        callback?.();
+        setTimeout(() => {
+          const mockReq = {
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+          };
+          const mockRes = {
+            writeHead: vi.fn(),
+            end: vi.fn(),
+          };
+          (callbackHandler as (req: unknown, res: unknown) => void)(
+            mockReq,
+            mockRes,
+          );
+        }, 10);
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse),
+      });
+
+      await MCPOAuthProvider.authenticate('test-server', mockConfig);
+
+      expect(capturedUrl!).toContain('response_type=code');
+      expect(capturedUrl!).toContain('client_id=test-client-id');
+      expect(capturedUrl!).toContain('code_challenge=code_challenge_mock');
+      expect(capturedUrl!).toContain('code_challenge_method=S256');
+      expect(capturedUrl!).toContain('scope=read+write');
+      expect(capturedUrl!).toContain('resource=https%3A%2F%2Fauth.example.com');
+    });
+  });
+});

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -1,0 +1,698 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as http from 'node:http';
+import * as crypto from 'node:crypto';
+import { URL } from 'node:url';
+import open from 'open';
+import { MCPOAuthToken, MCPOAuthTokenStorage } from './oauth-token-storage.js';
+import { getErrorMessage } from '../utils/errors.js';
+import { OAuthUtils } from './oauth-utils.js';
+
+/**
+ * OAuth configuration for an MCP server.
+ */
+export interface MCPOAuthConfig {
+  enabled?: boolean; // Whether OAuth is enabled for this server
+  clientId?: string;
+  clientSecret?: string;
+  authorizationUrl?: string;
+  tokenUrl?: string;
+  scopes?: string[];
+  redirectUri?: string;
+  tokenParamName?: string; // For SSE connections, specifies the query parameter name for the token
+}
+
+/**
+ * OAuth authorization response.
+ */
+export interface OAuthAuthorizationResponse {
+  code: string;
+  state: string;
+}
+
+/**
+ * OAuth token response from the authorization server.
+ */
+export interface OAuthTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in?: number;
+  refresh_token?: string;
+  scope?: string;
+}
+
+/**
+ * Dynamic client registration request.
+ */
+export interface OAuthClientRegistrationRequest {
+  client_name: string;
+  redirect_uris: string[];
+  grant_types: string[];
+  response_types: string[];
+  token_endpoint_auth_method: string;
+  code_challenge_method?: string[];
+  scope?: string;
+}
+
+/**
+ * Dynamic client registration response.
+ */
+export interface OAuthClientRegistrationResponse {
+  client_id: string;
+  client_secret?: string;
+  client_id_issued_at?: number;
+  client_secret_expires_at?: number;
+  redirect_uris: string[];
+  grant_types: string[];
+  response_types: string[];
+  token_endpoint_auth_method: string;
+  code_challenge_method?: string[];
+  scope?: string;
+}
+
+/**
+ * PKCE (Proof Key for Code Exchange) parameters.
+ */
+interface PKCEParams {
+  codeVerifier: string;
+  codeChallenge: string;
+  state: string;
+}
+
+/**
+ * Provider for handling OAuth authentication for MCP servers.
+ */
+export class MCPOAuthProvider {
+  private static readonly REDIRECT_PORT = 7777;
+  private static readonly REDIRECT_PATH = '/oauth/callback';
+  private static readonly HTTP_OK = 200;
+  private static readonly HTTP_REDIRECT = 302;
+
+  /**
+   * Register a client dynamically with the OAuth server.
+   *
+   * @param registrationUrl The client registration endpoint URL
+   * @param config OAuth configuration
+   * @returns The registered client information
+   */
+  private static async registerClient(
+    registrationUrl: string,
+    config: MCPOAuthConfig,
+  ): Promise<OAuthClientRegistrationResponse> {
+    const redirectUri =
+      config.redirectUri ||
+      `http://localhost:${this.REDIRECT_PORT}${this.REDIRECT_PATH}`;
+
+    const registrationRequest: OAuthClientRegistrationRequest = {
+      client_name: 'Gemini CLI MCP Client',
+      redirect_uris: [redirectUri],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none', // Public client
+      code_challenge_method: ['S256'],
+      scope: config.scopes?.join(' ') || '',
+    };
+
+    const response = await fetch(registrationUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(registrationRequest),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Client registration failed: ${response.status} ${response.statusText} - ${errorText}`,
+      );
+    }
+
+    return (await response.json()) as OAuthClientRegistrationResponse;
+  }
+
+  /**
+   * Discover OAuth configuration from an MCP server URL.
+   *
+   * @param mcpServerUrl The MCP server URL
+   * @returns OAuth configuration if discovered, null otherwise
+   */
+  private static async discoverOAuthFromMCPServer(
+    mcpServerUrl: string,
+  ): Promise<MCPOAuthConfig | null> {
+    const baseUrl = OAuthUtils.extractBaseUrl(mcpServerUrl);
+    return OAuthUtils.discoverOAuthConfig(baseUrl);
+  }
+
+  /**
+   * Generate PKCE parameters for OAuth flow.
+   *
+   * @returns PKCE parameters including code verifier, challenge, and state
+   */
+  private static generatePKCEParams(): PKCEParams {
+    // Generate code verifier (43-128 characters)
+    const codeVerifier = crypto.randomBytes(32).toString('base64url');
+
+    // Generate code challenge using SHA256
+    const codeChallenge = crypto
+      .createHash('sha256')
+      .update(codeVerifier)
+      .digest('base64url');
+
+    // Generate state for CSRF protection
+    const state = crypto.randomBytes(16).toString('base64url');
+
+    return { codeVerifier, codeChallenge, state };
+  }
+
+  /**
+   * Start a local HTTP server to handle OAuth callback.
+   *
+   * @param expectedState The state parameter to validate
+   * @returns Promise that resolves with the authorization code
+   */
+  private static async startCallbackServer(
+    expectedState: string,
+  ): Promise<OAuthAuthorizationResponse> {
+    return new Promise((resolve, reject) => {
+      const server = http.createServer(
+        async (req: http.IncomingMessage, res: http.ServerResponse) => {
+          try {
+            const url = new URL(
+              req.url!,
+              `http://localhost:${this.REDIRECT_PORT}`,
+            );
+
+            if (url.pathname !== this.REDIRECT_PATH) {
+              res.writeHead(404);
+              res.end('Not found');
+              return;
+            }
+
+            const code = url.searchParams.get('code');
+            const state = url.searchParams.get('state');
+            const error = url.searchParams.get('error');
+
+            if (error) {
+              res.writeHead(this.HTTP_OK, { 'Content-Type': 'text/html' });
+              res.end(`
+              <html>
+                <body>
+                  <h1>Authentication Failed</h1>
+                  <p>Error: ${(error as string).replace(/</g, '&lt;').replace(/>/g, '&gt;')}</p>
+                  <p>${((url.searchParams.get('error_description') || '') as string).replace(/</g, '&lt;').replace(/>/g, '&gt;')}</p>
+                  <p>You can close this window.</p>
+                </body>
+              </html>
+            `);
+              server.close();
+              reject(new Error(`OAuth error: ${error}`));
+              return;
+            }
+
+            if (!code || !state) {
+              res.writeHead(400);
+              res.end('Missing code or state parameter');
+              return;
+            }
+
+            if (state !== expectedState) {
+              res.writeHead(400);
+              res.end('Invalid state parameter');
+              server.close();
+              reject(new Error('State mismatch - possible CSRF attack'));
+              return;
+            }
+
+            // Send success response to browser
+            res.writeHead(this.HTTP_OK, { 'Content-Type': 'text/html' });
+            res.end(`
+            <html>
+              <body>
+                <h1>Authentication Successful!</h1>
+                <p>You can close this window and return to Gemini CLI.</p>
+                <script>window.close();</script>
+              </body>
+            </html>
+          `);
+
+            server.close();
+            resolve({ code, state });
+          } catch (error) {
+            server.close();
+            reject(error);
+          }
+        },
+      );
+
+      server.on('error', reject);
+      server.listen(this.REDIRECT_PORT, () => {
+        console.log(
+          `OAuth callback server listening on port ${this.REDIRECT_PORT}`,
+        );
+      });
+
+      // Timeout after 5 minutes
+      setTimeout(
+        () => {
+          server.close();
+          reject(new Error('OAuth callback timeout'));
+        },
+        5 * 60 * 1000,
+      );
+    });
+  }
+
+  /**
+   * Build the authorization URL with PKCE parameters.
+   *
+   * @param config OAuth configuration
+   * @param pkceParams PKCE parameters
+   * @returns The authorization URL
+   */
+  private static buildAuthorizationUrl(
+    config: MCPOAuthConfig,
+    pkceParams: PKCEParams,
+  ): string {
+    const redirectUri =
+      config.redirectUri ||
+      `http://localhost:${this.REDIRECT_PORT}${this.REDIRECT_PATH}`;
+
+    const params = new URLSearchParams({
+      client_id: config.clientId!,
+      response_type: 'code',
+      redirect_uri: redirectUri,
+      state: pkceParams.state,
+      code_challenge: pkceParams.codeChallenge,
+      code_challenge_method: 'S256',
+    });
+
+    if (config.scopes && config.scopes.length > 0) {
+      params.append('scope', config.scopes.join(' '));
+    }
+
+    // Add resource parameter for MCP OAuth spec compliance
+    params.append(
+      'resource',
+      OAuthUtils.buildResourceParameter(config.authorizationUrl!),
+    );
+
+    return `${config.authorizationUrl}?${params.toString()}`;
+  }
+
+  /**
+   * Exchange authorization code for tokens.
+   *
+   * @param config OAuth configuration
+   * @param code Authorization code
+   * @param codeVerifier PKCE code verifier
+   * @returns The token response
+   */
+  private static async exchangeCodeForToken(
+    config: MCPOAuthConfig,
+    code: string,
+    codeVerifier: string,
+  ): Promise<OAuthTokenResponse> {
+    const redirectUri =
+      config.redirectUri ||
+      `http://localhost:${this.REDIRECT_PORT}${this.REDIRECT_PATH}`;
+
+    const params = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+      client_id: config.clientId!,
+    });
+
+    if (config.clientSecret) {
+      params.append('client_secret', config.clientSecret);
+    }
+
+    // Add resource parameter for MCP OAuth spec compliance
+    params.append(
+      'resource',
+      OAuthUtils.buildResourceParameter(config.tokenUrl!),
+    );
+
+    const response = await fetch(config.tokenUrl!, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params.toString(),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Token exchange failed: ${response.status} - ${errorText}`,
+      );
+    }
+
+    return (await response.json()) as OAuthTokenResponse;
+  }
+
+  /**
+   * Refresh an access token using a refresh token.
+   *
+   * @param config OAuth configuration
+   * @param refreshToken The refresh token
+   * @returns The new token response
+   */
+  static async refreshAccessToken(
+    config: MCPOAuthConfig,
+    refreshToken: string,
+    tokenUrl: string,
+  ): Promise<OAuthTokenResponse> {
+    const params = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: config.clientId!,
+    });
+
+    if (config.clientSecret) {
+      params.append('client_secret', config.clientSecret);
+    }
+
+    if (config.scopes && config.scopes.length > 0) {
+      params.append('scope', config.scopes.join(' '));
+    }
+
+    // Add resource parameter for MCP OAuth spec compliance
+    params.append('resource', OAuthUtils.buildResourceParameter(tokenUrl));
+
+    const response = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params.toString(),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Token refresh failed: ${response.status} - ${errorText}`,
+      );
+    }
+
+    return (await response.json()) as OAuthTokenResponse;
+  }
+
+  /**
+   * Perform the full OAuth authorization code flow with PKCE.
+   *
+   * @param serverName The name of the MCP server
+   * @param config OAuth configuration
+   * @param mcpServerUrl Optional MCP server URL for OAuth discovery
+   * @returns The obtained OAuth token
+   */
+  static async authenticate(
+    serverName: string,
+    config: MCPOAuthConfig,
+    mcpServerUrl?: string,
+  ): Promise<MCPOAuthToken> {
+    // If no authorization URL is provided, try to discover OAuth configuration
+    if (!config.authorizationUrl && mcpServerUrl) {
+      console.log(
+        'No authorization URL provided, attempting OAuth discovery...',
+      );
+
+      // For SSE URLs, first check if authentication is required
+      if (OAuthUtils.isSSEEndpoint(mcpServerUrl)) {
+        try {
+          const response = await fetch(mcpServerUrl, {
+            method: 'HEAD',
+            headers: {
+              Accept: 'text/event-stream',
+            },
+          });
+
+          if (response.status === 401 || response.status === 307) {
+            const wwwAuthenticate = response.headers.get('www-authenticate');
+            if (wwwAuthenticate) {
+              const discoveredConfig =
+                await OAuthUtils.discoverOAuthFromWWWAuthenticate(
+                  wwwAuthenticate,
+                );
+              if (discoveredConfig) {
+                config = {
+                  ...config,
+                  ...discoveredConfig,
+                  scopes: discoveredConfig.scopes || config.scopes || [],
+                };
+              }
+            }
+          }
+        } catch (error) {
+          console.debug(
+            `Failed to check SSE endpoint for authentication requirements: ${getErrorMessage(error)}`,
+          );
+        }
+      }
+
+      // If we still don't have OAuth config, try the standard discovery
+      if (!config.authorizationUrl) {
+        const discoveredConfig =
+          await this.discoverOAuthFromMCPServer(mcpServerUrl);
+        if (discoveredConfig) {
+          config = { ...config, ...discoveredConfig };
+          console.log('OAuth configuration discovered successfully');
+        } else {
+          throw new Error(
+            'Failed to discover OAuth configuration from MCP server',
+          );
+        }
+      }
+    }
+
+    // If no client ID is provided, try dynamic client registration
+    if (!config.clientId) {
+      // Extract server URL from authorization URL
+      if (!config.authorizationUrl) {
+        throw new Error(
+          'Cannot perform dynamic registration without authorization URL',
+        );
+      }
+
+      const authUrl = new URL(config.authorizationUrl);
+      const serverUrl = `${authUrl.protocol}//${authUrl.host}`;
+
+      console.log(
+        'No client ID provided, attempting dynamic client registration...',
+      );
+
+      // Get the authorization server metadata for registration
+      const authServerMetadataUrl = new URL(
+        '/.well-known/oauth-authorization-server',
+        serverUrl,
+      ).toString();
+
+      const authServerMetadata =
+        await OAuthUtils.fetchAuthorizationServerMetadata(
+          authServerMetadataUrl,
+        );
+      if (!authServerMetadata) {
+        throw new Error(
+          'Failed to fetch authorization server metadata for client registration',
+        );
+      }
+
+      // Register client if registration endpoint is available
+      if (authServerMetadata.registration_endpoint) {
+        const clientRegistration = await this.registerClient(
+          authServerMetadata.registration_endpoint,
+          config,
+        );
+
+        config.clientId = clientRegistration.client_id;
+        if (clientRegistration.client_secret) {
+          config.clientSecret = clientRegistration.client_secret;
+        }
+
+        console.log('Dynamic client registration successful');
+      } else {
+        throw new Error(
+          'No client ID provided and dynamic registration not supported',
+        );
+      }
+    }
+
+    // Validate configuration
+    if (!config.clientId || !config.authorizationUrl || !config.tokenUrl) {
+      throw new Error(
+        'Missing required OAuth configuration after discovery and registration',
+      );
+    }
+
+    // Generate PKCE parameters
+    const pkceParams = this.generatePKCEParams();
+
+    // Build authorization URL
+    const authUrl = this.buildAuthorizationUrl(config, pkceParams);
+
+    console.log('\nOpening browser for OAuth authentication...');
+    console.log('If the browser does not open, please visit:');
+    console.log('');
+
+    // Get terminal width or default to 80
+    const terminalWidth = process.stdout.columns || 80;
+    const separatorLength = Math.min(terminalWidth - 2, 80);
+    const separator = '━'.repeat(separatorLength);
+
+    console.log(separator);
+    console.log(
+      'COPY THE ENTIRE URL BELOW (select all text between the lines):',
+    );
+    console.log(separator);
+    console.log(authUrl);
+    console.log(separator);
+    console.log('');
+    console.log(
+      '💡 TIP: Triple-click to select the entire URL, then copy and paste it into your browser.',
+    );
+    console.log(
+      '⚠️  Make sure to copy the COMPLETE URL - it may wrap across multiple lines.',
+    );
+    console.log('');
+
+    // Start callback server
+    const callbackPromise = this.startCallbackServer(pkceParams.state);
+
+    // Open browser
+    try {
+      await open(authUrl);
+    } catch (error) {
+      console.warn(
+        'Failed to open browser automatically:',
+        getErrorMessage(error),
+      );
+    }
+
+    // Wait for callback
+    const { code } = await callbackPromise;
+
+    console.log('\nAuthorization code received, exchanging for tokens...');
+
+    // Exchange code for tokens
+    const tokenResponse = await this.exchangeCodeForToken(
+      config,
+      code,
+      pkceParams.codeVerifier,
+    );
+
+    // Convert to our token format
+    const token: MCPOAuthToken = {
+      accessToken: tokenResponse.access_token,
+      tokenType: tokenResponse.token_type,
+      refreshToken: tokenResponse.refresh_token,
+      scope: tokenResponse.scope,
+    };
+
+    if (tokenResponse.expires_in) {
+      token.expiresAt = Date.now() + tokenResponse.expires_in * 1000;
+    }
+
+    // Save token
+    try {
+      await MCPOAuthTokenStorage.saveToken(
+        serverName,
+        token,
+        config.clientId,
+        config.tokenUrl,
+      );
+      console.log('Authentication successful! Token saved.');
+
+      // Verify token was saved
+      const savedToken = await MCPOAuthTokenStorage.getToken(serverName);
+      if (savedToken) {
+        console.log(
+          `Token verification successful: ${savedToken.token.accessToken.substring(0, 20)}...`,
+        );
+      } else {
+        console.error('Token verification failed: token not found after save');
+      }
+    } catch (saveError) {
+      console.error(`Failed to save token: ${getErrorMessage(saveError)}`);
+      throw saveError;
+    }
+
+    return token;
+  }
+
+  /**
+   * Get a valid access token for an MCP server, refreshing if necessary.
+   *
+   * @param serverName The name of the MCP server
+   * @param config OAuth configuration
+   * @returns A valid access token or null if not authenticated
+   */
+  static async getValidToken(
+    serverName: string,
+    config: MCPOAuthConfig,
+  ): Promise<string | null> {
+    console.debug(`Getting valid token for server: ${serverName}`);
+    const credentials = await MCPOAuthTokenStorage.getToken(serverName);
+
+    if (!credentials) {
+      console.debug(`No credentials found for server: ${serverName}`);
+      return null;
+    }
+
+    const { token } = credentials;
+    console.debug(
+      `Found token for server: ${serverName}, expired: ${MCPOAuthTokenStorage.isTokenExpired(token)}`,
+    );
+
+    // Check if token is expired
+    if (!MCPOAuthTokenStorage.isTokenExpired(token)) {
+      console.debug(`Returning valid token for server: ${serverName}`);
+      return token.accessToken;
+    }
+
+    // Try to refresh if we have a refresh token
+    if (token.refreshToken && config.clientId && credentials.tokenUrl) {
+      try {
+        console.log(`Refreshing expired token for MCP server: ${serverName}`);
+
+        const newTokenResponse = await this.refreshAccessToken(
+          config,
+          token.refreshToken,
+          credentials.tokenUrl,
+        );
+
+        // Update stored token
+        const newToken: MCPOAuthToken = {
+          accessToken: newTokenResponse.access_token,
+          tokenType: newTokenResponse.token_type,
+          refreshToken: newTokenResponse.refresh_token || token.refreshToken,
+          scope: newTokenResponse.scope || token.scope,
+        };
+
+        if (newTokenResponse.expires_in) {
+          newToken.expiresAt = Date.now() + newTokenResponse.expires_in * 1000;
+        }
+
+        await MCPOAuthTokenStorage.saveToken(
+          serverName,
+          newToken,
+          config.clientId,
+          credentials.tokenUrl,
+        );
+
+        return newToken.accessToken;
+      } catch (error) {
+        console.error(`Failed to refresh token: ${getErrorMessage(error)}`);
+        // Remove invalid token
+        await MCPOAuthTokenStorage.removeToken(serverName);
+      }
+    }
+
+    return null;
+  }
+}

--- a/packages/core/src/mcp/oauth-token-storage.test.ts
+++ b/packages/core/src/mcp/oauth-token-storage.test.ts
@@ -1,0 +1,325 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import {
+  MCPOAuthTokenStorage,
+  MCPOAuthToken,
+  MCPOAuthCredentials,
+} from './oauth-token-storage.js';
+
+// Mock file system operations
+vi.mock('node:fs', () => ({
+  promises: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    mkdir: vi.fn(),
+    unlink: vi.fn(),
+  },
+}));
+
+vi.mock('node:os', () => ({
+  homedir: vi.fn(() => '/mock/home'),
+}));
+
+describe('MCPOAuthTokenStorage', () => {
+  const mockToken: MCPOAuthToken = {
+    accessToken: 'access_token_123',
+    refreshToken: 'refresh_token_456',
+    tokenType: 'Bearer',
+    scope: 'read write',
+    expiresAt: Date.now() + 3600000, // 1 hour from now
+  };
+
+  const mockCredentials: MCPOAuthCredentials = {
+    serverName: 'test-server',
+    token: mockToken,
+    clientId: 'test-client-id',
+    tokenUrl: 'https://auth.example.com/token',
+    updatedAt: Date.now(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('loadTokens', () => {
+    it('should return empty map when token file does not exist', async () => {
+      vi.mocked(fs.readFile).mockRejectedValue({ code: 'ENOENT' });
+
+      const tokens = await MCPOAuthTokenStorage.loadTokens();
+
+      expect(tokens.size).toBe(0);
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('should load tokens from file successfully', async () => {
+      const tokensArray = [mockCredentials];
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(tokensArray));
+
+      const tokens = await MCPOAuthTokenStorage.loadTokens();
+
+      expect(tokens.size).toBe(1);
+      expect(tokens.get('test-server')).toEqual(mockCredentials);
+      expect(fs.readFile).toHaveBeenCalledWith(
+        path.join('/mock/home', '.gemini', 'mcp-oauth-tokens.json'),
+        'utf-8',
+      );
+    });
+
+    it('should handle corrupted token file gracefully', async () => {
+      vi.mocked(fs.readFile).mockResolvedValue('invalid json');
+
+      const tokens = await MCPOAuthTokenStorage.loadTokens();
+
+      expect(tokens.size).toBe(0);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to load MCP OAuth tokens'),
+      );
+    });
+
+    it('should handle file read errors other than ENOENT', async () => {
+      const error = new Error('Permission denied');
+      vi.mocked(fs.readFile).mockRejectedValue(error);
+
+      const tokens = await MCPOAuthTokenStorage.loadTokens();
+
+      expect(tokens.size).toBe(0);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to load MCP OAuth tokens'),
+      );
+    });
+  });
+
+  describe('saveToken', () => {
+    it('should save token with restricted permissions', async () => {
+      vi.mocked(fs.readFile).mockRejectedValue({ code: 'ENOENT' });
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+      await MCPOAuthTokenStorage.saveToken(
+        'test-server',
+        mockToken,
+        'client-id',
+        'https://token.url',
+      );
+
+      expect(fs.mkdir).toHaveBeenCalledWith(
+        path.join('/mock/home', '.gemini'),
+        { recursive: true },
+      );
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        path.join('/mock/home', '.gemini', 'mcp-oauth-tokens.json'),
+        expect.stringContaining('test-server'),
+        { mode: 0o600 },
+      );
+    });
+
+    it('should update existing token for same server', async () => {
+      const existingCredentials = {
+        ...mockCredentials,
+        serverName: 'existing-server',
+      };
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify([existingCredentials]),
+      );
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+      const newToken = { ...mockToken, accessToken: 'new_access_token' };
+      await MCPOAuthTokenStorage.saveToken('existing-server', newToken);
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0];
+      const savedData = JSON.parse(writeCall[1] as string);
+
+      expect(savedData).toHaveLength(1);
+      expect(savedData[0].token.accessToken).toBe('new_access_token');
+      expect(savedData[0].serverName).toBe('existing-server');
+    });
+
+    it('should handle write errors gracefully', async () => {
+      vi.mocked(fs.readFile).mockRejectedValue({ code: 'ENOENT' });
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      const writeError = new Error('Disk full');
+      vi.mocked(fs.writeFile).mockRejectedValue(writeError);
+
+      await expect(
+        MCPOAuthTokenStorage.saveToken('test-server', mockToken),
+      ).rejects.toThrow('Disk full');
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to save MCP OAuth token'),
+      );
+    });
+  });
+
+  describe('getToken', () => {
+    it('should return token for existing server', async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify([mockCredentials]),
+      );
+
+      const result = await MCPOAuthTokenStorage.getToken('test-server');
+
+      expect(result).toEqual(mockCredentials);
+    });
+
+    it('should return null for non-existent server', async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify([mockCredentials]),
+      );
+
+      const result = await MCPOAuthTokenStorage.getToken('non-existent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when no tokens file exists', async () => {
+      vi.mocked(fs.readFile).mockRejectedValue({ code: 'ENOENT' });
+
+      const result = await MCPOAuthTokenStorage.getToken('test-server');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('removeToken', () => {
+    it('should remove token for specific server', async () => {
+      const credentials1 = { ...mockCredentials, serverName: 'server1' };
+      const credentials2 = { ...mockCredentials, serverName: 'server2' };
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify([credentials1, credentials2]),
+      );
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+      await MCPOAuthTokenStorage.removeToken('server1');
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0];
+      const savedData = JSON.parse(writeCall[1] as string);
+
+      expect(savedData).toHaveLength(1);
+      expect(savedData[0].serverName).toBe('server2');
+    });
+
+    it('should remove token file when no tokens remain', async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify([mockCredentials]),
+      );
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+      await MCPOAuthTokenStorage.removeToken('test-server');
+
+      expect(fs.unlink).toHaveBeenCalledWith(
+        path.join('/mock/home', '.gemini', 'mcp-oauth-tokens.json'),
+      );
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should handle removal of non-existent token gracefully', async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify([mockCredentials]),
+      );
+
+      await MCPOAuthTokenStorage.removeToken('non-existent');
+
+      expect(fs.writeFile).not.toHaveBeenCalled();
+      expect(fs.unlink).not.toHaveBeenCalled();
+    });
+
+    it('should handle file operation errors gracefully', async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify([mockCredentials]),
+      );
+      vi.mocked(fs.unlink).mockRejectedValue(new Error('Permission denied'));
+
+      await MCPOAuthTokenStorage.removeToken('test-server');
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to remove MCP OAuth token'),
+      );
+    });
+  });
+
+  describe('isTokenExpired', () => {
+    it('should return false for token without expiry', () => {
+      const tokenWithoutExpiry = { ...mockToken };
+      delete tokenWithoutExpiry.expiresAt;
+
+      const result = MCPOAuthTokenStorage.isTokenExpired(tokenWithoutExpiry);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for valid token', () => {
+      const futureToken = {
+        ...mockToken,
+        expiresAt: Date.now() + 3600000, // 1 hour from now
+      };
+
+      const result = MCPOAuthTokenStorage.isTokenExpired(futureToken);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true for expired token', () => {
+      const expiredToken = {
+        ...mockToken,
+        expiresAt: Date.now() - 3600000, // 1 hour ago
+      };
+
+      const result = MCPOAuthTokenStorage.isTokenExpired(expiredToken);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for token expiring within buffer time', () => {
+      const soonToExpireToken = {
+        ...mockToken,
+        expiresAt: Date.now() + 60000, // 1 minute from now (within 5-minute buffer)
+      };
+
+      const result = MCPOAuthTokenStorage.isTokenExpired(soonToExpireToken);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('clearAllTokens', () => {
+    it('should remove token file successfully', async () => {
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+      await MCPOAuthTokenStorage.clearAllTokens();
+
+      expect(fs.unlink).toHaveBeenCalledWith(
+        path.join('/mock/home', '.gemini', 'mcp-oauth-tokens.json'),
+      );
+    });
+
+    it('should handle non-existent file gracefully', async () => {
+      vi.mocked(fs.unlink).mockRejectedValue({ code: 'ENOENT' });
+
+      await MCPOAuthTokenStorage.clearAllTokens();
+
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('should handle other file errors gracefully', async () => {
+      vi.mocked(fs.unlink).mockRejectedValue(new Error('Permission denied'));
+
+      await MCPOAuthTokenStorage.clearAllTokens();
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to clear MCP OAuth tokens'),
+      );
+    });
+  });
+});

--- a/packages/core/src/mcp/oauth-token-storage.ts
+++ b/packages/core/src/mcp/oauth-token-storage.ts
@@ -1,0 +1,205 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { getErrorMessage } from '../utils/errors.js';
+
+/**
+ * Interface for MCP OAuth tokens.
+ */
+export interface MCPOAuthToken {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  tokenType: string;
+  scope?: string;
+}
+
+/**
+ * Interface for stored MCP OAuth credentials.
+ */
+export interface MCPOAuthCredentials {
+  serverName: string;
+  token: MCPOAuthToken;
+  clientId?: string;
+  tokenUrl?: string;
+  updatedAt: number;
+}
+
+/**
+ * Class for managing MCP OAuth token storage and retrieval.
+ */
+export class MCPOAuthTokenStorage {
+  private static readonly TOKEN_FILE = 'mcp-oauth-tokens.json';
+  private static readonly CONFIG_DIR = '.gemini';
+
+  /**
+   * Get the path to the token storage file.
+   *
+   * @returns The full path to the token storage file
+   */
+  private static getTokenFilePath(): string {
+    const homeDir = os.homedir();
+    return path.join(homeDir, this.CONFIG_DIR, this.TOKEN_FILE);
+  }
+
+  /**
+   * Ensure the config directory exists.
+   */
+  private static async ensureConfigDir(): Promise<void> {
+    const configDir = path.dirname(this.getTokenFilePath());
+    await fs.mkdir(configDir, { recursive: true });
+  }
+
+  /**
+   * Load all stored MCP OAuth tokens.
+   *
+   * @returns A map of server names to credentials
+   */
+  static async loadTokens(): Promise<Map<string, MCPOAuthCredentials>> {
+    const tokenMap = new Map<string, MCPOAuthCredentials>();
+
+    try {
+      const tokenFile = this.getTokenFilePath();
+      const data = await fs.readFile(tokenFile, 'utf-8');
+      const tokens = JSON.parse(data) as MCPOAuthCredentials[];
+
+      for (const credential of tokens) {
+        tokenMap.set(credential.serverName, credential);
+      }
+    } catch (error) {
+      // File doesn't exist or is invalid, return empty map
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.error(
+          `Failed to load MCP OAuth tokens: ${getErrorMessage(error)}`,
+        );
+      }
+    }
+
+    return tokenMap;
+  }
+
+  /**
+   * Save a token for a specific MCP server.
+   *
+   * @param serverName The name of the MCP server
+   * @param token The OAuth token to save
+   * @param clientId Optional client ID used for this token
+   * @param tokenUrl Optional token URL used for this token
+   */
+  static async saveToken(
+    serverName: string,
+    token: MCPOAuthToken,
+    clientId?: string,
+    tokenUrl?: string,
+  ): Promise<void> {
+    await this.ensureConfigDir();
+
+    const tokens = await this.loadTokens();
+
+    const credential: MCPOAuthCredentials = {
+      serverName,
+      token,
+      clientId,
+      tokenUrl,
+      updatedAt: Date.now(),
+    };
+
+    tokens.set(serverName, credential);
+
+    const tokenArray = Array.from(tokens.values());
+    const tokenFile = this.getTokenFilePath();
+
+    try {
+      await fs.writeFile(
+        tokenFile,
+        JSON.stringify(tokenArray, null, 2),
+        { mode: 0o600 }, // Restrict file permissions
+      );
+    } catch (error) {
+      console.error(
+        `Failed to save MCP OAuth token: ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Get a token for a specific MCP server.
+   *
+   * @param serverName The name of the MCP server
+   * @returns The stored credentials or null if not found
+   */
+  static async getToken(
+    serverName: string,
+  ): Promise<MCPOAuthCredentials | null> {
+    const tokens = await this.loadTokens();
+    return tokens.get(serverName) || null;
+  }
+
+  /**
+   * Remove a token for a specific MCP server.
+   *
+   * @param serverName The name of the MCP server
+   */
+  static async removeToken(serverName: string): Promise<void> {
+    const tokens = await this.loadTokens();
+
+    if (tokens.delete(serverName)) {
+      const tokenArray = Array.from(tokens.values());
+      const tokenFile = this.getTokenFilePath();
+
+      try {
+        if (tokenArray.length === 0) {
+          // Remove file if no tokens left
+          await fs.unlink(tokenFile);
+        } else {
+          await fs.writeFile(tokenFile, JSON.stringify(tokenArray, null, 2), {
+            mode: 0o600,
+          });
+        }
+      } catch (error) {
+        console.error(
+          `Failed to remove MCP OAuth token: ${getErrorMessage(error)}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Check if a token is expired.
+   *
+   * @param token The token to check
+   * @returns True if the token is expired
+   */
+  static isTokenExpired(token: MCPOAuthToken): boolean {
+    if (!token.expiresAt) {
+      return false; // No expiry, assume valid
+    }
+
+    // Add a 5-minute buffer to account for clock skew
+    const bufferMs = 5 * 60 * 1000;
+    return Date.now() + bufferMs >= token.expiresAt;
+  }
+
+  /**
+   * Clear all stored MCP OAuth tokens.
+   */
+  static async clearAllTokens(): Promise<void> {
+    try {
+      const tokenFile = this.getTokenFilePath();
+      await fs.unlink(tokenFile);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.error(
+          `Failed to clear MCP OAuth tokens: ${getErrorMessage(error)}`,
+        );
+      }
+    }
+  }
+}

--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  OAuthUtils,
+  OAuthAuthorizationServerMetadata,
+  OAuthProtectedResourceMetadata,
+} from './oauth-utils.js';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe('OAuthUtils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('buildWellKnownUrls', () => {
+    it('should build correct well-known URLs', () => {
+      const urls = OAuthUtils.buildWellKnownUrls('https://example.com/path');
+      expect(urls.protectedResource).toBe(
+        'https://example.com/.well-known/oauth-protected-resource',
+      );
+      expect(urls.authorizationServer).toBe(
+        'https://example.com/.well-known/oauth-authorization-server',
+      );
+    });
+  });
+
+  describe('fetchProtectedResourceMetadata', () => {
+    const mockResourceMetadata: OAuthProtectedResourceMetadata = {
+      resource: 'https://api.example.com',
+      authorization_servers: ['https://auth.example.com'],
+      bearer_methods_supported: ['header'],
+    };
+
+    it('should fetch protected resource metadata successfully', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResourceMetadata),
+      });
+
+      const result = await OAuthUtils.fetchProtectedResourceMetadata(
+        'https://example.com/.well-known/oauth-protected-resource',
+      );
+
+      expect(result).toEqual(mockResourceMetadata);
+    });
+
+    it('should return null when fetch fails', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+      });
+
+      const result = await OAuthUtils.fetchProtectedResourceMetadata(
+        'https://example.com/.well-known/oauth-protected-resource',
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('fetchAuthorizationServerMetadata', () => {
+    const mockAuthServerMetadata: OAuthAuthorizationServerMetadata = {
+      issuer: 'https://auth.example.com',
+      authorization_endpoint: 'https://auth.example.com/authorize',
+      token_endpoint: 'https://auth.example.com/token',
+      scopes_supported: ['read', 'write'],
+    };
+
+    it('should fetch authorization server metadata successfully', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockAuthServerMetadata),
+      });
+
+      const result = await OAuthUtils.fetchAuthorizationServerMetadata(
+        'https://auth.example.com/.well-known/oauth-authorization-server',
+      );
+
+      expect(result).toEqual(mockAuthServerMetadata);
+    });
+
+    it('should return null when fetch fails', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+      });
+
+      const result = await OAuthUtils.fetchAuthorizationServerMetadata(
+        'https://auth.example.com/.well-known/oauth-authorization-server',
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('metadataToOAuthConfig', () => {
+    it('should convert metadata to OAuth config', () => {
+      const metadata: OAuthAuthorizationServerMetadata = {
+        issuer: 'https://auth.example.com',
+        authorization_endpoint: 'https://auth.example.com/authorize',
+        token_endpoint: 'https://auth.example.com/token',
+        scopes_supported: ['read', 'write'],
+      };
+
+      const config = OAuthUtils.metadataToOAuthConfig(metadata);
+
+      expect(config).toEqual({
+        authorizationUrl: 'https://auth.example.com/authorize',
+        tokenUrl: 'https://auth.example.com/token',
+        scopes: ['read', 'write'],
+      });
+    });
+
+    it('should handle empty scopes', () => {
+      const metadata: OAuthAuthorizationServerMetadata = {
+        issuer: 'https://auth.example.com',
+        authorization_endpoint: 'https://auth.example.com/authorize',
+        token_endpoint: 'https://auth.example.com/token',
+      };
+
+      const config = OAuthUtils.metadataToOAuthConfig(metadata);
+
+      expect(config.scopes).toEqual([]);
+    });
+  });
+
+  describe('parseWWWAuthenticateHeader', () => {
+    it('should parse resource metadata URI from WWW-Authenticate header', () => {
+      const header =
+        'Bearer realm="example", resource_metadata_uri="https://example.com/.well-known/oauth-protected-resource"';
+      const result = OAuthUtils.parseWWWAuthenticateHeader(header);
+      expect(result).toBe(
+        'https://example.com/.well-known/oauth-protected-resource',
+      );
+    });
+
+    it('should return null when no resource metadata URI is found', () => {
+      const header = 'Bearer realm="example"';
+      const result = OAuthUtils.parseWWWAuthenticateHeader(header);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('extractBaseUrl', () => {
+    it('should extract base URL from MCP server URL', () => {
+      const result = OAuthUtils.extractBaseUrl('https://example.com/mcp/v1');
+      expect(result).toBe('https://example.com');
+    });
+
+    it('should handle URLs with ports', () => {
+      const result = OAuthUtils.extractBaseUrl(
+        'https://example.com:8080/mcp/v1',
+      );
+      expect(result).toBe('https://example.com:8080');
+    });
+  });
+
+  describe('isSSEEndpoint', () => {
+    it('should return true for SSE endpoints', () => {
+      expect(OAuthUtils.isSSEEndpoint('https://example.com/sse')).toBe(true);
+      expect(OAuthUtils.isSSEEndpoint('https://example.com/api/v1/sse')).toBe(
+        true,
+      );
+    });
+
+    it('should return true for non-MCP endpoints', () => {
+      expect(OAuthUtils.isSSEEndpoint('https://example.com/api')).toBe(true);
+    });
+
+    it('should return false for MCP endpoints', () => {
+      expect(OAuthUtils.isSSEEndpoint('https://example.com/mcp')).toBe(false);
+      expect(OAuthUtils.isSSEEndpoint('https://example.com/api/mcp/v1')).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('buildResourceParameter', () => {
+    it('should build resource parameter from endpoint URL', () => {
+      const result = OAuthUtils.buildResourceParameter(
+        'https://example.com/oauth/token',
+      );
+      expect(result).toBe('https://example.com');
+    });
+
+    it('should handle URLs with ports', () => {
+      const result = OAuthUtils.buildResourceParameter(
+        'https://example.com:8080/oauth/token',
+      );
+      expect(result).toBe('https://example.com:8080');
+    });
+  });
+});

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -1,0 +1,285 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MCPOAuthConfig } from './oauth-provider.js';
+import { getErrorMessage } from '../utils/errors.js';
+
+/**
+ * OAuth authorization server metadata as per RFC 8414.
+ */
+export interface OAuthAuthorizationServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  token_endpoint_auth_methods_supported?: string[];
+  revocation_endpoint?: string;
+  revocation_endpoint_auth_methods_supported?: string[];
+  registration_endpoint?: string;
+  response_types_supported?: string[];
+  grant_types_supported?: string[];
+  code_challenge_methods_supported?: string[];
+  scopes_supported?: string[];
+}
+
+/**
+ * OAuth protected resource metadata as per RFC 9728.
+ */
+export interface OAuthProtectedResourceMetadata {
+  resource: string;
+  authorization_servers?: string[];
+  bearer_methods_supported?: string[];
+  resource_documentation?: string;
+  resource_signing_alg_values_supported?: string[];
+  resource_encryption_alg_values_supported?: string[];
+  resource_encryption_enc_values_supported?: string[];
+}
+
+/**
+ * Utility class for common OAuth operations.
+ */
+export class OAuthUtils {
+  /**
+   * Construct well-known OAuth endpoint URLs.
+   */
+  static buildWellKnownUrls(baseUrl: string) {
+    const serverUrl = new URL(baseUrl);
+    const base = `${serverUrl.protocol}//${serverUrl.host}`;
+
+    return {
+      protectedResource: new URL(
+        '/.well-known/oauth-protected-resource',
+        base,
+      ).toString(),
+      authorizationServer: new URL(
+        '/.well-known/oauth-authorization-server',
+        base,
+      ).toString(),
+    };
+  }
+
+  /**
+   * Fetch OAuth protected resource metadata.
+   *
+   * @param resourceMetadataUrl The protected resource metadata URL
+   * @returns The protected resource metadata or null if not available
+   */
+  static async fetchProtectedResourceMetadata(
+    resourceMetadataUrl: string,
+  ): Promise<OAuthProtectedResourceMetadata | null> {
+    try {
+      const response = await fetch(resourceMetadataUrl);
+      if (!response.ok) {
+        return null;
+      }
+      return (await response.json()) as OAuthProtectedResourceMetadata;
+    } catch (error) {
+      console.debug(
+        `Failed to fetch protected resource metadata from ${resourceMetadataUrl}: ${getErrorMessage(error)}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Fetch OAuth authorization server metadata.
+   *
+   * @param authServerMetadataUrl The authorization server metadata URL
+   * @returns The authorization server metadata or null if not available
+   */
+  static async fetchAuthorizationServerMetadata(
+    authServerMetadataUrl: string,
+  ): Promise<OAuthAuthorizationServerMetadata | null> {
+    try {
+      const response = await fetch(authServerMetadataUrl);
+      if (!response.ok) {
+        return null;
+      }
+      return (await response.json()) as OAuthAuthorizationServerMetadata;
+    } catch (error) {
+      console.debug(
+        `Failed to fetch authorization server metadata from ${authServerMetadataUrl}: ${getErrorMessage(error)}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Convert authorization server metadata to OAuth configuration.
+   *
+   * @param metadata The authorization server metadata
+   * @returns The OAuth configuration
+   */
+  static metadataToOAuthConfig(
+    metadata: OAuthAuthorizationServerMetadata,
+  ): MCPOAuthConfig {
+    return {
+      authorizationUrl: metadata.authorization_endpoint,
+      tokenUrl: metadata.token_endpoint,
+      scopes: metadata.scopes_supported || [],
+    };
+  }
+
+  /**
+   * Discover OAuth configuration using the standard well-known endpoints.
+   *
+   * @param serverUrl The base URL of the server
+   * @returns The discovered OAuth configuration or null if not available
+   */
+  static async discoverOAuthConfig(
+    serverUrl: string,
+  ): Promise<MCPOAuthConfig | null> {
+    try {
+      const wellKnownUrls = this.buildWellKnownUrls(serverUrl);
+
+      // First, try to get the protected resource metadata
+      const resourceMetadata = await this.fetchProtectedResourceMetadata(
+        wellKnownUrls.protectedResource,
+      );
+
+      if (resourceMetadata?.authorization_servers?.length) {
+        // Use the first authorization server
+        const authServerUrl = resourceMetadata.authorization_servers[0];
+        const authServerMetadataUrl = new URL(
+          '/.well-known/oauth-authorization-server',
+          authServerUrl,
+        ).toString();
+
+        const authServerMetadata = await this.fetchAuthorizationServerMetadata(
+          authServerMetadataUrl,
+        );
+
+        if (authServerMetadata) {
+          const config = this.metadataToOAuthConfig(authServerMetadata);
+          if (authServerMetadata.registration_endpoint) {
+            console.log(
+              'Dynamic client registration is supported at:',
+              authServerMetadata.registration_endpoint,
+            );
+          }
+          return config;
+        }
+      }
+
+      // Fallback: try /.well-known/oauth-authorization-server at the base URL
+      console.debug(
+        `Trying OAuth discovery fallback at ${wellKnownUrls.authorizationServer}`,
+      );
+      const authServerMetadata = await this.fetchAuthorizationServerMetadata(
+        wellKnownUrls.authorizationServer,
+      );
+
+      if (authServerMetadata) {
+        const config = this.metadataToOAuthConfig(authServerMetadata);
+        if (authServerMetadata.registration_endpoint) {
+          console.log(
+            'Dynamic client registration is supported at:',
+            authServerMetadata.registration_endpoint,
+          );
+        }
+        return config;
+      }
+
+      return null;
+    } catch (error) {
+      console.debug(
+        `Failed to discover OAuth configuration: ${getErrorMessage(error)}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Parse WWW-Authenticate header to extract OAuth information.
+   *
+   * @param header The WWW-Authenticate header value
+   * @returns The resource metadata URI if found
+   */
+  static parseWWWAuthenticateHeader(header: string): string | null {
+    // Parse Bearer realm and resource_metadata_uri
+    const match = header.match(/resource_metadata_uri="([^"]+)"/);
+    if (match) {
+      return match[1];
+    }
+    return null;
+  }
+
+  /**
+   * Discover OAuth configuration from WWW-Authenticate header.
+   *
+   * @param wwwAuthenticate The WWW-Authenticate header value
+   * @returns The discovered OAuth configuration or null if not available
+   */
+  static async discoverOAuthFromWWWAuthenticate(
+    wwwAuthenticate: string,
+  ): Promise<MCPOAuthConfig | null> {
+    const resourceMetadataUri =
+      this.parseWWWAuthenticateHeader(wwwAuthenticate);
+    if (!resourceMetadataUri) {
+      return null;
+    }
+
+    console.log(
+      `Found resource metadata URI from www-authenticate header: ${resourceMetadataUri}`,
+    );
+
+    const resourceMetadata =
+      await this.fetchProtectedResourceMetadata(resourceMetadataUri);
+    if (!resourceMetadata?.authorization_servers?.length) {
+      return null;
+    }
+
+    const authServerUrl = resourceMetadata.authorization_servers[0];
+    const authServerMetadataUrl = new URL(
+      '/.well-known/oauth-authorization-server',
+      authServerUrl,
+    ).toString();
+
+    const authServerMetadata = await this.fetchAuthorizationServerMetadata(
+      authServerMetadataUrl,
+    );
+
+    if (authServerMetadata) {
+      console.log(
+        'OAuth configuration discovered successfully from www-authenticate header',
+      );
+      return this.metadataToOAuthConfig(authServerMetadata);
+    }
+
+    return null;
+  }
+
+  /**
+   * Extract base URL from an MCP server URL.
+   *
+   * @param mcpServerUrl The MCP server URL
+   * @returns The base URL
+   */
+  static extractBaseUrl(mcpServerUrl: string): string {
+    const serverUrl = new URL(mcpServerUrl);
+    return `${serverUrl.protocol}//${serverUrl.host}`;
+  }
+
+  /**
+   * Check if a URL is an SSE endpoint.
+   *
+   * @param url The URL to check
+   * @returns True if the URL appears to be an SSE endpoint
+   */
+  static isSSEEndpoint(url: string): boolean {
+    return url.includes('/sse') || !url.includes('/mcp');
+  }
+
+  /**
+   * Build a resource parameter for OAuth requests.
+   *
+   * @param endpointUrl The endpoint URL
+   * @returns The resource parameter value
+   */
+  static buildResourceParameter(endpointUrl: string): string {
+    const url = new URL(endpointUrl);
+    return `${url.protocol}//${url.host}`;
+  }
+}

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -17,12 +17,15 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import * as SdkClientStdioLib from '@modelcontextprotocol/sdk/client/stdio.js';
 import * as ClientLib from '@modelcontextprotocol/sdk/client/index.js';
 import * as GenAiLib from '@google/genai';
+import { AuthProviderType } from '../config/config.js';
+import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
 
 vi.mock('@modelcontextprotocol/sdk/client/stdio.js');
 vi.mock('@modelcontextprotocol/sdk/client/index.js');
 vi.mock('@google/genai');
 vi.mock('../mcp/oauth-provider.js');
 vi.mock('../mcp/oauth-token-storage.js');
+vi.mock('../mcp/google-auth-provider.js');
 
 describe('mcp-client', () => {
   afterEach(() => {
@@ -173,6 +176,50 @@ describe('mcp-client', () => {
         env: { FOO: 'bar' },
         stderr: 'pipe',
       });
+    });
+
+    it('should use GoogleCredentialProvider when specified', async () => {
+      const transport = await createTransport(
+        'test-server',
+        {
+          httpUrl: 'http://test-server',
+          authProviderType: AuthProviderType.GOOGLE_CREDENTIALS,
+        },
+        false,
+      );
+
+      expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const authProvider = (transport as any)._authProvider;
+      expect(authProvider).toBeInstanceOf(GoogleCredentialProvider);
+    });
+
+    it('should use GoogleCredentialProvider with SSE transport', async () => {
+      const transport = await createTransport(
+        'test-server',
+        {
+          url: 'http://test-server',
+          authProviderType: AuthProviderType.GOOGLE_CREDENTIALS,
+        },
+        false,
+      );
+
+      expect(transport).toBeInstanceOf(SSEClientTransport);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const authProvider = (transport as any)._authProvider;
+      expect(authProvider).toBeInstanceOf(GoogleCredentialProvider);
+    });
+
+    it('should throw an error if no URL is provided with GoogleCredentialProvider', async () => {
+      await expect(
+        createTransport(
+          'test-server',
+          {
+            authProviderType: AuthProviderType.GOOGLE_CREDENTIALS,
+          },
+          false,
+        ),
+      ).rejects.toThrow('No URL configured for Google Credentials MCP server');
     });
   });
   describe('generateValidName', () => {

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -21,6 +21,8 @@ import * as GenAiLib from '@google/genai';
 vi.mock('@modelcontextprotocol/sdk/client/stdio.js');
 vi.mock('@modelcontextprotocol/sdk/client/index.js');
 vi.mock('@google/genai');
+vi.mock('../mcp/oauth-provider.js');
+vi.mock('../mcp/oauth-token-storage.js');
 
 describe('mcp-client', () => {
   afterEach(() => {
@@ -83,7 +85,7 @@ describe('mcp-client', () => {
 
     describe('should connect via httpUrl', () => {
       it('without headers', async () => {
-        const transport = createTransport(
+        const transport = await createTransport(
           'test-server',
           {
             httpUrl: 'http://test-server',
@@ -97,7 +99,7 @@ describe('mcp-client', () => {
       });
 
       it('with headers', async () => {
-        const transport = createTransport(
+        const transport = await createTransport(
           'test-server',
           {
             httpUrl: 'http://test-server',
@@ -118,7 +120,7 @@ describe('mcp-client', () => {
 
     describe('should connect via url', () => {
       it('without headers', async () => {
-        const transport = createTransport(
+        const transport = await createTransport(
           'test-server',
           {
             url: 'http://test-server',
@@ -131,7 +133,7 @@ describe('mcp-client', () => {
       });
 
       it('with headers', async () => {
-        const transport = createTransport(
+        const transport = await createTransport(
           'test-server',
           {
             url: 'http://test-server',
@@ -150,10 +152,10 @@ describe('mcp-client', () => {
       });
     });
 
-    it('should connect via command', () => {
+    it('should connect via command', async () => {
       const mockedTransport = vi.mocked(SdkClientStdioLib.StdioClientTransport);
 
-      createTransport(
+      await createTransport(
         'test-server',
         {
           command: 'test-command',

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -29,6 +29,8 @@ import {
   IDE_SERVER_NAME,
   ideContext,
 } from '../services/ideContext.js';
+import { AuthProviderType } from '../config/config.js';
+import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
 
 export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
 
@@ -854,6 +856,28 @@ export async function createTransport(
   mcpServerConfig: MCPServerConfig,
   debugMode: boolean,
 ): Promise<Transport> {
+  if (
+    mcpServerConfig.authProviderType === AuthProviderType.GOOGLE_CREDENTIALS
+  ) {
+    const provider = new GoogleCredentialProvider(mcpServerConfig);
+    const transportOptions:
+      | StreamableHTTPClientTransportOptions
+      | SSEClientTransportOptions = {
+      authProvider: provider,
+    };
+    if (mcpServerConfig.httpUrl) {
+      return new StreamableHTTPClientTransport(
+        new URL(mcpServerConfig.httpUrl),
+        transportOptions,
+      );
+    } else if (mcpServerConfig.url) {
+      return new SSEClientTransport(
+        new URL(mcpServerConfig.url),
+        transportOptions,
+      );
+    }
+    throw new Error('No URL configured for Google Credentials MCP server');
+  }
   // Check if we have OAuth configuration or stored tokens
   let accessToken: string | null = null;
   let hasOAuthConfig = mcpServerConfig.oauth?.enabled;

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -20,6 +20,10 @@ import { MCPServerConfig } from '../config/config.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import { FunctionDeclaration, Type, mcpToTool } from '@google/genai';
 import { sanitizeParameters, ToolRegistry } from './tool-registry.js';
+import { MCPOAuthProvider } from '../mcp/oauth-provider.js';
+import { OAuthUtils } from '../mcp/oauth-utils.js';
+import { getErrorMessage } from '../utils/errors.js';
+import { MCPOAuthTokenStorage } from '../mcp/oauth-token-storage.js';
 import {
   ActiveFileNotificationSchema,
   IDE_SERVER_NAME,
@@ -61,6 +65,11 @@ const mcpServerStatusesInternal: Map<string, MCPServerStatus> = new Map();
  * Track the overall MCP discovery state
  */
 let mcpDiscoveryState: MCPDiscoveryState = MCPDiscoveryState.NOT_STARTED;
+
+/**
+ * Map to track which MCP servers have been discovered to require OAuth
+ */
+export const mcpServerRequiresOAuth: Map<string, boolean> = new Map();
 
 /**
  * Event listeners for MCP server status changes
@@ -127,6 +136,165 @@ export function getAllMCPServerStatuses(): Map<string, MCPServerStatus> {
  */
 export function getMCPDiscoveryState(): MCPDiscoveryState {
   return mcpDiscoveryState;
+}
+
+/**
+ * Parse www-authenticate header to extract OAuth metadata URI.
+ *
+ * @param wwwAuthenticate The www-authenticate header value
+ * @returns The resource metadata URI if found, null otherwise
+ */
+function _parseWWWAuthenticate(wwwAuthenticate: string): string | null {
+  // Parse header like: Bearer realm="MCP Server", resource_metadata_uri="https://..."
+  const resourceMetadataMatch = wwwAuthenticate.match(
+    /resource_metadata_uri="([^"]+)"/,
+  );
+  return resourceMetadataMatch ? resourceMetadataMatch[1] : null;
+}
+
+/**
+ * Extract WWW-Authenticate header from error message string.
+ * This is a more robust approach than regex matching.
+ *
+ * @param errorString The error message string
+ * @returns The www-authenticate header value if found, null otherwise
+ */
+function extractWWWAuthenticateHeader(errorString: string): string | null {
+  // Try multiple patterns to extract the header
+  const patterns = [
+    /www-authenticate:\s*([^\n\r]+)/i,
+    /WWW-Authenticate:\s*([^\n\r]+)/i,
+    /"www-authenticate":\s*"([^"]+)"/i,
+    /'www-authenticate':\s*'([^']+)'/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = errorString.match(pattern);
+    if (match) {
+      return match[1].trim();
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Handle automatic OAuth discovery and authentication for a server.
+ *
+ * @param mcpServerName The name of the MCP server
+ * @param mcpServerConfig The MCP server configuration
+ * @param wwwAuthenticate The www-authenticate header value
+ * @returns True if OAuth was successfully configured and authenticated, false otherwise
+ */
+async function handleAutomaticOAuth(
+  mcpServerName: string,
+  mcpServerConfig: MCPServerConfig,
+  wwwAuthenticate: string,
+): Promise<boolean> {
+  try {
+    console.log(`🔐 '${mcpServerName}' requires OAuth authentication`);
+
+    // Always try to parse the resource metadata URI from the www-authenticate header
+    let oauthConfig;
+    const resourceMetadataUri =
+      OAuthUtils.parseWWWAuthenticateHeader(wwwAuthenticate);
+    if (resourceMetadataUri) {
+      oauthConfig = await OAuthUtils.discoverOAuthConfig(resourceMetadataUri);
+    } else if (mcpServerConfig.url) {
+      // Fallback: try to discover OAuth config from the base URL for SSE
+      const sseUrl = new URL(mcpServerConfig.url);
+      const baseUrl = `${sseUrl.protocol}//${sseUrl.host}`;
+      oauthConfig = await OAuthUtils.discoverOAuthConfig(baseUrl);
+    } else if (mcpServerConfig.httpUrl) {
+      // Fallback: try to discover OAuth config from the base URL for HTTP
+      const httpUrl = new URL(mcpServerConfig.httpUrl);
+      const baseUrl = `${httpUrl.protocol}//${httpUrl.host}`;
+      oauthConfig = await OAuthUtils.discoverOAuthConfig(baseUrl);
+    }
+
+    if (!oauthConfig) {
+      console.error(
+        `❌ Could not configure OAuth for '${mcpServerName}' - please authenticate manually with /mcp auth ${mcpServerName}`,
+      );
+      return false;
+    }
+
+    // OAuth configuration discovered - proceed with authentication
+
+    // Create OAuth configuration for authentication
+    const oauthAuthConfig = {
+      enabled: true,
+      authorizationUrl: oauthConfig.authorizationUrl,
+      tokenUrl: oauthConfig.tokenUrl,
+      scopes: oauthConfig.scopes || [],
+    };
+
+    // Perform OAuth authentication
+    console.log(
+      `Starting OAuth authentication for server '${mcpServerName}'...`,
+    );
+    await MCPOAuthProvider.authenticate(mcpServerName, oauthAuthConfig);
+
+    console.log(
+      `OAuth authentication successful for server '${mcpServerName}'`,
+    );
+    return true;
+  } catch (error) {
+    console.error(
+      `Failed to handle automatic OAuth for server '${mcpServerName}': ${getErrorMessage(error)}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Create a transport with OAuth token for the given server configuration.
+ *
+ * @param mcpServerName The name of the MCP server
+ * @param mcpServerConfig The MCP server configuration
+ * @param accessToken The OAuth access token
+ * @returns The transport with OAuth token, or null if creation fails
+ */
+async function createTransportWithOAuth(
+  mcpServerName: string,
+  mcpServerConfig: MCPServerConfig,
+  accessToken: string,
+): Promise<StreamableHTTPClientTransport | SSEClientTransport | null> {
+  try {
+    if (mcpServerConfig.httpUrl) {
+      // Create HTTP transport with OAuth token
+      const oauthTransportOptions: StreamableHTTPClientTransportOptions = {
+        requestInit: {
+          headers: {
+            ...mcpServerConfig.headers,
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      };
+
+      return new StreamableHTTPClientTransport(
+        new URL(mcpServerConfig.httpUrl),
+        oauthTransportOptions,
+      );
+    } else if (mcpServerConfig.url) {
+      // Create SSE transport with OAuth token in Authorization header
+      return new SSEClientTransport(new URL(mcpServerConfig.url), {
+        requestInit: {
+          headers: {
+            ...mcpServerConfig.headers,
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      });
+    }
+
+    return null;
+  } catch (error) {
+    console.error(
+      `Failed to create OAuth transport for server '${mcpServerName}': ${getErrorMessage(error)}`,
+    );
+    return null;
+  }
 }
 
 /**
@@ -238,7 +406,9 @@ export async function connectAndDiscover(
       throw error;
     }
   } catch (error) {
-    console.error(`Error connecting to MCP server '${mcpServerName}':`, error);
+    // Only show the error message, not the full stack trace
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`❌ ${errorMessage}`);
     updateMCPServerStatus(mcpServerName, MCPServerStatus.DISCONNECTED);
   }
 }
@@ -332,7 +502,7 @@ export async function connectToMcpServer(
   }
 
   try {
-    const transport = createTransport(
+    const transport = await createTransport(
       mcpServerName,
       mcpServerConfig,
       debugMode,
@@ -347,40 +517,396 @@ export async function connectToMcpServer(
       throw error;
     }
   } catch (error) {
-    // Create a safe config object that excludes sensitive information
-    const safeConfig = {
-      command: mcpServerConfig.command,
-      url: mcpServerConfig.url,
-      httpUrl: mcpServerConfig.httpUrl,
-      cwd: mcpServerConfig.cwd,
-      timeout: mcpServerConfig.timeout,
-      trust: mcpServerConfig.trust,
-      // Exclude args, env, and headers which may contain sensitive data
-    };
+    // Check if this is a 401 error that might indicate OAuth is required
+    const errorString = String(error);
+    if (
+      errorString.includes('401') &&
+      (mcpServerConfig.httpUrl || mcpServerConfig.url)
+    ) {
+      mcpServerRequiresOAuth.set(mcpServerName, true);
+      // Only trigger automatic OAuth discovery for HTTP servers or when OAuth is explicitly configured
+      // For SSE servers, we should not trigger new OAuth flows automatically
+      const shouldTriggerOAuth =
+        mcpServerConfig.httpUrl || mcpServerConfig.oauth?.enabled;
 
-    let errorString =
-      `failed to start or connect to MCP server '${mcpServerName}' ` +
-      `${JSON.stringify(safeConfig)}; \n${error}`;
-    if (process.env.SANDBOX) {
-      errorString += `\nMake sure it is available in the sandbox`;
+      if (!shouldTriggerOAuth) {
+        // For SSE servers without explicit OAuth config, if a token was found but rejected, report it accurately.
+        const credentials = await MCPOAuthTokenStorage.getToken(mcpServerName);
+        if (credentials) {
+          const hasStoredTokens = await MCPOAuthProvider.getValidToken(
+            mcpServerName,
+            {
+              // Pass client ID if available
+              clientId: credentials.clientId,
+            },
+          );
+          if (hasStoredTokens) {
+            console.log(
+              `Stored OAuth token for SSE server '${mcpServerName}' was rejected. ` +
+                `Please re-authenticate using: /mcp auth ${mcpServerName}`,
+            );
+          } else {
+            console.log(
+              `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
+                `Please authenticate using: /mcp auth ${mcpServerName}`,
+            );
+          }
+        }
+        throw new Error(
+          `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
+            `Please authenticate using: /mcp auth ${mcpServerName}`,
+        );
+      }
+
+      // Try to extract www-authenticate header from the error
+      let wwwAuthenticate = extractWWWAuthenticateHeader(errorString);
+
+      // If we didn't get the header from the error string, try to get it from the server
+      if (!wwwAuthenticate && mcpServerConfig.url) {
+        console.log(
+          `No www-authenticate header in error, trying to fetch it from server...`,
+        );
+        try {
+          const response = await fetch(mcpServerConfig.url, {
+            method: 'HEAD',
+            headers: {
+              Accept: 'text/event-stream',
+            },
+            signal: AbortSignal.timeout(5000),
+          });
+
+          if (response.status === 401) {
+            wwwAuthenticate = response.headers.get('www-authenticate');
+            if (wwwAuthenticate) {
+              console.log(
+                `Found www-authenticate header from server: ${wwwAuthenticate}`,
+              );
+            }
+          }
+        } catch (fetchError) {
+          console.debug(
+            `Failed to fetch www-authenticate header: ${getErrorMessage(fetchError)}`,
+          );
+        }
+      }
+
+      if (wwwAuthenticate) {
+        console.log(
+          `Received 401 with www-authenticate header: ${wwwAuthenticate}`,
+        );
+
+        // Try automatic OAuth discovery and authentication
+        const oauthSuccess = await handleAutomaticOAuth(
+          mcpServerName,
+          mcpServerConfig,
+          wwwAuthenticate,
+        );
+        if (oauthSuccess) {
+          // Retry connection with OAuth token
+          console.log(
+            `Retrying connection to '${mcpServerName}' with OAuth token...`,
+          );
+
+          // Get the valid token - we need to create a proper OAuth config
+          // The token should already be available from the authentication process
+          const credentials =
+            await MCPOAuthTokenStorage.getToken(mcpServerName);
+          if (credentials) {
+            const accessToken = await MCPOAuthProvider.getValidToken(
+              mcpServerName,
+              {
+                // Pass client ID if available
+                clientId: credentials.clientId,
+              },
+            );
+
+            if (accessToken) {
+              // Create transport with OAuth token
+              const oauthTransport = await createTransportWithOAuth(
+                mcpServerName,
+                mcpServerConfig,
+                accessToken,
+              );
+              if (oauthTransport) {
+                try {
+                  await mcpClient.connect(oauthTransport, {
+                    timeout:
+                      mcpServerConfig.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC,
+                  });
+                  // Connection successful with OAuth
+                  return mcpClient;
+                } catch (retryError) {
+                  console.error(
+                    `Failed to connect with OAuth token: ${getErrorMessage(
+                      retryError,
+                    )}`,
+                  );
+                  throw retryError;
+                }
+              } else {
+                console.error(
+                  `Failed to create OAuth transport for server '${mcpServerName}'`,
+                );
+                throw new Error(
+                  `Failed to create OAuth transport for server '${mcpServerName}'`,
+                );
+              }
+            } else {
+              console.error(
+                `Failed to get OAuth token for server '${mcpServerName}'`,
+              );
+              throw new Error(
+                `Failed to get OAuth token for server '${mcpServerName}'`,
+              );
+            }
+          } else {
+            console.error(
+              `Failed to get credentials for server '${mcpServerName}' after successful OAuth authentication`,
+            );
+            throw new Error(
+              `Failed to get credentials for server '${mcpServerName}' after successful OAuth authentication`,
+            );
+          }
+        } else {
+          console.error(
+            `Failed to handle automatic OAuth for server '${mcpServerName}'`,
+          );
+          throw new Error(
+            `Failed to handle automatic OAuth for server '${mcpServerName}'`,
+          );
+        }
+      } else {
+        // No www-authenticate header found, but we got a 401
+        // Only try OAuth discovery for HTTP servers or when OAuth is explicitly configured
+        // For SSE servers, we should not trigger new OAuth flows automatically
+        const shouldTryDiscovery =
+          mcpServerConfig.httpUrl || mcpServerConfig.oauth?.enabled;
+
+        if (!shouldTryDiscovery) {
+          const credentials =
+            await MCPOAuthTokenStorage.getToken(mcpServerName);
+          if (credentials) {
+            const hasStoredTokens = await MCPOAuthProvider.getValidToken(
+              mcpServerName,
+              {
+                // Pass client ID if available
+                clientId: credentials.clientId,
+              },
+            );
+            if (hasStoredTokens) {
+              console.log(
+                `Stored OAuth token for SSE server '${mcpServerName}' was rejected. ` +
+                  `Please re-authenticate using: /mcp auth ${mcpServerName}`,
+              );
+            } else {
+              console.log(
+                `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
+                  `Please authenticate using: /mcp auth ${mcpServerName}`,
+              );
+            }
+          }
+          throw new Error(
+            `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
+              `Please authenticate using: /mcp auth ${mcpServerName}`,
+          );
+        }
+
+        // For SSE servers, try to discover OAuth configuration from the base URL
+        console.log(`🔍 Attempting OAuth discovery for '${mcpServerName}'...`);
+
+        if (mcpServerConfig.url) {
+          const sseUrl = new URL(mcpServerConfig.url);
+          const baseUrl = `${sseUrl.protocol}//${sseUrl.host}`;
+
+          try {
+            // Try to discover OAuth configuration from the base URL
+            const oauthConfig = await OAuthUtils.discoverOAuthConfig(baseUrl);
+            if (oauthConfig) {
+              console.log(
+                `Discovered OAuth configuration from base URL for server '${mcpServerName}'`,
+              );
+
+              // Create OAuth configuration for authentication
+              const oauthAuthConfig = {
+                enabled: true,
+                authorizationUrl: oauthConfig.authorizationUrl,
+                tokenUrl: oauthConfig.tokenUrl,
+                scopes: oauthConfig.scopes || [],
+              };
+
+              // Perform OAuth authentication
+              console.log(
+                `Starting OAuth authentication for server '${mcpServerName}'...`,
+              );
+              await MCPOAuthProvider.authenticate(
+                mcpServerName,
+                oauthAuthConfig,
+              );
+
+              // Retry connection with OAuth token
+              const credentials =
+                await MCPOAuthTokenStorage.getToken(mcpServerName);
+              if (credentials) {
+                const accessToken = await MCPOAuthProvider.getValidToken(
+                  mcpServerName,
+                  {
+                    // Pass client ID if available
+                    clientId: credentials.clientId,
+                  },
+                );
+                if (accessToken) {
+                  // Create transport with OAuth token
+                  const oauthTransport = await createTransportWithOAuth(
+                    mcpServerName,
+                    mcpServerConfig,
+                    accessToken,
+                  );
+                  if (oauthTransport) {
+                    try {
+                      await mcpClient.connect(oauthTransport, {
+                        timeout:
+                          mcpServerConfig.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC,
+                      });
+                      // Connection successful with OAuth
+                      return mcpClient;
+                    } catch (retryError) {
+                      console.error(
+                        `Failed to connect with OAuth token: ${getErrorMessage(
+                          retryError,
+                        )}`,
+                      );
+                      throw retryError;
+                    }
+                  } else {
+                    console.error(
+                      `Failed to create OAuth transport for server '${mcpServerName}'`,
+                    );
+                    throw new Error(
+                      `Failed to create OAuth transport for server '${mcpServerName}'`,
+                    );
+                  }
+                } else {
+                  console.error(
+                    `Failed to get OAuth token for server '${mcpServerName}'`,
+                  );
+                  throw new Error(
+                    `Failed to get OAuth token for server '${mcpServerName}'`,
+                  );
+                }
+              } else {
+                console.error(
+                  `Failed to get stored credentials for server '${mcpServerName}'`,
+                );
+                throw new Error(
+                  `Failed to get stored credentials for server '${mcpServerName}'`,
+                );
+              }
+            } else {
+              console.error(
+                `❌ Could not configure OAuth for '${mcpServerName}' - please authenticate manually with /mcp auth ${mcpServerName}`,
+              );
+              throw new Error(
+                `OAuth configuration failed for '${mcpServerName}'. Please authenticate manually with /mcp auth ${mcpServerName}`,
+              );
+            }
+          } catch (discoveryError) {
+            console.error(
+              `❌ OAuth discovery failed for '${mcpServerName}' - please authenticate manually with /mcp auth ${mcpServerName}`,
+            );
+            throw discoveryError;
+          }
+        } else {
+          console.error(
+            `❌ '${mcpServerName}' requires authentication but no OAuth configuration found`,
+          );
+          throw new Error(
+            `MCP server '${mcpServerName}' requires authentication. Please configure OAuth or check server settings.`,
+          );
+        }
+      }
+    } else {
+      // Handle other connection errors
+      // Create a concise error message
+      const errorMessage = (error as Error).message || String(error);
+      const isNetworkError =
+        errorMessage.includes('ENOTFOUND') ||
+        errorMessage.includes('ECONNREFUSED');
+
+      let conciseError: string;
+      if (isNetworkError) {
+        conciseError = `Cannot connect to '${mcpServerName}' - server may be down or URL incorrect`;
+      } else {
+        conciseError = `Connection failed for '${mcpServerName}': ${errorMessage}`;
+      }
+
+      if (process.env.SANDBOX) {
+        conciseError += ` (check sandbox availability)`;
+      }
+
+      throw new Error(conciseError);
     }
-    throw new Error(errorString);
   }
 }
 
 /** Visible for Testing */
-export function createTransport(
+export async function createTransport(
   mcpServerName: string,
   mcpServerConfig: MCPServerConfig,
   debugMode: boolean,
-): Transport {
+): Promise<Transport> {
+  // Check if we have OAuth configuration or stored tokens
+  let accessToken: string | null = null;
+  let hasOAuthConfig = mcpServerConfig.oauth?.enabled;
+
+  if (hasOAuthConfig && mcpServerConfig.oauth) {
+    accessToken = await MCPOAuthProvider.getValidToken(
+      mcpServerName,
+      mcpServerConfig.oauth,
+    );
+
+    if (!accessToken) {
+      console.error(
+        `MCP server '${mcpServerName}' requires OAuth authentication. ` +
+          `Please authenticate using the /mcp auth command.`,
+      );
+      throw new Error(
+        `MCP server '${mcpServerName}' requires OAuth authentication. ` +
+          `Please authenticate using the /mcp auth command.`,
+      );
+    }
+  } else {
+    // Check if we have stored OAuth tokens for this server (from previous authentication)
+    const credentials = await MCPOAuthTokenStorage.getToken(mcpServerName);
+    if (credentials) {
+      accessToken = await MCPOAuthProvider.getValidToken(mcpServerName, {
+        // Pass client ID if available
+        clientId: credentials.clientId,
+      });
+
+      if (accessToken) {
+        hasOAuthConfig = true;
+        console.log(`Found stored OAuth token for server '${mcpServerName}'`);
+      }
+    }
+  }
+
   if (mcpServerConfig.httpUrl) {
     const transportOptions: StreamableHTTPClientTransportOptions = {};
-    if (mcpServerConfig.headers) {
+
+    // Set up headers with OAuth token if available
+    if (hasOAuthConfig && accessToken) {
+      transportOptions.requestInit = {
+        headers: {
+          ...mcpServerConfig.headers,
+          Authorization: `Bearer ${accessToken}`,
+        },
+      };
+    } else if (mcpServerConfig.headers) {
       transportOptions.requestInit = {
         headers: mcpServerConfig.headers,
       };
     }
+
     return new StreamableHTTPClientTransport(
       new URL(mcpServerConfig.httpUrl),
       transportOptions,
@@ -389,11 +915,21 @@ export function createTransport(
 
   if (mcpServerConfig.url) {
     const transportOptions: SSEClientTransportOptions = {};
-    if (mcpServerConfig.headers) {
+
+    // Set up headers with OAuth token if available
+    if (hasOAuthConfig && accessToken) {
+      transportOptions.requestInit = {
+        headers: {
+          ...mcpServerConfig.headers,
+          Authorization: `Bearer ${accessToken}`,
+        },
+      };
+    } else if (mcpServerConfig.headers) {
       transportOptions.requestInit = {
         headers: mcpServerConfig.headers,
       };
     }
+
     return new SSEClientTransport(
       new URL(mcpServerConfig.url),
       transportOptions,

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -315,5 +315,79 @@ describe('DiscoveredMCPTool', () => {
         );
       }
     });
+
+    it('should handle Cancel confirmation outcome', async () => {
+      const tool = new DiscoveredMCPTool(
+        mockCallableToolInstance,
+        serverName,
+        toolNameForModel,
+        baseDescription,
+        inputSchema,
+        serverToolName,
+      );
+      const confirmation = await tool.shouldConfirmExecute(
+        {},
+        new AbortController().signal,
+      );
+      expect(confirmation).not.toBe(false);
+      if (
+        confirmation &&
+        typeof confirmation === 'object' &&
+        'onConfirm' in confirmation &&
+        typeof confirmation.onConfirm === 'function'
+      ) {
+        // Cancel should not add anything to allowlist
+        await confirmation.onConfirm(ToolConfirmationOutcome.Cancel);
+        expect((DiscoveredMCPTool as any).allowlist.has(serverName)).toBe(
+          false,
+        );
+        expect(
+          (DiscoveredMCPTool as any).allowlist.has(
+            `${serverName}.${serverToolName}`,
+          ),
+        ).toBe(false);
+      } else {
+        throw new Error(
+          'Confirmation details or onConfirm not in expected format',
+        );
+      }
+    });
+
+    it('should handle ProceedOnce confirmation outcome', async () => {
+      const tool = new DiscoveredMCPTool(
+        mockCallableToolInstance,
+        serverName,
+        toolNameForModel,
+        baseDescription,
+        inputSchema,
+        serverToolName,
+      );
+      const confirmation = await tool.shouldConfirmExecute(
+        {},
+        new AbortController().signal,
+      );
+      expect(confirmation).not.toBe(false);
+      if (
+        confirmation &&
+        typeof confirmation === 'object' &&
+        'onConfirm' in confirmation &&
+        typeof confirmation.onConfirm === 'function'
+      ) {
+        // ProceedOnce should not add anything to allowlist
+        await confirmation.onConfirm(ToolConfirmationOutcome.ProceedOnce);
+        expect((DiscoveredMCPTool as any).allowlist.has(serverName)).toBe(
+          false,
+        );
+        expect(
+          (DiscoveredMCPTool as any).allowlist.has(
+            `${serverName}.${serverToolName}`,
+          ),
+        ).toBe(false);
+      } else {
+        throw new Error(
+          'Confirmation details or onConfirm not in expected format',
+        );
+      }
+    });
   });
 });

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -168,6 +168,30 @@ export class ToolRegistry {
     );
   }
 
+  /**
+   * Discover or re-discover tools for a single MCP server.
+   * @param serverName - The name of the server to discover tools from.
+   */
+  async discoverToolsForServer(serverName: string): Promise<void> {
+    // Remove any previously discovered tools from this server
+    for (const [name, tool] of this.tools.entries()) {
+      if (tool instanceof DiscoveredMCPTool && tool.serverName === serverName) {
+        this.tools.delete(name);
+      }
+    }
+
+    const mcpServers = this.config.getMcpServers() ?? {};
+    const serverConfig = mcpServers[serverName];
+    if (serverConfig) {
+      await discoverMcpTools(
+        { [serverName]: serverConfig },
+        undefined,
+        this,
+        this.config.getDebugMode(),
+      );
+    }
+  }
+
   private async discoverAndRegisterToolsFromCommand(): Promise<void> {
     const discoveryCmd = this.config.getToolDiscoveryCommand();
     if (!discoveryCmd) {
@@ -381,6 +405,19 @@ function _sanitizeParameters(schema: Schema | undefined, visited: Set<Schema>) {
       }
     }
   }
+
+  // Handle enum values - Gemini API only allows enum for STRING type
+  if (schema.enum && Array.isArray(schema.enum)) {
+    if (schema.type !== Type.STRING) {
+      // If enum is present but type is not STRING, convert type to STRING
+      schema.type = Type.STRING;
+    }
+    // Filter out null and undefined values, then convert remaining values to strings for Gemini API compatibility
+    schema.enum = schema.enum
+      .filter((value: unknown) => value !== null && value !== undefined)
+      .map((value: unknown) => String(value));
+  }
+
   // Vertex AI only supports 'enum' and 'date-time' for STRING format.
   if (schema.type === Type.STRING) {
     if (


### PR DESCRIPTION
## TLDR

    Adds support for Google Application Default Credentials (ADC)
    as an authentication method for MCP servers.

## Dive Deeper

    This introduces a new `authProviderType` setting for MCP servers
    in `settings.json`. When set to `google_credentials`, the CLI
    will use the `google-auth-library` to automatically obtain
    credentials from the environment.

    To improve security, the `oauth.scopes` property is now
    mandatory when using the `google_credentials` provider,
    ensuring that users explicitly grant the necessary permissions.

    Includes:
    - `GoogleCredentialProvider` implementation
    - Integration with MCP transport layer
    - Unit tests for the new provider
    - Documentation updates for the new configuration

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.


-->

Resolves #3704
Supersedes #1618