### PR TITLE
Include Schema Error Handling for Vertex and Google Auth methods

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -33,8 +33,7 @@ import {
 } from '../telemetry/types.js';
 import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { hasCycleInSchema } from '../tools/tools.js';
-import { isStructuredError } from '../utils/quotaErrorDetection.js';
-import {StructuredError} from './turn.js';
+import { StructuredError } from './turn.js';
 
 /**
  * Returns true if the response is valid, false otherwise.
@@ -379,10 +378,10 @@ export class GeminiChat {
    *   console.log(chunk.text);
    * }
    * ```
-  */
- async sendMessageStream(
-   params: SendMessageParameters,
-   prompt_id: string,
+   */
+  async sendMessageStream(
+    params: SendMessageParameters,
+    prompt_id: string,
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
     await this.sendPromise;
     const userContent = createUserContent(params.message);
@@ -438,8 +437,8 @@ export class GeminiChat {
       // for both success and failure response. The actual failure is still
       // propagated by the `await streamResponse`.
       this.sendPromise = Promise.resolve(streamResponse)
-      .then(() => undefined)
-      .catch(() => undefined);
+        .then(() => undefined)
+        .catch(() => undefined);
 
       const result = this.processStreamResponse(
         streamResponse,
@@ -458,50 +457,50 @@ export class GeminiChat {
 
   /**
    * Returns the chat history.
-  *
-  * @remarks
-  * The history is a list of contents alternating between user and model.
-  *
-  * There are two types of history:
-  * - The `curated history` contains only the valid turns between user and
-  * model, which will be included in the subsequent requests sent to the model.
-  * - The `comprehensive history` contains all turns, including invalid or
-  *   empty model outputs, providing a complete record of the history.
-  *
-  * The history is updated after receiving the response from the model,
-  * for streaming response, it means receiving the last chunk of the response.
-  *
-  * The `comprehensive history` is returned by default. To get the `curated
-  * history`, set the `curated` parameter to `true`.
-  *
-  * @param curated - whether to return the curated history or the comprehensive
-  *     history.
-  * @return History contents alternating between user and model for the entire
-  *     chat session.
-  */
- getHistory(curated: boolean = false): Content[] {
-   const history = curated
-   ? extractCuratedHistory(this.history)
-   : this.history;
-   // Deep copy the history to avoid mutating the history outside of the
-   // chat session.
-   return structuredClone(history);
+   *
+   * @remarks
+   * The history is a list of contents alternating between user and model.
+   *
+   * There are two types of history:
+   * - The `curated history` contains only the valid turns between user and
+   * model, which will be included in the subsequent requests sent to the model.
+   * - The `comprehensive history` contains all turns, including invalid or
+   *   empty model outputs, providing a complete record of the history.
+   *
+   * The history is updated after receiving the response from the model,
+   * for streaming response, it means receiving the last chunk of the response.
+   *
+   * The `comprehensive history` is returned by default. To get the `curated
+   * history`, set the `curated` parameter to `true`.
+   *
+   * @param curated - whether to return the curated history or the comprehensive
+   *     history.
+   * @return History contents alternating between user and model for the entire
+   *     chat session.
+   */
+  getHistory(curated: boolean = false): Content[] {
+    const history = curated
+      ? extractCuratedHistory(this.history)
+      : this.history;
+    // Deep copy the history to avoid mutating the history outside of the
+    // chat session.
+    return structuredClone(history);
   }
 
   /**
    * Clears the chat history.
-  */
- clearHistory(): void {
-   this.history = [];
+   */
+  clearHistory(): void {
+    this.history = [];
   }
 
   /**
    * Adds a new entry to the chat history.
-  *
-  * @param content - The content to add to the history.
-  */
- addHistory(content: Content): void {
-   this.history.push(content);
+   *
+   * @param content - The content to add to the history.
+   */
+  addHistory(content: Content): void {
+    this.history.push(content);
   }
   setHistory(history: Content[]): void {
     this.history = history;
@@ -515,9 +514,9 @@ export class GeminiChat {
     chunks: GenerateContentResponse[],
   ): GenerateContentResponseUsageMetadata | undefined {
     const lastChunkWithMetadata = chunks
-    .slice()
-    .reverse()
-    .find((chunk) => chunk.usageMetadata);
+      .slice()
+      .reverse()
+      .find((chunk) => chunk.usageMetadata);
 
     return lastChunkWithMetadata?.usageMetadata;
   }
@@ -525,7 +524,10 @@ export class GeminiChat {
   async maybeIncludeSchemaDepthContext(error: StructuredError): Promise<void> {
     // Check for potentially problematic cyclic tools with cyclic schemas
     // and include a recommendation to remove potentially problematic tools.
-    if (isSchemaDepthError(error.message) || isInvalidArgumentError(error.message)) {
+    if (
+      isSchemaDepthError(error.message) ||
+      isInvalidArgumentError(error.message)
+    ) {
       const tools = (await this.config.getToolRegistry()).getAllTools();
       const cyclicSchemaTools: string[] = [];
       for (const tool of tools) {
@@ -708,7 +710,6 @@ export class GeminiChat {
       content.parts[0].thought === true
     );
   }
-
 }
 
 /** Visible for Testing */

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -17,12 +17,14 @@ import { GeminiChat } from './geminiChat.js';
 
 const mockSendMessageStream = vi.fn();
 const mockGetHistory = vi.fn();
+const mockMaybeIncludeSchemaDepthContext = vi.fn();
 
 vi.mock('@google/genai', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@google/genai')>();
   const MockChat = vi.fn().mockImplementation(() => ({
     sendMessageStream: mockSendMessageStream,
     getHistory: mockGetHistory,
+    maybeIncludeSchemaDepthContext: mockMaybeIncludeSchemaDepthContext,
   }));
   return {
     ...actual,
@@ -46,6 +48,7 @@ describe('Turn', () => {
   type MockedChatInstance = {
     sendMessageStream: typeof mockSendMessageStream;
     getHistory: typeof mockGetHistory;
+    maybeIncludeSchemaDepthContext: typeof mockMaybeIncludeSchemaDepthContext;
   };
   let mockChatInstance: MockedChatInstance;
 
@@ -54,6 +57,7 @@ describe('Turn', () => {
     mockChatInstance = {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
+      maybeIncludeSchemaDepthContext: mockMaybeIncludeSchemaDepthContext,
     };
     turn = new Turn(mockChatInstance as unknown as GeminiChat, 'prompt-id-1');
     mockGetHistory.mockReturnValue([]);
@@ -200,7 +204,7 @@ describe('Turn', () => {
         { role: 'model', parts: [{ text: 'Previous history' }] },
       ];
       mockGetHistory.mockReturnValue(historyContent);
-
+      mockMaybeIncludeSchemaDepthContext.mockResolvedValue(undefined);
       const events = [];
       for await (const event of turn.run(
         reqParts,

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -275,7 +275,7 @@ export class Turn {
         message: getErrorMessage(error),
         status,
       };
-      await this.chat.maybeIncludeSchemaDepthContext(structuredError)
+      await this.chat.maybeIncludeSchemaDepthContext(structuredError);
       yield { type: GeminiEventType.Error, value: { error: structuredError } };
       return;
     }

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -275,6 +275,7 @@ export class Turn {
         message: getErrorMessage(error),
         status,
       };
+      await this.chat.maybeIncludeSchemaDepthContext(structuredError)
       yield { type: GeminiEventType.Error, value: { error: structuredError } };
       return;
     }


### PR DESCRIPTION
## TLDR

When authenticating via Google/Code Assist or Vertex schema depth errors get surfaces as 400 errors so are not being caught and shown to the user.

## Dive Deeper

The check is moved to within turn, after initial error processing has already happened. 

## Reviewer Test Plan

configure mcpServers to include
```
    "mcp-server-chart": {
      "command": "npx",
      "args": ["-y", "@antv/mcp-server-chart"],
    }
```

Confirm that authenticating via all 3 methods returns a warning that the following tools may have caused the error ("generate_organization_chart", "generate_mind_map", "generate_treemap_chart", "generate_fishbone_diagram")

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes: #5030
Fixes: #155
