### PR TITLE
Block >() process substitution in shell commands

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -1,4 +1,4 @@
-/**
+  /**
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
@@ -106,6 +106,12 @@ describe('isCommandAllowed', () => {
   describe('command substitution', () => {
     it('should block command substitution using `$(...)`', () => {
       const result = isCommandAllowed('echo $(rm -rf /)', config);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('Command substitution');
+    });
+
+    it('should block command substitution using `>(...)`', () => {
+      const result = isCommandAllowed('cat >(echo hi)', config);
       expect(result.allowed).toBe(false);
       expect(result.reason).toContain('Command substitution');
     });

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -1,4 +1,4 @@
-  /**
+/**
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -160,13 +160,8 @@ export function detectCommandSubstitution(command: string): boolean {
         return true;
       }
 
-      // >(...) process substitution - works unquoted only (not in double quotes)
-      if (char === '>' && nextChar === '(' && !inDoubleQuotes && !inBackticks) {
-        return true;
-      }
-
-      // <(...) process substitution - works unquoted only (not in double quotes)
-      if (char === '<' && nextChar === '(' && !inDoubleQuotes && !inBackticks) {
+      // >(...), <(...) process substitution - works unquoted only (not in double quotes)
+      if (['>', '<'].includes(char) && nextChar === '(' && !inDoubleQuotes && !inBackticks) {
         return true;
       }
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -160,6 +160,11 @@ export function detectCommandSubstitution(command: string): boolean {
         return true;
       }
 
+      // >(...) process substitution - works unquoted only (not in double quotes)
+      if (char === '>' && nextChar === '(' && !inDoubleQuotes && !inBackticks) {
+        return true;
+      }
+
       // <(...) process substitution - works unquoted only (not in double quotes)
       if (char === '<' && nextChar === '(' && !inDoubleQuotes && !inBackticks) {
         return true;


### PR DESCRIPTION
## TLDR

Bug fix related to command subtition

## Dive Deeper

User can inject any propmy inside gemini-cli, whereas gemini allow it execution. With following; `echo "malicious content" >(tee /tmp/malicious_script.sh)`, user can create malicious files...

## Reviewer Test Plan

Run dangerous command with `>(`, e.g. `echo "test" >(true && cat /etc/passwd)`

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  |✅|
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
