### PR TITLE
feat(core): Add side-effect metadata to tools for safer execution

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -31,9 +31,6 @@ import { getCliVersion } from './utils/version.js';
 import {
   ApprovalMode,
   Config,
-  EditTool,
-  ShellTool,
-  WriteFileTool,
   sessionId,
   logUserPrompt,
   AuthType,
@@ -335,7 +332,7 @@ function setWindowTitle(title: string, settings: LoadedSettings) {
   }
 }
 
-async function loadNonInteractiveConfig(
+export async function loadNonInteractiveConfig(
   config: Config,
   extensions: Extension[],
   settings: LoadedSettings,
@@ -345,11 +342,11 @@ async function loadNonInteractiveConfig(
   if (config.getApprovalMode() !== ApprovalMode.YOLO) {
     // Everything is not allowed, ensure that only read-only tools are configured.
     const existingExcludeTools = settings.merged.excludeTools || [];
-    const interactiveTools = [
-      ShellTool.Name,
-      EditTool.Name,
-      WriteFileTool.Name,
-    ];
+    const toolRegistry = await config.getToolRegistry();
+    const interactiveTools = toolRegistry
+      .getAllTools()
+      .filter((tool) => tool.hasSideEffects)
+      .map((tool) => tool.name);
 
     const newExcludeTools = [
       ...new Set([...existingExcludeTools, ...interactiveTools]),

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -31,7 +31,13 @@ class MockTool extends BaseTool<Record<string, unknown>, ToolResult> {
   executeFn = vi.fn();
 
   constructor(name = 'mockTool') {
-    super(name, name, 'A mock tool', Icon.Hammer, {});
+    super({
+      name,
+      displayName: name,
+      description: 'A mock tool',
+      icon: Icon.Hammer,
+      parameterSchema: {},
+    });
   }
 
   async shouldConfirmExecute(
@@ -415,13 +421,13 @@ describe('CoreToolScheduler edit cancellation', () => {
   it('should preserve diff when an edit is cancelled', async () => {
     class MockEditTool extends BaseTool<Record<string, unknown>, ToolResult> {
       constructor() {
-        super(
-          'mockEditTool',
-          'mockEditTool',
-          'A mock edit tool',
-          Icon.Pencil,
-          {},
-        );
+        super({
+          name: 'mockEditTool',
+          displayName: 'mockEditTool',
+          description: 'A mock edit tool',
+          icon: Icon.Pencil,
+          parameterSchema: {},
+        });
       }
 
       async shouldConfirmExecute(

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -50,6 +50,7 @@ describe('executeToolCall', () => {
       shouldConfirmExecute: vi.fn(() =>
         Promise.resolve(false as false | ToolCallConfirmationDetails),
       ),
+      hasSideEffects: false,
       isOutputMarkdown: false,
       canUpdateOutput: false,
       getDescription: vi.fn(),

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -77,10 +77,10 @@ export class EditTool
   static readonly Name = 'replace';
 
   constructor(private readonly config: Config) {
-    super(
-      EditTool.Name,
-      'Edit',
-      `Replaces text within a file. By default, replaces a single occurrence, but can replace multiple occurrences when \`expected_replacements\` is specified. This tool requires providing significant context around the change to ensure precise targeting. Always use the ${ReadFileTool.Name} tool to examine the file's current content before attempting a text replacement.
+    super({
+      name: EditTool.Name,
+      displayName: 'Edit',
+      description: `Replaces text within a file. By default, replaces a single occurrence, but can replace multiple occurrences when \`expected_replacements\` is specified. This tool requires providing significant context around the change to ensure precise targeting. Always use the ${ReadFileTool.Name} tool to examine the file's current content before attempting a text replacement.
 
       The user has the ability to modify the \`new_string\` content. If modified, this will be stated in the response.
 
@@ -91,8 +91,8 @@ Expectation for required parameters:
 4. NEVER escape \`old_string\` or \`new_string\`, that would break the exact literal text requirement.
 **Important:** If ANY of the above are not satisfied, the tool will fail. CRITICAL for \`old_string\`: Must uniquely identify the single instance to change. Include at least 3 lines of context BEFORE and AFTER the target text, matching whitespace and indentation precisely. If this string matches multiple locations, or does not match exactly, the tool will fail.
 **Multiple replacements:** Set \`expected_replacements\` to the number of occurrences you want to replace. The tool will replace ALL occurrences that match \`old_string\` exactly. Ensure the number of replacements matches your expectation.`,
-      Icon.Pencil,
-      {
+      icon: Icon.Pencil,
+      parameterSchema: {
         properties: {
           file_path: {
             description:
@@ -119,7 +119,7 @@ Expectation for required parameters:
         required: ['file_path', 'old_string', 'new_string'],
         type: Type.OBJECT,
       },
-    );
+    });
   }
 
   /**

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -112,6 +112,7 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
         required: ['pattern'],
         type: Type.OBJECT,
       },
+      false,
     );
   }
 

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -81,12 +81,13 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
   static readonly Name = 'glob';
 
   constructor(private config: Config) {
-    super(
-      GlobTool.Name,
-      'FindFiles',
-      'Efficiently finds files matching specific glob patterns (e.g., `src/**/*.ts`, `**/*.md`), returning absolute paths sorted by modification time (newest first). Ideal for quickly locating files based on their name or path structure, especially in large codebases.',
-      Icon.FileSearch,
-      {
+    super({
+      name: GlobTool.Name,
+      displayName: 'FindFiles',
+      description:
+        'Efficiently finds files matching specific glob patterns (e.g., `src/**/*.ts`, `**/*.md`), returning absolute paths sorted by modification time (newest first). Ideal for quickly locating files based on their name or path structure, especially in large codebases.',
+      icon: Icon.FileSearch,
+      parameterSchema: {
         properties: {
           pattern: {
             description:
@@ -112,8 +113,8 @@ export class GlobTool extends BaseTool<GlobToolParams, ToolResult> {
         required: ['pattern'],
         type: Type.OBJECT,
       },
-      false,
-    );
+      hasSideEffects: false,
+    });
   }
 
   /**

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -58,12 +58,13 @@ export class GrepTool extends BaseTool<GrepToolParams, ToolResult> {
   static readonly Name = 'search_file_content'; // Keep static name
 
   constructor(private readonly config: Config) {
-    super(
-      GrepTool.Name,
-      'SearchText',
-      'Searches for a regular expression pattern within the content of files in a specified directory (or current working directory). Can filter files by a glob pattern. Returns the lines containing matches, along with their file paths and line numbers.',
-      Icon.Regex,
-      {
+    super({
+      name: GrepTool.Name,
+      displayName: 'SearchText',
+      description:
+        'Searches for a regular expression pattern within the content of files in a specified directory (or current working directory). Can filter files by a glob pattern. Returns the lines containing matches, along with their file paths and line numbers.',
+      icon: Icon.Regex,
+      parameterSchema: {
         properties: {
           pattern: {
             description:
@@ -84,8 +85,8 @@ export class GrepTool extends BaseTool<GrepToolParams, ToolResult> {
         required: ['pattern'],
         type: Type.OBJECT,
       },
-      false,
-    );
+      hasSideEffects: false,
+    });
   }
 
   // --- Validation Methods ---

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -84,6 +84,7 @@ export class GrepTool extends BaseTool<GrepToolParams, ToolResult> {
         required: ['pattern'],
         type: Type.OBJECT,
       },
+      false,
     );
   }
 

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -72,12 +72,13 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
   static readonly Name = 'list_directory';
 
   constructor(private config: Config) {
-    super(
-      LSTool.Name,
-      'ReadFolder',
-      'Lists the names of files and subdirectories directly within a specified directory path. Can optionally ignore entries matching provided glob patterns.',
-      Icon.Folder,
-      {
+    super({
+      name: LSTool.Name,
+      displayName: 'ReadFolder',
+      description:
+        'Lists the names of files and subdirectories directly within a specified directory path. Can optionally ignore entries matching provided glob patterns.',
+      icon: Icon.Folder,
+      parameterSchema: {
         properties: {
           path: {
             description:
@@ -112,8 +113,8 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
         required: ['path'],
         type: Type.OBJECT,
       },
-      false,
-    );
+      hasSideEffects: false,
+    });
   }
 
   /**

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -112,6 +112,7 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
         required: ['path'],
         type: Type.OBJECT,
       },
+      false,
     );
   }
 

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -35,15 +35,15 @@ export class DiscoveredMCPTool extends BaseTool<ToolParams, ToolResult> {
     readonly trust?: boolean,
     nameOverride?: string,
   ) {
-    super(
-      nameOverride ?? generateValidName(serverToolName),
-      `${serverToolName} (${serverName} MCP Server)`,
+    super({
+      name: nameOverride ?? generateValidName(serverToolName),
+      displayName: `${serverToolName} (${serverName} MCP Server)`,
       description,
-      Icon.Hammer,
-      { type: Type.OBJECT }, // this is a dummy Schema for MCP, will be not be used to construct the FunctionDeclaration
-      true, // isOutputMarkdown
-      false, // canUpdateOutput
-    );
+      icon: Icon.Hammer,
+      parameterSchema: { type: Type.OBJECT }, // this is a dummy Schema for MCP, will be not be used to construct the FunctionDeclaration
+      hasSideEffects: true,
+      isOutputMarkdown: false,
+    });
   }
 
   asFullyQualifiedTool(): DiscoveredMCPTool {

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -42,7 +42,8 @@ export class DiscoveredMCPTool extends BaseTool<ToolParams, ToolResult> {
       icon: Icon.Hammer,
       parameterSchema: { type: Type.OBJECT }, // this is a dummy Schema for MCP, will be not be used to construct the FunctionDeclaration
       hasSideEffects: true,
-      isOutputMarkdown: false,
+      isOutputMarkdown: true,
+      canUpdateOutput: false,
     });
   }
 

--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -118,13 +118,16 @@ export class MemoryTool
 
   static readonly Name: string = memoryToolSchemaData.name!;
   constructor() {
-    super(
-      MemoryTool.Name,
-      'Save Memory',
-      memoryToolDescription,
-      Icon.LightBulb,
-      memoryToolSchemaData.parameters as Record<string, unknown>,
-    );
+    super({
+      name: MemoryTool.Name,
+      displayName: 'Save Memory',
+      description: memoryToolDescription,
+      icon: Icon.LightBulb,
+      parameterSchema: memoryToolSchemaData.parameters as Record<
+        string,
+        unknown
+      >,
+    });
   }
 
   getDescription(_params: SaveMemoryParams): string {

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -72,6 +72,7 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
         required: ['absolute_path'],
         type: Type.OBJECT,
       },
+      false,
     );
   }
 

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -46,12 +46,13 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
   static readonly Name: string = 'read_file';
 
   constructor(private config: Config) {
-    super(
-      ReadFileTool.Name,
-      'ReadFile',
-      'Reads and returns the content of a specified file from the local filesystem. Handles text, images (PNG, JPG, GIF, WEBP, SVG, BMP), and PDF files. For text files, it can read specific line ranges.',
-      Icon.FileSearch,
-      {
+    super({
+      name: ReadFileTool.Name,
+      displayName: 'ReadFile',
+      description:
+        'Reads and returns the content of a specified file from the local filesystem. Handles text, images (PNG, JPG, GIF, WEBP, SVG, BMP), and PDF files. For text files, it can read specific line ranges.',
+      icon: Icon.FileSearch,
+      parameterSchema: {
         properties: {
           absolute_path: {
             description:
@@ -72,8 +73,8 @@ export class ReadFileTool extends BaseTool<ReadFileToolParams, ToolResult> {
         required: ['absolute_path'],
         type: Type.OBJECT,
       },
-      false,
-    );
+      hasSideEffects: false,
+    });
   }
 
   validateToolParams(params: ReadFileToolParams): string | null {

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -195,10 +195,10 @@ export class ReadManyFilesTool extends BaseTool<
       required: ['paths'],
     };
 
-    super(
-      ReadManyFilesTool.Name,
-      'ReadManyFiles',
-      `Reads content from multiple files specified by paths or glob patterns within a configured target directory. For text files, it concatenates their content into a single string. It is primarily designed for text-based files. However, it can also process image (e.g., .png, .jpg) and PDF (.pdf) files if their file names or extensions are explicitly included in the 'paths' argument. For these explicitly requested non-text files, their data is read and included in a format suitable for model consumption (e.g., base64 encoded).
+    super({
+      name: ReadManyFilesTool.Name,
+      displayName: 'ReadManyFiles',
+      description: `Reads content from multiple files specified by paths or glob patterns within a configured target directory. For text files, it concatenates their content into a single string. It is primarily designed for text-based files. However, it can also process image (e.g., .png, .jpg) and PDF (.pdf) files if their file names or extensions are explicitly included in the 'paths' argument. For these explicitly requested non-text files, their data is read and included in a format suitable for model consumption (e.g., base64 encoded).
 
 This tool is useful when you need to understand or analyze a collection of files, such as:
 - Getting an overview of a codebase or parts of it (e.g., all TypeScript files in the 'src' directory).
@@ -208,10 +208,10 @@ This tool is useful when you need to understand or analyze a collection of files
 - When the user asks to "read all files in X directory" or "show me the content of all Y files".
 
 Use this tool when the user's query implies needing the content of several files simultaneously for context, analysis, or summarization. For text files, it uses default UTF-8 encoding and a '--- {filePath} ---' separator between file contents. Ensure paths are relative to the target directory. Glob patterns like 'src/**/*.js' are supported. Avoid using for single files if a more specific single-file reading tool is available, unless the user specifically requests to process a list containing just one file via this tool. Other binary files (not explicitly requested as image/PDF) are generally skipped. Default excludes apply to common non-text files (except for explicitly requested images/PDFs) and large dependency directories unless 'useDefaultExcludes' is false.`,
-      Icon.FileSearch,
+      icon: Icon.FileSearch,
       parameterSchema,
-      false,
-    );
+      hasSideEffects: false,
+    });
   }
 
   validateParams(params: ReadManyFilesParams): string | null {

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -210,6 +210,7 @@ This tool is useful when you need to understand or analyze a collection of files
 Use this tool when the user's query implies needing the content of several files simultaneously for context, analysis, or summarization. For text files, it uses default UTF-8 encoding and a '--- {filePath} ---' separator between file contents. Ensure paths are relative to the target directory. Glob patterns like 'src/**/*.js' are supported. Avoid using for single files if a more specific single-file reading tool is available, unless the user specifically requests to process a list containing just one file via this tool. Other binary files (not explicitly requested as image/PDF) are generally skipped. Default excludes apply to common non-text files (except for explicitly requested images/PDFs) and large dependency directories unless 'useDefaultExcludes' is false.`,
       Icon.FileSearch,
       parameterSchema,
+      false,
     );
   }
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -45,10 +45,10 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
   private allowlist: Set<string> = new Set();
 
   constructor(private readonly config: Config) {
-    super(
-      ShellTool.Name,
-      'Shell',
-      `This tool executes a given shell command as \`bash -c <command>\`. Command can start background processes using \`&\`. Command is executed as a subprocess that leads its own process group. Command process group can be terminated as \`kill -- -PGID\` or signaled as \`kill -s SIGNAL -- -PGID\`.
+    super({
+      name: ShellTool.Name,
+      displayName: 'Shell',
+      description: `This tool executes a given shell command as \`bash -c <command>\`. Command can start background processes using \`&\`. Command is executed as a subprocess that leads its own process group. Command process group can be terminated as \`kill -- -PGID\` or signaled as \`kill -s SIGNAL -- -PGID\`.
 
       The following information is returned:
 
@@ -60,9 +60,9 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
       Exit Code: Exit code or \`(none)\` if terminated by signal.
       Signal: Signal number or \`(none)\` if no signal was received.
       Background PIDs: List of background processes started or \`(none)\`.
-      Process Group PGID: Process group started or \`(none)\``,
-      Icon.Terminal,
-      {
+      Process Group PGID: Process group started or \`(none)\`:`,
+      icon: Icon.Terminal,
+      parameterSchema: {
         type: Type.OBJECT,
         properties: {
           command: {
@@ -82,10 +82,10 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
         },
         required: ['command'],
       },
-      false, // output is not markdown
-      true, // output can be updated
-      true, // has side effects
-    );
+      isOutputMarkdown: false,
+      canUpdateOutput: true,
+      hasSideEffects: true,
+    });
   }
 
   getDescription(params: ShellToolParams): string {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -84,6 +84,7 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
       },
       false, // output is not markdown
       true, // output can be updated
+      true, // has side effects
     );
   }
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -82,9 +82,9 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
         },
         required: ['command'],
       },
+      true, // has side effects
       false, // output is not markdown
       true, // output can be updated
-      true, // has side effects
     );
   }
 

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -113,12 +113,18 @@ class MockTool extends BaseTool<{ param: string }, ToolResult> {
     displayName = 'A mock tool',
     description = 'A mock tool description',
   ) {
-    super(name, displayName, description, Icon.Hammer, {
-      type: Type.OBJECT,
-      properties: {
-        param: { type: Type.STRING },
+    super({
+      name,
+      displayName,
+      description,
+      icon: Icon.Hammer,
+      parameterSchema: {
+        type: Type.OBJECT,
+        properties: {
+          param: { type: Type.STRING },
+        },
+        required: ['param'],
       },
-      required: ['param'],
     });
   }
   async execute(params: { param: string }): Promise<ToolResult> {

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -20,7 +20,7 @@ export class DiscoveredTool extends BaseTool<ToolParams, ToolResult> {
     private readonly config: Config,
     name: string,
     readonly description: string,
-    readonly parameterSchema: Record<string, unknown>,
+    readonly parameterSchema: Schema,
   ) {
     const discoveryCmd = config.getToolDiscoveryCommand()!;
     const callCommand = config.getToolCallCommand()!;
@@ -45,7 +45,7 @@ Signal: Signal number or \`(none)\` if no signal was received.
       displayName: name,
       description,
       icon: Icon.Hammer,
-      parameterSchema: parameterSchema as Schema,
+      parameterSchema,
       hasSideEffects: true,
       isOutputMarkdown: false,
       canUpdateOutput: false,
@@ -336,7 +336,7 @@ export class ToolRegistry {
             this.config,
             func.name,
             func.description ?? '',
-            parameters as Record<string, unknown>,
+            parameters,
           ),
         );
       }

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -40,15 +40,16 @@ Error: Error or \`(none)\` if no error was reported for the subprocess.
 Exit Code: Exit code or \`(none)\` if terminated by signal.
 Signal: Signal number or \`(none)\` if no signal was received.
 `;
-    super(
+    super({
       name,
-      name,
+      displayName: name,
       description,
-      Icon.Hammer,
-      parameterSchema,
-      false, // isOutputMarkdown
-      false, // canUpdateOutput
-    );
+      icon: Icon.Hammer,
+      parameterSchema: parameterSchema as Schema,
+      hasSideEffects: true,
+      isOutputMarkdown: false,
+      canUpdateOutput: false,
+    });
   }
 
   async execute(params: ToolParams): Promise<ToolResult> {

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -100,6 +100,41 @@ export interface Tool<
   ): Promise<TResult>;
 }
 
+export interface ToolOptions {
+  /**
+   * Internal name of the tool (used for API calls)
+   */
+  name: string;
+  /**
+   * User-friendly display name of the tool
+   */
+  displayName: string;
+  /**
+   * Description of what the tool does
+   */
+  description: string;
+  /**
+   * The icon to display when interacting via ACP
+   */
+  icon: Icon;
+  /**
+   * Open API 3.0 Schema defining the parameters
+   */
+  parameterSchema: Schema;
+  /**
+   * Whether the tool has side effects. Defaults to true.
+   */
+  hasSideEffects?: boolean;
+  /**
+   * Whether the tool's output should be rendered as markdown
+   */
+  isOutputMarkdown?: boolean;
+  /**
+   * Whether the tool supports live (streaming) output
+   */
+  canUpdateOutput?: boolean;
+}
+
 /**
  * Base implementation for tools with common functionality
  */
@@ -108,27 +143,29 @@ export abstract class BaseTool<
   TResult extends ToolResult = ToolResult,
 > implements Tool<TParams, TResult>
 {
+  readonly name: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly icon: Icon;
+  readonly parameterSchema: Schema;
+  readonly hasSideEffects: boolean;
+  readonly isOutputMarkdown: boolean;
+  readonly canUpdateOutput: boolean;
+
   /**
    * Creates a new instance of BaseTool
-   * @param name Internal name of the tool (used for API calls)
-   * @param displayName User-friendly display name of the tool
-   * @param description Description of what the tool does
-   * @param icon The icon to display when interacting via ACP
-   * @param parameterSchema Open API 3.0 Schema defining the parameters
-   * @param hasSideEffects Whether the tool has side effects. Defaults to true.
-   * @param isOutputMarkdown Whether the tool's output should be rendered as markdown
-   * @param canUpdateOutput Whether the tool supports live (streaming) output
+   * @param options The options for creating the tool
    */
-  constructor(
-    readonly name: string,
-    readonly displayName: string,
-    readonly description: string,
-    readonly icon: Icon,
-    readonly parameterSchema: Schema,
-    readonly hasSideEffects: boolean = true,
-    readonly isOutputMarkdown: boolean = true,
-    readonly canUpdateOutput: boolean = false,
-  ) {}
+  constructor(options: ToolOptions) {
+    this.name = options.name;
+    this.displayName = options.displayName;
+    this.description = options.description;
+    this.icon = options.icon;
+    this.parameterSchema = options.parameterSchema;
+    this.hasSideEffects = options.hasSideEffects ?? true;
+    this.isOutputMarkdown = options.isOutputMarkdown ?? true;
+    this.canUpdateOutput = options.canUpdateOutput ?? false;
+  }
 
   /**
    * Function declaration schema computed from name, description, and parameterSchema

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -50,6 +50,11 @@ export interface Tool<
   canUpdateOutput: boolean;
 
   /**
+   * Whether the tool has side effects
+   */
+  hasSideEffects: boolean;
+
+  /**
    * Validates the parameters for the tool
    * Should be called from both `shouldConfirmExecute` and `execute`
    * `shouldConfirmExecute` should return false immediately if invalid
@@ -108,9 +113,11 @@ export abstract class BaseTool<
    * @param name Internal name of the tool (used for API calls)
    * @param displayName User-friendly display name of the tool
    * @param description Description of what the tool does
+   * @param icon The icon to display when interacting via ACP
+   * @param parameterSchema Open API 3.0 Schema defining the parameters
+   * @param hasSideEffects Whether the tool has side effects. Defaults to true.
    * @param isOutputMarkdown Whether the tool's output should be rendered as markdown
    * @param canUpdateOutput Whether the tool supports live (streaming) output
-   * @param parameterSchema Open API 3.0 Schema defining the parameters
    */
   constructor(
     readonly name: string,
@@ -118,6 +125,7 @@ export abstract class BaseTool<
     readonly description: string,
     readonly icon: Icon,
     readonly parameterSchema: Schema,
+    readonly hasSideEffects: boolean = true,
     readonly isOutputMarkdown: boolean = true,
     readonly canUpdateOutput: boolean = false,
   ) {}

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -67,12 +67,13 @@ export class WebFetchTool extends BaseTool<WebFetchToolParams, ToolResult> {
   static readonly Name: string = 'web_fetch';
 
   constructor(private readonly config: Config) {
-    super(
-      WebFetchTool.Name,
-      'WebFetch',
-      "Processes content from URL(s), including local and private network addresses (e.g., localhost), embedded in a prompt. Include up to 20 URLs and instructions (e.g., summarize, extract specific data) directly in the 'prompt' parameter.",
-      Icon.Globe,
-      {
+    super({
+      name: WebFetchTool.Name,
+      displayName: 'WebFetch',
+      description:
+        "Processes content from URL(s), including local and private network addresses (e.g., localhost), embedded in a prompt. Include up to 20 URLs and instructions (e.g., summarize, extract specific data) directly in the 'prompt' parameter.",
+      icon: Icon.Globe,
+      parameterSchema: {
         properties: {
           prompt: {
             description:
@@ -83,8 +84,8 @@ export class WebFetchTool extends BaseTool<WebFetchToolParams, ToolResult> {
         required: ['prompt'],
         type: Type.OBJECT,
       },
-      true,
-    );
+      isOutputMarkdown: true,
+    });
     const proxy = config.getProxy();
     if (proxy) {
       setGlobalDispatcher(new ProxyAgent(proxy as string));

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -83,6 +83,7 @@ export class WebFetchTool extends BaseTool<WebFetchToolParams, ToolResult> {
         required: ['prompt'],
         type: Type.OBJECT,
       },
+      true,
     );
     const proxy = config.getProxy();
     if (proxy) {

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -65,12 +65,13 @@ export class WebSearchTool extends BaseTool<
   static readonly Name: string = 'google_web_search';
 
   constructor(private readonly config: Config) {
-    super(
-      WebSearchTool.Name,
-      'GoogleSearch',
-      'Performs a web search using Google Search (via the Gemini API) and returns the results. This tool is useful for finding information on the internet based on a query.',
-      Icon.Globe,
-      {
+    super({
+      name: WebSearchTool.Name,
+      displayName: 'GoogleSearch',
+      description:
+        'Performs a web search using Google Search (via the Gemini API) and returns the results. This tool is useful for finding information on the internet based on a query.',
+      icon: Icon.Globe,
+      parameterSchema: {
         type: Type.OBJECT,
         properties: {
           query: {
@@ -80,7 +81,7 @@ export class WebSearchTool extends BaseTool<
         },
         required: ['query'],
       },
-    );
+    });
   }
 
   /**

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -70,14 +70,14 @@ export class WriteFileTool
   static readonly Name: string = 'write_file';
 
   constructor(private readonly config: Config) {
-    super(
-      WriteFileTool.Name,
-      'WriteFile',
-      `Writes content to a specified file in the local filesystem.
+    super({
+      name: WriteFileTool.Name,
+      displayName: 'WriteFile',
+      description: `Writes content to a specified file in the local filesystem.
 
       The user has the ability to modify \`content\`. If modified, this will be stated in the response.`,
-      Icon.Pencil,
-      {
+      icon: Icon.Pencil,
+      parameterSchema: {
         properties: {
           file_path: {
             description:
@@ -92,7 +92,7 @@ export class WriteFileTool
         required: ['file_path', 'content'],
         type: Type.OBJECT,
       },
-    );
+    });
   }
 
   validateToolParams(params: WriteFileToolParams): string | null {


### PR DESCRIPTION
This change introduces a `hasSideEffects` property to tools to distinguish between read-only operations and those that can modify the user's system. This provides a safer default experience, especially in non-interactive mode.

As part of this change, the `BaseTool` constructor has been refactored to accept a single `ToolOptions` object, which simplifies tool definition and improves maintainability.

Key changes:
- All tools now use a `ToolOptions` object for construction instead of a long list of parameters.
- A new `hasSideEffects: boolean` property (defaulting to `true`) was added to `ToolOptions`.
- Read-only tools (`read_file`, `glob`, etc.) are now explicitly marked with `hasSideEffects: false`.
- In non-interactive mode, tools with side effects are automatically disabled unless the user is in `YOLO` mode.