### PR TITLE
Skip and reset loop checking around code blocks

### DIFF
--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -56,6 +56,15 @@ describe('LoopDetectionService', () => {
     value: content,
   });
 
+  const createRepetitiveContent = (id: number, length: number): string => {
+    const baseString = `This is a unique sentence, id=${id}. `;
+    let content = '';
+    while (content.length < length) {
+      content += baseString;
+    }
+    return content.slice(0, length);
+  };
+
   describe('Tool Call Loop Detection', () => {
     it(`should not detect a loop for fewer than TOOL_CALL_LOOP_THRESHOLD identical calls`, () => {
       const event = createToolCallRequestEvent('testTool', { param: 'value' });
@@ -149,13 +158,11 @@ describe('LoopDetectionService', () => {
 
     it('should detect a loop when a chunk of content repeats consecutively', () => {
       service.reset('');
-      const repeatedContent = 'a'.repeat(CONTENT_CHUNK_SIZE);
+      const repeatedContent = createRepetitiveContent(1, CONTENT_CHUNK_SIZE);
 
       let isLoop = false;
       for (let i = 0; i < CONTENT_LOOP_THRESHOLD; i++) {
-        for (const char of repeatedContent) {
-          isLoop = service.addAndCheck(createContentEvent(char));
-        }
+        isLoop = service.addAndCheck(createContentEvent(repeatedContent));
       }
       expect(isLoop).toBe(true);
       expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
@@ -163,19 +170,115 @@ describe('LoopDetectionService', () => {
 
     it('should not detect a loop if repetitions are very far apart', () => {
       service.reset('');
-      const repeatedContent = 'b'.repeat(CONTENT_CHUNK_SIZE);
+      const repeatedContent = createRepetitiveContent(1, CONTENT_CHUNK_SIZE);
       const fillerContent = generateRandomString(500);
 
       let isLoop = false;
       for (let i = 0; i < CONTENT_LOOP_THRESHOLD; i++) {
-        for (const char of repeatedContent) {
-          isLoop = service.addAndCheck(createContentEvent(char));
-        }
-        for (const char of fillerContent) {
-          isLoop = service.addAndCheck(createContentEvent(char));
-        }
+        isLoop = service.addAndCheck(createContentEvent(repeatedContent));
+        isLoop = service.addAndCheck(createContentEvent(fillerContent));
       }
       expect(isLoop).toBe(false);
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Content Loop Detection with Code Blocks', () => {
+    it('should not detect a loop when repetitive content is inside a code block', () => {
+      service.reset('');
+      const repeatedContent = createRepetitiveContent(1, CONTENT_CHUNK_SIZE);
+
+      service.addAndCheck(createContentEvent('```\n'));
+
+      for (let i = 0; i < CONTENT_LOOP_THRESHOLD; i++) {
+        const isLoop = service.addAndCheck(createContentEvent(repeatedContent));
+        expect(isLoop).toBe(false);
+      }
+
+      const isLoop = service.addAndCheck(createContentEvent('\n```'));
+      expect(isLoop).toBe(false);
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+
+    it('should detect a loop when repetitive content is outside a code block', () => {
+      service.reset('');
+      const repeatedContent = createRepetitiveContent(1, CONTENT_CHUNK_SIZE);
+
+      service.addAndCheck(createContentEvent('```'));
+      service.addAndCheck(createContentEvent('\nsome code\n'));
+      service.addAndCheck(createContentEvent('```'));
+
+      let isLoop = false;
+      for (let i = 0; i < CONTENT_LOOP_THRESHOLD; i++) {
+        isLoop = service.addAndCheck(createContentEvent(repeatedContent));
+      }
+      expect(isLoop).toBe(true);
+      expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle content with multiple code blocks and no loops', () => {
+      service.reset('');
+      service.addAndCheck(createContentEvent('```\ncode1\n```'));
+      service.addAndCheck(createContentEvent('\nsome text\n'));
+      const isLoop = service.addAndCheck(createContentEvent('```\ncode2\n```'));
+
+      expect(isLoop).toBe(false);
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+
+    it('should handle content with mixed code blocks and looping text', () => {
+      service.reset('');
+      const repeatedContent = createRepetitiveContent(1, CONTENT_CHUNK_SIZE);
+
+      service.addAndCheck(createContentEvent('```'));
+      service.addAndCheck(createContentEvent('\ncode1\n'));
+      service.addAndCheck(createContentEvent('```'));
+
+      let isLoop = false;
+      for (let i = 0; i < CONTENT_LOOP_THRESHOLD; i++) {
+        isLoop = service.addAndCheck(createContentEvent(repeatedContent));
+      }
+
+      expect(isLoop).toBe(true);
+      expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not detect a loop for a long code block with some repeating tokens', () => {
+      service.reset('');
+      const repeatingTokens =
+        'for (let i = 0; i < 10; i++) { console.log(i); }';
+
+      service.addAndCheck(createContentEvent('```\n'));
+
+      for (let i = 0; i < 20; i++) {
+        const isLoop = service.addAndCheck(createContentEvent(repeatingTokens));
+        expect(isLoop).toBe(false);
+      }
+
+      const isLoop = service.addAndCheck(createContentEvent('\n```'));
+      expect(isLoop).toBe(false);
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+
+    it('should reset tracking when a code fence is found', () => {
+      service.reset('');
+      const repeatedContent = createRepetitiveContent(1, CONTENT_CHUNK_SIZE);
+
+      for (let i = 0; i < CONTENT_LOOP_THRESHOLD - 1; i++) {
+        service.addAndCheck(createContentEvent(repeatedContent));
+      }
+
+      // This should not trigger a loop because of the reset
+      service.addAndCheck(createContentEvent('```'));
+
+      // We are now in a code block, so loop detection should be off.
+      // Let's add the repeated content again, it should not trigger a loop.
+      let isLoop = false;
+      for (let i = 0; i < CONTENT_LOOP_THRESHOLD; i++) {
+        isLoop = service.addAndCheck(createContentEvent(repeatedContent));
+        expect(isLoop).toBe(false);
+      }
+
       expect(loggers.logLoopDetected).not.toHaveBeenCalled();
     });
   });

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -164,16 +164,17 @@ export class LoopDetectionService {
     // Code blocks can often contain repetitive syntax that is not indicative of a loop.
     // To avoid false positives, we detect when we are inside a code block and
     // temporarily disable loop detection.
-    const numFences = (content.match('```') ?? []).length;
+    const numFences = (content.match(/```/g) ?? []).length;
     if (numFences) {
       // Reset tracking when a code fence is detected to avoid analyzing content
       // that spans across code block boundaries.
       this.resetContentTracking();
     }
 
+    const wasInCodeBlock = this.inCodeBlock;
     this.inCodeBlock =
       numFences % 2 === 0 ? this.inCodeBlock : !this.inCodeBlock;
-    if (this.inCodeBlock) {
+    if (wasInCodeBlock) {
       return false;
     }
 

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -61,6 +61,7 @@ export class LoopDetectionService {
   private contentStats = new Map<string, number[]>();
   private lastContentIndex = 0;
   private loopDetected = false;
+  private inCodeBlock = false;
 
   // LLM loop track tracking
   private turnsInCurrentPrompt = 0;
@@ -156,8 +157,26 @@ export class LoopDetectionService {
    * 2. Truncating history if it exceeds the maximum length
    * 3. Analyzing content chunks for repetitive patterns using hashing
    * 4. Detecting loops when identical chunks appear frequently within a short distance
+   * 5. Disabling loop detection within code blocks to prevent false positives,
+   *    as repetitive code structures are common and not necessarily loops.
    */
   private checkContentLoop(content: string): boolean {
+    // Code blocks can often contain repetitive syntax that is not indicative of a loop.
+    // To avoid false positives, we detect when we are inside a code block and
+    // temporarily disable loop detection.
+    const numFences = (content.match('```') ?? []).length;
+    if (numFences) {
+      // Reset tracking when a code fence is detected to avoid analyzing content
+      // that spans across code block boundaries.
+      this.resetContentTracking();
+    }
+
+    this.inCodeBlock =
+      numFences % 2 === 0 ? this.inCodeBlock : !this.inCodeBlock;
+    if (this.inCodeBlock) {
+      return false;
+    }
+
     this.streamContentHistory += content;
 
     this.truncateAndUpdate();


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

Enhances the loop detection service to prevent false positives by disabling content-based loop detection within code blocks.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

The previous implementation of the loop detection service was susceptible to incorrectly identifying repetitive but valid code syntax as a "chanting" loop. This was because it didn't differentiate between natural language content and code.

This PR introduces a stateful mechanism to the `LoopDetectionService` that tracks when it is inside a code block (delimited by ` ``` `). When the service detects it has entered a code block, it temporarily suspends the content loop check. The check is resumed once it exits the code block. This ensures that legitimate, repetitive code structures (like a series of import statements, function definitions, or boilerplate) are not flagged as loops, improving the accuracy and reliability of the detection mechanism.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

**Test loop detection in plain text:** Ask the CLI to perform a task that generates a lot of repetitive text, for example: `repeat the sentence "hello world" 50 times`. The loop detection should engage and terminate the process.

**Test for false positives in code:** Ask the CLI to generate a large file with highly repetitive code syntax, for example: `generate a python file with 100 functions that all print "hello world"`. The process should complete successfully without being flagged as a loop.

**Test mixed content:** Ask the CLI to write a tutorial that includes both text and code. Introduce repetition in the text portion (e.g., `write a tutorial on python functions. in the explanation, repeat the phrase "this is very important" many times. include several code blocks.`). The loop should be detected. Then, try the reverse, with repetition only in the code, and verify it is *not* detected.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅ | ❓ | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
#5085