### PR TITLE
Exclude companion extension from release versioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11934,7 +11934,7 @@
     },
     "packages/vscode-ide-companion": {
       "name": "gemini-cli-vscode-ide-companion",
-      "version": "0.1.15",
+      "version": "99.99.99",
       "license": "LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11934,7 +11934,7 @@
     },
     "packages/vscode-ide-companion": {
       "name": "gemini-cli-vscode-ide-companion",
-      "version": "99.99.99",
+      "version": "0.0.1",
       "license": "LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.1",

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -2,7 +2,7 @@
   "name": "gemini-cli-vscode-ide-companion",
   "displayName": "Gemini CLI Companion",
   "description": "Enable Gemini CLI with direct access to your VS Code workspace.",
-  "version": "99.99.99",
+  "version": "0.0.1",
   "publisher": "google",
   "icon": "assets/icon.png",
   "repository": {

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -2,7 +2,7 @@
   "name": "gemini-cli-vscode-ide-companion",
   "displayName": "Gemini CLI Companion",
   "description": "Enable Gemini CLI with direct access to your VS Code workspace.",
-  "version": "0.1.15",
+  "version": "99.99.99",
   "publisher": "google",
   "icon": "assets/icon.png",
   "repository": {


### PR DESCRIPTION
## TLDR
We'll be releasing the extension manually for the first few times so excluding the extension from the automated versioning.

Verified locally that versions packages/core/package.json, packages/cli/package.json, and gemini-cli/package.json still get bumped with this change