### PR TITLE
Fix resetting loop counts on every other event

### DIFF
--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -97,6 +97,27 @@ describe('LoopDetectionService', () => {
         expect(service.addAndCheck(event3)).toBe(false);
       }
     });
+
+    it('should not reset tool call counter for other event types', () => {
+      const toolCallEvent = createToolCallRequestEvent('testTool', {
+        param: 'value',
+      });
+      const otherEvent = {
+        type: 'thought',
+      } as unknown as ServerGeminiStreamEvent;
+
+      // Send events just below the threshold
+      for (let i = 0; i < TOOL_CALL_LOOP_THRESHOLD - 1; i++) {
+        expect(service.addAndCheck(toolCallEvent)).toBe(false);
+      }
+
+      // Send a different event type
+      expect(service.addAndCheck(otherEvent)).toBe(false);
+
+      // Send the tool call event again, which should now trigger the loop
+      expect(service.addAndCheck(toolCallEvent)).toBe(true);
+      expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Content Loop Detection', () => {

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -54,7 +54,6 @@ export class LoopDetectionService {
       case GeminiEventType.Content:
         return this.checkContentLoop(event.value);
       default:
-        this.reset();
         return false;
     }
   }


### PR DESCRIPTION
## TLDR

Do not reset on events other than ToolCallRequest and Content, with this line even Thought reset counts.

## Dive Deeper

Added by mistake. Reset all should only be called when the user starts a new prompt.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |