### PR TITLE
feat: Add tests for system file filtering in extensions

### DIFF
--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -84,6 +84,62 @@ describe('loadExtensions', () => {
       path.join(workspaceExtensionsDir, 'ext1', 'my-context-file.md'),
     ]);
   });
+
+  it('should ignore .DS_Store and other system files', () => {
+    const workspaceExtensionsDir = path.join(
+      tempWorkspaceDir,
+      EXTENSIONS_DIRECTORY_NAME,
+    );
+    fs.mkdirSync(workspaceExtensionsDir, { recursive: true });
+
+    createExtension(workspaceExtensionsDir, 'valid-ext', '1.0.0');
+
+    fs.writeFileSync(
+      path.join(workspaceExtensionsDir, '.DS_Store'),
+      'system file',
+    );
+    fs.writeFileSync(
+      path.join(workspaceExtensionsDir, 'Thumbs.db'),
+      'system file',
+    );
+    fs.writeFileSync(
+      path.join(workspaceExtensionsDir, 'Desktop.ini'),
+      'system file',
+    );
+    fs.writeFileSync(
+      path.join(workspaceExtensionsDir, '.hidden'),
+      'hidden file',
+    );
+
+    const extensions = loadExtensions(tempWorkspaceDir);
+
+    expect(extensions).toHaveLength(1);
+    expect(extensions[0].config.name).toBe('valid-ext');
+  });
+
+  it('should not log warnings for system files', () => {
+    const workspaceExtensionsDir = path.join(
+      tempWorkspaceDir,
+      EXTENSIONS_DIRECTORY_NAME,
+    );
+    fs.mkdirSync(workspaceExtensionsDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(workspaceExtensionsDir, '.DS_Store'),
+      'system file',
+    );
+    fs.writeFileSync(
+      path.join(workspaceExtensionsDir, 'Thumbs.db'),
+      'system file',
+    );
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    loadExtensions(tempWorkspaceDir);
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
 });
 
 describe('annotateActiveExtensions', () => {

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -99,11 +99,11 @@ describe('loadExtensions', () => {
       'system file',
     );
     fs.writeFileSync(
-      path.join(workspaceExtensionsDir, 'Thumbs.db'),
+      path.join(workspaceExtensionsDir, 'thumbs.db'), // Test case-insensitivity
       'system file',
     );
     fs.writeFileSync(
-      path.join(workspaceExtensionsDir, 'Desktop.ini'),
+      path.join(workspaceExtensionsDir, 'desktop.ini'), // Test case-insensitivity
       'system file',
     );
     fs.writeFileSync(
@@ -129,7 +129,7 @@ describe('loadExtensions', () => {
       'system file',
     );
     fs.writeFileSync(
-      path.join(workspaceExtensionsDir, 'Thumbs.db'),
+      path.join(workspaceExtensionsDir, 'thumbs.db'), // Lowercase to test case-insensitivity
       'system file',
     );
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -12,14 +12,14 @@ import * as os from 'os';
 export const EXTENSIONS_DIRECTORY_NAME = path.join('.gemini', 'extensions');
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
 
-const SYSTEM_FILES = [
-  'Thumbs.db', // Windows thumbnail cache
-  'Desktop.ini', // Windows folder config
+const SYSTEM_FILES = new Set([
+  'thumbs.db', // Windows thumbnail cache
+  'desktop.ini', // Windows folder config
   'ehthumbs.db', // Windows XP/Vista thumbnails
   'ehthumbs_vista.db',
-  '$RECYCLE.BIN', // Windows recycle bin
-  'System Volume Information', // Windows system folder
-] as const;
+  '$recycle.bin', // Windows recycle bin
+  'system volume information', // Windows system folder
+]);
 
 export interface Extension {
   config: ExtensionConfig;

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -40,7 +40,7 @@ function isSystemFile(filename: string): boolean {
     return true;
   }
 
-  return (SYSTEM_FILES as readonly string[]).includes(filename);
+  return SYSTEM_FILES.has(filename.toLowerCase());
 }
 
 export function loadExtensions(workspaceDir: string): Extension[] {

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -12,6 +12,15 @@ import * as os from 'os';
 export const EXTENSIONS_DIRECTORY_NAME = path.join('.gemini', 'extensions');
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
 
+const SYSTEM_FILES = [
+  'Thumbs.db', // Windows thumbnail cache
+  'Desktop.ini', // Windows folder config
+  'ehthumbs.db', // Windows XP/Vista thumbnails
+  'ehthumbs_vista.db',
+  '$RECYCLE.BIN', // Windows recycle bin
+  'System Volume Information', // Windows system folder
+] as const;
+
 export interface Extension {
   config: ExtensionConfig;
   contextFiles: string[];
@@ -23,6 +32,15 @@ export interface ExtensionConfig {
   mcpServers?: Record<string, MCPServerConfig>;
   contextFileName?: string | string[];
   excludeTools?: string[];
+}
+
+function isSystemFile(filename: string): boolean {
+  // Skip files starting with dot (hidden files like .DS_Store)
+  if (filename.startsWith('.')) {
+    return true;
+  }
+
+  return (SYSTEM_FILES as readonly string[]).includes(filename);
 }
 
 export function loadExtensions(workspaceDir: string): Extension[] {
@@ -49,6 +67,10 @@ function loadExtensionsFromDir(dir: string): Extension[] {
 
   const extensions: Extension[] = [];
   for (const subdir of fs.readdirSync(extensionsDir)) {
+    if (isSystemFile(subdir)) {
+      continue;
+    }
+
     const extensionDir = path.join(extensionsDir, subdir);
 
     const extension = loadExtension(extensionDir);


### PR DESCRIPTION
## TLDR
Fixed system file filtering in extensions directory to prevent `.DS_Store`, `Thumbs.db`, and other OS-generated files from being processed as extensions and generating warning messages. Added comprehensive test coverage for the filtering logic.

## Dive Deeper
The extensions loading mechanism was attempting to process all files in the extensions directory, including system files like `.DS_Store` (macOS), `Thumbs.db` (Windows), and `Desktop.ini`. This caused unnecessary warning messages and potential processing overhead.

Changes made:
  - Enhanced the extension loading logic to filter out common system files
  - Added pattern matching for `.DS_Store`, `Thumbs.db`, `Desktop.ini`, and hidden files starting with `'.'`
  - Added comprehensive tests to verify system files are ignored
  - Added tests to ensure no warning messages are logged for system files

## Reviewer Test Plan
  1. Pull the branch and run the test suite: `npm test packages/cli/src/config/extension.test.ts`
  2. Create an extensions directory with system files:
 ```bash
     mkdir .claude/extensions
     touch .claude/extensions/.DS_Store
     touch .claude/extensions/Thumbs.db
```
  3. Run the CLI and verify no warnings are shown for these files
  4. Add a valid extension and confirm it still loads properly

## Testing Matrix
  |          | 🍏  | 🪟  | 🐧  |
  |----------|-----|-----|-----|
  | npm run  | ✅   | ❓   | ❓   |
  | npx      | ❓   | ❓   | ❓   |
  | Docker   | ❓   | ❓   | ❓   |
  | Podman   | ❓   | -   | -   |
  | Seatbelt | ❓   | -   | -   |

## Linked issues / bugs
This PR makes progress on [#4721](https://github.com/google-gemini/gemini-cli/issues/4721)