### PR TITLE
(fix): broken releases and e2e workflows 

### DIFF
--- a/.gcp/release-docker.yaml
+++ b/.gcp/release-docker.yaml
@@ -48,7 +48,7 @@ steps:
       - |
         export GEMINI_SANDBOX_IMAGE_TAG=$$(cat /workspace/image_tag.txt)
         echo "Using Docker image tag for build: $$GEMINI_SANDBOX_IMAGE_TAG"
-        npm run build:sandbox
+        npm run build:sandbox -- --output-file /workspace/final_image_uri.txt
     env:
       - 'GEMINI_SANDBOX=$_CONTAINER_TOOL'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [main]
   merge_group:
-  pull_request: {}
 
 jobs:
   e2e-test:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [main]
   merge_group:
+  pull_request: {}
 
 jobs:
   e2e-test:

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -133,7 +133,8 @@ function buildImage(imageName, dockerfile) {
   const finalImageName = `${imageName.split(':')[0]}:${imageTag}`;
 
   execSync(
-    `${buildCommand} ${process.env.BUILD_SANDBOX_FLAGS || ''
+    `${buildCommand} ${
+      process.env.BUILD_SANDBOX_FLAGS || ''
     } --build-arg CLI_VERSION_ARG=${npmPackageVersion} -f "${dockerfile}" -t "${finalImageName}" .`,
     { stdio: buildStdout, shell: '/bin/bash' },
   );

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -141,7 +141,6 @@ function buildImage(imageName, dockerfile) {
   console.log(`built ${finalImageName}`);
 
   // If an output file path was provided via command-line, write the final image URI to it.
-  // TODO: Need a change to push the branch. REMOVE THIS
   if (argv.outputFile) {
     console.log(
       `Writing final image URI for CI artifact to: ${argv.outputFile}`,

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -40,6 +40,11 @@ const argv = yargs(hideBin(process.argv))
     alias: 'image',
     type: 'string',
     description: 'use <image> name for custom image',
+  })
+  .option('output-file', {
+    type: 'string',
+    description:
+      'Path to write the final image URI. Used for CI/CD pipeline integration.',
   }).argv;
 
 let sandboxCommand;
@@ -128,20 +133,26 @@ function buildImage(imageName, dockerfile) {
   const finalImageName = `${imageName.split(':')[0]}:${imageTag}`;
 
   execSync(
-    `${buildCommand} ${
-      process.env.BUILD_SANDBOX_FLAGS || ''
+    `${buildCommand} ${process.env.BUILD_SANDBOX_FLAGS || ''
     } --build-arg CLI_VERSION_ARG=${npmPackageVersion} -f "${dockerfile}" -t "${finalImageName}" .`,
     { stdio: buildStdout, shell: '/bin/bash' },
   );
   console.log(`built ${finalImageName}`);
-  if (existsSync('/workspace/final_image_uri.txt')) {
-    // The publish step only supports one image. If we build multiple, only the last one
-    // will be published. Throw an error to make this failure explicit.
-    throw new Error(
-      'CI artifact file /workspace/final_image_uri.txt already exists. Refusing to overwrite.',
+
+  // If an output file path was provided via command-line, write the final image URI to it.
+  if (argv.outputFile) {
+    console.log(
+      `Writing final image URI for CI artifact to: ${argv.outputFile}`,
     );
+    // The publish step only supports one image. If we build multiple, only the last one
+    // will be published. Throw an error to make this failure explicit if the file already exists.
+    if (existsSync(argv.outputFile)) {
+      throw new Error(
+        `CI artifact file ${argv.outputFile} already exists. Refusing to overwrite.`,
+      );
+    }
+    writeFileSync(argv.outputFile, finalImageName);
   }
-  writeFileSync('/workspace/final_image_uri.txt', finalImageName);
 }
 
 if (baseImage && baseDockerfile) {

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -141,6 +141,7 @@ function buildImage(imageName, dockerfile) {
   console.log(`built ${finalImageName}`);
 
   // If an output file path was provided via command-line, write the final image URI to it.
+  // TODO: Need a change to push the branch. REMOVE THIS
   if (argv.outputFile) {
     console.log(
       `Writing final image URI for CI artifact to: ${argv.outputFile}`,


### PR DESCRIPTION
## TLDR

This PR fixes a bug that was causing our `release` and post-merge `e2e` workflows to fail. The root cause was that the `build_sandbox.js` script was hardcoded to write an artifact to `/workspace`, a path that only exists in our Google Cloud Build environment, causing it to crash when run in GitHub Actions.

The fix makes the script environment-agnostic by introducing a new `--output-file` command-line argument. Only the Google Cloud Build pipeline explicitly uses this flag to generate the build artifact, resolving the crash in all other environments.

## Dive Deeper

The `build_sandbox.js` script had an implicit dependency on the filesystem layout of Google Cloud Build, making it brittle and causing failures when executed in the standard GitHub Actions environment during E2E and release pre-flight tests.

The error `ENOENT: no such file or directory, open '/workspace/final_image_uri.txt'` was a direct result of this assumption.

1.  **`scripts/build_sandbox.js` has been updated:**
    *   It now accepts a new command-line argument: `--output-file <path>`.
    *   The logic for writing the final image URI is now wrapped in a conditional block that only executes if the `--output-file` argument is provided. This removes the hardcoded dependency on `/workspace`.

2.  **`.gcp/release-docker.yaml` has been updated:**
    *   The "Build sandbox Docker image" step now explicitly instructs the build script to generate the artifact by passing the new argument: `npm run build:sandbox -- --output-file /workspace/final_image_uri.txt`.

This design makes the script's behavior explicit, decouples it from any specific CI environment, and makes the entire process more resilient and maintainable.

### Before and After

Since the triggers have to be removed before merge, I have the following screenshots to show the successful tests that were previous failing:

#### E2E Tests

Before:
<img width="1536" height="623" alt="Screenshot 2025-07-17 at 11 03 22 PM" src="https://github.com/user-attachments/assets/0dfdfb4b-524c-4ed6-8c82-d33fafffc8cd" />

After:
<img width="1077" height="583" alt="Screenshot 2025-07-17 at 11 03 29 PM" src="https://github.com/user-attachments/assets/64f20e87-3018-445c-882e-eaa444661b6e" />

#### Release

Before:
<img width="1549" height="971" alt="Screenshot 2025-07-17 at 11 08 25 PM" src="https://github.com/user-attachments/assets/5b146962-14ec-4b5f-92a7-baecd7c4677f" />

After (Dry-Run):
<img width="1044" height="983" alt="Screenshot 2025-07-17 at 11 19 24 PM" src="https://github.com/user-attachments/assets/fd470747-858d-4e13-a6a6-f560eb721c33" />

#### Cloud Run Test

<img width="1059" height="671" alt="Screenshot 2025-07-17 at 11 32 08 PM" src="https://github.com/user-attachments/assets/6570dc92-886f-4609-8e5d-2e0185b55c70" />


## Reviewer Test Plan

This plan validates that the fix works correctly in the actual CI workflows.

### Live CI Validation

Since these workflows normally only run on `main`, we have to temporarily alter the triggers to run them on this PR branch.

1.  **Test the E2E Workflow Fix:**
    *   **Action:** Temporarily modify `.github/workflows/e2e.yml` to add a `pull_request: {}` trigger to the `on:` block.
      ```diff
      on:
        push:
          branches: [main]
        merge_group:
      + pull_request: {}
      ```
    *   Push this change to your PR.
    *   **Validation:** Go to the PR's "Checks" tab and verify the **"E2E Tests"** workflow runs and the `E2E Test - sandbox:docker` job passes.

2.  **Test the Release Workflow Fix:**
    *   **Action:** Go to the "Actions" tab in the GitHub repo, select the **"Release"** workflow, and click **"Run workflow"**.
    *   **Fill out the form:**
        *   **Use workflow from:** Select **Branch** and choose your PR's branch name. **(This is critical)**.
        *   **dry_run:** Check the box to set it to `true`.
        *   **force_skip_tests:** Ensure this is **unchecked**.
    *   **Validation:** The workflow will start. Verify that the **"Run Tests"** step within the `release` job passes successfully.

## Testing Matrix


|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |
