### PR TITLE
fix(ci): Fix failing release workflow by creating a self-contained bundle

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -21,6 +21,7 @@ esbuild
     outfile: 'bundle/gemini.js',
     platform: 'node',
     format: 'esm',
+    external: [],
     alias: {
       'is-in-ci': path.resolve(
         __dirname,

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -34,27 +34,5 @@ esbuild
     banner: {
       js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url); globalThis.__filename = require('url').fileURLToPath(import.meta.url); globalThis.__dirname = require('path').dirname(globalThis.__filename);`,
     },
-    external: [
-      'es-toolkit/compat',
-      'ansi-escapes',
-      'auto-bind',
-      'command-exists',
-      '@babel/code-frame',
-      'cli-truncate',
-      'cli-cursor',
-      '@alcalzone/ansi-tokenize',
-      'cli-boxes',
-      'code-excerpt',
-      'chalk',
-      'cli-spinners',
-      'configstore',
-      'gradient-string',
-      'devlop',
-      'escape-goat',
-      '@iarna/toml',
-      '@pnpm/npm-conf',
-      'deep-extend',
-      'ansi-align',
-    ],
   })
   .catch(() => process.exit(1));

--- a/package-lock.json
+++ b/package-lock.json
@@ -11650,6 +11650,7 @@
       "version": "0.1.13",
       "dependencies": {
         "@google/gemini-cli-core": "file:../core",
+        "@google/genai": "1.11.0",
         "@iarna/toml": "^2.2.5",
         "@types/update-notifier": "^6.0.8",
         "command-exists": "^1.2.9",
@@ -11699,6 +11700,27 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "packages/cli/node_modules/@google/genai": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.11.0.tgz",
+      "integrity": "sha512-4XFAHCvU91ewdWOU3RUdSeXpDuZRJHNYLqT9LKw7WqPjRQcEJvVU+VOU49ocruaSp8VuLKMecl0iadlQK+Zgfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.14.2",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.11.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "packages/cli/node_modules/@testing-library/dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -918,27 +918,6 @@
       "resolved": "packages/core",
       "link": true
     },
-    "node_modules/@google/genai": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.11.0.tgz",
-      "integrity": "sha512-4XFAHCvU91ewdWOU3RUdSeXpDuZRJHNYLqT9LKw7WqPjRQcEJvVU+VOU49ocruaSp8VuLKMecl0iadlQK+Zgfw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^9.14.2",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
@@ -11650,7 +11629,7 @@
       "version": "0.1.13",
       "dependencies": {
         "@google/gemini-cli-core": "file:../core",
-        "@google/genai": "1.11.0",
+        "@google/genai": "1.9.0",
         "@iarna/toml": "^2.2.5",
         "@types/update-notifier": "^6.0.8",
         "command-exists": "^1.2.9",
@@ -11701,6 +11680,27 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "packages/cli/node_modules/@google/genai": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.9.0.tgz",
+      "integrity": "sha512-w9P93OXKPMs9H1mfAx9+p3zJqQGrWBGdvK/SVc7cLZEXNHr/3+vW2eif7ZShA6wU24rNLn9z9MK2vQFUvNRI2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.14.2",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.11.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "packages/cli/node_modules/@testing-library/dom": {
@@ -11839,7 +11839,7 @@
       "name": "@google/gemini-cli-core",
       "version": "0.1.13",
       "dependencies": {
-        "@google/genai": "1.11.0",
+        "@google/genai": "1.9.0",
         "@modelcontextprotocol/sdk": "^1.11.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",
@@ -11877,6 +11877,27 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "packages/core/node_modules/@google/genai": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.9.0.tgz",
+      "integrity": "sha512-w9P93OXKPMs9H1mfAx9+p3zJqQGrWBGdvK/SVc7cLZEXNHr/3+vW2eif7ZShA6wU24rNLn9z9MK2vQFUvNRI2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.14.2",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.11.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "packages/core/node_modules/ajv": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -919,9 +919,9 @@
       "link": true
     },
     "node_modules/@google/genai": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.9.0.tgz",
-      "integrity": "sha512-w9P93OXKPMs9H1mfAx9+p3zJqQGrWBGdvK/SVc7cLZEXNHr/3+vW2eif7ZShA6wU24rNLn9z9MK2vQFUvNRI2Q==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.11.0.tgz",
+      "integrity": "sha512-4XFAHCvU91ewdWOU3RUdSeXpDuZRJHNYLqT9LKw7WqPjRQcEJvVU+VOU49ocruaSp8VuLKMecl0iadlQK+Zgfw==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.14.2",
@@ -11674,7 +11674,8 @@
         "strip-ansi": "^7.1.0",
         "strip-json-comments": "^3.1.1",
         "update-notifier": "^7.3.1",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.2",
+        "zod": "^3.23.8"
       },
       "bin": {
         "gemini": "dist/index.js"
@@ -11700,27 +11701,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "packages/cli/node_modules/@google/genai": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.11.0.tgz",
-      "integrity": "sha512-4XFAHCvU91ewdWOU3RUdSeXpDuZRJHNYLqT9LKw7WqPjRQcEJvVU+VOU49ocruaSp8VuLKMecl0iadlQK+Zgfw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^9.14.2",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
       }
     },
     "packages/cli/node_modules/@testing-library/dom": {
@@ -11859,7 +11839,7 @@
       "name": "@google/gemini-cli-core",
       "version": "0.1.13",
       "dependencies": {
-        "@google/genai": "1.9.0",
+        "@google/genai": "1.11.0",
         "@modelcontextprotocol/sdk": "^1.11.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@google/gemini-cli-core": "file:../core",
+    "@google/genai": "1.11.0",
     "@iarna/toml": "^2.2.5",
     "@types/update-notifier": "^6.0.8",
     "command-exists": "^1.2.9",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@google/gemini-cli-core": "file:../core",
-    "@google/genai": "1.11.0",
+    "@google/genai": "1.9.0",
     "@iarna/toml": "^2.2.5",
     "@types/update-notifier": "^6.0.8",
     "command-exists": "^1.2.9",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,8 @@
     "strip-ansi": "^7.1.0",
     "strip-json-comments": "^3.1.1",
     "update-notifier": "^7.3.1",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@babel/runtime": "^7.27.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "dependencies": {
-    "@google/genai": "1.11.0",
+    "@google/genai": "1.9.0",
     "@modelcontextprotocol/sdk": "^1.11.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "dependencies": {
-    "@google/genai": "1.9.0",
+    "@google/genai": "1.11.0",
     "@modelcontextprotocol/sdk": "^1.11.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",


### PR DESCRIPTION
## TLDR

This PR fixes the failing `release` GitHub Action workflow. The integration tests (`test:integration:sandbox:docker`) were failing because the CLI, when run inside the Docker sandbox, could not find its required dependencies like `zod` and `@google/genai`.

The fix involves two main changes:
1.  Correcting the `package.json` files to ensure all packages properly declare their direct dependencies.
2.  Updating the `esbuild` configuration to create a single, self-contained executable file that includes all third-party modules.

This makes our build artifact robust and eliminates failures caused by a fragile dependency installation process inside Docker.

## Dive Deeper

The root cause of the failure was a fragile packaging pipeline. Our `esbuild` process was creating a "thin" bundle that did not include third-party `node_modules`. It expected these dependencies to be installed separately when the application was run. The `npm install -g` step inside our `Dockerfile` was failing to correctly reconstruct this complex dependency tree for our bundled application, leading to `ERR_MODULE_NOT_FOUND` errors at runtime.

This PR implements a more robust, industry-standard solution for distributing a CLI tool:

1.  **Corrected Dependency Declarations:** The first step was a dependency audit. Packages like `zod` and `@google/genai` were being imported directly in `@google/gemini-cli` but were not listed in its `package.json`. This has been corrected to ensure our dependency graph is accurate.

2.  **Creating a Standalone Bundle:** The primary fix was to modify `esbuild.config.js` by adding the `external: []` property. This is a critical change that instructs the bundler to stop treating third-party packages as external. Instead, it now bundles all necessary code from `node_modules` directly into the final `bundle/gemini.js` file.

This new approach creates a true standalone executable. The `bundle/gemini.js` file is now self-contained and has no external dependencies, which dramatically increases the reliability of our Docker image, simplifies the build process, and makes future deployments faster and less error-prone.

This has been validated with a manual dry run of the release workflow:

<img width="1070" height="587" alt="Screenshot 2025-07-25 at 3 50 46 PM" src="https://github.com/user-attachments/assets/5af8cfe6-dea5-4dcb-a398-6bce273e18c0" />

## Reviewer Test Plan

To validate these changes, a reviewer can pull down this branch and simulate the build and test process locally.

1.  **Install Dependencies:**
    ```bash
    npm install
    ```

2.  **Build the Standalone Bundle:**
    Run the bundle command.
    ```bash
    npm run bundle
    ```
    *   **Verification:** You can inspect the resulting `bundle/gemini.js` file. It will be significantly larger than before (several megabytes), as it now contains the code for all dependencies.

3.  **Run the Failing Integration Test Suite:**
    This is the most important step. Run the exact command that was failing in the CI pipeline.
    ```bash
    npm run test:integration:sandbox:docker
    ```
    *   **Expected Outcome:** The command should now complete successfully. The sandbox Docker image will be built, and all integration tests will pass without any `ERR_MODULE_NOT_FOUND` errors.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

Closes #4879 
Closes #4869 
Closes #4866 
Closes #4846 

