### PR TITLE
Add "Gemini CLI: Run" command shortcut

### DIFF
--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -30,6 +30,14 @@
   "activationEvents": [
     "onStartupFinished"
   ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "gemini-cli.runGeminiCLI",
+        "title": "Gemini CLI: Run"
+      }
+    ]
+  },
   "main": "./dist/extension.js",
   "scripts": {
     "vscode:prepublish": "npm run check-types && npm run lint && node esbuild.js --production",

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -29,8 +29,8 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('gemini-cli.runGeminiCLI', () => {
       const geminiCmd = 'gemini';
       const terminal = vscode.window.createTerminal(`Gemini CLI`);
-      terminal.sendText(geminiCmd);
       terminal.show();
+      terminal.sendText(geminiCmd);
     }),
   );
 }

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -24,6 +24,15 @@ export async function activate(context: vscode.ExtensionContext) {
     const message = err instanceof Error ? err.message : String(err);
     log(`Failed to start IDE server: ${message}`);
   }
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('gemini-cli.runGeminiCLI', () => {
+      const geminiCmd = 'gemini';
+      const terminal = vscode.window.createTerminal(`Gemini CLI`);
+      terminal.sendText(geminiCmd);
+      terminal.show();
+    }),
+  );
 }
 
 export async function deactivate(): Promise<void> {


### PR DESCRIPTION
## TLDR
This command opens up gemini-cli in a new terminal window if the user already has the extension installed

## Linked issues / bugs
#4390