### PR TITLE
Fix bug executing commands in windows whose flags contain spaces

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -91,9 +91,9 @@ describe('ShellExecutionService', () => {
       });
 
       expect(mockSpawn).toHaveBeenCalledWith(
-        'bash',
-        ['-c', 'ls -l'],
-        expect.any(Object),
+        'ls -l',
+        [],
+        expect.objectContaining({ shell: 'bash' }),
       );
       expect(result.exitCode).toBe(0);
       expect(result.signal).toBeNull();
@@ -334,23 +334,31 @@ describe('ShellExecutionService', () => {
   describe('Platform-Specific Behavior', () => {
     it('should use cmd.exe on Windows', async () => {
       mockPlatform.mockReturnValue('win32');
-      await simulateExecution('dir', (cp) => cp.emit('exit', 0, null));
+      await simulateExecution('dir "foo bar"', (cp) =>
+        cp.emit('exit', 0, null),
+      );
 
       expect(mockSpawn).toHaveBeenCalledWith(
-        'cmd.exe',
-        ['/c', 'dir'],
-        expect.objectContaining({ detached: false }),
+        'dir "foo bar"',
+        [],
+        expect.objectContaining({
+          shell: true,
+          detached: false,
+        }),
       );
     });
 
     it('should use bash and detached process group on Linux', async () => {
       mockPlatform.mockReturnValue('linux');
-      await simulateExecution('ls', (cp) => cp.emit('exit', 0, null));
+      await simulateExecution('ls "foo bar"', (cp) => cp.emit('exit', 0, null));
 
       expect(mockSpawn).toHaveBeenCalledWith(
-        'bash',
-        ['-c', 'ls'],
-        expect.objectContaining({ detached: true }),
+        'ls "foo bar"',
+        [],
+        expect.objectContaining({
+          shell: 'bash',
+          detached: true,
+        }),
       );
     });
   });

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -89,13 +89,16 @@ export class ShellExecutionService {
     abortSignal: AbortSignal,
   ): ShellExecutionHandle {
     const isWindows = os.platform() === 'win32';
-    const shell = isWindows ? 'cmd.exe' : 'bash';
-    const shellArgs = [isWindows ? '/c' : '-c', commandToExecute];
 
-    const child = spawn(shell, shellArgs, {
+    const child = spawn(commandToExecute, [], {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
-      detached: !isWindows, // Use process groups on non-Windows for robust killing
+      // Use bash unless in Windows (since it doesn't support bash).
+      // For windows, just use the default.
+      shell: isWindows ? true : 'bash',
+      // Use process groups on non-Windows for robust killing.
+      // Windows process termination is handled by `taskkill /t`.
+      detached: !isWindows,
       env: {
         ...process.env,
         GEMINI_CLI: '1',


### PR DESCRIPTION
## TLDR

Use shell:true option in spawn() command when running in windows to fix arg parsing

## Dive Deeper

It makes more sense to rely on spawn's built in shell handling rather than trying to hand roll our own.

## Reviewer Test Plan

Boot up in windows and asked it to create a dir called "foo bar" and then delete it.


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | x  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #5176 