### PR TITLE
feat(shell): Support subdirectories in all workspace directories

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -438,7 +438,7 @@ describe('build', () => {
     // Simulate only /root/test exists
     vi.mocked(fs.existsSync).mockImplementation((p) => {
       const normalizedPath =
-        typeof p === 'string' ? p.split(path.sep).join('/') : p;
+        typeof p === 'string' ? p.replace(/[\\/]+/g, '/') : p;
       return normalizedPath === '/root/test';
     });
     const invocation = shellTool.build({
@@ -461,7 +461,7 @@ describe('build', () => {
     // Simulate both /root/test and /users/test/test exist
     vi.mocked(fs.existsSync).mockImplementation((p) => {
       const normalizedPath =
-        typeof p === 'string' ? p.split(path.sep).join('/') : p;
+        typeof p === 'string' ? p.replace(/[\\/]+/g, '/') : p;
       return (
         normalizedPath === '/root/test' || normalizedPath === '/users/test/test'
       );
@@ -507,7 +507,7 @@ describe('build', () => {
     // Only /users/test/subdir exists
     vi.mocked(fs.existsSync).mockImplementation((p) => {
       const normalizedPath =
-        typeof p === 'string' ? p.split(path.sep).join('/') : p;
+        typeof p === 'string' ? p.replace(/[\\/]+/g, '/') : p;
       return normalizedPath === '/users/test/subdir';
     });
     const result = shellTool.validateToolParams({
@@ -547,7 +547,7 @@ describe('build', () => {
         // Mock isPathWithinWorkspace to return false for /users/test/dir (simulating it's outside workspace)
         mockContext.isPathWithinWorkspace = vi.fn().mockImplementation((p) => {
           const normalizedPath =
-            typeof p === 'string' ? p.split(path.sep).join('/') : p;
+            typeof p === 'string' ? p.replace(/[\\/]+/g, '/') : p;
           return normalizedPath !== '/users/test/dir';
         });
         return mockContext;
@@ -557,7 +557,7 @@ describe('build', () => {
     // Directory exists at /users/test/dir but isPathWithinWorkspace returns false for it
     vi.mocked(fs.existsSync).mockImplementation((p) => {
       const normalizedPath =
-        typeof p === 'string' ? p.split(path.sep).join('/') : p;
+        typeof p === 'string' ? p.replace(/[\\/]+/g, '/') : p;
       return normalizedPath === '/users/test/dir';
     });
     const result = shellTool.validateToolParams({
@@ -580,7 +580,7 @@ describe('build', () => {
     // Only /root/foo exists, not /root/foobar
     vi.mocked(fs.existsSync).mockImplementation((p) => {
       const normalizedPath =
-        typeof p === 'string' ? p.split(path.sep).join('/') : p;
+        typeof p === 'string' ? p.replace(/[\\/]+/g, '/') : p;
       return normalizedPath === '/root/foo';
     });
     const result = shellTool.validateToolParams({
@@ -622,13 +622,14 @@ describe('build', () => {
       getWorkspaceContext: () =>
         createMockWorkspaceContext('/root', ['/users/test']),
       getGeminiClient: vi.fn(),
+      getShouldUseNodePtyShell: vi.fn().mockReturnValue(false),
     } as unknown as Config;
     const shellTool = new ShellTool(config);
 
     // Only /users/test/subdir exists
     vi.mocked(fs.existsSync).mockImplementation((p) => {
       const normalizedPath =
-        typeof p === 'string' ? p.split(path.sep).join('/') : p;
+        typeof p === 'string' ? p.replace(/[\\/]+/g, '/') : p;
       return normalizedPath === '/users/test/subdir';
     });
 
@@ -659,7 +660,7 @@ describe('build', () => {
 
     // Normalize the captured cwd for comparison on Windows
     const normalizedCapturedCwd = capturedCwd
-      ? capturedCwd.split(path.sep).join('/')
+      ? capturedCwd.replace(/[\\/]+/g, '/')
       : capturedCwd;
     expect(normalizedCapturedCwd).toBe('/users/test/subdir');
   });

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -436,7 +436,11 @@ describe('build', () => {
     } as unknown as Config;
     const shellTool = new ShellTool(config);
     // Simulate only /root/test exists
-    vi.mocked(fs.existsSync).mockImplementation((p) => p === '/root/test');
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      const normalizedPath =
+        typeof p === 'string' ? p.split(path.sep).join('/') : p;
+      return normalizedPath === '/root/test';
+    });
     const invocation = shellTool.build({
       command: 'ls',
       directory: 'test',
@@ -455,9 +459,13 @@ describe('build', () => {
     } as unknown as Config;
     const shellTool = new ShellTool(config);
     // Simulate both /root/test and /users/test/test exist
-    vi.mocked(fs.existsSync).mockImplementation(
-      (p) => p === '/root/test' || p === '/users/test/test',
-    );
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      const normalizedPath =
+        typeof p === 'string' ? p.split(path.sep).join('/') : p;
+      return (
+        normalizedPath === '/root/test' || normalizedPath === '/users/test/test'
+      );
+    });
     const result = shellTool.validateToolParams({
       command: 'ls',
       directory: 'test',
@@ -497,9 +505,11 @@ describe('build', () => {
     } as unknown as Config;
     const shellTool = new ShellTool(config);
     // Only /users/test/subdir exists
-    vi.mocked(fs.existsSync).mockImplementation(
-      (p) => p === '/users/test/subdir',
-    );
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      const normalizedPath =
+        typeof p === 'string' ? p.split(path.sep).join('/') : p;
+      return normalizedPath === '/users/test/subdir';
+    });
     const result = shellTool.validateToolParams({
       command: 'ls',
       directory: 'subdir',
@@ -535,15 +545,21 @@ describe('build', () => {
           '/users/test',
         ]);
         // Mock isPathWithinWorkspace to return false for /users/test/dir (simulating it's outside workspace)
-        mockContext.isPathWithinWorkspace = vi
-          .fn()
-          .mockImplementation((p) => p !== '/users/test/dir');
+        mockContext.isPathWithinWorkspace = vi.fn().mockImplementation((p) => {
+          const normalizedPath =
+            typeof p === 'string' ? p.split(path.sep).join('/') : p;
+          return normalizedPath !== '/users/test/dir';
+        });
         return mockContext;
       },
     } as unknown as Config;
     const shellTool = new ShellTool(config);
     // Directory exists at /users/test/dir but isPathWithinWorkspace returns false for it
-    vi.mocked(fs.existsSync).mockImplementation((p) => p === '/users/test/dir');
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      const normalizedPath =
+        typeof p === 'string' ? p.split(path.sep).join('/') : p;
+      return normalizedPath === '/users/test/dir';
+    });
     const result = shellTool.validateToolParams({
       command: 'ls',
       directory: 'dir',
@@ -562,7 +578,11 @@ describe('build', () => {
     } as unknown as Config;
     const shellTool = new ShellTool(config);
     // Only /root/foo exists, not /root/foobar
-    vi.mocked(fs.existsSync).mockImplementation((p) => p === '/root/foo');
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      const normalizedPath =
+        typeof p === 'string' ? p.split(path.sep).join('/') : p;
+      return normalizedPath === '/root/foo';
+    });
     const result = shellTool.validateToolParams({
       command: 'ls',
       directory: 'foo',
@@ -606,9 +626,11 @@ describe('build', () => {
     const shellTool = new ShellTool(config);
 
     // Only /users/test/subdir exists
-    vi.mocked(fs.existsSync).mockImplementation(
-      (p) => p === '/users/test/subdir',
-    );
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      const normalizedPath =
+        typeof p === 'string' ? p.split(path.sep).join('/') : p;
+      return normalizedPath === '/users/test/subdir';
+    });
 
     const mockAbortSignal = new AbortController().signal;
 
@@ -635,6 +657,10 @@ describe('build', () => {
     const invocation = shellTool.build({ command: 'pwd', directory: 'subdir' });
     await invocation.execute(mockAbortSignal);
 
-    expect(capturedCwd).toBe('/users/test/subdir');
+    // Normalize the captured cwd for comparison on Windows
+    const normalizedCapturedCwd = capturedCwd
+      ? capturedCwd.split(path.sep).join('/')
+      : capturedCwd;
+    expect(normalizedCapturedCwd).toBe('/users/test/subdir');
   });
 });

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -363,7 +363,7 @@ export class ShellTool extends BaseDeclarativeTool<
           directory: {
             type: 'string',
             description:
-              '(OPTIONAL) Directory to run the command in, if not the project root directory. Must be relative to the project root directory and must already exist.',
+              '(OPTIONAL) Directory to run the command in, specified as a relative path that will be resolved from any registered workspace directory. Must be a relative path and must exist. If ambiguous (exists in multiple workspaces), the command will fail - in such cases, provide a longer, more specific relative path that uniquely identifies the directory (e.g., "packages/core/src" instead of just "src").',
           },
         },
         required: ['command'],


### PR DESCRIPTION
## TLDR

This PR fixes the `run_shell_command` tool's directory validation logic to properly support subdirectories across all workspace directories. The previous implementation used flawed basename matching that prevented valid subdirectory execution. This change replaces it with comprehensive multi-workspace directory resolution that handles ambiguity and provides robust validation.

**Key changes:**
- Replace basename matching with comprehensive multi-workspace directory resolution
- Add support for running shell commands in any subdirectory of any workspace directory
- Handle ambiguity when same subdirectory exists in multiple workspace locations
- Add comprehensive test coverage for new functionality
- Update CWD resolution to use getProjectRoot() as default
- Add 6 new test cases covering edge cases and validation scenarios

## Dive Deeper

**Root Cause Analysis:**
The original validation logic used `path.basename(dir) === params.directory`, which compared the base name of workspace roots (e.g., "gemini-cli") with relative subdirectory paths (e.g., "packages/core"). This comparison always failed, preventing valid subdirectory execution.

**Solution Implementation:**
- **Multi-workspace Resolution**: Now checks if the provided directory is a subdirectory of any registered workspace root
- **Ambiguity Handling**: When the same subdirectory exists in multiple workspace locations, the tool now provides clear error messages
- **Robust Validation**: Uses proper path resolution and validation instead of simple string comparison
- **Default CWD**: Updated to use `getProjectRoot()` as the default working directory for better consistency

**Backward Compatibility:**
- All existing functionality remains unchanged
- Commands that worked before continue to work
- Only fixes the validation logic, no breaking changes

## Reviewer Test Plan

**To validate this change works:**

1. **Pull and run the code:**
   ```bash
   git checkout fix/shell-subdirectory-validation
   npm run preflight  # Verify all tests pass
   ```

2. **Test subdirectory execution:**
   ```bash
   # Test in packages/core subdirectory
   run_shell_command(command="ls", directory="packages/core")
   
   # Test in docs subdirectory  
   run_shell_command(command="ls", directory="docs")
   
   # Test in nested subdirectory
   run_shell_command(command="ls", directory="packages/core/src")
   ```

3. **Test edge cases:**
   - Try invalid directories (should fail gracefully)
   - Test with absolute paths
   - Test with relative paths from different workspace roots

4. **Verify test coverage:**
   - Run `npm test` in packages/core to see the 6 new test cases
   - Check that all validation scenarios are covered

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

*Note: Tested on macOS (🍏). Other platforms need testing by reviewers.*

## Linked issues / bugs

**Fixes #5669**

This PR fully resolves the issue where `run_shell_command` failed to validate valid subdirectories within workspace directories. The reported bug is now fixed with comprehensive test coverage to prevent regression.