### PR TITLE
Fix typo in RFC 9728 impl

### DIFF
--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -140,7 +140,7 @@ describe('OAuthUtils', () => {
   describe('parseWWWAuthenticateHeader', () => {
     it('should parse resource metadata URI from WWW-Authenticate header', () => {
       const header =
-        'Bearer realm="example", resource_metadata_uri="https://example.com/.well-known/oauth-protected-resource"';
+        'Bearer realm="example", resource_metadata="https://example.com/.well-known/oauth-protected-resource"';
       const result = OAuthUtils.parseWWWAuthenticateHeader(header);
       expect(result).toBe(
         'https://example.com/.well-known/oauth-protected-resource',

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -198,8 +198,8 @@ export class OAuthUtils {
    * @returns The resource metadata URI if found
    */
   static parseWWWAuthenticateHeader(header: string): string | null {
-    // Parse Bearer realm and resource_metadata_uri
-    const match = header.match(/resource_metadata_uri="([^"]+)"/);
+    // Parse Bearer realm and resource_metadata
+    const match = header.match(/resource_metadata="([^"]+)"/);
     if (match) {
       return match[1];
     }

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -146,20 +146,6 @@ export function getMCPDiscoveryState(): MCPDiscoveryState {
 }
 
 /**
- * Parse www-authenticate header to extract OAuth metadata URI.
- *
- * @param wwwAuthenticate The www-authenticate header value
- * @returns The resource metadata URI if found, null otherwise
- */
-function _parseWWWAuthenticate(wwwAuthenticate: string): string | null {
-  // Parse header like: Bearer realm="MCP Server", resource_metadata_uri="https://..."
-  const resourceMetadataMatch = wwwAuthenticate.match(
-    /resource_metadata_uri="([^"]+)"/,
-  );
-  return resourceMetadataMatch ? resourceMetadataMatch[1] : null;
-}
-
-/**
  * Extract WWW-Authenticate header from error message string.
  * This is a more robust approach than regex matching.
  *


### PR DESCRIPTION
## TLDR

[RFC 9728 ](https://datatracker.ietf.org/doc/rfc9728/) specifies that `resource_metadata` should be used, not `resource_metadata_uri`.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #5011 