### PR TITLE
docs: improve discoverability of chat persistence feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,37 @@ gemini
 > Give me a summary of all of the changes that went in yesterday
 ```
 
+## Chat Persistence
+
+Continue your conversations across CLI sessions! Gemini CLI automatically saves your chat history and allows you to resume conversations later.
+
+### Save and Resume Conversations
+
+```bash
+# Save your current conversation
+/chat save my-project-work
+
+# List all saved conversations
+/chat list
+
+# Resume a previous conversation
+/chat resume my-project-work
+
+# Delete old conversations
+/chat delete my-project-work
+```
+
+### Storage Location
+
+Your chat history is saved locally:
+- **Linux/macOS:** `~/.config/google-generative-ai/checkpoints/`
+- **Windows:** `C:\Users\<YourUsername>\AppData\Roaming\google-generative-ai\checkpoints\`
+
+This is perfect for:
+- Continuing work on long-term projects
+- Switching between different codebases
+- Preserving context across development sessions
+
 ### Next steps
 
 - Learn how to [contribute to or build from the source](./CONTRIBUTING.md).
@@ -139,6 +170,20 @@ Integrate Gemini CLI directly into your GitHub workflows with the [**Gemini CLI 
 - **Custom Workflows**: Set up your own scheduled tasks and event-driven automations.
 
 ## Popular tasks
+
+### Continue previous work sessions
+
+```text
+> /chat list
+```
+
+```text
+> /chat resume yesterday-debugging
+```
+
+```text
+> Let's continue fixing that authentication bug we were working on
+```
 
 ### Explore a new codebase
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Continue your conversations across CLI sessions! Gemini CLI automatically saves 
 
 Your chat history is saved locally:
 - **Linux/macOS:** `~/.config/google-generative-ai/checkpoints/`
-- **Windows:** `C:\Users\<YourUsername>\AppData\Roaming\google-generative-ai\checkpoints\`
+- **Windows:** `%APPDATA%\google-generative-ai\checkpoints\`
 
 This is perfect for:
 - Continuing work on long-term projects


### PR DESCRIPTION
## Description

This PR improves the discoverability of the existing chat persistence feature that addresses user confusion about continuing conversations after restarting the CLI.

## Changes Made

- ✅ Add prominent "Chat Persistence" section to README.md
- ✅ Include storage location details for different operating systems
- ✅ Add practical use cases and examples
- ✅ Add chat persistence examples to "Popular tasks" section
- ✅ Fix markdown formatting issues

## Problem Solved

The `/chat save/resume` functionality already exists but is poorly discoverable:
- Not mentioned in the main README
- Buried in the CLI commands documentation  
- No examples showing practical usage
- Users restart CLI and lose context, not knowing they can resume

## Testing

- [x] Verified all `/chat` commands work as documented
- [x] Tested markdown formatting renders correctly
- [x] Confirmed storage locations are accurate for all platforms

## Fixes

Closes #5930