### PR TITLE
updated `/quit` to use new slash command arch 

### DIFF
--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -25,6 +25,7 @@ import { compressCommand } from '../ui/commands/compressCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { editorCommand } from '../ui/commands/editorCommand.js';
 import { bugCommand } from '../ui/commands/bugCommand.js';
+import { quitCommand } from '../ui/commands/quitCommand.js';
 
 // Mock the command modules to isolate the service from the command implementations.
 vi.mock('../ui/commands/memoryCommand.js', () => ({
@@ -74,6 +75,9 @@ vi.mock('../ui/commands/editorCommand.js', () => ({
 }));
 vi.mock('../ui/commands/bugCommand.js', () => ({
   bugCommand: { name: 'bug', description: 'Mock Bug' },
+}));
+vi.mock('../ui/commands/quitCommand.js', () => ({
+  quitCommand: { name: 'quit', description: 'Mock Quit' },
 }));
 
 describe('CommandService', () => {
@@ -144,6 +148,7 @@ describe('CommandService', () => {
         const commandNames = tree.map((cmd) => cmd.name);
         expect(commandNames).toContain('ide');
         expect(commandNames).toContain('editor');
+        expect(commandNames).toContain('quit');
       });
 
       it('should overwrite any existing commands when called again', async () => {
@@ -184,6 +189,7 @@ describe('CommandService', () => {
           memoryCommand,
           privacyCommand,
           statsCommand,
+          quitCommand,
           themeCommand,
           toolsCommand,
         ]);

--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -81,7 +81,7 @@ vi.mock('../ui/commands/quitCommand.js', () => ({
 }));
 
 describe('CommandService', () => {
-  const subCommandLen = 16;
+  const subCommandLen = 17;
   let mockConfig: Mocked<Config>;
 
   beforeEach(() => {
@@ -188,8 +188,8 @@ describe('CommandService', () => {
           mcpCommand,
           memoryCommand,
           privacyCommand,
-          statsCommand,
           quitCommand,
+          statsCommand,
           themeCommand,
           toolsCommand,
         ]);

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -43,8 +43,8 @@ const loadBuiltInCommands = async (
     mcpCommand,
     memoryCommand,
     privacyCommand,
-    statsCommand,
     quitCommand,
+    statsCommand,
     themeCommand,
     toolsCommand,
   ];

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -23,6 +23,7 @@ import { toolsCommand } from '../ui/commands/toolsCommand.js';
 import { compressCommand } from '../ui/commands/compressCommand.js';
 import { ideCommand } from '../ui/commands/ideCommand.js';
 import { bugCommand } from '../ui/commands/bugCommand.js';
+import { quitCommand } from '../ui/commands/quitCommand.js';
 
 const loadBuiltInCommands = async (
   config: Config | null,
@@ -43,6 +44,7 @@ const loadBuiltInCommands = async (
     memoryCommand,
     privacyCommand,
     statsCommand,
+    quitCommand,
     themeCommand,
     toolsCommand,
   ];

--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -76,15 +76,13 @@ export const createMockCommandContext = (
         const targetValue = output[key];
 
         if (
-          sourceValue &&
-          typeof sourceValue === 'object' &&
-          !Array.isArray(sourceValue) &&
-          targetValue &&
-          typeof targetValue === 'object' &&
-          !Array.isArray(targetValue)
+          // We only want to recursivlty merge plain objects
+          Object.prototype.toString.call(sourceValue) === '[object Object]' &&
+          Object.prototype.toString.call(targetValue) === '[object Object]'
         ) {
           output[key] = merge(targetValue, sourceValue);
         } else {
+          // If not, we do a direct assignment. This preserves Date objects and others.
           output[key] = sourceValue;
         }
       }

--- a/packages/cli/src/ui/commands/quitCommand.test.ts
+++ b/packages/cli/src/ui/commands/quitCommand.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { quitCommand } from './quitCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { formatDuration } from '../utils/formatters.js';
+
+vi.mock('../utils/formatters.js');
+
+describe('quitCommand', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T01:00:00Z'));
+    vi.mocked(formatDuration).mockReturnValue('1h 0m 0s');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('returns a QuitActionReturn object with the correct messages', () => {
+    const mockContext = createMockCommandContext({
+      session: {
+        stats: {
+          sessionStartTime: new Date('2025-01-01T00:00:00Z'),
+        },
+      },
+    });
+
+    if (!quitCommand.action) throw new Error('Action is not defined');
+    const result = quitCommand.action(mockContext, 'quit');
+
+    expect(formatDuration).toHaveBeenCalledWith(3600000); // 1 hour in ms
+    expect(result).toEqual({
+      type: 'quit',
+      messages: [
+        {
+          type: 'user',
+          text: '/quit',
+          id: expect.any(Number),
+        },
+        {
+          type: 'quit',
+          duration: '1h 0m 0s',
+          id: expect.any(Number),
+        },
+      ],
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/quitCommand.ts
+++ b/packages/cli/src/ui/commands/quitCommand.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { formatDuration } from '../utils/formatters.js';
+import { type SlashCommand } from './types.js';
+
+export const quitCommand: SlashCommand = {
+  name: 'quit',
+  altName: 'exit',
+  description: 'exit the cli',
+  action: (context) => {
+    const now = Date.now();
+    const { sessionStartTime } = context.session.stats;
+    const wallDuration = now - sessionStartTime.getTime();
+
+    return {
+      type: 'quit',
+      messages: [
+        {
+          type: 'user',
+          text: `/quit`, // Keep it consistent, even if /exit was used
+          id: now - 1,
+        },
+        {
+          type: 'quit',
+          duration: formatDuration(wallDuration),
+          id: now,
+        },
+      ],
+    };
+  },
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -9,6 +9,7 @@ import { HistoryItemWithoutId } from '../types.js';
 import { Config, GitService, Logger } from '@google/gemini-cli-core';
 import { LoadedSettings } from '../../config/settings.js';
 import { UseHistoryManagerReturn } from '../hooks/useHistoryManager.js';
+import type { HistoryItem } from '../types.js';
 import { SessionStatsState } from '../contexts/SessionContext.js';
 
 // Grouped dependencies for clarity and easier mocking
@@ -56,6 +57,12 @@ export interface ToolActionReturn {
   toolArgs: Record<string, unknown>;
 }
 
+/** The return type for a command action that results in the app quitting. */
+export interface QuitActionReturn {
+  type: 'quit';
+  messages: HistoryItem[];
+}
+
 /**
  * The return type for a command action that results in a simple message
  * being displayed to the user.
@@ -87,6 +94,7 @@ export interface LoadHistoryActionReturn {
 export type SlashCommandActionReturn =
   | ToolActionReturn
   | MessageActionReturn
+  | QuitActionReturn
   | OpenDialogActionReturn
   | LoadHistoryActionReturn;
 // The standardized contract for any command in the system.

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -54,16 +54,7 @@ vi.mock('../../utils/version.js', () => ({
 }));
 
 import { act, renderHook } from '@testing-library/react';
-import {
-  vi,
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  Mock,
-} from 'vitest';
+import { vi, describe, it, expect, beforeEach, beforeAll, Mock } from 'vitest';
 import open from 'open';
 import { useSlashCommandProcessor } from './slashCommandProcessor.js';
 import { SlashCommandProcessorResult } from '../types.js';
@@ -202,8 +193,6 @@ describe('useSlashCommandProcessor', () => {
       ),
     );
   };
-
-  const getProcessor = () => getProcessorHook().result.current;
 
   describe('New command registry', () => {
     let ActualCommandService: typeof CommandService;

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -451,47 +451,4 @@ describe('useSlashCommandProcessor', () => {
       );
     });
   });
-
-  describe('/quit and /exit commands', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it.each([['/quit'], ['/exit']])(
-      'should handle %s, set quitting messages, and exit the process',
-      async (command) => {
-        const { handleSlashCommand } = getProcessor();
-        const mockDate = new Date('2025-01-01T01:02:03.000Z');
-        vi.setSystemTime(mockDate);
-
-        await act(async () => {
-          handleSlashCommand(command);
-        });
-
-        expect(mockAddItem).not.toHaveBeenCalled();
-        expect(mockSetQuittingMessages).toHaveBeenCalledWith([
-          {
-            type: 'user',
-            text: command,
-            id: expect.any(Number),
-          },
-          {
-            type: 'quit',
-            duration: '1h 2m 3s',
-            id: expect.any(Number),
-          },
-        ]);
-
-        // Fast-forward timers to trigger process.exit
-        await act(async () => {
-          vi.advanceTimersByTime(100);
-        });
-        expect(mockProcessExit).toHaveBeenCalledWith(0);
-      },
-    );
-  });
 });

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -202,33 +202,6 @@ export const useSlashCommandProcessor = (
           toggleCorgiMode();
         },
       },
-      {
-        name: 'quit',
-        altName: 'exit',
-        description: 'exit the cli',
-        action: async (mainCommand, _subCommand, _args) => {
-          const now = new Date();
-          const { sessionStartTime } = session.stats;
-          const wallDuration = now.getTime() - sessionStartTime.getTime();
-
-          setQuittingMessages([
-            {
-              type: 'user',
-              text: `/${mainCommand}`,
-              id: now.getTime() - 1,
-            },
-            {
-              type: 'quit',
-              duration: formatDuration(wallDuration),
-              id: now.getTime(),
-            },
-          ]);
-
-          setTimeout(() => {
-            process.exit(0);
-          }, 100);
-        },
-      },
     ];
 
     if (config?.getCheckpointingEnabled()) {
@@ -359,7 +332,6 @@ export const useSlashCommandProcessor = (
     session,
     gitService,
     loadHistory,
-    setQuittingMessages,
   ]);
 
   const handleSlashCommand = useCallback(
@@ -470,6 +442,12 @@ export const useSlashCommandProcessor = (
                 });
                 return { type: 'handled' };
               }
+              case 'quit':
+                setQuittingMessages(result.messages);
+                setTimeout(() => {
+                  process.exit(0);
+                }, 100);
+                return { type: 'handled' };
               default: {
                 const unhandled: never = result;
                 throw new Error(`Unhandled slash command result: ${unhandled}`);
@@ -549,6 +527,7 @@ export const useSlashCommandProcessor = (
       openThemeDialog,
       openPrivacyNotice,
       openEditorDialog,
+      setQuittingMessages,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -20,7 +20,6 @@ import {
 } from '../types.js';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { formatDuration } from '../utils/formatters.js';
 import { LoadedSettings } from '../../config/settings.js';
 import {
   type CommandContext,
@@ -325,14 +324,7 @@ export const useSlashCommandProcessor = (
       });
     }
     return commands;
-  }, [
-    addMessage,
-    toggleCorgiMode,
-    config,
-    session,
-    gitService,
-    loadHistory,
-  ]);
+  }, [addMessage, toggleCorgiMode, config, gitService, loadHistory]);
 
   const handleSlashCommand = useCallback(
     async (


### PR DESCRIPTION
## TLDR

Updated the `/quit` command to use the new slash command architecture

## Dive Deeper

This pr migrates the legacy slash command `/quit` to the new CommandService Architecture. The command has been refactored to a standalone module and removes it from the legacy handler in slashCommandProcessor.ts

## Reviewer Test Plan

Run `/quit`. The terminal should exit out of Gemini CLI

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |


<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
