### PR TITLE
fix(oauth): Add Accept header to token requests

### DIFF
--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -236,7 +236,10 @@ describe('MCPOAuthProvider', () => {
         'https://discovered.auth.com/token',
         expect.objectContaining({
           method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Accept: 'application/json',
+          },
         }),
       );
     });
@@ -461,7 +464,10 @@ describe('MCPOAuthProvider', () => {
         'https://auth.example.com/token',
         expect.objectContaining({
           method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Accept: 'application/json',
+          },
           body: expect.stringContaining('grant_type=refresh_token'),
         }),
       );

--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -236,10 +236,10 @@ describe('MCPOAuthProvider', () => {
         'https://discovered.auth.com/token',
         expect.objectContaining({
           method: 'POST',
-          headers: {
+          headers: expect.objectContaining({
             'Content-Type': 'application/x-www-form-urlencoded',
             Accept: 'application/json',
-          },
+          }),
         }),
       );
     });
@@ -464,10 +464,10 @@ describe('MCPOAuthProvider', () => {
         'https://auth.example.com/token',
         expect.objectContaining({
           method: 'POST',
-          headers: {
+          headers: expect.objectContaining({
             'Content-Type': 'application/x-www-form-urlencoded',
             Accept: 'application/json',
-          },
+          }),
           body: expect.stringContaining('grant_type=refresh_token'),
         }),
       );

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -370,6 +370,7 @@ export class MCPOAuthProvider {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
       },
       body: params.toString(),
     });
@@ -432,6 +433,7 @@ export class MCPOAuthProvider {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
       },
       body: params.toString(),
     });

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -382,6 +382,13 @@ export class MCPOAuthProvider {
       );
     }
 
+    const contentType = response.headers?.get('content-type');
+    if (!contentType || !contentType.includes('application/json')) {
+      throw new Error(
+        `Token exchange failed: Expected JSON response but received Content-Type: ${contentType || 'undefined'}`,
+      );
+    }
+
     return (await response.json()) as OAuthTokenResponse;
   }
 
@@ -442,6 +449,13 @@ export class MCPOAuthProvider {
       const errorText = await response.text();
       throw new Error(
         `Token refresh failed: ${response.status} - ${errorText}`,
+      );
+    }
+
+    const contentType = response.headers?.get('content-type');
+    if (!contentType || !contentType.includes('application/json')) {
+      throw new Error(
+        `Token refresh failed: Expected JSON response but received Content-Type: ${contentType || 'undefined'}`,
       );
     }
 


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

This PR adds the `Accept: application/json` header to OAuth token requests. This ensures the CLI can correctly parse responses from authorization servers that default to a non-JSON content type.
## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

Some authorization servers respond with a content type like `application/x-www-form-urlencoded` if the Accept header is not specified. When this happens, the CLI, which expects a JSON response, fails to parse it, and the authentication flow breaks.

This fix explicitly adds the `Accept: 'application/json'` header to the fetch requests in both the `exchangeCodeForToken` and `refreshAccessToken` functions within `packages/core/src/mcp/oauth-provider.ts`. This guarantees that a JSON-formatted response is always received, making the authentication flow more robust.
## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

To validate this change, a reviewer should test the OAuth authentication flow. The fix is best verified by testing against an OAuth server that is known to return a non-JSON response when the Accept header is missing.

1. Check out this branch.
2. Run npm install.
3. Run npm run preflight and confirm all tests pass.
4. (If possible) Run the /mcp auth command against an OAuth server that returns a non-JSON response without the Accept header and confirm that authentication now succeeds.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅   | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Fixes #5687
