### PR TITLE
fix(testing): make ModelStatsDisplay snapshot test deterministic

### DIFF
--- a/packages/cli/src/ui/components/ModelStatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ModelStatsDisplay.test.tsx
@@ -5,17 +5,10 @@
  */
 
 import { render } from 'ink-testing-library';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { ModelStatsDisplay } from './ModelStatsDisplay.js';
 import * as SessionContext from '../contexts/SessionContext.js';
 import { SessionMetrics } from '../contexts/SessionContext.js';
-
-vi.spyOn(Number.prototype, 'toLocaleString').mockImplementation(function (
-  this: number,
-) {
-  // Use a stable 'en-US' format for test consistency.
-  return new Intl.NumberFormat('en-US').format(this);
-});
 
 // Mock the context to provide controlled data for testing
 vi.mock('../contexts/SessionContext.js', async (importOriginal) => {
@@ -45,6 +38,19 @@ const renderWithMockedStats = (metrics: SessionMetrics) => {
 };
 
 describe('<ModelStatsDisplay />', () => {
+  beforeAll(() => {
+    vi.spyOn(Number.prototype, 'toLocaleString').mockImplementation(function (
+      this: number,
+    ) {
+      // Use a stable 'en-US' format for test consistency.
+      return new Intl.NumberFormat('en-US').format(this);
+    });
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should render "no API calls" message when there are no active models', () => {
     const { lastFrame } = renderWithMockedStats({
       models: {},

--- a/packages/cli/src/ui/components/ModelStatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ModelStatsDisplay.test.tsx
@@ -10,6 +10,13 @@ import { ModelStatsDisplay } from './ModelStatsDisplay.js';
 import * as SessionContext from '../contexts/SessionContext.js';
 import { SessionMetrics } from '../contexts/SessionContext.js';
 
+vi.spyOn(Number.prototype, 'toLocaleString').mockImplementation(function (
+  this: number,
+) {
+  // Use a stable 'en-US' format for test consistency.
+  return new Intl.NumberFormat('en-US').format(this);
+});
+
 // Mock the context to provide controlled data for testing
 vi.mock('../contexts/SessionContext.js', async (importOriginal) => {
   const actual = await importOriginal<typeof SessionContext>();


### PR DESCRIPTION
The snapshot test for the `ModelStatsDisplay` component was non-deterministic due to the use of `Number.prototype.toLocaleString()`, which formats numbers based on the system's locale. This caused the test to fail in environments with non-US locales.

This change mocks `toLocaleString()` to use a stable `en-US` format during testing, ensuring that the snapshot remains consistent across all environments.

Fixes #5227
