### PR TITLE
Remove the "local modifications" string from bug and about reports.

### DIFF
--- a/scripts/generate-git-commit-info.js
+++ b/scripts/generate-git-commit-info.js
@@ -39,12 +39,6 @@ try {
   }).trim();
   if (gitHash) {
     gitCommitInfo = gitHash;
-    const gitStatus = execSync('git status --porcelain', {
-      encoding: 'utf-8',
-    }).trim();
-    if (gitStatus) {
-      gitCommitInfo = `${gitHash} (local modifications)`;
-    }
   }
 } catch {
   // ignore


### PR DESCRIPTION
Fixes #5550

## TLDR

Removes the now spurious "local modifications" string from GIT_COMMIT_INFO in the /bug and /about reports. 

## Reviewer Test Plan

Make a local change. Build and run /about. Check the git commit.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #5550
