### PR TITLE
Fix incorrect error messages for IDE mode

### DIFF
--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -83,7 +83,7 @@ export class IdeClient {
     if (!port) {
       this.setState(
         IDEConnectionStatus.Disconnected,
-        `IDE companion extension for ${this.currentIdeDisplayName} isn't running. Please ensure the extension is installed and enabled. You can run '/ide install' to install it.`,
+        `Failed to connect to IDE companion extension for ${this.getDetectedIdeDisplayName}. Please ensure the extension is running and try refreshing your terminal. To install the extension, run /ide install.`,
       );
       return undefined;
     }
@@ -95,7 +95,7 @@ export class IdeClient {
     if (ideWorkspacePath === undefined) {
       this.setState(
         IDEConnectionStatus.Disconnected,
-        `IDE companion extension for ${this.currentIdeDisplayName} isn't running. Please ensure the extension is installed and enabled. You can run '/ide install' to install it.`,
+        `Failed to connect to IDE companion extension for ${this.getDetectedIdeDisplayName}. Please ensure the extension is running and try refreshing your terminal. To install the extension, run /ide install.`,
       );
       return false;
     }
@@ -165,7 +165,7 @@ export class IdeClient {
     } catch (_error) {
       this.setState(
         IDEConnectionStatus.Disconnected,
-        `Failed to connect to IDE companion extension for ${this.getDetectedIdeDisplayName()}. Please ensure the extension is running and refresh your terminal window.`,
+        `Failed to connect to IDE companion extension for ${this.getDetectedIdeDisplayName}. Please ensure the extension is running and try refreshing your terminal. To install the extension, run /ide install.`,
       );
       if (transport) {
         try {

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -70,7 +70,15 @@ export class IdeClient {
   }
 
   private setState(status: IDEConnectionStatus, details?: string) {
-    this.state = { status, details };
+    const isAlreadyDisconnected =
+      this.state.status === IDEConnectionStatus.Disconnected &&
+      status === IDEConnectionStatus.Disconnected;
+
+    // Only update details if the state wasn't already disconnected, so that
+    // the first detail message is preserved.
+    if (!isAlreadyDisconnected) {
+      this.state = { status, details };
+    }
 
     if (status === IDEConnectionStatus.Disconnected) {
       logger.debug('IDE integration disconnected:', details);


### PR DESCRIPTION
## TLDR
Previously, we were displaying the directory mismatch error if the companion extension was not installed or running. Instead, we should show a more helpful error message when we detect that the extension is not running. This should fix confusing UX flagged by a internal dogfooder

## Linked issues / bugs
#4390 
