### PR TITLE
Fix #4220: allow up/down arrow to toggle history when only one sugges…

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -95,7 +95,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const inputHistory = useInputHistory({
     userMessages,
     onSubmit: handleSubmitAndClear,
-    isActive: !completion.showSuggestions && !shellModeActive,
+    isActive:
+      (!completion.showSuggestions || completion.suggestions.length === 1) &&
+      !shellModeActive,
     currentQuery: buffer.text,
     onChange: customSetTextAndResetCompletionSignal,
   });
@@ -265,13 +267,15 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       if (completion.showSuggestions) {
-        if (key.name === 'up') {
-          completion.navigateUp();
-          return;
-        }
-        if (key.name === 'down') {
-          completion.navigateDown();
-          return;
+        if (completion.suggestions.length > 1) {
+          if (key.name === 'up') {
+            completion.navigateUp();
+            return;
+          }
+          if (key.name === 'down') {
+            completion.navigateDown();
+            return;
+          }
         }
 
         if (key.name === 'tab' || (key.name === 'return' && !key.ctrl)) {
@@ -286,61 +290,61 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           }
           return;
         }
-      } else {
-        if (!shellModeActive) {
-          if (key.ctrl && key.name === 'p') {
-            inputHistory.navigateUp();
-            return;
-          }
-          if (key.ctrl && key.name === 'n') {
-            inputHistory.navigateDown();
-            return;
-          }
-          // Handle arrow-up/down for history on single-line or at edges
-          if (
-            key.name === 'up' &&
-            (buffer.allVisualLines.length === 1 ||
-              (buffer.visualCursor[0] === 0 && buffer.visualScrollRow === 0))
-          ) {
-            inputHistory.navigateUp();
-            return;
-          }
-          if (
-            key.name === 'down' &&
-            (buffer.allVisualLines.length === 1 ||
-              buffer.visualCursor[0] === buffer.allVisualLines.length - 1)
-          ) {
-            inputHistory.navigateDown();
-            return;
-          }
-        } else {
-          // Shell History Navigation
-          if (key.name === 'up') {
-            const prevCommand = shellHistory.getPreviousCommand();
-            if (prevCommand !== null) buffer.setText(prevCommand);
-            return;
-          }
-          if (key.name === 'down') {
-            const nextCommand = shellHistory.getNextCommand();
-            if (nextCommand !== null) buffer.setText(nextCommand);
-            return;
-          }
-        }
+      }
 
-        if (key.name === 'return' && !key.ctrl && !key.meta && !key.paste) {
-          if (buffer.text.trim()) {
-            const [row, col] = buffer.cursor;
-            const line = buffer.lines[row];
-            const charBefore = col > 0 ? cpSlice(line, col - 1, col) : '';
-            if (charBefore === '\\') {
-              buffer.backspace();
-              buffer.newline();
-            } else {
-              handleSubmitAndClear(buffer.text);
-            }
-          }
+      if (!shellModeActive) {
+        if (key.ctrl && key.name === 'p') {
+          inputHistory.navigateUp();
           return;
         }
+        if (key.ctrl && key.name === 'n') {
+          inputHistory.navigateDown();
+          return;
+        }
+        // Handle arrow-up/down for history on single-line or at edges
+        if (
+          key.name === 'up' &&
+          (buffer.allVisualLines.length === 1 ||
+            (buffer.visualCursor[0] === 0 && buffer.visualScrollRow === 0))
+        ) {
+          inputHistory.navigateUp();
+          return;
+        }
+        if (
+          key.name === 'down' &&
+          (buffer.allVisualLines.length === 1 ||
+            buffer.visualCursor[0] === buffer.allVisualLines.length - 1)
+        ) {
+          inputHistory.navigateDown();
+          return;
+        }
+      } else {
+        // Shell History Navigation
+        if (key.name === 'up') {
+          const prevCommand = shellHistory.getPreviousCommand();
+          if (prevCommand !== null) buffer.setText(prevCommand);
+          return;
+        }
+        if (key.name === 'down') {
+          const nextCommand = shellHistory.getNextCommand();
+          if (nextCommand !== null) buffer.setText(nextCommand);
+          return;
+        }
+      }
+
+      if (key.name === 'return' && !key.ctrl && !key.meta && !key.paste) {
+        if (buffer.text.trim()) {
+          const [row, col] = buffer.cursor;
+          const line = buffer.lines[row];
+          const charBefore = col > 0 ? cpSlice(line, col - 1, col) : '';
+          if (charBefore === '\\') {
+            buffer.backspace();
+            buffer.newline();
+          } else {
+            handleSubmitAndClear(buffer.text);
+          }
+        }
+        return;
       }
 
       // Newline insertion


### PR DESCRIPTION

## TLDR

When the completion UI shows **exactly one** suggestion, the `up` / `down` arrow keys were still being intercepted by suggestion navigation. This blocked users from navigating their prompt history unless they typed an extra space or Esc. This PR changes the key handling logic so that **history navigation works when there is only one suggestion**, while preserving existing multi‑suggestion navigation and Tab/Enter acceptance behavior.

## Dive Deeper

**Root cause:** `completion.showSuggestions` gated the arrow‑key handlers, but did not consider how many suggestions were present. Even a single suggestion caused `completion.navigateUp/Down()` to run, which effectively “consumed” the keystroke and prevented history navigation downstream.

*Fix details:**
- Only call `completion.navigateUp()` / `completion.navigateDown()` when `completion.suggestions.length > 1`.
- When `completion.suggestions.length === 1`, fall through to the normal history handlers.
- Updated `isActive` (history mode) so history remains active when a single suggestion is visible.
- No changes to Tab / Enter autocomplete flow.
- Change isolated to **`packages/cli/src/ui/components/InputPrompt.tsx`**.

## Reviewer Test Plan

**Before applying this PR:**
1. Run `gemini-cli`.
2. Type `@` plus the start of a filename that yields exactly **one** completion.
3. Press `↑` or `↓`.  
4. Observe: the keypress is absorbed by the suggestion UI and you cannot navigate your command history.

**After applying this PR:**
1. Repeat the above with a single filename suggestion.
   - Now pressing `↑` / `↓` will cycle through your previous commands (history).
2. Type `@` plus a path that produces **multiple** filename suggestions.
   - Pressing `↑` / `↓` still navigates the list of completions as before.
3. Confirm that `Tab` and `Enter` continue to accept the highlighted suggestion.
4. (Optional) When no completions are visible, verify that `↑` / `↓` navigate history normally.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ✅  |
| npx      | ❓  | ✅  | ✅  |
| Docker   | ❓  | ✅  | ✅  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Resolves #4220
