### PR TITLE
feat: add native binary compilation to releases

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,3 +71,24 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: npm run test:e2e
+
+  e2e-test-native-binary:
+    name: E2E Native Binary Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20.x
+          cache: 'npm'
+      - uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2
+        with:
+          bun-version: '1.2.20'
+      - run: npm ci
+      - run: npm run bundle
+      - run: npm run build:binaries
+      - name: Smoke test native binary
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_BINARY: ${{ github.workspace }}/bundle/binaries/gemini-cli-linux-x64
+        run: npm run test:integration:sandbox:none -- list_directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,11 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2
+        with:
+          bun-version: '1.2.20'
+
       - name: Install Dependencies
         run: npm ci
 
@@ -129,6 +134,9 @@ jobs:
           npm run build:packages
           npm run prepare:package
 
+      - name: Build Native Binaries
+        run: npm run build:binaries
+
       - name: Configure npm for publishing
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -158,6 +166,7 @@ jobs:
         run: |
           gh release create ${{ steps.version.outputs.RELEASE_TAG }} \
             bundle/gemini.js \
+            bundle/binaries/* \
             --target "$RELEASE_BRANCH" \
             --title "Release ${{ steps.version.outputs.RELEASE_TAG }}" \
             --generate-notes

--- a/integration-tests/test-helper.js
+++ b/integration-tests/test-helper.js
@@ -169,7 +169,7 @@ export class TestRig {
   }
 
   run(promptOrOptions, ...args) {
-    let command = this.isNativeBinary 
+    let command = this.isNativeBinary
       ? `${this.binaryPath} --yolo`
       : `node ${this.bundlePath} --yolo`;
     const execOptions = {

--- a/integration-tests/test-helper.js
+++ b/integration-tests/test-helper.js
@@ -103,7 +103,14 @@ export function validateModelOutput(
 
 export class TestRig {
   constructor() {
-    this.bundlePath = join(__dirname, '..', 'bundle/gemini.js');
+    // Support testing native binaries via GEMINI_BINARY env variable
+    if (env.GEMINI_BINARY) {
+      this.binaryPath = env.GEMINI_BINARY;
+      this.isNativeBinary = true;
+    } else {
+      this.bundlePath = join(__dirname, '..', 'bundle/gemini.js');
+      this.isNativeBinary = false;
+    }
     this.testDir = null;
   }
 
@@ -162,7 +169,9 @@ export class TestRig {
   }
 
   run(promptOrOptions, ...args) {
-    let command = `node ${this.bundlePath} --yolo`;
+    let command = this.isNativeBinary 
+      ? `${this.binaryPath} --yolo`
+      : `node ${this.bundlePath} --yolo`;
     const execOptions = {
       cwd: this.testDir,
       encoding: 'utf-8',
@@ -185,9 +194,9 @@ export class TestRig {
     command += ` ${args.join(' ')}`;
 
     const commandArgs = parse(command);
-    const node = commandArgs.shift();
+    const executable = commandArgs.shift();
 
-    const child = spawn(node, commandArgs, {
+    const child = spawn(executable, commandArgs, {
       cwd: this.testDir,
       stdio: 'pipe',
     });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:all": "npm run build && npm run build:sandbox && npm run build:vscode",
     "build:packages": "npm run build --workspaces",
     "build:sandbox": "node scripts/build_sandbox.js --skip-npm-install-build",
+    "build:binaries": "node scripts/build_binaries.js",
     "bundle": "npm run generate && node esbuild.config.js && node scripts/copy_bundle_assets.js",
     "test": "npm run test --workspaces --if-present",
     "test:ci": "npm run test:ci --workspaces --if-present && npm run test:scripts",

--- a/scripts/build_binaries.js
+++ b/scripts/build_binaries.js
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+
+const bundleJs = path.join(rootDir, 'bundle', 'gemini.js');
+const outputDir = path.join(rootDir, 'bundle', 'binaries');
+
+// Binary targets configuration
+const targets = [
+  { name: 'gemini-cli-darwin-x64', target: 'bun-darwin-x64' },
+  { name: 'gemini-cli-darwin-arm64', target: 'bun-darwin-arm64' },
+  { name: 'gemini-cli-linux-x64', target: 'bun-linux-x64' },
+  { name: 'gemini-cli-linux-arm64', target: 'bun-linux-arm64' },
+  { name: 'gemini-cli-windows-x64.exe', target: 'bun-windows-x64' },
+];
+
+// Check if bundle/gemini.js exists
+if (!fs.existsSync(bundleJs)) {
+  console.error('Error: bundle/gemini.js not found. Please run "npm run bundle" first.');
+  process.exit(1);
+}
+
+// Create output directory
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
+  console.log(`Created directory: ${outputDir}`);
+}
+
+console.log('Building native binaries from bundle/gemini.js...\n');
+
+let successCount = 0;
+let failedTargets = [];
+
+for (const { name, target } of targets) {
+  const outputPath = path.join(outputDir, name);
+  console.log(`Building ${name}...`);
+  
+  try {
+    const command = `bun build --compile --target=${target} ${bundleJs} --outfile ${outputPath}`;
+    execSync(command, { stdio: 'pipe' });
+    
+    // Check if file was created
+    if (fs.existsSync(outputPath)) {
+      const stats = fs.statSync(outputPath);
+      const sizeMB = (stats.size / (1024 * 1024)).toFixed(1);
+      console.log(`  ✓ Built ${name} (${sizeMB} MB)`);
+      successCount++;
+    } else {
+      throw new Error('Binary file was not created');
+    }
+  } catch (error) {
+    console.error(`  ✗ Failed to build ${name}`);
+    console.error(`    ${error.message}`);
+    failedTargets.push(name);
+  }
+}
+
+console.log('\n' + '='.repeat(50));
+console.log(`Build complete: ${successCount}/${targets.length} binaries built successfully`);
+
+if (failedTargets.length > 0) {
+  console.log(`Failed targets: ${failedTargets.join(', ')}`);
+  console.log('\nNote: Cross-compilation may require Bun 1.1.0+ and might not work for all targets from all host platforms.');
+  console.log('In CI, all targets should build successfully on the appropriate runner.');
+}
+
+console.log(`\nBinaries saved to: ${outputDir}`);

--- a/scripts/build_binaries.js
+++ b/scripts/build_binaries.js
@@ -27,7 +27,9 @@ const targets = [
 
 // Check if bundle/gemini.js exists
 if (!fs.existsSync(bundleJs)) {
-  console.error('Error: bundle/gemini.js not found. Please run "npm run bundle" first.');
+  console.error(
+    'Error: bundle/gemini.js not found. Please run "npm run bundle" first.',
+  );
   process.exit(1);
 }
 
@@ -45,11 +47,11 @@ let failedTargets = [];
 for (const { name, target } of targets) {
   const outputPath = path.join(outputDir, name);
   console.log(`Building ${name}...`);
-  
+
   try {
     const command = `bun build --compile --target=${target} ${bundleJs} --outfile ${outputPath}`;
     execSync(command, { stdio: 'pipe' });
-    
+
     // Check if file was created
     if (fs.existsSync(outputPath)) {
       const stats = fs.statSync(outputPath);
@@ -67,12 +69,18 @@ for (const { name, target } of targets) {
 }
 
 console.log('\n' + '='.repeat(50));
-console.log(`Build complete: ${successCount}/${targets.length} binaries built successfully`);
+console.log(
+  `Build complete: ${successCount}/${targets.length} binaries built successfully`,
+);
 
 if (failedTargets.length > 0) {
   console.log(`Failed targets: ${failedTargets.join(', ')}`);
-  console.log('\nNote: Cross-compilation may require Bun 1.1.0+ and might not work for all targets from all host platforms.');
-  console.log('In CI, all targets should build successfully on the appropriate runner.');
+  console.log(
+    '\nNote: Cross-compilation may require Bun 1.1.0+ and might not work for all targets from all host platforms.',
+  );
+  console.log(
+    'In CI, all targets should build successfully on the appropriate runner.',
+  );
 }
 
 console.log(`\nBinaries saved to: ${outputDir}`);

--- a/scripts/build_binaries.js
+++ b/scripts/build_binaries.js
@@ -49,14 +49,18 @@ for (const { name, target } of targets) {
   console.log(`Building ${name}...`);
 
   try {
-    execFileSync('bun', [
-      'build',
-      '--compile',
-      `--target=${target}`,
-      bundleJs,
-      '--outfile',
-      outputPath
-    ], { stdio: ['pipe', 'pipe', 'pipe'] });
+    execFileSync(
+      'bun',
+      [
+        'build',
+        '--compile',
+        `--target=${target}`,
+        bundleJs,
+        '--outfile',
+        outputPath,
+      ],
+      { stdio: ['pipe', 'pipe', 'pipe'] },
+    );
 
     if (fs.existsSync(outputPath)) {
       const stats = fs.statSync(outputPath);
@@ -68,9 +72,16 @@ for (const { name, target } of targets) {
     }
   } catch (error) {
     console.error(`  ✗ Failed to build ${name}`);
-    console.error(`    ${error.message}`);
-    if (error.stderr) {
-      console.error(`    ${error.stderr.toString()}`);
+    const errorDetails =
+      error.stderr || error.stdout || error.message || 'Unknown error';
+    const errorString = errorDetails.toString().trim();
+    if (errorString) {
+      console.error(
+        errorString
+          .split('\n')
+          .map((line) => `    ${line}`)
+          .join('\n'),
+      );
     }
     failedTargets.push(name);
   }


### PR DESCRIPTION
## TLDR

Adds native binary compilation using Bun to create standalone executables for macOS, Linux, and Windows. These binaries will be included in GitHub releases alongside the existing `gemini.js` bundle, making it easier for users to download and run gemini-cli without needing Node.js installed.

## Dive Deeper

This PR introduces Bun-based compilation to generate native binaries from our existing `bundle/gemini.js`. The approach:
- Compiles from the already-bundled JS (ensuring version info and all transformations are included)
- Targets 5 platforms: macOS (Intel & ARM), Linux (x64 & ARM), Windows (x64)
- Integrates seamlessly into the existing release workflow
- Binary sizes range from 68MB (macOS ARM) to 124MB (Windows)

The implementation is minimal and non-breaking - it only adds to the release process without changing existing functionality.

## Reviewer Test Plan

1. Build and test the binaries locally:
   ```bash
   npm run bundle
   npm run build:binaries
   ./bundle/binaries/gemini-cli-darwin-arm64 --version  # or your platform
   ```

2. Test basic functionality with a compiled binary:
   ```bash
   ./bundle/binaries/gemini-cli-darwin-arm64 --prompt "What is 2+2?"
   ```

3. Verify the release workflow changes look correct in `.github/workflows/release.yml`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | -   | -   |
| Seatbelt | N/A | -   | -   |

Note: Native binaries tested on macOS ARM64. Cross-compilation to other platforms successful but binaries not executed on target platforms yet.

## Linked issues / bugs

Related to #3804

## TODO
- [ ] Add E2E tests for native binaries
- [ ] Test binaries in release workflow before uploading
- [ ] Verify cross-platform compilation works correctly in CI environment