### PR TITLE
feat(cli): route non-interactive output to stderr

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -70,6 +70,7 @@ describe('runNonInteractive', () => {
       getIdeMode: vi.fn().mockReturnValue(false),
       getFullContext: vi.fn().mockReturnValue(false),
       getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      getDebugMode: vi.fn().mockReturnValue(false),
     } as unknown as Config;
   });
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -25,7 +25,7 @@ export async function runNonInteractive(
   prompt_id: string,
 ): Promise<void> {
   const consolePatcher = new ConsolePatcher({
-    stderrOnly: true,
+    stderr: true,
     debugMode: config.getDebugMode(),
   });
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -24,12 +24,12 @@ export async function runNonInteractive(
   input: string,
   prompt_id: string,
 ): Promise<void> {
+  await config.initialize();
   const consolePatcher = new ConsolePatcher({
     stderrOnly: true,
     debugMode: config.getDebugMode(),
   });
   consolePatcher.patch();
-  await config.initialize();
   // Handle EPIPE errors when the output is piped to a command that closes early.
   process.stdout.on('error', (err: NodeJS.ErrnoException) => {
     if (err.code === 'EPIPE') {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -17,12 +17,18 @@ import {
 import { Content, Part, FunctionCall } from '@google/genai';
 
 import { parseAndFormatApiError } from './ui/utils/errorParsing.js';
+import { ConsolePatcher } from './ui/utils/ConsolePatcher.js';
 
 export async function runNonInteractive(
   config: Config,
   input: string,
   prompt_id: string,
 ): Promise<void> {
+  const consolePatcher = new ConsolePatcher({
+    stderrOnly: true,
+    debugMode: config.getDebugMode(),
+  });
+  consolePatcher.patch();
   await config.initialize();
   // Handle EPIPE errors when the output is piped to a command that closes early.
   process.stdout.on('error', (err: NodeJS.ErrnoException) => {
@@ -133,6 +139,7 @@ export async function runNonInteractive(
     );
     process.exit(1);
   } finally {
+    consolePatcher.cleanup();
     if (isTelemetrySdkInitialized()) {
       await shutdownTelemetry();
     }

--- a/packages/cli/src/ui/utils/ConsolePatcher.ts
+++ b/packages/cli/src/ui/utils/ConsolePatcher.ts
@@ -48,7 +48,9 @@ export class ConsolePatcher {
     ) =>
     (...args: unknown[]) => {
       if (this.params.stderrOnly) {
-        this.originalConsoleError(this.formatArgs(args));
+        if (type !== 'debug' || this.params.debugMode) {
+          this.originalConsoleError(this.formatArgs(args));
+        }
         return;
       }
 
@@ -57,13 +59,11 @@ export class ConsolePatcher {
       }
 
       if (type !== 'debug' || this.params.debugMode) {
-        if (this.params.onNewMessage) {
-          this.params.onNewMessage({
-            type,
-            content: this.formatArgs(args),
-            count: 1,
-          });
-        }
+        this.params.onNewMessage?.({
+          type,
+          content: this.formatArgs(args),
+          count: 1,
+        });
       }
     };
 }

--- a/packages/cli/src/ui/utils/ConsolePatcher.ts
+++ b/packages/cli/src/ui/utils/ConsolePatcher.ts
@@ -10,7 +10,7 @@ import { ConsoleMessageItem } from '../types.js';
 interface ConsolePatcherParams {
   onNewMessage?: (message: Omit<ConsoleMessageItem, 'id'>) => void;
   debugMode: boolean;
-  stderrOnly?: boolean;
+  stderr?: boolean;
 }
 
 export class ConsolePatcher {
@@ -47,23 +47,22 @@ export class ConsolePatcher {
       originalMethod: (...args: unknown[]) => void,
     ) =>
     (...args: unknown[]) => {
-      if (this.params.stderrOnly) {
+      if (this.params.stderr) {
         if (type !== 'debug' || this.params.debugMode) {
           this.originalConsoleError(this.formatArgs(args));
         }
-        return;
-      }
+      } else {
+        if (this.params.debugMode) {
+          originalMethod.apply(console, args);
+        }
 
-      if (this.params.debugMode) {
-        originalMethod.apply(console, args);
-      }
-
-      if (type !== 'debug' || this.params.debugMode) {
-        this.params.onNewMessage?.({
-          type,
-          content: this.formatArgs(args),
-          count: 1,
-        });
+        if (type !== 'debug' || this.params.debugMode) {
+          this.params.onNewMessage?.({
+            type,
+            content: this.formatArgs(args),
+            count: 1,
+          });
+        }
       }
     };
 }


### PR DESCRIPTION
This change introduces the ConsoleLoggingPatcher to non-interactive mode. This ensures that all framework and logging messages are routed to STDERR, reserving STDOUT exclusively for the model's response.

This improves the experience for users who are piping the output of the CLI to other tools.

Fixes #5602
Related to #2511
