### PR TITLE
feat: Add /init command and research communication opt-in

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -424,6 +424,7 @@ export async function loadCliConfig(
     summarizeToolOutput: settings.summarizeToolOutput,
     ideMode,
     ideClient,
+    researchOptIn: settings.researchOptIn,
   });
 }
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -106,6 +106,14 @@ export interface Settings {
   disableAutoUpdate?: boolean;
 
   memoryDiscoveryMaxDirs?: number;
+
+  // Research communication opt-in settings
+  researchOptIn?: {
+    enabled?: boolean;
+    email?: string;
+    allowUserResearch?: boolean;
+    allowFeedbackCollection?: boolean;
+  };
 }
 
 export interface SettingsError {

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -20,10 +20,12 @@ import { editorCommand } from '../ui/commands/editorCommand.js';
 import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { ideCommand } from '../ui/commands/ideCommand.js';
+import { initCommand } from '../ui/commands/initCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
+import { researchCommand } from '../ui/commands/researchCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
@@ -59,10 +61,12 @@ export class BuiltinCommandLoader implements ICommandLoader {
       extensionsCommand,
       helpCommand,
       ideCommand(this.config),
+      initCommand,
       memoryCommand,
       privacyCommand,
       mcpCommand,
       quitCommand,
+      researchCommand,
       restoreCommand(this.config),
       statsCommand,
       themeCommand,

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -26,6 +26,7 @@ import { useEditorSettings } from './hooks/useEditorSettings.js';
 import { useSlashCommandProcessor } from './hooks/slashCommandProcessor.js';
 import { useAutoAcceptIndicator } from './hooks/useAutoAcceptIndicator.js';
 import { useConsoleMessages } from './hooks/useConsoleMessages.js';
+import { useResearchDialog } from './hooks/useResearchDialog.js';
 import { Header } from './components/Header.js';
 import { LoadingIndicator } from './components/LoadingIndicator.js';
 import { AutoAcceptIndicator } from './components/AutoAcceptIndicator.js';
@@ -90,6 +91,7 @@ import { ShowMoreLines } from './components/ShowMoreLines.js';
 import { PrivacyNotice } from './privacy/PrivacyNotice.js';
 import { setUpdateHandler } from '../utils/handleAutoUpdate.js';
 import { appEvents, AppEvent } from '../utils/events.js';
+import { ResearchOptInDialog } from './components/ResearchOptInDialog.js';
 
 const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
 
@@ -150,6 +152,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   const [themeError, setThemeError] = useState<string | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
   const [editorError, setEditorError] = useState<string | null>(null);
+  const [researchError, setResearchError] = useState<string | null>(null);
   const [footerHeight, setFooterHeight] = useState<number>(0);
   const [corgiMode, setCorgiMode] = useState(false);
   const [currentModel, setCurrentModel] = useState(config.getModel());
@@ -257,6 +260,13 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     handleEditorSelect,
     exitEditorDialog,
   } = useEditorSettings(settings, setEditorError, addItem);
+
+  const {
+    isResearchDialogOpen,
+    openResearchDialog,
+    closeResearchDialog,
+    handleResearchSelect,
+  } = useResearchDialog(settings, setResearchError, addItem);
 
   const toggleCorgiMode = useCallback(() => {
     setCorgiMode((prev) => !prev);
@@ -477,6 +487,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     openPrivacyNotice,
     toggleVimEnabled,
     setIsProcessing,
+    openResearchDialog,
   );
 
   const {
@@ -903,6 +914,19 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
                 onSelect={handleEditorSelect}
                 settings={settings}
                 onExit={exitEditorDialog}
+              />
+            </Box>
+          ) : isResearchDialogOpen ? (
+            <Box flexDirection="column">
+              {researchError && (
+                <Box marginBottom={1}>
+                  <Text color={Colors.AccentRed}>{researchError}</Text>
+                </Box>
+              )}
+              <ResearchOptInDialog
+                onSelect={handleResearchSelect}
+                settings={settings.merged.researchOptIn || {}}
+                onExit={closeResearchDialog}
               />
             </Box>
           ) : showPrivacyNotice ? (

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommandKind, SlashCommand } from './types.js';
+import * as path from 'path';
+import * as fs from 'fs';
+
+export const initCommand: SlashCommand = {
+  name: 'init',
+  description: 'create a GEMINI.md project file',
+  kind: CommandKind.BUILT_IN,
+  action: async (context, _args) => {
+    const projectRoot =
+      context.services.config?.getTargetDir() || process.cwd();
+    const geminiMdPath = path.join(projectRoot, 'GEMINI.md');
+
+    // Check if GEMINI.md already exists
+    if (fs.existsSync(geminiMdPath)) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `GEMINI.md already exists at ${path.relative(process.cwd(), geminiMdPath)}. Use the existing file or rename it first.`,
+      };
+    }
+
+    // Create a basic GEMINI.md template
+    const template = `# Project Context
+
+This file contains context and information about this project for Gemini CLI.
+
+## Project Overview
+
+Describe your project here. What is it? What does it do? What are the main goals?
+
+## Key Files and Directories
+
+- \`src/\` - Source code
+- \`docs/\` - Documentation
+- \`tests/\` - Test files
+
+## Development Setup
+
+How to set up and run this project locally.
+
+## Common Tasks
+
+- Building the project
+- Running tests
+- Deployment
+
+## Notes
+
+Add any additional context, conventions, or important information here.
+`;
+
+    try {
+      // Ensure the directory exists
+      const dir = path.dirname(geminiMdPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+
+      // Write the template file
+      fs.writeFileSync(geminiMdPath, template, 'utf8');
+
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `✅ Created GEMINI.md at ${path.relative(process.cwd(), geminiMdPath)}\n\nThis file contains project context for Gemini CLI. Edit it to add information about your project, key files, setup instructions, and any other context that would be helpful for AI assistance.`,
+      };
+    } catch (error) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Failed to create GEMINI.md: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  },
+};

--- a/packages/cli/src/ui/commands/researchCommand.ts
+++ b/packages/cli/src/ui/commands/researchCommand.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommandKind, OpenDialogActionReturn, SlashCommand } from './types.js';
+
+export const researchCommand: SlashCommand = {
+  name: 'research',
+  description: 'configure research communication opt-in settings',
+  kind: CommandKind.BUILT_IN,
+  action: (_context, _args): OpenDialogActionReturn => ({
+    type: 'dialog',
+    dialog: 'research',
+  }),
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -98,7 +98,7 @@ export interface MessageActionReturn {
  */
 export interface OpenDialogActionReturn {
   type: 'dialog';
-  dialog: 'help' | 'auth' | 'theme' | 'editor' | 'privacy';
+  dialog: 'help' | 'auth' | 'theme' | 'editor' | 'privacy' | 'research';
 }
 
 /**

--- a/packages/cli/src/ui/components/ResearchOptInDialog.tsx
+++ b/packages/cli/src/ui/components/ResearchOptInDialog.tsx
@@ -1,0 +1,272 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useCallback } from 'react';
+import { Box, Text } from 'ink';
+import { useInput } from 'ink';
+import { Colors } from '../colors.js';
+import { SettingScope } from '../../config/settings.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+import { TextInput } from './shared/TextInput.js';
+
+export interface ResearchOptInSettings {
+  enabled?: boolean;
+  email?: string;
+  allowUserResearch?: boolean;
+  allowFeedbackCollection?: boolean;
+}
+
+export interface ResearchOptInDialogProps {
+  onSelect: (
+    settings: ResearchOptInSettings | undefined,
+    scope: SettingScope,
+  ) => void;
+  settings: ResearchOptInSettings;
+  onExit: () => void;
+}
+
+export function ResearchOptInDialog({
+  onSelect,
+  settings,
+  onExit,
+}: ResearchOptInDialogProps): React.JSX.Element {
+  const [selectedScope, setSelectedScope] = useState<SettingScope>(
+    SettingScope.User,
+  );
+  const [focusedSection, setFocusedSection] = useState<
+    'optin' | 'email' | 'scope'
+  >('optin');
+  const [email, setEmail] = useState(settings.email || '');
+  const [allowUserResearch, setAllowUserResearch] = useState(
+    settings.allowUserResearch ?? false,
+  );
+  const [allowFeedbackCollection, setAllowFeedbackCollection] = useState(
+    settings.allowFeedbackCollection ?? false,
+  );
+
+  useInput((_, key) => {
+    if (key.tab) {
+      setFocusedSection((prev) => {
+        if (prev === 'optin') return 'email';
+        if (prev === 'email') return 'scope';
+        return 'optin';
+      });
+    }
+    if (key.escape) {
+      onExit();
+    }
+  });
+
+  const handleOptInSelect = useCallback(
+    (enabled: boolean) => {
+      if (enabled) {
+        onSelect(
+          {
+            enabled: true,
+            email,
+            allowUserResearch,
+            allowFeedbackCollection,
+          },
+          selectedScope,
+        );
+      } else {
+        onSelect(
+          {
+            enabled: false,
+            email: '',
+            allowUserResearch: false,
+            allowFeedbackCollection: false,
+          },
+          selectedScope,
+        );
+      }
+    },
+    [
+      onSelect,
+      email,
+      allowUserResearch,
+      allowFeedbackCollection,
+      selectedScope,
+    ],
+  );
+
+  const handleEmailChange = useCallback(
+    (newEmail: string) => {
+      setEmail(newEmail);
+      if (settings.enabled) {
+        onSelect(
+          {
+            ...settings,
+            email: newEmail,
+          },
+          selectedScope,
+        );
+      }
+    },
+    [settings, onSelect, selectedScope],
+  );
+
+  const handleUserResearchChange = useCallback(
+    (allow: boolean) => {
+      setAllowUserResearch(allow);
+      if (settings.enabled) {
+        onSelect(
+          {
+            ...settings,
+            allowUserResearch: allow,
+          },
+          selectedScope,
+        );
+      }
+    },
+    [settings, onSelect, selectedScope],
+  );
+
+  const handleFeedbackCollectionChange = useCallback(
+    (allow: boolean) => {
+      setAllowFeedbackCollection(allow);
+      if (settings.enabled) {
+        onSelect(
+          {
+            ...settings,
+            allowFeedbackCollection: allow,
+          },
+          selectedScope,
+        );
+      }
+    },
+    [settings, onSelect, selectedScope],
+  );
+
+  const handleScopeSelect = useCallback((scope: SettingScope) => {
+    setSelectedScope(scope);
+    setFocusedSection('optin');
+  }, []);
+
+  const optInItems = [
+    { label: 'Yes, I want to participate in research', value: true },
+    { label: 'No, I do not want to participate', value: false },
+  ];
+
+  const scopeItems = [
+    { label: 'User Settings', value: SettingScope.User },
+    { label: 'Workspace Settings', value: SettingScope.Workspace },
+  ];
+
+  const userResearchItems = [
+    { label: 'Yes, allow user research contact', value: true },
+    { label: 'No, do not contact me for research', value: false },
+  ];
+
+  const feedbackCollectionItems = [
+    { label: 'Yes, allow feedback collection', value: true },
+    { label: 'No, do not collect feedback', value: false },
+  ];
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={Colors.Gray}
+      flexDirection="column"
+      padding={1}
+      width="100%"
+    >
+      <Text bold>Research Communication Opt-In</Text>
+      <Box marginTop={1}>
+        <Text>
+          Help us improve Gemini CLI by participating in user research and
+          providing feedback. Your participation is completely voluntary and you
+          can change these settings at any time.
+        </Text>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text bold>Scope:</Text>
+      </Box>
+      <Box marginTop={1}>
+        <RadioButtonSelect
+          items={scopeItems}
+          initialIndex={scopeItems.findIndex(
+            (item) => item.value === selectedScope,
+          )}
+          onSelect={handleScopeSelect}
+          isFocused={focusedSection === 'scope'}
+        />
+      </Box>
+
+      <Box marginTop={1}>
+        <Text bold>Would you like to participate in Gemini CLI research?</Text>
+      </Box>
+      <Box marginTop={1}>
+        <RadioButtonSelect
+          items={optInItems}
+          initialIndex={optInItems.findIndex(
+            (item) => item.value === (settings.enabled ?? false),
+          )}
+          onSelect={handleOptInSelect}
+          isFocused={focusedSection === 'optin'}
+        />
+      </Box>
+
+      {settings.enabled && (
+        <>
+          <Box marginTop={1}>
+            <Text bold>Email address (for research contact):</Text>
+          </Box>
+          <Box marginTop={1}>
+            <TextInput
+              value={email}
+              onChange={handleEmailChange}
+              placeholder="your.email@example.com"
+              isFocused={focusedSection === 'email'}
+            />
+          </Box>
+
+          <Box marginTop={1}>
+            <Text bold>User Research Contact:</Text>
+          </Box>
+          <Box marginTop={1}>
+            <RadioButtonSelect
+              items={userResearchItems}
+              initialIndex={userResearchItems.findIndex(
+                (item) => item.value === allowUserResearch,
+              )}
+              onSelect={handleUserResearchChange}
+              isFocused={false}
+            />
+          </Box>
+
+          <Box marginTop={1}>
+            <Text bold>Feedback Collection:</Text>
+          </Box>
+          <Box marginTop={1}>
+            <RadioButtonSelect
+              items={feedbackCollectionItems}
+              initialIndex={feedbackCollectionItems.findIndex(
+                (item) => item.value === allowFeedbackCollection,
+              )}
+              onSelect={handleFeedbackCollectionChange}
+              isFocused={false}
+            />
+          </Box>
+        </>
+      )}
+
+      <Box marginTop={1}>
+        <Text color={Colors.Gray}>
+          (Use Tab to navigate, Enter to select, Esc to exit)
+        </Text>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text color={Colors.AccentBlue}>
+          Privacy Notice:
+          https://github.com/google-gemini/gemini-cli/blob/main/docs/tos-privacy.md
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback } from 'react';
+import { Box, Text } from 'ink';
+import { useInput, type Key } from 'ink';
+import { Colors } from '../../colors.js';
+
+export interface TextInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  isFocused?: boolean;
+}
+
+export function TextInput({
+  value,
+  onChange,
+  placeholder = '',
+  isFocused = false,
+}: TextInputProps): React.JSX.Element {
+  const handleInput = useCallback(
+    (input: string, key: Key) => {
+      if (!isFocused) return;
+
+      if (key.backspace) {
+        onChange(value.slice(0, -1));
+      } else if (key.delete) {
+        // Delete key - no action needed for single-line input
+      } else if (key.return) {
+        // Enter key - no action needed for single-line input
+      } else if (input && !key.ctrl && !key.meta) {
+        onChange(value + input);
+      }
+    },
+    [value, onChange, isFocused],
+  );
+
+  useInput(handleInput, { isActive: isFocused });
+
+  const displayValue = value || (isFocused ? '' : placeholder);
+
+  return (
+    <Box borderStyle="round" borderColor={Colors.Gray} paddingX={1}>
+      <Text color={value ? Colors.Foreground : Colors.Gray}>
+        {displayValue}
+        {isFocused && <Text color={Colors.AccentBlue}>|</Text>}
+      </Text>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -50,6 +50,7 @@ export const useSlashCommandProcessor = (
   openPrivacyNotice: () => void,
   toggleVimEnabled: () => Promise<boolean>,
   setIsProcessing: (isProcessing: boolean) => void,
+  openResearchDialog: () => void,
 ) => {
   const session = useSessionStats();
   const [commands, setCommands] = useState<readonly SlashCommand[]>([]);
@@ -331,6 +332,9 @@ export const useSlashCommandProcessor = (
                     case 'privacy':
                       openPrivacyNotice();
                       return { type: 'handled' };
+                    case 'research':
+                      openResearchDialog();
+                      return { type: 'handled' };
                     default: {
                       const unhandled: never = result.dialog;
                       throw new Error(
@@ -457,6 +461,7 @@ export const useSlashCommandProcessor = (
       setShellConfirmationRequest,
       setSessionShellAllowlist,
       setIsProcessing,
+      openResearchDialog,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/useResearchDialog.ts
+++ b/packages/cli/src/ui/hooks/useResearchDialog.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useState } from 'react';
+import { LoadedSettings, SettingScope } from '../../config/settings.js';
+import { ResearchOptInSettings } from '../components/ResearchOptInDialog.js';
+import { UseHistoryManagerReturn } from './useHistoryManager.js';
+
+export function useResearchDialog(
+  settings: LoadedSettings,
+  setResearchError: (error: string | null) => void,
+  addItem: UseHistoryManagerReturn['addItem'],
+) {
+  const [isResearchDialogOpen, setIsResearchDialogOpen] = useState(false);
+
+  const openResearchDialog = useCallback(() => {
+    setIsResearchDialogOpen(true);
+    setResearchError(null);
+  }, [setResearchError]);
+
+  const closeResearchDialog = useCallback(() => {
+    setIsResearchDialogOpen(false);
+    setResearchError(null);
+  }, [setResearchError]);
+
+  const handleResearchSelect = useCallback(
+    (
+      researchSettings: ResearchOptInSettings | undefined,
+      scope: SettingScope,
+    ) => {
+      if (researchSettings) {
+        settings.setValue(scope, 'researchOptIn', researchSettings);
+        addItem(
+          {
+            type: 'info',
+            text: researchSettings.enabled
+              ? 'Research opt-in settings saved. Thank you for helping improve Gemini CLI!'
+              : 'Research opt-in disabled.',
+          },
+          Date.now(),
+        );
+      }
+      closeResearchDialog();
+    },
+    [settings, closeResearchDialog, addItem],
+  );
+
+  return {
+    isResearchDialogOpen,
+    openResearchDialog,
+    closeResearchDialog,
+    handleResearchSelect,
+  };
+}

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -184,6 +184,12 @@ export interface ConfigParameters {
   summarizeToolOutput?: Record<string, SummarizeToolOutputSettings>;
   ideMode?: boolean;
   ideClient?: IdeClient;
+  researchOptIn?: {
+    enabled?: boolean;
+    email?: string;
+    allowUserResearch?: boolean;
+    allowFeedbackCollection?: boolean;
+  };
 }
 
 export class Config {
@@ -241,6 +247,12 @@ export class Config {
     | Record<string, SummarizeToolOutputSettings>
     | undefined;
   private readonly experimentalAcp: boolean = false;
+  private readonly researchOptIn?: {
+    enabled?: boolean;
+    email?: string;
+    allowUserResearch?: boolean;
+    allowFeedbackCollection?: boolean;
+  };
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -293,6 +305,7 @@ export class Config {
     this.summarizeToolOutput = params.summarizeToolOutput;
     this.ideMode = params.ideMode ?? false;
     this.ideClient = params.ideClient;
+    this.researchOptIn = params.researchOptIn;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -584,6 +597,17 @@ export class Config {
 
   getIdeClient(): IdeClient | undefined {
     return this.ideClient;
+  }
+
+  getResearchOptIn():
+    | {
+        enabled?: boolean;
+        email?: string;
+        allowUserResearch?: boolean;
+        allowFeedbackCollection?: boolean;
+      }
+    | undefined {
+    return this.researchOptIn;
   }
 
   async getGitService(): Promise<GitService> {


### PR DESCRIPTION
# Add /init command and research communication opt-in

## TLDR

This PR adds two UX features to make Gemini CLI more user-friendly and enable user research:

1. **`/init` command**: Creates a `GEMINI.md` project file with a comprehensive template, eliminating the need for manual file creation
2. **`/research` command**: Opens an interactive dialog for users to opt-in to research communications, enabling the team to collect feedback and improve the CLI

Both features are fully integrated into the existing CLI architecture with proper error handling and user feedback.

## Dive Deeper

### `/init` Command
- Creates a well-structured `GEMINI.md` template with sections for project overview, key files, setup instructions, common tasks, and notes
- Prevents overwriting existing files with clear user messaging
- Uses the project root directory from CLI configuration
- Provides helpful success messages with usage instructions

### Research Communication Opt-In
- Interactive dialog with radio button selections for opt-in preferences
- Supports three settings scopes: user (personal), workspace (project), and system (global)
- Configurable options: enable/disable research, email address, user research studies, and feedback collection
- Settings are persisted to `settings.json` files and loaded on CLI startup
- Includes a reusable `TextInput` component for email input

### Technical Implementation
- Both commands follow existing slash command patterns and are registered in `BuiltinCommandLoader`
- Research dialog integrates with the existing Ink/React UI architecture
- Settings system extended to support research preferences with proper TypeScript types
- Core Config class updated to handle research opt-in settings
- All components include proper error handling and user feedback


## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Resolves #5074 - Add research communication opt-in capability