### PR TITLE
feat(clearcut): add ClearcutDecodeError and improve decodeLogResponse error handling

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -542,7 +542,8 @@ describe('ClearcutLogger', () => {
       ) as { event_id: string };
       expect(firstRequeuedEvent.event_id).toBe('failed_5');
     });
-//asdf
+  });
+});
 
 function encodeVarint(value: number): Buffer {
   const bytes: number[] = [];
@@ -572,7 +573,7 @@ describe('decodeLogResponse', () => {
     expect(result).toEqual({ nextRequestWaitMs: 123 });
   });
 
-  it('thorws for empty buffer', () => {
+  it('throws for empty buffer', () => {
     expect(() => logger.decodeLogResponse(Buffer.alloc(0))).toThrow(
       ClearcutDecodeError,
     );
@@ -584,7 +585,7 @@ describe('decodeLogResponse', () => {
     );
   });
 
-  it('thorws for unterminated varint', () => {
+  it('throws for unterminated varint', () => {
     const buf = Buffer.from([8, 0x80]);
     expect(() => logger.decodeLogResponse(buf)).toThrow(ClearcutDecodeError);
   });
@@ -594,4 +595,3 @@ describe('decodeLogResponse', () => {
     expect(() => logger.decodeLogResponse(buf)).toThrow(ClearcutDecodeError);
   });
 });
-  

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -322,19 +322,6 @@ export class ClearcutLogger {
       this.flushToClearcut().catch((error) => {
         if (this.config?.getDebugMode()) {
           console.debug('Error in pending flush to Clearcut:', error);
-        // Add the events back to the front of the queue to be retried.
-        this.events.unshift(...eventsToSend);
-        reject(e);
-      });
-      req.end(body);
-    })
-      .then((buf: Buffer) => {
-        try {
-          this.last_flush_time = Date.now();
-          return this.decodeLogResponse(buf);
-        } catch (error: unknown) {
-          console.error('Error flushing log events:', error);
-          return {};
         }
       });
     }
@@ -410,11 +397,6 @@ export class ClearcutLogger {
       },
       {
         gemini_cli_key:
-          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
-        value: event.vertex_ai_enabled.toString(),
-      },
-      {
-        gemini_cli_key:
           EventMetadataKey.GEMINI_CLI_START_SESSION_DEBUG_MODE_ENABLED,
         value: event.debug_enabled.toString(),
       },
@@ -426,11 +408,6 @@ export class ClearcutLogger {
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_START_SESSION_MCP_SERVERS,
         value: event.mcp_servers,
-      },
-      {
-        gemini_cli_key:
-          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
-        value: event.vertex_ai_enabled.toString(),
       },
       {
         gemini_cli_key:


### PR DESCRIPTION
## TLDR

This pull request introduces a dedicated `ClearcutDecodeError` class and improves the robustness of `decodeLogResponse` by adding explicit error handling for malformed or unexpected Clearcut response buffers.

It also adds comprehensive unit tests to ensure both successful and failure decoding cases are covered.

---

## Dive Deeper

### Why?

Previously, `decodeLogResponse` had limited error handling, which could lead to vague or uninformative exceptions when decoding failed due to malformed data. This made debugging difficult and reduced the reliability of upstream usage.

By introducing `ClearcutDecodeError`, we can now:

- Distinguish decode-specific failures from other logic errors
- Catch and report:
  - Empty buffer inputs
  - Missing required protobuf fields
  - Unterminated or oversized varint encodings
  - Invalid wire types or unknown tag formats

### What’s included?

- `ClearcutDecodeError` class (in `clearcut-logger.ts`)
- Enhanced error handling in `decodeLogResponse`
- Unit tests for:
  - Valid decoding
  - Unknown field tolerance
  - Empty input
  - Invalid tag or wire type
  - Truncated or oversized varint

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ✅  |
| Docker   | ❓  | ❓  | ✅  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #4434
