### PR TITLE
migrate restore command

### DIFF
--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -24,6 +24,7 @@ import { compressCommand } from '../ui/commands/compressCommand.js';
 import { ideCommand } from '../ui/commands/ideCommand.js';
 import { bugCommand } from '../ui/commands/bugCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
+import { restoreCommand } from '../ui/commands/restoreCommand.js';
 
 const loadBuiltInCommands = async (
   config: Config | null,
@@ -44,6 +45,7 @@ const loadBuiltInCommands = async (
     memoryCommand,
     privacyCommand,
     quitCommand,
+    restoreCommand(config),
     statsCommand,
     themeCommand,
     toolsCommand,

--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -46,6 +46,7 @@ export const createMockCommandContext = (
       setDebugMessage: vi.fn(),
       pendingItem: null,
       setPendingItem: vi.fn(),
+      loadHistory: vi.fn(),
     },
     session: {
       stats: {

--- a/packages/cli/src/ui/commands/restoreCommand.test.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { restoreCommand } from './restoreCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { Config } from '@google/gemini-cli-core';
+
+vi.mock('node:fs/promises', () => ({
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+  mkdir: vi.fn(),
+}));
+
+describe('restoreCommand', () => {
+  let context: ReturnType<typeof createMockCommandContext>;
+  let mockConfig: Config;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    context = createMockCommandContext();
+    mockConfig = {
+      getCheckpointingEnabled: vi.fn(() => true),
+      getProjectTempDir: vi.fn(() => '/test/dir/.gemini'),
+      getGeminiClient: vi.fn(() => ({
+        setHistory: vi.fn().mockResolvedValue(undefined),
+      })),
+    } as unknown as Config;
+    context.services.config = mockConfig;
+  });
+
+  it('should be null if checkpointing is disabled', () => {
+    (mockConfig.getCheckpointingEnabled as vi.Mock).mockReturnValue(false);
+    const command = restoreCommand(mockConfig);
+    expect(command).toBeNull();
+  });
+
+  it('should be defined if checkpointing is enabled', () => {
+    const command = restoreCommand(mockConfig);
+    expect(command).not.toBeNull();
+    expect(command?.name).toBe('restore');
+  });
+
+  describe('action', () => {
+    it('should show "no restorable calls" message if no checkpoints exist', async () => {
+      (fs.readdir as vi.Mock).mockResolvedValue([]);
+      const command = restoreCommand(mockConfig);
+      const result = await command!.action!(context, '');
+      expect(fs.mkdir).toHaveBeenCalledWith('/test/dir/.gemini/checkpoints', {
+        recursive: true,
+      });
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'No restorable tool calls found.',
+      });
+    });
+
+    it('should list available checkpoints if no argument is provided', async () => {
+      (fs.readdir as vi.Mock).mockResolvedValue([
+        'checkpoint1.json',
+        'checkpoint2.json',
+      ]);
+      const command = restoreCommand(mockConfig);
+      const result = await command!.action!(context, '');
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'Available tool calls to restore:\n\ncheckpoint1\ncheckpoint2',
+      });
+    });
+
+    it('should return an error if the specified checkpoint is not found', async () => {
+      (fs.readdir as vi.Mock).mockResolvedValue(['checkpoint1.json']);
+      const command = restoreCommand(mockConfig);
+      const result = await command!.action!(context, 'nonexistent');
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'File not found: nonexistent.json',
+      });
+    });
+
+    it('should restore history, client history, and git state, then return a tool call', async () => {
+      const checkpointName = 'my-checkpoint';
+      const toolCallData = {
+        history: [{ type: 'user', text: 'previous prompt' }],
+        clientHistory: [{ role: 'user', parts: [{ text: 'client history' }] }],
+        commitHash: 'abcdef123',
+        toolCall: { name: 'test_tool', args: { foo: 'bar' } },
+      };
+      (fs.readdir as vi.Mock).mockResolvedValue([`${checkpointName}.json`]);
+      (fs.readFile as vi.Mock).mockResolvedValue(JSON.stringify(toolCallData));
+
+      const command = restoreCommand(mockConfig);
+      const result = await command!.action!(context, checkpointName);
+
+      expect(context.ui.loadHistory).toHaveBeenCalledWith(toolCallData.history);
+      expect(
+        context.services.config?.getGeminiClient()?.setHistory,
+      ).toHaveBeenCalledWith(toolCallData.clientHistory);
+      expect(
+        context.services.git?.restoreProjectFromSnapshot,
+      ).toHaveBeenCalledWith(toolCallData.commitHash);
+      expect(context.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: 'info',
+          text: 'Restored project to the state before the tool call.',
+        },
+        expect.any(Number),
+      );
+      expect(result).toEqual({
+        type: 'tool',
+        toolName: 'test_tool',
+        toolArgs: { foo: 'bar' },
+      });
+    });
+
+    it('should handle errors during file operations', async () => {
+      const error = new Error('Read failed');
+      (fs.readdir as vi.Mock).mockRejectedValue(error);
+      const command = restoreCommand(mockConfig);
+      const result = await command!.action!(context, 'any');
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: `Could not read restorable tool calls. This is the error: ${error}`,
+      });
+    });
+  });
+
+  describe('completion', () => {
+    it('should return a list of available checkpoint names', async () => {
+      (fs.readdir as vi.Mock).mockResolvedValue([
+        'cp1.json',
+        'cp2.json',
+        'not-a-checkpoint.txt',
+      ]);
+      const command = restoreCommand(mockConfig);
+      const completions = await command!.completion!(context, '');
+      expect(completions).toEqual(['cp1', 'cp2']);
+    });
+
+    it('should return an empty array if reading the directory fails', async () => {
+      (fs.readdir as vi.Mock).mockRejectedValue(new Error('Failed to read'));
+      const command = restoreCommand(mockConfig);
+      const completions = await command!.completion!(context, '');
+      expect(completions).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/restoreCommand.test.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.test.ts
@@ -4,152 +4,234 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { promises as fs } from 'fs';
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  Mocked,
+  Mock,
+} from 'vitest';
+import * as fs from 'fs/promises';
 import { restoreCommand } from './restoreCommand.js';
+import { type CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
-import { Config } from '@google/gemini-cli-core';
+import { Config, GitService } from '@google/gemini-cli-core';
 
-vi.mock('node:fs/promises', () => ({
+vi.mock('fs/promises', () => ({
   readdir: vi.fn(),
   readFile: vi.fn(),
   mkdir: vi.fn(),
 }));
 
 describe('restoreCommand', () => {
-  let context: ReturnType<typeof createMockCommandContext>;
+  let mockContext: CommandContext;
   let mockConfig: Config;
+  let mockGitService: GitService;
+  const mockFsPromises = fs as Mocked<typeof fs>;
+  let mockSetHistory: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    context = createMockCommandContext();
+    mockSetHistory = vi.fn().mockResolvedValue(undefined);
+    mockGitService = {
+      restoreProjectFromSnapshot: vi.fn().mockResolvedValue(undefined),
+    } as unknown as GitService;
+
     mockConfig = {
-      getCheckpointingEnabled: vi.fn(() => true),
-      getProjectTempDir: vi.fn(() => '/test/dir/.gemini'),
-      getGeminiClient: vi.fn(() => ({
-        setHistory: vi.fn().mockResolvedValue(undefined),
-      })),
+      getCheckpointingEnabled: vi.fn().mockReturnValue(true),
+      getProjectTempDir: vi.fn().mockReturnValue('/tmp/gemini'),
+      getGeminiClient: vi.fn().mockReturnValue({
+        setHistory: mockSetHistory,
+      }),
     } as unknown as Config;
-    context.services.config = mockConfig;
+
+    mockContext = createMockCommandContext({
+      services: {
+        config: mockConfig,
+        git: mockGitService,
+      },
+    });
   });
 
-  it('should be null if checkpointing is disabled', () => {
-    (mockConfig.getCheckpointingEnabled as vi.Mock).mockReturnValue(false);
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return null if checkpointing is not enabled', () => {
+    (mockConfig.getCheckpointingEnabled as Mock).mockReturnValue(false);
     const command = restoreCommand(mockConfig);
     expect(command).toBeNull();
   });
 
-  it('should be defined if checkpointing is enabled', () => {
+  it('should return the command if checkpointing is enabled', () => {
     const command = restoreCommand(mockConfig);
     expect(command).not.toBeNull();
     expect(command?.name).toBe('restore');
+    expect(command?.description).toBeDefined();
+    expect(command?.action).toBeDefined();
+    expect(command?.completion).toBeDefined();
   });
 
   describe('action', () => {
-    it('should show "no restorable calls" message if no checkpoints exist', async () => {
-      (fs.readdir as vi.Mock).mockResolvedValue([]);
+    it('should return an error if temp dir is not found', async () => {
+      (mockConfig.getProjectTempDir as Mock).mockReturnValue(undefined);
       const command = restoreCommand(mockConfig);
-      const result = await command!.action!(context, '');
-      expect(fs.mkdir).toHaveBeenCalledWith('/test/dir/.gemini/checkpoints', {
-        recursive: true,
+      const result = await command?.action?.(mockContext, '');
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Could not determine the .gemini directory path.',
       });
+    });
+
+    it('should inform when no checkpoints are found if no args are passed', async () => {
+      mockFsPromises.readdir.mockResolvedValue([]);
+      const command = restoreCommand(mockConfig);
+      const result = await command?.action?.(mockContext, '');
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
         content: 'No restorable tool calls found.',
       });
+      expect(mockFsPromises.mkdir).toHaveBeenCalledWith(
+        '/tmp/gemini/checkpoints',
+        {
+          recursive: true,
+        },
+      );
     });
 
-    it('should list available checkpoints if no argument is provided', async () => {
-      (fs.readdir as vi.Mock).mockResolvedValue([
-        'checkpoint1.json',
-        'checkpoint2.json',
-      ]);
+    it('should list available checkpoints if no args are passed', async () => {
+      mockFsPromises.readdir.mockResolvedValue([
+        'test1.json',
+        'test2.json',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any);
       const command = restoreCommand(mockConfig);
-      const result = await command!.action!(context, '');
+      const result = await command?.action?.(mockContext, '');
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
-        content: 'Available tool calls to restore:\n\ncheckpoint1\ncheckpoint2',
+        content: 'Available tool calls to restore:\n\ntest1\ntest2',
       });
     });
 
-    it('should return an error if the specified checkpoint is not found', async () => {
-      (fs.readdir as vi.Mock).mockResolvedValue(['checkpoint1.json']);
+    it('should return an error if the specified file is not found', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockFsPromises.readdir.mockResolvedValue(['test1.json'] as any);
       const command = restoreCommand(mockConfig);
-      const result = await command!.action!(context, 'nonexistent');
+      const result = await command?.action?.(mockContext, 'test2');
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: 'File not found: nonexistent.json',
+        content: 'File not found: test2.json',
       });
     });
 
-    it('should restore history, client history, and git state, then return a tool call', async () => {
-      const checkpointName = 'my-checkpoint';
+    it('should handle file read errors gracefully', async () => {
+      const readError = new Error('Read failed');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockFsPromises.readdir.mockResolvedValue(['test1.json'] as any);
+      mockFsPromises.readFile.mockRejectedValue(readError);
+      const command = restoreCommand(mockConfig);
+      const result = await command?.action?.(mockContext, 'test1');
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: `Could not read restorable tool calls. This is the error: ${readError}`,
+      });
+    });
+
+    it('should restore a tool call and project state', async () => {
       const toolCallData = {
-        history: [{ type: 'user', text: 'previous prompt' }],
-        clientHistory: [{ role: 'user', parts: [{ text: 'client history' }] }],
+        history: [{ type: 'user', text: 'do a thing' }],
+        clientHistory: [{ role: 'user', parts: [{ text: 'do a thing' }] }],
         commitHash: 'abcdef123',
-        toolCall: { name: 'test_tool', args: { foo: 'bar' } },
+        toolCall: { name: 'run_shell_command', args: 'ls' },
       };
-      (fs.readdir as vi.Mock).mockResolvedValue([`${checkpointName}.json`]);
-      (fs.readFile as vi.Mock).mockResolvedValue(JSON.stringify(toolCallData));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockFsPromises.readdir.mockResolvedValue(['my-checkpoint.json'] as any);
+      mockFsPromises.readFile.mockResolvedValue(JSON.stringify(toolCallData));
 
       const command = restoreCommand(mockConfig);
-      const result = await command!.action!(context, checkpointName);
+      const result = await command?.action?.(mockContext, 'my-checkpoint');
 
-      expect(context.ui.loadHistory).toHaveBeenCalledWith(toolCallData.history);
-      expect(
-        context.services.config?.getGeminiClient()?.setHistory,
-      ).toHaveBeenCalledWith(toolCallData.clientHistory);
-      expect(
-        context.services.git?.restoreProjectFromSnapshot,
-      ).toHaveBeenCalledWith(toolCallData.commitHash);
-      expect(context.ui.addItem).toHaveBeenCalledWith(
+      // Check history restoration
+      expect(mockContext.ui.loadHistory).toHaveBeenCalledWith(
+        toolCallData.history,
+      );
+      expect(mockSetHistory).toHaveBeenCalledWith(toolCallData.clientHistory);
+
+      // Check git restoration
+      expect(mockGitService.restoreProjectFromSnapshot).toHaveBeenCalledWith(
+        toolCallData.commitHash,
+      );
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
           type: 'info',
           text: 'Restored project to the state before the tool call.',
         },
         expect.any(Number),
       );
+
+      // Check returned action
       expect(result).toEqual({
         type: 'tool',
-        toolName: 'test_tool',
-        toolArgs: { foo: 'bar' },
+        toolName: 'run_shell_command',
+        toolArgs: 'ls',
       });
     });
 
-    it('should handle errors during file operations', async () => {
-      const error = new Error('Read failed');
-      (fs.readdir as vi.Mock).mockRejectedValue(error);
+    it('should restore even if only toolCall is present', async () => {
+      const toolCallData = {
+        toolCall: { name: 'run_shell_command', args: 'ls' },
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockFsPromises.readdir.mockResolvedValue(['my-checkpoint.json'] as any);
+      mockFsPromises.readFile.mockResolvedValue(JSON.stringify(toolCallData));
+
       const command = restoreCommand(mockConfig);
-      const result = await command!.action!(context, 'any');
+      const result = await command?.action?.(mockContext, 'my-checkpoint');
+
+      expect(mockContext.ui.loadHistory).not.toHaveBeenCalled();
+      expect(mockSetHistory).not.toHaveBeenCalled();
+      expect(mockGitService.restoreProjectFromSnapshot).not.toHaveBeenCalled();
+
       expect(result).toEqual({
-        type: 'message',
-        messageType: 'error',
-        content: `Could not read restorable tool calls. This is the error: ${error}`,
+        type: 'tool',
+        toolName: 'run_shell_command',
+        toolArgs: 'ls',
       });
     });
   });
 
   describe('completion', () => {
-    it('should return a list of available checkpoint names', async () => {
-      (fs.readdir as vi.Mock).mockResolvedValue([
-        'cp1.json',
-        'cp2.json',
-        'not-a-checkpoint.txt',
-      ]);
+    it('should return an empty array if temp dir is not found', async () => {
+      (mockConfig.getProjectTempDir as Mock).mockReturnValue(undefined);
       const command = restoreCommand(mockConfig);
-      const completions = await command!.completion!(context, '');
-      expect(completions).toEqual(['cp1', 'cp2']);
+      const result = await command?.completion?.(mockContext, '');
+      expect(result).toEqual([]);
     });
 
-    it('should return an empty array if reading the directory fails', async () => {
-      (fs.readdir as vi.Mock).mockRejectedValue(new Error('Failed to read'));
+    it('should return an empty array on readdir error', async () => {
+      mockFsPromises.readdir.mockRejectedValue(new Error('ENOENT'));
       const command = restoreCommand(mockConfig);
-      const completions = await command!.completion!(context, '');
-      expect(completions).toEqual([]);
+      const result = await command?.completion?.(mockContext, '');
+      expect(result).toEqual([]);
+    });
+
+    it('should return a list of checkpoint names', async () => {
+      mockFsPromises.readdir.mockResolvedValue([
+        'test1.json',
+        'test2.json',
+        'not-a-checkpoint.txt',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any);
+      const command = restoreCommand(mockConfig);
+      const result = await command?.completion?.(mockContext, '');
+      expect(result).toEqual(['test1', 'test2']);
     });
   });
 });

--- a/packages/cli/src/ui/commands/restoreCommand.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { promises as fs } from 'fs';
+import * as fs from 'fs/promises';
 import path from 'path';
 import {
   type CommandContext,
@@ -120,6 +120,7 @@ async function restoreAction(
 
 async function completion(
   context: CommandContext,
+  _partialArg: string,
 ): Promise<string[]> {
   const { services } = context;
   const { config } = services;

--- a/packages/cli/src/ui/commands/restoreCommand.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import {
+  type CommandContext,
+  type SlashCommand,
+  type SlashCommandActionReturn,
+} from './types.js';
+import { Config } from '@google/gemini-cli-core';
+
+async function restoreAction(
+  context: CommandContext,
+  args: string,
+): Promise<void | SlashCommandActionReturn> {
+  const { services, ui } = context;
+  const { config, git: gitService } = services;
+  const { addItem, loadHistory } = ui;
+
+  const checkpointDir = config?.getProjectTempDir()
+    ? path.join(config.getProjectTempDir(), 'checkpoints')
+    : undefined;
+
+  if (!checkpointDir) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: 'Could not determine the .gemini directory path.',
+    };
+  }
+
+  try {
+    // Ensure the directory exists before trying to read it.
+    await fs.mkdir(checkpointDir, { recursive: true });
+    const files = await fs.readdir(checkpointDir);
+    const jsonFiles = files.filter((file) => file.endsWith('.json'));
+
+    if (!args) {
+      if (jsonFiles.length === 0) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: 'No restorable tool calls found.',
+        };
+      }
+      const truncatedFiles = jsonFiles.map((file) => {
+        const components = file.split('.');
+        if (components.length <= 1) {
+          return file;
+        }
+        components.pop();
+        return components.join('.');
+      });
+      const fileList = truncatedFiles.join('\n');
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `Available tool calls to restore:\n\n${fileList}`,
+      };
+    }
+
+    const selectedFile = args.endsWith('.json') ? args : `${args}.json`;
+
+    if (!jsonFiles.includes(selectedFile)) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `File not found: ${selectedFile}`,
+      };
+    }
+
+    const filePath = path.join(checkpointDir, selectedFile);
+    const data = await fs.readFile(filePath, 'utf-8');
+    const toolCallData = JSON.parse(data);
+
+    if (toolCallData.history) {
+      if (!loadHistory) {
+        // This should not happen
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: 'loadHistory function is not available.',
+        };
+      }
+      loadHistory(toolCallData.history);
+    }
+
+    if (toolCallData.clientHistory) {
+      await config?.getGeminiClient()?.setHistory(toolCallData.clientHistory);
+    }
+
+    if (toolCallData.commitHash) {
+      await gitService?.restoreProjectFromSnapshot(toolCallData.commitHash);
+      addItem(
+        {
+          type: 'info',
+          text: 'Restored project to the state before the tool call.',
+        },
+        Date.now(),
+      );
+    }
+
+    return {
+      type: 'tool',
+      toolName: toolCallData.toolCall.name,
+      toolArgs: toolCallData.toolCall.args,
+    };
+  } catch (error) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: `Could not read restorable tool calls. This is the error: ${error}`,
+    };
+  }
+}
+
+async function completion(
+  context: CommandContext,
+): Promise<string[]> {
+  const { services } = context;
+  const { config } = services;
+  const checkpointDir = config?.getProjectTempDir()
+    ? path.join(config.getProjectTempDir(), 'checkpoints')
+    : undefined;
+  if (!checkpointDir) {
+    return [];
+  }
+  try {
+    const files = await fs.readdir(checkpointDir);
+    return files
+      .filter((file) => file.endsWith('.json'))
+      .map((file) => file.replace('.json', ''));
+  } catch (_err) {
+    return [];
+  }
+}
+
+export const restoreCommand = (config: Config | null): SlashCommand | null => {
+  if (!config?.getCheckpointingEnabled()) {
+    return null;
+  }
+
+  return {
+    name: 'restore',
+    description:
+      'Restore a tool call. This will reset the conversation and file history to the state it was in when the tool call was suggested',
+    action: restoreAction,
+    completion,
+  };
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -41,6 +41,12 @@ export interface CommandContext {
      * @param item The history item to display as pending, or `null` to clear.
      */
     setPendingItem: (item: HistoryItemWithoutId | null) => void;
+    /**
+     * Loads a new set of history items, replacing the current history.
+     *
+     * @param history The array of history items to load.
+     */
+    loadHistory: UseHistoryManagerReturn['loadHistory'];
   };
   // Session-specific data
   session: {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -18,8 +18,6 @@ import {
   HistoryItem,
   SlashCommandProcessorResult,
 } from '../types.js';
-import { promises as fs } from 'fs';
-import path from 'path';
 import { LoadedSettings } from '../../config/settings.js';
 import {
   type CommandContext,
@@ -155,6 +153,7 @@ export const useSlashCommandProcessor = (
           console.clear();
           refreshStatic();
         },
+        loadHistory,
         setDebugMessage: onDebugMessage,
         pendingItem: pendingCompressionItemRef.current,
         setPendingItem: setPendingCompressionItem,
@@ -168,6 +167,7 @@ export const useSlashCommandProcessor = (
       settings,
       gitService,
       logger,
+      loadHistory,
       addItem,
       clearItems,
       refreshStatic,
@@ -203,128 +203,8 @@ export const useSlashCommandProcessor = (
       },
     ];
 
-    if (config?.getCheckpointingEnabled()) {
-      commands.push({
-        name: 'restore',
-        description:
-          'restore a tool call. This will reset the conversation and file history to the state it was in when the tool call was suggested',
-        completion: async () => {
-          const checkpointDir = config?.getProjectTempDir()
-            ? path.join(config.getProjectTempDir(), 'checkpoints')
-            : undefined;
-          if (!checkpointDir) {
-            return [];
-          }
-          try {
-            const files = await fs.readdir(checkpointDir);
-            return files
-              .filter((file) => file.endsWith('.json'))
-              .map((file) => file.replace('.json', ''));
-          } catch (_err) {
-            return [];
-          }
-        },
-        action: async (_mainCommand, subCommand, _args) => {
-          const checkpointDir = config?.getProjectTempDir()
-            ? path.join(config.getProjectTempDir(), 'checkpoints')
-            : undefined;
-
-          if (!checkpointDir) {
-            addMessage({
-              type: MessageType.ERROR,
-              content: 'Could not determine the .gemini directory path.',
-              timestamp: new Date(),
-            });
-            return;
-          }
-
-          try {
-            // Ensure the directory exists before trying to read it.
-            await fs.mkdir(checkpointDir, { recursive: true });
-            const files = await fs.readdir(checkpointDir);
-            const jsonFiles = files.filter((file) => file.endsWith('.json'));
-
-            if (!subCommand) {
-              if (jsonFiles.length === 0) {
-                addMessage({
-                  type: MessageType.INFO,
-                  content: 'No restorable tool calls found.',
-                  timestamp: new Date(),
-                });
-                return;
-              }
-              const truncatedFiles = jsonFiles.map((file) => {
-                const components = file.split('.');
-                if (components.length <= 1) {
-                  return file;
-                }
-                components.pop();
-                return components.join('.');
-              });
-              const fileList = truncatedFiles.join('\n');
-              addMessage({
-                type: MessageType.INFO,
-                content: `Available tool calls to restore:\n\n${fileList}`,
-                timestamp: new Date(),
-              });
-              return;
-            }
-
-            const selectedFile = subCommand.endsWith('.json')
-              ? subCommand
-              : `${subCommand}.json`;
-
-            if (!jsonFiles.includes(selectedFile)) {
-              addMessage({
-                type: MessageType.ERROR,
-                content: `File not found: ${selectedFile}`,
-                timestamp: new Date(),
-              });
-              return;
-            }
-
-            const filePath = path.join(checkpointDir, selectedFile);
-            const data = await fs.readFile(filePath, 'utf-8');
-            const toolCallData = JSON.parse(data);
-
-            if (toolCallData.history) {
-              loadHistory(toolCallData.history);
-            }
-
-            if (toolCallData.clientHistory) {
-              await config
-                ?.getGeminiClient()
-                ?.setHistory(toolCallData.clientHistory);
-            }
-
-            if (toolCallData.commitHash) {
-              await gitService?.restoreProjectFromSnapshot(
-                toolCallData.commitHash,
-              );
-              addMessage({
-                type: MessageType.INFO,
-                content: `Restored project to the state before the tool call.`,
-                timestamp: new Date(),
-              });
-            }
-
-            return {
-              type: 'tool',
-              toolName: toolCallData.toolCall.name,
-              toolArgs: toolCallData.toolCall.args,
-            };
-          } catch (error) {
-            addMessage({
-              type: MessageType.ERROR,
-              content: `Could not read restorable tool calls. This is the error: ${error}`,
-              timestamp: new Date(),
-            });
-          }
-        },
-      });
-    }
     return commands;
-  }, [addMessage, toggleCorgiMode, config, gitService, loadHistory]);
+  }, [toggleCorgiMode]);
 
   const handleSlashCommand = useCallback(
     async (


### PR DESCRIPTION
## TLDR

This PR migrates the `/restore` slash command from the legacy `slashCommandProcessor.ts` to a modern, standalone command file. This improves modularity, maintainability, and testability by isolating the command's logic and dependencies.

## Dive Deeper

The `/restore` command allows a user to restore the application state from a previously saved checkpoint. This includes the conversation history, file history, and git state. The migration involved the following steps:

1.  **Created `packages/cli/src/ui/commands/restoreCommand.ts`:** This file now contains the full logic for the `/restore` command, including its action and completion handlers.
2.  **Created `packages/cli/src/ui/commands/restoreCommand.test.ts`:** Added a dedicated test suite for the new command, ensuring all functionality is covered, including error handling and edge cases.
3.  **Registered in `CommandService.ts`:** The new `restoreCommand` is now registered with the `CommandService`, making it available to the application.
4.  **Updated `CommandService.test.ts`:** The `CommandService` tests were updated to mock and verify the registration of the new command.
5.  **Removed Legacy Code:** The old `/restore` command implementation was removed from `slashCommandProcessor.ts` and its corresponding tests were removed from `slashCommandProcessor.test.ts`.

## Reviewer Test Plan

1.  Pull down this branch.
2.  Run `npm install && npm run build` and `npm start -- --checkpointing`.
3.  Create a checkpoint by running a tool call (e.g., ask GC to write a file or edit a file and then approve it).
4.  Run `/restore` and verify that the created checkpoint is listed.
5.  Run `/restore <checkpoint_name>` and verify that the application state is restored to the point before the tool call.

Also:

1. Run `npm start` without checkpointing
2. `/restore` should not appear in the list of commands.


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

