### PR TITLE
feat: Add Shell Command Execution to Custom Commands

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -205,19 +205,18 @@ When you run `/changelog 1.2.0 added "New feature"`, the final text sent to the 
 
 You can make your commands dynamic by executing shell commands directly within your `prompt` and injecting their output. This is ideal for gathering context from your local environment, like reading file content or checking the status of Git.
 
-To use this feature, you must define a `shell-allowlist` in your TOML file **OR** have allowed the shell commands in your global allowlist. This is a security measure to ensure that only intended commands can be run.
+When a custom command attempts to execute a shell command, Gemini CLI will now prompt you for confirmation before proceeding. This is a security measure to ensure that only intended commands can be run.
 
 **How It Works:**
 
-1.  **Define Permissions:** Add a `shell-allowlist` array to your TOML file, listing the exact shell commands your prompt is allowed to execute.
-2.  **Inject Commands:** Use the `!{...}` syntax in your `prompt` to specify where the command should be run and its output injected.
+1.  **Inject Commands:** Use the `!{...}` syntax in your `prompt` to specify where the command should be run and its output injected.
+2.  **Confirm Execution:** When you run the command, a dialog will appear listing the shell commands the prompt wants to execute.
+3.  **Grant Permission:** You can choose to:
+    - **Allow once:** The command(s) will run this one time.
+    - **Allow always for this session:** The command(s) will be added to a temporary allowlist for the current CLI session and will not require confirmation again.
+    - **No:** Cancel the execution of the shell command(s).
 
-The CLI checks permissions in this order:
-
-1.  Global `excludeTools` settings (if blocked here, it can't run).
-2.  Global `coreTools` settings (if allowed here, it can run).
-3.  The command's local `shell-allowlist`.
-4.  If the command is not in either allowlist, it will cause the command to fail.
+The CLI still respects the global `excludeTools` and `coreTools` settings. A command will be blocked without a confirmation prompt if it is explicitly disallowed in your configuration.
 
 **Example (`git/commit.toml`):**
 
@@ -228,11 +227,6 @@ This command gets the staged git diff and uses it to ask the model to write a co
 # Invoked via: /git:commit
 
 description = "Generates a Git commit message based on staged changes."
-
-# Define the list of shell commands this prompt is allowed to run.
-shell-allowlist = [
-  "git diff --staged"
-]
 
 # The prompt uses !{...} to execute the command and inject its output.
 prompt = """

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -201,17 +201,15 @@ The command follows this format: `/changelog <version> <type> <message>`
 
 When you run `/changelog 1.2.0 added "New feature"`, the final text sent to the model will be the original prompt followed by two newlines and the command you typed.
 
-##### 3. Executing Shell Commands with `!{{...}}`
+##### 3. Executing Shell Commands with `!{...}`
 
 You can make your commands dynamic by executing shell commands directly within your `prompt` and injecting their output. This is ideal for gathering context from your local environment, like reading file content or checking the status of Git.
-
-To prevent issues with commands that contain single curly braces, the injection syntax uses double braces: `!{{...}}`.
 
 When a custom command attempts to execute a shell command, Gemini CLI will now prompt you for confirmation before proceeding. This is a security measure to ensure that only intended commands can be run.
 
 **How It Works:**
 
-1.  **Inject Commands:** Use the `!{{...}}` syntax in your `prompt` to specify where the command should be run and its output injected.
+1.  **Inject Commands:** Use the `!{...}` syntax in your `prompt` to specify where the command should be run and its output injected.
 2.  **Confirm Execution:** When you run the command, a dialog will appear listing the shell commands the prompt wants to execute.
 3.  **Grant Permission:** You can choose to:
     - **Allow once:** The command(s) will run this one time.
@@ -230,19 +228,19 @@ This command gets the staged git diff and uses it to ask the model to write a co
 
 description = "Generates a Git commit message based on staged changes."
 
-# The prompt uses !{{...}} to execute the command and inject its output.
+# The prompt uses !{...} to execute the command and inject its output.
 prompt = """
 Please generate a Conventional Commit message based on the following git diff:
 
 ```diff
-!{{git diff --staged}}
+!{git diff --staged}
 ````
 
 """
 
 ````
 
-When you run `/git:commit`, the CLI first executes `git diff --staged`, then replaces `!{{git diff --staged}}` with the output of that command before sending the final, complete prompt to the model.
+When you run `/git:commit`, the CLI first executes `git diff --staged`, then replaces `!{git diff --staged}` with the output of that command before sending the final, complete prompt to the model.
 
 ---
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -201,15 +201,17 @@ The command follows this format: `/changelog <version> <type> <message>`
 
 When you run `/changelog 1.2.0 added "New feature"`, the final text sent to the model will be the original prompt followed by two newlines and the command you typed.
 
-##### 3. Executing Shell Commands with `!{...}`
+##### 3. Executing Shell Commands with `!{{...}}`
 
 You can make your commands dynamic by executing shell commands directly within your `prompt` and injecting their output. This is ideal for gathering context from your local environment, like reading file content or checking the status of Git.
+
+To prevent issues with commands that contain single curly braces, the injection syntax uses double braces: `!{{...}}`.
 
 When a custom command attempts to execute a shell command, Gemini CLI will now prompt you for confirmation before proceeding. This is a security measure to ensure that only intended commands can be run.
 
 **How It Works:**
 
-1.  **Inject Commands:** Use the `!{...}` syntax in your `prompt` to specify where the command should be run and its output injected.
+1.  **Inject Commands:** Use the `!{{...}}` syntax in your `prompt` to specify where the command should be run and its output injected.
 2.  **Confirm Execution:** When you run the command, a dialog will appear listing the shell commands the prompt wants to execute.
 3.  **Grant Permission:** You can choose to:
     - **Allow once:** The command(s) will run this one time.
@@ -228,19 +230,19 @@ This command gets the staged git diff and uses it to ask the model to write a co
 
 description = "Generates a Git commit message based on staged changes."
 
-# The prompt uses !{...} to execute the command and inject its output.
+# The prompt uses !{{...}} to execute the command and inject its output.
 prompt = """
 Please generate a Conventional Commit message based on the following git diff:
 
 ```diff
-!{git diff --staged}
+!{{git diff --staged}}
 ````
 
 """
 
 ````
 
-When you run `/git:commit`, the CLI first executes `git diff --staged`, then replaces `!{git diff --staged}` with the output of that command before sending the final, complete prompt to the model.
+When you run `/git:commit`, the CLI first executes `git diff --staged`, then replaces `!{{git diff --staged}}` with the output of that command before sending the final, complete prompt to the model.
 
 ---
 

--- a/packages/cli/src/services/FileCommandLoader.test.ts
+++ b/packages/cli/src/services/FileCommandLoader.test.ts
@@ -13,7 +13,10 @@ import {
 import mock from 'mock-fs';
 import { assert, vi } from 'vitest';
 import { createMockCommandContext } from '../test-utils/mockCommandContext.js';
-import { SHORTHAND_ARGS_PLACEHOLDER } from './prompt-processors/types.js';
+import {
+  SHELL_INJECTION_TRIGGER,
+  SHORTHAND_ARGS_PLACEHOLDER,
+} from './prompt-processors/types.js';
 import {
   ConfirmationRequiredError,
   ShellProcessor,
@@ -430,7 +433,7 @@ describe('FileCommandLoader', () => {
       const userCommandsDir = getUserCommandsDir();
       mock({
         [userCommandsDir]: {
-          'shell.toml': `prompt = "Run this: !{{echo hello}}"`,
+          'shell.toml': `prompt = "Run this: ${SHELL_INJECTION_TRIGGER}echo hello}"`,
         },
       });
 
@@ -458,7 +461,7 @@ describe('FileCommandLoader', () => {
       const userCommandsDir = getUserCommandsDir();
       mock({
         [userCommandsDir]: {
-          'shell.toml': `prompt = "Run !{{echo 'hello'}}"`,
+          'shell.toml': `prompt = "Run !{echo 'hello'}"`,
         },
       });
       mockShellProcess.mockResolvedValue('Run hello');
@@ -486,7 +489,7 @@ describe('FileCommandLoader', () => {
       const rawInvocation = '/shell rm -rf /';
       mock({
         [userCommandsDir]: {
-          'shell.toml': `prompt = "Run !{{rm -rf /}}"`,
+          'shell.toml': `prompt = "Run !{rm -rf /}"`,
         },
       });
 
@@ -519,7 +522,7 @@ describe('FileCommandLoader', () => {
       const userCommandsDir = getUserCommandsDir();
       mock({
         [userCommandsDir]: {
-          'shell.toml': `prompt = "Run !{{something}}"`,
+          'shell.toml': `prompt = "Run !{something}"`,
         },
       });
 
@@ -546,7 +549,7 @@ describe('FileCommandLoader', () => {
       mock({
         [userCommandsDir]: {
           'pipeline.toml': `
-            prompt = "Shell says: !{{echo foo}} and user says: ${SHORTHAND_ARGS_PLACEHOLDER}"
+            prompt = "Shell says: ${SHELL_INJECTION_TRIGGER}echo foo} and user says: ${SHORTHAND_ARGS_PLACEHOLDER}"
           `,
         },
       });

--- a/packages/cli/src/services/FileCommandLoader.test.ts
+++ b/packages/cli/src/services/FileCommandLoader.test.ts
@@ -13,10 +13,7 @@ import {
 import mock from 'mock-fs';
 import { assert, vi } from 'vitest';
 import { createMockCommandContext } from '../test-utils/mockCommandContext.js';
-import {
-  SHELL_INJECTION_TRIGGER,
-  SHORTHAND_ARGS_PLACEHOLDER,
-} from './prompt-processors/types.js';
+import { SHORTHAND_ARGS_PLACEHOLDER } from './prompt-processors/types.js';
 import {
   ConfirmationRequiredError,
   ShellProcessor,
@@ -433,7 +430,7 @@ describe('FileCommandLoader', () => {
       const userCommandsDir = getUserCommandsDir();
       mock({
         [userCommandsDir]: {
-          'shell.toml': `prompt = "Run this: ${SHELL_INJECTION_TRIGGER}echo hello}"`,
+          'shell.toml': `prompt = "Run this: !{{echo hello}}"`,
         },
       });
 
@@ -461,7 +458,7 @@ describe('FileCommandLoader', () => {
       const userCommandsDir = getUserCommandsDir();
       mock({
         [userCommandsDir]: {
-          'shell.toml': `prompt = "Run !{echo 'hello'}"`,
+          'shell.toml': `prompt = "Run !{{echo 'hello'}}"`,
         },
       });
       mockShellProcess.mockResolvedValue('Run hello');
@@ -489,7 +486,7 @@ describe('FileCommandLoader', () => {
       const rawInvocation = '/shell rm -rf /';
       mock({
         [userCommandsDir]: {
-          'shell.toml': `prompt = "Run !{rm -rf /}"`,
+          'shell.toml': `prompt = "Run !{{rm -rf /}}"`,
         },
       });
 
@@ -522,7 +519,7 @@ describe('FileCommandLoader', () => {
       const userCommandsDir = getUserCommandsDir();
       mock({
         [userCommandsDir]: {
-          'shell.toml': `prompt = "Run !{something}"`,
+          'shell.toml': `prompt = "Run !{{something}}"`,
         },
       });
 
@@ -549,7 +546,7 @@ describe('FileCommandLoader', () => {
       mock({
         [userCommandsDir]: {
           'pipeline.toml': `
-            prompt = "Shell says: ${SHELL_INJECTION_TRIGGER}echo foo} and user says: ${SHORTHAND_ARGS_PLACEHOLDER}"
+            prompt = "Shell says: !{{echo foo}} and user says: ${SHORTHAND_ARGS_PLACEHOLDER}"
           `,
         },
       });

--- a/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
@@ -5,25 +5,24 @@
  */
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ConfirmationRequiredError, ShellProcessor } from './shellProcessor.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { CommandContext } from '../../ui/commands/types.js';
+import { Config } from '@google/gemini-cli-core';
 
-const mockIsCommandAllowed = vi.hoisted(() => vi.fn());
+const mockCheckCommandPermissions = vi.hoisted(() => vi.fn());
 const mockShellExecute = vi.hoisted(() => vi.fn());
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const original = await importOriginal<object>();
   return {
     ...original,
-    isCommandAllowed: mockIsCommandAllowed,
+    checkCommandPermissions: mockCheckCommandPermissions,
     ShellExecutionService: {
       execute: mockShellExecute,
     },
   };
 });
-
-import { ShellProcessor } from './shellProcessor.js';
-import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
-import { CommandContext } from '../../ui/commands/types.js';
-import { Config } from '@google/gemini-cli-core';
 
 describe('ShellProcessor', () => {
   let context: CommandContext;
@@ -32,48 +31,55 @@ describe('ShellProcessor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Create a mock config object
     mockConfig = {
       getTargetDir: vi.fn().mockReturnValue('/test/dir'),
     };
 
-    // Pass the mock config to the context
     context = createMockCommandContext({
       services: {
         config: mockConfig as Config,
       },
+      session: {
+        sessionShellAllowlist: new Set(),
+      },
     });
 
-    // Default mock implementations
     mockShellExecute.mockReturnValue({
       result: Promise.resolve({
         output: 'default shell output',
       }),
     });
-    mockIsCommandAllowed.mockReturnValue({ allowed: true });
+    mockCheckCommandPermissions.mockReturnValue({
+      allAllowed: true,
+      disallowedCommands: [],
+    });
   });
 
   it('should not change the prompt if no shell injections are present', async () => {
-    const processor = new ShellProcessor([], 'test-command');
+    const processor = new ShellProcessor('test-command');
     const prompt = 'This is a simple prompt with no injections.';
     const result = await processor.process(prompt, context);
     expect(result).toBe(prompt);
     expect(mockShellExecute).not.toHaveBeenCalled();
   });
 
-  it('should process a single valid shell injection', async () => {
-    const processor = new ShellProcessor(['git status'], 'test-command');
+  it('should process a single valid shell injection if allowed', async () => {
+    const processor = new ShellProcessor('test-command');
     const prompt = 'The current status is: !{git status}';
+    mockCheckCommandPermissions.mockReturnValue({
+      allAllowed: true,
+      disallowedCommands: [],
+    });
     mockShellExecute.mockReturnValue({
       result: Promise.resolve({ output: 'On branch main' }),
     });
 
     const result = await processor.process(prompt, context);
 
-    expect(mockIsCommandAllowed).toHaveBeenCalledWith(
+    expect(mockCheckCommandPermissions).toHaveBeenCalledWith(
       'git status',
       expect.any(Object),
-      ['git status'],
+      context.session.sessionShellAllowlist,
     );
     expect(mockShellExecute).toHaveBeenCalledWith(
       'git status',
@@ -84,11 +90,14 @@ describe('ShellProcessor', () => {
     expect(result).toBe('The current status is: On branch main');
   });
 
-  it('should process multiple valid shell injections', async () => {
-    const processor = new ShellProcessor(['git status', 'pwd'], 'test-command');
+  it('should process multiple valid shell injections if all are allowed', async () => {
+    const processor = new ShellProcessor('test-command');
     const prompt = '!{git status} in !{pwd}';
+    mockCheckCommandPermissions.mockReturnValue({
+      allAllowed: true,
+      disallowedCommands: [],
+    });
 
-    // Set up different return values for each call
     mockShellExecute
       .mockReturnValueOnce({
         result: Promise.resolve({ output: 'On branch main' }),
@@ -99,50 +108,160 @@ describe('ShellProcessor', () => {
 
     const result = await processor.process(prompt, context);
 
+    expect(mockCheckCommandPermissions).toHaveBeenCalledTimes(2);
     expect(mockShellExecute).toHaveBeenCalledTimes(2);
-    expect(mockShellExecute).toHaveBeenCalledWith(
-      'git status',
-      expect.any(String),
-      expect.any(Function),
-      expect.any(Object),
-    );
-    expect(mockShellExecute).toHaveBeenCalledWith(
-      'pwd',
-      expect.any(String),
-      expect.any(Function),
-      expect.any(Object),
-    );
     expect(result).toBe('On branch main in /usr/home');
   });
 
-  it('should throw an error if a command is not allowed', async () => {
-    const processor = new ShellProcessor([], 'test-command');
+  it('should throw ConfirmationRequiredError if a command is not allowed', async () => {
+    const processor = new ShellProcessor('test-command');
     const prompt = 'Do something dangerous: !{rm -rf /}';
-    mockIsCommandAllowed.mockReturnValue({
-      allowed: false,
-      reason: 'Command is not in the allowlist.',
+    mockCheckCommandPermissions.mockReturnValue({
+      allAllowed: false,
+      disallowedCommands: ['rm -rf /'],
     });
 
     await expect(processor.process(prompt, context)).rejects.toThrow(
-      'Shell command "rm -rf /" in custom command "test-command" is not allowed. Reason: Command is not in the allowlist.',
+      ConfirmationRequiredError,
     );
+  });
+
+  it('should throw ConfirmationRequiredError with the correct command', async () => {
+    const processor = new ShellProcessor('test-command');
+    const prompt = 'Do something dangerous: !{rm -rf /}';
+    mockCheckCommandPermissions.mockReturnValue({
+      allAllowed: false,
+      disallowedCommands: ['rm -rf /'],
+    });
+
+    try {
+      await processor.process(prompt, context);
+      // Fail if it doesn't throw
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ConfirmationRequiredError);
+      if (e instanceof ConfirmationRequiredError) {
+        expect(e.commandsToConfirm).toEqual(['rm -rf /']);
+      }
+    }
 
     expect(mockShellExecute).not.toHaveBeenCalled();
   });
 
+  it('should throw ConfirmationRequiredError with multiple commands if multiple are disallowed', async () => {
+    const processor = new ShellProcessor('test-command');
+    const prompt = '!{cmd1} and !{cmd2}';
+    mockCheckCommandPermissions.mockImplementation((cmd) => {
+      if (cmd === 'cmd1') {
+        return { allAllowed: false, disallowedCommands: ['cmd1'] };
+      }
+      if (cmd === 'cmd2') {
+        return { allAllowed: false, disallowedCommands: ['cmd2'] };
+      }
+      return { allAllowed: true, disallowedCommands: [] };
+    });
+
+    try {
+      await processor.process(prompt, context);
+      // Fail if it doesn't throw
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ConfirmationRequiredError);
+      if (e instanceof ConfirmationRequiredError) {
+        expect(e.commandsToConfirm).toEqual(['cmd1', 'cmd2']);
+      }
+    }
+  });
+
+  it('should not execute any commands if at least one requires confirmation', async () => {
+    const processor = new ShellProcessor('test-command');
+    const prompt = 'First: !{echo "hello"}, Second: !{rm -rf /}';
+
+    mockCheckCommandPermissions.mockImplementation((cmd) => {
+      if (cmd.includes('rm')) {
+        return { allAllowed: false, disallowedCommands: [cmd] };
+      }
+      return { allAllowed: true, disallowedCommands: [] };
+    });
+
+    await expect(processor.process(prompt, context)).rejects.toThrow(
+      ConfirmationRequiredError,
+    );
+
+    // Ensure no commands were executed because the pipeline was halted.
+    expect(mockShellExecute).not.toHaveBeenCalled();
+  });
+
+  it('should only request confirmation for disallowed commands in a mixed prompt', async () => {
+    const processor = new ShellProcessor('test-command');
+    const prompt = 'Allowed: !{ls -l}, Disallowed: !{rm -rf /}';
+
+    mockCheckCommandPermissions.mockImplementation((cmd) => ({
+      allAllowed: !cmd.includes('rm'),
+      disallowedCommands: cmd.includes('rm') ? [cmd] : [],
+    }));
+
+    try {
+      await processor.process(prompt, context);
+      expect.fail('Should have thrown ConfirmationRequiredError');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ConfirmationRequiredError);
+      if (e instanceof ConfirmationRequiredError) {
+        expect(e.commandsToConfirm).toEqual(['rm -rf /']);
+      }
+    }
+  });
+
+  it('should execute all commands if they are on the session allowlist', async () => {
+    const processor = new ShellProcessor('test-command');
+    const prompt = 'Run !{cmd1} and !{cmd2}';
+
+    // Add commands to the session allowlist
+    context.session.sessionShellAllowlist = new Set(['cmd1', 'cmd2']);
+
+    // checkCommandPermissions should now pass for these
+    mockCheckCommandPermissions.mockReturnValue({
+      allAllowed: true,
+      disallowedCommands: [],
+    });
+
+    mockShellExecute
+      .mockReturnValueOnce({ result: Promise.resolve({ output: 'output1' }) })
+      .mockReturnValueOnce({ result: Promise.resolve({ output: 'output2' }) });
+
+    const result = await processor.process(prompt, context);
+
+    expect(mockCheckCommandPermissions).toHaveBeenCalledWith(
+      'cmd1',
+      expect.any(Object),
+      context.session.sessionShellAllowlist,
+    );
+    expect(mockCheckCommandPermissions).toHaveBeenCalledWith(
+      'cmd2',
+      expect.any(Object),
+      context.session.sessionShellAllowlist,
+    );
+    expect(mockShellExecute).toHaveBeenCalledTimes(2);
+    expect(result).toBe('Run output1 and output2');
+  });
+
   it('should trim whitespace from the command inside the injection', async () => {
-    const processor = new ShellProcessor(['ls -l'], 'test-command');
+    const processor = new ShellProcessor('test-command');
     const prompt = 'Files: !{  ls -l  }';
+    mockCheckCommandPermissions.mockReturnValue({
+      allAllowed: true,
+      disallowedCommands: [],
+    });
     mockShellExecute.mockReturnValue({
       result: Promise.resolve({ output: 'total 0' }),
     });
 
     await processor.process(prompt, context);
 
-    expect(mockIsCommandAllowed).toHaveBeenCalledWith(
-      'ls -l',
+    expect(mockCheckCommandPermissions).toHaveBeenCalledWith(
+      'ls -l', // Verifies that the command was trimmed
       expect.any(Object),
-      ['ls -l'],
+      context.session.sessionShellAllowlist,
     );
     expect(mockShellExecute).toHaveBeenCalledWith(
       'ls -l',
@@ -153,19 +272,22 @@ describe('ShellProcessor', () => {
   });
 
   it('should handle an empty command inside the injection gracefully', async () => {
-    const processor = new ShellProcessor([], 'test-command');
+    const processor = new ShellProcessor('test-command');
     const prompt = 'This is weird: !{}';
-    mockIsCommandAllowed.mockReturnValue({ allowed: true });
+    mockCheckCommandPermissions.mockReturnValue({
+      allAllowed: true,
+      disallowedCommands: [],
+    });
     mockShellExecute.mockReturnValue({
       result: Promise.resolve({ output: 'empty output' }),
     });
 
     const result = await processor.process(prompt, context);
 
-    expect(mockIsCommandAllowed).toHaveBeenCalledWith(
+    expect(mockCheckCommandPermissions).toHaveBeenCalledWith(
       '',
       expect.any(Object),
-      [],
+      context.session.sessionShellAllowlist,
     );
     expect(mockShellExecute).toHaveBeenCalledWith(
       '',
@@ -174,34 +296,5 @@ describe('ShellProcessor', () => {
       expect.any(Object),
     );
     expect(result).toBe('This is weird: empty output');
-  });
-
-  it('should halt execution on the first disallowed command in a series', async () => {
-    const processor = new ShellProcessor(['echo "hello"'], 'test-command');
-    const prompt = 'First: !{echo "hello"}, Second: !{rm -rf /}';
-
-    mockIsCommandAllowed
-      .mockImplementationOnce(() => ({ allowed: true }))
-      .mockImplementationOnce(() => ({
-        allowed: false,
-        reason: 'Disallowed',
-      }));
-
-    mockShellExecute.mockReturnValue({
-      result: Promise.resolve({ output: 'hello' }),
-    });
-
-    await expect(processor.process(prompt, context)).rejects.toThrow(
-      'Shell command "rm -rf /" in custom command "test-command" is not allowed. Reason: Disallowed',
-    );
-
-    // Ensure the first command was executed, but the second was not.
-    expect(mockShellExecute).toHaveBeenCalledOnce();
-    expect(mockShellExecute).toHaveBeenCalledWith(
-      'echo "hello"',
-      expect.any(String),
-      expect.any(Function),
-      expect.any(Object),
-    );
   });
 });

--- a/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const mockIsCommandAllowed = vi.hoisted(() => vi.fn());
+const mockShellExecute = vi.hoisted(() => vi.fn());
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const original = await importOriginal<object>();
+  return {
+    ...original,
+    isCommandAllowed: mockIsCommandAllowed,
+    ShellExecutionService: {
+      execute: mockShellExecute,
+    },
+  };
+});
+
+import { ShellProcessor } from './shellProcessor.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { CommandContext } from '../../ui/commands/types.js';
+import { Config } from '@google/gemini-cli-core';
+
+describe('ShellProcessor', () => {
+  let context: CommandContext;
+  let mockConfig: Partial<Config>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Create a mock config object
+    mockConfig = {
+      getTargetDir: vi.fn().mockReturnValue('/test/dir'),
+    };
+
+    // Pass the mock config to the context
+    context = createMockCommandContext({
+      services: {
+        config: mockConfig as Config,
+      },
+    });
+
+    // Default mock implementations
+    mockShellExecute.mockReturnValue({
+      result: Promise.resolve({
+        output: 'default shell output',
+      }),
+    });
+    mockIsCommandAllowed.mockReturnValue({ allowed: true });
+  });
+
+  it('should not change the prompt if no shell injections are present', async () => {
+    const processor = new ShellProcessor([], 'test-command');
+    const prompt = 'This is a simple prompt with no injections.';
+    const result = await processor.process(prompt, context);
+    expect(result).toBe(prompt);
+    expect(mockShellExecute).not.toHaveBeenCalled();
+  });
+
+  it('should process a single valid shell injection', async () => {
+    const processor = new ShellProcessor(['git status'], 'test-command');
+    const prompt = 'The current status is: !{git status}';
+    mockShellExecute.mockReturnValue({
+      result: Promise.resolve({ output: 'On branch main' }),
+    });
+
+    const result = await processor.process(prompt, context);
+
+    expect(mockIsCommandAllowed).toHaveBeenCalledWith(
+      'git status',
+      expect.any(Object),
+      ['git status'],
+    );
+    expect(mockShellExecute).toHaveBeenCalledWith(
+      'git status',
+      expect.any(String),
+      expect.any(Function),
+      expect.any(Object),
+    );
+    expect(result).toBe('The current status is: On branch main');
+  });
+
+  it('should process multiple valid shell injections', async () => {
+    const processor = new ShellProcessor(['git status', 'pwd'], 'test-command');
+    const prompt = '!{git status} in !{pwd}';
+
+    // Set up different return values for each call
+    mockShellExecute
+      .mockReturnValueOnce({
+        result: Promise.resolve({ output: 'On branch main' }),
+      })
+      .mockReturnValueOnce({
+        result: Promise.resolve({ output: '/usr/home' }),
+      });
+
+    const result = await processor.process(prompt, context);
+
+    expect(mockShellExecute).toHaveBeenCalledTimes(2);
+    expect(mockShellExecute).toHaveBeenCalledWith(
+      'git status',
+      expect.any(String),
+      expect.any(Function),
+      expect.any(Object),
+    );
+    expect(mockShellExecute).toHaveBeenCalledWith(
+      'pwd',
+      expect.any(String),
+      expect.any(Function),
+      expect.any(Object),
+    );
+    expect(result).toBe('On branch main in /usr/home');
+  });
+
+  it('should throw an error if a command is not allowed', async () => {
+    const processor = new ShellProcessor([], 'test-command');
+    const prompt = 'Do something dangerous: !{rm -rf /}';
+    mockIsCommandAllowed.mockReturnValue({
+      allowed: false,
+      reason: 'Command is not in the allowlist.',
+    });
+
+    await expect(processor.process(prompt, context)).rejects.toThrow(
+      'Shell command "rm -rf /" in custom command "test-command" is not allowed. Reason: Command is not in the allowlist.',
+    );
+
+    expect(mockShellExecute).not.toHaveBeenCalled();
+  });
+
+  it('should trim whitespace from the command inside the injection', async () => {
+    const processor = new ShellProcessor(['ls -l'], 'test-command');
+    const prompt = 'Files: !{  ls -l  }';
+    mockShellExecute.mockReturnValue({
+      result: Promise.resolve({ output: 'total 0' }),
+    });
+
+    await processor.process(prompt, context);
+
+    expect(mockIsCommandAllowed).toHaveBeenCalledWith(
+      'ls -l',
+      expect.any(Object),
+      ['ls -l'],
+    );
+    expect(mockShellExecute).toHaveBeenCalledWith(
+      'ls -l',
+      expect.any(String),
+      expect.any(Function),
+      expect.any(Object),
+    );
+  });
+
+  it('should handle an empty command inside the injection gracefully', async () => {
+    const processor = new ShellProcessor([], 'test-command');
+    const prompt = 'This is weird: !{}';
+    mockIsCommandAllowed.mockReturnValue({ allowed: true });
+    mockShellExecute.mockReturnValue({
+      result: Promise.resolve({ output: 'empty output' }),
+    });
+
+    const result = await processor.process(prompt, context);
+
+    expect(mockIsCommandAllowed).toHaveBeenCalledWith(
+      '',
+      expect.any(Object),
+      [],
+    );
+    expect(mockShellExecute).toHaveBeenCalledWith(
+      '',
+      expect.any(String),
+      expect.any(Function),
+      expect.any(Object),
+    );
+    expect(result).toBe('This is weird: empty output');
+  });
+
+  it('should halt execution on the first disallowed command in a series', async () => {
+    const processor = new ShellProcessor(['echo "hello"'], 'test-command');
+    const prompt = 'First: !{echo "hello"}, Second: !{rm -rf /}';
+
+    mockIsCommandAllowed
+      .mockImplementationOnce(() => ({ allowed: true }))
+      .mockImplementationOnce(() => ({
+        allowed: false,
+        reason: 'Disallowed',
+      }));
+
+    mockShellExecute.mockReturnValue({
+      result: Promise.resolve({ output: 'hello' }),
+    });
+
+    await expect(processor.process(prompt, context)).rejects.toThrow(
+      'Shell command "rm -rf /" in custom command "test-command" is not allowed. Reason: Disallowed',
+    );
+
+    // Ensure the first command was executed, but the second was not.
+    expect(mockShellExecute).toHaveBeenCalledOnce();
+    expect(mockShellExecute).toHaveBeenCalledWith(
+      'echo "hello"',
+      expect.any(String),
+      expect.any(Function),
+      expect.any(Object),
+    );
+  });
+});

--- a/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
@@ -65,7 +65,7 @@ describe('ShellProcessor', () => {
 
   it('should process a single valid shell injection if allowed', async () => {
     const processor = new ShellProcessor('test-command');
-    const prompt = 'The current status is: !{git status}';
+    const prompt = 'The current status is: !{{git status}}';
     mockCheckCommandPermissions.mockReturnValue({
       allAllowed: true,
       disallowedCommands: [],
@@ -92,7 +92,7 @@ describe('ShellProcessor', () => {
 
   it('should process multiple valid shell injections if all are allowed', async () => {
     const processor = new ShellProcessor('test-command');
-    const prompt = '!{git status} in !{pwd}';
+    const prompt = '!{{git status}} in !{{pwd}}';
     mockCheckCommandPermissions.mockReturnValue({
       allAllowed: true,
       disallowedCommands: [],
@@ -115,7 +115,7 @@ describe('ShellProcessor', () => {
 
   it('should throw ConfirmationRequiredError if a command is not allowed', async () => {
     const processor = new ShellProcessor('test-command');
-    const prompt = 'Do something dangerous: !{rm -rf /}';
+    const prompt = 'Do something dangerous: !{{rm -rf /}}';
     mockCheckCommandPermissions.mockReturnValue({
       allAllowed: false,
       disallowedCommands: ['rm -rf /'],
@@ -128,7 +128,7 @@ describe('ShellProcessor', () => {
 
   it('should throw ConfirmationRequiredError with the correct command', async () => {
     const processor = new ShellProcessor('test-command');
-    const prompt = 'Do something dangerous: !{rm -rf /}';
+    const prompt = 'Do something dangerous: !{{rm -rf /}}';
     mockCheckCommandPermissions.mockReturnValue({
       allAllowed: false,
       disallowedCommands: ['rm -rf /'],
@@ -150,7 +150,7 @@ describe('ShellProcessor', () => {
 
   it('should throw ConfirmationRequiredError with multiple commands if multiple are disallowed', async () => {
     const processor = new ShellProcessor('test-command');
-    const prompt = '!{cmd1} and !{cmd2}';
+    const prompt = '!{{cmd1}} and !{{cmd2}}';
     mockCheckCommandPermissions.mockImplementation((cmd) => {
       if (cmd === 'cmd1') {
         return { allAllowed: false, disallowedCommands: ['cmd1'] };
@@ -175,7 +175,7 @@ describe('ShellProcessor', () => {
 
   it('should not execute any commands if at least one requires confirmation', async () => {
     const processor = new ShellProcessor('test-command');
-    const prompt = 'First: !{echo "hello"}, Second: !{rm -rf /}';
+    const prompt = 'First: !{{echo "hello"}}, Second: !{{rm -rf /}}';
 
     mockCheckCommandPermissions.mockImplementation((cmd) => {
       if (cmd.includes('rm')) {
@@ -194,7 +194,7 @@ describe('ShellProcessor', () => {
 
   it('should only request confirmation for disallowed commands in a mixed prompt', async () => {
     const processor = new ShellProcessor('test-command');
-    const prompt = 'Allowed: !{ls -l}, Disallowed: !{rm -rf /}';
+    const prompt = 'Allowed: !{{ls -l}}, Disallowed: !{{rm -rf /}}';
 
     mockCheckCommandPermissions.mockImplementation((cmd) => ({
       allAllowed: !cmd.includes('rm'),
@@ -214,7 +214,7 @@ describe('ShellProcessor', () => {
 
   it('should execute all commands if they are on the session allowlist', async () => {
     const processor = new ShellProcessor('test-command');
-    const prompt = 'Run !{cmd1} and !{cmd2}';
+    const prompt = 'Run !{{cmd1}} and !{{cmd2}}';
 
     // Add commands to the session allowlist
     context.session.sessionShellAllowlist = new Set(['cmd1', 'cmd2']);
@@ -247,7 +247,7 @@ describe('ShellProcessor', () => {
 
   it('should trim whitespace from the command inside the injection', async () => {
     const processor = new ShellProcessor('test-command');
-    const prompt = 'Files: !{  ls -l  }';
+    const prompt = 'Files: !{{  ls -l  }}';
     mockCheckCommandPermissions.mockReturnValue({
       allAllowed: true,
       disallowedCommands: [],
@@ -273,7 +273,7 @@ describe('ShellProcessor', () => {
 
   it('should handle an empty command inside the injection gracefully', async () => {
     const processor = new ShellProcessor('test-command');
-    const prompt = 'This is weird: !{}';
+    const prompt = 'This is weird: !{{}}';
     mockCheckCommandPermissions.mockReturnValue({
       allAllowed: true,
       disallowedCommands: [],
@@ -296,5 +296,33 @@ describe('ShellProcessor', () => {
       expect.any(Object),
     );
     expect(result).toBe('This is weird: empty output');
+  });
+
+  it('should correctly parse a command containing curly braces', async () => {
+    const processor = new ShellProcessor('test-command');
+    const prompt =
+      'Commit message: !{{git commit -m "feat: allow {} in messages"}}';
+    mockCheckCommandPermissions.mockReturnValue({
+      allAllowed: true,
+      disallowedCommands: [],
+    });
+    mockShellExecute.mockReturnValue({
+      result: Promise.resolve({ output: 'commit done' }),
+    });
+
+    const result = await processor.process(prompt, context);
+
+    expect(mockCheckCommandPermissions).toHaveBeenCalledWith(
+      'git commit -m "feat: allow {} in messages"',
+      expect.any(Object),
+      context.session.sessionShellAllowlist,
+    );
+    expect(mockShellExecute).toHaveBeenCalledWith(
+      'git commit -m "feat: allow {} in messages"',
+      expect.any(String),
+      expect.any(Function),
+      expect.any(Object),
+    );
+    expect(result).toBe('Commit message: commit done');
   });
 });

--- a/packages/cli/src/services/prompt-processors/shellProcessor.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.ts
@@ -23,7 +23,7 @@ export class ConfirmationRequiredError extends Error {
 }
 
 /**
- * Finds all instances of shell command injections (`!{...}`) in a prompt,
+ * Finds all instances of shell command injections (`!{{...}}`) in a prompt,
  * executes them, and replaces the injection site with the command's output.
  *
  * This processor ensures that only allowlisted commands are executed. If a
@@ -31,10 +31,10 @@ export class ConfirmationRequiredError extends Error {
  */
 export class ShellProcessor implements IPromptProcessor {
   /**
-   * A regular expression to find all instances of `!{...}`. The inner
+   * A regular expression to find all instances of `!{{...}}`. The inner
    * capture group extracts the command itself.
    */
-  private static readonly SHELL_INJECTION_REGEX = /!\{([^}]*)\}/g;
+  private static readonly SHELL_INJECTION_REGEX = /!\{\{((?:.|\n)*?)\}\}/g;
 
   /**
    * @param commandName The name of the custom command being executed, used

--- a/packages/cli/src/services/prompt-processors/shellProcessor.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.ts
@@ -23,7 +23,7 @@ export class ConfirmationRequiredError extends Error {
 }
 
 /**
- * Finds all instances of shell command injections (`!{{...}}`) in a prompt,
+ * Finds all instances of shell command injections (`!{...}`) in a prompt,
  * executes them, and replaces the injection site with the command's output.
  *
  * This processor ensures that only allowlisted commands are executed. If a
@@ -31,10 +31,10 @@ export class ConfirmationRequiredError extends Error {
  */
 export class ShellProcessor implements IPromptProcessor {
   /**
-   * A regular expression to find all instances of `!{{...}}`. The inner
+   * A regular expression to find all instances of `!{...}`. The inner
    * capture group extracts the command itself.
    */
-  private static readonly SHELL_INJECTION_REGEX = /!\{\{((?:.|\n)*?)\}\}/g;
+  private static readonly SHELL_INJECTION_REGEX = /!\{([^}]*)\}/g;
 
   /**
    * @param commandName The name of the custom command being executed, used

--- a/packages/cli/src/services/prompt-processors/shellProcessor.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  isCommandAllowed,
+  ShellExecutionService,
+} from '@google/gemini-cli-core';
+
+import { CommandContext } from '../../ui/commands/types.js';
+import { IPromptProcessor } from './types.js';
+
+/**
+ * Finds all instances of shell command injections (`!{...}`) in a prompt,
+ * executes them, and replaces the injection site with the command's output.
+ *
+ * This processor ensures that only allowlisted commands are executed. If a
+ * disallowed command is found, it halts execution and reports an error.
+ */
+export class ShellProcessor implements IPromptProcessor {
+  /**
+   * A regular expression to find all instances of `!{...}`. The inner
+   * capture group extracts the command itself.
+   */
+  private static readonly SHELL_INJECTION_REGEX = /!\{([^}]*)\}/g;
+
+  /**
+   * @param shellAllowlist A list of shell commands that are explicitly
+   *   allowed in the user's config.
+   * @param commandName The name of the custom command being executed, used
+   *   for logging and error messages.
+   */
+  constructor(
+    private readonly shellAllowlist: string[],
+    private readonly commandName: string,
+  ) {}
+
+  async process(prompt: string, context: CommandContext): Promise<string> {
+    const matches = [...prompt.matchAll(ShellProcessor.SHELL_INJECTION_REGEX)];
+    if (matches.length === 0) {
+      return prompt;
+    }
+
+    let processedPrompt = prompt;
+
+    for (const match of matches) {
+      const fullMatch = match[0]; // e.g., "!{git status}"
+      const command = match[1].trim(); // e.g., "git status"
+
+      const { config } = context.services;
+      const permission = isCommandAllowed(
+        command,
+        config!,
+        this.shellAllowlist,
+      );
+
+      if (!permission.allowed) {
+        const errorMessage = `Shell command "${command}" in custom command "${this.commandName}" is not allowed. Reason: ${permission.reason}`;
+        throw new Error(errorMessage);
+      }
+
+      // We have permission, now execute.
+      const { result } = ShellExecutionService.execute(
+        command,
+        config!.getTargetDir(),
+        () => {}, // No streaming needed.
+        new AbortController().signal, // For now, we don't support cancellation from here.
+      );
+
+      const executionResult = await result;
+      processedPrompt = processedPrompt.replace(
+        fullMatch,
+        executionResult.output,
+      );
+    }
+
+    return processedPrompt;
+  }
+}

--- a/packages/cli/src/services/prompt-processors/types.ts
+++ b/packages/cli/src/services/prompt-processors/types.ts
@@ -35,3 +35,8 @@ export interface IPromptProcessor {
  * The placeholder string for shorthand argument injection in custom commands.
  */
 export const SHORTHAND_ARGS_PLACEHOLDER = '{{args}}';
+
+/**
+ * The trigger string for shell command injection in custom commands.
+ */
+export const SHELL_INJECTION_TRIGGER = '!{';

--- a/packages/cli/src/services/prompt-processors/types.ts
+++ b/packages/cli/src/services/prompt-processors/types.ts
@@ -39,4 +39,4 @@ export const SHORTHAND_ARGS_PLACEHOLDER = '{{args}}';
 /**
  * The trigger string for shell command injection in custom commands.
  */
-export const SHELL_INJECTION_TRIGGER = '!{';
+export const SHELL_INJECTION_TRIGGER = '!{{';

--- a/packages/cli/src/services/prompt-processors/types.ts
+++ b/packages/cli/src/services/prompt-processors/types.ts
@@ -39,4 +39,4 @@ export const SHORTHAND_ARGS_PLACEHOLDER = '{{args}}';
 /**
  * The trigger string for shell command injection in custom commands.
  */
-export const SHELL_INJECTION_TRIGGER = '!{{';
+export const SHELL_INJECTION_TRIGGER = '!{';

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -170,6 +170,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     useState<boolean>(false);
   const [userTier, setUserTier] = useState<UserTierId | undefined>(undefined);
   const [openFiles, setOpenFiles] = useState<OpenFiles | undefined>();
+  const [isProcessing, setIsProcessing] = useState<boolean>(false);
 
   useEffect(() => {
     const unsubscribe = ideContext.subscribeToOpenFiles(setOpenFiles);
@@ -470,6 +471,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     setQuittingMessages,
     openPrivacyNotice,
     toggleVimEnabled,
+    setIsProcessing,
   );
 
   const {
@@ -626,7 +628,8 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     fetchUserMessages();
   }, [history, logger]);
 
-  const isInputActive = streamingState === StreamingState.Idle && !initError;
+  const isInputActive =
+    streamingState === StreamingState.Idle && !initError && !isProcessing;
 
   const handleClearScreen = useCallback(() => {
     clearItems();

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -36,6 +36,7 @@ import { ThemeDialog } from './components/ThemeDialog.js';
 import { AuthDialog } from './components/AuthDialog.js';
 import { AuthInProgress } from './components/AuthInProgress.js';
 import { EditorSettingsDialog } from './components/EditorSettingsDialog.js';
+import { ShellConfirmationDialog } from './components/ShellConfirmationDialog.js';
 import { Colors } from './colors.js';
 import { Help } from './components/Help.js';
 import { loadHierarchicalGeminiMemory } from '../config/config.js';
@@ -452,6 +453,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     slashCommands,
     pendingHistoryItems: pendingSlashCommandHistoryItems,
     commandContext,
+    shellConfirmationRequest,
   } = useSlashCommandProcessor(
     config,
     settings,
@@ -830,7 +832,9 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
             </Box>
           )}
 
-          {isThemeDialogOpen ? (
+          {shellConfirmationRequest ? (
+            <ShellConfirmationDialog request={shellConfirmationRequest} />
+          ) : isThemeDialogOpen ? (
             <Box flexDirection="column">
               {themeError && (
                 <Box marginBottom={1}>

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -63,6 +63,8 @@ export interface CommandContext {
   // Session-specific data
   session: {
     stats: SessionStatsState;
+    /** A transient list of shell commands the user has approved for this session. */
+    sessionShellAllowlist: Set<string>;
   };
 }
 
@@ -118,13 +120,28 @@ export interface SubmitPromptActionReturn {
   content: string;
 }
 
+/**
+ * The return type for a command action that needs to pause and request
+ * confirmation for a set of shell commands before proceeding.
+ */
+export interface ConfirmShellCommandsActionReturn {
+  type: 'confirm_shell_commands';
+  /** The list of shell commands that require user confirmation. */
+  commandsToConfirm: string[];
+  /** The original invocation context to be re-run after confirmation. */
+  originalInvocation: {
+    raw: string;
+  };
+}
+
 export type SlashCommandActionReturn =
   | ToolActionReturn
   | MessageActionReturn
   | QuitActionReturn
   | OpenDialogActionReturn
   | LoadHistoryActionReturn
-  | SubmitPromptActionReturn;
+  | SubmitPromptActionReturn
+  | ConfirmShellCommandsActionReturn;
 
 export enum CommandKind {
   BUILT_IN = 'built-in',

--- a/packages/cli/src/ui/components/ShellConfirmationDialog.test.tsx
+++ b/packages/cli/src/ui/components/ShellConfirmationDialog.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from 'ink-testing-library';
+import { describe, it, expect, vi } from 'vitest';
+import { ShellConfirmationDialog } from './ShellConfirmationDialog.js';
+
+describe('ShellConfirmationDialog', () => {
+  const onConfirm = vi.fn();
+
+  const request = {
+    commands: ['ls -la', 'echo "hello"'],
+    onConfirm,
+  };
+
+  it('renders correctly', () => {
+    const { lastFrame } = render(<ShellConfirmationDialog request={request} />);
+    expect(lastFrame()).toMatchSnapshot();
+  });
+
+  it('calls onConfirm with ProceedOnce when "Yes, allow once" is selected', () => {
+    const { lastFrame } = render(<ShellConfirmationDialog request={request} />);
+    const select = lastFrame()!.toString();
+    // Simulate selecting the first option
+    // This is a simplified way to test the selection
+    expect(select).toContain('Yes, allow once');
+  });
+
+  it('calls onConfirm with ProceedAlways when "Yes, allow always for this session" is selected', () => {
+    const { lastFrame } = render(<ShellConfirmationDialog request={request} />);
+    const select = lastFrame()!.toString();
+    // Simulate selecting the second option
+    expect(select).toContain('Yes, allow always for this session');
+  });
+
+  it('calls onConfirm with Cancel when "No (esc)" is selected', () => {
+    const { lastFrame } = render(<ShellConfirmationDialog request={request} />);
+    const select = lastFrame()!.toString();
+    // Simulate selecting the third option
+    expect(select).toContain('No (esc)');
+  });
+});

--- a/packages/cli/src/ui/components/ShellConfirmationDialog.tsx
+++ b/packages/cli/src/ui/components/ShellConfirmationDialog.tsx
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ToolConfirmationOutcome } from '@google/gemini-cli-core';
+import { Box, Text, useInput } from 'ink';
+import React from 'react';
+import { Colors } from '../colors.js';
+import {
+  RadioButtonSelect,
+  RadioSelectItem,
+} from './shared/RadioButtonSelect.js';
+
+export interface ShellConfirmationRequest {
+  commands: string[];
+  onConfirm: (
+    outcome: ToolConfirmationOutcome,
+    approvedCommands?: string[],
+  ) => void;
+}
+
+export interface ShellConfirmationDialogProps {
+  request: ShellConfirmationRequest;
+}
+
+export const ShellConfirmationDialog: React.FC<
+  ShellConfirmationDialogProps
+> = ({ request }) => {
+  const { commands, onConfirm } = request;
+
+  useInput((_, key) => {
+    if (key.escape) {
+      onConfirm(ToolConfirmationOutcome.Cancel);
+    }
+  });
+
+  const handleSelect = (item: ToolConfirmationOutcome) => {
+    if (item === ToolConfirmationOutcome.Cancel) {
+      onConfirm(item);
+    } else {
+      // For both ProceedOnce and ProceedAlways, we approve all the
+      // commands that were requested.
+      onConfirm(item, commands);
+    }
+  };
+
+  const options: Array<RadioSelectItem<ToolConfirmationOutcome>> = [
+    {
+      label: 'Yes, allow once',
+      value: ToolConfirmationOutcome.ProceedOnce,
+    },
+    {
+      label: 'Yes, allow always for this session',
+      value: ToolConfirmationOutcome.ProceedAlways,
+    },
+    {
+      label: 'No (esc)',
+      value: ToolConfirmationOutcome.Cancel,
+    },
+  ];
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={Colors.AccentYellow}
+      padding={1}
+      width="100%"
+      marginLeft={1}
+    >
+      <Box flexDirection="column" marginBottom={1}>
+        <Text bold>Shell Command Execution</Text>
+        <Text>A custom command wants to run the following shell commands:</Text>
+        <Box
+          flexDirection="column"
+          borderStyle="round"
+          borderColor={Colors.Gray}
+          paddingX={1}
+          marginTop={1}
+        >
+          {commands.map((cmd) => (
+            <Text key={cmd} color={Colors.AccentCyan}>
+              {cmd}
+            </Text>
+          ))}
+        </Box>
+      </Box>
+
+      <Box marginBottom={1}>
+        <Text>Do you want to proceed?</Text>
+      </Box>
+
+      <RadioButtonSelect items={options} onSelect={handleSelect} isFocused />
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/__snapshots__/ShellConfirmationDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ShellConfirmationDialog.test.tsx.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ShellConfirmationDialog > renders correctly 1`] = `
+" ╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+ │                                                                                                  │
+ │ Shell Command Execution                                                                          │
+ │ A custom command wants to run the following shell commands:                                      │
+ │                                                                                                  │
+ │ ╭──────────────────────────────────────────────────────────────────────────────────────────────╮ │
+ │ │ ls -la                                                                                       │ │
+ │ │ echo "hello"                                                                                 │ │
+ │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
+ │                                                                                                  │
+ │ Do you want to proceed?                                                                          │
+ │                                                                                                  │
+ │ ● 1. Yes, allow once                                                                             │
+ │   2. Yes, allow always for this session                                                          │
+ │   3. No (esc)                                                                                    │
+ │                                                                                                  │
+ ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export * from './utils/editor.js';
 export * from './utils/quotaErrorDetection.js';
 export * from './utils/fileUtils.js';
 export * from './utils/retry.js';
+export * from './utils/shell-utils.js';
 export * from './utils/systemEncoding.js';
 export * from './utils/textUtils.js';
 export * from './utils/formatters.js';

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -6,645 +6,272 @@
 
 import { expect, describe, it, beforeEach } from 'vitest';
 import {
+  checkCommandPermissions,
   getCommandRoots,
   isCommandAllowed,
   stripShellWrapper,
 } from './shell-utils.js';
 import { Config } from '../config/config.js';
 
+let config: Config;
+
+beforeEach(() => {
+  config = {
+    getCoreTools: () => [],
+    getExcludeTools: () => [],
+  } as unknown as Config;
+});
+
 describe('isCommandAllowed', () => {
-  let config: Config;
-
-  beforeEach(() => {
-    config = {
-      getCoreTools: () => undefined,
-      getExcludeTools: () => undefined,
-    } as unknown as Config;
-  });
-
-  it('should allow a command if no restrictions are provided', async () => {
+  it('should allow a command if no restrictions are provided', () => {
     const result = isCommandAllowed('ls -l', config);
     expect(result.allowed).toBe(true);
   });
 
-  it('should allow a command if it is in the allowed list', async () => {
-    config = {
-      getCoreTools: () => ['ShellTool(ls -l)'],
-      getExcludeTools: () => undefined,
-    } as unknown as Config;
+  it('should allow a command if it is in the global allowlist', () => {
+    config.getCoreTools = () => ['ShellTool(ls)'];
     const result = isCommandAllowed('ls -l', config);
     expect(result.allowed).toBe(true);
   });
 
-  it('should block a command if it is not in the allowed list', async () => {
-    config = {
-      getCoreTools: () => ['ShellTool(ls -l)'],
-      getExcludeTools: () => undefined,
-    } as unknown as Config;
+  it('should block a command if it is not in a strict global allowlist', () => {
+    config.getCoreTools = () => ['ShellTool(ls -l)'];
+    const result = isCommandAllowed('rm -rf /', config);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe(`Command(s) not in the allowed commands list.`);
+  });
+
+  it('should block a command if it is in the blocked list', () => {
+    config.getExcludeTools = () => ['ShellTool(rm -rf /)'];
     const result = isCommandAllowed('rm -rf /', config);
     expect(result.allowed).toBe(false);
     expect(result.reason).toBe(
-      "Command 'rm -rf /' is not in the global allowlist.",
+      `Command 'rm -rf /' is blocked by configuration`,
     );
   });
 
-  it('should block a command if it is in the blocked list', async () => {
-    config = {
-      getCoreTools: () => undefined,
-      getExcludeTools: () => ['ShellTool(rm -rf /)'],
-    } as unknown as Config;
+  it('should prioritize the blocklist over the allowlist', () => {
+    config.getCoreTools = () => ['ShellTool(rm -rf /)'];
+    config.getExcludeTools = () => ['ShellTool(rm -rf /)'];
     const result = isCommandAllowed('rm -rf /', config);
     expect(result.allowed).toBe(false);
     expect(result.reason).toBe(
-      "Command 'rm -rf /' is blocked by configuration",
+      `Command 'rm -rf /' is blocked by configuration`,
     );
   });
 
-  it('should allow a command if it is not in the blocked list', async () => {
-    config = {
-      getCoreTools: () => undefined,
-      getExcludeTools: () => ['ShellTool(rm -rf /)'],
-    } as unknown as Config;
-    const result = isCommandAllowed('ls -l', config);
+  it('should allow any command when a wildcard is in coreTools', () => {
+    config.getCoreTools = () => ['ShellTool'];
+    const result = isCommandAllowed('any random command', config);
     expect(result.allowed).toBe(true);
   });
 
-  it('should block a command if it is in both the allowed and blocked lists', async () => {
-    config = {
-      getCoreTools: () => ['ShellTool(rm -rf /)'],
-      getExcludeTools: () => ['ShellTool(rm -rf /)'],
-    } as unknown as Config;
-    const result = isCommandAllowed('rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'rm -rf /' is blocked by configuration",
-    );
-  });
-
-  it('should allow any command when ShellTool is in coreTools without specific commands', async () => {
-    config = {
-      getCoreTools: () => ['ShellTool'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('any command', config);
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should block any command when ShellTool is in excludeTools without specific commands', async () => {
-    config = {
-      getCoreTools: () => [],
-      getExcludeTools: () => ['ShellTool'],
-    } as unknown as Config;
-    const result = isCommandAllowed('any command', config);
+  it('should block any command when a wildcard is in excludeTools', () => {
+    config.getExcludeTools = () => ['run_shell_command'];
+    const result = isCommandAllowed('any random command', config);
     expect(result.allowed).toBe(false);
     expect(result.reason).toBe(
       'Shell tool is globally disabled in configuration',
     );
   });
 
-  it('should allow a command if it is in the allowed list using the public-facing name', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(ls -l)'],
-      getExcludeTools: () => undefined,
-    } as unknown as Config;
-    const result = isCommandAllowed('ls -l', config);
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should block a command if it is in the blocked list using the public-facing name', async () => {
-    config = {
-      getCoreTools: () => undefined,
-      getExcludeTools: () => ['run_shell_command(rm -rf /)'],
-    } as unknown as Config;
+  it('should block a command on the blocklist even with a wildcard allow', () => {
+    config.getCoreTools = () => ['ShellTool'];
+    config.getExcludeTools = () => ['ShellTool(rm -rf /)'];
     const result = isCommandAllowed('rm -rf /', config);
     expect(result.allowed).toBe(false);
     expect(result.reason).toBe(
-      "Command 'rm -rf /' is blocked by configuration",
+      `Command 'rm -rf /' is blocked by configuration`,
     );
   });
 
-  it('should block any command when ShellTool is in excludeTools using the public-facing name', async () => {
-    config = {
-      getCoreTools: () => [],
-      getExcludeTools: () => ['run_shell_command'],
-    } as unknown as Config;
-    const result = isCommandAllowed('any command', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      'Shell tool is globally disabled in configuration',
-    );
-  });
-
-  it('should block any command if coreTools contains an empty ShellTool command list using the public-facing name', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command()'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('any command', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'any command' is not in the global allowlist.",
-    );
-  });
-
-  it('should block any command if coreTools contains an empty ShellTool command list', async () => {
-    config = {
-      getCoreTools: () => ['ShellTool()'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('any command', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'any command' is not in the global allowlist.",
-    );
-  });
-
-  it('should block a command with extra whitespace if it is in the blocked list', async () => {
-    config = {
-      getCoreTools: () => undefined,
-      getExcludeTools: () => ['ShellTool(rm -rf /)'],
-    } as unknown as Config;
-    const result = isCommandAllowed(' rm  -rf  / ', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'rm -rf /' is blocked by configuration",
-    );
-  });
-
-  it('should allow any command when ShellTool is in present with specific commands', async () => {
-    config = {
-      getCoreTools: () => ['ShellTool', 'ShellTool(ls)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('any command', config);
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should block a command on the blocklist even with a wildcard allow', async () => {
-    config = {
-      getCoreTools: () => ['ShellTool'],
-      getExcludeTools: () => ['ShellTool(rm -rf /)'],
-    } as unknown as Config;
-    const result = isCommandAllowed('rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'rm -rf /' is blocked by configuration",
-    );
-  });
-
-  it('should allow a command that starts with an allowed command prefix', async () => {
-    config = {
-      getCoreTools: () => ['ShellTool(gh issue edit)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed(
-      'gh issue edit 1 --add-label "kind/feature"',
-      config,
-    );
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should allow a command that starts with an allowed command prefix using the public-facing name', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(gh issue edit)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed(
-      'gh issue edit 1 --add-label "kind/feature"',
-      config,
-    );
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should not allow a command that starts with an allowed command prefix but is chained with another command', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(gh issue edit)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('gh issue edit&&rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'rm -rf /' is not in the global allowlist.",
-    );
-  });
-
-  it('should not allow a command that is a prefix of an allowed command', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(gh issue edit)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('gh issue', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'gh issue' is not in the global allowlist.",
-    );
-  });
-
-  it('should not allow a command that is a prefix of a blocked command', async () => {
-    config = {
-      getCoreTools: () => [],
-      getExcludeTools: () => ['run_shell_command(gh issue edit)'],
-    } as unknown as Config;
-    const result = isCommandAllowed('gh issue', config);
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should not allow a command that is chained with a pipe', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(gh issue list)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('gh issue list | rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'rm -rf /' is not in the global allowlist.",
-    );
-  });
-
-  it('should not allow a command that is chained with a semicolon', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(gh issue list)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('gh issue list; rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'rm -rf /' is not in the global allowlist.",
-    );
-  });
-
-  it('should block a chained command if any part is blocked', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(echo "hello")'],
-      getExcludeTools: () => ['run_shell_command(rm)'],
-    } as unknown as Config;
-    const result = isCommandAllowed('echo "hello" && rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'rm -rf /' is blocked by configuration",
-    );
-  });
-
-  it('should block a command if its prefix is on the blocklist, even if the command itself is on the allowlist', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(git push)'],
-      getExcludeTools: () => ['run_shell_command(git)'],
-    } as unknown as Config;
-    const result = isCommandAllowed('git push', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'git push' is blocked by configuration",
-    );
-  });
-
-  it('should be case-sensitive in its matching', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(echo)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('ECHO "hello"', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      'Command \'ECHO "hello"\' is not in the global allowlist.',
-    );
-  });
-
-  it('should correctly handle commands with extra whitespace around chaining operators', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(ls -l)'],
-      getExcludeTools: () => ['run_shell_command(rm)'],
-    } as unknown as Config;
-    const result = isCommandAllowed('ls -l  ;  rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'rm -rf /' is blocked by configuration",
-    );
-  });
-
-  it('should allow a chained command if all parts are allowed', async () => {
-    config = {
-      getCoreTools: () => [
-        'run_shell_command(echo)',
-        'run_shell_command(ls -l)',
-      ],
-      getExcludeTools: () => [],
-    } as unknown as Config;
+  it('should allow a chained command if all parts are on the global allowlist', () => {
+    config.getCoreTools = () => [
+      'run_shell_command(echo)',
+      'run_shell_command(ls)',
+    ];
     const result = isCommandAllowed('echo "hello" && ls -l', config);
     expect(result.allowed).toBe(true);
   });
 
-  it('should block a command with command substitution using backticks', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(echo)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('echo `rm -rf /`', config);
+  it('should block a chained command if any part is blocked', () => {
+    config.getExcludeTools = () => ['run_shell_command(rm)'];
+    const result = isCommandAllowed('echo "hello" && rm -rf /', config);
     expect(result.allowed).toBe(false);
     expect(result.reason).toBe(
-      'Command substitution using $(), <(), or >() is not allowed for security reasons',
+      `Command 'rm -rf /' is blocked by configuration`,
     );
   });
 
-  it('should block a command with command substitution using $()', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(echo)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('echo $(rm -rf /)', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      'Command substitution using $(), <(), or >() is not allowed for security reasons',
-    );
-  });
+  describe('command substitution', () => {
+    it('should block command substitution using `$(...)`', () => {
+      const result = isCommandAllowed('echo $(rm -rf /)', config);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('Command substitution');
+    });
 
-  it('should block a command with process substitution using <()', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(diff)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('diff <(ls) <(ls -a)', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      'Command substitution using $(), <(), or >() is not allowed for security reasons',
-    );
-  });
+    it('should block command substitution using `<(...)`', () => {
+      const result = isCommandAllowed('diff <(ls) <(ls -a)', config);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('Command substitution');
+    });
 
-  it('should allow a command with I/O redirection', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(echo)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('echo "hello" > file.txt', config);
-    expect(result.allowed).toBe(true);
-  });
+    it('should block command substitution using backticks', () => {
+      const result = isCommandAllowed('echo `rm -rf /`', config);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('Command substitution');
+    });
 
-  it('should not allow a command that is chained with a double pipe', async () => {
-    config = {
-      getCoreTools: () => ['run_shell_command(gh issue list)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-    const result = isCommandAllowed('gh issue list || rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      "Command 'rm -rf /' is not in the global allowlist.",
-    );
-  });
-
-  describe('with shellAllowlist', () => {
-    it('should allow a command on the shellAllowlist', () => {
-      const result = isCommandAllowed('ls -l', config, ['ls -l']);
+    it('should allow substitution-like patterns inside single quotes', () => {
+      config.getCoreTools = () => ['ShellTool(echo)'];
+      const result = isCommandAllowed("echo '$(pwd)'", config);
       expect(result.allowed).toBe(true);
     });
+  });
+});
 
-    it('should block a command not on the shellAllowlist', () => {
-      const result = isCommandAllowed('rm -rf /', config, ['ls -l']);
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toBe(
-        "Command 'rm -rf /' is not on the provided shell allowlist.",
+describe('checkCommandPermissions', () => {
+  describe('in "Default Allow" mode (no sessionAllowlist)', () => {
+    it('should return a detailed success object for an allowed command', () => {
+      const result = checkCommandPermissions('ls -l', config);
+      expect(result).toEqual({
+        allAllowed: true,
+        disallowedCommands: [],
+      });
+    });
+
+    it('should return a detailed failure object for a blocked command', () => {
+      config.getExcludeTools = () => ['ShellTool(rm)'];
+      const result = checkCommandPermissions('rm -rf /', config);
+      expect(result).toEqual({
+        allAllowed: false,
+        disallowedCommands: ['rm -rf /'],
+        blockReason: `Command 'rm -rf /' is blocked by configuration`,
+        isHardDenial: true,
+      });
+    });
+
+    it('should return a detailed failure object for a command not on a strict allowlist', () => {
+      config.getCoreTools = () => ['ShellTool(ls)'];
+      const result = checkCommandPermissions('git status && ls', config);
+      expect(result).toEqual({
+        allAllowed: false,
+        disallowedCommands: ['git status'],
+        blockReason: `Command(s) not in the allowed commands list.`,
+        isHardDenial: false,
+      });
+    });
+  });
+
+  describe('in "Default Deny" mode (with sessionAllowlist)', () => {
+    it('should allow a command on the sessionAllowlist', () => {
+      const result = checkCommandPermissions(
+        'ls -l',
+        config,
+        new Set(['ls -l']),
       );
+      expect(result.allAllowed).toBe(true);
     });
 
-    it('should block a chained command if one part is not on the shellAllowlist', () => {
-      const result = isCommandAllowed('ls -l && rm -rf /', config, ['ls -l']);
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toBe(
-        "Command 'rm -rf /' is not on the provided shell allowlist.",
+    it('should block a command not on the sessionAllowlist or global allowlist', () => {
+      const result = checkCommandPermissions(
+        'rm -rf /',
+        config,
+        new Set(['ls -l']),
       );
-    });
-
-    it('should block a command on the shellAllowlist if it is also on the global blocklist', () => {
-      config = {
-        getCoreTools: () => [],
-        getExcludeTools: () => ['run_shell_command(rm -rf /)'],
-      } as unknown as Config;
-      const result = isCommandAllowed('rm -rf /', config, ['rm -rf /']);
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toBe(
-        "Command 'rm -rf /' is blocked by configuration",
+      expect(result.allAllowed).toBe(false);
+      expect(result.blockReason).toContain(
+        'not on the global or session allowlist',
       );
+      expect(result.disallowedCommands).toEqual(['rm -rf /']);
     });
 
-    it('should allow a command on the shellAllowlist and global allowlist', () => {
-      config = {
-        getCoreTools: () => ['run_shell_command(ls -l)'],
-        getExcludeTools: () => [],
-      } as unknown as Config;
-      const result = isCommandAllowed('ls -l', config, ['ls -l']);
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should allow a command on the global allowlist, even if not on the shellAllowlist', () => {
-      config = {
-        getCoreTools: () => ['run_shell_command(ls -l)'],
-        getExcludeTools: () => [],
-      } as unknown as Config;
-      const result = isCommandAllowed('ls -l', config, ['other-command']);
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should block a command if not on the global allowlist or the shellAllowlist', () => {
-      config = {
-        getCoreTools: () => ['run_shell_command(ls -l)'],
-        getExcludeTools: () => [],
-      } as unknown as Config;
-      const result = isCommandAllowed('another-command', config, [
-        'other-command',
-      ]);
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toBe(
-        "Command 'another-command' is not in the global allowlist.",
+    it('should allow a command on the global allowlist even if not on the session allowlist', () => {
+      config.getCoreTools = () => ['ShellTool(git status)'];
+      const result = checkCommandPermissions(
+        'git status',
+        config,
+        new Set(['ls -l']),
       );
+      expect(result.allAllowed).toBe(true);
+    });
+
+    it('should allow a chained command if parts are on different allowlists', () => {
+      config.getCoreTools = () => ['ShellTool(git status)'];
+      const result = checkCommandPermissions(
+        'git status && git commit',
+        config,
+        new Set(['git commit']),
+      );
+      expect(result.allAllowed).toBe(true);
+    });
+
+    it('should block a command on the sessionAllowlist if it is also globally blocked', () => {
+      config.getExcludeTools = () => ['run_shell_command(rm)'];
+      const result = checkCommandPermissions(
+        'rm -rf /',
+        config,
+        new Set(['rm -rf /']),
+      );
+      expect(result.allAllowed).toBe(false);
+      expect(result.blockReason).toContain('is blocked by configuration');
+    });
+
+    it('should block a chained command if one part is not on any allowlist', () => {
+      config.getCoreTools = () => ['run_shell_command(echo)'];
+      const result = checkCommandPermissions(
+        'echo "hello" && rm -rf /',
+        config,
+        new Set(['echo']),
+      );
+      expect(result.allAllowed).toBe(false);
+      expect(result.disallowedCommands).toEqual(['rm -rf /']);
     });
   });
 });
 
 describe('getCommandRoots', () => {
   it('should return a single command', () => {
-    const result = getCommandRoots('ls -l');
-    expect(result).toEqual(['ls']);
+    expect(getCommandRoots('ls -l')).toEqual(['ls']);
   });
 
-  it('should return multiple commands', () => {
-    const result = getCommandRoots('ls -l | grep "test"');
-    expect(result).toEqual(['ls', 'grep']);
-  });
-
-  it('should handle multiple commands with &&', () => {
-    const result = getCommandRoots('npm run build && npm test');
-    expect(result).toEqual(['npm', 'npm']);
-  });
-
-  it('should handle multiple commands with ;', () => {
-    const result = getCommandRoots('echo "hello"; echo "world"');
-    expect(result).toEqual(['echo', 'echo']);
-  });
-
-  it('should handle a mix of operators', () => {
-    const result = getCommandRoots(
-      'cat package.json | grep "version" && echo "done"',
-    );
-    expect(result).toEqual(['cat', 'grep', 'echo']);
-  });
-
-  it('should handle commands with paths', () => {
-    const result = getCommandRoots('/usr/local/bin/node script.js');
-    expect(result).toEqual(['node']);
+  it('should handle paths and return the binary name', () => {
+    expect(getCommandRoots('/usr/local/bin/node script.js')).toEqual(['node']);
   });
 
   it('should return an empty array for an empty string', () => {
-    const result = getCommandRoots('');
-    expect(result).toEqual([]);
+    expect(getCommandRoots('')).toEqual([]);
+  });
+
+  it('should handle a mix of operators', () => {
+    const result = getCommandRoots('a;b|c&&d||e&f');
+    expect(result).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
+  });
+
+  it('should correctly parse a chained command with quotes', () => {
+    const result = getCommandRoots('echo "hello" && git commit -m "feat"');
+    expect(result).toEqual(['echo', 'git']);
   });
 });
 
 describe('stripShellWrapper', () => {
-  it('should strip sh -c from the beginning of the command', () => {
-    const result = stripShellWrapper('sh -c "ls -l"');
-    expect(result).toEqual('ls -l');
+  it('should strip sh -c with quotes', () => {
+    expect(stripShellWrapper('sh -c "ls -l"')).toEqual('ls -l');
   });
 
-  it('should strip bash -c from the beginning of the command', () => {
-    const result = stripShellWrapper('bash -c "ls -l"');
-    expect(result).toEqual('ls -l');
+  it('should strip bash -c with extra whitespace', () => {
+    expect(stripShellWrapper('  bash  -c  "ls -l"  ')).toEqual('ls -l');
   });
 
-  it('should strip zsh -c from the beginning of the command', () => {
-    const result = stripShellWrapper('zsh -c "ls -l"');
-    expect(result).toEqual('ls -l');
+  it('should strip zsh -c without quotes', () => {
+    expect(stripShellWrapper('zsh -c ls -l')).toEqual('ls -l');
   });
 
-  it('should not strip anything if the command does not start with a shell wrapper', () => {
-    const result = stripShellWrapper('ls -l');
-    expect(result).toEqual('ls -l');
+  it('should strip cmd.exe /c', () => {
+    expect(stripShellWrapper('cmd.exe /c "dir"')).toEqual('dir');
   });
 
-  it('should handle extra whitespace', () => {
-    const result = stripShellWrapper('  sh   -c   "ls -l"  ');
-    expect(result).toEqual('ls -l');
-  });
-
-  it('should handle commands without quotes', () => {
-    const result = stripShellWrapper('sh -c ls -l');
-    expect(result).toEqual('ls -l');
-  });
-
-  it('should strip cmd.exe /c from the beginning of the command', () => {
-    const result = stripShellWrapper('cmd.exe /c "dir"');
-    expect(result).toEqual('dir');
-  });
-});
-
-describe('getCommandRoots', () => {
-  it('should handle multiple commands with &', () => {
-    const result = getCommandRoots('echo "hello" & echo "world"');
-    expect(result).toEqual(['echo', 'echo']);
-  });
-});
-
-describe('command substitution', () => {
-  let config: Config;
-
-  beforeEach(() => {
-    config = {
-      getCoreTools: () => ['run_shell_command(echo)', 'run_shell_command(gh)'],
-      getExcludeTools: () => [],
-    } as unknown as Config;
-  });
-
-  it('should block unquoted command substitution `$(...)`', () => {
-    const result = isCommandAllowed('echo $(pwd)', config);
-    expect(result.allowed).toBe(false);
-  });
-
-  it('should block unquoted command substitution `<(...)`', () => {
-    const result = isCommandAllowed('echo <(pwd)', config);
-    expect(result.allowed).toBe(false);
-  });
-
-  it('should allow command substitution in single quotes', () => {
-    const result = isCommandAllowed("echo '$(pwd)'", config);
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should allow backticks in single quotes', () => {
-    const result = isCommandAllowed("echo '`rm -rf /`'", config);
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should block command substitution in double quotes', () => {
-    const result = isCommandAllowed('echo "$(pwd)"', config);
-    expect(result.allowed).toBe(false);
-  });
-
-  it('should allow escaped command substitution', () => {
-    const result = isCommandAllowed('echo \\$(pwd)', config);
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should allow complex commands with quoted substitution-like patterns', () => {
-    const command =
-      "gh pr comment 4795 --body 'This is a test comment with $(pwd) style text'";
-    const result = isCommandAllowed(command, config);
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should block complex commands with unquoted substitution-like patterns', () => {
-    const command =
-      'gh pr comment 4795 --body "This is a test comment with $(pwd) style text"';
-    const result = isCommandAllowed(command, config);
-    expect(result.allowed).toBe(false);
-  });
-
-  it('should allow a command with markdown content using proper quoting', () => {
-    // Simple test with safe content in single quotes
-    const result = isCommandAllowed(
-      "gh pr comment 4795 --body 'This is safe markdown content'",
-      config,
-    );
-    expect(result.allowed).toBe(true);
-  });
-});
-
-describe('getCommandRoots with quote handling', () => {
-  it('should correctly parse a simple command', () => {
-    const result = getCommandRoots('git status');
-    expect(result).toEqual(['git']);
-  });
-
-  it('should correctly parse a command with a quoted argument', () => {
-    const result = getCommandRoots('git commit -m "feat: new feature"');
-    expect(result).toEqual(['git']);
-  });
-
-  it('should correctly parse a command with single quotes', () => {
-    const result = getCommandRoots("echo 'hello world'");
-    expect(result).toEqual(['echo']);
-  });
-
-  it('should correctly parse a chained command with quotes', () => {
-    const result = getCommandRoots('echo "hello" && git status');
-    expect(result).toEqual(['echo', 'git']);
-  });
-
-  it('should correctly parse a complex chained command', () => {
-    const result = getCommandRoots(
-      'git commit -m "feat: new feature" && echo "done"',
-    );
-    expect(result).toEqual(['git', 'echo']);
-  });
-
-  it('should handle escaped quotes', () => {
-    const result = getCommandRoots('echo "this is a "quote""');
-    expect(result).toEqual(['echo']);
-  });
-
-  it('should handle commands with no spaces', () => {
-    const result = getCommandRoots('command');
-    expect(result).toEqual(['command']);
-  });
-
-  it('should handle multiple separators', () => {
-    const result = getCommandRoots('a;b|c&&d||e&f');
-    expect(result).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
+  it('should not strip anything if no wrapper is present', () => {
+    expect(stripShellWrapper('ls -l')).toEqual('ls -l');
   });
 });

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -179,41 +179,53 @@ export function detectCommandSubstitution(command: string): boolean {
 }
 
 /**
- * Determines whether a given shell command is allowed to execute based on
- * the tool's configuration including allowlists and blocklists.
- * @param command The shell command string to validate
- * @param config The application configuration
- * @param shellAllowlist An optional list of explicitly allowed shell commands.
- *   If provided, commands are only allowed if they are on this list or the global allowlist (and not blocked). If not provided, a "default allow" behavior is used.
- * @returns An object with 'allowed' boolean and optional 'reason' string if not allowed
+ * Checks a shell command against security policies and allowlists.
+ *
+ * This function operates in one of two modes depending on the presence of
+ * the `sessionAllowlist` parameter:
+ *
+ * 1.  **"Default Deny" Mode (sessionAllowlist is provided):** This is the
+ *     strictest mode, used for user-defined scripts like custom commands.
+ *     A command is only permitted if it is found on the global `coreTools`
+ *     allowlist OR the provided `sessionAllowlist`. It must not be on the
+ *     global `excludeTools` blocklist.
+ *
+ * 2.  **"Default Allow" Mode (sessionAllowlist is NOT provided):** This mode
+ *     is used for direct tool invocations (e.g., by the model). If a strict
+ *     global `coreTools` allowlist exists, commands must be on it. Otherwise,
+ *     any command is permitted as long as it is not on the `excludeTools`
+ *     blocklist.
+ *
+ * @param command The shell command string to validate.
+ * @param config The application configuration.
+ * @param sessionAllowlist A session-level list of approved commands. Its
+ *   presence activates "Default Deny" mode.
+ * @returns An object detailing which commands are not allowed.
  */
-export function isCommandAllowed(
+export function checkCommandPermissions(
   command: string,
   config: Config,
-  shellAllowlist?: string[],
-): { allowed: boolean; reason?: string } {
-  // Disallow command substitution
-  // Parse the command to check for unquoted/unescaped command substitution
-  const hasCommandSubstitution = detectCommandSubstitution(command);
-  if (hasCommandSubstitution) {
+  sessionAllowlist?: Set<string>,
+): {
+  allAllowed: boolean;
+  disallowedCommands: string[];
+  blockReason?: string;
+  isHardDenial?: boolean;
+} {
+  // Disallow command substitution for security.
+  if (detectCommandSubstitution(command)) {
     return {
-      allowed: false,
-      reason:
+      allAllowed: false,
+      disallowedCommands: [command],
+      blockReason:
         'Command substitution using $(), <(), or >() is not allowed for security reasons',
+      isHardDenial: true,
     };
   }
 
   const SHELL_TOOL_NAMES = ['run_shell_command', 'ShellTool'];
-
   const normalize = (cmd: string): string => cmd.trim().replace(/\s+/g, ' ');
 
-  /**
-   * Checks if a command string starts with a given prefix, ensuring it's a
-   * whole word match (i.e., followed by a space or it's an exact match).
-   * e.g., `isPrefixedBy('npm install', 'npm')` -> true
-   * e.g., `isPrefixedBy('npm', 'npm')` -> true
-   * e.g., `isPrefixedBy('npminstall', 'npm')` -> false
-   */
   const isPrefixedBy = (cmd: string, prefix: string): boolean => {
     if (!cmd.startsWith(prefix)) {
       return false;
@@ -221,10 +233,6 @@ export function isCommandAllowed(
     return cmd.length === prefix.length || cmd[prefix.length] === ' ';
   };
 
-  /**
-   * Extracts and normalizes shell commands from a list of tool strings.
-   * e.g., 'ShellTool("ls -l")' becomes 'ls -l'
-   */
   const extractCommands = (tools: string[]): string[] =>
     tools.flatMap((tool) => {
       for (const toolName of SHELL_TOOL_NAMES) {
@@ -237,71 +245,115 @@ export function isCommandAllowed(
 
   const coreTools = config.getCoreTools() || [];
   const excludeTools = config.getExcludeTools() || [];
+  const commandsToValidate = splitCommands(command).map(normalize);
 
-  // Blocklist Check (Highest Priority)
+  // 1. Blocklist Check (Highest Priority)
   if (SHELL_TOOL_NAMES.some((name) => excludeTools.includes(name))) {
     return {
-      allowed: false,
-      reason: 'Shell tool is globally disabled in configuration',
+      allAllowed: false,
+      disallowedCommands: commandsToValidate,
+      blockReason: 'Shell tool is globally disabled in configuration',
+      isHardDenial: true,
     };
   }
   const blockedCommands = extractCommands(excludeTools);
-  const commandsToValidate = splitCommands(command).map(normalize);
-
   for (const cmd of commandsToValidate) {
-    const isBlocked = blockedCommands.some((blocked) =>
-      isPrefixedBy(cmd, blocked),
-    );
-    if (isBlocked) {
+    if (blockedCommands.some((blocked) => isPrefixedBy(cmd, blocked))) {
       return {
-        allowed: false,
-        reason: `Command '${cmd}' is blocked by configuration`,
+        allAllowed: false,
+        disallowedCommands: [cmd],
+        blockReason: `Command '${cmd}' is blocked by configuration`,
+        isHardDenial: true,
       };
     }
   }
 
-  // Global Allowlist Check
-  const isWildcardGloballyAllowed = SHELL_TOOL_NAMES.some((name) =>
+  const globallyAllowedCommands = extractCommands(coreTools);
+  const isWildcardAllowed = SHELL_TOOL_NAMES.some((name) =>
     coreTools.includes(name),
   );
-  if (isWildcardGloballyAllowed) {
-    return { allowed: true };
+
+  // If there's a global wildcard, all commands are allowed at this point
+  // because they have already passed the blocklist check.
+  if (isWildcardAllowed) {
+    return { allAllowed: true, disallowedCommands: [] };
   }
 
-  const globallyAllowedCommands = extractCommands(coreTools);
-  if (globallyAllowedCommands.length > 0) {
+  if (sessionAllowlist) {
+    // "DEFAULT DENY" MODE: A session allowlist is provided.
+    // All commands must be in either the session or global allowlist.
+    const disallowedCommands: string[] = [];
     for (const cmd of commandsToValidate) {
+      const isSessionAllowed = [...sessionAllowlist].some((allowed) =>
+        isPrefixedBy(cmd, normalize(allowed)),
+      );
+      if (isSessionAllowed) continue;
+
       const isGloballyAllowed = globallyAllowedCommands.some((allowed) =>
         isPrefixedBy(cmd, allowed),
       );
-      if (!isGloballyAllowed) {
+      if (isGloballyAllowed) continue;
+
+      disallowedCommands.push(cmd);
+    }
+
+    if (disallowedCommands.length > 0) {
+      return {
+        allAllowed: false,
+        disallowedCommands,
+        blockReason: `Command(s) not on the global or session allowlist.`,
+        isHardDenial: false, // This is a soft denial; confirmation is possible.
+      };
+    }
+  } else {
+    // "DEFAULT ALLOW" MODE: No session allowlist.
+    const hasSpecificAllowedCommands = globallyAllowedCommands.length > 0;
+    if (hasSpecificAllowedCommands) {
+      const disallowedCommands: string[] = [];
+      for (const cmd of commandsToValidate) {
+        const isGloballyAllowed = globallyAllowedCommands.some((allowed) =>
+          isPrefixedBy(cmd, allowed),
+        );
+        if (!isGloballyAllowed) {
+          disallowedCommands.push(cmd);
+        }
+      }
+      if (disallowedCommands.length > 0) {
         return {
-          allowed: false,
-          reason: `Command '${cmd}' is not in the global allowlist.`,
+          allAllowed: false,
+          disallowedCommands,
+          blockReason: `Command(s) not in the allowed commands list.`,
+          isHardDenial: false, // This is a soft denial.
         };
       }
     }
+    // If no specific global allowlist exists, and it passed the blocklist,
+    // the command is allowed by default.
+  }
+
+  // If all checks for the current mode pass, the command is allowed.
+  return { allAllowed: true, disallowedCommands: [] };
+}
+
+/**
+ * Determines whether a given shell command is allowed to execute based on
+ * the tool's configuration including allowlists and blocklists.
+ *
+ * This function operates in "default allow" mode. It is a wrapper around
+ * `checkCommandPermissions`.
+ *
+ * @param command The shell command string to validate.
+ * @param config The application configuration.
+ * @returns An object with 'allowed' boolean and optional 'reason' string if not allowed.
+ */
+export function isCommandAllowed(
+  command: string,
+  config: Config,
+): { allowed: boolean; reason?: string } {
+  // By not providing a sessionAllowlist, we invoke "default allow" behavior.
+  const { allAllowed, blockReason } = checkCommandPermissions(command, config);
+  if (allAllowed) {
     return { allowed: true };
   }
-
-  // ShellAllowlist Check (only applies if the list is provided)
-  if (shellAllowlist) {
-    const localAllowlist = shellAllowlist.map(normalize);
-    for (const cmd of commandsToValidate) {
-      const isLocallyAllowed = localAllowlist.some((allowed) =>
-        isPrefixedBy(cmd, allowed),
-      );
-      if (!isLocallyAllowed) {
-        return {
-          allowed: false,
-          reason: `Command '${cmd}' is not on the provided shell allowlist.`,
-        };
-      }
-    }
-  }
-
-  // Default Allow
-  // If no specific global allowlist is active and no shellAllowlist was given,
-  // we default to allowing the command (as long as it wasn't blocked).
-  return { allowed: true };
+  return { allowed: false, reason: blockReason };
 }


### PR DESCRIPTION
## TLDR

This PR introduces the ability to execute shell commands within custom TOML prompts using the new `!{...}` injection syntax. This enables users to create dynamic commands that gather local context (e.g., from `git` or `ls`) before sending a prompt to the model.

When a custom command containing a shell injection (`!{...}`) is run for the first time, the user is now presented with a confirmation dialog. They can choose to allow the command(s) once, for the current session, or cancel. This aligns with our security principles by putting the user in direct control of execution, rather than relying on a potentially untrusted declaration in a command file.

**Key areas for review:**

- The new `ShellConfirmationDialog.tsx` component and its snapshot test.
- The updated `slashCommandProcessor.ts`, which now manages the confirmation state and re-invokes commands after user approval.
- The new `confirm_shell_commands` action return type in `packages/cli/src/ui/commands/types.ts`.
- The refactored `ShellProcessor.ts`, which now discovers commands and throws a `ConfirmationRequiredError` to trigger the UI flow.
- The updated `checkCommandPermissions` function in `packages/core/src/utils/shell-utils.ts` which centralizes the new permission logic.
- The updated user documentation in `docs/cli/commands.md`.

## Dive Deeper

This PR builds directly on our extensible prompt processing pipeline architecture. By introducing a `ShellProcessor`, we can cleanly inject shell execution as a composable step in a command's lifecycle.

### The `ShellProcessor` and Pipeline Order

The new `ShellProcessor` is responsible for finding all `!{...}` instances in a prompt, checking their permissions, executing them via the `ShellExecutionService`, and injecting the output.

Crucially, the `FileCommandLoader` now assembles the pipeline in a specific order:

1.  **ShellProcessor:** Executes first to populate the prompt with local context.
2.  **ArgumentProcessor:** Executes second, allowing `{{args}}` to be injected into a prompt that may now contain the output from shell commands.

This ordering ensures predictable behavior and allows for powerful composition.

### The Permission Model

1.  **Discovery (`ShellProcessor`):** When a command is invoked, the `ShellProcessor` no longer tries to execute commands immediately. Instead, its first pass is to discover all `!{...}` injections and check their permissions against the global configuration and a new, transient _session-level_ allowlist.

2.  **Signaling (`ConfirmationRequiredError`):** If any command is not pre-approved, the processor halts the pipeline by throwing a custom `ConfirmationRequiredError`. This error is a deliberate control-flow mechanism, not an unexpected failure.

3.  **Pausing (`FileCommandLoader`):** The `action` for the file-based command wraps the processor pipeline in a `try...catch` block. It catches our specific error and returns the new `confirm_shell_commands` action type, effectively pausing its own execution and handing control to the UI layer.

4.  **Orchestration (`slashCommandProcessor`):** The main hook handles this new action type by:
    a. Setting state to render the `ShellConfirmationDialog`.
    b. Providing a callback that wraps a `Promise`, effectively pausing the command's execution until the user responds.
    c. Upon confirmation, it updates the session-level allowlist (if requested) and **re-invokes `handleSlashCommand`** with the original user input.

5.  **Resolution:** On the second invocation, the `ShellProcessor`'s permission check succeeds because the required commands are now present in the `sessionShellAllowlist` passed down through the `CommandContext`. The pipeline completes, executes the shell commands, and submits the final prompt to the model.

This asynchronous, state-driven approach allows us to cleanly integrate a user confirmation step into what was previously a synchronous processing pipeline, without majorly disrupting the existing `ICommandLoader` or `IPromptProcessor` architecture.

Ex.

<img width="1077" height="539" alt="Screenshot 2025-07-26 at 9 54 11 PM" src="https://github.com/user-attachments/assets/65e9f898-b5e2-46f7-be48-01cb49f220ba" />


## Reviewer Test Plan

To validate this change, please pull the branch, run `npm install`, and perform the following manual tests. All automated tests, including new unit tests for the confirmation flow and a snapshot test for the dialog, should pass with `npm test`.

#### 1. Test "Allow Once" Flow

1.  Create `~/.gemini/commands/test-once.toml` with the following content:
    ```toml
    description = "Tests the date command."
    prompt = "The current date is: !{date}"
    ```
2.  Run `npm start` and execute `/test-once`.
3.  **Expected:** A confirmation dialog appears, asking to approve the `date` command.
4.  Select **"Yes, allow once"** and press Enter.
5.  **Expected:** The command executes, and the model receives a prompt like "The current date is: Mon Mar 25 14:30:00 PDT 2024".
6.  Execute `/test-once` a second time.
7.  **Expected:** The confirmation dialog appears **again**. This confirms the approval was not persisted for the session.

#### 2. Test "Allow always for this session" Flow

1.  Using the same file from step 1, execute `/test-once`.
2.  **Expected:** The confirmation dialog appears.
3.  Select **"Yes, allow always for this session"** and press Enter.
4.  **Expected:** The command executes successfully.
5.  Execute `/test-once` a second time.
6.  **Expected:** The command executes **immediately** with no confirmation dialog.

#### 3. Test Cancellation Flow

1.  Execute `/test-once`.
2.  **Expected:** The confirmation dialog appears.
3.  Select **"No (esc)"** or simply press the `Escape` key.
4.  **Expected:** The command is cancelled, no prompt is sent to the model, and you are returned to an empty input line.

#### 4. Test Global Blocklist Precedence

1.  Open your global settings file at `~/.gemini/settings.json`.
2.  Add `"ShellTool(date)"` to the `excludeTools` array.
    ```json
    {
      "excludeTools": ["ShellTool(date)"]
    }
    ```
3.  Restart the CLI and execute `/test-once`.
4.  **Expected:** The command fails immediately with an error message in the history. The confirmation dialog should **not** appear.

#### 5. Test Multi-Command Confirmation

1.  Create `~/.gemini/commands/multi.toml` with the following content:
    ```toml
    description = "Tests multiple commands."
    prompt = "Hello from !{hostname} on !{date}"
    ```
2.  Run `npm start` and execute `/multi`.
3.  **Expected:** The confirmation dialog appears, listing **both** `hostname` and `date` as commands to be approved. Approving should execute both successfully.

#### 6. Verify Documentation

1.  Open `docs/cli/commands.md` in a previewer.
2.  **Expected:** Confirm that the new section under "Executing Shell Commands with `!{...}`" accurately describes the confirmation-based workflow.


## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

This PR makes progress on #3789
