### PR TITLE
feat: add environment variable support for generation config

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1890,7 +1890,7 @@ describe('environment variable generation config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
-    expect(config.getGenerationConfig()).toEqual({
+    expect(config.getHyperparameters()).toEqual({
       temperature: 0.7,
     });
   });
@@ -1900,7 +1900,7 @@ describe('environment variable generation config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
-    expect(config.getGenerationConfig()).toEqual({
+    expect(config.getHyperparameters()).toEqual({
       topK: 40,
     });
   });
@@ -1910,7 +1910,7 @@ describe('environment variable generation config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
-    expect(config.getGenerationConfig()).toEqual({
+    expect(config.getHyperparameters()).toEqual({
       thinking_budget: 1024,
     });
   });
@@ -1922,7 +1922,7 @@ describe('environment variable generation config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
-    expect(config.getGenerationConfig()).toEqual({
+    expect(config.getHyperparameters()).toEqual({
       temperature: 1.5,
       topK: 20,
       thinking_budget: 512,
@@ -1935,7 +1935,7 @@ describe('environment variable generation config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
-    expect(config.getGenerationConfig()).toBeUndefined();
+    expect(config.getHyperparameters()).toEqual({});
     expect(consoleSpy).toHaveBeenCalledWith(
       '[WARN]',
       'Invalid GEMINI_TEMPERATURE value: 3.0. Must be between 0.0 and 2.0',
@@ -1949,7 +1949,7 @@ describe('environment variable generation config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
-    expect(config.getGenerationConfig()).toBeUndefined();
+    expect(config.getHyperparameters()).toEqual({});
     expect(consoleSpy).toHaveBeenCalledWith(
       '[WARN]',
       'Invalid GEMINI_TOP_K value: -5. Must be a positive integer',
@@ -1963,7 +1963,7 @@ describe('environment variable generation config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
-    expect(config.getGenerationConfig()).toBeUndefined();
+    expect(config.getHyperparameters()).toEqual({});
     expect(consoleSpy).toHaveBeenCalledWith(
       '[WARN]',
       'Invalid GEMINI_THINKING_BUDGET value: -100. Must be a non-negative integer',
@@ -1975,7 +1975,7 @@ describe('environment variable generation config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
-    expect(config.getGenerationConfig()).toBeUndefined();
+    expect(config.getHyperparameters()).toEqual({});
   });
 
   it('should handle empty string environment variables', async () => {
@@ -1985,7 +1985,7 @@ describe('environment variable generation config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
-    expect(config.getGenerationConfig()).toBeUndefined();
+    expect(config.getHyperparameters()).toEqual({});
   });
 
   it('should handle non-numeric environment variable values', async () => {
@@ -1996,7 +1996,7 @@ describe('environment variable generation config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
-    expect(config.getGenerationConfig()).toBeUndefined();
+    expect(config.getHyperparameters()).toEqual({});
     expect(consoleSpy).toHaveBeenCalledTimes(3);
     consoleSpy.mockRestore();
   });
@@ -2006,7 +2006,7 @@ describe('environment variable generation config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
-    expect(config.getGenerationConfig()).toEqual({
+    expect(config.getHyperparameters()).toEqual({
       temperature: 0,
     });
   });
@@ -2016,7 +2016,7 @@ describe('environment variable generation config', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
-    expect(config.getGenerationConfig()).toEqual({
+    expect(config.getHyperparameters()).toEqual({
       thinking_budget: 0,
     });
   });

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -536,7 +536,7 @@ export async function loadCliConfig(
   }
 
   const sandboxConfig = await loadSandboxConfig(settings, argv);
-  const generationConfig = parseGenerationConfigFromEnv();
+  const hyperparameters = parseGenerationConfigFromEnv();
 
   return new Config({
     sessionId,
@@ -599,7 +599,7 @@ export async function loadCliConfig(
     fileDiscoveryService: fileService,
     bugCommand: settings.bugCommand,
     model: argv.model || settings.model || DEFAULT_GEMINI_MODEL,
-    ...(generationConfig && { generationConfig }),
+    ...(hyperparameters && { hyperparameters }),
     extensionContextFilePaths,
     maxSessionTurns: settings.maxSessionTurns ?? -1,
     experimentalZedIntegration: argv.experimentalAcp || false,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -199,6 +199,11 @@ export interface ConfigParameters {
   chatCompression?: ChatCompressionSettings;
   interactive?: boolean;
   trustedFolder?: boolean;
+  generationConfig?: {
+    temperature?: number;
+    topK?: number;
+    thinking_budget?: number;
+  };
 }
 
 export class Config {
@@ -264,6 +269,13 @@ export class Config {
   private readonly interactive: boolean;
   private readonly trustedFolder: boolean | undefined;
   private initialized: boolean = false;
+  private readonly generationConfig:
+    | {
+        temperature?: number;
+        topK?: number;
+        thinking_budget?: number;
+      }
+    | undefined;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -329,6 +341,7 @@ export class Config {
     this.chatCompression = params.chatCompression;
     this.interactive = params.interactive ?? false;
     this.trustedFolder = params.trustedFolder;
+    this.generationConfig = params.generationConfig;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -709,6 +722,16 @@ export class Config {
 
   isInteractive(): boolean {
     return this.interactive;
+  }
+
+  getGenerationConfig():
+    | {
+        temperature?: number;
+        topK?: number;
+        thinking_budget?: number;
+      }
+    | undefined {
+    return this.generationConfig;
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -199,7 +199,7 @@ export interface ConfigParameters {
   chatCompression?: ChatCompressionSettings;
   interactive?: boolean;
   trustedFolder?: boolean;
-  generationConfig?: {
+  hyperparameters?: {
     temperature?: number;
     topK?: number;
     thinking_budget?: number;
@@ -269,7 +269,7 @@ export class Config {
   private readonly interactive: boolean;
   private readonly trustedFolder: boolean | undefined;
   private initialized: boolean = false;
-  private readonly generationConfig:
+  private readonly hyperparameters:
     | {
         temperature?: number;
         topK?: number;
@@ -341,7 +341,7 @@ export class Config {
     this.chatCompression = params.chatCompression;
     this.interactive = params.interactive ?? false;
     this.trustedFolder = params.trustedFolder;
-    this.generationConfig = params.generationConfig;
+    this.hyperparameters = params.hyperparameters;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -724,14 +724,12 @@ export class Config {
     return this.interactive;
   }
 
-  getGenerationConfig():
-    | {
-        temperature?: number;
-        topK?: number;
-        thinking_budget?: number;
-      }
-    | undefined {
-    return this.generationConfig;
+  getHyperparameters(): {
+    temperature?: number;
+    topK?: number;
+    thinking_budget?: number;
+  } {
+    return this.hyperparameters ?? {};
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -208,7 +208,7 @@ describe('Gemini Client (client.ts)', () => {
       getGeminiClient: vi.fn(),
       setFallbackMode: vi.fn(),
       getChatCompression: vi.fn().mockReturnValue(undefined),
-      getGenerationConfig: vi.fn().mockReturnValue(undefined),
+      getHyperparameters: vi.fn().mockReturnValue({}),
     };
     const MockedConfig = vi.mocked(Config, true);
     MockedConfig.mockImplementation(
@@ -2021,7 +2021,7 @@ ${JSON.stringify(
             getProxy: vi.fn().mockReturnValue(undefined),
             getEmbeddingModel: vi.fn().mockReturnValue('test-embedding-model'),
             getSessionId: vi.fn().mockReturnValue('test-session-id'),
-            getGenerationConfig: vi.fn().mockReturnValue(undefined),
+            getHyperparameters: vi.fn().mockReturnValue({}),
           } as unknown as Config;
 
           const client = new GeminiClient(mockConfig);
@@ -2040,7 +2040,7 @@ ${JSON.stringify(
             getProxy: vi.fn().mockReturnValue(undefined),
             getEmbeddingModel: vi.fn().mockReturnValue('test-embedding-model'),
             getSessionId: vi.fn().mockReturnValue('test-session-id'),
-            getGenerationConfig: vi.fn().mockReturnValue({
+            getHyperparameters: vi.fn().mockReturnValue({
               temperature: 1.2,
               topK: 30,
               thinking_budget: 2048,
@@ -2064,7 +2064,7 @@ ${JSON.stringify(
             getProxy: vi.fn().mockReturnValue(undefined),
             getEmbeddingModel: vi.fn().mockReturnValue('test-embedding-model'),
             getSessionId: vi.fn().mockReturnValue('test-session-id'),
-            getGenerationConfig: vi.fn().mockReturnValue({
+            getHyperparameters: vi.fn().mockReturnValue({
               temperature: 0.5,
             }),
           } as unknown as Config;
@@ -2083,7 +2083,7 @@ ${JSON.stringify(
             getProxy: vi.fn().mockReturnValue(undefined),
             getEmbeddingModel: vi.fn().mockReturnValue('test-embedding-model'),
             getSessionId: vi.fn().mockReturnValue('test-session-id'),
-            getGenerationConfig: vi.fn().mockReturnValue({
+            getHyperparameters: vi.fn().mockReturnValue({
               topK: 15,
             }),
           } as unknown as Config;
@@ -2102,15 +2102,15 @@ ${JSON.stringify(
             getProxy: vi.fn().mockReturnValue(undefined),
             getEmbeddingModel: vi.fn().mockReturnValue('test-embedding-model'),
             getSessionId: vi.fn().mockReturnValue('test-session-id'),
-            getGenerationConfig: vi.fn().mockReturnValue({
+            getHyperparameters: vi.fn().mockReturnValue({
               thinking_budget: 1024,
             }),
           } as unknown as Config;
 
           new GeminiClient(mockConfig);
 
-          // Check that getGenerationConfig returns the thinking_budget
-          expect(mockConfig.getGenerationConfig()).toEqual({
+          // Check that getHyperparameters returns the thinking_budget
+          expect(mockConfig.getHyperparameters()).toEqual({
             thinking_budget: 1024,
           });
         });
@@ -2120,7 +2120,7 @@ ${JSON.stringify(
             getProxy: vi.fn().mockReturnValue(undefined),
             getEmbeddingModel: vi.fn().mockReturnValue('test-embedding-model'),
             getSessionId: vi.fn().mockReturnValue('test-session-id'),
-            getGenerationConfig: vi.fn().mockReturnValue({
+            getHyperparameters: vi.fn().mockReturnValue({
               temperature: 0,
               thinking_budget: 0,
             }),
@@ -2133,7 +2133,7 @@ ${JSON.stringify(
           expect(clientConfig.temperature).toBe(0);
 
           // Verify the config stores thinking_budget correctly
-          expect(mockConfig.getGenerationConfig()).toEqual({
+          expect(mockConfig.getHyperparameters()).toEqual({
             temperature: 0,
             thinking_budget: 0,
           });
@@ -2144,7 +2144,7 @@ ${JSON.stringify(
             getProxy: vi.fn().mockReturnValue(undefined),
             getEmbeddingModel: vi.fn().mockReturnValue('test-embedding-model'),
             getSessionId: vi.fn().mockReturnValue('test-session-id'),
-            getGenerationConfig: vi.fn().mockReturnValue({
+            getHyperparameters: vi.fn().mockReturnValue({
               temperature: 0.8,
             }),
           } as unknown as Config;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -122,12 +122,12 @@ export class GeminiClient {
     this.lastPromptId = this.config.getSessionId();
 
     // Initialize generation config from Config or use defaults
-    const configGenerationConfig = config.getGenerationConfig();
+    const configHyperparameters = config.getHyperparameters();
     this.generateContentConfig = {
-      temperature: configGenerationConfig?.temperature ?? 0,
+      temperature: configHyperparameters.temperature ?? 0,
       topP: 1, // Keep default topP as 1
-      ...(configGenerationConfig?.topK !== undefined && {
-        topK: configGenerationConfig.topK,
+      ...(configHyperparameters.topK !== undefined && {
+        topK: configHyperparameters.topK,
       }),
     };
   }
@@ -242,7 +242,7 @@ export class GeminiClient {
     try {
       const userMemory = this.config.getUserMemory();
       const systemInstruction = getCoreSystemPrompt(userMemory);
-      const configGenerationConfig = this.config.getGenerationConfig();
+      const configHyperparameters = this.config.getHyperparameters();
       const generateContentConfigWithThinking = isThinkingSupported(
         this.config.getModel(),
       )
@@ -250,8 +250,8 @@ export class GeminiClient {
             ...this.generateContentConfig,
             thinkingConfig: {
               includeThoughts: true,
-              ...(configGenerationConfig?.thinking_budget !== undefined && {
-                thinkingBudget: configGenerationConfig.thinking_budget,
+              ...(configHyperparameters.thinking_budget !== undefined && {
+                thinkingBudget: configHyperparameters.thinking_budget,
               }),
             },
           }

--- a/packages/core/src/core/subagent.test.ts
+++ b/packages/core/src/core/subagent.test.ts
@@ -141,7 +141,7 @@ describe('subagent.ts', () => {
     });
 
     // Helper to safely access generationConfig from mock calls
-    const getGenerationConfigFromMock = (
+    const getHyperparametersFromMock = (
       callIndex = 0,
     ): GenerateContentConfig & { systemInstruction?: string | Content } => {
       const callArgs = vi.mocked(GeminiChat).mock.calls[callIndex];
@@ -307,7 +307,7 @@ describe('subagent.ts', () => {
         const callArgs = vi.mocked(GeminiChat).mock.calls[0];
 
         // Check Generation Config
-        const generationConfig = getGenerationConfigFromMock();
+        const generationConfig = getHyperparametersFromMock();
 
         // Check temperature override
         expect(generationConfig.temperature).toBe(defaultModelConfig.temp);
@@ -356,7 +356,7 @@ describe('subagent.ts', () => {
 
         await scope.runNonInteractive(context);
 
-        const generationConfig = getGenerationConfigFromMock();
+        const generationConfig = getHyperparametersFromMock();
         const systemInstruction = generationConfig.systemInstruction as string;
 
         expect(systemInstruction).toContain('Do the task.');
@@ -392,7 +392,7 @@ describe('subagent.ts', () => {
         await scope.runNonInteractive(context);
 
         const callArgs = vi.mocked(GeminiChat).mock.calls[0];
-        const generationConfig = getGenerationConfigFromMock();
+        const generationConfig = getHyperparametersFromMock();
         const history = callArgs[3];
 
         expect(generationConfig.systemInstruction).toBeUndefined();

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -409,6 +409,7 @@ describe('loggers', () => {
       getToolRegistry: () => new ToolRegistry(cfg1),
       getFullContext: () => false,
       getUserMemory: () => 'user-memory',
+      getGenerationConfig: () => undefined,
     } as unknown as Config;
 
     const mockGeminiClient = new GeminiClient(cfg2);

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -409,7 +409,7 @@ describe('loggers', () => {
       getToolRegistry: () => new ToolRegistry(cfg1),
       getFullContext: () => false,
       getUserMemory: () => 'user-memory',
-      getGenerationConfig: () => undefined,
+      getHyperparameters: () => ({}),
     } as unknown as Config;
 
     const mockGeminiClient = new GeminiClient(cfg2);


### PR DESCRIPTION
## Summary
- Add support for reading generation configuration from environment variables
- Implements parsing for `GEMINI_TEMPERATURE`, `GEMINI_TOP_K`, and `GEMINI_THINKING_BUDGET`
- Integrates environment variables into the Config class and GeminiClient

## Changes
- Added `parseGenerationConfigFromEnv()` function to parse and validate environment variables
- Extended Config class to store and provide generation configuration
- Updated GeminiClient to use generation config from Config instead of hardcoded values
- Added comprehensive tests for environment variable parsing and client integration

## Test plan
- [x] Added unit tests for environment variable parsing with validation
- [x] Added tests for GeminiClient using generation config
- [x] Verified environment variables are properly passed to API calls
- [x] Tested invalid values show appropriate warnings

Fixes #5280