### PR TITLE
bug(tests): fix test errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,7 @@ export default tseslint.config(
       'packages/vscode-ide-companion/dist/**',
       'bundle/**',
       'package/bundle/**',
+      '.integration-tests/**',
     ],
   },
   eslint.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build:packages": "npm run build --workspaces",
     "build:sandbox": "node scripts/build_sandbox.js --skip-npm-install-build",
     "bundle": "npm run generate && node esbuild.config.js && node scripts/copy_bundle_assets.js",
-    "test": "npm run test --workspaces",
+    "test": "npm run test --workspaces --if-present",
     "test:ci": "npm run test:ci --workspaces --if-present && npm run test:scripts",
     "test:scripts": "vitest run --config ./scripts/tests/vitest.config.ts",
     "test:e2e": "npm run test:integration:sandbox:none -- --verbose --keep-output",


### PR DESCRIPTION
## TLDR

Fix errors when running `npm run test` & `npm run lint`

## Dive Deeper

1. `npm run test` was showing the error:
    ```
    JUNIT report written to /Users/leehagoodjames/repos/gemini-cli/packages/core/junit.xml
     % Coverage report from v8
    npm error Lifecycle script `test` failed with error:
    npm error workspace @google/gemini-cli-test-utils@0.1.0
    npm error location /Users/leehagoodjames/repos/gemini-cli/packages/test-utils
    npm error Missing script: "test"
    npm error
    npm error To see a list of scripts, run:
    npm error   npm run --workspace=@google/gemini-cli-test-utils@0.1.0
    
    
    > gemini-cli-vscode-ide-companion@0.0.1 test
    > vitest run
    ```

    This was occurring because there was no `test` script, and that is being resolved by only triggering tests when there is a         `test` script by adding the `--is-present` flag to `npm run test --workspaces`.

1. `npm run lint` was showing errors such as:

    ```
    /Users/leehagoodjames/repos/gemini-cli/.integration-tests/1754486676792/simple-mcp-server.test.js/simple-mcp-server/mcp-server.cjs
       8:18  error  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
       8:18  error  'require' is not defined                 no-undef
       9:12  error  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
       9:12  error  'require' is not defined                 no-undef
      12:22  error  'process' is not defined                 no-undef
      12:58  error  'process' is not defined                 no-undef
      26:14  error  'process' is not defined                 no-undef
      27:15  error  'process' is not defined                 no-undef
      46:5   error  'process' is not defined                 no-undef
      93:29  error  'params' is defined but never used       @typescript-eslint/no-unused-vars
    
    ✖ 20 problems (20 errors, 0 warnings)
    ```
    
    This is because linting was occurring on files in the `.integration-tests/` directory, which contains autogenerated files. This directory is now ignored by the linter