### PR TITLE
feat(cli): display timestamp in /chat list

### DIFF
--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -131,10 +131,33 @@ describe('chatCommand', () => {
       const content = result?.content ?? '';
       expect(result?.type).toBe('message');
       expect(content).toContain('List of saved conversations:');
+      const isoDate = date
+        .toISOString()
+        .match(/(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})/);
+      const formattedDate = isoDate ? `${isoDate[1]} ${isoDate[2]}` : '';
+      expect(content).toContain(formattedDate);
       const index1 = content.indexOf('- \u001b[36mtest1\u001b[0m');
       const index2 = content.indexOf('- \u001b[36mtest2\u001b[0m');
       expect(index1).toBeGreaterThanOrEqual(0);
       expect(index2).toBeGreaterThan(index1);
+    });
+
+    it('should handle invalid date formats gracefully', async () => {
+      const fakeFiles = ['checkpoint-baddate.json'];
+      const badDate = {
+        toISOString: () => 'an-invalid-date-string',
+      } as Date;
+
+      mockFs.readdir.mockResolvedValue(fakeFiles);
+      mockFs.stat.mockResolvedValue({ mtime: badDate } as Stats);
+
+      const result = (await listCommand?.action?.(
+        mockContext,
+        '',
+      )) as MessageActionReturn;
+
+      const content = result?.content ?? '';
+      expect(content).toContain('(saved on Invalid Date)');
     });
   });
   describe('save subcommand', () => {

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -70,9 +70,17 @@ const listCommand: SlashCommand = {
       };
     }
 
+    const maxNameLength = Math.max(
+      ...chatDetails.map((chat) => chat.name.length),
+    );
+
     let message = 'List of saved conversations:\n\n';
     for (const chat of chatDetails) {
-      message += `  - \u001b[36m${chat.name}\u001b[0m\n`;
+      const paddedName = chat.name.padEnd(maxNameLength, ' ');
+      const isoString = chat.mtime.toISOString();
+      const match = isoString.match(/(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})/);
+      const formattedDate = match ? `${match[1]} ${match[2]}` : 'Invalid Date';
+      message += `  - \u001b[36m${paddedName}\u001b[0m  \u001b[90m(saved on ${formattedDate})\u001b[0m\n`;
     }
     message += `\n\u001b[90mNote: Newest last, oldest first\u001b[0m`;
     return {


### PR DESCRIPTION
## TLDR

This pull request enhances the `/chat list` command to display the last modification timestamp for each saved chat checkpoint. This makes it significantly easier for users to identify and manage their conversation histories.

## Dive Deeper

The existing `/chat list` command only shows the user-defined tag for each saved session. When many sessions are saved, it becomes difficult to recall when each session was created.

This change addresses that by:
1.  Retrieving the file's last modification time (`mtime`) for each checkpoint.
2.  Formatting the timestamp into a consistent, locale-independent `YYYY-MM-DD hh:mm:ss` format.
3.  Calculating the longest tag name and using padding to align all timestamps into a clean, readable column.

<img width="740" height="753" alt="Screenshot 2025-07-23 at 1 20 07 PM" src="https://github.com/user-attachments/assets/8ef3cd16-e6b4-4d48-ad08-0bb35a7e4b11" />

The corresponding unit test has also been updated to validate the presence of the timestamp, ensuring the feature remains stable.

## Reviewer Test Plan

1.  Pull this branch: `git checkout feat/chat-list-timestamp`
2.  Install dependencies and build the project: `npm install && npm run build`
3.  Run the CLI: `npm start`
4.  Save a few chat sessions with varying name lengths:
    - `/chat save short`
    - `/chat save a-much-longer-name`
    - `/chat save another`
5.  Run the command: `/chat list`
6.  **Validation:**
    - Confirm that each chat name is followed by a formatted timestamp.
    - Confirm that all timestamps are vertically aligned in a neat column.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | ❓  |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #4731
