### PR TITLE
ide-mode flag cleanup

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -62,7 +62,6 @@ export interface CliArgs {
   experimentalAcp: boolean | undefined;
   extensions: string[] | undefined;
   listExtensions: boolean | undefined;
-  ideMode?: boolean | undefined;
   ideModeFeature: boolean | undefined;
   proxy: string | undefined;
   includeDirectories: string[] | undefined;
@@ -287,9 +286,7 @@ export async function loadCliConfig(
     ) ||
     false;
   const memoryImportFormat = settings.memoryImportFormat || 'tree';
-  const ideMode =
-    (argv.ideMode ?? settings.ideMode ?? false) &&
-    process.env.TERM_PROGRAM === 'vscode';
+  const ideMode = settings.ideMode ?? false
 
   const ideModeFeature =
     (argv.ideModeFeature ?? settings.ideModeFeature ?? false) &&

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -286,7 +286,7 @@ export async function loadCliConfig(
     ) ||
     false;
   const memoryImportFormat = settings.memoryImportFormat || 'tree';
-  const ideMode = settings.ideMode ?? false
+  const ideMode = settings.ideMode ?? false;
 
   const ideModeFeature =
     (argv.ideModeFeature ?? settings.ideModeFeature ?? false) &&

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -302,7 +302,7 @@ export class Config {
     this.noBrowser = params.noBrowser ?? false;
     this.summarizeToolOutput = params.summarizeToolOutput;
     this.ideModeFeature = params.ideModeFeature ?? false;
-    this.ideMode = params.ideMode ?? true;
+    this.ideMode = params.ideMode ?? false;
     this.ideClient = params.ideClient;
 
     if (params.contextFileName) {


### PR DESCRIPTION
## Dive Deeper
* Removes deprecated ideMode CLI flag (ideMode is a setting only as of [#5146) ](https://github.com/google-gemini/gemini-cli/pull/5146)
* Set ideMode to false by default if the setting is missing instead of true
* Remove logic for checking which terminal the CLI is running in (the ide client handles this now)

## Linked issues / bugs
#4390 