### PR TITLE
improve command completion trigger logic based on cursor position

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -761,7 +761,7 @@ describe('InputPrompt', () => {
       mockBuffer.text = '@src/file👍.txt';
       mockBuffer.lines = ['@src/file👍.txt'];
       mockBuffer.cursor = [0, 14]; // After the emoji character
-      
+
       mockedUseCompletion.mockReturnValue({
         ...mockCompletion,
         showSuggestions: true,
@@ -788,7 +788,7 @@ describe('InputPrompt', () => {
       mockBuffer.text = '@src/file👍.txt hello';
       mockBuffer.lines = ['@src/file👍.txt hello'];
       mockBuffer.cursor = [0, 20]; // After the space
-      
+
       mockedUseCompletion.mockReturnValue({
         ...mockCompletion,
         showSuggestions: false,
@@ -815,7 +815,7 @@ describe('InputPrompt', () => {
       mockBuffer.text = '@src/my\\ file.txt';
       mockBuffer.lines = ['@src/my\\ file.txt'];
       mockBuffer.cursor = [0, 16]; // After the escaped space and filename
-      
+
       mockedUseCompletion.mockReturnValue({
         ...mockCompletion,
         showSuggestions: true,
@@ -842,7 +842,7 @@ describe('InputPrompt', () => {
       mockBuffer.text = '@path/my\\ file.txt hello';
       mockBuffer.lines = ['@path/my\\ file.txt hello'];
       mockBuffer.cursor = [0, 24]; // After "hello"
-      
+
       mockedUseCompletion.mockReturnValue({
         ...mockCompletion,
         showSuggestions: false,
@@ -869,11 +869,13 @@ describe('InputPrompt', () => {
       mockBuffer.text = '@docs/my\\ long\\ file\\ name.md';
       mockBuffer.lines = ['@docs/my\\ long\\ file\\ name.md'];
       mockBuffer.cursor = [0, 29]; // At the end
-      
+
       mockedUseCompletion.mockReturnValue({
         ...mockCompletion,
         showSuggestions: true,
-        suggestions: [{ label: 'my long file name.md', value: 'my long file name.md' }],
+        suggestions: [
+          { label: 'my long file name.md', value: 'my long file name.md' },
+        ],
       });
 
       const { unmount } = render(<InputPrompt {...props} />);
@@ -896,7 +898,7 @@ describe('InputPrompt', () => {
       mockBuffer.text = '/memory\\ test';
       mockBuffer.lines = ['/memory\\ test'];
       mockBuffer.cursor = [0, 13]; // At the end
-      
+
       mockedUseCompletion.mockReturnValue({
         ...mockCompletion,
         showSuggestions: true,
@@ -923,11 +925,13 @@ describe('InputPrompt', () => {
       mockBuffer.text = '@files/emoji\\ 👍\\ test.txt';
       mockBuffer.lines = ['@files/emoji\\ 👍\\ test.txt'];
       mockBuffer.cursor = [0, 25]; // After the escaped space and emoji
-      
+
       mockedUseCompletion.mockReturnValue({
         ...mockCompletion,
         showSuggestions: true,
-        suggestions: [{ label: 'emoji 👍 test.txt', value: 'emoji 👍 test.txt' }],
+        suggestions: [
+          { label: 'emoji 👍 test.txt', value: 'emoji 👍 test.txt' },
+        ],
       });
 
       const { unmount } = render(<InputPrompt {...props} />);

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -755,5 +755,194 @@ describe('InputPrompt', () => {
 
       unmount();
     });
+
+    it('should handle Unicode characters (emojis) correctly in paths', async () => {
+      // Test with emoji in path after @
+      mockBuffer.text = '@src/file👍.txt';
+      mockBuffer.lines = ['@src/file👍.txt'];
+      mockBuffer.cursor = [0, 14]; // After the emoji character
+      
+      mockedUseCompletion.mockReturnValue({
+        ...mockCompletion,
+        showSuggestions: true,
+        suggestions: [{ label: 'file👍.txt', value: 'file👍.txt' }],
+      });
+
+      const { unmount } = render(<InputPrompt {...props} />);
+      await wait();
+
+      expect(mockedUseCompletion).toHaveBeenCalledWith(
+        '@src/file👍.txt',
+        '/test/project/src',
+        true, // shouldShowCompletion should be true
+        mockSlashCommands,
+        mockCommandContext,
+        expect.any(Object),
+      );
+
+      unmount();
+    });
+
+    it('should handle Unicode characters with spaces after them', async () => {
+      // Test with emoji followed by space - should NOT trigger completion
+      mockBuffer.text = '@src/file👍.txt hello';
+      mockBuffer.lines = ['@src/file👍.txt hello'];
+      mockBuffer.cursor = [0, 20]; // After the space
+      
+      mockedUseCompletion.mockReturnValue({
+        ...mockCompletion,
+        showSuggestions: false,
+        suggestions: [],
+      });
+
+      const { unmount } = render(<InputPrompt {...props} />);
+      await wait();
+
+      expect(mockedUseCompletion).toHaveBeenCalledWith(
+        '@src/file👍.txt hello',
+        '/test/project/src',
+        false, // shouldShowCompletion should be false
+        mockSlashCommands,
+        mockCommandContext,
+        expect.any(Object),
+      );
+
+      unmount();
+    });
+
+    it('should handle escaped spaces in paths correctly', async () => {
+      // Test with escaped space in path - should trigger completion
+      mockBuffer.text = '@src/my\\ file.txt';
+      mockBuffer.lines = ['@src/my\\ file.txt'];
+      mockBuffer.cursor = [0, 16]; // After the escaped space and filename
+      
+      mockedUseCompletion.mockReturnValue({
+        ...mockCompletion,
+        showSuggestions: true,
+        suggestions: [{ label: 'my file.txt', value: 'my file.txt' }],
+      });
+
+      const { unmount } = render(<InputPrompt {...props} />);
+      await wait();
+
+      expect(mockedUseCompletion).toHaveBeenCalledWith(
+        '@src/my\\ file.txt',
+        '/test/project/src',
+        true, // shouldShowCompletion should be true
+        mockSlashCommands,
+        mockCommandContext,
+        expect.any(Object),
+      );
+
+      unmount();
+    });
+
+    it('should NOT trigger completion after unescaped space following escaped space', async () => {
+      // Test: @path/my\ file.txt hello (unescaped space after escaped space)
+      mockBuffer.text = '@path/my\\ file.txt hello';
+      mockBuffer.lines = ['@path/my\\ file.txt hello'];
+      mockBuffer.cursor = [0, 24]; // After "hello"
+      
+      mockedUseCompletion.mockReturnValue({
+        ...mockCompletion,
+        showSuggestions: false,
+        suggestions: [],
+      });
+
+      const { unmount } = render(<InputPrompt {...props} />);
+      await wait();
+
+      expect(mockedUseCompletion).toHaveBeenCalledWith(
+        '@path/my\\ file.txt hello',
+        '/test/project/src',
+        false, // shouldShowCompletion should be false
+        mockSlashCommands,
+        mockCommandContext,
+        expect.any(Object),
+      );
+
+      unmount();
+    });
+
+    it('should handle multiple escaped spaces in paths', async () => {
+      // Test with multiple escaped spaces
+      mockBuffer.text = '@docs/my\\ long\\ file\\ name.md';
+      mockBuffer.lines = ['@docs/my\\ long\\ file\\ name.md'];
+      mockBuffer.cursor = [0, 29]; // At the end
+      
+      mockedUseCompletion.mockReturnValue({
+        ...mockCompletion,
+        showSuggestions: true,
+        suggestions: [{ label: 'my long file name.md', value: 'my long file name.md' }],
+      });
+
+      const { unmount } = render(<InputPrompt {...props} />);
+      await wait();
+
+      expect(mockedUseCompletion).toHaveBeenCalledWith(
+        '@docs/my\\ long\\ file\\ name.md',
+        '/test/project/src',
+        true, // shouldShowCompletion should be true
+        mockSlashCommands,
+        mockCommandContext,
+        expect.any(Object),
+      );
+
+      unmount();
+    });
+
+    it('should handle escaped spaces in slash commands', async () => {
+      // Test escaped spaces with slash commands (though less common)
+      mockBuffer.text = '/memory\\ test';
+      mockBuffer.lines = ['/memory\\ test'];
+      mockBuffer.cursor = [0, 13]; // At the end
+      
+      mockedUseCompletion.mockReturnValue({
+        ...mockCompletion,
+        showSuggestions: true,
+        suggestions: [{ label: 'test-command', value: 'test-command' }],
+      });
+
+      const { unmount } = render(<InputPrompt {...props} />);
+      await wait();
+
+      expect(mockedUseCompletion).toHaveBeenCalledWith(
+        '/memory\\ test',
+        '/test/project/src',
+        true, // shouldShowCompletion should be true
+        mockSlashCommands,
+        mockCommandContext,
+        expect.any(Object),
+      );
+
+      unmount();
+    });
+
+    it('should handle Unicode characters with escaped spaces', async () => {
+      // Test combining Unicode and escaped spaces
+      mockBuffer.text = '@files/emoji\\ 👍\\ test.txt';
+      mockBuffer.lines = ['@files/emoji\\ 👍\\ test.txt'];
+      mockBuffer.cursor = [0, 25]; // After the escaped space and emoji
+      
+      mockedUseCompletion.mockReturnValue({
+        ...mockCompletion,
+        showSuggestions: true,
+        suggestions: [{ label: 'emoji 👍 test.txt', value: 'emoji 👍 test.txt' }],
+      });
+
+      const { unmount } = render(<InputPrompt {...props} />);
+      await wait();
+
+      expect(mockedUseCompletion).toHaveBeenCalledWith(
+        '@files/emoji\\ 👍\\ test.txt',
+        '/test/project/src',
+        true, // shouldShowCompletion should be true
+        mockSlashCommands,
+        mockCommandContext,
+        expect.any(Object),
+      );
+
+      unmount();
+    });
   });
 });

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -73,23 +73,23 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
     // Search backwards from cursor position using code points
     const codePoints = toCodePoints(text);
-    
+
     for (let i = offset - 1; i >= 0; i--) {
       const char = codePoints[i];
-      
+
       if (char === ' ' || char === '\n') {
         // Check if this space is escaped by looking at the character before it
         let isEscaped = false;
         let backslashCount = 0;
-        
+
         // Count consecutive backslashes before the space
         for (let j = i - 1; j >= 0 && codePoints[j] === '\\'; j--) {
           backslashCount++;
         }
-        
+
         // If there's an odd number of backslashes, the space is escaped
         isEscaped = backslashCount % 2 === 1;
-        
+
         if (!isEscaped) {
           // Found unescaped space before @ or /, return false
           return false;


### PR DESCRIPTION
## TLDR

Improved command completion trigger logic to only generation suggestions when the cursor is positioned immediately after ``@`` or ``/`` symbols without any intervening spaces.

## Dive Deeper

Previously, the auto completion system would generate suggestions (even though they are not shown) whenever text contained @ or / commands, regardless of cursor position. This led to inappropriate suggestion happening when users were navigating through history.

The new implementation adds a cursor-aware check that:
1. Calculates the exact cursor offset position in multiline text
2. Searches backwards from the cursor to find the nearest @ or / symbol
3. Only triggers completion if no spaces or newlines exist between the symbol and cursor
4. Maintains compatibility with existing isAtCommand and isSlashCommand functions

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

1. Test @ file completion
2. Test / command completion
3. Test multiline scenarios

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
