### PR TITLE
Add support for logging the entire request and response object

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -27,10 +27,6 @@ import {
   logApiError,
 } from '../telemetry/loggers.js';
 import {
-  getStructuredResponse,
-  getStructuredResponseFromParts,
-} from '../utils/generateContentResponseUtilities.js';
-import {
   ApiErrorEvent,
   ApiRequestEvent,
   ApiResponseEvent,
@@ -142,11 +138,7 @@ export class GeminiChat {
   }
 
   private _getRequestTextFromContents(contents: Content[]): string {
-    return contents
-      .flatMap((content) => content.parts ?? [])
-      .map((part) => part.text)
-      .filter(Boolean)
-      .join('');
+    return JSON.stringify(contents);
   }
 
   private async _logApiRequest(
@@ -318,7 +310,7 @@ export class GeminiChat {
         durationMs,
         prompt_id,
         response.usageMetadata,
-        getStructuredResponse(response),
+        JSON.stringify(response),
       );
 
       this.sendPromise = (async () => {
@@ -554,12 +546,11 @@ export class GeminiChat {
           allParts.push(...content.parts);
         }
       }
-      const fullText = getStructuredResponseFromParts(allParts);
       await this._logApiResponse(
         durationMs,
         prompt_id,
         this.getFinalUsageMetadata(chunks),
-        fullText,
+        JSON.stringify(chunks),
       );
     }
     this.recordHistory(inputContent, outputContent);


### PR DESCRIPTION
We currently only log the text and function call parts of the request/response objects. We should log the raw request and depend on the post processing to filter out what we don't need. 

This is especially important when debugging issue related to model quality.

One risk i see with this change is if we have different media types which might result in very large request/response objects being sent. We might want to filter that specific content potentially.