### PR TITLE
prefactor(commands): Command Service Prefactor for Extensible Commands

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { BuiltinCommandLoader } from './BuiltinCommandLoader.js';
+import { Config } from '@google/gemini-cli-core';
+
+vi.mock('../ui/commands/aboutCommand.js', () => ({
+  aboutCommand: { name: 'about', description: 'About the CLI' },
+}));
+vi.mock('../ui/commands/chatCommand.js', () => ({
+  chatCommand: {
+    name: 'chat',
+    description: 'A nested command',
+    subCommands: [{ name: 'save', description: 'A subcommand' }],
+  },
+}));
+
+vi.mock('../ui/commands/ideCommand.js', () => ({ ideCommand: vi.fn() }));
+vi.mock('../ui/commands/restoreCommand.js', () => ({
+  restoreCommand: vi.fn(),
+}));
+
+import { ideCommand } from '../ui/commands/ideCommand.js';
+import { restoreCommand } from '../ui/commands/restoreCommand.js';
+
+vi.mock('../ui/commands/authCommand.js', () => ({ authCommand: {} }));
+vi.mock('../ui/commands/bugCommand.js', () => ({ bugCommand: {} }));
+vi.mock('../ui/commands/clearCommand.js', () => ({ clearCommand: {} }));
+vi.mock('../ui/commands/compressCommand.js', () => ({ compressCommand: {} }));
+vi.mock('../ui/commands/corgiCommand.js', () => ({ corgiCommand: {} }));
+vi.mock('../ui/commands/docsCommand.js', () => ({ docsCommand: {} }));
+vi.mock('../ui/commands/editorCommand.js', () => ({ editorCommand: {} }));
+vi.mock('../ui/commands/extensionsCommand.js', () => ({
+  extensionsCommand: {},
+}));
+vi.mock('../ui/commands/helpCommand.js', () => ({ helpCommand: {} }));
+vi.mock('../ui/commands/mcpCommand.js', () => ({ mcpCommand: {} }));
+vi.mock('../ui/commands/memoryCommand.js', () => ({ memoryCommand: {} }));
+vi.mock('../ui/commands/privacyCommand.js', () => ({ privacyCommand: {} }));
+vi.mock('../ui/commands/quitCommand.js', () => ({ quitCommand: {} }));
+vi.mock('../ui/commands/statsCommand.js', () => ({ statsCommand: {} }));
+vi.mock('../ui/commands/themeCommand.js', () => ({ themeCommand: {} }));
+vi.mock('../ui/commands/toolsCommand.js', () => ({ toolsCommand: {} }));
+
+describe('BuiltinCommandLoader', () => {
+  let mockConfig: Config;
+
+  const ideCommandMock = ideCommand as Mock;
+  const restoreCommandMock = restoreCommand as Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig = { some: 'config' } as unknown as Config;
+
+    ideCommandMock.mockReturnValue({
+      name: 'ide',
+      description: 'IDE command',
+    });
+    restoreCommandMock.mockReturnValue({
+      name: 'restore',
+      description: 'Restore command',
+    });
+  });
+
+  it('should load all command definitions and add built-in metadata', async () => {
+    const loader = new BuiltinCommandLoader(mockConfig);
+    const commands = await loader.loadCommands();
+    const aboutCmd = commands.find((c) => c.name === 'about');
+    expect(aboutCmd).toBeDefined();
+    expect(aboutCmd?.metadata).toEqual({
+      source: 'built-in',
+      behavior: 'Custom',
+    });
+  });
+
+  it('should recursively add metadata to nested sub-commands', async () => {
+    const loader = new BuiltinCommandLoader(mockConfig);
+    const commands = await loader.loadCommands();
+    const chatCmd = commands.find((c) => c.name === 'chat');
+    expect(chatCmd).toBeDefined();
+    expect(chatCmd?.metadata).toEqual({
+      source: 'built-in',
+      behavior: 'Custom',
+    });
+    expect(chatCmd?.subCommands).toHaveLength(1);
+    const saveSubCmd = chatCmd?.subCommands?.[0];
+    expect(saveSubCmd?.name).toBe('save');
+    expect(saveSubCmd?.metadata).toEqual({
+      source: 'built-in',
+      behavior: 'Custom',
+    });
+  });
+
+  it('should correctly pass the config object to command factory functions', async () => {
+    const loader = new BuiltinCommandLoader(mockConfig);
+    await loader.loadCommands();
+
+    expect(ideCommandMock).toHaveBeenCalledTimes(1);
+    expect(ideCommandMock).toHaveBeenCalledWith(mockConfig);
+    expect(restoreCommandMock).toHaveBeenCalledTimes(1);
+    expect(restoreCommandMock).toHaveBeenCalledWith(mockConfig);
+  });
+
+  it('should filter out null command definitions returned by factories', async () => {
+    // Override the imported mock's behavior for this test
+    ideCommandMock.mockReturnValue(null);
+    const loader = new BuiltinCommandLoader(mockConfig);
+    const commands = await loader.loadCommands();
+    const ideCmd = commands.find((c) => c.name === 'ide');
+    expect(ideCmd).toBeUndefined();
+    const aboutCmd = commands.find((c) => c.name === 'about');
+    expect(aboutCmd).toBeDefined();
+  });
+
+  it('should handle a null config gracefully when calling factories', async () => {
+    const loader = new BuiltinCommandLoader(null);
+    await loader.loadCommands();
+    expect(ideCommandMock).toHaveBeenCalledTimes(1);
+    expect(ideCommandMock).toHaveBeenCalledWith(null);
+    expect(restoreCommandMock).toHaveBeenCalledTimes(1);
+    expect(restoreCommandMock).toHaveBeenCalledWith(null);
+  });
+
+  it('should not modify the original command definition objects', async () => {
+    const { chatCommand: originalChatCommand } = await import(
+      '../ui/commands/chatCommand.js'
+    );
+    const loader = new BuiltinCommandLoader(mockConfig);
+    const commands = await loader.loadCommands();
+    const transformedChatCommand = commands.find((c) => c.name === 'chat');
+
+    expect(transformedChatCommand?.metadata).toBeDefined();
+    expect(originalChatCommand).not.toHaveProperty('metadata');
+  });
+});

--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -4,22 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
-import { BuiltinCommandLoader } from './BuiltinCommandLoader.js';
-import { Config } from '@google/gemini-cli-core';
-
-vi.mock('../ui/commands/aboutCommand.js', () => ({
-  aboutCommand: {
-    name: 'about',
-    description: 'About the CLI',
-    kind: 'built-in',
-  },
-}));
+vi.mock('../ui/commands/aboutCommand.js', async () => {
+  const { CommandKind } = await import('../ui/commands/types.js');
+  return {
+    aboutCommand: {
+      name: 'about',
+      description: 'About the CLI',
+      kind: CommandKind.BUILT_IN,
+    },
+  };
+});
 
 vi.mock('../ui/commands/ideCommand.js', () => ({ ideCommand: vi.fn() }));
 vi.mock('../ui/commands/restoreCommand.js', () => ({
   restoreCommand: vi.fn(),
 }));
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { BuiltinCommandLoader } from './BuiltinCommandLoader.js';
+import { Config } from '@google/gemini-cli-core';
+import { CommandKind } from '../ui/commands/types.js';
 
 import { ideCommand } from '../ui/commands/ideCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
@@ -57,12 +61,12 @@ describe('BuiltinCommandLoader', () => {
     ideCommandMock.mockReturnValue({
       name: 'ide',
       description: 'IDE command',
-      kind: 'built-in',
+      kind: CommandKind.BUILT_IN,
     });
     restoreCommandMock.mockReturnValue({
       name: 'restore',
       description: 'Restore command',
-      kind: 'built-in',
+      kind: CommandKind.BUILT_IN,
     });
   });
 
@@ -106,7 +110,7 @@ describe('BuiltinCommandLoader', () => {
 
     const aboutCmd = commands.find((c) => c.name === 'about');
     expect(aboutCmd).toBeDefined();
-    expect(aboutCmd?.kind).toBe('built-in');
+    expect(aboutCmd?.kind).toBe(CommandKind.BUILT_IN);
 
     const ideCmd = commands.find((c) => c.name === 'ide');
     expect(ideCmd).toBeDefined();

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ICommandLoader } from './types.js';
+import { SlashCommand, SlashCommandDefinition } from '../ui/commands/types.js';
+import { Config } from '@google/gemini-cli-core';
+import { aboutCommand } from '../ui/commands/aboutCommand.js';
+import { authCommand } from '../ui/commands/authCommand.js';
+import { bugCommand } from '../ui/commands/bugCommand.js';
+import { chatCommand } from '../ui/commands/chatCommand.js';
+import { clearCommand } from '../ui/commands/clearCommand.js';
+import { compressCommand } from '../ui/commands/compressCommand.js';
+import { corgiCommand } from '../ui/commands/corgiCommand.js';
+import { docsCommand } from '../ui/commands/docsCommand.js';
+import { editorCommand } from '../ui/commands/editorCommand.js';
+import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
+import { helpCommand } from '../ui/commands/helpCommand.js';
+import { ideCommand } from '../ui/commands/ideCommand.js';
+import { mcpCommand } from '../ui/commands/mcpCommand.js';
+import { memoryCommand } from '../ui/commands/memoryCommand.js';
+import { privacyCommand } from '../ui/commands/privacyCommand.js';
+import { quitCommand } from '../ui/commands/quitCommand.js';
+import { restoreCommand } from '../ui/commands/restoreCommand.js';
+import { statsCommand } from '../ui/commands/statsCommand.js';
+import { themeCommand } from '../ui/commands/themeCommand.js';
+import { toolsCommand } from '../ui/commands/toolsCommand.js';
+
+/**
+ * Recursively transforms a raw SlashCommandDefinition into a fully hydrated
+ * SlashCommand by adding the required 'built-in' metadata.
+ *
+ * @param definition The raw command definition.
+ * @returns A new SlashCommand object with metadata applied recursively.
+ */
+function addBuiltinMetadata(definition: SlashCommandDefinition): SlashCommand {
+  const { subCommands, ...rest } = definition;
+
+  const command: SlashCommand = {
+    ...rest,
+    // Add the required metadata.
+    metadata: {
+      source: 'built-in',
+      behavior: 'Custom',
+    },
+
+    subCommands: subCommands ? subCommands.map(addBuiltinMetadata) : undefined,
+  };
+
+  return command;
+}
+
+/**
+ * Loads the core, hard-coded slash commands that are an integral part
+ * of the Gemini CLI application. It is responsible for taking the raw
+ * command definitions and transforming them to include the necessary
+ * system-level metadata before they are used by the rest of the application.
+ */
+export class BuiltinCommandLoader implements ICommandLoader {
+  constructor(private config: Config | null) {}
+
+  /**
+   * Gathers all raw built-in command definitions, injects dependencies where
+   * needed (e.g., config), filters out any that are not available, and
+   * transforms them into the final SlashCommand structure.
+   *
+   * @returns A promise that resolves to an array of fully-formed `SlashCommand` objects.
+   */
+  async loadCommands(): Promise<SlashCommand[]> {
+    const allDefinitions: Array<SlashCommandDefinition | null> = [
+      aboutCommand,
+      authCommand,
+      bugCommand,
+      chatCommand,
+      clearCommand,
+      compressCommand,
+      corgiCommand,
+      docsCommand,
+      editorCommand,
+      extensionsCommand,
+      helpCommand,
+      ideCommand(this.config),
+      mcpCommand,
+      memoryCommand,
+      privacyCommand,
+      quitCommand,
+      restoreCommand(this.config),
+      statsCommand,
+      themeCommand,
+      toolsCommand,
+    ];
+
+    return allDefinitions
+      .filter((cmd): cmd is SlashCommandDefinition => cmd !== null)
+      .map(addBuiltinMetadata);
+  }
+}

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -66,9 +66,10 @@ export class BuiltinCommandLoader implements ICommandLoader {
    * needed (e.g., config), filters out any that are not available, and
    * transforms them into the final SlashCommand structure.
    *
+   * @param _signal An optional AbortSignal (unused for this synchronous loader).
    * @returns A promise that resolves to an array of fully-formed `SlashCommand` objects.
    */
-  async loadCommands(): Promise<SlashCommand[]> {
+  async loadCommands(_signal?: AbortSignal): Promise<SlashCommand[]> {
     const allDefinitions: Array<SlashCommandDefinition | null> = [
       aboutCommand,
       authCommand,

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -5,7 +5,7 @@
  */
 
 import { ICommandLoader } from './types.js';
-import { SlashCommand, SlashCommandDefinition } from '../ui/commands/types.js';
+import { SlashCommand } from '../ui/commands/types.js';
 import { Config } from '@google/gemini-cli-core';
 import { aboutCommand } from '../ui/commands/aboutCommand.js';
 import { authCommand } from '../ui/commands/authCommand.js';
@@ -29,48 +29,21 @@ import { themeCommand } from '../ui/commands/themeCommand.js';
 import { toolsCommand } from '../ui/commands/toolsCommand.js';
 
 /**
- * Recursively transforms a raw SlashCommandDefinition into a fully hydrated
- * SlashCommand by adding the required 'built-in' metadata.
- *
- * @param definition The raw command definition.
- * @returns A new SlashCommand object with metadata applied recursively.
- */
-function addBuiltinMetadata(definition: SlashCommandDefinition): SlashCommand {
-  const { subCommands, ...rest } = definition;
-
-  const command: SlashCommand = {
-    ...rest,
-    // Add the required metadata.
-    metadata: {
-      source: 'built-in',
-      behavior: 'Custom',
-    },
-
-    subCommands: subCommands ? subCommands.map(addBuiltinMetadata) : undefined,
-  };
-
-  return command;
-}
-
-/**
  * Loads the core, hard-coded slash commands that are an integral part
- * of the Gemini CLI application. It is responsible for taking the raw
- * command definitions and transforming them to include the necessary
- * system-level metadata before they are used by the rest of the application.
+ * of the Gemini CLI application.
  */
 export class BuiltinCommandLoader implements ICommandLoader {
   constructor(private config: Config | null) {}
 
   /**
    * Gathers all raw built-in command definitions, injects dependencies where
-   * needed (e.g., config), filters out any that are not available, and
-   * transforms them into the final SlashCommand structure.
+   * needed (e.g., config) and filters out any that are not available.
    *
    * @param _signal An optional AbortSignal (unused for this synchronous loader).
-   * @returns A promise that resolves to an array of fully-formed `SlashCommand` objects.
+   * @returns A promise that resolves to an array of `SlashCommand` objects.
    */
   async loadCommands(_signal?: AbortSignal): Promise<SlashCommand[]> {
-    const allDefinitions: Array<SlashCommandDefinition | null> = [
+    const allDefinitions: Array<SlashCommand | null> = [
       aboutCommand,
       authCommand,
       bugCommand,
@@ -93,8 +66,6 @@ export class BuiltinCommandLoader implements ICommandLoader {
       toolsCommand,
     ];
 
-    return allDefinitions
-      .filter((cmd): cmd is SlashCommandDefinition => cmd !== null)
-      .map(addBuiltinMetadata);
+    return allDefinitions.filter((cmd): cmd is SlashCommand => cmd !== null);
   }
 }

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -40,10 +40,10 @@ export class BuiltinCommandLoader implements ICommandLoader {
    * Gathers all raw built-in command definitions, injects dependencies where
    * needed (e.g., config) and filters out any that are not available.
    *
-   * @param _signal An optional AbortSignal (unused for this synchronous loader).
+   * @param _signal An AbortSignal (unused for this synchronous loader).
    * @returns A promise that resolves to an array of `SlashCommand` objects.
    */
-  async loadCommands(_signal?: AbortSignal): Promise<SlashCommand[]> {
+  async loadCommands(_signal: AbortSignal): Promise<SlashCommand[]> {
     const allDefinitions: Array<SlashCommand | null> = [
       aboutCommand,
       authCommand,

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -13,6 +13,7 @@ import { bugCommand } from '../ui/commands/bugCommand.js';
 import { chatCommand } from '../ui/commands/chatCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
 import { compressCommand } from '../ui/commands/compressCommand.js';
+import { copyCommand } from '../ui/commands/copyCommand.js';
 import { corgiCommand } from '../ui/commands/corgiCommand.js';
 import { docsCommand } from '../ui/commands/docsCommand.js';
 import { editorCommand } from '../ui/commands/editorCommand.js';
@@ -50,6 +51,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       chatCommand,
       clearCommand,
       compressCommand,
+      copyCommand,
       corgiCommand,
       docsCommand,
       editorCommand,

--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect, beforeEach, type Mocked } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { CommandService } from './CommandService.js';
-import { type Config } from '@google/gemini-cli-core';
+import { type ICommandLoader } from './types.js';
 import { type SlashCommand } from '../ui/commands/types.js';
+<<<<<<< HEAD
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
@@ -96,15 +97,45 @@ describe('CommandService', () => {
   const subCommandLen = 19;
   let mockConfig: Mocked<Config>;
 
+=======
+
+const createMockCommand = (
+  name: string,
+  source: 'built-in' | 'file',
+): SlashCommand => ({
+  name,
+  description: `Description for ${name}`,
+  metadata: {
+    source,
+    behavior: 'Custom',
+  },
+  action: vi.fn(),
+});
+
+const mockCommandA = createMockCommand('command-a', 'built-in');
+const mockCommandB = createMockCommand('command-b', 'built-in');
+const mockCommandC = createMockCommand('command-c', 'file');
+const mockCommandB_Override = createMockCommand('command-b', 'file');
+
+class MockCommandLoader implements ICommandLoader {
+  private commandsToLoad: SlashCommand[];
+
+  constructor(commandsToLoad: SlashCommand[]) {
+    this.commandsToLoad = commandsToLoad;
+  }
+
+  loadCommands = vi.fn(
+    async (): Promise<SlashCommand[]> => Promise.resolve(this.commandsToLoad),
+  );
+}
+
+describe('CommandService', () => {
+>>>>>>> 3d81bcd6 ((prefactor): Use loader system for slash commands)
   beforeEach(() => {
-    mockConfig = {
-      getIdeMode: vi.fn(),
-      getCheckpointingEnabled: vi.fn(),
-    } as unknown as Mocked<Config>;
-    vi.mocked(ideCommand).mockReturnValue(null);
-    vi.mocked(restoreCommand).mockReturnValue(null);
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
   });
 
+<<<<<<< HEAD
   describe('when using default production loader', () => {
     let commandService: CommandService;
 
@@ -227,31 +258,148 @@ describe('CommandService', () => {
         ]);
       });
     });
+=======
+  afterEach(() => {
+    vi.restoreAllMocks();
+>>>>>>> 3d81bcd6 ((prefactor): Use loader system for slash commands)
   });
 
-  describe('when initialized with an injected loader function', () => {
-    it('should use the provided loader instead of the built-in one', async () => {
-      // Arrange: Create a set of mock commands.
-      const mockCommands: SlashCommand[] = [
-        { name: 'injected-test-1', description: 'injected 1' },
-        { name: 'injected-test-2', description: 'injected 2' },
-      ];
+  it('should initialize with an empty list of commands', () => {
+    const service = new CommandService([]);
+    expect(service.getCommands()).toEqual([]);
+  });
 
-      // Arrange: Create a mock loader FUNCTION that resolves with our mock commands.
-      const mockLoader = vi.fn().mockResolvedValue(mockCommands);
+  it('should load commands from a single loader', async () => {
+    const mockLoader = new MockCommandLoader([mockCommandA, mockCommandB]);
+    const service = new CommandService([mockLoader]);
 
-      // Act: Instantiate the service WITH the injected loader function.
-      const commandService = new CommandService(mockConfig, mockLoader);
-      await commandService.loadCommands();
-      const tree = commandService.getCommands();
+    await service.loadCommands();
+    const commands = service.getCommands();
 
-      // Assert: The tree should contain ONLY our injected commands.
-      expect(mockLoader).toHaveBeenCalled(); // Verify our mock loader was actually called.
-      expect(tree.length).toBe(2);
-      expect(tree).toEqual(mockCommands);
+    expect(mockLoader.loadCommands).toHaveBeenCalledTimes(1);
+    expect(commands).toHaveLength(2);
+    expect(commands).toEqual(
+      expect.arrayContaining([mockCommandA, mockCommandB]),
+    );
+  });
 
-      const commandNames = tree.map((cmd) => cmd.name);
-      expect(commandNames).not.toContain('memory'); // Verify it didn't load production commands.
-    });
+  it('should aggregate commands from multiple loaders', async () => {
+    const loader1 = new MockCommandLoader([mockCommandA]);
+    const loader2 = new MockCommandLoader([mockCommandC]);
+    const service = new CommandService([loader1, loader2]);
+
+    await service.loadCommands();
+    const commands = service.getCommands();
+
+    expect(loader1.loadCommands).toHaveBeenCalledTimes(1);
+    expect(loader2.loadCommands).toHaveBeenCalledTimes(1);
+    expect(commands).toHaveLength(2);
+    expect(commands).toEqual(
+      expect.arrayContaining([mockCommandA, mockCommandC]),
+    );
+  });
+
+  it('should override commands from earlier loaders with those from later loaders', async () => {
+    const loader1 = new MockCommandLoader([mockCommandA, mockCommandB]);
+    const loader2 = new MockCommandLoader([
+      mockCommandB_Override,
+      mockCommandC,
+    ]);
+    const service = new CommandService([loader1, loader2]);
+
+    await service.loadCommands();
+    const commands = service.getCommands();
+
+    expect(commands).toHaveLength(3); // Should be A, C, and the overridden B.
+
+    // The final list should contain the override from the *last* loader.
+    const commandB = commands.find((cmd) => cmd.name === 'command-b');
+    expect(commandB).toBeDefined();
+    expect(commandB?.metadata.source).toBe('file'); // Verify it's the overridden version.
+    expect(commandB).toEqual(mockCommandB_Override);
+
+    // Ensure the other commands are still present.
+    expect(commands).toEqual(
+      expect.arrayContaining([
+        mockCommandA,
+        mockCommandC,
+        mockCommandB_Override,
+      ]),
+    );
+  });
+
+  it('should handle loaders that return an empty array of commands gracefully', async () => {
+    const loader1 = new MockCommandLoader([mockCommandA]);
+    const emptyLoader = new MockCommandLoader([]);
+    const loader3 = new MockCommandLoader([mockCommandB]);
+    const service = new CommandService([loader1, emptyLoader, loader3]);
+
+    await service.loadCommands();
+    const commands = service.getCommands();
+
+    expect(emptyLoader.loadCommands).toHaveBeenCalledTimes(1);
+    expect(commands).toHaveLength(2);
+    expect(commands).toEqual(
+      expect.arrayContaining([mockCommandA, mockCommandB]),
+    );
+  });
+
+  it('should clear existing commands and reload when loadCommands is called again', async () => {
+    const loader = new MockCommandLoader([]);
+    const loadCommandsSpy = vi.spyOn(loader, 'loadCommands');
+    const service = new CommandService([loader]);
+
+    // First load
+    loadCommandsSpy.mockResolvedValueOnce([mockCommandA]);
+    await service.loadCommands();
+    expect(service.getCommands()).toEqual([mockCommandA]);
+    expect(service.getCommands()).toHaveLength(1);
+
+    // Second load with different data
+    loadCommandsSpy.mockResolvedValueOnce([mockCommandB, mockCommandC]);
+    await service.loadCommands();
+    const finalCommands = service.getCommands();
+
+    // Assert: The list should be completely replaced, not appended to.
+    expect(finalCommands).toHaveLength(2);
+    expect(finalCommands).toEqual(
+      expect.arrayContaining([mockCommandB, mockCommandC]),
+    );
+    expect(finalCommands).not.toContain(mockCommandA);
+    expect(loadCommandsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should load commands from successful loaders even if one fails', async () => {
+    const successfulLoader = new MockCommandLoader([mockCommandA]);
+    const failingLoader = new MockCommandLoader([]);
+    const error = new Error('Loader failed');
+    vi.spyOn(failingLoader, 'loadCommands').mockRejectedValue(error);
+
+    const service = new CommandService([successfulLoader, failingLoader]);
+    await service.loadCommands();
+
+    const commands = service.getCommands();
+    expect(commands).toHaveLength(1);
+    expect(commands).toEqual([mockCommandA]);
+    expect(console.debug).toHaveBeenCalledWith(
+      'A command loader failed:',
+      error,
+    );
+  });
+
+  it('getCommands should return a readonly array that cannot be mutated', async () => {
+    const service = new CommandService([new MockCommandLoader([mockCommandA])]);
+    await service.loadCommands();
+
+    const commands = service.getCommands();
+
+    // Expect it to throw a TypeError at runtime because the array is frozen.
+    expect(() => {
+      // @ts-expect-error - Testing immutability is intentional here.
+      commands.push(mockCommandB);
+    }).toThrow();
+
+    // Verify the original array was not mutated.
+    expect(service.getCommands()).toHaveLength(1);
   });
 });

--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -375,4 +375,19 @@ describe('CommandService', () => {
     // Verify the original array was not mutated.
     expect(service.getCommands()).toHaveLength(1);
   });
+
+  it('should pass the abort signal to all loaders', async () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const loader1 = new MockCommandLoader([mockCommandA]);
+    const loader2 = new MockCommandLoader([mockCommandB]);
+
+    await CommandService.create([loader1, loader2], signal);
+
+    expect(loader1.loadCommands).toHaveBeenCalledTimes(1);
+    expect(loader1.loadCommands).toHaveBeenCalledWith(signal);
+    expect(loader2.loadCommands).toHaveBeenCalledTimes(1);
+    expect(loader2.loadCommands).toHaveBeenCalledWith(signal);
+  });
 });

--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -8,107 +8,14 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { CommandService } from './CommandService.js';
 import { type ICommandLoader } from './types.js';
 import { type SlashCommand } from '../ui/commands/types.js';
-<<<<<<< HEAD
-import { memoryCommand } from '../ui/commands/memoryCommand.js';
-import { helpCommand } from '../ui/commands/helpCommand.js';
-import { clearCommand } from '../ui/commands/clearCommand.js';
-import { copyCommand } from '../ui/commands/copyCommand.js';
-import { corgiCommand } from '../ui/commands/corgiCommand.js';
-import { docsCommand } from '../ui/commands/docsCommand.js';
-import { chatCommand } from '../ui/commands/chatCommand.js';
-import { authCommand } from '../ui/commands/authCommand.js';
-import { themeCommand } from '../ui/commands/themeCommand.js';
-import { statsCommand } from '../ui/commands/statsCommand.js';
-import { privacyCommand } from '../ui/commands/privacyCommand.js';
-import { aboutCommand } from '../ui/commands/aboutCommand.js';
-import { ideCommand } from '../ui/commands/ideCommand.js';
-import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
-import { toolsCommand } from '../ui/commands/toolsCommand.js';
-import { compressCommand } from '../ui/commands/compressCommand.js';
-import { mcpCommand } from '../ui/commands/mcpCommand.js';
-import { editorCommand } from '../ui/commands/editorCommand.js';
-import { bugCommand } from '../ui/commands/bugCommand.js';
-import { quitCommand } from '../ui/commands/quitCommand.js';
-import { restoreCommand } from '../ui/commands/restoreCommand.js';
-
-// Mock the command modules to isolate the service from the command implementations.
-vi.mock('../ui/commands/memoryCommand.js', () => ({
-  memoryCommand: { name: 'memory', description: 'Mock Memory' },
-}));
-vi.mock('../ui/commands/helpCommand.js', () => ({
-  helpCommand: { name: 'help', description: 'Mock Help' },
-}));
-vi.mock('../ui/commands/clearCommand.js', () => ({
-  clearCommand: { name: 'clear', description: 'Mock Clear' },
-}));
-vi.mock('../ui/commands/corgiCommand.js', () => ({
-  corgiCommand: { name: 'corgi', description: 'Mock Corgi' },
-}));
-vi.mock('../ui/commands/docsCommand.js', () => ({
-  docsCommand: { name: 'docs', description: 'Mock Docs' },
-}));
-vi.mock('../ui/commands/authCommand.js', () => ({
-  authCommand: { name: 'auth', description: 'Mock Auth' },
-}));
-vi.mock('../ui/commands/themeCommand.js', () => ({
-  themeCommand: { name: 'theme', description: 'Mock Theme' },
-}));
-vi.mock('../ui/commands/copyCommand.js', () => ({
-  copyCommand: { name: 'copy', description: 'Mock Copy' },
-}));
-vi.mock('../ui/commands/privacyCommand.js', () => ({
-  privacyCommand: { name: 'privacy', description: 'Mock Privacy' },
-}));
-vi.mock('../ui/commands/statsCommand.js', () => ({
-  statsCommand: { name: 'stats', description: 'Mock Stats' },
-}));
-vi.mock('../ui/commands/aboutCommand.js', () => ({
-  aboutCommand: { name: 'about', description: 'Mock About' },
-}));
-vi.mock('../ui/commands/ideCommand.js', () => ({
-  ideCommand: vi.fn(),
-}));
-vi.mock('../ui/commands/extensionsCommand.js', () => ({
-  extensionsCommand: { name: 'extensions', description: 'Mock Extensions' },
-}));
-vi.mock('../ui/commands/toolsCommand.js', () => ({
-  toolsCommand: { name: 'tools', description: 'Mock Tools' },
-}));
-vi.mock('../ui/commands/compressCommand.js', () => ({
-  compressCommand: { name: 'compress', description: 'Mock Compress' },
-}));
-vi.mock('../ui/commands/mcpCommand.js', () => ({
-  mcpCommand: { name: 'mcp', description: 'Mock MCP' },
-}));
-vi.mock('../ui/commands/editorCommand.js', () => ({
-  editorCommand: { name: 'editor', description: 'Mock Editor' },
-}));
-vi.mock('../ui/commands/bugCommand.js', () => ({
-  bugCommand: { name: 'bug', description: 'Mock Bug' },
-}));
-vi.mock('../ui/commands/quitCommand.js', () => ({
-  quitCommand: { name: 'quit', description: 'Mock Quit' },
-}));
-vi.mock('../ui/commands/restoreCommand.js', () => ({
-  restoreCommand: vi.fn(),
-}));
-
-describe('CommandService', () => {
-  const subCommandLen = 19;
-  let mockConfig: Mocked<Config>;
-
-=======
 
 const createMockCommand = (
   name: string,
-  source: 'built-in' | 'file',
+  kind: 'built-in' | 'file',
 ): SlashCommand => ({
   name,
   description: `Description for ${name}`,
-  metadata: {
-    source,
-    behavior: 'Custom',
-  },
+  kind,
   action: vi.fn(),
 });
 
@@ -130,138 +37,12 @@ class MockCommandLoader implements ICommandLoader {
 }
 
 describe('CommandService', () => {
->>>>>>> 3d81bcd6 ((prefactor): Use loader system for slash commands)
   beforeEach(() => {
     vi.spyOn(console, 'debug').mockImplementation(() => {});
   });
 
-<<<<<<< HEAD
-  describe('when using default production loader', () => {
-    let commandService: CommandService;
-
-    beforeEach(() => {
-      commandService = new CommandService(mockConfig);
-    });
-
-    it('should initialize with an empty command tree', () => {
-      const tree = commandService.getCommands();
-      expect(tree).toBeInstanceOf(Array);
-      expect(tree.length).toBe(0);
-    });
-
-    describe('loadCommands', () => {
-      it('should load the built-in commands into the command tree', async () => {
-        // Pre-condition check
-        expect(commandService.getCommands().length).toBe(0);
-
-        // Action
-        await commandService.loadCommands();
-        const tree = commandService.getCommands();
-
-        // Post-condition assertions
-        expect(tree.length).toBe(subCommandLen);
-
-        const commandNames = tree.map((cmd) => cmd.name);
-        expect(commandNames).toContain('auth');
-        expect(commandNames).toContain('bug');
-        expect(commandNames).toContain('memory');
-        expect(commandNames).toContain('help');
-        expect(commandNames).toContain('clear');
-        expect(commandNames).toContain('copy');
-        expect(commandNames).toContain('compress');
-        expect(commandNames).toContain('corgi');
-        expect(commandNames).toContain('docs');
-        expect(commandNames).toContain('chat');
-        expect(commandNames).toContain('theme');
-        expect(commandNames).toContain('stats');
-        expect(commandNames).toContain('privacy');
-        expect(commandNames).toContain('about');
-        expect(commandNames).toContain('extensions');
-        expect(commandNames).toContain('tools');
-        expect(commandNames).toContain('mcp');
-        expect(commandNames).not.toContain('ide');
-      });
-
-      it('should include ide command when ideMode is on', async () => {
-        mockConfig.getIdeMode.mockReturnValue(true);
-        vi.mocked(ideCommand).mockReturnValue({
-          name: 'ide',
-          description: 'Mock IDE',
-        });
-        await commandService.loadCommands();
-        const tree = commandService.getCommands();
-
-        expect(tree.length).toBe(subCommandLen + 1);
-        const commandNames = tree.map((cmd) => cmd.name);
-        expect(commandNames).toContain('ide');
-        expect(commandNames).toContain('editor');
-        expect(commandNames).toContain('quit');
-      });
-
-      it('should include restore command when checkpointing is on', async () => {
-        mockConfig.getCheckpointingEnabled.mockReturnValue(true);
-        vi.mocked(restoreCommand).mockReturnValue({
-          name: 'restore',
-          description: 'Mock Restore',
-        });
-        await commandService.loadCommands();
-        const tree = commandService.getCommands();
-
-        expect(tree.length).toBe(subCommandLen + 1);
-        const commandNames = tree.map((cmd) => cmd.name);
-        expect(commandNames).toContain('restore');
-      });
-
-      it('should overwrite any existing commands when called again', async () => {
-        // Load once
-        await commandService.loadCommands();
-        expect(commandService.getCommands().length).toBe(subCommandLen);
-
-        // Load again
-        await commandService.loadCommands();
-        const tree = commandService.getCommands();
-
-        // Should not append, but overwrite
-        expect(tree.length).toBe(subCommandLen);
-      });
-    });
-
-    describe('getCommandTree', () => {
-      it('should return the current command tree', async () => {
-        const initialTree = commandService.getCommands();
-        expect(initialTree).toEqual([]);
-
-        await commandService.loadCommands();
-
-        const loadedTree = commandService.getCommands();
-        expect(loadedTree.length).toBe(subCommandLen);
-        expect(loadedTree).toEqual([
-          aboutCommand,
-          authCommand,
-          bugCommand,
-          chatCommand,
-          clearCommand,
-          copyCommand,
-          compressCommand,
-          corgiCommand,
-          docsCommand,
-          editorCommand,
-          extensionsCommand,
-          helpCommand,
-          mcpCommand,
-          memoryCommand,
-          privacyCommand,
-          quitCommand,
-          statsCommand,
-          themeCommand,
-          toolsCommand,
-        ]);
-      });
-    });
-=======
   afterEach(() => {
     vi.restoreAllMocks();
->>>>>>> 3d81bcd6 ((prefactor): Use loader system for slash commands)
   });
 
   it('should load commands from a single loader', async () => {
@@ -307,7 +88,7 @@ describe('CommandService', () => {
     // The final list should contain the override from the *last* loader.
     const commandB = commands.find((cmd) => cmd.name === 'command-b');
     expect(commandB).toBeDefined();
-    expect(commandB?.metadata.source).toBe('file'); // Verify it's the overridden version.
+    expect(commandB?.kind).toBe('file'); // Verify it's the overridden version.
     expect(commandB).toEqual(mockCommandB_Override);
 
     // Ensure the other commands are still present.

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -5,63 +5,7 @@
  */
 
 import { SlashCommand } from '../ui/commands/types.js';
-<<<<<<< HEAD
-import { memoryCommand } from '../ui/commands/memoryCommand.js';
-import { helpCommand } from '../ui/commands/helpCommand.js';
-import { clearCommand } from '../ui/commands/clearCommand.js';
-import { copyCommand } from '../ui/commands/copyCommand.js';
-import { corgiCommand } from '../ui/commands/corgiCommand.js';
-import { docsCommand } from '../ui/commands/docsCommand.js';
-import { mcpCommand } from '../ui/commands/mcpCommand.js';
-import { authCommand } from '../ui/commands/authCommand.js';
-import { themeCommand } from '../ui/commands/themeCommand.js';
-import { editorCommand } from '../ui/commands/editorCommand.js';
-import { chatCommand } from '../ui/commands/chatCommand.js';
-import { statsCommand } from '../ui/commands/statsCommand.js';
-import { privacyCommand } from '../ui/commands/privacyCommand.js';
-import { aboutCommand } from '../ui/commands/aboutCommand.js';
-import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
-import { toolsCommand } from '../ui/commands/toolsCommand.js';
-import { compressCommand } from '../ui/commands/compressCommand.js';
-import { ideCommand } from '../ui/commands/ideCommand.js';
-import { bugCommand } from '../ui/commands/bugCommand.js';
-import { quitCommand } from '../ui/commands/quitCommand.js';
-import { restoreCommand } from '../ui/commands/restoreCommand.js';
-
-const loadBuiltInCommands = async (
-  config: Config | null,
-): Promise<SlashCommand[]> => {
-  const allCommands = [
-    aboutCommand,
-    authCommand,
-    bugCommand,
-    chatCommand,
-    clearCommand,
-    copyCommand,
-    compressCommand,
-    corgiCommand,
-    docsCommand,
-    editorCommand,
-    extensionsCommand,
-    helpCommand,
-    ideCommand(config),
-    mcpCommand,
-    memoryCommand,
-    privacyCommand,
-    quitCommand,
-    restoreCommand(config),
-    statsCommand,
-    themeCommand,
-    toolsCommand,
-  ];
-
-  return allCommands.filter(
-    (command): command is SlashCommand => command !== null,
-  );
-};
-=======
 import { ICommandLoader } from './types.js';
->>>>>>> 3d81bcd6 ((prefactor): Use loader system for slash commands)
 
 /**
  * Orchestrates the discovery and loading of all slash commands for the CLI.

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Config } from '@google/gemini-cli-core';
 import { SlashCommand } from '../ui/commands/types.js';
+<<<<<<< HEAD
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
@@ -59,26 +59,80 @@ const loadBuiltInCommands = async (
     (command): command is SlashCommand => command !== null,
   );
 };
+=======
+import { ICommandLoader } from './types.js';
+>>>>>>> 3d81bcd6 ((prefactor): Use loader system for slash commands)
 
+/**
+ * Orchestrates the discovery and loading of all slash commands for the CLI.
+ *
+ * This service operates on a provider-based loader pattern. It is initialized
+ * with an array of `ICommandLoader` instances, each responsible for fetching
+ * commands from a specific source (e.g., built-in code, local files).
+ *
+ * The CommandService is responsible for invoking these loaders, aggregating their
+ * results, and resolving any name conflicts. This architecture allows the command
+ * system to be extended with new sources without modifying the service itself.
+ */
 export class CommandService {
-  private commands: SlashCommand[] = [];
+  // Use ReadonlyArray to enforce immutability on our internal state.
+  private commands: readonly SlashCommand[] = [];
 
-  constructor(
-    private config: Config | null,
-    private commandLoader: (
-      config: Config | null,
-    ) => Promise<SlashCommand[]> = loadBuiltInCommands,
-  ) {
-    // The constructor can be used for dependency injection in the future.
-  }
+  /**
+   * Constructs the CommandService.
+   *
+   * @param loaders An array of objects that conform to the `ICommandLoader`
+   *   interface. The order of loaders is significant: if multiple loaders
+   *   provide a command with the same name, the command from the loader that
+   *   appears later in the array will take precedence and override any earlier ones.
+   */
+  constructor(private loaders: ICommandLoader[]) {}
 
+  /**
+   * Triggers all registered command loaders to discover and load their respective
+   * commands.
+   *
+   * This method runs all loaders in parallel using `Promise.allSettled` to ensure
+   * that a failure in one loader does not prevent others from succeeding. It
+   * aggregates the results from successful loaders, resolves any name conflicts
+   * by letting the last-loaded command win, and stores the unified list internally.
+   *
+   * @returns A promise that resolves when all loading and processing is complete.
+   */
   async loadCommands(): Promise<void> {
-    // For now, we only load the built-in commands.
-    // File-based and remote commands will be added later.
-    this.commands = await this.commandLoader(this.config);
+    const results = await Promise.allSettled(
+      this.loaders.map((loader) => loader.loadCommands()),
+    );
+
+    const allCommands: SlashCommand[] = [];
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        allCommands.push(...result.value);
+      } else {
+        console.debug('A command loader failed:', result.reason);
+      }
+    }
+
+    // De-duplicate commands using a Map. The last one found with a given name wins.
+    // This creates a natural override system based on the order of the loaders
+    // passed to the constructor.
+    const commandMap = new Map<string, SlashCommand>();
+    for (const cmd of allCommands) {
+      commandMap.set(cmd.name, cmd);
+    }
+
+    this.commands = Object.freeze(Array.from(commandMap.values()));
   }
 
-  getCommands(): SlashCommand[] {
+  /**
+   * Retrieves the currently loaded and de-duplicated list of slash commands.
+   *
+   * This method is a safe accessor for the service's state. It returns a
+   * readonly array, preventing consumers from modifying the service's internal state.
+   *
+   * @returns A readonly, unified array of available `SlashCommand` objects.
+   */
+  getCommands(): readonly SlashCommand[] {
     return this.commands;
   }
 }

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -93,11 +93,15 @@ export class CommandService {
    *   interface. The order of loaders is significant: if multiple loaders
    *   provide a command with the same name, the command from the loader that
    *   appears later in the array will take precedence.
+   * @param signal An optional AbortSignal to cancel the loading process.
    * @returns A promise that resolves to a new, fully initialized `CommandService` instance.
    */
-  static async create(loaders: ICommandLoader[]): Promise<CommandService> {
+  static async create(
+    loaders: ICommandLoader[],
+    signal?: AbortSignal,
+  ): Promise<CommandService> {
     const results = await Promise.allSettled(
-      loaders.map((loader) => loader.loadCommands()),
+      loaders.map((loader) => loader.loadCommands(signal)),
     );
 
     const allCommands: SlashCommand[] = [];

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -42,7 +42,7 @@ export class CommandService {
    */
   static async create(
     loaders: ICommandLoader[],
-    signal?: AbortSignal,
+    signal: AbortSignal,
   ): Promise<CommandService> {
     const results = await Promise.allSettled(
       loaders.map((loader) => loader.loadCommands(signal)),

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -37,7 +37,7 @@ export class CommandService {
    *   interface. The order of loaders is significant: if multiple loaders
    *   provide a command with the same name, the command from the loader that
    *   appears later in the array will take precedence.
-   * @param signal An optional AbortSignal to cancel the loading process.
+   * @param signal An AbortSignal to cancel the loading process.
    * @returns A promise that resolves to a new, fully initialized `CommandService` instance.
    */
   static async create(

--- a/packages/cli/src/services/types.ts
+++ b/packages/cli/src/services/types.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SlashCommand } from '../ui/commands/types.js';
+
+/**
+ * Defines the contract for any class that can load and provide slash commands.
+ * This allows the CommandService to be extended with new command sources
+ * (e.g., file-based, remote APIs) without modification.
+ *
+ * Loaders should receive any necessary dependencies (like Config) via their
+ * constructor.
+ */
+export interface ICommandLoader {
+  /**
+   * Discovers and returns a list of slash commands from the loader's source.
+   * @returns A promise that resolves to an array of SlashCommand objects.
+   */
+  loadCommands(): Promise<SlashCommand[]>;
+}

--- a/packages/cli/src/services/types.ts
+++ b/packages/cli/src/services/types.ts
@@ -17,7 +17,8 @@ import { SlashCommand } from '../ui/commands/types.js';
 export interface ICommandLoader {
   /**
    * Discovers and returns a list of slash commands from the loader's source.
+   * @param signal An optional AbortSignal to allow cancellation.
    * @returns A promise that resolves to an array of SlashCommand objects.
    */
-  loadCommands(): Promise<SlashCommand[]>;
+  loadCommands(signal?: AbortSignal): Promise<SlashCommand[]>;
 }

--- a/packages/cli/src/services/types.ts
+++ b/packages/cli/src/services/types.ts
@@ -17,8 +17,8 @@ import { SlashCommand } from '../ui/commands/types.js';
 export interface ICommandLoader {
   /**
    * Discovers and returns a list of slash commands from the loader's source.
-   * @param signal An optional AbortSignal to allow cancellation.
+   * @param signal An AbortSignal to allow cancellation.
    * @returns A promise that resolves to an array of SlashCommand objects.
    */
-  loadCommands(signal?: AbortSignal): Promise<SlashCommand[]>;
+  loadCommands(signal: AbortSignal): Promise<SlashCommand[]>;
 }

--- a/packages/cli/src/ui/commands/aboutCommand.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.ts
@@ -5,11 +5,11 @@
  */
 
 import { getCliVersion } from '../../utils/version.js';
-import { SlashCommand } from './types.js';
+import { SlashCommandDefinition } from './types.js';
 import process from 'node:process';
 import { MessageType, type HistoryItemAbout } from '../types.js';
 
-export const aboutCommand: SlashCommand = {
+export const aboutCommand: SlashCommandDefinition = {
   name: 'about',
   description: 'show version info',
   action: async (context) => {

--- a/packages/cli/src/ui/commands/aboutCommand.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.ts
@@ -5,13 +5,14 @@
  */
 
 import { getCliVersion } from '../../utils/version.js';
-import { SlashCommandDefinition } from './types.js';
+import { SlashCommand } from './types.js';
 import process from 'node:process';
 import { MessageType, type HistoryItemAbout } from '../types.js';
 
-export const aboutCommand: SlashCommandDefinition = {
+export const aboutCommand: SlashCommand = {
   name: 'about',
   description: 'show version info',
+  kind: 'built-in',
   action: async (context) => {
     const osVersion = process.platform;
     let sandboxEnv = 'no sandbox';

--- a/packages/cli/src/ui/commands/aboutCommand.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.ts
@@ -5,14 +5,14 @@
  */
 
 import { getCliVersion } from '../../utils/version.js';
-import { SlashCommand } from './types.js';
+import { CommandKind, SlashCommand } from './types.js';
 import process from 'node:process';
 import { MessageType, type HistoryItemAbout } from '../types.js';
 
 export const aboutCommand: SlashCommand = {
   name: 'about',
   description: 'show version info',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: async (context) => {
     const osVersion = process.platform;
     let sandboxEnv = 'no sandbox';

--- a/packages/cli/src/ui/commands/authCommand.ts
+++ b/packages/cli/src/ui/commands/authCommand.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenDialogActionReturn, SlashCommand } from './types.js';
+import { OpenDialogActionReturn, SlashCommandDefinition } from './types.js';
 
-export const authCommand: SlashCommand = {
+export const authCommand: SlashCommandDefinition = {
   name: 'auth',
   description: 'change the auth method',
   action: (_context, _args): OpenDialogActionReturn => ({

--- a/packages/cli/src/ui/commands/authCommand.ts
+++ b/packages/cli/src/ui/commands/authCommand.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenDialogActionReturn, SlashCommand } from './types.js';
+import { CommandKind, OpenDialogActionReturn, SlashCommand } from './types.js';
 
 export const authCommand: SlashCommand = {
   name: 'auth',
   description: 'change the auth method',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: (_context, _args): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'auth',

--- a/packages/cli/src/ui/commands/authCommand.ts
+++ b/packages/cli/src/ui/commands/authCommand.ts
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenDialogActionReturn, SlashCommandDefinition } from './types.js';
+import { OpenDialogActionReturn, SlashCommand } from './types.js';
 
-export const authCommand: SlashCommandDefinition = {
+export const authCommand: SlashCommand = {
   name: 'auth',
   description: 'change the auth method',
+  kind: 'built-in',
   action: (_context, _args): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'auth',

--- a/packages/cli/src/ui/commands/bugCommand.ts
+++ b/packages/cli/src/ui/commands/bugCommand.ts
@@ -6,13 +6,13 @@
 
 import open from 'open';
 import process from 'node:process';
-import { type CommandContext, type SlashCommand } from './types.js';
+import { type CommandContext, type SlashCommandDefinition } from './types.js';
 import { MessageType } from '../types.js';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 import { formatMemoryUsage } from '../utils/formatters.js';
 import { getCliVersion } from '../../utils/version.js';
 
-export const bugCommand: SlashCommand = {
+export const bugCommand: SlashCommandDefinition = {
   name: 'bug',
   description: 'submit a bug report',
   action: async (context: CommandContext, args?: string): Promise<void> => {

--- a/packages/cli/src/ui/commands/bugCommand.ts
+++ b/packages/cli/src/ui/commands/bugCommand.ts
@@ -6,15 +6,16 @@
 
 import open from 'open';
 import process from 'node:process';
-import { type CommandContext, type SlashCommandDefinition } from './types.js';
+import { type CommandContext, type SlashCommand } from './types.js';
 import { MessageType } from '../types.js';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 import { formatMemoryUsage } from '../utils/formatters.js';
 import { getCliVersion } from '../../utils/version.js';
 
-export const bugCommand: SlashCommandDefinition = {
+export const bugCommand: SlashCommand = {
   name: 'bug',
   description: 'submit a bug report',
+  kind: 'built-in',
   action: async (context: CommandContext, args?: string): Promise<void> => {
     const bugDescription = (args || '').trim();
     const { config } = context.services;

--- a/packages/cli/src/ui/commands/bugCommand.ts
+++ b/packages/cli/src/ui/commands/bugCommand.ts
@@ -6,7 +6,11 @@
 
 import open from 'open';
 import process from 'node:process';
-import { type CommandContext, type SlashCommand } from './types.js';
+import {
+  type CommandContext,
+  type SlashCommand,
+  CommandKind,
+} from './types.js';
 import { MessageType } from '../types.js';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 import { formatMemoryUsage } from '../utils/formatters.js';
@@ -15,7 +19,7 @@ import { getCliVersion } from '../../utils/version.js';
 export const bugCommand: SlashCommand = {
   name: 'bug',
   description: 'submit a bug report',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext, args?: string): Promise<void> => {
     const bugDescription = (args || '').trim();
     const { config } = context.services;

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -5,7 +5,11 @@
  */
 
 import * as fsPromises from 'fs/promises';
-import { CommandContext, SlashCommand, MessageActionReturn } from './types.js';
+import {
+  CommandContext,
+  SlashCommandDefinition,
+  MessageActionReturn,
+} from './types.js';
 import path from 'path';
 import { HistoryItemWithoutId, MessageType } from '../types.js';
 
@@ -51,7 +55,7 @@ const getSavedChatTags = async (
   }
 };
 
-const listCommand: SlashCommand = {
+const listCommand: SlashCommandDefinition = {
   name: 'list',
   description: 'List saved conversation checkpoints',
   action: async (context): Promise<MessageActionReturn> => {
@@ -77,7 +81,7 @@ const listCommand: SlashCommand = {
   },
 };
 
-const saveCommand: SlashCommand = {
+const saveCommand: SlashCommandDefinition = {
   name: 'save',
   description:
     'Save the current conversation as a checkpoint. Usage: /chat save <tag>',
@@ -120,7 +124,7 @@ const saveCommand: SlashCommand = {
   },
 };
 
-const resumeCommand: SlashCommand = {
+const resumeCommand: SlashCommandDefinition = {
   name: 'resume',
   altName: 'load',
   description:
@@ -190,7 +194,7 @@ const resumeCommand: SlashCommand = {
   },
 };
 
-export const chatCommand: SlashCommand = {
+export const chatCommand: SlashCommandDefinition = {
   name: 'chat',
   description: 'Manage conversation history.',
   subCommands: [listCommand, saveCommand, resumeCommand],

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -5,11 +5,7 @@
  */
 
 import * as fsPromises from 'fs/promises';
-import {
-  CommandContext,
-  SlashCommandDefinition,
-  MessageActionReturn,
-} from './types.js';
+import { CommandContext, SlashCommand, MessageActionReturn } from './types.js';
 import path from 'path';
 import { HistoryItemWithoutId, MessageType } from '../types.js';
 
@@ -55,9 +51,10 @@ const getSavedChatTags = async (
   }
 };
 
-const listCommand: SlashCommandDefinition = {
+const listCommand: SlashCommand = {
   name: 'list',
   description: 'List saved conversation checkpoints',
+  kind: 'built-in',
   action: async (context): Promise<MessageActionReturn> => {
     const chatDetails = await getSavedChatTags(context, false);
     if (chatDetails.length === 0) {
@@ -81,10 +78,11 @@ const listCommand: SlashCommandDefinition = {
   },
 };
 
-const saveCommand: SlashCommandDefinition = {
+const saveCommand: SlashCommand = {
   name: 'save',
   description:
     'Save the current conversation as a checkpoint. Usage: /chat save <tag>',
+  kind: 'built-in',
   action: async (context, args): Promise<MessageActionReturn> => {
     const tag = args.trim();
     if (!tag) {
@@ -124,11 +122,12 @@ const saveCommand: SlashCommandDefinition = {
   },
 };
 
-const resumeCommand: SlashCommandDefinition = {
+const resumeCommand: SlashCommand = {
   name: 'resume',
   altNames: ['load'],
   description:
     'Resume a conversation from a checkpoint. Usage: /chat resume <tag>',
+  kind: 'built-in',
   action: async (context, args) => {
     const tag = args.trim();
     if (!tag) {
@@ -194,8 +193,9 @@ const resumeCommand: SlashCommandDefinition = {
   },
 };
 
-export const chatCommand: SlashCommandDefinition = {
+export const chatCommand: SlashCommand = {
   name: 'chat',
   description: 'Manage conversation history.',
+  kind: 'built-in',
   subCommands: [listCommand, saveCommand, resumeCommand],
 };

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -5,7 +5,12 @@
  */
 
 import * as fsPromises from 'fs/promises';
-import { CommandContext, SlashCommand, MessageActionReturn } from './types.js';
+import {
+  CommandContext,
+  SlashCommand,
+  MessageActionReturn,
+  CommandKind,
+} from './types.js';
 import path from 'path';
 import { HistoryItemWithoutId, MessageType } from '../types.js';
 
@@ -54,7 +59,7 @@ const getSavedChatTags = async (
 const listCommand: SlashCommand = {
   name: 'list',
   description: 'List saved conversation checkpoints',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: async (context): Promise<MessageActionReturn> => {
     const chatDetails = await getSavedChatTags(context, false);
     if (chatDetails.length === 0) {
@@ -82,7 +87,7 @@ const saveCommand: SlashCommand = {
   name: 'save',
   description:
     'Save the current conversation as a checkpoint. Usage: /chat save <tag>',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: async (context, args): Promise<MessageActionReturn> => {
     const tag = args.trim();
     if (!tag) {
@@ -127,7 +132,7 @@ const resumeCommand: SlashCommand = {
   altNames: ['load'],
   description:
     'Resume a conversation from a checkpoint. Usage: /chat resume <tag>',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: async (context, args) => {
     const tag = args.trim();
     if (!tag) {
@@ -196,6 +201,6 @@ const resumeCommand: SlashCommand = {
 export const chatCommand: SlashCommand = {
   name: 'chat',
   description: 'Manage conversation history.',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   subCommands: [listCommand, saveCommand, resumeCommand],
 };

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -126,7 +126,7 @@ const saveCommand: SlashCommandDefinition = {
 
 const resumeCommand: SlashCommandDefinition = {
   name: 'resume',
-  altName: 'load',
+  altNames: ['load'],
   description:
     'Resume a conversation from a checkpoint. Usage: /chat resume <tag>',
   action: async (context, args) => {

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -5,9 +5,9 @@
  */
 
 import { uiTelemetryService } from '@google/gemini-cli-core';
-import { SlashCommand } from './types.js';
+import { SlashCommandDefinition } from './types.js';
 
-export const clearCommand: SlashCommand = {
+export const clearCommand: SlashCommandDefinition = {
   name: 'clear',
   description: 'clear the screen and conversation history',
   action: async (context, _args) => {

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -5,11 +5,12 @@
  */
 
 import { uiTelemetryService } from '@google/gemini-cli-core';
-import { SlashCommandDefinition } from './types.js';
+import { SlashCommand } from './types.js';
 
-export const clearCommand: SlashCommandDefinition = {
+export const clearCommand: SlashCommand = {
   name: 'clear',
   description: 'clear the screen and conversation history',
+  kind: 'built-in',
   action: async (context, _args) => {
     const geminiClient = context.services.config?.getGeminiClient();
 

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -5,12 +5,12 @@
  */
 
 import { uiTelemetryService } from '@google/gemini-cli-core';
-import { SlashCommand } from './types.js';
+import { CommandKind, SlashCommand } from './types.js';
 
 export const clearCommand: SlashCommand = {
   name: 'clear',
   description: 'clear the screen and conversation history',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: async (context, _args) => {
     const geminiClient = context.services.config?.getGeminiClient();
 

--- a/packages/cli/src/ui/commands/compressCommand.ts
+++ b/packages/cli/src/ui/commands/compressCommand.ts
@@ -5,9 +5,9 @@
  */
 
 import { HistoryItemCompression, MessageType } from '../types.js';
-import { SlashCommand } from './types.js';
+import { SlashCommandDefinition } from './types.js';
 
-export const compressCommand: SlashCommand = {
+export const compressCommand: SlashCommandDefinition = {
   name: 'compress',
   altName: 'summarize',
   description: 'Compresses the context by replacing it with a summary.',

--- a/packages/cli/src/ui/commands/compressCommand.ts
+++ b/packages/cli/src/ui/commands/compressCommand.ts
@@ -5,12 +5,13 @@
  */
 
 import { HistoryItemCompression, MessageType } from '../types.js';
-import { SlashCommandDefinition } from './types.js';
+import { SlashCommand } from './types.js';
 
-export const compressCommand: SlashCommandDefinition = {
+export const compressCommand: SlashCommand = {
   name: 'compress',
   altNames: ['summarize'],
   description: 'Compresses the context by replacing it with a summary.',
+  kind: 'built-in',
   action: async (context) => {
     const { ui } = context;
     if (ui.pendingItem) {

--- a/packages/cli/src/ui/commands/compressCommand.ts
+++ b/packages/cli/src/ui/commands/compressCommand.ts
@@ -5,13 +5,13 @@
  */
 
 import { HistoryItemCompression, MessageType } from '../types.js';
-import { SlashCommand } from './types.js';
+import { CommandKind, SlashCommand } from './types.js';
 
 export const compressCommand: SlashCommand = {
   name: 'compress',
   altNames: ['summarize'],
   description: 'Compresses the context by replacing it with a summary.',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: async (context) => {
     const { ui } = context;
     if (ui.pendingItem) {

--- a/packages/cli/src/ui/commands/compressCommand.ts
+++ b/packages/cli/src/ui/commands/compressCommand.ts
@@ -9,7 +9,7 @@ import { SlashCommandDefinition } from './types.js';
 
 export const compressCommand: SlashCommandDefinition = {
   name: 'compress',
-  altName: 'summarize',
+  altNames: ['summarize'],
   description: 'Compresses the context by replacing it with a summary.',
   action: async (context) => {
     const { ui } = context;

--- a/packages/cli/src/ui/commands/copyCommand.ts
+++ b/packages/cli/src/ui/commands/copyCommand.ts
@@ -5,12 +5,16 @@
  */
 
 import { copyToClipboard } from '../utils/commandUtils.js';
-import { SlashCommand, SlashCommandActionReturn } from './types.js';
+import {
+  CommandKind,
+  SlashCommand,
+  SlashCommandActionReturn,
+} from './types.js';
 
 export const copyCommand: SlashCommand = {
   name: 'copy',
   description: 'Copy the last result or code snippet to clipboard',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: async (context, _args): Promise<SlashCommandActionReturn | void> => {
     const chat = await context.services.config?.getGeminiClient()?.getChat();
     const history = chat?.getHistory();

--- a/packages/cli/src/ui/commands/copyCommand.ts
+++ b/packages/cli/src/ui/commands/copyCommand.ts
@@ -10,6 +10,7 @@ import { SlashCommand, SlashCommandActionReturn } from './types.js';
 export const copyCommand: SlashCommand = {
   name: 'copy',
   description: 'Copy the last result or code snippet to clipboard',
+  kind: 'built-in',
   action: async (context, _args): Promise<SlashCommandActionReturn | void> => {
     const chat = await context.services.config?.getGeminiClient()?.getChat();
     const history = chat?.getHistory();

--- a/packages/cli/src/ui/commands/corgiCommand.ts
+++ b/packages/cli/src/ui/commands/corgiCommand.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type SlashCommand } from './types.js';
+import { type SlashCommandDefinition } from './types.js';
 
-export const corgiCommand: SlashCommand = {
+export const corgiCommand: SlashCommandDefinition = {
   name: 'corgi',
   description: 'Toggles corgi mode.',
   action: (context, _args) => {

--- a/packages/cli/src/ui/commands/corgiCommand.ts
+++ b/packages/cli/src/ui/commands/corgiCommand.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type SlashCommand } from './types.js';
+import { CommandKind, type SlashCommand } from './types.js';
 
 export const corgiCommand: SlashCommand = {
   name: 'corgi',
   description: 'Toggles corgi mode.',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: (context, _args) => {
     context.ui.toggleCorgiMode();
   },

--- a/packages/cli/src/ui/commands/corgiCommand.ts
+++ b/packages/cli/src/ui/commands/corgiCommand.ts
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type SlashCommandDefinition } from './types.js';
+import { type SlashCommand } from './types.js';
 
-export const corgiCommand: SlashCommandDefinition = {
+export const corgiCommand: SlashCommand = {
   name: 'corgi',
   description: 'Toggles corgi mode.',
+  kind: 'built-in',
   action: (context, _args) => {
     context.ui.toggleCorgiMode();
   },

--- a/packages/cli/src/ui/commands/docsCommand.ts
+++ b/packages/cli/src/ui/commands/docsCommand.ts
@@ -6,10 +6,10 @@
 
 import open from 'open';
 import process from 'node:process';
-import { type CommandContext, type SlashCommand } from './types.js';
+import { type CommandContext, type SlashCommandDefinition } from './types.js';
 import { MessageType } from '../types.js';
 
-export const docsCommand: SlashCommand = {
+export const docsCommand: SlashCommandDefinition = {
   name: 'docs',
   description: 'open full Gemini CLI documentation in your browser',
   action: async (context: CommandContext): Promise<void> => {

--- a/packages/cli/src/ui/commands/docsCommand.ts
+++ b/packages/cli/src/ui/commands/docsCommand.ts
@@ -6,13 +6,17 @@
 
 import open from 'open';
 import process from 'node:process';
-import { type CommandContext, type SlashCommand } from './types.js';
+import {
+  type CommandContext,
+  type SlashCommand,
+  CommandKind,
+} from './types.js';
 import { MessageType } from '../types.js';
 
 export const docsCommand: SlashCommand = {
   name: 'docs',
   description: 'open full Gemini CLI documentation in your browser',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext): Promise<void> => {
     const docsUrl = 'https://goo.gle/gemini-cli-docs';
 

--- a/packages/cli/src/ui/commands/docsCommand.ts
+++ b/packages/cli/src/ui/commands/docsCommand.ts
@@ -6,12 +6,13 @@
 
 import open from 'open';
 import process from 'node:process';
-import { type CommandContext, type SlashCommandDefinition } from './types.js';
+import { type CommandContext, type SlashCommand } from './types.js';
 import { MessageType } from '../types.js';
 
-export const docsCommand: SlashCommandDefinition = {
+export const docsCommand: SlashCommand = {
   name: 'docs',
   description: 'open full Gemini CLI documentation in your browser',
+  kind: 'built-in',
   action: async (context: CommandContext): Promise<void> => {
     const docsUrl = 'https://goo.gle/gemini-cli-docs';
 

--- a/packages/cli/src/ui/commands/editorCommand.ts
+++ b/packages/cli/src/ui/commands/editorCommand.ts
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type OpenDialogActionReturn, type SlashCommand } from './types.js';
+import {
+  type OpenDialogActionReturn,
+  type SlashCommandDefinition,
+} from './types.js';
 
-export const editorCommand: SlashCommand = {
+export const editorCommand: SlashCommandDefinition = {
   name: 'editor',
   description: 'set external editor preference',
   action: (): OpenDialogActionReturn => ({

--- a/packages/cli/src/ui/commands/editorCommand.ts
+++ b/packages/cli/src/ui/commands/editorCommand.ts
@@ -4,12 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type OpenDialogActionReturn, type SlashCommand } from './types.js';
+import {
+  CommandKind,
+  type OpenDialogActionReturn,
+  type SlashCommand,
+} from './types.js';
 
 export const editorCommand: SlashCommand = {
   name: 'editor',
   description: 'set external editor preference',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: (): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'editor',

--- a/packages/cli/src/ui/commands/editorCommand.ts
+++ b/packages/cli/src/ui/commands/editorCommand.ts
@@ -4,14 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  type OpenDialogActionReturn,
-  type SlashCommandDefinition,
-} from './types.js';
+import { type OpenDialogActionReturn, type SlashCommand } from './types.js';
 
-export const editorCommand: SlashCommandDefinition = {
+export const editorCommand: SlashCommand = {
   name: 'editor',
   description: 'set external editor preference',
+  kind: 'built-in',
   action: (): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'editor',

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type CommandContext, type SlashCommand } from './types.js';
+import { type CommandContext, type SlashCommandDefinition } from './types.js';
 import { MessageType } from '../types.js';
 
-export const extensionsCommand: SlashCommand = {
+export const extensionsCommand: SlashCommandDefinition = {
   name: 'extensions',
   description: 'list active extensions',
   action: async (context: CommandContext): Promise<void> => {

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -4,13 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type CommandContext, type SlashCommand } from './types.js';
+import {
+  type CommandContext,
+  type SlashCommand,
+  CommandKind,
+} from './types.js';
 import { MessageType } from '../types.js';
 
 export const extensionsCommand: SlashCommand = {
   name: 'extensions',
   description: 'list active extensions',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext): Promise<void> => {
     const activeExtensions = context.services.config
       ?.getExtensions()

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type CommandContext, type SlashCommandDefinition } from './types.js';
+import { type CommandContext, type SlashCommand } from './types.js';
 import { MessageType } from '../types.js';
 
-export const extensionsCommand: SlashCommandDefinition = {
+export const extensionsCommand: SlashCommand = {
   name: 'extensions',
   description: 'list active extensions',
+  kind: 'built-in',
   action: async (context: CommandContext): Promise<void> => {
     const activeExtensions = context.services.config
       ?.getExtensions()

--- a/packages/cli/src/ui/commands/helpCommand.test.ts
+++ b/packages/cli/src/ui/commands/helpCommand.test.ts
@@ -32,9 +32,9 @@ describe('helpCommand', () => {
   });
 
   it("should also be triggered by its alternative name '?'", () => {
-    // This test is more conceptual. The routing of altName to the command
+    // This test is more conceptual. The routing of altNames to the command
     // is handled by the slash command processor, but we can assert the
-    // altName is correctly defined on the command object itself.
-    expect(helpCommand.altName).toBe('?');
+    // altNames is correctly defined on the command object itself.
+    expect(helpCommand.altNames).toContain('?');
   });
 });

--- a/packages/cli/src/ui/commands/helpCommand.ts
+++ b/packages/cli/src/ui/commands/helpCommand.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenDialogActionReturn, SlashCommand } from './types.js';
+import { OpenDialogActionReturn, SlashCommandDefinition } from './types.js';
 
-export const helpCommand: SlashCommand = {
+export const helpCommand: SlashCommandDefinition = {
   name: 'help',
   altName: '?',
   description: 'for help on gemini-cli',

--- a/packages/cli/src/ui/commands/helpCommand.ts
+++ b/packages/cli/src/ui/commands/helpCommand.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenDialogActionReturn, SlashCommand } from './types.js';
+import { CommandKind, OpenDialogActionReturn, SlashCommand } from './types.js';
 
 export const helpCommand: SlashCommand = {
   name: 'help',
   altNames: ['?'],
   description: 'for help on gemini-cli',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: (_context, _args): OpenDialogActionReturn => {
     console.debug('Opening help UI ...');
     return {

--- a/packages/cli/src/ui/commands/helpCommand.ts
+++ b/packages/cli/src/ui/commands/helpCommand.ts
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenDialogActionReturn, SlashCommandDefinition } from './types.js';
+import { OpenDialogActionReturn, SlashCommand } from './types.js';
 
-export const helpCommand: SlashCommandDefinition = {
+export const helpCommand: SlashCommand = {
   name: 'help',
   altNames: ['?'],
   description: 'for help on gemini-cli',
+  kind: 'built-in',
   action: (_context, _args): OpenDialogActionReturn => {
     console.debug('Opening help UI ...');
     return {

--- a/packages/cli/src/ui/commands/helpCommand.ts
+++ b/packages/cli/src/ui/commands/helpCommand.ts
@@ -8,7 +8,7 @@ import { OpenDialogActionReturn, SlashCommandDefinition } from './types.js';
 
 export const helpCommand: SlashCommandDefinition = {
   name: 'help',
-  altName: '?',
+  altNames: ['?'],
   description: 'for help on gemini-cli',
   action: (_context, _args): OpenDialogActionReturn => {
     console.debug('Opening help UI ...');

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -15,7 +15,7 @@ import {
 } from '@google/gemini-cli-core';
 import {
   CommandContext,
-  SlashCommand,
+  SlashCommandDefinition,
   SlashCommandActionReturn,
 } from './types.js';
 import * as child_process from 'child_process';
@@ -40,7 +40,9 @@ function isVSCodeInstalled(): boolean {
   }
 }
 
-export const ideCommand = (config: Config | null): SlashCommand | null => {
+export const ideCommand = (
+  config: Config | null,
+): SlashCommandDefinition | null => {
   if (!config?.getIdeMode()) {
     return null;
   }

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -17,6 +17,7 @@ import {
   CommandContext,
   SlashCommand,
   SlashCommandActionReturn,
+  CommandKind,
 } from './types.js';
 import * as child_process from 'child_process';
 import * as process from 'process';
@@ -48,12 +49,12 @@ export const ideCommand = (config: Config | null): SlashCommand | null => {
   return {
     name: 'ide',
     description: 'manage IDE integration',
-    kind: 'built-in',
+    kind: CommandKind.BUILT_IN,
     subCommands: [
       {
         name: 'status',
         description: 'check status of IDE integration',
-        kind: 'built-in',
+        kind: CommandKind.BUILT_IN,
         action: (_context: CommandContext): SlashCommandActionReturn => {
           const status = getMCPServerStatus(IDE_SERVER_NAME);
           const discoveryState = getMCPDiscoveryState();
@@ -91,7 +92,7 @@ export const ideCommand = (config: Config | null): SlashCommand | null => {
       {
         name: 'install',
         description: 'install required VS Code companion extension',
-        kind: 'built-in',
+        kind: CommandKind.BUILT_IN,
         action: async (context) => {
           if (!isVSCodeInstalled()) {
             context.ui.addItem(

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -15,7 +15,7 @@ import {
 } from '@google/gemini-cli-core';
 import {
   CommandContext,
-  SlashCommandDefinition,
+  SlashCommand,
   SlashCommandActionReturn,
 } from './types.js';
 import * as child_process from 'child_process';
@@ -40,9 +40,7 @@ function isVSCodeInstalled(): boolean {
   }
 }
 
-export const ideCommand = (
-  config: Config | null,
-): SlashCommandDefinition | null => {
+export const ideCommand = (config: Config | null): SlashCommand | null => {
   if (!config?.getIdeMode()) {
     return null;
   }
@@ -50,10 +48,12 @@ export const ideCommand = (
   return {
     name: 'ide',
     description: 'manage IDE integration',
+    kind: 'built-in',
     subCommands: [
       {
         name: 'status',
         description: 'check status of IDE integration',
+        kind: 'built-in',
         action: (_context: CommandContext): SlashCommandActionReturn => {
           const status = getMCPServerStatus(IDE_SERVER_NAME);
           const discoveryState = getMCPDiscoveryState();
@@ -91,6 +91,7 @@ export const ideCommand = (
       {
         name: 'install',
         description: 'install required VS Code companion extension',
+        kind: 'built-in',
         action: async (context) => {
           if (!isVSCodeInstalled()) {
             context.ui.addItem(

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -5,7 +5,7 @@
  */
 
 import {
-  SlashCommand,
+  SlashCommandDefinition,
   SlashCommandActionReturn,
   CommandContext,
 } from './types.js';
@@ -226,7 +226,7 @@ const getMcpStatus = async (
   };
 };
 
-export const mcpCommand: SlashCommand = {
+export const mcpCommand: SlashCommandDefinition = {
   name: 'mcp',
   description: 'list configured MCP servers and tools',
   action: async (context: CommandContext, args: string) => {

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -8,6 +8,7 @@ import {
   SlashCommand,
   SlashCommandActionReturn,
   CommandContext,
+  CommandKind,
 } from './types.js';
 import {
   DiscoveredMCPTool,
@@ -229,7 +230,7 @@ const getMcpStatus = async (
 export const mcpCommand: SlashCommand = {
   name: 'mcp',
   description: 'list configured MCP servers and tools',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext, args: string) => {
     const lowerCaseArgs = args.toLowerCase().split(/\s+/).filter(Boolean);
 

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -5,7 +5,7 @@
  */
 
 import {
-  SlashCommandDefinition,
+  SlashCommand,
   SlashCommandActionReturn,
   CommandContext,
 } from './types.js';
@@ -226,9 +226,10 @@ const getMcpStatus = async (
   };
 };
 
-export const mcpCommand: SlashCommandDefinition = {
+export const mcpCommand: SlashCommand = {
   name: 'mcp',
   description: 'list configured MCP servers and tools',
+  kind: 'built-in',
   action: async (context: CommandContext, args: string) => {
     const lowerCaseArgs = args.toLowerCase().split(/\s+/).filter(Boolean);
 

--- a/packages/cli/src/ui/commands/memoryCommand.ts
+++ b/packages/cli/src/ui/commands/memoryCommand.ts
@@ -6,9 +6,9 @@
 
 import { getErrorMessage } from '@google/gemini-cli-core';
 import { MessageType } from '../types.js';
-import { SlashCommand, SlashCommandActionReturn } from './types.js';
+import { SlashCommandDefinition, SlashCommandActionReturn } from './types.js';
 
-export const memoryCommand: SlashCommand = {
+export const memoryCommand: SlashCommandDefinition = {
   name: 'memory',
   description: 'Commands for interacting with memory.',
   subCommands: [

--- a/packages/cli/src/ui/commands/memoryCommand.ts
+++ b/packages/cli/src/ui/commands/memoryCommand.ts
@@ -6,17 +6,21 @@
 
 import { getErrorMessage } from '@google/gemini-cli-core';
 import { MessageType } from '../types.js';
-import { SlashCommand, SlashCommandActionReturn } from './types.js';
+import {
+  CommandKind,
+  SlashCommand,
+  SlashCommandActionReturn,
+} from './types.js';
 
 export const memoryCommand: SlashCommand = {
   name: 'memory',
   description: 'Commands for interacting with memory.',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   subCommands: [
     {
       name: 'show',
       description: 'Show the current memory contents.',
-      kind: 'built-in',
+      kind: CommandKind.BUILT_IN,
       action: async (context) => {
         const memoryContent = context.services.config?.getUserMemory() || '';
         const fileCount = context.services.config?.getGeminiMdFileCount() || 0;
@@ -38,7 +42,7 @@ export const memoryCommand: SlashCommand = {
     {
       name: 'add',
       description: 'Add content to the memory.',
-      kind: 'built-in',
+      kind: CommandKind.BUILT_IN,
       action: (context, args): SlashCommandActionReturn | void => {
         if (!args || args.trim() === '') {
           return {
@@ -66,7 +70,7 @@ export const memoryCommand: SlashCommand = {
     {
       name: 'refresh',
       description: 'Refresh the memory from the source.',
-      kind: 'built-in',
+      kind: CommandKind.BUILT_IN,
       action: async (context) => {
         context.ui.addItem(
           {

--- a/packages/cli/src/ui/commands/memoryCommand.ts
+++ b/packages/cli/src/ui/commands/memoryCommand.ts
@@ -6,15 +6,17 @@
 
 import { getErrorMessage } from '@google/gemini-cli-core';
 import { MessageType } from '../types.js';
-import { SlashCommandDefinition, SlashCommandActionReturn } from './types.js';
+import { SlashCommand, SlashCommandActionReturn } from './types.js';
 
-export const memoryCommand: SlashCommandDefinition = {
+export const memoryCommand: SlashCommand = {
   name: 'memory',
   description: 'Commands for interacting with memory.',
+  kind: 'built-in',
   subCommands: [
     {
       name: 'show',
       description: 'Show the current memory contents.',
+      kind: 'built-in',
       action: async (context) => {
         const memoryContent = context.services.config?.getUserMemory() || '';
         const fileCount = context.services.config?.getGeminiMdFileCount() || 0;
@@ -36,6 +38,7 @@ export const memoryCommand: SlashCommandDefinition = {
     {
       name: 'add',
       description: 'Add content to the memory.',
+      kind: 'built-in',
       action: (context, args): SlashCommandActionReturn | void => {
         if (!args || args.trim() === '') {
           return {
@@ -63,6 +66,7 @@ export const memoryCommand: SlashCommandDefinition = {
     {
       name: 'refresh',
       description: 'Refresh the memory from the source.',
+      kind: 'built-in',
       action: async (context) => {
         context.ui.addItem(
           {

--- a/packages/cli/src/ui/commands/privacyCommand.ts
+++ b/packages/cli/src/ui/commands/privacyCommand.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenDialogActionReturn, SlashCommand } from './types.js';
+import { OpenDialogActionReturn, SlashCommandDefinition } from './types.js';
 
-export const privacyCommand: SlashCommand = {
+export const privacyCommand: SlashCommandDefinition = {
   name: 'privacy',
   description: 'display the privacy notice',
   action: (): OpenDialogActionReturn => ({

--- a/packages/cli/src/ui/commands/privacyCommand.ts
+++ b/packages/cli/src/ui/commands/privacyCommand.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenDialogActionReturn, SlashCommand } from './types.js';
+import { CommandKind, OpenDialogActionReturn, SlashCommand } from './types.js';
 
 export const privacyCommand: SlashCommand = {
   name: 'privacy',
   description: 'display the privacy notice',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: (): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'privacy',

--- a/packages/cli/src/ui/commands/privacyCommand.ts
+++ b/packages/cli/src/ui/commands/privacyCommand.ts
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenDialogActionReturn, SlashCommandDefinition } from './types.js';
+import { OpenDialogActionReturn, SlashCommand } from './types.js';
 
-export const privacyCommand: SlashCommandDefinition = {
+export const privacyCommand: SlashCommand = {
   name: 'privacy',
   description: 'display the privacy notice',
+  kind: 'built-in',
   action: (): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'privacy',

--- a/packages/cli/src/ui/commands/quitCommand.ts
+++ b/packages/cli/src/ui/commands/quitCommand.ts
@@ -5,9 +5,9 @@
  */
 
 import { formatDuration } from '../utils/formatters.js';
-import { type SlashCommand } from './types.js';
+import { type SlashCommandDefinition } from './types.js';
 
-export const quitCommand: SlashCommand = {
+export const quitCommand: SlashCommandDefinition = {
   name: 'quit',
   altName: 'exit',
   description: 'exit the cli',

--- a/packages/cli/src/ui/commands/quitCommand.ts
+++ b/packages/cli/src/ui/commands/quitCommand.ts
@@ -9,7 +9,7 @@ import { type SlashCommandDefinition } from './types.js';
 
 export const quitCommand: SlashCommandDefinition = {
   name: 'quit',
-  altName: 'exit',
+  altNames: ['exit'],
   description: 'exit the cli',
   action: (context) => {
     const now = Date.now();

--- a/packages/cli/src/ui/commands/quitCommand.ts
+++ b/packages/cli/src/ui/commands/quitCommand.ts
@@ -5,13 +5,13 @@
  */
 
 import { formatDuration } from '../utils/formatters.js';
-import { type SlashCommand } from './types.js';
+import { CommandKind, type SlashCommand } from './types.js';
 
 export const quitCommand: SlashCommand = {
   name: 'quit',
   altNames: ['exit'],
   description: 'exit the cli',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: (context) => {
     const now = Date.now();
     const { sessionStartTime } = context.session.stats;

--- a/packages/cli/src/ui/commands/quitCommand.ts
+++ b/packages/cli/src/ui/commands/quitCommand.ts
@@ -5,12 +5,13 @@
  */
 
 import { formatDuration } from '../utils/formatters.js';
-import { type SlashCommandDefinition } from './types.js';
+import { type SlashCommand } from './types.js';
 
-export const quitCommand: SlashCommandDefinition = {
+export const quitCommand: SlashCommand = {
   name: 'quit',
   altNames: ['exit'],
   description: 'exit the cli',
+  kind: 'built-in',
   action: (context) => {
     const now = Date.now();
     const { sessionStartTime } = context.session.stats;

--- a/packages/cli/src/ui/commands/restoreCommand.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs/promises';
 import path from 'path';
 import {
   type CommandContext,
-  type SlashCommand,
+  type SlashCommandDefinition,
   type SlashCommandActionReturn,
 } from './types.js';
 import { Config } from '@google/gemini-cli-core';
@@ -140,7 +140,9 @@ async function completion(
   }
 }
 
-export const restoreCommand = (config: Config | null): SlashCommand | null => {
+export const restoreCommand = (
+  config: Config | null,
+): SlashCommandDefinition | null => {
   if (!config?.getCheckpointingEnabled()) {
     return null;
   }

--- a/packages/cli/src/ui/commands/restoreCommand.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs/promises';
 import path from 'path';
 import {
   type CommandContext,
-  type SlashCommandDefinition,
+  type SlashCommand,
   type SlashCommandActionReturn,
 } from './types.js';
 import { Config } from '@google/gemini-cli-core';
@@ -140,9 +140,7 @@ async function completion(
   }
 }
 
-export const restoreCommand = (
-  config: Config | null,
-): SlashCommandDefinition | null => {
+export const restoreCommand = (config: Config | null): SlashCommand | null => {
   if (!config?.getCheckpointingEnabled()) {
     return null;
   }
@@ -151,6 +149,7 @@ export const restoreCommand = (
     name: 'restore',
     description:
       'Restore a tool call. This will reset the conversation and file history to the state it was in when the tool call was suggested',
+    kind: 'built-in',
     action: restoreAction,
     completion,
   };

--- a/packages/cli/src/ui/commands/restoreCommand.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.ts
@@ -10,6 +10,7 @@ import {
   type CommandContext,
   type SlashCommand,
   type SlashCommandActionReturn,
+  CommandKind,
 } from './types.js';
 import { Config } from '@google/gemini-cli-core';
 
@@ -149,7 +150,7 @@ export const restoreCommand = (config: Config | null): SlashCommand | null => {
     name: 'restore',
     description:
       'Restore a tool call. This will reset the conversation and file history to the state it was in when the tool call was suggested',
-    kind: 'built-in',
+    kind: CommandKind.BUILT_IN,
     action: restoreAction,
     completion,
   };

--- a/packages/cli/src/ui/commands/statsCommand.ts
+++ b/packages/cli/src/ui/commands/statsCommand.ts
@@ -6,9 +6,9 @@
 
 import { MessageType, HistoryItemStats } from '../types.js';
 import { formatDuration } from '../utils/formatters.js';
-import { type CommandContext, type SlashCommand } from './types.js';
+import { type CommandContext, type SlashCommandDefinition } from './types.js';
 
-export const statsCommand: SlashCommand = {
+export const statsCommand: SlashCommandDefinition = {
   name: 'stats',
   altName: 'usage',
   description: 'check session stats. Usage: /stats [model|tools]',

--- a/packages/cli/src/ui/commands/statsCommand.ts
+++ b/packages/cli/src/ui/commands/statsCommand.ts
@@ -6,13 +6,17 @@
 
 import { MessageType, HistoryItemStats } from '../types.js';
 import { formatDuration } from '../utils/formatters.js';
-import { type CommandContext, type SlashCommand } from './types.js';
+import {
+  type CommandContext,
+  type SlashCommand,
+  CommandKind,
+} from './types.js';
 
 export const statsCommand: SlashCommand = {
   name: 'stats',
   altNames: ['usage'],
   description: 'check session stats. Usage: /stats [model|tools]',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: (context: CommandContext) => {
     const now = new Date();
     const { sessionStartTime } = context.session.stats;
@@ -39,7 +43,7 @@ export const statsCommand: SlashCommand = {
     {
       name: 'model',
       description: 'Show model-specific usage statistics.',
-      kind: 'built-in',
+      kind: CommandKind.BUILT_IN,
       action: (context: CommandContext) => {
         context.ui.addItem(
           {
@@ -52,7 +56,7 @@ export const statsCommand: SlashCommand = {
     {
       name: 'tools',
       description: 'Show tool-specific usage statistics.',
-      kind: 'built-in',
+      kind: CommandKind.BUILT_IN,
       action: (context: CommandContext) => {
         context.ui.addItem(
           {

--- a/packages/cli/src/ui/commands/statsCommand.ts
+++ b/packages/cli/src/ui/commands/statsCommand.ts
@@ -6,12 +6,13 @@
 
 import { MessageType, HistoryItemStats } from '../types.js';
 import { formatDuration } from '../utils/formatters.js';
-import { type CommandContext, type SlashCommandDefinition } from './types.js';
+import { type CommandContext, type SlashCommand } from './types.js';
 
-export const statsCommand: SlashCommandDefinition = {
+export const statsCommand: SlashCommand = {
   name: 'stats',
   altNames: ['usage'],
   description: 'check session stats. Usage: /stats [model|tools]',
+  kind: 'built-in',
   action: (context: CommandContext) => {
     const now = new Date();
     const { sessionStartTime } = context.session.stats;
@@ -38,6 +39,7 @@ export const statsCommand: SlashCommandDefinition = {
     {
       name: 'model',
       description: 'Show model-specific usage statistics.',
+      kind: 'built-in',
       action: (context: CommandContext) => {
         context.ui.addItem(
           {
@@ -50,6 +52,7 @@ export const statsCommand: SlashCommandDefinition = {
     {
       name: 'tools',
       description: 'Show tool-specific usage statistics.',
+      kind: 'built-in',
       action: (context: CommandContext) => {
         context.ui.addItem(
           {

--- a/packages/cli/src/ui/commands/statsCommand.ts
+++ b/packages/cli/src/ui/commands/statsCommand.ts
@@ -10,7 +10,7 @@ import { type CommandContext, type SlashCommandDefinition } from './types.js';
 
 export const statsCommand: SlashCommandDefinition = {
   name: 'stats',
-  altName: 'usage',
+  altNames: ['usage'],
   description: 'check session stats. Usage: /stats [model|tools]',
   action: (context: CommandContext) => {
     const now = new Date();

--- a/packages/cli/src/ui/commands/themeCommand.ts
+++ b/packages/cli/src/ui/commands/themeCommand.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenDialogActionReturn, SlashCommand } from './types.js';
+import { OpenDialogActionReturn, SlashCommandDefinition } from './types.js';
 
-export const themeCommand: SlashCommand = {
+export const themeCommand: SlashCommandDefinition = {
   name: 'theme',
   description: 'change the theme',
   action: (_context, _args): OpenDialogActionReturn => ({

--- a/packages/cli/src/ui/commands/themeCommand.ts
+++ b/packages/cli/src/ui/commands/themeCommand.ts
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenDialogActionReturn, SlashCommandDefinition } from './types.js';
+import { OpenDialogActionReturn, SlashCommand } from './types.js';
 
-export const themeCommand: SlashCommandDefinition = {
+export const themeCommand: SlashCommand = {
   name: 'theme',
   description: 'change the theme',
+  kind: 'built-in',
   action: (_context, _args): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'theme',

--- a/packages/cli/src/ui/commands/themeCommand.ts
+++ b/packages/cli/src/ui/commands/themeCommand.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenDialogActionReturn, SlashCommand } from './types.js';
+import { CommandKind, OpenDialogActionReturn, SlashCommand } from './types.js';
 
 export const themeCommand: SlashCommand = {
   name: 'theme',
   description: 'change the theme',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: (_context, _args): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'theme',

--- a/packages/cli/src/ui/commands/toolsCommand.ts
+++ b/packages/cli/src/ui/commands/toolsCommand.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type CommandContext, type SlashCommand } from './types.js';
+import { type CommandContext, type SlashCommandDefinition } from './types.js';
 import { MessageType } from '../types.js';
 
-export const toolsCommand: SlashCommand = {
+export const toolsCommand: SlashCommandDefinition = {
   name: 'tools',
   description: 'list available Gemini CLI tools',
   action: async (context: CommandContext, args?: string): Promise<void> => {

--- a/packages/cli/src/ui/commands/toolsCommand.ts
+++ b/packages/cli/src/ui/commands/toolsCommand.ts
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type CommandContext, type SlashCommandDefinition } from './types.js';
+import { type CommandContext, type SlashCommand } from './types.js';
 import { MessageType } from '../types.js';
 
-export const toolsCommand: SlashCommandDefinition = {
+export const toolsCommand: SlashCommand = {
   name: 'tools',
   description: 'list available Gemini CLI tools',
+  kind: 'built-in',
   action: async (context: CommandContext, args?: string): Promise<void> => {
     const subCommand = args?.trim();
 

--- a/packages/cli/src/ui/commands/toolsCommand.ts
+++ b/packages/cli/src/ui/commands/toolsCommand.ts
@@ -4,13 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type CommandContext, type SlashCommand } from './types.js';
+import {
+  type CommandContext,
+  type SlashCommand,
+  CommandKind,
+} from './types.js';
 import { MessageType } from '../types.js';
 
 export const toolsCommand: SlashCommand = {
   name: 'tools',
   description: 'list available Gemini CLI tools',
-  kind: 'built-in',
+  kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext, args?: string): Promise<void> => {
     const subCommand = args?.trim();
 

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -142,7 +142,7 @@ export interface SlashCommandDefinition {
     partialArg: string,
   ) => Promise<string[]>;
 
-  subCommands?: SlashCommandDefinition[];
+  subCommands?: readonly SlashCommandDefinition[];
 }
 
 // The standardized contract for any command in the system.

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -106,11 +106,53 @@ export type SlashCommandActionReturn =
   | OpenDialogActionReturn
   | LoadHistoryActionReturn;
 
+/**
+ * Metadata describing a command's origin and expected behavior.
+ */
+export interface SlashCommandMetadata {
+  /** The source of the command definition. */
+  source: 'built-in' | 'file';
+
+  /** The primary behavior of the command. 'Custom' is for commands with unique,
+   * hard-coded logic (e.g., opening a dialog).
+   */
+  behavior: 'Custom'; // `| 'Prompt'` will be added in next PR for Custom Commands.
+
+  /** The absolute path to the definition file, if applicable. */
+  // TODO: filePath?: string;
+}
+
+export interface SlashCommandDefinition {
+  name: string;
+  altName?: string;
+  description?: string;
+
+  // The action to run. Optional for parent commands that only group sub-commands.
+  action?: (
+    context: CommandContext,
+    args: string,
+  ) =>
+    | void
+    | SlashCommandActionReturn
+    | Promise<void | SlashCommandActionReturn>;
+
+  // Provides argument completion (e.g., completing a tag for `/chat resume <tag>`).
+  completion?: (
+    context: CommandContext,
+    partialArg: string,
+  ) => Promise<string[]>;
+
+  subCommands?: SlashCommandDefinition[];
+}
+
 // The standardized contract for any command in the system.
+// This version is separated from SlashCommandDefinition as it requires metadata.
 export interface SlashCommand {
   name: string;
   altName?: string;
   description?: string;
+
+  metadata: SlashCommandMetadata;
 
   // The action to run. Optional for parent commands that only group sub-commands.
   action?: (

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -112,7 +112,7 @@ export interface SlashCommand {
   altNames?: string[];
   description: string;
 
-  kind: 'built-in';
+  kind: 'built-in' | 'file';
 
   // The action to run. Optional for parent commands that only group sub-commands.
   action?: (

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -106,13 +106,18 @@ export type SlashCommandActionReturn =
   | OpenDialogActionReturn
   | LoadHistoryActionReturn;
 
+export enum CommandKind {
+  BUILT_IN = 'built-in',
+  FILE = 'file',
+}
+
 // The standardized contract for any command in the system.
 export interface SlashCommand {
   name: string;
   altNames?: string[];
   description: string;
 
-  kind: 'built-in' | 'file';
+  kind: CommandKind;
 
   // The action to run. Optional for parent commands that only group sub-commands.
   action?: (

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -124,7 +124,7 @@ export interface SlashCommandMetadata {
 
 export interface SlashCommandDefinition {
   name: string;
-  altName?: string;
+  altNames?: string[];
   description?: string;
 
   // The action to run. Optional for parent commands that only group sub-commands.
@@ -149,7 +149,7 @@ export interface SlashCommandDefinition {
 // This version is separated from SlashCommandDefinition as it requires metadata.
 export interface SlashCommand {
   name: string;
-  altName?: string;
+  altNames?: string[];
   description?: string;
 
   metadata: SlashCommandMetadata;

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -125,7 +125,7 @@ export interface SlashCommandMetadata {
 export interface SlashCommandDefinition {
   name: string;
   altNames?: string[];
-  description?: string;
+  description: string;
 
   // The action to run. Optional for parent commands that only group sub-commands.
   action?: (
@@ -150,7 +150,7 @@ export interface SlashCommandDefinition {
 export interface SlashCommand {
   name: string;
   altNames?: string[];
-  description?: string;
+  description: string;
 
   metadata: SlashCommandMetadata;
 

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -106,53 +106,13 @@ export type SlashCommandActionReturn =
   | OpenDialogActionReturn
   | LoadHistoryActionReturn;
 
-/**
- * Metadata describing a command's origin and expected behavior.
- */
-export interface SlashCommandMetadata {
-  /** The source of the command definition. */
-  source: 'built-in' | 'file';
-
-  /** The primary behavior of the command. 'Custom' is for commands with unique,
-   * hard-coded logic (e.g., opening a dialog).
-   */
-  behavior: 'Custom'; // `| 'Prompt'` will be added in next PR for Custom Commands.
-
-  /** The absolute path to the definition file, if applicable. */
-  // TODO: filePath?: string;
-}
-
-export interface SlashCommandDefinition {
-  name: string;
-  altNames?: string[];
-  description: string;
-
-  // The action to run. Optional for parent commands that only group sub-commands.
-  action?: (
-    context: CommandContext,
-    args: string,
-  ) =>
-    | void
-    | SlashCommandActionReturn
-    | Promise<void | SlashCommandActionReturn>;
-
-  // Provides argument completion (e.g., completing a tag for `/chat resume <tag>`).
-  completion?: (
-    context: CommandContext,
-    partialArg: string,
-  ) => Promise<string[]>;
-
-  subCommands?: readonly SlashCommandDefinition[];
-}
-
 // The standardized contract for any command in the system.
-// This version is separated from SlashCommandDefinition as it requires metadata.
 export interface SlashCommand {
   name: string;
   altNames?: string[];
   description: string;
 
-  metadata: SlashCommandMetadata;
+  kind: 'built-in';
 
   // The action to run. Optional for parent commands that only group sub-commands.
   action?: (

--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -10,7 +10,7 @@ import { Colors } from '../colors.js';
 import { SlashCommand } from '../commands/types.js';
 
 interface Help {
-  commands: SlashCommand[];
+  commands: readonly SlashCommand[];
 }
 
 export const Help: React.FC<Help> = ({ commands }) => (

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -451,13 +451,13 @@ describe('InputPrompt', () => {
     unmount();
   });
 
-  it('should complete a command based on its altName', async () => {
-    // Add a command with an altName to our mock for this test
+  it('should complete a command based on its altNames', async () => {
+    // Add a command with an altNames to our mock for this test
     props.slashCommands.push({
       name: 'help',
-      altName: '?',
+      altNames: ['?'],
       description: '...',
-    });
+    } as SlashCommand);
 
     mockedUseCompletion.mockReturnValue({
       ...mockCompletion,

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -32,7 +32,7 @@ export interface InputPromptProps {
   userMessages: readonly string[];
   onClearScreen: () => void;
   config: Config;
-  slashCommands: SlashCommand[];
+  slashCommands: readonly SlashCommand[];
   commandContext: CommandContext;
   placeholder?: string;
   focus?: boolean;
@@ -180,7 +180,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         // If there's no trailing space, we need to check if the current query
         // is already a complete path to a parent command.
         if (!hasTrailingSpace) {
-          let currentLevel: SlashCommand[] | undefined = slashCommands;
+          let currentLevel: readonly SlashCommand[] | undefined = slashCommands;
           for (let i = 0; i < parts.length; i++) {
             const part = parts[i];
             const found: SlashCommand | undefined = currentLevel?.find(
@@ -191,7 +191,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
               if (i === parts.length - 1 && found.subCommands) {
                 isParentPath = true;
               }
-              currentLevel = found.subCommands;
+              currentLevel = found.subCommands as
+                | readonly SlashCommand[]
+                | undefined;
             } else {
               // Path is invalid, so it can't be a parent path.
               currentLevel = undefined;

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -184,7 +184,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           for (let i = 0; i < parts.length; i++) {
             const part = parts[i];
             const found: SlashCommand | undefined = currentLevel?.find(
-              (cmd) => cmd.name === part || cmd.altName === part,
+              (cmd) => cmd.name === part || cmd.altNames?.includes(part),
             );
 
             if (found) {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -11,419 +11,325 @@ const { mockProcessExit } = vi.hoisted(() => ({
 vi.mock('node:process', () => ({
   default: {
     exit: mockProcessExit,
-    cwd: vi.fn(() => '/mock/cwd'),
-    get env() {
-      return process.env;
-    },
-    platform: 'test-platform',
-    version: 'test-node-version',
-    memoryUsage: vi.fn(() => ({
-      rss: 12345678,
-      heapTotal: 23456789,
-      heapUsed: 10234567,
-      external: 1234567,
-      arrayBuffers: 123456,
-    })),
   },
-  exit: mockProcessExit,
-  cwd: vi.fn(() => '/mock/cwd'),
-  get env() {
-    return process.env;
-  },
-  platform: 'test-platform',
-  version: 'test-node-version',
-  memoryUsage: vi.fn(() => ({
-    rss: 12345678,
-    heapTotal: 23456789,
-    heapUsed: 10234567,
-    external: 1234567,
-    arrayBuffers: 123456,
+}));
+
+const mockLoadCommands = vi.fn();
+vi.mock('../../services/BuiltinCommandLoader.js', () => ({
+  BuiltinCommandLoader: vi.fn().mockImplementation(() => ({
+    loadCommands: mockLoadCommands,
   })),
 }));
 
-vi.mock('node:fs/promises', () => ({
-  readFile: vi.fn(),
-  writeFile: vi.fn(),
-  mkdir: vi.fn(),
-}));
-
-const mockGetCliVersionFn = vi.fn(() => Promise.resolve('0.1.0'));
-vi.mock('../../utils/version.js', () => ({
-  getCliVersion: (...args: []) => mockGetCliVersionFn(...args),
-}));
-
-import { act, renderHook } from '@testing-library/react';
-import { vi, describe, it, expect, beforeEach, beforeAll, Mock } from 'vitest';
-import open from 'open';
-import { useSlashCommandProcessor } from './slashCommandProcessor.js';
-import { SlashCommandProcessorResult } from '../types.js';
-import { Config, GeminiClient } from '@google/gemini-cli-core';
-import { useSessionStats } from '../contexts/SessionContext.js';
-import { LoadedSettings } from '../../config/settings.js';
-import * as ShowMemoryCommandModule from './useShowMemoryCommand.js';
-import { CommandService } from '../../services/CommandService.js';
-import { SlashCommand } from '../commands/types.js';
-
 vi.mock('../contexts/SessionContext.js', () => ({
-  useSessionStats: vi.fn(),
+  useSessionStats: vi.fn(() => ({ stats: {} })),
 }));
 
-vi.mock('../../services/CommandService.js');
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
+import { useSlashCommandProcessor } from './slashCommandProcessor.js';
+import { SlashCommand, SlashCommandDefinition } from '../commands/types.js';
+import { Config } from '@google/gemini-cli-core';
+import { LoadedSettings } from '../../config/settings.js';
+import { MessageType } from '../types.js';
+import { BuiltinCommandLoader } from '../../services/BuiltinCommandLoader.js';
 
-vi.mock('./useShowMemoryCommand.js', () => ({
-  SHOW_MEMORY_COMMAND_NAME: '/memory show',
-  createShowMemoryAction: vi.fn(() => vi.fn()),
-}));
-
-vi.mock('open', () => ({
-  default: vi.fn(),
-}));
-
-vi.mock('@google/gemini-cli-core', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('@google/gemini-cli-core')>();
-  return {
-    ...actual,
+// Helper function to create a fully hydrated SlashCommand for testing
+const createTestCommand = (
+  definition: SlashCommandDefinition,
+): SlashCommand => {
+  const command: SlashCommand = {
+    ...definition,
+    metadata: { source: 'built-in', behavior: 'Custom' },
+    subCommands: definition.subCommands
+      ? definition.subCommands.map(createTestCommand)
+      : undefined,
   };
-});
+  return command;
+};
 
 describe('useSlashCommandProcessor', () => {
-  let mockAddItem: ReturnType<typeof vi.fn>;
-  let mockClearItems: ReturnType<typeof vi.fn>;
-  let mockLoadHistory: ReturnType<typeof vi.fn>;
-  let mockRefreshStatic: ReturnType<typeof vi.fn>;
-  let mockSetShowHelp: ReturnType<typeof vi.fn>;
-  let mockOnDebugMessage: ReturnType<typeof vi.fn>;
-  let mockOpenThemeDialog: ReturnType<typeof vi.fn>;
-  let mockOpenAuthDialog: ReturnType<typeof vi.fn>;
-  let mockOpenEditorDialog: ReturnType<typeof vi.fn>;
-  let mockSetQuittingMessages: ReturnType<typeof vi.fn>;
-  let mockTryCompressChat: ReturnType<typeof vi.fn>;
-  let mockGeminiClient: GeminiClient;
-  let mockConfig: Config;
-  let mockCorgiMode: ReturnType<typeof vi.fn>;
-  const mockUseSessionStats = useSessionStats as Mock;
+  const mockAddItem = vi.fn();
+  const mockClearItems = vi.fn();
+  const mockLoadHistory = vi.fn();
+  const mockSetShowHelp = vi.fn();
+  const mockOpenAuthDialog = vi.fn();
+  const mockSetQuittingMessages = vi.fn();
+
+  const mockConfig = {
+    getProjectRoot: () => '/mock/cwd',
+    getSessionId: () => 'test-session',
+    getGeminiClient: () => ({
+      setHistory: vi.fn().mockResolvedValue(undefined),
+    }),
+  } as unknown as Config;
+
+  const mockSettings = {} as LoadedSettings;
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    mockAddItem = vi.fn();
-    mockClearItems = vi.fn();
-    mockLoadHistory = vi.fn();
-    mockRefreshStatic = vi.fn();
-    mockSetShowHelp = vi.fn();
-    mockOnDebugMessage = vi.fn();
-    mockOpenThemeDialog = vi.fn();
-    mockOpenAuthDialog = vi.fn();
-    mockOpenEditorDialog = vi.fn();
-    mockSetQuittingMessages = vi.fn();
-    mockTryCompressChat = vi.fn();
-    mockGeminiClient = {
-      tryCompressChat: mockTryCompressChat,
-    } as unknown as GeminiClient;
-    mockConfig = {
-      getDebugMode: vi.fn(() => false),
-      getGeminiClient: () => mockGeminiClient,
-      getSandbox: vi.fn(() => 'test-sandbox'),
-      getModel: vi.fn(() => 'test-model'),
-      getProjectRoot: vi.fn(() => '/test/dir'),
-      getCheckpointingEnabled: vi.fn(() => true),
-      getBugCommand: vi.fn(() => undefined),
-      getSessionId: vi.fn(() => 'test-session-id'),
-      getIdeMode: vi.fn(() => false),
-    } as unknown as Config;
-    mockCorgiMode = vi.fn();
-    mockUseSessionStats.mockReturnValue({
-      stats: {
-        sessionStartTime: new Date('2025-01-01T00:00:00.000Z'),
-        cumulative: {
-          promptCount: 0,
-          promptTokenCount: 0,
-          candidatesTokenCount: 0,
-          totalTokenCount: 0,
-          cachedContentTokenCount: 0,
-          toolUsePromptTokenCount: 0,
-          thoughtsTokenCount: 0,
-        },
-      },
-    });
-
-    (open as Mock).mockClear();
-    mockProcessExit.mockClear();
-    (ShowMemoryCommandModule.createShowMemoryAction as Mock).mockClear();
-    process.env = { ...globalThis.process.env };
+    (vi.mocked(BuiltinCommandLoader) as Mock).mockClear();
+    mockLoadCommands.mockResolvedValue([]);
   });
 
-  const getProcessorHook = () => {
-    const settings = {
-      merged: {
-        contextFileName: 'GEMINI.md',
-      },
-    } as unknown as LoadedSettings;
-    return renderHook(() =>
+  const setupProcessorHook = (commands: SlashCommand[] = []) => {
+    mockLoadCommands.mockResolvedValue(Object.freeze(commands));
+    const { result } = renderHook(() =>
       useSlashCommandProcessor(
         mockConfig,
-        settings,
+        mockSettings,
         mockAddItem,
         mockClearItems,
         mockLoadHistory,
-        mockRefreshStatic,
+        vi.fn(), // refreshStatic
         mockSetShowHelp,
-        mockOnDebugMessage,
-        mockOpenThemeDialog,
+        vi.fn(), // onDebugMessage
+        vi.fn(), // openThemeDialog
         mockOpenAuthDialog,
-        mockOpenEditorDialog,
-        mockCorgiMode,
+        vi.fn(), // openEditorDialog
+        vi.fn(), // toggleCorgiMode
         mockSetQuittingMessages,
-        vi.fn(), // mockOpenPrivacyNotice
+        vi.fn(), // openPrivacyNotice
       ),
     );
+
+    return result;
   };
 
-  describe('Command Processing', () => {
-    let ActualCommandService: typeof CommandService;
-
-    beforeAll(async () => {
-      const actual = (await vi.importActual(
-        '../../services/CommandService.js',
-      )) as { CommandService: typeof CommandService };
-      ActualCommandService = actual.CommandService;
+  describe('Initialization and Command Loading', () => {
+    it('should initialize CommandService with BuiltinCommandLoader', () => {
+      setupProcessorHook();
+      expect(BuiltinCommandLoader).toHaveBeenCalledTimes(1);
+      expect(BuiltinCommandLoader).toHaveBeenCalledWith(mockConfig);
     });
 
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
+    it('should call loadCommands and populate state after mounting', async () => {
+      const testCommand = createTestCommand({ name: 'test' });
+      const result = setupProcessorHook([testCommand]);
 
-    it('should execute a registered command', async () => {
-      const mockAction = vi.fn();
-      const newCommand: SlashCommand = { name: 'test', action: mockAction };
-      const mockLoader = async () => [newCommand];
-
-      // We create the instance outside the mock implementation.
-      const commandServiceInstance = new ActualCommandService(
-        mockConfig,
-        mockLoader,
-      );
-
-      // This mock ensures the hook uses our pre-configured instance.
-      vi.mocked(CommandService).mockImplementation(
-        () => commandServiceInstance,
-      );
-
-      const { result } = getProcessorHook();
-
-      await vi.waitFor(() => {
-        // We check that the `slashCommands` array, which is the public API
-        // of our hook, eventually contains the command we injected.
-        expect(
-          result.current.slashCommands.some((c) => c.name === 'test'),
-        ).toBe(true);
+      await waitFor(() => {
+        expect(result.current.slashCommands).toHaveLength(1);
       });
 
-      let commandResult: SlashCommandProcessorResult | false = false;
+      expect(result.current.slashCommands[0]?.name).toBe('test');
+      expect(mockLoadCommands).toHaveBeenCalledTimes(1);
+    });
+
+    it('should provide an immutable array of commands to consumers', async () => {
+      const testCommand = createTestCommand({ name: 'test' });
+      const result = setupProcessorHook([testCommand]);
+
+      await waitFor(() => {
+        expect(result.current.slashCommands).toHaveLength(1);
+      });
+
+      const commands = result.current.slashCommands;
+
+      expect(() => {
+        // @ts-expect-error - We are intentionally testing a violation of the readonly type.
+        commands.push(createTestCommand({ name: 'rogue' }));
+      }).toThrow(TypeError);
+    });
+  });
+
+  describe('Command Execution Logic', () => {
+    it('should display an error for an unknown command', async () => {
+      const result = setupProcessorHook();
+      await waitFor(() => expect(result.current.slashCommands).toBeDefined());
+
       await act(async () => {
-        commandResult = await result.current.handleSlashCommand('/test');
+        await result.current.handleSlashCommand('/nonexistent');
       });
 
-      expect(mockAction).toHaveBeenCalledTimes(1);
-      expect(commandResult).toEqual({ type: 'handled' });
-    });
-
-    it('should return "schedule_tool" for a command returning a tool action', async () => {
-      const mockAction = vi.fn().mockResolvedValue({
-        type: 'tool',
-        toolName: 'my_tool',
-        toolArgs: { arg1: 'value1' },
-      });
-      const newCommand: SlashCommand = { name: 'test', action: mockAction };
-      const mockLoader = async () => [newCommand];
-      const commandServiceInstance = new ActualCommandService(
-        mockConfig,
-        mockLoader,
-      );
-      vi.mocked(CommandService).mockImplementation(
-        () => commandServiceInstance,
-      );
-
-      const { result } = getProcessorHook();
-      await vi.waitFor(() => {
-        expect(
-          result.current.slashCommands.some((c) => c.name === 'test'),
-        ).toBe(true);
-      });
-
-      const commandResult = await result.current.handleSlashCommand('/test');
-
-      expect(mockAction).toHaveBeenCalledTimes(1);
-      expect(commandResult).toEqual({
-        type: 'schedule_tool',
-        toolName: 'my_tool',
-        toolArgs: { arg1: 'value1' },
-      });
-    });
-
-    it('should return "handled" for a command returning a message action', async () => {
-      const mockAction = vi.fn().mockResolvedValue({
-        type: 'message',
-        messageType: 'info',
-        content: 'This is a message',
-      });
-      const newCommand: SlashCommand = { name: 'test', action: mockAction };
-      const mockLoader = async () => [newCommand];
-      const commandServiceInstance = new ActualCommandService(
-        mockConfig,
-        mockLoader,
-      );
-      vi.mocked(CommandService).mockImplementation(
-        () => commandServiceInstance,
-      );
-
-      const { result } = getProcessorHook();
-      await vi.waitFor(() => {
-        expect(
-          result.current.slashCommands.some((c) => c.name === 'test'),
-        ).toBe(true);
-      });
-
-      const commandResult = await result.current.handleSlashCommand('/test');
-
-      expect(mockAction).toHaveBeenCalledTimes(1);
-      expect(mockAddItem).toHaveBeenCalledWith(
+      // Expect 2 calls: one for the user's input, one for the error message.
+      expect(mockAddItem).toHaveBeenCalledTimes(2);
+      expect(mockAddItem).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          type: 'info',
-          text: 'This is a message',
+          type: MessageType.ERROR,
+          text: 'Unknown command: /nonexistent',
         }),
         expect.any(Number),
       );
-      expect(commandResult).toEqual({ type: 'handled' });
     });
 
-    it('should return "handled" for a command returning a dialog action', async () => {
-      const mockAction = vi.fn().mockResolvedValue({
-        type: 'dialog',
-        dialog: 'help',
-      });
-      const newCommand: SlashCommand = { name: 'test', action: mockAction };
-      const mockLoader = async () => [newCommand];
-      const commandServiceInstance = new ActualCommandService(
-        mockConfig,
-        mockLoader,
-      );
-      vi.mocked(CommandService).mockImplementation(
-        () => commandServiceInstance,
-      );
-
-      const { result } = getProcessorHook();
-      await vi.waitFor(() => {
-        expect(
-          result.current.slashCommands.some((c) => c.name === 'test'),
-        ).toBe(true);
-      });
-
-      const commandResult = await result.current.handleSlashCommand('/test');
-
-      expect(mockAction).toHaveBeenCalledTimes(1);
-      expect(mockSetShowHelp).toHaveBeenCalledWith(true);
-      expect(commandResult).toEqual({ type: 'handled' });
-    });
-
-    it('should open the auth dialog for a command returning an auth dialog action', async () => {
-      const mockAction = vi.fn().mockResolvedValue({
-        type: 'dialog',
-        dialog: 'auth',
-      });
-      const newAuthCommand: SlashCommand = { name: 'auth', action: mockAction };
-
-      const mockLoader = async () => [newAuthCommand];
-      const commandServiceInstance = new ActualCommandService(
-        mockConfig,
-        mockLoader,
-      );
-      vi.mocked(CommandService).mockImplementation(
-        () => commandServiceInstance,
-      );
-
-      const { result } = getProcessorHook();
-      await vi.waitFor(() => {
-        expect(
-          result.current.slashCommands.some((c) => c.name === 'auth'),
-        ).toBe(true);
-      });
-
-      const commandResult = await result.current.handleSlashCommand('/auth');
-
-      expect(mockAction).toHaveBeenCalledTimes(1);
-      expect(mockOpenAuthDialog).toHaveBeenCalledWith();
-      expect(commandResult).toEqual({ type: 'handled' });
-    });
-
-    it('should open the theme dialog for a command returning a theme dialog action', async () => {
-      const mockAction = vi.fn().mockResolvedValue({
-        type: 'dialog',
-        dialog: 'theme',
-      });
-      const newCommand: SlashCommand = { name: 'test', action: mockAction };
-      const mockLoader = async () => [newCommand];
-      const commandServiceInstance = new ActualCommandService(
-        mockConfig,
-        mockLoader,
-      );
-      vi.mocked(CommandService).mockImplementation(
-        () => commandServiceInstance,
-      );
-
-      const { result } = getProcessorHook();
-      await vi.waitFor(() => {
-        expect(
-          result.current.slashCommands.some((c) => c.name === 'test'),
-        ).toBe(true);
-      });
-
-      const commandResult = await result.current.handleSlashCommand('/test');
-
-      expect(mockAction).toHaveBeenCalledTimes(1);
-      expect(mockOpenThemeDialog).toHaveBeenCalledWith();
-      expect(commandResult).toEqual({ type: 'handled' });
-    });
-
-    it('should show help for a parent command with no action', async () => {
-      const parentCommand: SlashCommand = {
+    it('should display help for a parent command invoked without a subcommand', async () => {
+      const parentCommand = createTestCommand({
         name: 'parent',
-        subCommands: [
-          { name: 'child', description: 'A child.', action: vi.fn() },
-        ],
-      };
-
-      const mockLoader = async () => [parentCommand];
-      const commandServiceInstance = new ActualCommandService(
-        mockConfig,
-        mockLoader,
-      );
-      vi.mocked(CommandService).mockImplementation(
-        () => commandServiceInstance,
-      );
-
-      const { result } = getProcessorHook();
-
-      await vi.waitFor(() => {
-        expect(
-          result.current.slashCommands.some((c) => c.name === 'parent'),
-        ).toBe(true);
+        subCommands: [{ name: 'child1', description: 'First child.' }],
       });
+      const result = setupProcessorHook([parentCommand]);
+      await waitFor(() => expect(result.current.slashCommands).toHaveLength(1));
 
       await act(async () => {
         await result.current.handleSlashCommand('/parent');
       });
 
-      expect(mockAddItem).toHaveBeenCalledWith(
+      expect(mockAddItem).toHaveBeenCalledTimes(2);
+      expect(mockAddItem).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          type: 'info',
+          type: MessageType.INFO,
           text: expect.stringContaining(
             "Command '/parent' requires a subcommand.",
           ),
         }),
         expect.any(Number),
       );
+    });
+
+    it('should correctly find and execute a nested subcommand', async () => {
+      const childAction = vi.fn();
+      const parentCommand = createTestCommand({
+        name: 'parent',
+        subCommands: [{ name: 'child', action: childAction }],
+      });
+      const result = setupProcessorHook([parentCommand]);
+      await waitFor(() => expect(result.current.slashCommands).toHaveLength(1));
+
+      await act(async () => {
+        await result.current.handleSlashCommand('/parent child with args');
+      });
+
+      expect(childAction).toHaveBeenCalledTimes(1);
+
+      expect(childAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          services: expect.objectContaining({
+            config: mockConfig,
+          }),
+          ui: expect.objectContaining({
+            addItem: mockAddItem,
+          }),
+        }),
+        'with args',
+      );
+    });
+  });
+
+  describe('Action Result Handling', () => {
+    it('should handle "dialog: help" action', async () => {
+      const command = createTestCommand({
+        name: 'helpcmd',
+        action: vi.fn().mockResolvedValue({ type: 'dialog', dialog: 'help' }),
+      });
+      const result = setupProcessorHook([command]);
+      await waitFor(() => expect(result.current.slashCommands).toHaveLength(1));
+
+      await act(async () => {
+        await result.current.handleSlashCommand('/helpcmd');
+      });
+
+      expect(mockSetShowHelp).toHaveBeenCalledWith(true);
+    });
+
+    it('should handle "load_history" action', async () => {
+      const command = createTestCommand({
+        name: 'load',
+        action: vi.fn().mockResolvedValue({
+          type: 'load_history',
+          history: [{ type: MessageType.USER, text: 'old prompt' }],
+          clientHistory: [{ role: 'user', parts: [{ text: 'old prompt' }] }],
+        }),
+      });
+      const result = setupProcessorHook([command]);
+      await waitFor(() => expect(result.current.slashCommands).toHaveLength(1));
+
+      await act(async () => {
+        await result.current.handleSlashCommand('/load');
+      });
+
+      expect(mockClearItems).toHaveBeenCalledTimes(1);
+      expect(mockAddItem).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'user', text: 'old prompt' }),
+        expect.any(Number),
+      );
+    });
+
+    describe('with fake timers', () => {
+      // This test needs to let the async `waitFor` complete with REAL timers
+      // before switching to FAKE timers to test setTimeout.
+      it('should handle a "quit" action', async () => {
+        const quitAction = vi
+          .fn()
+          .mockResolvedValue({ type: 'quit', messages: [] });
+        const command = createTestCommand({ name: 'exit', action: quitAction });
+        const result = setupProcessorHook([command]);
+
+        await waitFor(() =>
+          expect(result.current.slashCommands).toHaveLength(1),
+        );
+
+        vi.useFakeTimers();
+
+        try {
+          await act(async () => {
+            await result.current.handleSlashCommand('/exit');
+          });
+
+          await act(async () => {
+            await vi.advanceTimersByTimeAsync(200);
+          });
+
+          expect(mockSetQuittingMessages).toHaveBeenCalledWith([]);
+          expect(mockProcessExit).toHaveBeenCalledWith(0);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+    });
+  });
+
+  describe('Command Parsing and Matching', () => {
+    it('should be case-sensitive', async () => {
+      const command = createTestCommand({ name: 'test' });
+      const result = setupProcessorHook([command]);
+      await waitFor(() => expect(result.current.slashCommands).toHaveLength(1));
+
+      await act(async () => {
+        // Use uppercase when command is lowercase
+        await result.current.handleSlashCommand('/Test');
+      });
+
+      // It should fail and call addItem with an error
+      expect(mockAddItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          text: 'Unknown command: /Test',
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should correctly match an altName', async () => {
+      const action = vi.fn();
+      const command = createTestCommand({
+        name: 'main',
+        altName: 'alias',
+        action,
+      });
+      const result = setupProcessorHook([command]);
+      await waitFor(() => expect(result.current.slashCommands).toHaveLength(1));
+
+      await act(async () => {
+        await result.current.handleSlashCommand('/alias');
+      });
+
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(mockAddItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: MessageType.ERROR }),
+      );
+    });
+
+    it('should handle extra whitespace around the command', async () => {
+      const action = vi.fn();
+      const command = createTestCommand({ name: 'test', action });
+      const result = setupProcessorHook([command]);
+      await waitFor(() => expect(result.current.slashCommands).toHaveLength(1));
+
+      await act(async () => {
+        await result.current.handleSlashCommand('  /test  with-args  ');
+      });
+
+      expect(action).toHaveBeenCalledWith(expect.anything(), 'with-args');
     });
   });
 });

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -332,4 +332,32 @@ describe('useSlashCommandProcessor', () => {
       expect(action).toHaveBeenCalledWith(expect.anything(), 'with-args');
     });
   });
+
+  describe('Lifecycle', () => {
+    it('should abort command loading when the hook unmounts', async () => {
+      const abortSpy = vi.spyOn(AbortController.prototype, 'abort');
+      const { unmount } = renderHook(() =>
+        useSlashCommandProcessor(
+          mockConfig,
+          mockSettings,
+          mockAddItem,
+          mockClearItems,
+          mockLoadHistory,
+          vi.fn(), // refreshStatic
+          mockSetShowHelp,
+          vi.fn(), // onDebugMessage
+          vi.fn(), // openThemeDialog
+          mockOpenAuthDialog,
+          vi.fn(), // openEditorDialog
+          vi.fn(), // toggleCorgiMode
+          mockSetQuittingMessages,
+          vi.fn(), // openPrivacyNotice
+        ),
+      );
+
+      unmount();
+
+      expect(abortSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -303,7 +303,7 @@ describe('useSlashCommandProcessor', () => {
       const action = vi.fn();
       const command = createTestCommand({
         name: 'main',
-        altName: 'alias',
+        altNames: ['alias'],
         action,
       });
       const result = setupProcessorHook([command]);

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -21,6 +21,7 @@ import {
 import { LoadedSettings } from '../../config/settings.js';
 import { type CommandContext, type SlashCommand } from '../commands/types.js';
 import { CommandService } from '../../services/CommandService.js';
+import { BuiltinCommandLoader } from '../../services/BuiltinCommandLoader.js';
 
 /**
  * Hook to define and process slash commands (e.g., /help, /clear).
@@ -42,7 +43,7 @@ export const useSlashCommandProcessor = (
   openPrivacyNotice: () => void,
 ) => {
   const session = useSessionStats();
-  const [commands, setCommands] = useState<SlashCommand[]>([]);
+  const [commands, setCommands] = useState<readonly SlashCommand[]>([]);
   const gitService = useMemo(() => {
     if (!config?.getProjectRoot()) {
       return;
@@ -158,7 +159,11 @@ export const useSlashCommandProcessor = (
     ],
   );
 
-  const commandService = useMemo(() => new CommandService(config), [config]);
+  const commandService = useMemo(() => {
+    // TODO - Add other loaders for custom commands.
+    const loaders = [new BuiltinCommandLoader(config)];
+    return new CommandService(loaders);
+  }, [config]);
 
   useEffect(() => {
     const load = async () => {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -208,7 +208,7 @@ export const useSlashCommandProcessor = (
 
       for (const part of commandPath) {
         const foundCommand = currentCommands.find(
-          (cmd) => cmd.name === part || cmd.altName === part,
+          (cmd) => cmd.name === part || cmd.altNames?.includes(part),
         );
 
         if (foundCommand) {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -160,14 +160,22 @@ export const useSlashCommandProcessor = (
   );
 
   useEffect(() => {
+    const controller = new AbortController();
     const load = async () => {
       // TODO - Add other loaders for custom commands.
       const loaders = [new BuiltinCommandLoader(config)];
-      const commandService = await CommandService.create(loaders);
+      const commandService = await CommandService.create(
+        loaders,
+        controller.signal,
+      );
       setCommands(commandService.getCommands());
     };
 
     load();
+
+    return () => {
+      controller.abort();
+    };
   }, [config]);
 
   const handleSlashCommand = useCallback(

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -159,20 +159,16 @@ export const useSlashCommandProcessor = (
     ],
   );
 
-  const commandService = useMemo(() => {
-    // TODO - Add other loaders for custom commands.
-    const loaders = [new BuiltinCommandLoader(config)];
-    return new CommandService(loaders);
-  }, [config]);
-
   useEffect(() => {
     const load = async () => {
-      await commandService.loadCommands();
+      // TODO - Add other loaders for custom commands.
+      const loaders = [new BuiltinCommandLoader(config)];
+      const commandService = await CommandService.create(loaders);
       setCommands(commandService.getCommands());
     };
 
     load();
-  }, [commandService]);
+  }, [config]);
 
   const handleSlashCommand = useCallback(
     async (

--- a/packages/cli/src/ui/hooks/useCompletion.integration.test.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.integration.test.ts
@@ -53,13 +53,13 @@ describe('useCompletion git-aware filtering integration', () => {
   const mockSlashCommands: SlashCommand[] = [
     {
       name: 'help',
-      altName: '?',
+      altNames: ['?'],
       description: 'Show help',
       action: vi.fn(),
     },
     {
       name: 'stats',
-      altName: 'usage',
+      altNames: ['usage'],
       description: 'check session stats. Usage: /stats [model|tools]',
       action: vi.fn(),
     },
@@ -553,7 +553,7 @@ describe('useCompletion git-aware filtering integration', () => {
   });
 
   it.each([['/?'], ['/usage']])(
-    'should not suggest commands when altName is fully typed',
+    'should not suggest commands when altNames is fully typed',
     async (altName) => {
       const { result } = renderHook(() =>
         useCompletion(
@@ -569,7 +569,7 @@ describe('useCompletion git-aware filtering integration', () => {
     },
   );
 
-  it('should suggest commands based on partial altName matches', async () => {
+  it('should suggest commands based on partial altNames matches', async () => {
     const { result } = renderHook(() =>
       useCompletion(
         '/usag', // part of the word "usage"

--- a/packages/cli/src/ui/hooks/useCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.test.ts
@@ -66,13 +66,13 @@ describe('useCompletion', () => {
     mockSlashCommands = [
       {
         name: 'help',
-        altName: '?',
+        altNames: ['?'],
         description: 'Show help',
         action: vi.fn(),
       },
       {
         name: 'stats',
-        altName: 'usage',
+        altNames: ['usage'],
         description: 'check session stats. Usage: /stats [model|tools]',
         action: vi.fn(),
       },
@@ -410,7 +410,7 @@ describe('useCompletion', () => {
     });
 
     it.each([['/?'], ['/usage']])(
-      'should not suggest commands when altName is fully typed',
+      'should not suggest commands when altNames is fully typed',
       (altName) => {
         const { result } = renderHook(() =>
           useCompletion(
@@ -427,7 +427,7 @@ describe('useCompletion', () => {
       },
     );
 
-    it('should suggest commands based on partial altName matches', () => {
+    it('should suggest commands based on partial altNames matches', () => {
       const { result } = renderHook(() =>
         useCompletion(
           '/usag', // part of the word "usage"

--- a/packages/cli/src/ui/hooks/useCompletion.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.ts
@@ -41,7 +41,7 @@ export function useCompletion(
   query: string,
   cwd: string,
   isActive: boolean,
-  slashCommands: SlashCommand[],
+  slashCommands: readonly SlashCommand[],
   commandContext: CommandContext,
   config?: Config,
 ): UseCompletionReturn {
@@ -151,7 +151,7 @@ export function useCompletion(
       }
 
       // Traverse the Command Tree using the tentative completed path
-      let currentLevel: SlashCommand[] | undefined = slashCommands;
+      let currentLevel: readonly SlashCommand[] | undefined = slashCommands;
       let leafCommand: SlashCommand | null = null;
 
       for (const part of commandPathParts) {
@@ -165,7 +165,9 @@ export function useCompletion(
         );
         if (found) {
           leafCommand = found;
-          currentLevel = found.subCommands;
+          currentLevel = found.subCommands as
+            | readonly SlashCommand[]
+            | undefined;
         } else {
           leafCommand = null;
           currentLevel = [];

--- a/packages/cli/src/ui/hooks/useCompletion.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.ts
@@ -161,7 +161,7 @@ export function useCompletion(
           break;
         }
         const found: SlashCommand | undefined = currentLevel.find(
-          (cmd) => cmd.name === part || cmd.altName === part,
+          (cmd) => cmd.name === part || cmd.altNames?.includes(part),
         );
         if (found) {
           leafCommand = found;
@@ -179,7 +179,7 @@ export function useCompletion(
       if (!hasTrailingSpace && currentLevel) {
         const exactMatchAsParent = currentLevel.find(
           (cmd) =>
-            (cmd.name === partial || cmd.altName === partial) &&
+            (cmd.name === partial || cmd.altNames?.includes(partial)) &&
             cmd.subCommands,
         );
 
@@ -201,7 +201,8 @@ export function useCompletion(
           // Case: /command subcommand<enter>
           const perfectMatch = currentLevel.find(
             (cmd) =>
-              (cmd.name === partial || cmd.altName === partial) && cmd.action,
+              (cmd.name === partial || cmd.altNames?.includes(partial)) &&
+              cmd.action,
           );
           if (perfectMatch) {
             setIsPerfectMatch(true);
@@ -240,14 +241,15 @@ export function useCompletion(
         let potentialSuggestions = commandsToSearch.filter(
           (cmd) =>
             cmd.description &&
-            (cmd.name.startsWith(partial) || cmd.altName?.startsWith(partial)),
+            (cmd.name.startsWith(partial) ||
+              cmd.altNames?.some((alt) => alt.startsWith(partial))),
         );
 
         // If a user's input is an exact match and it is a leaf command,
         // enter should submit immediately.
         if (potentialSuggestions.length > 0 && !hasTrailingSpace) {
           const perfectMatch = potentialSuggestions.find(
-            (s) => s.name === partial || s.altName === partial,
+            (s) => s.name === partial || s.altNames?.includes(partial),
           );
           if (perfectMatch && perfectMatch.action) {
             potentialSuggestions = [];


### PR DESCRIPTION
## TLDR

This PR introduces an extensible architecture for handling slash commands. It replaces the previous loading logic with an updated `CommandService` that operates on a provider-based `ICommandLoader` pattern.

This is prefactor step towards supporting custom, file-based commands and other future sources. There are **no user-facing changes** in this PR. It is a pure architectural refactoring designed to improve maintainability, testability, and extensibility.

**Key areas for review:**
*   The new `CommandService` and `BuiltinCommandLoader` in `packages/cli/src/services/`.
*   The addition of the `kind: CommandKind` enum to the `SlashCommand` interface in `packages/cli/src/ui/commands/types.ts`.
*   The updated instantiation logic in `packages/cli/src/ui/hooks/slashCommandProcessor.ts`, which now uses the async factory `CommandService.create()`.
*   The new unit tests that verify the service's resilience and override behavior.

## Dive Deeper

This refactor addresses the technical debt and limitations of our previous command handling system, preparing us for the strategic vision of an extensible automation platform.

### The New Command Service Architecture

The core of this change is the new service-oriented architecture:
*   **`CommandService`**: The central orchestrator for the command lifecycle. It uses a static `create()` factory method to asynchronously load commands.
*   **`ICommandLoader`**: A simple interface defining the contract for any class that can provide commands. This is the key to our future extensibility.
*   **`BuiltinCommandLoader`**: The first implementation of `ICommandLoader`. It is now solely responsible for gathering all hard-coded command definitions (including those created by factories like `ideCommand`) and providing them to the `CommandService`.

### Architectural Decision: Static Command Classification

A key decision in this implementation was how to classify commands based on their source. Instead of introducing a separate `SlashCommandDefinition` type, after reviews, I opted for a simpler and more direct approach:

**I added a `kind: CommandKind` enum directly to the `SlashCommand` interface.**

This `kind` property (`BUILT_IN` or `FILE`) provides essential static information about a command's origin without needing to inspect its runtime behavior. All existing built-in command definitions have been updated to include `kind: CommandKind.BUILT_IN`.

**Justification:**
*   **Simplicity:** This avoids the need for a transformation step within the loader, simplifying the data flow. The command objects are now defined in their final shape.
*   **Clarity:** It makes the source of any command explicit and type-safe.
*   **Future-Proofing:** This static classification is crucial for future features. It will allow us to easily build an intelligent `/help` command that can group commands by kind (e.g., "Built-in Commands", "Custom Prompts") or to create other UI experiences that treat commands differently based on their source.

## Reviewer Test Plan

The primary success criteria for this PR is that the application's command handling behavior is **identical** to `main`, proving the refactor was successful and introduced no regressions.

1.  **Code Review Focus:**
    *   Examine the new files in `packages/cli/src/services/`.
    *   Review the `CommandKind` enum and updated `SlashCommand` interface in `packages/cli/src/ui/commands/types.ts`.
    *   Confirm the new service instantiation in `packages/cli/src/ui/hooks/slashCommandProcessor.ts`.

2.  **Run Automated Tests:**
    *   Run `npm preflight`. All tests should pass, including the new unit tests for `CommandService.test.ts` and `BuiltinCommandLoader.test.ts` which validate the new architecture's core logic, resilience, and override behavior.

3.  **Manual Sanity Check:**
    *   Start the CLI with `npm start`.
    *   Execute a simple, top-level command: `/help`. The help dialog should appear as normal.
    *   Execute a nested command: `/chat list`. The list of saved chats should appear as normal.
    *   Execute a command that depends on `config` being passed in: `/ide status` (if you have IDE mode enabled). It should report the status correctly.
    *   Confirm that command autocompletion still works as expected (e.g., typing `/ch` suggests `chat`).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

This PR makes progress on #3789