### PR TITLE
Skip checking loop inside Markdown codeblcoks

### DIFF
--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -162,15 +162,18 @@ export class LoopDetectionService {
       const fenceIndex = content.indexOf('```', currentPos);
 
       if (fenceIndex === -1) {
+        let remaining = content.substring(currentPos);
         // No more fences in the rest of the content.
-        if (!this.inCodeBlock) {
-          contentOutsideCodeblocks += content.substring(currentPos);
-        }
-        // Check for partial fence at the end of the content.
-        if (content.endsWith('``')) {
+        if (remaining.endsWith('``')) {
           this.partialFence = '``';
-        } else if (content.endsWith('`')) {
+          remaining = remaining.slice(0, -2);
+        } else if (remaining.endsWith('`')) {
           this.partialFence = '`';
+          remaining = remaining.slice(0, -1);
+        }
+
+        if (!this.inCodeBlock) {
+          contentOutsideCodeblocks += remaining;
         }
         break;
       }

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -150,16 +150,7 @@ export class LoopDetectionService {
     return false;
   }
 
-  /**
-   * Detects content loops by analyzing streaming text for repetitive patterns.
-   *
-   * The algorithm works by:
-   * 1. Appending new content to the streaming history
-   * 2. Truncating history if it exceeds the maximum length
-   * 3. Analyzing content chunks for repetitive patterns using hashing
-   * 4. Detecting loops when identical chunks appear frequently within a short distance
-   */
-  private checkContentLoop(content: string): boolean {
+  private _stripCodeBlocks(content: string): string {
     let contentOutsideCodeblocks = '';
     let currentPos = 0;
 
@@ -194,6 +185,21 @@ export class LoopDetectionService {
       this.inCodeBlock = !this.inCodeBlock;
       currentPos = fenceIndex + 3;
     }
+
+    return contentOutsideCodeblocks;
+  }
+
+  /**
+   * Detects content loops by analyzing streaming text for repetitive patterns.
+   *
+   * The algorithm works by:
+   * 1. Appending new content to the streaming history
+   * 2. Truncating history if it exceeds the maximum length
+   * 3. Analyzing content chunks for repetitive patterns using hashing
+   * 4. Detecting loops when identical chunks appear frequently within a short distance
+   */
+  private checkContentLoop(content: string): boolean {
+    const contentOutsideCodeblocks = this._stripCodeBlocks(content);
 
     if (!contentOutsideCodeblocks) {
       return false;


### PR DESCRIPTION
## TLDR

Modifies the `loopDetectionService.ts` to prevent the content loop detector (aka "chanting" detector) from analyzing text inside markdown code blocks (```). This change avoids false-positive loop detections caused by repeated code snippets, which is a valid and common pattern.

## Dive Deeper

The core of this change is in the `checkContentLoop` method within `packages/core/src/services/loopDetectionService.ts`. I've introduced two new state properties to the `LoopDetectionService` class:
- `inCodeBlock`: A boolean flag to track whether the current position in the stream is inside a code block.
- `partialFence`: A string to buffer and handle fence markers (` ``` `) that might be incomplete at the end of a streaming chunk.

The updated logic processes each incoming content chunk by scanning for ` ``` ` markers. When a marker is found, it toggles the `inCodeBlock` state. Only text that is outside of a code block is appended to the `streamContentHistory`, which is the string analyzed for repetitions. This ensures that any content inside the code fences is completely ignored by the loop detection algorithm.

To validate this new logic, I added a new test suite named "Content Loop Detection with Code Blocks" to `packages/core/src/services/loopDetectionService.test.ts`. These tests cover several key scenarios:
- Content entirely within a code block is ignored.
- Loops in content outside of code blocks are still detected.
- Code blocks that are split across multiple streamed chunks are handled correctly.
- Multiple, separate code blocks within the same response are processed correctly.
- A stream ending in a partial fence (e.g., ` `` `) is handled without errors.

During this process, I identified and corrected a flawed test case that was failing due to an incorrect assertion, improving the overall reliability of the test suite.

## Reviewer Test Plan

**Test Case 1: Ignored Loop Inside Code Block**
      - **Prompt:** `Repeat the following line 20 times: "Here is some code: ```javascript\nconsole.log('hello');\n```"`
      - **Expected Behavior:** The response should be generated without being flagged as a loop, as the repetitive content is inside the code block.
      - 
**Test Case 2: Detected Loop Outside Code Block**
      - **Prompt:** `Repeat the following line 20 times: "This is a test."`
      - **Expected Behavior:** The CLI should detect a content loop and terminate the response as expected.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
N/A