### PR TITLE
feat: add GEMINI_CLI environment variable to spawned shell commands

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -282,3 +282,5 @@ The `!` prefix lets you interact with your system's shell directly from within G
       - When exited, the UI reverts to its standard appearance and normal Gemini CLI behavior resumes.
 
 - **Caution for all `!` usage:** Commands you execute in shell mode have the same permissions and impact as if you ran them directly in your terminal.
+
+- **Environment Variable:** When a command is executed via `!` or in shell mode, the `GEMINI_CLI=1` environment variable is set in the subprocess's environment. This allows scripts or tools to detect if they are being run from within the Gemini CLI.

--- a/docs/tools/shell.md
+++ b/docs/tools/shell.md
@@ -60,6 +60,10 @@ run_shell_command(command="npm run dev &", description="Start development server
 - **Error handling:** Check the `Stderr`, `Error`, and `Exit Code` fields to determine if a command executed successfully.
 - **Background processes:** When a command is run in the background with `&`, the tool will return immediately and the process will continue to run in the background. The `Background PIDs` field will contain the process ID of the background process.
 
+## Environment Variables
+
+When `run_shell_command` executes a command, it sets the `GEMINI_CLI=1` environment variable in the subprocess's environment. This allows scripts or tools to detect if they are being run from within the Gemini CLI.
+
 ## Command Restrictions
 
 You can restrict the commands that can be executed by the `run_shell_command` tool by using the `coreTools` and `excludeTools` settings in your configuration file.

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
@@ -7,7 +7,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { vi } from 'vitest';
 import { spawn } from 'child_process';
-import type { ChildProcess } from 'child_process';
+import type { ChildProcessWithoutNullStreams } from 'child_process';
 import { useShellCommandProcessor } from './shellCommandProcessor';
 import { Config, GeminiClient } from '@google/gemini-cli-core';
 import * as fs from 'fs';
@@ -45,7 +45,9 @@ describe('useShellCommandProcessor', () => {
     spawnEmitter = new EventEmitter();
     spawnEmitter.stdout = new EventEmitter();
     spawnEmitter.stderr = new EventEmitter();
-    vi.mocked(spawn).mockReturnValue(spawnEmitter as any);
+    vi.mocked(spawn).mockReturnValue(
+      spawnEmitter as ChildProcessWithoutNullStreams,
+    );
 
     vi.spyOn(fs, 'existsSync').mockReturnValue(false);
     vi.spyOn(fs, 'readFileSync').mockReturnValue('');

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
@@ -81,12 +81,23 @@ describe('useShellCommandProcessor', () => {
     );
 
   it('should execute a command and update history on success', async () => {
+    const { spawn } = await import('child_process');
     const { result } = renderProcessorHook();
     const abortController = new AbortController();
 
     act(() => {
       result.current.handleShellCommand('ls -l', abortController.signal);
     });
+
+    expect(spawn).toHaveBeenCalledWith(
+      'bash',
+      ['-c', expect.any(String)],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          GEMINI_CLI: '1',
+        }),
+      }),
+    );
 
     expect(onExecMock).toHaveBeenCalledTimes(1);
     const execPromise = onExecMock.mock.calls[0][0];

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
@@ -6,6 +6,8 @@
 
 import { act, renderHook } from '@testing-library/react';
 import { vi } from 'vitest';
+import { spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
 import { useShellCommandProcessor } from './shellCommandProcessor';
 import { Config, GeminiClient } from '@google/gemini-cli-core';
 import * as fs from 'fs';
@@ -39,12 +41,11 @@ describe('useShellCommandProcessor', () => {
   let configMock: Config;
   let geminiClientMock: GeminiClient;
 
-  beforeEach(async () => {
-    const { spawn } = await import('child_process');
+  beforeEach(() => {
     spawnEmitter = new EventEmitter();
     spawnEmitter.stdout = new EventEmitter();
     spawnEmitter.stderr = new EventEmitter();
-    (spawn as vi.Mock).mockReturnValue(spawnEmitter);
+    vi.mocked(spawn).mockReturnValue(spawnEmitter as any);
 
     vi.spyOn(fs, 'existsSync').mockReturnValue(false);
     vi.spyOn(fs, 'readFileSync').mockReturnValue('');
@@ -81,7 +82,6 @@ describe('useShellCommandProcessor', () => {
     );
 
   it('should execute a command and update history on success', async () => {
-    const { spawn } = await import('child_process');
     const { result } = renderProcessorHook();
     const abortController = new AbortController();
 

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -74,8 +74,8 @@ function executeShellCommand(
       detached: !isWindows, // Use process groups on non-Windows for robust killing
       env: {
         ...process.env,
-        GEMINI_CLI: '1'
-      }
+        GEMINI_CLI: '1',
+      },
     });
 
     // Use decoders to handle multi-byte characters safely (for streaming output).

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -72,6 +72,10 @@ function executeShellCommand(
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: !isWindows, // Use process groups on non-Windows for robust killing
+      env: {
+        ...process.env,
+        GEMINI_CLI: '1'
+      }
     });
 
     // Use decoders to handle multi-byte characters safely (for streaming output).

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -514,4 +514,24 @@ describe('ShellTool Bug Reproduction', () => {
       undefined,
     );
   });
+
+  it('should pass GEMINI_CLI environment variable to executed commands', async () => {
+    config = {
+      getCoreTools: () => undefined,
+      getExcludeTools: () => undefined,
+      getDebugMode: () => false,
+      getGeminiClient: () => ({}) as GeminiClient,
+      getTargetDir: () => '.',
+      getSummarizeToolOutputConfig: () => ({}),
+    } as unknown as Config;
+    shellTool = new ShellTool(config);
+
+    const abortSignal = new AbortController().signal;
+    const result = await shellTool.execute(
+      { command: 'echo "$GEMINI_CLI"' },
+      abortSignal,
+    );
+
+    expect(result.returnDisplay).toBe('1\n');
+  });
 });

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -324,8 +324,8 @@ Process Group PGID: Process group started or \`(none)\``,
           cwd: path.resolve(this.config.getTargetDir(), params.directory || ''),
           env: {
             ...process.env,
-            GEMINI_CLI: '1'
-          }
+            GEMINI_CLI: '1',
+          },
         })
       : spawn('bash', ['-c', command], {
           stdio: ['ignore', 'pipe', 'pipe'],
@@ -333,8 +333,8 @@ Process Group PGID: Process group started or \`(none)\``,
           cwd: path.resolve(this.config.getTargetDir(), params.directory || ''),
           env: {
             ...process.env,
-            GEMINI_CLI: '1'
-          }
+            GEMINI_CLI: '1',
+          },
         });
 
     let exited = false;

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -322,11 +322,19 @@ Process Group PGID: Process group started or \`(none)\``,
           stdio: ['ignore', 'pipe', 'pipe'],
           // detached: true, // ensure subprocess starts its own process group (esp. in Linux)
           cwd: path.resolve(this.config.getTargetDir(), params.directory || ''),
+          env: {
+            ...process.env,
+            GEMINI_CLI: '1'
+          }
         })
       : spawn('bash', ['-c', command], {
           stdio: ['ignore', 'pipe', 'pipe'],
           detached: true, // ensure subprocess starts its own process group (esp. in Linux)
           cwd: path.resolve(this.config.getTargetDir(), params.directory || ''),
+          env: {
+            ...process.env,
+            GEMINI_CLI: '1'
+          }
         });
 
     let exited = false;


### PR DESCRIPTION
## Summary

Adds `GEMINI_CLI=1` environment variable to all spawned shell commands, allowing CLI tools to detect they're running inside Gemini CLI and adjust behavior (e.g., less verbose output, non-interactive mode).

## Changes

- Set `GEMINI_CLI=1` when spawning commands in shellCommandProcessor.ts and shell.ts
- Added tests for both implementations
- Cleaned up test imports

## Testing

- Unit tests verify spawn is called with correct env
- Integration test verifies env var is accessible to child processes
- All tests pass