### PR TITLE
Fix to send user tool confirmation decision for yolo or non interacti…

### DIFF
--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -468,7 +468,10 @@ export class CoreToolScheduler {
       const { request: reqInfo, tool: toolInstance } = toolCall;
       try {
         if (this.config.getApprovalMode() === ApprovalMode.YOLO) {
-          this.setToolCallOutcome(reqInfo.callId, ToolConfirmationOutcome.ProceedAlways);
+          this.setToolCallOutcome(
+            reqInfo.callId,
+            ToolConfirmationOutcome.ProceedAuto,
+          );
           this.setStatusInternal(reqInfo.callId, 'scheduled');
         } else {
           const confirmationDetails = await toolInstance.shouldConfirmExecute(
@@ -498,7 +501,10 @@ export class CoreToolScheduler {
               wrappedConfirmationDetails,
             );
           } else {
-            this.setToolCallOutcome(reqInfo.callId, ToolConfirmationOutcome.ProceedAlways);
+            this.setToolCallOutcome(
+              reqInfo.callId,
+              ToolConfirmationOutcome.ProceedAuto,
+            );
             this.setStatusInternal(reqInfo.callId, 'scheduled');
           }
         }

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -468,6 +468,13 @@ export class CoreToolScheduler {
       const { request: reqInfo, tool: toolInstance } = toolCall;
       try {
         if (this.config.getApprovalMode() === ApprovalMode.YOLO) {
+          this.toolCalls = this.toolCalls.map((call) => {
+            if (call.request.callId !== reqInfo.callId) return call;
+            return {
+              ...call,
+              outcome: ToolConfirmationOutcome.ProceedAlways,
+            };
+          });
           this.setStatusInternal(reqInfo.callId, 'scheduled');
         } else {
           const confirmationDetails = await toolInstance.shouldConfirmExecute(
@@ -497,6 +504,13 @@ export class CoreToolScheduler {
               wrappedConfirmationDetails,
             );
           } else {
+            this.toolCalls = this.toolCalls.map((call) => {
+              if (call.request.callId !== reqInfo.callId) return call;
+              return {
+                ...call,
+                outcome: ToolConfirmationOutcome.ProceedAlways,
+              };
+            });
             this.setStatusInternal(reqInfo.callId, 'scheduled');
           }
         }

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -470,7 +470,7 @@ export class CoreToolScheduler {
         if (this.config.getApprovalMode() === ApprovalMode.YOLO) {
           this.setToolCallOutcome(
             reqInfo.callId,
-            ToolConfirmationOutcome.ProceedAuto,
+            ToolConfirmationOutcome.ProceedAlways,
           );
           this.setStatusInternal(reqInfo.callId, 'scheduled');
         } else {
@@ -503,7 +503,7 @@ export class CoreToolScheduler {
           } else {
             this.setToolCallOutcome(
               reqInfo.callId,
-              ToolConfirmationOutcome.ProceedAuto,
+              ToolConfirmationOutcome.ProceedAlways,
             );
             this.setStatusInternal(reqInfo.callId, 'scheduled');
           }

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -468,13 +468,7 @@ export class CoreToolScheduler {
       const { request: reqInfo, tool: toolInstance } = toolCall;
       try {
         if (this.config.getApprovalMode() === ApprovalMode.YOLO) {
-          this.toolCalls = this.toolCalls.map((call) => {
-            if (call.request.callId !== reqInfo.callId) return call;
-            return {
-              ...call,
-              outcome: ToolConfirmationOutcome.ProceedAlways,
-            };
-          });
+          this.setToolCallOutcome(reqInfo.callId, ToolConfirmationOutcome.ProceedAlways);
           this.setStatusInternal(reqInfo.callId, 'scheduled');
         } else {
           const confirmationDetails = await toolInstance.shouldConfirmExecute(
@@ -504,13 +498,7 @@ export class CoreToolScheduler {
               wrappedConfirmationDetails,
             );
           } else {
-            this.toolCalls = this.toolCalls.map((call) => {
-              if (call.request.callId !== reqInfo.callId) return call;
-              return {
-                ...call,
-                outcome: ToolConfirmationOutcome.ProceedAlways,
-              };
-            });
+            this.setToolCallOutcome(reqInfo.callId, ToolConfirmationOutcome.ProceedAlways);
             this.setStatusInternal(reqInfo.callId, 'scheduled');
           }
         }
@@ -545,13 +533,7 @@ export class CoreToolScheduler {
       await originalOnConfirm(outcome);
     }
 
-    this.toolCalls = this.toolCalls.map((call) => {
-      if (call.request.callId !== callId) return call;
-      return {
-        ...call,
-        outcome,
-      };
-    });
+    this.setToolCallOutcome(callId, outcome);
 
     if (outcome === ToolConfirmationOutcome.Cancel || signal.aborted) {
       this.setStatusInternal(
@@ -763,5 +745,15 @@ export class CoreToolScheduler {
     if (this.onToolCallsUpdate) {
       this.onToolCallsUpdate([...this.toolCalls]);
     }
+  }
+
+  private setToolCallOutcome(callId: string, outcome: ToolConfirmationOutcome) {
+    this.toolCalls = this.toolCalls.map((call) => {
+      if (call.request.callId !== callId) return call;
+      return {
+        ...call,
+        outcome,
+      };
+    });
   }
 }

--- a/packages/core/src/core/nonInteractiveToolExecutor.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.ts
@@ -14,6 +14,7 @@ import {
 } from '../index.js';
 import { Config } from '../config/config.js';
 import { convertToFunctionResponse } from './coreToolScheduler.js';
+import { ToolCallDecision } from '../telemetry/types.js';
 
 /**
  * Executes a single tool call non-interactively.
@@ -87,6 +88,7 @@ export async function executeToolCall(
       error_type:
         toolResult.error === undefined ? undefined : toolResult.error.type,
       prompt_id: toolCallRequest.prompt_id,
+      decision: ToolCallDecision.ACCEPT,
     });
 
     const response = convertToFunctionResponse(

--- a/packages/core/src/core/nonInteractiveToolExecutor.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.ts
@@ -88,7 +88,7 @@ export async function executeToolCall(
       error_type:
         toolResult.error === undefined ? undefined : toolResult.error.type,
       prompt_id: toolCallRequest.prompt_id,
-      decision: ToolCallDecision.ACCEPT,
+      decision: ToolCallDecision.AUTO_ACCEPT,
     });
 
     const response = convertToFunctionResponse(

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -100,7 +100,7 @@ export function recordToolCallMetrics(
   functionName: string,
   durationMs: number,
   success: boolean,
-  decision?: 'accept' | 'reject' | 'modify',
+  decision?: 'accept' | 'reject' | 'modify' | 'auto_accept',
 ): void {
   if (!toolCallCounter || !toolCallLatencyHistogram || !isMetricsInitialized)
     return;

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -22,14 +22,13 @@ export function getDecisionFromOutcome(
 ): ToolCallDecision {
   switch (outcome) {
     case ToolConfirmationOutcome.ProceedOnce:
+      return ToolCallDecision.ACCEPT;
     case ToolConfirmationOutcome.ProceedAlways:
     case ToolConfirmationOutcome.ProceedAlwaysServer:
     case ToolConfirmationOutcome.ProceedAlwaysTool:
-      return ToolCallDecision.ACCEPT;
+      return ToolCallDecision.AUTO_ACCEPT;
     case ToolConfirmationOutcome.ModifyWithEditor:
       return ToolCallDecision.MODIFY;
-    case ToolConfirmationOutcome.ProceedAuto:
-      return ToolCallDecision.AUTO_ACCEPT;
     case ToolConfirmationOutcome.Cancel:
     default:
       return ToolCallDecision.REJECT;

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -14,6 +14,7 @@ export enum ToolCallDecision {
   ACCEPT = 'accept',
   REJECT = 'reject',
   MODIFY = 'modify',
+  AUTO_ACCEPT = 'auto_accept',
 }
 
 export function getDecisionFromOutcome(
@@ -27,6 +28,8 @@ export function getDecisionFromOutcome(
       return ToolCallDecision.ACCEPT;
     case ToolConfirmationOutcome.ModifyWithEditor:
       return ToolCallDecision.MODIFY;
+    case ToolConfirmationOutcome.ProceedAuto:
+      return ToolCallDecision.AUTO_ACCEPT;
     case ToolConfirmationOutcome.Cancel:
     default:
       return ToolCallDecision.REJECT;

--- a/packages/core/src/telemetry/uiTelemetry.test.ts
+++ b/packages/core/src/telemetry/uiTelemetry.test.ts
@@ -104,6 +104,7 @@ describe('UiTelemetryService', () => {
           [ToolCallDecision.ACCEPT]: 0,
           [ToolCallDecision.REJECT]: 0,
           [ToolCallDecision.MODIFY]: 0,
+          [ToolCallDecision.AUTO_ACCEPT]: 0,
         },
         byName: {},
       },
@@ -362,6 +363,7 @@ describe('UiTelemetryService', () => {
           [ToolCallDecision.ACCEPT]: 1,
           [ToolCallDecision.REJECT]: 0,
           [ToolCallDecision.MODIFY]: 0,
+          [ToolCallDecision.AUTO_ACCEPT]: 0,
         },
       });
     });
@@ -395,6 +397,7 @@ describe('UiTelemetryService', () => {
           [ToolCallDecision.ACCEPT]: 0,
           [ToolCallDecision.REJECT]: 1,
           [ToolCallDecision.MODIFY]: 0,
+          [ToolCallDecision.AUTO_ACCEPT]: 0,
         },
       });
     });
@@ -434,11 +437,13 @@ describe('UiTelemetryService', () => {
         [ToolCallDecision.ACCEPT]: 0,
         [ToolCallDecision.REJECT]: 0,
         [ToolCallDecision.MODIFY]: 0,
+        [ToolCallDecision.AUTO_ACCEPT]: 0,
       });
       expect(tools.byName['test_tool'].decisions).toEqual({
         [ToolCallDecision.ACCEPT]: 0,
         [ToolCallDecision.REJECT]: 0,
         [ToolCallDecision.MODIFY]: 0,
+        [ToolCallDecision.AUTO_ACCEPT]: 0,
       });
     });
 
@@ -483,6 +488,7 @@ describe('UiTelemetryService', () => {
           [ToolCallDecision.ACCEPT]: 1,
           [ToolCallDecision.REJECT]: 1,
           [ToolCallDecision.MODIFY]: 0,
+          [ToolCallDecision.AUTO_ACCEPT]: 0,
         },
       });
     });

--- a/packages/core/src/telemetry/uiTelemetry.ts
+++ b/packages/core/src/telemetry/uiTelemetry.ts
@@ -32,6 +32,7 @@ export interface ToolCallStats {
     [ToolCallDecision.ACCEPT]: number;
     [ToolCallDecision.REJECT]: number;
     [ToolCallDecision.MODIFY]: number;
+    [ToolCallDecision.AUTO_ACCEPT]: number;
   };
 }
 
@@ -62,6 +63,7 @@ export interface SessionMetrics {
       [ToolCallDecision.ACCEPT]: number;
       [ToolCallDecision.REJECT]: number;
       [ToolCallDecision.MODIFY]: number;
+      [ToolCallDecision.AUTO_ACCEPT]: number;
     };
     byName: Record<string, ToolCallStats>;
   };
@@ -94,6 +96,7 @@ const createInitialMetrics = (): SessionMetrics => ({
       [ToolCallDecision.ACCEPT]: 0,
       [ToolCallDecision.REJECT]: 0,
       [ToolCallDecision.MODIFY]: 0,
+      [ToolCallDecision.AUTO_ACCEPT]: 0,
     },
     byName: {},
   },
@@ -192,6 +195,7 @@ export class UiTelemetryService extends EventEmitter {
           [ToolCallDecision.ACCEPT]: 0,
           [ToolCallDecision.REJECT]: 0,
           [ToolCallDecision.MODIFY]: 0,
+          [ToolCallDecision.AUTO_ACCEPT]: 0,
         },
       };
     }

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -376,7 +376,6 @@ export type ToolCallConfirmationDetails =
 export enum ToolConfirmationOutcome {
   ProceedOnce = 'proceed_once',
   ProceedAlways = 'proceed_always',
-  ProceedAuto = 'proceed_auto',
   ProceedAlwaysServer = 'proceed_always_server',
   ProceedAlwaysTool = 'proceed_always_tool',
   ModifyWithEditor = 'modify_with_editor',

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -376,6 +376,7 @@ export type ToolCallConfirmationDetails =
 export enum ToolConfirmationOutcome {
   ProceedOnce = 'proceed_once',
   ProceedAlways = 'proceed_always',
+  ProceedAuto = 'proceed_auto',
   ProceedAlwaysServer = 'proceed_always_server',
   ProceedAlwaysTool = 'proceed_always_tool',
   ModifyWithEditor = 'modify_with_editor',


### PR DESCRIPTION
…ve mode

## TLDR

Changes has been done so that User Tool Confirmation Decision is logged in Yolo, non interactive mode as these are the implicit accept mode and hence considered as Accept

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Fixes #5676 
