### PR TITLE
Update documentation to use the latest Docker image version 0.1.18

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -41,7 +41,7 @@ For security and isolation, Gemini CLI can be run inside a container. This is th
   You can run the published sandbox image directly. This is useful for environments where you only have Docker and want to run the CLI.
   ```bash
   # Run the published sandbox image
-  docker run --rm -it us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.1
+  docker run --rm -it us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.18
   ```
 - **Using the `--sandbox` flag:**
   If you have Gemini CLI installed locally (using the standard installation described above), you can instruct it to run inside the sandbox container.


### PR DESCRIPTION
## TLDR
For new comers, ideally they should use the most up to date version. `0.1.11` was release a month ago (July 7th).

## Dive Deeper
N/A

## Reviewer Test Plan

Simply run 
`docker run --rm -it us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.18`

## Testing Matrix

Only applicable on Docker. It should work just fine on other platforms. 

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ✅   | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A