### PR TITLE
fix: Corrected logging error in edit tool

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -652,7 +652,7 @@ describe('EditTool', () => {
       expect(result.error?.type).toBe('ATTEMPT_TO_CREATE_EXISTING_FILE');
     });
 
-    it('should return NO_OCCURENCE_FOUND error', async () => {
+    it('should return NO_OCCURRENCE_FOUND error', async () => {
       fs.writeFileSync(filePath, 'content', 'utf8');
       const params: EditToolParams = {
         file_path: filePath,
@@ -660,10 +660,10 @@ describe('EditTool', () => {
         new_string: 'new',
       };
       const result = await tool.execute(params, new AbortController().signal);
-      expect(result.error?.type).toBe('NO_OCCURENCE_FOUND');
+      expect(result.error?.type).toBe('NO_OCCURRENCE_FOUND');
     });
 
-    it('should return EXPECTED_OCCURENCE_MISMATCH error', async () => {
+    it('should return EXPECTED_OCCURRENCE_MISMATCH error', async () => {
       fs.writeFileSync(filePath, 'one one two', 'utf8');
       const params: EditToolParams = {
         file_path: filePath,
@@ -672,7 +672,7 @@ describe('EditTool', () => {
         expected_replacements: 3,
       };
       const result = await tool.execute(params, new AbortController().signal);
-      expect(result.error?.type).toBe('EXPECTED_OCCURENCE_MISMATCH');
+      expect(result.error?.type).toBe('EXPECTED_OCCURRENCE_MISMATCH');
     });
 
     it('should return NO_CHANGE error', async () => {

--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -623,6 +623,94 @@ describe('EditTool', () => {
     });
   });
 
+  describe('Error Scenarios', () => {
+    const testFile = 'error_test.txt';
+    let filePath: string;
+
+    beforeEach(() => {
+      filePath = path.join(rootDir, testFile);
+    });
+
+    it('should return FILE_NOT_FOUND error', async () => {
+      const params: EditToolParams = {
+        file_path: filePath,
+        old_string: 'any',
+        new_string: 'new',
+      };
+      const result = await tool.execute(params, new AbortController().signal);
+      expect(result.error?.type).toBe('FILE_NOT_FOUND');
+    });
+
+    it('should return ATTEMPT_TO_CREATE_EXISTING_FILE error', async () => {
+      fs.writeFileSync(filePath, 'existing content', 'utf8');
+      const params: EditToolParams = {
+        file_path: filePath,
+        old_string: '',
+        new_string: 'new content',
+      };
+      const result = await tool.execute(params, new AbortController().signal);
+      expect(result.error?.type).toBe('ATTEMPT_TO_CREATE_EXISTING_FILE');
+    });
+
+    it('should return NO_OCCURENCE_FOUND error', async () => {
+      fs.writeFileSync(filePath, 'content', 'utf8');
+      const params: EditToolParams = {
+        file_path: filePath,
+        old_string: 'not-found',
+        new_string: 'new',
+      };
+      const result = await tool.execute(params, new AbortController().signal);
+      expect(result.error?.type).toBe('NO_OCCURENCE_FOUND');
+    });
+
+    it('should return EXPECTED_OCCURENCE_MISMATCH error', async () => {
+      fs.writeFileSync(filePath, 'one one two', 'utf8');
+      const params: EditToolParams = {
+        file_path: filePath,
+        old_string: 'one',
+        new_string: 'new',
+        expected_replacements: 3,
+      };
+      const result = await tool.execute(params, new AbortController().signal);
+      expect(result.error?.type).toBe('EXPECTED_OCCURENCE_MISMATCH');
+    });
+
+    it('should return NO_CHANGE error', async () => {
+      fs.writeFileSync(filePath, 'content', 'utf8');
+      const params: EditToolParams = {
+        file_path: filePath,
+        old_string: 'content',
+        new_string: 'content',
+      };
+      const result = await tool.execute(params, new AbortController().signal);
+      expect(result.error?.type).toBe('NO_CHANGE');
+    });
+
+    it('should return INVALID_PARAMETERS error for relative path', async () => {
+      const params: EditToolParams = {
+        file_path: 'relative/path.txt',
+        old_string: 'a',
+        new_string: 'b',
+      };
+      const result = await tool.execute(params, new AbortController().signal);
+      expect(result.error?.type).toBe('INVALID_PARAMETERS');
+    });
+
+    it('should return FILE_WRITE_FAILURE on write error', async () => {
+      fs.writeFileSync(filePath, 'content', 'utf8');
+      // Make file readonly to trigger a write error
+      fs.chmodSync(filePath, '444');
+
+      const params: EditToolParams = {
+        file_path: filePath,
+        old_string: 'content',
+        new_string: 'new content',
+      };
+      const result = await tool.execute(params, new AbortController().signal);
+      expect(result.error?.type).toBe('FILE_WRITE_FAILURE');
+    });
+  });
+
   describe('getDescription', () => {
     it('should return "No file changes to..." if old_string and new_string are the same', () => {
       const testFileName = 'test.txt';

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -240,7 +240,7 @@ Expectation for required parameters:
         error = {
           display: `Failed to edit, could not find the string to replace.`,
           raw: `Failed to edit, 0 occurrences found for old_string in ${params.file_path}. No edits made. The exact text in old_string was not found. Ensure you're not escaping content incorrectly and check whitespace, indentation, and context. Use ${ReadFileTool.Name} tool to verify.`,
-          type: 'NO_OCCURENCE_FOUND',
+          type: 'NO_OCCURRENCE_FOUND',
         };
       } else if (occurrences !== expectedReplacements) {
         const occurrenceTerm =
@@ -249,7 +249,7 @@ Expectation for required parameters:
         error = {
           display: `Failed to edit, expected ${expectedReplacements} ${occurrenceTerm} but found ${occurrences}.`,
           raw: `Failed to edit, Expected ${expectedReplacements} ${occurrenceTerm} but found ${occurrences} for old_string in file: ${params.file_path}`,
-          type: 'EXPECTED_OCCURENCE_MISMATCH',
+          type: 'EXPECTED_OCCURRENCE_MISMATCH',
         };
       } else if (finalOldString === finalNewString) {
         error = {


### PR DESCRIPTION
## TLDR

Includes error reporting to the toolResult that is returned by the tool, so that they are correctly logged/marked as succesful or failures. 

this PR follows https://github.com/google-gemini/gemini-cli/pull/5222
This PR makes progress on [#61](https://github.com/google-gemini/maintainers-gemini-cli/issues/61)
## Dive Deeper


## Reviewer Test Plan

Ran tests and e2e tests. 
Run 20 examples of swebench lite and got 40 failures logged out of 85 total calls.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | YES  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
This PR makes progress on [#61](https://github.com/google-gemini/maintainers-gemini-cli/issues/61)

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
