### PR TITLE
Add a context percentage threshold setting for auto compression

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -270,7 +270,7 @@ In addition to a project settings file, a project's `.gemini` directory can cont
 
 - **`chatCompression`** (object):
   - **Description:** Controls the settings for chat history compression, both automatic and
-  when manually invoked through the /compress command.
+    when manually invoked through the /compress command.
   - **Properties:**
     - **`contextPercentageThreshold`** (number): A value between 0 and 1 that specifies the token threshold for compression as a percentage of the model's total token limit. For example, a value of `0.6` will trigger compression when the chat history exceeds 60% of the token limit.
   - **Example:**

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -268,6 +268,18 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     "loadMemoryFromIncludeDirectories": true
     ```
 
+- **`chatCompression`** (object):
+  - **Description:** Controls the settings for chat history compression, both automatic and
+  when manually invoked through the /compress command.
+  - **Properties:**
+    - **`contextPercentageThreshold`** (number): A value between 0 and 1 that specifies the token threshold for compression as a percentage of the model's total token limit. For example, a value of `0.6` will trigger compression when the chat history exceeds 60% of the token limit.
+  - **Example:**
+    ```json
+    "chatCompression": {
+      "contextPercentageThreshold": 0.6
+    }
+    ```
+
 ### Example `settings.json`:
 
 ```json

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1090,3 +1090,42 @@ describe('loadCliConfig with includeDirectories', () => {
     );
   });
 });
+
+describe('loadCliConfig chatCompression', () => {
+  const originalArgv = process.argv;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    process.env.GEMINI_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('should pass chatCompression settings to the core config', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      chatCompression: {
+        maxContextSize: 5000,
+      },
+    };
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.getChatCompression()).toEqual({
+      maxContextSize: 5000,
+    });
+  });
+
+  it('should have undefined chatCompression if not in settings', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.getChatCompression()).toBeUndefined();
+  });
+});

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1112,12 +1112,12 @@ describe('loadCliConfig chatCompression', () => {
     const argv = await parseArguments();
     const settings: Settings = {
       chatCompression: {
-        maxContextSize: 5000,
+        contextPercentageThreshold: 0.5,
       },
     };
     const config = await loadCliConfig(settings, [], 'test-session', argv);
     expect(config.getChatCompression()).toEqual({
-      maxContextSize: 5000,
+      contextPercentageThreshold: 0.5,
     });
   });
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -480,6 +480,7 @@ export async function loadCliConfig(
     summarizeToolOutput: settings.summarizeToolOutput,
     ideMode,
     ideModeFeature,
+    chatCompression: settings.chatCompression,
   });
 }
 

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -113,6 +113,7 @@ describe('Settings Loading and Merging', () => {
         customThemes: {},
         mcpServers: {},
         includeDirectories: [],
+        chatCompression: {},
       });
       expect(settings.errors.length).toBe(0);
     });
@@ -147,6 +148,7 @@ describe('Settings Loading and Merging', () => {
         customThemes: {},
         mcpServers: {},
         includeDirectories: [],
+        chatCompression: {},
       });
     });
 
@@ -181,6 +183,7 @@ describe('Settings Loading and Merging', () => {
         customThemes: {},
         mcpServers: {},
         includeDirectories: [],
+        chatCompression: {},
       });
     });
 
@@ -213,6 +216,7 @@ describe('Settings Loading and Merging', () => {
         customThemes: {},
         mcpServers: {},
         includeDirectories: [],
+        chatCompression: {},
       });
     });
 
@@ -251,6 +255,7 @@ describe('Settings Loading and Merging', () => {
         customThemes: {},
         mcpServers: {},
         includeDirectories: [],
+        chatCompression: {},
       });
     });
 
@@ -301,6 +306,7 @@ describe('Settings Loading and Merging', () => {
         customThemes: {},
         mcpServers: {},
         includeDirectories: [],
+        chatCompression: {},
       });
     });
 
@@ -675,15 +681,15 @@ describe('Settings Loading and Merging', () => {
       });
     });
 
-    it('should have chatCompression as undefined if not in any settings file', () => {
+    it('should have chatCompression as an empty object if not in any settings file', () => {
       (mockFsExistsSync as Mock).mockReturnValue(false); // No settings files exist
       (fs.readFileSync as Mock).mockReturnValue('{}');
       const settings = loadSettings(MOCK_WORKSPACE_DIR);
-      expect(settings.merged.chatCompression).toBeUndefined();
+      expect(settings.merged.chatCompression).toEqual({});
     });
 
     it('should ignore chatCompression if contextPercentageThreshold is invalid', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
       (mockFsExistsSync as Mock).mockImplementation(
         (p: fs.PathLike) => p === USER_SETTINGS_PATH,
       );
@@ -805,6 +811,7 @@ describe('Settings Loading and Merging', () => {
         customThemes: {},
         mcpServers: {},
         includeDirectories: [],
+        chatCompression: {},
       });
 
       // Check that error objects are populated in settings.errors
@@ -1242,6 +1249,7 @@ describe('Settings Loading and Merging', () => {
           customThemes: {},
           mcpServers: {},
           includeDirectories: [],
+          chatCompression: {},
         });
       });
     });
@@ -1252,7 +1260,7 @@ describe('Settings Loading and Merging', () => {
       (mockFsExistsSync as Mock).mockReturnValue(false);
       const loadedSettings = loadSettings(MOCK_WORKSPACE_DIR);
 
-      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+      vi.mocked(fs.writeFileSync).mockImplementation(() => { });
       // mkdirSync is mocked in beforeEach to return undefined, which is fine for void usage
 
       loadedSettings.setValue(SettingScope.User, 'theme', 'matrix');

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -706,6 +706,32 @@ describe('Settings Loading and Merging', () => {
       warnSpy.mockRestore();
     });
 
+    it('should deep merge chatCompression settings', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const userSettingsContent = {
+        chatCompression: { contextPercentageThreshold: 0.5 },
+      };
+      const workspaceSettingsContent = {
+        chatCompression: {},
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.chatCompression).toEqual({
+        contextPercentageThreshold: 0.5,
+      });
+    });
+
     it('should merge includeDirectories from all scopes', () => {
       (mockFsExistsSync as Mock).mockReturnValue(true);
       const systemSettingsContent = {

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -689,7 +689,7 @@ describe('Settings Loading and Merging', () => {
     });
 
     it('should ignore chatCompression if contextPercentageThreshold is invalid', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       (mockFsExistsSync as Mock).mockImplementation(
         (p: fs.PathLike) => p === USER_SETTINGS_PATH,
       );
@@ -1260,7 +1260,7 @@ describe('Settings Loading and Merging', () => {
       (mockFsExistsSync as Mock).mockReturnValue(false);
       const loadedSettings = loadSettings(MOCK_WORKSPACE_DIR);
 
-      vi.mocked(fs.writeFileSync).mockImplementation(() => { });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
       // mkdirSync is mocked in beforeEach to return undefined, which is fine for void usage
 
       loadedSettings.setValue(SettingScope.User, 'theme', 'matrix');

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -13,6 +13,7 @@ import {
   GEMINI_CONFIG_DIR as GEMINI_DIR,
   getErrorMessage,
   BugCommandSettings,
+  ChatCompressionSettings,
   TelemetrySettings,
   AuthType,
 } from '@google/gemini-cli-core';
@@ -133,6 +134,8 @@ export interface Settings {
   includeDirectories?: string[];
 
   loadMemoryFromIncludeDirectories?: boolean;
+
+  chatCompression?: ChatCompressionSettings;
 }
 
 export interface SettingsError {

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -200,7 +200,7 @@ export class LoadedSettings {
         ...(system.chatCompression || {}),
         ...(user.chatCompression || {}),
         ...(workspace.chatCompression || {}),
-      }
+      },
     };
   }
 
@@ -491,14 +491,13 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
 
   // Validate chatCompression settings
   const chatCompression = loadedSettings.merged.chatCompression;
+  const threshold = chatCompression?.contextPercentageThreshold;
   if (
-    chatCompression &&
-    chatCompression.contextPercentageThreshold &&
-    (chatCompression.contextPercentageThreshold < 0 ||
-      chatCompression.contextPercentageThreshold > 1)
+    threshold != null &&
+    (typeof threshold !== 'number' || threshold < 0 || threshold > 1)
   ) {
     console.warn(
-      `Invalid value for chatCompression.contextPercentageThreshold: "${chatCompression.contextPercentageThreshold}". Please use a value between 0 and 1. Using default compression settings.`,
+      `Invalid value for chatCompression.contextPercentageThreshold: "${threshold}". Please use a value between 0 and 1. Using default compression settings.`,
     );
     delete loadedSettings.merged.chatCompression;
   }

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -484,6 +484,20 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
     settingsErrors,
   );
 
+  // Validate chatCompression settings
+  const chatCompression = loadedSettings.merged.chatCompression;
+  if (
+    chatCompression &&
+    chatCompression.contextPercentageThreshold &&
+    (chatCompression.contextPercentageThreshold < 0 ||
+      chatCompression.contextPercentageThreshold > 1)
+  ) {
+    console.warn(
+      `Invalid value for chatCompression.contextPercentageThreshold: "${chatCompression.contextPercentageThreshold}". Please use a value between 0 and 1. Using default compression settings.`,
+    );
+    delete loadedSettings.merged.chatCompression;
+  }
+
   // Load environment with merged settings
   loadEnvironment(loadedSettings.merged);
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -196,6 +196,11 @@ export class LoadedSettings {
         ...(user.includeDirectories || []),
         ...(workspace.includeDirectories || []),
       ],
+      chatCompression: {
+        ...(system.chatCompression || {}),
+        ...(user.chatCompression || {}),
+        ...(workspace.chatCompression || {}),
+      }
     };
   }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -70,7 +70,7 @@ export interface BugCommandSettings {
 }
 
 export interface ChatCompressionSettings {
-  maxContextSize?: number;
+  contextPercentageThreshold?: number;
 }
 
 export interface SummarizeToolOutputSettings {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -69,6 +69,10 @@ export interface BugCommandSettings {
   urlTemplate: string;
 }
 
+export interface ChatCompressionSettings {
+  maxContextSize?: number;
+}
+
 export interface SummarizeToolOutputSettings {
   tokenBudget?: number;
 }
@@ -190,6 +194,7 @@ export interface ConfigParameters {
   ideModeFeature?: boolean;
   ideMode?: boolean;
   loadMemoryFromIncludeDirectories?: boolean;
+  chatCompression?: ChatCompressionSettings;
 }
 
 export class Config {
@@ -250,6 +255,7 @@ export class Config {
     | undefined;
   private readonly experimentalAcp: boolean = false;
   private readonly loadMemoryFromIncludeDirectories: boolean = false;
+  private readonly chatCompression: ChatCompressionSettings | undefined;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -313,6 +319,7 @@ export class Config {
     }
     this.loadMemoryFromIncludeDirectories =
       params.loadMemoryFromIncludeDirectories ?? false;
+    this.chatCompression = params.chatCompression;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -658,6 +665,10 @@ export class Config {
 
   getIdeClient(): IdeClient {
     return this.ideClient;
+  }
+
+  getChatCompression(): ChatCompressionSettings | undefined {
+    return this.chatCompression;
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -206,6 +206,7 @@ describe('Gemini Client (client.ts)', () => {
       }),
       getGeminiClient: vi.fn(),
       setFallbackMode: vi.fn(),
+      getChatCompression: vi.fn().mockReturnValue(undefined),
     };
     const MockedConfig = vi.mocked(Config, true);
     MockedConfig.mockImplementation(
@@ -531,14 +532,19 @@ describe('Gemini Client (client.ts)', () => {
       expect(newChat).toBe(initialChat);
     });
 
-    it('should trigger summarization if token count is at threshold', async () => {
+    it('should trigger summarization if token count is at threshold with contextPercentageThreshold setting', async () => {
       const MOCKED_TOKEN_LIMIT = 1000;
+      const MOCKED_CONTEXT_PERCENTAGE_THRESHOLD = 0.5;
       vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      vi.spyOn(client['config'], 'getChatCompression').mockReturnValue({
+        contextPercentageThreshold: MOCKED_CONTEXT_PERCENTAGE_THRESHOLD,
+      });
       mockGetHistory.mockReturnValue([
         { role: 'user', parts: [{ text: '...history...' }] },
       ]);
 
-      const originalTokenCount = 1000 * 0.7;
+      const originalTokenCount =
+        MOCKED_TOKEN_LIMIT * MOCKED_CONTEXT_PERCENTAGE_THRESHOLD;
       const newTokenCount = 100;
 
       mockCountTokens

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -694,12 +694,16 @@ export class GeminiClient {
       return null;
     }
 
+    const contextPercentageThreshold =
+      this.config.getChatCompression()?.contextPercentageThreshold;
+
     // Don't compress if not forced and we are under the limit.
-    if (
-      !force &&
-      originalTokenCount < this.COMPRESSION_TOKEN_THRESHOLD * tokenLimit(model)
-    ) {
-      return null;
+    if (!force) {
+      const threshold =
+        contextPercentageThreshold ?? this.COMPRESSION_TOKEN_THRESHOLD;
+      if (originalTokenCount < threshold * tokenLimit(model)) {
+        return null;
+      }
     }
 
     let compressBeforeIndex = findIndexAfterFraction(


### PR DESCRIPTION
## TLDR

By default we auto-compress at 70% of the context window size, this allows you to override that, either higher or lower depending on your preference.

## Dive Deeper

I added this as a part of a larger chat compression settings object in anticipation of future compression related settings.

## Reviewer Test Plan

You can set the setting very low (see the docs in this PR) and then resume a saved chat that is larger than that or just chat until you reach the maximum size (ideally doing something useful....). It will compress based on your setting instead of the default 70%.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

We just discussed this over lunch, decided I should just send a PR.
