### PR TITLE
docs: update typo in commands.md

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -46,7 +46,7 @@ Slash commands provide meta-level control over the CLI itself.
       - **Usage:** `/directory add <path1>,<path2>`
       - **Note:** Disabled in restrictive sandbox profiles. If you're using that, use `--include-directories` when starting the session instead.
     - **`show`**:
-      - **Description:** Display all directories added by `/direcotry add` and `--include-directories`.
+      - **Description:** Display all directories added by `/directory add` and `--include-directories`.
       - **Usage:** `/directory show`
 
 - **`/editor`**


### PR DESCRIPTION
Small docs typo fix.
