### PR TITLE
adh/bugfix/1563

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -21,6 +21,12 @@ esbuild
     outfile: 'bundle/gemini.js',
     platform: 'node',
     format: 'esm',
+    alias: {
+      'is-in-ci': path.resolve(
+        __dirname,
+        'packages/cli/src/patches/is-in-ci.ts',
+      ),
+    },
     define: {
       'process.env.CLI_VERSION': JSON.stringify(pkg.version),
     },

--- a/packages/cli/src/patches/is-in-ci.ts
+++ b/packages/cli/src/patches/is-in-ci.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This is a replacement for the `is-in-ci` package that always returns false.
+// We are doing this to avoid the issue where `ink` does not render the UI
+// when it detects that it is running in a CI environment.
+// This is safe because `ink` (and thus `is-in-ci`) is only used in the
+// interactive code path of the CLI.
+// See issue #1563 for more details.
+
+const isInCi = false;
+
+// eslint-disable-next-line import/no-default-export
+export default isInCi;

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -64,6 +64,28 @@ const env = {
   DEV: 'true',
 };
 
+// Fix for issue #1563.
+// The `ink` library uses `is-in-ci` to detect if the process is running in a
+// CI environment. `is-in-ci` checks for the existence of `CI`,
+// `CONTINUOUS_INTEGRATION`, or any variable starting with `CI_`.
+// If any of these are set, `ink` will not render the UI.
+// By unsetting these variables, we force `ink` to render the UI,
+// which is the desired behavior for the Gemini CLI.
+if (env.CI) {
+  console.error('Unsetting CI environment variable: CI');
+  delete env.CI;
+}
+if (env.CONTINUOUS_INTEGRATION) {
+  console.error('Unsetting CI environment variable: CONTINUOUS_INTEGRATION');
+  delete env.CONTINUOUS_INTEGRATION;
+}
+for (const key in env) {
+  if (key.startsWith('CI_')) {
+    console.error(`Unsetting CI environment variable: ${key}`);
+    delete env[key];
+  }
+}
+
 if (process.env.DEBUG) {
   // If this is not set, the debugger will pause on the outer process rather
   // than the relaunched process making it harder to debug.

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -64,28 +64,6 @@ const env = {
   DEV: 'true',
 };
 
-// Fix for issue #1563.
-// The `ink` library uses `is-in-ci` to detect if the process is running in a
-// CI environment. `is-in-ci` checks for the existence of `CI`,
-// `CONTINUOUS_INTEGRATION`, or any variable starting with `CI_`.
-// If any of these are set, `ink` will not render the UI.
-// By unsetting these variables, we force `ink` to render the UI,
-// which is the desired behavior for the Gemini CLI.
-if (env.CI) {
-  console.error('Unsetting CI environment variable: CI');
-  delete env.CI;
-}
-if (env.CONTINUOUS_INTEGRATION) {
-  console.error('Unsetting CI environment variable: CONTINUOUS_INTEGRATION');
-  delete env.CONTINUOUS_INTEGRATION;
-}
-for (const key in env) {
-  if (key.startsWith('CI_')) {
-    console.error(`Unsetting CI environment variable: ${key}`);
-    delete env[key];
-  }
-}
-
 if (process.env.DEBUG) {
   // If this is not set, the debugger will pause on the outer process rather
   // than the relaunched process making it harder to debug.


### PR DESCRIPTION
The `ink` UI framework uses the `is-in-ci` library to detect whether it
is running in a CI environment. This detection is based on the presence
of environment variables like `CI`, `CONTINUOUS_INTEGRATION`, or any
variable starting with `CI_`.

When these variables are set, `ink` assumes a non-interactive
environment and does not render the UI, causing the CLI to hang.

This change patches the `is-in-ci` dependency at build time using an
esbuild alias. The patch replaces the module with one that always
returns `false`, ensuring that `ink` will always render the UI in
interactive mode.

This patch only affects the bundled application and does not apply when
running in local development mode via `npm run start`. To test this
change locally, you must build and run the bundle directly:
`npm run bundle && node bundle/gemini.js`

Fixes https://github.com/google-gemini/gemini-cli/issues/1563
