### PR TITLE
check for the prompt capability before listing prompts from MCP servers

### DIFF
--- a/.github/workflows/weekly-velocity-report.yml
+++ b/.github/workflows/weekly-velocity-report.yml
@@ -4,7 +4,7 @@ name: Weekly Velocity Report
 
 on:
   schedule:
-    - cron: "0 9 * * 1" # Runs every Monday at 9:00 AM UTC
+    - cron: '0 9 * * 1' # Runs every Monday at 9:00 AM UTC
   workflow_dispatch:
 
 jobs:

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -22,7 +22,6 @@ import { AuthProviderType } from '../config/config.js';
 import { PromptRegistry } from '../prompts/prompt-registry.js';
 
 import { DiscoveredMCPTool } from './mcp-tool.js';
-import { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
 
 vi.mock('@modelcontextprotocol/sdk/client/stdio.js');
 vi.mock('@modelcontextprotocol/sdk/client/index.js');
@@ -115,7 +114,7 @@ describe('mcp-client', () => {
         ],
       });
       const mockGetServerCapabilities = vi.fn().mockReturnValue({
-        prompts: {}
+        prompts: {},
       });
       const mockedClient = {
         getServerCapabilities: mockGetServerCapabilities,
@@ -136,7 +135,7 @@ describe('mcp-client', () => {
         prompts: [],
       });
       const mockGetServerCapabilities = vi.fn().mockReturnValue({
-        'prompts': {}
+        prompts: {},
       });
 
       const mockedClient = {
@@ -190,7 +189,7 @@ describe('mcp-client', () => {
       testError.message = 'test error';
       const mockRequest = vi.fn().mockRejectedValue(testError);
       const mockGetServerCapabilities = vi.fn().mockReturnValue({
-        prompts: {}
+        prompts: {},
       });
       const mockedClient = {
         getServerCapabilities: mockGetServerCapabilities,

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -58,9 +58,7 @@ describe('mcp-client', () => {
       const mockedClient = {} as unknown as ClientLib.Client;
       const consoleErrorSpy = vi
         .spyOn(console, 'error')
-        .mockImplementation(() => {
-          // no-op
-        });
+        .mockImplementation(() => {});
 
       const testError = new Error('Invalid tool name');
       vi.mocked(DiscoveredMCPTool).mockImplementation(
@@ -145,9 +143,7 @@ describe('mcp-client', () => {
 
       const consoleLogSpy = vi
         .spyOn(console, 'debug')
-        .mockImplementation(() => {
-          // no-op
-        });
+        .mockImplementation(() => {});
 
       await discoverPrompts('test-server', mockedClient, mockedPromptRegistry);
 
@@ -171,9 +167,7 @@ describe('mcp-client', () => {
 
       const consoleLogSpy = vi
         .spyOn(console, 'debug')
-        .mockImplementation(() => {
-          // no-op
-        });
+        .mockImplementation(() => {});
 
       await discoverPrompts('test-server', mockedClient, mockedPromptRegistry);
 
@@ -198,9 +192,7 @@ describe('mcp-client', () => {
 
       const consoleErrorSpy = vi
         .spyOn(console, 'error')
-        .mockImplementation(() => {
-          // no-op
-        });
+        .mockImplementation(() => {});
 
       await discoverPrompts('test-server', mockedClient, mockedPromptRegistry);
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -461,7 +461,8 @@ export async function discoverTools(
         );
       } catch (error) {
         console.error(
-          `Error discovering tool: '${funcDecl.name
+          `Error discovering tool: '${
+            funcDecl.name
           }' from MCP server '${mcpServerName}': ${(error as Error).message}`,
         );
       }
@@ -646,18 +647,18 @@ export async function connectToMcpServer(
           if (hasStoredTokens) {
             console.log(
               `Stored OAuth token for SSE server '${mcpServerName}' was rejected. ` +
-              `Please re-authenticate using: /mcp auth ${mcpServerName}`,
+                `Please re-authenticate using: /mcp auth ${mcpServerName}`,
             );
           } else {
             console.log(
               `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-              `Please authenticate using: /mcp auth ${mcpServerName}`,
+                `Please authenticate using: /mcp auth ${mcpServerName}`,
             );
           }
         }
         throw new Error(
           `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-          `Please authenticate using: /mcp auth ${mcpServerName}`,
+            `Please authenticate using: /mcp auth ${mcpServerName}`,
         );
       }
 
@@ -799,18 +800,18 @@ export async function connectToMcpServer(
             if (hasStoredTokens) {
               console.log(
                 `Stored OAuth token for SSE server '${mcpServerName}' was rejected. ` +
-                `Please re-authenticate using: /mcp auth ${mcpServerName}`,
+                  `Please re-authenticate using: /mcp auth ${mcpServerName}`,
               );
             } else {
               console.log(
                 `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-                `Please authenticate using: /mcp auth ${mcpServerName}`,
+                  `Please authenticate using: /mcp auth ${mcpServerName}`,
               );
             }
           }
           throw new Error(
             `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-            `Please authenticate using: /mcp auth ${mcpServerName}`,
+              `Please authenticate using: /mcp auth ${mcpServerName}`,
           );
         }
 
@@ -993,11 +994,11 @@ export async function createTransport(
     if (!accessToken) {
       console.error(
         `MCP server '${mcpServerName}' requires OAuth authentication. ` +
-        `Please authenticate using the /mcp auth command.`,
+          `Please authenticate using the /mcp auth command.`,
       );
       throw new Error(
         `MCP server '${mcpServerName}' requires OAuth authentication. ` +
-        `Please authenticate using the /mcp auth command.`,
+          `Please authenticate using the /mcp auth command.`,
       );
     }
   } else {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -461,8 +461,7 @@ export async function discoverTools(
         );
       } catch (error) {
         console.error(
-          `Error discovering tool: '${
-            funcDecl.name
+          `Error discovering tool: '${funcDecl.name
           }' from MCP server '${mcpServerName}': ${(error as Error).message}`,
         );
       }
@@ -496,6 +495,9 @@ export async function discoverPrompts(
   promptRegistry: PromptRegistry,
 ): Promise<Prompt[]> {
   try {
+    // Only request prompts if the server supports them.
+    if (mcpClient.getServerCapabilities()?.prompts == null) return [];
+
     const response = await mcpClient.request(
       { method: 'prompts/list', params: {} },
       ListPromptsResultSchema,
@@ -644,18 +646,18 @@ export async function connectToMcpServer(
           if (hasStoredTokens) {
             console.log(
               `Stored OAuth token for SSE server '${mcpServerName}' was rejected. ` +
-                `Please re-authenticate using: /mcp auth ${mcpServerName}`,
+              `Please re-authenticate using: /mcp auth ${mcpServerName}`,
             );
           } else {
             console.log(
               `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-                `Please authenticate using: /mcp auth ${mcpServerName}`,
+              `Please authenticate using: /mcp auth ${mcpServerName}`,
             );
           }
         }
         throw new Error(
           `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-            `Please authenticate using: /mcp auth ${mcpServerName}`,
+          `Please authenticate using: /mcp auth ${mcpServerName}`,
         );
       }
 
@@ -797,18 +799,18 @@ export async function connectToMcpServer(
             if (hasStoredTokens) {
               console.log(
                 `Stored OAuth token for SSE server '${mcpServerName}' was rejected. ` +
-                  `Please re-authenticate using: /mcp auth ${mcpServerName}`,
+                `Please re-authenticate using: /mcp auth ${mcpServerName}`,
               );
             } else {
               console.log(
                 `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-                  `Please authenticate using: /mcp auth ${mcpServerName}`,
+                `Please authenticate using: /mcp auth ${mcpServerName}`,
               );
             }
           }
           throw new Error(
             `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-              `Please authenticate using: /mcp auth ${mcpServerName}`,
+            `Please authenticate using: /mcp auth ${mcpServerName}`,
           );
         }
 
@@ -991,11 +993,11 @@ export async function createTransport(
     if (!accessToken) {
       console.error(
         `MCP server '${mcpServerName}' requires OAuth authentication. ` +
-          `Please authenticate using the /mcp auth command.`,
+        `Please authenticate using the /mcp auth command.`,
       );
       throw new Error(
         `MCP server '${mcpServerName}' requires OAuth authentication. ` +
-          `Please authenticate using the /mcp auth command.`,
+        `Please authenticate using the /mcp auth command.`,
       );
     }
   } else {


### PR DESCRIPTION
## TLDR

MCP clients should check for server capabilities before making requests, this adds a check for the prompts capability before requesting the prompts which avoids the error for servers that don't implement prompts.

## Reviewer Test Plan

Connect to an MPC server which doesn't implement the prompts/list handler, you will no longer see an error on startup (but would previously).

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/gemini-cli/issues/5383
