### PR TITLE
feat(docs): document GEMINI.md import syntax

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -442,6 +442,7 @@ This example demonstrates how you can provide general project context, specific 
       - Location: The CLI also scans for the configured context file in subdirectories _below_ the current working directory (respecting common ignore patterns like `node_modules`, `.git`, etc.). The breadth of this search is limited to 200 directories by default, but can be configured with a `memoryDiscoveryMaxDirs` field in your `settings.json` file.
       - Scope: Allows for highly specific instructions relevant to a particular component, module, or subsection of your project.
 - **Concatenation & UI Indication:** The contents of all found context files are concatenated (with separators indicating their origin and path) and provided as part of the system prompt to the Gemini model. The CLI footer displays the count of loaded context files, giving you a quick visual cue about the active instructional context.
+- **Importing Content:** You can modularize your context files by importing other Markdown files using the `@path/to/file.md` syntax. For more details, see the [Memory Import Processor documentation](../core/memport.md).
 - **Commands for Memory Management:**
   - Use `/memory refresh` to force a re-scan and reload of all context files from all configured locations. This updates the AI's instructional context.
   - Use `/memory show` to display the combined instructional context currently loaded, allowing you to verify the hierarchy and content being used by the AI.


### PR DESCRIPTION
This PR adds documentation for the ability to import other markdown files into a GEMINI.md file using the `@file.md` syntax.

The `docs/cli/configuration.md` file has been updated to include a reference to this feature, with a link to the more detailed documentation in `docs/core/memport.md`.

Fixes #5133