### PR TITLE
docs: Fix typo in commands.md code block

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -234,7 +234,7 @@ Please generate a Conventional Commit message based on the following git diff:
 
 ```diff
 !{git diff --staged}
-````
+```
 
 """
 


### PR DESCRIPTION
Corrected the number of backticks for a nested code block to fix a Markdown rendering issue.

Rendering issues as below
<img width="1054" height="468" alt="image" src="https://github.com/user-attachments/assets/9dc16603-db39-4fa7-9b7c-a8ba393385e4" />

## TLDR

Fix typo in commands.md code block.
Corrected the number of backticks for a nested code block to fix a Markdown rendering issue.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan
This doesn't required. Since it's change of markdown document.

## Testing Matrix
This doesn't required. Since it's change of markdown document.

## Linked issues / bugs
N/A