### PR TITLE
fix(actions): swap gha bot for cla allowlisted gemini-cli-robot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,8 @@ jobs:
 
       - name: Configure Git User
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "gemini-cli-robot"
+          git config user.email "gemini-cli-robot@google.com"
 
       - name: Create and switch to a release branch
         id: release_branch


### PR DESCRIPTION
## TLDR

gemini-cli-robot is a robot account meant for commits in GitHub automation for gemini-cli, responsible for automated tasks such as bumping package versions. 

## Dive Deeper

Currently the github actions bot used is not allowlisted for CLA checks that are required to commit to this repo,.

## Reviewer Test Plan

Verify that this account has been allowlisted in CLA checks at go/signcla-search.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #3792 
