### PR TITLE
fix: /help ux remove flickering

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -693,6 +693,32 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   // Arbitrary threshold to ensure that items in the static area are large
   // enough but not too large to make the terminal hard to use.
   const staticAreaMaxItemHeight = Math.max(terminalHeight * 4, 100);
+
+  const staticItems = [
+    <Box flexDirection="column" key="header">
+      {!settings.merged.hideBanner && <Header terminalWidth={terminalWidth} version={version} nightly={nightly} />}
+      {!settings.merged.hideTips && <Tips config={config} />}
+    </Box>,
+    ...history.map((h) => (
+      <HistoryItemDisplay
+        terminalWidth={mainAreaWidth}
+        availableTerminalHeight={staticAreaMaxItemHeight}
+        key={h.id}
+        item={h}
+        isPending={false}
+        config={config}
+      />
+    )),
+  ]
+
+  // Only add help to static items when it should be shown
+  if (showHelp) {
+    staticItems.push(
+      <Box key="help">
+        <Help commands={slashCommands} />
+      </Box>,
+    )
+  }
   return (
     <StreamingContext.Provider value={streamingState}>
       <Box flexDirection="column" marginBottom={1} width="90%">
@@ -712,28 +738,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
          */}
         <Static
           key={staticKey}
-          items={[
-            <Box flexDirection="column" key="header">
-              {!settings.merged.hideBanner && (
-                <Header
-                  terminalWidth={terminalWidth}
-                  version={version}
-                  nightly={nightly}
-                />
-              )}
-              {!settings.merged.hideTips && <Tips config={config} />}
-            </Box>,
-            ...history.map((h) => (
-              <HistoryItemDisplay
-                terminalWidth={mainAreaWidth}
-                availableTerminalHeight={staticAreaMaxItemHeight}
-                key={h.id}
-                item={h}
-                isPending={false}
-                config={config}
-              />
-            )),
-          ]}
+          items={staticItems}
         >
           {(item) => item}
         </Static>
@@ -758,7 +763,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
           </Box>
         </OverflowProvider>
 
-        {showHelp && <Help commands={slashCommands} />}
+
 
         <Box flexDirection="column" ref={mainControlsRef}>
           {startupWarnings.length > 0 && (


### PR DESCRIPTION
## TLDR


Rendering the `/help` UI outside of Static causes flickering
This is because in most cases `/help` renders a UI component that exceeds Ink's internal calculation of terminal height

When items outside of static exceed Ink's calculation of terminal height, it triggers an entire re render of the terminal on every key press.

This solution is to render these components inside Static.

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

For components rendered outside of Static in Ink:
From Ink:
```
174		if (outputHeight >= this.options.stdout.rows) {
			this.options.stdout.write(
				ansiEscapes.clearTerminal + this.fullStaticOutput + output,
			);
			this.lastOutput = output;
			return;
		}
```
`outputHeight` represents only the dynamic (non-static) content,

reference: https://github.com/vadimdemedes/ink
https://github.com/vadimdemedes/ink/blob/a31d76d0/src/ink.tsx

If the `outputHeight ` (the height of the rendered content) is greater than or equal to `this.options.stdout.rows` (the number of rows in the terminal), Ink will clear the entire terminal using `ansiEscapes.clearTerminal` before writing the new output. ink.tsx:173-176 

This full clear and redraw is what causes the visible flickering, especially for larger components like Help that occupy a significant portion of the terminal height. 

A better solution might be to use MaxSizedBox which would require changes depending on the desired UX

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

1. Run the current release of gemini cli in a normal sized terminal
2. type /help
3. notice every keypress causes flickering
4. Pull this code
5. Build and run it
6. type /help
7. determine if the flickering is gone for you too


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ✅  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

