### PR TITLE
bug(core): UI reporting for truncated read_file.

### DIFF
--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -222,7 +222,7 @@ describe('ReadFileTool', () => {
           'Line 7',
           'Line 8',
         ].join('\n'),
-        returnDisplay: 'Read lines 6-8 of 20 from paginated.txt (truncated)',
+        returnDisplay: 'Read lines 6-8 of 20 from paginated.txt',
       });
     });
 

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -222,7 +222,7 @@ describe('ReadFileTool', () => {
           'Line 7',
           'Line 8',
         ].join('\n'),
-        returnDisplay: '(truncated)',
+        returnDisplay: 'Read lines 6-8 of 20 from paginated.txt (truncated)',
       });
     });
 

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -420,9 +420,7 @@ describe('fileUtils', () => {
       expect(result.llmContent).toContain(
         '[File content truncated: showing lines 6-10 of 20 total lines. Use offset/limit parameters to view more.]',
       );
-      expect(result.returnDisplay).toBe(
-        'Read lines 6-10 of 20 from test.txt (truncated)',
-      );
+      expect(result.returnDisplay).toBe('Read lines 6-10 of 20 from test.txt');
       expect(result.isTruncated).toBe(true);
       expect(result.originalLineCount).toBe(20);
       expect(result.linesShown).toEqual([6, 10]);
@@ -468,39 +466,68 @@ describe('fileUtils', () => {
         '[File content partially truncated: some lines exceeded maximum length of 2000 characters.]',
       );
       expect(result.returnDisplay).toBe(
-        'Read all 3 lines from test.txt (truncated due to long lines)',
+        'Read all 3 lines from test.txt (some lines were shortened)',
       );
       expect(result.isTruncated).toBe(true);
     });
 
-    it('should handle both line count and line length truncation', async () => {
-      const longLine = 'b'.repeat(2500);
-      const lines = Array.from({ length: 10 }, (_, i) => `Line ${i + 1}`);
-      lines.push(longLine);
+    it('should truncate when line count exceeds the limit', async () => {
+      const lines = Array.from({ length: 11 }, (_, i) => `Line ${i + 1}`);
       actualNodeFs.writeFileSync(testTextFilePath, lines.join('\n'));
 
+      // Read 5 lines, but there are 11 total
       const result = await processSingleFileContent(
         testTextFilePath,
         tempRootDir,
         0,
         5,
-      ); // Read 5 lines, but there are 11 total
-
-      expect(result.isTruncated).toBe(true);
-      expect(result.returnDisplay).toBe(
-        'Read lines 1-5 of 11 from test.txt (truncated)',
       );
 
-      const result2 = await processSingleFileContent(
+      expect(result.isTruncated).toBe(true);
+      expect(result.returnDisplay).toBe('Read lines 1-5 of 11 from test.txt');
+    });
+
+    it('should truncate when a line length exceeds the character limit', async () => {
+      const longLine = 'b'.repeat(2500);
+      const lines = Array.from({ length: 10 }, (_, i) => `Line ${i + 1}`);
+      lines.push(longLine); // Total 11 lines
+      actualNodeFs.writeFileSync(testTextFilePath, lines.join('\n'));
+
+      // Read all 11 lines, including the long one
+      const result = await processSingleFileContent(
         testTextFilePath,
         tempRootDir,
         0,
         11,
-      ); // Read all 11 lines
+      );
 
-      expect(result2.isTruncated).toBe(true);
-      expect(result2.returnDisplay).toBe(
-        'Read all 11 lines from test.txt (truncated due to long lines)',
+      expect(result.isTruncated).toBe(true);
+      expect(result.returnDisplay).toBe(
+        'Read all 11 lines from test.txt (some lines were shortened)',
+      );
+    });
+
+    it('should truncate both line count and line length when both exceed limits', async () => {
+      const linesWithLongInMiddle = Array.from(
+        { length: 20 },
+        (_, i) => `Line ${i + 1}`,
+      );
+      linesWithLongInMiddle[4] = 'c'.repeat(2500);
+      actualNodeFs.writeFileSync(
+        testTextFilePath,
+        linesWithLongInMiddle.join('\n'),
+      );
+
+      // Read 10 lines out of 20, including the long line
+      const result = await processSingleFileContent(
+        testTextFilePath,
+        tempRootDir,
+        0,
+        10,
+      );
+      expect(result.isTruncated).toBe(true);
+      expect(result.returnDisplay).toBe(
+        'Read lines 1-10 of 20 from test.txt (some lines were shortened)',
       );
     });
 

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -304,33 +304,28 @@ export async function processSingleFileContent(
 
         let llmTextContent = '';
         if (contentRangeTruncated) {
-          llmTextContent += `[File content truncated: showing lines ${
-            actualStartLine + 1
-          }-${endLine} of ${originalLineCount} total lines. Use offset/limit parameters to view more.]\n`;
+          llmTextContent += `[File content truncated: showing lines ${actualStartLine + 1}-${endLine} of ${originalLineCount} total lines. Use offset/limit parameters to view more.]\n`;
         } else if (linesWereTruncatedInLength) {
           llmTextContent += `[File content partially truncated: some lines exceeded maximum length of ${MAX_LINE_LENGTH_TEXT_FILE} characters.]\n`;
         }
         llmTextContent += formattedLines.join('\n');
 
-        let returnDisplay = `Read file ${relativePathForDisplay}`;
-        if (isTruncated) {
-          if (contentRangeTruncated) {
-            returnDisplay = `Read lines ${
-              actualStartLine + 1
-            }-${endLine} of ${originalLineCount} from ${relativePathForDisplay} (truncated`;
-            if (linesWereTruncatedInLength) {
-              returnDisplay += ', and some lines were shortened)';
-            } else {
-              returnDisplay += ')';
-            }
-          } else if (linesWereTruncatedInLength) {
-            returnDisplay = `Read all ${originalLineCount} lines from ${relativePathForDisplay} (truncated due to long lines)`;
+        // By default, return nothing to streamline the common case of a successful read_file.
+        let returnDisplay = '';
+        if (contentRangeTruncated) {
+          returnDisplay = `Read lines ${
+            actualStartLine + 1
+          }-${endLine} of ${originalLineCount} from ${relativePathForDisplay}`;
+          if (linesWereTruncatedInLength) {
+            returnDisplay += ' (some lines were shortened)';
           }
+        } else if (linesWereTruncatedInLength) {
+          returnDisplay = `Read all ${originalLineCount} lines from ${relativePathForDisplay} (some lines were shortened)`;
         }
 
         return {
           llmContent: llmTextContent,
-          returnDisplay: isTruncated ? returnDisplay : '',
+          returnDisplay,
           isTruncated,
           originalLineCount,
           linesShown: [actualStartLine + 1, endLine],

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -304,15 +304,33 @@ export async function processSingleFileContent(
 
         let llmTextContent = '';
         if (contentRangeTruncated) {
-          llmTextContent += `[File content truncated: showing lines ${actualStartLine + 1}-${endLine} of ${originalLineCount} total lines. Use offset/limit parameters to view more.]\n`;
+          llmTextContent += `[File content truncated: showing lines ${
+            actualStartLine + 1
+          }-${endLine} of ${originalLineCount} total lines. Use offset/limit parameters to view more.]\n`;
         } else if (linesWereTruncatedInLength) {
           llmTextContent += `[File content partially truncated: some lines exceeded maximum length of ${MAX_LINE_LENGTH_TEXT_FILE} characters.]\n`;
         }
         llmTextContent += formattedLines.join('\n');
 
+        let returnDisplay = `Read file ${relativePathForDisplay}`;
+        if (isTruncated) {
+          if (contentRangeTruncated) {
+            returnDisplay = `Read lines ${
+              actualStartLine + 1
+            }-${endLine} of ${originalLineCount} from ${relativePathForDisplay} (truncated`;
+            if (linesWereTruncatedInLength) {
+              returnDisplay += ', and some lines were shortened)';
+            } else {
+              returnDisplay += ')';
+            }
+          } else if (linesWereTruncatedInLength) {
+            returnDisplay = `Read all ${originalLineCount} lines from ${relativePathForDisplay} (truncated due to long lines)`;
+          }
+        }
+
         return {
           llmContent: llmTextContent,
-          returnDisplay: isTruncated ? '(truncated)' : '',
+          returnDisplay: isTruncated ? returnDisplay : '',
           isTruncated,
           originalLineCount,
           linesShown: [actualStartLine + 1, endLine],


### PR DESCRIPTION
BUG: #4948

## TLDR

Cleans up the UI messages around truncation.

## Dive Deeper

This is the initial change to tackle #4948. The next CL in this series will improve the prompt engineering.

## Reviewer Test Plan

There are new tests for this logic. I'm happy to add more. The change is fairly localized.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | :heavy_check_mark:   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Makes progress on #4948
