### PR TITLE
feat: add support for separate quota project for use with Code Assist API

### DIFF
--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -124,6 +124,18 @@ export class CodeAssistServer implements ContentGenerator {
     throw Error();
   }
 
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...this.httpOptions.headers,
+    };
+    const quotaProject = process.env.CODE_ASSIST_QUOTA_PROJECT;
+    if (quotaProject) {
+      headers['x-goog-user-project'] = quotaProject;
+    }
+    return headers;
+  }
+
   async requestPost<T>(
     method: string,
     req: object,
@@ -132,10 +144,7 @@ export class CodeAssistServer implements ContentGenerator {
     const res = await this.client.request({
       url: this.getMethodUrl(method),
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...this.httpOptions.headers,
-      },
+      headers: this.getHeaders(),
       responseType: 'json',
       body: JSON.stringify(req),
       signal,
@@ -147,10 +156,7 @@ export class CodeAssistServer implements ContentGenerator {
     const res = await this.client.request({
       url: this.getMethodUrl(method),
       method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        ...this.httpOptions.headers,
-      },
+      headers: this.getHeaders(),
       responseType: 'json',
       signal,
     });
@@ -168,10 +174,7 @@ export class CodeAssistServer implements ContentGenerator {
       params: {
         alt: 'sse',
       },
-      headers: {
-        'Content-Type': 'application/json',
-        ...this.httpOptions.headers,
-      },
+      headers: this.getHeaders(),
       responseType: 'stream',
       body: JSON.stringify(req),
       signal,

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -124,7 +124,11 @@ export class CodeAssistServer implements ContentGenerator {
     throw Error();
   }
 
-  private getHeaders(): Record<string, string> {
+  async requestPost<T>(
+    method: string,
+    req: object,
+    signal?: AbortSignal,
+  ): Promise<T> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       ...this.httpOptions.headers,
@@ -133,18 +137,10 @@ export class CodeAssistServer implements ContentGenerator {
     if (quotaProject) {
       headers['x-goog-user-project'] = quotaProject;
     }
-    return headers;
-  }
-
-  async requestPost<T>(
-    method: string,
-    req: object,
-    signal?: AbortSignal,
-  ): Promise<T> {
     const res = await this.client.request({
       url: this.getMethodUrl(method),
       method: 'POST',
-      headers: this.getHeaders(),
+      headers: headers,
       responseType: 'json',
       body: JSON.stringify(req),
       signal,
@@ -153,10 +149,18 @@ export class CodeAssistServer implements ContentGenerator {
   }
 
   async requestGet<T>(method: string, signal?: AbortSignal): Promise<T> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...this.httpOptions.headers,
+    };
+    const quotaProject = process.env.CODE_ASSIST_QUOTA_PROJECT;
+    if (quotaProject) {
+      headers['x-goog-user-project'] = quotaProject;
+    }
     const res = await this.client.request({
       url: this.getMethodUrl(method),
       method: 'GET',
-      headers: this.getHeaders(),
+      headers: headers,
       responseType: 'json',
       signal,
     });
@@ -168,13 +172,21 @@ export class CodeAssistServer implements ContentGenerator {
     req: object,
     signal?: AbortSignal,
   ): Promise<AsyncGenerator<T>> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...this.httpOptions.headers,
+    };
+    const quotaProject = process.env.CODE_ASSIST_QUOTA_PROJECT;
+    if (quotaProject) {
+      headers['x-goog-user-project'] = quotaProject;
+    }
     const res = await this.client.request({
       url: this.getMethodUrl(method),
       method: 'POST',
       params: {
         alt: 'sse',
       },
-      headers: this.getHeaders(),
+      headers: headers,
       responseType: 'stream',
       body: JSON.stringify(req),
       signal,

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -140,7 +140,7 @@ export class CodeAssistServer implements ContentGenerator {
     const res = await this.client.request({
       url: this.getMethodUrl(method),
       method: 'POST',
-      headers: headers,
+      headers,
       responseType: 'json',
       body: JSON.stringify(req),
       signal,
@@ -160,7 +160,7 @@ export class CodeAssistServer implements ContentGenerator {
     const res = await this.client.request({
       url: this.getMethodUrl(method),
       method: 'GET',
-      headers: headers,
+      headers,
       responseType: 'json',
       signal,
     });
@@ -186,7 +186,7 @@ export class CodeAssistServer implements ContentGenerator {
       params: {
         alt: 'sse',
       },
-      headers: headers,
+      headers,
       responseType: 'stream',
       body: JSON.stringify(req),
       signal,


### PR DESCRIPTION
## TLDR

This PR adds support for specifying a quota project for use with the Code Assist API backend via the `CODE_ASSIST_QUOTA_PROJECT` environment variable.  This feature is only useful for internal users for running evals.

## Reviewer Test Plan

You can verify by using setting `NODE_DEBUG=http,http2` and look for the `x-goog-user-project` header.  For example:

```shell
$ echo "hello" | NODE_DEBUG=http,http2 GOOGLE_CLOUD_PROJECT=my-project CODE_ASSIST_QUOTA_PROJECT=my-project npm run start
...
headers: [Object: null prototype] {
    'Content-Type': [ 'application/json' ],
    'User-Agent': [ 'GeminiCLI/0.1.13 (darwin; arm64)' ],
    'x-goog-user-project': [ 'my-project' ],
...
```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
