### PR TITLE
Add FolderTrustDialog that shows on launch and enables folderTrust setting

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -486,8 +486,8 @@ export async function loadCliConfig(
     ideModeFeature,
     chatCompression: settings.chatCompression,
     folderTrustFeature,
-    interactive,
     folderTrust,
+    interactive,
   });
 }
 

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -203,6 +203,13 @@ vi.mock('./hooks/useAuthCommand', () => ({
   })),
 }));
 
+vi.mock('./hooks/useFolderTrust', () => ({
+  useFolderTrust: vi.fn(() => ({
+    isFolderTrustDialogOpen: false,
+    handleFolderTrustSelect: vi.fn(),
+  })),
+}));
+
 vi.mock('./hooks/useLogger', () => ({
   useLogger: vi.fn(() => ({
     getPreviousUserMessages: vi.fn().mockResolvedValue([]),
@@ -1089,6 +1096,27 @@ describe('App UI', () => {
       );
       currentUnmount = unmount;
       expect(lastFrame()).toMatchSnapshot();
+    });
+  });
+
+  describe('FolderTrustDialog', () => {
+    it('should display the folder trust dialog when isFolderTrustDialogOpen is true', async () => {
+      const { useFolderTrust } = await import('./hooks/useFolderTrust.js');
+      vi.mocked(useFolderTrust).mockReturnValue({
+        isFolderTrustDialogOpen: true,
+        handleFolderTrustSelect: vi.fn(),
+      });
+
+      const { lastFrame, unmount } = render(
+        <App
+          config={mockConfig as unknown as ServerConfig}
+          settings={mockSettings}
+          version={mockVersion}
+        />,
+      );
+      currentUnmount = unmount;
+      await Promise.resolve();
+      expect(lastFrame()).toContain('Do you trust this folder?');
     });
   });
 });

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -22,6 +22,7 @@ import { useGeminiStream } from './hooks/useGeminiStream.js';
 import { useLoadingIndicator } from './hooks/useLoadingIndicator.js';
 import { useThemeCommand } from './hooks/useThemeCommand.js';
 import { useAuthCommand } from './hooks/useAuthCommand.js';
+import { useFolderTrust } from './hooks/useFolderTrust.js';
 import { useEditorSettings } from './hooks/useEditorSettings.js';
 import { useSlashCommandProcessor } from './hooks/slashCommandProcessor.js';
 import { useAutoAcceptIndicator } from './hooks/useAutoAcceptIndicator.js';
@@ -36,6 +37,7 @@ import { ThemeDialog } from './components/ThemeDialog.js';
 import { AuthDialog } from './components/AuthDialog.js';
 import { AuthInProgress } from './components/AuthInProgress.js';
 import { EditorSettingsDialog } from './components/EditorSettingsDialog.js';
+import { FolderTrustDialog } from './components/FolderTrustDialog.js';
 import { ShellConfirmationDialog } from './components/ShellConfirmationDialog.js';
 import { Colors } from './colors.js';
 import { loadHierarchicalGeminiMemory } from '../config/config.js';
@@ -239,6 +241,9 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     handleThemeSelect,
     handleThemeHighlight,
   } = useThemeCommand(settings, setThemeError, addItem);
+
+  const { isFolderTrustDialogOpen, handleFolderTrustSelect } =
+    useFolderTrust(settings);
 
   const {
     isAuthDialogOpen,
@@ -905,6 +910,8 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
               description="If you select Yes, we'll install an extension that allows the CLI to access your open files and display diffs directly in VS Code."
               onComplete={handleIdePromptComplete}
             />
+          ) : isFolderTrustDialogOpen ? (
+            <FolderTrustDialog onSelect={handleFolderTrustSelect} />
           ) : shellConfirmationRequest ? (
             <ShellConfirmationDialog request={shellConfirmationRequest} />
           ) : isThemeDialogOpen ? (

--- a/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from 'ink-testing-library';
+import { vi } from 'vitest';
+import { FolderTrustDialog, FolderTrustChoice } from './FolderTrustDialog.js';
+
+describe('FolderTrustDialog', () => {
+  it('should render the dialog with title and description', () => {
+    const { lastFrame } = render(<FolderTrustDialog onSelect={vi.fn()} />);
+
+    expect(lastFrame()).toContain('Do you trust this folder?');
+    expect(lastFrame()).toContain(
+      'Trusting a folder allows Gemini to execute commands it suggests.',
+    );
+  });
+
+  it('should call onSelect with DO_NOT_TRUST when escape is pressed', () => {
+    const onSelect = vi.fn();
+    const { stdin } = render(<FolderTrustDialog onSelect={onSelect} />);
+
+    stdin.write('\u001B'); // Simulate escape key
+
+    expect(onSelect).toHaveBeenCalledWith(FolderTrustChoice.DO_NOT_TRUST);
+  });
+});

--- a/packages/cli/src/ui/components/FolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.tsx
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Text, useInput } from 'ink';
+import React from 'react';
+import { Colors } from '../colors.js';
+import {
+  RadioButtonSelect,
+  RadioSelectItem,
+} from './shared/RadioButtonSelect.js';
+
+export enum FolderTrustChoice {
+  TRUST_FOLDER = 'trust_folder',
+  TRUST_PARENT = 'trust_parent',
+  DO_NOT_TRUST = 'do_not_trust',
+}
+
+interface FolderTrustDialogProps {
+  onSelect: (choice: FolderTrustChoice) => void;
+}
+
+export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
+  onSelect,
+}) => {
+  useInput((_, key) => {
+    if (key.escape) {
+      onSelect(FolderTrustChoice.DO_NOT_TRUST);
+    }
+  });
+
+  const options: Array<RadioSelectItem<FolderTrustChoice>> = [
+    {
+      label: 'Trust folder',
+      value: FolderTrustChoice.TRUST_FOLDER,
+    },
+    {
+      label: 'Trust parent folder',
+      value: FolderTrustChoice.TRUST_PARENT,
+    },
+    {
+      label: "Don't trust (esc)",
+      value: FolderTrustChoice.DO_NOT_TRUST,
+    },
+  ];
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={Colors.AccentYellow}
+      padding={1}
+      width="100%"
+      marginLeft={1}
+    >
+      <Box flexDirection="column" marginBottom={1}>
+        <Text bold>Do you trust this folder?</Text>
+        <Text>
+          Trusting a folder allows Gemini to execute commands it suggests. This
+          is a security feature to prevent accidental execution in untrusted
+          directories.
+        </Text>
+      </Box>
+
+      <RadioButtonSelect items={options} onSelect={onSelect} isFocused />
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/hooks/useFolderTrust.test.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useFolderTrust } from './useFolderTrust.js';
+import { LoadedSettings, SettingScope } from '../../config/settings.js';
+import { FolderTrustChoice } from '../components/FolderTrustDialog.js';
+
+describe('useFolderTrust', () => {
+  it('should set isFolderTrustDialogOpen to true when folderTrustFeature is true and folderTrust is undefined', () => {
+    const settings = {
+      merged: {
+        folderTrustFeature: true,
+        folderTrust: undefined,
+      },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    const { result } = renderHook(() => useFolderTrust(settings));
+
+    expect(result.current.isFolderTrustDialogOpen).toBe(true);
+  });
+
+  it('should set isFolderTrustDialogOpen to false when folderTrustFeature is false', () => {
+    const settings = {
+      merged: {
+        folderTrustFeature: false,
+        folderTrust: undefined,
+      },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    const { result } = renderHook(() => useFolderTrust(settings));
+
+    expect(result.current.isFolderTrustDialogOpen).toBe(false);
+  });
+
+  it('should set isFolderTrustDialogOpen to false when folderTrust is defined', () => {
+    const settings = {
+      merged: {
+        folderTrustFeature: true,
+        folderTrust: true,
+      },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    const { result } = renderHook(() => useFolderTrust(settings));
+
+    expect(result.current.isFolderTrustDialogOpen).toBe(false);
+  });
+
+  it('should call setValue and set isFolderTrustDialogOpen to false on handleFolderTrustSelect', () => {
+    const settings = {
+      merged: {
+        folderTrustFeature: true,
+        folderTrust: undefined,
+      },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    const { result } = renderHook(() => useFolderTrust(settings));
+
+    act(() => {
+      result.current.handleFolderTrustSelect(FolderTrustChoice.TRUST_FOLDER);
+    });
+
+    expect(settings.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'folderTrust',
+      true,
+    );
+    expect(result.current.isFolderTrustDialogOpen).toBe(false);
+  });
+});

--- a/packages/cli/src/ui/hooks/useFolderTrust.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useCallback } from 'react';
+import { LoadedSettings, SettingScope } from '../../config/settings.js';
+import { FolderTrustChoice } from '../components/FolderTrustDialog.js';
+
+export const useFolderTrust = (settings: LoadedSettings) => {
+  const [isFolderTrustDialogOpen, setIsFolderTrustDialogOpen] = useState(
+    !!settings.merged.folderTrustFeature &&
+      // TODO: Update to avoid showing dialog for folders that are trusted.
+      settings.merged.folderTrust === undefined,
+  );
+
+  const handleFolderTrustSelect = useCallback(
+    (_choice: FolderTrustChoice) => {
+      // TODO: Store folderPath in the trusted folders config file based on the choice.
+      settings.setValue(SettingScope.User, 'folderTrust', true);
+      setIsFolderTrustDialogOpen(false);
+    },
+    [settings],
+  );
+
+  return {
+    isFolderTrustDialogOpen,
+    handleFolderTrustSelect,
+  };
+};


### PR DESCRIPTION
## TLDR

Add new FolderTrustDialog that shows on launch when folderTrust setting is true. It currently just enables folderTrust setting for all options. Will update the trusted folders file based on the selected option in a follow up PR.

## Dive Deeper

Screenshot of the dialog:
<img width="3182" height="1272" alt="image" src="https://github.com/user-attachments/assets/243e6c0c-d9a2-4df8-beb3-b02f9988e18c" />

## Reviewer Test Plan

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to https://github.com/google-gemini/maintainers-gemini-cli/issues/640.
