### PR TITLE
fix: Clean up transport on IDE connection failure

### DIFF
--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -10,8 +10,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 
 const logger = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  debug: (...args: any[]) =>
-    console.debug('[DEBUG] [IDEClient]', ...args),
+  debug: (...args: any[]) => console.debug('[DEBUG] [IDEClient]', ...args),
 };
 
 export type IDEConnectionState = {

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -11,7 +11,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 const logger = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   debug: (...args: any[]) =>
-    console.debug('[DEBUG] [ImportProcessor]', ...args),
+    console.debug('[DEBUG] [IDEClient]', ...args),
 };
 
 export type IDEConnectionState = {
@@ -37,6 +37,7 @@ export class IdeClient {
       logger.debug('Failed to initialize IdeClient:', err);
     });
   }
+
   getConnectionStatus(): {
     status: IDEConnectionStatus;
     details?: string;
@@ -64,16 +65,18 @@ export class IdeClient {
       return;
     }
 
+    let transport: StreamableHTTPClientTransport | undefined;
     try {
       this.client = new Client({
         name: 'streamable-http-client',
         // TODO(#3487): use the CLI version here.
         version: '1.0.0',
       });
-      const transport = new StreamableHTTPClientTransport(
+      transport = new StreamableHTTPClientTransport(
         new URL(`http://localhost:${idePort}/mcp`),
       );
       await this.client.connect(transport);
+
       this.client.setNotificationHandler(
         OpenFilesNotificationSchema,
         (notification) => {
@@ -95,6 +98,13 @@ export class IdeClient {
     } catch (error) {
       this.connectionStatus = IDEConnectionStatus.Disconnected;
       logger.debug('Failed to connect to MCP server:', error);
+      if (transport) {
+        try {
+          await transport.close();
+        } catch (closeError) {
+          logger.debug('Failed to close transport:', closeError);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## TLDR
This fix ensures that transport.close() is called within the catch block of the connectToMcpServer method. This guarantees that if any part of the connection process fails after the transport has been instantiated, the transport is properly closed, preventing resource leaks

## Linked issues / bugs
#4800 