### PR TITLE
feat: open repo secrets page in addition to README

### DIFF
--- a/packages/cli/src/ui/commands/setupGithubCommand.test.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../utils/gitUtils.js', () => ({
   isGitHubRepository: vi.fn(),
   getGitRepoRoot: vi.fn(),
   getLatestGitHubRelease: vi.fn(),
+  getGitHubRepoInfo: vi.fn(),
 }));
 
 describe('setupGithubCommand', async () => {
@@ -30,7 +31,9 @@ describe('setupGithubCommand', async () => {
   });
 
   it('returns a tool action to download github workflows and handles paths', async () => {
-    const fakeRepoRoot = '/github.com/fake/repo/root';
+    const fakeRepoOwner = 'fake';
+    const fakeRepoName = 'repo';
+    const fakeRepoRoot = `/github.com/${fakeRepoOwner}/${fakeRepoName}/root`;
     const fakeReleaseVersion = 'v1.2.3';
 
     vi.mocked(gitUtils.isGitHubRepository).mockReturnValueOnce(true);
@@ -38,6 +41,10 @@ describe('setupGithubCommand', async () => {
     vi.mocked(gitUtils.getLatestGitHubRelease).mockResolvedValueOnce(
       fakeReleaseVersion,
     );
+    vi.mocked(gitUtils.getGitHubRepoInfo).mockReturnValue({
+      owner: fakeRepoOwner,
+      repo: fakeRepoName,
+    });
 
     const result = (await setupGithubCommand.action?.(
       {} as CommandContext,

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -11,6 +11,7 @@ import {
   isAtCommand,
   isSlashCommand,
   copyToClipboard,
+  getUrlOpenCommand,
 } from './commandUtils.js';
 
 // Mock child_process
@@ -339,6 +340,44 @@ describe('commandUtils', () => {
         await copyToClipboard(specialText);
 
         expect(mockChild.stdin.write).toHaveBeenCalledWith(specialText);
+      });
+    });
+  });
+
+  describe('getUrlOpenCommand', () => {
+    describe('on macOS (darwin)', () => {
+      beforeEach(() => {
+        mockProcess.platform = 'darwin';
+      });
+      it('should return open', () => {
+        expect(getUrlOpenCommand()).toBe('open');
+      });
+    });
+
+    describe('on Windows (win32)', () => {
+      beforeEach(() => {
+        mockProcess.platform = 'win32';
+      });
+      it('should return start', () => {
+        expect(getUrlOpenCommand()).toBe('start');
+      });
+    });
+
+    describe('on Linux (linux)', () => {
+      beforeEach(() => {
+        mockProcess.platform = 'linux';
+      });
+      it('should return xdg-open', () => {
+        expect(getUrlOpenCommand()).toBe('xdg-open');
+      });
+    });
+
+    describe('on unmatched OS', () => {
+      beforeEach(() => {
+        mockProcess.platform = 'unmatched';
+      });
+      it('should return xdg-open', () => {
+        expect(getUrlOpenCommand()).toBe('xdg-open');
       });
     });
   });

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -27,7 +27,7 @@ export const isAtCommand = (query: string): boolean =>
  */
 export const isSlashCommand = (query: string): boolean => query.startsWith('/');
 
-//Copies a string snippet to the clipboard for different platforms
+// Copies a string snippet to the clipboard for different platforms
 export const copyToClipboard = async (text: string): Promise<void> => {
   const run = (cmd: string, args: string[]) =>
     new Promise<void>((resolve, reject) => {
@@ -79,4 +79,28 @@ export const copyToClipboard = async (text: string): Promise<void> => {
     default:
       throw new Error(`Unsupported platform: ${process.platform}`);
   }
+};
+
+export const getUrlOpenCommand = (): string => {
+  // --- Determine the OS-specific command to open URLs ---
+  let openCmd: string;
+  switch (process.platform) {
+    case 'darwin':
+      openCmd = 'open';
+      break;
+    case 'win32':
+      openCmd = 'start';
+      break;
+    case 'linux':
+      openCmd = 'xdg-open';
+      break;
+    default:
+      // Default to xdg-open, which appears to be supported for the less popular operating systems.
+      openCmd = 'xdg-open';
+      console.warn(
+        `Unknown platform: ${process.platform}. Attempting to open URLs with: ${openCmd}.`,
+      );
+      break;
+  }
+  return openCmd;
 };

--- a/packages/cli/src/utils/gitUtils.ts
+++ b/packages/cli/src/utils/gitUtils.ts
@@ -91,3 +91,28 @@ export const getLatestGitHubRelease = async (
     );
   }
 };
+
+/**
+ * getGitHubRepoInfo returns the owner and repository for a GitHub repo.
+ * @returns the owner and repository of the github repo.
+ * @throws error if the exec command fails.
+ */
+export function getGitHubRepoInfo(): { owner: string; repo: string } {
+  const remoteUrl = execSync('git remote get-url origin', {
+    encoding: 'utf-8',
+  }).trim();
+
+  // Matches either https://github.com/owner/repo.git or git@github.com:owner/repo.git
+  const match = remoteUrl.match(
+    /(?:https?:\/\/|git@)github\.com(?::|\/)([^/]+)\/([^/]+?)(?:\.git)?$/,
+  );
+
+  // If the regex fails match, throw an error.
+  if (!match || !match[1] || !match[2]) {
+    throw new Error(
+      `Owner & repo could not be extracted from remote URL: ${remoteUrl}`,
+    );
+  }
+
+  return { owner: match[1], repo: match[2] };
+}


### PR DESCRIPTION
When running `/setup-github`, open both the README and the repo's action's secrets settings page.
