### PR TITLE
docs: Add more examples to Popular tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ Start by `cd`ing into an existing or newly-cloned repository and running `gemini
 ```
 
 ```text
-> Identify potential areas for improvement or refactoring in this codebase, highlighting parts that appear fragile, complex, or hard to maintain. 
+> Identify potential areas for improvement or refactoring in this codebase, highlighting parts that appear fragile, complex, or hard to maintain.
 ```
 
 ```text
-> Which parts of this codebase might be challenging to scale or debug? 
+> Which parts of this codebase might be challenging to scale or debug?
 ```
 
 ```text
@@ -163,11 +163,11 @@ Start by `cd`ing into an existing or newly-cloned repository and running `gemini
 ```
 
 ```text
-> What kind of error handling and logging strategies does the project use? 
+> What kind of error handling and logging strategies does the project use?
 ```
 
 ```text
-> Which tools, libraries, and dependencies are used in this project? 
+> Which tools, libraries, and dependencies are used in this project?
 ```
 
 ### Work with your existing code

--- a/README.md
+++ b/README.md
@@ -142,6 +142,34 @@ Start by `cd`ing into an existing or newly-cloned repository and running `gemini
 > What security mechanisms are in place?
 ```
 
+```text
+> Provide a step-by-step dev onboarding doc for developers new to the codebase.
+```
+
+```text
+> Summarize this codebase and highlight the most interesting patterns or techniques I could learn from.
+```
+
+```text
+> Identify potential areas for improvement or refactoring in this codebase, highlighting parts that appear fragile, complex, or hard to maintain. 
+```
+
+```text
+> Which parts of this codebase might be challenging to scale or debug? 
+```
+
+```text
+> Generate a README section for the [module name] module explaining what it does and how to use it.
+```
+
+```text
+> What kind of error handling and logging strategies does the project use? 
+```
+
+```text
+> Which tools, libraries, and dependencies are used in this project? 
+```
+
 ### Work with your existing code
 
 ```text


### PR DESCRIPTION
What: "Adds several new example prompts to the 'Popular tasks' section of the README.md."

Why: "These prompts provide a broader range of practical use cases for the Gemini CLI, helping users more effectively explore new codebases. The examples cover common developer workflows like onboarding, code analysis, and understanding codebase patterns. This improves the documentation by giving users concrete starting points to leverage Gemini CLI's capabilities for code exploration."
