### PR TITLE
fix: Enable reading files with brackets in paths (e.g., expo-router `[id]` routes)

### DIFF
--- a/packages/cli/src/acp/acpPeer.ts
+++ b/packages/cli/src/acp/acpPeer.ts
@@ -47,6 +47,10 @@ export async function runAcpPeer(config: Config, settings: LoadedSettings) {
   );
 }
 
+function escapeGlobPattern(pattern: string): string {
+  return pattern.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&');
+}
+
 class GeminiAgent implements Agent {
   chat?: GeminiChat;
   pendingSend?: AbortController;
@@ -408,9 +412,11 @@ class GeminiAgent implements Agent {
               `Path ${pathName} not found directly, attempting glob search.`,
             );
             try {
+              // Escape the pathName to handle special glob characters like brackets
+              const escapedPathName = escapeGlobPattern(pathName);
               const globResult = await globTool.execute(
                 {
-                  pattern: `**/*${pathName}*`,
+                  pattern: `**/*${escapedPathName}*`,
                   path: this.config.getTargetDir(),
                 },
                 abortSignal,

--- a/packages/cli/src/ui/hooks/useCompletion.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.ts
@@ -26,6 +26,10 @@ import { TextBuffer } from '../components/shared/text-buffer.js';
 import { isSlashCommand } from '../utils/commandUtils.js';
 import { toCodePoints } from '../utils/textUtils.js';
 
+function escapeGlobPattern(pattern: string): string {
+  return pattern.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&');
+}
+
 export interface UseCompletionReturn {
   suggestions: Suggestion[];
   activeSuggestionIndex: number;
@@ -419,7 +423,9 @@ export function useCompletion(
       },
       maxResults = 50,
     ): Promise<Suggestion[]> => {
-      const globPattern = `**/${searchPrefix}*`;
+      // Escape the searchPrefix to handle special glob characters like brackets
+      const escapedSearchPrefix = escapeGlobPattern(searchPrefix);
+      const globPattern = `**/${escapedSearchPrefix}*`;
       const files = await glob(globPattern, {
         cwd,
         dot: searchPrefix.startsWith('.'),


### PR DESCRIPTION
#5086

### TLDR

- The tool couldn't read files like `src/app/(app)/Tab1/[id]/index.tsx` because glob patterns treat brackets as special characters. Added `escapeGlobPattern()` function to escape special glob characters, allowing proper file discovery for expo-router and similar projects.

### Dive Deeper

The issue occurred in the fallback glob search when direct file paths weren't found. The pattern `**/*${pathName}*` would fail for paths containing `[`, `]`, `(`, `)`, etc. because these have special meaning in glob patterns.

**Root cause**: Glob interprets `[id]` as a character class matching any single character that is 'i' or 'd', not as literal brackets.

**Solution**: Added `escapeGlobPattern()` function that escapes special glob characters using regex replacement. Applied this to all three places where glob patterns are used with user input:
- `@` command processing in `atCommandProcessor.ts`
- ACP peer file handling in `acpPeer.ts` 
- File completion suggestions in `useCompletion.ts`

**Impact**: Minimal changes that preserve existing API and functionality while enabling support for modern routing patterns.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
