### PR TITLE
feat(memory): make directory search limit on memory discovery configurable with settings.json

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -429,7 +429,7 @@ This example demonstrates how you can provide general project context, specific 
       - Location: The CLI searches for the configured context file in the current working directory and then in each parent directory up to either the project root (identified by a `.git` folder) or your home directory.
       - Scope: Provides context relevant to the entire project or a significant portion of it.
   3.  **Sub-directory Context Files (Contextual/Local):**
-      - Location: The CLI also scans for the configured context file in subdirectories _below_ the current working directory (respecting common ignore patterns like `node_modules`, `.git`, etc.).
+      - Location: The CLI also scans for the configured context file in subdirectories _below_ the current working directory (respecting common ignore patterns like `node_modules`, `.git`, etc.). The breadth of this search is limited to 200 directories by default, but can be configured with a `memoryDiscoveryMaxDirs` field in your `settings.json` file.
       - Scope: Allows for highly specific instructions relevant to a particular component, module, or subsection of your project.
 - **Concatenation & UI Indication:** The contents of all found context files are concatenated (with separators indicating their origin and path) and provided as part of the system prompt to the Gemini model. The CLI footer displays the count of loaded context files, giving you a quick visual cue about the active instructional context.
 - **Commands for Memory Management:**

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -37,7 +37,7 @@ vi.mock('@google/gemini-cli-core', async () => {
     ...actualServer,
     loadEnvironment: vi.fn(),
     loadServerHierarchicalMemory: vi.fn(
-      (cwd, debug, fileService, extensionPaths) =>
+      (cwd, debug, fileService, extensionPaths, _maxDirs) =>
         Promise.resolve({
           memoryContent: extensionPaths?.join(',') || '',
           fileCount: extensionPaths?.length || 0,
@@ -491,6 +491,7 @@ describe('Hierarchical Memory Loading (config.ts) - Placeholder Suite', () => {
         respectGitIgnore: false,
         respectGeminiIgnore: true,
       },
+      undefined, // maxDirs
     );
   });
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -220,6 +220,7 @@ export async function loadHierarchicalGeminiMemory(
   currentWorkingDirectory: string,
   debugMode: boolean,
   fileService: FileDiscoveryService,
+  settings: Settings,
   extensionContextFilePaths: string[] = [],
   fileFilteringOptions?: FileFilteringOptions,
 ): Promise<{ memoryContent: string; fileCount: number }> {
@@ -237,6 +238,7 @@ export async function loadHierarchicalGeminiMemory(
     fileService,
     extensionContextFilePaths,
     fileFilteringOptions,
+    settings.memoryDiscoveryMaxDirs,
   );
 }
 
@@ -293,6 +295,7 @@ export async function loadCliConfig(
     process.cwd(),
     debugMode,
     fileService,
+    settings,
     extensionContextFilePaths,
     fileFiltering,
   );

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -100,6 +100,7 @@ export interface Settings {
 
   // Add other settings here.
   ideMode?: boolean;
+  memoryDiscoveryMaxDirs?: number;
 }
 
 export interface SettingsError {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -236,6 +236,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
         process.cwd(),
         config.getDebugMode(),
         config.getFileService(),
+        settings.merged,
         config.getExtensionContextFilePaths(),
         config.getFileFilteringOptions(),
       );
@@ -267,7 +268,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
       );
       console.error('Error refreshing memory:', error);
     }
-  }, [config, addItem]);
+  }, [config, addItem, settings.merged]);
 
   // Watch for model changes (e.g., from Flash fallback)
   useEffect(() => {

--- a/packages/cli/src/ui/commands/memoryCommand.test.ts
+++ b/packages/cli/src/ui/commands/memoryCommand.test.ts
@@ -9,7 +9,11 @@ import { memoryCommand } from './memoryCommand.js';
 import { type CommandContext, SlashCommand } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { MessageType } from '../types.js';
-import { getErrorMessage } from '@google/gemini-cli-core';
+import {
+  getErrorMessage,
+  loadServerHierarchicalMemory,
+  type FileDiscoveryService,
+} from '@google/gemini-cli-core';
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const original =
@@ -20,8 +24,11 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
       if (error instanceof Error) return error.message;
       return String(error);
     }),
+    loadServerHierarchicalMemory: vi.fn(),
   };
 });
+
+const mockLoadServerHierarchicalMemory = loadServerHierarchicalMemory as Mock;
 
 describe('memoryCommand', () => {
   let mockContext: CommandContext;
@@ -139,19 +146,26 @@ describe('memoryCommand', () => {
 
   describe('/memory refresh', () => {
     let refreshCommand: SlashCommand;
-    let mockRefreshMemory: Mock;
+    let mockSetUserMemory: Mock;
+    let mockSetGeminiMdFileCount: Mock;
 
     beforeEach(() => {
       refreshCommand = getSubCommand('refresh');
-      mockRefreshMemory = vi.fn();
+      mockSetUserMemory = vi.fn();
+      mockSetGeminiMdFileCount = vi.fn();
       mockContext = createMockCommandContext({
         services: {
           config: {
-            refreshMemory: mockRefreshMemory,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } as any,
+            setUserMemory: mockSetUserMemory,
+            setGeminiMdFileCount: mockSetGeminiMdFileCount,
+            getWorkingDir: () => '/test/dir',
+            getDebugMode: () => false,
+            getFileService: () => ({}) as FileDiscoveryService,
+            getExtensionContextFilePaths: () => [],
+          },
         },
       });
+      mockLoadServerHierarchicalMemory.mockClear();
     });
 
     it('should display success message when memory is refreshed with content', async () => {
@@ -161,7 +175,7 @@ describe('memoryCommand', () => {
         memoryContent: 'new memory content',
         fileCount: 2,
       };
-      mockRefreshMemory.mockResolvedValue(refreshResult);
+      mockLoadServerHierarchicalMemory.mockResolvedValue(refreshResult);
 
       await refreshCommand.action(mockContext, '');
 
@@ -173,7 +187,13 @@ describe('memoryCommand', () => {
         expect.any(Number),
       );
 
-      expect(mockRefreshMemory).toHaveBeenCalledOnce();
+      expect(loadServerHierarchicalMemory).toHaveBeenCalledOnce();
+      expect(mockSetUserMemory).toHaveBeenCalledWith(
+        refreshResult.memoryContent,
+      );
+      expect(mockSetGeminiMdFileCount).toHaveBeenCalledWith(
+        refreshResult.fileCount,
+      );
 
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
@@ -188,11 +208,13 @@ describe('memoryCommand', () => {
       if (!refreshCommand.action) throw new Error('Command has no action');
 
       const refreshResult = { memoryContent: '', fileCount: 0 };
-      mockRefreshMemory.mockResolvedValue(refreshResult);
+      mockLoadServerHierarchicalMemory.mockResolvedValue(refreshResult);
 
       await refreshCommand.action(mockContext, '');
 
-      expect(mockRefreshMemory).toHaveBeenCalledOnce();
+      expect(loadServerHierarchicalMemory).toHaveBeenCalledOnce();
+      expect(mockSetUserMemory).toHaveBeenCalledWith('');
+      expect(mockSetGeminiMdFileCount).toHaveBeenCalledWith(0);
 
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
@@ -207,11 +229,13 @@ describe('memoryCommand', () => {
       if (!refreshCommand.action) throw new Error('Command has no action');
 
       const error = new Error('Failed to read memory files.');
-      mockRefreshMemory.mockRejectedValue(error);
+      mockLoadServerHierarchicalMemory.mockRejectedValue(error);
 
       await refreshCommand.action(mockContext, '');
 
-      expect(mockRefreshMemory).toHaveBeenCalledOnce();
+      expect(loadServerHierarchicalMemory).toHaveBeenCalledOnce();
+      expect(mockSetUserMemory).not.toHaveBeenCalled();
+      expect(mockSetGeminiMdFileCount).not.toHaveBeenCalled();
 
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
@@ -243,7 +267,7 @@ describe('memoryCommand', () => {
         expect.any(Number),
       );
 
-      expect(mockRefreshMemory).not.toHaveBeenCalled();
+      expect(loadServerHierarchicalMemory).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/ui/commands/memoryCommand.test.ts
+++ b/packages/cli/src/ui/commands/memoryCommand.test.ts
@@ -9,6 +9,7 @@ import { memoryCommand } from './memoryCommand.js';
 import { type CommandContext, SlashCommand } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { MessageType } from '../types.js';
+import { LoadedSettings } from '../../config/settings.js';
 import {
   getErrorMessage,
   loadServerHierarchicalMemory,
@@ -153,16 +154,27 @@ describe('memoryCommand', () => {
       refreshCommand = getSubCommand('refresh');
       mockSetUserMemory = vi.fn();
       mockSetGeminiMdFileCount = vi.fn();
+      const mockConfig = {
+        setUserMemory: mockSetUserMemory,
+        setGeminiMdFileCount: mockSetGeminiMdFileCount,
+        getWorkingDir: () => '/test/dir',
+        getDebugMode: () => false,
+        getFileService: () => ({}) as FileDiscoveryService,
+        getExtensionContextFilePaths: () => [],
+        getFileFilteringOptions: () => ({
+          ignore: [],
+          include: [],
+        }),
+      };
+
       mockContext = createMockCommandContext({
         services: {
-          config: {
-            setUserMemory: mockSetUserMemory,
-            setGeminiMdFileCount: mockSetGeminiMdFileCount,
-            getWorkingDir: () => '/test/dir',
-            getDebugMode: () => false,
-            getFileService: () => ({}) as FileDiscoveryService,
-            getExtensionContextFilePaths: () => [],
-          },
+          config: Promise.resolve(mockConfig),
+          settings: {
+            merged: {
+              memoryDiscoveryMaxDirs: 1000,
+            },
+          } as LoadedSettings,
         },
       });
       mockLoadServerHierarchicalMemory.mockClear();

--- a/packages/cli/src/ui/commands/memoryCommand.ts
+++ b/packages/cli/src/ui/commands/memoryCommand.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getErrorMessage } from '@google/gemini-cli-core';
+import {
+  getErrorMessage,
+  loadServerHierarchicalMemory,
+} from '@google/gemini-cli-core';
 import { MessageType } from '../types.js';
 import {
   CommandKind,
@@ -81,10 +84,20 @@ export const memoryCommand: SlashCommand = {
         );
 
         try {
-          const result = await context.services.config?.refreshMemory();
+          const config = await context.services.config;
+          if (config) {
+            const { memoryContent, fileCount } =
+              await loadServerHierarchicalMemory(
+                config.getWorkingDir(),
+                config.getDebugMode(),
+                config.getFileService(),
+                config.getExtensionContextFilePaths(),
+                config.getFileFilteringOptions(),
+                context.services.settings.merged.memoryDiscoveryMaxDirs,
+              );
+            config.setUserMemory(memoryContent);
+            config.setGeminiMdFileCount(fileCount);
 
-          if (result) {
-            const { memoryContent, fileCount } = result;
             const successMessage =
               memoryContent.length > 0
                 ? `Memory refreshed successfully. Loaded ${memoryContent.length} characters from ${fileCount} file(s).`

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -18,7 +18,6 @@ import {
 } from '../core/contentGenerator.js';
 import { GeminiClient } from '../core/client.js';
 import { GitService } from '../services/gitService.js';
-import { loadServerHierarchicalMemory } from '../utils/memoryDiscovery.js';
 
 // Mock dependencies that might be called during Config construction or createServerConfig
 vi.mock('../tools/tool-registry', () => {
@@ -311,41 +310,6 @@ describe('Server Config (config.ts)', () => {
       delete paramsWithoutTelemetry.telemetry;
       const config = new Config(paramsWithoutTelemetry);
       expect(config.getTelemetryOtlpEndpoint()).toBe(DEFAULT_OTLP_ENDPOINT);
-    });
-  });
-
-  describe('refreshMemory', () => {
-    it('should update memory and file count on successful refresh', async () => {
-      const config = new Config(baseParams);
-      const mockMemoryData = {
-        memoryContent: 'new memory content',
-        fileCount: 5,
-      };
-
-      (loadServerHierarchicalMemory as Mock).mockResolvedValue(mockMemoryData);
-
-      const result = await config.refreshMemory();
-
-      expect(loadServerHierarchicalMemory).toHaveBeenCalledWith(
-        config.getWorkingDir(),
-        config.getDebugMode(),
-        config.getFileService(),
-        config.getExtensionContextFilePaths(),
-        config.getFileFilteringOptions(),
-      );
-
-      expect(config.getUserMemory()).toBe(mockMemoryData.memoryContent);
-      expect(config.getGeminiMdFileCount()).toBe(mockMemoryData.fileCount);
-      expect(result).toEqual(mockMemoryData);
-    });
-
-    it('should propagate errors from loadServerHierarchicalMemory', async () => {
-      const config = new Config(baseParams);
-      const testError = new Error('Failed to load memory');
-
-      (loadServerHierarchicalMemory as Mock).mockRejectedValue(testError);
-
-      await expect(config.refreshMemory()).rejects.toThrow(testError);
     });
   });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -30,7 +30,6 @@ import { WebSearchTool } from '../tools/web-search.js';
 import { GeminiClient } from '../core/client.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { GitService } from '../services/gitService.js';
-import { loadServerHierarchicalMemory } from '../utils/memoryDiscovery.js';
 import { getProjectTempDir } from '../utils/paths.js';
 import {
   initializeTelemetry,
@@ -569,21 +568,6 @@ export class Config {
       await this.gitService.initialize();
     }
     return this.gitService;
-  }
-
-  async refreshMemory(): Promise<{ memoryContent: string; fileCount: number }> {
-    const { memoryContent, fileCount } = await loadServerHierarchicalMemory(
-      this.getWorkingDir(),
-      this.getDebugMode(),
-      this.getFileService(),
-      this.getExtensionContextFilePaths(),
-      this.getFileFilteringOptions(),
-    );
-
-    this.setUserMemory(memoryContent);
-    this.setGeminiMdFileCount(fileCount);
-
-    return { memoryContent, fileCount };
   }
 
   async createToolRegistry(): Promise<ToolRegistry> {

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -33,8 +33,6 @@ const logger = {
     console.error('[ERROR] [MemoryDiscovery]', ...args),
 };
 
-const MAX_DIRECTORIES_TO_SCAN_FOR_MEMORY = 200;
-
 interface GeminiFileContent {
   filePath: string;
   content: string | null;
@@ -90,6 +88,7 @@ async function getGeminiMdFilePathsInternal(
   fileService: FileDiscoveryService,
   extensionContextFilePaths: string[] = [],
   fileFilteringOptions: FileFilteringOptions,
+  maxDirs: number,
 ): Promise<string[]> {
   const allPaths = new Set<string>();
   const geminiMdFilenames = getAllGeminiMdFilenames();
@@ -194,7 +193,7 @@ async function getGeminiMdFilePathsInternal(
 
     const downwardPaths = await bfsFileSearch(resolvedCwd, {
       fileName: geminiMdFilename,
-      maxDirs: MAX_DIRECTORIES_TO_SCAN_FOR_MEMORY,
+      maxDirs,
       debug: debugMode,
       fileService,
       fileFilteringOptions: mergedOptions, // Pass merged options as fileFilter
@@ -295,6 +294,7 @@ export async function loadServerHierarchicalMemory(
   fileService: FileDiscoveryService,
   extensionContextFilePaths: string[] = [],
   fileFilteringOptions?: FileFilteringOptions,
+  maxDirs: number = 200,
 ): Promise<{ memoryContent: string; fileCount: number }> {
   if (debugMode)
     logger.debug(
@@ -311,6 +311,7 @@ export async function loadServerHierarchicalMemory(
     fileService,
     extensionContextFilePaths,
     fileFilteringOptions || DEFAULT_MEMORY_FILE_FILTERING_OPTIONS,
+    maxDirs,
   );
   if (filePaths.length === 0) {
     if (debugMode) logger.debug('No GEMINI.md files found in hierarchy.');


### PR DESCRIPTION
This change makes the directory search limit for hierarchical memory discovery configurable.

A new memoryDiscoveryMaxDirs field can be added to the user's settings.json to override the default limit of 200 directories.

To implement this, the refreshMemory method was removed from the core config service and its logic was moved into the memoryCommand. This was done to avoid adding the new memoryDiscoveryMaxDirs setting to the core Config interface, keeping the change localized to the CLI package where it is used.

**Recommended Review Order**

   1. packages/core/src/services/memory/memoryDiscovery.ts (to see the new parameter)
   2. packages/cli/src/config/config.ts (to see the setting being passed down)
   3. packages/cli/src/ui/commands/memoryCommand.ts (to see the refactored refresh logic)
   4. packages/cli/src/config/settings.ts (to see the new setting definition)
   5. packages/cli/src/ui/App.tsx (to see the setting passed during initial load)

The remaining changes are corollary updates to tests and call sites.

----

[DEPRECATED PR DESCRIPTION BEFORE INITIAL REVIEW. LEFT TO MAINTAIN THE PAPER TRAIL]

~~This change introduces a configuration option for the memory discovery mechanism.~~

~~The primary change is the addition of the `GEMINI_MEMORY_DISCOVERY_MAX_DIRS` environment variable. This variable allows users to configure the maximum number of directories that will be scanned during the downward traversal phase of memory discovery. The default value is 200.~~

~~A test case has been added to verify that the `GEMINI_MEMORY_DISCOVERY_MAX_DIRS` environment variable is respected. The documentation in `docs/cli/configuration.md` has been updated to reflect this new environment variable and its effect on the breadth of the directory search.~~