### PR TITLE
Use the correct flash lite string for gemini cli

### DIFF
--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -6,5 +6,5 @@
 
 export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
-export const DEFAULT_GEMINI_FLASH_LITE_MODEL = 'gemini-2.5-flash-lite';
+export const DEFAULT_GEMINI_FLASH_LITE_MODEL = 'gemini-2.5-flash-lite-code';
 export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -21,7 +21,7 @@ export function tokenLimit(model: Model): TokenCount {
     case 'gemini-2.5-pro':
     case 'gemini-2.5-flash-preview-05-20':
     case 'gemini-2.5-flash':
-    case 'gemini-2.5-flash-lite':
+    case 'gemini-2.5-flash-lite-code':
     case 'gemini-2.0-flash':
       return 1_048_576;
     case 'gemini-2.0-flash-preview-image-generation':


### PR DESCRIPTION
## TLDR

Flash Lite is using the incorrect model string. Changes it to `gemini-2.5-flash-lite-code`