### PR TITLE
fix(cli) - Adding logging for response and error in LoggingContentGenerator

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -14,15 +14,12 @@ import {
   SendMessageParameters,
   createUserContent,
   Part,
-  GenerateContentResponseUsageMetadata,
   Tool,
 } from '@google/genai';
 import { retryWithBackoff } from '../utils/retry.js';
 import { isFunctionResponse } from '../utils/messageInspectors.js';
 import { ContentGenerator, AuthType } from './contentGenerator.js';
 import { Config } from '../config/config.js';
-import { logApiResponse, logApiError } from '../telemetry/loggers.js';
-import { ApiErrorEvent, ApiResponseEvent } from '../telemetry/types.js';
 import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { hasCycleInSchema } from '../tools/tools.js';
 import { StructuredError } from './turn.js';
@@ -129,46 +126,6 @@ export class GeminiChat {
     private history: Content[] = [],
   ) {
     validateHistory(history);
-  }
-
-  private async _logApiResponse(
-    durationMs: number,
-    prompt_id: string,
-    usageMetadata?: GenerateContentResponseUsageMetadata,
-    responseText?: string,
-  ): Promise<void> {
-    logApiResponse(
-      this.config,
-      new ApiResponseEvent(
-        this.config.getModel(),
-        durationMs,
-        prompt_id,
-        this.config.getContentGeneratorConfig()?.authType,
-        usageMetadata,
-        responseText,
-      ),
-    );
-  }
-
-  private _logApiError(
-    durationMs: number,
-    error: unknown,
-    prompt_id: string,
-  ): void {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    const errorType = error instanceof Error ? error.name : 'unknown';
-
-    logApiError(
-      this.config,
-      new ApiErrorEvent(
-        this.config.getModel(),
-        errorMessage,
-        durationMs,
-        prompt_id,
-        this.config.getContentGeneratorConfig()?.authType,
-        errorType,
-      ),
-    );
   }
 
   /**
@@ -291,12 +248,6 @@ export class GeminiChat {
         authType: this.config.getContentGeneratorConfig()?.authType,
       });
       const durationMs = Date.now() - startTime;
-      await this._logApiResponse(
-        durationMs,
-        prompt_id,
-        response.usageMetadata,
-        JSON.stringify(response),
-      );
 
       this.sendPromise = (async () => {
         const outputContent = response.candidates?.[0]?.content;
@@ -324,8 +275,6 @@ export class GeminiChat {
       });
       return response;
     } catch (error) {
-      const durationMs = Date.now() - startTime;
-      this._logApiError(durationMs, error, prompt_id);
       this.sendPromise = Promise.resolve();
       throw error;
     }
@@ -421,8 +370,6 @@ export class GeminiChat {
       );
       return result;
     } catch (error) {
-      const durationMs = Date.now() - startTime;
-      this._logApiError(durationMs, error, prompt_id);
       this.sendPromise = Promise.resolve();
       throw error;
     }
@@ -483,17 +430,6 @@ export class GeminiChat {
     this.generationConfig.tools = tools;
   }
 
-  getFinalUsageMetadata(
-    chunks: GenerateContentResponse[],
-  ): GenerateContentResponseUsageMetadata | undefined {
-    const lastChunkWithMetadata = chunks
-      .slice()
-      .reverse()
-      .find((chunk) => chunk.usageMetadata);
-
-    return lastChunkWithMetadata?.usageMetadata;
-  }
-
   async maybeIncludeSchemaDepthContext(error: StructuredError): Promise<void> {
     // Check for potentially problematic cyclic tools with cyclic schemas
     // and include a recommendation to remove potentially problematic tools.
@@ -549,25 +485,16 @@ export class GeminiChat {
       }
     } catch (error) {
       errorOccurred = true;
-      const durationMs = Date.now() - startTime;
-      this._logApiError(durationMs, error, prompt_id);
       throw error;
     }
 
     if (!errorOccurred) {
-      const durationMs = Date.now() - startTime;
       const allParts: Part[] = [];
       for (const content of outputContent) {
         if (content.parts) {
           allParts.push(...content.parts);
         }
       }
-      await this._logApiResponse(
-        durationMs,
-        prompt_id,
-        this.getFinalUsageMetadata(chunks),
-        JSON.stringify(chunks),
-      );
     }
     this.recordHistory(inputContent, outputContent);
   }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -206,7 +206,6 @@ export class GeminiChat {
     const userContent = createUserContent(params.message);
     const requestContents = this.getHistory(true).concat(userContent);
 
-    const startTime = Date.now();
     let response: GenerateContentResponse;
 
     try {
@@ -247,7 +246,6 @@ export class GeminiChat {
           await this.handleFlashFallback(authType, error),
         authType: this.config.getContentGeneratorConfig()?.authType,
       });
-      const durationMs = Date.now() - startTime;
 
       this.sendPromise = (async () => {
         const outputContent = response.candidates?.[0]?.content;
@@ -310,8 +308,6 @@ export class GeminiChat {
     const userContent = createUserContent(params.message);
     const requestContents = this.getHistory(true).concat(userContent);
 
-    const startTime = Date.now();
-
     try {
       const apiCall = () => {
         const modelToUse = this.config.getModel();
@@ -362,12 +358,7 @@ export class GeminiChat {
         .then(() => undefined)
         .catch(() => undefined);
 
-      const result = this.processStreamResponse(
-        streamResponse,
-        userContent,
-        startTime,
-        prompt_id,
-      );
+      const result = this.processStreamResponse(streamResponse, userContent);
       return result;
     } catch (error) {
       this.sendPromise = Promise.resolve();
@@ -461,8 +452,6 @@ export class GeminiChat {
   private async *processStreamResponse(
     streamResponse: AsyncGenerator<GenerateContentResponse>,
     inputContent: Content,
-    startTime: number,
-    prompt_id: string,
   ) {
     const outputContent: Content[] = [];
     const chunks: GenerateContentResponse[] = [];

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -137,9 +137,13 @@ export class LoggingContentGenerator implements ContentGenerator {
     userPromptId: string,
   ): AsyncGenerator<GenerateContentResponse> {
     let lastResponse: GenerateContentResponse | undefined;
+    let lastUsageMetadata: GenerateContentResponseUsageMetadata | undefined;
     try {
       for await (const response of stream) {
         lastResponse = response;
+        if (response.usageMetadata) {
+          lastUsageMetadata = response.usageMetadata;
+        }
         yield response;
       }
     } catch (error) {
@@ -152,7 +156,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       this._logApiResponse(
         durationMs,
         userPromptId,
-        lastResponse.usageMetadata,
+        lastUsageMetadata,
         JSON.stringify(lastResponse),
       );
     }

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -128,31 +128,34 @@ export class LoggingContentGenerator implements ContentGenerator {
       throw error;
     }
 
-    const self = this;
-    async function* loggingStreamWrapper(): AsyncGenerator<GenerateContentResponse> {
-      let lastResponse: GenerateContentResponse | undefined;
-      try {
-        for await (const response of stream) {
-          lastResponse = response;
-          yield response;
-        }
-      } catch (error) {
-        const durationMs = Date.now() - startTime;
-        self._logApiError(durationMs, error, userPromptId);
-        throw error;
-      }
-      const durationMs = Date.now() - startTime;
-      if (lastResponse) {
-        self._logApiResponse(
-          durationMs,
-          userPromptId,
-          lastResponse.usageMetadata,
-          JSON.stringify(lastResponse),
-        );
-      }
-    }
+    return this.loggingStreamWrapper(stream, startTime, userPromptId);
+  }
 
-    return loggingStreamWrapper();
+  private async *loggingStreamWrapper(
+    stream: AsyncGenerator<GenerateContentResponse>,
+    startTime: number,
+    userPromptId: string,
+  ): AsyncGenerator<GenerateContentResponse> {
+    let lastResponse: GenerateContentResponse | undefined;
+    try {
+      for await (const response of stream) {
+        lastResponse = response;
+        yield response;
+      }
+    } catch (error) {
+      const durationMs = Date.now() - startTime;
+      this._logApiError(durationMs, error, userPromptId);
+      throw error;
+    }
+    const durationMs = Date.now() - startTime;
+    if (lastResponse) {
+      this._logApiResponse(
+        durationMs,
+        userPromptId,
+        lastResponse.usageMetadata,
+        JSON.stringify(lastResponse),
+      );
+    }
   }
 
   async countTokens(req: CountTokensParameters): Promise<CountTokensResponse> {


### PR DESCRIPTION
## TLDR

This adds response and error logging to the `LoggingContentGenerator wrapper` class

## Dive Deeper

I had to create another generator so the consumer isn't blocked on the whole stream finishing, allowing us to go through logging logic as the user consumes the stream. 

## Reviewer Test Plan

For response testing, I added a breakpoint and console logs to make sure only the last responses are being logged.

For error testing, I wasn't sure how to test so I just threw an error in the try block of `generateContentStream`, then I added breakpoint to see that the error was being logged.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | x  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #5082