### PR TITLE
docs: add Ramparts MCP Security Scanner to Featured Extensions and examples

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,57 @@
+# Featured Extensions
+
+## Ramparts — MCP Security Scanner
+
+Ramparts scans Model Context Protocol (MCP) servers for capabilities (tools, resources, prompts) and flags security risks (SQL/command injection, secrets leakage, prompt injection/jailbreak, path traversal). It can also run as an MCP server.
+
+### Install
+
+**Option A (npm, when available):**
+```bash
+npm install -g @getjavelin/gemini-ramparts-extension
+```
+
+**Option B (manual):**
+```bash
+# Clone and copy extension
+git clone https://github.com/getjavelin/ramparts.git
+cp -r ramparts/gemini-extension ~/.gemini/extensions/ramparts/
+
+# Install Ramparts CLI
+cargo install ramparts
+```
+
+### Verify
+
+```bash
+gemini -l
+# Should show: Installed extensions: ramparts
+```
+
+### Slash Commands
+
+```bash
+/ramparts --version
+/ramparts scan <url> [--auth-headers "Authorization: Bearer <token>"] [--report]
+/ramparts scan-config [--report]
+```
+
+### Run as MCP Server
+
+Configure in your extension manifest or run directly:
+
+```bash
+ramparts mcp-stdio
+```
+
+In Gemini CLI:
+```bash
+/mcp desc
+# Should show "ramparts-mcp" with tools: health, scan-config, scan
+```
+
+### Tips
+
+- Use `--format json` or `--report` for readable artifacts
+- If LLM checks return 401, set your API key: `ramparts init-config`
+- Repository: https://github.com/getjavelin/ramparts

--- a/examples/ramparts-security/README.md
+++ b/examples/ramparts-security/README.md
@@ -1,0 +1,63 @@
+# Example: MCP Security Scanning with Ramparts
+
+This example demonstrates how to use Ramparts to scan MCP servers for security vulnerabilities.
+
+## Install
+
+```bash
+# Option A: npm (when available)
+npm i -g @getjavelin/gemini-ramparts-extension
+
+# Option B: manual
+git clone https://github.com/getjavelin/ramparts.git
+cp -r ramparts/gemini-extension ~/.gemini/extensions/ramparts/
+cargo install ramparts
+```
+
+## Verify Extension
+
+```bash
+gemini -l
+# Output: Installed extensions: ramparts
+```
+
+## Slash Commands
+
+From within Gemini CLI:
+
+```bash
+# Check version
+/ramparts --version
+
+# Scan all IDE-configured MCP servers
+/ramparts scan-config --report
+
+# Scan specific server with authentication
+/ramparts scan https://api.example.com/mcp/ --format json --auth-headers "Authorization: Bearer $TOKEN"
+```
+
+## Using MCP Tools
+
+Start Ramparts as an MCP server:
+
+```bash
+ramparts mcp-stdio
+```
+
+In Gemini CLI:
+
+```bash
+# View available MCP servers and tools
+/mcp desc
+# Should show: ramparts-mcp is Ready
+
+# Call tools directly
+scan-config
+
+# Call with JSON arguments
+scan {"url":"https://api.githubcopilot.com/mcp/","format":"json","auth_headers":{"Authorization":"Bearer TOKEN"}}
+```
+
+## Troubleshooting
+
+- **Slash commands dont


### PR DESCRIPTION
Summary
- Adds Ramparts (MCP Security Scanner) to Featured Extensions.
- Provides installation and usage examples for slash commands and MCP tools.
- Includes examples/ramparts-security walkthrough.

Why
- Gemini users increasingly use MCP. Ramparts discovers tools/resources/prompts and surfaces security risks (SQL/command injection, secrets leakage, prompt injection/jailbreak, path traversal), improving safety with minimal maintenance burden.

Key points
- Slash commands: /ramparts, /ramparts-scan, /ramparts-config  
- MCP tools: health, scan-config, scan (via stdio)

Verified locally
- Extension detection: gemini -l shows ramparts
- Slash commands: /ramparts --version, /ramparts-config work
- MCP tools: scan-config via MCP server returns JSON results