### PR TITLE
fix(cli) issue 2193: positioning cursor in command prompt when using home or end

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -715,6 +715,28 @@ describe('InputPrompt', () => {
     unmount();
   });
 
+   it('should call buffer.move("home") on home key', async () => {
+    const { stdin, unmount } = render(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\u001b[H'); // Home key
+    await wait();
+
+    expect(mockBuffer.move).toHaveBeenCalledWith('home');
+    unmount();
+  });
+
+  it('should call buffer.move("end") on end key', async () => {
+    const { stdin, unmount } = render(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\u001b[F'); // End key
+    await wait();
+
+    expect(mockBuffer.move).toHaveBeenCalledWith('end');
+    unmount();
+  });
+  
   describe('cursor-based completion trigger', () => {
     it('should trigger completion when cursor is after @ without spaces', async () => {
       // Set up buffer state

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -307,11 +307,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       // Ctrl+A (Home) / Ctrl+E (End)
-      if (key.ctrl && key.name === 'a') {
+      if  ((key.ctrl && key.name === 'a') || key.name === 'home') {
         buffer.move('home');
         return;
       }
-      if (key.ctrl && key.name === 'e') {
+      if ((key.ctrl && key.name === 'e') || key.name === 'end') {
         buffer.move('end');
         buffer.moveToOffset(cpLen(buffer.text));
         return;


### PR DESCRIPTION
## TLDR

This pull request add the option to used move the position of the cursor to the front of the command prompt with key 'POS1' and to the end with key 'END'.
## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

To test this run the code and use the home and end key to validate if the cursor moves to the start and end of the line.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
- Fixes #2193 

