### PR TITLE
[4845] Invalid OAUth Authorization Url

### DIFF
--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -301,7 +301,14 @@ export class MCPOAuthProvider {
       OAuthUtils.buildResourceParameter(config.authorizationUrl!),
     );
 
-    return `${config.authorizationUrl}?${params.toString()}`;
+    // Parse the authorizationUrl and merge parameters
+    const url = new URL(config.authorizationUrl!);
+    // Add/overwrite parameters from params
+    for (const [key, value] of params.entries()) {
+      url.searchParams.set(key, value);
+    }
+
+    return url.toString();
   }
 
   /**


### PR DESCRIPTION
## TLDR

Fixed an issue where authorization urls that already contained query parameters would cause the url to become malformed when appending the additional query parameters.

## Linked issues / bugs

- Fixes #4845

