### PR TITLE
Add memory compression telemetry

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -19,6 +19,7 @@ import {
   FlashFallbackEvent,
   LoopDetectedEvent,
   FlashDecidedToContinueEvent,
+  MemoryCompressionEvent,
 } from '../types.js';
 import { EventMetadataKey } from './event-metadata-key.js';
 import { Config } from '../../config/config.js';
@@ -39,6 +40,7 @@ const end_session_event_name = 'end_session';
 const flash_fallback_event_name = 'flash_fallback';
 const loop_detected_event_name = 'loop_detected';
 const flash_decided_to_continue_event_name = 'flash_decided_to_continue';
+const memory_compression_event_name = 'memory_compression';
 
 export interface LogResponse {
   nextRequestWaitMs?: number;
@@ -508,6 +510,34 @@ export class ClearcutLogger {
 
     this.enqueueLogEvent(
       this.createLogEvent(flash_decided_to_continue_event_name, data),
+    );
+    this.flushIfNeeded();
+  }
+
+  logMemoryCompressionEvent(event: MemoryCompressionEvent): void {
+    const data = [
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
+        value: this.config?.getSessionId() ?? '',
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_PROMPT_ID,
+        value: JSON.stringify(event.prompt_id),
+      },
+      {
+        gemini_cli_key:
+          EventMetadataKey.GEMINI_CLI_MEMORY_COMPRESSION_ORIGINAL_SIZE,
+        value: JSON.stringify(event.original_token_count),
+      },
+      {
+        gemini_cli_key:
+          EventMetadataKey.GEMINI_CLI_MEMORY_COMPRESSION_COMPRESSED_SIZE,
+        value: JSON.stringify(event.compressed_token_count),
+      },
+    ];
+
+    this.enqueueLogEvent(
+      this.createLogEvent(memory_compression_event_name, data),
     );
     this.flushIfNeeded();
   }

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -163,6 +163,10 @@ export enum EventMetadataKey {
 
   // Logs the type of loop detected.
   GEMINI_CLI_LOOP_DETECTED_TYPE = 38,
+
+  // Logs a memory compression event
+  GEMINI_CLI_MEMORY_COMPRESSION_ORIGINAL_SIZE = 48,
+  GEMINI_CLI_MEMORY_COMPRESSION_COMPRESSED_SIZE = 49,
 }
 
 export function getEventMetadataKey(

--- a/packages/core/src/telemetry/constants.ts
+++ b/packages/core/src/telemetry/constants.ts
@@ -23,3 +23,9 @@ export const METRIC_API_REQUEST_LATENCY = 'gemini_cli.api.request.latency';
 export const METRIC_TOKEN_USAGE = 'gemini_cli.token.usage';
 export const METRIC_SESSION_COUNT = 'gemini_cli.session.count';
 export const METRIC_FILE_OPERATION_COUNT = 'gemini_cli.file.operation.count';
+
+export const EVENT_MEMORY_COMPRESSION = 'gemini_cli.memory_compression';
+export const METRIC_MEMORY_COMPRESSION_COUNT =
+  'gemini_cli.memory.compression.count';
+export const METRIC_MEMORY_COMPRESSION_SIZE =
+  'gemini_cli.memory.compression.size';

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -276,6 +276,26 @@ export class FlashDecidedToContinueEvent {
   }
 }
 
+export class MemoryCompressionEvent {
+  'event.name': 'memory_compression';
+  'event.timestamp': string; // ISO 8601
+  prompt_id: string;
+  original_token_count: number;
+  compressed_token_count: number;
+
+  constructor(
+    prompt_id: string,
+    original_token_count: number,
+    compressed_token_count: number,
+  ) {
+    this['event.name'] = 'memory_compression';
+    this['event.timestamp'] = new Date().toISOString();
+    this.prompt_id = prompt_id;
+    this.original_token_count = original_token_count;
+    this.compressed_token_count = compressed_token_count;
+  }
+}
+
 export type TelemetryEvent =
   | StartSessionEvent
   | EndSessionEvent
@@ -286,4 +306,5 @@ export type TelemetryEvent =
   | ApiResponseEvent
   | FlashFallbackEvent
   | LoopDetectedEvent
-  | FlashDecidedToContinueEvent;
+  | FlashDecidedToContinueEvent
+  | MemoryCompressionEvent;


### PR DESCRIPTION
## TLDR

- Add MemoryCompressionEvent type and metadata keys
- Implement logging via Clearcut and OpenTelemetry
- Add compression count and size metrics collection

## Dive Deeper

Questions from the issue:
- How often do we compress memory? We've added a counter (METRIC_MEMORY_COMPRESSION_COUNT) that increments every time a compression event occurs. This will give us a clear picture of how frequently users are engaging in long conversations that require compression.
- What are the thresholds that users require memory compression? The MemoryCompressionEvent captures the original_token_count at the time of compression. This will help us understand the distribution of conversation lengths and identify the optimal thresholds for triggering compression.
- Is the memory compression of sufficiently high quality? We are tracking both the original_token_count and the compressed_token_count. The ratio of these two values will give us a preliminary idea of the compression quality. While a high compression ratio might seem good, it could also indicate that we are losing important details. This metric, combined with user feedback and other signals, will help us evaluate the quality of our compression strategy.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix


|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅ |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
https://github.com/google-gemini/gemini-cli/issues/4658

- Closes #4658 

