### PR TITLE
feat(cli): Add the '/model set' command, enabling users to choose their model and more granularly manage theis quotas

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -24,6 +24,7 @@ import { ideCommand } from '../ui/commands/ideCommand.js';
 import { initCommand } from '../ui/commands/initCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
+import { modelCommand } from '../ui/commands/modelCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
@@ -67,6 +68,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       initCommand,
       mcpCommand,
       memoryCommand,
+      modelCommand,
       privacyCommand,
       quitCommand,
       restoreCommand(this.config),

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -18,6 +18,7 @@ import { StreamingState, type HistoryItem, MessageType } from './types.js';
 import { useTerminalSize } from './hooks/useTerminalSize.js';
 import { useGeminiStream } from './hooks/useGeminiStream.js';
 import { useLoadingIndicator } from './hooks/useLoadingIndicator.js';
+import { useModelCommand } from './hooks/useModelCommand.js';
 import { useThemeCommand } from './hooks/useThemeCommand.js';
 import { useAuthCommand } from './hooks/useAuthCommand.js';
 import { useFolderTrust } from './hooks/useFolderTrust.js';
@@ -31,6 +32,7 @@ import { AutoAcceptIndicator } from './components/AutoAcceptIndicator.js';
 import { ShellModeIndicator } from './components/ShellModeIndicator.js';
 import { InputPrompt } from './components/InputPrompt.js';
 import { Footer } from './components/Footer.js';
+import { ModelDialog } from './components/ModelDialog.js';
 import { ThemeDialog } from './components/ThemeDialog.js';
 import { AuthDialog } from './components/AuthDialog.js';
 import { AuthInProgress } from './components/AuthInProgress.js';
@@ -241,6 +243,13 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
         .reduce((total, msg) => total + msg.count, 0),
     [consoleMessages],
   );
+
+  const {
+    isModelDialogOpen,
+    openModelDialog,
+    handleModelSelect,
+    availableModels,
+  } = useModelCommand(config, addItem, setCurrentModel);
 
   const {
     isThemeDialogOpen,
@@ -509,6 +518,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     loadHistory,
     refreshStatic,
     setDebugMessage,
+    openModelDialog,
     openThemeDialog,
     openAuthDialog,
     openEditorDialog,
@@ -966,6 +976,12 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
                 />
               </Box>
             </Box>
+          ) : isModelDialogOpen ? (
+            <ModelDialog
+              onSelect={handleModelSelect}
+              currentModel={currentModel}
+              availableModels={availableModels}
+            />
           ) : isThemeDialogOpen ? (
             <Box flexDirection="column">
               {themeError && (

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { modelCommand } from './modelCommand.js';
+import { CommandContext } from './types.js';
+
+describe('/model command', () => {
+  it('should return the correct action for /model set', () => {
+    const setCommand = modelCommand.subCommands?.find(
+      (sc) => sc.name === 'set',
+    );
+    const result = setCommand?.action?.({} as CommandContext, '');
+    expect(result).toEqual({ type: 'dialog', dialog: 'model' });
+  });
+});

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommandKind, OpenDialogActionReturn, SlashCommand } from './types.js';
+
+export const modelCommand: SlashCommand = {
+  name: 'model',
+  description: 'View and manage the generative model',
+  kind: CommandKind.BUILT_IN,
+  subCommands: [
+    {
+      name: 'set',
+      description: 'Select the model to use for the current session',
+      kind: CommandKind.BUILT_IN,
+      action: (): OpenDialogActionReturn => ({
+        type: 'dialog',
+        dialog: 'model',
+      }),
+    },
+  ],
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -103,7 +103,14 @@ export interface MessageActionReturn {
 export interface OpenDialogActionReturn {
   type: 'dialog';
 
-  dialog: 'help' | 'auth' | 'theme' | 'editor' | 'privacy' | 'settings';
+  dialog:
+    | 'help'
+    | 'auth'
+    | 'theme'
+    | 'editor'
+    | 'privacy'
+    | 'model'
+    | 'settings';
 }
 
 /**

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from 'ink-testing-library';
+import { ModelDialog } from './ModelDialog.js';
+import { vi } from 'vitest';
+
+describe('<ModelDialog />', () => {
+  it('renders the dialog with the correct title', () => {
+    const { lastFrame } = render(
+      <ModelDialog
+        onSelect={() => {}}
+        currentModel="gemini-2.5-pro"
+        availableModels={['gemini-2.5-pro', 'gemini-2.5-flash']}
+      />,
+    );
+
+    expect(lastFrame()).toContain('Select a Model');
+  });
+
+  it('displays the available models', () => {
+    const { lastFrame } = render(
+      <ModelDialog
+        onSelect={() => {}}
+        currentModel="gemini-2.5-pro"
+        availableModels={['gemini-2.5-pro', 'gemini-2.5-flash']}
+      />,
+    );
+
+    expect(lastFrame()).toContain('gemini-2.5-pro');
+    expect(lastFrame()).toContain('gemini-2.5-flash');
+  });
+
+  it('highlights the current model', () => {
+    const { lastFrame } = render(
+      <ModelDialog
+        onSelect={() => {}}
+        currentModel="gemini-2.5-flash"
+        availableModels={['gemini-2.5-pro', 'gemini-2.5-flash']}
+      />,
+    );
+
+    expect(lastFrame()).toContain('● 2. gemini-2.5-flash');
+  });
+
+  it('calls onSelect when a model is selected via keyboard down arrow', async () => {
+    const onSelect = vi.fn();
+    const { stdin } = render(
+      <ModelDialog
+        onSelect={onSelect}
+        currentModel="gemini-2.5-pro"
+        availableModels={['gemini-2.5-pro', 'gemini-2.5-flash']}
+      />,
+    );
+
+    // Initial selection is 'gemini-2.5-pro' (index 0).
+    // Press down arrow to move to 'gemini-2.5-flash' (index 1).
+    stdin.write('\u001B[B');
+
+    // THE FIX: Wait for the event loop to tick and React to re-render.
+    // This gives the component time to process the down-arrow state change.
+    await new Promise((resolve) => setTimeout(resolve, 100)); // 100ms is a safe delay
+
+    // Press Enter to select.
+    stdin.write('\r');
+
+    expect(onSelect).toHaveBeenCalledWith('gemini-2.5-flash');
+  });
+
+  it('selects the correct model when the user presses a number', async () => {
+    const onSelect = vi.fn();
+
+    const { stdin } = render(
+      <ModelDialog
+        onSelect={onSelect}
+        currentModel="gemini-2.5-pro"
+        availableModels={['gemini-2.5-pro', 'gemini-2.5-flash']}
+      />,
+    );
+
+    // Simulate the user pressing the '2' key to select the second model.
+    stdin.write('2');
+
+    // Although this is a more direct action, it's still best practice
+    // to wait briefly for React to process the state update.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // The component should call onSelect immediately upon a valid number press.
+    // The user does not need to press Enter after pressing a number.
+    expect(onSelect).toHaveBeenCalledWith('gemini-2.5-flash');
+  });
+});

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Box, Text, useInput } from 'ink';
+import { Colors } from '../colors.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+
+interface ModelDialogProps {
+  onSelect: (modelName: string | undefined) => void;
+  currentModel: string;
+  availableModels: string[];
+}
+
+export function ModelDialog({
+  onSelect,
+  currentModel,
+  availableModels,
+}: ModelDialogProps): React.JSX.Element {
+  useInput((input, key) => {
+    if (key.escape) {
+      onSelect(undefined);
+    }
+  });
+
+  const modelItems = availableModels.map((model) => ({
+    label: model,
+    value: model,
+    isSelectedIndicator:
+      model === currentModel ? '(already selected)' : undefined,
+  }));
+
+  const initialModelIndex = modelItems.findIndex(
+    (item) => item.value === currentModel,
+  );
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={Colors.Gray}
+      flexDirection="column"
+      padding={1}
+      width="100%"
+    >
+      <Text bold>Select a Model</Text>
+      <RadioButtonSelect
+        items={modelItems}
+        initialIndex={initialModelIndex >= 0 ? initialModelIndex : 0}
+        onSelect={onSelect}
+        isFocused={true}
+        showNumbers={true}
+      />
+      <Box marginTop={1}>
+        <Text color={Colors.Gray}>(Use Enter to select)</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -18,6 +18,7 @@ export interface RadioSelectItem<T> {
   disabled?: boolean;
   themeNameDisplay?: string;
   themeTypeDisplay?: string;
+  isSelectedIndicator?: string;
 }
 
 /**
@@ -211,6 +212,9 @@ export function RadioButtonSelect<T>({
             ) : (
               <Text color={textColor} wrap="truncate">
                 {item.label}
+                {isSelected && item.isSelectedIndicator && (
+                  <Text color={Colors.Gray}> {item.isSelectedIndicator}</Text>
+                )}
               </Text>
             )}
           </Box>

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -99,6 +99,7 @@ describe('useSlashCommandProcessor', () => {
   const mockClearItems = vi.fn();
   const mockLoadHistory = vi.fn();
   const mockOpenThemeDialog = vi.fn();
+  const mockOpenModelDialog = vi.fn();
   const mockOpenAuthDialog = vi.fn();
   const mockSetQuittingMessages = vi.fn();
 
@@ -141,6 +142,7 @@ describe('useSlashCommandProcessor', () => {
         mockLoadHistory,
         vi.fn(), // refreshStatic
         vi.fn(), // onDebugMessage
+        mockOpenModelDialog, // openModelDialog
         mockOpenThemeDialog, // openThemeDialog
         mockOpenAuthDialog,
         vi.fn(), // openEditorDialog
@@ -870,6 +872,7 @@ describe('useSlashCommandProcessor', () => {
           vi.fn(), // toggleVimEnabled
           vi.fn().mockResolvedValue(false), // toggleVimEnabled
           vi.fn(), // setIsProcessing
+          vi.fn(), // setGeminiMdFileCount
         ),
       );
 

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -44,6 +44,7 @@ export const useSlashCommandProcessor = (
   loadHistory: UseHistoryManagerReturn['loadHistory'],
   refreshStatic: () => void,
   onDebugMessage: (message: string) => void,
+  openModelDialog: () => void,
   openThemeDialog: () => void,
   openAuthDialog: () => void,
   openEditorDialog: () => void,
@@ -348,6 +349,9 @@ export const useSlashCommandProcessor = (
                   return { type: 'handled' };
                 case 'dialog':
                   switch (result.dialog) {
+                    case 'model':
+                      openModelDialog();
+                      return { type: 'handled' };
                     case 'auth':
                       openAuthDialog();
                       return { type: 'handled' };
@@ -514,6 +518,7 @@ export const useSlashCommandProcessor = (
       commands,
       commandContext,
       addMessage,
+      openModelDialog,
       openThemeDialog,
       openPrivacyNotice,
       openEditorDialog,

--- a/packages/cli/src/ui/hooks/useModelCommand.test.ts
+++ b/packages/cli/src/ui/hooks/useModelCommand.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useModelCommand } from './useModelCommand.js';
+import { vi } from 'vitest';
+import { Config, DEFAULT_GEMINI_MODEL } from '@google/gemini-cli-core';
+
+describe('useModelCommand', () => {
+  const mockAddItem = vi.fn();
+  const mockSetCurrentModel = vi.fn();
+  const mockConfig = {
+    setModel: vi.fn(),
+    getModel: vi.fn().mockReturnValue(DEFAULT_GEMINI_MODEL),
+  } as unknown as Config;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should be initially closed', () => {
+    const { result } = renderHook(() =>
+      useModelCommand(mockConfig, mockAddItem, mockSetCurrentModel),
+    );
+    expect(result.current.isModelDialogOpen).toBe(false);
+  });
+
+  it('should open the dialog', () => {
+    const { result } = renderHook(() =>
+      useModelCommand(mockConfig, mockAddItem, mockSetCurrentModel),
+    );
+    act(() => {
+      result.current.openModelDialog();
+    });
+    expect(result.current.isModelDialogOpen).toBe(true);
+  });
+
+  it('should set the model and close the dialog on select', () => {
+    const { result } = renderHook(() =>
+      useModelCommand(mockConfig, mockAddItem, mockSetCurrentModel),
+    );
+    act(() => {
+      result.current.openModelDialog();
+    });
+
+    act(() => {
+      result.current.handleModelSelect('gemini-2.5-flash');
+    });
+
+    expect(mockConfig.setModel).toHaveBeenCalledWith('gemini-2.5-flash');
+    expect(mockSetCurrentModel).toHaveBeenCalledWith('gemini-2.5-flash');
+    expect(mockAddItem).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Model set to gemini-2.5-flash' }),
+      expect.any(Number),
+    );
+    expect(result.current.isModelDialogOpen).toBe(false);
+  });
+
+  it('should close the dialog without setting the model if no model is selected', () => {
+    const { result } = renderHook(() =>
+      useModelCommand(mockConfig, mockAddItem, mockSetCurrentModel),
+    );
+    act(() => {
+      result.current.openModelDialog();
+    });
+
+    act(() => {
+      result.current.handleModelSelect(undefined);
+    });
+
+    expect(mockConfig.setModel).not.toHaveBeenCalled();
+    expect(mockSetCurrentModel).not.toHaveBeenCalled();
+    expect(result.current.isModelDialogOpen).toBe(false);
+  });
+});

--- a/packages/cli/src/ui/hooks/useModelCommand.ts
+++ b/packages/cli/src/ui/hooks/useModelCommand.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+import { ALL_GEMINI_MODELS, Config } from '@google/gemini-cli-core';
+import { HistoryItem, MessageType } from '../types.js';
+
+interface UseModelCommandReturn {
+  isModelDialogOpen: boolean;
+  openModelDialog: () => void;
+  handleModelSelect: (modelName: string | undefined) => void;
+  availableModels: string[];
+}
+
+export const useModelCommand = (
+  config: Config | null,
+  addItem: (item: Omit<HistoryItem, 'id'>, timestamp: number) => void,
+  setCurrentModel: (model: string) => void,
+): UseModelCommandReturn => {
+  const [isModelDialogOpen, setIsModelDialogOpen] = useState(false);
+  const availableModels = useMemo(() => ALL_GEMINI_MODELS, []);
+
+  const openModelDialog = useCallback(() => {
+    setIsModelDialogOpen(true);
+  }, []);
+
+  const handleModelSelect = useCallback(
+    (modelName: string | undefined) => {
+      if (config && modelName && availableModels.includes(modelName)) {
+        config.setModel(modelName);
+        setCurrentModel(modelName);
+        addItem(
+          {
+            type: MessageType.INFO,
+            text: `Model set to ${modelName}`,
+          },
+          Date.now(),
+        );
+      }
+      setIsModelDialogOpen(false);
+    },
+    [config, addItem, availableModels, setCurrentModel],
+  );
+
+  return {
+    isModelDialogOpen,
+    openModelDialog,
+    handleModelSelect,
+    availableModels,
+  };
+};

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -8,6 +8,7 @@ export * from './src/index.js';
 export {
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
+  ALL_GEMINI_MODELS,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
 } from './src/config/models.js';
 export { logIdeConnection } from './src/telemetry/loggers.js';

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -8,4 +8,9 @@ export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
 export const DEFAULT_GEMINI_FLASH_LITE_MODEL = 'gemini-2.5-flash-lite';
 
+export const ALL_GEMINI_MODELS = [
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_GEMINI_FLASH_MODEL,
+];
+
 export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';


### PR DESCRIPTION
## TLDR

Add the '/model set' command, enabling users to tactically choose their model to better manage their quotas. Note, this does not disrupt current auto fallback from gemini pro to flash. Note the new dialog:

<img width="1750" height="532" alt="image" src="https://github.com/user-attachments/assets/2ed8e94f-4e57-4aa6-9079-70abbe3f142d" />

## Dive Deeper

Add the '/model set' command, enabling users to tactically choose their model to better manage their quotas. Note, this does not disrupt current auto fallback from gemini pro to flash

## Reviewer Test Plan

added proper tests

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | Y  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
[Resolves and closes #5574](https://github.com/google-gemini/gemini-cli/issues/5574)


