### PR TITLE
Removing history curation logic

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -554,7 +554,7 @@ This is the cursor position in the file:
     prompt_id: string,
     force: boolean = false,
   ): Promise<ChatCompressionInfo | null> {
-    const curatedHistory = this.getChat().getHistory(true);
+    const curatedHistory = this.getChat().getHistory();
 
     // Regardless of `force`, don't do anything if the history is empty.
     if (curatedHistory.length === 0) {

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -234,7 +234,7 @@ export class Turn {
         return;
       }
 
-      const contextForReport = [...this.chat.getHistory(/*curated*/ true), req];
+      const contextForReport = [...this.chat.getHistory(), req];
       await reportError(
         error,
         'Error when talking to Gemini API',

--- a/packages/core/src/utils/nextSpeakerChecker.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.ts
@@ -68,7 +68,7 @@ export async function checkNextSpeaker(
   // that when passed back up to the endpoint will break subsequent calls. An example of this is when the model decides
   // to respond with an empty part collection if you were to send that message back to the server it will respond with
   // a 400 indicating that model part collections MUST have content.
-  const curatedHistory = chat.getHistory(/* curated */ true);
+  const curatedHistory = chat.getHistory();
 
   // Ensure there's a model response to analyze
   if (curatedHistory.length === 0) {


### PR DESCRIPTION
## TLDR

This change addresses the "looping problem" that many have seen. The extractCuratedHistory function edits the chat history, removing empty responses from Gemini and associated user messages. There have been other reported cases where messing with history causes Gemini to start looping, and when we remove this function from Gemini CLI's flow, indeed we no longer see looping in the evals.

## Dive Deeper

Other notes:
* After several conversations, we believe this function was branched from a similar function that exists in the Gemini SDK. It was likely important for resolving empty return issues that have since been resolved in the core Gemini API.
* I left in the checks for empty history, as that seemed like good hygiene, but moved them to the getHistory function for brevity. 
* This PR does not back out @SandyTao520 's loop detection service. If we want to back that out (after monitoring logs), I can do so in a separate PR. (For reference, loop detection PRs I found: #4348 , #4337 , #4193 , #3919 )
* There may be other causes of looping, but this seems to be a major driver based on eval runs.

## Reviewer Test Plan

1. Run SWEbench evals and check for looping or any other errors that might result from removing this block of code. (Note that you must back out the loop detection changes as well in order to check for looping; I have a branch for this, `karmel/looping`, that has both this change and the four PRs related to loop detection reverted.)

## Testing Matrix

Checked basic functioning as indicated below. Ran evals on linux with npx.

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓ | ❓  |  ✅ |
| npx      | ✅  | ❓  | ✅  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

I believe this 
- Fixes #3934

But there is some chance there are other causes of looping. I will still mark that as closed for now, with the undestanding that we may have to reopen/recreate if we find other causes.