### PR TITLE
fix(core): Add missing mnemonist dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7865,7 +7865,6 @@
       "version": "0.40.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.40.3.tgz",
       "integrity": "sha512-Vjyr90sJ23CKKH/qPAgUKicw/v6pRoamxIEDFOF8uSgFME7DqPRpHgRTejWVjkdGg5dXj0/NyxZHZ9bcjH+2uQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "obliterator": "^2.0.4"
@@ -8305,7 +8304,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
       "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -11916,6 +11914,7 @@
         "ignore": "^7.0.0",
         "marked": "^15.0.12",
         "micromatch": "^4.0.8",
+        "mnemonist": "^0.40.3",
         "open": "^10.1.2",
         "picomatch": "^4.0.1",
         "shell-quote": "^1.8.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,7 @@
     "ignore": "^7.0.0",
     "marked": "^15.0.12",
     "micromatch": "^4.0.8",
+    "mnemonist": "^0.40.3",
     "open": "^10.1.2",
     "picomatch": "^4.0.1",
     "shell-quote": "^1.8.3",


### PR DESCRIPTION
## TLDR

The `mnemonist` package was not explicitly listed as a dependency in the `core` package, leading to failing e2e tests in environments with stricter dependency resolution. This change adds the missing dependency to resolve the test failures.

## Dive Deeper

The root cause of the failing e2e tests was a missing dependency, `mnemonist`, in the `packages/core/package.json` file. While it may have been resolved as a transitive dependency in some environments, it was not guaranteed, leading to inconsistent test outcomes.

This PR directly addresses the issue by adding `mnemonist` to the `dependencies` section of the `core` package, ensuring it is always installed.

## Reviewer Test Plan

To validate the fix, a reviewer should:
1. Pull down this branch.
2. Run `npm install` from the root directory.
3. Run the full test suite via `npm run preflight`.
4. Confirm that all tests, including the e2e tests, pass successfully.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

