### PR TITLE
Update documentation for read_many_files.

### DIFF
--- a/docs/tools/multi-file.md
+++ b/docs/tools/multi-file.md
@@ -11,12 +11,14 @@ Use `read_many_files` to read content from multiple files specified by paths or 
 
 `read_many_files` can be used to perform tasks such as getting an overview of a codebase, finding where specific functionality is implemented, reviewing documentation, or gathering context from multiple configuration files.
 
+**Note:** `read_many_files` looks for files following the provided paths or glob patterns. A directory path such as `"/docs"` will return an empty result; the tool requires a pattern such as `"/docs/*"` or `"/docs/*.md"` to identify the relevant files.
+
 ### Arguments
 
 `read_many_files` takes the following arguments:
 
-- `paths` (list[string], required): An array of glob patterns or paths relative to the tool's target directory (e.g., `["src/**/*.ts"]`, `["README.md", "docs/", "assets/logo.png"]`).
-- `exclude` (list[string], optional): Glob patterns for files/directories to exclude (e.g., `["**/*.log", "temp/"]`). These are added to default excludes if `useDefaultExcludes` is true.
+- `paths` (list[string], required): An array of glob patterns or paths relative to the tool's target directory (e.g., `["src/**/*.ts"]`, `["README.md", "docs/*", "assets/logo.png"]`).
+- `exclude` (list[string], optional): Glob patterns for files/directories to exclude (e.g., `["**/*.log", "temp/*"]`). These are added to default excludes if `useDefaultExcludes` is true.
 - `include` (list[string], optional): Additional glob patterns to include. These are merged with `paths` (e.g., `["*.test.ts"]` to specifically add test files if they were broadly excluded, or `["images/*.jpg"]` to include specific image types).
 - `recursive` (boolean, optional): Whether to search recursively. This is primarily controlled by `**` in glob patterns. Defaults to `true`.
 - `useDefaultExcludes` (boolean, optional): Whether to apply a list of default exclusion patterns (e.g., `node_modules`, `.git`, non image/pdf binary files). Defaults to `true`.

--- a/docs/tools/multi-file.md
+++ b/docs/tools/multi-file.md
@@ -18,7 +18,7 @@ Use `read_many_files` to read content from multiple files specified by paths or 
 `read_many_files` takes the following arguments:
 
 - `paths` (list[string], required): An array of glob patterns or paths relative to the tool's target directory (e.g., `["src/**/*.ts"]`, `["README.md", "docs/*", "assets/logo.png"]`).
-- `exclude` (list[string], optional): Glob patterns for files/directories to exclude (e.g., `["**/*.log", "temp/*"]`). These are added to default excludes if `useDefaultExcludes` is true.
+- `exclude` (list[string], optional): Glob patterns for files/directories to exclude (e.g., `["**/*.log", "temp/"]`). These are added to default excludes if `useDefaultExcludes` is true.
 - `include` (list[string], optional): Additional glob patterns to include. These are merged with `paths` (e.g., `["*.test.ts"]` to specifically add test files if they were broadly excluded, or `["images/*.jpg"]` to include specific image types).
 - `recursive` (boolean, optional): Whether to search recursively. This is primarily controlled by `**` in glob patterns. Defaults to `true`.
 - `useDefaultExcludes` (boolean, optional): Whether to apply a list of default exclusion patterns (e.g., `node_modules`, `.git`, non image/pdf binary files). Defaults to `true`.


### PR DESCRIPTION
## TLDR

Update documentation for read_many_files to note that simply referencing a directory, such as ("docs"), will not surface files.

## Dive Deeper

The read_many_files command uses glob patterns rather than just direct paths. Consequently, using "docs" or "docs/" will not reveal files within a directory; the required pattern is "docs/*".

## Reviewer Test Plan

N/A

## Linked issues / bugs

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Fixes #4293 