### PR TITLE
migrate compress command

### DIFF
--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -16,6 +16,7 @@ import { themeCommand } from '../ui/commands/themeCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { aboutCommand } from '../ui/commands/aboutCommand.js';
+import { compressCommand } from '../ui/commands/compressCommand.js';
 import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 
 // Mock the command modules to isolate the service from the command implementations.
@@ -42,6 +43,9 @@ vi.mock('../ui/commands/statsCommand.js', () => ({
 }));
 vi.mock('../ui/commands/aboutCommand.js', () => ({
   aboutCommand: { name: 'about', description: 'Mock About' },
+}));
+vi.mock('../ui/commands/compressCommand.js', () => ({
+  compressCommand: { name: 'compress', description: 'Mock Compress' },
 }));
 vi.mock('../ui/commands/extensionsCommand.js', () => ({
   extensionsCommand: { name: 'extensions', description: 'Mock Extensions' },
@@ -85,6 +89,7 @@ describe('CommandService', () => {
         expect(commandNames).toContain('stats');
         expect(commandNames).toContain('privacy');
         expect(commandNames).toContain('about');
+        expect(commandNames).toContain('compress');
         expect(commandNames).toContain('extensions');
       });
 
@@ -116,6 +121,7 @@ describe('CommandService', () => {
           authCommand,
           chatCommand,
           clearCommand,
+          compressCommand,
           extensionsCommand,
           helpCommand,
           memoryCommand,

--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -52,7 +52,7 @@ vi.mock('../ui/commands/extensionsCommand.js', () => ({
 }));
 
 describe('CommandService', () => {
-  const subCommandLen = 10;
+  const subCommandLen = 11;
 
   describe('when using default production loader', () => {
     let commandService: CommandService;

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -14,6 +14,7 @@ import { chatCommand } from '../ui/commands/chatCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { aboutCommand } from '../ui/commands/aboutCommand.js';
+import { compressCommand } from '../ui/commands/compressCommand.js';
 import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 
 const loadBuiltInCommands = async (): Promise<SlashCommand[]> => [
@@ -21,6 +22,7 @@ const loadBuiltInCommands = async (): Promise<SlashCommand[]> => [
   authCommand,
   chatCommand,
   clearCommand,
+  compressCommand,
   extensionsCommand,
   helpCommand,
   memoryCommand,

--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -44,6 +44,8 @@ export const createMockCommandContext = (
       addItem: vi.fn(),
       clear: vi.fn(),
       setDebugMessage: vi.fn(),
+      pendingItem: null,
+      setPendingItem: vi.fn(),
     },
     session: {
       stats: {

--- a/packages/cli/src/ui/commands/compressCommand.test.ts
+++ b/packages/cli/src/ui/commands/compressCommand.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GeminiClient } from '@google/gemini-cli-core';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { compressCommand } from './compressCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { MessageType } from '../types.js';
+
+describe('compressCommand', () => {
+  let context: ReturnType<typeof createMockCommandContext>;
+  let mockTryCompressChat: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockTryCompressChat = vi.fn();
+    context = createMockCommandContext({
+      services: {
+        config: {
+          getGeminiClient: () =>
+            ({
+              tryCompressChat: mockTryCompressChat,
+            }) as unknown as GeminiClient,
+        },
+      },
+    });
+  });
+
+  it('should do nothing if a compression is already pending', async () => {
+    context.ui.pendingItem = {
+      type: MessageType.COMPRESSION,
+      compression: {
+        isPending: true,
+        originalTokenCount: null,
+        newTokenCount: null,
+      },
+    };
+    await compressCommand.action!(context, '');
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.ERROR,
+        text: 'Already compressing, wait for previous request to complete',
+      }),
+      expect.any(Number),
+    );
+    expect(context.ui.setPendingItem).not.toHaveBeenCalled();
+    expect(mockTryCompressChat).not.toHaveBeenCalled();
+  });
+
+  it('should set pending item, call tryCompressChat, and add result on success', async () => {
+    const compressedResult = {
+      originalTokenCount: 200,
+      newTokenCount: 100,
+    };
+    mockTryCompressChat.mockResolvedValue(compressedResult);
+
+    await compressCommand.action!(context, '');
+
+    expect(context.ui.setPendingItem).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        type: MessageType.COMPRESSION,
+        compression: {
+          isPending: true,
+          originalTokenCount: null,
+          newTokenCount: null,
+        },
+      }),
+    );
+
+    expect(mockTryCompressChat).toHaveBeenCalledWith('Prompt Id not set', true);
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.COMPRESSION,
+        compression: {
+          isPending: false,
+          originalTokenCount: 200,
+          newTokenCount: 100,
+        },
+      }),
+      expect.any(Number),
+    );
+
+    expect(context.ui.setPendingItem).toHaveBeenNthCalledWith(2, null);
+  });
+
+  it('should add an error message if tryCompressChat returns falsy', async () => {
+    mockTryCompressChat.mockResolvedValue(null);
+
+    await compressCommand.action!(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.ERROR,
+        text: 'Failed to compress chat history.',
+      }),
+      expect.any(Number),
+    );
+    expect(context.ui.setPendingItem).toHaveBeenCalledWith(null);
+  });
+
+  it('should add an error message if tryCompressChat throws', async () => {
+    const error = new Error('Compression failed');
+    mockTryCompressChat.mockRejectedValue(error);
+
+    await compressCommand.action!(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.ERROR,
+        text: `Failed to compress chat history: ${error.message}`,
+      }),
+      expect.any(Number),
+    );
+    expect(context.ui.setPendingItem).toHaveBeenCalledWith(null);
+  });
+
+  it('should clear the pending item in a finally block', async () => {
+    mockTryCompressChat.mockRejectedValue(new Error('some error'));
+    await compressCommand.action!(context, '');
+    expect(context.ui.setPendingItem).toHaveBeenCalledWith(null);
+  });
+});

--- a/packages/cli/src/ui/commands/compressCommand.test.ts
+++ b/packages/cli/src/ui/commands/compressCommand.test.ts
@@ -70,7 +70,10 @@ describe('compressCommand', () => {
       }),
     );
 
-    expect(mockTryCompressChat).toHaveBeenCalledWith('Prompt Id not set', true);
+    expect(mockTryCompressChat).toHaveBeenCalledWith(
+      expect.stringMatching(/^compress-\d+$/),
+      true,
+    );
 
     expect(context.ui.addItem).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/cli/src/ui/commands/compressCommand.ts
+++ b/packages/cli/src/ui/commands/compressCommand.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { HistoryItemCompression, MessageType } from '../types.js';
+import { SlashCommand } from './types.js';
+
+export const compressCommand: SlashCommand = {
+  name: 'compress',
+  altName: 'summarize',
+  description: 'Compresses the context by replacing it with a summary.',
+  action: async (context) => {
+    const { ui } = context;
+    if (ui.pendingItem) {
+      ui.addItem(
+        {
+          type: MessageType.ERROR,
+          text: 'Already compressing, wait for previous request to complete',
+        },
+        Date.now(),
+      );
+      return;
+    }
+
+    const pendingMessage: HistoryItemCompression = {
+      type: MessageType.COMPRESSION,
+      compression: {
+        isPending: true,
+        originalTokenCount: null,
+        newTokenCount: null,
+      },
+    };
+
+    try {
+      ui.setPendingItem(pendingMessage);
+      const compressed = await context.services.config
+        ?.getGeminiClient()
+        ?.tryCompressChat('Prompt Id not set', true);
+      if (compressed) {
+        ui.addItem(
+          {
+            type: MessageType.COMPRESSION,
+            compression: {
+              isPending: false,
+              originalTokenCount: compressed.originalTokenCount,
+              newTokenCount: compressed.newTokenCount,
+            },
+          } as HistoryItemCompression,
+          Date.now(),
+        );
+      } else {
+        ui.addItem(
+          {
+            type: MessageType.ERROR,
+            text: 'Failed to compress chat history.',
+          },
+          Date.now(),
+        );
+      }
+    } catch (e) {
+      ui.addItem(
+        {
+          type: MessageType.ERROR,
+          text: `Failed to compress chat history: ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+        },
+        Date.now(),
+      );
+    } finally {
+      ui.setPendingItem(null);
+    }
+  },
+};

--- a/packages/cli/src/ui/commands/compressCommand.ts
+++ b/packages/cli/src/ui/commands/compressCommand.ts
@@ -35,9 +35,10 @@ export const compressCommand: SlashCommand = {
 
     try {
       ui.setPendingItem(pendingMessage);
+      const promptId = `compress-${Date.now()}`;
       const compressed = await context.services.config
         ?.getGeminiClient()
-        ?.tryCompressChat('Prompt Id not set', true);
+        ?.tryCompressChat(promptId, true);
       if (compressed) {
         ui.addItem(
           {

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -10,7 +10,6 @@ import { Config, GitService, Logger } from '@google/gemini-cli-core';
 import { LoadedSettings } from '../../config/settings.js';
 import { UseHistoryManagerReturn } from '../hooks/useHistoryManager.js';
 import { SessionStatsState } from '../contexts/SessionContext.js';
-import { HistoryItemWithoutId } from '../types.js';
 
 // Grouped dependencies for clarity and easier mocking
 export interface CommandContext {

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -23,11 +23,6 @@ export interface CommandContext {
   };
   // UI state and history management
   ui: {
-    // TODO - As more commands are add some additions may be needed or reworked using this new context.
-    // Ex.
-    // history: HistoryItem[];
-    // pendingHistoryItems: HistoryItemWithoutId[];
-
     /** Adds a new item to the history display. */
     addItem: UseHistoryManagerReturn['addItem'];
     /** Clears all history items and the console screen. */
@@ -43,7 +38,6 @@ export interface CommandContext {
      * that a long-running operation is in progress.
      *
      * @param item The history item to display as pending, or `null` to clear.
-     * @throws If a pending item is already set.
      */
     setPendingItem: (item: HistoryItemWithoutId | null) => void;
   };

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -10,6 +10,7 @@ import { Config, GitService, Logger } from '@google/gemini-cli-core';
 import { LoadedSettings } from '../../config/settings.js';
 import { UseHistoryManagerReturn } from '../hooks/useHistoryManager.js';
 import { SessionStatsState } from '../contexts/SessionContext.js';
+import { HistoryItemWithoutId } from '../types.js';
 
 // Grouped dependencies for clarity and easier mocking
 export interface CommandContext {
@@ -36,6 +37,16 @@ export interface CommandContext {
      * Sets the transient debug message displayed in the application footer in debug mode.
      */
     setDebugMessage: (message: string) => void;
+    /** The currently pending history item, if any. */
+    pendingItem: HistoryItemWithoutId | null;
+    /**
+     * Sets a pending item in the history, which is useful for indicating
+     * that a long-running operation is in progress.
+     *
+     * @param item The history item to display as pending, or `null` to clear.
+     * @throws If a pending item is already set.
+     */
+    setPendingItem: (item: HistoryItemWithoutId | null) => void;
   };
   // Session-specific data
   session: {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -1204,38 +1204,4 @@ describe('useSlashCommandProcessor', () => {
       expect(commandResult).toEqual({ type: 'handled' });
     });
   });
-
-  describe('/compress command', () => {
-    it('should call tryCompressChat(true)', async () => {
-      const hook = getProcessorHook();
-      mockTryCompressChat.mockResolvedValue({
-        originalTokenCount: 100,
-        newTokenCount: 50,
-      });
-
-      await act(async () => {
-        hook.result.current.handleSlashCommand('/compress');
-      });
-      await act(async () => {
-        hook.rerender();
-      });
-      expect(hook.result.current.pendingHistoryItems).toEqual([]);
-      expect(mockGeminiClient.tryCompressChat).toHaveBeenCalledWith(
-        'Prompt Id not set',
-        true,
-      );
-      expect(mockAddItem).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          type: MessageType.COMPRESSION,
-          compression: {
-            isPending: false,
-            originalTokenCount: 100,
-            newTokenCount: 50,
-          },
-        }),
-        expect.any(Number),
-      );
-    });
-  });
 });


### PR DESCRIPTION
## TLDR

This PR migrates the `/compress` slash command from the legacy `slashCommandProcessor.ts` to a modern, standalone command file. This change improves modularity, maintainability, and testability by isolating the command's logic and dependencies.

## Dive Deeper

The migration follows the established plan for moving commands to the new architecture. The core changes include:

- **`packages/cli/src/ui/commands/compressCommand.ts`**: A new file containing the logic for the `/compress` command. It uses the `CommandContext` to interact with the UI and other services.
- **`packages/cli/src/ui/commands/compressCommand.test.ts`**: New tests for the `compress` command, ensuring its functionality is covered.
- **`packages/cli/src/services/CommandService.ts`**: The new command is registered in the `CommandService`.
- **`packages/cli/src/services/CommandService.test.ts`**: The `CommandService` tests are updated to include the new command.
- **`packages/cli/src/ui/hooks/slashCommandProcessor.ts`**: The legacy `/compress` command logic has been removed.
- **`packages/cli/src/ui/hooks/slashCommandProcessor.test.ts`**: The legacy tests for the `/compress` command have been removed.
- **`packages/cli/src/ui/commands/types.ts`**: The `CommandContext` has been updated to include `pendingItem` and `setPendingItem` to allow commands to manage their own pending states.

## Reviewer Test Plan

To test this change, you can run the following:

1.  Start the CLI: `npm start`
2.  Run the `/compress` command. You should see a pending message, and then a success or error message.
3.  Run the tests: `npm run test -w packages/cli packages/cli/src/ui/commands/compressCommand.test.ts`
4.  Run the preflight check: `npm run preflight`


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |
