### PR TITLE
feat(rag): add initial specification for RAG command

### DIFF
--- a/RAG_SPECIFICATION.md
+++ b/RAG_SPECIFICATION.md
@@ -1,0 +1,100 @@
+# Specification: `gemini labs rag` Command
+
+This document provides a detailed specification for the `gemini labs rag` command, a feature that enables Retrieval-Augmented Generation (RAG) using a user's local file system.
+
+## 1. Overview
+
+The `gemini labs rag` feature will provide a suite of commands to create a local, persistent knowledge base from a directory of files and then chat with the Gemini model using that knowledge base for context.
+
+This will involve two main commands:
+- `gemini labs rag index`: To create or update the knowledge base.
+- `gemini labs rag chat`: To interact with the knowledge base.
+
+## 2. Core Components & Technology
+
+The implementation will be based on the `LangChain.js` library to orchestrate the different parts of the RAG pipeline.
+
+- **File Loaders:** `LangChain.js` provides loaders for various file types. We will initially support plain text files (`.md`, `.txt`) and common source code files.
+- **Text Splitter:** `RecursiveCharacterTextSplitter` from `LangChain.js` will be used to split documents into smaller chunks.
+- **Embedding Model:** We will use the `gemini-embedding-001` model via the Gemini API to generate vector embeddings for the text chunks.
+- **Vector Store:** `LanceDB` will be used as the local, file-based vector store. It's serverless, persists to disk, and has good integration with `LangChain.js`.
+- **Retriever:** The vector store will be used to create a retriever that can find the most relevant document chunks for a given query.
+- **Chat Logic:** A `ConversationalRetrievalQAChain` from `LangChain.js` will be used to manage the chat flow. It will combine chat history, the retrieved context, and the user's new question into a prompt for the Gemini model.
+
+**Note on Technology Choice:** While Google now offers a managed Vertex AI RAG API, this feature will use a local-first approach with `LangChain.js` and a local vector store. This aligns with the goal of providing a tool that runs entirely on the user's machine, ensuring data privacy and offline capabilities.
+
+
+## 3. Detailed CLI Design
+
+### `gemini labs rag index`
+
+This command will be responsible for creating or updating the vector store.
+
+**Usage:**
+```bash
+gemini labs rag index --source <PATH> --persist-directory <PATH>
+```
+
+**Options:**
+- `--source <PATH>`: (Required) The path to the directory containing the source documents. The command will recursively scan this directory.
+- `--persist-directory <PATH>`: (Required) The path where the `LanceDB` vector store will be created or updated.
+
+**Process Flow:**
+1. Validate that the `--source` and `--persist-directory` paths are provided and valid.
+2. Recursively find all supported files in the `--source` directory.
+3. For each file, use the appropriate `LangChain.js` document loader to load its content.
+4. Use the `RecursiveCharacterTextSplitter` to split the loaded documents into chunks.
+5. Use the Gemini embedding model to create vector embeddings for each chunk.
+6. Initialize a `LanceDB` vector store at the `--persist-directory`.
+7. Add the documents and their embeddings to the vector store. The store will be saved to disk automatically.
+8. Display a confirmation message to the user indicating that the indexing is complete.
+
+### `gemini labs rag chat`
+
+This command will start an interactive chat session that uses the previously created vector store.
+
+**Usage:**
+```bash
+gemini labs rag chat --persist-directory <PATH>
+```
+
+**Options:**
+- `--persist-directory <PATH>`: (Required) The path to the existing `LanceDB` vector store.
+
+**Process Flow:**
+1. Validate that the `--persist-directory` path is provided and that a valid `LanceDB` store exists at that location.
+2. Load the existing `LanceDB` vector store.
+3. Initialize the Gemini chat model and the Gemini embedding model.
+4. Create a `ConversationalRetrievalQAChain`. This chain will be configured with the vector store's retriever, the chat model, and memory to keep track of the conversation.
+5. Start an interactive read-eval-print loop (REPL) for the chat.
+6. For each user input:
+    a. The `ConversationalRetrievalQAChain` will first retrieve relevant documents from the vector store based on the user's question and the chat history.
+    b. It will then combine the retrieved context with the question and send it to the Gemini model.
+    c. The model's response will be streamed to the console.
+7. The chat session will continue until the user exits (e.g., by typing `/exit`).
+
+## 4. Dependencies
+
+The following new npm packages will be added:
+- `langchain`
+- `@langchain/community`
+- `@langchain/core`
+- `vectordb` (for LanceDB)
+- `commander` (already in use, but will be used for the new commands)
+
+## 5. Implementation Plan
+
+1. **Setup:** Add the new dependencies to `packages/cli/package.json`.
+2. **Command Structure:** Create the file `packages/cli/src/labs/rag/rag.ts` and define the `rag` command with its `index` and `chat` subcommands using `commander`.
+3. **Index Command Logic:** Implement the `index` command's action, following the process flow described above.
+4. **Chat Command Logic:** Implement the `chat` command's action, following its process flow.
+5. **Integration:** Wire up the new `ragCommand` to the main `gemini` command in `packages/cli/src/gemini.ts`.
+6. **Testing:** Add unit and integration tests for the new commands.
+7. **Documentation:** Update the CLI documentation to include the new `gemini labs rag` command.
+
+## 6. Future Enhancements
+
+- Support for more file types (e.g., PDF, DOCX).
+- Automatic re-indexing by watching for file changes.
+- Allow the user to configure the chunking strategy and other parameters.
+- A command to delete or reset the vector store.

--- a/TEST_FAILURE_ANALYSIS_AND_RESOLUTION_PLAN.md
+++ b/TEST_FAILURE_ANALYSIS_AND_RESOLUTION_PLAN.md
@@ -1,0 +1,46 @@
+# Test Failure Analysis & Resolution Plan
+
+This document details the test failures encountered during the `npm run preflight` command and the step-by-step plan to resolve them.
+
+---
+
+## 1. `packages/cli/src/ui/hooks/useCompletion.test.ts`
+
+### Failure Details
+
+-   **Test:** `useCompletion > File Path Completion (` @`) > Basic Completion > should use glob for top-level @ completions when available`
+-   **Error:** `AssertionError: expected [] to have a length of 2 but got +0`
+-   **Location:** `src/ui/hooks/useCompletion.test.ts:810:44`
+
+### Analysis
+
+The test expects file and directory suggestions when a user types `@s`, but it receives none. The root cause is that the `glob` function, as currently used, does not return directories in its results, only files. The test setup includes a directory (`src`) and a file within another directory (`derp/script.ts`) that should match.
+
+### Resolution Plan
+
+1.  **Modify `glob` Usage:** I will update the `glob` call within the `findFilesWithGlob` function in `packages/cli/src/ui/hooks/useCompletion.ts`.
+2.  **Add `mark: true` Option:** I will add the `mark: true` option to the `glob` configuration. This option appends a `/` to all returned directory paths.
+3.  **Verify Suggestions:** This change will ensure that directories are included in the results, allowing the test to find the expected `src/` directory and `derp/script.ts` file, resolving the assertion error.
+
+---
+
+## 2. `packages/core/src/services/loopDetectionService.test.ts`
+
+### Failure Details
+
+-   **Test:** `LoopDetectionService > Content Loop Detection > should not detect a loop if repetitions are very far apart`
+-   **Error:** `Error: Test timed out in 5000ms.`
+-   **Location:** `src/services/loopDetectionService.test.ts:164:5`
+
+### Analysis
+
+The test, which checks for loops in content with widely spaced repetitions, is timing out. This indicates a significant performance issue in the `detect` method of the `LoopDetectionService`. The current algorithm is likely using an inefficient method (e.g., `indexOf` on a growing string) to find repetitions, which does not scale for very long content streams.
+
+### Resolution Plan
+
+1.  **Analyze `loopDetectionService.ts`:** I will read the source code of the `detect` method to confirm the algorithm and identify the performance bottleneck.
+2.  **Implement an Efficient Algorithm:** I will replace the inefficient loop detection logic. Instead of searching the entire history buffer on every invocation, I will implement a more optimized approach. A possible solution is to only check for a loop when the content buffer doubles in size, which prevents the check from running on every single character and makes the check less frequent as the content grows.
+3.  **Modify `loopDetectionService.ts`:** I will apply the optimized algorithm directly to the `addAndCheck` method within the `LoopDetectionService`.
+4.  **Verify the Fix:** I will run the `npm run preflight` command to ensure the test passes within the original 5000ms timeout and that no other tests have been broken by the change. This approach fixes the root cause of the performance issue rather than just accommodating it with a longer timeout.
+
+```

--- a/packages/cli/src/labs/rag.ts
+++ b/packages/cli/src/labs/rag.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FileDiscoveryService, findRagContext } from '@google/gemini-cli-core';
+
+export async function rag(
+  question: string,
+  files: string[],
+  recursive: boolean,
+  all: boolean,
+) {
+  const fds = new FileDiscoveryService(process.cwd());
+  const context = await findRagContext(question, files, recursive, all, fds);
+  console.log(JSON.stringify(context, null, 2));
+}

--- a/packages/core/src/labs/rag.ts
+++ b/packages/core/src/labs/rag.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
+
+export async function findRagContext(
+  question: string,
+  files: string[],
+  recursive: boolean,
+  all: boolean,
+  _fds: FileDiscoveryService,
+) {
+  // TODO: Implement the actual RAG logic here.
+  return {
+    question,
+    files,
+    recursive,
+    all,
+    context: 'This is a dummy context.',
+  };
+}


### PR DESCRIPTION
This PR introduces the initial specification for the 'gemini labs rag' command, as requested in #4507. The specification outlines the design, CLI, and implementation plan for a local RAG feature.