### PR TITLE
feat(triage): enhance workflow to handle incomplete issues

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -40,7 +40,8 @@ jobs:
               "coreTools": [
                 "run_shell_command(gh label list)",
                 "run_shell_command(gh issue edit)",
-                "run_shell_command(gh issue list)"
+                "run_shell_command(gh issue list)",
+                "run_shell_command(gh issue comment)"
               ],
               "telemetry": {
                 "enabled": true,
@@ -49,19 +50,37 @@ jobs:
               "sandbox": false
             }
           prompt: |
-            You are an issue triage assistant. Analyze the current GitHub issues apply the most appropriate existing labels. Do not remove labels titled help wanted or good first issue.
+            You are an issue triage assistant. You are going to perform the following two tasks: 
+
+            Task 1: Information Completeness Check
+            Steps:
+            1. Analyze the issue to determine if it contains enough information. Review the issue for:
+              - A clear problem description.
+              - Steps to reproduce (for bugs).
+              - CLI version number.
+              - Relevant logs or error messages.
+            2. Action (If Incomplete): If information is missing, perform the following steps:
+              - Add Label: First, run this command to apply the `status/need-information` label:
+              `gh issue edit ${{ github.event.issue.number }} --repo ${{ github.repository }} --add-label "status/need-information"`
+              - Post a Tailored Comment: Next, identify *only the specific information that is missing*. Construct a polite, concise comment asking for those items and post it using the `gh issue comment` command.
+              Example: If the user forgot to include reproduction steps and the version number, your generated command should look like this:
+              # Note: The --body content is an example. You will generate it based on what is missing.
+              `gh issue comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "Thanks for filing this issue! To help us investigate, could you please provide:\n\n*   **Steps to reproduce the issue.**\n*   **The version of the CLI you are using.**\n\nOnce we have these details, we can look into it further."`
+            3. Action (If Complete): If the issue has all required information, do not add a label or comment. Proceed directly to Task 2.
+
+            Task 2: Categorization and Labeling 
+            Analyze the current GitHub issues apply the most appropriate existing labels. Do not remove labels titled help wanted or good first issue.
             Steps:
             1. Run: `gh label list --repo ${{ github.repository }} --limit 100` to get all available labels.
             2. Review the issue title, body and any comments provided in the environment variables.
             3. Ignore any existing priorities or tags on the issue. Just report your findings.
             4. Select the most relevant labels from the existing labels, focusing on kind/*, area/*, sub-area/* and priority/*. For area/* and kind/* limit yourself to only the single most applicable label in each case. 
-            6. Apply the selected labels to this issue using: `gh issue edit ${{ github.event.issue.number }} --repo ${{ github.repository }} --add-label "label1,label2"`
-            7. For each issue please check if CLI version is present, this is usually in the output of the /about command  and will look like 0.1.5 for anything more than 6 versions older than the most recent should add the status/need-retesting label
-            8. If you see that the issue doesn’t look like it has sufficient information recommend the status/need-information label
-            9. Use Area definitions mentioned below to help you narrow down issues
+            5. Apply the selected labels to this issue using: `gh issue edit ${{ github.event.issue.number }} --repo ${{ github.repository }} --add-label "label1,label2"`
+            6. For each issue please check if CLI version is present, this is usually in the output of the /about command  and will look like 0.1.5 for anything more than 6 versions older than the most recent should add the status/need-retesting label
+            7. Use Area definitions mentioned below to help you narrow down issues
             Guidelines:
             - Only use labels that already exist in the repository.
-            - Do not add comments or modify the issue content.
+            - Do not add comments or modify the issue content in this task.
             - Triage only the current issue.
             - Apply only one area/ label
             - Apply only one kind/ label

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -91,7 +91,12 @@ jobs:
               - IMPORTANT: Remove each label one at a time, one command per issue if needed.
             10. For each issue please check if CLI version is present, this is usually in the output of the /about command and will look like 0.1.5 
               - Anything more than 6 versions older than the most recent should add the status/need-retesting label
-            11. If you see that the issue doesn’t look like it has sufficient information recommend the status/need-information label
+            11. Analyze the issue to determine if it contains enough information. Review the issue for:
+              - A clear problem description.
+              - Steps to reproduce (for bugs).
+              - CLI version number.
+              - Relevant logs or error messages.
+            12. If you see that the issue doesn’t look like it has sufficient information recommend the status/need-information label
               - After applying appropriate labels to an issue, remove the "status/need-triage" label if present: `gh issue edit ISSUE_NUMBER --repo ${{ github.repository }} --remove-label "status/need-triage"`
               - Execute one `gh issue edit` command per issue, wait for success before proceeding to the next
             Process each issue sequentially and confirm each labeling operation before moving to the next issue.


### PR DESCRIPTION
## TLDR

This pull request introduces an automated issue triage workflow using Gemini to ensure new issues are complete and actionable. When a user files an issue that lacks key information (like reproduction steps, version numbers, or logs), the workflow now automatically adds a `status/need-information` label and posts a comment politely requesting the specific missing details. This reduces manual triage effort and communication delays.

## Dive Deeper

This PR adds a new GitHub workflow, `gemini-automated-issue-triage.yml`, which triggers whenever an issue is opened or reopened. It uses the `gemini-cli-action` to analyze the issue's title and body against a set of completeness criteria defined in the prompt.

-   **If an issue is incomplete:** The workflow is instructed to use the `gh` CLI to add the `status/need-information` label and post a comment tailored to the *specific* information that is missing.
-   **If an issue is complete:** The workflow takes no action regarding completeness and proceeds with its categorization tasks.

Additionally, the existing `gemini-scheduled-issue-triage.yml` has been updated to align its information-checking logic with the new automated workflow, ensuring consistent standards are applied across the board. The scheduled workflow will label incomplete issues but will not comment, correctly separating the roles of automated workflow and scheduled workflow.

## Reviewer Test Plan

Since this is a prompt-only change, a full integration test is not required. Instead, please validate the logic by reviewing the workflow files directly:

1.  **Review the Automated Triage Prompt:**
    *   Open `.github/workflows/gemini-automated-issue-triage.yml`.
    *   Read the `prompt` section for the `triage-issue` job.
    *   **Verify:** Confirm that the instructions clearly direct the model to check for completeness, add the `status/need-information` label, and post a comment when an issue is incomplete.

2.  **Review the Scheduled Triage Prompt:**
    *   Open `.github/workflows/gemini-scheduled-issue-triage.yml`.
    *   Read the `prompt` section for the `triage-issues` job.
    *   **Verify:** Confirm that the instructions have been updated to include the completeness check and direct the model to add the `status/need-information` label, but crucially, **not** to post a comment.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | -  | -  | -  |
| npx      | -  | -  | -  |
| Docker   | -  | -  | -  |
| Podman   | -  | -   | -   |
| Seatbelt | -  | -   | -   |

## Linked issues / bugs

Fixes #3820 
<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
