### PR TITLE
Fix bug where ctrl+c did not exit properly

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -437,6 +437,9 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
         );
         if (quitCommand && quitCommand.action) {
           quitCommand.action(commandContext, '');
+          setTimeout(() => {
+            process.exit(0);
+          }, 100);
         } else {
           // This is unlikely to be needed but added for an additional fallback.
           process.exit(0);


### PR DESCRIPTION
## TLDR
Fix bug where ctrl+c did not exit properly. In the new slash command architecture, the quit action just prints out a message to the UI so we need to manually add a process.exit call 

## Linked issues / bugs
Resolves #4367
