### PR TITLE
feat(file-search): Add support for non-recursive file search

### DIFF
--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -50,6 +50,7 @@ describe('useAtCompletion', () => {
         respectGitIgnore: true,
         respectGeminiIgnore: true,
       })),
+      getEnableRecursiveFileSearch: () => true,
     } as unknown as Config;
     vi.clearAllMocks();
   });
@@ -430,6 +431,43 @@ describe('useAtCompletion', () => {
 
       await cleanupTmpDir(rootDir1);
       await cleanupTmpDir(rootDir2);
+    });
+
+    it.only('should perform a non-recursive search when enableRecursiveFileSearch is false', async () => {
+      const structure: FileSystemStructure = {
+        'file.txt': '',
+        src: {
+          'index.js': '',
+        },
+      };
+      testRootDir = await createTmpDir(structure);
+
+      const nonRecursiveConfig = {
+        getEnableRecursiveFileSearch: () => false,
+        getFileFilteringOptions: vi.fn(() => ({
+          respectGitIgnore: true,
+          respectGeminiIgnore: true,
+        })),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(
+          true,
+          '',
+          nonRecursiveConfig,
+          testRootDir,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+
+      // Should only contain top-level items
+      expect(result.current.suggestions.map((s) => s.value)).toEqual([
+        'src/',
+        'file.txt',
+      ]);
     });
   });
 });

--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -433,7 +433,7 @@ describe('useAtCompletion', () => {
       await cleanupTmpDir(rootDir2);
     });
 
-    it.only('should perform a non-recursive search when enableRecursiveFileSearch is false', async () => {
+    it('should perform a non-recursive search when enableRecursiveFileSearch is false', async () => {
       const structure: FileSystemStructure = {
         'file.txt': '',
         src: {

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -165,6 +165,7 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
             config?.getFileFilteringOptions()?.respectGeminiIgnore ?? true,
           cache: true,
           cacheTtl: 30, // 30 seconds
+          maxDepth: !config?.getEnableRecursiveFileSearch() ? 0 : undefined,
         });
         await searcher.initialize();
         fileSearch.current = searcher;

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -165,7 +165,9 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
             config?.getFileFilteringOptions()?.respectGeminiIgnore ?? true,
           cache: true,
           cacheTtl: 30, // 30 seconds
-          maxDepth: !config?.getEnableRecursiveFileSearch() ? 0 : undefined,
+          maxDepth: !(config?.getEnableRecursiveFileSearch() ?? true)
+            ? 0
+            : undefined,
         });
         await searcher.initialize();
         fileSearch.current = searcher;

--- a/packages/core/src/utils/filesearch/crawlCache.test.ts
+++ b/packages/core/src/utils/filesearch/crawlCache.test.ts
@@ -26,6 +26,17 @@ describe('CrawlCache', () => {
       const key2 = getCacheKey('/foo', 'baz');
       expect(key1).not.toBe(key2);
     });
+
+    it('should generate a different hash for different maxDepth values', () => {
+      const key1 = getCacheKey('/foo', 'bar', 1);
+      const key2 = getCacheKey('/foo', 'bar', 2);
+      const key3 = getCacheKey('/foo', 'bar', undefined);
+      const key4 = getCacheKey('/foo', 'bar');
+      expect(key1).not.toBe(key2);
+      expect(key1).not.toBe(key3);
+      expect(key2).not.toBe(key3);
+      expect(key3).toBe(key4);
+    });
   });
 
   describe('in-memory cache operations', () => {

--- a/packages/core/src/utils/filesearch/crawlCache.ts
+++ b/packages/core/src/utils/filesearch/crawlCache.ts
@@ -17,10 +17,14 @@ const cacheTimers = new Map<string, NodeJS.Timeout>();
 export const getCacheKey = (
   directory: string,
   ignoreContent: string,
+  maxDepth?: number,
 ): string => {
   const hash = crypto.createHash('sha256');
   hash.update(directory);
   hash.update(ignoreContent);
+  if (maxDepth !== undefined) {
+    hash.update(String(maxDepth));
+  }
   return hash.digest('hex');
 };
 

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -19,6 +19,7 @@ export type FileSearchOptions = {
   useGeminiignore: boolean;
   cache: boolean;
   cacheTtl: number;
+  maxDepth?: number;
 };
 
 export class AbortError extends Error {
@@ -256,6 +257,10 @@ export class FileSearch {
         const relativePath = path.relative(this.absoluteDir, dirPath);
         return dirFilter(`${relativePath}/`);
       });
+
+    if (this.options.maxDepth !== undefined) {
+      api.withMaxDepth(this.options.maxDepth);
+    }
 
     return api.crawl(this.absoluteDir).withPromise();
   }

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -216,6 +216,7 @@ export class FileSearch {
       const cacheKey = cache.getCacheKey(
         this.absoluteDir,
         this.ignore.getFingerprint(),
+        this.options.maxDepth,
       );
       const cachedResults = cache.read(cacheKey);
 
@@ -231,6 +232,7 @@ export class FileSearch {
       const cacheKey = cache.getCacheKey(
         this.absoluteDir,
         this.ignore.getFingerprint(),
+        this.options.maxDepth,
       );
       cache.write(cacheKey, this.allFiles, this.options.cacheTtl * 1000);
     }


### PR DESCRIPTION
This commit introduces a feature to disable recursive file searching for `@` completions, respecting the `enableRecursiveFileSearch` setting in the configuration.

The key changes are:
- The `FileSearch` utility in `@google/gemini-cli-core` now accepts a `maxDepth` option, which is passed to the underlying `fdir` file crawler. This allows for fine-grained control over the search depth.
- The `useAtCompletion` hook in `@google/gemini-cli-cli` now checks the `enableRecursiveFileSearch` configuration. If it's `false`, it sets `maxDepth: 0` in the `FileSearch` options to limit the search to the top-level directory.
- The file search cache key now incorporates the `maxDepth` to ensure that cached results from a recursive search aren't incorrectly used for a non-recursive one.
- New test cases have been added to `fileSearch.test.ts` to verify the behavior of `maxDepth` at various levels, ensuring the implementation is robust.
- A new test case has been added to `useAtCompletion.test.ts` to ensure that when recursive search is disabled, only top-level files and directories are returned as suggestions.

This change gives users more control over the file completion behavior and can improve performance in large repositories by avoiding deep directory traversal.

## Reviewer Test Plan

Try setting `enableRecursiveFileSearch` to false and verify that it actually only shows top level results. Also remove the setting and make that full recursion also works.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | 🐧  |
| Docker   | ❓  | ❓  | 🐧   |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
