### PR TITLE
doc: use standard Google security policy for GitHub projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,3 +209,7 @@ Head over to the [Uninstall](docs/Uninstall.md) guide for uninstallation instruc
 ## Terms of Service and Privacy Notice
 
 For details on the terms of service and privacy notice applicable to your use of Gemini CLI, see the [Terms of Service and Privacy Notice](./docs/tos-privacy.md).
+
+## Security Disclosures
+
+Please see our [security disclosure process](SECURITY.md).  All [security advisories](https://github.com/google-gemini/gemini-cli/security/advisories) are managed on Github.

--- a/README.md
+++ b/README.md
@@ -212,4 +212,4 @@ For details on the terms of service and privacy notice applicable to your use of
 
 ## Security Disclosures
 
-Please see our [security disclosure process](SECURITY.md).  All [security advisories](https://github.com/google-gemini/gemini-cli/security/advisories) are managed on Github.
+Please see our [security disclosure process](SECURITY.md). All [security advisories](https://github.com/google-gemini/gemini-cli/security/advisories) are managed on Github.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
 # Reporting Security Issues
 
-To report a security issue, please use http://g.co/vulnz. We use
-http://g.co/vulnz for our intake, and do coordination and disclosure here on
-GitHub (including using [GitHub Security Advisory]). The Google Security Team will
+To report a security issue, please use [https://g.co/vulnz](https://g.co/vulnz).
+We use g.co/vulnz for our intake, and do coordination and disclosure here on
+GitHub (including using GitHub Security Advisory). The Google Security Team will
 respond within 5 working days of your report on g.co/vulnz.
 
 [GitHub Security Advisory]: https://github.com/google-gemini/gemini-cli/security/advisories

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Reporting Security Issues
+
+To report a security issue, please use http://g.co/vulnz. We use
+http://g.co/vulnz for our intake, and do coordination and disclosure here on
+GitHub (including using [GitHub Security Advisory]). The Google Security Team will
+respond within 5 working days of your report on g.co/vulnz.
+
+[GitHub Security Advisory]: https://github.com/google-gemini/gemini-cli/security/advisories


### PR DESCRIPTION
## TLDR

Add standard Google security disclosure process for the vulnerability reward program via Google Bug Hunters.
