### PR TITLE
feat(extension): resolve environment variables in extension configurations

### DIFF
--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -109,6 +109,100 @@ describe('loadExtensions', () => {
       path.join(workspaceExtensionsDir, 'ext1', 'my-context-file.md'),
     ]);
   });
+
+  it('should resolve environment variables in extension configuration', () => {
+    process.env.TEST_API_KEY = 'test-api-key-123';
+    process.env.TEST_DB_URL = 'postgresql://localhost:5432/testdb';
+
+    try {
+      const workspaceExtensionsDir = path.join(
+        tempWorkspaceDir,
+        EXTENSIONS_DIRECTORY_NAME,
+      );
+      fs.mkdirSync(workspaceExtensionsDir, { recursive: true });
+
+      const extDir = path.join(workspaceExtensionsDir, 'test-extension');
+      fs.mkdirSync(extDir);
+
+      // Write config to a separate file for clarity and good practices
+      const configPath = path.join(extDir, EXTENSIONS_CONFIG_FILENAME);
+      const extensionConfig = {
+        name: 'test-extension',
+        version: '1.0.0',
+        mcpServers: {
+          'test-server': {
+            command: 'node',
+            args: ['server.js'],
+            env: {
+              API_KEY: '$TEST_API_KEY',
+              DATABASE_URL: '${TEST_DB_URL}',
+              STATIC_VALUE: 'no-substitution',
+            },
+          },
+        },
+      };
+      fs.writeFileSync(configPath, JSON.stringify(extensionConfig));
+
+      const extensions = loadExtensions(tempWorkspaceDir);
+
+      expect(extensions).toHaveLength(1);
+      const extension = extensions[0];
+      expect(extension.config.name).toBe('test-extension');
+      expect(extension.config.mcpServers).toBeDefined();
+
+      const serverConfig = extension.config.mcpServers?.['test-server'];
+      expect(serverConfig).toBeDefined();
+      expect(serverConfig?.env).toBeDefined();
+      expect(serverConfig?.env?.API_KEY).toBe('test-api-key-123');
+      expect(serverConfig?.env?.DATABASE_URL).toBe(
+        'postgresql://localhost:5432/testdb',
+      );
+      expect(serverConfig?.env?.STATIC_VALUE).toBe('no-substitution');
+    } finally {
+      delete process.env.TEST_API_KEY;
+      delete process.env.TEST_DB_URL;
+    }
+  });
+
+  it('should handle missing environment variables gracefully', () => {
+    const workspaceExtensionsDir = path.join(
+      tempWorkspaceDir,
+      EXTENSIONS_DIRECTORY_NAME,
+    );
+    fs.mkdirSync(workspaceExtensionsDir, { recursive: true });
+
+    const extDir = path.join(workspaceExtensionsDir, 'test-extension');
+    fs.mkdirSync(extDir);
+
+    const extensionConfig = {
+      name: 'test-extension',
+      version: '1.0.0',
+      mcpServers: {
+        'test-server': {
+          command: 'node',
+          args: ['server.js'],
+          env: {
+            MISSING_VAR: '$UNDEFINED_ENV_VAR',
+            MISSING_VAR_BRACES: '${ALSO_UNDEFINED}',
+          },
+        },
+      },
+    };
+
+    fs.writeFileSync(
+      path.join(extDir, EXTENSIONS_CONFIG_FILENAME),
+      JSON.stringify(extensionConfig),
+    );
+
+    const extensions = loadExtensions(tempWorkspaceDir);
+
+    expect(extensions).toHaveLength(1);
+    const extension = extensions[0];
+    const serverConfig = extension.config.mcpServers!['test-server'];
+    expect(serverConfig.env).toBeDefined();
+    expect(serverConfig.env!.MISSING_VAR).toBe('$UNDEFINED_ENV_VAR');
+    expect(serverConfig.env!.MISSING_VAR_BRACES).toBe('${ALSO_UNDEFINED}');
+  });
 });
 
 describe('annotateActiveExtensions', () => {

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -8,6 +8,7 @@ import { MCPServerConfig, GeminiCLIExtension } from '@google/gemini-cli-core';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { resolveEnvVarsInObject } from '../utils/envVarResolver.js';
 
 export const EXTENSIONS_DIRECTORY_NAME = path.join('.gemini', 'extensions');
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
@@ -78,13 +79,16 @@ function loadExtension(extensionDir: string): Extension | null {
 
   try {
     const configContent = fs.readFileSync(configFilePath, 'utf-8');
-    const config = JSON.parse(configContent) as ExtensionConfig;
+    let config = JSON.parse(configContent) as ExtensionConfig;
+
     if (!config.name || !config.version) {
       console.error(
         `Invalid extension config in ${configFilePath}: missing name or version.`,
       );
       return null;
     }
+
+    config = resolveEnvVarsInObject(config);
 
     const contextFiles = getContextFileNames(config)
       .map((contextFileName) => path.join(extensionDir, contextFileName))

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { homedir, platform } from 'os';
 import * as dotenv from 'dotenv';
+import process from 'node:process';
 import {
   GEMINI_CONFIG_DIR as GEMINI_DIR,
   getErrorMessage,
@@ -16,6 +17,7 @@ import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
 import { DefaultDark } from '../ui/themes/default.js';
 import { Settings, MemoryImportFormat } from './settingsSchema.js';
+import { resolveEnvVarsInObject } from '../utils/envVarResolver.js';
 
 export type { Settings, MemoryImportFormat };
 
@@ -154,48 +156,6 @@ export class LoadedSettings {
     this._merged = this.computeMergedSettings();
     saveSettings(settingsFile);
   }
-}
-
-function resolveEnvVarsInString(value: string): string {
-  const envVarRegex = /\$(?:(\w+)|{([^}]+)})/g; // Find $VAR_NAME or ${VAR_NAME}
-  return value.replace(envVarRegex, (match, varName1, varName2) => {
-    const varName = varName1 || varName2;
-    if (process && process.env && typeof process.env[varName] === 'string') {
-      return process.env[varName]!;
-    }
-    return match;
-  });
-}
-
-function resolveEnvVarsInObject<T>(obj: T): T {
-  if (
-    obj === null ||
-    obj === undefined ||
-    typeof obj === 'boolean' ||
-    typeof obj === 'number'
-  ) {
-    return obj;
-  }
-
-  if (typeof obj === 'string') {
-    return resolveEnvVarsInString(obj) as unknown as T;
-  }
-
-  if (Array.isArray(obj)) {
-    return obj.map((item) => resolveEnvVarsInObject(item)) as unknown as T;
-  }
-
-  if (typeof obj === 'object') {
-    const newObj = { ...obj } as T;
-    for (const key in newObj) {
-      if (Object.prototype.hasOwnProperty.call(newObj, key)) {
-        newObj[key] = resolveEnvVarsInObject(newObj[key]);
-      }
-    }
-    return newObj;
-  }
-
-  return obj;
 }
 
 function findEnvFile(startDir: string): string | null {

--- a/packages/cli/src/utils/envVarResolver.test.ts
+++ b/packages/cli/src/utils/envVarResolver.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  resolveEnvVarsInString,
+  resolveEnvVarsInObject,
+} from './envVarResolver.js';
+
+describe('resolveEnvVarsInString', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should resolve $VAR_NAME format', () => {
+    process.env['TEST_VAR'] = 'test-value';
+
+    const result = resolveEnvVarsInString('Value is $TEST_VAR');
+
+    expect(result).toBe('Value is test-value');
+  });
+
+  it('should resolve ${VAR_NAME} format', () => {
+    process.env['TEST_VAR'] = 'test-value';
+
+    const result = resolveEnvVarsInString('Value is ${TEST_VAR}');
+
+    expect(result).toBe('Value is test-value');
+  });
+
+  it('should resolve multiple variables in the same string', () => {
+    process.env['HOST'] = 'localhost';
+    process.env['PORT'] = '3000';
+
+    const result = resolveEnvVarsInString('URL: http://$HOST:${PORT}/api');
+
+    expect(result).toBe('URL: http://localhost:3000/api');
+  });
+
+  it('should leave undefined variables unchanged', () => {
+    const result = resolveEnvVarsInString('Value is $UNDEFINED_VAR');
+
+    expect(result).toBe('Value is $UNDEFINED_VAR');
+  });
+
+  it('should leave undefined variables with braces unchanged', () => {
+    const result = resolveEnvVarsInString('Value is ${UNDEFINED_VAR}');
+
+    expect(result).toBe('Value is ${UNDEFINED_VAR}');
+  });
+
+  it('should handle empty string', () => {
+    const result = resolveEnvVarsInString('');
+
+    expect(result).toBe('');
+  });
+
+  it('should handle string without variables', () => {
+    const result = resolveEnvVarsInString('No variables here');
+
+    expect(result).toBe('No variables here');
+  });
+
+  it('should handle mixed defined and undefined variables', () => {
+    process.env['DEFINED'] = 'value';
+
+    const result = resolveEnvVarsInString('$DEFINED and $UNDEFINED mixed');
+
+    expect(result).toBe('value and $UNDEFINED mixed');
+  });
+});
+
+describe('resolveEnvVarsInObject', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should resolve variables in nested objects', () => {
+    process.env['API_KEY'] = 'secret-123';
+    process.env['DB_URL'] = 'postgresql://localhost/test';
+
+    const config = {
+      server: {
+        auth: {
+          key: '$API_KEY',
+        },
+        database: '${DB_URL}',
+      },
+      port: 3000,
+    };
+
+    const result = resolveEnvVarsInObject(config);
+
+    expect(result).toEqual({
+      server: {
+        auth: {
+          key: 'secret-123',
+        },
+        database: 'postgresql://localhost/test',
+      },
+      port: 3000,
+    });
+  });
+
+  it('should resolve variables in arrays', () => {
+    process.env['ENV'] = 'production';
+    process.env['VERSION'] = '1.0.0';
+
+    const config = {
+      tags: ['$ENV', 'app', '${VERSION}'],
+      metadata: {
+        env: '$ENV',
+      },
+    };
+
+    const result = resolveEnvVarsInObject(config);
+
+    expect(result).toEqual({
+      tags: ['production', 'app', '1.0.0'],
+      metadata: {
+        env: 'production',
+      },
+    });
+  });
+
+  it('should preserve non-string types', () => {
+    const config = {
+      enabled: true,
+      count: 42,
+      value: null,
+      data: undefined,
+      tags: ['item1', 'item2'],
+    };
+
+    const result = resolveEnvVarsInObject(config);
+
+    expect(result).toEqual(config);
+  });
+
+  it('should handle MCP server config structure', () => {
+    process.env['API_TOKEN'] = 'token-123';
+    process.env['SERVER_PORT'] = '8080';
+
+    const extensionConfig = {
+      name: 'test-extension',
+      version: '1.0.0',
+      mcpServers: {
+        'test-server': {
+          command: 'node',
+          args: ['server.js', '--port', '${SERVER_PORT}'],
+          env: {
+            API_KEY: '$API_TOKEN',
+            STATIC_VALUE: 'unchanged',
+          },
+          timeout: 5000,
+        },
+      },
+    };
+
+    const result = resolveEnvVarsInObject(extensionConfig);
+
+    expect(result).toEqual({
+      name: 'test-extension',
+      version: '1.0.0',
+      mcpServers: {
+        'test-server': {
+          command: 'node',
+          args: ['server.js', '--port', '8080'],
+          env: {
+            API_KEY: 'token-123',
+            STATIC_VALUE: 'unchanged',
+          },
+          timeout: 5000,
+        },
+      },
+    });
+  });
+
+  it('should handle empty and null values', () => {
+    const config = {
+      empty: '',
+      nullValue: null,
+      undefinedValue: undefined,
+      zero: 0,
+      false: false,
+    };
+
+    const result = resolveEnvVarsInObject(config);
+
+    expect(result).toEqual(config);
+  });
+});

--- a/packages/cli/src/utils/envVarResolver.ts
+++ b/packages/cli/src/utils/envVarResolver.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Resolves environment variables in a string.
+ * Replaces $VAR_NAME and ${VAR_NAME} with their corresponding environment variable values.
+ * If the environment variable is not defined, the original placeholder is preserved.
+ *
+ * @param value - The string that may contain environment variable placeholders
+ * @returns The string with environment variables resolved
+ *
+ * @example
+ * resolveEnvVarsInString("Token: $API_KEY") // Returns "Token: secret-123"
+ * resolveEnvVarsInString("URL: ${BASE_URL}/api") // Returns "URL: https://api.example.com/api"
+ * resolveEnvVarsInString("Missing: $UNDEFINED_VAR") // Returns "Missing: $UNDEFINED_VAR"
+ */
+export function resolveEnvVarsInString(value: string): string {
+  const envVarRegex = /\$(?:(\w+)|{([^}]+)})/g; // Find $VAR_NAME or ${VAR_NAME}
+  return value.replace(envVarRegex, (match, varName1, varName2) => {
+    const varName = varName1 || varName2;
+    if (process && process.env && typeof process.env[varName] === 'string') {
+      return process.env[varName]!;
+    }
+    return match;
+  });
+}
+
+/**
+ * Recursively resolves environment variables in an object of any type.
+ * Handles strings, arrays, nested objects, and preserves other primitive types.
+ *
+ * @param obj - The object to process for environment variable resolution
+ * @returns A new object with environment variables resolved
+ *
+ * @example
+ * const config = {
+ *   server: {
+ *     host: "$HOST",
+ *     port: "${PORT}",
+ *     enabled: true,
+ *     tags: ["$ENV", "api"]
+ *   }
+ * };
+ * const resolved = resolveEnvVarsInObject(config);
+ */
+export function resolveEnvVarsInObject<T>(obj: T): T {
+  if (
+    obj === null ||
+    obj === undefined ||
+    typeof obj === 'boolean' ||
+    typeof obj === 'number'
+  ) {
+    return obj;
+  }
+
+  if (typeof obj === 'string') {
+    return resolveEnvVarsInString(obj) as unknown as T;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => resolveEnvVarsInObject(item)) as unknown as T;
+  }
+
+  if (typeof obj === 'object') {
+    const newObj = { ...obj } as T;
+    for (const key in newObj) {
+      if (Object.prototype.hasOwnProperty.call(newObj, key)) {
+        newObj[key] = resolveEnvVarsInObject(newObj[key]);
+      }
+    }
+    return newObj;
+  }
+
+  return obj;
+}


### PR DESCRIPTION
## TLDR

Resolve environment variables in extension configurations. Previously, variables like `$API_KEY` or `${DATABASE_URL}` in `gemini-extension.json` files were not being substituted with their actual values from `.env` files, while the main `settings.json` files had this functionality working correctly.

## Dive Deeper

This change extends the existing environment variable resolution mechanism to work consistently across both settings and extension configurations.

**What was the problem?**
- Environment variables (e.g., `$API_TOKEN`, `${DB_URL}`) in extension `gemini-extension.json` files were not being resolved
- This inconsistency meant users couldn't use `.env` files for extension configurations like they could for main settings
- Led to hardcoded credentials and poor separation of configuration from secrets

**How was it solved?**
1. **Refactored shared logic**: Extracted environment variable resolution functions into a dedicated utility module (`utils/envVarResolver.ts`)
2. **Applied DRY principle**: Both `settings.ts` and `extension.ts` now use the same underlying resolution logic
3. **Maintained backwards compatibility**: Existing configurations without environment variables continue to work unchanged
4. **Added comprehensive testing**: Created dedicated tests for the utility functions plus integration tests in existing extension tests

**Technical implementation:**
- Created `packages/cli/src/utils/envVarResolver.ts` with `resolveEnvVarsInString` and `resolveEnvVarsInObject` functions
- Updated `packages/cli/src/config/settings.ts` to use the shared utility (removing duplicate code)
- Updated `packages/cli/src/config/extension.ts` to apply environment variable resolution during extension loading
- Supports both `$VAR_NAME` and `${VAR_NAME}` syntax consistently
- Gracefully handles undefined variables by leaving them unchanged


## Reviewer Test Plan

### 1. Test extension environment variable resolution:

**Create test extension:**
```bash
mkdir -p .gemini/extensions/test-env-ext
```

Create .gemini/extensions/test-env-ext/gemini-extension.json:
```json
{
  "name": "test-env-ext",
  "version": "1.0.0",
  "mcpServers": {
    "test-server": {
      "command": "echo",
      "args": ["Hello from $USER_NAME"],
      "env": {
        "API_KEY": "$TEST_API_KEY",
        "DATABASE_URL": "${TEST_DB_URL}",
        "STATIC_VALUE": "no-substitution-needed"
      }
    }
  }
}
```

Create `.env` file in project root:
```bash
TEST_API_KEY=secret-token-12345
TEST_DB_URL=postgresql://user:pass@localhost:5432/testdb
USER_NAME=TestUser
```

**Verify resolution:**

Run gemini and use /mcp command
Verify in the output that:
`API_KEY` shows secret-token-12345 (not $TEST_API_KEY)
shows postgresql://user:pass@localhost:5432/testdb (not ${TEST_DB_URL})
- `DATABASE_URL` shows postgresql://user:pass@localhost:5432/testdb (not ${TEST_DB_URL})
- `STATIC_VALUE` remains no-substitution-needed
- Args show ["Hello from TestUser"] (not ["Hello from $USER_NAME"])

### 2. Test backwards compatibility:
Create extension without environment variables:

Verify: Extension loads normally and values remain unchanged.

3. Test undefined variables:
Add to test extension:

Verify: Undefined variables remain as-is (not replaced with empty strings).


## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ✅  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #4473
