### PR TITLE
Fix excessive console logging + remove unnecessary try catch

### DIFF
--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -83,15 +83,10 @@ async function getIdeStatusMessageWithFiles(ideClient: IdeClient): Promise<{
   switch (connection.status) {
     case IDEConnectionStatus.Connected: {
       let content = `🟢 Connected to ${ideClient.getDetectedIdeDisplayName()}`;
-      try {
-        const context = await ideContext.getIdeContext();
-        const openFiles = context?.workspaceState?.openFiles;
-
-        if (openFiles && openFiles.length > 0) {
-          content += formatFileList(openFiles);
-        }
-      } catch (_e) {
-        // Ignore
+      const context = await ideContext.getIdeContext();
+      const openFiles = context?.workspaceState?.openFiles;
+      if (openFiles && openFiles.length > 0) {
+        content += formatFileList(openFiles);
       }
       return {
         messageType: 'info',

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -83,7 +83,7 @@ async function getIdeStatusMessageWithFiles(ideClient: IdeClient): Promise<{
   switch (connection.status) {
     case IDEConnectionStatus.Connected: {
       let content = `🟢 Connected to ${ideClient.getDetectedIdeDisplayName()}`;
-      const context = await ideContext.getIdeContext();
+      const context = ideContext.getIdeContext();
       const openFiles = context?.workspaceState?.openFiles;
       if (openFiles && openFiles.length > 0) {
         content += formatFileList(openFiles);

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -211,16 +211,16 @@ export class IdeClient {
       this.state.status === IDEConnectionStatus.Disconnected &&
       status === IDEConnectionStatus.Disconnected;
 
-    // Only update details if the state wasn't already disconnected, so that
-    // the first detail message is preserved.
+    // Only update details & log to console if the state wasn't already
+    // disconnected, so that the first detail message is preserved.
     if (!isAlreadyDisconnected) {
       this.state = { status, details };
-    }
-
-    if (status === IDEConnectionStatus.Disconnected) {
       if (logToConsole) {
         logger.error(details);
       }
+    }
+
+    if (status === IDEConnectionStatus.Disconnected) {
       logger.debug(details);
       ideContext.clearIdeContext();
     }


### PR DESCRIPTION
- Only log errors to console if the previous state wasn't already disconnected to prevent spamming. This also preserves the earlier more useful error messages