### PR TITLE
fix(core): populate a request ID as a UUID for calls to the Code Assist backend

### DIFF
--- a/packages/core/src/code_assist/converter.test.ts
+++ b/packages/core/src/code_assist/converter.test.ts
@@ -24,7 +24,11 @@ describe('converter', () => {
         model: 'gemini-pro',
         contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
       };
-      const codeAssistReq = toGenerateContentRequest(genaiReq, 'my-project');
+      const { requestId, ...codeAssistReq } = toGenerateContentRequest(
+        genaiReq,
+        'my-project',
+      );
+      expect(requestId).toEqual(expect.any(String));
       expect(codeAssistReq).toEqual({
         model: 'gemini-pro',
         project: 'my-project',
@@ -47,7 +51,9 @@ describe('converter', () => {
         model: 'gemini-pro',
         contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
       };
-      const codeAssistReq = toGenerateContentRequest(genaiReq);
+      const { requestId, ...codeAssistReq } =
+        toGenerateContentRequest(genaiReq);
+      expect(requestId).toEqual(expect.any(String));
       expect(codeAssistReq).toEqual({
         model: 'gemini-pro',
         project: undefined,
@@ -70,11 +76,12 @@ describe('converter', () => {
         model: 'gemini-pro',
         contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
       };
-      const codeAssistReq = toGenerateContentRequest(
+      const { requestId, ...codeAssistReq } = toGenerateContentRequest(
         genaiReq,
         'my-project',
         'session-123',
       );
+      expect(requestId).toEqual(expect.any(String));
       expect(codeAssistReq).toEqual({
         model: 'gemini-pro',
         project: 'my-project',
@@ -180,6 +187,15 @@ describe('converter', () => {
         seed: 9,
         responseMimeType: 'application/json',
       });
+    });
+
+    it('should set a requestId', () => {
+      const genaiReq: GenerateContentParameters = {
+        model: 'gemini-pro',
+        contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
+      };
+      const codeAssistReq = toGenerateContentRequest(genaiReq);
+      expect(codeAssistReq.requestId).toEqual(expect.any(String));
     });
   });
 

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -28,11 +28,13 @@ import {
   ToolListUnion,
   ToolConfig,
 } from '@google/genai';
+import { randomUUID } from 'crypto';
 
 export interface CAGenerateContentRequest {
   model: string;
   project?: string;
   request: VertexGenerateContentRequest;
+  requestId: string;
 }
 
 interface VertexGenerateContentRequest {
@@ -122,6 +124,7 @@ export function toGenerateContentRequest(
     model: req.model,
     project,
     request: toVertexGenerateContentRequest(req, sessionId),
+    requestId: randomUUID(),
   };
 }
 


### PR DESCRIPTION
## TLDR

Provide a UUID for the Code Assist request's `request_id` field.  The request ID is expected to be a unique identifier such as a UUID.

## Reviewer Test Plan

This was harder to verify than I expected.  Although I found some mention that `NODE_DEBUG=request` showing request bodies, that doesn't seem to be the case.  I ended up instrumenting the server-side call to verify that the value was being passed.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to [b/433633002](http://b/433633002).

