### PR TITLE
Minor refactoring of VS Code companion extension code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,8 +34,12 @@
       "name": "Launch Companion VS Code Extension",
       "type": "extensionHost",
       "request": "launch",
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-ide-companion"],
-      "outFiles": ["${workspaceFolder}/packages/vscode-ide-companion/dist/**/*.js"],
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-ide-companion"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/packages/vscode-ide-companion/dist/**/*.js"
+      ],
       "preLaunchTask": "npm: build: vscode-ide-companion"
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,14 @@
       }
     },
     {
+      "name": "Launch Companion VS Code Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-ide-companion"],
+      "outFiles": ["${workspaceFolder}/packages/vscode-ide-companion/dist/**/*.js"],
+      "preLaunchTask": "npm: build: vscode-ide-companion"
+    },
+    {
       "name": "Attach",
       "port": 9229,
       "request": "attach",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,6 +11,15 @@
       "problemMatcher": [],
       "label": "npm: build",
       "detail": "scripts/build.sh"
+    },
+    {
+      "type": "npm",
+      "script": "build",
+      "path": "packages/vscode-ide-companion",
+      "group": "build",
+      "problemMatcher": [],
+      "label": "npm: build: vscode-ide-companion",
+      "detail": "npm run build -w packages/vscode-ide-companion"
     }
   ]
 }

--- a/packages/vscode-ide-companion/README.md
+++ b/packages/vscode-ide-companion/README.md
@@ -13,7 +13,7 @@ The Gemini CLI Companion extension seamlessly integrates [Gemini CLI](https://gi
 To use this extension, you'll need:
 
 - VS Code version 1.101.0 or newer
-- Gemini CLI (installed separately) and running within the VS Code integrated terminal
+- Gemini CLI (installed separately) running within the VS Code integrated terminal
 
 # Terms of Service and Privacy Notice
 

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -28,10 +28,16 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate(): Promise<void> {
   log('Extension deactivated');
-  if (ideServer) {
-    await ideServer.stop();
-  }
-  if (logger) {
-    logger.dispose();
+  try {
+    if (ideServer) {
+      await ideServer.stop();
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log(`Failed to stop IDE server during deactivation: ${message}`);
+  } finally {
+    if (logger) {
+      logger.dispose();
+    }
   }
 }

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -6,27 +6,30 @@
 
 import * as vscode from 'vscode';
 import { IDEServer } from './ide-server';
+import { createLogger } from './utils/logger';
 
 let ideServer: IDEServer;
 let logger: vscode.OutputChannel;
+let log: (message: string) => void;
 
 export async function activate(context: vscode.ExtensionContext) {
   logger = vscode.window.createOutputChannel('Gemini CLI IDE Companion');
-  ideServer = new IDEServer(logger);
+  log = createLogger(context, logger);
+
+  log('Extension activated');
+  ideServer = new IDEServer(log);
   try {
     await ideServer.start(context);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    log(`Failed to start IDE server: ${message}`);
   }
 }
 
-export function deactivate() {
+export async function deactivate(): Promise<void> {
+  log('Extension deactivated');
   if (ideServer) {
-    return ideServer.stop().finally(() => {
-      if (logger) {
-        logger.dispose();
-      }
-    });
+    await ideServer.stop();
   }
   if (logger) {
     logger.dispose();

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -23,13 +23,21 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
+  if (!logger) {
+    return;
+  }
+
   if (ideServer) {
     logger.appendLine('Deactivating Gemini CLI IDE Companion...');
     return ideServer.stop().finally(() => {
+      logger.appendLine('Gemini CLI IDE Companion extension deactivated.');
       logger.dispose();
     });
   }
-  if (logger) {
-    logger.dispose();
-  }
+
+  logger.appendLine(
+    'Deactivating Gemini CLI IDE Companion (no server was started).',
+  );
+  logger.appendLine('Gemini CLI IDE Companion extension deactivated.');
+  logger.dispose();
 }

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -12,32 +12,23 @@ let logger: vscode.OutputChannel;
 
 export async function activate(context: vscode.ExtensionContext) {
   logger = vscode.window.createOutputChannel('Gemini CLI IDE Companion');
-  logger.appendLine('Starting Gemini CLI IDE Companion server...');
   ideServer = new IDEServer(logger);
   try {
     await ideServer.start(context);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    logger.appendLine(`Failed to start IDE server: ${message}`);
   }
 }
 
 export function deactivate() {
-  if (!logger) {
-    return;
-  }
-
   if (ideServer) {
-    logger.appendLine('Deactivating Gemini CLI IDE Companion...');
     return ideServer.stop().finally(() => {
-      logger.appendLine('Gemini CLI IDE Companion extension deactivated.');
-      logger.dispose();
+      if (logger) {
+        logger.dispose();
+      }
     });
   }
-
-  logger.appendLine(
-    'Deactivating Gemini CLI IDE Companion (no server was started).',
-  );
-  logger.appendLine('Gemini CLI IDE Companion extension deactivated.');
-  logger.dispose();
+  if (logger) {
+    logger.dispose();
+  }
 }

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -10,7 +10,7 @@ import { createLogger } from './utils/logger';
 
 let ideServer: IDEServer;
 let logger: vscode.OutputChannel;
-let log: (message: string) => void;
+let log: (message: string) => void = () => {};
 
 export async function activate(context: vscode.ExtensionContext) {
   logger = vscode.window.createOutputChannel('Gemini CLI IDE Companion');

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -25,7 +25,10 @@ function sendOpenFilesChangedNotification(
   recentFilesManager: RecentFilesManager,
 ) {
   const editor = vscode.window.activeTextEditor;
-  const filePath = editor ? editor.document.uri.fsPath : '';
+  const filePath =
+    editor && editor.document.uri.scheme === 'file'
+      ? editor.document.uri.fsPath
+      : '';
   const notification: JSONRPCNotification = {
     jsonrpc: '2.0',
     method: 'ide/openFilesChanged',

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -49,16 +49,10 @@ function sendOpenFilesChangedNotification(
 export class IDEServer {
   private server: HTTPServer | undefined;
   private context: vscode.ExtensionContext | undefined;
-  private logger: vscode.OutputChannel;
+  private log: (message: string) => void;
 
-  constructor(logger: vscode.OutputChannel) {
-    this.logger = logger;
-  }
-
-  private log(message: string) {
-    if (this.context?.extensionMode === vscode.ExtensionMode.Development) {
-      this.logger.appendLine(message);
-    }
+  constructor(log: (message: string) => void) {
+    this.log = log;
   }
 
   async start(context: vscode.ExtensionContext) {
@@ -104,14 +98,12 @@ export class IDEServer {
           try {
             transport.send({ jsonrpc: '2.0', method: 'ping' });
           } catch (e) {
-            // If sending a ping fails, the connection is likely broken.
-            // Log the error and clear the interval to prevent further attempts.
             this.log(
               'Failed to send keep-alive ping, cleaning up interval.' + e,
             );
             clearInterval(keepAlive);
           }
-        }, 60000); // Send ping every 60 seconds
+        }, 60000); // 60 sec
 
         transport.onclose = () => {
           clearInterval(keepAlive);

--- a/packages/vscode-ide-companion/src/recent-files-manager.ts
+++ b/packages/vscode-ide-companion/src/recent-files-manager.ts
@@ -16,14 +16,14 @@ interface RecentFile {
 
 /**
  * Keeps track of the 10 most recently-opened files
- * opened less than 5 ago. If a file is closed or deleted,
- * it will be removed. If the length is maxxed out,
- * the now-removed file will not be replaced by an older file.
+ * opened less than 5 min ago. If a file is closed or deleted,
+ * it will be removed. If the max length is reached, older files will get removed first.
  */
 export class RecentFilesManager {
   private readonly files: RecentFile[] = [];
   private readonly onDidChangeEmitter = new vscode.EventEmitter<void>();
   readonly onDidChange = this.onDidChangeEmitter.event;
+  private debounceTimer: NodeJS.Timeout | undefined;
 
   constructor(private readonly context: vscode.ExtensionContext) {
     const editorWatcher = vscode.window.onDidChangeActiveTextEditor(
@@ -33,7 +33,7 @@ export class RecentFilesManager {
         }
       },
     );
-    const fileWatcher = vscode.workspace.onDidDeleteFiles((event) => {
+    const deleteWatcher = vscode.workspace.onDidDeleteFiles((event) => {
       for (const uri of event.files) {
         this.remove(uri);
       }
@@ -49,10 +49,19 @@ export class RecentFilesManager {
     });
     context.subscriptions.push(
       editorWatcher,
-      fileWatcher,
+      deleteWatcher,
       closeWatcher,
       renameWatcher,
     );
+  }
+
+  private fireWithDebounce() {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.onDidChangeEmitter.fire();
+    }, 50); // 50ms debounce
   }
 
   private remove(uri: vscode.Uri, fireEvent = true) {
@@ -62,12 +71,16 @@ export class RecentFilesManager {
     if (index !== -1) {
       this.files.splice(index, 1);
       if (fireEvent) {
-        this.onDidChangeEmitter.fire();
+        this.fireWithDebounce();
       }
     }
   }
 
   add(uri: vscode.Uri) {
+    if (uri.scheme !== 'file') {
+      return;
+    }
+
     // Remove if it already exists to avoid duplicates and move it to the top.
     this.remove(uri, false);
 
@@ -76,7 +89,7 @@ export class RecentFilesManager {
     if (this.files.length > MAX_FILES) {
       this.files.pop();
     }
-    this.onDidChangeEmitter.fire();
+    this.fireWithDebounce();
   }
 
   get recentFiles(): Array<{ filePath: string; timestamp: number }> {

--- a/packages/vscode-ide-companion/src/recent-files-manager.ts
+++ b/packages/vscode-ide-companion/src/recent-files-manager.ts
@@ -61,7 +61,7 @@ export class RecentFilesManager {
     }
     this.debounceTimer = setTimeout(() => {
       this.onDidChangeEmitter.fire();
-    }, 50); // 50ms debounce
+    }, 50); // 50ms
   }
 
   private remove(uri: vscode.Uri, fireEvent = true) {
@@ -81,9 +81,7 @@ export class RecentFilesManager {
       return;
     }
 
-    // Remove if it already exists to avoid duplicates and move it to the top.
     this.remove(uri, false);
-
     this.files.unshift({ uri, timestamp: Date.now() });
 
     if (this.files.length > MAX_FILES) {

--- a/packages/vscode-ide-companion/src/utils/logger.ts
+++ b/packages/vscode-ide-companion/src/utils/logger.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode';
+
+export function createLogger(
+  context: vscode.ExtensionContext,
+  logger: vscode.OutputChannel,
+) {
+  return (message: string) => {
+    if (context.extensionMode === vscode.ExtensionMode.Development) {
+      logger.appendLine(message);
+    }
+  };
+}


### PR DESCRIPTION
## TLDR
Minor refactoring of VS Code companion extension code

## Dive Deeper
- Logs are now only outputted when running the extension locally for development and debugging
- Prevents the currently active file from appearing in the "recent active files" list
- Eliminates unnecessary notifications for non-file editor windows (ex. debug output views)
- Introduces a notification delay to prevent spam. Instead of sending two rapid notifications (for file removal and addition) when a new file replaces an old one, we now send a single, consolidated notification.

## Linked issues / bugs
#4242 