### PR TITLE
MCP OAuth Part 3 - CLI/UI/Documentation

### DIFF
--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -265,6 +265,7 @@ const getMcpStatus = async (
 const authCommand: SlashCommand = {
   name: 'auth',
   description: 'Authenticate with an OAuth-enabled MCP server',
+  kind: CommandKind.BUILT_IN,
   action: async (
     context: CommandContext,
     args: string,
@@ -394,6 +395,7 @@ const authCommand: SlashCommand = {
 const listCommand: SlashCommand = {
   name: 'list',
   description: 'List configured MCP servers and tools',
+  kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext, args: string) => {
     const lowerCaseArgs = args.toLowerCase().split(/\s+/).filter(Boolean);
 
@@ -419,6 +421,7 @@ export const mcpCommand: SlashCommand = {
   name: 'mcp',
   description:
     'list configured MCP servers and tools, or authenticate with OAuth-enabled servers',
+  kind: CommandKind.BUILT_IN,
   subCommands: [listCommand, authCommand],
   // Default action when no subcommand is provided
   action: async (context: CommandContext, args: string) =>

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -9,6 +9,7 @@ import {
   SlashCommandActionReturn,
   CommandContext,
   CommandKind,
+  MessageActionReturn,
 } from './types.js';
 import {
   DiscoveredMCPTool,
@@ -16,12 +17,16 @@ import {
   getMCPServerStatus,
   MCPDiscoveryState,
   MCPServerStatus,
+  mcpServerRequiresOAuth,
+  getErrorMessage,
 } from '@google/gemini-cli-core';
 import open from 'open';
 
 const COLOR_GREEN = '\u001b[32m';
 const COLOR_YELLOW = '\u001b[33m';
+const COLOR_RED = '\u001b[31m';
 const COLOR_CYAN = '\u001b[36m';
+const COLOR_GREY = '\u001b[90m';
 const RESET_COLOR = '\u001b[0m';
 
 const getMcpStatus = async (
@@ -128,6 +133,31 @@ const getMcpStatus = async (
     // Format server header with bold formatting and status
     message += `${statusIndicator} \u001b[1m${serverDisplayName}\u001b[0m - ${statusText}`;
 
+    let needsAuthHint = mcpServerRequiresOAuth.get(serverName) || false;
+    // Add OAuth status if applicable
+    if (server?.oauth?.enabled) {
+      needsAuthHint = true;
+      try {
+        const { MCPOAuthTokenStorage } = await import(
+          '@google/gemini-cli-core'
+        );
+        const hasToken = await MCPOAuthTokenStorage.getToken(serverName);
+        if (hasToken) {
+          const isExpired = MCPOAuthTokenStorage.isTokenExpired(hasToken.token);
+          if (isExpired) {
+            message += ` ${COLOR_YELLOW}(OAuth token expired)${RESET_COLOR}`;
+          } else {
+            message += ` ${COLOR_GREEN}(OAuth authenticated)${RESET_COLOR}`;
+            needsAuthHint = false;
+          }
+        } else {
+          message += ` ${COLOR_RED}(OAuth not authenticated)${RESET_COLOR}`;
+        }
+      } catch (_err) {
+        // If we can't check OAuth status, just continue
+      }
+    }
+
     // Add tool count with conditional messaging
     if (status === MCPServerStatus.CONNECTED) {
       message += ` (${serverTools.length} tools)`;
@@ -193,7 +223,11 @@ const getMcpStatus = async (
         }
       });
     } else {
-      message += '  No tools available\n';
+      message += '  No tools available';
+      if (status === MCPServerStatus.DISCONNECTED && needsAuthHint) {
+        message += ` ${COLOR_GREY}(type: "/mcp auth ${serverName}" to authenticate this server)${RESET_COLOR}`;
+      }
+      message += '\n';
     }
     message += '\n';
   }
@@ -213,6 +247,7 @@ const getMcpStatus = async (
     message += `  • Use ${COLOR_CYAN}/mcp desc${RESET_COLOR} to show server and tool descriptions\n`;
     message += `  • Use ${COLOR_CYAN}/mcp schema${RESET_COLOR} to show tool parameter schemas\n`;
     message += `  • Use ${COLOR_CYAN}/mcp nodesc${RESET_COLOR} to hide descriptions\n`;
+    message += `  • Use ${COLOR_CYAN}/mcp auth <server-name>${RESET_COLOR} to authenticate with OAuth-enabled servers\n`;
     message += `  • Press ${COLOR_CYAN}Ctrl+T${RESET_COLOR} to toggle tool descriptions on/off\n`;
     message += '\n';
   }
@@ -227,10 +262,138 @@ const getMcpStatus = async (
   };
 };
 
-export const mcpCommand: SlashCommand = {
-  name: 'mcp',
-  description: 'list configured MCP servers and tools',
-  kind: CommandKind.BUILT_IN,
+const authCommand: SlashCommand = {
+  name: 'auth',
+  description: 'Authenticate with an OAuth-enabled MCP server',
+  action: async (
+    context: CommandContext,
+    args: string,
+  ): Promise<MessageActionReturn> => {
+    const serverName = args.trim();
+    const { config } = context.services;
+
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Config not loaded.',
+      };
+    }
+
+    const mcpServers = config.getMcpServers() || {};
+
+    if (!serverName) {
+      // List servers that support OAuth
+      const oauthServers = Object.entries(mcpServers)
+        .filter(([_, server]) => server.oauth?.enabled)
+        .map(([name, _]) => name);
+
+      if (oauthServers.length === 0) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: 'No MCP servers configured with OAuth authentication.',
+        };
+      }
+
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `MCP servers with OAuth authentication:\n${oauthServers.map((s) => `  - ${s}`).join('\n')}\n\nUse /mcp auth <server-name> to authenticate.`,
+      };
+    }
+
+    const server = mcpServers[serverName];
+    if (!server) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `MCP server '${serverName}' not found.`,
+      };
+    }
+
+    // Always attempt OAuth authentication, even if not explicitly configured
+    // The authentication process will discover OAuth requirements automatically
+
+    try {
+      context.ui.addItem(
+        {
+          type: 'info',
+          text: `Starting OAuth authentication for MCP server '${serverName}'...`,
+        },
+        Date.now(),
+      );
+
+      // Import dynamically to avoid circular dependencies
+      const { MCPOAuthProvider } = await import('@google/gemini-cli-core');
+
+      // Create OAuth config for authentication (will be discovered automatically)
+      const oauthConfig = server.oauth || {
+        authorizationUrl: '', // Will be discovered automatically
+        tokenUrl: '', // Will be discovered automatically
+      };
+
+      // Pass the MCP server URL for OAuth discovery
+      const mcpServerUrl = server.httpUrl || server.url;
+      await MCPOAuthProvider.authenticate(
+        serverName,
+        oauthConfig,
+        mcpServerUrl,
+      );
+
+      context.ui.addItem(
+        {
+          type: 'info',
+          text: `✅ Successfully authenticated with MCP server '${serverName}'!`,
+        },
+        Date.now(),
+      );
+
+      // Trigger tool re-discovery to pick up authenticated server
+      const toolRegistry = await config.getToolRegistry();
+      if (toolRegistry) {
+        context.ui.addItem(
+          {
+            type: 'info',
+            text: `Re-discovering tools from '${serverName}'...`,
+          },
+          Date.now(),
+        );
+        await toolRegistry.discoverToolsForServer(serverName);
+      }
+      // Update the client with the new tools
+      const geminiClient = config.getGeminiClient();
+      if (geminiClient) {
+        await geminiClient.setTools();
+      }
+
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `Successfully authenticated and refreshed tools for '${serverName}'.`,
+      };
+    } catch (error) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Failed to authenticate with MCP server '${serverName}': ${getErrorMessage(error)}`,
+      };
+    }
+  },
+  completion: async (context: CommandContext, partialArg: string) => {
+    const { config } = context.services;
+    if (!config) return [];
+
+    const mcpServers = config.getMcpServers() || {};
+    return Object.keys(mcpServers).filter((name) =>
+      name.startsWith(partialArg),
+    );
+  },
+};
+
+const listCommand: SlashCommand = {
+  name: 'list',
+  description: 'List configured MCP servers and tools',
   action: async (context: CommandContext, args: string) => {
     const lowerCaseArgs = args.toLowerCase().split(/\s+/).filter(Boolean);
 
@@ -250,4 +413,15 @@ export const mcpCommand: SlashCommand = {
 
     return getMcpStatus(context, showDescriptions, showSchema, showTips);
   },
+};
+
+export const mcpCommand: SlashCommand = {
+  name: 'mcp',
+  description:
+    'list configured MCP servers and tools, or authenticate with OAuth-enabled servers',
+  subCommands: [listCommand, authCommand],
+  // Default action when no subcommand is provided
+  action: async (context: CommandContext, args: string) =>
+    // If no subcommand, run the list command
+    listCommand.action!(context, args),
 };


### PR DESCRIPTION
## Summary

This is Part 3 of a 3-part series to implement OAuth support for MCP servers. This PR adds the user-facing CLI commands and comprehensive documentation to complete the OAuth feature.

**PR Series Overview:**
- **Part 1**: OAuth Infrastructure - Core OAuth implementation - PR #4316
- **Part 2**: MCP Client Integration - Integration with MCP client and tool registry - PR #4318
- **Part 3 - This PR**: CLI/UI/Documentation - User interface and documentation updates

## What is Included

This PR completes the OAuth implementation with user-facing features:

- **CLI Command - /mcp auth**:
  - Lists OAuth-enabled servers when no argument provided
  - Authenticates with a specific server when server name provided
  - Displays clear success/error messages
  - Automatically refreshes tools after authentication
  - Supports tab completion for server names

- **UI Enhancements**:
  - OAuth status indicators in /mcp command output
  - Shows authentication status next to server names
  - Displays token expiration status
  - Provides authentication hints for disconnected servers
  - Updates tips section to include OAuth command

- **Comprehensive Documentation**:
  - OAuth support section in mcp-server.md
  - Automatic OAuth discovery explanation
  - Browser redirect requirements and limitations
  - Token management and storage details
  - Configuration examples and properties

## User Experience

### OAuth Authentication Flow

1. User runs `/mcp` and sees servers with OAuth status
2. User runs `/mcp auth serverName` to authenticate
3. Browser opens for authentication
4. Success message confirms authentication
5. Tools are automatically refreshed and available

### Status Indicators

The `/mcp` command now shows OAuth status:
- 🟢 Green: OAuth authenticated and valid
- 🟡 Yellow: OAuth token expired
- 🔴 Red: OAuth not authenticated
- Grey hint: Authentication suggestion for disconnected servers

### Managing Authentication

Users can:
- View OAuth-enabled servers: `/mcp auth`
- Authenticate with a server: `/mcp auth serverName`
- Re-authenticate expired tokens: `/mcp auth serverName`
- See authentication status: `/mcp`

## Testing

All tests pass with new OAuth UI features:
- /mcp auth command tests cover all scenarios
- OAuth status display tests verify indicators
- Tab completion tests ensure server name completion
- Error handling tests for edge cases

## Dependencies

This PR depends on:
- Part 1 - PR #4316: OAuth Infrastructure
- Part 2 - PR #4318: MCP Client Integration

## Documentation Highlights

The documentation includes:
- Clear explanation of OAuth support
- Browser requirements and limitations
- Automatic discovery process
- Token management details
- Configuration examples
- Troubleshooting guidance

## Test Plan

- [x] All unit tests pass
- [x] Code formatting and linting pass
- [x] /mcp auth command tested
- [x] OAuth status indicators verified
- [x] Documentation reviewed
- [x] End-to-end OAuth flow with real servers
- [ ] User acceptance testing

This completes the OAuth feature implementation, providing a seamless authentication experience for MCP servers.