### PR TITLE
feat(core): Enhance Agent's Proactive Self-Modification Capabilities

### DIFF
--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -61,6 +61,7 @@ You are an interactive CLI agent specializing in software engineering tasks. You
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., ${ReadFileTool.Name}' or '${WriteFileTool.Name}'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Proactive Self-Improvement:** Actively identify opportunities to improve your own configuration and context. If you notice the user repeatedly giving the same instruction or could benefit from a new tool, proactively suggest adding it to your `GEMINI.md` context or `settings.json` configuration. Always ask for permission before making changes.
 
 # Primary Workflows
 


### PR DESCRIPTION
By modifying prompts in packages/core/src/core/prompts.ts, added a new line in Core Mandates about Proactive Self-Modification
	modified:   packages/core/src/core/prompts.ts

## TLDR

This change introduces a "Proactive Self-Improvement" directive into the agent's core system prompt (packages/core/src/core/prompts.ts). The goal is to encourage the agent to shift from a purely passive tool to a more collaborative partner by proactively suggesting that it save user preferences or add new capabilities to its configuration files (GEMINI.md or settings.json).

## Dive Deeper

Currently, only the prompt of "should do" have been modified, next we will add "how to do" in the prompts.

## Reviewer Test Plan

This change modifies the agent's core prompt. To verify its effectiveness, the reviewer
  should test for the emergence of new, proactive conversational behaviors in the following
  scenarios.

  Test 1: Verifying `GEMINI.md` Modification Suggestion

   * Scenario: The agent should offer to remember a recurring user preference.
   * Steps to Reproduce:
       1. Start a fresh Gemini CLI session.
       2. State a clear, persistent rule. For example:
          > "From now on, whenever you write Python code for me, you must include type
  hints."
   * Expected Behavior:
       * The agent should not only acknowledge the request but also proactively offer to
         persist this rule.
       * A successful response would be something like: "I can do that. To ensure I remember
          this preference for all our future interactions, would you like me to add the rule
          'Always include type hints in Python code' to my GEMINI.md context file?"

  Test 2: Verifying `settings.json` Modification Suggestion

   * Scenario: The agent should offer to learn a new skill by adding a tool configuration.
   * Steps to Reproduce:
       1. Start a fresh Gemini CLI session.
       2. Ask the agent to perform a task that requires a new, external tool that it doesn't
          have. For example:
          > "Can you connect to my Jira instance and tell me the status of ticket
  'PROJ-123'?"
   * Expected Behavior:
       * The agent should recognize its current limitation and proactively suggest a path to
         gaining the new capability.
       * A successful response would be something like: "I can't connect to Jira out of the
         box, but I can learn to do so if you set up an MCP server for it. Once that's ready,
         I can add it to my settings.json configuration. Would you like me to guide you on how
          to do that?"

  Test 3: Sanity Check (No False Positives)

   * Scenario: The agent should not offer to modify files for simple, one-off commands.
   * Steps to Reproduce:
       1. Start a fresh Gemini CLI session.
       2. Issue a simple, non-recurring command, such as:
          > "List the files in the current directory."
          or
          > "What is the capital of Germany?"
   * Expected Behavior:
       * The agent should execute the command or answer the question directly without
         offering to modify any configuration files. This ensures the new directive doesn't
         make the agent overly eager to change its configuration for no reason.

## Testing Matrix


|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This PR makes progress on #5748 
