### PR TITLE
feat(cli): add warnings when gemini-cli is called in the root directory

### DIFF
--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getUserStartupWarnings } from './userStartupWarnings.js';
 import * as os from 'os';
 import fs from 'fs/promises';
+import path from 'path';
 
 vi.mock('os', () => ({
   default: { homedir: vi.fn() },
@@ -84,7 +85,7 @@ describe('getUserStartupWarnings', () => {
         expect.stringContaining('root directory'),
       );
       expect(warnings).toContainEqual(
-        expect.stringContaining('folder structure is being used'),
+        expect.stringContaining('folder structure will be used'),
       );
     });
 
@@ -93,13 +94,15 @@ describe('getUserStartupWarnings', () => {
         .mockResolvedValueOnce('C:\\')
         .mockResolvedValueOnce(homeDir);
 
+      vi.spyOn(path, 'dirname').mockImplementation(path.win32.dirname);
+
       const warnings = await getUserStartupWarnings('C:\\');
 
       expect(warnings).toContainEqual(
         expect.stringContaining('root directory'),
       );
       expect(warnings).toContainEqual(
-        expect.stringContaining('folder structure is being used'),
+        expect.stringContaining('folder structure will be used'),
       );
     });
 

--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -71,4 +71,58 @@ describe('getUserStartupWarnings', () => {
   //   // Tests for node version check would go here
   //   // This shows how easy it is to add new test sections
   // });
+
+  describe('root directory check', () => {
+    it('should return a warning when running in root directory on Unix', async () => {
+      vi.mocked(fs.realpath)
+        .mockResolvedValueOnce('/')
+        .mockResolvedValueOnce(homeDir);
+
+      const warnings = await getUserStartupWarnings('/');
+
+      expect(warnings).toContainEqual(
+        expect.stringContaining('root directory'),
+      );
+      expect(warnings).toContainEqual(
+        expect.stringContaining('folder structure is being used'),
+      );
+    });
+
+    it('should return a warning when running in root directory on Windows', async () => {
+      vi.mocked(fs.realpath)
+        .mockResolvedValueOnce('C:\\')
+        .mockResolvedValueOnce(homeDir);
+
+      const warnings = await getUserStartupWarnings('C:\\');
+
+      expect(warnings).toContainEqual(
+        expect.stringContaining('root directory'),
+      );
+      expect(warnings).toContainEqual(
+        expect.stringContaining('folder structure is being used'),
+      );
+    });
+
+    it('should not return a warning when running in a non-root directory', async () => {
+      vi.mocked(fs.realpath)
+        .mockResolvedValueOnce('/some/project/path')
+        .mockResolvedValueOnce(homeDir);
+
+      const warnings = await getUserStartupWarnings('/some/project/path');
+      expect(warnings).not.toContainEqual(
+        expect.stringContaining('root directory'),
+      );
+    });
+
+    it('should handle errors when checking root directory', async () => {
+      vi.mocked(fs.realpath)
+        .mockRejectedValueOnce(new Error('FS error'))
+        .mockResolvedValueOnce(homeDir);
+
+      const warnings = await getUserStartupWarnings('/');
+      expect(warnings).toContainEqual(
+        expect.stringContaining('Could not verify'),
+      );
+    });
+  });
 });

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -6,6 +6,7 @@
 
 import fs from 'fs/promises';
 import * as os from 'os';
+import path from 'path';
 
 type WarningCheck = {
   id: string;
@@ -41,13 +42,7 @@ const rootDirectoryCheck: WarningCheck = {
         'Warning: You are running Gemini CLI in the root directory. Your entire folder structure will be used for context. It is strongly recommended to run in a project-specific directory.';
 
       // Check for Unix root directory
-      if (workspaceRealPath === '/') {
-        return errorMessage;
-      }
-
-      // Check for Windows root directories (C:\, D:\, etc.)
-      const windowsRootPattern = /^[A-Z]:\\$/i;
-      if (windowsRootPattern.test(workspaceRealPath)) {
+      if (path.dirname(workspaceRealPath) === workspaceRealPath) {
         return errorMessage;
       }
 

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -32,8 +32,36 @@ const homeDirectoryCheck: WarningCheck = {
   },
 };
 
+const rootDirectoryCheck: WarningCheck = {
+  id: 'root-directory',
+  check: async (workspaceRoot: string) => {
+    try {
+      const workspaceRealPath = await fs.realpath(workspaceRoot);
+      const errorMessage = 'Warning: You are running Gemini CLI in the root directory. Your entire folder structure is being used for context. It is strongly recommended to run in a project-specific directory.';
+      
+      // Check for Unix root directory
+      if (workspaceRealPath === '/') {
+        return errorMessage;
+      }
+      
+      // Check for Windows root directories (C:\, D:\, etc.)
+      const windowsRootPattern = /^[A-Z]:\\$/;
+      if (windowsRootPattern.test(workspaceRealPath)) {
+        return errorMessage;
+      }
+      
+      return null;
+    } catch (_err: unknown) {
+      return 'Could not verify the current directory due to a file system error.';
+    }
+  },
+};
+
 // All warning checks
-const WARNING_CHECKS: readonly WarningCheck[] = [homeDirectoryCheck];
+const WARNING_CHECKS: readonly WarningCheck[] = [
+  homeDirectoryCheck,
+  rootDirectoryCheck,
+];
 
 export async function getUserStartupWarnings(
   workspaceRoot: string,

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -37,19 +37,20 @@ const rootDirectoryCheck: WarningCheck = {
   check: async (workspaceRoot: string) => {
     try {
       const workspaceRealPath = await fs.realpath(workspaceRoot);
-      const errorMessage = 'Warning: You are running Gemini CLI in the root directory. Your entire folder structure is being used for context. It is strongly recommended to run in a project-specific directory.';
-      
+      const errorMessage =
+        'Warning: You are running Gemini CLI in the root directory. Your entire folder structure is being used for context. It is strongly recommended to run in a project-specific directory.';
+
       // Check for Unix root directory
       if (workspaceRealPath === '/') {
         return errorMessage;
       }
-      
+
       // Check for Windows root directories (C:\, D:\, etc.)
       const windowsRootPattern = /^[A-Z]:\\$/;
       if (windowsRootPattern.test(workspaceRealPath)) {
         return errorMessage;
       }
-      
+
       return null;
     } catch (_err: unknown) {
       return 'Could not verify the current directory due to a file system error.';

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -46,7 +46,7 @@ const rootDirectoryCheck: WarningCheck = {
       }
 
       // Check for Windows root directories (C:\, D:\, etc.)
-      const windowsRootPattern = /^[A-Z]:\\$/;
+      const windowsRootPattern = /^[A-Z]:\\$/i;
       if (windowsRootPattern.test(workspaceRealPath)) {
         return errorMessage;
       }

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -38,7 +38,7 @@ const rootDirectoryCheck: WarningCheck = {
     try {
       const workspaceRealPath = await fs.realpath(workspaceRoot);
       const errorMessage =
-        'Warning: You are running Gemini CLI in the root directory. Your entire folder structure is being used for context. It is strongly recommended to run in a project-specific directory.';
+        'Warning: You are running Gemini CLI in the root directory. Your entire folder structure will be used for context. It is strongly recommended to run in a project-specific directory.';
 
       // Check for Unix root directory
       if (workspaceRealPath === '/') {


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->
As described in #2792 , added a warning feature when gemini-cli is called in the root directory. 

## Dive Deeper

<!-- more thoughts and in depth discussion here -->
This is similar to `homeDirectoryCheck` in [userStartupWarnings.ts](https://github.com/google-gemini/gemini-cli/blob/main/packages/cli/src/utils/userStartupWarnings.ts#L16). Just like that method warns users because it's recommended to run gemini-cli in the project-specific directory, for the same reason, it shouldn't be run in the root directory.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

Pull this repository and in the gemini-cli's directory, run `npm install && npm run build`.
Then, go to the root directory and run ` node <PATH_TO_GEMINI_CLI_DIR>/packages/cli`

Before
<img width="1373" height="536" alt="スクリーンショット 2025-07-20 17 52 56" src="https://github.com/user-attachments/assets/b05089c3-18d9-41d9-bf09-7eb3b9d6a718" />

After
<img width="1342" height="502" alt="スクリーンショット 2025-07-20 17 58 40" src="https://github.com/user-attachments/assets/b0a90e15-63af-4ac9-b3d7-ff67d363c0c4" />


|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #2792 

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
