### PR TITLE
feat(cli): support single Ctrl+C to cancel streaming, preserving double Ctrl+C to exit

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -656,6 +656,9 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
         if (isAuthenticating) {
           return;
         }
+        if (!ctrlCPressedOnce) {
+          cancelOngoingRequest?.();
+        }
         handleExit(ctrlCPressedOnce, setCtrlCPressedOnce, ctrlCTimerRef);
       } else if (keyMatchers[Command.EXIT](key)) {
         if (buffer.text.length > 0) {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -545,6 +545,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     initError,
     pendingHistoryItems: pendingGeminiHistoryItems,
     thought,
+    cancelOngoingRequest,
   } = useGeminiStream(
     config.getGeminiClient(),
     history,
@@ -686,6 +687,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
       ctrlDTimerRef,
       handleSlashCommand,
       isAuthenticating,
+      cancelOngoingRequest,
     ],
   );
 

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -56,9 +56,9 @@ export const ToolConfirmationMessage: React.FC<
     onConfirm(outcome);
   };
 
-  useInput((_, key) => {
+  useInput((input, key) => {
     if (!isFocused) return;
-    if (key.escape) {
+    if (key.escape || (key.ctrl && (input === 'c' || input === 'C'))) {
       handleConfirm(ToolConfirmationOutcome.Cancel);
     }
   });


### PR DESCRIPTION
### TL;DR

This PR improves the Gemini CLI experience by allowing a **single `Ctrl+C` press** to cancel an in-progress stream, matching common CLI expectations. The existing behavior of **double `Ctrl+C` to exit** the app is preserved.

---

### Summary of Changes

The main logic updates are in:

* `packages/cli/src/ui/App.tsx` – to detect a single `Ctrl+C` press during streaming.
* `packages/cli/src/ui/hooks/useGeminiStream.ts` – where the cancellation logic was extracted into a reusable `cancelRequest` function.

---

### Why This Matters

Previously, users needed to press the **`Esc` key** to cancel a long response — not a familiar pattern in most CLI tools. With this update, the CLI aligns with standard UX expectations:

* **Intuitive Interruption**: Pressing `Ctrl+C` once during streaming now cancels the stream immediately.
* **Unified Cancellation Logic**: Both `Esc` and `Ctrl+C` call a centralized `cancelRequest` function, reducing code duplication.
* **User Feedback**:

  * If you cancel during streaming: `Request cancelled.` is shown.
  * If no stream is active: `Press Ctrl+C again to exit.` is shown, just like before.

---

### How to Test It

1. **Start Gemini CLI.**
2. **Trigger a long streaming response** (e.g., ask it to write a novel about space-faring cats).
3. **Single `Ctrl+C` Cancellation**:

   * During the stream, press `Ctrl+C` once.
   * ✅ Expected: Stream cancels, you see `Request cancelled.`, and return to the input prompt.
4. **`Esc` Key Cancellation**:

   * Trigger another stream, press `Esc`.
   * ✅ Expected: Same behavior as `Ctrl+C`.
5. **Double `Ctrl+C` Exit**:

   * During a stream, press `Ctrl+C` twice quickly.
   * ✅ Expected: CLI exits.
6. **Idle `Ctrl+C` Handling**:

   * While idle (no stream), press `Ctrl+C` once.
   * ✅ Expected: Shows `Press Ctrl+C again to exit.` and waits. Press again within the window to exit.

---

### Testing Matrix

| Platform    | npm run | npx | Docker | Podman | Seatbelt |
| ----------- | ------- | --- | ------ | ------ | -------- |
| **Linux**   | ✅       | ❓   | ❓      | ❓      | ❓        |
| **macOS**   | ❓       | ❓   | ❓      | –      | –        |
| **Windows** | ❓       | ❓   | ❓      | –      | –        |

*(✅ = Tested; ❓ = Untested; – = Unsupported)*

---

### Linked Issue
#5837

