### PR TITLE
Add echo tool to automated triage workflow

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -75,6 +75,7 @@ jobs:
             {
               "maxSessionTurns": 25,
               "coreTools": [
+                "run_shell_command(echo)",
                 "run_shell_command(gh label list)",
                 "run_shell_command(gh issue edit)",
                 "run_shell_command(gh issue list)"


### PR DESCRIPTION
This tool is useful for accessing env vars like the issue title and body.

This tool already exists in scheduled triage workflows.

