### PR TITLE
Updates UX for context selection via IDE integration 

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -530,7 +530,7 @@ describe('App UI', () => {
     );
     currentUnmount = unmount;
     await Promise.resolve();
-    expect(lastFrame()).toContain('1 open file (ctrl+e to view)');
+    expect(lastFrame()).toContain('1 open file (ctrl+e to toggle)');
   });
 
   it('should not display any files when not available', async () => {
@@ -613,7 +613,7 @@ describe('App UI', () => {
     );
     currentUnmount = unmount;
     await Promise.resolve();
-    expect(lastFrame()).toContain('3 open files (ctrl+e to view)');
+    expect(lastFrame()).toContain('3 open files (ctrl+e to toggle)');
   });
 
   it('should display active file and other context', async () => {
@@ -652,7 +652,7 @@ describe('App UI', () => {
     currentUnmount = unmount;
     await Promise.resolve();
     expect(lastFrame()).toContain(
-      'Using: 1 open file (ctrl+e to view) | 1 GEMINI.md file',
+      'Using: 1 open file (ctrl+e to toggle) | 1 GEMINI.md file',
     );
   });
 

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -169,6 +169,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const ideContextMock = {
     getIdeContext: vi.fn(),
     subscribeToIdeContext: vi.fn(() => vi.fn()), // subscribe returns an unsubscribe function
+    getSelectedFiles: vi.fn(),
   };
 
   return {
@@ -511,6 +512,14 @@ describe('App UI', () => {
         ],
       },
     });
+    vi.mocked(ideContext.getSelectedFiles).mockReturnValue([
+      {
+        path: '/path/to/my-file.ts',
+        isActive: true,
+        selectedText: 'hello',
+        timestamp: 0,
+      },
+    ]);
 
     const { lastFrame, unmount } = render(
       <App
@@ -530,6 +539,15 @@ describe('App UI', () => {
         openFiles: [],
       },
     });
+
+    vi.mocked(ideContext.getSelectedFiles).mockReturnValue([
+      {
+        path: '/path/to/my-file.ts',
+        isActive: true,
+        selectedText: 'hello',
+        timestamp: 0,
+      },
+    ]);
 
     const { lastFrame, unmount } = render(
       <App
@@ -567,6 +585,25 @@ describe('App UI', () => {
       },
     });
 
+    vi.mocked(ideContext.getSelectedFiles).mockReturnValue([
+      {
+        path: '/path/to/my-file.ts',
+        isActive: true,
+        selectedText: 'hello',
+        timestamp: 0,
+      },
+      {
+        path: '/path/to/another-file.ts',
+        isActive: false,
+        timestamp: 1,
+      },
+      {
+        path: '/path/to/third-file.ts',
+        isActive: false,
+        timestamp: 2,
+      },
+    ]);
+
     const { lastFrame, unmount } = render(
       <App
         config={mockConfig as unknown as ServerConfig}
@@ -592,6 +629,16 @@ describe('App UI', () => {
         ],
       },
     });
+
+    vi.mocked(ideContext.getSelectedFiles).mockReturnValue([
+      {
+        path: '/path/to/my-file.ts',
+        isActive: true,
+        selectedText: 'hello',
+        timestamp: 0,
+      },
+    ]);
+
     mockConfig.getGeminiMdFileCount.mockReturnValue(1);
     mockConfig.getAllGeminiMdFilenames.mockReturnValue(['GEMINI.md']);
 

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -1017,6 +1017,9 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
                       mcpServers={config.getMcpServers()}
                       blockedMcpServers={config.getBlockedMcpServers()}
                       showToolDescriptions={showToolDescriptions}
+                      selectedFileCount={
+                        ideContext.getSelectedFiles()?.length ?? 0
+                      }
                     />
                   )}
                 </Box>
@@ -1036,6 +1039,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
                   detectedIdeDisplay={config
                     .getIdeClient()
                     .getDetectedIdeDisplayName()}
+                  isFileSelected={ideContext.isFileSelected}
                 />
               )}
               {showErrorDetails && (

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -625,12 +625,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
       return;
     }
 
-    if (
-      key.ctrl &&
-      input === 'e' &&
-      config.getIdeMode() &&
-      ideContextState
-    ) {
+    if (key.ctrl && input === 'e' && config.getIdeMode() && ideContextState) {
       setShowIDEContextDetail((prev) => !prev);
     } else if (activeComponent === 'ideContext') {
       // Any other key press will switch focus back to the input.

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -1060,6 +1060,8 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
                     .getIdeClient()
                     .getDetectedIdeDisplayName()}
                   isFileSelected={ideContext.isFileSelected}
+                  selectFile={ideContext.selectFile}
+                  deselectFile={ideContext.deselectFile}
                   isFocused={activeComponent === 'ideContext'}
                 />
               )}

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.test.tsx
@@ -32,9 +32,10 @@ describe('<ContextSummaryDisplay />', () => {
     showToolDescriptions: false,
     ideContext: {
       workspaceState: {
-        openFiles: [{ path: '/a/b/c' }],
+        openFiles: [{ path: '/a/b/c', isActive: true, timestamp: 0 }],
       },
     },
+    selectedFileCount: 1,
   };
 
   it('should render on a single line on a wide screen', () => {

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.test.tsx
@@ -42,7 +42,7 @@ describe('<ContextSummaryDisplay />', () => {
     const { lastFrame } = renderWithWidth(120, baseProps);
     const output = lastFrame();
     expect(output).toContain(
-      'Using: 1 open file (ctrl+e to view) | 1 GEMINI.md file | 1 MCP server (ctrl+t to view)',
+      'Using: 1 open file (ctrl+e to toggle) | 1 GEMINI.md file | 1 MCP server (ctrl+t to view)',
     );
     // Check for absence of newlines
     expect(output.includes('\n')).toBe(false);
@@ -53,7 +53,7 @@ describe('<ContextSummaryDisplay />', () => {
     const output = lastFrame();
     const expectedLines = [
       'Using:',
-      '  - 1 open file (ctrl+e to view)',
+      '  - 1 open file (ctrl+e to toggle)',
       '  - 1 GEMINI.md file',
       '  - 1 MCP server (ctrl+t to view)',
     ];
@@ -79,7 +79,7 @@ describe('<ContextSummaryDisplay />', () => {
       mcpServers: {},
     };
     const { lastFrame } = renderWithWidth(60, props);
-    const expectedLines = ['Using:', '  - 1 open file (ctrl+e to view)'];
+    const expectedLines = ['Using:', '  - 1 open file (ctrl+e to toggle)'];
     const actualLines = lastFrame().split('\n');
     expect(actualLines).toEqual(expectedLines);
   });

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
@@ -51,11 +51,11 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
     }
 
     if (selectedFileCount === 0) {
-      return '0 open files';
+      return '0 open files (ctrl+e to toggle)';
     }
     return `${selectedFileCount} open file${
       selectedFileCount > 1 ? 's' : ''
-    } (ctrl+e to view)`;
+    } (ctrl+e to toggle)`;
   })();
 
   const geminiMdText = (() => {

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
@@ -18,6 +18,7 @@ interface ContextSummaryDisplayProps {
   blockedMcpServers?: Array<{ name: string; extensionName: string }>;
   showToolDescriptions?: boolean;
   ideContext?: IdeContext;
+  selectedFileCount: number;
 }
 
 export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
@@ -27,6 +28,7 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
   blockedMcpServers,
   showToolDescriptions,
   ideContext,
+  selectedFileCount,
 }) => {
   const { columns: terminalWidth } = useTerminalSize();
   const isNarrow = isNarrowWidth(terminalWidth);
@@ -47,8 +49,12 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
     if (openFileCount === 0) {
       return '';
     }
-    return `${openFileCount} open file${
-      openFileCount > 1 ? 's' : ''
+
+    if (selectedFileCount === 0) {
+      return '0 open files';
+    }
+    return `${selectedFileCount} open file${
+      selectedFileCount > 1 ? 's' : ''
     } (ctrl+e to view)`;
   })();
 

--- a/packages/cli/src/ui/components/IDEContextDetailDisplay.test.tsx
+++ b/packages/cli/src/ui/components/IDEContextDetailDisplay.test.tsx
@@ -20,6 +20,7 @@ describe('IDEContextDetailDisplay', () => {
       <IDEContextDetailDisplay
         ideContext={ideContext}
         detectedIdeDisplay="VS Code"
+        isFileSelected={() => false}
       />,
     );
     expect(lastFrame()).toBe('');
@@ -29,8 +30,8 @@ describe('IDEContextDetailDisplay', () => {
     const ideContext: IdeContext = {
       workspaceState: {
         openFiles: [
-          { path: '/foo/bar.txt', isActive: true },
-          { path: '/foo/baz.txt', isActive: false },
+          { path: '/foo/bar.txt', isActive: true, timestamp: 0 },
+          { path: '/foo/baz.txt', isActive: false, timestamp: 0 },
         ],
       },
     };
@@ -38,6 +39,7 @@ describe('IDEContextDetailDisplay', () => {
       <IDEContextDetailDisplay
         ideContext={ideContext}
         detectedIdeDisplay="VS Code"
+        isFileSelected={(path) => path === '/foo/bar.txt'}
       />,
     );
     const output = lastFrame();
@@ -48,9 +50,9 @@ describe('IDEContextDetailDisplay', () => {
     const ideContext: IdeContext = {
       workspaceState: {
         openFiles: [
-          { path: '/foo/bar.txt', isActive: true },
-          { path: '/qux/bar.txt', isActive: false },
-          { path: '/foo/unique.txt', isActive: false },
+          { path: '/foo/bar.txt', isActive: true, timestamp: 0 },
+          { path: '/qux/bar.txt', isActive: false, timestamp: 0 },
+          { path: '/foo/unique.txt', isActive: false, timestamp: 0 },
         ],
       },
     };
@@ -58,6 +60,7 @@ describe('IDEContextDetailDisplay', () => {
       <IDEContextDetailDisplay
         ideContext={ideContext}
         detectedIdeDisplay="VS Code"
+        isFileSelected={(path) => path === '/foo/bar.txt'}
       />,
     );
     const output = lastFrame();

--- a/packages/cli/src/ui/components/IDEContextDetailDisplay.tsx
+++ b/packages/cli/src/ui/components/IDEContextDetailDisplay.tsx
@@ -12,11 +12,13 @@ import { Colors } from '../colors.js';
 interface IDEContextDetailDisplayProps {
   ideContext: IdeContext | undefined;
   detectedIdeDisplay: string | undefined;
+  isFileSelected: (path: string) => boolean;
 }
 
 export function IDEContextDetailDisplay({
   ideContext,
   detectedIdeDisplay,
+  isFileSelected,
 }: IDEContextDetailDisplayProps) {
   const openFiles = ideContext?.workspaceState?.openFiles;
   if (!openFiles || openFiles.length === 0) {
@@ -51,10 +53,12 @@ export function IDEContextDetailDisplay({
             const displayName = isDuplicate
               ? `${basename} (/${parentDir})`
               : basename;
+            const isSelected = isFileSelected(file.path);
+            const indicator = isSelected ? '[x]' : '[]';
 
             return (
               <Text key={file.path}>
-                - {displayName}
+                {indicator} {displayName}
                 {file.isActive ? ' (active)' : ''}
               </Text>
             );

--- a/packages/cli/src/ui/components/IDEContextDetailDisplay.tsx
+++ b/packages/cli/src/ui/components/IDEContextDetailDisplay.tsx
@@ -94,17 +94,9 @@ export function IDEContextDetailDisplay({
               isCurrentlyFocused && isFocused
                 ? theme.text.accent
                 : theme.text.primary;
-            const bgColor =
-              isCurrentlyFocused && isFocused
-                ? theme.ui.comment
-                : undefined;
 
             return (
-              <Box
-                key={file.path}
-                paddingX={1}
-                flexGrow={1}
-              >
+              <Box key={file.path} paddingX={1} flexGrow={1}>
                 <Text color={textColor}>
                   {indicator} {displayName}
                   {file.isActive ? ' (active)' : ''}

--- a/packages/cli/src/ui/components/IDEContextDetailDisplay.tsx
+++ b/packages/cli/src/ui/components/IDEContextDetailDisplay.tsx
@@ -7,7 +7,7 @@
 import { type File, type IdeContext } from '@google/gemini-cli-core';
 import { Box, Text, useInput } from 'ink';
 import path from 'node:path';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { theme } from '../semantic-colors.js';
 
 interface IDEContextDetailDisplayProps {
@@ -29,6 +29,12 @@ export function IDEContextDetailDisplay({
 }: IDEContextDetailDisplayProps) {
   const openFiles = propsIdeContext?.workspaceState?.openFiles;
   const [focusIndex, setFocusIndex] = useState(0);
+
+  useEffect(() => {
+    if (openFiles && focusIndex >= openFiles.length) {
+      setFocusIndex(Math.max(0, openFiles.length - 1));
+    }
+  }, [openFiles, focusIndex]);
 
   useInput(
     (input, key) => {

--- a/packages/cli/src/ui/components/IDEContextDetailDisplay.tsx
+++ b/packages/cli/src/ui/components/IDEContextDetailDisplay.tsx
@@ -4,11 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  type File,
-  type IdeContext,
-  ideContext,
-} from '@google/gemini-cli-core';
+import { type File, type IdeContext } from '@google/gemini-cli-core';
 import { Box, Text, useInput } from 'ink';
 import path from 'node:path';
 import { useState } from 'react';
@@ -18,6 +14,8 @@ interface IDEContextDetailDisplayProps {
   ideContext: IdeContext | undefined;
   detectedIdeDisplay: string | undefined;
   isFileSelected: (path: string) => boolean;
+  selectFile: (path: string) => void;
+  deselectFile: (path: string) => void;
   isFocused: boolean;
 }
 
@@ -25,6 +23,8 @@ export function IDEContextDetailDisplay({
   ideContext: propsIdeContext,
   detectedIdeDisplay,
   isFileSelected,
+  selectFile,
+  deselectFile,
   isFocused,
 }: IDEContextDetailDisplayProps) {
   const openFiles = propsIdeContext?.workspaceState?.openFiles;
@@ -43,9 +43,9 @@ export function IDEContextDetailDisplay({
         const focusedFile = openFiles[focusIndex];
         if (focusedFile) {
           if (isFileSelected(focusedFile.path)) {
-            ideContext.deselectFile(focusedFile.path);
+            deselectFile(focusedFile.path);
           } else {
-            ideContext.selectFile(focusedFile.path);
+            selectFile(focusedFile.path);
           }
         }
       }

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -189,7 +189,7 @@ describe('InputPrompt', () => {
       setShellModeActive: vi.fn(),
       inputWidth: 80,
       suggestionsWidth: 80,
-      focus: true,
+      isFocused: true,
     };
   });
 
@@ -1162,7 +1162,7 @@ describe('InputPrompt', () => {
 
   describe('unfocused paste', () => {
     it('should handle bracketed paste when not focused', async () => {
-      props.focus = false;
+      props.isFocused = false;
       const { stdin, unmount } = render(<InputPrompt {...props} />);
       await wait();
 
@@ -1179,7 +1179,7 @@ describe('InputPrompt', () => {
     });
 
     it('should ignore regular keypresses when not focused', async () => {
-      props.focus = false;
+      props.isFocused = false;
       const { stdin, unmount } = render(<InputPrompt {...props} />);
       await wait();
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -35,7 +35,7 @@ export interface InputPromptProps {
   slashCommands: readonly SlashCommand[];
   commandContext: CommandContext;
   placeholder?: string;
-  focus?: boolean;
+  isFocused?: boolean;
   inputWidth: number;
   suggestionsWidth: number;
   shellModeActive: boolean;
@@ -52,7 +52,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   slashCommands,
   commandContext,
   placeholder = '  Type your message or @path/to/file',
-  focus = true,
+  isFocused = true,
   inputWidth,
   suggestionsWidth,
   shellModeActive,
@@ -203,7 +203,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const handleInput = useCallback(
     (key: Key) => {
       /// We want to handle paste even when not focused to support drag and drop.
-      if (!focus && !key.paste) {
+      if (!isFocused && !key.paste) {
         return;
       }
 
@@ -439,7 +439,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       buffer.handleInput(key);
     },
     [
-      focus,
+      isFocused,
       buffer,
       completion,
       shellModeActive,
@@ -489,7 +489,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         </Text>
         <Box flexGrow={1} flexDirection="column">
           {buffer.text.length === 0 && placeholder ? (
-            focus ? (
+            isFocused ? (
               <Text>
                 {chalk.inverse(placeholder.slice(0, 1))}
                 <Text color={theme.text.secondary}>{placeholder.slice(1)}</Text>
@@ -506,7 +506,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 display = display + ' '.repeat(inputWidth - currentVisualWidth);
               }
 
-              if (focus && visualIdxInRenderedSet === cursorVisualRow) {
+              if (isFocused && visualIdxInRenderedSet === cursorVisualRow) {
                 const relativeVisualColForHighlight = cursorVisualColAbsolute;
 
                 if (relativeVisualColForHighlight >= 0) {

--- a/packages/cli/src/ui/components/__snapshots__/IDEContextDetailDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/IDEContextDetailDisplay.test.tsx.snap
@@ -3,22 +3,26 @@
 exports[`IDEContextDetailDisplay > handles duplicate basenames by showing path hints 1`] = `
 "
 ╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ VS Code Context (ctrl+e to toggle)                                                               │
+│ VS Code Context                                                                                  │
 │                                                                                                  │
 │ Open files:                                                                                      │
-│ [x] bar.txt (/foo) (active)                                                                      │
-│ [] bar.txt (/qux)                                                                                │
-│ [] unique.txt                                                                                    │
+│  [✓] bar.txt (/foo) (active)                                                                     │
+│  [ ] bar.txt (/qux)                                                                              │
+│  [ ] unique.txt                                                                                  │
+│                                                                                                  │
+│ Press Tab to edit included context.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;
 
 exports[`IDEContextDetailDisplay > renders a list of open files with active status 1`] = `
 "
 ╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ VS Code Context (ctrl+e to toggle)                                                               │
+│ VS Code Context                                                                                  │
 │                                                                                                  │
 │ Open files:                                                                                      │
-│ [x] bar.txt (active)                                                                             │
-│ [] baz.txt                                                                                       │
+│  [✓] bar.txt (active)                                                                            │
+│  [ ] baz.txt                                                                                     │
+│                                                                                                  │
+│ Press Tab to edit included context.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;

--- a/packages/cli/src/ui/components/__snapshots__/IDEContextDetailDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/IDEContextDetailDisplay.test.tsx.snap
@@ -6,9 +6,9 @@ exports[`IDEContextDetailDisplay > handles duplicate basenames by showing path h
 │ VS Code Context (ctrl+e to toggle)                                                               │
 │                                                                                                  │
 │ Open files:                                                                                      │
-│ - bar.txt (/foo) (active)                                                                        │
-│ - bar.txt (/qux)                                                                                 │
-│ - unique.txt                                                                                     │
+│ [x] bar.txt (/foo) (active)                                                                      │
+│ [] bar.txt (/qux)                                                                                │
+│ [] unique.txt                                                                                    │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;
 
@@ -18,7 +18,7 @@ exports[`IDEContextDetailDisplay > renders a list of open files with active stat
 │ VS Code Context (ctrl+e to toggle)                                                               │
 │                                                                                                  │
 │ Open files:                                                                                      │
-│ - bar.txt (active)                                                                               │
-│ - baz.txt                                                                                        │
+│ [x] bar.txt (active)                                                                             │
+│ [] baz.txt                                                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -669,27 +669,23 @@ describe('Gemini Client (client.ts)', () => {
   describe('sendMessageStream', () => {
     it('should include IDE context when ideModeFeature is enabled', async () => {
       // Arrange
-      vi.mocked(ideContext.getIdeContext).mockReturnValue({
-        workspaceState: {
-          openFiles: [
-            {
-              path: '/path/to/active/file.ts',
-              timestamp: Date.now(),
-              isActive: true,
-              selectedText: 'hello',
-              cursor: { line: 5, character: 10 },
-            },
-            {
-              path: '/path/to/recent/file1.ts',
-              timestamp: Date.now(),
-            },
-            {
-              path: '/path/to/recent/file2.ts',
-              timestamp: Date.now(),
-            },
-          ],
+      vi.mocked(ideContext.getSelectedFiles).mockReturnValue([
+        {
+          path: '/path/to/active/file.ts',
+          timestamp: Date.now(),
+          isActive: true,
+          selectedText: 'hello',
+          cursor: { line: 5, character: 10 },
         },
-      });
+        {
+          path: '/path/to/recent/file1.ts',
+          timestamp: Date.now(),
+        },
+        {
+          path: '/path/to/recent/file2.ts',
+          timestamp: Date.now(),
+        },
+      ]);
 
       vi.spyOn(client['config'], 'getIdeModeFeature').mockReturnValue(true);
 
@@ -723,7 +719,7 @@ describe('Gemini Client (client.ts)', () => {
       }
 
       // Assert
-      expect(ideContext.getIdeContext).toHaveBeenCalled();
+      expect(ideContext.getSelectedFiles).toHaveBeenCalled();
       const expectedContext = `
 This is the file that the user is looking at:
 - Path: /path/to/active/file.ts
@@ -744,11 +740,7 @@ Here are some other files the user has open, with the most recent at the top:
 
     it('should not add context if ideModeFeature is enabled but no open files', async () => {
       // Arrange
-      vi.mocked(ideContext.getIdeContext).mockReturnValue({
-        workspaceState: {
-          openFiles: [],
-        },
-      });
+      vi.mocked(ideContext.getSelectedFiles).mockReturnValue([]);
 
       vi.spyOn(client['config'], 'getIdeModeFeature').mockReturnValue(true);
 
@@ -782,7 +774,7 @@ Here are some other files the user has open, with the most recent at the top:
       }
 
       // Assert
-      expect(ideContext.getIdeContext).toHaveBeenCalled();
+      expect(ideContext.getSelectedFiles).toHaveBeenCalled();
       expect(mockTurnRunFn).toHaveBeenCalledWith(
         initialRequest,
         expect.any(Object),
@@ -791,19 +783,15 @@ Here are some other files the user has open, with the most recent at the top:
 
     it('should add context if ideModeFeature is enabled and there is one active file', async () => {
       // Arrange
-      vi.mocked(ideContext.getIdeContext).mockReturnValue({
-        workspaceState: {
-          openFiles: [
-            {
-              path: '/path/to/active/file.ts',
-              timestamp: Date.now(),
-              isActive: true,
-              selectedText: 'hello',
-              cursor: { line: 5, character: 10 },
-            },
-          ],
+      vi.mocked(ideContext.getSelectedFiles).mockReturnValue([
+        {
+          path: '/path/to/active/file.ts',
+          timestamp: Date.now(),
+          isActive: true,
+          selectedText: 'hello',
+          cursor: { line: 5, character: 10 },
         },
-      });
+      ]);
 
       vi.spyOn(client['config'], 'getIdeModeFeature').mockReturnValue(true);
 
@@ -837,7 +825,7 @@ Here are some other files the user has open, with the most recent at the top:
       }
 
       // Assert
-      expect(ideContext.getIdeContext).toHaveBeenCalled();
+      expect(ideContext.getSelectedFiles).toHaveBeenCalled();
       const expectedContext = `
 This is the file that the user is looking at:
 - Path: /path/to/active/file.ts
@@ -855,20 +843,16 @@ This is the selected text in the file:
 
     it('should add context if ideModeFeature is enabled and there are open files but no active file', async () => {
       // Arrange
-      vi.mocked(ideContext.getIdeContext).mockReturnValue({
-        workspaceState: {
-          openFiles: [
-            {
-              path: '/path/to/recent/file1.ts',
-              timestamp: Date.now(),
-            },
-            {
-              path: '/path/to/recent/file2.ts',
-              timestamp: Date.now(),
-            },
-          ],
+      vi.mocked(ideContext.getSelectedFiles).mockReturnValue([
+        {
+          path: '/path/to/recent/file1.ts',
+          timestamp: Date.now(),
         },
-      });
+        {
+          path: '/path/to/recent/file2.ts',
+          timestamp: Date.now(),
+        },
+      ]);
 
       vi.spyOn(client['config'], 'getIdeModeFeature').mockReturnValue(true);
 
@@ -902,7 +886,7 @@ This is the selected text in the file:
       }
 
       // Assert
-      expect(ideContext.getIdeContext).toHaveBeenCalled();
+      expect(ideContext.getSelectedFiles).toHaveBeenCalled();
       const expectedContext = `
 Here are some files the user has open, with the most recent at the top:
 - /path/to/recent/file1.ts

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -273,12 +273,11 @@ export class GeminiClient {
     }
 
     if (this.config.getIdeModeFeature() && this.config.getIdeMode()) {
-      const ideContextState = ideContext.getIdeContext();
-      const openFiles = ideContextState?.workspaceState?.openFiles;
+      const selectedFiles = ideContext.getSelectedFiles();
 
-      if (openFiles && openFiles.length > 0) {
+      if (selectedFiles && selectedFiles.length > 0) {
         const contextParts: string[] = [];
-        const firstFile = openFiles[0];
+        const firstFile = selectedFiles[0];
         const activeFile = firstFile.isActive ? firstFile : undefined;
 
         if (activeFile) {
@@ -297,7 +296,9 @@ export class GeminiClient {
           }
         }
 
-        const otherOpenFiles = activeFile ? openFiles.slice(1) : openFiles;
+        const otherOpenFiles = activeFile
+          ? selectedFiles.slice(1)
+          : selectedFiles;
 
         if (otherOpenFiles.length > 0) {
           const recentFiles = otherOpenFiles


### PR DESCRIPTION
## TLDR
Instead of auto-including all open files as context, we now only include the active file by default. The user can  include other open files by navigating to the open files context menu. 

## Dive Deeper
* The active file will always be included in the context. This active file can be excluded by the user, however, if they click into that file again or select context it will be included again
* When a new file becomes active, the previous active file is not included anymore by default

https://github.com/user-attachments/assets/d76c9839-cab1-4c7b-819d-1e09ccecfb2a

## Linked issues / bugs
#4392