### PR TITLE
fix: keep command help text visible when full command name is typed

### DIFF
--- a/packages/cli/src/ui/hooks/useCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.test.ts
@@ -1244,4 +1244,27 @@ describe('useCompletion', () => {
       );
     });
   });
+
+  describe('showSuggestions', () => {
+    it('should show suggestions for exact leaf command match', () => {
+      const slashCommands = [
+        {
+          name: 'clear',
+          description: 'Clear the screen',
+        },
+      ] as unknown as SlashCommand[];
+      const { result } = renderHook(() =>
+        useCompletion(
+          useTextBufferForTest('/clear'),
+          testRootDir,
+          slashCommands,
+          mockCommandContext,
+          mockConfig,
+        ),
+      );
+
+      expect(result.current.suggestions).toHaveLength(1);
+      expect(result.current.suggestions[0].label).toBe('clear');
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/useCompletion.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.ts
@@ -273,23 +273,12 @@ export function useCompletion(
       // Command/Sub-command Completion
       const commandsToSearch = currentLevel || [];
       if (commandsToSearch.length > 0) {
-        let potentialSuggestions = commandsToSearch.filter(
+        const potentialSuggestions = commandsToSearch.filter(
           (cmd) =>
             cmd.description &&
             (cmd.name.startsWith(partial) ||
               cmd.altNames?.some((alt) => alt.startsWith(partial))),
         );
-
-        // If a user's input is an exact match and it is a leaf command,
-        // enter should submit immediately.
-        if (potentialSuggestions.length > 0 && !hasTrailingSpace) {
-          const perfectMatch = potentialSuggestions.find(
-            (s) => s.name === partial || s.altNames?.includes(partial),
-          );
-          if (perfectMatch && perfectMatch.action) {
-            potentialSuggestions = [];
-          }
-        }
 
         const finalSuggestions = potentialSuggestions.map((cmd) => ({
           label: cmd.name,


### PR DESCRIPTION
## Brief Description

This PR fixes a UX issue where command help text disappears when typing the full command name. Previously, typing `/bu` would show "bug" with help text, but typing `/bug` would hide the help text. Now the help text remains visible regardless of whether you type a partial or full command name.

## Dive Deeper

- The issue was in `useCompletion.ts` where logic intentionally cleared suggestions for exact leaf command matches. This was removed to maintain consistent help text visibility, improving the user experience by keeping contextual information available.

## Reviewer Test Plan

1. Start the CLI and type `/bu` - should show "bug" with help text
2. Type `/bug` - should still show "bug" with help text (previously would hide it)
3. Test with other commands like `/he` vs `/help` to verify consistent behavior

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ✅  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #4284

