### PR TITLE
(fix) - regression to quit shortcut from command migration

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -432,15 +432,8 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
         if (timerRef.current) {
           clearTimeout(timerRef.current);
         }
-        const quitCommand = slashCommands.find(
-          (cmd) => cmd.name === 'quit' || cmd.altName === 'exit',
-        );
-        if (quitCommand && quitCommand.action) {
-          quitCommand.action(commandContext, '');
-        } else {
-          // This is unlikely to be needed but added for an additional fallback.
-          process.exit(0);
-        }
+        // Directly invoke the central command handler.
+        handleSlashCommand('/quit');
       } else {
         setPressedOnce(true);
         timerRef.current = setTimeout(() => {
@@ -449,8 +442,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
         }, CTRL_EXIT_PROMPT_DURATION_MS);
       }
     },
-    // Add commandContext to the dependency array here!
-    [slashCommands, commandContext],
+    [handleSlashCommand],
   );
 
   useInput((input: string, key: InkKeyType) => {


### PR DESCRIPTION
## TLDR

This pull request fixes a regression where pressing `Ctrl+C` twice no longer gracefully exits the CLI. The `Ctrl+C` event handler was directly calling the `quit` command's action, but this action only returns a "quit" message object and doesn't actually terminate the process. The handler now correctly invokes the central `handleSlashCommand` processor with the `/quit` command, which properly handles the quit sequence, displays the exit message, and terminates the application.

## Dive Deeper

The regression was introduced when the `/quit` command logic was refactored from an inline function within `slashCommandProcessor.ts` into its own dedicated command module (`quitCommand.ts`).

The original `Ctrl+C` handler in `App.tsx` (`handleExit`) was designed to find the `quit` command in the list of slash commands and execute its `action` directly. However, the refactored `quitCommand.action` only returns a `QuitActionReturn` object (`{ type: 'quit', messages: [...] }`). It does not contain the `process.exit(0)` call.

The logic responsible for interpreting the `QuitActionReturn` object and actually exiting the process resides within the `handleSlashCommand` hook. The `Ctrl+C` flow was completely bypassing this central processor.

The fix is to change `handleExit` in `App.tsx` to no longer execute the command's action directly. Instead, it now calls `handleSlashCommand('/quit')`. This ensures the `Ctrl+C` shortcut behaves identically to a user typing `/quit`, leveraging the existing, correct exit logic. The `useCallback` dependency array for `handleExit` has also been updated to correctly include `handleSlashCommand`.

## Reviewer Test Plan

1.  Pull down this branch and run the CLI (`npm start`).
2.  Once the CLI is running, press `Ctrl+C` once. You should see the message "Press Ctrl+C again to exit."
3.  Press `Ctrl+C` a second time within one second.
4.  **Expected Result:** The CLI should exit gracefully, displaying the session duration message.
5.  Run the CLI again.
6.  Type `/quit` and press Enter.
7.  **Expected Result:** The CLI should exit gracefully with the same session duration message, confirming both exit methods work identically.
8.  Run the CLI again.
9.  Type `/exit` and press Enter.
10. **Expected Result:** The CLI should exit gracefully with the same session duration message, confirming the alias also works.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |
