### PR TITLE
[proposal] Add reverse-i-search for user input

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -535,6 +535,9 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     useLoadingIndicator(streamingState);
   const showAutoAcceptIndicator = useAutoAcceptIndicator({ config });
 
+  const isInputActive =
+    streamingState === StreamingState.Idle && !initError && !isProcessing;
+
   const handleExit = useCallback(
     (
       pressedOnce: boolean,
@@ -643,9 +646,6 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     };
     fetchUserMessages();
   }, [history, logger]);
-
-  const isInputActive =
-    streamingState === StreamingState.Idle && !initError && !isProcessing;
 
   const handleClearScreen = useCallback(() => {
     clearItems();

--- a/packages/cli/src/ui/hooks/useInputHistory.test.ts
+++ b/packages/cli/src/ui/hooks/useInputHistory.test.ts
@@ -31,7 +31,8 @@ describe('useInputHistory', () => {
     // Internal state is not directly testable, but we can infer from behavior.
     // Attempting to navigate down should do nothing if historyIndex is -1.
     act(() => {
-      result.current.navigateDown();
+      const navigated = result.current.navigateDown();
+      expect(navigated).toBe(false);
     });
     expect(mockOnChange).not.toHaveBeenCalled();
   });
@@ -55,7 +56,8 @@ describe('useInputHistory', () => {
       expect(mockOnSubmit).toHaveBeenCalledWith('submit value');
       // Check if history is reset (e.g., by trying to navigate down)
       act(() => {
-        result.current.navigateDown();
+        const navigated = result.current.navigateDown();
+        expect(navigated).toBe(false);
       });
       expect(mockOnChange).not.toHaveBeenCalled();
     });
@@ -146,7 +148,7 @@ describe('useInputHistory', () => {
       );
 
       act(() => {
-        result.current.navigateUp(); // historyIndex becomes 0
+        result.current.navigateUp(); // historyIndex becomes 2
       });
       expect(mockOnChange).toHaveBeenCalledWith(userMessages[2]);
 

--- a/packages/cli/src/ui/hooks/useReverseHistorySearch.test.ts
+++ b/packages/cli/src/ui/hooks/useReverseHistorySearch.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useReverseHistorySearch } from './useReverseHistorySearch.js';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+describe('useReverseHistorySearch', () => {
+  const history = ['a', 'b', 'a', 'c', 'a', 'b'];
+  const onSearch = vi.fn();
+
+  beforeEach(() => {
+    onSearch.mockClear();
+  });
+
+  it('should start a search and find the last match', () => {
+    const { result } = renderHook(() =>
+      useReverseHistorySearch({ history, onSearch }),
+    );
+
+    act(() => {
+      result.current.startSearch('a');
+    });
+
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.searchTerm).toBe('a');
+    expect(onSearch).toHaveBeenCalledWith('a');
+  });
+
+  it('should continue a search and find the next unique match', () => {
+    const { result } = renderHook(() =>
+      useReverseHistorySearch({ history, onSearch }),
+    );
+
+    act(() => {
+      result.current.startSearch('a');
+    });
+
+    act(() => {
+      result.current.continueSearch();
+    });
+
+    expect(onSearch).toHaveBeenCalledWith('a');
+
+    act(() => {
+      result.current.continueSearch();
+    });
+
+    expect(onSearch).toHaveBeenCalledWith('a');
+  });
+
+  it('should navigate up and down the history', () => {
+    const { result } = renderHook(() =>
+      useReverseHistorySearch({ history, onSearch }),
+    );
+
+    act(() => {
+      result.current.startSearch('a');
+    });
+
+    act(() => {
+      result.current.navigateUp();
+    });
+
+    expect(onSearch).toHaveBeenCalledWith('c');
+
+    act(() => {
+      result.current.navigateDown();
+    });
+
+    expect(onSearch).toHaveBeenCalledWith('a');
+  });
+
+  it('should stop the search', () => {
+    const { result } = renderHook(() =>
+      useReverseHistorySearch({ history, onSearch }),
+    );
+
+    act(() => {
+      result.current.startSearch('a');
+    });
+
+    act(() => {
+      result.current.stopSearch();
+    });
+
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.searchTerm).toBe(null);
+  });
+});

--- a/packages/cli/src/ui/hooks/useReverseHistorySearch.ts
+++ b/packages/cli/src/ui/hooks/useReverseHistorySearch.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useState } from 'react';
+
+export interface UseReverseHistorySearchProps {
+  history: readonly string[];
+  onSearch: (result: string) => void;
+}
+
+export const useReverseHistorySearch = ({
+  history,
+  onSearch,
+}: UseReverseHistorySearchProps) => {
+  const [searchTerm, setSearchTerm] = useState<string | null>(null);
+  const [matchIndex, setMatchIndex] = useState(-1);
+
+  const search = (term: string, startIndex: number) => {
+    for (let i = startIndex; i >= 0; i--) {
+      if (history[i].includes(term)) {
+        setMatchIndex(i);
+        onSearch(history[i]);
+        return;
+      }
+    }
+  };
+
+  const startSearch = (newTerm: string) => {
+    setSearchTerm(newTerm);
+    search(newTerm, history.length - 1);
+  };
+
+  const continueSearch = () => {
+    if (searchTerm === null) return;
+
+    for (let i = matchIndex - 1; i >= 0; i--) {
+      if (
+        history[i].includes(searchTerm) &&
+        history[i] !== history[matchIndex]
+      ) {
+        setMatchIndex(i);
+        onSearch(history[i]);
+        return;
+      }
+    }
+  };
+
+  const navigateUp = () => {
+    const newIndex = matchIndex > 0 ? matchIndex - 1 : 0;
+    setMatchIndex(newIndex);
+    onSearch(history[newIndex]);
+  };
+
+  const navigateDown = () => {
+    const newIndex =
+      matchIndex < history.length - 1 ? matchIndex + 1 : history.length - 1;
+    setMatchIndex(newIndex);
+    onSearch(history[newIndex]);
+  };
+
+  const stopSearch = useCallback(() => {
+    setSearchTerm(null);
+    setMatchIndex(-1);
+  }, []);
+
+  return {
+    startSearch,
+    continueSearch,
+    navigateUp,
+    navigateDown,
+    stopSearch,
+    isActive: searchTerm !== null,
+    searchTerm,
+  };
+};


### PR DESCRIPTION
## TLDR

Add support for reverse-i-search.

ctrl+r will begin reverse-i searching for the given input and pressing it again will tab up through it. pressing the arrow keys will move back and forth at that point in history (in line with the mac experience).

Interested in feedback/thoughts!


## Dive Deeper

https://github.com/user-attachments/assets/eb288170-21e4-4b3d-b0cf-36aac85a0310


<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
