### PR TITLE
bug(core): fix `contentRangeTruncated` calculation.

### DIFF
--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -426,6 +426,29 @@ describe('fileUtils', () => {
       expect(result.linesShown).toEqual([6, 10]);
     });
 
+    it('should identify truncation when reading the end of a file', async () => {
+      const lines = Array.from({ length: 20 }, (_, i) => `Line ${i + 1}`);
+      actualNodeFs.writeFileSync(testTextFilePath, lines.join('\n'));
+
+      // Read from line 11 to 20. The start is not 0, so it's truncated.
+      const result = await processSingleFileContent(
+        testTextFilePath,
+        tempRootDir,
+        10,
+        10,
+      );
+      const expectedContent = lines.slice(10, 20).join('\n');
+
+      expect(result.llmContent).toContain(expectedContent);
+      expect(result.llmContent).toContain(
+        '[File content truncated: showing lines 11-20 of 20 total lines. Use offset/limit parameters to view more.]',
+      );
+      expect(result.returnDisplay).toBe('Read lines 11-20 of 20 from test.txt');
+      expect(result.isTruncated).toBe(true); // This is the key check for the bug
+      expect(result.originalLineCount).toBe(20);
+      expect(result.linesShown).toEqual([11, 20]);
+    });
+
     it('should handle limit exceeding file length', async () => {
       const lines = ['Line 1', 'Line 2'];
       actualNodeFs.writeFileSync(testTextFilePath, lines.join('\n'));

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -299,7 +299,8 @@ export async function processSingleFileContent(
           return line;
         });
 
-        const contentRangeTruncated = endLine < originalLineCount;
+        const contentRangeTruncated =
+          startLine > 0 || endLine < originalLineCount;
         const isTruncated = contentRangeTruncated || linesWereTruncatedInLength;
 
         let llmTextContent = '';


### PR DESCRIPTION
## TLDR

A minor bug fix, found while prototyping other fixes for #4948 .

## Dive Deeper

Handles a corner case in the truncation calculation.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | :heavy_check_mark:   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Another small fix somewhat related to #4948 