### PR TITLE
Document --prompt-interactive/-i command-line argument

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -340,6 +340,8 @@ Arguments passed directly when running the CLI can override other configurations
   - Example: `npm start -- --model gemini-1.5-pro-latest`
 - **`--prompt <your_prompt>`** (**`-p <your_prompt>`**):
   - Used to pass a prompt directly to the command. This invokes Gemini CLI in a non-interactive mode.
+- **`--prompt-interactive <your_prompt>`** (**`-i <your_prompt>`**):
+  - Used to pass a prompt directly to the command, but continues in interactive mode afterward. Cannot be used in conjunction with `--prompt` (`-p`).
 - **`--sandbox`** (**`-s`**):
   - Enables sandbox mode for this session.
 - **`--sandbox-image`**:


### PR DESCRIPTION
This PR adds documentation to [docs/cli/configuration.md](docs/cli/configuration.md) for the --prompt-interactive (-i) command-line argument, which was implemented in PR #1743 but not documented.

## TLDR

This just adds one more entry to the "Command-line arguments" section of [docs/cli/configuration.md](docs/cli/configuration.md) for an already-implemented but undocumented option.

## Dive Deeper

I  had wanted to implement this feature myself for my own use-cases until examining the code and finding that it had already been done. I'm Just finishing up the documentation job so that other users can take advantage of the option and other developers don't have to go down the same path I did.

## Reviewer Test Plan

The change is only to documentation, not code. A simple check to verify 

- that the `-i` option has indeed been implemented, and
- the truth of the second sentence in my proposed documentation ("Cannot be used in conjunction with `--prompt` (`-p`).") 

should be all that is needed. A reviewer might also reasonably decide that this second sentence is not necessary and leave it out as being too obvious.

## Testing Matrix

No testing is required

## Linked issues / bugs

Feature was originally implemented in PR #1743.
