### PR TITLE
[ide-mode] Use active files and selected text in user prompt

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -149,8 +149,8 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     });
 
   const ideContextMock = {
-    getActiveFileContext: vi.fn(),
-    subscribeToActiveFile: vi.fn(() => vi.fn()), // subscribe returns an unsubscribe function
+    getOpenFilesContext: vi.fn(),
+    subscribeToOpenFiles: vi.fn(() => vi.fn()), // subscribe returns an unsubscribe function
   };
 
   return {
@@ -265,7 +265,7 @@ describe('App UI', () => {
 
     // Ensure a theme is set so the theme dialog does not appear.
     mockSettings = createMockSettings({ workspace: { theme: 'Default' } });
-    vi.mocked(ideContext.getActiveFileContext).mockReturnValue(undefined);
+    vi.mocked(ideContext.getOpenFilesContext).mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -277,10 +277,9 @@ describe('App UI', () => {
   });
 
   it('should display active file when available', async () => {
-    vi.mocked(ideContext.getActiveFileContext).mockReturnValue({
-      filePath: '/path/to/my-file.ts',
-      content: 'const a = 1;',
-      cursor: 0,
+    vi.mocked(ideContext.getOpenFilesContext).mockReturnValue({
+      activeFile: '/path/to/my-file.ts',
+      selectedText: 'hello',
     });
 
     const { lastFrame, unmount } = render(
@@ -296,10 +295,8 @@ describe('App UI', () => {
   });
 
   it('should not display active file when not available', async () => {
-    vi.mocked(ideContext.getActiveFileContext).mockReturnValue({
-      filePath: '',
-      content: '',
-      cursor: 0,
+    vi.mocked(ideContext.getOpenFilesContext).mockReturnValue({
+      activeFile: '',
     });
 
     const { lastFrame, unmount } = render(
@@ -315,10 +312,9 @@ describe('App UI', () => {
   });
 
   it('should display active file and other context', async () => {
-    vi.mocked(ideContext.getActiveFileContext).mockReturnValue({
-      filePath: '/path/to/my-file.ts',
-      content: 'const a = 1;',
-      cursor: 0,
+    vi.mocked(ideContext.getOpenFilesContext).mockReturnValue({
+      activeFile: '/path/to/my-file.ts',
+      selectedText: 'hello',
     });
     mockConfig.getGeminiMdFileCount.mockReturnValue(1);
 

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -58,7 +58,7 @@ import {
   FlashFallbackEvent,
   logFlashFallback,
   AuthType,
-  type ActiveFile,
+  type OpenFiles,
   ideContext,
 } from '@google/gemini-cli-core';
 import { validateAuthMethod } from '../config/auth.js';
@@ -160,12 +160,12 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   const [modelSwitchedFromQuotaError, setModelSwitchedFromQuotaError] =
     useState<boolean>(false);
   const [userTier, setUserTier] = useState<UserTierId | undefined>(undefined);
-  const [activeFile, setActiveFile] = useState<ActiveFile | undefined>();
+  const [activeFile, setOpenFiles] = useState<OpenFiles | undefined>();
 
   useEffect(() => {
-    const unsubscribe = ideContext.subscribeToActiveFile(setActiveFile);
+    const unsubscribe = ideContext.subscribeToOpenFiles(setOpenFiles);
     // Set the initial value
-    setActiveFile(ideContext.getActiveFileContext());
+    setOpenFiles(ideContext.getOpenFilesContext());
     return unsubscribe;
   }, []);
 

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -160,7 +160,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   const [modelSwitchedFromQuotaError, setModelSwitchedFromQuotaError] =
     useState<boolean>(false);
   const [userTier, setUserTier] = useState<UserTierId | undefined>(undefined);
-  const [activeFile, setOpenFiles] = useState<OpenFiles | undefined>();
+  const [openFiles, setOpenFiles] = useState<OpenFiles | undefined>();
 
   useEffect(() => {
     const unsubscribe = ideContext.subscribeToOpenFiles(setOpenFiles);
@@ -895,7 +895,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
                     </Text>
                   ) : (
                     <ContextSummaryDisplay
-                      activeFile={activeFile}
+                      openFiles={openFiles}
                       geminiMdFileCount={geminiMdFileCount}
                       contextFileNames={contextFileNames}
                       mcpServers={config.getMcpServers()}

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { Text } from 'ink';
 import { Colors } from '../colors.js';
-import { type ActiveFile, type MCPServerConfig } from '@google/gemini-cli-core';
+import { type OpenFiles, type MCPServerConfig } from '@google/gemini-cli-core';
 import path from 'path';
 
 interface ContextSummaryDisplayProps {
@@ -16,7 +16,7 @@ interface ContextSummaryDisplayProps {
   mcpServers?: Record<string, MCPServerConfig>;
   blockedMcpServers?: Array<{ name: string; extensionName: string }>;
   showToolDescriptions?: boolean;
-  activeFile?: ActiveFile;
+  openFiles?: OpenFiles;
 }
 
 export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
@@ -25,7 +25,7 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
   mcpServers,
   blockedMcpServers,
   showToolDescriptions,
-  activeFile,
+  openFiles,
 }) => {
   const mcpServerCount = Object.keys(mcpServers || {}).length;
   const blockedMcpServerCount = blockedMcpServers?.length || 0;
@@ -34,16 +34,16 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
     geminiMdFileCount === 0 &&
     mcpServerCount === 0 &&
     blockedMcpServerCount === 0 &&
-    !activeFile?.filePath
+    !openFiles?.activeFile
   ) {
     return <Text> </Text>; // Render an empty space to reserve height
   }
 
   const activeFileText = (() => {
-    if (!activeFile?.filePath) {
+    if (!openFiles?.activeFile) {
       return '';
     }
-    return `Open File (${path.basename(activeFile.filePath)})`;
+    return `Open File (${path.basename(openFiles.activeFile)})`;
   })();
 
   const geminiMdText = (() => {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -306,20 +306,40 @@ export class GeminiClient {
     }
 
     if (this.config.getIdeMode()) {
-      const activeFile = ideContext.getActiveFileContext();
-      if (activeFile?.filePath) {
-        let context = `
-This is the file that the user was most recently looking at:
-- Path: ${activeFile.filePath}`;
-        if (activeFile.cursor) {
-          context += `
-This is the cursor position in the file:
-- Cursor Position: Line ${activeFile.cursor.line}, Character ${activeFile.cursor.character}`;
+      const openFiles = ideContext.getOpenFilesContext();
+      if (openFiles) {
+        const contextParts: string[] = [];
+        if (openFiles.activeFile) {
+          contextParts.push(
+            `This is the file that the user was most recently looking at:\n- Path: ${openFiles.activeFile}`,
+          );
+          if (openFiles.cursor) {
+            contextParts.push(
+              `This is the cursor position in the file:\n- Cursor Position: Line ${openFiles.cursor.line}, Character ${openFiles.cursor.character}`,
+            );
+          }
+          if (openFiles.selectedText) {
+            contextParts.push(
+              `This is the selected text in the active file:\n- ${openFiles.selectedText}`,
+            );
+          }
         }
-        request = [
-          { text: context },
-          ...(Array.isArray(request) ? request : [request]),
-        ];
+
+        if (openFiles.recentOpenFiles && openFiles.recentOpenFiles.length > 0) {
+          const recentFiles = openFiles.recentOpenFiles
+            .map((file) => `- ${file.filePath}`)
+            .join('\n');
+          contextParts.push(
+            `Here are files the user has recently opened, with the most recent at the top:\n${recentFiles}`,
+          );
+        }
+
+        if (contextParts.length > 0) {
+          request = [
+            { text: contextParts.join('\n') },
+            ...(Array.isArray(request) ? request : [request]),
+          ];
+        }
       }
     }
 

--- a/packages/core/src/services/ideContext.test.ts
+++ b/packages/core/src/services/ideContext.test.ts
@@ -16,59 +16,59 @@ describe('ideContext - Active File', () => {
   });
 
   it('should return undefined initially for active file context', () => {
-    expect(ideContext.getActiveFileContext()).toBeUndefined();
+    expect(ideContext.getOpenFilesContext()).toBeUndefined();
   });
 
   it('should set and retrieve the active file context', () => {
     const testFile = {
-      filePath: '/path/to/test/file.ts',
-      cursor: { line: 5, character: 10 },
+      activeFile: '/path/to/test/file.ts',
+      selectedText: '1234',
     };
 
-    ideContext.setActiveFileContext(testFile);
+    ideContext.setOpenFilesContext(testFile);
 
-    const activeFile = ideContext.getActiveFileContext();
+    const activeFile = ideContext.getOpenFilesContext();
     expect(activeFile).toEqual(testFile);
   });
 
   it('should update the active file context when called multiple times', () => {
     const firstFile = {
-      filePath: '/path/to/first.js',
-      cursor: { line: 1, character: 1 },
+      activeFile: '/path/to/first.js',
+      selectedText: '1234',
     };
-    ideContext.setActiveFileContext(firstFile);
+    ideContext.setOpenFilesContext(firstFile);
 
     const secondFile = {
-      filePath: '/path/to/second.py',
+      activeFile: '/path/to/second.py',
       cursor: { line: 20, character: 30 },
     };
-    ideContext.setActiveFileContext(secondFile);
+    ideContext.setOpenFilesContext(secondFile);
 
-    const activeFile = ideContext.getActiveFileContext();
+    const activeFile = ideContext.getOpenFilesContext();
     expect(activeFile).toEqual(secondFile);
   });
 
   it('should handle empty string for file path', () => {
     const testFile = {
-      filePath: '',
-      cursor: { line: 0, character: 0 },
+      activeFile: '',
+      selectedText: '1234',
     };
-    ideContext.setActiveFileContext(testFile);
-    expect(ideContext.getActiveFileContext()).toEqual(testFile);
+    ideContext.setOpenFilesContext(testFile);
+    expect(ideContext.getOpenFilesContext()).toEqual(testFile);
   });
 
   it('should notify subscribers when active file context changes', () => {
     const subscriber1 = vi.fn();
     const subscriber2 = vi.fn();
 
-    ideContext.subscribeToActiveFile(subscriber1);
-    ideContext.subscribeToActiveFile(subscriber2);
+    ideContext.subscribeToOpenFiles(subscriber1);
+    ideContext.subscribeToOpenFiles(subscriber2);
 
     const testFile = {
-      filePath: '/path/to/subscribed.ts',
+      activeFile: '/path/to/subscribed.ts',
       cursor: { line: 15, character: 25 },
     };
-    ideContext.setActiveFileContext(testFile);
+    ideContext.setOpenFilesContext(testFile);
 
     expect(subscriber1).toHaveBeenCalledTimes(1);
     expect(subscriber1).toHaveBeenCalledWith(testFile);
@@ -77,10 +77,10 @@ describe('ideContext - Active File', () => {
 
     // Test with another update
     const newFile = {
-      filePath: '/path/to/new.js',
-      cursor: { line: 1, character: 1 },
+      activeFile: '/path/to/new.js',
+      selectedText: '1234',
     };
-    ideContext.setActiveFileContext(newFile);
+    ideContext.setOpenFilesContext(newFile);
 
     expect(subscriber1).toHaveBeenCalledTimes(2);
     expect(subscriber1).toHaveBeenCalledWith(newFile);
@@ -92,21 +92,21 @@ describe('ideContext - Active File', () => {
     const subscriber1 = vi.fn();
     const subscriber2 = vi.fn();
 
-    const unsubscribe1 = ideContext.subscribeToActiveFile(subscriber1);
-    ideContext.subscribeToActiveFile(subscriber2);
+    const unsubscribe1 = ideContext.subscribeToOpenFiles(subscriber1);
+    ideContext.subscribeToOpenFiles(subscriber2);
 
-    ideContext.setActiveFileContext({
-      filePath: '/path/to/file1.txt',
-      cursor: { line: 1, character: 1 },
+    ideContext.setOpenFilesContext({
+      activeFile: '/path/to/file1.txt',
+      selectedText: '1234',
     });
     expect(subscriber1).toHaveBeenCalledTimes(1);
     expect(subscriber2).toHaveBeenCalledTimes(1);
 
     unsubscribe1();
 
-    ideContext.setActiveFileContext({
-      filePath: '/path/to/file2.txt',
-      cursor: { line: 2, character: 2 },
+    ideContext.setOpenFilesContext({
+      activeFile: '/path/to/file2.txt',
+      selectedText: '1234',
     });
     expect(subscriber1).toHaveBeenCalledTimes(1); // Should not be called again
     expect(subscriber2).toHaveBeenCalledTimes(2);
@@ -114,27 +114,27 @@ describe('ideContext - Active File', () => {
 
   it('should allow the cursor to be optional', () => {
     const testFile = {
-      filePath: '/path/to/test/file.ts',
+      activeFile: '/path/to/test/file.ts',
     };
 
-    ideContext.setActiveFileContext(testFile);
+    ideContext.setOpenFilesContext(testFile);
 
-    const activeFile = ideContext.getActiveFileContext();
+    const activeFile = ideContext.getOpenFilesContext();
     expect(activeFile).toEqual(testFile);
   });
 
   it('should clear the active file context', () => {
     const testFile = {
-      filePath: '/path/to/test/file.ts',
-      cursor: { line: 5, character: 10 },
+      activeFile: '/path/to/test/file.ts',
+      selectedText: '1234',
     };
 
-    ideContext.setActiveFileContext(testFile);
+    ideContext.setOpenFilesContext(testFile);
 
-    expect(ideContext.getActiveFileContext()).toEqual(testFile);
+    expect(ideContext.getOpenFilesContext()).toEqual(testFile);
 
-    ideContext.clearActiveFileContext();
+    ideContext.clearOpenFilesContext();
 
-    expect(ideContext.getActiveFileContext()).toBeUndefined();
+    expect(ideContext.getOpenFilesContext()).toBeUndefined();
   });
 });

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -22,7 +22,7 @@ import { DiscoveredMCPTool } from './mcp-tool.js';
 import { FunctionDeclaration, mcpToTool } from '@google/genai';
 import { ToolRegistry } from './tool-registry.js';
 import {
-  ActiveFileNotificationSchema,
+  OpenFilesNotificationSchema,
   IDE_SERVER_NAME,
   ideContext,
 } from '../services/ideContext.js';
@@ -217,15 +217,15 @@ export async function connectAndDiscover(
         console.error(`MCP ERROR (${mcpServerName}):`, error.toString());
         updateMCPServerStatus(mcpServerName, MCPServerStatus.DISCONNECTED);
         if (mcpServerName === IDE_SERVER_NAME) {
-          ideContext.clearActiveFileContext();
+          ideContext.clearOpenFilesContext();
         }
       };
 
       if (mcpServerName === IDE_SERVER_NAME) {
         mcpClient.setNotificationHandler(
-          ActiveFileNotificationSchema,
+          OpenFilesNotificationSchema,
           (notification) => {
-            ideContext.setActiveFileContext(notification.params);
+            ideContext.setOpenFilesContext(notification.params);
           },
         );
       }

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -19,7 +19,7 @@ import { RecentFilesManager } from './recent-files-manager.js';
 const MCP_SESSION_ID_HEADER = 'mcp-session-id';
 const IDE_SERVER_PORT_ENV_VAR = 'GEMINI_CLI_IDE_SERVER_PORT';
 
-function sendActiveFileChangedNotification(
+function sendOpenFilesChangedNotification(
   transport: StreamableHTTPServerTransport,
   logger: vscode.OutputChannel,
   recentFilesManager: RecentFilesManager,
@@ -29,9 +29,9 @@ function sendActiveFileChangedNotification(
   logger.appendLine(`Sending active file changed notification: ${filePath}`);
   const notification: JSONRPCNotification = {
     jsonrpc: '2.0',
-    method: 'ide/activeFileChanged',
+    method: 'ide/openFilesChanged',
     params: {
-      filePath,
+      activeFile: filePath,
       recentOpenFiles: recentFilesManager.recentFiles,
     },
   };
@@ -60,7 +60,7 @@ export class IDEServer {
     const recentFilesManager = new RecentFilesManager(context);
     const disposable = recentFilesManager.onDidChange(() => {
       for (const transport of Object.values(transports)) {
-        sendActiveFileChangedNotification(
+        sendOpenFilesChangedNotification(
           transport,
           this.logger,
           recentFilesManager,
@@ -168,7 +168,7 @@ export class IDEServer {
       }
 
       if (!sessionsWithInitialNotification.has(sessionId)) {
-        sendActiveFileChangedNotification(
+        sendOpenFilesChangedNotification(
           transport,
           this.logger,
           recentFilesManager,
@@ -224,7 +224,7 @@ const createMcpServer = () => {
     { capabilities: { logging: {} } },
   );
   server.registerTool(
-    'getActiveFile',
+    'getOpenFiles',
     {
       description:
         '(IDE Tool) Get the path of the file currently active in VS Code.',


### PR DESCRIPTION
## TLDR

Including active files and text in the prompt to the user. We should run evals as a follow-up.

Will also include this in the UI in a follow-up!

NOTE: I left in cursor but also added selected text. I think we might as well thread both through from the IDE and see which works best in the prompt.

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
#3907