### PR TITLE
feat(memory): markdown-aware imports and tree view

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -27,6 +27,7 @@ import {
   setGeminiMdFilename,
   GEMINI_CONFIG_DIR as GEMINI_DIR,
 } from '../tools/memoryTool.js';
+import { MemorySource } from '../utils/memoryImportProcessor.js';
 import { WebSearchTool } from '../tools/web-search.js';
 import { GeminiClient } from '../core/client.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
@@ -157,6 +158,7 @@ export interface ConfigParameters {
   mcpServers?: Record<string, MCPServerConfig>;
   userMemory?: string;
   geminiMdFileCount?: number;
+  importTrees?: MemorySource[];
   approvalMode?: ApprovalMode;
   showMemoryUsage?: boolean;
   contextFileName?: string | string[];
@@ -205,6 +207,7 @@ export class Config {
   private readonly mcpServers: Record<string, MCPServerConfig> | undefined;
   private userMemory: string;
   private geminiMdFileCount: number;
+  private importTrees: MemorySource[];
   private approvalMode: ApprovalMode;
   private readonly showMemoryUsage: boolean;
   private readonly accessibility: AccessibilitySettings;
@@ -259,6 +262,7 @@ export class Config {
     this.mcpServers = params.mcpServers;
     this.userMemory = params.userMemory ?? '';
     this.geminiMdFileCount = params.geminiMdFileCount ?? 0;
+    this.importTrees = params.importTrees ?? [];
     this.approvalMode = params.approvalMode ?? ApprovalMode.DEFAULT;
     this.showMemoryUsage = params.showMemoryUsage ?? false;
     this.accessibility = params.accessibility ?? {};
@@ -449,6 +453,14 @@ export class Config {
 
   setGeminiMdFileCount(count: number): void {
     this.geminiMdFileCount = count;
+  }
+
+  getImportTrees(): MemorySource[] {
+    return this.importTrees;
+  }
+
+  setImportTrees(trees: MemorySource[]): void {
+    this.importTrees = trees;
   }
 
   getApprovalMode(): ApprovalMode {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,10 @@ export * from './utils/schemaValidator.js';
 export * from './utils/errors.js';
 export * from './utils/getFolderStructure.js';
 export * from './utils/memoryDiscovery.js';
+export type {
+  ImportNode,
+  MemorySource,
+} from './utils/memoryImportProcessor.js';
 export * from './utils/gitIgnoreParser.js';
 export * from './utils/gitUtils.js';
 export * from './utils/editor.js';

--- a/packages/core/src/utils/markdownParser.test.ts
+++ b/packages/core/src/utils/markdownParser.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseMarkdown } from './markdownParser.js';
+
+describe('MarkdownParser', () => {
+  it('should parse a simple string with no code', () => {
+    const content = 'This is a simple string.';
+    const ast = parseMarkdown(content);
+    expect(ast).toEqual([{ type: 'text', content }]);
+  });
+
+  it('should parse a fenced code block', () => {
+    const content = 'Some text\n```typescript\nconst x = 1;\n```\nmore text';
+    const ast = parseMarkdown(content);
+    expect(ast).toEqual([
+      { type: 'text', content: 'Some text\n' },
+      {
+        type: 'code_block',
+        content: '```typescript\nconst x = 1;\n```',
+      },
+      { type: 'text', content: '\nmore text' },
+    ]);
+  });
+
+  it('should parse an inline code span', () => {
+    const content = 'Some text `const x = 1;` more text';
+    const ast = parseMarkdown(content);
+    expect(ast).toEqual([
+      { type: 'text', content: 'Some text ' },
+      { type: 'code_span', content: '`const x = 1;`' },
+      { type: 'text', content: ' more text' },
+    ]);
+  });
+
+  it('should handle multiple code constructs', () => {
+    const content = 'Text 1 `code 1` Text 2\n```\ncode 2\n```\nText 3 `code 3`';
+    const ast = parseMarkdown(content);
+    expect(ast).toEqual([
+      { type: 'text', content: 'Text 1 ' },
+      { type: 'code_span', content: '`code 1`' },
+      { type: 'text', content: ' Text 2\n' },
+      { type: 'code_block', content: '```\ncode 2\n```' },
+      { type: 'text', content: '\nText 3 ' },
+      { type: 'code_span', content: '`code 3`' },
+    ]);
+  });
+
+  it('should handle content starting with a code block', () => {
+    const content = '```\nstart\n```\ntext';
+    const ast = parseMarkdown(content);
+    expect(ast).toEqual([
+      { type: 'code_block', content: '```\nstart\n```' },
+      { type: 'text', content: '\ntext' },
+    ]);
+  });
+
+  it('should handle content ending with a code span', () => {
+    const content = 'text `end`';
+    const ast = parseMarkdown(content);
+    expect(ast).toEqual([
+      { type: 'text', content: 'text ' },
+      { type: 'code_span', content: '`end`' },
+    ]);
+  });
+
+  it('should return an empty array for an empty string', () => {
+    const content = '';
+    const ast = parseMarkdown(content);
+    expect(ast).toEqual([]);
+  });
+});

--- a/packages/core/src/utils/markdownParser.ts
+++ b/packages/core/src/utils/markdownParser.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file markdownParser.ts
+ * @brief A lightweight markdown parser for GEMINI.md import processing.
+ */
+
+export interface AstNode {
+  type: 'text' | 'code_block' | 'code_span';
+  content: string;
+}
+
+/**
+ * @brief Parses a markdown string into a simple Abstract Syntax Tree (AST).
+ * @param content The markdown content to parse.
+ * @returns An array of AstNode objects.
+ */
+export function parseMarkdown(content: string): AstNode[] {
+  const ast: AstNode[] = [];
+  let currentIndex = 0;
+
+  while (currentIndex < content.length) {
+    const remainingContent = content.slice(currentIndex);
+
+    // Match fenced code blocks (including language identifiers)
+    const codeBlockMatch = remainingContent.match(
+      /^```[a-zA-Z]*\n[\s\S]*?\n```/,
+    );
+    if (codeBlockMatch) {
+      ast.push({ type: 'code_block', content: codeBlockMatch[0] });
+      currentIndex += codeBlockMatch[0].length;
+      continue;
+    }
+
+    // Match inline code spans
+    const codeSpanMatch = remainingContent.match(/^`[^`]*`/);
+    if (codeSpanMatch) {
+      ast.push({ type: 'code_span', content: codeSpanMatch[0] });
+      currentIndex += codeSpanMatch[0].length;
+      continue;
+    }
+
+    // Find the next occurrence of a code delimiter
+    const nextCodeMatch = remainingContent.match(/`{1,3}/);
+    const textEndIndex = nextCodeMatch
+      ? currentIndex + nextCodeMatch.index!
+      : content.length;
+
+    if (textEndIndex > currentIndex) {
+      ast.push({
+        type: 'text',
+        content: content.slice(currentIndex, textEndIndex),
+      });
+    }
+    currentIndex = textEndIndex;
+  }
+
+  return ast;
+}

--- a/packages/core/src/utils/markdownParser.ts
+++ b/packages/core/src/utils/markdownParser.ts
@@ -28,7 +28,7 @@ export function parseMarkdown(content: string): AstNode[] {
 
     // Match fenced code blocks (including language identifiers)
     const codeBlockMatch = remainingContent.match(
-      /^```[a-zA-Z]*\n[\s\S]*?\n```/,
+      /^```[^\n]*\n[\s\S]*?\n?```/,
     );
     if (codeBlockMatch) {
       ast.push({ type: 'code_block', content: codeBlockMatch[0] });


### PR DESCRIPTION
This commit introduces a robust, markdown-aware `@import` feature for `GEMINI.md` files and enhances the `/memory show` command to display a tree of imported files.

The key changes are:

- **Markdown-Aware Parsing:** Replaces the naive regex-based import logic with a lightweight, dependency-free markdown parser. This correctly ignores `@import` statements within fenced code blocks and inline code spans, fixing a critical bug where text like `user@10.1.0.190` was incorrectly identified as a file path.
- **Enhanced `/memory` Command:** The `/memory show` command now displays a tree of all successfully imported files, providing users with a clear view of the context sources.
- **Updated Import Logic:** The import processor now supports recursive imports up to a defined depth, handles path validation securely, and includes each file only once to prevent circular dependencies.
- **API Changes:** The internal functions for processing and discovering memory files have been updated to return both the concatenated content and the import tree structure.

This feature significantly improves the stability and usability of the `GEMINI.md` context system.

Fixes: https://github.com/google-gemini/gemini-cli/issues/2185