### PR TITLE
doc(lint): fix docs on how to run linter in "fix" mode

### DIFF
--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -109,10 +109,10 @@ To check for linting errors, run the following command:
 npm run lint
 ```
 
-You can include the `--fix` flag in the command to automatically fix any fixable linting errors:
+You can include the `:fix` flag in the command to automatically fix any fixable linting errors:
 
 ```bash
-npm run lint --fix
+npm run lint:fix
 ```
 
 ## Directory structure


### PR DESCRIPTION
## TLDR

Fix docs to properly call `lint:fix`, ref: https://github.com/google-gemini/gemini-cli/blob/main/package.json#L41