### PR TITLE
feat(cli): allow executing commands on perfect match

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gemini CLI CI](https://github.com/google-gemini/gemini-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/google-gemini/gemini-cli/actions/workflows/ci.yml)
 
-![Gemini CLI Screenshot](./docs/assets/gemini-screenshot.png)
+![Gemini CLI Screenshot](https://raw.githubusercontent.com/google-gemini/gemini-cli/refs/heads/main/docs/assets/gemini-screenshot.png)
 
 This repository contains the Gemini CLI, a command-line AI workflow tool that connects to your
 tools, understands your code and accelerates your workflows.
@@ -26,7 +26,7 @@ With the Gemini CLI you can:
    npx https://github.com/google-gemini/gemini-cli
    ```
 
-   Or install it with:
+   Or install the [Gemini CLI package](https://www.npmjs.com/package/@google/gemini-cli) with NPM:
 
    ```bash
    npm install -g @google/gemini-cli

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gemini CLI CI](https://github.com/google-gemini/gemini-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/google-gemini/gemini-cli/actions/workflows/ci.yml)
 
-![Gemini CLI Screenshot](https://raw.githubusercontent.com/google-gemini/gemini-cli/refs/heads/main/docs/assets/gemini-screenshot.png)
+![Gemini CLI Screenshot](./docs/assets/gemini-screenshot.png)
 
 This repository contains the Gemini CLI, a command-line AI workflow tool that connects to your
 tools, understands your code and accelerates your workflows.
@@ -26,7 +26,7 @@ With the Gemini CLI you can:
    npx https://github.com/google-gemini/gemini-cli
    ```
 
-   Or install the [Gemini CLI package](https://www.npmjs.com/package/@google/gemini-cli) with NPM:
+   Or install it with:
 
    ```bash
    npm install -g @google/gemini-cli

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -9,7 +9,7 @@ import { InputPrompt, InputPromptProps } from './InputPrompt.js';
 import type { TextBuffer } from './shared/text-buffer.js';
 import { Config } from '@google/gemini-cli-core';
 import { CommandContext, SlashCommand } from '../commands/types.js';
-import { vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useShellHistory } from '../hooks/useShellHistory.js';
 import { useCompletion } from '../hooks/useCompletion.js';
 import { useInputHistory } from '../hooks/useInputHistory.js';
@@ -341,7 +341,7 @@ describe('InputPrompt', () => {
     });
   });
 
-  it('should complete a partial parent command and add a space', async () => {
+  it('should complete a partial parent command', async () => {
     // SCENARIO: /mem -> Tab
     mockedUseCompletion.mockReturnValue({
       ...mockCompletion,
@@ -357,12 +357,12 @@ describe('InputPrompt', () => {
     stdin.write('\t'); // Press Tab
     await wait();
 
-    expect(props.buffer.setText).toHaveBeenCalledWith('/memory ');
+    expect(props.buffer.setText).toHaveBeenCalledWith('/memory');
     unmount();
   });
 
-  it('should append a sub-command when the parent command is already complete with a space', async () => {
-    // SCENARIO: /memory  -> Tab (to accept 'add')
+  it('should append a sub-command when the parent command is already complete', async () => {
+    // SCENARIO: /memory -> Tab (to accept 'add')
     mockedUseCompletion.mockReturnValue({
       ...mockCompletion,
       showSuggestions: true,
@@ -380,13 +380,12 @@ describe('InputPrompt', () => {
     stdin.write('\t'); // Press Tab
     await wait();
 
-    expect(props.buffer.setText).toHaveBeenCalledWith('/memory add ');
+    expect(props.buffer.setText).toHaveBeenCalledWith('/memory add');
     unmount();
   });
 
   it('should handle the "backspace" edge case correctly', async () => {
-    // SCENARIO: /memory  -> Backspace -> /memory -> Tab (to accept 'show')
-    // This is the critical bug we fixed.
+    // SCENARIO: /memory -> Backspace -> /memory -> Tab (to accept 'show')
     mockedUseCompletion.mockReturnValue({
       ...mockCompletion,
       showSuggestions: true,
@@ -405,8 +404,8 @@ describe('InputPrompt', () => {
     stdin.write('\t'); // Press Tab
     await wait();
 
-    // It should NOT become '/show '. It should correctly become '/memory show '.
-    expect(props.buffer.setText).toHaveBeenCalledWith('/memory show ');
+    // It should NOT become '/show'. It should correctly become '/memory show'.
+    expect(props.buffer.setText).toHaveBeenCalledWith('/memory show');
     unmount();
   });
 
@@ -426,7 +425,7 @@ describe('InputPrompt', () => {
     stdin.write('\t'); // Press Tab
     await wait();
 
-    expect(props.buffer.setText).toHaveBeenCalledWith('/chat resume fix-foo ');
+    expect(props.buffer.setText).toHaveBeenCalledWith('/chat resume fix-foo');
     unmount();
   });
 
@@ -446,7 +445,7 @@ describe('InputPrompt', () => {
     await wait();
 
     // The app should autocomplete the text, NOT submit.
-    expect(props.buffer.setText).toHaveBeenCalledWith('/memory ');
+    expect(props.buffer.setText).toHaveBeenCalledWith('/memory');
 
     expect(props.onSubmit).not.toHaveBeenCalled();
     unmount();
@@ -471,10 +470,10 @@ describe('InputPrompt', () => {
     const { stdin, unmount } = render(<InputPrompt {...props} />);
     await wait();
 
-    stdin.write('\t'); // Press Tab
+    stdin.write('\t'); // Press Tab for autocomplete
     await wait();
 
-    expect(props.buffer.setText).toHaveBeenCalledWith('/help ');
+    expect(props.buffer.setText).toHaveBeenCalledWith('/help');
     unmount();
   });
 
@@ -505,7 +504,6 @@ describe('InputPrompt', () => {
     await wait();
 
     expect(props.onSubmit).toHaveBeenCalledWith('/clear');
-    expect(props.buffer.setText).not.toHaveBeenCalledWith('/clear ');
     unmount();
   });
 
@@ -530,7 +528,10 @@ describe('InputPrompt', () => {
   });
 
   it('should add a newline on enter when the line ends with a backslash', async () => {
-    props.buffer.setText('first line\\');
+    // This test simulates multi-line input, not submission
+    mockBuffer.text = 'first line\\';
+    mockBuffer.cursor = [0, 11];
+    mockBuffer.lines = ['first line\\'];
 
     const { stdin, unmount } = render(<InputPrompt {...props} />);
     await wait();

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -160,7 +160,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         // - Otherwise, the base is everything EXCEPT the last partial part.
         const basePath =
           hasTrailingSpace || isParentPath ? parts : parts.slice(0, -1);
-        const newValue = `/${[...basePath, suggestion].join(' ')} `;
+        const newValue = `/${[...basePath, suggestion].join(' ')}`;
 
         buffer.setText(newValue);
       } else {
@@ -275,6 +275,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
 
         if (key.name === 'tab' || (key.name === 'return' && !key.ctrl)) {
+          // If the command is a perfect match, pressing enter should execute it.
+          if (completion.isPerfectMatch && key.name === 'return') {
+            handleSubmitAndClear(buffer.text);
+            return;
+          }
+
           if (completion.suggestions.length > 0) {
             const targetIndex =
               completion.activeSuggestionIndex === -1

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -264,6 +264,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return;
       }
 
+      // If the command is a perfect match, pressing enter should execute it.
+      if (completion.isPerfectMatch && key.name === 'return') {
+        handleSubmitAndClear(buffer.text);
+        return;
+      }
+
       if (completion.showSuggestions) {
         if (key.name === 'up') {
           completion.navigateUp();
@@ -275,12 +281,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
 
         if (key.name === 'tab' || (key.name === 'return' && !key.ctrl)) {
-          // If the command is a perfect match, pressing enter should execute it.
-          if (completion.isPerfectMatch && key.name === 'return') {
-            handleSubmitAndClear(buffer.text);
-            return;
-          }
-
           if (completion.suggestions.length > 0) {
             const targetIndex =
               completion.activeSuggestionIndex === -1

--- a/packages/cli/src/ui/hooks/useCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/** @vitest-environment jsdom */
+
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import type { Mocked } from 'vitest';
 import { renderHook, act } from '@testing-library/react';

--- a/packages/cli/src/ui/hooks/useCompletion.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.ts
@@ -28,6 +28,7 @@ export interface UseCompletionReturn {
   visibleStartIndex: number;
   showSuggestions: boolean;
   isLoadingSuggestions: boolean;
+  isPerfectMatch: boolean;
   setActiveSuggestionIndex: React.Dispatch<React.SetStateAction<number>>;
   setShowSuggestions: React.Dispatch<React.SetStateAction<boolean>>;
   resetCompletionState: () => void;
@@ -50,6 +51,7 @@ export function useCompletion(
   const [showSuggestions, setShowSuggestions] = useState<boolean>(false);
   const [isLoadingSuggestions, setIsLoadingSuggestions] =
     useState<boolean>(false);
+  const [isPerfectMatch, setIsPerfectMatch] = useState<boolean>(false);
 
   const resetCompletionState = useCallback(() => {
     setSuggestions([]);
@@ -57,6 +59,7 @@ export function useCompletion(
     setVisibleStartIndex(0);
     setShowSuggestions(false);
     setIsLoadingSuggestions(false);
+    setIsPerfectMatch(false);
   }, []);
 
   const navigateUp = useCallback(() => {
@@ -127,6 +130,9 @@ export function useCompletion(
     const trimmedQuery = query.trimStart();
 
     if (trimmedQuery.startsWith('/')) {
+      // Always reset perfect match at the beginning of processing.
+      setIsPerfectMatch(false);
+
       const fullPath = trimmedQuery.substring(1);
       const hasTrailingSpace = trimmedQuery.endsWith(' ');
 
@@ -183,6 +189,23 @@ export function useCompletion(
         }
       }
 
+      // Check for perfect, executable match
+      if (!hasTrailingSpace) {
+        if (leafCommand && partial === '' && leafCommand.action) {
+          // Case: /command<enter> - command has action, no sub-commands were suggested
+          setIsPerfectMatch(true);
+        } else if (currentLevel) {
+          // Case: /command subcommand<enter>
+          const perfectMatch = currentLevel.find(
+            (cmd) =>
+              (cmd.name === partial || cmd.altName === partial) && cmd.action,
+          );
+          if (perfectMatch) {
+            setIsPerfectMatch(true);
+          }
+        }
+      }
+
       const depth = commandPathParts.length;
 
       // Provide Suggestions based on the now-corrected context
@@ -223,7 +246,7 @@ export function useCompletion(
           const perfectMatch = potentialSuggestions.find(
             (s) => s.name === partial || s.altName === partial,
           );
-          if (perfectMatch && !perfectMatch.subCommands) {
+          if (perfectMatch && perfectMatch.action) {
             potentialSuggestions = [];
           }
         }
@@ -534,6 +557,7 @@ export function useCompletion(
     visibleStartIndex,
     showSuggestions,
     isLoadingSuggestions,
+    isPerfectMatch,
     setActiveSuggestionIndex,
     setShowSuggestions,
     resetCompletionState,


### PR DESCRIPTION
## TLDR

 Introduces a new behavior where a command is executed upon pressing "Enter" if it's a perfect match. This avoids the sub-commands from being added when the command is a perfect match

## Dive Deeper

When typing a command that is executable and has sub-commands, the terminal would auto populate with a sub-commands rather than executing the command. This pr changes the logic to add isPerfectMatch state to detect when the current input is a valid executable command. This uses isPerfectMatch to trigger command execution on "Enter".

## Reviewer Test Plan


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
