### PR TITLE
docs(fix): Update themes documentation to include new color keys for…

### DIFF
--- a/docs/cli/themes.md
+++ b/docs/cli/themes.md
@@ -58,10 +58,17 @@ Add a `customThemes` block to your user, project, or system `settings.json` file
       "AccentYellow": "#E5C07B",
       "AccentRed": "#E06C75",
       "Comment": "#5C6370",
-      "Gray": "#ABB2BF"
-    }
-  }
-}
+      "Gray": "#ABB2BF",
+      "DiffAdded": "#A6E3A1",
+      "DiffRemoved": "#F38BA8",
+      "DiffModified": "#89B4FA",
+      "GradientColors": [
+        "#4796E4",
+        "#847ACE",
+        "#C3677F"
+      ]
+    },
+},
 ```
 
 **Color keys:**
@@ -77,6 +84,9 @@ Add a `customThemes` block to your user, project, or system `settings.json` file
 - `AccentRed`
 - `Comment`
 - `Gray`
+- `DiffAdded` (optional, for added lines in diffs)
+- `DiffRemoved` (optional, for removed lines in diffs)
+- `DiffModified` (optional, for modified lines in diffs)
 
 **Required Properties:**
 
@@ -93,6 +103,9 @@ Add a `customThemes` block to your user, project, or system `settings.json` file
 - `AccentRed`
 - `Comment`
 - `Gray`
+- `DiffAdded`
+- `DiffRemoved`
+- `DiffModified`
 
 You can use either hex codes (e.g., `#FF0000`) **or** standard CSS color names (e.g., `coral`, `teal`, `blue`) for any color value. See [CSS color names](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#color_keywords) for a full list of supported names.
 

--- a/docs/cli/themes.md
+++ b/docs/cli/themes.md
@@ -62,13 +62,10 @@ Add a `customThemes` block to your user, project, or system `settings.json` file
       "DiffAdded": "#A6E3A1",
       "DiffRemoved": "#F38BA8",
       "DiffModified": "#89B4FA",
-      "GradientColors": [
-        "#4796E4",
-        "#847ACE",
-        "#C3677F"
-      ]
-    },
-},
+      "GradientColors": ["#4796E4", "#847ACE", "#C3677F"]
+    }
+  }
+}
 ```
 
 **Color keys:**
@@ -103,9 +100,6 @@ Add a `customThemes` block to your user, project, or system `settings.json` file
 - `AccentRed`
 - `Comment`
 - `Gray`
-- `DiffAdded`
-- `DiffRemoved`
-- `DiffModified`
 
 You can use either hex codes (e.g., `#FF0000`) **or** standard CSS color names (e.g., `coral`, `teal`, `blue`) for any color value. See [CSS color names](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#color_keywords) for a full list of supported names.
 


### PR DESCRIPTION

## TLDR

There was missing keys in the documentaion so user not aware of them updated them
## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
