### PR TITLE
Fix grep.test to work on windows.

### DIFF
--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -125,7 +125,9 @@ describe('GrepTool', () => {
       expect(result.llmContent).toContain('File: fileA.txt');
       expect(result.llmContent).toContain('L1: hello world');
       expect(result.llmContent).toContain('L2: second line with world');
-      expect(result.llmContent).toContain('File: sub/fileC.txt');
+      expect(result.llmContent).toContain(
+        `File: ${path.join('sub', 'fileC.txt')}`,
+      );
       expect(result.llmContent).toContain('L1: another world in sub dir');
       expect(result.returnDisplay).toBe('Found 3 matches');
     });
@@ -235,7 +237,7 @@ describe('GrepTool', () => {
     it('should generate correct description with pattern and path', () => {
       const params: GrepToolParams = {
         pattern: 'testPattern',
-        path: 'src/app',
+        path: path.join('src', 'app'),
       };
       // The path will be relative to the tempRootDir, so we check for containment.
       expect(grepTool.getDescription(params)).toContain("'testPattern' within");
@@ -248,12 +250,14 @@ describe('GrepTool', () => {
       const params: GrepToolParams = {
         pattern: 'testPattern',
         include: '*.ts',
-        path: 'src/app',
+        path: path.join('src', 'app'),
       };
       expect(grepTool.getDescription(params)).toContain(
         "'testPattern' in *.ts within",
       );
-      expect(grepTool.getDescription(params)).toContain('src/app');
+      expect(grepTool.getDescription(params)).toContain(
+        path.join('src', 'app'),
+      );
     });
 
     it('should use ./ for root path in description', () => {


### PR DESCRIPTION
## TLDR

Refactors and fixes this test to work on windows.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |x  | x  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

For https://github.com/google-gemini/gemini-cli/issues/3718