### PR TITLE
Bug: add resource parameter to MCP OAuth Flow

### DIFF
--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -151,6 +151,7 @@ describe('MCPOAuthProvider', () => {
         expect.objectContaining({ accessToken: 'access_token_123' }),
         'test-client-id',
         'https://auth.example.com/token',
+        undefined,
       );
     });
 
@@ -551,6 +552,7 @@ describe('MCPOAuthProvider', () => {
         expect.objectContaining({ accessToken: 'new_access_token' }),
         'test-client-id',
         'https://auth.example.com/token',
+        undefined,
       );
     });
 

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -300,7 +300,13 @@ export class MCPOAuthProvider {
     // Add resource parameter for MCP OAuth spec compliance
     // Use the MCP server URL if provided, otherwise fall back to authorization URL
     const resourceUrl = mcpServerUrl || config.authorizationUrl!;
-    params.append('resource', OAuthUtils.buildResourceParameter(resourceUrl));
+    try {
+      params.append('resource', OAuthUtils.buildResourceParameter(resourceUrl));
+    } catch (error) {
+      throw new Error(
+        `Invalid resource URL: "${resourceUrl}". ${getErrorMessage(error)}`,
+      );
+    }
 
     return `${config.authorizationUrl}?${params.toString()}`;
   }
@@ -339,7 +345,13 @@ export class MCPOAuthProvider {
     // Add resource parameter for MCP OAuth spec compliance
     // Use the MCP server URL if provided, otherwise fall back to token URL
     const resourceUrl = mcpServerUrl || config.tokenUrl!;
-    params.append('resource', OAuthUtils.buildResourceParameter(resourceUrl));
+    try {
+      params.append('resource', OAuthUtils.buildResourceParameter(resourceUrl));
+    } catch (error) {
+      throw new Error(
+        `Invalid resource URL: "${resourceUrl}". ${getErrorMessage(error)}`,
+      );
+    }
 
     const response = await fetch(config.tokenUrl!, {
       method: 'POST',
@@ -391,7 +403,13 @@ export class MCPOAuthProvider {
     // Add resource parameter for MCP OAuth spec compliance
     // Use the MCP server URL if provided, otherwise fall back to token URL
     const resourceUrl = mcpServerUrl || tokenUrl;
-    params.append('resource', OAuthUtils.buildResourceParameter(resourceUrl));
+    try {
+      params.append('resource', OAuthUtils.buildResourceParameter(resourceUrl));
+    } catch (error) {
+      throw new Error(
+        `Invalid resource URL: "${resourceUrl}". ${getErrorMessage(error)}`,
+      );
+    }
 
     const response = await fetch(tokenUrl, {
       method: 'POST',

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -272,11 +272,13 @@ export class MCPOAuthProvider {
    *
    * @param config OAuth configuration
    * @param pkceParams PKCE parameters
+   * @param mcpServerUrl The MCP server URL to use as the resource parameter
    * @returns The authorization URL
    */
   private static buildAuthorizationUrl(
     config: MCPOAuthConfig,
     pkceParams: PKCEParams,
+    mcpServerUrl?: string,
   ): string {
     const redirectUri =
       config.redirectUri ||
@@ -296,9 +298,11 @@ export class MCPOAuthProvider {
     }
 
     // Add resource parameter for MCP OAuth spec compliance
+    // Use the MCP server URL if provided, otherwise fall back to authorization URL
+    const resourceUrl = mcpServerUrl || config.authorizationUrl!;
     params.append(
       'resource',
-      OAuthUtils.buildResourceParameter(config.authorizationUrl!),
+      OAuthUtils.buildResourceParameter(resourceUrl),
     );
 
     return `${config.authorizationUrl}?${params.toString()}`;
@@ -310,12 +314,14 @@ export class MCPOAuthProvider {
    * @param config OAuth configuration
    * @param code Authorization code
    * @param codeVerifier PKCE code verifier
+   * @param mcpServerUrl The MCP server URL to use as the resource parameter
    * @returns The token response
    */
   private static async exchangeCodeForToken(
     config: MCPOAuthConfig,
     code: string,
     codeVerifier: string,
+    mcpServerUrl?: string,
   ): Promise<OAuthTokenResponse> {
     const redirectUri =
       config.redirectUri ||
@@ -334,9 +340,11 @@ export class MCPOAuthProvider {
     }
 
     // Add resource parameter for MCP OAuth spec compliance
+    // Use the MCP server URL if provided, otherwise fall back to token URL
+    const resourceUrl = mcpServerUrl || config.tokenUrl!;
     params.append(
       'resource',
-      OAuthUtils.buildResourceParameter(config.tokenUrl!),
+      OAuthUtils.buildResourceParameter(resourceUrl),
     );
 
     const response = await fetch(config.tokenUrl!, {
@@ -362,12 +370,15 @@ export class MCPOAuthProvider {
    *
    * @param config OAuth configuration
    * @param refreshToken The refresh token
+   * @param tokenUrl The token endpoint URL
+   * @param mcpServerUrl The MCP server URL to use as the resource parameter
    * @returns The new token response
    */
   static async refreshAccessToken(
     config: MCPOAuthConfig,
     refreshToken: string,
     tokenUrl: string,
+    mcpServerUrl?: string,
   ): Promise<OAuthTokenResponse> {
     const params = new URLSearchParams({
       grant_type: 'refresh_token',
@@ -384,7 +395,9 @@ export class MCPOAuthProvider {
     }
 
     // Add resource parameter for MCP OAuth spec compliance
-    params.append('resource', OAuthUtils.buildResourceParameter(tokenUrl));
+    // Use the MCP server URL if provided, otherwise fall back to token URL
+    const resourceUrl = mcpServerUrl || tokenUrl;
+    params.append('resource', OAuthUtils.buildResourceParameter(resourceUrl));
 
     const response = await fetch(tokenUrl, {
       method: 'POST',
@@ -534,7 +547,7 @@ export class MCPOAuthProvider {
     const pkceParams = this.generatePKCEParams();
 
     // Build authorization URL
-    const authUrl = this.buildAuthorizationUrl(config, pkceParams);
+    const authUrl = this.buildAuthorizationUrl(config, pkceParams, mcpServerUrl);
 
     console.log('\nOpening browser for OAuth authentication...');
     console.log('If the browser does not open, please visit:');
@@ -584,6 +597,7 @@ export class MCPOAuthProvider {
       config,
       code,
       pkceParams.codeVerifier,
+      mcpServerUrl,
     );
 
     // Convert to our token format
@@ -605,6 +619,7 @@ export class MCPOAuthProvider {
         token,
         config.clientId,
         config.tokenUrl,
+        mcpServerUrl,
       );
       console.log('Authentication successful! Token saved.');
 
@@ -664,6 +679,7 @@ export class MCPOAuthProvider {
           config,
           token.refreshToken,
           credentials.tokenUrl,
+          credentials.mcpServerUrl,
         );
 
         // Update stored token
@@ -683,6 +699,7 @@ export class MCPOAuthProvider {
           newToken,
           config.clientId,
           credentials.tokenUrl,
+          credentials.mcpServerUrl,
         );
 
         return newToken.accessToken;

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -300,10 +300,7 @@ export class MCPOAuthProvider {
     // Add resource parameter for MCP OAuth spec compliance
     // Use the MCP server URL if provided, otherwise fall back to authorization URL
     const resourceUrl = mcpServerUrl || config.authorizationUrl!;
-    params.append(
-      'resource',
-      OAuthUtils.buildResourceParameter(resourceUrl),
-    );
+    params.append('resource', OAuthUtils.buildResourceParameter(resourceUrl));
 
     return `${config.authorizationUrl}?${params.toString()}`;
   }
@@ -342,10 +339,7 @@ export class MCPOAuthProvider {
     // Add resource parameter for MCP OAuth spec compliance
     // Use the MCP server URL if provided, otherwise fall back to token URL
     const resourceUrl = mcpServerUrl || config.tokenUrl!;
-    params.append(
-      'resource',
-      OAuthUtils.buildResourceParameter(resourceUrl),
-    );
+    params.append('resource', OAuthUtils.buildResourceParameter(resourceUrl));
 
     const response = await fetch(config.tokenUrl!, {
       method: 'POST',
@@ -547,7 +541,11 @@ export class MCPOAuthProvider {
     const pkceParams = this.generatePKCEParams();
 
     // Build authorization URL
-    const authUrl = this.buildAuthorizationUrl(config, pkceParams, mcpServerUrl);
+    const authUrl = this.buildAuthorizationUrl(
+      config,
+      pkceParams,
+      mcpServerUrl,
+    );
 
     console.log('\nOpening browser for OAuth authentication...');
     console.log('If the browser does not open, please visit:');

--- a/packages/core/src/mcp/oauth-token-storage.ts
+++ b/packages/core/src/mcp/oauth-token-storage.ts
@@ -28,6 +28,7 @@ export interface MCPOAuthCredentials {
   token: MCPOAuthToken;
   clientId?: string;
   tokenUrl?: string;
+  mcpServerUrl?: string;
   updatedAt: number;
 }
 
@@ -91,12 +92,14 @@ export class MCPOAuthTokenStorage {
    * @param token The OAuth token to save
    * @param clientId Optional client ID used for this token
    * @param tokenUrl Optional token URL used for this token
+   * @param mcpServerUrl Optional MCP server URL
    */
   static async saveToken(
     serverName: string,
     token: MCPOAuthToken,
     clientId?: string,
     tokenUrl?: string,
+    mcpServerUrl?: string,
   ): Promise<void> {
     await this.ensureConfigDir();
 
@@ -107,6 +110,7 @@ export class MCPOAuthTokenStorage {
       token,
       clientId,
       tokenUrl,
+      mcpServerUrl,
       updatedAt: Date.now(),
     };
 


### PR DESCRIPTION
## TLDR

  This PR fixes the OAuth authentication issue where MCP servers were
  receiving an "invalid_target" error due to incorrect resource
  parameter values. The resource parameter now correctly identifies the
  protected MCP server URL instead of the authorization server URL,
  enabling successful OAuth flows for MCP servers.

 ## Dive Deeper

  The root cause of the OAuth authentication failures was that the
  resource parameter in OAuth requests was incorrectly set to the
  authorization server URL instead of the actual MCP server URL.
 According to OAuth specifications, the
  resource parameter should identify the protected resource being
  accessed.

  Changes made:

  1. Updated OAuth flow methods to accept and use the MCP server URL:
    - buildAuthorizationUrl() - Now accepts mcpServerUrl parameter
    - exchangeCodeForToken() - Now accepts mcpServerUrl parameter
    - refreshAccessToken() - Now accepts mcpServerUrl parameter
  2. Enhanced token storage to persist the MCP server URL:
    - Added mcpServerUrl field to MCPOAuthCredentials interface
    - Updated saveToken() to store the MCP server URL for use during
  token refresh
  3. Added error handling for invalid URLs:
    - Wrapped buildResourceParameter() calls in try-catch blocks
    - Provide descriptive error messages when invalid URLs are
  encountered
  4. Updated tests to reflect the new method signatures

  Reviewer Test Plan

  1. Set up an OAuth-enabled MCP server in your settings:
  "mcpServers": {
    "testServer": {
      "httpUrl": "https://mcp.myserver.com"
    }
  }
  2. Test initial OAuth authentication:
    - Run /mcp auth testServer
    - Verify the authorization URL includes the correct resource
  parameter
    - Complete the OAuth flow and verify successful authentication
  3. Test token refresh:
    - Wait for token expiration or manually expire the token
    - Make a request that requires authentication
    - Verify the token refresh includes the correct resource parameter
  4. Test error handling:
    - Try authenticating with an invalid MCP server URL
    - Verify you get a descriptive error message about the invalid URL
  5. Run the test suite:
  npm test -- oauth-provider.test.ts
  6. Verify backwards compatibility:
    - Test with MCP servers that don't provide a URL (stdio-based
  servers)
    - Ensure existing OAuth flows continue to work
## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
