### PR TITLE
feat(vim): Support "Undo" Command in Vim Mode

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -144,7 +144,7 @@ describe('textBufferReducer', () => {
     });
   });
 
-  describe('create_undo_snapshot action', () => {
+  describe('vim_create_undo_snapshot action', () => {
     it('should create a snapshot without changing state', () => {
       const stateWithText: TextBufferState = {
         ...initialState,
@@ -152,7 +152,7 @@ describe('textBufferReducer', () => {
         cursorRow: 0,
         cursorCol: 5,
       };
-      const action: TextBufferAction = { type: 'create_undo_snapshot' };
+      const action: TextBufferAction = { type: 'vim_create_undo_snapshot' };
       const state = textBufferReducer(stateWithText, action);
       expect(state).toHaveOnlyValidCharacters();
 

--- a/packages/cli/src/ui/components/shared/vim-buffer-actions.ts
+++ b/packages/cli/src/ui/components/shared/vim-buffer-actions.ts
@@ -52,6 +52,7 @@ export type VimAction = Extract<
   | { type: 'vim_move_to_last_line' }
   | { type: 'vim_move_to_line' }
   | { type: 'vim_escape_insert_mode' }
+  | { type: 'vim_create_undo_snapshot' }
 >;
 
 export function handleVimAction(
@@ -876,6 +877,10 @@ export function handleVimAction(
         cursorCol: newCol,
         preferredCol: null,
       };
+    }
+
+    case 'vim_create_undo_snapshot': {
+      return pushUndo(state);
     }
 
     default: {

--- a/packages/cli/src/ui/hooks/vim.test.ts
+++ b/packages/cli/src/ui/hooks/vim.test.ts
@@ -85,6 +85,7 @@ describe('useVim hook', () => {
       replaceRangeByOffset: vi.fn(),
       handleInput: vi.fn(),
       setText: vi.fn(),
+      vimCreateUndoSnapshot: vi.fn(),
       // Vim-specific methods
       vimDeleteWordForward: vi.fn(),
       vimDeleteWordBackward: vi.fn(),

--- a/packages/cli/src/ui/hooks/vim.ts
+++ b/packages/cli/src/ui/hooks/vim.ts
@@ -689,6 +689,13 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
             return true;
           }
 
+          case 'u': {
+            // Undo last command
+            buffer.undo();
+            dispatch({ type: 'CLEAR_COUNT' });
+            return true;
+          }
+
           default: {
             // Check for arrow keys (they have different sequences but known names)
             if (normalizedKey.name === 'left') {


### PR DESCRIPTION
Adds support for the "Undo" command in the Gemini CLIs Vim Mode. This allows users to revert changes made to the prompt by pressing the `u` key in normal mode, which is the standard undo command in Vim.

Resolves #5463.

## TLDR

This pull request introduces undo `(u)` functionality to the Vim editing mode. It leverages the existing undo/redo stack within the text buffer, ensuring that any command that modifies the prompt (x, dd, cw, etc.) can be reverted. This aligns the CLI's Vim mode more closely with standard Vim behavior, improving the user experience.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

 1. Pull this branch.
 2. Run `npm install && npm start`.
 3. Enable Vim mode with the `/vim` command.
 4. Type some text into the prompt.
 5. Press `esc` to enter `NORMAL` mode.
 6. Perform a few modifications, for example:
     - Move the cursor and press x to delete a character.
     - Use cw to change a word, type new text, and press esc.
 7. Press `u` after each modification. The change should be reverted.
 9. Chain multiple commands and then multiple undos to test the history stack.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

#5463 
<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
