### PR TITLE
Fix: log api response error status codes

### DIFF
--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -29,8 +29,7 @@ import { ContentGenerator } from './contentGenerator.js';
 import { toContents } from '../code_assist/converter.js';
 
 interface StructuredError {
-  message: string;
-  status?: number;
+  status: number;
 }
 
 export function isStructuredError(error: unknown): error is StructuredError {

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -99,7 +99,9 @@ export class LoggingContentGenerator implements ContentGenerator {
         prompt_id,
         this.config.getContentGeneratorConfig()?.authType,
         errorType,
-        isStructuredError(error) ? (error as StructuredError).status : undefined,
+        isStructuredError(error)
+          ? (error as StructuredError).status
+          : undefined,
       ),
     );
   }

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -28,6 +28,20 @@ import {
 import { ContentGenerator } from './contentGenerator.js';
 import { toContents } from '../code_assist/converter.js';
 
+interface StructuredError {
+  message: string;
+  status?: number;
+}
+
+export function isStructuredError(error: unknown): error is StructuredError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    typeof (error as StructuredError).status === 'number'
+  );
+}
+
 /**
  * A decorator that wraps a ContentGenerator to add logging to API calls.
  */
@@ -85,6 +99,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         prompt_id,
         this.config.getContentGeneratorConfig()?.authType,
         errorType,
+        isStructuredError(error) ? (error as StructuredError).status : undefined,
       ),
     );
   }


### PR DESCRIPTION
## TLDR

We're currently never logging error status codes for api requests.

## Dive Deeper

This should fix the issue for Clearcut, OTel, and UI telemetry.

## Reviewer Test Plan

Simple change, auto tests should suffice here

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | y  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/maintainers-gemini-cli/issues/650