### PR TITLE
fix(cli): Escape before calling read_many_files

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import { handleAtCommand } from './atCommandProcessor.js';
 import {
   Config,
+  escapePath,
   FileDiscoveryService,
   GlobTool,
   ReadManyFilesTool,
@@ -254,7 +255,7 @@ describe('handleAtCommand', () => {
 
     expect(result).toEqual({
       processedQuery: [
-        { text: `@${filePath}` },
+        { text: `@${escapedpath}` },
         { text: '\n--- Content from referenced files ---' },
         { text: `\nContent from @${filePath}:\n` },
         { text: fileContent },
@@ -869,7 +870,7 @@ describe('handleAtCommand', () => {
 
       expect(result).toEqual({
         processedQuery: [
-          { text: `Check @${filePath}, it has spaces.` },
+          { text: `Check @${escapedPath}, it has spaces.` },
           { text: '\n--- Content from referenced files ---' },
           { text: `\nContent from @${filePath}:\n` },
           { text: fileContent },
@@ -1030,7 +1031,8 @@ describe('handleAtCommand', () => {
         path.join(testRootDir, 'file$with&special#chars.txt'),
         fileContent,
       );
-      const query = `Check @${filePath} for content.`;
+      const escapedPath = escapePath(filePath);
+      const query = `Check @${escapedPath} for content.`;
 
       const result = await handleAtCommand({
         query,
@@ -1043,7 +1045,7 @@ describe('handleAtCommand', () => {
 
       expect(result).toEqual({
         processedQuery: [
-          { text: `Check @${filePath} for content.` },
+          { text: `Check @${escapedPath} for content.` },
           { text: '\n--- Content from referenced files ---' },
           { text: `\nContent from @${filePath}:\n` },
           { text: fileContent },

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -172,7 +172,7 @@ describe('handleAtCommand', () => {
     const dirPath = path.dirname(filePath);
     const escapedDirPath = escapePath(dirPath);
     const query = `@${escapedDirPath}`;
-    const resolvedGlob = `${dirPath}/**`;
+    const resolvedGlob = `${escapedDirPath}/**`;
 
     const result = await handleAtCommand({
       query,
@@ -185,7 +185,7 @@ describe('handleAtCommand', () => {
 
     expect(result).toEqual({
       processedQuery: [
-        { text: `@${escapedDirPath}` },
+        { text: `@${resolvedGlob}` },
         { text: '\n--- Content from referenced files ---' },
         { text: `\nContent from @${filePath}:\n` },
         { text: fileContent },

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -244,7 +244,7 @@ describe('handleAtCommand', () => {
       path.join(testRootDir, 'path', 'to', 'my file.txt'),
       fileContent,
     );
-    const escapedpath = path.join(testRootDir, 'path', 'to', 'my\\ file.txt');
+    const escapedpath = escapePath(filePath);
     const query = `@${escapedpath}`;
 
     const result = await handleAtCommand({
@@ -869,7 +869,7 @@ describe('handleAtCommand', () => {
         path.join(testRootDir, 'spaced file.txt'),
         fileContent,
       );
-      const escapedPath = path.join(testRootDir, 'spaced\\ file.txt');
+      const escapedPath = escapePath(path.join(testRootDir, 'spaced file.txt'));
       const query = `Check @${escapedPath}, it has spaces.`;
 
       const result = await handleAtCommand({

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -128,7 +128,8 @@ describe('handleAtCommand', () => {
       path.join(testRootDir, 'path', 'to', 'file.txt'),
       fileContent,
     );
-    const query = `@${filePath}`;
+    const escapedFilePath = escapePath(filePath);
+    const query = `@${escapedFilePath}`;
 
     const result = await handleAtCommand({
       query,
@@ -141,7 +142,7 @@ describe('handleAtCommand', () => {
 
     expect(result).toEqual({
       processedQuery: [
-        { text: `@${filePath}` },
+        { text: `@${escapedFilePath}` },
         { text: '\n--- Content from referenced files ---' },
         { text: `\nContent from @${filePath}:\n` },
         { text: fileContent },
@@ -169,7 +170,8 @@ describe('handleAtCommand', () => {
       fileContent,
     );
     const dirPath = path.dirname(filePath);
-    const query = `@${dirPath}`;
+    const escapedDirPath = escapePath(dirPath);
+    const query = `@${escapedDirPath}`;
     const resolvedGlob = `${dirPath}/**`;
 
     const result = await handleAtCommand({
@@ -183,7 +185,7 @@ describe('handleAtCommand', () => {
 
     expect(result).toEqual({
       processedQuery: [
-        { text: `@${resolvedGlob}` },
+        { text: `@${escapedDirPath}` },
         { text: '\n--- Content from referenced files ---' },
         { text: `\nContent from @${filePath}:\n` },
         { text: fileContent },
@@ -206,9 +208,10 @@ describe('handleAtCommand', () => {
       path.join(testRootDir, 'doc.md'),
       fileContent,
     );
+    const escapedFilePath = escapePath(filePath);
     const textBefore = 'Explain this: ';
     const textAfter = ' in detail.';
-    const query = `${textBefore}@${filePath}${textAfter}`;
+    const query = `${textBefore}@${escapedFilePath}${textAfter}`;
 
     const result = await handleAtCommand({
       query,
@@ -221,7 +224,7 @@ describe('handleAtCommand', () => {
 
     expect(result).toEqual({
       processedQuery: [
-        { text: `${textBefore}@${filePath}${textAfter}` },
+        { text: `${textBefore}@${escapedFilePath}${textAfter}` },
         { text: '\n--- Content from referenced files ---' },
         { text: `\nContent from @${filePath}:\n` },
         { text: fileContent },
@@ -287,7 +290,9 @@ describe('handleAtCommand', () => {
       path.join(testRootDir, 'file2.md'),
       content2,
     );
-    const query = `@${file1Path} @${file2Path}`;
+    const escapedFile1Path = escapePath(file1Path);
+    const escapedFile2Path = escapePath(file2Path);
+    const query = `@${escapedFile1Path} @${escapedFile2Path}`;
 
     const result = await handleAtCommand({
       query,
@@ -326,7 +331,9 @@ describe('handleAtCommand', () => {
       content2,
     );
     const text3 = ' please.';
-    const query = `${text1}@${file1Path}${text2}@${file2Path}${text3}`;
+    const escapedFile1Path = escapePath(file1Path);
+    const escapedFile2Path = escapePath(file2Path);
+    const query = `${text1}@${escapedFile1Path}${text2}@${escapedFile2Path}${text3}`;
 
     const result = await handleAtCommand({
       query,
@@ -363,7 +370,9 @@ describe('handleAtCommand', () => {
       path.join(testRootDir, 'resolved', 'valid2.actual'),
       content2,
     );
-    const query = `Look at @${file1Path} then @${invalidFile} and also just @ symbol, then @${file2Path}`;
+    const escapedFile1Path = escapePath(file1Path);
+    const escapedFile2Path = escapePath(file2Path);
+    const query = `Look at @${escapedFile1Path} then @${invalidFile} and also just @ symbol, then @${escapedFile2Path}`;
 
     const result = await handleAtCommand({
       query,
@@ -377,7 +386,7 @@ describe('handleAtCommand', () => {
     expect(result).toEqual({
       processedQuery: [
         {
-          text: `Look at @${file1Path} then @${invalidFile} and also just @ symbol, then @${file2Path}`,
+          text: `Look at @${escapedFile1Path} then @${invalidFile} and also just @ symbol, then @${escapedFile2Path}`,
         },
         { text: '\n--- Content from referenced files ---' },
         { text: `\nContent from @${file2Path}:\n` },
@@ -825,7 +834,9 @@ describe('handleAtCommand', () => {
         path.join(testRootDir, 'second.txt'),
         content2,
       );
-      const query = `Compare @${file1Path}, @${file2Path}; what's different?`;
+      const escapedFile1Path = escapePath(file1Path);
+      const escapedFile2Path = escapePath(file2Path);
+      const query = `Compare @${escapedFile1Path}, @${escapedFile2Path}; what's different?`;
 
       const result = await handleAtCommand({
         query,
@@ -838,7 +849,9 @@ describe('handleAtCommand', () => {
 
       expect(result).toEqual({
         processedQuery: [
-          { text: `Compare @${file1Path}, @${file2Path}; what's different?` },
+          {
+            text: `Compare @${escapedFile1Path}, @${escapedFile2Path}; what's different?`,
+          },
           { text: '\n--- Content from referenced files ---' },
           { text: `\nContent from @${file1Path}:\n` },
           { text: content1 },
@@ -886,7 +899,8 @@ describe('handleAtCommand', () => {
         path.join(testRootDir, 'example.d.ts'),
         fileContent,
       );
-      const query = `Analyze @${filePath} for type definitions.`;
+      const escapedFilePath = escapePath(filePath);
+      const query = `Analyze @${escapedFilePath} for type definitions.`;
 
       const result = await handleAtCommand({
         query,
@@ -899,7 +913,7 @@ describe('handleAtCommand', () => {
 
       expect(result).toEqual({
         processedQuery: [
-          { text: `Analyze @${filePath} for type definitions.` },
+          { text: `Analyze @${escapedFilePath} for type definitions.` },
           { text: '\n--- Content from referenced files ---' },
           { text: `\nContent from @${filePath}:\n` },
           { text: fileContent },
@@ -915,7 +929,8 @@ describe('handleAtCommand', () => {
         path.join(testRootDir, 'config.json'),
         fileContent,
       );
-      const query = `Check @${filePath}. This file contains settings.`;
+      const escapedFilePath = escapePath(filePath);
+      const query = `Check @${escapedFilePath}. This file contains settings.`;
 
       const result = await handleAtCommand({
         query,
@@ -928,7 +943,7 @@ describe('handleAtCommand', () => {
 
       expect(result).toEqual({
         processedQuery: [
-          { text: `Check @${filePath}. This file contains settings.` },
+          { text: `Check @${escapedFilePath}. This file contains settings.` },
           { text: '\n--- Content from referenced files ---' },
           { text: `\nContent from @${filePath}:\n` },
           { text: fileContent },
@@ -944,7 +959,8 @@ describe('handleAtCommand', () => {
         path.join(testRootDir, 'package.json'),
         fileContent,
       );
-      const query = `Review @${filePath}, then check dependencies.`;
+      const escapedFilePath = escapePath(filePath);
+      const query = `Review @${escapedFilePath}, then check dependencies.`;
 
       const result = await handleAtCommand({
         query,
@@ -957,7 +973,7 @@ describe('handleAtCommand', () => {
 
       expect(result).toEqual({
         processedQuery: [
-          { text: `Review @${filePath}, then check dependencies.` },
+          { text: `Review @${escapedFilePath}, then check dependencies.` },
           { text: '\n--- Content from referenced files ---' },
           { text: `\nContent from @${filePath}:\n` },
           { text: fileContent },
@@ -973,7 +989,8 @@ describe('handleAtCommand', () => {
         path.join(testRootDir, 'version.1.2.3.txt'),
         fileContent,
       );
-      const query = `Check @${filePath} contains version information.`;
+      const escapedFilePath = escapePath(filePath);
+      const query = `Check @${escapedFilePath} contains version information.`;
 
       const result = await handleAtCommand({
         query,
@@ -986,7 +1003,7 @@ describe('handleAtCommand', () => {
 
       expect(result).toEqual({
         processedQuery: [
-          { text: `Check @${filePath} contains version information.` },
+          { text: `Check @${escapedFilePath} contains version information.` },
           { text: '\n--- Content from referenced files ---' },
           { text: `\nContent from @${filePath}:\n` },
           { text: fileContent },
@@ -1002,7 +1019,8 @@ describe('handleAtCommand', () => {
         path.join(testRootDir, 'end.txt'),
         fileContent,
       );
-      const query = `Show me @${filePath}.`;
+      const escapedFilePath = escapePath(filePath);
+      const query = `Show me @${escapedFilePath}.`;
 
       const result = await handleAtCommand({
         query,
@@ -1015,7 +1033,7 @@ describe('handleAtCommand', () => {
 
       expect(result).toEqual({
         processedQuery: [
-          { text: `Show me @${filePath}.` },
+          { text: `Show me @${escapedFilePath}.` },
           { text: '\n--- Content from referenced files ---' },
           { text: `\nContent from @${filePath}:\n` },
           { text: fileContent },
@@ -1061,7 +1079,8 @@ describe('handleAtCommand', () => {
         path.join(testRootDir, 'basicfile.txt'),
         fileContent,
       );
-      const query = `Check @${filePath} please.`;
+      const escapedFilePath = escapePath(filePath);
+      const query = `Check @${escapedFilePath} please.`;
 
       const result = await handleAtCommand({
         query,
@@ -1074,7 +1093,7 @@ describe('handleAtCommand', () => {
 
       expect(result).toEqual({
         processedQuery: [
-          { text: `Check @${filePath} please.` },
+          { text: `Check @${escapedFilePath} please.` },
           { text: '\n--- Content from referenced files ---' },
           { text: `\nContent from @${filePath}:\n` },
           { text: fileContent },

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import { PartListUnion, PartUnion } from '@google/genai';
 import {
   Config,
+  escapePath,
   getErrorMessage,
   isNodeError,
   unescapePath,
@@ -232,7 +233,7 @@ export async function handleAtCommand({
     }
 
     for (const dir of config.getWorkspaceContext().getDirectories()) {
-      let currentPathSpec = pathName;
+      let currentPathSpec = escapePath(pathName);
       let resolvedSuccessfully = false;
       try {
         const absolutePath = path.resolve(dir, pathName);

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -12,6 +12,7 @@ import {
   escapePath,
   getErrorMessage,
   isNodeError,
+  normalizePath,
   unescapePath,
 } from '@google/gemini-cli-core';
 import {
@@ -104,7 +105,7 @@ function parseAllAtCommands(query: string): AtCommandPart[] {
     }
     const rawAtPath = query.substring(atIndex, pathEndIndex);
     // unescapePath expects the @ symbol to be present, and will handle it.
-    const atPath = unescapePath(rawAtPath);
+    const atPath = unescapePath(normalizePath(rawAtPath));
     parts.push({ type: 'atPath', content: atPath });
     currentIndex = pathEndIndex;
   }

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -327,18 +327,15 @@ Use this tool when the user's query implies needing the content of several files
       const workspaceDirs = this.config.getWorkspaceContext().getDirectories();
 
       for (const dir of workspaceDirs) {
-        const entriesInDir = await glob(
-          searchPatterns.map((p) => p.replace(/\\/g, '/')),
-          {
-            cwd: dir,
-            ignore: effectiveExcludes,
-            nodir: true,
-            dot: true,
-            absolute: true,
-            nocase: true,
-            signal,
-          },
-        );
+        const entriesInDir = await glob(searchPatterns, {
+          cwd: dir,
+          ignore: effectiveExcludes,
+          nodir: true,
+          dot: true,
+          absolute: true,
+          nocase: true,
+          signal,
+        });
         for (const entry of entriesInDir) {
           allEntries.add(entry);
         }

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -64,9 +64,7 @@ export class GitIgnoreParser implements GitIgnoreFilter {
       return false;
     }
 
-    // Even in windows, Ignore expects forward slashes.
-    const normalizedPath = relativePath.replace(/\\/g, '/');
-    return this.ig.ignores(normalizedPath);
+    return this.ig.ignores(relativePath);
   }
 
   getPatterns(): string[] {

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -166,6 +166,34 @@ export function unescapePath(filePath: string): string {
 }
 
 /**
+ * Normalizes Windows-style paths by converting backslashes to forward slashes.
+ * Preserves backslashes that are used to escape shell special characters.
+ * @param filePath The path to normalize.
+ * @returns The normalized path with forward slashes.
+ */
+export function normalizePath(filePath: string): string {
+  let result = '';
+  for (let i = 0; i < filePath.length; i++) {
+    const char = filePath[i];
+
+    if (char === '\\') {
+      const nextChar = filePath[i + 1];
+
+      // If the backslash is escaping a shell special character, keep it
+      if (nextChar && SHELL_SPECIAL_CHARS.test(nextChar)) {
+        result += char; // Keep the backslash for escaping
+      } else {
+        // Convert path separator backslash to forward slash
+        result += '/';
+      }
+    } else {
+      result += char;
+    }
+  }
+  return result;
+}
+
+/**
  * Generates a unique hash for a project based on its root path.
  * @param projectRoot The absolute path to the project's root directory.
  * @returns A SHA256 hash of the project root path.


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
