### PR TITLE
Add a setting to disable the version update nag message

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -111,6 +111,9 @@ export interface Settings {
   // Setting for disabling auto-update.
   disableAutoUpdate?: boolean;
 
+  // Setting for disabling the update nag message.
+  disableUpdateNag?: boolean;
+
   memoryDiscoveryMaxDirs?: number;
   dnsResolutionOrder?: DnsResolutionOrder;
 }

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -91,6 +91,14 @@ describe('handleAutoUpdate', () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
+  it('should do nothing if update nag is disabled', () => {
+    mockSettings.merged.disableUpdateNag = true;
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+    expect(mockGetInstallationInfo).not.toHaveBeenCalled();
+    expect(mockUpdateEventEmitter.emit).not.toHaveBeenCalled();
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
   it('should emit "update-received" but not update if auto-updates are disabled', () => {
     mockSettings.merged.disableAutoUpdate = true;
     mockGetInstallationInfo.mockReturnValue({

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -22,6 +22,10 @@ export function handleAutoUpdate(
     return;
   }
 
+  if (settings.merged.disableUpdateNag) {
+    return;
+  }
+
   const installationInfo = getInstallationInfo(
     projectRoot,
     settings.merged.disableAutoUpdate ?? false,


### PR DESCRIPTION
## TLDR

Add a setting to disable the version update nag message.

## Dive Deeper

In package managers that have their own auto-update mechanism, the update nag message in Gemini CLI can be confusing. While the user may have npm locally in their account, they may be running a version of Gemini CLI from a package manager. A setting allows a package distribution distribute a system config that disables the version update message.  This setting is a peer to disableAutoUpdate - users may still wish to manually update, but know when there is a new version. 

## Linked issues / bugs

Fixes #5447