### PR TITLE
fix: handle cross-device issues with running otel collector

### DIFF
--- a/scripts/telemetry_utils.js
+++ b/scripts/telemetry_utils.js
@@ -248,7 +248,16 @@ export async function ensureBinary(
       );
     }
 
-    fs.renameSync(foundBinaryPath, executablePath);
+    try {
+      fs.renameSync(foundBinaryPath, executablePath);
+    } catch (error) {
+      if (error.code === 'EXDEV') {
+        fs.copyFileSync(foundBinaryPath, executablePath);
+        fs.unlinkSync(foundBinaryPath);
+      } else {
+        throw error;
+      }
+    }
 
     if (platform !== 'windows') {
       fs.chmodSync(executablePath, '755');

--- a/scripts/telemetry_utils.js
+++ b/scripts/telemetry_utils.js
@@ -111,6 +111,32 @@ export function writeJsonFile(filePath, data) {
   fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
 }
 
+export function moveBinary(source, destination) {
+  try {
+    fs.renameSync(source, destination);
+  } catch (error) {
+    if (error.code !== 'EXDEV') {
+      throw error;
+    }
+    // Handle a cross-device error: copy-to-temp-then-rename.
+    const destDir = path.dirname(destination);
+    const destFile = path.basename(destination);
+    const tempDest = path.join(destDir, `${destFile}.tmp`);
+
+    try {
+      fs.copyFileSync(source, tempDest);
+      fs.renameSync(tempDest, destination);
+    } catch (moveError) {
+      // If copy or rename fails, clean up the intermediate temp file.
+      if (fs.existsSync(tempDest)) {
+        fs.unlinkSync(tempDest);
+      }
+      throw moveError;
+    }
+    fs.unlinkSync(source);
+  }
+}
+
 export function waitForPort(port, timeout = 10000) {
   return new Promise((resolve, reject) => {
     const startTime = Date.now();
@@ -248,16 +274,7 @@ export async function ensureBinary(
       );
     }
 
-    try {
-      fs.renameSync(foundBinaryPath, executablePath);
-    } catch (error) {
-      if (error.code === 'EXDEV') {
-        fs.copyFileSync(foundBinaryPath, executablePath);
-        fs.unlinkSync(foundBinaryPath);
-      } else {
-        throw error;
-      }
-    }
+    moveBinary(foundBinaryPath, executablePath);
 
     if (platform !== 'windows') {
       fs.chmodSync(executablePath, '755');


### PR DESCRIPTION
## TLDR

This PR addresses an issue when running `npm run telemetry -- --target=gcp` in an environment where source and destination (/tmp and ~/.gemini) are on different partitions/devices, causing an EXDEV error. It falls back to copy and delete logic when the current rename logic does not work. 

## Dive Deeper

The PR updates `telemetry_utils.js` to run `fs.copyFileSync` and `fs.unlinkSync` when an EXDEV error is caught during `ensureBinary`.

## Reviewer Test Plan

In an environment where /tmp and ~/ are on different devices, run `npm run telemetry -- --target=gcp` with and without this change. 

Without this change, the error should look like that outlined in issue #4455, with this change, the telemetry setup should succeed with this message:

```
✨ Local OTEL collector for GCP is running.

🚀 To send telemetry, run the Gemini CLI in a separate terminal window.
```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |  ✅  | ❓  |  ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Resolves #4455