### PR TITLE
fix:(cli): Remove duplicate option --show-memory-usage

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -122,11 +122,6 @@ export async function parseArguments(): Promise<CliArgs> {
       description: 'Show memory usage in status bar',
       default: false,
     })
-    .option('show_memory_usage', {
-      type: 'boolean',
-      description: 'Show memory usage in status bar',
-      default: false,
-    })
     .deprecateOption(
       'show_memory_usage',
       'Use --show-memory-usage instead. We will be removing --show_memory_usage in the coming weeks.',


### PR DESCRIPTION


## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

1. Removed duplicate of option `show-memory-usage`

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

1. Executing `gemini --help` shows a duplicate argument, which has been removed. 

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
