### PR TITLE
Log when flash model decided to continue

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -198,6 +198,7 @@ describe('Gemini Client (client.ts)', () => {
       getQuotaErrorOccurred: vi.fn().mockReturnValue(false),
       setQuotaErrorOccurred: vi.fn(),
       getNoBrowser: vi.fn().mockReturnValue(false),
+      getUsageStatisticsEnabled: vi.fn().mockReturnValue(true),
       getIdeMode: vi.fn().mockReturnValue(false),
       getGeminiClient: vi.fn(),
     };

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -43,6 +43,8 @@ import { ProxyAgent, setGlobalDispatcher } from 'undici';
 import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { LoopDetectionService } from '../services/loopDetectionService.js';
 import { ideContext } from '../services/ideContext.js';
+import { ClearcutLogger } from '../telemetry/clearcut-logger/clearcut-logger.js';
+import { FlashDecidedToContinueEvent } from '../telemetry/types.js';
 
 function isThinkingSupported(model: string) {
   if (model.startsWith('gemini-2.5')) return true;
@@ -386,6 +388,9 @@ export class GeminiClient {
         signal,
       );
       if (nextSpeakerCheck?.next_speaker === 'model') {
+        ClearcutLogger.getInstance(this.config)?.logFlashDecidedToContinueEvent(
+          new FlashDecidedToContinueEvent(prompt_id),
+        );
         const nextRequest = [{ text: 'Please continue.' }];
         // This recursive call's events will be yielded out, but the final
         // turn object will be from the top-level call.

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -500,6 +500,10 @@ export class ClearcutLogger {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_PROMPT_ID,
         value: JSON.stringify(event.prompt_id),
       },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
+        value: this.config?.getSessionId() ?? '',
+      },
     ];
 
     this.enqueueLogEvent(

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -18,6 +18,7 @@ import {
   ApiErrorEvent,
   FlashFallbackEvent,
   LoopDetectedEvent,
+  FlashDecidedToContinueEvent,
 } from '../types.js';
 import { EventMetadataKey } from './event-metadata-key.js';
 import { Config } from '../../config/config.js';
@@ -37,6 +38,7 @@ const api_error_event_name = 'api_error';
 const end_session_event_name = 'end_session';
 const flash_fallback_event_name = 'flash_fallback';
 const loop_detected_event_name = 'loop_detected';
+const flash_decided_to_continue_event_name = 'flash_decided_to_continue';
 
 export interface LogResponse {
   nextRequestWaitMs?: number;
@@ -489,6 +491,20 @@ export class ClearcutLogger {
     ];
 
     this.enqueueLogEvent(this.createLogEvent(loop_detected_event_name, data));
+    this.flushIfNeeded();
+  }
+
+  logFlashDecidedToContinueEvent(event: FlashDecidedToContinueEvent): void {
+    const data = [
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_PROMPT_ID,
+        value: JSON.stringify(event.prompt_id),
+      },
+    ];
+
+    this.enqueueLogEvent(
+      this.createLogEvent(flash_decided_to_continue_event_name, data),
+    );
     this.flushIfNeeded();
   }
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -264,6 +264,18 @@ export class LoopDetectedEvent {
   }
 }
 
+export class FlashDecidedToContinueEvent {
+  'event.name': 'flash_decided_to_continue';
+  'event.timestamp': string; // ISO 8601
+  prompt_id: string;
+
+  constructor(prompt_id: string) {
+    this['event.name'] = 'flash_decided_to_continue';
+    this['event.timestamp'] = new Date().toISOString();
+    this.prompt_id = prompt_id;
+  }
+}
+
 export type TelemetryEvent =
   | StartSessionEvent
   | EndSessionEvent
@@ -273,4 +285,5 @@ export type TelemetryEvent =
   | ApiErrorEvent
   | ApiResponseEvent
   | FlashFallbackEvent
-  | LoopDetectedEvent;
+  | LoopDetectedEvent
+  | FlashDecidedToContinueEvent;


### PR DESCRIPTION
## TLDR

Use clearcut to log when nextSpeakerCheck by flash decided to continue;

## Dive Deeper

Add some metrics to prove if this is a cause of looping.

## Reviewer Test Plan

N/A

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
#4651 