### PR TITLE
remove unnecessary checks in WriteFileChecks.getDescription

### DIFF
--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -13,7 +13,7 @@ import {
   vi,
   type Mocked,
 } from 'vitest';
-import { WriteFileTool } from './write-file.js';
+import { WriteFileTool, WriteFileToolParams } from './write-file.js';
 import {
   FileDiff,
   ToolConfirmationOutcome,
@@ -200,6 +200,32 @@ describe('WriteFileTool', () => {
       };
       expect(tool.validateToolParams(params)).toMatch(
         `Path is a directory, not a file: ${dirAsFilePath}`,
+      );
+    });
+
+    it('should return error if the content is null', () => {
+      const dirAsFilePath = path.join(rootDir, 'a_directory');
+      fs.mkdirSync(dirAsFilePath);
+      const params = {
+        file_path: dirAsFilePath,
+        content: null,
+      } as unknown as WriteFileToolParams; // Intentionally non-conforming
+      expect(tool.validateToolParams(params)).toMatch(
+        `params/content must be string`,
+      );
+    });
+  });
+
+  describe('getDescription', () => {
+    it('should return error if the file_path is empty', () => {
+      const dirAsFilePath = path.join(rootDir, 'a_directory');
+      fs.mkdirSync(dirAsFilePath);
+      const params = {
+        file_path: '',
+        content: '',
+      };
+      expect(tool.getDescription(params)).toMatch(
+        `Model did not provide valid parameters for write file tool, missing or empty "file_path"`,
       );
     });
   });

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -65,8 +65,7 @@ interface GetCorrectedFileContentResult {
  */
 export class WriteFileTool
   extends BaseTool<WriteFileToolParams, ToolResult>
-  implements ModifiableTool<WriteFileToolParams>
-{
+  implements ModifiableTool<WriteFileToolParams> {
   static readonly Name: string = 'write_file';
 
   constructor(private readonly config: Config) {
@@ -131,8 +130,8 @@ export class WriteFileTool
   }
 
   getDescription(params: WriteFileToolParams): string {
-    if (!params.file_path || !params.content) {
-      return `Model did not provide valid parameters for write file tool`;
+    if (!params.file_path) {
+      return `Model did not provide valid parameters for write file tool, missing or empty "file_path"`;
     }
     const relativePath = makeRelative(
       params.file_path,

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -65,7 +65,8 @@ interface GetCorrectedFileContentResult {
  */
 export class WriteFileTool
   extends BaseTool<WriteFileToolParams, ToolResult>
-  implements ModifiableTool<WriteFileToolParams> {
+  implements ModifiableTool<WriteFileToolParams>
+{
   static readonly Name: string = 'write_file';
 
   constructor(private readonly config: Config) {


### PR DESCRIPTION
## TLDR

Remove bad validation of the "content" parameter  in WriteFileTool.getDescription - this previously would return an error message if the content was the empty string.

Add a new error specific to empty paths - although validateToolParams would already handle this, we probably shouldn't assume it has been called.

## Reviewer Test Plan

You can test this by just asking Gemini to create any empty file - previously it would output some error text about invalid params (although it would actually then succeed which is interesting). The schema was ultimately valid and this is just a description of the command I guess.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes https://github.com/google-gemini/gemini-cli/issues/2376
