### PR TITLE
fix(cli): improve Ctrl+Backspace word deletion functionality

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -119,6 +119,12 @@ their corresponding top-level category object in your `settings.json` file.
   - **Description:** Enable debug logging of keystrokes to the console.
   - **Default:** `false`
 
+- **`general.ctrlBackspaceModeFix`** (boolean):
+  - **Description:** Enables a fix for `Ctrl+Backspace` functionality in the CLI
+    prompt. This is useful if you are experiencing issues with word deletion in
+    your terminal.
+  - **Default:** `false`
+
 - **`general.sessionRetention.enabled`** (boolean):
   - **Description:** Enable automatic session cleanup.
   - **Default:** `false`

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -203,6 +203,16 @@ const SETTINGS_SCHEMA = {
         description: 'Enable debug logging of keystrokes to the console.',
         showInDialog: true,
       },
+      ctrlBackspaceModeFix: {
+        type: 'boolean',
+        label: 'Ctrl+Backspace mode fix',
+        category: 'General',
+        requiresRestart: true,
+        default: false,
+        description:
+          'Enable fix for Ctrl+Backspace functionality on non-kitty terminals',
+        showInDialog: false,
+      },
       sessionRetention: {
         type: 'object',
         label: 'Session Retention',

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -175,6 +175,7 @@ export async function startInteractiveUI(
           kittyProtocolEnabled={kittyProtocolStatus.enabled}
           config={config}
           debugKeystrokeLogging={settings.merged.general?.debugKeystrokeLogging}
+          ctrlBackspaceModeFix={settings.merged.general?.ctrlBackspaceModeFix}
         >
           <SessionStatsProvider>
             <VimModeProvider settings={settings}>

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -430,6 +430,111 @@ describe('useTextBuffer', () => {
     });
   });
 
+  describe('Word Deletion ctrl+backspace', () => {
+    it('should handle ctrl+backspace to delete word left', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'ab cd',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      act(() => result.current.move('end'));
+      act(() =>
+        result.current.handleInput({
+          name: 'backspace',
+          ctrl: true,
+          meta: false,
+          shift: false,
+          paste: false,
+        }),
+      );
+      const state = getBufferState(result);
+      expect(state.text).toBe('ab ');
+      expect(state.cursor).toEqual([0, 3]);
+    });
+
+    it('should handle ctrl+backspace at line beginning to merge lines', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'hello\nworld',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      act(() => result.current.move('down'));
+      act(() =>
+        result.current.handleInput({
+          name: 'backspace',
+          ctrl: true,
+          meta: false,
+          shift: false,
+          paste: false,
+        }),
+      );
+      const state = getBufferState(result);
+      expect(state.text).toBe('helloworld');
+      expect(state.cursor).toEqual([0, 5]);
+    });
+
+    it('should handle ctrl+backspace with multiple spaces', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'word   more',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      // Position cursor after the spaces
+      act(() => result.current.move('right'));
+      act(() => result.current.move('right'));
+      act(() => result.current.move('right'));
+      act(() => result.current.move('right'));
+      act(() => result.current.move('right'));
+      act(() => result.current.move('right'));
+      act(() => result.current.move('right'));
+
+      act(() =>
+        result.current.handleInput({
+          name: 'backspace',
+          ctrl: true,
+          meta: false,
+          shift: false,
+          paste: false,
+        }),
+      );
+      const state = getBufferState(result);
+      expect(state.text).toBe('more');
+      expect(state.cursor).toEqual([0, 0]);
+    });
+
+    it('should handle ctrl+backspace at beginning of buffer', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'ab cd',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      act(() =>
+        result.current.handleInput({
+          name: 'backspace',
+          ctrl: true,
+          meta: false,
+          shift: false,
+          paste: false,
+        }),
+      );
+      const state = getBufferState(result);
+      expect(state.text).toBe('ab cd');
+      expect(state.cursor).toEqual([0, 0]);
+    });
+  });
+
   describe('Basic Editing', () => {
     it('insert: should insert a character and update cursor', () => {
       const { result } = renderHook(() =>


### PR DESCRIPTION
Fix Ctrl+Backspace word deletion that wasn't working in certain cases. Add platform-specific detection (Linux: \x08, Windows: \x7f) and environment variable control via GEMINI_CLI_CTRL_BACKSPACE_MODE.

Fixes #3101

## TLDR

 Fixes Ctrl+Backspace word deletion functionality that wasn't working in certain terminals
   by improving key sequence detection and adding platform-specific handling.
## Dive Deeper

### Problem

Different terminals handle backspace and Ctrl+Backspace inconsistently, creating compatibility issues:

- **Most Linux terminals by default** (st, alacritty, kitty, rxvt-unicode, xfce-terminal, terminator, etc.) use:
  - `\x7f` for backspace
  - `\x08` for Ctrl+Backspace

- **Other terminals like Windows Terminal or xterm** use:
  - `\x08` for backspace
  - Different sequence for Ctrl+Backspace


Although gemini-cli has logic to support Ctrl+Backspace, it relies on Node's readline module for key processing. When readline encounters the `\x08` byte, it always interprets it as a regular backspace:

```javascript
{
  sequence: '\x08',
  name: 'backspace',
  ctrl: false,
  // ...
}
```

This causes the following conditional to never evaluate to `true` for Ctrl+Backspace in terminals that use `\x08` or `\x7f` for ctrl+backspace:

```javascript
else if (
  (key.meta || key.ctrl) &&
  (key.name === 'backspace' || input === '\x7f')
)
  deleteWordLeft();
```

We cannot simply check if the byte is `\x08` and set the `ctrl` flag to true, because this would cause terminals like Windows terminal to treat regular a backspace as Ctrl+Backspace.


While it would be ideal to detect which byte sequence the terminal uses for backspace, the most straightforward solution is to implement an environment variable that users can set to enable Ctrl+Backspace functionality, this will avoid breaking existing functionality while solving the issue on most terminals.

### Implementation

The implemented solution uses a feature flag approach with platform-aware detection, when linux users opt-in via `GEMINI_CLI_CTRL_BACKSPACE_MODE=true` we manually set the `ctrl` flag as true for the byte `\x08` (this will make ctrl+backspace work on most terminals), and for Windows users we do the same but for `\x7f`

The environment variable approach ensures backward compatibility while solving the issue for users who need it.

**Opt-in behavior**: Users can enable when needed
**Backward compatibility**: Existing workflows remain unchanged

## Reviewer Test Plan

  1. **Enable the feature**: Set `export GEMINI_CLI_CTRL_BACKSPACE_MODE="true"`
  2. **Test previously broken scenarios**:
     - Type "hello world test"
     - Press Ctrl+Backspace → should now reliably delete "test" on terminals that use `x08` on linux or `x7f` on windows. 


The implementation includes tests in two separate files:

`useKeypress.test.ts`: Tests the low-level key detection logic - verifies that the `ctrl` flag gets set correctly based on platform and byte sequence when the environment variable is enabled.
`text-buffer.test.ts`: Tests the ctrl+backspace word deletion behavior, ensures that when `ctrl` is `true`, the `deleteWordLeft()` function actually gets called and removes the correct text.



## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Fixes: #3101 
- #4067 Duplicate of 3101
