### PR TITLE
Reduce noisy IDE integration error message in standalone terminal

### DIFF
--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -79,8 +79,6 @@ export class IdeClient {
   }
 
   async connect(): Promise<void> {
-    this.setState(IDEConnectionStatus.Connecting);
-
     if (!this.currentIde || !this.currentIdeDisplayName) {
       this.setState(
         IDEConnectionStatus.Disconnected,
@@ -93,6 +91,8 @@ export class IdeClient {
       );
       return;
     }
+
+    this.setState(IDEConnectionStatus.Connecting);
 
     if (!this.validateWorkspacePath()) {
       return;

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -89,7 +89,7 @@ export class IdeClient {
         )
           .map((ide) => getIdeDisplayName(ide))
           .join(', ')}`,
-        true,
+        false,
       );
       return;
     }


### PR DESCRIPTION
Removes error log from console when IDE mode is started up in non-supported terminal (/ide status still shows error)