### PR TITLE
feat: Add portable CLI configuration feature

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -448,6 +448,64 @@ Arguments passed directly when running the CLI can override other configurations
   - Example: `--include-directories /path/to/project1,/path/to/project2` or `--include-directories /path/to/project1 --include-directories /path/to/project2`
 - **`--version`**:
   - Displays the version of the CLI.
+- **`--portable-config <path_to_yaml>`**:
+  - **Description:** Loads all configuration from a single YAML file. When this flag is used, all `settings.json` files are ignored, and the specified YAML file becomes the single source of truth for all file-based settings. This is ideal for creating a portable, self-contained CLI environment.
+  - **Example:** `gemini --portable-config /path/to/my-config.yaml`
+  - **YAML File Structure:**
+
+    ```yaml
+    # config.yaml
+
+    # Simulates environment variables
+    env:
+      GEMINI_API_KEY: 'your-api-key'
+      GOOGLE_CLOUD_PROJECT: 'your-gcp-project'
+
+    # Simulates command-line arguments
+    cli:
+      model: 'gemini-1.5-pro-latest'
+      debug: true
+      # Corresponds to --yolo
+      auto_approve_tool_calls: true
+
+    # Simulates settings.json content
+    settings:
+      theme: 'GitHub'
+      sandbox: 'docker'
+      telemetry:
+        enabled: false
+      mcpServers:
+        myPythonServer:
+          command: 'python'
+          args: ['mcp_server.py']
+
+    # Simulates instructional context (GEMINI.md, extensions, etc.)
+    context:
+      # Content that would normally be in GEMINI.md
+      geminiMd: |
+        # Project: My Awesome TypeScript Library
+        - Follow the existing coding style.
+        - Ensure all new functions have JSDoc comments.
+
+      # Simulates content from extension docs
+      extensions:
+        - name: 'my-custom-extension'
+          content: |
+            # My Custom Extension
+            - This extension provides tools for database interaction.
+
+      # Simulates .gemini-ignore content
+      ignoreFiles:
+        - 'node_modules/'
+        - 'dist/'
+        - '*.log'
+
+    # Simulates custom commands
+    commands:
+      my_command:
+        description: 'A custom command'
+        prompt: 'This is a custom prompt'
+    ```
 
 ## Context Files (Hierarchical Instructional Context)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,14 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/marked": "^5.0.2",
         "@types/micromatch": "^4.0.9",
         "@types/mime-types": "^3.0.1",
@@ -2330,6 +2334,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3123,7 +3134,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -7308,7 +7318,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "LICENSE"
   ],
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/marked": "^5.0.2",
     "@types/micromatch": "^4.0.9",
     "@types/mime-types": "^3.0.1",
@@ -79,12 +80,15 @@
     "json": "^11.0.0",
     "lodash": "^4.17.21",
     "memfs": "^4.17.2",
+    "mnemonist": "^0.40.3",
     "mock-fs": "^5.5.0",
     "prettier": "^3.5.3",
     "react-devtools-core": "^4.28.5",
     "typescript-eslint": "^8.30.1",
     "vitest": "^3.2.4",
-    "yargs": "^17.7.2",
-    "mnemonist": "^0.40.3"
+    "yargs": "^17.7.2"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
   }
 }

--- a/packages/cli/src/config/config.portable.test.ts
+++ b/packages/cli/src/config/config.portable.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import { loadCliConfig, parseArguments } from './config.js';
+import { Settings } from './settingsSchema.js';
+
+vi.mock('fs', async () => {
+  const actualFs = await vi.importActual<typeof fs>('fs');
+  return {
+    ...actualFs,
+    existsSync: () => true,
+    readFileSync: () => '',
+  };
+});
+vi.mock('js-yaml');
+vi.mock('os', async (importOriginal) => {
+  const actualOs = await importOriginal<typeof os>();
+  return {
+    ...actualOs,
+    homedir: vi.fn(() => '/mock/home/user'),
+  };
+});
+
+describe('loadCliConfig with portable config', () => {
+  const originalArgv = process.argv;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    process.env.GEMINI_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('should load config from portable config file', async () => {
+    const mockYaml = `
+      settings:
+        theme: "GitHub"
+      env:
+        MY_VAR: "my_value"
+      context:
+        geminiMd: "My custom context"
+    `;
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(mockYaml);
+    vi.spyOn(yaml, 'load').mockReturnValue({
+      settings: { theme: 'GitHub' },
+      env: { MY_VAR: 'my_value' },
+      context: { geminiMd: 'My custom context' },
+    });
+
+    process.argv = ['node', 'script.js', '--portable-config', 'config.yaml'];
+    const argv = await parseArguments();
+    const config = await loadCliConfig({}, [], 'test-session', argv);
+
+    expect(config.getSettings().theme).toBe('GitHub');
+    expect(process.env.MY_VAR).toBe('my_value');
+    expect(config.getUserMemory()).toBe('My custom context');
+  });
+
+  it('should ignore settings.json when portable config is used', async () => {
+    const mockYaml = `
+      settings:
+        theme: "Dracula"
+    `;
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(mockYaml);
+    vi.spyOn(yaml, 'load').mockReturnValue({
+      settings: { theme: 'Dracula' },
+    });
+
+    process.argv = ['node', 'script.js', '--portable-config', 'config.yaml'];
+    const argv = await parseArguments();
+    // These settings should be ignored
+    const settings: Settings = { theme: 'GitHub' };
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+
+    expect(config.getSettings().theme).toBe('Dracula');
+  });
+});

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -14,6 +14,7 @@ import { Settings } from './settings.js';
 import { Extension } from './extension.js';
 import * as ServerConfig from '@google/gemini-cli-core';
 
+vi.mock('fs');
 vi.mock('os', async (importOriginal) => {
   const actualOs = await importOriginal<typeof os>();
   return {

--- a/packages/cli/src/config/portable.test.ts
+++ b/packages/cli/src/config/portable.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { loadPortableConfig } from './portable.js';
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('fs');
+vi.mock('js-yaml');
+
+describe('portable config', () => {
+  it('should load and parse a valid YAML file', () => {
+    const mockYaml = `
+      settings:
+        theme: "GitHub"
+    `;
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(mockYaml);
+    vi.spyOn(yaml, 'load').mockReturnValue({
+      settings: { theme: 'GitHub' },
+    });
+
+    const config = loadPortableConfig('config.yaml');
+
+    expect(config.settings?.theme).toBe('GitHub');
+    expect(fs.readFileSync).toHaveBeenCalledWith('config.yaml', 'utf8');
+    expect(yaml.load).toHaveBeenCalledWith(mockYaml);
+  });
+
+  it('should exit if the file cannot be read', () => {
+    const exit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      throw new Error('File not found');
+    });
+
+    loadPortableConfig('nonexistent.yaml');
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error loading portable config file: Error: File not found',
+    );
+  });
+});

--- a/packages/cli/src/config/portable.ts
+++ b/packages/cli/src/config/portable.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import { Settings } from './settings.js';
+
+// Defines the structure of the portable configuration YAML file.
+export interface PortableConfig {
+  env?: Record<string, string>;
+  cli?: Record<string, unknown>;
+  settings?: Settings;
+  context?: {
+    geminiMd?: string;
+    extensions?: Array<{ name: string; content: string }>;
+    ignoreFiles?: string[];
+  };
+  commands?: Record<string, { description: string; prompt: string }>;
+}
+
+/**
+ * Reads and parses the portable configuration from a YAML file.
+ *
+ * @param filePath The path to the YAML configuration file.
+ * @returns The parsed portable configuration.
+ */
+export function loadPortableConfig(filePath: string): PortableConfig {
+  try {
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+    return yaml.load(fileContents) as PortableConfig;
+  } catch (e) {
+    console.error(`Error loading portable config file: ${e}`);
+    process.exit(1);
+  }
+}

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -198,6 +198,7 @@ export interface ConfigParameters {
   loadMemoryFromIncludeDirectories?: boolean;
   chatCompression?: ChatCompressionSettings;
   interactive?: boolean;
+  settings?: object;
 }
 
 export class Config {
@@ -263,6 +264,7 @@ export class Config {
   private readonly chatCompression: ChatCompressionSettings | undefined;
   private readonly interactive: boolean;
   private initialized: boolean = false;
+  private readonly settings: object;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -330,6 +332,7 @@ export class Config {
       params.loadMemoryFromIncludeDirectories ?? false;
     this.chatCompression = params.chatCompression;
     this.interactive = params.interactive ?? false;
+    this.settings = params.settings ?? {};
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -694,6 +697,10 @@ export class Config {
 
   getChatCompression(): ChatCompressionSettings | undefined {
     return this.chatCompression;
+  }
+
+  getSettings(): object {
+    return this.settings;
   }
 
   isInteractive(): boolean {


### PR DESCRIPTION
## TLDR

Loads all configuration from a single YAML file. When this flag is used, all `settings.json` files are ignored, and the specified YAML file becomes the single source of truth for all file-based settings. 

## Dive Deeper

This is ideal for creating a portable, self-contained CLI environment.

## Reviewer Test Plan

I add packages/cli/src/config/config.portable.test.ts

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
