### PR TITLE
Add save/resume support to ACP.

### DIFF
--- a/packages/cli/src/acp/acp.ts
+++ b/packages/cli/src/acp/acp.ts
@@ -6,6 +6,7 @@
 
 /* ACP defines a schema for a simple (experimental) JSON-RPC protocol that allows GUI applications to interact with agents. */
 
+import { Content } from '@google/genai';
 import { Icon } from '@google/gemini-cli-core';
 import { WritableStream, ReadableStream } from 'node:stream/web';
 
@@ -272,7 +273,7 @@ export class RequestError extends Error {
 
 // Protocol types
 
-export const LATEST_PROTOCOL_VERSION = '0.0.9';
+export const LATEST_PROTOCOL_VERSION = '0.0.10';
 
 export type AssistantMessageChunk =
   | {
@@ -390,10 +391,23 @@ export interface InitializeParams {
    * This should be the latest version supported by the client.
    */
   protocolVersion: string;
+  sessionId: string;
 }
 
 export interface SendUserMessageParams {
   chunks: UserMessageChunk[];
+}
+
+export interface SaveHistoryParams {
+  tag: string;
+}
+
+export interface ResumeHistoryParams {
+  tag: string;
+}
+
+export interface ResumeHistoryResponse {
+  history: Content[]
 }
 
 export interface InitializeResponse {
@@ -408,6 +422,8 @@ export interface InitializeResponse {
    * Otherwise, the agent should respond with the latest version it supports.
    */
   protocolVersion: string;
+
+  sessionId: string;
 }
 
 export interface Error {
@@ -461,4 +477,14 @@ export interface Agent {
    * Cancels the current generation.
    */
   cancelSendMessage(): Promise<void>;
+
+  /**
+   * Saves the current chat history to a file based on tag string.
+   */
+  saveHistory(params: SaveHistoryParams): Promise<void>;
+
+  /**
+   * Resumes the chat history from a file based on tag string.
+   */
+  resumeHistory(params: ResumeHistoryParams): Promise<ResumeHistoryResponse>;
 }


### PR DESCRIPTION
This PR builds on #4266 and introduces the save and resume commands the same as an interactive chat to allow saving and restoring the chat history while in experimental json rpc mode.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

The ACP mode is nearly enough to power a wide range of alternative UI experiences, except it lacks the ability to save and resume a chat in the event the gemini cli is stopped.

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

This adds two new methods to the ACP Agent interface: saveHistory and resumeHistory that mirror the /chat commands in interactive chat. I didn't do the exact same logic as the resume command because it both has logic that looks specific to the Ink frontend, and also logic that looks like it's trying to handle older versions of the log being restored.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

To test this you can start gemini-cli with `--experimental-acp` and issue the new commands after initializing a session.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
