### PR TITLE
Fix bugs breaking drag and drop of files.

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -164,7 +164,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const handleInput = useCallback(
     (key: Key) => {
-      if (!focus) {
+      /// We want to handle paste even when not focused to support drag and drop.
+      if (!focus && !key.paste) {
         return;
       }
 
@@ -349,7 +350,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     ],
   );
 
-  useKeypress(handleInput, { isActive: focus });
+  useKeypress(handleInput, { isActive: true });
 
   const linesToRender = buffer.viewportVisualLines;
   const [cursorVisualRowAbsolute, cursorVisualColAbsolute] =

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -407,8 +407,8 @@ describe('useTextBuffer', () => {
         useTextBuffer({ viewport, isValidPath: () => true }),
       );
       const filePath = '/path/to/a/valid/file.txt';
-      act(() => result.current.insert(filePath));
-      expect(getBufferState(result).text).toBe(`@${filePath}`);
+      act(() => result.current.insert(filePath, { paste: true }));
+      expect(getBufferState(result).text).toBe(`@${filePath} `);
     });
 
     it('should not prepend @ to an invalid file path on insert', () => {
@@ -416,7 +416,7 @@ describe('useTextBuffer', () => {
         useTextBuffer({ viewport, isValidPath: () => false }),
       );
       const notAPath = 'this is just some long text';
-      act(() => result.current.insert(notAPath));
+      act(() => result.current.insert(notAPath, { paste: true }));
       expect(getBufferState(result).text).toBe(notAPath);
     });
 
@@ -425,8 +425,8 @@ describe('useTextBuffer', () => {
         useTextBuffer({ viewport, isValidPath: () => true }),
       );
       const filePath = "'/path/to/a/valid/file.txt'";
-      act(() => result.current.insert(filePath));
-      expect(getBufferState(result).text).toBe(`@/path/to/a/valid/file.txt`);
+      act(() => result.current.insert(filePath, { paste: true }));
+      expect(getBufferState(result).text).toBe(`@/path/to/a/valid/file.txt `);
     });
 
     it('should not prepend @ to short text that is not a path', () => {
@@ -434,7 +434,7 @@ describe('useTextBuffer', () => {
         useTextBuffer({ viewport, isValidPath: () => true }),
       );
       const shortText = 'ab';
-      act(() => result.current.insert(shortText));
+      act(() => result.current.insert(shortText, { paste: true }));
       expect(getBufferState(result).text).toBe(shortText);
     });
   });
@@ -449,7 +449,7 @@ describe('useTextBuffer', () => {
         }),
       );
       const filePath = '/path/to/a/valid/file.txt';
-      act(() => result.current.insert(filePath));
+      act(() => result.current.insert(filePath, { paste: true }));
       expect(getBufferState(result).text).toBe(filePath); // No @ prefix
     });
 
@@ -462,7 +462,7 @@ describe('useTextBuffer', () => {
         }),
       );
       const quotedFilePath = "'/path/to/a/valid/file.txt'";
-      act(() => result.current.insert(quotedFilePath));
+      act(() => result.current.insert(quotedFilePath, { paste: true }));
       expect(getBufferState(result).text).toBe(quotedFilePath); // No @ prefix, keeps quotes
     });
 
@@ -475,7 +475,7 @@ describe('useTextBuffer', () => {
         }),
       );
       const notAPath = 'this is just some text';
-      act(() => result.current.insert(notAPath));
+      act(() => result.current.insert(notAPath, { paste: true }));
       expect(getBufferState(result).text).toBe(notAPath);
     });
 
@@ -488,7 +488,7 @@ describe('useTextBuffer', () => {
         }),
       );
       const shortText = 'ls';
-      act(() => result.current.insert(shortText));
+      act(() => result.current.insert(shortText, { paste: true }));
       expect(getBufferState(result).text).toBe(shortText); // No @ prefix for short text
     });
   });
@@ -849,6 +849,7 @@ describe('useTextBuffer', () => {
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: '\x7f',
         });
         result.current.handleInput({
@@ -856,6 +857,7 @@ describe('useTextBuffer', () => {
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: '\x7f',
         });
         result.current.handleInput({
@@ -863,6 +865,7 @@ describe('useTextBuffer', () => {
           ctrl: false,
           meta: false,
           shift: false,
+          paste: false,
           sequence: '\x7f',
         });
       });
@@ -990,9 +993,9 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
 
       // Simulate pasting the long text multiple times
       act(() => {
-        result.current.insert(longText);
-        result.current.insert(longText);
-        result.current.insert(longText);
+        result.current.insert(longText, { paste: true });
+        result.current.insert(longText, { paste: true });
+        result.current.insert(longText, { paste: true });
       });
 
       const state = getBufferState(result);


### PR DESCRIPTION
## TLDR

https://github.com/google-gemini/gemini-cli/pull/4012/files supporting hiding the cursor when the terminal is not focused broke drag and drop and right click paste as those events occurred when the terminal was not focused.

Fixed so we still handle paste even when not focused.
Also made code detecting pastes that were file paths more robust.

I'll fast follow with some regression tests. Long term we really need good keyboard integration tests.

## Linked issues / bugs

- Fixes #4615
