### PR TITLE
Fixes bug where companion extension was not being included in release bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build:all": "npm run build && npm run build:sandbox && npm run build:vscode",
     "build:packages": "npm run build --workspaces",
     "build:sandbox": "node scripts/build_sandbox.js --skip-npm-install-build",
-    "bundle": "npm run generate && node esbuild.config.js && node scripts/copy_bundle_assets.js",
+    "bundle": "npm run generate && node esbuild.config.js && npm run build:vscode && node scripts/copy_bundle_assets.js",
     "test": "npm run test --workspaces",
     "test:ci": "npm run test:ci --workspaces --if-present && npm run test:scripts",
     "test:scripts": "vitest run --config ./scripts/tests/vitest.config.ts",


### PR DESCRIPTION
## TLDR
The companion extension VSIX was previously not being included in the released NPM package because the VSIX was not being built/

Note: This is to support the /ide install command before we publish the extension to marketplace. Once we publish the extension, this change will be reverted as /ide install will always point to the latest released public version of the extension