### PR TITLE
update `/bug` to new slash command arch

### DIFF
--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -21,13 +21,10 @@ import { aboutCommand } from '../ui/commands/aboutCommand.js';
 import { ideCommand } from '../ui/commands/ideCommand.js';
 import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 import { toolsCommand } from '../ui/commands/toolsCommand.js';
-<<<<<<< HEAD
 import { compressCommand } from '../ui/commands/compressCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { editorCommand } from '../ui/commands/editorCommand.js';
-=======
 import { bugCommand } from '../ui/commands/bugCommand.js';
->>>>>>> 0024d086 (updated /bug slash command)
 
 // Mock the command modules to isolate the service from the command implementations.
 vi.mock('../ui/commands/memoryCommand.js', () => ({
@@ -66,7 +63,6 @@ vi.mock('../ui/commands/extensionsCommand.js', () => ({
 vi.mock('../ui/commands/toolsCommand.js', () => ({
   toolsCommand: { name: 'tools', description: 'Mock Tools' },
 }));
-<<<<<<< HEAD
 vi.mock('../ui/commands/compressCommand.js', () => ({
   compressCommand: { name: 'compress', description: 'Mock Compress' },
 }));
@@ -75,14 +71,13 @@ vi.mock('../ui/commands/mcpCommand.js', () => ({
 }));
 vi.mock('../ui/commands/editorCommand.js', () => ({
   editorCommand: { name: 'editor', description: 'Mock Editor' },
-=======
+}));
 vi.mock('../ui/commands/bugCommand.js', () => ({
   bugCommand: { name: 'bug', description: 'Mock Bug' },
->>>>>>> 0024d086 (updated /bug slash command)
 }));
 
 describe('CommandService', () => {
-  const subCommandLen = 15;
+  const subCommandLen = 16;
   let mockConfig: Mocked<Config>;
 
   beforeEach(() => {
@@ -115,14 +110,11 @@ describe('CommandService', () => {
         const tree = commandService.getCommands();
 
         // Post-condition assertions
-<<<<<<< HEAD
         expect(tree.length).toBe(subCommandLen);
-=======
-        expect(tree.length).toBe(10);
->>>>>>> 0024d086 (updated /bug slash command)
 
         const commandNames = tree.map((cmd) => cmd.name);
         expect(commandNames).toContain('auth');
+        expect(commandNames).toContain('bug');
         expect(commandNames).toContain('memory');
         expect(commandNames).toContain('help');
         expect(commandNames).toContain('clear');
@@ -134,7 +126,6 @@ describe('CommandService', () => {
         expect(commandNames).toContain('about');
         expect(commandNames).toContain('extensions');
         expect(commandNames).toContain('tools');
-<<<<<<< HEAD
         expect(commandNames).toContain('compress');
         expect(commandNames).toContain('mcp');
         expect(commandNames).not.toContain('ide');
@@ -153,30 +144,19 @@ describe('CommandService', () => {
         const commandNames = tree.map((cmd) => cmd.name);
         expect(commandNames).toContain('ide');
         expect(commandNames).toContain('editor');
-=======
-        expect(commandNames).toContain('bug');
->>>>>>> 0024d086 (updated /bug slash command)
       });
 
       it('should overwrite any existing commands when called again', async () => {
         // Load once
         await commandService.loadCommands();
-<<<<<<< HEAD
         expect(commandService.getCommands().length).toBe(subCommandLen);
-=======
-        expect(commandService.getCommands().length).toBe(10);
->>>>>>> 0024d086 (updated /bug slash command)
 
         // Load again
         await commandService.loadCommands();
         const tree = commandService.getCommands();
 
         // Should not append, but overwrite
-<<<<<<< HEAD
         expect(tree.length).toBe(subCommandLen);
-=======
-        expect(tree.length).toBe(10);
->>>>>>> 0024d086 (updated /bug slash command)
       });
     });
 
@@ -188,19 +168,12 @@ describe('CommandService', () => {
         await commandService.loadCommands();
 
         const loadedTree = commandService.getCommands();
-<<<<<<< HEAD
         expect(loadedTree.length).toBe(subCommandLen);
         expect(loadedTree).toEqual([
           aboutCommand,
           authCommand,
-          chatCommand,
-=======
-        expect(loadedTree.length).toBe(10);
-        expect(loadedTree).toEqual([
-          aboutCommand,
-          authCommand,
           bugCommand,
->>>>>>> 0024d086 (updated /bug slash command)
+          chatCommand,
           clearCommand,
           compressCommand,
           docsCommand,

--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -21,9 +21,13 @@ import { aboutCommand } from '../ui/commands/aboutCommand.js';
 import { ideCommand } from '../ui/commands/ideCommand.js';
 import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 import { toolsCommand } from '../ui/commands/toolsCommand.js';
+<<<<<<< HEAD
 import { compressCommand } from '../ui/commands/compressCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { editorCommand } from '../ui/commands/editorCommand.js';
+=======
+import { bugCommand } from '../ui/commands/bugCommand.js';
+>>>>>>> 0024d086 (updated /bug slash command)
 
 // Mock the command modules to isolate the service from the command implementations.
 vi.mock('../ui/commands/memoryCommand.js', () => ({
@@ -62,6 +66,7 @@ vi.mock('../ui/commands/extensionsCommand.js', () => ({
 vi.mock('../ui/commands/toolsCommand.js', () => ({
   toolsCommand: { name: 'tools', description: 'Mock Tools' },
 }));
+<<<<<<< HEAD
 vi.mock('../ui/commands/compressCommand.js', () => ({
   compressCommand: { name: 'compress', description: 'Mock Compress' },
 }));
@@ -70,6 +75,10 @@ vi.mock('../ui/commands/mcpCommand.js', () => ({
 }));
 vi.mock('../ui/commands/editorCommand.js', () => ({
   editorCommand: { name: 'editor', description: 'Mock Editor' },
+=======
+vi.mock('../ui/commands/bugCommand.js', () => ({
+  bugCommand: { name: 'bug', description: 'Mock Bug' },
+>>>>>>> 0024d086 (updated /bug slash command)
 }));
 
 describe('CommandService', () => {
@@ -106,7 +115,11 @@ describe('CommandService', () => {
         const tree = commandService.getCommands();
 
         // Post-condition assertions
+<<<<<<< HEAD
         expect(tree.length).toBe(subCommandLen);
+=======
+        expect(tree.length).toBe(10);
+>>>>>>> 0024d086 (updated /bug slash command)
 
         const commandNames = tree.map((cmd) => cmd.name);
         expect(commandNames).toContain('auth');
@@ -121,6 +134,7 @@ describe('CommandService', () => {
         expect(commandNames).toContain('about');
         expect(commandNames).toContain('extensions');
         expect(commandNames).toContain('tools');
+<<<<<<< HEAD
         expect(commandNames).toContain('compress');
         expect(commandNames).toContain('mcp');
         expect(commandNames).not.toContain('ide');
@@ -139,19 +153,30 @@ describe('CommandService', () => {
         const commandNames = tree.map((cmd) => cmd.name);
         expect(commandNames).toContain('ide');
         expect(commandNames).toContain('editor');
+=======
+        expect(commandNames).toContain('bug');
+>>>>>>> 0024d086 (updated /bug slash command)
       });
 
       it('should overwrite any existing commands when called again', async () => {
         // Load once
         await commandService.loadCommands();
+<<<<<<< HEAD
         expect(commandService.getCommands().length).toBe(subCommandLen);
+=======
+        expect(commandService.getCommands().length).toBe(10);
+>>>>>>> 0024d086 (updated /bug slash command)
 
         // Load again
         await commandService.loadCommands();
         const tree = commandService.getCommands();
 
         // Should not append, but overwrite
+<<<<<<< HEAD
         expect(tree.length).toBe(subCommandLen);
+=======
+        expect(tree.length).toBe(10);
+>>>>>>> 0024d086 (updated /bug slash command)
       });
     });
 
@@ -163,11 +188,19 @@ describe('CommandService', () => {
         await commandService.loadCommands();
 
         const loadedTree = commandService.getCommands();
+<<<<<<< HEAD
         expect(loadedTree.length).toBe(subCommandLen);
         expect(loadedTree).toEqual([
           aboutCommand,
           authCommand,
           chatCommand,
+=======
+        expect(loadedTree.length).toBe(10);
+        expect(loadedTree).toEqual([
+          aboutCommand,
+          authCommand,
+          bugCommand,
+>>>>>>> 0024d086 (updated /bug slash command)
           clearCommand,
           compressCommand,
           docsCommand,

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -22,6 +22,7 @@ import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 import { toolsCommand } from '../ui/commands/toolsCommand.js';
 import { compressCommand } from '../ui/commands/compressCommand.js';
 import { ideCommand } from '../ui/commands/ideCommand.js';
+import { bugCommand } from '../ui/commands/bugCommand.js';
 
 const loadBuiltInCommands = async (
   config: Config | null,
@@ -29,6 +30,7 @@ const loadBuiltInCommands = async (
   const allCommands = [
     aboutCommand,
     authCommand,
+    bugCommand,
     chatCommand,
     clearCommand,
     compressCommand,

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -43,7 +43,7 @@ const loadBuiltInCommands = async (
     statsCommand,
     themeCommand,
     toolsCommand,
-  ];
+];
 
   return allCommands.filter(
     (command): command is SlashCommand => command !== null,

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -43,7 +43,7 @@ const loadBuiltInCommands = async (
     statsCommand,
     themeCommand,
     toolsCommand,
-];
+  ];
 
   return allCommands.filter(
     (command): command is SlashCommand => command !== null,

--- a/packages/cli/src/ui/commands/bugCommand.test.ts
+++ b/packages/cli/src/ui/commands/bugCommand.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import open from 'open';
+import { bugCommand } from './bugCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { getCliVersion } from '../../utils/version.js';
+import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
+import { formatMemoryUsage } from '../utils/formatters.js';
+
+// Mock dependencies
+vi.mock('open');
+vi.mock('../../utils/version.js');
+vi.mock('../utils/formatters.js');
+
+describe('bugCommand', () => {
+  beforeEach(() => {
+    vi.mocked(getCliVersion).mockResolvedValue('0.1.0');
+    vi.mocked(formatMemoryUsage).mockReturnValue('100 MB');
+    vi.stubEnv('SANDBOX', 'gemini-test');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it('should generate the default GitHub issue URL', async () => {
+    const mockContext = createMockCommandContext({
+      services: {
+        config: {
+          getModel: () => 'gemini-pro',
+          getBugCommand: () => undefined,
+        },
+      },
+    });
+
+    if (!bugCommand.action) throw new Error('Action is not defined');
+    await bugCommand.action(mockContext, 'A test bug');
+
+    const expectedInfo = `
+* **CLI Version:** 0.1.0
+* **Git Commit:** ${GIT_COMMIT_INFO}
+* **Operating System:** ${process.platform} ${process.version}
+* **Sandbox Environment:** test
+* **Model Version:** gemini-pro
+* **Memory Usage:** 100 MB
+`;
+    const expectedUrl =
+      'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml&title=A%20test%20bug&info=' +
+      encodeURIComponent(expectedInfo);
+
+    expect(open).toHaveBeenCalledWith(expectedUrl);
+  });
+
+  it('should use a custom URL template from config if provided', async () => {
+    const customTemplate =
+      'https://internal.bug-tracker.com/new?desc={title}&details={info}';
+    const mockContext = createMockCommandContext({
+      services: {
+        config: {
+          getModel: () => 'gemini-pro',
+          getBugCommand: () => ({ urlTemplate: customTemplate }),
+        },
+      },
+    });
+
+    if (!bugCommand.action) throw new Error('Action is not defined');
+    await bugCommand.action(mockContext, 'A custom bug');
+
+    const expectedInfo = `
+* **CLI Version:** 0.1.0
+* **Git Commit:** ${GIT_COMMIT_INFO}
+* **Operating System:** ${process.platform} ${process.version}
+* **Sandbox Environment:** test
+* **Model Version:** gemini-pro
+* **Memory Usage:** 100 MB
+`;
+    const expectedUrl = customTemplate
+      .replace('{title}', encodeURIComponent('A custom bug'))
+      .replace('{info}', encodeURIComponent(expectedInfo));
+
+    expect(open).toHaveBeenCalledWith(expectedUrl);
+  });
+});

--- a/packages/cli/src/ui/commands/bugCommand.test.ts
+++ b/packages/cli/src/ui/commands/bugCommand.test.ts
@@ -16,6 +16,15 @@ import { formatMemoryUsage } from '../utils/formatters.js';
 vi.mock('open');
 vi.mock('../../utils/version.js');
 vi.mock('../utils/formatters.js');
+vi.mock('node:process', () => ({
+  default: {
+    platform: 'test-platform',
+    version: 'v20.0.0',
+    // Keep other necessary process properties if needed by other parts of the code
+    env: process.env,
+    memoryUsage: () => ({ rss: 0 }),
+  },
+}));
 
 describe('bugCommand', () => {
   beforeEach(() => {
@@ -75,7 +84,7 @@ describe('bugCommand', () => {
     const expectedInfo = `
 * **CLI Version:** 0.1.0
 * **Git Commit:** ${GIT_COMMIT_INFO}
-* **Operating System:** ${process.platform} ${process.version}
+* **Operating System:** test-platform v20.0.0
 * **Sandbox Environment:** test
 * **Model Version:** gemini-pro
 * **Memory Usage:** 100 MB

--- a/packages/cli/src/ui/commands/bugCommand.test.ts
+++ b/packages/cli/src/ui/commands/bugCommand.test.ts
@@ -45,7 +45,7 @@ describe('bugCommand', () => {
     const expectedInfo = `
 * **CLI Version:** 0.1.0
 * **Git Commit:** ${GIT_COMMIT_INFO}
-* **Operating System:** ${process.platform} ${process.version}
+* **Operating System:** test-platform v20.0.0
 * **Sandbox Environment:** test
 * **Model Version:** gemini-pro
 * **Memory Usage:** 100 MB

--- a/packages/cli/src/ui/commands/bugCommand.ts
+++ b/packages/cli/src/ui/commands/bugCommand.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import open from 'open';
+import process from 'node:process';
+import { type CommandContext, type SlashCommand } from './types.js';
+import { MessageType } from '../types.js';
+import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
+import { formatMemoryUsage } from '../utils/formatters.js';
+import { getCliVersion } from '../../utils/version.js';
+
+export const bugCommand: SlashCommand = {
+  name: 'bug',
+  description: 'submit a bug report',
+  action: async (context: CommandContext, args?: string): Promise<void> => {
+    const bugDescription = (args || '').trim();
+    const { config } = context.services;
+
+    const osVersion = `${process.platform} ${process.version}`;
+    let sandboxEnv = 'no sandbox';
+    if (process.env.SANDBOX && process.env.SANDBOX !== 'sandbox-exec') {
+      sandboxEnv = process.env.SANDBOX.replace(/^gemini-(?:code-)?/, '');
+    } else if (process.env.SANDBOX === 'sandbox-exec') {
+      sandboxEnv = `sandbox-exec (${
+        process.env.SEATBELT_PROFILE || 'unknown'
+      })`;
+    }
+    const modelVersion = config?.getModel() || 'Unknown';
+    const cliVersion = await getCliVersion();
+    const memoryUsage = formatMemoryUsage(process.memoryUsage().rss);
+
+    const info = `
+* **CLI Version:** ${cliVersion}
+* **Git Commit:** ${GIT_COMMIT_INFO}
+* **Operating System:** ${osVersion}
+* **Sandbox Environment:** ${sandboxEnv}
+* **Model Version:** ${modelVersion}
+* **Memory Usage:** ${memoryUsage}
+`;
+
+    let bugReportUrl =
+      'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml&title={title}&info={info}';
+
+    const bugCommandSettings = config?.getBugCommand();
+    if (bugCommandSettings?.urlTemplate) {
+      bugReportUrl = bugCommandSettings.urlTemplate;
+    }
+
+    bugReportUrl = bugReportUrl
+      .replace('{title}', encodeURIComponent(bugDescription))
+      .replace('{info}', encodeURIComponent(info));
+
+    context.ui.addItem(
+      {
+        type: MessageType.INFO,
+        text: `To submit your bug report, please open the following URL in your browser:\n${bugReportUrl}`,
+      },
+      Date.now(),
+    );
+
+    try {
+      await open(bugReportUrl);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      context.ui.addItem(
+        {
+          type: MessageType.ERROR,
+          text: `Could not open URL in browser: ${errorMessage}`,
+        },
+        Date.now(),
+      );
+    }
+  },
+};

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -23,10 +23,12 @@ export const extensionsCommand: SlashCommand = {
       return;
     }
 
-    const extensionLines = activeExtensions.map(
-      (ext) => `  - \u001b[36m${ext.name} (v${ext.version})\u001b[0m`,
-    );
-    const message = `Active extensions:\n\n${extensionLines.join('\n')}\n`;
+    let message = 'Active extensions:\n\n';
+    for (const ext of activeExtensions) {
+      message += `  - \u001b[36m${ext.name} (v${ext.version})\u001b[0m\n`;
+    }
+    // Make sure to reset any ANSI formatting at the end to prevent it from affecting the terminal
+    message += '\u001b[0m';
 
     context.ui.addItem(
       {

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -23,12 +23,10 @@ export const extensionsCommand: SlashCommand = {
       return;
     }
 
-    let message = 'Active extensions:\n\n';
-    for (const ext of activeExtensions) {
-      message += `  - \u001b[36m${ext.name} (v${ext.version})\u001b[0m\n`;
-    }
-    // Make sure to reset any ANSI formatting at the end to prevent it from affecting the terminal
-    message += '\u001b[0m';
+    const extensionLines = activeExtensions.map(
+      (ext) => `  - \u001b[36m${ext.name} (v${ext.version})\u001b[0m`,
+    );
+    const message = `Active extensions:\n\n${extensionLines.join('\n')}\n`;
 
     context.ui.addItem(
       {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -21,9 +21,7 @@ import {
 } from '../types.js';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
-import { formatDuration, formatMemoryUsage } from '../utils/formatters.js';
-import { getCliVersion } from '../../utils/version.js';
+import { formatDuration } from '../utils/formatters.js';
 import { LoadedSettings } from '../../config/settings.js';
 import {
   type CommandContext,
@@ -205,69 +203,6 @@ export const useSlashCommandProcessor = (
           toggleCorgiMode();
         },
       },
-      {
-        name: 'bug',
-        description: 'submit a bug report',
-        action: async (_mainCommand, _subCommand, args) => {
-          let bugDescription = _subCommand || '';
-          if (args) {
-            bugDescription += ` ${args}`;
-          }
-          bugDescription = bugDescription.trim();
-
-          const osVersion = `${process.platform} ${process.version}`;
-          let sandboxEnv = 'no sandbox';
-          if (process.env.SANDBOX && process.env.SANDBOX !== 'sandbox-exec') {
-            sandboxEnv = process.env.SANDBOX.replace(/^gemini-(?:code-)?/, '');
-          } else if (process.env.SANDBOX === 'sandbox-exec') {
-            sandboxEnv = `sandbox-exec (${
-              process.env.SEATBELT_PROFILE || 'unknown'
-            })`;
-          }
-          const modelVersion = config?.getModel() || 'Unknown';
-          const cliVersion = await getCliVersion();
-          const memoryUsage = formatMemoryUsage(process.memoryUsage().rss);
-
-          const info = `
-*   **CLI Version:** ${cliVersion}
-*   **Git Commit:** ${GIT_COMMIT_INFO}
-*   **Operating System:** ${osVersion}
-*   **Sandbox Environment:** ${sandboxEnv}
-*   **Model Version:** ${modelVersion}
-*   **Memory Usage:** ${memoryUsage}
-`;
-
-          let bugReportUrl =
-            'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml&title={title}&info={info}';
-          const bugCommand = config?.getBugCommand();
-          if (bugCommand?.urlTemplate) {
-            bugReportUrl = bugCommand.urlTemplate;
-          }
-          bugReportUrl = bugReportUrl
-            .replace('{title}', encodeURIComponent(bugDescription))
-            .replace('{info}', encodeURIComponent(info));
-
-          addMessage({
-            type: MessageType.INFO,
-            content: `To submit your bug report, please open the following URL in your browser:\n${bugReportUrl}`,
-            timestamp: new Date(),
-          });
-          (async () => {
-            try {
-              await open(bugReportUrl);
-            } catch (error) {
-              const errorMessage =
-                error instanceof Error ? error.message : String(error);
-              addMessage({
-                type: MessageType.ERROR,
-                content: `Could not open URL in browser: ${errorMessage}`,
-                timestamp: new Date(),
-              });
-            }
-          })();
-        },
-      },
-
       {
         name: 'quit',
         altName: 'exit',

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -6,7 +6,6 @@
 
 import { useCallback, useMemo, useEffect, useState } from 'react';
 import { type PartListUnion } from '@google/genai';
-import open from 'open';
 import process from 'node:process';
 import { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { useStateAndRef } from './useStateAndRef.js';


### PR DESCRIPTION
## TLDR

Refactored the `/bug` slash command to adhere to a new architecture. Integrating it with the CommandService, and slashCommandProcessor and adding unit test

## Dive Deeper

This pr migrates the legacy slash command `/bug` to the new CommandService Architecture. The command has been refactored to a standalone module and removes it from the legacy handler in slashCommandProcessor.ts

## Reviewer Test Plan

Run `/bug`. The terminal should open the link to Gemini CLI github to create an issue.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |


<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
