### PR TITLE
Fix EISDIR error when directory exists instead of GEMINI.md file

### DIFF
--- a/src/memory/MemoryDiscovery.ts
+++ b/src/memory/MemoryDiscovery.ts
@@ -12,12 +12,11 @@ export class MemoryDiscovery {
         } catch (error: unknown) {
             // Check if it's a Node.js file system error.
             if (error instanceof Error && 'code' in error) {
-                const nodeError = error as { code: string; message: string };
-                if (nodeError.code === 'ENOENT') {
+                if ((error as any).code === 'ENOENT') {
                     // File doesn't exist, which is an expected and valid case.
                     return null;
                 }
-                if (nodeError.code === 'EISDIR') {
+                if ((error as any).code === 'EISDIR') {
                     // Path is a directory, not a file. Log a warning and skip.
                     console.warn(`[WARN] [MemoryDiscovery] Skipping ${filePath}: is a directory, expected a file`);
                     return null;

--- a/src/memory/MemoryDiscovery.ts
+++ b/src/memory/MemoryDiscovery.ts
@@ -12,14 +12,14 @@ export class MemoryDiscovery {
         } catch (error: unknown) {
             // Check if it's a Node.js file system error.
             if (error instanceof Error && 'code' in error) {
-                if ((error as any).code === 'ENOENT') {
-                    // File doesn't exist, which is an expected and valid case.
-                    return null;
-                }
-                if ((error as any).code === 'EISDIR') {
-                    // Path is a directory, not a file. Log a warning and skip.
-                    console.warn(`[WARN] [MemoryDiscovery] Skipping ${filePath}: is a directory, expected a file`);
-                    return null;
+                switch ((error as { code: string }).code) {
+                    case 'ENOENT':
+                        // File doesn't exist, which is an expected and valid case.
+                        return null;
+                    case 'EISDIR':
+                        // Path is a directory, not a file. Log a warning and skip.
+                        console.warn(`[WARN] [MemoryDiscovery] Skipping ${filePath}: is a directory, expected a file`);
+                        return null;
                 }
             }
             

--- a/src/memory/MemoryDiscovery.ts
+++ b/src/memory/MemoryDiscovery.ts
@@ -6,23 +6,28 @@ export class MemoryDiscovery {
 
     private async readGeminiFile(filePath: string): Promise<string | null> {
         try {
-            // Check if path exists and is a file (not a directory)
-            const stats = await fs.promises.stat(filePath);
-            if (stats.isDirectory()) {
-                console.warn(`[WARN] [MemoryDiscovery] Skipping ${filePath}: is a directory, expected a file`);
-                return null;
-            }
-            
+            // Attempt to read the file directly. This is more efficient than stat + read.
             const content = await fs.promises.readFile(filePath, 'utf8');
             return content;
-        } catch (error: any) {
-            if (error.code === 'ENOENT') {
-                // File doesn't exist, this is expected behavior
-                return null;
-            } else {
-                console.warn(`[WARN] [MemoryDiscovery] Warning: Could not read GEMINI.md file at ${filePath}. Error: ${error.message}`);
-                return null;
+        } catch (error: unknown) {
+            // Check if it's a Node.js file system error.
+            if (error instanceof Error && 'code' in error) {
+                const nodeError = error as { code: string; message: string };
+                if (nodeError.code === 'ENOENT') {
+                    // File doesn't exist, which is an expected and valid case.
+                    return null;
+                }
+                if (nodeError.code === 'EISDIR') {
+                    // Path is a directory, not a file. Log a warning and skip.
+                    console.warn(`[WARN] [MemoryDiscovery] Skipping ${filePath}: is a directory, expected a file`);
+                    return null;
+                }
             }
+            
+            // For all other errors, log a generic warning.
+            const message = error instanceof Error ? error.message : String(error);
+            console.warn(`[WARN] [MemoryDiscovery] Warning: Could not read GEMINI.md file at ${filePath}. Error: ${message}`);
+            return null;
         }
     }
 

--- a/src/memory/MemoryDiscovery.ts
+++ b/src/memory/MemoryDiscovery.ts
@@ -5,14 +5,18 @@ export class MemoryDiscovery {
     // ...existing code...
 
     private async readGeminiFile(filePath: string): Promise<string | null> {
+        const isErrnoException = (e: unknown): e is NodeJS.ErrnoException => {
+            return e instanceof Error && 'code' in e;
+        };
+
         try {
             // Attempt to read the file directly. This is more efficient than stat + read.
             const content = await fs.promises.readFile(filePath, 'utf8');
             return content;
         } catch (error: unknown) {
             // Check if it's a Node.js file system error.
-            if (error instanceof Error && 'code' in error) {
-                switch ((error as { code: string }).code) {
+            if (isErrnoException(error)) {
+                switch (error.code) {
                     case 'ENOENT':
                         // File doesn't exist, which is an expected and valid case.
                         return null;

--- a/src/memory/MemoryDiscovery.ts
+++ b/src/memory/MemoryDiscovery.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export class MemoryDiscovery {
+    // ...existing code...
+
+    private async readGeminiFile(filePath: string): Promise<string | null> {
+        try {
+            // Check if path exists and is a file (not a directory)
+            const stats = await fs.promises.stat(filePath);
+            if (stats.isDirectory()) {
+                console.warn(`[WARN] [MemoryDiscovery] Skipping ${filePath}: is a directory, expected a file`);
+                return null;
+            }
+            
+            const content = await fs.promises.readFile(filePath, 'utf8');
+            return content;
+        } catch (error: any) {
+            if (error.code === 'ENOENT') {
+                // File doesn't exist, this is expected behavior
+                return null;
+            } else {
+                console.warn(`[WARN] [MemoryDiscovery] Warning: Could not read GEMINI.md file at ${filePath}. Error: ${error.message}`);
+                return null;
+            }
+        }
+    }
+
+    private async discoverGeminiFiles(): Promise<void> {
+        const searchPaths = this.getSearchPaths();
+        
+        for (const searchPath of searchPaths) {
+            const geminiPath = path.join(searchPath, 'GEMINI.md');
+            const result = await this.readGeminiFile(geminiPath);
+            // ...existing code...
+        }
+    }
+
+    // ...existing code...
+}


### PR DESCRIPTION
## Summary
Fixes EISDIR crash when a directory named `gemini.md` exists instead of the expected file.

## TLDR
Added directory check before file read to prevent `EISDIR: illegal operation on a directory, read` error. CLI now shows graceful warning and continues normally instead of crashing.

## Dive Deeper
The `MemoryDiscovery.readGeminiFile()` method was directly calling `fs.promises.readFile()` on paths that could be directories, causing crashes. The fix adds `fs.promises.stat()` to detect directories before attempting file reads.

**Before:** CLI crashes with EISDIR error  
**After:** CLI shows warning and continues: `[WARN] [MemoryDiscovery] Skipping [path]: is a directory, expected a file`

## Reviewer Test Plan
1. Create test directory: `mkdir ~/gemini.md`
2. Run CLI: `gemini /about` 
3. Verify: Should see warning instead of crash
4. Cleanup: `rmdir ~/gemini.md`

## Linked issues / bugs
Fixes #4760