### PR TITLE
Extend mcp-server timeout.

### DIFF
--- a/integration-tests/simple-mcp-server.test.js
+++ b/integration-tests/simple-mcp-server.test.js
@@ -54,7 +54,7 @@ describe('simple-mcp-server', () => {
       console.error(`stderr: ${data}`);
     });
     // Wait for the server to be ready
-    return new Promise((resolve) => setTimeout(resolve, 500));
+    return new Promise((resolve) => setTimeout(resolve, 2000));
   });
 
   after(() => {


### PR DESCRIPTION
- MCP servers take a bit longer to spinup, especially on CI.
