### PR TITLE
feat(core): add host validation to GoogleCredentialProvider

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -568,7 +568,7 @@ describe('mcp-client', () => {
         const transport = await createTransport(
           'test-server',
           {
-            httpUrl: 'http://test-server',
+            httpUrl: 'http://test.googleapis.com',
             authProviderType: AuthProviderType.GOOGLE_CREDENTIALS,
             oauth: {
               scopes: ['scope1'],
@@ -587,7 +587,7 @@ describe('mcp-client', () => {
         const transport = await createTransport(
           'test-server',
           {
-            url: 'http://test-server',
+            url: 'http://test.googleapis.com',
             authProviderType: AuthProviderType.GOOGLE_CREDENTIALS,
             oauth: {
               scopes: ['scope1'],
@@ -615,7 +615,7 @@ describe('mcp-client', () => {
             false,
           ),
         ).rejects.toThrow(
-          'No URL configured for Google Credentials MCP server',
+          'URL must be provided in the config for Google Credentials provider',
         );
       });
     });


### PR DESCRIPTION
This change adds host validation to the `GoogleCredentialProvider`.

The provider now validates the server URL against a predefined allowlist to ensure it only connects to intended services. The allowed hosts are `*.googleapis.com` and `*.luci.app`.

- Throws an error if the host is not in the allowed list.
- Adds comprehensive unit tests to verify the new validation logic.
- Updates existing tests to use valid, allowlisted URLs.
