### PR TITLE
feat: Unset CI environment variables to ensure interactive mode

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -64,6 +64,28 @@ const env = {
   DEV: 'true',
 };
 
+// Fix for issue #1563.
+// The `ink` library uses `is-in-ci` to detect if the process is running in a
+// CI environment. `is-in-ci` checks for the existence of `CI`,
+// `CONTINUOUS_INTEGRATION`, or any variable starting with `CI_`.
+// If any of these are set, `ink` will not render the UI.
+// By unsetting these variables, we force `ink` to render the UI,
+// which is the desired behavior for the Gemini CLI.
+if (env.CI) {
+  console.error('Unsetting CI environment variable: CI');
+  delete env.CI;
+}
+if (env.CONTINUOUS_INTEGRATION) {
+  console.error('Unsetting CI environment variable: CONTINUOUS_INTEGRATION');
+  delete env.CONTINUOUS_INTEGRATION;
+}
+for (const key in env) {
+  if (key.startsWith('CI_')) {
+    console.error(`Unsetting CI environment variable: ${key}`);
+    delete env[key];
+  }
+}
+
 if (process.env.DEBUG) {
   // If this is not set, the debugger will pause on the outer process rather
   // than the relaunched process making it harder to debug.


### PR DESCRIPTION
The `ink` UI framework uses the `is-in-ci` library to detect whether it
is running in a CI environment. This detection is based on the presence
of environment variables like `CI`, `CONTINUOUS_INTEGRATION`, or any
variable starting with `CI_`.

When these variables are set, `ink` assumes a non-interactive
environment and does not render the UI, causing the CLI to hang.

This change unsets these CI-related environment variables at startup,
forcing `ink` to render the UI and ensuring the CLI remains interactive
even when these variables are present in the user's environment.

A warning is printed to stderr when a variable is unset to inform users
who may be scripting with the CLI and expecting these variables to be
present.

Fixes #1563
