### PR TITLE
feat(quality): Prompt engineer LLM-based loop detection

### DIFF
--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -325,18 +325,28 @@ export class LoopDetectionService {
       .getHistory()
       .slice(-LLM_LOOP_CHECK_HISTORY_COUNT);
 
-    const prompt = `You are a sophisticated AI diagnostic agent specializing in identifying when a conversational AI is stuck in an unproductive state. Your task is to analyze the provided conversation history and determine if the assistant has ceased to make meaningful progress.
+    const prompt = `You are a sophisticated AI diagnostic agent. Your task is to analyze a conversation history and determine if the assistant is stuck in an unproductive loop.
 
-An unproductive state is characterized by one or more of the following patterns over the last 5 or more assistant turns:
+To perform your analysis, follow these steps:
+1.  Briefly summarize the assistant's last 5-10 actions to understand the recent activity.
+2.  Evaluate these actions against the criteria below to determine if they constitute a loop.
+3.  Provide your final assessment in a JSON object with your reasoning and a confidence score.
 
-Repetitive Actions: The assistant repeats the same tool calls or conversational responses a decent number of times. This includes simple loops (e.g., tool_A, tool_A, tool_A) and alternating patterns (e.g., tool_A, tool_B, tool_A, tool_B, ...).
+---
+### Criteria for Evaluation
 
-Cognitive Loop: The assistant seems unable to determine the next logical step. It might express confusion, repeatedly ask the same questions, or generate responses that don't logically follow from the previous turns, indicating it's stuck and not advancing the task.
+#### What IS an Unproductive Loop:
+1.  **Repetitive Actions without Progress:** The assistant repeats the same tool calls or responses, resulting in no net change. This includes simple loops (A, A, A) and alternating patterns (A, B, A, B) that don't advance the goal.
+2.  **Cognitive Stagnation:** The assistant seems confused, repeatedly asks the same questions, or gives illogical responses, indicating it cannot determine the next step.
 
-Crucially, differentiate between a true unproductive state and legitimate, incremental progress.
-For example, a series of 'tool_A' or 'tool_B' tool calls that make small, distinct changes to the same file (like adding docstrings to functions one by one) is considered forward progress and is NOT a loop. A loop would be repeatedly replacing the same text with the same content, or cycling between a small set of files with no net change.
+#### What is NOT a Loop (Legitimate Progress):
+1.  **Incremental Progress:** A series of similar tool calls that each make a small, distinct, and cumulative change.
+    *   **Example:** Applying docstrings to several functions in a file, one by one. Each call, though similar, makes forward progress.
+2.  **User-Directed Repetition:** A repetitive sequence of actions explicitly requested by the user.
+    *   **Example:** The user asks to "apply the same change to all 10 of these files." This is a valid, user-driven task, not a loop.
 
-Please analyze the conversation history to determine the possibility that the conversation is stuck in a repetitive, non-productive state.`;
+---
+Based on your analysis, determine the possibility that the conversation is stuck in a repetitive, non-productive state. Your output must be a JSON object.`;
     const contents = [
       ...recentHistory,
       { role: 'user', parts: [{ text: prompt }] },


### PR DESCRIPTION
## TLDR

This pull request refines the prompt used by the LLM-based loop detection service (`loopDetectionService.ts`). The goal is to improve the accuracy of loop detection by providing the LLM with clearer, more structured instructions. Key changes include explicitly differentiating between unproductive loops and legitimate, user-directed repetitive tasks.

## Dive Deeper

The prompt for the `checkForLoopWithLLM` function was enhanced to be more robust and less prone to false positives. The improvements include:

1.  **Structured Guidance**: The prompt now instructs the LLM to follow a clear, step-by-step process: first summarize the recent actions, then evaluate them against specific criteria, and finally provide a structured JSON output. This encourages a more logical and transparent reasoning process.
2.  **Clearer Criteria**: The rules for what constitutes a loop versus what is considered legitimate progress are now organized under distinct headings (`What IS an Unproductive Loop` vs. `What is NOT a Loop`). This reduces ambiguity.
3.  **Handling User-Directed Repetition**: A crucial addition is the rule that explicitly states a series of repetitive actions should *not* be considered a loop if it was directly requested by the user (e.g., "apply this change to 10 files").
4.  **Reinforced Output Format**: The prompt re-emphasizes that the output must be a JSON object, which helps ensure the LLM's response is always machine-readable.

These changes should lead to more reliable loop detection, reducing the chances of incorrectly terminating a task that involves legitimate, user-requested repetition.

## Reviewer Test Plan

N/A

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
