### PR TITLE
Add a setting to disable auth mode validation on startup

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -60,6 +60,7 @@ export interface Settings {
   theme?: string;
   customThemes?: Record<string, CustomTheme>;
   selectedAuthType?: AuthType;
+  disableAuthValidation?: boolean;
   sandbox?: boolean | string;
   coreTools?: string[];
   excludeTools?: string[];

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -60,7 +60,7 @@ export interface Settings {
   theme?: string;
   customThemes?: Record<string, CustomTheme>;
   selectedAuthType?: AuthType;
-  disableAuthValidation?: boolean;
+  useExternalAuth?: boolean;
   sandbox?: boolean | string;
   coreTools?: string[];
   excludeTools?: string[];

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -186,7 +186,10 @@ export async function main() {
       : [];
     const sandboxConfig = config.getSandbox();
     if (sandboxConfig) {
-      if (settings.merged.selectedAuthType && !settings.merged.disableAuthValidation) {
+      if (
+        settings.merged.selectedAuthType &&
+        !settings.merged.useExternalAuth
+      ) {
         // Validate authentication here because the sandbox will interfere with the Oauth2 web redirect.
         try {
           const err = validateAuthMethod(settings.merged.selectedAuthType);
@@ -344,6 +347,7 @@ async function loadNonInteractiveConfig(
 
   return await validateNonInteractiveAuth(
     settings.merged.selectedAuthType,
+    settings.merged.useExternalAuth,
     finalConfig,
   );
 }

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -186,7 +186,7 @@ export async function main() {
       : [];
     const sandboxConfig = config.getSandbox();
     if (sandboxConfig) {
-      if (settings.merged.selectedAuthType) {
+      if (settings.merged.selectedAuthType && !settings.merged.disableAuthValidation) {
         // Validate authentication here because the sandbox will interfere with the Oauth2 web redirect.
         try {
           const err = validateAuthMethod(settings.merged.selectedAuthType);

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -232,6 +232,10 @@ vi.mock('./utils/updateCheck.js', () => ({
   checkForUpdates: vi.fn(),
 }));
 
+vi.mock('./config/auth.js', () => ({
+  validateAuthMethod: vi.fn(),
+}));
+
 const mockedCheckForUpdates = vi.mocked(checkForUpdates);
 const { isGitRepository: mockedIsGitRepository } = vi.mocked(
   await import('@google/gemini-cli-core'),
@@ -1003,6 +1007,54 @@ describe('App UI', () => {
 
       // Total error count should be 1 + 3 + 1 = 5
       expect(lastFrame()).toContain('5 errors');
+    });
+  });
+
+  describe('auth validation', () => {
+    it('should call validateAuthMethod when useExternalAuth is false', async () => {
+      const auth = await import('../config/auth.js');
+      const validateAuthMethodSpy = vi.spyOn(auth, 'validateAuthMethod');
+      mockSettings = createMockSettings({
+        workspace: {
+          selectedAuthType: 'USE_GEMINI' as AuthType,
+          useExternalAuth: false,
+          theme: 'Default',
+        },
+      });
+
+      const { unmount } = render(
+        <App
+          config={mockConfig as unknown as ServerConfig}
+          settings={mockSettings}
+          version={mockVersion}
+        />,
+      );
+      currentUnmount = unmount;
+
+      expect(validateAuthMethodSpy).toHaveBeenCalledWith('USE_GEMINI');
+    });
+
+    it('should NOT call validateAuthMethod when useExternalAuth is true', async () => {
+      const auth = await import('../config/auth.js');
+      const validateAuthMethodSpy = vi.spyOn(auth, 'validateAuthMethod');
+      mockSettings = createMockSettings({
+        workspace: {
+          selectedAuthType: 'USE_GEMINI' as AuthType,
+          useExternalAuth: true,
+          theme: 'Default',
+        },
+      });
+
+      const { unmount } = render(
+        <App
+          config={mockConfig as unknown as ServerConfig}
+          settings={mockSettings}
+          version={mockVersion}
+        />,
+      );
+      currentUnmount = unmount;
+
+      expect(validateAuthMethodSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -26,6 +26,7 @@ import { Tips } from './components/Tips.js';
 import { checkForUpdates, UpdateObject } from './utils/updateCheck.js';
 import { EventEmitter } from 'events';
 import { updateEventEmitter } from '../utils/updateEventEmitter.js';
+import * as auth from '../config/auth.js';
 
 // Define a more complete mock server config based on actual Config
 interface MockServerConfig {
@@ -1012,7 +1013,6 @@ describe('App UI', () => {
 
   describe('auth validation', () => {
     it('should call validateAuthMethod when useExternalAuth is false', async () => {
-      const auth = await import('../config/auth.js');
       const validateAuthMethodSpy = vi.spyOn(auth, 'validateAuthMethod');
       mockSettings = createMockSettings({
         workspace: {
@@ -1035,7 +1035,6 @@ describe('App UI', () => {
     });
 
     it('should NOT call validateAuthMethod when useExternalAuth is true', async () => {
-      const auth = await import('../config/auth.js');
       const validateAuthMethodSpy = vi.spyOn(auth, 'validateAuthMethod');
       mockSettings = createMockSettings({
         workspace: {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -234,14 +234,19 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   } = useAuthCommand(settings, setAuthError, config);
 
   useEffect(() => {
-    if (settings.merged.selectedAuthType && !settings.merged.disableAuthValidation) {
+    if (settings.merged.selectedAuthType && !settings.merged.useExternalAuth) {
       const error = validateAuthMethod(settings.merged.selectedAuthType);
       if (error) {
         setAuthError(error);
         openAuthDialog();
       }
     }
-  }, [settings.merged.selectedAuthType, openAuthDialog, setAuthError]);
+  }, [
+    settings.merged.selectedAuthType,
+    settings.merged.useExternalAuth,
+    openAuthDialog,
+    setAuthError,
+  ]);
 
   // Sync user tier from config when authentication changes
   useEffect(() => {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -234,7 +234,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   } = useAuthCommand(settings, setAuthError, config);
 
   useEffect(() => {
-    if (settings.merged.selectedAuthType) {
+    if (settings.merged.selectedAuthType && !settings.merged.disableAuthValidation) {
       const error = validateAuthMethod(settings.merged.selectedAuthType);
       if (error) {
         setAuthError(error);

--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -10,6 +10,7 @@ import {
   NonInteractiveConfig,
 } from './validateNonInterActiveAuth.js';
 import { AuthType } from '@google/gemini-cli-core';
+import * as auth from './config/auth.js';
 
 describe('validateNonInterActiveAuth', () => {
   let originalEnvGeminiApiKey: string | undefined;
@@ -194,8 +195,7 @@ describe('validateNonInterActiveAuth', () => {
 
   it('exits if validateAuthMethod returns error', async () => {
     // Mock validateAuthMethod to return error
-    const mod = await import('./config/auth.js');
-    vi.spyOn(mod, 'validateAuthMethod').mockReturnValue('Auth error!');
+    vi.spyOn(auth, 'validateAuthMethod').mockReturnValue('Auth error!');
     const nonInteractiveConfig: NonInteractiveConfig = {
       refreshAuth: refreshAuthMock,
     };
@@ -215,9 +215,8 @@ describe('validateNonInterActiveAuth', () => {
 
   it('skips validation if useExternalAuth is true', async () => {
     // Mock validateAuthMethod to return error to ensure it's not being called
-    const mod = await import('./config/auth.js');
     const validateAuthMethodSpy = vi
-      .spyOn(mod, 'validateAuthMethod')
+      .spyOn(auth, 'validateAuthMethod')
       .mockReturnValue('Auth error!');
     const nonInteractiveConfig: NonInteractiveConfig = {
       refreshAuth: refreshAuthMock,

--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -59,7 +59,11 @@ describe('validateNonInterActiveAuth', () => {
       refreshAuth: refreshAuthMock,
     };
     try {
-      await validateNonInteractiveAuth(undefined, nonInteractiveConfig);
+      await validateNonInteractiveAuth(
+        undefined,
+        undefined,
+        nonInteractiveConfig,
+      );
       expect.fail('Should have exited');
     } catch (e) {
       expect((e as Error).message).toContain('process.exit(1) called');
@@ -75,7 +79,11 @@ describe('validateNonInterActiveAuth', () => {
     const nonInteractiveConfig: NonInteractiveConfig = {
       refreshAuth: refreshAuthMock,
     };
-    await validateNonInteractiveAuth(undefined, nonInteractiveConfig);
+    await validateNonInteractiveAuth(
+      undefined,
+      undefined,
+      nonInteractiveConfig,
+    );
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.LOGIN_WITH_GOOGLE);
   });
 
@@ -84,7 +92,11 @@ describe('validateNonInterActiveAuth', () => {
     const nonInteractiveConfig: NonInteractiveConfig = {
       refreshAuth: refreshAuthMock,
     };
-    await validateNonInteractiveAuth(undefined, nonInteractiveConfig);
+    await validateNonInteractiveAuth(
+      undefined,
+      undefined,
+      nonInteractiveConfig,
+    );
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_GEMINI);
   });
 
@@ -95,7 +107,11 @@ describe('validateNonInterActiveAuth', () => {
     const nonInteractiveConfig: NonInteractiveConfig = {
       refreshAuth: refreshAuthMock,
     };
-    await validateNonInteractiveAuth(undefined, nonInteractiveConfig);
+    await validateNonInteractiveAuth(
+      undefined,
+      undefined,
+      nonInteractiveConfig,
+    );
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_VERTEX_AI);
   });
 
@@ -105,7 +121,11 @@ describe('validateNonInterActiveAuth', () => {
     const nonInteractiveConfig: NonInteractiveConfig = {
       refreshAuth: refreshAuthMock,
     };
-    await validateNonInteractiveAuth(undefined, nonInteractiveConfig);
+    await validateNonInteractiveAuth(
+      undefined,
+      undefined,
+      nonInteractiveConfig,
+    );
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_VERTEX_AI);
   });
 
@@ -118,7 +138,11 @@ describe('validateNonInterActiveAuth', () => {
     const nonInteractiveConfig: NonInteractiveConfig = {
       refreshAuth: refreshAuthMock,
     };
-    await validateNonInteractiveAuth(undefined, nonInteractiveConfig);
+    await validateNonInteractiveAuth(
+      undefined,
+      undefined,
+      nonInteractiveConfig,
+    );
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.LOGIN_WITH_GOOGLE);
   });
 
@@ -130,7 +154,11 @@ describe('validateNonInterActiveAuth', () => {
     const nonInteractiveConfig: NonInteractiveConfig = {
       refreshAuth: refreshAuthMock,
     };
-    await validateNonInteractiveAuth(undefined, nonInteractiveConfig);
+    await validateNonInteractiveAuth(
+      undefined,
+      undefined,
+      nonInteractiveConfig,
+    );
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_VERTEX_AI);
   });
 
@@ -142,7 +170,11 @@ describe('validateNonInterActiveAuth', () => {
     const nonInteractiveConfig: NonInteractiveConfig = {
       refreshAuth: refreshAuthMock,
     };
-    await validateNonInteractiveAuth(undefined, nonInteractiveConfig);
+    await validateNonInteractiveAuth(
+      undefined,
+      undefined,
+      nonInteractiveConfig,
+    );
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_GEMINI);
   });
 
@@ -152,7 +184,11 @@ describe('validateNonInterActiveAuth', () => {
     const nonInteractiveConfig: NonInteractiveConfig = {
       refreshAuth: refreshAuthMock,
     };
-    await validateNonInteractiveAuth(AuthType.USE_GEMINI, nonInteractiveConfig);
+    await validateNonInteractiveAuth(
+      AuthType.USE_GEMINI,
+      undefined,
+      nonInteractiveConfig,
+    );
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_GEMINI);
   });
 
@@ -166,6 +202,7 @@ describe('validateNonInterActiveAuth', () => {
     try {
       await validateNonInteractiveAuth(
         AuthType.USE_GEMINI,
+        undefined,
         nonInteractiveConfig,
       );
       expect.fail('Should have exited');

--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -212,4 +212,29 @@ describe('validateNonInterActiveAuth', () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith('Auth error!');
     expect(processExitSpy).toHaveBeenCalledWith(1);
   });
+
+  it('skips validation if useExternalAuth is true', async () => {
+    // Mock validateAuthMethod to return error to ensure it's not being called
+    const mod = await import('./config/auth.js');
+    const validateAuthMethodSpy = vi
+      .spyOn(mod, 'validateAuthMethod')
+      .mockReturnValue('Auth error!');
+    const nonInteractiveConfig: NonInteractiveConfig = {
+      refreshAuth: refreshAuthMock,
+    };
+
+    // Even with an invalid auth type, it should not exit
+    // because validation is skipped.
+    await validateNonInteractiveAuth(
+      'invalid-auth-type' as AuthType,
+      true, // useExternalAuth = true
+      nonInteractiveConfig,
+    );
+
+    expect(validateAuthMethodSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(processExitSpy).not.toHaveBeenCalled();
+    // We still expect refreshAuth to be called with the (invalid) type
+    expect(refreshAuthMock).toHaveBeenCalledWith('invalid-auth-type');
+  });
 });

--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -23,6 +23,7 @@ function getAuthTypeFromEnv(): AuthType | undefined {
 
 export async function validateNonInteractiveAuth(
   configuredAuthType: AuthType | undefined,
+  useExternalAuth: boolean | undefined,
   nonInteractiveConfig: Config,
 ) {
   const effectiveAuthType = configuredAuthType || getAuthTypeFromEnv();
@@ -34,10 +35,12 @@ export async function validateNonInteractiveAuth(
     process.exit(1);
   }
 
-  const err = validateAuthMethod(effectiveAuthType);
-  if (err != null) {
-    console.error(err);
-    process.exit(1);
+  if (!useExternalAuth) {
+    const err = validateAuthMethod(effectiveAuthType);
+    if (err != null) {
+      console.error(err);
+      process.exit(1);
+    }
   }
 
   await nonInteractiveConfig.refreshAuth(effectiveAuthType);


### PR DESCRIPTION
## TLDR

Add a setting to disable auth mode validation on app startup

## Dive Deeper

Each of the auth modes (Gemini API, Login with Google) have a complex set of environment variables they support to set up the right quota/credentials/access for the APIs they use. This change adds a setting to disable auth validation on startup: we let the app start up in GEMINI_API mode even if no API key environment variable is set. This allows for using or scripting the CLI in tests where there are no API calls needed, test harnesses where the key is passed externally, or use in scenarios where the auth credentials are passed via a separate channel.

## Linked issues / bugs

Fixes #5357