### PR TITLE
Add support for tracking slash command usage + log usage of /ide commands

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -209,6 +209,27 @@ Logs are timestamped records of specific events. The following events are logged
   - **Attributes**:
     - `auth_type`
 
+- `gemini_cli.loop_detected`: This event occurs when a loop is detected.
+  - **Attributes**:
+    - `loop_type` (string)
+
+- `gemini_cli.flash_decided_to_continue`: This event occurs when flash decides to continue.
+  - **Attributes**:
+    - `auth_type`
+
+- `gemini_cli.ide_command_triggered`: This event occurs when an IDE command is triggered.
+  - **Attributes**:
+    - `subcommand` (string)
+
+- `gemini_cli.slash_command_triggered`: This event occurs when a slash command is triggered.
+  - **Attributes**:
+    - `command` (string)
+    - `subcommand` (string)
+
+- `gemini_cli.ide_notification_received`: This event occurs when an IDE notification is received. Only one notification per session is logged.
+  - **Attributes**:
+    - `notification_type` (string)
+
 ### Metrics
 
 Metrics are numerical measurements of behavior over time. The following metrics are collected for Gemini CLI:

--- a/packages/cli/src/ui/commands/ideCommand.test.ts
+++ b/packages/cli/src/ui/commands/ideCommand.test.ts
@@ -25,6 +25,8 @@ import {
   IDE_SERVER_NAME,
   MCPDiscoveryState,
   MCPServerStatus,
+  logIdeCommandTriggered,
+  IdeCommandTriggeredEvent,
 } from '@google/gemini-cli-core';
 
 vi.mock('child_process');
@@ -36,6 +38,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     ...original,
     getMCPServerStatus: vi.fn(),
     getMCPDiscoveryState: vi.fn(),
+    logIdeCommandTriggered: vi.fn(),
   };
 });
 
@@ -51,6 +54,7 @@ describe('ideCommand', () => {
   let platformSpy: MockInstance;
   let getMCPServerStatusSpy: MockInstance;
   let getMCPDiscoveryStateSpy: MockInstance;
+  let logIdeCommandTriggeredSpy: MockInstance;
 
   beforeEach(() => {
     mockContext = {
@@ -61,6 +65,7 @@ describe('ideCommand', () => {
 
     mockConfig = {
       getIdeMode: vi.fn(),
+      getUsageStatisticsEnabled: vi.fn(),
     } as unknown as Config;
 
     execSyncSpy = vi.spyOn(child_process, 'execSync');
@@ -68,6 +73,7 @@ describe('ideCommand', () => {
     platformSpy = vi.spyOn(process, 'platform', 'get');
     getMCPServerStatusSpy = vi.mocked(getMCPServerStatus);
     getMCPDiscoveryStateSpy = vi.mocked(getMCPDiscoveryState);
+    logIdeCommandTriggeredSpy = vi.mocked(logIdeCommandTriggered);
   });
 
   afterEach(() => {
@@ -105,6 +111,10 @@ describe('ideCommand', () => {
         messageType: 'info',
         content: '🟢 Connected',
       });
+      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(IdeCommandTriggeredEvent),
+      );
     });
 
     it('should show connecting status', () => {
@@ -116,6 +126,10 @@ describe('ideCommand', () => {
         messageType: 'info',
         content: '🔄 Initializing...',
       });
+      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(IdeCommandTriggeredEvent),
+      );
     });
 
     it('should show discovery in progress status', () => {
@@ -128,6 +142,10 @@ describe('ideCommand', () => {
         messageType: 'info',
         content: '🔄 Initializing...',
       });
+      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(IdeCommandTriggeredEvent),
+      );
     });
 
     it('should show disconnected status', () => {
@@ -140,6 +158,10 @@ describe('ideCommand', () => {
         messageType: 'error',
         content: '🔴 Disconnected',
       });
+      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(IdeCommandTriggeredEvent),
+      );
     });
   });
 
@@ -164,6 +186,10 @@ describe('ideCommand', () => {
         }),
         expect.any(Number),
       );
+      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(IdeCommandTriggeredEvent),
+      );
     });
 
     it('should show an error if the VSIX file is not found', async () => {
@@ -179,6 +205,10 @@ describe('ideCommand', () => {
           text: 'Could not find the required VS Code companion extension. Please file a bug via /bug.',
         }),
         expect.any(Number),
+      );
+      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(IdeCommandTriggeredEvent),
       );
     });
 
@@ -215,6 +245,10 @@ describe('ideCommand', () => {
         }),
         expect.any(Number),
       );
+      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(IdeCommandTriggeredEvent),
+      );
     });
 
     it('should install the extension if found in the dev directory', async () => {
@@ -242,6 +276,10 @@ describe('ideCommand', () => {
         }),
         expect.any(Number),
       );
+      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(IdeCommandTriggeredEvent),
+      );
     });
 
     it('should show an error if installation fails', async () => {
@@ -268,6 +306,10 @@ describe('ideCommand', () => {
           text: `Failed to install VS Code companion extension.`,
         }),
         expect.any(Number),
+      );
+      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(IdeCommandTriggeredEvent),
       );
     });
   });

--- a/packages/cli/src/ui/commands/ideCommand.test.ts
+++ b/packages/cli/src/ui/commands/ideCommand.test.ts
@@ -25,8 +25,6 @@ import {
   IDE_SERVER_NAME,
   MCPDiscoveryState,
   MCPServerStatus,
-  logSlashCommandTriggered,
-  SlashCommandTriggeredEvent,
 } from '@google/gemini-cli-core';
 
 vi.mock('child_process');
@@ -38,7 +36,6 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     ...original,
     getMCPServerStatus: vi.fn(),
     getMCPDiscoveryState: vi.fn(),
-    logSlashCommandTriggered: vi.fn(),
   };
 });
 
@@ -54,7 +51,6 @@ describe('ideCommand', () => {
   let platformSpy: MockInstance;
   let getMCPServerStatusSpy: MockInstance;
   let getMCPDiscoveryStateSpy: MockInstance;
-  let logSlashCommandTriggeredSpy: MockInstance;
 
   beforeEach(() => {
     mockContext = {
@@ -73,7 +69,6 @@ describe('ideCommand', () => {
     platformSpy = vi.spyOn(process, 'platform', 'get');
     getMCPServerStatusSpy = vi.mocked(getMCPServerStatus);
     getMCPDiscoveryStateSpy = vi.mocked(getMCPDiscoveryState);
-    logSlashCommandTriggeredSpy = vi.mocked(logSlashCommandTriggered);
   });
 
   afterEach(() => {
@@ -91,6 +86,7 @@ describe('ideCommand', () => {
     const command = ideCommand(mockConfig);
     expect(command).not.toBeNull();
     expect(command?.name).toBe('ide');
+    expect(command?.action).toBeUndefined();
     expect(command?.subCommands).toHaveLength(2);
     expect(command?.subCommands?.[0].name).toBe('status');
     expect(command?.subCommands?.[1].name).toBe('install');
@@ -111,10 +107,6 @@ describe('ideCommand', () => {
         messageType: 'info',
         content: '🟢 Connected',
       });
-      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
-        mockConfig,
-        expect.any(SlashCommandTriggeredEvent),
-      );
     });
 
     it('should show connecting status', () => {
@@ -126,10 +118,6 @@ describe('ideCommand', () => {
         messageType: 'info',
         content: '🔄 Initializing...',
       });
-      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
-        mockConfig,
-        expect.any(SlashCommandTriggeredEvent),
-      );
     });
 
     it('should show discovery in progress status', () => {
@@ -142,10 +130,6 @@ describe('ideCommand', () => {
         messageType: 'info',
         content: '🔄 Initializing...',
       });
-      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
-        mockConfig,
-        expect.any(SlashCommandTriggeredEvent),
-      );
     });
 
     it('should show disconnected status', () => {
@@ -158,10 +142,6 @@ describe('ideCommand', () => {
         messageType: 'error',
         content: '🔴 Disconnected',
       });
-      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
-        mockConfig,
-        expect.any(SlashCommandTriggeredEvent),
-      );
     });
   });
 
@@ -186,10 +166,6 @@ describe('ideCommand', () => {
         }),
         expect.any(Number),
       );
-      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
-        mockConfig,
-        expect.any(SlashCommandTriggeredEvent),
-      );
     });
 
     it('should show an error if the VSIX file is not found', async () => {
@@ -205,10 +181,6 @@ describe('ideCommand', () => {
           text: 'Could not find the required VS Code companion extension. Please file a bug via /bug.',
         }),
         expect.any(Number),
-      );
-      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
-        mockConfig,
-        expect.any(SlashCommandTriggeredEvent),
       );
     });
 
@@ -245,10 +217,6 @@ describe('ideCommand', () => {
         }),
         expect.any(Number),
       );
-      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
-        mockConfig,
-        expect.any(SlashCommandTriggeredEvent),
-      );
     });
 
     it('should install the extension if found in the dev directory', async () => {
@@ -276,10 +244,6 @@ describe('ideCommand', () => {
         }),
         expect.any(Number),
       );
-      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
-        mockConfig,
-        expect.any(SlashCommandTriggeredEvent),
-      );
     });
 
     it('should show an error if installation fails', async () => {
@@ -306,10 +270,6 @@ describe('ideCommand', () => {
           text: `Failed to install VS Code companion extension.`,
         }),
         expect.any(Number),
-      );
-      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
-        mockConfig,
-        expect.any(SlashCommandTriggeredEvent),
       );
     });
   });

--- a/packages/cli/src/ui/commands/ideCommand.test.ts
+++ b/packages/cli/src/ui/commands/ideCommand.test.ts
@@ -25,8 +25,8 @@ import {
   IDE_SERVER_NAME,
   MCPDiscoveryState,
   MCPServerStatus,
-  logIdeCommandTriggered,
-  IdeCommandTriggeredEvent,
+  logSlashCommandTriggered,
+  SlashCommandTriggeredEvent,
 } from '@google/gemini-cli-core';
 
 vi.mock('child_process');
@@ -38,7 +38,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     ...original,
     getMCPServerStatus: vi.fn(),
     getMCPDiscoveryState: vi.fn(),
-    logIdeCommandTriggered: vi.fn(),
+    logSlashCommandTriggered: vi.fn(),
   };
 });
 
@@ -54,7 +54,7 @@ describe('ideCommand', () => {
   let platformSpy: MockInstance;
   let getMCPServerStatusSpy: MockInstance;
   let getMCPDiscoveryStateSpy: MockInstance;
-  let logIdeCommandTriggeredSpy: MockInstance;
+  let logSlashCommandTriggeredSpy: MockInstance;
 
   beforeEach(() => {
     mockContext = {
@@ -73,7 +73,7 @@ describe('ideCommand', () => {
     platformSpy = vi.spyOn(process, 'platform', 'get');
     getMCPServerStatusSpy = vi.mocked(getMCPServerStatus);
     getMCPDiscoveryStateSpy = vi.mocked(getMCPDiscoveryState);
-    logIdeCommandTriggeredSpy = vi.mocked(logIdeCommandTriggered);
+    logSlashCommandTriggeredSpy = vi.mocked(logSlashCommandTriggered);
   });
 
   afterEach(() => {
@@ -111,9 +111,9 @@ describe('ideCommand', () => {
         messageType: 'info',
         content: '🟢 Connected',
       });
-      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
         mockConfig,
-        expect.any(IdeCommandTriggeredEvent),
+        expect.any(SlashCommandTriggeredEvent),
       );
     });
 
@@ -126,9 +126,9 @@ describe('ideCommand', () => {
         messageType: 'info',
         content: '🔄 Initializing...',
       });
-      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
         mockConfig,
-        expect.any(IdeCommandTriggeredEvent),
+        expect.any(SlashCommandTriggeredEvent),
       );
     });
 
@@ -142,9 +142,9 @@ describe('ideCommand', () => {
         messageType: 'info',
         content: '🔄 Initializing...',
       });
-      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
         mockConfig,
-        expect.any(IdeCommandTriggeredEvent),
+        expect.any(SlashCommandTriggeredEvent),
       );
     });
 
@@ -158,9 +158,9 @@ describe('ideCommand', () => {
         messageType: 'error',
         content: '🔴 Disconnected',
       });
-      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
         mockConfig,
-        expect.any(IdeCommandTriggeredEvent),
+        expect.any(SlashCommandTriggeredEvent),
       );
     });
   });
@@ -186,9 +186,9 @@ describe('ideCommand', () => {
         }),
         expect.any(Number),
       );
-      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
         mockConfig,
-        expect.any(IdeCommandTriggeredEvent),
+        expect.any(SlashCommandTriggeredEvent),
       );
     });
 
@@ -206,9 +206,9 @@ describe('ideCommand', () => {
         }),
         expect.any(Number),
       );
-      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
         mockConfig,
-        expect.any(IdeCommandTriggeredEvent),
+        expect.any(SlashCommandTriggeredEvent),
       );
     });
 
@@ -245,9 +245,9 @@ describe('ideCommand', () => {
         }),
         expect.any(Number),
       );
-      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
         mockConfig,
-        expect.any(IdeCommandTriggeredEvent),
+        expect.any(SlashCommandTriggeredEvent),
       );
     });
 
@@ -276,9 +276,9 @@ describe('ideCommand', () => {
         }),
         expect.any(Number),
       );
-      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
         mockConfig,
-        expect.any(IdeCommandTriggeredEvent),
+        expect.any(SlashCommandTriggeredEvent),
       );
     });
 
@@ -307,9 +307,9 @@ describe('ideCommand', () => {
         }),
         expect.any(Number),
       );
-      expect(logIdeCommandTriggeredSpy).toHaveBeenCalledWith(
+      expect(logSlashCommandTriggeredSpy).toHaveBeenCalledWith(
         mockConfig,
-        expect.any(IdeCommandTriggeredEvent),
+        expect.any(SlashCommandTriggeredEvent),
       );
     });
   });

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -12,8 +12,8 @@ import {
   IDE_SERVER_NAME,
   MCPDiscoveryState,
   MCPServerStatus,
-  logIdeCommandTriggered,
-  IdeCommandTriggeredEvent,
+  logSlashCommandTriggered,
+  SlashCommandTriggeredEvent,
 } from '@google/gemini-cli-core';
 import {
   CommandContext,
@@ -54,7 +54,7 @@ export const ideCommand = (config: Config | null): SlashCommand | null => {
     kind: CommandKind.BUILT_IN,
     action: () => {
       if (config) {
-        logIdeCommandTriggered(config, new IdeCommandTriggeredEvent('ide'));
+        logSlashCommandTriggered(config, new SlashCommandTriggeredEvent('ide'));
       }
     },
     subCommands: [
@@ -64,9 +64,9 @@ export const ideCommand = (config: Config | null): SlashCommand | null => {
         kind: CommandKind.BUILT_IN,
         action: (_context: CommandContext): SlashCommandActionReturn => {
           if (config) {
-            logIdeCommandTriggered(
+            logSlashCommandTriggered(
               config,
-              new IdeCommandTriggeredEvent('status'),
+              new SlashCommandTriggeredEvent('ide', 'status'),
             );
           }
           const status = getMCPServerStatus(IDE_SERVER_NAME);
@@ -108,9 +108,9 @@ export const ideCommand = (config: Config | null): SlashCommand | null => {
         kind: CommandKind.BUILT_IN,
         action: async (context) => {
           if (config) {
-            logIdeCommandTriggered(
+            logSlashCommandTriggered(
               config,
-              new IdeCommandTriggeredEvent('install'),
+              new SlashCommandTriggeredEvent('ide', 'install'),
             );
           }
           if (!isVSCodeInstalled()) {

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -12,6 +12,8 @@ import {
   IDE_SERVER_NAME,
   MCPDiscoveryState,
   MCPServerStatus,
+  logIdeCommandTriggered,
+  IdeCommandTriggeredEvent,
 } from '@google/gemini-cli-core';
 import {
   CommandContext,
@@ -50,12 +52,23 @@ export const ideCommand = (config: Config | null): SlashCommand | null => {
     name: 'ide',
     description: 'manage IDE integration',
     kind: CommandKind.BUILT_IN,
+    action: () => {
+      if (config) {
+        logIdeCommandTriggered(config, new IdeCommandTriggeredEvent('ide'));
+      }
+    },
     subCommands: [
       {
         name: 'status',
         description: 'check status of IDE integration',
         kind: CommandKind.BUILT_IN,
         action: (_context: CommandContext): SlashCommandActionReturn => {
+          if (config) {
+            logIdeCommandTriggered(
+              config,
+              new IdeCommandTriggeredEvent('status'),
+            );
+          }
           const status = getMCPServerStatus(IDE_SERVER_NAME);
           const discoveryState = getMCPDiscoveryState();
           switch (status) {
@@ -94,6 +107,12 @@ export const ideCommand = (config: Config | null): SlashCommand | null => {
         description: 'install required VS Code companion extension',
         kind: CommandKind.BUILT_IN,
         action: async (context) => {
+          if (config) {
+            logIdeCommandTriggered(
+              config,
+              new IdeCommandTriggeredEvent('install'),
+            );
+          }
           if (!isVSCodeInstalled()) {
             context.ui.addItem(
               {

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -12,8 +12,6 @@ import {
   IDE_SERVER_NAME,
   MCPDiscoveryState,
   MCPServerStatus,
-  logSlashCommandTriggered,
-  SlashCommandTriggeredEvent,
 } from '@google/gemini-cli-core';
 import {
   CommandContext,
@@ -52,23 +50,12 @@ export const ideCommand = (config: Config | null): SlashCommand | null => {
     name: 'ide',
     description: 'manage IDE integration',
     kind: CommandKind.BUILT_IN,
-    action: () => {
-      if (config) {
-        logSlashCommandTriggered(config, new SlashCommandTriggeredEvent('ide'));
-      }
-    },
     subCommands: [
       {
         name: 'status',
         description: 'check status of IDE integration',
         kind: CommandKind.BUILT_IN,
         action: (_context: CommandContext): SlashCommandActionReturn => {
-          if (config) {
-            logSlashCommandTriggered(
-              config,
-              new SlashCommandTriggeredEvent('ide', 'status'),
-            );
-          }
           const status = getMCPServerStatus(IDE_SERVER_NAME);
           const discoveryState = getMCPDiscoveryState();
           switch (status) {
@@ -107,12 +94,6 @@ export const ideCommand = (config: Config | null): SlashCommand | null => {
         description: 'install required VS Code companion extension',
         kind: CommandKind.BUILT_IN,
         action: async (context) => {
-          if (config) {
-            logSlashCommandTriggered(
-              config,
-              new SlashCommandTriggeredEvent('ide', 'install'),
-            );
-          }
           if (!isVSCodeInstalled()) {
             context.ui.addItem(
               {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -19,6 +19,8 @@ import {
   FlashFallbackEvent,
   LoopDetectedEvent,
   FlashDecidedToContinueEvent,
+  IdeCommandTriggeredEvent,
+  IdeNotificationReceivedEvent,
 } from '../types.js';
 import { EventMetadataKey } from './event-metadata-key.js';
 import { Config } from '../../config/config.js';
@@ -39,6 +41,8 @@ const end_session_event_name = 'end_session';
 const flash_fallback_event_name = 'flash_fallback';
 const loop_detected_event_name = 'loop_detected';
 const flash_decided_to_continue_event_name = 'flash_decided_to_continue';
+const ide_command_triggered_event_name = 'ide_command_triggered';
+const ide_notification_received_event_name = 'ide_notification_received';
 
 export interface LogResponse {
   nextRequestWaitMs?: number;
@@ -508,6 +512,42 @@ export class ClearcutLogger {
 
     this.enqueueLogEvent(
       this.createLogEvent(flash_decided_to_continue_event_name, data),
+    );
+    this.flushIfNeeded();
+  }
+
+  logIdeCommandTriggeredEvent(event: IdeCommandTriggeredEvent): void {
+    const data = [
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_IDE_COMMAND_SUBCOMMAND,
+        value: event.subcommand,
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
+        value: this.config?.getSessionId() ?? '',
+      },
+    ];
+
+    this.enqueueLogEvent(
+      this.createLogEvent(ide_command_triggered_event_name, data),
+    );
+    this.flushIfNeeded();
+  }
+
+  logIdeNotificationReceivedEvent(event: IdeNotificationReceivedEvent): void {
+    const data = [
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_IDE_NOTIFICATION_TYPE,
+        value: event.notification_type,
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
+        value: this.config?.getSessionId() ?? '',
+      },
+    ];
+
+    this.enqueueLogEvent(
+      this.createLogEvent(ide_notification_received_event_name, data),
     );
     this.flushIfNeeded();
   }

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -21,6 +21,7 @@ import {
   FlashDecidedToContinueEvent,
   IdeCommandTriggeredEvent,
   IdeNotificationReceivedEvent,
+  SlashCommandTriggeredEvent,
 } from '../types.js';
 import { EventMetadataKey } from './event-metadata-key.js';
 import { Config } from '../../config/config.js';
@@ -43,6 +44,7 @@ const loop_detected_event_name = 'loop_detected';
 const flash_decided_to_continue_event_name = 'flash_decided_to_continue';
 const ide_command_triggered_event_name = 'ide_command_triggered';
 const ide_notification_received_event_name = 'ide_notification_received';
+const slash_command_triggered_event_name = 'slash_command_triggered';
 
 export interface LogResponse {
   nextRequestWaitMs?: number;
@@ -548,6 +550,28 @@ export class ClearcutLogger {
 
     this.enqueueLogEvent(
       this.createLogEvent(ide_notification_received_event_name, data),
+    );
+    this.flushIfNeeded();
+  }
+
+  logSlashCommandTriggeredEvent(event: SlashCommandTriggeredEvent): void {
+    const data = [
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SLASH_COMMAND_COMMAND,
+        value: event.command,
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SLASH_COMMAND_SUBCOMMAND,
+        value: event.subcommand ?? '',
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
+        value: this.config?.getSessionId() ?? '',
+      },
+    ];
+
+    this.enqueueLogEvent(
+      this.createLogEvent(slash_command_triggered_event_name, data),
     );
     this.flushIfNeeded();
   }

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -163,6 +163,20 @@ export enum EventMetadataKey {
 
   // Logs the type of loop detected.
   GEMINI_CLI_LOOP_DETECTED_TYPE = 38,
+
+  // ==========================================================================
+  // IDE Command Triggered Event Keys
+  // ===========================================================================
+
+  // Logs the subcommand of the /ide command that was triggered.
+  GEMINI_CLI_IDE_COMMAND_SUBCOMMAND = 41,
+
+  // ==========================================================================
+  // IDE Notification Received Event Keys
+  // ===========================================================================
+
+  // Logs the type of notification received from the IDE.
+  GEMINI_CLI_IDE_NOTIFICATION_TYPE = 42,
 }
 
 export function getEventMetadataKey(

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -177,6 +177,16 @@ export enum EventMetadataKey {
 
   // Logs the type of notification received from the IDE.
   GEMINI_CLI_IDE_NOTIFICATION_TYPE = 42,
+
+  // ==========================================================================
+  // Slash Command Triggered Event Keys
+  // ===========================================================================
+
+  // Logs the command of the slash command that was triggered.
+  GEMINI_CLI_SLASH_COMMAND_COMMAND = 43,
+
+  // Logs the subcommand of the slash command that was triggered.
+  GEMINI_CLI_SLASH_COMMAND_SUBCOMMAND = 44,
 }
 
 export function getEventMetadataKey(

--- a/packages/core/src/telemetry/constants.ts
+++ b/packages/core/src/telemetry/constants.ts
@@ -15,6 +15,8 @@ export const EVENT_CLI_CONFIG = 'gemini_cli.config';
 export const EVENT_FLASH_FALLBACK = 'gemini_cli.flash_fallback';
 export const EVENT_FLASH_DECIDED_TO_CONTINUE =
   'gemini_cli.flash_decided_to_continue';
+export const EVENT_IDE_COMMAND = 'gemini_cli.ide_command';
+export const EVENT_IDE_NOTIFICATION = 'gemini_cli.ide_notification';
 
 export const METRIC_TOOL_CALL_COUNT = 'gemini_cli.tool.call.count';
 export const METRIC_TOOL_CALL_LATENCY = 'gemini_cli.tool.call.latency';

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -26,6 +26,7 @@ export {
   logApiError,
   logApiResponse,
   logFlashFallback,
+  logIdeCommandTriggered,
 } from './loggers.js';
 export {
   StartSessionEvent,
@@ -37,6 +38,7 @@ export {
   ApiResponseEvent,
   TelemetryEvent,
   FlashFallbackEvent,
+  IdeCommandTriggeredEvent,
 } from './types.js';
 export { SpanStatusCode, ValueType } from '@opentelemetry/api';
 export { SemanticAttributes } from '@opentelemetry/semantic-conventions';

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -27,6 +27,7 @@ export {
   logApiResponse,
   logFlashFallback,
   logIdeCommandTriggered,
+  logSlashCommandTriggered,
 } from './loggers.js';
 export {
   StartSessionEvent,
@@ -39,6 +40,7 @@ export {
   TelemetryEvent,
   FlashFallbackEvent,
   IdeCommandTriggeredEvent,
+  SlashCommandTriggeredEvent,
 } from './types.js';
 export { SpanStatusCode, ValueType } from '@opentelemetry/api';
 export { SemanticAttributes } from '@opentelemetry/semantic-conventions';

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -32,6 +32,9 @@ import {
   logUserPrompt,
   logToolCall,
   logFlashFallback,
+  logIdeCommandTriggered,
+  logIdeNotificationReceived,
+  initializeLastLoggedNotificationSessionId,
 } from './loggers.js';
 import {
   ApiRequestEvent,
@@ -41,6 +44,7 @@ import {
   ToolCallEvent,
   UserPromptEvent,
   FlashFallbackEvent,
+  IdeCommandTriggeredEvent,
 } from './types.js';
 import * as metrics from './metrics.js';
 import * as sdk from './sdk.js';
@@ -64,6 +68,8 @@ describe('loggers', () => {
     );
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+    initializeLastLoggedNotificationSessionId();
+    mockLogger.emit.mockClear();
   });
 
   describe('logCliConfiguration', () => {
@@ -748,6 +754,56 @@ describe('loggers', () => {
         'event.name': EVENT_TOOL_CALL,
         'event.timestamp': '2025-01-01T00:00:00.000Z',
       });
+    });
+  });
+
+  describe('logIdeCommandTriggered', () => {
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+    } as unknown as Config;
+
+    it('should log an IDE command trigger event', () => {
+      const event = new IdeCommandTriggeredEvent('test-subcommand');
+      logIdeCommandTriggered(mockConfig, event);
+
+      expect(mockLogger.emit).toHaveBeenCalledWith({
+        body: 'IDE command triggered: test-subcommand',
+        attributes: {
+          'session.id': 'test-session-id',
+          'event.name': 'gemini_cli.ide_command',
+          'event.timestamp': '2025-01-01T00:00:00.000Z',
+          subcommand: 'test-subcommand',
+        },
+      });
+    });
+  });
+
+  describe('logIdeNotificationReceived', () => {
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+    } as unknown as Config;
+
+    it('should log an IDE notification received event', () => {
+      logIdeNotificationReceived(mockConfig, 'test-notification');
+
+      expect(mockLogger.emit).toHaveBeenCalledWith({
+        body: 'IDE notification received: test-notification',
+        attributes: {
+          'session.id': 'test-session-id',
+          'event.name': 'gemini_cli.ide_notification',
+          'event.timestamp': '2025-01-01T00:00:00.000Z',
+          notification_type: 'test-notification',
+        },
+      });
+    });
+
+    it('should not log if the session ID is the same', () => {
+      logIdeNotificationReceived(mockConfig, 'test-notification');
+      logIdeNotificationReceived(mockConfig, 'test-notification');
+
+      expect(mockLogger.emit).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -45,6 +45,7 @@ import {
   UserPromptEvent,
   FlashFallbackEvent,
   IdeCommandTriggeredEvent,
+  IdeNotificationReceivedEvent,
 } from './types.js';
 import * as metrics from './metrics.js';
 import * as sdk from './sdk.js';
@@ -786,22 +787,24 @@ describe('loggers', () => {
     } as unknown as Config;
 
     it('should log an IDE notification received event', () => {
-      logIdeNotificationReceived(mockConfig, 'test-notification');
+      const event = new IdeNotificationReceivedEvent('test-notification');
+      logIdeNotificationReceived(mockConfig, event);
 
       expect(mockLogger.emit).toHaveBeenCalledWith({
         body: 'IDE notification received: test-notification',
         attributes: {
           'session.id': 'test-session-id',
           'event.name': 'gemini_cli.ide_notification',
-          'event.timestamp': '2025-01-01T00:00:00.000Z',
+          event_name: 'ide_notification_received',
           notification_type: 'test-notification',
         },
       });
     });
 
     it('should not log if the session ID is the same', () => {
-      logIdeNotificationReceived(mockConfig, 'test-notification');
-      logIdeNotificationReceived(mockConfig, 'test-notification');
+      const event = new IdeNotificationReceivedEvent('test-notification');
+      logIdeNotificationReceived(mockConfig, event);
+      logIdeNotificationReceived(mockConfig, event);
 
       expect(mockLogger.emit).toHaveBeenCalledTimes(1);
     });

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -803,10 +803,17 @@ describe('loggers', () => {
 
     it('should not log if the session ID is the same', () => {
       const event = new IdeNotificationReceivedEvent('test-notification');
-      logIdeNotificationReceived(mockConfig, event);
-      logIdeNotificationReceived(mockConfig, event);
+      const mockConfig2 = {
+        ...mockConfig,
+        getSessionId: () => 'test-session-id-2',
+      } as unknown as Config;
 
-      expect(mockLogger.emit).toHaveBeenCalledTimes(1);
+      logIdeNotificationReceived(mockConfig, event);
+      logIdeNotificationReceived(mockConfig, event);
+      logIdeNotificationReceived(mockConfig2, event);
+      logIdeNotificationReceived(mockConfig2, event);
+
+      expect(mockLogger.emit).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -795,7 +795,7 @@ describe('loggers', () => {
         attributes: {
           'session.id': 'test-session-id',
           'event.name': 'gemini_cli.ide_notification',
-          event_name: 'ide_notification_received',
+          'event.timestamp': '2025-01-01T00:00:00.000Z',
           notification_type: 'test-notification',
         },
       });

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -32,6 +32,7 @@ import {
   IdeCommandTriggeredEvent,
   IdeNotificationReceivedEvent,
   LoopDetectedEvent,
+  SlashCommandTriggeredEvent,
 } from './types.js';
 import {
   recordApiErrorMetrics,
@@ -359,6 +360,27 @@ export function logIdeCommandTriggered(
   const logger = logs.getLogger(SERVICE_NAME);
   const logRecord: LogRecord = {
     body: `IDE command triggered: ${event.subcommand}`,
+    attributes,
+  };
+  logger.emit(logRecord);
+}
+
+export function logSlashCommandTriggered(
+  config: Config,
+  event: SlashCommandTriggeredEvent,
+) {
+  ClearcutLogger.getInstance(config)?.logSlashCommandTriggeredEvent(event);
+  if (!isTelemetrySdkInitialized()) return;
+
+  const attributes: LogAttributes = {
+    ...getCommonAttributes(config),
+    ...event,
+    'event.name': 'slash_command_triggered',
+  };
+
+  const logger = logs.getLogger(SERVICE_NAME);
+  const logRecord: LogRecord = {
+    body: `Slash command triggered: ${event.command} ${event.subcommand ?? ''}`,
     attributes,
   };
   logger.emit(logRecord);

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -366,14 +366,13 @@ export function logIdeCommandTriggered(
 
 export function logIdeNotificationReceived(
   config: Config,
-  notification_type: string,
+  event: IdeNotificationReceivedEvent,
 ) {
   const currentSessionId = config.getSessionId();
   if (lastLoggedNotificationSessionId === currentSessionId) {
     return;
   }
 
-  const event = new IdeNotificationReceivedEvent(notification_type);
   ClearcutLogger.getInstance(config)?.logIdeNotificationReceivedEvent(event);
   lastLoggedNotificationSessionId = currentSessionId;
   if (!isTelemetrySdkInitialized()) return;
@@ -386,7 +385,7 @@ export function logIdeNotificationReceived(
 
   const logger = logs.getLogger(SERVICE_NAME);
   const logRecord: LogRecord = {
-    body: `IDE notification received: ${notification_type}`,
+    body: `IDE notification received: ${event.notification_type}`,
     attributes,
   };
   logger.emit(logRecord);

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -44,10 +44,10 @@ import { uiTelemetryService, UiEvent } from './uiTelemetry.js';
 import { ClearcutLogger } from './clearcut-logger/clearcut-logger.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 
-export let lastLoggedNotificationSessionId: string | null = null;
+export const loggedNotificationSessionIds = new Set<string>();
 
 export function initializeLastLoggedNotificationSessionId() {
-  lastLoggedNotificationSessionId = null;
+  loggedNotificationSessionIds.clear();
 }
 
 const shouldLogUserPrompts = (config: Config): boolean =>
@@ -369,12 +369,12 @@ export function logIdeNotificationReceived(
   event: IdeNotificationReceivedEvent,
 ) {
   const currentSessionId = config.getSessionId();
-  if (lastLoggedNotificationSessionId === currentSessionId) {
+  if (loggedNotificationSessionIds.has(currentSessionId)) {
     return;
   }
 
   ClearcutLogger.getInstance(config)?.logIdeNotificationReceivedEvent(event);
-  lastLoggedNotificationSessionId = currentSessionId;
+  loggedNotificationSessionIds.add(currentSessionId);
   if (!isTelemetrySdkInitialized()) return;
 
   const attributes: LogAttributes = {

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -278,6 +278,30 @@ export class FlashDecidedToContinueEvent {
   }
 }
 
+export class IdeNotificationReceivedEvent {
+  'event.name': 'ide_notification_received';
+  'event.timestamp': string; // ISO 8601
+  notification_type: string;
+
+  constructor(notification_type: string) {
+    this['event.name'] = 'ide_notification_received';
+    this['event.timestamp'] = new Date().toISOString();
+    this.notification_type = notification_type;
+  }
+}
+
+export class IdeCommandTriggeredEvent {
+  'event.name': 'ide_command_triggered';
+  'event.timestamp': string; // ISO 8601
+  subcommand: string;
+
+  constructor(subcommand: string) {
+    this['event.name'] = 'ide_command_triggered';
+    this['event.timestamp'] = new Date().toISOString();
+    this.subcommand = subcommand;
+  }
+}
+
 export type TelemetryEvent =
   | StartSessionEvent
   | EndSessionEvent
@@ -288,4 +312,6 @@ export type TelemetryEvent =
   | ApiResponseEvent
   | FlashFallbackEvent
   | LoopDetectedEvent
-  | FlashDecidedToContinueEvent;
+  | FlashDecidedToContinueEvent
+  | IdeCommandTriggeredEvent
+  | IdeNotificationReceivedEvent;

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -302,6 +302,20 @@ export class IdeCommandTriggeredEvent {
   }
 }
 
+export class SlashCommandTriggeredEvent {
+  'event.name': 'slash_command_triggered';
+  'event.timestamp': string; // ISO 8601
+  command: string;
+  subcommand?: string;
+
+  constructor(command: string, subcommand?: string) {
+    this['event.name'] = 'slash_command_triggered';
+    this['event.timestamp'] = new Date().toISOString();
+    this.command = command;
+    this.subcommand = subcommand;
+  }
+}
+
 export type TelemetryEvent =
   | StartSessionEvent
   | EndSessionEvent
@@ -314,4 +328,5 @@ export type TelemetryEvent =
   | LoopDetectedEvent
   | FlashDecidedToContinueEvent
   | IdeCommandTriggeredEvent
-  | IdeNotificationReceivedEvent;
+  | IdeNotificationReceivedEvent
+  | SlashCommandTriggeredEvent;

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -31,6 +31,7 @@ import {
 } from '../services/ideContext.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { logIdeNotificationReceived } from '../telemetry/loggers.js';
+import { IdeNotificationReceivedEvent } from '../telemetry/types.js';
 
 export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
 
@@ -396,7 +397,10 @@ export async function connectAndDiscover(
         mcpClient.setNotificationHandler(
           OpenFilesNotificationSchema,
           (notification) => {
-            logIdeNotificationReceived(config, notification.method);
+            logIdeNotificationReceived(
+              config,
+              new IdeNotificationReceivedEvent(notification.method),
+            );
             ideContext.setOpenFilesContext(notification.params);
           },
         );

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -16,7 +16,7 @@ import {
   StreamableHTTPClientTransportOptions,
 } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { parse } from 'shell-quote';
-import { AuthProviderType, MCPServerConfig } from '../config/config.js';
+import { Config, AuthProviderType, MCPServerConfig } from '../config/config.js';
 import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import { FunctionDeclaration, mcpToTool } from '@google/genai';
@@ -30,6 +30,7 @@ import {
   ideContext,
 } from '../services/ideContext.js';
 import { getErrorMessage } from '../utils/errors.js';
+import { logIdeNotificationReceived } from '../telemetry/loggers.js';
 
 export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
 
@@ -313,6 +314,7 @@ export async function discoverMcpTools(
   mcpServerCommand: string | undefined,
   toolRegistry: ToolRegistry,
   debugMode: boolean,
+  config: Config,
 ): Promise<void> {
   mcpDiscoveryState = MCPDiscoveryState.IN_PROGRESS;
   try {
@@ -325,6 +327,7 @@ export async function discoverMcpTools(
           mcpServerConfig,
           toolRegistry,
           debugMode,
+          config,
         ),
     );
     await Promise.all(discoveryPromises);
@@ -368,6 +371,7 @@ export async function connectAndDiscover(
   mcpServerConfig: MCPServerConfig,
   toolRegistry: ToolRegistry,
   debugMode: boolean,
+  config: Config,
 ): Promise<void> {
   updateMCPServerStatus(mcpServerName, MCPServerStatus.CONNECTING);
 
@@ -392,6 +396,7 @@ export async function connectAndDiscover(
         mcpClient.setNotificationHandler(
           OpenFilesNotificationSchema,
           (notification) => {
+            logIdeNotificationReceived(config, notification.method);
             ideContext.setOpenFilesContext(notification.params);
           },
         );

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -345,6 +345,7 @@ describe('ToolRegistry', () => {
         undefined,
         toolRegistry,
         false,
+        config,
       );
     });
 
@@ -367,6 +368,7 @@ describe('ToolRegistry', () => {
         undefined,
         toolRegistry,
         false,
+        config,
       );
     });
   });

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -194,6 +194,7 @@ export class ToolRegistry {
       this.config.getMcpServerCommand(),
       this,
       this.config.getDebugMode(),
+      this.config,
     );
   }
 

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -170,6 +170,7 @@ export class ToolRegistry {
       this.config.getMcpServerCommand(),
       this,
       this.config.getDebugMode(),
+      this.config,
     );
   }
 
@@ -193,6 +194,7 @@ export class ToolRegistry {
         undefined,
         this,
         this.config.getDebugMode(),
+        this.config,
       );
     }
   }


### PR DESCRIPTION
## TLDR

- Logs every time the /ide, /ide status and /ide install commands are invoked
- Logs once per session when a notification is recieved

## Linked issues / bugs
Fixes #4395