### PR TITLE
fix(core): Improve errors in situations where the command spawn does …

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -188,7 +188,7 @@ describe('ShellExecutionService', () => {
 
     it('handles errors that do not fire the exit event', async () => {
       const error = new Error('spawn abc ENOENT');
-      const {result} = await simulateExecution('touch cat.jpg', (cp) => {
+      const { result } = await simulateExecution('touch cat.jpg', (cp) => {
         cp.emit('error', error); // No exit event is fired.
       });
 

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -185,6 +185,16 @@ describe('ShellExecutionService', () => {
       expect(result.error).toBe(spawnError);
       expect(result.exitCode).toBe(1);
     });
+
+    it('handles errors that do not fire the exit event', async () => {
+      const error = new Error('spawn abc ENOENT');
+      const {result} = await simulateExecution('touch cat.jpg', (cp) => {
+        cp.emit('error', error); // No exit event is fired.
+      });
+
+      expect(result.error).toBe(error);
+      expect(result.exitCode).toBe(1);
+    });
   });
 
   describe('Aborting Commands', () => {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -48,23 +48,23 @@ export interface ShellExecutionHandle {
  */
 export type ShellOutputEvent =
   | {
-    /** The event contains a chunk of output data. */
-    type: 'data';
-    /** The stream from which the data originated. */
-    stream: 'stdout' | 'stderr';
-    /** The decoded string chunk. */
-    chunk: string;
-  }
+      /** The event contains a chunk of output data. */
+      type: 'data';
+      /** The stream from which the data originated. */
+      stream: 'stdout' | 'stderr';
+      /** The decoded string chunk. */
+      chunk: string;
+    }
   | {
-    /** Signals that the output stream has been identified as binary. */
-    type: 'binary_detected';
-  }
+      /** Signals that the output stream has been identified as binary. */
+      type: 'binary_detected';
+    }
   | {
-    /** Provides progress updates for a binary stream. */
-    type: 'binary_progress';
-    /** The total number of bytes received so far. */
-    bytesReceived: number;
-  };
+      /** Provides progress updates for a binary stream. */
+      type: 'binary_progress';
+      /** The total number of bytes received so far. */
+      bytesReceived: number;
+    };
 
 /**
  * A centralized service for executing shell commands with robust process
@@ -176,7 +176,17 @@ export class ShellExecutionService {
       child.on('error', (err) => {
         const { stdout, stderr, finalBuffer } = cleanup();
         error = err;
-        resolve({ error, stdout, stderr, rawOutput: finalBuffer, output: '', exitCode: 1, signal: null, aborted: false, pid: child.pid });
+        resolve({
+          error,
+          stdout,
+          stderr,
+          rawOutput: finalBuffer,
+          output: stdout + (stderr ? `\n${stderr}` : ''),
+          exitCode: 1,
+          signal: null,
+          aborted: false,
+          pid: child.pid,
+        });
       });
 
       const abortHandler = async () => {
@@ -231,7 +241,7 @@ export class ShellExecutionService {
 
         const finalBuffer = Buffer.concat(outputChunks);
 
-        return { stdout, stderr, finalBuffer }
+        return { stdout, stderr, finalBuffer };
       }
     });
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -228,7 +228,10 @@ export class ShellExecutionService {
         });
       });
 
-      /** Cleans up a process (and it's accompanying state) that is exiting or erroring and returns output formatted output buffers and strings */
+      /**
+       * Cleans up a process (and it's accompanying state) that is exiting or
+       * erroring and returns output formatted output buffers and strings
+       */
       function cleanup() {
         exited = true;
         abortSignal.removeEventListener('abort', abortHandler);


### PR DESCRIPTION
## TLDR

Handle situations where `exit` event is not fired by making the `error` handler very similar to `exit`, also consolidate the logic into a helper function.

## Dive Deeper

Previously, if you didn't have the `bash` shell, the `error` event would fire (and _NOT_ `exit`). This would cause Gemini to "act" like it was thinking, but in reality, the Promise that's managing the shell command execution never resolved and was in a pending state forever.

According to NodeJS - https://nodejs.org/api/child_process.html#event-error

> The 'exit' event may or may not fire after an error has occurred. When listening to both the 'exit' and 'error' events, guard against accidentally invoking handler functions multiple times.

## Reviewer Test Plan

- [ ] Commands still spawn
- [ ] Error'd commands still return useful errors

<img width="404" height="303" alt="image" src="https://github.com/user-attachments/assets/903cf72c-0242-48ee-8565-cb8b30f7817b" />


- [ ] Win32 code paths are unchanged.
- [ ] HACK HACK HACK: You can set your shell to something like `zzz` [here](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/shellExecutionService.ts#L98) and dupe.

<img width="354" height="376" alt="image" src="https://github.com/user-attachments/assets/f9b9cda9-ed1c-493e-b131-9d2a93da7b23" />


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | x  | x  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | x  | -   | -   |

## Linked issues / bugs

- Fixes #3448 
