### PR TITLE
Report MCP servers that are ignored

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -298,7 +298,13 @@ export async function loadCliConfig(
     const allowedNames = new Set(argv.allowedMcpServerNames.filter(Boolean));
     if (allowedNames.size > 0) {
       mcpServers = Object.fromEntries(
-        Object.entries(mcpServers).filter(([key]) => allowedNames.has(key)),
+        Object.entries(mcpServers).filter(([key]) => {
+          if (allowedNames.has(key)) {
+            return true;
+          }
+          logger.warn(`Ignoring non-allowed MCP server: ${key}`);
+          return false;
+        }),
       );
     } else {
       mcpServers = {};


### PR DESCRIPTION
## TLDR

Currently MCP servers that are rejected due to not being listed in --allowed-mcp-server-name are silently dropped leading to some confusion when the servers aren't invoked while using the tool.

This change prints a warning when a configured MCP server isn't listed in the allowed serv names.


## Reviewer Test Plan

Add an MCP server named "test_server" to settings.json. Run with --allowed-mcp-server-names="foo", look for warning about test_server not being loaded.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A