### PR TITLE
Add detection of tools with bad schemas and automatically omit them with a warning

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -58,7 +58,7 @@ describe('mcp-client', () => {
       const mockedClient = {} as unknown as ClientLib.Client;
       const consoleErrorSpy = vi
         .spyOn(console, 'error')
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
 
       const testError = new Error('Invalid tool name');
       vi.mocked(DiscoveredMCPTool).mockImplementation(
@@ -102,7 +102,7 @@ describe('mcp-client', () => {
       const mockedClient = {} as unknown as ClientLib.Client;
       const consoleWarnSpy = vi
         .spyOn(console, 'warn')
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
       vi.mocked(GenAiLib.mcpToTool).mockReturnValue({
         tool: () =>
           Promise.resolve({
@@ -136,7 +136,7 @@ describe('mcp-client', () => {
       expect(consoleWarnSpy).toHaveBeenCalledOnce();
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         `Skipping tool 'invalidTool' from MCP server 'test-server' because it has ` +
-        `missing types in its parameter schema. Please file an issue with the owner of the MCP server.`,
+          `missing types in its parameter schema. Please file an issue with the owner of the MCP server.`,
       );
       consoleWarnSpy.mockRestore();
     });
@@ -145,7 +145,7 @@ describe('mcp-client', () => {
       const mockedClient = {} as unknown as ClientLib.Client;
       const consoleWarnSpy = vi
         .spyOn(console, 'warn')
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
       vi.mocked(GenAiLib.mcpToTool).mockReturnValue({
         tool: () =>
           Promise.resolve({
@@ -176,7 +176,7 @@ describe('mcp-client', () => {
       expect(consoleWarnSpy).toHaveBeenCalledOnce();
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         `Skipping tool 'invalidTool' from MCP server 'test-server' because it has ` +
-        `missing types in its parameter schema. Please file an issue with the owner of the MCP server.`,
+          `missing types in its parameter schema. Please file an issue with the owner of the MCP server.`,
       );
       consoleWarnSpy.mockRestore();
     });
@@ -185,7 +185,7 @@ describe('mcp-client', () => {
       const mockedClient = {} as unknown as ClientLib.Client;
       const consoleWarnSpy = vi
         .spyOn(console, 'warn')
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
       vi.mocked(GenAiLib.mcpToTool).mockReturnValue({
         tool: () =>
           Promise.resolve({
@@ -214,7 +214,7 @@ describe('mcp-client', () => {
       expect(consoleWarnSpy).toHaveBeenCalledOnce();
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         `Skipping tool 'invalidTool' from MCP server 'test-server' because it has ` +
-        `missing types in its parameter schema. Please file an issue with the owner of the MCP server.`,
+          `missing types in its parameter schema. Please file an issue with the owner of the MCP server.`,
       );
       consoleWarnSpy.mockRestore();
     });
@@ -223,7 +223,7 @@ describe('mcp-client', () => {
       const mockedClient = {} as unknown as ClientLib.Client;
       const consoleWarnSpy = vi
         .spyOn(console, 'warn')
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
       vi.mocked(GenAiLib.mcpToTool).mockReturnValue({
         tool: () =>
           Promise.resolve({
@@ -250,7 +250,7 @@ describe('mcp-client', () => {
       const mockedClient = {} as unknown as ClientLib.Client;
       const consoleWarnSpy = vi
         .spyOn(console, 'warn')
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
       vi.mocked(GenAiLib.mcpToTool).mockReturnValue({
         tool: () =>
           Promise.resolve({
@@ -319,7 +319,7 @@ describe('mcp-client', () => {
 
       const consoleLogSpy = vi
         .spyOn(console, 'debug')
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
 
       await discoverPrompts('test-server', mockedClient, mockedPromptRegistry);
 
@@ -343,7 +343,7 @@ describe('mcp-client', () => {
 
       const consoleLogSpy = vi
         .spyOn(console, 'debug')
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
 
       await discoverPrompts('test-server', mockedClient, mockedPromptRegistry);
 
@@ -368,7 +368,7 @@ describe('mcp-client', () => {
 
       const consoleErrorSpy = vi
         .spyOn(console, 'error')
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
 
       await discoverPrompts('test-server', mockedClient, mockedPromptRegistry);
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -491,8 +491,8 @@ export async function discoverTools(
         if (!hasValidTypes(funcDecl.parametersJsonSchema)) {
           console.warn(
             `Skipping tool '${funcDecl.name}' from MCP server '${mcpServerName}' ` +
-            `because it has missing types in its parameter schema. Please file an ` +
-            `issue with the owner of the MCP server.`,
+              `because it has missing types in its parameter schema. Please file an ` +
+              `issue with the owner of the MCP server.`,
           );
           continue;
         }
@@ -510,7 +510,8 @@ export async function discoverTools(
         );
       } catch (error) {
         console.error(
-          `Error discovering tool: '${funcDecl.name
+          `Error discovering tool: '${
+            funcDecl.name
           }' from MCP server '${mcpServerName}': ${(error as Error).message}`,
         );
       }
@@ -695,18 +696,18 @@ export async function connectToMcpServer(
           if (hasStoredTokens) {
             console.log(
               `Stored OAuth token for SSE server '${mcpServerName}' was rejected. ` +
-              `Please re-authenticate using: /mcp auth ${mcpServerName}`,
+                `Please re-authenticate using: /mcp auth ${mcpServerName}`,
             );
           } else {
             console.log(
               `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-              `Please authenticate using: /mcp auth ${mcpServerName}`,
+                `Please authenticate using: /mcp auth ${mcpServerName}`,
             );
           }
         }
         throw new Error(
           `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-          `Please authenticate using: /mcp auth ${mcpServerName}`,
+            `Please authenticate using: /mcp auth ${mcpServerName}`,
         );
       }
 
@@ -848,18 +849,18 @@ export async function connectToMcpServer(
             if (hasStoredTokens) {
               console.log(
                 `Stored OAuth token for SSE server '${mcpServerName}' was rejected. ` +
-                `Please re-authenticate using: /mcp auth ${mcpServerName}`,
+                  `Please re-authenticate using: /mcp auth ${mcpServerName}`,
               );
             } else {
               console.log(
                 `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-                `Please authenticate using: /mcp auth ${mcpServerName}`,
+                  `Please authenticate using: /mcp auth ${mcpServerName}`,
               );
             }
           }
           throw new Error(
             `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-            `Please authenticate using: /mcp auth ${mcpServerName}`,
+              `Please authenticate using: /mcp auth ${mcpServerName}`,
           );
         }
 
@@ -1042,11 +1043,11 @@ export async function createTransport(
     if (!accessToken) {
       console.error(
         `MCP server '${mcpServerName}' requires OAuth authentication. ` +
-        `Please authenticate using the /mcp auth command.`,
+          `Please authenticate using the /mcp auth command.`,
       );
       throw new Error(
         `MCP server '${mcpServerName}' requires OAuth authentication. ` +
-        `Please authenticate using the /mcp auth command.`,
+          `Please authenticate using the /mcp auth command.`,
       );
     }
   } else {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -422,8 +422,10 @@ export async function connectAndDiscover(
  *
  * @param schema The JSON schema to validate.
  * @returns `true` if the schema is valid, `false` otherwise.
+ *
+ * @visiblefortesting
  */
-function hasValidTypes(schema: unknown): boolean {
+export function hasValidTypes(schema: unknown): boolean {
   if (typeof schema !== 'object' || schema === null) {
     // Not a schema object we can validate, or not a schema at all.
     // Treat as valid as it has no properties to be invalid.
@@ -453,8 +455,6 @@ function hasValidTypes(schema: unknown): boolean {
     // If the node itself is missing a type and had no subschemas, then it isn't valid.
     if (!hasSubSchema) return false;
   }
-
-
 
   if (s.type === 'object' && s.properties) {
     if (typeof s.properties === 'object' && s.properties !== null) {
@@ -510,8 +510,8 @@ export async function discoverTools(
         if (!hasValidTypes(funcDecl.parametersJsonSchema)) {
           console.warn(
             `Skipping tool '${funcDecl.name}' from MCP server '${mcpServerName}' ` +
-            `because it has missing types in its parameter schema. Please file an ` +
-            `issue with the owner of the MCP server.`,
+              `because it has missing types in its parameter schema. Please file an ` +
+              `issue with the owner of the MCP server.`,
           );
           continue;
         }
@@ -529,7 +529,8 @@ export async function discoverTools(
         );
       } catch (error) {
         console.error(
-          `Error discovering tool: '${funcDecl.name
+          `Error discovering tool: '${
+            funcDecl.name
           }' from MCP server '${mcpServerName}': ${(error as Error).message}`,
         );
       }
@@ -714,18 +715,18 @@ export async function connectToMcpServer(
           if (hasStoredTokens) {
             console.log(
               `Stored OAuth token for SSE server '${mcpServerName}' was rejected. ` +
-              `Please re-authenticate using: /mcp auth ${mcpServerName}`,
+                `Please re-authenticate using: /mcp auth ${mcpServerName}`,
             );
           } else {
             console.log(
               `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-              `Please authenticate using: /mcp auth ${mcpServerName}`,
+                `Please authenticate using: /mcp auth ${mcpServerName}`,
             );
           }
         }
         throw new Error(
           `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-          `Please authenticate using: /mcp auth ${mcpServerName}`,
+            `Please authenticate using: /mcp auth ${mcpServerName}`,
         );
       }
 
@@ -867,18 +868,18 @@ export async function connectToMcpServer(
             if (hasStoredTokens) {
               console.log(
                 `Stored OAuth token for SSE server '${mcpServerName}' was rejected. ` +
-                `Please re-authenticate using: /mcp auth ${mcpServerName}`,
+                  `Please re-authenticate using: /mcp auth ${mcpServerName}`,
               );
             } else {
               console.log(
                 `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-                `Please authenticate using: /mcp auth ${mcpServerName}`,
+                  `Please authenticate using: /mcp auth ${mcpServerName}`,
               );
             }
           }
           throw new Error(
             `401 error received for SSE server '${mcpServerName}' without OAuth configuration. ` +
-            `Please authenticate using: /mcp auth ${mcpServerName}`,
+              `Please authenticate using: /mcp auth ${mcpServerName}`,
           );
         }
 
@@ -1061,11 +1062,11 @@ export async function createTransport(
     if (!accessToken) {
       console.error(
         `MCP server '${mcpServerName}' requires OAuth authentication. ` +
-        `Please authenticate using the /mcp auth command.`,
+          `Please authenticate using the /mcp auth command.`,
       );
       throw new Error(
         `MCP server '${mcpServerName}' requires OAuth authentication. ` +
-        `Please authenticate using the /mcp auth command.`,
+          `Please authenticate using the /mcp auth command.`,
       );
     }
   } else {


### PR DESCRIPTION
## TLDR

Checks MCP tool parameter schemas to ensure all properties have a specified type.

If they don't then we skip adding the tool, and emit a warning asking the user to file an issue on the MCP Server implementation.

## Dive Deeper

Gemini function calling requires types on all schema properties, and if this is not the case then all requests will error out making the entire CLI unusable. It is best to pre-emptively skip these tools in this case since we know they will fail.

It is not actually clear to me if MCP itself allows un-typed parameters from the spec. But either way, Gemini does not.

## Reviewer Test Plan

You can connect to a known MCP server that omits types, and should see a message on startup about the skipped tool. I just created my own, but https://github.com/awslabs/mcp/issues/661 has a real one you could try installing and connecting.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/gemini-cli/issues/4594