### PR TITLE
feat(extensions): introduce system-level extensions, and disable them in settings

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -946,6 +946,40 @@ describe('loadCliConfig extensions', () => {
     );
     expect(config.getExtensionContextFilePaths()).toEqual(['/path/to/ext1.md']);
   });
+
+  it('should disable extensions from settings if --extensions flag is not used', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      extensions: {
+        disabled: ['ext2'],
+      },
+    };
+    const config = await loadCliConfig(
+      settings,
+      mockExtensions,
+      'test-session',
+      argv,
+    );
+    expect(config.getExtensionContextFilePaths()).toEqual(['/path/to/ext1.md']);
+  });
+
+  it('should prioritize --extensions flag over settings.extensions.disabled', async () => {
+    process.argv = ['node', 'script.js', '--extensions', 'ext2'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      extensions: {
+        disabled: ['ext1'],
+      },
+    };
+    const config = await loadCliConfig(
+      settings,
+      mockExtensions,
+      'test-session',
+      argv,
+    );
+    expect(config.getExtensionContextFilePaths()).toEqual(['/path/to/ext2.md']);
+  });
 });
 
 describe('loadCliConfig model selection', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -314,9 +314,25 @@ export async function loadCliConfig(
   const folderTrustSetting = settings.folderTrust ?? false;
   const folderTrust = folderTrustFeature && folderTrustSetting;
 
+  let enabledExtensions: string[];
+  if (argv.extensions) {
+    // If the CLI flag is used, it takes precedence.
+    enabledExtensions = argv.extensions;
+  } else {
+    // Otherwise, use the settings to determine the enabled list.
+    const allAvailableNames = extensions.map((ext) => ext.config.name);
+    const disabledFromSettings = settings.extensions?.disabled || [];
+    const disabledNamesSet = new Set(
+      disabledFromSettings.map((name) => name.toLowerCase()),
+    );
+    enabledExtensions = allAvailableNames.filter(
+      (name) => !disabledNamesSet.has(name.toLowerCase()),
+    );
+  }
+
   const allExtensions = annotateActiveExtensions(
     extensions,
-    argv.extensions || [],
+    enabledExtensions || [],
   );
 
   const activeExtensions = extensions.filter(

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -38,11 +38,10 @@ function getSystemExtensionsPath(): string {
       'extensions',
     );
   } else if (os.platform() === 'win32') {
-    return path.join(
-      process.env.PROGRAMDATA || 'C:\\ProgramData',
-      'gemini-cli',
-      'extensions',
-    );
+    if (process.env.PROGRAMDATA) {
+      return path.join(process.env.PROGRAMDATA, 'gemini-cli', 'extensions');
+    }
+    return '';
   } else {
     return '/usr/share/gemini-cli/extensions';
   }

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -31,7 +31,10 @@ export function getSystemSettingsPath(): string {
   if (platform() === 'darwin') {
     return '/Library/Application Support/GeminiCli/settings.json';
   } else if (platform() === 'win32') {
-    return 'C:\\ProgramData\\gemini-cli\\settings.json';
+    if (process.env.PROGRAMDATA) {
+      return path.join(process.env.PROGRAMDATA, 'gemini-cli', 'settings.json');
+    }
+    return '';
   } else {
     return '/etc/gemini-cli/settings.json';
   }

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -485,6 +485,26 @@ export const SETTINGS_SCHEMA = {
     description: 'Setting to track whether Folder trust is enabled.',
     showInDialog: true,
   },
+  extensions: {
+    type: 'object',
+    label: 'Extensions',
+    category: 'Advanced',
+    requiresRestart: true,
+    default: {},
+    description: 'Extension settings.',
+    showInDialog: false,
+    properties: {
+      disabled: {
+        type: 'array',
+        label: 'Disabled Extensions',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: [] as string[],
+        description: 'A list of extension names to disable.',
+        showInDialog: false,
+      },
+    },
+  },
   chatCompression: {
     type: 'object',
     label: 'Chat Compression',


### PR DESCRIPTION
## TLDR

This sets up the basics for the planned extension management system, by adding a system-wide location for extensions, and exposing a new setting `extensions.disabled` to disable specific extensions by name.

## Dive Deeper

Similar to how settings use `getSystemSettingsPath()`, extensions now have a predefined path for looking up system-wide extensions (which can be overridden by using `GEMINI_CLI_SYSTEM_EXTENSIONS_PATH` env variable).
- For non-Linux systems, the location is right next to the system-wide settings.json file.
- For Linux systems, instead of /etc/ I decided to use /usr/share/ - since the extension use-case is pretty much "read-only package data" which aligns with the FHS definition.

Extensions are already loaded with precedence `Workspace > Home` - this extends the logic by adding the `System` level as the lowest precedence.

Additionally, before running the `annotateActiveExtensions()`, the code first filters out extensions specified in `extensions.disabled` - reusing the existing logic that allows to disable extensions from argv. The commandline flag still takes precedence over the settings.

## Reviewer Test Plan

I added unit tests for the new logic to make sure this works, so hopefully nothing to test manually.

## Linked issues / bugs

Fixes #5988
