### PR TITLE
experiment: Add feature exp flag for folder trust

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1009,6 +1009,39 @@ describe('loadCliConfig ideModeFeature', () => {
   });
 });
 
+describe('loadCliConfig folderTrustFeature', () => {
+  const originalArgv = process.argv;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    process.env.GEMINI_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('should be false by default', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings: Settings = {};
+    const argv = await parseArguments();
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.getFolderTrustFeature()).toBe(false);
+  });
+
+  it('should be true when settings.folderTrustFeature is true', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = { folderTrustFeature: true };
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.getFolderTrustFeature()).toBe(true);
+  });
+});
+
 vi.mock('fs', async () => {
   const actualFs = await vi.importActual<typeof fs>('fs');
   const MOCK_CWD1 = process.cwd();

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -313,6 +313,8 @@ export async function loadCliConfig(
   const ideModeFeature =
     argv.ideModeFeature ?? settings.ideModeFeature ?? false;
 
+  const folderTrustFeature = settings.folderTrustFeature ?? false;
+
   const allExtensions = annotateActiveExtensions(
     extensions,
     argv.extensions || [],
@@ -480,6 +482,7 @@ export async function loadCliConfig(
     summarizeToolOutput: settings.summarizeToolOutput,
     ideMode,
     ideModeFeature,
+    folderTrustFeature,
   });
 }
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -112,6 +112,7 @@ export interface Settings {
 
   // Flag to be removed post-launch.
   ideModeFeature?: boolean;
+  folderTrustFeature?: boolean;
   /// IDE mode setting configured via slash command toggle.
   ideMode?: boolean;
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -188,6 +188,7 @@ export interface ConfigParameters {
   noBrowser?: boolean;
   summarizeToolOutput?: Record<string, SummarizeToolOutputSettings>;
   ideModeFeature?: boolean;
+  folderTrustFeature?: boolean;
   ideMode?: boolean;
   loadMemoryFromIncludeDirectories?: boolean;
 }
@@ -233,6 +234,7 @@ export class Config {
   private readonly extensionContextFilePaths: string[];
   private readonly noBrowser: boolean;
   private readonly ideModeFeature: boolean;
+  private readonly folderTrustFeature: boolean;
   private ideMode: boolean;
   private ideClient: IdeClient;
   private inFallbackMode = false;
@@ -305,6 +307,7 @@ export class Config {
     this.noBrowser = params.noBrowser ?? false;
     this.summarizeToolOutput = params.summarizeToolOutput;
     this.ideModeFeature = params.ideModeFeature ?? false;
+    this.folderTrustFeature = params.folderTrustFeature ?? false;
     this.ideMode = params.ideMode ?? false;
     this.ideClient = IdeClient.getInstance();
     if (this.ideMode && this.ideModeFeature) {
@@ -636,6 +639,10 @@ export class Config {
 
   getIdeModeFeature(): boolean {
     return this.ideModeFeature;
+  }
+
+  getFolderTrustFeature(): boolean {
+    return this.folderTrustFeature;
   }
 
   getIdeMode(): boolean {


### PR DESCRIPTION
## TLDR

Added a feature flag for folderTrust feature. Will implement all the logic for folderTrust behind this.

## Dive Deeper

## Reviewer Test Plan

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to https://github.com/google-gemini/maintainers-gemini-cli/issues/640

