### PR TITLE
fix(tests): add missing deps in cli to fix sandbox runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ USER node
 COPY packages/cli/dist/google-gemini-cli-*.tgz /usr/local/share/npm-global/gemini-cli.tgz
 COPY packages/core/dist/google-gemini-cli-core-*.tgz /usr/local/share/npm-global/gemini-core.tgz
 RUN npm install -g /usr/local/share/npm-global/gemini-cli.tgz /usr/local/share/npm-global/gemini-core.tgz \
+  && npm install -g @modelcontextprotocol/sdk undici \
   && npm cache clean --force \
   && rm -f /usr/local/share/npm-global/gemini-{cli,core}.tgz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ USER node
 COPY packages/cli/dist/google-gemini-cli-*.tgz /usr/local/share/npm-global/gemini-cli.tgz
 COPY packages/core/dist/google-gemini-cli-core-*.tgz /usr/local/share/npm-global/gemini-core.tgz
 RUN npm install -g /usr/local/share/npm-global/gemini-cli.tgz /usr/local/share/npm-global/gemini-core.tgz \
-  && npm install -g @modelcontextprotocol/sdk undici \
   && npm cache clean --force \
   && rm -f /usr/local/share/npm-global/gemini-{cli,core}.tgz
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11681,6 +11681,7 @@
         "@google/gemini-cli-core": "file:../core",
         "@google/genai": "1.9.0",
         "@iarna/toml": "^2.2.5",
+        "@modelcontextprotocol/sdk": "^1.15.1",
         "@types/update-notifier": "^6.0.8",
         "command-exists": "^1.2.9",
         "diff": "^7.0.0",
@@ -11702,6 +11703,7 @@
         "string-width": "^7.1.0",
         "strip-ansi": "^7.1.0",
         "strip-json-comments": "^3.1.1",
+        "undici": "^7.10.0",
         "update-notifier": "^7.3.1",
         "yargs": "^17.7.2",
         "zod": "^3.23.8"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,7 @@
     "@google/gemini-cli-core": "file:../core",
     "@google/genai": "1.9.0",
     "@iarna/toml": "^2.2.5",
+    "@modelcontextprotcol/sdk": "^1.15.0",
     "@types/update-notifier": "^6.0.8",
     "command-exists": "^1.2.9",
     "diff": "^7.0.0",
@@ -52,6 +53,7 @@
     "string-width": "^7.1.0",
     "strip-ansi": "^7.1.0",
     "strip-json-comments": "^3.1.1",
+    "undici": "^7.10.0",
     "update-notifier": "^7.3.1",
     "yargs": "^17.7.2",
     "zod": "^3.23.8"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "@google/gemini-cli-core": "file:../core",
     "@google/genai": "1.9.0",
     "@iarna/toml": "^2.2.5",
-    "@modelcontextprotcol/sdk": "^1.15.0",
+    "@modelcontextprotcol/sdk": "^1.15.1",
     "@types/update-notifier": "^6.0.8",
     "command-exists": "^1.2.9",
     "diff": "^7.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "@google/gemini-cli-core": "file:../core",
     "@google/genai": "1.9.0",
     "@iarna/toml": "^2.2.5",
-    "@modelcontextprotcol/sdk": "^1.15.1",
+    "@modelcontextprotocol/sdk": "^1.15.1",
     "@types/update-notifier": "^6.0.8",
     "command-exists": "^1.2.9",
     "diff": "^7.0.0",


### PR DESCRIPTION
## TLDR

Resolves MODULE_NOT_FOUND errors for modelcontextprotocol/sdk and undici that caused integration tests (specifically those run in the sandbox).

## Dive Deeper

This resolves missing deps in `cli`.

## Reviewer Test Plan

`npm run test:integration:all` should succeed with the changes to the sandbox Dockerfile.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | Yes  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | Yes  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Fixes #5735
- Fixes #5736 