### PR TITLE
fix: prevent GOOGLE_GENAI_USE_VERTEXAI from interfering with CLI auth

### DIFF
--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -91,7 +91,7 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
 
 You can create a **`.gemini/.env`** file in your project directory or in your home directory. Creating a plain **`.env`** file also works, but `.gemini/.env` is recommended to keep Gemini variables isolated from other tools.
 
-**Important:** Some environment variables (like `DEBUG` and `DEBUG_MODE`) are automatically excluded from project `.env` files to prevent interference with gemini-cli behavior. Use `.gemini/.env` files for gemini-cli specific variables.
+**Important:** Some environment variables (like `DEBUG`, `DEBUG_MODE`, and `GOOGLE_GENAI_USE_VERTEXAI`) are automatically excluded from project `.env` files to prevent interference with gemini-cli behavior. This prevents project-specific authentication variables intended for your application code from inadvertently affecting the CLI's authentication method. Use `.gemini/.env` files for gemini-cli specific variables.
 
 Gemini CLI automatically loads environment variables from the **first** `.env` file it finds, using the following search order:
 
@@ -122,6 +122,39 @@ GOOGLE_CLOUD_PROJECT="your-project-id"
 GEMINI_API_KEY="your-gemini-api-key"
 EOF
 ```
+
+## Troubleshooting Authentication Issues
+
+### Issue: GOOGLE_GENAI_USE_VERTEXAI Environment Variable Conflicts
+
+**Problem:** You have `GOOGLE_GENAI_USE_VERTEXAI=true` in your project's `.env` file for your application code, but you want to use a different authentication method (like Gemini API Key) for the CLI itself.
+
+**What happens:** The CLI detects this environment variable and automatically attempts to use Vertex AI authentication, even when you select "Gemini API Key" in the `/auth` dialog.
+
+**Solutions:**
+
+1. **Recommended:** Move CLI-specific environment variables to a `.gemini/.env` file:
+   ```bash
+   mkdir -p .gemini
+   echo 'GEMINI_API_KEY="your-api-key"' > .gemini/.env
+   ```
+
+2. **Alternative:** Customize which environment variables are excluded from project `.env` files by adding this to your `~/.gemini/settings.json`:
+   ```json
+   {
+     "excludedProjectEnvVars": ["DEBUG", "DEBUG_MODE", "GOOGLE_GENAI_USE_VERTEXAI", "YOUR_OTHER_VARS"]
+   }
+   ```
+
+3. **If you want to use Vertex AI for the CLI:** Move the Vertex AI configuration to `.gemini/.env`:
+   ```bash
+   mkdir -p .gemini
+   cat >> .gemini/.env <<'EOF'
+   GOOGLE_GENAI_USE_VERTEXAI=true
+   GOOGLE_CLOUD_PROJECT="your-project-id"
+   GOOGLE_CLOUD_LOCATION="us-central1"
+   EOF
+   ```
 
 ## Non-Interactive Mode / Headless Environments
 

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -324,7 +324,7 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
 2.  If not found, it searches upwards in parent directories until it finds an `.env` file or reaches the project root (identified by a `.git` folder) or the home directory.
 3.  If still not found, it looks for `~/.env` (in the user's home directory).
 
-**Environment Variable Exclusion:** Some environment variables (like `DEBUG` and `DEBUG_MODE`) are automatically excluded from being loaded from project `.env` files to prevent interference with gemini-cli behavior. Variables from `.gemini/.env` files are never excluded. You can customize this behavior using the `excludedProjectEnvVars` setting in your `settings.json` file.
+**Environment Variable Exclusion:** Some environment variables (like `DEBUG`, `DEBUG_MODE`, and `GOOGLE_GENAI_USE_VERTEXAI`) are automatically excluded from being loaded from project `.env` files to prevent interference with gemini-cli behavior. This is particularly important for `GOOGLE_GENAI_USE_VERTEXAI`, which is often used in project code to configure application behavior but should not automatically force the CLI to use Vertex AI authentication. Variables from `.gemini/.env` files are never excluded. You can customize this behavior using the `excludedProjectEnvVars` setting in your `settings.json` file.
 
 - **`GEMINI_API_KEY`** (Required):
   - Your API key for the Gemini API.

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -24,7 +24,7 @@ import { CustomTheme } from '../ui/themes/theme.js';
 export const SETTINGS_DIRECTORY_NAME = '.gemini';
 export const USER_SETTINGS_DIR = path.join(homedir(), SETTINGS_DIRECTORY_NAME);
 export const USER_SETTINGS_PATH = path.join(USER_SETTINGS_DIR, 'settings.json');
-export const DEFAULT_EXCLUDED_ENV_VARS = ['DEBUG', 'DEBUG_MODE'];
+export const DEFAULT_EXCLUDED_ENV_VARS = ['DEBUG', 'DEBUG_MODE', 'GOOGLE_GENAI_USE_VERTEXAI'];
 
 export function getSystemSettingsPath(): string {
   if (process.env.GEMINI_CLI_SYSTEM_SETTINGS_PATH) {

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -57,6 +57,16 @@ export function AuthDialog({
     ) {
       return 'Existing API key detected (GEMINI_API_KEY). Select "Gemini API Key" option to use it.';
     }
+
+    if (process.env.GOOGLE_GENAI_USE_VERTEXAI === 'true') {
+      return (
+        'Warning: GOOGLE_GENAI_USE_VERTEXAI=true detected in environment. ' +
+        'This variable is intended for your project code, not the Gemini CLI. ' +
+        'Consider moving it to a .gemini/.env file if you want to use Vertex AI for the CLI, ' +
+        'or ignore this warning if using a different auth method for the CLI.'
+      );
+    }
+
     return null;
   });
   const items = [


### PR DESCRIPTION
- Add GOOGLE_GENAI_USE_VERTEXAI to DEFAULT_EXCLUDED_ENV_VARS to prevent project .env files from forcing CLI to use Vertex AI auth
- Add warning in AuthDialog when GOOGLE_GENAI_USE_VERTEXAI is detected in environment to guide users on proper configuration
- Update documentation to explain exclusion behavior and provide troubleshooting guidance for auth conflicts
- Add test coverage for new exclusion behavior

Fixes issue where users with GOOGLE_GENAI_USE_VERTEXAI=true in project .env files could not use Gemini API Key authentication for the CLI, even when explicitly selected in /auth dialog.

Users can still use Vertex AI for CLI by placing config in .gemini/.env

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Closes #5585
- Fixes #5585
- Resolves #5585

