### PR TITLE
Minor UX updates for IDE mode

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -955,7 +955,62 @@ describe('loadCliConfig ideMode', () => {
     await expect(
       loadCliConfig(settings, [], 'test-session', argv),
     ).rejects.toThrow(
-      "Could not run in ide mode, make sure you're running in vs code integrated terminal. Try running in a fresh terminal.",
+      'Could not connect to IDE. Make sure you have the companion VS Code extension installed from the marketplace or via /ide install.',
     );
+  });
+
+  it('should warn and overwrite if settings contain the reserved _ide_server name and ideMode is active', async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    process.argv = ['node', 'script.js', '--ide-mode'];
+    const argv = await parseArguments();
+    process.env.TERM_PROGRAM = 'vscode';
+    process.env.GEMINI_CLI_IDE_SERVER_PORT = '3000';
+    const settings: Settings = {
+      mcpServers: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        _ide_server: { url: 'http://malicious:1234' } as any,
+      },
+    };
+
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[WARN]',
+      'Ignoring user-defined MCP server config for "_ide_server" as it is a reserved name.',
+    );
+
+    const mcpServers = config.getMcpServers();
+    expect(mcpServers['_ide_server']).toBeDefined();
+    expect(mcpServers['_ide_server'].httpUrl).toBe('http://localhost:3000/mcp');
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should NOT warn if settings contain the reserved _ide_server name and ideMode is NOT active', async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      mcpServers: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        _ide_server: { url: 'http://malicious:1234' } as any,
+      },
+    };
+
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    const mcpServers = config.getMcpServers();
+    expect(mcpServers['_ide_server']).toBeDefined();
+    expect(mcpServers['_ide_server'].url).toBe('http://malicious:1234');
+
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -970,8 +970,13 @@ describe('loadCliConfig ideMode', () => {
     process.env.GEMINI_CLI_IDE_SERVER_PORT = '3000';
     const settings: Settings = {
       mcpServers: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        _ide_server: { url: 'http://malicious:1234' } as any,
+        _ide_server: new ServerConfig.MCPServerConfig(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'http://malicious:1234'
+        ),
       },
     };
 
@@ -998,8 +1003,13 @@ describe('loadCliConfig ideMode', () => {
     const argv = await parseArguments();
     const settings: Settings = {
       mcpServers: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        _ide_server: { url: 'http://malicious:1234' } as any,
+        _ide_server: new ServerConfig.MCPServerConfig(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'http://malicious:1234'
+        ),
       },
     };
 

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -975,7 +975,7 @@ describe('loadCliConfig ideMode', () => {
           undefined,
           undefined,
           undefined,
-          'http://malicious:1234'
+          'http://malicious:1234',
         ),
       },
     };
@@ -1008,7 +1008,7 @@ describe('loadCliConfig ideMode', () => {
           undefined,
           undefined,
           undefined,
-          'http://malicious:1234'
+          'http://malicious:1234',
         ),
       },
     };

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -306,10 +306,15 @@ export async function loadCliConfig(
   }
 
   if (ideMode) {
+    if (mcpServers[IDE_SERVER_NAME]) {
+      logger.warn(
+        `Ignoring user-defined MCP server config for "${IDE_SERVER_NAME}" as it is a reserved name.`,
+      );
+    }
     const companionPort = process.env.GEMINI_CLI_IDE_SERVER_PORT;
     if (!companionPort) {
       throw new Error(
-        "Could not connect to IDE. Make sure you have the companion VS Code extension installed from the marketplace or via /ide install.",
+        'Could not connect to IDE. Make sure you have the companion VS Code extension installed from the marketplace or via /ide install.',
       );
     }
     const httpUrl = `http://localhost:${companionPort}/mcp`;

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -309,7 +309,7 @@ export async function loadCliConfig(
     const companionPort = process.env.GEMINI_CLI_IDE_SERVER_PORT;
     if (!companionPort) {
       throw new Error(
-        "Could not run in ide mode, make sure you're running in vs code integrated terminal. Try running in a fresh terminal.",
+        "Could not connect to IDE. Make sure you have the companion VS Code extension installed from the marketplace or via /ide install.",
       );
     }
     const httpUrl = `http://localhost:${companionPort}/mcp`;

--- a/packages/core/src/services/ideContext.test.ts
+++ b/packages/core/src/services/ideContext.test.ts
@@ -122,4 +122,19 @@ describe('ideContext - Active File', () => {
     const activeFile = ideContext.getActiveFileContext();
     expect(activeFile).toEqual(testFile);
   });
+
+  it('should clear the active file context', () => {
+    const testFile = {
+      filePath: '/path/to/test/file.ts',
+      cursor: { line: 5, character: 10 },
+    };
+
+    ideContext.setActiveFileContext(testFile);
+
+    expect(ideContext.getActiveFileContext()).toEqual(testFile);
+
+    ideContext.clearActiveFileContext();
+
+    expect(ideContext.getActiveFileContext()).toBeUndefined();
+  });
 });

--- a/packages/core/src/services/ideContext.ts
+++ b/packages/core/src/services/ideContext.ts
@@ -69,6 +69,14 @@ export function createIdeContextStore() {
   }
 
   /**
+   * Clears the active file context and notifies all registered subscribers of the change.
+   */
+  function clearActiveFileContext(): void {
+    activeFileContext = undefined;
+    notifySubscribers();
+  }
+
+  /**
    * Retrieves the current active file context.
    * @returns The `ActiveFile` object if a file is active, otherwise `undefined`.
    */
@@ -96,6 +104,7 @@ export function createIdeContextStore() {
     setActiveFileContext,
     getActiveFileContext,
     subscribeToActiveFile,
+    clearActiveFileContext,
   };
 }
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -293,7 +293,7 @@ export async function discoverTools(
         ),
       );
     }
-    if (discoveredTools.length === 0 && mcpServerName !== IDE_SERVER_NAME) {
+    if (discoveredTools.length === 0) {
       throw Error('No enabled tools found');
     }
     return discoveredTools;

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -214,6 +214,9 @@ export async function connectAndDiscover(
       mcpClient.onerror = (error) => {
         console.error(`MCP ERROR (${mcpServerName}):`, error.toString());
         updateMCPServerStatus(mcpServerName, MCPServerStatus.DISCONNECTED);
+        if (mcpServerName === IDE_SERVER_NAME) {
+          ideContext.clearActiveFileContext();
+        }
       };
 
       if (mcpServerName === IDE_SERVER_NAME) {
@@ -290,7 +293,7 @@ export async function discoverTools(
         ),
       );
     }
-    if (discoveredTools.length === 0) {
+    if (discoveredTools.length === 0 && mcpServerName !== IDE_SERVER_NAME) {
       throw Error('No enabled tools found');
     }
     return discoveredTools;

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -149,5 +149,44 @@ const createMcpServer = () => {
     },
     { capabilities: { logging: {} } },
   );
+  server.registerTool(
+    'getActiveFile',
+    {
+      description:
+        '(IDE Tool) Get the path of the file currently active in VS Code.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const activeEditor = vscode.window.activeTextEditor;
+        const filePath = activeEditor ? activeEditor.document.uri.fsPath : '';
+        if (filePath) {
+          return {
+            content: [{ type: 'text', text: `Active file: ${filePath}` }],
+          };
+        } else {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'No file is currently active in the editor.',
+              },
+            ],
+          };
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to get active file: ${
+                (error as Error).message || 'Unknown error'
+              }`,
+            },
+          ],
+        };
+      }
+    },
+  );
   return server;
 };

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -149,44 +149,5 @@ const createMcpServer = () => {
     },
     { capabilities: { logging: {} } },
   );
-  server.registerTool(
-    'getActiveFile',
-    {
-      description:
-        '(IDE Tool) Get the path of the file currently active in VS Code.',
-      inputSchema: {},
-    },
-    async () => {
-      try {
-        const activeEditor = vscode.window.activeTextEditor;
-        const filePath = activeEditor ? activeEditor.document.uri.fsPath : '';
-        if (filePath) {
-          return {
-            content: [{ type: 'text', text: `Active file: ${filePath}` }],
-          };
-        } else {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: 'No file is currently active in the editor.',
-              },
-            ],
-          };
-        }
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to get active file: ${
-                (error as Error).message || 'Unknown error'
-              }`,
-            },
-          ],
-        };
-      }
-    },
-  );
   return server;
 };


### PR DESCRIPTION
## TLDR
Minor UX updates for IDE mode (all flag-guarded by --ide-mode / ideMode setting)

## Dive Deeper
* Clears the active file context if the IDE server disconnects
* Logs a warning if the user defines a MCP server with the same name as the IDE server
* Updates the error message to indicate requirement of having companion extension installed

## Linked issues / bugs
This PR improves #3905 
