### PR TITLE
docs(config): Add showLineNumbers option to documentation

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -280,6 +280,14 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     }
     ```
 
+- **`showLineNumbers`** (boolean):
+  - **Description:** Controls whether line numbers are displayed in code blocks in the CLI output.
+  - **Default:** `true`
+  - **Example:**
+    ```json
+    "showLineNumbers": false
+    ```
+
 ### Example `settings.json`:
 
 ```json


### PR DESCRIPTION
  This commit updates the configuration.md with a new configuration option, showLineNumbers, which allows users to control the visibility of line numbers in code blocks within
  the CLI output.

  The following changes are included:
   - Documentation for the new option in docs/cli/configuration.md.
