### PR TITLE
chore(cli): log a debug message about why rev-parse fails in /setup-github

### DIFF
--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -30,7 +30,8 @@ export const setupGithubCommand: SlashCommand = {
       gitRootRepo = execSync('git rev-parse --show-toplevel', {
         encoding: 'utf-8',
       }).trim();
-    } catch {
+    } catch (_error) {
+      console.debug(`Failed to get top-level git repo:`, _error);
       throw new Error(
         'Unable to determine the GitHub repository. /setup-github must be run from a git repository.',
       );


### PR DESCRIPTION
## TLDR

Log a debug message about why rev-parse fails. This will help address why `/setup-github` might be failing in a particular directory.

## Dive Deeper

I have no thoughts :)

## Reviewer Test Plan

It's a log message

## Testing Matrix

N/A, just logs

## Linked issues / bugs

N/A