### PR TITLE
skip loop check if it is currently inside a loop

### DIFF
--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -217,7 +217,9 @@ describe('LoopDetectionService', () => {
 
       // Continue adding repetitive content inside the code block - should not trigger loop
       for (let i = 0; i < CONTENT_LOOP_THRESHOLD; i++) {
-        const isLoopInside = service.addAndCheck(createContentEvent(repeatedContent));
+        const isLoopInside = service.addAndCheck(
+          createContentEvent(repeatedContent),
+        );
         expect(isLoopInside).toBe(false);
       }
 
@@ -226,7 +228,7 @@ describe('LoopDetectionService', () => {
 
     it('should skip loop detection when already inside a code block (this.inCodeBlock)', () => {
       service.reset('');
-      
+
       // Start with content that puts us inside a code block
       service.addAndCheck(createContentEvent('Here is some code:\n```\n'));
 
@@ -253,7 +255,9 @@ describe('LoopDetectionService', () => {
 
       // Inside code block - should not track loops
       for (let i = 0; i < 5; i++) {
-        const insideResult = service.addAndCheck(createContentEvent(repeatedContent));
+        const insideResult = service.addAndCheck(
+          createContentEvent(repeatedContent),
+        );
         expect(insideResult).toBe(false);
       }
 
@@ -262,7 +266,9 @@ describe('LoopDetectionService', () => {
       expect(exitResult).toBe(false);
 
       // Enter code block again (3rd fence) - should stop tracking again
-      const reenterResult = service.addAndCheck(createContentEvent('```python\n'));
+      const reenterResult = service.addAndCheck(
+        createContentEvent('```python\n'),
+      );
       expect(reenterResult).toBe(false);
 
       expect(loggers.logLoopDetected).not.toHaveBeenCalled();

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -200,6 +200,74 @@ describe('LoopDetectionService', () => {
       expect(loggers.logLoopDetected).not.toHaveBeenCalled();
     });
 
+    it('should not detect loops when content transitions into a code block', () => {
+      service.reset('');
+      const repeatedContent = createRepetitiveContent(1, CONTENT_CHUNK_SIZE);
+
+      // Add some repetitive content outside of code block
+      for (let i = 0; i < CONTENT_LOOP_THRESHOLD - 2; i++) {
+        service.addAndCheck(createContentEvent(repeatedContent));
+      }
+
+      // Now transition into a code block - this should prevent loop detection
+      // even though we were already close to the threshold
+      const codeBlockStart = '```javascript\n';
+      const isLoop = service.addAndCheck(createContentEvent(codeBlockStart));
+      expect(isLoop).toBe(false);
+
+      // Continue adding repetitive content inside the code block - should not trigger loop
+      for (let i = 0; i < CONTENT_LOOP_THRESHOLD; i++) {
+        const isLoopInside = service.addAndCheck(createContentEvent(repeatedContent));
+        expect(isLoopInside).toBe(false);
+      }
+
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+
+    it('should skip loop detection when already inside a code block (this.inCodeBlock)', () => {
+      service.reset('');
+      
+      // Start with content that puts us inside a code block
+      service.addAndCheck(createContentEvent('Here is some code:\n```\n'));
+
+      // Verify we are now inside a code block and any content should be ignored for loop detection
+      const repeatedContent = createRepetitiveContent(1, CONTENT_CHUNK_SIZE);
+      for (let i = 0; i < CONTENT_LOOP_THRESHOLD + 5; i++) {
+        const isLoop = service.addAndCheck(createContentEvent(repeatedContent));
+        expect(isLoop).toBe(false);
+      }
+
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+
+    it('should correctly track inCodeBlock state with multiple fence transitions', () => {
+      service.reset('');
+      const repeatedContent = createRepetitiveContent(1, CONTENT_CHUNK_SIZE);
+
+      // Outside code block - should track content
+      service.addAndCheck(createContentEvent('Normal text '));
+
+      // Enter code block (1 fence) - should stop tracking
+      const enterResult = service.addAndCheck(createContentEvent('```\n'));
+      expect(enterResult).toBe(false);
+
+      // Inside code block - should not track loops
+      for (let i = 0; i < 5; i++) {
+        const insideResult = service.addAndCheck(createContentEvent(repeatedContent));
+        expect(insideResult).toBe(false);
+      }
+
+      // Exit code block (2nd fence) - should reset tracking but still return false
+      const exitResult = service.addAndCheck(createContentEvent('```\n'));
+      expect(exitResult).toBe(false);
+
+      // Enter code block again (3rd fence) - should stop tracking again
+      const reenterResult = service.addAndCheck(createContentEvent('```python\n'));
+      expect(reenterResult).toBe(false);
+
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+
     it('should detect a loop when repetitive content is outside a code block', () => {
       service.reset('');
       const repeatedContent = createRepetitiveContent(1, CONTENT_CHUNK_SIZE);

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -180,7 +180,7 @@ export class LoopDetectionService {
     const wasInCodeBlock = this.inCodeBlock;
     this.inCodeBlock =
       numFences % 2 === 0 ? this.inCodeBlock : !this.inCodeBlock;
-    if (wasInCodeBlock) {
+    if (wasInCodeBlock || this.inCodeBlock) {
       return false;
     }
 


### PR DESCRIPTION
## TLDR

Prevent false positives within code blocks. The check for "chanting" (repetitive content) is now skipped not only if the service was already in a code block, but also if the current content chunk transitions it into a code block.

## Dive Deeper

The `checkContentLoop` method in `@packages/core/src/services/loopDetectionService.ts` tracks whether the current content stream is inside a markdown code block (delimited by ` ``` `). Previously, the logic to skip the loop analysis was `if (wasInCodeBlock)`. This created a bug where the opening ` ``` ` and the first line of code would be analyzed before the state was updated. Since code often contains repetitive syntax (e.g., import statements, function definitions), this could trigger the loop detection incorrectly.

The condition has been changed to `if (wasInCodeBlock || this.inCodeBlock)`. This ensures that as soon as a code block is entered, the content is no longer checked for loops, correctly avoiding false positives.

## Reviewer Test Plan

Ask Gemini to print code block that starts with a table, the ``----------------...`` dashes should not trigger loop detection.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅ | ❓  | ❓  |
| npx      | ✅ | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
