### PR TITLE
feat(rag): add specification for local RAG command

### DIFF
--- a/RAG_SPECIFICATION.md
+++ b/RAG_SPECIFICATION.md
@@ -1,99 +1,93 @@
-# Specification: `gemini labs rag` Command
+# Specification: Minimalist Local RAG (`gemini labs rag`)
 
-This document provides a detailed specification for the `gemini labs rag` command, a feature that enables Retrieval-Augmented Generation (RAG) using a user's local file system.
+This document outlines a minimal, self-contained implementation for the `gemini labs rag` command, prioritizing the use of existing project dependencies and Google's own `@google/genai` library.
 
-## 1. Overview
+**Guiding Principles:**
+- **Minimal Dependencies:** Avoid adding heavy libraries like `LangChain.js`.
+- **Linear & Simple:** The process should be straightforward and easy to follow.
+- **Leverage Existing Tools:** Use `@google/genai`, `glob`, and built-in Node.js modules.
 
-The `gemini labs rag` feature will provide a suite of commands to create a local, persistent knowledge base from a directory of files and then chat with the Gemini model using that knowledge base for context.
+**Cost Considerations:**
+The `gemini-embedding-001` model is priced at $0.15 per 1M input tokens. Users should be mindful of potential costs when indexing very large directories. This information should be included in the command's help text.
 
-This will involve two main commands:
-- `gemini labs rag index`: To create or update the knowledge base.
-- `gemini labs rag chat`: To interact with the knowledge base.
 
-**Note on Technology Choice:** While Google now offers a managed Vertex AI RAG API, this feature will use a local-first approach with `LangChain.js` and a local vector store. This aligns with the goal of providing a tool that runs entirely on the user's machine, ensuring data privacy and offline capabilities.
+---
 
-## 2. Core Components & Technology
+## 1. CLI Structure (`yargs`)
 
-The implementation will be based on the `LangChain.js` library to orchestrate the different parts of the RAG pipeline.
-
-- **File Loaders:** `LangChain.js` provides loaders for various file types. We will initially support plain text files (`.md`, `.txt`) and common source code files.
-- **Text Splitter:** `RecursiveCharacterTextSplitter` from `LangChain.js` will be used to split documents into smaller chunks.
-- **Embedding Model:** We will use the `gemini-embedding-001` model via the Gemini API to generate vector embeddings for the text chunks.
-- **Vector Store:** `LanceDB` will be used as the local, file-based vector store. It's serverless, persists to disk, and has good integration with `LangChain.js`.
-- **Retriever:** The vector store will be used to create a retriever that can find the most relevant document chunks for a given query.
-- **Chat Logic:** A `ConversationalRetrievalQAChain` from `LangChain.js` will be used to manage the chat flow. It will combine chat history, the retrieved context, and the user's new question into a prompt for the Gemini model.
-
-## 3. Detailed CLI Design
+The feature will be implemented using `yargs`, which is the existing CLI framework for this project.
 
 ### `gemini labs rag index`
-
-This command will be responsible for creating or updating the vector store.
+Creates or overwrites a local vector store.
 
 **Usage:**
 ```bash
 gemini labs rag index --source <PATH> --persist-directory <PATH>
 ```
-
-**Options:**
-- `--source <PATH>`: (Required) The path to the directory containing the source documents. The command will recursively scan this directory.
-- `--persist-directory <PATH>`: (Required) The path where the `LanceDB` vector store will be created or updated.
-
-**Process Flow:**
-1. Validate that the `--source` and `--persist-directory` paths are provided and valid.
-2. Recursively find all supported files in the `--source` directory.
-3. For each file, use the appropriate `LangChain.js` document loader to load its content.
-4. Use the `RecursiveCharacterTextSplitter` to split the loaded documents into chunks.
-5. Use the Gemini embedding model to create vector embeddings for each chunk.
-6. Initialize a `LanceDB` vector store at the `--persist-directory`.
-7. Add the documents and their embeddings to the vector store. The store will be saved to disk automatically.
-8. Display a confirmation message to the user indicating that the indexing is complete.
+- `--source`: Directory of source files.
+- `--persist-directory`: Directory where the vector store will be saved.
 
 ### `gemini labs rag chat`
-
-This command will start an interactive chat session that uses the previously created vector store.
+Starts an interactive chat using an existing vector store.
 
 **Usage:**
 ```bash
 gemini labs rag chat --persist-directory <PATH>
 ```
+- `--persist-directory`: Directory where the vector store is located.
 
-**Options:**
-- `--persist-directory <PATH>`: (Required) The path to the existing `LanceDB` vector store.
+---
 
-**Process Flow:**
-1. Validate that the `--persist-directory` path is provided and that a valid `LanceDB` store exists at that location.
-2. Load the existing `LanceDB` vector store.
-3. Initialize the Gemini chat model and the Gemini embedding model.
-4. Create a `ConversationalRetrievalQAChain`. This chain will be configured with the vector store's retriever, the chat model, and memory to keep track of the conversation.
-5. Start an interactive read-eval-print loop (REPL) for the chat.
-6. For each user input:
-    a. The `ConversationalRetrievalQAChain` will first retrieve relevant documents from the vector store based on the user's question and the chat history.
-    b. It will then combine the retrieved context with the question and send it to the Gemini model.
-    c. The model's response will be streamed to the console.
-7. The chat session will continue until the user exits (e.g., by typing `/exit`).
+## 2. Technical Implementation
 
-## 4. Dependencies
+### **Step 1: Indexing (`index` command)**
 
-The following new npm packages will be added:
-- `langchain`
-- `@langchain/community`
-- `@langchain/core`
-- `vectordb` (for LanceDB)
-- `yargs` (already in use, and will be used for the new commands)
+1.  **File Discovery:** Use the `glob` package (existing dependency) to recursively find all supported files (e.g., `.md`, `.txt`, `.ts`, `.py`) in the `--source` directory.
+2.  **File Reading:** Use the built-in Node.js `fs/promises` module to read the content of each discovered file.
+3.  **Text Chunking:**
+    - Implement a simple, custom `chunkText` function.
+    - This function will split text first by paragraphs (e.g., `
 
-## 5. Implementation Plan
+`).
+    - It will then ensure each chunk is small enough to not exceed the `gemini-embedding-001` model's **2048 token limit**.
+4.  **Embedding Generation:**
+    - For each text chunk, call the `embedContent` function from the `@google/genai` package to get its vector embedding.
+    - To manage API rate limits and efficiency, process chunks in batches.
+5.  **Vector Storage:**
+    - Create a single JSON file, e.g., `vector_store.json`, inside the `--persist-directory`.
+    - This file will contain an array of objects: `[{ chunk: string, embedding: number[] }]`.
+    - This approach avoids adding a new database dependency.
 
-1. **Setup:** Add the new dependencies to `packages/cli/package.json`.
-2. **Command Structure:** Create the file `packages/cli/src/labs/rag.ts` and define the `rag` command with its `index` and `chat` subcommands using `yargs`.
-3. **Index Command Logic:** Implement the `index` command's action, following the process flow described above.
-4. **Chat Command Logic:** Implement the `chat` command's action, following its process flow.
-5. **Integration:** Wire up the new `ragCommand` to the main `gemini` command in `packages/cli/src/gemini.ts`.
-6. **Testing:** Add unit and integration tests for the new commands.
-7. **Documentation:** Update the CLI documentation to include the new `gemini labs rag` command.
+### **Step 2: Chatting (`chat` command)**
 
-## 6. Future Enhancements
+1.  **Load Vector Store:** Read and parse the `vector_store.json` file from the `--persist-directory` into memory.
+2.  **Implement Retriever:**
+    - Create a custom `findSimilarChunks` function.
+    - When a user asks a question, first generate an embedding for the question using `embedContent`.
+    - **Cosine Similarity:** Implement a `cosineSimilarity` helper function to calculate the similarity between the user's question vector and each chunk's vector in the store.
+    - The retriever will return the text of the top 3-5 chunks with the highest similarity scores.
+3.  **Contextual Prompting:**
+    - Construct a prompt for the final generation step. The prompt will include the retrieved chunks as context and the user's original question.
+4.  **Content Generation:**
+    - Call the `generateContent` function from `@google/genai` with the constructed prompt.
+    - Stream the response back to the user in the interactive chat session.
+5.  **Chat History (Optional, for follow-up questions):** For a more conversational experience, a simple in-memory array can store the last few turns of the conversation to be added to the prompt.
 
-- Support for more file types (e.g., PDF, DOCX).
-- Automatic re-indexing by watching for file changes.
-- Allow the user to configure the chunking strategy and other parameters.
-- A command to delete or reset the vector store.
+---
+
+## 3. Dependencies
+
+- **New Dependencies:** None. This plan is designed to work with the existing dependencies in the project.
+- **Key Existing Dependencies:**
+    - `@google/genai`
+    - `glob`
+    - `yargs`
+
+---
+
+## 4. Future Enhancements
+
+- **Configurable Embedding Dimensions:** Leverage the model's Matryoshka Representation Learning (MRL) to allow users to select smaller embedding dimensions (e.g., 768 or 1536 instead of 3072) to trade off accuracy for performance and reduced storage.
+- **Support for more file types (e.g., PDF, DOCX).**
+- **Automatic re-indexing by watching for file changes.**
+- **A command to delete or reset the vector store.**

--- a/RAG_SPECIFICATION.md
+++ b/RAG_SPECIFICATION.md
@@ -1,0 +1,99 @@
+# Specification: `gemini labs rag` Command
+
+This document provides a detailed specification for the `gemini labs rag` command, a feature that enables Retrieval-Augmented Generation (RAG) using a user's local file system.
+
+## 1. Overview
+
+The `gemini labs rag` feature will provide a suite of commands to create a local, persistent knowledge base from a directory of files and then chat with the Gemini model using that knowledge base for context.
+
+This will involve two main commands:
+- `gemini labs rag index`: To create or update the knowledge base.
+- `gemini labs rag chat`: To interact with the knowledge base.
+
+**Note on Technology Choice:** While Google now offers a managed Vertex AI RAG API, this feature will use a local-first approach with `LangChain.js` and a local vector store. This aligns with the goal of providing a tool that runs entirely on the user's machine, ensuring data privacy and offline capabilities.
+
+## 2. Core Components & Technology
+
+The implementation will be based on the `LangChain.js` library to orchestrate the different parts of the RAG pipeline.
+
+- **File Loaders:** `LangChain.js` provides loaders for various file types. We will initially support plain text files (`.md`, `.txt`) and common source code files.
+- **Text Splitter:** `RecursiveCharacterTextSplitter` from `LangChain.js` will be used to split documents into smaller chunks.
+- **Embedding Model:** We will use the `gemini-embedding-001` model via the Gemini API to generate vector embeddings for the text chunks.
+- **Vector Store:** `LanceDB` will be used as the local, file-based vector store. It's serverless, persists to disk, and has good integration with `LangChain.js`.
+- **Retriever:** The vector store will be used to create a retriever that can find the most relevant document chunks for a given query.
+- **Chat Logic:** A `ConversationalRetrievalQAChain` from `LangChain.js` will be used to manage the chat flow. It will combine chat history, the retrieved context, and the user's new question into a prompt for the Gemini model.
+
+## 3. Detailed CLI Design
+
+### `gemini labs rag index`
+
+This command will be responsible for creating or updating the vector store.
+
+**Usage:**
+```bash
+gemini labs rag index --source <PATH> --persist-directory <PATH>
+```
+
+**Options:**
+- `--source <PATH>`: (Required) The path to the directory containing the source documents. The command will recursively scan this directory.
+- `--persist-directory <PATH>`: (Required) The path where the `LanceDB` vector store will be created or updated.
+
+**Process Flow:**
+1. Validate that the `--source` and `--persist-directory` paths are provided and valid.
+2. Recursively find all supported files in the `--source` directory.
+3. For each file, use the appropriate `LangChain.js` document loader to load its content.
+4. Use the `RecursiveCharacterTextSplitter` to split the loaded documents into chunks.
+5. Use the Gemini embedding model to create vector embeddings for each chunk.
+6. Initialize a `LanceDB` vector store at the `--persist-directory`.
+7. Add the documents and their embeddings to the vector store. The store will be saved to disk automatically.
+8. Display a confirmation message to the user indicating that the indexing is complete.
+
+### `gemini labs rag chat`
+
+This command will start an interactive chat session that uses the previously created vector store.
+
+**Usage:**
+```bash
+gemini labs rag chat --persist-directory <PATH>
+```
+
+**Options:**
+- `--persist-directory <PATH>`: (Required) The path to the existing `LanceDB` vector store.
+
+**Process Flow:**
+1. Validate that the `--persist-directory` path is provided and that a valid `LanceDB` store exists at that location.
+2. Load the existing `LanceDB` vector store.
+3. Initialize the Gemini chat model and the Gemini embedding model.
+4. Create a `ConversationalRetrievalQAChain`. This chain will be configured with the vector store's retriever, the chat model, and memory to keep track of the conversation.
+5. Start an interactive read-eval-print loop (REPL) for the chat.
+6. For each user input:
+    a. The `ConversationalRetrievalQAChain` will first retrieve relevant documents from the vector store based on the user's question and the chat history.
+    b. It will then combine the retrieved context with the question and send it to the Gemini model.
+    c. The model's response will be streamed to the console.
+7. The chat session will continue until the user exits (e.g., by typing `/exit`).
+
+## 4. Dependencies
+
+The following new npm packages will be added:
+- `langchain`
+- `@langchain/community`
+- `@langchain/core`
+- `vectordb` (for LanceDB)
+- `yargs` (already in use, and will be used for the new commands)
+
+## 5. Implementation Plan
+
+1. **Setup:** Add the new dependencies to `packages/cli/package.json`.
+2. **Command Structure:** Create the file `packages/cli/src/labs/rag.ts` and define the `rag` command with its `index` and `chat` subcommands using `yargs`.
+3. **Index Command Logic:** Implement the `index` command's action, following the process flow described above.
+4. **Chat Command Logic:** Implement the `chat` command's action, following its process flow.
+5. **Integration:** Wire up the new `ragCommand` to the main `gemini` command in `packages/cli/src/gemini.ts`.
+6. **Testing:** Add unit and integration tests for the new commands.
+7. **Documentation:** Update the CLI documentation to include the new `gemini labs rag` command.
+
+## 6. Future Enhancements
+
+- Support for more file types (e.g., PDF, DOCX).
+- Automatic re-indexing by watching for file changes.
+- Allow the user to configure the chunking strategy and other parameters.
+- A command to delete or reset the vector store.

--- a/RAG_SPECIFICATION.md
+++ b/RAG_SPECIFICATION.md
@@ -45,11 +45,13 @@ gemini labs rag chat --persist-directory <PATH>
 1.  **File Discovery:** Use the `glob` package (existing dependency) to recursively find all supported files (e.g., `.md`, `.txt`, `.ts`, `.py`) in the `--source` directory.
 2.  **File Reading:** Use the built-in Node.js `fs/promises` module to read the content of each discovered file.
 3.  **Text Chunking:**
-    - Implement a simple, custom `chunkText` function.
-    - This function will split text first by paragraphs (e.g., `
-
-`).
-    - It will then ensure each chunk is small enough to not exceed the `gemini-embedding-001` model's **2048 token limit**.
+    - Implement a custom, asynchronous `chunkText` function that is aware of the model's token limit.
+    - **Token-Aware Splitting Strategy:**
+        1. Start with an initial block of text (e.g., a whole file or a large paragraph).
+        2. Use the `model.countTokens()` method from the `@google/genai` SDK to get an accurate token count for the block.
+        3. If the token count is within the **2048 token limit**, the block is considered a valid chunk.
+        4. If the token count exceeds the limit, the block must be split. It will be divided into smaller pieces (e.g., split by sentences or lines).
+        5. Each new, smaller piece will then be passed recursively through this same process (check token count, then split if needed) until all resulting sub-chunks are under the token limit. This ensures no data is truncated and all text is indexed reliably.
 4.  **Embedding Generation:**
     - For each text chunk, call the `embedContent` function from the `@google/genai` package to get its vector embedding.
     - To manage API rate limits and efficiency, process chunks in batches.


### PR DESCRIPTION
This PR introduces the specification for the 'gemini labs rag' command, as requested in #4507. This version of the specification is aligned with the project's existing 'yargs' CLI framework and outlines a minimal, Google-centric implementation plan.