### PR TITLE
docs: Add Basic Usage section with Alt+Enter shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For other authentication methods, including Google Workspace accounts, see the [
 ## Basic Usage
 
 - **Enter prompts:** Type your question or command and press Enter to submit
-- **Multiline input:** Use **Alt+Enter** to insert line breaks in your prompts
+- **Multiline input:** Use **Alt+Enter** to insert line breaks in your prompts. (Note: This shortcut's availability may vary depending on your terminal and operating system).
 - **Include files:** Use `@filename` to include file contents in your prompt
 - **Run commands:** Use `!command` to execute shell commands
 - **View commands:** Type `/help` to see all available slash commands

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ The Vertex AI API provides a [free tier](https://cloud.google.com/vertex-ai/gene
 
 For other authentication methods, including Google Workspace accounts, see the [authentication](./docs/cli/authentication.md) guide.
 
+## Basic Usage
+
+- **Enter prompts:** Type your question or command and press Enter to submit
+- **Multiline input:** Use **Alt+Enter** to insert line breaks in your prompts
+- **Include files:** Use `@filename` to include file contents in your prompt
+- **Run commands:** Use `!command` to execute shell commands
+- **View commands:** Type `/help` to see all available slash commands
+
 ## Examples
 
 Once the CLI is running, you can start interacting with Gemini from your shell.


### PR DESCRIPTION
## Description:
  - Added new Basic Usage section to README
  - Documented Alt+Enter for multiline input
  - Added other essential usage tips for new users
  - Positioned section between authentication and examples

  ## TLDR

  Added documentation for the Alt+Enter multiline input feature that was already implemented but undocumented.
  Users can now easily discover how to write multiline prompts in the CLI.

  ## Dive Deeper

  The multiline input functionality using Alt+Enter allows users to:
  - Write complex prompts with proper formatting
  - Paste multi-line code snippets
  - Create structured queries with better readability

  I added a new "Basic Usage" section to make these essential features more discoverable for new users,
  positioned strategically after authentication setup and before the examples section.

  ## Reviewer Test Plan

  1. View the updated README.md to verify the new Basic Usage section is well-positioned and clearly formatted
  2. To test the documented feature:
     - Run `npx https://github.com/google-gemini/gemini-cli` or `gemini` if installed
     - Try entering a multiline prompt using Alt+Enter to insert line breaks
     - Verify that line breaks are inserted correctly without submitting the prompt
     - Press Enter without Alt to submit the multiline prompt

  ## Testing Matrix

  |          | 🍏  | 🪟  | 🐧  |
  | -------- | --- | --- | --- |
  | npm run  | ❓  | ❓  | ✅  |
  | npx      | ❓  | ❓  | ✅  |
  | Docker   | ❓  | ❓  | ❓  |
  | Podman   | ❓  | -   | -   |
  | Seatbelt | ❓  | -   | -   |

  ## Linked issues / bugs

  No related issues - this is a documentation improvement for an existing but undocumented feature.

  The PR is ready at: https://github.com/vmsaif/gemini-cli/pull/new/add-alt-enter-docs