### PR TITLE
feat(auth): Enhance non-interactive gcp auth

### DIFF
--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -525,6 +525,14 @@ export async function start_sandbox(
     );
   }
 
+  // copy GOOGLE_GENAI_USE_GCP
+  if (process.env.GOOGLE_GENAI_USE_GCP) {
+    args.push(
+      '--env',
+      `GOOGLE_GENAI_USE_GCP=${process.env.GOOGLE_GENAI_USE_GCP}`,
+    );
+  }
+
   // copy GOOGLE_CLOUD_PROJECT
   if (process.env.GOOGLE_CLOUD_PROJECT) {
     args.push(

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -525,11 +525,11 @@ export async function start_sandbox(
     );
   }
 
-  // copy GOOGLE_GENAI_USE_GCP
-  if (process.env.GOOGLE_GENAI_USE_GCP) {
+  // copy GOOGLE_GENAI_USE_GCA
+  if (process.env.GOOGLE_GENAI_USE_GCA) {
     args.push(
       '--env',
-      `GOOGLE_GENAI_USE_GCP=${process.env.GOOGLE_GENAI_USE_GCP}`,
+      `GOOGLE_GENAI_USE_GCA=${process.env.GOOGLE_GENAI_USE_GCA}`,
     );
   }
 

--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -14,6 +14,7 @@ import { AuthType } from '@google/gemini-cli-core';
 describe('validateNonInterActiveAuth', () => {
   let originalEnvGeminiApiKey: string | undefined;
   let originalEnvVertexAi: string | undefined;
+  let originalEnvGcp: string | undefined;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
   let processExitSpy: ReturnType<typeof vi.spyOn>;
   let refreshAuthMock: jest.MockedFunction<
@@ -23,8 +24,10 @@ describe('validateNonInterActiveAuth', () => {
   beforeEach(() => {
     originalEnvGeminiApiKey = process.env.GEMINI_API_KEY;
     originalEnvVertexAi = process.env.GOOGLE_GENAI_USE_VERTEXAI;
+    originalEnvGcp = process.env.GOOGLE_GENAI_USE_GCP;
     delete process.env.GEMINI_API_KEY;
     delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
+    delete process.env.GOOGLE_GENAI_USE_GCP;
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     processExitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new Error(`process.exit(${code}) called`);
@@ -43,6 +46,11 @@ describe('validateNonInterActiveAuth', () => {
     } else {
       delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
     }
+    if (originalEnvGcp !== undefined) {
+      process.env.GOOGLE_GENAI_USE_GCP = originalEnvGcp;
+    } else {
+      delete process.env.GOOGLE_GENAI_USE_GCP;
+    }
     vi.restoreAllMocks();
   });
 
@@ -60,6 +68,15 @@ describe('validateNonInterActiveAuth', () => {
       expect.stringContaining('Please set an Auth method'),
     );
     expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('uses LOGIN_WITH_GOOGLE if GOOGLE_GENAI_USE_GCP is set', async () => {
+    process.env.GOOGLE_GENAI_USE_GCP = 'true';
+    const nonInteractiveConfig: NonInteractiveConfig = {
+      refreshAuth: refreshAuthMock,
+    };
+    await validateNonInteractiveAuth(undefined, nonInteractiveConfig);
+    expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.LOGIN_WITH_GOOGLE);
   });
 
   it('uses USE_GEMINI if GEMINI_API_KEY is set', async () => {
@@ -90,6 +107,19 @@ describe('validateNonInterActiveAuth', () => {
     };
     await validateNonInteractiveAuth(undefined, nonInteractiveConfig);
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_VERTEX_AI);
+  });
+
+  it('uses LOGIN_WITH_GOOGLE if GOOGLE_GENAI_USE_GCP is set, even with other env vars', async () => {
+    process.env.GOOGLE_GENAI_USE_GCP = 'true';
+    process.env.GEMINI_API_KEY = 'fake-key';
+    process.env.GOOGLE_GENAI_USE_VERTEXAI = 'true';
+    process.env.GOOGLE_CLOUD_PROJECT = 'test-project';
+    process.env.GOOGLE_CLOUD_LOCATION = 'us-central1';
+    const nonInteractiveConfig: NonInteractiveConfig = {
+      refreshAuth: refreshAuthMock,
+    };
+    await validateNonInteractiveAuth(undefined, nonInteractiveConfig);
+    expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.LOGIN_WITH_GOOGLE);
   });
 
   it('uses USE_VERTEX_AI if both GEMINI_API_KEY and GOOGLE_GENAI_USE_VERTEXAI are set', async () => {

--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -24,10 +24,10 @@ describe('validateNonInterActiveAuth', () => {
   beforeEach(() => {
     originalEnvGeminiApiKey = process.env.GEMINI_API_KEY;
     originalEnvVertexAi = process.env.GOOGLE_GENAI_USE_VERTEXAI;
-    originalEnvGcp = process.env.GOOGLE_GENAI_USE_GCP;
+    originalEnvGcp = process.env.GOOGLE_GENAI_USE_GCA;
     delete process.env.GEMINI_API_KEY;
     delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
-    delete process.env.GOOGLE_GENAI_USE_GCP;
+    delete process.env.GOOGLE_GENAI_USE_GCA;
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     processExitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new Error(`process.exit(${code}) called`);
@@ -47,9 +47,9 @@ describe('validateNonInterActiveAuth', () => {
       delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
     }
     if (originalEnvGcp !== undefined) {
-      process.env.GOOGLE_GENAI_USE_GCP = originalEnvGcp;
+      process.env.GOOGLE_GENAI_USE_GCA = originalEnvGcp;
     } else {
-      delete process.env.GOOGLE_GENAI_USE_GCP;
+      delete process.env.GOOGLE_GENAI_USE_GCA;
     }
     vi.restoreAllMocks();
   });
@@ -70,8 +70,8 @@ describe('validateNonInterActiveAuth', () => {
     expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 
-  it('uses LOGIN_WITH_GOOGLE if GOOGLE_GENAI_USE_GCP is set', async () => {
-    process.env.GOOGLE_GENAI_USE_GCP = 'true';
+  it('uses LOGIN_WITH_GOOGLE if GOOGLE_GENAI_USE_GCA is set', async () => {
+    process.env.GOOGLE_GENAI_USE_GCA = 'true';
     const nonInteractiveConfig: NonInteractiveConfig = {
       refreshAuth: refreshAuthMock,
     };
@@ -109,8 +109,8 @@ describe('validateNonInterActiveAuth', () => {
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_VERTEX_AI);
   });
 
-  it('uses LOGIN_WITH_GOOGLE if GOOGLE_GENAI_USE_GCP is set, even with other env vars', async () => {
-    process.env.GOOGLE_GENAI_USE_GCP = 'true';
+  it('uses LOGIN_WITH_GOOGLE if GOOGLE_GENAI_USE_GCA is set, even with other env vars', async () => {
+    process.env.GOOGLE_GENAI_USE_GCA = 'true';
     process.env.GEMINI_API_KEY = 'fake-key';
     process.env.GOOGLE_GENAI_USE_VERTEXAI = 'true';
     process.env.GOOGLE_CLOUD_PROJECT = 'test-project';

--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -14,15 +14,17 @@ export async function validateNonInteractiveAuth(
 ) {
   const effectiveAuthType =
     configuredAuthType ||
-    (process.env.GOOGLE_GENAI_USE_VERTEXAI === 'true'
-      ? AuthType.USE_VERTEX_AI
-      : process.env.GEMINI_API_KEY
-        ? AuthType.USE_GEMINI
-        : undefined);
+    (process.env.GOOGLE_GENAI_USE_GCP === 'true'
+      ? AuthType.LOGIN_WITH_GOOGLE
+      : process.env.GOOGLE_GENAI_USE_VERTEXAI === 'true'
+        ? AuthType.USE_VERTEX_AI
+        : process.env.GEMINI_API_KEY
+          ? AuthType.USE_GEMINI
+          : undefined);
 
   if (!effectiveAuthType) {
     console.error(
-      `Please set an Auth method in your ${USER_SETTINGS_PATH} or specify either the GEMINI_API_KEY or GOOGLE_GENAI_USE_VERTEXAI environment variables before running`,
+      `Please set an Auth method in your ${USER_SETTINGS_PATH} or specify one of the following environment variables before running: GEMINI_API_KEY, GOOGLE_GENAI_USE_VERTEXAI, GOOGLE_GENAI_USE_GCP`,
     );
     process.exit(1);
   }

--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -8,23 +8,28 @@ import { AuthType, Config } from '@google/gemini-cli-core';
 import { USER_SETTINGS_PATH } from './config/settings.js';
 import { validateAuthMethod } from './config/auth.js';
 
+function getAuthTypeFromEnv(): AuthType | undefined {
+  if (process.env.GOOGLE_GENAI_USE_GCA === 'true') {
+    return AuthType.LOGIN_WITH_GOOGLE;
+  }
+  if (process.env.GOOGLE_GENAI_USE_VERTEXAI === 'true') {
+    return AuthType.USE_VERTEX_AI;
+  }
+  if (process.env.GEMINI_API_KEY) {
+    return AuthType.USE_GEMINI;
+  }
+  return undefined;
+}
+
 export async function validateNonInteractiveAuth(
   configuredAuthType: AuthType | undefined,
   nonInteractiveConfig: Config,
 ) {
-  const effectiveAuthType =
-    configuredAuthType ||
-    (process.env.GOOGLE_GENAI_USE_GCP === 'true'
-      ? AuthType.LOGIN_WITH_GOOGLE
-      : process.env.GOOGLE_GENAI_USE_VERTEXAI === 'true'
-        ? AuthType.USE_VERTEX_AI
-        : process.env.GEMINI_API_KEY
-          ? AuthType.USE_GEMINI
-          : undefined);
+  const effectiveAuthType = configuredAuthType || getAuthTypeFromEnv();
 
   if (!effectiveAuthType) {
     console.error(
-      `Please set an Auth method in your ${USER_SETTINGS_PATH} or specify one of the following environment variables before running: GEMINI_API_KEY, GOOGLE_GENAI_USE_VERTEXAI, GOOGLE_GENAI_USE_GCP`,
+      `Please set an Auth method in your ${USER_SETTINGS_PATH} or specify one of the following environment variables before running: GEMINI_API_KEY, GOOGLE_GENAI_USE_VERTEXAI, GOOGLE_GENAI_USE_GCA`,
     );
     process.exit(1);
   }

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -57,6 +57,8 @@ describe('oauth2', () => {
     fs.rmSync(tempHomeDir, { recursive: true, force: true });
     vi.clearAllMocks();
     delete process.env.CLOUD_SHELL;
+    delete process.env.GOOGLE_GENAI_USE_GCP;
+    delete process.env.GOOGLE_CLOUD_ACCESS_TOKEN;
   });
 
   it('should perform a web login', async () => {
@@ -333,25 +335,15 @@ describe('oauth2', () => {
     });
   });
 
-  describe('with GCP access token environment variables', () => {
-    const OLD_ENV = process.env;
-
-    beforeEach(() => {
-      process.env = { ...OLD_ENV }; // create a copy
-    });
-
-    afterEach(() => {
-      process.env = OLD_ENV; // restore original
-    });
-
-    it('should use GCP access token when GOOGLE_GENAI_USE_GCP and GOOGLE_CLOUD_ACCESS_TOKEN are set', async () => {
+  describe('with GCP environment variables', () => {
+    it('should use GOOGLE_CLOUD_ACCESS_TOKEN when GOOGLE_GENAI_USE_GCP is true', async () => {
       process.env.GOOGLE_GENAI_USE_GCP = 'true';
-      process.env.GOOGLE_CLOUD_ACCESS_TOKEN = 'test-gcp-access-token';
+      process.env.GOOGLE_CLOUD_ACCESS_TOKEN = 'gcp-access-token';
 
       const mockSetCredentials = vi.fn();
       const mockGetAccessToken = vi
         .fn()
-        .mockResolvedValue({ token: 'test-gcp-access-token' });
+        .mockResolvedValue({ token: 'gcp-access-token' });
       const mockOAuth2Client = {
         setCredentials: mockSetCredentials,
         getAccessToken: mockGetAccessToken,
@@ -361,10 +353,17 @@ describe('oauth2', () => {
         () => mockOAuth2Client,
       );
 
+      // Mock the UserInfo API response for fetchAndCacheUserInfo
       (global.fetch as Mock).mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue({ email: 'test-gcp-user@example.com' }),
-      });
+        json: vi
+          .fn()
+          .mockResolvedValue({ email: 'test-gcp-account@gmail.com' }),
+      } as unknown as Response);
+
+      const writeFileSpy = vi
+        .spyOn(fs.promises, 'writeFile')
+        .mockResolvedValue(undefined);
 
       const client = await getOauthClient(
         AuthType.LOGIN_WITH_GOOGLE,
@@ -372,20 +371,101 @@ describe('oauth2', () => {
       );
 
       expect(client).toBe(mockOAuth2Client);
-      expect(OAuth2Client).toHaveBeenCalledOnce();
       expect(mockSetCredentials).toHaveBeenCalledWith({
-        access_token: 'test-gcp-access-token',
+        access_token: 'gcp-access-token',
       });
 
-      // Verify user info was fetched and cached
+      // Verify fetchAndCacheUserInfo was effectively called
+      expect(mockGetAccessToken).toHaveBeenCalled();
       expect(global.fetch).toHaveBeenCalledWith(
         'https://www.googleapis.com/oauth2/v2/userinfo',
         {
           headers: {
-            Authorization: 'Bearer test-gcp-access-token',
+            Authorization: 'Bearer gcp-access-token',
           },
         },
       );
+
+      // Verify Google Account was cached
+      const googleAccountPath = path.join(
+        tempHomeDir,
+        '.gemini',
+        'google_accounts.json',
+      );
+      expect(writeFileSpy).toHaveBeenCalledWith(
+        googleAccountPath,
+        JSON.stringify(
+          {
+            active: 'test-gcp-account@gmail.com',
+            old: [],
+          },
+          null,
+          2,
+        ),
+        'utf-8',
+      );
+    });
+
+    it('should not use GCP token if GOOGLE_CLOUD_ACCESS_TOKEN is not set', async () => {
+      process.env.GOOGLE_GENAI_USE_GCP = 'true';
+
+      const mockSetCredentials = vi.fn();
+      const mockGetAccessToken = vi
+        .fn()
+        .mockResolvedValue({ token: 'cached-access-token' });
+      const mockGetTokenInfo = vi.fn().mockResolvedValue({});
+      const mockOAuth2Client = {
+        setCredentials: mockSetCredentials,
+        getAccessToken: mockGetAccessToken,
+        getTokenInfo: mockGetTokenInfo,
+        on: vi.fn(),
+      } as unknown as OAuth2Client;
+      (OAuth2Client as unknown as Mock).mockImplementation(
+        () => mockOAuth2Client,
+      );
+
+      // Make it fall through to cached credentials path
+      const cachedCreds = { refresh_token: 'cached-token' };
+      vi.spyOn(fs.promises, 'readFile').mockResolvedValue(
+        JSON.stringify(cachedCreds),
+      );
+
+      await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfig);
+
+      // It should be called with the cached credentials, not the GCP access token.
+      expect(mockSetCredentials).toHaveBeenCalledTimes(1);
+      expect(mockSetCredentials).toHaveBeenCalledWith(cachedCreds);
+    });
+
+    it('should not use GCP token if GOOGLE_GENAI_USE_GCP is not set', async () => {
+      process.env.GOOGLE_CLOUD_ACCESS_TOKEN = 'gcp-access-token';
+
+      const mockSetCredentials = vi.fn();
+      const mockGetAccessToken = vi
+        .fn()
+        .mockResolvedValue({ token: 'cached-access-token' });
+      const mockGetTokenInfo = vi.fn().mockResolvedValue({});
+      const mockOAuth2Client = {
+        setCredentials: mockSetCredentials,
+        getAccessToken: mockGetAccessToken,
+        getTokenInfo: mockGetTokenInfo,
+        on: vi.fn(),
+      } as unknown as OAuth2Client;
+      (OAuth2Client as unknown as Mock).mockImplementation(
+        () => mockOAuth2Client,
+      );
+
+      // Make it fall through to cached credentials path
+      const cachedCreds = { refresh_token: 'cached-token' };
+      vi.spyOn(fs.promises, 'readFile').mockResolvedValue(
+        JSON.stringify(cachedCreds),
+      );
+
+      await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfig);
+
+      // It should be called with the cached credentials, not the GCP access token.
+      expect(mockSetCredentials).toHaveBeenCalledTimes(1);
+      expect(mockSetCredentials).toHaveBeenCalledWith(cachedCreds);
     });
   });
 });

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -57,7 +57,7 @@ describe('oauth2', () => {
     fs.rmSync(tempHomeDir, { recursive: true, force: true });
     vi.clearAllMocks();
     delete process.env.CLOUD_SHELL;
-    delete process.env.GOOGLE_GENAI_USE_GCP;
+    delete process.env.GOOGLE_GENAI_USE_GCA;
     delete process.env.GOOGLE_CLOUD_ACCESS_TOKEN;
   });
 
@@ -336,8 +336,8 @@ describe('oauth2', () => {
   });
 
   describe('with GCP environment variables', () => {
-    it('should use GOOGLE_CLOUD_ACCESS_TOKEN when GOOGLE_GENAI_USE_GCP is true', async () => {
-      process.env.GOOGLE_GENAI_USE_GCP = 'true';
+    it('should use GOOGLE_CLOUD_ACCESS_TOKEN when GOOGLE_GENAI_USE_GCA is true', async () => {
+      process.env.GOOGLE_GENAI_USE_GCA = 'true';
       process.env.GOOGLE_CLOUD_ACCESS_TOKEN = 'gcp-access-token';
 
       const mockSetCredentials = vi.fn();
@@ -407,7 +407,7 @@ describe('oauth2', () => {
     });
 
     it('should not use GCP token if GOOGLE_CLOUD_ACCESS_TOKEN is not set', async () => {
-      process.env.GOOGLE_GENAI_USE_GCP = 'true';
+      process.env.GOOGLE_GENAI_USE_GCA = 'true';
 
       const mockSetCredentials = vi.fn();
       const mockGetAccessToken = vi
@@ -437,7 +437,7 @@ describe('oauth2', () => {
       expect(mockSetCredentials).toHaveBeenCalledWith(cachedCreds);
     });
 
-    it('should not use GCP token if GOOGLE_GENAI_USE_GCP is not set', async () => {
+    it('should not use GCP token if GOOGLE_GENAI_USE_GCA is not set', async () => {
       process.env.GOOGLE_CLOUD_ACCESS_TOKEN = 'gcp-access-token';
 
       const mockSetCredentials = vi.fn();

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -70,17 +70,6 @@ export async function getOauthClient(
   authType: AuthType,
   config: Config,
 ): Promise<OAuth2Client> {
-  if (
-    process.env.GOOGLE_GENAI_USE_GCP &&
-    process.env.GOOGLE_CLOUD_ACCESS_TOKEN
-  ) {
-    const client = new OAuth2Client();
-    client.setCredentials({
-      access_token: process.env.GOOGLE_CLOUD_ACCESS_TOKEN,
-    });
-    await fetchAndCacheUserInfo(client);
-    return client;
-  }
   const client = new OAuth2Client({
     clientId: OAUTH_CLIENT_ID,
     clientSecret: OAUTH_CLIENT_SECRET,
@@ -88,6 +77,17 @@ export async function getOauthClient(
       proxy: config.getProxy(),
     },
   });
+
+  if (
+    process.env.GOOGLE_GENAI_USE_GCP &&
+    process.env.GOOGLE_CLOUD_ACCESS_TOKEN
+  ) {
+    client.setCredentials({
+      access_token: process.env.GOOGLE_CLOUD_ACCESS_TOKEN,
+    });
+    await fetchAndCacheUserInfo(client);
+    return client;
+  }
 
   client.on('tokens', async (tokens: Credentials) => {
     await cacheCredentials(tokens);

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -70,6 +70,17 @@ export async function getOauthClient(
   authType: AuthType,
   config: Config,
 ): Promise<OAuth2Client> {
+  if (
+    process.env.GOOGLE_GENAI_USE_GCP &&
+    process.env.GOOGLE_CLOUD_ACCESS_TOKEN
+  ) {
+    const client = new OAuth2Client();
+    client.setCredentials({
+      access_token: process.env.GOOGLE_CLOUD_ACCESS_TOKEN,
+    });
+    await fetchAndCacheUserInfo(client);
+    return client;
+  }
   const client = new OAuth2Client({
     clientId: OAUTH_CLIENT_ID,
     clientSecret: OAUTH_CLIENT_SECRET,

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -79,7 +79,7 @@ export async function getOauthClient(
   });
 
   if (
-    process.env.GOOGLE_GENAI_USE_GCP &&
+    process.env.GOOGLE_GENAI_USE_GCA &&
     process.env.GOOGLE_CLOUD_ACCESS_TOKEN
   ) {
     client.setCredentials({

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -5,7 +5,6 @@
  */
 
 import { OAuth2Client } from 'google-auth-library';
-import { Readable } from 'stream';
 import {
   CodeAssistGlobalUserSettingResponse,
   LoadCodeAssistRequest,
@@ -130,22 +129,6 @@ export class CodeAssistServer implements ContentGenerator {
     req: object,
     signal?: AbortSignal,
   ): Promise<T> {
-    if (
-      process.env.GOOGLE_GENAI_USE_GCP &&
-      process.env.GOOGLE_CLOUD_ACCESS_TOKEN
-    ) {
-      const res = await fetch(this.getMethodUrl(method), {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${process.env.GOOGLE_CLOUD_ACCESS_TOKEN}`,
-          ...this.httpOptions.headers,
-        },
-        body: JSON.stringify(req),
-        signal,
-      });
-      return res.json() as T;
-    }
     const res = await this.client.request({
       url: this.getMethodUrl(method),
       method: 'POST',
@@ -161,21 +144,6 @@ export class CodeAssistServer implements ContentGenerator {
   }
 
   async requestGet<T>(method: string, signal?: AbortSignal): Promise<T> {
-    if (
-      process.env.GOOGLE_GENAI_USE_GCP &&
-      process.env.GOOGLE_CLOUD_ACCESS_TOKEN
-    ) {
-      const res = await fetch(this.getMethodUrl(method), {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${process.env.GOOGLE_CLOUD_ACCESS_TOKEN}`,
-          ...this.httpOptions.headers,
-        },
-        signal,
-      });
-      return res.json() as T;
-    }
     const res = await this.client.request({
       url: this.getMethodUrl(method),
       method: 'GET',
@@ -194,11 +162,24 @@ export class CodeAssistServer implements ContentGenerator {
     req: object,
     signal?: AbortSignal,
   ): Promise<AsyncGenerator<T>> {
-    const streamParser = async function* (
-      stream: NodeJS.ReadableStream,
-    ): AsyncGenerator<T> {
+    const res = await this.client.request({
+      url: this.getMethodUrl(method),
+      method: 'POST',
+      params: {
+        alt: 'sse',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        ...this.httpOptions.headers,
+      },
+      responseType: 'stream',
+      body: JSON.stringify(req),
+      signal,
+    });
+
+    return (async function* (): AsyncGenerator<T> {
       const rl = readline.createInterface({
-        input: stream,
+        input: res.data as NodeJS.ReadableStream,
         crlfDelay: Infinity, // Recognizes '\r\n' and '\n' as line breaks
       });
 
@@ -217,45 +198,7 @@ export class CodeAssistServer implements ContentGenerator {
           throw new Error(`Unexpected line format in response: ${line}`);
         }
       }
-    };
-
-    if (
-      process.env.GOOGLE_GENAI_USE_GCP &&
-      process.env.GOOGLE_CLOUD_ACCESS_TOKEN
-    ) {
-      const res = await fetch(this.getMethodUrl(method) + '?alt=sse', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${process.env.GOOGLE_CLOUD_ACCESS_TOKEN}`,
-          ...this.httpOptions.headers,
-        },
-        body: JSON.stringify(req),
-        signal,
-      });
-      if (!res.body) {
-        throw new Error('Response body is null');
-      }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return streamParser(Readable.fromWeb(res.body as any));
-    }
-
-    const res = await this.client.request({
-      url: this.getMethodUrl(method),
-      method: 'POST',
-      params: {
-        alt: 'sse',
-      },
-      headers: {
-        'Content-Type': 'application/json',
-        ...this.httpOptions.headers,
-      },
-      responseType: 'stream',
-      body: JSON.stringify(req),
-      signal,
-    });
-
-    return streamParser(res.data as NodeJS.ReadableStream);
+    })();
   }
 
   getMethodUrl(method: string): string {

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -5,6 +5,7 @@
  */
 
 import { OAuth2Client } from 'google-auth-library';
+import { Readable } from 'stream';
 import {
   CodeAssistGlobalUserSettingResponse,
   LoadCodeAssistRequest,
@@ -129,6 +130,22 @@ export class CodeAssistServer implements ContentGenerator {
     req: object,
     signal?: AbortSignal,
   ): Promise<T> {
+    if (
+      process.env.GOOGLE_GENAI_USE_GCP &&
+      process.env.GOOGLE_CLOUD_ACCESS_TOKEN
+    ) {
+      const res = await fetch(this.getMethodUrl(method), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${process.env.GOOGLE_CLOUD_ACCESS_TOKEN}`,
+          ...this.httpOptions.headers,
+        },
+        body: JSON.stringify(req),
+        signal,
+      });
+      return res.json() as T;
+    }
     const res = await this.client.request({
       url: this.getMethodUrl(method),
       method: 'POST',
@@ -144,6 +161,21 @@ export class CodeAssistServer implements ContentGenerator {
   }
 
   async requestGet<T>(method: string, signal?: AbortSignal): Promise<T> {
+    if (
+      process.env.GOOGLE_GENAI_USE_GCP &&
+      process.env.GOOGLE_CLOUD_ACCESS_TOKEN
+    ) {
+      const res = await fetch(this.getMethodUrl(method), {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${process.env.GOOGLE_CLOUD_ACCESS_TOKEN}`,
+          ...this.httpOptions.headers,
+        },
+        signal,
+      });
+      return res.json() as T;
+    }
     const res = await this.client.request({
       url: this.getMethodUrl(method),
       method: 'GET',
@@ -162,24 +194,11 @@ export class CodeAssistServer implements ContentGenerator {
     req: object,
     signal?: AbortSignal,
   ): Promise<AsyncGenerator<T>> {
-    const res = await this.client.request({
-      url: this.getMethodUrl(method),
-      method: 'POST',
-      params: {
-        alt: 'sse',
-      },
-      headers: {
-        'Content-Type': 'application/json',
-        ...this.httpOptions.headers,
-      },
-      responseType: 'stream',
-      body: JSON.stringify(req),
-      signal,
-    });
-
-    return (async function* (): AsyncGenerator<T> {
+    const streamParser = async function* (
+      stream: NodeJS.ReadableStream,
+    ): AsyncGenerator<T> {
       const rl = readline.createInterface({
-        input: res.data as NodeJS.ReadableStream,
+        input: stream,
         crlfDelay: Infinity, // Recognizes '\r\n' and '\n' as line breaks
       });
 
@@ -198,7 +217,45 @@ export class CodeAssistServer implements ContentGenerator {
           throw new Error(`Unexpected line format in response: ${line}`);
         }
       }
-    })();
+    };
+
+    if (
+      process.env.GOOGLE_GENAI_USE_GCP &&
+      process.env.GOOGLE_CLOUD_ACCESS_TOKEN
+    ) {
+      const res = await fetch(this.getMethodUrl(method) + '?alt=sse', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${process.env.GOOGLE_CLOUD_ACCESS_TOKEN}`,
+          ...this.httpOptions.headers,
+        },
+        body: JSON.stringify(req),
+        signal,
+      });
+      if (!res.body) {
+        throw new Error('Response body is null');
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return streamParser(Readable.fromWeb(res.body as any));
+    }
+
+    const res = await this.client.request({
+      url: this.getMethodUrl(method),
+      method: 'POST',
+      params: {
+        alt: 'sse',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        ...this.httpOptions.headers,
+      },
+      responseType: 'stream',
+      body: JSON.stringify(req),
+      signal,
+    });
+
+    return streamParser(res.data as NodeJS.ReadableStream);
   }
 
   getMethodUrl(method: string): string {


### PR DESCRIPTION
## TLDR

This pull request significantly enhances the GCA authentication flow, particularly for non-interactive and containerized environments. Key additions include support for direct authentication via an access token.

## Dive Deeper

### 1. Non-Browser & Pre-Authenticated Auth Flows

- **Access Token Authentication**: The CLI can now directly use a `GOOGLE_CLOUD_ACCESS_TOKEN` for authentication when `GOOGLE_GENAI_USE_GCP=true` is also set. This is ideal for CI/CD pipelines or other pre-authenticated environments, allowing the CLI to work without initiating an OAuth2 flow.

### 3. Non-Interactive Auth Logic

- The logic for determining the authentication method in non-interactive mode has been clarified to correctly prioritize `GOOGLE_GENAI_USE_GCP` and `GOOGLE_GENAI_USE_VERTEXAI` over the `GEMINI_API_KEY`.

## Reviewer Test Plan

1.  **Test Access Token Auth**:
    - Set the following environment variables:
      - `export GOOGLE_GENAI_USE_GCP=true`
      - `export GOOGLE_CLOUD_ACCESS_TOKEN=$(gcloud auth print-access-token)`
    - Run `gemini prompt "hello"`.
    - Verify the command executes successfully without triggering any interactive login prompts.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

