### PR TITLE
Add support for a shellToolRcFile setting

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -425,6 +425,7 @@ export async function loadCliConfig(
     toolDiscoveryCommand: settings.toolDiscoveryCommand,
     toolCallCommand: settings.toolCallCommand,
     mcpServerCommand: settings.mcpServerCommand,
+    shellToolRcFile: settings.shellToolRcFile,
     mcpServers,
     userMemory: memoryContent,
     geminiMdFileCount: fileCount,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -341,6 +341,16 @@ export const SETTINGS_SCHEMA = {
     description: 'Command to start an MCP server.',
     showInDialog: false,
   },
+  shellToolRcFile: {
+    type: 'string',
+    label: 'Shell Tool RC File',
+    category: 'Advanced',
+    requiresRestart: false,
+    default: undefined as string | undefined,
+    description:
+      'The path to a bash file (e.g., .bashrc) to source before executing shell commands.',
+    showInDialog: false,
+  },
   mcpServers: {
     type: 'object',
     label: 'MCP Servers',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -162,6 +162,7 @@ export interface ConfigParameters {
   toolDiscoveryCommand?: string;
   toolCallCommand?: string;
   mcpServerCommand?: string;
+  shellToolRcFile?: string;
   mcpServers?: Record<string, MCPServerConfig>;
   userMemory?: string;
   geminiMdFileCount?: number;
@@ -217,6 +218,7 @@ export class Config {
   private readonly toolDiscoveryCommand: string | undefined;
   private readonly toolCallCommand: string | undefined;
   private readonly mcpServerCommand: string | undefined;
+  private readonly shellToolRcFile: string | undefined;
   private readonly mcpServers: Record<string, MCPServerConfig> | undefined;
   private userMemory: string;
   private geminiMdFileCount: number;
@@ -282,6 +284,7 @@ export class Config {
     this.toolDiscoveryCommand = params.toolDiscoveryCommand;
     this.toolCallCommand = params.toolCallCommand;
     this.mcpServerCommand = params.mcpServerCommand;
+    this.shellToolRcFile = params.shellToolRcFile;
     this.mcpServers = params.mcpServers;
     this.userMemory = params.userMemory ?? '';
     this.geminiMdFileCount = params.geminiMdFileCount ?? 0;
@@ -509,6 +512,10 @@ export class Config {
 
   getMcpServerCommand(): string | undefined {
     return this.mcpServerCommand;
+  }
+
+  getShellToolRcFile(): string | undefined {
+    return this.shellToolRcFile;
   }
 
   getMcpServers(): Record<string, MCPServerConfig> | undefined {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -57,6 +57,7 @@ describe('ShellTool', () => {
       getSummarizeToolOutputConfig: vi.fn().mockReturnValue(undefined),
       getWorkspaceContext: () => createMockWorkspaceContext('.'),
       getGeminiClient: vi.fn(),
+      getShellToolRcFile: vi.fn().mockReturnValue(undefined),
     } as unknown as Config;
 
     shellTool = new ShellTool(mockConfig);
@@ -174,6 +175,28 @@ describe('ShellTool', () => {
       await promise;
       expect(mockShellExecutionService).toHaveBeenCalledWith(
         'dir',
+        expect.any(String),
+        expect.any(Function),
+        mockAbortSignal,
+      );
+    });
+
+    it('should source rcfile when shellToolRcFile setting is present', async () => {
+      const rcFilePath = '~/.geminirc';
+      (mockConfig.getShellToolRcFile as Mock).mockReturnValue(rcFilePath);
+
+      const promise = shellTool.execute(
+        { command: 'my-command' },
+        mockAbortSignal,
+      );
+      resolveShellExecution();
+      await promise;
+
+      const expectedCommandRegex = new RegExp(
+        `^\\{ source ${rcFilePath} && my-command`,
+      );
+      expect(mockShellExecutionService).toHaveBeenCalledWith(
+        expect.stringMatching(expectedCommandRegex),
         expect.any(String),
         expect.any(Function),
         mockAbortSignal,


### PR DESCRIPTION
## TLDR

Adds a new setting "shellToolRcfile" that gives a path to an "rcfile" that should be executed in each spawned shell environment.

## Dive Deeper

A custom rcfile for the shell tool allows providing aliases or environment variables within the shell context that should apply when gemini runs commands, but not in the users' normal shell environment.

## Reviewer Test Plan

The filename provided is passed directly in a command as follows:

```
  source $rcFile && command
```

As such, bash substitutions like $HOME or ~ should both apply as bash would handle them.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #5843

