### PR TITLE
Use flash for MCP prompts

### DIFF
--- a/packages/cli/src/services/McpPromptLoader.ts
+++ b/packages/cli/src/services/McpPromptLoader.ts
@@ -17,6 +17,7 @@ import {
 } from '../ui/commands/types.js';
 import { ICommandLoader } from './types.js';
 import { PromptArgument } from '@modelcontextprotocol/sdk/types.js';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '@google/gemini-cli-core';
 
 /**
  * Discovers and loads executable slash commands from prompts exposed by
@@ -135,6 +136,7 @@ export class McpPromptLoader implements ICommandLoader {
               return {
                 type: 'submit_prompt',
                 content: JSON.stringify(result.messages[0].content.text),
+                model: DEFAULT_GEMINI_FLASH_MODEL,
               };
             } catch (error) {
               return {

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -118,6 +118,7 @@ export interface LoadHistoryActionReturn {
 export interface SubmitPromptActionReturn {
   type: 'submit_prompt';
   content: string;
+  model?: string;
 }
 
 /**

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -376,6 +376,7 @@ export const useSlashCommandProcessor = (
                   return {
                     type: 'submit_prompt',
                     content: result.content,
+                    model: result.model,
                   };
                 case 'confirm_shell_commands': {
                   const { outcome, approvedCommands } = await new Promise<{

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -575,6 +575,7 @@ describe('useGeminiStream', () => {
       expectedMergedResponse,
       expect.any(AbortSignal),
       'prompt-id-2',
+      undefined,
     );
   });
 
@@ -858,6 +859,7 @@ describe('useGeminiStream', () => {
         toolCallResponseParts,
         expect.any(AbortSignal),
         'prompt-id-4',
+        undefined,
       );
     });
 
@@ -1089,6 +1091,7 @@ describe('useGeminiStream', () => {
           'This is the actual prompt from the command file.',
           expect.any(AbortSignal),
           expect.any(String),
+          undefined,
         );
 
         expect(mockScheduleToolCalls).not.toHaveBeenCalled();
@@ -1115,6 +1118,7 @@ describe('useGeminiStream', () => {
           '',
           expect.any(AbortSignal),
           expect.any(String),
+          undefined,
         );
       });
     });

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -224,6 +224,7 @@ export interface ConsoleMessageItem {
 export interface SubmitPromptResult {
   type: 'submit_prompt';
   content: string;
+  model?: string;
 }
 
 /**

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -722,6 +722,7 @@ Here are some other files the user has open, with the most recent at the top:
       expect(mockTurnRunFn).toHaveBeenCalledWith(
         expectedRequest,
         expect.any(Object),
+        undefined,
       );
     });
 
@@ -769,6 +770,7 @@ Here are some other files the user has open, with the most recent at the top:
       expect(mockTurnRunFn).toHaveBeenCalledWith(
         initialRequest,
         expect.any(Object),
+        undefined,
       );
     });
 
@@ -833,6 +835,7 @@ This is the selected text in the file:
       expect(mockTurnRunFn).toHaveBeenCalledWith(
         expectedRequest,
         expect.any(Object),
+        undefined,
       );
     });
 
@@ -895,6 +898,7 @@ Here are some files the user has open, with the most recent at the top:
       expect(mockTurnRunFn).toHaveBeenCalledWith(
         expectedRequest,
         expect.any(Object),
+        undefined,
       );
     });
 
@@ -1132,6 +1136,7 @@ Here are some files the user has open, with the most recent at the top:
         [{ text: 'Start conversation' }],
         signal,
         'prompt-id-3',
+        undefined,
         Number.MAX_SAFE_INTEGER, // Bypass the MAX_TURNS protection
       );
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -309,6 +309,7 @@ export class GeminiClient {
     request: PartListUnion,
     signal: AbortSignal,
     prompt_id: string,
+    model: string | undefined = undefined,
     turns: number = this.MAX_TURNS,
     originalModel?: string,
   ): AsyncGenerator<ServerGeminiStreamEvent, Turn> {
@@ -393,7 +394,7 @@ export class GeminiClient {
       return turn;
     }
 
-    const resultStream = turn.run(request, signal);
+    const resultStream = turn.run(request, signal, model);
     for await (const event of resultStream) {
       if (this.loopDetector.addAndCheck(event)) {
         yield { type: GeminiEventType.LoopDetected };
@@ -431,6 +432,7 @@ export class GeminiClient {
           nextRequest,
           signal,
           prompt_id,
+          undefined,
           boundedTurns - 1,
           initialModel,
         );

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -263,6 +263,7 @@ export class GeminiChat {
   async sendMessage(
     params: SendMessageParameters,
     prompt_id: string,
+    model?: string,
   ): Promise<GenerateContentResponse> {
     await this.sendPromise;
     const userContent = createUserContent(params.message);
@@ -275,7 +276,8 @@ export class GeminiChat {
 
     try {
       const apiCall = () => {
-        const modelToUse = this.config.getModel() || DEFAULT_GEMINI_FLASH_MODEL;
+        const modelToUse =
+          model || this.config.getModel() || DEFAULT_GEMINI_FLASH_MODEL;
 
         // Prevent Flash model calls immediately after quota error
         if (
@@ -372,6 +374,7 @@ export class GeminiChat {
   async sendMessageStream(
     params: SendMessageParameters,
     prompt_id: string,
+    model?: string,
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
     await this.sendPromise;
     const userContent = createUserContent(params.message);
@@ -382,8 +385,7 @@ export class GeminiChat {
 
     try {
       const apiCall = () => {
-        const modelToUse = this.config.getModel();
-
+        const modelToUse = model || this.config.getModel();
         // Prevent Flash model calls immediately after quota error
         if (
           this.config.getQuotaErrorOccurred() &&

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -98,6 +98,7 @@ describe('Turn', () => {
           config: { abortSignal: expect.any(AbortSignal) },
         },
         'prompt-id-1',
+        undefined,
       );
 
       expect(events).toEqual([

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -177,6 +177,7 @@ export class Turn {
   async *run(
     req: PartListUnion,
     signal: AbortSignal,
+    model?: string,
   ): AsyncGenerator<ServerGeminiStreamEvent> {
     try {
       const responseStream = await this.chat.sendMessageStream(
@@ -187,6 +188,7 @@ export class Turn {
           },
         },
         this.prompt_id,
+        model,
       );
 
       for await (const resp of responseStream) {


### PR DESCRIPTION
## TLDR

Switch over to using flash when a user invokes an MCP prompt. When testing locally, this resulted in faster and pretty accurate results.

Do we want to make this configurable somehow?

## Dive Deeper


## Reviewer Test Plan

Use an MCP server with prompts, invoke the prompts, and confirm that you get a reasonable result.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
