### PR TITLE
Logging surface field in the start_session_event. Also logging sessio…

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -276,7 +276,6 @@ export class ClearcutLogger {
         value: surface,
       },
     ];
-console.log('################################# data ##################', data);
 
     // Flush start event immediately
     this.enqueueLogEvent(this.createLogEvent(start_session_event_name, data));
@@ -304,7 +303,6 @@ console.log('################################# data ##################', data);
         value: JSON.stringify(event.auth_type),
       },
     ];
-console.log('################################# data ##################', data);
 
     this.enqueueLogEvent(this.createLogEvent(new_prompt_event_name, data));
     this.flushIfNeeded();

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -205,7 +205,7 @@ export class ClearcutLogger {
   }
 
   logStartSessionEvent(event: StartSessionEvent): void {
-    const surface = process.env.SURFACE || undefined;
+    const surface = process.env.SURFACE || 'SURFACE_NOT_SET';
     const data = [
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_START_SESSION_MODEL,
@@ -213,7 +213,7 @@ export class ClearcutLogger {
       },
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
-        value: this.config?.getSessionId(),
+        value: this.config?.getSessionId() ?? '',
       },
       {
         gemini_cli_key:
@@ -276,6 +276,8 @@ export class ClearcutLogger {
         value: surface,
       },
     ];
+console.log('################################# data ##################', data);
+
     // Flush start event immediately
     this.enqueueLogEvent(this.createLogEvent(start_session_event_name, data));
     this.flushToClearcut().catch((error) => {
@@ -291,7 +293,7 @@ export class ClearcutLogger {
       },
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
-        value: this.config?.getSessionId(),
+        value: this.config?.getSessionId() ?? '',
       },
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_PROMPT_ID,
@@ -302,6 +304,7 @@ export class ClearcutLogger {
         value: JSON.stringify(event.auth_type),
       },
     ];
+console.log('################################# data ##################', data);
 
     this.enqueueLogEvent(this.createLogEvent(new_prompt_event_name, data));
     this.flushIfNeeded();
@@ -457,7 +460,7 @@ export class ClearcutLogger {
       },
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
-        value: this.config?.getSessionId(),
+        value: this.config?.getSessionId() ?? '',
       },
     ];
 
@@ -471,7 +474,7 @@ export class ClearcutLogger {
     const data = [
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
-        value: this.config?.getSessionId(),
+        value: this.config?.getSessionId() ?? '',
       },
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_LOOP_DETECTED_TYPE,

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -205,10 +205,15 @@ export class ClearcutLogger {
   }
 
   logStartSessionEvent(event: StartSessionEvent): void {
+    const surface = process.env.SURFACE || undefined;
     const data = [
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_START_SESSION_MODEL,
         value: event.model,
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
+        value: this.config?.getSessionId(),
       },
       {
         gemini_cli_key:
@@ -266,6 +271,10 @@ export class ClearcutLogger {
           EventMetadataKey.GEMINI_CLI_START_SESSION_TELEMETRY_LOG_USER_PROMPTS_ENABLED,
         value: event.telemetry_log_user_prompts_enabled.toString(),
       },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
+        value: surface,
+      },
     ];
     // Flush start event immediately
     this.enqueueLogEvent(this.createLogEvent(start_session_event_name, data));
@@ -279,6 +288,10 @@ export class ClearcutLogger {
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_USER_PROMPT_LENGTH,
         value: JSON.stringify(event.prompt_length),
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
+        value: this.config?.getSessionId(),
       },
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_PROMPT_ID,
@@ -442,6 +455,10 @@ export class ClearcutLogger {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_AUTH_TYPE,
         value: JSON.stringify(event.auth_type),
       },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
+        value: this.config?.getSessionId(),
+      },
     ];
 
     this.enqueueLogEvent(this.createLogEvent(flash_fallback_event_name, data));
@@ -452,6 +469,10 @@ export class ClearcutLogger {
 
   logLoopDetectedEvent(event: LoopDetectedEvent): void {
     const data = [
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
+        value: this.config?.getSessionId(),
+      },
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_LOOP_DETECTED_TYPE,
         value: JSON.stringify(event.loop_type),
@@ -465,7 +486,7 @@ export class ClearcutLogger {
   logEndSessionEvent(event: EndSessionEvent): void {
     const data = [
       {
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_END_SESSION_ID,
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
         value: event?.session_id?.toString() ?? '',
       },
     ];

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -151,6 +151,12 @@ export enum EventMetadataKey {
   // Logs the total number of Google accounts ever used.
   GEMINI_CLI_GOOGLE_ACCOUNTS_COUNT = 37,
 
+  // Logs the Surface from where the Gemini CLI was invoked, eg: VSCode.
+  GEMINI_CLI_SURFACE = 39,
+
+  // Logs the session id
+  GEMINI_CLI_SESSION_ID = 40,
+
   // ==========================================================================
   // Loop Detected Event Keys
   // ===========================================================================


### PR DESCRIPTION

## TLDR

Logging surface field in the start_session_event. Also logging session_id in other events so that we can join the data in a single session.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

closes #4361 