### PR TITLE
fix(oauth): Add Accept: application/json header for token exchange

### DIFF
--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -236,7 +236,10 @@ describe('MCPOAuthProvider', () => {
         'https://discovered.auth.com/token',
         expect.objectContaining({
           method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Accept: 'application/json',
+          },
         }),
       );
     });
@@ -461,7 +464,10 @@ describe('MCPOAuthProvider', () => {
         'https://auth.example.com/token',
         expect.objectContaining({
           method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Accept: 'application/json',
+          },
           body: expect.stringContaining('grant_type=refresh_token'),
         }),
       );

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -370,7 +370,7 @@ export class MCPOAuthProvider {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
-        'Accept': 'application/json',
+        Accept: 'application/json',
       },
       body: params.toString(),
     });
@@ -433,6 +433,7 @@ export class MCPOAuthProvider {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
       },
       body: params.toString(),
     });

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -370,6 +370,7 @@ export class MCPOAuthProvider {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
+        'Accept': 'application/json',
       },
       body: params.toString(),
     });


### PR DESCRIPTION
## TLDR

Adds `Accept: application/json` header to OAuth token exchange requests in `MCPOAuthProvider`. This is a **workaround** for GitHub OAuth, which appears to deviate from OAuth 2.0/2.1 spec (RFC 6749, Section 5.1) by not always returning JSON without an explicit `Accept` header.

## Dive Deep

According to OAuth 2.0 (RFC 6749, Section 5.1 "Access Token Response"), a successful access token response **MUST** use the `application/json` media type. This implies that an OAuth 2.0 compliant client should expect a JSON response by default, and a compliant server should provide it.

However, observations suggest that GitHub's OAuth token endpoint might not consistently return `application/json` without an explicit `Accept: application/json` header in the request. This behavior, if confirmed, would be a non-compliance with the OAuth 2.0 specification, as the client should not be required to explicitly request the mandated response format.

By adding this header, we are explicitly instructing GitHub's token endpoint to return JSON, thereby mitigating the issue and allowing the Gemini CLI to correctly parse the token response. This is a pragmatic solution to ensure interoperability with GitHub's current implementation.

## Reviewer Test Plan

To fully validate this change, you will need to set up a GitHub OAuth App and configure the Gemini CLI to interact with a GitHub Remote MCP server.

1.  **Set up GitHub OAuth App:**
    *   Go to your GitHub account settings -> Developer settings -> OAuth Apps.
    *   Create a new OAuth App.
    *   Set the "Homepage URL" to `http://localhost:7777`.
    *   Set the "Authorization callback URL" to `http://localhost:7777/oauth/callback`.
    *   Note down the `Client ID` and `Client Secret`. These will be used in the Gemini CLI configuration.

2.  **Configure Gemini CLI for GitHub Remote MCP Server:**
    *   The Gemini CLI connects to MCP servers via its configuration file, typically located at `~/.gemini/settings.json`.
    *   You need to add an entry under the `mcpServers` property in this `settings.json` file. This entry will define how the Gemini CLI interacts with the GitHub Remote MCP Server.

    *   **Example `settings.json` snippet for GitHub Remote MCP Server:**
        ```json
        {
          "mcpServers": {
            "github-remote-mcp": {
              "httpUrl": "https://api.githubcopilot.com/mcp/",
              "oauth": {
                "clientId": "YOUR_GITHUB_OAUTH_APP_CLIENT_ID",
                "clientSecret": "YOUR_GITHUB_OAUTH_APP_CLIENT_SECRET",
                "authorizationUrl": "https://github.com/login/oauth/authorize",
                "tokenUrl": "https://github.com/login/oauth/access_token",
                "scopes": [
                  "gist",
                  "notifications",
                  "public_repo",
                  "repo",
                  "repo:status",
                  "repo_deployment",
                  "user",
                  "read:gpg_key",
                  "read:org"
                ]
              }
            }
        }
        ```

3.  **Test Authentication:**
    *   Check out this branch: `git checkout fix/github-oauth-token-exchange`
    *   Build the project: `npm install && npm run build`
    *   Start your configured GitHub Remote MCP Server using the command specified in your `settings.json`.
    *   Attempt to authenticate with GitHub OAuth using the Gemini CLI. The CLI should now use your configured GitHub Remote MCP server.
    *   Verify that the token exchange process completes successfully.
    *   Confirm that a valid access token is obtained and saved.
    *   (Optional) Observe network requests during the token exchange to confirm the `Accept: application/json` header is sent.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- No linked issues at this time. -->