### PR TITLE
feat: Add thinking traces display support for gemini-2.5 models

### DIFF
--- a/packages/cli/src/ui/components/AboutBox.tsx
+++ b/packages/cli/src/ui/components/AboutBox.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import { Colors } from '../colors.js';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
+import { isThinkingSupported } from '@google/gemini-cli-core';
 
 interface AboutBoxProps {
   cliVersion: string;
@@ -71,6 +72,18 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
         <Text>{modelVersion}</Text>
       </Box>
     </Box>
+    {isThinkingSupported(modelVersion) && (
+      <Box flexDirection="row">
+        <Box width="35%">
+          <Text bold color={Colors.LightBlue}>
+            Thinking Budget
+          </Text>
+        </Box>
+        <Box>
+          <Text color={Colors.AccentGreen}>32,768 tokens</Text>
+        </Box>
+      </Box>
+    )}
     <Box flexDirection="row">
       <Box width="35%">
         <Text bold color={Colors.LightBlue}>

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -14,6 +14,7 @@ import { ErrorMessage } from './messages/ErrorMessage.js';
 import { ToolGroupMessage } from './messages/ToolGroupMessage.js';
 import { GeminiMessageContent } from './messages/GeminiMessageContent.js';
 import { CompressionMessage } from './messages/CompressionMessage.js';
+import { ThinkingMessage } from './messages/ThinkingMessage.js';
 import { Box } from 'ink';
 import { AboutBox } from './AboutBox.js';
 import { StatsDisplay } from './StatsDisplay.js';
@@ -92,6 +93,9 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
     )}
     {item.type === 'compression' && (
       <CompressionMessage compression={item.compression} />
+    )}
+    {item.type === 'thinking' && (
+      <ThinkingMessage subject={item.subject} description={item.description} />
     )}
   </Box>
 );

--- a/packages/cli/src/ui/components/messages/ThinkingMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ThinkingMessage.tsx
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { Colors } from '../../colors.js';
+
+interface ThinkingMessageProps {
+  subject: string;
+  description: string;
+}
+
+export const ThinkingMessage: React.FC<ThinkingMessageProps> = ({
+  subject,
+  description,
+}) => (
+  <Box flexDirection="column" marginBottom={1}>
+    <Box>
+      <Text color={Colors.AccentPurple} bold>
+        💭 Thinking: {subject}
+      </Text>
+    </Box>
+    {description && (
+      <Box marginLeft={2}>
+        <Text color={Colors.Gray}>{description}</Text>
+      </Box>
+    )}
+  </Box>
+);

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -534,6 +534,15 @@ export const useGeminiStream = (
         switch (event.type) {
           case ServerGeminiEventType.Thought:
             setThought(event.value);
+            // Add thinking trace to history for display
+            addItem(
+              {
+                type: 'thinking',
+                subject: event.value.subject,
+                description: event.value.description,
+              } as HistoryItemWithoutId,
+              userMessageTimestamp,
+            );
             break;
           case ServerGeminiEventType.Content:
             geminiMessageBuffer = handleContentEvent(

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -135,6 +135,12 @@ export type HistoryItemCompression = HistoryItemBase & {
   compression: CompressionProps;
 };
 
+export type HistoryItemThinking = HistoryItemBase & {
+  type: 'thinking';
+  subject: string;
+  description: string;
+};
+
 // Using Omit<HistoryItem, 'id'> seems to have some issues with typescript's
 // type inference e.g. historyItem.type === 'tool_group' isn't auto-inferring that
 // 'tools' in historyItem.
@@ -153,7 +159,8 @@ export type HistoryItemWithoutId =
   | HistoryItemModelStats
   | HistoryItemToolStats
   | HistoryItemQuit
-  | HistoryItemCompression;
+  | HistoryItemCompression
+  | HistoryItemThinking;
 
 export type HistoryItem = HistoryItemWithoutId & { id: number };
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -50,7 +50,7 @@ import {
 } from '../telemetry/types.js';
 import { ClearcutLogger } from '../telemetry/clearcut-logger/clearcut-logger.js';
 
-function isThinkingSupported(model: string) {
+export function isThinkingSupported(model: string) {
   if (model.startsWith('gemini-2.5')) return true;
   return false;
 }
@@ -314,11 +314,15 @@ export class GeminiClient {
       )
         ? {
             ...this.generateContentConfig,
+            temperature: 0,  // Disable temperature for thinking models
             thinkingConfig: {
-              includeThoughts: true,
+              thinkingBudget: 32768,  // Use maximum budget for gemini-2.5-pro
+              includeThoughts: true,  // Include thinking traces in response
             },
           }
         : this.generateContentConfig;
+      
+      
       return new GeminiChat(
         this.config,
         this.getContentGenerator(),

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -317,6 +317,7 @@ export class GeminiChat {
         JSON.stringify(response),
       );
 
+
       this.sendPromise = (async () => {
         const outputContent = response.candidates?.[0]?.content;
         // Because the AFC input contains the entire curated chat history in
@@ -525,11 +526,17 @@ export class GeminiChat {
 
     try {
       for await (const chunk of streamResponse) {
+        
         if (isValidResponse(chunk)) {
           chunks.push(chunk);
           const content = chunk.candidates?.[0]?.content;
+          
+          
           if (content !== undefined) {
-            if (this.isThoughtContent(content)) {
+            const isThought = this.isThoughtContent(content);
+            
+            
+            if (isThought) {
               yield chunk;
               continue;
             }
@@ -559,6 +566,7 @@ export class GeminiChat {
         this.getFinalUsageMetadata(chunks),
         JSON.stringify(chunks),
       );
+      
     }
     this.recordHistory(inputContent, outputContent);
   }
@@ -665,7 +673,8 @@ export class GeminiChat {
   private isThoughtContent(
     content: Content | undefined,
   ): content is Content & { parts: [{ thought: boolean }, ...Part[]] } {
-    return !!(
+    
+    const result = !!(
       content &&
       content.role === 'model' &&
       content.parts &&
@@ -673,5 +682,6 @@ export class GeminiChat {
       typeof content.parts[0].thought === 'boolean' &&
       content.parts[0].thought === true
     );
+    return result;
   }
 }

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -192,6 +192,7 @@ export class Turn {
       );
 
       for await (const resp of responseStream) {
+        
         if (signal?.aborted) {
           yield { type: GeminiEventType.UserCancelled };
           // Do not add resp to debugResponses if aborted before processing
@@ -199,7 +200,10 @@ export class Turn {
         }
         this.debugResponses.push(resp);
 
-        const thoughtPart = resp.candidates?.[0]?.content?.parts?.[0];
+        const content = resp.candidates?.[0]?.content;
+        const thoughtPart = content?.parts?.[0];
+        
+        
         if (thoughtPart?.thought) {
           // Thought always has a bold "subject" part enclosed in double asterisks
           // (e.g., **Subject**). The rest of the string is considered the description.
@@ -213,6 +217,7 @@ export class Turn {
             subject,
             description,
           };
+
 
           yield {
             type: GeminiEventType.Thought,


### PR DESCRIPTION
## Summary

This PR adds support for displaying thinking traces when using gemini-2.5 models, similar to how they appear in other tools like Aider.

## What's Changed

- Set 32k thinking token budget for gemini-2.5 models with temperature 0
- Add new  type to display thinking traces in the UI
- Create  component with purple thinking emoji (💭) and formatted display
- Update  to add thinking events to history
- Export  function for UI use
- Display thinking budget (32,768 tokens) in AboutBox for supported models
- Remove all debug logging for cleaner output

## Motivation

When using gemini-2.5-pro models, thinking traces provide valuable insight into the model's reasoning process. This PR ensures these traces are properly displayed in the UI rather than being hidden.

## Testing

Tested locally with gemini-2.5-pro-002 model to verify:
- Thinking traces appear with purple emoji and formatted subject/description
- Thinking budget shows correctly in /about command
- No debug spam in output
- TypeScript builds without errors