### PR TITLE
feat(core): Introduce "fancy sort" for intuitive file search results

### DIFF
--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -793,6 +793,8 @@ describe('FileSearch', () => {
       // - Natural numeric sorting (`helper-2.ts` vs `helper-10.ts`)
       // - Extension length sorting (`Button.ts` vs `Button.test.ts`)
       // - Grouping of files within the same subdirectory
+      // - Case-insensitive sorting (`api.ts` vs `API.ts` vs `apple.ts`)
+      // - Subdirectory sorting
       const fancySortStructure = {
         src: {
           components: [
@@ -801,7 +803,14 @@ describe('FileSearch', () => {
             'Button.integration.test.ts',
             'Modal.ts',
           ],
-          utils: ['helper-10.ts', 'helper-2.ts'],
+          utils: {
+            'helper-10.ts': '',
+            'helper-2.ts': '',
+            'API.ts': '',
+            'api.ts': '',
+            'apple.ts': '',
+            access: ['access.ts', 'more.ts'],
+          },
           'App.ts': '',
         },
         'package.json': '',
@@ -816,7 +825,7 @@ describe('FileSearch', () => {
         ignoreDirs: [],
         cache: false,
         cacheTtl: 0,
-        fastSortThreshold: 20,
+        fastSortThreshold: 40,
       });
 
       await fileSearch.initialize();
@@ -825,11 +834,12 @@ describe('FileSearch', () => {
       // Expected order for fancySort:
       // 1. Dirs first, sorted by path.
       // 2. Root files, sorted by name.
-      // 3. Files sorted by dir, then name (numeric), then extension length.
+      // 3. Files sorted by dir, then name (numeric, case-insensitive), then extension length.
       expect(results).toEqual([
         'src/',
         'src/components/',
         'src/utils/',
+        'src/utils/access/',
         'package.json',
         'README.md',
         'src/App.ts',
@@ -837,8 +847,13 @@ describe('FileSearch', () => {
         'src/components/Button.test.ts',
         'src/components/Button.integration.test.ts',
         'src/components/Modal.ts',
+        'src/utils/API.ts',
+        'src/utils/api.ts',
+        'src/utils/apple.ts',
         'src/utils/helper-2.ts',
         'src/utils/helper-10.ts',
+        'src/utils/access/access.ts',
+        'src/utils/access/more.ts',
       ]);
     });
 

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -59,7 +59,10 @@ function fastSort(results: string[]): string[] {
  * @returns The sorted list of paths.
  */
 function fancySort(results: string[]): string[] {
-  const collator = new Intl.Collator(undefined, { numeric: true });
+  const collator = new Intl.Collator(undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
 
   // Schwartzian transform with manual parsing to avoid calling path.parse repeatedly.
   const mapped = results.map((p) => {


### PR DESCRIPTION
Implements a more sophisticated sorting algorithm for file search results, significantly improving the discoverability and intuitive ordering of files for most common queries.

Previously, all file search results were sorted using a purely lexicographical ("fast") sort. While performant, this method could lead to unnatural ordering (e.g., `helper-10.ts` appearing before `helper-2.ts`) and didn't group related files logically, making results harder to parse.

This change introduces `fancySort`, a new algorithm that provides a more human-friendly sort order by considering:
1.  **Directory Grouping**: Lists all directories first, then files.
2.  **Natural Numeric Sorting**: Correctly orders numbered files (`file-2.ts` before `file-10.ts`).
3.  **File Structure Logic**: Groups files within the same directory and sorts them by name, then by extension length (e.g., `Button.ts`, `Button.test.ts`).

To ensure performance is maintained for very broad queries, a hybrid approach has been implemented:
- `fancySort` is now the default for any search query that returns fewer than 20,000 results.
- The original `fastSort` is retained for larger result sets where raw speed is the priority.

This provides users with a much more intuitive list for their everyday, specific searches, while ensuring the system remains highly responsive for repo-wide queries.

Comprehensive tests have been added to validate the behavior of both sorting strategies and the switching mechanism.

## Reviewer Test Plan

1) Try out various sorting scenarios and make sure the order makes sense.
2) Make sure that the sort is still fast for a short query in a really large workspace. eg. Just @ in chromium.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | 🐧  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
