### PR TITLE
tests: fix e2e tests

### DIFF
--- a/integration-tests/test-helper.js
+++ b/integration-tests/test-helper.js
@@ -169,13 +169,13 @@ export class TestRig {
     };
 
     if (typeof promptOrOptions === 'string') {
-      command += ` --prompt "${promptOrOptions}"`;
+      command += ` --prompt ${JSON.stringify(promptOrOptions)}`;
     } else if (
       typeof promptOrOptions === 'object' &&
       promptOrOptions !== null
     ) {
       if (promptOrOptions.prompt) {
-        command += ` --prompt "${promptOrOptions.prompt}"`;
+        command += ` --prompt ${JSON.stringify(promptOrOptions.prompt)}`;
       }
       if (promptOrOptions.stdin) {
         execOptions.input = promptOrOptions.stdin;


### PR DESCRIPTION
Previous PR #5481 updated the base `gemini` command structure which made `.strict()` kick in and block unknown arguments.

This exposed a flaw in an integration test. The nested quotes break the shell parsing, and parts of the prompt get interpreted as separate command arguments, which yargs rejects due to `.strict()`

Instead of manually quoting with double quotes, use `JSON.stringify()` which properly escapes all quotes and special characters.
