### PR TITLE
Migrate /corgi

### DIFF
--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -11,6 +11,7 @@ import { type SlashCommand } from '../ui/commands/types.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
+import { corgiCommand } from '../ui/commands/corgiCommand.js';
 import { docsCommand } from '../ui/commands/docsCommand.js';
 import { chatCommand } from '../ui/commands/chatCommand.js';
 import { authCommand } from '../ui/commands/authCommand.js';
@@ -37,6 +38,9 @@ vi.mock('../ui/commands/helpCommand.js', () => ({
 }));
 vi.mock('../ui/commands/clearCommand.js', () => ({
   clearCommand: { name: 'clear', description: 'Mock Clear' },
+}));
+vi.mock('../ui/commands/corgiCommand.js', () => ({
+  corgiCommand: { name: 'corgi', description: 'Mock Corgi' },
 }));
 vi.mock('../ui/commands/docsCommand.js', () => ({
   docsCommand: { name: 'docs', description: 'Mock Docs' },
@@ -85,7 +89,7 @@ vi.mock('../ui/commands/restoreCommand.js', () => ({
 }));
 
 describe('CommandService', () => {
-  const subCommandLen = 17;
+  const subCommandLen = 18;
   let mockConfig: Mocked<Config>;
 
   beforeEach(() => {
@@ -128,6 +132,8 @@ describe('CommandService', () => {
         expect(commandNames).toContain('memory');
         expect(commandNames).toContain('help');
         expect(commandNames).toContain('clear');
+        expect(commandNames).toContain('compress');
+        expect(commandNames).toContain('corgi');
         expect(commandNames).toContain('docs');
         expect(commandNames).toContain('chat');
         expect(commandNames).toContain('theme');
@@ -136,7 +142,6 @@ describe('CommandService', () => {
         expect(commandNames).toContain('about');
         expect(commandNames).toContain('extensions');
         expect(commandNames).toContain('tools');
-        expect(commandNames).toContain('compress');
         expect(commandNames).toContain('mcp');
         expect(commandNames).not.toContain('ide');
       });
@@ -201,6 +206,7 @@ describe('CommandService', () => {
           chatCommand,
           clearCommand,
           compressCommand,
+          corgiCommand,
           docsCommand,
           editorCommand,
           extensionsCommand,

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -9,6 +9,7 @@ import { SlashCommand } from '../ui/commands/types.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
+import { corgiCommand } from '../ui/commands/corgiCommand.js';
 import { docsCommand } from '../ui/commands/docsCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { authCommand } from '../ui/commands/authCommand.js';
@@ -36,6 +37,7 @@ const loadBuiltInCommands = async (
     chatCommand,
     clearCommand,
     compressCommand,
+    corgiCommand,
     docsCommand,
     editorCommand,
     extensionsCommand,

--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -47,6 +47,7 @@ export const createMockCommandContext = (
       pendingItem: null,
       setPendingItem: vi.fn(),
       loadHistory: vi.fn(),
+      toggleCorgiMode: vi.fn(),
     },
     session: {
       stats: {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -379,7 +379,6 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   } = useSlashCommandProcessor(
     config,
     settings,
-    history,
     addItem,
     clearItems,
     loadHistory,

--- a/packages/cli/src/ui/commands/corgiCommand.test.ts
+++ b/packages/cli/src/ui/commands/corgiCommand.test.ts
@@ -24,7 +24,7 @@ describe('corgiCommand', () => {
 
     await corgiCommand.action(mockContext, '');
 
-\    expect(mockContext.ui.toggleCorgiMode).toHaveBeenCalledTimes(1);
+    expect(mockContext.ui.toggleCorgiMode).toHaveBeenCalledTimes(1);
   });
 
   it('should have the correct name and description', () => {

--- a/packages/cli/src/ui/commands/corgiCommand.test.ts
+++ b/packages/cli/src/ui/commands/corgiCommand.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { corgiCommand } from './corgiCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+
+describe('corgiCommand', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext();
+    vi.spyOn(mockContext.ui, 'toggleCorgiMode');
+  });
+
+  it('should call the toggleCorgiMode function on the UI context', async () => {
+    if (!corgiCommand.action) {
+      throw new Error('The corgi command must have an action.');
+    }
+
+    await corgiCommand.action(mockContext, '');
+
+\    expect(mockContext.ui.toggleCorgiMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('should have the correct name and description', () => {
+    expect(corgiCommand.name).toBe('corgi');
+    expect(corgiCommand.description).toBe('Toggles corgi mode.');
+  });
+});

--- a/packages/cli/src/ui/commands/corgiCommand.ts
+++ b/packages/cli/src/ui/commands/corgiCommand.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type SlashCommand } from './types.js';
+
+export const corgiCommand: SlashCommand = {
+  name: 'corgi',
+  description: 'Toggles corgi mode.',
+  action: (context, _args) => {
+    context.ui.toggleCorgiMode();
+  },
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -47,6 +47,8 @@ export interface CommandContext {
      * @param history The array of history items to load.
      */
     loadHistory: UseHistoryManagerReturn['loadHistory'];
+    /** Toggles a special display mode. */
+    toggleCorgiMode: () => void;
   };
   // Session-specific data
   session: {
@@ -103,6 +105,7 @@ export type SlashCommandActionReturn =
   | QuitActionReturn
   | OpenDialogActionReturn
   | LoadHistoryActionReturn;
+
 // The standardized contract for any command in the system.
 export interface SlashCommand {
   name: string;

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -14,7 +14,7 @@ vi.mock('node:process', () => ({
     cwd: vi.fn(() => '/mock/cwd'),
     get env() {
       return process.env;
-    }, // Use a getter to ensure current process.env is used
+    },
     platform: 'test-platform',
     version: 'test-node-version',
     memoryUsage: vi.fn(() => ({
@@ -25,12 +25,11 @@ vi.mock('node:process', () => ({
       arrayBuffers: 123456,
     })),
   },
-  // Provide top-level exports as well for compatibility
   exit: mockProcessExit,
   cwd: vi.fn(() => '/mock/cwd'),
   get env() {
     return process.env;
-  }, // Use a getter here too
+  },
   platform: 'test-platform',
   version: 'test-node-version',
   memoryUsage: vi.fn(() => ({
@@ -106,19 +105,7 @@ describe('useSlashCommandProcessor', () => {
   const mockUseSessionStats = useSessionStats as Mock;
 
   beforeEach(() => {
-    // Reset all mocks to clear any previous state or calls.
     vi.clearAllMocks();
-
-    // Default mock setup for CommandService for all the OLD tests.
-    // This makes them pass again by simulating the original behavior where
-    // the service is constructed but doesn't do much yet.
-    vi.mocked(CommandService).mockImplementation(
-      () =>
-        ({
-          loadCommands: vi.fn().mockResolvedValue(undefined),
-          getCommands: vi.fn().mockReturnValue([]), // Return an empty array by default
-        }) as unknown as CommandService,
-    );
 
     mockAddItem = vi.fn();
     mockClearItems = vi.fn();
@@ -177,7 +164,6 @@ describe('useSlashCommandProcessor', () => {
       useSlashCommandProcessor(
         mockConfig,
         settings,
-        [],
         mockAddItem,
         mockClearItems,
         mockLoadHistory,
@@ -194,7 +180,7 @@ describe('useSlashCommandProcessor', () => {
     );
   };
 
-  describe('New command registry', () => {
+  describe('Command Processing', () => {
     let ActualCommandService: typeof CommandService;
 
     beforeAll(async () => {
@@ -208,7 +194,7 @@ describe('useSlashCommandProcessor', () => {
       vi.clearAllMocks();
     });
 
-    it('should execute a command from the new registry', async () => {
+    it('should execute a registered command', async () => {
       const mockAction = vi.fn();
       const newCommand: SlashCommand = { name: 'test', action: mockAction };
       const mockLoader = async () => [newCommand];
@@ -243,7 +229,7 @@ describe('useSlashCommandProcessor', () => {
       expect(commandResult).toEqual({ type: 'handled' });
     });
 
-    it('should return "schedule_tool" when a new command returns a tool action', async () => {
+    it('should return "schedule_tool" for a command returning a tool action', async () => {
       const mockAction = vi.fn().mockResolvedValue({
         type: 'tool',
         toolName: 'my_tool',
@@ -276,7 +262,7 @@ describe('useSlashCommandProcessor', () => {
       });
     });
 
-    it('should return "handled" when a new command returns a message action', async () => {
+    it('should return "handled" for a command returning a message action', async () => {
       const mockAction = vi.fn().mockResolvedValue({
         type: 'message',
         messageType: 'info',
@@ -312,7 +298,7 @@ describe('useSlashCommandProcessor', () => {
       expect(commandResult).toEqual({ type: 'handled' });
     });
 
-    it('should return "handled" when a new command returns a dialog action', async () => {
+    it('should return "handled" for a command returning a dialog action', async () => {
       const mockAction = vi.fn().mockResolvedValue({
         type: 'dialog',
         dialog: 'help',
@@ -341,7 +327,7 @@ describe('useSlashCommandProcessor', () => {
       expect(commandResult).toEqual({ type: 'handled' });
     });
 
-    it('should open the auth dialog when a new command returns an auth dialog action', async () => {
+    it('should open the auth dialog for a command returning an auth dialog action', async () => {
       const mockAction = vi.fn().mockResolvedValue({
         type: 'dialog',
         dialog: 'auth',
@@ -371,7 +357,7 @@ describe('useSlashCommandProcessor', () => {
       expect(commandResult).toEqual({ type: 'handled' });
     });
 
-    it('should open the theme dialog when a new command returns a theme dialog action', async () => {
+    it('should open the theme dialog for a command returning a theme dialog action', async () => {
       const mockAction = vi.fn().mockResolvedValue({
         type: 'dialog',
         dialog: 'theme',


### PR DESCRIPTION
## TLDR

This PR completes the command migration project by migrating the final legacy command, `/corgi`, to the new command structure. With this change, the entire legacy command processing system, including the `legacyCommands` array and related fallback logic in `slashCommandProcessor.ts`, has been removed. 

## Dive Deeper

The migration of the `/corgi` command followed the established plan:

1.  A new command file was created at `packages/cli/src/ui/commands/corgiCommand.ts`.
2.  A corresponding test file, `corgiCommand.test.ts`, was added to ensure the command's functionality is covered.
3.  The new command was registered in `CommandService.ts` and its test file.

The most significant part of this PR is the cleanup phase. Since `/corgi` was the last command, I was able to:

- Delete the `LegacySlashCommand` interface.
- Remove the `legacyCommands` array and the `useMemo` hook that created it.
- Eliminate the legacy fallback logic from the `handleSlashCommand` function.
- Remove the `allCommands` memoized value and its associated logic for adapting legacy commands.
- Clean up the `useSlashCommandProcessor` hook's signature and dependency arrays, removing props that were only used by the legacy system.

This leaves the `slashCommandProcessor` hook much leaner.

## Reviewer Test Plan

1.  Start the application using `npm start`.
2.  Type `/corgi` and press Enter.
3.  Verify that the corgi mode is toggled (the footer should change).
4.  Type `/corgi` again and press Enter.
5.  Verify that the corgi mode is toggled back to its original state.
6.  Test a few other commands (e.g., `/help`, `/theme`, `/clear`) to ensure that the removal of the legacy system has not caused any regressions.
7.  Confirm that typing an unknown command like `/foo` correctly displays an "Unknown command" error.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |
