### PR TITLE
Add --experimental-cli to speed up prettier formatting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint": "eslint . --ext .ts,.tsx && eslint integration-tests",
     "lint:fix": "eslint . --fix && eslint integration-tests --fix",
     "lint:ci": "eslint . --ext .ts,.tsx --max-warnings 0 && eslint integration-tests --max-warnings 0",
-    "format": "prettier --write .",
+    "format": "prettier --experimental-cli --write .",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "preflight": "npm run clean && npm ci && npm run format && npm run lint:ci && npm run build && npm run typecheck && npm run test:ci",
     "prepare": "npm run bundle",


### PR DESCRIPTION
The flag speeds up running prettier from ~5s to ~3s on my macbook and should be even better on Github runners.

The behavior should be identical: https://prettier.io/blog/2023/11/30/cli-deep-dive

## TLDR

Adds the --experimental-cli flag which speeds up prettier. The behavior should be identical with and without the flag.
