### PR TITLE
chore: migrate from responseSchema to use responseJsonSchema.

### DIFF
--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -22,7 +22,6 @@ import {
   Part,
   SafetySetting,
   PartUnion,
-  SchemaUnion,
   SpeechConfigUnion,
   ThinkingConfig,
   ToolListUnion,
@@ -61,7 +60,7 @@ interface VertexGenerationConfig {
   frequencyPenalty?: number;
   seed?: number;
   responseMimeType?: string;
-  responseSchema?: SchemaUnion;
+  responseJsonSchema?: unknown;
   routingConfig?: GenerationConfigRoutingConfig;
   modelSelectionConfig?: ModelSelectionConfig;
   responseModalities?: string[];
@@ -230,7 +229,7 @@ function toVertexGenerationConfig(
     frequencyPenalty: config.frequencyPenalty,
     seed: config.seed,
     responseMimeType: config.responseMimeType,
-    responseSchema: config.responseSchema,
+    responseJsonSchema: config.responseJsonSchema,
     routingConfig: config.routingConfig,
     modelSelectionConfig: config.modelSelectionConfig,
     responseModalities: config.responseModalities,

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -395,7 +395,7 @@ describe('Gemini Client (client.ts)', () => {
             systemInstruction: getCoreSystemPrompt(''),
             temperature: 0,
             topP: 1,
-            responseSchema: schema,
+            responseJsonSchema: schema,
             responseMimeType: 'application/json',
           },
           contents,
@@ -434,7 +434,7 @@ describe('Gemini Client (client.ts)', () => {
             temperature: 0.9,
             topP: 1, // from default
             topK: 20,
-            responseSchema: schema,
+            responseJsonSchema: schema,
             responseMimeType: 'application/json',
           },
           contents,

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -7,7 +7,6 @@
 import {
   EmbedContentParameters,
   GenerateContentConfig,
-  SchemaUnion,
   PartListUnion,
   Content,
   Tool,
@@ -374,7 +373,7 @@ export class GeminiClient {
 
   async generateJson(
     contents: Content[],
-    schema: SchemaUnion,
+    schema: Record<string, unknown>,
     abortSignal: AbortSignal,
     model?: string,
     config: GenerateContentConfig = {},
@@ -398,7 +397,7 @@ export class GeminiClient {
             config: {
               ...requestConfig,
               systemInstruction,
-              responseSchema: schema,
+              responseJsonSchema: schema,
               responseMimeType: 'application/json',
             },
             contents,

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -9,7 +9,6 @@ import { GeminiEventType, ServerGeminiStreamEvent } from '../core/turn.js';
 import { logLoopDetected } from '../telemetry/loggers.js';
 import { LoopDetectedEvent, LoopType } from '../telemetry/types.js';
 import { Config, DEFAULT_GEMINI_FLASH_MODEL } from '../config/config.js';
-import { SchemaUnion, Type } from '@google/genai';
 
 const TOOL_CALL_LOOP_THRESHOLD = 5;
 const CONTENT_LOOP_THRESHOLD = 10;
@@ -341,16 +340,16 @@ Please analyze the conversation history to determine the possibility that the co
       ...recentHistory,
       { role: 'user', parts: [{ text: prompt }] },
     ];
-    const schema: SchemaUnion = {
-      type: Type.OBJECT,
+    const schema: Record<string, unknown> = {
+      type: 'object',
       properties: {
         reasoning: {
-          type: Type.STRING,
+          type: 'string',
           description:
             'Your reasoning on if the conversation is looping without forward progress.',
         },
         confidence: {
-          type: Type.NUMBER,
+          type: 'number',
           description:
             'A number between 0.0 and 1.0 representing your confidence that the conversation is in an unproductive state.',
         },

--- a/packages/core/src/utils/editCorrector.ts
+++ b/packages/core/src/utils/editCorrector.ts
@@ -4,12 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  Content,
-  GenerateContentConfig,
-  SchemaUnion,
-  Type,
-} from '@google/genai';
+import { Content, GenerateContentConfig } from '@google/genai';
 import { GeminiClient } from '../core/client.js';
 import { EditToolParams, EditTool } from '../tools/edit.js';
 import { WriteFileTool } from '../tools/write-file.js';
@@ -364,11 +359,11 @@ export async function ensureCorrectFileContent(
 }
 
 // Define the expected JSON schema for the LLM response for old_string correction
-const OLD_STRING_CORRECTION_SCHEMA: SchemaUnion = {
-  type: Type.OBJECT,
+const OLD_STRING_CORRECTION_SCHEMA: Record<string, unknown> = {
+  type: 'object',
   properties: {
     corrected_target_snippet: {
-      type: Type.STRING,
+      type: 'string',
       description:
         'The corrected version of the target snippet that exactly and uniquely matches a segment within the provided file content.',
     },
@@ -438,11 +433,11 @@ Return ONLY the corrected target snippet in the specified JSON format with the k
 }
 
 // Define the expected JSON schema for the new_string correction LLM response
-const NEW_STRING_CORRECTION_SCHEMA: SchemaUnion = {
-  type: Type.OBJECT,
+const NEW_STRING_CORRECTION_SCHEMA: Record<string, unknown> = {
+  type: 'object',
   properties: {
     corrected_new_string: {
-      type: Type.STRING,
+      type: 'string',
       description:
         'The original_new_string adjusted to be a suitable replacement for the corrected_old_string, while maintaining the original intent of the change.',
     },
@@ -521,11 +516,11 @@ Return ONLY the corrected string in the specified JSON format with the key 'corr
   }
 }
 
-const CORRECT_NEW_STRING_ESCAPING_SCHEMA: SchemaUnion = {
-  type: Type.OBJECT,
+const CORRECT_NEW_STRING_ESCAPING_SCHEMA: Record<string, unknown> = {
+  type: 'object',
   properties: {
     corrected_new_string_escaping: {
-      type: Type.STRING,
+      type: 'string',
       description:
         'The new_string with corrected escaping, ensuring it is a proper replacement for the old_string, especially considering potential over-escaping issues from previous LLM generations.',
     },
@@ -593,11 +588,11 @@ Return ONLY the corrected string in the specified JSON format with the key 'corr
   }
 }
 
-const CORRECT_STRING_ESCAPING_SCHEMA: SchemaUnion = {
-  type: Type.OBJECT,
+const CORRECT_STRING_ESCAPING_SCHEMA: Record<string, unknown> = {
+  type: 'object',
   properties: {
     corrected_string_escaping: {
-      type: Type.STRING,
+      type: 'string',
       description:
         'The string with corrected escaping, ensuring it is valid, specially considering potential over-escaping issues from previous LLM generations.',
     },

--- a/packages/core/src/utils/nextSpeakerChecker.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Content, SchemaUnion, Type } from '@google/genai';
+import { Content } from '@google/genai';
 import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { GeminiClient } from '../core/client.js';
 import { GeminiChat } from '../core/geminiChat.js';
@@ -16,16 +16,16 @@ const CHECK_PROMPT = `Analyze *only* the content and structure of your immediate
 2.  **Question to User:** If your last response ends with a direct question specifically addressed *to the user*, then the **'user'** should speak next.
 3.  **Waiting for User:** If your last response completed a thought, statement, or task *and* does not meet the criteria for Rule 1 (Model Continues) or Rule 2 (Question to User), it implies a pause expecting user input or reaction. In this case, the **'user'** should speak next.`;
 
-const RESPONSE_SCHEMA: SchemaUnion = {
-  type: Type.OBJECT,
+const RESPONSE_SCHEMA: Record<string, unknown> = {
+  type: 'object',
   properties: {
     reasoning: {
-      type: Type.STRING,
+      type: 'string',
       description:
         "Brief explanation justifying the 'next_speaker' choice based *strictly* on the applicable rule and the content/structure of the preceding turn.",
     },
     next_speaker: {
-      type: Type.STRING,
+      type: 'string',
       enum: ['user', 'model'],
       description:
         'Who should speak next based *only* on the preceding turn and the decision rules',


### PR DESCRIPTION
Since Gemini SDK v1.7.0 a new field in GenerateContentConfig is exposed. This field is backed by backend directly to accept the JSON schema.

Switch to use responseJsonSchema so it would be easier to incorporate backend supports for new fields. 
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->
Investigate on how `responseSchema` is used in Gemini_CLI, my understanding is the `responseSchema` fields is only used in `generateJson` for [ref](https://github.com/google-gemini/gemini-cli/blob/83c4dddb7ee7ba34d7dec09d00819972d2e1ff5f/packages/core/src/core/client.ts#L418) to constrain the model to generate json output so that Gemini_CLI can parse the information easily.

It seems like user doesn't supply the responseSchema directly to the model.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->
npm run preflight -> all pass
npm run test:e2e -> all pass

No noticeable behavior difference between using `responseSchema` or `responseJsonSchema`. See test results in the Appendix part.


local build with following settings.json

```
{
  "selectedAuthType": "gemini-api-key",
  "theme": "Dracula",
  "mcpServers": {
    "context7": {
      "command": "npx",
      "args": ["-y", "@upstash/context7-mcp"]
    },
    "git": {
      "command": "uvx",
      "args": [
        "mcp-server-git",
        "--repository",
        "/usr/local/google/home/wanlindu/gemini-cli"
      ]
    },
    "github": {
      "command": "docker",
      "args": [
        "run",
        "-i",
        "--rm",
        "-e",
        "GITHUB_PERSONAL_ACCESS_TOKEN",
        "ghcr.io/github/github-mcp-server"
      ],
      "env": {
        "GITHUB_PERSONAL_ACCESS_TOKEN": "my-token"
      }
    },
    "playwright": {
      "command": "npx",
      "args": ["@playwright/mcp@latest"]
    },
    "sequential-thinking": {
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
    },
    "memory": {
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-memory"]
    },
    "time": {
      "command": "uvx",
      "args": ["mcp-server-time"]
    },
    "firebase": {
      "command": "npx",
      "args": [
        "-y",
        "firebase-tools@latest",
        "experimental:mcp"
      ]
    }
  },
  "preferredEditor": "nano"
}
```

All servers are up and ready.

## Testing Matrix


<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->


## Appendix : 

### Verify backend behavior.
Tested on Gemini JS sdk for backend behavior, no error thrown, no noticeable behavior difference:
```
*********** Vertex AI: NEW_STRING_CORRECTION_SCHEMA***************
The user provided project/location will take precedence over the API key from the environment variables.
Response from the responseJsonSchema {
  text: '{\n  "corrected_new_string": "example corrected new string"\n}'
}
Response from the responseSchema { text: '{"corrected_new_string":"This is the corrected new string"}' }
.*********** ML dev: NEW_STRING_CORRECTION_SCHEMA***************
Response from the responseJsonSchema {
  text: '{"corrected_new_string": "The updated and validated version of the text."}'
}
Response from the responseSchema {
  text: '{"corrected_new_string": "The quick brown fox jumps over the lazy dog."}'
}
.*********** Vertex AI: OLD_STRING_CORRECTION_SCHEMA***************
The user provided project/location will take precedence over the API key from the environment variables.
Response from the responseJsonSchema {
  text: '{\n' +
    '  "corrected_target_snippet": "This is an example of a corrected target snippet that would exactly match a segment within the file content."\n' +
    '}'
}
Response from the responseSchema {
  text: '{"corrected_target_snippet": "This is a corrected version of the target snippet."}'
}
.*********** ML dev: CORRECT_NEW_STRING_ESCAPING_SCHEMA***************
Response from the responseJsonSchema {
  text: '{"corrected_new_string_escaping":"This is a new string with \\\\\\"quotes\\\\\\" and a backslash: \\\\\\\\ that are correctly escaped."}'
}
Response from the responseSchema {
  text: '{"corrected_new_string_escaping": "This is a corrected string with proper escaping for \\"quotes\\" and a backslash \\\\ character."}'
}
.*********** ML dev: OLD_STRING_CORRECTION_SCHEMA***************
Response from the responseJsonSchema {
  text: '{"corrected_target_snippet": "The quick brown fox jumps over the lazy dog."}'
}
Response from the responseSchema {
  text: `{"corrected_target_snippet": "Your corrected target snippet goes here, ensuring it's an exact match."}`
}
.*********** Vertex AI: loop detection service***************
The user provided project/location will take precedence over the API key from the environment variables.
Response from the responseJsonSchema {
  text: '{\n' +
    '  "confidence": 0.75,\n' +
    '  "reasoning": "The user has repeatedly asked for the same information or action despite previous attempts to provide it, indicating a lack of forward progress or understanding of the previous responses. The conversation seems to be stuck on a single point."\n' +
    '}'
}
Response from the responseSchema {
  text: `{"confidence":0.1,"reasoning":"The conversation has just started and there's no indication of looping or unproductive behavior yet. More turns are needed to assess its state."}`
}
.*********** ML dev: CORRECT_STRING_ESCAPING_SCHEMA***************
Response from the responseJsonSchema {
  text: '{"corrected_string_escaping": "This is a \\"corrected\\" string with a backslash \\\\ and a newline \\\\n character shown literally."}'
}
Response from the responseSchema {
  text: '{"corrected_string_escaping": "This is a string with a backslash: C:\\\\path\\\\to\\\\file.txt, and an escaped quote: \\"Hello, world!\\""}'
}
.*********** ML dev: RESPONSE_SCHEMA***************
Response from the responseJsonSchema {
  text: '{"next_speaker": "user", "reasoning": "No specific context or preceding turn was provided, so it is assumed the model is awaiting user input to initiate or continue the conversation."}'
}
Response from the responseSchema {
  text: '{"next_speaker": "user", "reasoning": "No preceding turn was provided; therefore, the system is awaiting initial input from the user."}'
}
.*********** Vertex AI: CORRECT_NEW_STRING_ESCAPING_SCHEMA***************
The user provided project/location will take precedence over the API key from the environment variables.
Response from the responseJsonSchema {
  text: '{\n' +
    '  "corrected_new_string_escaping": "This is a corrected string with \\\\\\"escaped quotes\\\\\\" and a backslash: \\\\\\\\, ensuring proper JSON parsing."\n' +
    '}'
}
Response from the responseSchema {
  text: '{"corrected_new_string_escaping":"C:\\\\Users\\\\John\\\\Documents\\\\report.pdf"}'
}
.*********** Vertex AI: CORRECT_STRING_ESCAPING_SCHEMA***************
The user provided project/location will take precedence over the API key from the environment variables.
Response from the responseJsonSchema {
  text: '{\n' +
    '  "corrected_string_escaping": "This string contains a \\"double quote\\" and a backslash: C:\\\\path\\\\to\\\\file. It also has a newline.\\\\nAnd a tab\\\\tcharacter."\n' +
    '}'
}
Response from the responseSchema {
  text: '{"corrected_string_escaping":"This is a sample string with \\"quotes\\" and a backslash \\\\ and even a unicode character \\n."}'
}
.*********** ML dev: loop detection service***************
Response from the responseJsonSchema {
  text: '{"confidence": 0.75, "reasoning": "The conversation appears to be stuck in a repetitive clarification loop without new information being introduced or a clear path to resolution."}'
}
Response from the responseSchema {
  text: `{"confidence": 0.8, "reasoning": "The user has repeatedly asked the same question or made the same request, and the assistant's responses are not leading to a resolution or new information. The conversation appears stuck on a particular point without forward progress."}`
}
.*********** Vertex AI: RESPONSE_SCHEMA***************
The user provided project/location will take precedence over the API key from the environment variables.
Response from the responseJsonSchema {
  text: '{\n' +
    '  "next_speaker": "model",\n' +
    `  "reasoning": "The user has just made a request ('populate the given data structure'), and it is the model's turn to respond to that request by providing the populated JSON."\n` +
    '}'
}
Response from the responseSchema {
  text: `{"next_speaker": "user", "reasoning": "The model has completed its turn, and it is now the user's opportunity to respond or ask a follow-up question."}`
}
```
Make progress towards https://github.com/google-gemini/gemini-cli/issues/4387