### PR TITLE
feat(core, cli): Introduce high-performance FileSearch engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -918,6 +918,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@google/gemini-cli-test-utils": {
+      "resolved": "packages/test-utils",
+      "link": true
+    },
     "node_modules/@google/genai": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.9.0.tgz",
@@ -2399,6 +2403,13 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/picomatch": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.1.tgz",
+      "integrity": "sha512-dLqxmi5VJRC9XTvc/oaTtk+bDb4RRqxLZPZ3jIpYBHEnDXX8lu02w2yWI6NsPPsELuVK298Z2iR8jgoWKRdUVQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -11680,6 +11691,7 @@
       },
       "devDependencies": {
         "@babel/runtime": "^7.27.6",
+        "@google/gemini-cli-test-utils": "file:../test-utils",
         "@testing-library/react": "^16.3.0",
         "@types/command-exists": "^1.2.3",
         "@types/diff": "^7.0.2",
@@ -11851,6 +11863,7 @@
         "chardet": "^2.1.0",
         "diff": "^7.0.0",
         "dotenv": "^17.1.0",
+        "fdir": "^6.4.6",
         "glob": "^10.4.5",
         "google-auth-library": "^9.11.0",
         "html-to-text": "^9.0.5",
@@ -11858,6 +11871,7 @@
         "ignore": "^7.0.0",
         "micromatch": "^4.0.8",
         "open": "^10.1.2",
+        "picomatch": "^4.0.1",
         "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
@@ -11865,10 +11879,12 @@
         "ws": "^8.18.0"
       },
       "devDependencies": {
+        "@google/gemini-cli-test-utils": "file:../test-utils",
         "@types/diff": "^7.0.2",
         "@types/dotenv": "^6.1.1",
         "@types/micromatch": "^4.0.8",
         "@types/minimatch": "^5.1.2",
+        "@types/picomatch": "^4.0.1",
         "@types/ws": "^8.5.10",
         "typescript": "^5.3.3",
         "vitest": "^3.1.1"
@@ -11893,6 +11909,20 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "packages/core/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "packages/core/node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -11907,6 +11937,29 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "packages/core/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/test-utils": {
+      "name": "@google/gemini-cli-test-utils",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "packages/vscode-ide-companion": {
       "name": "gemini-cli-vscode-ide-companion",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -71,7 +71,8 @@
     "pretty-format": "^30.0.2",
     "react-dom": "^19.1.0",
     "typescript": "^5.3.3",
-    "vitest": "^3.1.1"
+    "vitest": "^3.1.1",
+    "@google/gemini-cli-test-utils": "file:../test-utils"
   },
   "engines": {
     "node": ">=20"

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -214,21 +214,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       } else {
         const atIndex = query.lastIndexOf('@');
         if (atIndex === -1) return;
-        const pathPart = query.substring(atIndex + 1);
-        const lastSlashIndexInPath = pathPart.lastIndexOf('/');
-        let autoCompleteStartIndex = atIndex + 1;
-        if (lastSlashIndexInPath !== -1) {
-          autoCompleteStartIndex += lastSlashIndexInPath + 1;
-        }
         buffer.replaceRangeByOffset(
-          autoCompleteStartIndex,
+          atIndex + 1,
           buffer.text.length,
           suggestion,
         );
       }
-      resetCompletionState();
     },
-    [resetCompletionState, buffer, completionSuggestions, slashCommands],
+    [buffer, completionSuggestions, slashCommands],
   );
 
   // Handle clipboard image pasting with Ctrl+V

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -5,28 +5,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
-import type { Mocked } from 'vitest';
 import { handleAtCommand } from './atCommandProcessor.js';
-import { Config, FileDiscoveryService } from '@google/gemini-cli-core';
+import { Config } from '@google/gemini-cli-core';
 import { ToolCallStatus } from '../types.js';
 import { UseHistoryManagerReturn } from './useHistoryManager.js';
-import * as fsPromises from 'fs/promises';
-import type { Stats } from 'fs';
 
 const mockGetToolRegistry = vi.fn();
-const mockGetTargetDir = vi.fn();
 const mockConfig = {
   getToolRegistry: mockGetToolRegistry,
-  getTargetDir: mockGetTargetDir,
-  isSandboxed: vi.fn(() => false),
-  getFileService: vi.fn(),
-  getFileFilteringRespectGitIgnore: vi.fn(() => true),
-  getFileFilteringRespectGeminiIgnore: vi.fn(() => true),
-  getFileFilteringOptions: vi.fn(() => ({
-    respectGitIgnore: true,
-    respectGeminiIgnore: true,
-  })),
-  getEnableRecursiveFileSearch: vi.fn(() => true),
 } as unknown as Config;
 
 const mockReadManyFilesExecute = vi.fn();
@@ -38,76 +24,21 @@ const mockReadManyFilesTool = {
   getDescription: vi.fn((params) => `Read files: ${params.paths.join(', ')}`),
 };
 
-const mockGlobExecute = vi.fn();
-const mockGlobTool = {
-  name: 'glob',
-  displayName: 'Glob Tool',
-  execute: mockGlobExecute,
-  getDescription: vi.fn(() => 'Glob tool description'),
-};
-
 const mockAddItem: Mock<UseHistoryManagerReturn['addItem']> = vi.fn();
 const mockOnDebugMessage: Mock<(message: string) => void> = vi.fn();
 
-vi.mock('fs/promises', async () => {
-  const actual = await vi.importActual('fs/promises');
-  return {
-    ...actual,
-    stat: vi.fn(),
-  };
-});
-
-vi.mock('@google/gemini-cli-core', async () => {
-  const actual = await vi.importActual('@google/gemini-cli-core');
-  return {
-    ...actual,
-    FileDiscoveryService: vi.fn(),
-  };
-});
-
 describe('handleAtCommand', () => {
   let abortController: AbortController;
-  let mockFileDiscoveryService: Mocked<FileDiscoveryService>;
 
   beforeEach(() => {
     vi.resetAllMocks();
     abortController = new AbortController();
-    mockGetTargetDir.mockReturnValue('/test/dir');
     mockGetToolRegistry.mockReturnValue({
       getTool: vi.fn((toolName: string) => {
         if (toolName === 'read_many_files') return mockReadManyFilesTool;
-        if (toolName === 'glob') return mockGlobTool;
         return undefined;
       }),
     });
-    vi.mocked(fsPromises.stat).mockResolvedValue({
-      isDirectory: () => false,
-    } as Stats);
-    mockReadManyFilesExecute.mockResolvedValue({
-      llmContent: '',
-      returnDisplay: '',
-    });
-    mockGlobExecute.mockResolvedValue({
-      llmContent: 'No files found',
-      returnDisplay: '',
-    });
-
-    // Mock FileDiscoveryService
-    mockFileDiscoveryService = {
-      initialize: vi.fn(),
-      shouldIgnoreFile: vi.fn(() => false),
-      filterFiles: vi.fn((files) => files),
-      getIgnoreInfo: vi.fn(() => ({ gitIgnored: [] })),
-      isGitRepository: vi.fn(() => true),
-    };
-    vi.mocked(FileDiscoveryService).mockImplementation(
-      () => mockFileDiscoveryService,
-    );
-
-    // Mock getFileService to return the mocked FileDiscoveryService
-    mockConfig.getFileService = vi
-      .fn()
-      .mockReturnValue(mockFileDiscoveryService);
   });
 
   afterEach(() => {
@@ -133,34 +64,48 @@ describe('handleAtCommand', () => {
     expect(mockReadManyFilesExecute).not.toHaveBeenCalled();
   });
 
-  it('should pass through original query if only a lone @ symbol is present', async () => {
-    const queryWithSpaces = '  @  ';
+  it('should process a single @file command', async () => {
+    const filePath = 'src/index.ts';
+    const query = `@${filePath}`;
+    const fileContent = 'console.log("hello world")';
+    mockReadManyFilesExecute.mockResolvedValue({
+      llmContent: [`--- ${filePath} ---\n\n${fileContent}\n\n`],
+    });
+
     const result = await handleAtCommand({
-      query: queryWithSpaces,
+      query,
       config: mockConfig,
       addItem: mockAddItem,
       onDebugMessage: mockOnDebugMessage,
       messageId: 124,
       signal: abortController.signal,
     });
-    expect(mockAddItem).toHaveBeenCalledWith(
-      { type: 'user', text: queryWithSpaces },
-      124,
+
+    expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
+      { paths: [filePath] },
+      abortController.signal,
     );
-    expect(result.processedQuery).toEqual([{ text: queryWithSpaces }]);
+    expect(result.processedQuery).toEqual([
+      { text: query },
+      { text: '\n--- Content from referenced files ---' },
+      { text: `\nContent from @${filePath}:\n` },
+      { text: fileContent },
+      { text: '\n--- End of content ---' },
+    ]);
     expect(result.shouldProceed).toBe(true);
-    expect(mockOnDebugMessage).toHaveBeenCalledWith(
-      'Lone @ detected, will be treated as text in the modified query.',
-    );
   });
 
-  it('should process a valid text file path', async () => {
-    const filePath = 'path/to/file.txt';
-    const query = `@${filePath}`;
-    const fileContent = 'This is the file content.';
+  it('should process multiple @file commands', async () => {
+    const file1 = 'src/index.ts';
+    const file2 = 'src/app.ts';
+    const query = `@${file1} @${file2}`;
+    const content1 = 'console.log("hello world")';
+    const content2 = 'console.log("hello app")';
     mockReadManyFilesExecute.mockResolvedValue({
-      llmContent: [`--- ${filePath} ---\n\n${fileContent}\n\n`],
-      returnDisplay: 'Read 1 file.',
+      llmContent: [
+        `--- ${file1} ---\n\n${content1}\n\n`,
+        `--- ${file2} ---\n\n${content2}\n\n`,
+      ],
     });
 
     const result = await handleAtCommand({
@@ -171,48 +116,34 @@ describe('handleAtCommand', () => {
       messageId: 125,
       signal: abortController.signal,
     });
-    expect(mockAddItem).toHaveBeenCalledWith(
-      { type: 'user', text: query },
-      125,
-    );
+
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      {
-        paths: [filePath],
-        file_filtering_options: {
-          respect_git_ignore: true,
-          respect_gemini_ignore: true,
-        },
-      },
+      { paths: [file1, file2] },
       abortController.signal,
     );
-    expect(mockAddItem).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'tool_group',
-        tools: [expect.objectContaining({ status: ToolCallStatus.Success })],
-      }),
-      125,
-    );
     expect(result.processedQuery).toEqual([
-      { text: `@${filePath}` },
+      { text: query },
       { text: '\n--- Content from referenced files ---' },
-      { text: `\nContent from @${filePath}:\n` },
-      { text: fileContent },
+      { text: `\nContent from @${file1}:\n` },
+      { text: content1 },
+      { text: `\nContent from @${file2}:\n` },
+      { text: content2 },
       { text: '\n--- End of content ---' },
     ]);
     expect(result.shouldProceed).toBe(true);
   });
 
-  it('should process a valid directory path and convert to glob', async () => {
-    const dirPath = 'path/to/dir';
-    const query = `@${dirPath}`;
-    const resolvedGlob = `${dirPath}/**`;
-    const fileContent = 'Directory content.';
-    vi.mocked(fsPromises.stat).mockResolvedValue({
-      isDirectory: () => true,
-    } as Stats);
+  it('should handle interleaved text', async () => {
+    const file1 = 'src/index.ts';
+    const file2 = 'src/app.ts';
+    const query = `hello @${file1} world @${file2} !`;
+    const content1 = 'console.log("hello world")';
+    const content2 = 'console.log("hello app")';
     mockReadManyFilesExecute.mockResolvedValue({
-      llmContent: [`--- ${resolvedGlob} ---\n\n${fileContent}\n\n`],
-      returnDisplay: 'Read directory contents.',
+      llmContent: [
+        `--- ${file1} ---\n\n${content1}\n\n`,
+        `--- ${file2} ---\n\n${content2}\n\n`,
+      ],
     });
 
     const result = await handleAtCommand({
@@ -223,48 +154,28 @@ describe('handleAtCommand', () => {
       messageId: 126,
       signal: abortController.signal,
     });
-    expect(mockAddItem).toHaveBeenCalledWith(
-      { type: 'user', text: query },
-      126,
-    );
+
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      {
-        paths: [resolvedGlob],
-        file_filtering_options: {
-          respect_git_ignore: true,
-          respect_gemini_ignore: true,
-        },
-      },
+      { paths: [file1, file2] },
       abortController.signal,
     );
-    expect(mockOnDebugMessage).toHaveBeenCalledWith(
-      `Path ${dirPath} resolved to directory, using glob: ${resolvedGlob}`,
-    );
     expect(result.processedQuery).toEqual([
-      { text: `@${resolvedGlob}` },
+      { text: query },
       { text: '\n--- Content from referenced files ---' },
-      { text: `\nContent from @${resolvedGlob}:\n` },
-      { text: fileContent },
+      { text: `\nContent from @${file1}:\n` },
+      { text: content1 },
+      { text: `\nContent from @${file2}:\n` },
+      { text: content2 },
       { text: '\n--- End of content ---' },
     ]);
     expect(result.shouldProceed).toBe(true);
   });
 
-  it('should process a valid image file path (as text content for now)', async () => {
-    const imagePath = 'path/to/image.png';
-    const query = `@${imagePath}`;
-    // For @-commands, read_many_files is expected to return text or structured text.
-    // If it were to return actual image Part, the test and handling would be different.
-    // Current implementation of read_many_files for images returns base64 in text.
-    const imageFileTextContent = '[base64 image data for path/to/image.png]';
-    const imagePart = {
-      mimeType: 'image/png',
-      inlineData: imageFileTextContent,
-    };
-    mockReadManyFilesExecute.mockResolvedValue({
-      llmContent: [imagePart],
-      returnDisplay: 'Read 1 image.',
-    });
+  it('should handle error from read_many_files tool', async () => {
+    const filePath = 'src/index.ts';
+    const query = `@${filePath}`;
+    const error = new Error('File not found');
+    mockReadManyFilesExecute.mockRejectedValue(error);
 
     const result = await handleAtCommand({
       query,
@@ -274,24 +185,32 @@ describe('handleAtCommand', () => {
       messageId: 127,
       signal: abortController.signal,
     });
-    expect(result.processedQuery).toEqual([
-      { text: `@${imagePath}` },
-      { text: '\n--- Content from referenced files ---' },
-      imagePart,
-      { text: '\n--- End of content ---' },
-    ]);
-    expect(result.shouldProceed).toBe(true);
+
+    expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
+      { paths: [filePath] },
+      abortController.signal,
+    );
+    expect(mockAddItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool_group',
+        tools: [
+          expect.objectContaining({
+            status: ToolCallStatus.Error,
+            resultDisplay: `Error reading files (@${filePath}): ${error.message}`,
+          }),
+        ],
+      }),
+      127,
+    );
+    expect(result.processedQuery).toBeNull();
+    expect(result.shouldProceed).toBe(false);
   });
 
-  it('should handle query with text before and after @command', async () => {
-    const textBefore = 'Explain this: ';
-    const filePath = 'doc.md';
-    const textAfter = ' in detail.';
-    const query = `${textBefore}@${filePath}${textAfter}`;
-    const fileContent = 'Markdown content.';
-    mockReadManyFilesExecute.mockResolvedValue({
-      llmContent: [`--- ${filePath} ---\n\n${fileContent}\n\n`],
-      returnDisplay: 'Read 1 doc.',
+  it('should handle case where read_many_files tool is not found', async () => {
+    const filePath = 'src/index.ts';
+    const query = `@${filePath}`;
+    mockGetToolRegistry.mockReturnValue({
+      getTool: vi.fn(() => undefined),
     });
 
     const result = await handleAtCommand({
@@ -302,804 +221,12 @@ describe('handleAtCommand', () => {
       messageId: 128,
       signal: abortController.signal,
     });
+
     expect(mockAddItem).toHaveBeenCalledWith(
-      { type: 'user', text: query },
+      { type: 'error', text: 'Error: read_many_files tool not found.' },
       128,
     );
-    expect(result.processedQuery).toEqual([
-      { text: `${textBefore}@${filePath}${textAfter}` },
-      { text: '\n--- Content from referenced files ---' },
-      { text: `\nContent from @${filePath}:\n` },
-      { text: fileContent },
-      { text: '\n--- End of content ---' },
-    ]);
-    expect(result.shouldProceed).toBe(true);
-  });
-
-  it('should correctly unescape paths with escaped spaces', async () => {
-    const rawPath = 'path/to/my\\ file.txt';
-    const unescapedPath = 'path/to/my file.txt';
-    const query = `@${rawPath}`;
-    const fileContent = 'Content of file with space.';
-    mockReadManyFilesExecute.mockResolvedValue({
-      llmContent: [`--- ${unescapedPath} ---\n\n${fileContent}\n\n`],
-      returnDisplay: 'Read 1 file.',
-    });
-
-    await handleAtCommand({
-      query,
-      config: mockConfig,
-      addItem: mockAddItem,
-      onDebugMessage: mockOnDebugMessage,
-      messageId: 129,
-      signal: abortController.signal,
-    });
-    expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      {
-        paths: [unescapedPath],
-        file_filtering_options: {
-          respect_git_ignore: true,
-          respect_gemini_ignore: true,
-        },
-      },
-      abortController.signal,
-    );
-  });
-
-  it('should handle multiple @file references', async () => {
-    const file1 = 'file1.txt';
-    const content1 = 'Content file1';
-    const file2 = 'file2.md';
-    const content2 = 'Content file2';
-    const query = `@${file1} @${file2}`;
-
-    mockReadManyFilesExecute.mockResolvedValue({
-      llmContent: [
-        `--- ${file1} ---\n\n${content1}\n\n`,
-        `--- ${file2} ---\n\n${content2}\n\n`,
-      ],
-      returnDisplay: 'Read 2 files.',
-    });
-
-    const result = await handleAtCommand({
-      query,
-      config: mockConfig,
-      addItem: mockAddItem,
-      onDebugMessage: mockOnDebugMessage,
-      messageId: 130,
-      signal: abortController.signal,
-    });
-    expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      {
-        paths: [file1, file2],
-        file_filtering_options: {
-          respect_git_ignore: true,
-          respect_gemini_ignore: true,
-        },
-      },
-      abortController.signal,
-    );
-    expect(result.processedQuery).toEqual([
-      { text: `@${file1} @${file2}` },
-      { text: '\n--- Content from referenced files ---' },
-      { text: `\nContent from @${file1}:\n` },
-      { text: content1 },
-      { text: `\nContent from @${file2}:\n` },
-      { text: content2 },
-      { text: '\n--- End of content ---' },
-    ]);
-    expect(result.shouldProceed).toBe(true);
-  });
-
-  it('should handle multiple @file references with interleaved text', async () => {
-    const text1 = 'Check ';
-    const file1 = 'f1.txt';
-    const content1 = 'C1';
-    const text2 = ' and ';
-    const file2 = 'f2.md';
-    const content2 = 'C2';
-    const text3 = ' please.';
-    const query = `${text1}@${file1}${text2}@${file2}${text3}`;
-
-    mockReadManyFilesExecute.mockResolvedValue({
-      llmContent: [
-        `--- ${file1} ---\n\n${content1}\n\n`,
-        `--- ${file2} ---\n\n${content2}\n\n`,
-      ],
-      returnDisplay: 'Read 2 files.',
-    });
-
-    const result = await handleAtCommand({
-      query,
-      config: mockConfig,
-      addItem: mockAddItem,
-      onDebugMessage: mockOnDebugMessage,
-      messageId: 131,
-      signal: abortController.signal,
-    });
-    expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      {
-        paths: [file1, file2],
-        file_filtering_options: {
-          respect_git_ignore: true,
-          respect_gemini_ignore: true,
-        },
-      },
-      abortController.signal,
-    );
-    expect(result.processedQuery).toEqual([
-      { text: `${text1}@${file1}${text2}@${file2}${text3}` },
-      { text: '\n--- Content from referenced files ---' },
-      { text: `\nContent from @${file1}:\n` },
-      { text: content1 },
-      { text: `\nContent from @${file2}:\n` },
-      { text: content2 },
-      { text: '\n--- End of content ---' },
-    ]);
-    expect(result.shouldProceed).toBe(true);
-  });
-
-  it('should handle a mix of valid, invalid, and lone @ references', async () => {
-    const file1 = 'valid1.txt';
-    const content1 = 'Valid content 1';
-    const invalidFile = 'nonexistent.txt';
-    const query = `Look at @${file1} then @${invalidFile} and also just @ symbol, then @valid2.glob`;
-    const file2Glob = 'valid2.glob';
-    const resolvedFile2 = 'resolved/valid2.actual';
-    const content2 = 'Globbed content';
-
-    // Mock fs.stat for file1 (valid)
-    vi.mocked(fsPromises.stat).mockImplementation(async (p) => {
-      if (p.toString().endsWith(file1))
-        return { isDirectory: () => false } as Stats;
-      if (p.toString().endsWith(invalidFile))
-        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
-      // For valid2.glob, stat will fail, triggering glob
-      if (p.toString().endsWith(file2Glob))
-        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
-      return { isDirectory: () => false } as Stats; // Default
-    });
-
-    // Mock glob to find resolvedFile2 for valid2.glob
-    mockGlobExecute.mockImplementation(async (params) => {
-      if (params.pattern.includes('valid2.glob')) {
-        return {
-          llmContent: `Found files:\n${mockGetTargetDir()}/${resolvedFile2}`,
-          returnDisplay: 'Found 1 file',
-        };
-      }
-      return { llmContent: 'No files found', returnDisplay: '' };
-    });
-
-    mockReadManyFilesExecute.mockResolvedValue({
-      llmContent: [
-        `--- ${file1} ---\n\n${content1}\n\n`,
-        `--- ${resolvedFile2} ---\n\n${content2}\n\n`,
-      ],
-      returnDisplay: 'Read 2 files.',
-    });
-
-    const result = await handleAtCommand({
-      query,
-      config: mockConfig,
-      addItem: mockAddItem,
-      onDebugMessage: mockOnDebugMessage,
-      messageId: 132,
-      signal: abortController.signal,
-    });
-
-    expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      {
-        paths: [file1, resolvedFile2],
-        file_filtering_options: {
-          respect_git_ignore: true,
-          respect_gemini_ignore: true,
-        },
-      },
-      abortController.signal,
-    );
-    expect(result.processedQuery).toEqual([
-      // Original query has @nonexistent.txt and @, but resolved has @resolved/valid2.actual
-      {
-        text: `Look at @${file1} then @${invalidFile} and also just @ symbol, then @${resolvedFile2}`,
-      },
-      { text: '\n--- Content from referenced files ---' },
-      { text: `\nContent from @${file1}:\n` },
-      { text: content1 },
-      { text: `\nContent from @${resolvedFile2}:\n` },
-      { text: content2 },
-      { text: '\n--- End of content ---' },
-    ]);
-    expect(result.shouldProceed).toBe(true);
-    expect(mockOnDebugMessage).toHaveBeenCalledWith(
-      `Path ${invalidFile} not found directly, attempting glob search.`,
-    );
-    expect(mockOnDebugMessage).toHaveBeenCalledWith(
-      `Glob search for '**/*${invalidFile}*' found no files or an error. Path ${invalidFile} will be skipped.`,
-    );
-    expect(mockOnDebugMessage).toHaveBeenCalledWith(
-      'Lone @ detected, will be treated as text in the modified query.',
-    );
-  });
-
-  it('should return original query if all @paths are invalid or lone @', async () => {
-    const query = 'Check @nonexistent.txt and @ also';
-    vi.mocked(fsPromises.stat).mockRejectedValue(
-      Object.assign(new Error('ENOENT'), { code: 'ENOENT' }),
-    );
-    mockGlobExecute.mockResolvedValue({
-      llmContent: 'No files found',
-      returnDisplay: '',
-    });
-
-    const result = await handleAtCommand({
-      query,
-      config: mockConfig,
-      addItem: mockAddItem,
-      onDebugMessage: mockOnDebugMessage,
-      messageId: 133,
-      signal: abortController.signal,
-    });
-    expect(mockReadManyFilesExecute).not.toHaveBeenCalled();
-    // The modified query string will be "Check @nonexistent.txt and @ also" because no paths were resolved for reading.
-    expect(result.processedQuery).toEqual([
-      { text: 'Check @nonexistent.txt and @ also' },
-    ]);
-
-    expect(result.shouldProceed).toBe(true);
-  });
-
-  it('should process a file path case-insensitively', async () => {
-    // const actualFilePath = 'path/to/MyFile.txt'; // Unused, path in llmContent should match queryPath
-    const queryPath = 'path/to/myfile.txt'; // Different case
-    const query = `@${queryPath}`;
-    const fileContent = 'This is the case-insensitive file content.';
-
-    // Mock fs.stat to "find" MyFile.txt when looking for myfile.txt
-    // This simulates a case-insensitive file system or resolution
-    vi.mocked(fsPromises.stat).mockImplementation(async (p) => {
-      if (p.toString().toLowerCase().endsWith('myfile.txt')) {
-        return {
-          isDirectory: () => false,
-          // You might need to add other Stats properties if your code uses them
-        } as Stats;
-      }
-      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
-    });
-
-    mockReadManyFilesExecute.mockResolvedValue({
-      llmContent: [`--- ${queryPath} ---\n\n${fileContent}\n\n`],
-      returnDisplay: 'Read 1 file.',
-    });
-
-    const result = await handleAtCommand({
-      query,
-      config: mockConfig,
-      addItem: mockAddItem,
-      onDebugMessage: mockOnDebugMessage,
-      messageId: 134, // New messageId
-      signal: abortController.signal,
-    });
-
-    expect(mockAddItem).toHaveBeenCalledWith(
-      { type: 'user', text: query },
-      134,
-    );
-    // The atCommandProcessor resolves the path before calling read_many_files.
-    // We expect it to be called with the path that fs.stat "found".
-    // In a real case-insensitive FS, stat(myfile.txt) might return info for MyFile.txt.
-    // The key is that *a* valid path that points to the content is used.
-    expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      // Depending on how path resolution and fs.stat mock interact,
-      // this could be queryPath or actualFilePath.
-      // For this test, we'll assume the processor uses the path that stat "succeeded" with.
-      // If the underlying fs/stat is truly case-insensitive, it might resolve to actualFilePath.
-      // If the mock is simpler, it might use queryPath if stat(queryPath) succeeds.
-      // The most important part is that *some* version of the path that leads to the content is used.
-      // Let's assume it uses the path from the query if stat confirms it exists (even if different case on disk)
-      {
-        paths: [queryPath],
-        file_filtering_options: {
-          respect_git_ignore: true,
-          respect_gemini_ignore: true,
-        },
-      },
-      abortController.signal,
-    );
-    expect(mockAddItem).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'tool_group',
-        tools: [expect.objectContaining({ status: ToolCallStatus.Success })],
-      }),
-      134,
-    );
-    expect(result.processedQuery).toEqual([
-      { text: `@${queryPath}` }, // Query uses the input path
-      { text: '\n--- Content from referenced files ---' },
-      { text: `\nContent from @${queryPath}:\n` }, // Content display also uses input path
-      { text: fileContent },
-      { text: '\n--- End of content ---' },
-    ]);
-    expect(result.shouldProceed).toBe(true);
-  });
-
-  describe('git-aware filtering', () => {
-    it('should skip git-ignored files in @ commands', async () => {
-      const gitIgnoredFile = 'node_modules/package.json';
-      const query = `@${gitIgnoredFile}`;
-
-      // Mock the file discovery service to report this file as git-ignored
-      mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
-        (
-          path: string,
-          options?: {
-            respectGitIgnore?: boolean;
-            respectGeminiIgnore?: boolean;
-          },
-        ) => {
-          if (path !== gitIgnoredFile) return false;
-          if (options?.respectGitIgnore) return true;
-          if (options?.respectGeminiIgnore) return false;
-          return false;
-        },
-      );
-
-      const result = await handleAtCommand({
-        query,
-        config: mockConfig,
-        addItem: mockAddItem,
-        onDebugMessage: mockOnDebugMessage,
-        messageId: 200,
-        signal: abortController.signal,
-      });
-
-      // Should be called twice - once for git ignore check and once for gemini ignore check
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledTimes(
-        2,
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        gitIgnoredFile,
-        { respectGitIgnore: true, respectGeminiIgnore: false },
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        gitIgnoredFile,
-        { respectGitIgnore: false, respectGeminiIgnore: true },
-      );
-
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        `Path ${gitIgnoredFile} is git-ignored and will be skipped.`,
-      );
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        'Ignored 1 files:\nGit-ignored: node_modules/package.json',
-      );
-      expect(mockReadManyFilesExecute).not.toHaveBeenCalled();
-      expect(result.processedQuery).toEqual([{ text: query }]);
-      expect(result.shouldProceed).toBe(true);
-    });
-
-    it('should process non-git-ignored files normally', async () => {
-      const validFile = 'src/index.ts';
-      const query = `@${validFile}`;
-      const fileContent = 'console.log("Hello world");';
-
-      mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
-        (
-          _path: string,
-          _options?: {
-            respectGitIgnore?: boolean;
-            respectGeminiIgnore?: boolean;
-          },
-        ) => false,
-      );
-      mockReadManyFilesExecute.mockResolvedValue({
-        llmContent: [`--- ${validFile} ---\n\n${fileContent}\n\n`],
-        returnDisplay: 'Read 1 file.',
-      });
-
-      const result = await handleAtCommand({
-        query,
-        config: mockConfig,
-        addItem: mockAddItem,
-        onDebugMessage: mockOnDebugMessage,
-        messageId: 201,
-        signal: abortController.signal,
-      });
-
-      // Should be called twice - once for git ignore check and once for gemini ignore check
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledTimes(
-        2,
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        validFile,
-        { respectGitIgnore: true, respectGeminiIgnore: false },
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        validFile,
-        { respectGitIgnore: false, respectGeminiIgnore: true },
-      );
-      expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-        {
-          paths: [validFile],
-          file_filtering_options: {
-            respect_git_ignore: true,
-            respect_gemini_ignore: true,
-          },
-        },
-        abortController.signal,
-      );
-      expect(result.processedQuery).toEqual([
-        { text: `@${validFile}` },
-        { text: '\n--- Content from referenced files ---' },
-        { text: `\nContent from @${validFile}:\n` },
-        { text: fileContent },
-        { text: '\n--- End of content ---' },
-      ]);
-      expect(result.shouldProceed).toBe(true);
-    });
-
-    it('should handle mixed git-ignored and valid files', async () => {
-      const validFile = 'README.md';
-      const gitIgnoredFile = '.env';
-      const query = `@${validFile} @${gitIgnoredFile}`;
-      const fileContent = '# Project README';
-
-      mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
-        (
-          path: string,
-          options?: {
-            respectGitIgnore?: boolean;
-            respectGeminiIgnore?: boolean;
-          },
-        ) => {
-          if (path === gitIgnoredFile && options?.respectGitIgnore) {
-            return true;
-          }
-          if (options?.respectGeminiIgnore) {
-            return false;
-          }
-          return false;
-        },
-      );
-      mockReadManyFilesExecute.mockResolvedValue({
-        llmContent: [`--- ${validFile} ---\n\n${fileContent}\n\n`],
-        returnDisplay: 'Read 1 file.',
-      });
-
-      const result = await handleAtCommand({
-        query,
-        config: mockConfig,
-        addItem: mockAddItem,
-        onDebugMessage: mockOnDebugMessage,
-        messageId: 202,
-        signal: abortController.signal,
-      });
-
-      // Should be called twice for each file - once for git ignore check and once for gemini ignore check
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledTimes(
-        4,
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        validFile,
-        { respectGitIgnore: true, respectGeminiIgnore: false },
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        validFile,
-        { respectGitIgnore: false, respectGeminiIgnore: true },
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        gitIgnoredFile,
-        { respectGitIgnore: true, respectGeminiIgnore: false },
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        gitIgnoredFile,
-        { respectGitIgnore: false, respectGeminiIgnore: true },
-      );
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        `Path ${gitIgnoredFile} is git-ignored and will be skipped.`,
-      );
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        'Ignored 1 files:\nGit-ignored: .env',
-      );
-      expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-        {
-          paths: [validFile],
-          file_filtering_options: {
-            respect_git_ignore: true,
-            respect_gemini_ignore: true,
-          },
-        },
-        abortController.signal,
-      );
-      expect(result.processedQuery).toEqual([
-        { text: `@${validFile} @${gitIgnoredFile}` },
-        { text: '\n--- Content from referenced files ---' },
-        { text: `\nContent from @${validFile}:\n` },
-        { text: fileContent },
-        { text: '\n--- End of content ---' },
-      ]);
-      expect(result.shouldProceed).toBe(true);
-    });
-
-    it('should always ignore .git directory files', async () => {
-      const gitFile = '.git/config';
-      const query = `@${gitFile}`;
-
-      // Mock to return true for git ignore check, false for gemini ignore check
-      mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
-        (
-          _path: string,
-          options?: {
-            respectGitIgnore?: boolean;
-            respectGeminiIgnore?: boolean;
-          },
-        ) => options?.respectGitIgnore === true,
-      );
-
-      const result = await handleAtCommand({
-        query,
-        config: mockConfig,
-        addItem: mockAddItem,
-        onDebugMessage: mockOnDebugMessage,
-        messageId: 203,
-        signal: abortController.signal,
-      });
-
-      // Should be called twice - once for git ignore check and once for gemini ignore check
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledTimes(
-        2,
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        gitFile,
-        { respectGitIgnore: true, respectGeminiIgnore: false },
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        gitFile,
-        { respectGitIgnore: false, respectGeminiIgnore: true },
-      );
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        `Path ${gitFile} is git-ignored and will be skipped.`,
-      );
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        'Ignored 1 files:\nGit-ignored: .git/config',
-      );
-      expect(mockReadManyFilesExecute).not.toHaveBeenCalled();
-      expect(result.processedQuery).toEqual([{ text: query }]);
-      expect(result.shouldProceed).toBe(true);
-    });
-  });
-
-  describe('when recursive file search is disabled', () => {
-    beforeEach(() => {
-      vi.mocked(mockConfig.getEnableRecursiveFileSearch).mockReturnValue(false);
-    });
-
-    it('should not use glob search for a nonexistent file', async () => {
-      const invalidFile = 'nonexistent.txt';
-      const query = `@${invalidFile}`;
-
-      vi.mocked(fsPromises.stat).mockRejectedValue(
-        Object.assign(new Error('ENOENT'), { code: 'ENOENT' }),
-      );
-
-      const result = await handleAtCommand({
-        query,
-        config: mockConfig,
-        addItem: mockAddItem,
-        onDebugMessage: mockOnDebugMessage,
-        messageId: 300,
-        signal: abortController.signal,
-      });
-
-      expect(mockGlobExecute).not.toHaveBeenCalled();
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        `Glob tool not found. Path ${invalidFile} will be skipped.`,
-      );
-      expect(result.processedQuery).toEqual([{ text: query }]);
-      expect(result.shouldProceed).toBe(true);
-    });
-  });
-
-  describe('gemini-ignore filtering', () => {
-    it('should skip gemini-ignored files in @ commands', async () => {
-      const geminiIgnoredFile = 'build/output.js';
-      const query = `@${geminiIgnoredFile}`;
-
-      // Mock the file discovery service to report this file as gemini-ignored
-      mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
-        (
-          path: string,
-          options?: {
-            respectGitIgnore?: boolean;
-            respectGeminiIgnore?: boolean;
-          },
-        ) => {
-          if (path !== geminiIgnoredFile) return false;
-          if (options?.respectGeminiIgnore) return true;
-          if (options?.respectGitIgnore) return false;
-          return false;
-        },
-      );
-
-      const result = await handleAtCommand({
-        query,
-        config: mockConfig,
-        addItem: mockAddItem,
-        onDebugMessage: mockOnDebugMessage,
-        messageId: 204,
-        signal: abortController.signal,
-      });
-
-      // Should be called twice - once for git ignore check and once for gemini ignore check
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledTimes(
-        2,
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        geminiIgnoredFile,
-        { respectGitIgnore: true, respectGeminiIgnore: false },
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        geminiIgnoredFile,
-        { respectGitIgnore: false, respectGeminiIgnore: true },
-      );
-
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        `Path ${geminiIgnoredFile} is gemini-ignored and will be skipped.`,
-      );
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        'No valid file paths found in @ commands to read.',
-      );
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        'Ignored 1 files:\nGemini-ignored: build/output.js',
-      );
-      expect(mockReadManyFilesExecute).not.toHaveBeenCalled();
-      expect(result.processedQuery).toEqual([{ text: query }]);
-      expect(result.shouldProceed).toBe(true);
-    });
-
-    it('should process non-ignored files when .geminiignore is present', async () => {
-      const validFile = 'src/index.ts';
-      const query = `@${validFile}`;
-      const fileContent = 'console.log("Hello world")';
-
-      mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
-        (
-          _path: string,
-          _options?: {
-            respectGitIgnore?: boolean;
-            respectGeminiIgnore?: boolean;
-          },
-        ) => false,
-      );
-      mockReadManyFilesExecute.mockResolvedValue({
-        llmContent: [`--- ${validFile} ---\n\n${fileContent}\n\n`],
-        returnDisplay: 'Read 1 file.',
-      });
-
-      const result = await handleAtCommand({
-        query,
-        config: mockConfig,
-        addItem: mockAddItem,
-        onDebugMessage: mockOnDebugMessage,
-        messageId: 205,
-        signal: abortController.signal,
-      });
-
-      // Should be called twice - once for git ignore check and once for gemini ignore check
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledTimes(
-        2,
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        validFile,
-        { respectGitIgnore: true, respectGeminiIgnore: false },
-      );
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-        validFile,
-        { respectGitIgnore: false, respectGeminiIgnore: true },
-      );
-
-      expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-        {
-          paths: [validFile],
-          file_filtering_options: {
-            respect_git_ignore: true,
-            respect_gemini_ignore: true,
-          },
-        },
-        abortController.signal,
-      );
-      expect(result.processedQuery).toEqual([
-        { text: `@${validFile}` },
-        { text: '\n--- Content from referenced files ---' },
-        { text: `\nContent from @${validFile}:\n` },
-        { text: fileContent },
-        { text: '\n--- End of content ---' },
-      ]);
-      expect(result.shouldProceed).toBe(true);
-    });
-
-    it('should handle mixed gemini-ignored and valid files', async () => {
-      const validFile = 'src/main.ts';
-      const geminiIgnoredFile = 'dist/bundle.js';
-      const query = `@${validFile} @${geminiIgnoredFile}`;
-      const fileContent = '// Main application entry';
-
-      mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
-        (
-          path: string,
-          options?: {
-            respectGitIgnore?: boolean;
-            respectGeminiIgnore?: boolean;
-          },
-        ) => {
-          if (path === geminiIgnoredFile && options?.respectGeminiIgnore) {
-            return true;
-          }
-          if (options?.respectGitIgnore) {
-            return false;
-          }
-          return false;
-        },
-      );
-      mockReadManyFilesExecute.mockResolvedValue({
-        llmContent: [`--- ${validFile} ---\n\n${fileContent}\n\n`],
-        returnDisplay: 'Read 1 file.',
-      });
-
-      const result = await handleAtCommand({
-        query,
-        config: mockConfig,
-        addItem: mockAddItem,
-        onDebugMessage: mockOnDebugMessage,
-        messageId: 206,
-        signal: abortController.signal,
-      });
-
-      // Should be called twice for each file - once for git ignore check and once for gemini ignore check
-      expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledTimes(
-        4,
-      );
-
-      // Verify both files were checked against both ignore types
-      [validFile, geminiIgnoredFile].forEach((file) => {
-        expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-          file,
-          { respectGitIgnore: true, respectGeminiIgnore: false },
-        );
-        expect(mockFileDiscoveryService.shouldIgnoreFile).toHaveBeenCalledWith(
-          file,
-          { respectGitIgnore: false, respectGeminiIgnore: true },
-        );
-      });
-
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        `Path ${validFile} resolved to file: ${validFile}`,
-      );
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        `Path ${geminiIgnoredFile} is gemini-ignored and will be skipped.`,
-      );
-      expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        'Ignored 1 files:\nGemini-ignored: dist/bundle.js',
-      );
-
-      expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-        {
-          paths: [validFile],
-          file_filtering_options: {
-            respect_git_ignore: true,
-            respect_gemini_ignore: true,
-          },
-        },
-        abortController.signal,
-      );
-
-      expect(result.processedQuery).toEqual([
-        { text: `@${validFile} @${geminiIgnoredFile}` },
-        { text: '\n--- Content from referenced files ---' },
-        { text: `\nContent from @${validFile}:\n` },
-        { text: fileContent },
-        { text: '\n--- End of content ---' },
-      ]);
-      expect(result.shouldProceed).toBe(true);
-    });
+    expect(result.processedQuery).toBeNull();
+    expect(result.shouldProceed).toBe(false);
   });
 });

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -4,15 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'fs/promises';
-import * as path from 'path';
 import { PartListUnion, PartUnion } from '@google/genai';
-import {
-  Config,
-  getErrorMessage,
-  isNodeError,
-  unescapePath,
-} from '@google/gemini-cli-core';
+import { Config, getErrorMessage } from '@google/gemini-cli-core';
 import {
   HistoryItem,
   IndividualToolCallDisplay,
@@ -34,77 +27,6 @@ interface HandleAtCommandResult {
   shouldProceed: boolean;
 }
 
-interface AtCommandPart {
-  type: 'text' | 'atPath';
-  content: string;
-}
-
-/**
- * Parses a query string to find all '@<path>' commands and text segments.
- * Handles \ escaped spaces within paths.
- */
-function parseAllAtCommands(query: string): AtCommandPart[] {
-  const parts: AtCommandPart[] = [];
-  let currentIndex = 0;
-
-  while (currentIndex < query.length) {
-    let atIndex = -1;
-    let nextSearchIndex = currentIndex;
-    // Find next unescaped '@'
-    while (nextSearchIndex < query.length) {
-      if (
-        query[nextSearchIndex] === '@' &&
-        (nextSearchIndex === 0 || query[nextSearchIndex - 1] !== '\\')
-      ) {
-        atIndex = nextSearchIndex;
-        break;
-      }
-      nextSearchIndex++;
-    }
-
-    if (atIndex === -1) {
-      // No more @
-      if (currentIndex < query.length) {
-        parts.push({ type: 'text', content: query.substring(currentIndex) });
-      }
-      break;
-    }
-
-    // Add text before @
-    if (atIndex > currentIndex) {
-      parts.push({
-        type: 'text',
-        content: query.substring(currentIndex, atIndex),
-      });
-    }
-
-    // Parse @path
-    let pathEndIndex = atIndex + 1;
-    let inEscape = false;
-    while (pathEndIndex < query.length) {
-      const char = query[pathEndIndex];
-      if (inEscape) {
-        inEscape = false;
-      } else if (char === '\\') {
-        inEscape = true;
-      } else if (/\s/.test(char)) {
-        // Path ends at first whitespace not escaped
-        break;
-      }
-      pathEndIndex++;
-    }
-    const rawAtPath = query.substring(atIndex, pathEndIndex);
-    // unescapePath expects the @ symbol to be present, and will handle it.
-    const atPath = unescapePath(rawAtPath);
-    parts.push({ type: 'atPath', content: atPath });
-    currentIndex = pathEndIndex;
-  }
-  // Filter out empty text parts that might result from consecutive @paths or leading/trailing spaces
-  return parts.filter(
-    (part) => !(part.type === 'text' && part.content.trim() === ''),
-  );
-}
-
 /**
  * Processes user input potentially containing one or more '@<path>' commands.
  * If found, it attempts to read the specified files/directories using the
@@ -122,10 +44,13 @@ export async function handleAtCommand({
   messageId: userMessageTimestamp,
   signal,
 }: HandleAtCommandParams): Promise<HandleAtCommandResult> {
-  const commandParts = parseAllAtCommands(query);
-  const atPathCommandParts = commandParts.filter(
-    (part) => part.type === 'atPath',
-  );
+  // This regex finds all occurrences of '@' followed by a path.
+  // A path is a sequence of non-whitespace characters, or any character
+  // escaped with a backslash.
+  // It uses a positive lookbehind `(?<=\s)` to ensure the '@' is preceded
+  // by whitespace, or `^` to catch commands at the start of the string.
+  const atCommandRegex = /(^|(?<=\s))@(?:\\ |[^\s])+/g;
+  const atPathCommandParts = query.match(atCommandRegex) || [];
 
   if (atPathCommandParts.length === 0) {
     addItem({ type: 'user', text: query }, userMessageTimestamp);
@@ -134,23 +59,8 @@ export async function handleAtCommand({
 
   addItem({ type: 'user', text: query }, userMessageTimestamp);
 
-  // Get centralized file discovery service
-  const fileDiscovery = config.getFileService();
-
-  const respectFileIgnore = config.getFileFilteringOptions();
-
-  const pathSpecsToRead: string[] = [];
-  const atPathToResolvedSpecMap = new Map<string, string>();
-  const contentLabelsForDisplay: string[] = [];
-  const ignoredByReason: Record<string, string[]> = {
-    git: [],
-    gemini: [],
-    both: [],
-  };
-
   const toolRegistry = await config.getToolRegistry();
   const readManyFilesTool = toolRegistry.getTool('read_many_files');
-  const globTool = toolRegistry.getTool('glob');
 
   if (!readManyFilesTool) {
     addItem(
@@ -160,239 +70,10 @@ export async function handleAtCommand({
     return { processedQuery: null, shouldProceed: false };
   }
 
-  for (const atPathPart of atPathCommandParts) {
-    const originalAtPath = atPathPart.content; // e.g., "@file.txt" or "@"
-
-    if (originalAtPath === '@') {
-      onDebugMessage(
-        'Lone @ detected, will be treated as text in the modified query.',
-      );
-      continue;
-    }
-
-    const pathName = originalAtPath.substring(1);
-    if (!pathName) {
-      // This case should ideally not be hit if parseAllAtCommands ensures content after @
-      // but as a safeguard:
-      addItem(
-        {
-          type: 'error',
-          text: `Error: Invalid @ command '${originalAtPath}'. No path specified.`,
-        },
-        userMessageTimestamp,
-      );
-      // Decide if this is a fatal error for the whole command or just skip this @ part
-      // For now, let's be strict and fail the command if one @path is malformed.
-      return { processedQuery: null, shouldProceed: false };
-    }
-
-    // Check if path should be ignored based on filtering options
-
-    const gitIgnored =
-      respectFileIgnore.respectGitIgnore &&
-      fileDiscovery.shouldIgnoreFile(pathName, {
-        respectGitIgnore: true,
-        respectGeminiIgnore: false,
-      });
-    const geminiIgnored =
-      respectFileIgnore.respectGeminiIgnore &&
-      fileDiscovery.shouldIgnoreFile(pathName, {
-        respectGitIgnore: false,
-        respectGeminiIgnore: true,
-      });
-
-    if (gitIgnored || geminiIgnored) {
-      const reason =
-        gitIgnored && geminiIgnored ? 'both' : gitIgnored ? 'git' : 'gemini';
-      ignoredByReason[reason].push(pathName);
-      const reasonText =
-        reason === 'both'
-          ? 'ignored by both git and gemini'
-          : reason === 'git'
-            ? 'git-ignored'
-            : 'gemini-ignored';
-      onDebugMessage(`Path ${pathName} is ${reasonText} and will be skipped.`);
-      continue;
-    }
-
-    let currentPathSpec = pathName;
-    let resolvedSuccessfully = false;
-
-    try {
-      const absolutePath = path.resolve(config.getTargetDir(), pathName);
-      const stats = await fs.stat(absolutePath);
-      if (stats.isDirectory()) {
-        currentPathSpec = pathName.endsWith('/')
-          ? `${pathName}**`
-          : `${pathName}/**`;
-        onDebugMessage(
-          `Path ${pathName} resolved to directory, using glob: ${currentPathSpec}`,
-        );
-      } else {
-        onDebugMessage(`Path ${pathName} resolved to file: ${currentPathSpec}`);
-      }
-      resolvedSuccessfully = true;
-    } catch (error) {
-      if (isNodeError(error) && error.code === 'ENOENT') {
-        if (config.getEnableRecursiveFileSearch() && globTool) {
-          onDebugMessage(
-            `Path ${pathName} not found directly, attempting glob search.`,
-          );
-          try {
-            const globResult = await globTool.execute(
-              { pattern: `**/*${pathName}*`, path: config.getTargetDir() },
-              signal,
-            );
-            if (
-              globResult.llmContent &&
-              typeof globResult.llmContent === 'string' &&
-              !globResult.llmContent.startsWith('No files found') &&
-              !globResult.llmContent.startsWith('Error:')
-            ) {
-              const lines = globResult.llmContent.split('\n');
-              if (lines.length > 1 && lines[1]) {
-                const firstMatchAbsolute = lines[1].trim();
-                currentPathSpec = path.relative(
-                  config.getTargetDir(),
-                  firstMatchAbsolute,
-                );
-                onDebugMessage(
-                  `Glob search for ${pathName} found ${firstMatchAbsolute}, using relative path: ${currentPathSpec}`,
-                );
-                resolvedSuccessfully = true;
-              } else {
-                onDebugMessage(
-                  `Glob search for '**/*${pathName}*' did not return a usable path. Path ${pathName} will be skipped.`,
-                );
-              }
-            } else {
-              onDebugMessage(
-                `Glob search for '**/*${pathName}*' found no files or an error. Path ${pathName} will be skipped.`,
-              );
-            }
-          } catch (globError) {
-            console.error(
-              `Error during glob search for ${pathName}: ${getErrorMessage(globError)}`,
-            );
-            onDebugMessage(
-              `Error during glob search for ${pathName}. Path ${pathName} will be skipped.`,
-            );
-          }
-        } else {
-          onDebugMessage(
-            `Glob tool not found. Path ${pathName} will be skipped.`,
-          );
-        }
-      } else {
-        console.error(
-          `Error stating path ${pathName}: ${getErrorMessage(error)}`,
-        );
-        onDebugMessage(
-          `Error stating path ${pathName}. Path ${pathName} will be skipped.`,
-        );
-      }
-    }
-
-    if (resolvedSuccessfully) {
-      pathSpecsToRead.push(currentPathSpec);
-      atPathToResolvedSpecMap.set(originalAtPath, currentPathSpec);
-      contentLabelsForDisplay.push(pathName);
-    }
-  }
-
-  // Construct the initial part of the query for the LLM
-  let initialQueryText = '';
-  for (let i = 0; i < commandParts.length; i++) {
-    const part = commandParts[i];
-    if (part.type === 'text') {
-      initialQueryText += part.content;
-    } else {
-      // type === 'atPath'
-      const resolvedSpec = atPathToResolvedSpecMap.get(part.content);
-      if (
-        i > 0 &&
-        initialQueryText.length > 0 &&
-        !initialQueryText.endsWith(' ') &&
-        resolvedSpec
-      ) {
-        // Add space if previous part was text and didn't end with space, or if previous was @path
-        const prevPart = commandParts[i - 1];
-        if (
-          prevPart.type === 'text' ||
-          (prevPart.type === 'atPath' &&
-            atPathToResolvedSpecMap.has(prevPart.content))
-        ) {
-          initialQueryText += ' ';
-        }
-      }
-      if (resolvedSpec) {
-        initialQueryText += `@${resolvedSpec}`;
-      } else {
-        // If not resolved for reading (e.g. lone @ or invalid path that was skipped),
-        // add the original @-string back, ensuring spacing if it's not the first element.
-        if (
-          i > 0 &&
-          initialQueryText.length > 0 &&
-          !initialQueryText.endsWith(' ') &&
-          !part.content.startsWith(' ')
-        ) {
-          initialQueryText += ' ';
-        }
-        initialQueryText += part.content;
-      }
-    }
-  }
-  initialQueryText = initialQueryText.trim();
-
-  // Inform user about ignored paths
-  const totalIgnored =
-    ignoredByReason.git.length +
-    ignoredByReason.gemini.length +
-    ignoredByReason.both.length;
-
-  if (totalIgnored > 0) {
-    const messages = [];
-    if (ignoredByReason.git.length) {
-      messages.push(`Git-ignored: ${ignoredByReason.git.join(', ')}`);
-    }
-    if (ignoredByReason.gemini.length) {
-      messages.push(`Gemini-ignored: ${ignoredByReason.gemini.join(', ')}`);
-    }
-    if (ignoredByReason.both.length) {
-      messages.push(`Ignored by both: ${ignoredByReason.both.join(', ')}`);
-    }
-
-    const message = `Ignored ${totalIgnored} files:\n${messages.join('\n')}`;
-    console.log(message);
-    onDebugMessage(message);
-  }
-
-  // Fallback for lone "@" or completely invalid @-commands resulting in empty initialQueryText
-  if (pathSpecsToRead.length === 0) {
-    onDebugMessage('No valid file paths found in @ commands to read.');
-    if (initialQueryText === '@' && query.trim() === '@') {
-      // If the only thing was a lone @, pass original query (which might have spaces)
-      return { processedQuery: [{ text: query }], shouldProceed: true };
-    } else if (!initialQueryText && query) {
-      // If all @-commands were invalid and no surrounding text, pass original query
-      return { processedQuery: [{ text: query }], shouldProceed: true };
-    }
-    // Otherwise, proceed with the (potentially modified) query text that doesn't involve file reading
-    return {
-      processedQuery: [{ text: initialQueryText || query }],
-      shouldProceed: true,
-    };
-  }
-
-  const processedQueryParts: PartUnion[] = [{ text: initialQueryText }];
+  const processedQueryParts: PartUnion[] = [{ text: query }];
 
   const toolArgs = {
-    paths: pathSpecsToRead,
-    file_filtering_options: {
-      respect_git_ignore: respectFileIgnore.respectGitIgnore,
-      respect_gemini_ignore: respectFileIgnore.respectGeminiIgnore,
-    },
-    // Use configuration setting
+    paths: atPathCommandParts.map((part) => part.substring(1)),
   };
   let toolCallDisplay: IndividualToolCallDisplay;
 
@@ -405,7 +86,7 @@ export async function handleAtCommand({
       status: ToolCallStatus.Success,
       resultDisplay:
         result.returnDisplay ||
-        `Successfully read: ${contentLabelsForDisplay.join(', ')}`,
+        `Successfully read: ${atPathCommandParts.join(', ')}`,
       confirmationDetails: undefined,
     };
 
@@ -453,7 +134,7 @@ export async function handleAtCommand({
       name: readManyFilesTool.displayName,
       description: readManyFilesTool.getDescription(toolArgs),
       status: ToolCallStatus.Error,
-      resultDisplay: `Error reading files (${contentLabelsForDisplay.join(', ')}): ${getErrorMessage(error)}`,
+      resultDisplay: `Error reading files (${atPathCommandParts.join(', ')}): ${getErrorMessage(error)}`,
       confirmationDetails: undefined,
     };
     addItem(

--- a/packages/cli/src/ui/hooks/useCompletion.integration.test.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.integration.test.ts
@@ -4,66 +4,187 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import type { Mocked } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useCompletion } from './useCompletion.js';
-import * as fs from 'fs/promises';
-import { glob } from 'glob';
 import {
   CommandContext,
   CommandKind,
   SlashCommand,
 } from '../commands/types.js';
-import { Config, FileDiscoveryService } from '@google/gemini-cli-core';
+import {
+  createTmpDir,
+  cleanupTmpDir,
+  FileSystemStructure,
+} from '@google/gemini-cli-test-utils';
 
-interface MockConfig {
-  getFileFilteringOptions: () => {
-    respectGitIgnore: boolean;
-    respectGeminiIgnore: boolean;
-  };
-  getEnableRecursiveFileSearch: () => boolean;
-  getFileService: () => FileDiscoveryService | null;
-}
+const mockCommandContext = {} as CommandContext;
 
-// Mock dependencies
-vi.mock('fs/promises');
-vi.mock('@google/gemini-cli-core', async () => {
-  const actual = await vi.importActual('@google/gemini-cli-core');
-  return {
-    ...actual,
-    FileDiscoveryService: vi.fn(),
-    isNodeError: vi.fn((error) => error.code === 'ENOENT'),
-    escapePath: vi.fn((path) => path),
-    unescapePath: vi.fn((path) => path),
-    getErrorMessage: vi.fn((error) => error.message),
-  };
-});
-vi.mock('glob');
+const fileSystemStructure: FileSystemStructure = {
+  'README.md': '# Test Project',
+  src: {
+    'index.ts': 'console.log("hello");',
+    'App.tsx': '<App />',
+    components: {
+      'Button.tsx': '<button />',
+      'Input.tsx': '<input />',
+    },
+  },
+  // To be ignored by .gitignore
+  node_modules: { react: '...' },
+  dist: { 'bundle.js': '...' },
+  coverage: { 'lcov.info': '...' },
+  data: {
+    logs: {
+      'test.log': 'log data',
+    },
+  },
+  // To be ignored by .geminiignore
+  secrets: { 'api.key': '...' },
+  temp_data: { 'temp.txt': '...' },
+  // The ignore files themselves
+  '.gitignore': ['node_modules/', 'dist/', '/coverage', '*.log'].join('\n'),
+  '.geminiignore': ['secrets/', 'temp_data/'].join('\n'),
+};
 
-describe('useCompletion git-aware filtering integration', () => {
-  let mockFileDiscoveryService: Mocked<FileDiscoveryService>;
-  let mockConfig: MockConfig;
+describe('useCompletion integration with FileSearch', () => {
+  let testCwd: string;
 
-  const testCwd = '/test/project';
-  const slashCommands = [
+  // We are not testing slash commands here, so a minimal mock is fine.
+  const mockSlashCommands: SlashCommand[] = [
     {
       name: 'help',
       description: 'Show help',
       kind: CommandKind.BUILT_IN,
       action: vi.fn(),
     },
-    {
-      name: 'clear',
-      description: 'Clear screen',
-      kind: CommandKind.BUILT_IN,
-      action: vi.fn(),
-    },
   ];
 
-  // A minimal mock is sufficient for these tests.
-  const mockCommandContext = {} as CommandContext;
+  beforeAll(async () => {
+    testCwd = await createTmpDir(fileSystemStructure);
+  });
 
+  afterAll(async () => {
+    await cleanupTmpDir(testCwd);
+  });
+
+  it('should provide basic completion for a nested file', async () => {
+    const { result } = renderHook(() =>
+      useCompletion(
+        '@src/App',
+        testCwd,
+        true,
+        mockSlashCommands,
+        mockCommandContext,
+      ),
+    );
+
+    await waitFor(() => {
+      const labels = result.current.suggestions.map((s) => s.label);
+      expect(labels).toEqual(['src/App.tsx']);
+    });
+  });
+
+  it('should respect .gitignore and not suggest ignored files', async () => {
+    const { result } = renderHook(() =>
+      useCompletion(
+        '@data/logs/t',
+        testCwd,
+        true,
+        mockSlashCommands,
+        mockCommandContext,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoadingSuggestions).toBe(false);
+    });
+
+    const labels = result.current.suggestions.map((s) => s.label);
+    expect(labels).toEqual([]);
+  });
+
+  it('should respect .gitignore and not suggest ignored directories', async () => {
+    const { result } = renderHook(() =>
+      useCompletion(
+        '@di',
+        testCwd,
+        true,
+        mockSlashCommands,
+        mockCommandContext,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoadingSuggestions).toBe(false);
+    });
+
+    const labels = result.current.suggestions.map((s) => s.label);
+    expect(labels).toEqual([]);
+  });
+
+  it('should respect .geminiignore and not suggest ignored directories', async () => {
+    const { result } = renderHook(() =>
+      useCompletion(
+        '@sec',
+        testCwd,
+        true,
+        mockSlashCommands,
+        mockCommandContext,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoadingSuggestions).toBe(false);
+    });
+
+    const labels = result.current.suggestions.map((s) => s.label);
+    expect(labels).toEqual([]);
+  });
+
+  it('should provide suggestions for the root directory', async () => {
+    const { result } = renderHook(() =>
+      useCompletion('@', testCwd, true, mockSlashCommands, mockCommandContext),
+    );
+
+    await waitFor(() => {
+      expect(result.current.suggestions.length).toBeGreaterThan(0);
+    });
+
+    const labels = result.current.suggestions.map((s) => s.label);
+    // Directories come first, then files, sorted alphabetically.
+    expect(labels).toEqual([
+      'data/',
+      'data/logs/',
+      'src/',
+      'src/components/',
+      '.geminiignore',
+      '.gitignore',
+      'README.md',
+      'src/App.tsx',
+    ]);
+  });
+
+  it('should show no suggestions for a nonexistent file', async () => {
+    const { result } = renderHook(() =>
+      useCompletion(
+        '@nonexistent',
+        testCwd,
+        true,
+        mockSlashCommands,
+        mockCommandContext,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoadingSuggestions).toBe(false);
+    });
+
+    expect(result.current.suggestions).toEqual([]);
+  });
+});
+
+describe('useCompletion slash commands', () => {
   const mockSlashCommands: SlashCommand[] = [
     {
       name: 'help',
@@ -134,430 +255,6 @@ describe('useCompletion git-aware filtering integration', () => {
     },
   ];
 
-  beforeEach(() => {
-    mockFileDiscoveryService = {
-      shouldGitIgnoreFile: vi.fn(),
-      shouldGeminiIgnoreFile: vi.fn(),
-      shouldIgnoreFile: vi.fn(),
-      filterFiles: vi.fn(),
-      getGeminiIgnorePatterns: vi.fn(),
-      projectRoot: '',
-      gitIgnoreFilter: null,
-      geminiIgnoreFilter: null,
-      isFileIgnored: vi.fn(),
-    } as unknown as Mocked<FileDiscoveryService>;
-
-    mockConfig = {
-      getFileFilteringOptions: vi.fn(() => ({
-        respectGitIgnore: true,
-        respectGeminiIgnore: true,
-      })),
-      getEnableRecursiveFileSearch: vi.fn(() => true),
-      getFileService: vi.fn(() => mockFileDiscoveryService),
-    };
-
-    vi.mocked(FileDiscoveryService).mockImplementation(
-      () => mockFileDiscoveryService,
-    );
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('should filter git-ignored entries from @ completions', async () => {
-    const globResults = [`${testCwd}/data`, `${testCwd}/dist`];
-    vi.mocked(glob).mockResolvedValue(globResults);
-
-    // Mock git ignore service to ignore certain files
-    mockFileDiscoveryService.shouldGitIgnoreFile.mockImplementation(
-      (path: string) => path.includes('dist'),
-    );
-    mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
-      (path: string, options) => {
-        if (options?.respectGitIgnore !== false) {
-          return mockFileDiscoveryService.shouldGitIgnoreFile(path);
-        }
-        return false;
-      },
-    );
-
-    const { result } = renderHook(() =>
-      useCompletion(
-        '@d',
-        testCwd,
-        true,
-        slashCommands,
-        mockCommandContext,
-        mockConfig as Config,
-      ),
-    );
-
-    // Wait for async operations to complete
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150)); // Account for debounce
-    });
-
-    expect(result.current.suggestions).toHaveLength(1);
-    expect(result.current.suggestions).toEqual(
-      expect.arrayContaining([{ label: 'data', value: 'data' }]),
-    );
-    expect(result.current.showSuggestions).toBe(true);
-  });
-
-  it('should filter git-ignored directories from @ completions', async () => {
-    // Mock fs.readdir to return both regular and git-ignored directories
-    vi.mocked(fs.readdir).mockResolvedValue([
-      { name: 'src', isDirectory: () => true },
-      { name: 'node_modules', isDirectory: () => true },
-      { name: 'dist', isDirectory: () => true },
-      { name: 'README.md', isDirectory: () => false },
-      { name: '.env', isDirectory: () => false },
-    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
-
-    // Mock ignore service to ignore certain files
-    mockFileDiscoveryService.shouldGitIgnoreFile.mockImplementation(
-      (path: string) =>
-        path.includes('node_modules') ||
-        path.includes('dist') ||
-        path.includes('.env'),
-    );
-    mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
-      (path: string, options) => {
-        if (
-          options?.respectGitIgnore &&
-          mockFileDiscoveryService.shouldGitIgnoreFile(path)
-        ) {
-          return true;
-        }
-        if (
-          options?.respectGeminiIgnore &&
-          mockFileDiscoveryService.shouldGeminiIgnoreFile
-        ) {
-          return mockFileDiscoveryService.shouldGeminiIgnoreFile(path);
-        }
-        return false;
-      },
-    );
-
-    const { result } = renderHook(() =>
-      useCompletion(
-        '@',
-        testCwd,
-        true,
-        slashCommands,
-        mockCommandContext,
-        mockConfig as Config,
-      ),
-    );
-
-    // Wait for async operations to complete
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150)); // Account for debounce
-    });
-
-    expect(result.current.suggestions).toHaveLength(2);
-    expect(result.current.suggestions).toEqual(
-      expect.arrayContaining([
-        { label: 'src/', value: 'src/' },
-        { label: 'README.md', value: 'README.md' },
-      ]),
-    );
-    expect(result.current.showSuggestions).toBe(true);
-  });
-
-  it('should handle recursive search with git-aware filtering', async () => {
-    // Mock the recursive file search scenario
-    vi.mocked(fs.readdir).mockImplementation(
-      async (
-        dirPath: string | Buffer | URL,
-        options?: { withFileTypes?: boolean },
-      ) => {
-        const path = dirPath.toString();
-        if (options?.withFileTypes) {
-          if (path === testCwd) {
-            return [
-              { name: 'data', isDirectory: () => true },
-              { name: 'dist', isDirectory: () => true },
-              { name: 'node_modules', isDirectory: () => true },
-              { name: 'README.md', isDirectory: () => false },
-              { name: '.env', isDirectory: () => false },
-            ] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
-          }
-          if (path.endsWith('/src')) {
-            return [
-              { name: 'index.ts', isDirectory: () => false },
-              { name: 'components', isDirectory: () => true },
-            ] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
-          }
-          if (path.endsWith('/temp')) {
-            return [
-              { name: 'temp.log', isDirectory: () => false },
-            ] as unknown as Awaited<ReturnType<typeof fs.readdir>>;
-          }
-        }
-        return [];
-      },
-    );
-
-    // Mock ignore service
-    mockFileDiscoveryService.shouldGitIgnoreFile.mockImplementation(
-      (path: string) => path.includes('node_modules') || path.includes('temp'),
-    );
-    mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
-      (path: string, options) => {
-        if (
-          options?.respectGitIgnore &&
-          mockFileDiscoveryService.shouldGitIgnoreFile(path)
-        ) {
-          return true;
-        }
-        if (
-          options?.respectGeminiIgnore &&
-          mockFileDiscoveryService.shouldGeminiIgnoreFile
-        ) {
-          return mockFileDiscoveryService.shouldGeminiIgnoreFile(path);
-        }
-        return false;
-      },
-    );
-
-    const { result } = renderHook(() =>
-      useCompletion(
-        '@t',
-        testCwd,
-        true,
-        slashCommands,
-        mockCommandContext,
-        mockConfig as Config,
-      ),
-    );
-
-    // Wait for async operations to complete
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150));
-    });
-
-    // Should not include anything from node_modules or dist
-    const suggestionLabels = result.current.suggestions.map((s) => s.label);
-    expect(suggestionLabels).not.toContain('temp/');
-    expect(suggestionLabels.some((l) => l.includes('node_modules'))).toBe(
-      false,
-    );
-  });
-
-  it('should not perform recursive search when disabled in config', async () => {
-    const globResults = [`${testCwd}/data`, `${testCwd}/dist`];
-    vi.mocked(glob).mockResolvedValue(globResults);
-
-    // Disable recursive search in the mock config
-    const mockConfigNoRecursive = {
-      ...mockConfig,
-      getEnableRecursiveFileSearch: vi.fn(() => false),
-    } as unknown as Config;
-
-    vi.mocked(fs.readdir).mockResolvedValue([
-      { name: 'data', isDirectory: () => true },
-      { name: 'dist', isDirectory: () => true },
-    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
-
-    renderHook(() =>
-      useCompletion(
-        '@d',
-        testCwd,
-        true,
-        slashCommands,
-        mockCommandContext,
-        mockConfigNoRecursive,
-      ),
-    );
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150));
-    });
-
-    // `glob` should not be called because recursive search is disabled
-    expect(glob).not.toHaveBeenCalled();
-    // `fs.readdir` should be called for the top-level directory instead
-    expect(fs.readdir).toHaveBeenCalledWith(testCwd, { withFileTypes: true });
-  });
-
-  it('should work without config (fallback behavior)', async () => {
-    vi.mocked(fs.readdir).mockResolvedValue([
-      { name: 'src', isDirectory: () => true },
-      { name: 'node_modules', isDirectory: () => true },
-      { name: 'README.md', isDirectory: () => false },
-    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
-
-    const { result } = renderHook(() =>
-      useCompletion(
-        '@',
-        testCwd,
-        true,
-        slashCommands,
-        mockCommandContext,
-        undefined,
-      ),
-    );
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150));
-    });
-
-    // Without config, should include all files
-    expect(result.current.suggestions).toHaveLength(3);
-    expect(result.current.suggestions).toEqual(
-      expect.arrayContaining([
-        { label: 'src/', value: 'src/' },
-        { label: 'node_modules/', value: 'node_modules/' },
-        { label: 'README.md', value: 'README.md' },
-      ]),
-    );
-  });
-
-  it('should handle git discovery service initialization failure gracefully', async () => {
-    vi.mocked(fs.readdir).mockResolvedValue([
-      { name: 'src', isDirectory: () => true },
-      { name: 'README.md', isDirectory: () => false },
-    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
-
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const { result } = renderHook(() =>
-      useCompletion(
-        '@',
-        testCwd,
-        true,
-        slashCommands,
-        mockCommandContext,
-        mockConfig as Config,
-      ),
-    );
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150));
-    });
-
-    // Since we use centralized service, initialization errors are handled at config level
-    // This test should verify graceful fallback behavior
-    expect(result.current.suggestions.length).toBeGreaterThanOrEqual(0);
-    // Should still show completions even if git discovery fails
-    expect(result.current.suggestions.length).toBeGreaterThan(0);
-
-    consoleSpy.mockRestore();
-  });
-
-  it('should handle directory-specific completions with git filtering', async () => {
-    vi.mocked(fs.readdir).mockResolvedValue([
-      { name: 'component.tsx', isDirectory: () => false },
-      { name: 'temp.log', isDirectory: () => false },
-      { name: 'index.ts', isDirectory: () => false },
-    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
-
-    mockFileDiscoveryService.shouldGitIgnoreFile.mockImplementation(
-      (path: string) => path.includes('.log'),
-    );
-    mockFileDiscoveryService.shouldIgnoreFile.mockImplementation(
-      (path: string, options) => {
-        if (options?.respectGitIgnore) {
-          return mockFileDiscoveryService.shouldGitIgnoreFile(path);
-        }
-        if (options?.respectGeminiIgnore) {
-          return mockFileDiscoveryService.shouldGeminiIgnoreFile(path);
-        }
-        return false;
-      },
-    );
-
-    const { result } = renderHook(() =>
-      useCompletion(
-        '@src/comp',
-        testCwd,
-        true,
-        slashCommands,
-        mockCommandContext,
-        mockConfig as Config,
-      ),
-    );
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150));
-    });
-
-    // Should filter out .log files but include matching .tsx files
-    expect(result.current.suggestions).toEqual([
-      { label: 'component.tsx', value: 'component.tsx' },
-    ]);
-  });
-
-  it('should use glob for top-level @ completions when available', async () => {
-    const globResults = [`${testCwd}/src/index.ts`, `${testCwd}/README.md`];
-    vi.mocked(glob).mockResolvedValue(globResults);
-
-    const { result } = renderHook(() =>
-      useCompletion(
-        '@s',
-        testCwd,
-        true,
-        slashCommands,
-        mockCommandContext,
-        mockConfig as Config,
-      ),
-    );
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150));
-    });
-
-    expect(glob).toHaveBeenCalledWith('**/s*', {
-      cwd: testCwd,
-      dot: false,
-      nocase: true,
-    });
-    expect(fs.readdir).not.toHaveBeenCalled(); // Ensure glob is used instead of readdir
-    expect(result.current.suggestions).toEqual([
-      { label: 'README.md', value: 'README.md' },
-      { label: 'src/index.ts', value: 'src/index.ts' },
-    ]);
-  });
-
-  it('should include dotfiles in glob search when input starts with a dot', async () => {
-    const globResults = [
-      `${testCwd}/.env`,
-      `${testCwd}/.gitignore`,
-      `${testCwd}/src/index.ts`,
-    ];
-    vi.mocked(glob).mockResolvedValue(globResults);
-
-    const { result } = renderHook(() =>
-      useCompletion(
-        '@.',
-        testCwd,
-        true,
-        slashCommands,
-        mockCommandContext,
-        mockConfig as Config,
-      ),
-    );
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150));
-    });
-
-    expect(glob).toHaveBeenCalledWith('**/.*', {
-      cwd: testCwd,
-      dot: true,
-      nocase: true,
-    });
-    expect(fs.readdir).not.toHaveBeenCalled();
-    expect(result.current.suggestions).toEqual([
-      { label: '.env', value: '.env' },
-      { label: '.gitignore', value: '.gitignore' },
-      { label: 'src/index.ts', value: 'src/index.ts' },
-    ]);
-  });
-
   it('should suggest top-level command names based on partial input', async () => {
     const { result } = renderHook(() =>
       useCompletion(
@@ -569,10 +266,12 @@ describe('useCompletion git-aware filtering integration', () => {
       ),
     );
 
-    expect(result.current.suggestions).toEqual([
-      { label: 'memory', value: 'memory', description: 'Manage memory' },
-    ]);
-    expect(result.current.showSuggestions).toBe(true);
+    await waitFor(() => {
+      expect(result.current.suggestions).toEqual([
+        { label: 'memory', value: 'memory', description: 'Manage memory' },
+      ]);
+      expect(result.current.showSuggestions).toBe(true);
+    });
   });
 
   it.each([['/?'], ['/usage']])(
@@ -588,7 +287,9 @@ describe('useCompletion git-aware filtering integration', () => {
         ),
       );
 
-      expect(result.current.suggestions).toHaveLength(0);
+      await waitFor(() => {
+        expect(result.current.suggestions).toHaveLength(0);
+      });
     },
   );
 
@@ -603,13 +304,15 @@ describe('useCompletion git-aware filtering integration', () => {
       ),
     );
 
-    expect(result.current.suggestions).toEqual([
-      {
-        label: 'stats',
-        value: 'stats',
-        description: 'check session stats. Usage: /stats [model|tools]',
-      },
-    ]);
+    await waitFor(() => {
+      expect(result.current.suggestions).toEqual([
+        {
+          label: 'stats',
+          value: 'stats',
+          description: 'check session stats. Usage: /stats [model|tools]',
+        },
+      ]);
+    });
   });
 
   it('should suggest sub-command names for a parent command', async () => {
@@ -623,9 +326,11 @@ describe('useCompletion git-aware filtering integration', () => {
       ),
     );
 
-    expect(result.current.suggestions).toEqual([
-      { label: 'add', value: 'add', description: 'Add to memory' },
-    ]);
+    await waitFor(() => {
+      expect(result.current.suggestions).toEqual([
+        { label: 'add', value: 'add', description: 'Add to memory' },
+      ]);
+    });
   });
 
   it('should suggest all sub-commands when the query ends with the parent command and a space', async () => {
@@ -639,13 +344,15 @@ describe('useCompletion git-aware filtering integration', () => {
       ),
     );
 
-    expect(result.current.suggestions).toHaveLength(2);
-    expect(result.current.suggestions).toEqual(
-      expect.arrayContaining([
-        { label: 'show', value: 'show', description: 'Show memory' },
-        { label: 'add', value: 'add', description: 'Add to memory' },
-      ]),
-    );
+    await waitFor(() => {
+      expect(result.current.suggestions).toHaveLength(2);
+      expect(result.current.suggestions).toEqual(
+        expect.arrayContaining([
+          { label: 'show', value: 'show', description: 'Show memory' },
+          { label: 'add', value: 'add', description: 'Add to memory' },
+        ]),
+      );
+    });
   });
 
   it('should call the command.completion function for argument suggestions', async () => {
@@ -688,16 +395,17 @@ describe('useCompletion git-aware filtering integration', () => {
       ),
     );
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150));
+    await waitFor(() => {
+      expect(mockCompletionFn).toHaveBeenCalledWith(
+        mockCommandContext,
+        'my-ch',
+      );
+
+      expect(result.current.suggestions).toEqual([
+        { label: 'my-chat-tag-1', value: 'my-chat-tag-1' },
+        { label: 'my-chat-tag-2', value: 'my-chat-tag-2' },
+      ]);
     });
-
-    expect(mockCompletionFn).toHaveBeenCalledWith(mockCommandContext, 'my-ch');
-
-    expect(result.current.suggestions).toEqual([
-      { label: 'my-chat-tag-1', value: 'my-chat-tag-1' },
-      { label: 'my-chat-tag-2', value: 'my-chat-tag-2' },
-    ]);
   });
 
   it('should not provide suggestions for a fully typed command that has no sub-commands or argument completion', async () => {
@@ -711,8 +419,10 @@ describe('useCompletion git-aware filtering integration', () => {
       ),
     );
 
-    expect(result.current.suggestions).toHaveLength(0);
-    expect(result.current.showSuggestions).toBe(false);
+    await waitFor(() => {
+      expect(result.current.suggestions).toHaveLength(0);
+      expect(result.current.showSuggestions).toBe(false);
+    });
   });
 
   it('should not provide suggestions for an unknown command', async () => {
@@ -726,8 +436,10 @@ describe('useCompletion git-aware filtering integration', () => {
       ),
     );
 
-    expect(result.current.suggestions).toHaveLength(0);
-    expect(result.current.showSuggestions).toBe(false);
+    await waitFor(() => {
+      expect(result.current.suggestions).toHaveLength(0);
+      expect(result.current.showSuggestions).toBe(false);
+    });
   });
 
   it('should suggest sub-commands for a fully typed parent command without a trailing space', async () => {
@@ -741,15 +453,17 @@ describe('useCompletion git-aware filtering integration', () => {
       ),
     );
 
-    // Assert that suggestions for sub-commands are shown immediately
-    expect(result.current.suggestions).toHaveLength(2);
-    expect(result.current.suggestions).toEqual(
-      expect.arrayContaining([
-        { label: 'show', value: 'show', description: 'Show memory' },
-        { label: 'add', value: 'add', description: 'Add to memory' },
-      ]),
-    );
-    expect(result.current.showSuggestions).toBe(true);
+    await waitFor(() => {
+      // Assert that suggestions for sub-commands are shown immediately
+      expect(result.current.suggestions).toHaveLength(2);
+      expect(result.current.suggestions).toEqual(
+        expect.arrayContaining([
+          { label: 'show', value: 'show', description: 'Show memory' },
+          { label: 'add', value: 'add', description: 'Add to memory' },
+        ]),
+      );
+      expect(result.current.showSuggestions).toBe(true);
+    });
   });
 
   it('should NOT provide suggestions for a perfectly typed command that is a leaf node', async () => {
@@ -763,8 +477,10 @@ describe('useCompletion git-aware filtering integration', () => {
       ),
     );
 
-    expect(result.current.suggestions).toHaveLength(0);
-    expect(result.current.showSuggestions).toBe(false);
+    await waitFor(() => {
+      expect(result.current.suggestions).toHaveLength(0);
+      expect(result.current.showSuggestions).toBe(false);
+    });
   });
 
   it('should call command.completion with an empty string when args start with a space', async () => {
@@ -797,13 +513,11 @@ describe('useCompletion git-aware filtering integration', () => {
       ),
     );
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150));
+    await waitFor(() => {
+      expect(mockCompletionFn).toHaveBeenCalledWith(mockCommandContext, '');
+      expect(result.current.suggestions).toHaveLength(3);
+      expect(result.current.showSuggestions).toBe(true);
     });
-
-    expect(mockCompletionFn).toHaveBeenCalledWith(mockCommandContext, '');
-    expect(result.current.suggestions).toHaveLength(3);
-    expect(result.current.showSuggestions).toBe(true);
   });
 
   it('should suggest all top-level commands for the root slash', async () => {
@@ -817,10 +531,12 @@ describe('useCompletion git-aware filtering integration', () => {
       ),
     );
 
-    expect(result.current.suggestions.length).toBe(mockSlashCommands.length);
-    expect(result.current.suggestions.map((s) => s.label)).toEqual(
-      expect.arrayContaining(['help', 'clear', 'memory', 'chat', 'stats']),
-    );
+    await waitFor(() => {
+      expect(result.current.suggestions.length).toBe(mockSlashCommands.length);
+      expect(result.current.suggestions.map((s) => s.label)).toEqual(
+        expect.arrayContaining(['help', 'clear', 'memory', 'chat', 'stats']),
+      );
+    });
   });
 
   it('should provide no suggestions for an invalid sub-command', async () => {
@@ -834,7 +550,9 @@ describe('useCompletion git-aware filtering integration', () => {
       ),
     );
 
-    expect(result.current.suggestions).toHaveLength(0);
-    expect(result.current.showSuggestions).toBe(false);
+    await waitFor(() => {
+      expect(result.current.suggestions).toHaveLength(0);
+      expect(result.current.showSuggestions).toBe(false);
+    });
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,8 +31,10 @@
     "@types/glob": "^8.1.0",
     "@types/html-to-text": "^9.0.4",
     "ajv": "^8.17.1",
+    "chardet": "^2.1.0",
     "diff": "^7.0.0",
     "dotenv": "^17.1.0",
+    "fdir": "^6.4.6",
     "glob": "^10.4.5",
     "google-auth-library": "^9.11.0",
     "html-to-text": "^9.0.5",
@@ -40,18 +42,20 @@
     "ignore": "^7.0.0",
     "micromatch": "^4.0.8",
     "open": "^10.1.2",
+    "picomatch": "^4.0.1",
     "shell-quote": "^1.8.3",
     "simple-git": "^3.28.0",
     "strip-ansi": "^7.1.0",
     "undici": "^7.10.0",
-    "ws": "^8.18.0",
-    "chardet": "^2.1.0"
+    "ws": "^8.18.0"
   },
   "devDependencies": {
+    "@google/gemini-cli-test-utils": "file:../test-utils",
     "@types/diff": "^7.0.2",
     "@types/dotenv": "^6.1.1",
     "@types/micromatch": "^4.0.8",
     "@types/minimatch": "^5.1.2",
+    "@types/picomatch": "^4.0.1",
     "@types/ws": "^8.5.10",
     "typescript": "^5.3.3",
     "vitest": "^3.1.1"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,7 @@ export * from './utils/quotaErrorDetection.js';
 export * from './utils/fileUtils.js';
 export * from './utils/retry.js';
 export * from './utils/systemEncoding.js';
+export * from './utils/filesearch/fileSearch.js';
 
 // Export services
 export * from './services/fileDiscoveryService.js';

--- a/packages/core/src/utils/filesearch/crawlCache.test.ts
+++ b/packages/core/src/utils/filesearch/crawlCache.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { getCacheKey, read, write, clear } from './crawlCache.js';
+
+describe('CrawlCache', () => {
+  describe('getCacheKey', () => {
+    it('should generate a consistent hash', () => {
+      const key1 = getCacheKey('/foo', 'bar');
+      const key2 = getCacheKey('/foo', 'bar');
+      expect(key1).toBe(key2);
+    });
+
+    it('should generate a different hash for different directories', () => {
+      const key1 = getCacheKey('/foo', 'bar');
+      const key2 = getCacheKey('/bar', 'bar');
+      expect(key1).not.toBe(key2);
+    });
+
+    it('should generate a different hash for different ignore content', () => {
+      const key1 = getCacheKey('/foo', 'bar');
+      const key2 = getCacheKey('/foo', 'baz');
+      expect(key1).not.toBe(key2);
+    });
+  });
+
+  describe('in-memory cache operations', () => {
+    beforeEach(() => {
+      // Ensure a clean slate before each test
+      clear();
+    });
+
+    afterEach(() => {
+      // Restore real timers after each test that uses fake ones
+      vi.useRealTimers();
+    });
+
+    it('should write and read data from the cache', () => {
+      const key = 'test-key';
+      const data = ['foo', 'bar'];
+      write(key, data, 10000); // 10 second TTL
+      const cachedData = read(key);
+      expect(cachedData).toEqual(data);
+    });
+
+    it('should return undefined for a nonexistent key', () => {
+      const cachedData = read('nonexistent-key');
+      expect(cachedData).toBeUndefined();
+    });
+
+    it('should clear the cache', () => {
+      const key = 'test-key';
+      const data = ['foo', 'bar'];
+      write(key, data, 10000);
+      clear();
+      const cachedData = read(key);
+      expect(cachedData).toBeUndefined();
+    });
+
+    it('should automatically evict a cache entry after its TTL expires', async () => {
+      vi.useFakeTimers();
+      const key = 'ttl-key';
+      const data = ['foo'];
+      const ttl = 5000; // 5 seconds
+
+      write(key, data, ttl);
+
+      // Should exist immediately after writing
+      expect(read(key)).toEqual(data);
+
+      // Advance time just before expiration
+      await vi.advanceTimersByTimeAsync(ttl - 1);
+      expect(read(key)).toEqual(data);
+
+      // Advance time past expiration
+      await vi.advanceTimersByTimeAsync(1);
+      expect(read(key)).toBeUndefined();
+    });
+
+    it('should reset the timer when an entry is updated', async () => {
+      vi.useFakeTimers();
+      const key = 'update-key';
+      const initialData = ['initial'];
+      const updatedData = ['updated'];
+      const ttl = 5000; // 5 seconds
+
+      // Write initial data
+      write(key, initialData, ttl);
+
+      // Advance time, but not enough to expire
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(read(key)).toEqual(initialData);
+
+      // Update the data, which should reset the timer
+      write(key, updatedData, ttl);
+      expect(read(key)).toEqual(updatedData);
+
+      // Advance time again. If the timer wasn't reset, the total elapsed
+      // time (3000 + 3000 = 6000) would cause an eviction.
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(read(key)).toEqual(updatedData);
+
+      // Advance past the new expiration time
+      await vi.advanceTimersByTimeAsync(2001);
+      expect(read(key)).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/utils/filesearch/crawlCache.ts
+++ b/packages/core/src/utils/filesearch/crawlCache.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import crypto from 'node:crypto';
+
+const crawlCache = new Map<string, string[]>();
+const cacheTimers = new Map<string, NodeJS.Timeout>();
+
+/**
+ * Generates a unique cache key based on the project directory and the content
+ * of ignore files. This ensures that the cache is invalidated if the project
+ * or ignore rules change.
+ */
+export const getCacheKey = (
+  directory: string,
+  ignoreContent: string,
+): string => {
+  const hash = crypto.createHash('sha256');
+  hash.update(directory);
+  hash.update(ignoreContent);
+  return hash.digest('hex');
+};
+
+/**
+ * Reads cached data from the in-memory cache.
+ * Returns undefined if the key is not found.
+ */
+export const read = (key: string): string[] | undefined => crawlCache.get(key);
+
+/**
+ * Writes data to the in-memory cache and sets a timer to evict it after the TTL.
+ */
+export const write = (key: string, results: string[], ttlMs: number): void => {
+  // Clear any existing timer for this key to prevent premature deletion
+  if (cacheTimers.has(key)) {
+    clearTimeout(cacheTimers.get(key)!);
+  }
+
+  // Store the new data
+  crawlCache.set(key, results);
+
+  // Set a timer to automatically delete the cache entry after the TTL
+  const timerId = setTimeout(() => {
+    crawlCache.delete(key);
+    cacheTimers.delete(key);
+  }, ttlMs);
+
+  // Store the timer handle so we can clear it if the entry is updated
+  cacheTimers.set(key, timerId);
+};
+
+/**
+ * Clears the entire cache and all active timers.
+ * Primarily used for testing.
+ */
+export const clear = (): void => {
+  for (const timerId of cacheTimers.values()) {
+    clearTimeout(timerId);
+  }
+  crawlCache.clear();
+  cacheTimers.clear();
+};

--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -1,0 +1,605 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as cache from './crawlCache.js';
+import { FileSearch, AbortError, filter } from './fileSearch.js';
+import { createTmpDir, cleanupTmpDir } from '@google/gemini-cli-test-utils';
+
+type FileSearchWithPrivateMethods = FileSearch & {
+  performCrawl: () => Promise<void>;
+};
+
+describe('FileSearch', () => {
+  let tmpDir: string;
+  afterEach(async () => {
+    if (tmpDir) {
+      await cleanupTmpDir(tmpDir);
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('should use .geminiignore rules', async () => {
+    tmpDir = await createTmpDir({
+      '.geminiignore': 'dist/',
+      dist: ['ignored.js'],
+      src: ['not-ignored.js'],
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: false,
+      useGeminiignore: true,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('');
+
+    expect(results).toEqual(['src/', '.geminiignore', 'src/not-ignored.js']);
+  });
+
+  it('should combine .gitignore and .geminiignore rules', async () => {
+    tmpDir = await createTmpDir({
+      '.gitignore': 'dist/',
+      '.geminiignore': 'build/',
+      dist: ['ignored-by-git.js'],
+      build: ['ignored-by-gemini.js'],
+      src: ['not-ignored.js'],
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: true,
+      useGeminiignore: true,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('');
+
+    expect(results).toEqual([
+      'src/',
+      '.geminiignore',
+      '.gitignore',
+      'src/not-ignored.js',
+    ]);
+  });
+
+  it('should use ignoreDirs option', async () => {
+    tmpDir = await createTmpDir({
+      logs: ['some.log'],
+      src: ['main.js'],
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: false,
+      useGeminiignore: false,
+      ignoreDirs: ['logs'],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('');
+
+    expect(results).toEqual(['src/', 'src/main.js']);
+  });
+
+  it('should handle negated directories', async () => {
+    tmpDir = await createTmpDir({
+      '.gitignore': ['build/**', '!build/public', '!build/public/**'].join(
+        '\n',
+      ),
+      build: {
+        'private.js': '',
+        public: ['index.html'],
+      },
+      src: ['main.js'],
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: true,
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('');
+
+    expect(results).toEqual([
+      'build/',
+      'build/public/',
+      'src/',
+      '.gitignore',
+      'build/public/index.html',
+      'src/main.js',
+    ]);
+  });
+
+  it('should filter results with a search pattern', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'main.js': '',
+        'util.ts': '',
+        'style.css': '',
+      },
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: false,
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('**/*.js');
+
+    expect(results).toEqual(['src/main.js']);
+  });
+
+  it('should handle root-level file negation', async () => {
+    tmpDir = await createTmpDir({
+      '.gitignore': ['*.mk', '!Foo.mk'].join('\n'),
+      'bar.mk': '',
+      'Foo.mk': '',
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: true,
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('');
+
+    expect(results).toEqual(['.gitignore', 'Foo.mk']);
+  });
+
+  it('should handle directory negation with glob', async () => {
+    tmpDir = await createTmpDir({
+      '.gitignore': [
+        'third_party/**',
+        '!third_party/foo',
+        '!third_party/foo/bar',
+        '!third_party/foo/bar/baz_buffer',
+      ].join('\n'),
+      third_party: {
+        foo: {
+          bar: {
+            baz_buffer: '',
+          },
+        },
+        ignore_this: '',
+      },
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: true,
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('');
+
+    expect(results).toEqual([
+      'third_party/',
+      'third_party/foo/',
+      'third_party/foo/bar/',
+      '.gitignore',
+      'third_party/foo/bar/baz_buffer',
+    ]);
+  });
+
+  it('should correctly handle negated patterns in .gitignore', async () => {
+    tmpDir = await createTmpDir({
+      '.gitignore': ['dist/**', '!dist/keep.js'].join('\n'),
+      dist: ['ignore.js', 'keep.js'],
+      src: ['main.js'],
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: true,
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('');
+
+    expect(results).toEqual([
+      'dist/',
+      'src/',
+      '.gitignore',
+      'dist/keep.js',
+      'src/main.js',
+    ]);
+  });
+
+  // New test cases start here
+
+  it('should initialize correctly when ignore files are missing', async () => {
+    tmpDir = await createTmpDir({
+      src: ['file1.js'],
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: true,
+      useGeminiignore: true,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    // Expect no errors to be thrown during initialization
+    await expect(fileSearch.initialize()).resolves.toBeUndefined();
+    const results = await fileSearch.search('');
+    expect(results).toEqual(['src/', 'src/file1.js']);
+  });
+
+  it('should respect maxResults option in search', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'file1.js': '',
+        'file2.js': '',
+        'file3.js': '',
+        'file4.js': '',
+      },
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: false,
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('**/*.js', { maxResults: 2 });
+
+    expect(results).toEqual(['src/file1.js', 'src/file2.js']); // Assuming alphabetical sort
+  });
+
+  it('should return empty array when no matches are found', async () => {
+    tmpDir = await createTmpDir({
+      src: ['file1.js'],
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: false,
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('nonexistent-file.xyz');
+
+    expect(results).toEqual([]);
+  });
+
+  it('should throw AbortError when filter is aborted', async () => {
+    const controller = new AbortController();
+    const dummyPaths = Array.from({ length: 5000 }, (_, i) => `file${i}.js`); // Large array to ensure yielding
+
+    const filterPromise = filter(dummyPaths, '*.js', controller.signal);
+
+    // Abort after a short delay to ensure filter has started
+    setTimeout(() => controller.abort(), 1);
+
+    await expect(filterPromise).rejects.toThrow(AbortError);
+  });
+
+  describe('with in-memory cache', () => {
+    beforeEach(() => {
+      cache.clear();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should throw an error if search is called before initialization', async () => {
+      tmpDir = await createTmpDir({});
+      const fileSearch = new FileSearch({
+        projectRoot: tmpDir,
+        useGitignore: false,
+        useGeminiignore: false,
+        ignoreDirs: [],
+        cache: false,
+        cacheTtl: 0,
+      });
+
+      await expect(fileSearch.search('')).rejects.toThrow(
+        'Engine not initialized. Call initialize() first.',
+      );
+    });
+
+    it('should hit the cache for subsequent searches', async () => {
+      tmpDir = await createTmpDir({ 'file1.js': '' });
+      const getOptions = () => ({
+        projectRoot: tmpDir,
+        useGitignore: false,
+        useGeminiignore: false,
+        ignoreDirs: [],
+        cache: true,
+        cacheTtl: 10,
+      });
+
+      const fs1 = new FileSearch(getOptions());
+      const crawlSpy1 = vi.spyOn(
+        fs1 as FileSearchWithPrivateMethods,
+        'performCrawl',
+      );
+      await fs1.initialize();
+      expect(crawlSpy1).toHaveBeenCalledTimes(1);
+
+      // Second search should hit the cache because the options are identical
+      const fs2 = new FileSearch(getOptions());
+      const crawlSpy2 = vi.spyOn(
+        fs2 as FileSearchWithPrivateMethods,
+        'performCrawl',
+      );
+      await fs2.initialize();
+      expect(crawlSpy2).not.toHaveBeenCalled();
+    });
+
+    it('should miss the cache when ignore rules change', async () => {
+      tmpDir = await createTmpDir({
+        '.gitignore': 'a.txt',
+        'a.txt': '',
+        'b.txt': '',
+      });
+      const options = {
+        projectRoot: tmpDir,
+        useGitignore: true,
+        useGeminiignore: false,
+        ignoreDirs: [],
+        cache: true,
+        cacheTtl: 10000,
+      };
+
+      // Initial search to populate the cache
+      const fs1 = new FileSearch(options);
+      const crawlSpy1 = vi.spyOn(
+        fs1 as FileSearchWithPrivateMethods,
+        'performCrawl',
+      );
+      await fs1.initialize();
+      const results1 = await fs1.search('');
+      expect(crawlSpy1).toHaveBeenCalledTimes(1);
+      expect(results1).toEqual(['.gitignore', 'b.txt']);
+
+      // Modify the ignore file
+      await fs.writeFile(path.join(tmpDir, '.gitignore'), 'b.txt');
+
+      // Second search should miss the cache and trigger a recrawl
+      const fs2 = new FileSearch(options);
+      const crawlSpy2 = vi.spyOn(
+        fs2 as FileSearchWithPrivateMethods,
+        'performCrawl',
+      );
+      await fs2.initialize();
+      const results2 = await fs2.search('');
+      expect(crawlSpy2).toHaveBeenCalledTimes(1);
+      expect(results2).toEqual(['.gitignore', 'a.txt']);
+    });
+
+    it('should miss the cache after TTL expires', async () => {
+      vi.useFakeTimers();
+      tmpDir = await createTmpDir({ 'file1.js': '' });
+      const options = {
+        projectRoot: tmpDir,
+        useGitignore: false,
+        useGeminiignore: false,
+        ignoreDirs: [],
+        cache: true,
+        cacheTtl: 10, // 10 seconds
+      };
+
+      // Initial search to populate the cache
+      const fs1 = new FileSearch(options);
+      await fs1.initialize();
+
+      // Advance time past the TTL
+      await vi.advanceTimersByTimeAsync(11000);
+
+      // Second search should miss the cache and trigger a recrawl
+      const fs2 = new FileSearch(options);
+      const crawlSpy = vi.spyOn(
+        fs2 as FileSearchWithPrivateMethods,
+        'performCrawl',
+      );
+      await fs2.initialize();
+
+      expect(crawlSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should handle empty or commented-only ignore files', async () => {
+    tmpDir = await createTmpDir({
+      '.gitignore': '# This is a comment\n\n   \n',
+      src: ['main.js'],
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: true,
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('');
+
+    expect(results).toEqual(['src/', '.gitignore', 'src/main.js']);
+  });
+
+  it('should always ignore the .git directory', async () => {
+    tmpDir = await createTmpDir({
+      '.git': ['config', 'HEAD'],
+      src: ['main.js'],
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: false, // Explicitly disable .gitignore to isolate this rule
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+    const results = await fileSearch.search('');
+
+    expect(results).toEqual(['src/', 'src/main.js']);
+  });
+
+  it('should be cancellable via AbortSignal', async () => {
+    const largeDir: Record<string, string> = {};
+    for (let i = 0; i < 5000; i++) {
+      largeDir[`file${i}.js`] = '';
+    }
+    tmpDir = await createTmpDir(largeDir);
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: false,
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+
+    const controller = new AbortController();
+    const searchPromise = fileSearch.search('**/*.js', {
+      signal: controller.signal,
+    });
+
+    // Yield to allow the search to start before aborting.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    controller.abort();
+
+    await expect(searchPromise).rejects.toThrow(AbortError);
+  });
+
+  it('should leverage ResultCache for bestBaseQuery optimization', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'foo.js': '',
+        'bar.ts': '',
+        nested: {
+          'baz.js': '',
+        },
+      },
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: false,
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: true, // Enable caching for this test
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+
+    // Perform a broad search to prime the cache
+    const broadResults = await fileSearch.search('src/**');
+    expect(broadResults).toEqual([
+      'src/',
+      'src/nested/',
+      'src/bar.ts',
+      'src/foo.js',
+      'src/nested/baz.js',
+    ]);
+
+    // Perform a more specific search that should leverage the broad search's cached results
+    const specificResults = await fileSearch.search('src/**/*.js');
+    expect(specificResults).toEqual(['src/foo.js', 'src/nested/baz.js']);
+
+    // Although we can't directly inspect ResultCache.hits/misses from here,
+    // the correctness of specificResults after a broad search implicitly
+    // verifies that the caching mechanism, including bestBaseQuery, is working.
+  });
+
+  it('should be case-insensitive by default', async () => {
+    tmpDir = await createTmpDir({
+      'File1.Js': '',
+      'file2.js': '',
+      'FILE3.JS': '',
+      'other.txt': '',
+    });
+
+    const fileSearch = new FileSearch({
+      projectRoot: tmpDir,
+      useGitignore: false,
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+    });
+
+    await fileSearch.initialize();
+
+    // Search with a lowercase pattern
+    let results = await fileSearch.search('file*.js');
+    expect(results).toHaveLength(3);
+    expect(results).toEqual(
+      expect.arrayContaining(['File1.Js', 'file2.js', 'FILE3.JS']),
+    );
+
+    // Search with an uppercase pattern
+    results = await fileSearch.search('FILE*.JS');
+    expect(results).toHaveLength(3);
+    expect(results).toEqual(
+      expect.arrayContaining(['File1.Js', 'file2.js', 'FILE3.JS']),
+    );
+
+    // Search with a mixed-case pattern
+    results = await fileSearch.search('FiLe*.Js');
+    expect(results).toHaveLength(3);
+    expect(results).toEqual(
+      expect.arrayContaining(['File1.Js', 'file2.js', 'FILE3.JS']),
+    );
+  });
+});

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -1,0 +1,265 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+import { fdir } from 'fdir';
+import picomatch from 'picomatch';
+import { Ignore } from './ignore.js';
+import { ResultCache } from './result-cache.js';
+import * as cache from './crawlCache.js';
+
+export type FileSearchOptions = {
+  projectRoot: string;
+  ignoreDirs: string[];
+  useGitignore: boolean;
+  useGeminiignore: boolean;
+  cache: boolean;
+  cacheTtl: number;
+};
+
+export class AbortError extends Error {
+  constructor(message = 'Search aborted') {
+    super(message);
+    this.name = 'AbortError';
+  }
+}
+
+/**
+ * Filters a list of paths based on a given pattern.
+ * @param allPaths The list of all paths to filter.
+ * @param pattern The picomatch pattern to filter by.
+ * @param signal An AbortSignal to cancel the operation.
+ * @returns A promise that resolves to the filtered and sorted list of paths.
+ */
+export async function filter(
+  allPaths: string[],
+  pattern: string,
+  signal: AbortSignal | undefined,
+): Promise<string[]> {
+  const patternFilter = picomatch(pattern, {
+    dot: true,
+    contains: true,
+    nocase: true,
+  });
+
+  const results: string[] = [];
+  for (const [i, p] of allPaths.entries()) {
+    // Yield control to the event loop periodically to prevent blocking.
+    if (i % 1000 === 0) {
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+      if (signal?.aborted) {
+        throw new AbortError();
+      }
+    }
+
+    if (patternFilter(p)) {
+      results.push(p);
+    }
+  }
+
+  results.sort((a, b) => {
+    const aIsDir = a.endsWith('/');
+    const bIsDir = b.endsWith('/');
+
+    if (aIsDir && !bIsDir) return -1;
+    if (!aIsDir && bIsDir) return 1;
+    return a.localeCompare(b);
+  });
+
+  return results;
+}
+
+export type SearchOptions = {
+  signal?: AbortSignal;
+  maxResults?: number;
+};
+
+/**
+ * Provides a fast and efficient way to search for files within a project,
+ * respecting .gitignore and .geminiignore rules, and utilizing caching
+ * for improved performance.
+ */
+export class FileSearch {
+  private readonly absoluteDir: string;
+  private readonly ignore: Ignore = new Ignore();
+  private resultCache: ResultCache | undefined;
+  private allFiles: string[] = [];
+
+  /**
+   * Constructs a new `FileSearch` instance.
+   * @param options Configuration options for the file search.
+   */
+  constructor(private readonly options: FileSearchOptions) {
+    this.absoluteDir = path.resolve(options.projectRoot);
+    options.ignoreDirs = ['.git', ...options.ignoreDirs];
+  }
+
+  /**
+   * Initializes the file search engine by loading ignore rules, crawling the
+   * file system, and building the in-memory cache. This method must be called
+   * before performing any searches.
+   */
+  async initialize(): Promise<void> {
+    this.loadIgnoreRules();
+    await this.crawlFiles();
+    this.buildMemoryCache();
+  }
+
+  /**
+   * Searches for files matching a given pattern.
+   * @param pattern The picomatch pattern to search for (e.g., '*.js', 'src/**').
+   * @param options Search options, including an AbortSignal and maxResults.
+   * @returns A promise that resolves to a list of matching file paths, relative
+   *          to the project root.
+   */
+  async search(
+    pattern: string,
+    options: SearchOptions = {},
+  ): Promise<string[]> {
+    if (!this.resultCache) {
+      throw new Error('Engine not initialized. Call initialize() first.');
+    }
+
+    pattern = pattern || '*';
+
+    const { files: candidates, isExactMatch } =
+      await this.resultCache!.get(pattern);
+
+    if (isExactMatch) {
+      return candidates;
+    }
+
+    // Apply the user's picomatch pattern filter
+    const filteredCandidates = await filter(
+      candidates,
+      pattern,
+      options.signal,
+    );
+
+    this.resultCache!.set(pattern, filteredCandidates);
+
+    // Trade-off: We apply a two-stage filtering process.
+    // 1. During the file system crawl (`performCrawl`), we only apply directory-level
+    //    ignore rules (e.g., `node_modules/`, `dist/`). This is because applying
+    //    a full ignore filter (which includes file-specific patterns like `*.log`)
+    //    during the crawl can significantly slow down `fdir`.
+    // 2. Here, in the `search` method, we apply the full ignore filter
+    //    (including file patterns) to the `filteredCandidates` (which have already
+    //    been filtered by the user's search pattern and sorted). For autocomplete,
+    //    the number of displayed results is small (MAX_SUGGESTIONS_TO_SHOW),
+    //    so applying the full filter to this truncated list is much more efficient
+    //    than applying it to every file during the initial crawl.
+    const fileFilter = this.ignore.getFileFilter();
+    const results: string[] = [];
+    for (const candidate of filteredCandidates) {
+      if (results.length >= (options.maxResults ?? Infinity)) {
+        break;
+      }
+      // The `ignore` library throws an error if the path is '.', so we skip it.
+      if (candidate === '.') {
+        continue;
+      }
+      if (!fileFilter(candidate)) {
+        results.push(candidate);
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Loads ignore rules from .gitignore and .geminiignore files, and applies
+   * any additional ignore directories specified in the options.
+   */
+  private loadIgnoreRules(): void {
+    if (this.options.useGitignore) {
+      const gitignorePath = path.join(this.absoluteDir, '.gitignore');
+      if (fs.existsSync(gitignorePath)) {
+        this.ignore.add(fs.readFileSync(gitignorePath, 'utf8'));
+      }
+    }
+
+    if (this.options.useGeminiignore) {
+      const geminiignorePath = path.join(this.absoluteDir, '.geminiignore');
+      if (fs.existsSync(geminiignorePath)) {
+        this.ignore.add(fs.readFileSync(geminiignorePath, 'utf8'));
+      }
+    }
+
+    if (this.options.ignoreDirs.length > 0) {
+      this.ignore.add(
+        this.options.ignoreDirs.map((dir) => {
+          if (dir.endsWith('/')) {
+            return dir;
+          }
+          return `${dir}/`;
+        }),
+      );
+    }
+  }
+
+  /**
+   * Crawls the file system to get a list of all files and directories,
+   * optionally using a cache for faster initialization.
+   */
+  private async crawlFiles(): Promise<void> {
+    if (this.options.cache) {
+      const cacheKey = cache.getCacheKey(
+        this.absoluteDir,
+        this.ignore.getFingerprint(),
+      );
+      const cachedResults = cache.read(cacheKey);
+
+      if (cachedResults) {
+        this.allFiles = cachedResults;
+        return;
+      }
+    }
+
+    this.allFiles = await this.performCrawl();
+
+    if (this.options.cache) {
+      const cacheKey = cache.getCacheKey(
+        this.absoluteDir,
+        this.ignore.getFingerprint(),
+      );
+      cache.write(cacheKey, this.allFiles, this.options.cacheTtl * 1000);
+    }
+  }
+
+  /**
+   * Performs the actual file system crawl using `fdir`, applying directory
+   * ignore rules.
+   * @returns A promise that resolves to a list of all files and directories.
+   */
+  private async performCrawl(): Promise<string[]> {
+    const dirFilter = this.ignore.getDirectoryFilter();
+
+    // We use `fdir` for fast file system traversal. A key performance
+    // optimization for large workspaces is to exclude entire directories
+    // early in the traversal process. This is why we apply directory-specific
+    // ignore rules (e.g., `node_modules/`, `dist/`) directly to `fdir`'s
+    // exclude filter.
+    const api = new fdir()
+      .withRelativePaths()
+      .withDirs()
+      .exclude((_, dirPath) => {
+        const relativePath = path.relative(this.absoluteDir, dirPath);
+        return dirFilter(`${relativePath}/`);
+      });
+
+    return api.crawl(this.absoluteDir).withPromise();
+  }
+
+  /**
+   * Builds the in-memory cache for fast pattern matching.
+   */
+  private buildMemoryCache(): void {
+    this.resultCache = new ResultCache(this.allFiles, this.absoluteDir);
+  }
+}

--- a/packages/core/src/utils/filesearch/ignore.test.ts
+++ b/packages/core/src/utils/filesearch/ignore.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Ignore } from './ignore.js';
+
+describe('Ignore', () => {
+  describe('getDirectoryFilter', () => {
+    it('should ignore directories matching directory patterns', () => {
+      const ig = new Ignore().add(['foo/', 'bar/']);
+      const dirFilter = ig.getDirectoryFilter();
+      expect(dirFilter('foo/')).toBe(true);
+      expect(dirFilter('bar/')).toBe(true);
+      expect(dirFilter('baz/')).toBe(false);
+    });
+
+    it('should not ignore directories with file patterns', () => {
+      const ig = new Ignore().add(['foo.js', '*.log']);
+      const dirFilter = ig.getDirectoryFilter();
+      expect(dirFilter('foo.js')).toBe(false);
+      expect(dirFilter('foo.log')).toBe(false);
+    });
+  });
+
+  describe('getFileFilter', () => {
+    it('should not ignore files with directory patterns', () => {
+      const ig = new Ignore().add(['foo/', 'bar/']);
+      const fileFilter = ig.getFileFilter();
+      expect(fileFilter('foo')).toBe(false);
+      expect(fileFilter('foo/file.txt')).toBe(false);
+    });
+
+    it('should ignore files matching file patterns', () => {
+      const ig = new Ignore().add(['*.log', 'foo.js']);
+      const fileFilter = ig.getFileFilter();
+      expect(fileFilter('foo.log')).toBe(true);
+      expect(fileFilter('foo.js')).toBe(true);
+      expect(fileFilter('bar.txt')).toBe(false);
+    });
+  });
+
+  it('should accumulate patterns across multiple add() calls', () => {
+    const ig = new Ignore().add('foo.js');
+    ig.add('bar.js');
+    const fileFilter = ig.getFileFilter();
+    expect(fileFilter('foo.js')).toBe(true);
+    expect(fileFilter('bar.js')).toBe(true);
+    expect(fileFilter('baz.js')).toBe(false);
+  });
+
+  it('should return a stable and consistent fingerprint', () => {
+    const ig1 = new Ignore().add(['foo', '!bar']);
+    const ig2 = new Ignore().add('foo\n!bar');
+
+    // Fingerprints should be identical for the same rules.
+    expect(ig1.getFingerprint()).toBe(ig2.getFingerprint());
+
+    // Adding a new rule should change the fingerprint.
+    ig2.add('baz');
+    expect(ig1.getFingerprint()).not.toBe(ig2.getFingerprint());
+  });
+});

--- a/packages/core/src/utils/filesearch/ignore.ts
+++ b/packages/core/src/utils/filesearch/ignore.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import ignore from 'ignore';
+import picomatch from 'picomatch';
+
+const hasFileExtension = picomatch('**/*[*.]*');
+
+export class Ignore {
+  private readonly allPatterns: string[] = [];
+  private dirIgnorer = ignore();
+  private fileIgnorer = ignore();
+
+  /**
+   * Adds one or more ignore patterns.
+   * @param patterns A single pattern string or an array of pattern strings.
+   *                 Each pattern can be a glob-like string similar to .gitignore rules.
+   * @returns The `Ignore` instance for chaining.
+   */
+  add(patterns: string | string[]): this {
+    if (typeof patterns === 'string') {
+      patterns = patterns.split(/\r?\n/);
+    }
+
+    for (const p of patterns) {
+      const pattern = p.trim();
+
+      if (pattern === '' || pattern.startsWith('#')) {
+        continue;
+      }
+
+      this.allPatterns.push(pattern);
+
+      const isPositiveDirPattern =
+        pattern.endsWith('/') && !pattern.startsWith('!');
+
+      if (isPositiveDirPattern) {
+        this.dirIgnorer.add(pattern);
+      } else {
+        // An ambiguous pattern (e.g., "build") could match a file or a
+        // directory. To optimize the file system crawl, we use a heuristic:
+        // patterns without a dot in the last segment are included in the
+        // directory exclusion check.
+        //
+        // This heuristic can fail. For example, an ignore pattern of "my.assets"
+        // intended to exclude a directory will not be treated as a directory
+        // pattern because it contains a ".". This results in crawling a
+        // directory that should have been excluded, reducing efficiency.
+        // Correctness is still maintained. The incorrectly crawled directory
+        // will be filtered out by the final ignore check.
+        //
+        // For maximum crawl efficiency, users should explicitly mark directory
+        // patterns with a trailing slash (e.g., "my.assets/").
+        this.fileIgnorer.add(pattern);
+        if (!hasFileExtension(pattern)) {
+          this.dirIgnorer.add(pattern);
+        }
+      }
+    }
+
+    return this;
+  }
+
+  /**
+   * Returns a predicate that matches explicit directory ignore patterns (patterns ending with '/').
+   * @returns {(dirPath: string) => boolean}
+   */
+  getDirectoryFilter(): (dirPath: string) => boolean {
+    return (dirPath: string) => this.dirIgnorer.ignores(dirPath);
+  }
+
+  /**
+   * Returns a predicate that matches file ignore patterns (all patterns not ending with '/').
+   * Note: This may also match directories if a file pattern matches a directory name, but all explicit directory patterns are handled by getDirectoryFilter.
+   * @returns {(filePath: string) => boolean}
+   */
+  getFileFilter(): (filePath: string) => boolean {
+    return (filePath: string) => this.fileIgnorer.ignores(filePath);
+  }
+
+  /**
+   * Returns a string representing the current set of ignore patterns.
+   * This can be used to generate a unique identifier for the ignore configuration,
+   * useful for caching purposes.
+   * @returns A string fingerprint of the ignore patterns.
+   */
+  getFingerprint(): string {
+    return this.allPatterns.join('\n');
+  }
+}

--- a/packages/core/src/utils/filesearch/result-cache.test.ts
+++ b/packages/core/src/utils/filesearch/result-cache.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import path from 'node:path';
+import { test, expect } from 'vitest';
+import { ResultCache } from './result-cache.js';
+
+test('ResultCache basic usage', async () => {
+  const files = [
+    'foo.txt',
+    'bar.js',
+    'baz.md',
+    'subdir/file.txt',
+    'subdir/other.js',
+    'subdir/nested/file.md',
+  ];
+  const cache = new ResultCache(files, path.resolve('.'));
+  const { files: resultFiles, isExactMatch } = await cache.get('*.js');
+  expect(resultFiles).toEqual(files);
+  expect(isExactMatch).toBe(false);
+});
+
+test('ResultCache cache hit/miss', async () => {
+  const files = ['foo.txt', 'bar.js', 'baz.md'];
+  const cache = new ResultCache(files, path.resolve('.'));
+  // First call: miss
+  const { files: result1Files, isExactMatch: isExactMatch1 } =
+    await cache.get('*.js');
+  expect(result1Files).toEqual(files);
+  expect(isExactMatch1).toBe(false);
+
+  // Simulate FileSearch applying the filter and setting the result
+  cache.set('*.js', ['bar.js']);
+
+  // Second call: hit
+  const { files: result2Files, isExactMatch: isExactMatch2 } =
+    await cache.get('*.js');
+  expect(result2Files).toEqual(['bar.js']);
+  expect(isExactMatch2).toBe(true);
+});
+
+test('ResultCache best base query', async () => {
+  const files = ['foo.txt', 'foobar.js', 'baz.md'];
+  const cache = new ResultCache(files, path.resolve('.'));
+
+  // Cache a broader query
+  cache.set('foo', ['foo.txt', 'foobar.js']);
+
+  // Search for a more specific query that starts with the broader one
+  const { files: resultFiles, isExactMatch } = await cache.get('foobar');
+  expect(resultFiles).toEqual(['foo.txt', 'foobar.js']);
+  expect(isExactMatch).toBe(false);
+});

--- a/packages/core/src/utils/filesearch/result-cache.ts
+++ b/packages/core/src/utils/filesearch/result-cache.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Implements an in-memory cache for file search results.
+ * This cache optimizes subsequent searches by leveraging previously computed results.
+ */
+export class ResultCache {
+  private readonly cache: Map<string, string[]>;
+  private hits = 0;
+  private misses = 0;
+
+  constructor(
+    private readonly allFiles: string[],
+    private readonly absoluteDir: string,
+  ) {
+    this.cache = new Map();
+  }
+
+  /**
+   * Retrieves cached search results for a given query, or provides a base set
+   * of files to search from.
+   * @param query The search query pattern.
+   * @returns An object containing the files to search and a boolean indicating
+   *          if the result is an exact cache hit.
+   */
+  async get(
+    query: string,
+  ): Promise<{ files: string[]; isExactMatch: boolean }> {
+    const isCacheHit = this.cache.has(query);
+
+    if (isCacheHit) {
+      this.hits++;
+      return { files: this.cache.get(query)!, isExactMatch: true };
+    }
+
+    this.misses++;
+
+    // This is the core optimization of the memory cache.
+    // If a user first searches for "foo", and then for "foobar",
+    // we don't need to search through all files again. We can start
+    // from the results of the "foo" search.
+    // This finds the most specific, already-cached query that is a prefix
+    // of the current query.
+    let bestBaseQuery = '';
+    for (const key of this.cache?.keys?.() ?? []) {
+      if (query.startsWith(key) && key.length > bestBaseQuery.length) {
+        bestBaseQuery = key;
+      }
+    }
+
+    const filesToSearch = bestBaseQuery
+      ? this.cache.get(bestBaseQuery)!
+      : this.allFiles;
+
+    return { files: filesToSearch, isExactMatch: false };
+  }
+
+  /**
+   * Stores search results in the cache.
+   * @param query The search query pattern.
+   * @param results The matching file paths to cache.
+   */
+  set(query: string, results: string[]): void {
+    this.cache.set(query, results);
+  }
+}

--- a/packages/test-utils/index.ts
+++ b/packages/test-utils/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './src/file-system-test-helpers.js';

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@google/gemini-cli-test-utils",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "node ../../scripts/build_package.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/test-utils/src/file-system-test-helpers.ts
+++ b/packages/test-utils/src/file-system-test-helpers.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Defines the structure of a virtual file system to be created for testing.
+ * Keys are file or directory names, and values can be:
+ * - A string: The content of a file.
+ * - A `FileSystemStructure` object: Represents a subdirectory with its own structure.
+ * - An array of strings or `FileSystemStructure` objects: Represents a directory
+ *   where strings are empty files and objects are subdirectories.
+ *
+ * @example
+ * // Example 1: Simple files and directories
+ * const structure1 = {
+ *   'file1.txt': 'Hello, world!',
+ *   'empty-dir': [],
+ *   'src': {
+ *     'main.js': '// Main application file',
+ *     'utils.ts': '// Utility functions',
+ *   },
+ * };
+ *
+ * @example
+ * // Example 2: Nested directories and empty files within an array
+ * const structure2 = {
+ *   'config.json': '{ "port": 3000 }',
+ *   'data': [
+ *     'users.csv',
+ *     'products.json',
+ *     {
+ *       'logs': [
+ *         'error.log',
+ *         'access.log',
+ *       ],
+ *     },
+ *   ],
+ * };
+ */
+export type FileSystemStructure = {
+  [name: string]:
+    | string
+    | FileSystemStructure
+    | Array<string | FileSystemStructure>;
+};
+
+/**
+ * Recursively creates files and directories based on the provided `FileSystemStructure`.
+ * @param dir The base directory where the structure will be created.
+ * @param structure The `FileSystemStructure` defining the files and directories.
+ */
+async function create(dir: string, structure: FileSystemStructure) {
+  for (const [name, content] of Object.entries(structure)) {
+    const newPath = path.join(dir, name);
+    if (typeof content === 'string') {
+      await fs.writeFile(newPath, content);
+    } else if (Array.isArray(content)) {
+      await fs.mkdir(newPath, { recursive: true });
+      for (const item of content) {
+        if (typeof item === 'string') {
+          await fs.writeFile(path.join(newPath, item), '');
+        } else {
+          await create(newPath, item as FileSystemStructure);
+        }
+      }
+    } else if (typeof content === 'object' && content !== null) {
+      await fs.mkdir(newPath, { recursive: true });
+      await create(newPath, content as FileSystemStructure);
+    }
+  }
+}
+
+/**
+ * Creates a temporary directory and populates it with a given file system structure.
+ * @param structure The `FileSystemStructure` to create within the temporary directory.
+ * @returns A promise that resolves to the absolute path of the created temporary directory.
+ */
+export async function createTmpDir(
+  structure: FileSystemStructure,
+): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gemini-cli-test-'));
+  await create(tmpDir, structure);
+  return tmpDir;
+}
+
+/**
+ * Cleans up (deletes) a temporary directory and its contents.
+ * @param dir The absolute path to the temporary directory to clean up.
+ */
+export async function cleanupTmpDir(dir: string) {
+  await fs.rm(dir, { recursive: true, force: true });
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './file-system-test-helpers.js';

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "lib": ["DOM", "DOM.Iterable", "ES2021"],
+    "composite": true,
+    "types": ["node"]
+  },
+  "include": ["index.ts", "src/**/*.ts", "src/**/*.json"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## TLDR

This pull request introduces a new, high-performance `FileSearch` engine in `@google/gemini-cli-core` and integrates it into the CLI's file path autocompletion (`@` syntax). This significantly improves the speed and responsiveness of file searching, especially in large repositories. The processing of `@` commands in prompts has also been made more robust.

## Dive Deeper

The previous file completion logic was slow, relying on recursive `fs` calls or `glob` which did not scale well. This PR replaces it with a purpose-built `FileSearch` engine with the following characteristics:

-   **High-Performance Crawling**: Uses `fdir` to rapidly crawl the project directory. For performance, the initial crawl only respects directory-level ignores (e.g., `node_modules/`, `.git/`), which is where the biggest performance gains are.
-   **Powerful Matching**: Uses `picomatch` for `.gitignore`-style pattern matching and an incremental in-memory cache to make subsequent searches extremely fast.
-   **Caching**: Implements a two-tier cache:
    1.  **On-disk cache**: Persists the file list between CLI runs to speed up initial startup.
    2.  **In-memory cache**: Provides near-instantaneous results for searches within the same session by filtering down from previous, broader search results.

This new engine provides a much better user experience for file-based context fetching and lays the groundwork for potentially replacing the `glob` tool's backend in the future.

## Future work

FileSearch can be used to replace existing usages of glob, such as `GlobTool`.

## Reviewer Test Plan

To test these changes, pull this branch and run the CLI. The primary area to test is the `@` file path autocompletion and submission.

1.  **Test Autocompletion Performance**:
    -   `cd` into a very large repository (e.g., a checkout of `chromium`).
    -   Run Gemini CLI.
    -   Type `@` and start typing a file name. The suggestions should appear quickly. No need to do any manual globbing. You can just start typing any file or directory name from any level of the file structure.
    -   Try searching for a few different files to test the in-memory cache.

2.  **Test Ignore Directory Logic**:
    -   In a standard repo, type `@node_modules/` and verify that no files from `node_modules` are suggested.

3.  **Test Submission Logic**:
    -   Submit a prompt with multiple files: `What are the differences between @packages/core/index.ts and @packages/cli/index.ts?`
    -   Submit a prompt with an ignored file and text: `Why is @package-lock.json so big?` The command should proceed, but you should see a debug message indicating the file was skipped.

## Testing Matrix

|          | Linux | macOS | Windows |
| -------- | :---: | :---: | :---: |
| npm run  |  ✅   |  ❓   |  ❓   |
| npx      |  ✅   |  ❓   |  ❓   |
| Docker   |  ❓   |  ❓   |  ❓   |
| Podman   |  ❓   |   -   |   -   |
| Seatbelt |  ❓   |   -   |   -   |

## Linked issues / bugs

<!-- Link to any related issues or bugs here. -->
