### PR TITLE
bug(core): Prompt engineering for truncated read_file.

### DIFF
--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -524,11 +524,15 @@ Use this tool when the user's query implies needing the content of several files
               '{filePath}',
               filePath,
             );
-            contentParts.push(
-              `${separator}\n\n${fileReadResult.llmContent}\n\n`,
-            );
+            let fileContentForLlm = '';
+            if (fileReadResult.isTruncated) {
+              fileContentForLlm += `[WARNING: This file was truncated. To view the full content, use the 'read_file' tool on this specific file.]\n\n`;
+            }
+            fileContentForLlm += fileReadResult.llmContent;
+            contentParts.push(`${separator}\n\n${fileContentForLlm}\n\n`);
           } else {
-            contentParts.push(fileReadResult.llmContent); // This is a Part for image/pdf
+            // This is a Part for image/pdf, which we don't add the separator to.
+            contentParts.push(fileReadResult.llmContent);
           }
 
           processedFilesRelativePaths.push(relativePathForDisplay);

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -420,10 +420,7 @@ describe('fileUtils', () => {
       ); // Read lines 6-10
       const expectedContent = lines.slice(5, 10).join('\n');
 
-      expect(result.llmContent).toContain(expectedContent);
-      expect(result.llmContent).toContain(
-        '[File content truncated: showing lines 6-10 of 20 total lines. Use offset/limit parameters to view more.]',
-      );
+      expect(result.llmContent).toBe(expectedContent);
       expect(result.returnDisplay).toBe('Read lines 6-10 of 20 from test.txt');
       expect(result.isTruncated).toBe(true);
       expect(result.originalLineCount).toBe(20);
@@ -444,9 +441,6 @@ describe('fileUtils', () => {
       const expectedContent = lines.slice(10, 20).join('\n');
 
       expect(result.llmContent).toContain(expectedContent);
-      expect(result.llmContent).toContain(
-        '[File content truncated: showing lines 11-20 of 20 total lines. Use offset/limit parameters to view more.]',
-      );
       expect(result.returnDisplay).toBe('Read lines 11-20 of 20 from test.txt');
       expect(result.isTruncated).toBe(true); // This is the key check for the bug
       expect(result.originalLineCount).toBe(20);
@@ -489,9 +483,6 @@ describe('fileUtils', () => {
         longLine.substring(0, 2000) + '... [truncated]',
       );
       expect(result.llmContent).toContain('Another short line');
-      expect(result.llmContent).toContain(
-        '[File content partially truncated: some lines exceeded maximum length of 2000 characters.]',
-      );
       expect(result.returnDisplay).toBe(
         'Read all 3 lines from test.txt (some lines were shortened)',
       );

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -303,14 +303,7 @@ export async function processSingleFileContent(
         const contentRangeTruncated =
           startLine > 0 || endLine < originalLineCount;
         const isTruncated = contentRangeTruncated || linesWereTruncatedInLength;
-
-        let llmTextContent = '';
-        if (contentRangeTruncated) {
-          llmTextContent += `[File content truncated: showing lines ${actualStartLine + 1}-${endLine} of ${originalLineCount} total lines. Use offset/limit parameters to view more.]\n`;
-        } else if (linesWereTruncatedInLength) {
-          llmTextContent += `[File content partially truncated: some lines exceeded maximum length of ${MAX_LINE_LENGTH_TEXT_FILE} characters.]\n`;
-        }
-        llmTextContent += formattedLines.join('\n');
+        const llmContent = formattedLines.join('\n');
 
         // By default, return nothing to streamline the common case of a successful read_file.
         let returnDisplay = '';
@@ -326,7 +319,7 @@ export async function processSingleFileContent(
         }
 
         return {
-          llmContent: llmTextContent,
+          llmContent,
           returnDisplay,
           isTruncated,
           originalLineCount,


### PR DESCRIPTION
## TLDR

Follow-up prompt engineering to address #4948 

## Dive Deeper

Prioritizes the addressable content truncation vs. long line length truncation which AFAICT is not currently addressable by the agent.

## Reviewer Test Plan

Confirm prompt looks reasonable, run evals

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | :heavy_check_mark:    |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

There could be more we can do with #4948, but this is probably a good first step.
