### PR TITLE
feat: Enable /setup-github to always run, and error appropriately

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -32,7 +32,6 @@ import { themeCommand } from '../ui/commands/themeCommand.js';
 import { toolsCommand } from '../ui/commands/toolsCommand.js';
 import { vimCommand } from '../ui/commands/vimCommand.js';
 import { setupGithubCommand } from '../ui/commands/setupGithubCommand.js';
-import { isGitHubRepository } from '../utils/gitUtils.js';
 
 /**
  * Loads the core, hard-coded slash commands that are an integral part
@@ -74,7 +73,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       themeCommand,
       toolsCommand,
       vimCommand,
-      ...(isGitHubRepository() ? [setupGithubCommand] : []),
+      setupGithubCommand,
     ];
 
     return allDefinitions.filter((cmd): cmd is SlashCommand => cmd !== null);

--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -19,12 +19,21 @@ export const setupGithubCommand: SlashCommand = {
   description: 'Set up GitHub Actions',
   kind: CommandKind.BUILT_IN,
   action: (): SlashCommandActionReturn => {
-    const gitRootRepo = execSync('git rev-parse --show-toplevel', {
-      encoding: 'utf-8',
-    }).trim();
-
     if (!isGitHubRepository()) {
-      throw new Error('Unable to determine the Git root directory.');
+      throw new Error(
+        'Unable to determine the Git root directory. /setup-github must be run from a git repository.',
+      );
+    }
+
+    let gitRootRepo: string;
+    try {
+      gitRootRepo = execSync('git rev-parse --show-toplevel', {
+        encoding: 'utf-8',
+      }).trim();
+    } catch {
+      throw new Error(
+        'Unable to determine the Git root directory. /setup-github must be run from a git repository.',
+      );
     }
 
     const version = 'v0';

--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -19,12 +19,21 @@ export const setupGithubCommand: SlashCommand = {
   description: 'Set up GitHub Actions',
   kind: CommandKind.BUILT_IN,
   action: (): SlashCommandActionReturn => {
-    const gitRootRepo = execSync('git rev-parse --show-toplevel', {
-      encoding: 'utf-8',
-    }).trim();
-
     if (!isGitHubRepository()) {
-      throw new Error('Unable to determine the Git root directory.');
+      throw new Error(
+        'Unable to determine the Git repository. /setup-github must be run from a git repository.',
+      );
+    }
+
+    let gitRootRepo: string;
+    try {
+      gitRootRepo = execSync('git rev-parse --show-toplevel', {
+        encoding: 'utf-8',
+      }).trim();
+    } catch {
+      throw new Error(
+        'Unable to determine the Git root directory. /setup-github must be run from a git repository.',
+      );
     }
 
     const version = 'v0';


### PR DESCRIPTION
## TLDR

Previously `/setup-github` was gated to only show when a GitHub repo was detected. Now it can always be run, and diplays and explicit error when it is run outside of a github repo.


## Dive Deeper

Below are the before/after cases for running `/setup-github` **outside** of a GitHub repository. Cases for running `/setup-github` **inside** a repository are excluded, because they don't change (they autocomplete and no error is displayed)

### Before (outside of GitHub repo)
- User types `/setup-` and `gemini-cli` does not show any slash commands or support autocomplete
  <img width="943" height="197" alt="image" src="https://github.com/user-attachments/assets/3000a8a8-cfeb-4157-84f0-8c770596f9a3" />
- User types `/setup-github`, then hits `enter`, and `gemini-cli` responds with `Unknown command: /setup-github`
  <img width="934" height="212" alt="image" src="https://github.com/user-attachments/assets/4be26e98-ec8b-46d6-ad2e-144b405a4922" />


### After (outside of GitHub repo)
- User types `/setup-` and `gemini-cli` enables autocomplete to `/setup-github` 
  <img width="929" height="123" alt="image" src="https://github.com/user-attachments/assets/f0fb9dd1-3037-47a5-9985-3181afc580b4" />
- User types `/setup-github`, then hits `enter`, and `gemini-cli` responds with `Unable to determine the Git root directory. /setup-github must be run from a git repository.` 
  <img width="927" height="213" alt="image" src="https://github.com/user-attachments/assets/aff57b59-d322-4ed6-8c38-e625031b0f30" />

