### PR TITLE
feat(cli): get the run-gemini-cli version from the GitHub API

### DIFF
--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -5,8 +5,13 @@
  */
 
 import path from 'path';
-import { execSync } from 'child_process';
-import { isGitHubRepository } from '../../utils/gitUtils.js';
+
+import { CommandContext } from '../../ui/commands/types.js';
+import {
+  getGitRepoRoot,
+  getLatestGitHubRelease,
+  isGitHubRepository,
+} from '../../utils/gitUtils.js';
 
 import {
   CommandKind,
@@ -18,26 +23,29 @@ export const setupGithubCommand: SlashCommand = {
   name: 'setup-github',
   description: 'Set up GitHub Actions',
   kind: CommandKind.BUILT_IN,
-  action: (): SlashCommandActionReturn => {
+  action: async (
+    context: CommandContext,
+  ): Promise<SlashCommandActionReturn> => {
     if (!isGitHubRepository()) {
       throw new Error(
         'Unable to determine the GitHub repository. /setup-github must be run from a git repository.',
       );
     }
 
-    let gitRootRepo: string;
+    // Find the root directory of the repo
+    let gitRepoRoot: string;
     try {
-      gitRootRepo = execSync('git rev-parse --show-toplevel', {
-        encoding: 'utf-8',
-      }).trim();
-    } catch {
+      gitRepoRoot = getGitRepoRoot();
+    } catch (_error) {
+      console.debug(`Failed to get git repo root:`, _error);
       throw new Error(
         'Unable to determine the GitHub repository. /setup-github must be run from a git repository.',
       );
     }
 
-    const version = 'v0';
-    const workflowBaseUrl = `https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/refs/tags/${version}/examples/workflows/`;
+    // Get the latest release tag from GitHub
+    const proxy = context?.services?.config?.getProxy();
+    const releaseTag = await getLatestGitHubRelease(proxy);
 
     const workflows = [
       'gemini-cli/gemini-cli.yml',
@@ -46,16 +54,29 @@ export const setupGithubCommand: SlashCommand = {
       'pr-review/gemini-pr-review.yml',
     ];
 
-    const command = [
-      'set -e',
-      `mkdir -p "${gitRootRepo}/.github/workflows"`,
-      ...workflows.map((workflow) => {
-        const fileName = path.basename(workflow);
-        return `curl -fsSL -o "${gitRootRepo}/.github/workflows/${fileName}" "${workflowBaseUrl}/${workflow}"`;
-      }),
-      'echo "Workflows downloaded successfully. Follow steps in https://github.com/google-github-actions/run-gemini-cli/blob/v0/README.md#quick-start (skipping the /setup-github step) to complete setup."',
-      'open https://github.com/google-github-actions/run-gemini-cli/blob/v0/README.md#quick-start',
-    ].join(' && ');
+    const commands = [];
+
+    // Ensure fast exit
+    commands.push(`set -eEuo pipefail`);
+
+    // Make the directory if it doesn't exist
+    commands.push(`mkdir -p "${gitRepoRoot}/.github/workflows"`);
+
+    for (const workflow of workflows) {
+      const fileName = path.basename(workflow);
+      const curlCommand = buildCurlCommand(
+        `https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/refs/tags/${releaseTag}/examples/workflows/${workflow}`,
+        [`--output "${gitRepoRoot}/.github/workflows/${fileName}"`],
+      );
+      commands.push(curlCommand);
+    }
+
+    commands.push(
+      `echo "Successfully downloaded ${workflows.length} workflows. Follow the steps in https://github.com/google-github-actions/run-gemini-cli/blob/${releaseTag}/README.md#quick-start (skipping the /setup-github step) to complete setup."`,
+      `open https://github.com/google-github-actions/run-gemini-cli/blob/${releaseTag}/README.md#quick-start`,
+    );
+
+    const command = `(${commands.join(' && ')})`;
     return {
       type: 'tool',
       toolName: 'run_shell_command',
@@ -67,3 +88,20 @@ export const setupGithubCommand: SlashCommand = {
     };
   },
 };
+
+// buildCurlCommand is a helper for constructing a consistent curl command.
+function buildCurlCommand(u: string, additionalArgs?: string[]): string {
+  const args = [];
+  args.push('--fail');
+  args.push('--location');
+  args.push('--show-error');
+  args.push('--silent');
+
+  for (const val of additionalArgs || []) {
+    args.push(val);
+  }
+
+  args.sort();
+
+  return `curl ${args.join(' ')} "${u}"`;
+}

--- a/packages/cli/src/utils/gitUtils.ts
+++ b/packages/cli/src/utils/gitUtils.ts
@@ -5,22 +5,89 @@
  */
 
 import { execSync } from 'child_process';
+import { ProxyAgent, setGlobalDispatcher } from 'undici';
 
 /**
  * Checks if a directory is within a git repository hosted on GitHub.
  * @returns true if the directory is in a git repository with a github.com remote, false otherwise
  */
-export function isGitHubRepository(): boolean {
+export const isGitHubRepository = (): boolean => {
   try {
-    const remotes = execSync('git remote -v', {
-      encoding: 'utf-8',
-    });
+    const remotes = (
+      execSync('git remote -v', {
+        encoding: 'utf-8',
+      }) || ''
+    ).trim();
 
     const pattern = /github\.com/;
 
     return pattern.test(remotes);
   } catch (_error) {
     // If any filesystem error occurs, assume not a git repo
+    console.debug(`Failed to get git remote:`, _error);
     return false;
   }
-}
+};
+
+/**
+ * getGitRepoRoot returns the root directory of the git repository.
+ * @returns the path to the root of the git repo.
+ * @throws error if the exec command fails.
+ */
+export const getGitRepoRoot = (): string => {
+  const gitRepoRoot = (
+    execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf-8',
+    }) || ''
+  ).trim();
+
+  if (!gitRepoRoot) {
+    throw new Error(`Git repo returned empty value`);
+  }
+
+  return gitRepoRoot;
+};
+
+/**
+ * getLatestGitHubRelease returns the release tag as a string.
+ * @returns string of the release tag (e.g. "v1.2.3").
+ */
+export const getLatestGitHubRelease = async (
+  proxy?: string,
+): Promise<string> => {
+  try {
+    const controller = new AbortController();
+    if (proxy) {
+      setGlobalDispatcher(new ProxyAgent(proxy));
+    }
+
+    const endpoint = `https://api.github.com/repos/google-github-actions/run-gemini-cli/releases/latest`;
+
+    const response = await fetch(endpoint, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Invalid response code: ${response.status} - ${response.statusText}`,
+      );
+    }
+
+    const releaseTag = (await response.json()).tag_name;
+    if (!releaseTag) {
+      throw new Error(`Response did not include tag_name field`);
+    }
+    return releaseTag;
+  } catch (_error) {
+    console.debug(`Failed to determine latest run-gemini-cli release:`, _error);
+    throw new Error(
+      `Unable to determine the latest run-gemini-cli release on GitHub.`,
+    );
+  }
+};


### PR DESCRIPTION
## TLDR

This changes the logic on the `/setup-github` command to compute the latest tagged release at the time of invocation and pull the config files that correspond to that release.

## Dive Deeper

The existing implementation relies on keeping a floating tag available upstream, which is error prone. This ensures users get the version that is the latest published when they run `/setup-github`.

This PR also introduced some questions worth discussing like... why do we shell out to the tool command to run curl instead of using Node.js directly to download these files onto the workstation?

## Reviewer Test Plan

Run `/setup-github`.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
