### PR TITLE
Fix `/setup-github` command since the gemini-cli-action repo has moved

### DIFF
--- a/packages/cli/src/ui/commands/setupGithubCommand.test.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.test.ts
@@ -49,7 +49,7 @@ describe('setupGithubCommand', () => {
       `curl -fsSL -o "${fakeRepoRoot}/.github/workflows/gemini-issue-automated-triage.yml"`,
       `curl -fsSL -o "${fakeRepoRoot}/.github/workflows/gemini-issue-scheduled-triage.yml"`,
       `curl -fsSL -o "${fakeRepoRoot}/.github/workflows/gemini-pr-review.yml"`,
-      'https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/refs/heads/main/workflows/',
+      'https://raw.githubusercontent.com/google-gemini/gemini-cli-action/refs/heads/main/examples/',
     ];
 
     for (const substring of expectedSubstrings) {

--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -29,13 +29,13 @@ export const setupGithubCommand: SlashCommand = {
 
     // TODO(#5198): pin workflow versions for release controls
     const version = 'main';
-    const workflowBaseUrl = `https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/refs/heads/${version}/workflows/`;
+    const workflowBaseUrl = `https://raw.githubusercontent.com/google-gemini/gemini-cli-action/refs/heads/${version}/examples/`;
 
     const workflows = [
-      'gemini-cli/gemini-cli.yml',
-      'issue-triage/gemini-issue-automated-triage.yml',
-      'issue-triage/gemini-issue-scheduled-triage.yml',
-      'pr-review/gemini-pr-review.yml',
+      'gemini-cli.yml',
+      'gemini-issue-automated-triage.yml',
+      'gemini-issue-scheduled-triage.yml',
+      'gemini-pr-review.yml',
     ];
 
     const command = [


### PR DESCRIPTION
## TLDR

Fix `/setup-github` 404s by switching workflow download URLs from the non-existent `google-github-actions/run-gemini-cli/.../workflows` path to the **canonical examples** in `google-gemini/gemini-cli-action/main/examples`.

## Dive Deeper

- **Root cause:** The command fetched from a repo/path that doesn’t exist, causing `curl: (56) ... 404`.
- **Change:** Point installer to `https://raw.githubusercontent.com/google-gemini/gemini-cli-action/main/examples`
- **Why this source:** The Action’s examples are the intended consumer-facing workflows, reducing drift and future maintenance.
- **Safety:** Only writes YAML under `.github/workflows/`; no behavior change to other CLI features.

## Reviewer Test Plan

- In a scratch repo, run the updated `/setup-github`.
- Verify four files appear under `.github/workflows/` with expected `name:` headers.
- Confirm Actions picks up the workflows without YAML errors.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | ❓  |
| Seatbelt | ❓  | -   | -   |

> Notes: Verified locally on macOS for `npm run` and `npx`. Others are straightforward (OS-agnostic file writes + HTTP fetch), but please spot-check.

## Linked issues / bugs

Related to: setup github 404 on workflow install