### PR TITLE
feat: fix loading extension commands

### DIFF
--- a/integration-tests/extension-commands.test.js
+++ b/integration-tests/extension-commands.test.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test, describe } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { TestRig } from './test-helper.js';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('extension-commands', () => {
+  test('should run extension command', (t) => {
+    const rig = new TestRig();
+    rig.setup(t.name);
+
+    const extensionDir = path.join(
+      rig.testDir,
+      '.gemini',
+      'extensions',
+      'my-extension',
+    );
+    const commandsDir = path.join(extensionDir, 'commands');
+    fs.mkdirSync(commandsDir, { recursive: true });
+
+    const extensionConfig = {
+      name: 'my-extension',
+      version: '1.0.0',
+    };
+    fs.writeFileSync(
+      path.join(extensionDir, 'gemini-extension.json'),
+      JSON.stringify(extensionConfig),
+    );
+
+    const command = `
+name = "hello"
+prompt = "echo hello from extension"
+`;
+    fs.writeFileSync(path.join(commandsDir, 'hello.toml'), command);
+
+    const output = rig.run('/hello');
+    assert.ok(output.includes('hello from extension'));
+  });
+});

--- a/packages/cli/src/services/ExtensionCommandLoader.test.ts
+++ b/packages/cli/src/services/ExtensionCommandLoader.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ExtensionCommandLoader } from './ExtensionCommandLoader.js';
+import { Extension } from '../config/extension.js';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { glob } from 'glob';
+
+vi.mock('fs/promises');
+vi.mock('glob');
+
+describe('ExtensionCommandLoader', () => {
+  const mockExtensions: Extension[] = [
+    {
+      path: '/path/to/extension1',
+      config: { name: 'extension1', version: '1.0.0' },
+      contextFiles: [],
+    },
+  ];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should load commands from .toml files', async () => {
+    const loader = new ExtensionCommandLoader(mockExtensions);
+    const signal = new AbortController().signal;
+
+    vi.spyOn(fs, 'access').mockResolvedValue(undefined);
+    (glob as vi.Mock).mockResolvedValue(['command1.toml']);
+    vi.spyOn(fs, 'readFile').mockResolvedValue(
+      'name = "test"\nprompt = "test prompt"',
+    );
+
+    const commands = await loader.loadCommands(signal);
+    const action = await commands[0].action({} as never);
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0].name).toBe('test');
+    expect(action.type).toBe('submit_prompt');
+    expect(action.content).toBe('test prompt');
+    expect(commands[0].extensionName).toBe('extension1');
+  });
+});

--- a/packages/cli/src/services/ExtensionCommandLoader.ts
+++ b/packages/cli/src/services/ExtensionCommandLoader.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ICommandLoader } from './types.js';
+import { CommandKind, SlashCommand } from '../ui/commands/types.js';
+import { Extension } from '../config/extension.js';
+import * as path from 'path';
+import toml from '@iarna/toml';
+import { promises as fs } from 'fs';
+import { glob } from 'glob';
+
+interface TomlCommand {
+  name?: unknown;
+  prompt?: unknown;
+  description?: unknown;
+}
+
+export class ExtensionCommandLoader implements ICommandLoader {
+  constructor(private readonly extensions: Extension[]) {}
+
+  async loadCommands(signal: AbortSignal): Promise<SlashCommand[]> {
+    const commands: SlashCommand[] = [];
+    for (const extension of this.extensions) {
+      if (signal.aborted) {
+        return commands;
+      }
+      const commandsDir = path.join(extension.path, 'commands');
+      try {
+        await fs.access(commandsDir);
+
+        const files = await glob('**/*.toml', {
+          cwd: commandsDir,
+          nodir: true,
+          dot: true,
+          signal,
+          follow: true,
+        });
+
+        for (const file of files) {
+          if (signal.aborted) {
+            return commands;
+          }
+          const fullPath = path.join(commandsDir, file);
+          try {
+            const content = await fs.readFile(fullPath, 'utf-8');
+            const parsed = toml.parse(content) as TomlCommand;
+
+            if (
+              typeof parsed.name === 'string' &&
+              parsed.name.trim() !== '' &&
+              typeof parsed.prompt === 'string'
+            ) {
+              commands.push({
+                name: parsed.name,
+                description:
+                  typeof parsed.description === 'string'
+                    ? parsed.description
+                    : '',
+                kind: CommandKind.FILE, // Treat extension commands like file commands
+                extensionName: extension.config.name,
+                action: async () => ({
+                  type: 'submit_prompt',
+                  content: parsed.prompt as string,
+                }),
+              });
+            }
+          } catch (e) {
+            // Also log the file that failed to load for better debugging.
+            console.warn(`Failed to load command from ${fullPath}: ${e}`);
+          }
+        }
+      } catch (e) {
+        console.warn(`Failed to load extensions commands: ${e}`);
+        continue;
+      }
+    }
+    return commands;
+  }
+}

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -28,6 +28,7 @@ vi.mock('node:process', () => {
   const mockProcess = {
     exit: mockProcessExit,
     platform: 'test-platform',
+    cwd: vi.fn(() => '/mock/cwd'),
   };
   return {
     ...mockProcess,

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -31,6 +31,8 @@ import { CommandService } from '../../services/CommandService.js';
 import { BuiltinCommandLoader } from '../../services/BuiltinCommandLoader.js';
 import { FileCommandLoader } from '../../services/FileCommandLoader.js';
 import { McpPromptLoader } from '../../services/McpPromptLoader.js';
+import { ExtensionCommandLoader } from '../../services/ExtensionCommandLoader.js';
+import { loadExtensions } from '../../config/extension.js';
 
 /**
  * Hook to define and process slash commands (e.g., /help, /clear).
@@ -190,10 +192,12 @@ export const useSlashCommandProcessor = (
   useEffect(() => {
     const controller = new AbortController();
     const load = async () => {
+      const extensions = loadExtensions(process.cwd());
       const loaders = [
         new McpPromptLoader(config),
         new BuiltinCommandLoader(config),
         new FileCommandLoader(config),
+        new ExtensionCommandLoader(extensions),
       ];
       const commandService = await CommandService.create(
         loaders,


### PR DESCRIPTION
- Introduce ExtensionCommandLoader to load slash commands from .toml files in extensions
- Add integration test for extension command execution
- Update slashCommandProcessor to include ExtensionCommandLoader
- Load extensions from current working directory
- Add unit tests for ExtensionCommandLoader

fixes #5279