### PR TITLE
Add Starcraft ref to witty loading phrases

### DIFF
--- a/packages/cli/src/ui/hooks/usePhraseCycler.ts
+++ b/packages/cli/src/ui/hooks/usePhraseCycler.ts
@@ -138,6 +138,7 @@ export const WITTY_LOADING_PHRASES = [
   'Enhancing... Enhancing... Still loading.',
   "It's not a bug, it's a feature... of this loading screen.",
   'Have you tried turning it off and on again? (The loading screen, not me.)',
+  'Constructing additional pylons...',
 ];
 
 export const PHRASE_CHANGE_INTERVAL_MS = 15000;


### PR DESCRIPTION
## TLDR

This adds a Starcraft reference to the set of witty loading phrases, as described in #5118 

## Dive Deeper

https://knowyourmeme.com/memes/you-must-construct-additional-pylons

## Reviewer Test Plan

Attempt to give a hearty chuckle when you see a reference to an old meme

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ✅  | ❓  | ✅  |
| Docker   | ✅  | ❓  | ✅  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

- Fixes #5118
