### PR TITLE
Add new folderTrust setting that the users can enable or disable

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1042,6 +1042,58 @@ describe('loadCliConfig folderTrustFeature', () => {
   });
 });
 
+describe('loadCliConfig folderTrust', () => {
+  const originalArgv = process.argv;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    process.env.GEMINI_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('should be false if folderTrustFeature is false and folderTrust is false', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings: Settings = {
+      folderTrustFeature: false,
+      folderTrust: false,
+    };
+    const argv = await parseArguments();
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.getFolderTrust()).toBe(false);
+  });
+
+  it('should be false if folderTrustFeature is true and folderTrust is false', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = { folderTrustFeature: true, folderTrust: false };
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.getFolderTrust()).toBe(false);
+  });
+
+  it('should be false if folderTrustFeature is false and folderTrust is true', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = { folderTrustFeature: false, folderTrust: true };
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.getFolderTrust()).toBe(false);
+  });
+
+  it('should be true when folderTrustFeature is true and folderTrust is true', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = { folderTrustFeature: true, folderTrust: true };
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.getFolderTrust()).toBe(true);
+  });
+});
+
 vi.mock('fs', async () => {
   const actualFs = await vi.importActual<typeof fs>('fs');
   const MOCK_CWD1 = process.cwd();

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -314,6 +314,8 @@ export async function loadCliConfig(
     argv.ideModeFeature ?? settings.ideModeFeature ?? false;
 
   const folderTrustFeature = settings.folderTrustFeature ?? false;
+  const folderTrustSetting = settings.folderTrust ?? false;
+  const folderTrust = folderTrustFeature && folderTrustSetting;
 
   const allExtensions = annotateActiveExtensions(
     extensions,
@@ -484,6 +486,7 @@ export async function loadCliConfig(
     ideModeFeature,
     chatCompression: settings.chatCompression,
     folderTrustFeature,
+    folderTrust,
   });
 }
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -113,9 +113,13 @@ export interface Settings {
 
   // Flag to be removed post-launch.
   ideModeFeature?: boolean;
-  folderTrustFeature?: boolean;
   /// IDE mode setting configured via slash command toggle.
   ideMode?: boolean;
+
+  // Flag to be removed post-launch.
+  folderTrustFeature?: boolean;
+  // Setting to track whether Folder trust is enabled.
+  folderTrust?: boolean;
 
   // Setting to track if the user has seen the IDE integration nudge.
   hasSeenIdeIntegrationNudge?: boolean;
@@ -178,9 +182,13 @@ export class LoadedSettings {
     const user = this.user.settings;
     const workspace = this.workspace.settings;
 
+    // folderTrust is not supported at workspace level.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { folderTrust, ...workspaceWithoutFolderTrust } = workspace;
+
     return {
       ...user,
-      ...workspace,
+      ...workspaceWithoutFolderTrust,
       ...system,
       customThemes: {
         ...(user.customThemes || {}),

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -193,6 +193,7 @@ export interface ConfigParameters {
   summarizeToolOutput?: Record<string, SummarizeToolOutputSettings>;
   ideModeFeature?: boolean;
   folderTrustFeature?: boolean;
+  folderTrust?: boolean;
   ideMode?: boolean;
   loadMemoryFromIncludeDirectories?: boolean;
   chatCompression?: ChatCompressionSettings;
@@ -240,6 +241,7 @@ export class Config {
   private readonly noBrowser: boolean;
   private readonly ideModeFeature: boolean;
   private readonly folderTrustFeature: boolean;
+  private readonly folderTrust: boolean;
   private ideMode: boolean;
   private ideClient: IdeClient;
   private inFallbackMode = false;
@@ -314,6 +316,7 @@ export class Config {
     this.summarizeToolOutput = params.summarizeToolOutput;
     this.ideModeFeature = params.ideModeFeature ?? false;
     this.folderTrustFeature = params.folderTrustFeature ?? false;
+    this.folderTrust = params.folderTrust ?? false;
     this.ideMode = params.ideMode ?? false;
     this.ideClient = IdeClient.getInstance();
     if (this.ideMode && this.ideModeFeature) {
@@ -648,12 +651,16 @@ export class Config {
     return this.ideModeFeature;
   }
 
+  getIdeMode(): boolean {
+    return this.ideMode;
+  }
+
   getFolderTrustFeature(): boolean {
     return this.folderTrustFeature;
   }
 
-  getIdeMode(): boolean {
-    return this.ideMode;
+  getFolderTrust(): boolean {
+    return this.folderTrust;
   }
 
   setIdeMode(value: boolean): void {


### PR DESCRIPTION
## TLDR

Add new User and System level folderTrust setting to enable or disable Folder Trust

## Dive Deeper

## Reviewer Test Plan

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to https://github.com/google-gemini/maintainers-gemini-cli/issues/640
