### PR TITLE
Include api key in header instead of in the URL

### DIFF
--- a/packages/core/src/core/modelCheck.ts
+++ b/packages/core/src/core/modelCheck.ts
@@ -28,7 +28,7 @@ export async function getEffectiveModel(
 
   const modelToTest = DEFAULT_GEMINI_MODEL;
   const fallbackModel = DEFAULT_GEMINI_FLASH_MODEL;
-  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${modelToTest}:generateContent?key=${apiKey}`;
+  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${modelToTest}:generateContent`;
   const body = JSON.stringify({
     contents: [{ parts: [{ text: 'test' }] }],
     generationConfig: {
@@ -45,7 +45,10 @@ export async function getEffectiveModel(
   try {
     const response = await fetch(endpoint, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': apiKey,
+      },
       body,
       signal: controller.signal,
     });


### PR DESCRIPTION
## TLDR

For security, it's better not to include the key parameter in the URL.

## Dive Deeper

Per https://cloud.google.com/docs/authentication/api-keys-use#using-with-rest, it's better to include API key in the header.

## Reviewer Test Plan

Use Sherlog or Proxy to see the model check request no longer includes the key parameter.

<img width="979" height="692" alt="image" src="https://github.com/user-attachments/assets/fcc75c13-b652-4192-9ca1-6f19f7d43691" />


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

N/A