### PR TITLE
feat(config): Implement alwaysAllow for tool permissions

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -81,6 +81,19 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     `excludeTools` for `run_shell_command` are based on simple string matching and can be easily bypassed. This feature is **not a security mechanism** and should not be relied upon to safely execute untrusted code. It is recommended to use `coreTools` to explicitly select commands
     that can be executed.
 
+- **`toolPermissions`** (object):
+  - **Description:** Provides fine-grained control over tool execution approvals, allowing specific tools to bypass manual confirmation.
+  - **Default:** `{}`
+  - **Properties:**
+    - **`alwaysAllow`** (array of strings): A list of tool names that will be executed immediately without requiring user confirmation, even if they would normally prompt for approval.
+  - **Example:**
+    ```json
+    "toolPermissions": {
+      "alwaysAllow": ["ls", "cat", "pwd"]
+    }
+    ```
+  - **Security Note:** This feature is designed for convenience, not as a security boundary. Listing a tool in `alwaysAllow` means it will execute with the same permissions as the Gemini CLI itself. Do not add tools that could perform destructive or unintended actions without understanding the risks.
+
 - **`allowMCPServers`** (array of strings):
   - **Description:** Allows you to specify a list of MCP server names that should be made available to the model. This can be used to restrict the set of MCP servers to connect to. Note that this will be ignored if `--allowed-mcp-server-names` is set.
   - **Default:** All MCP servers are available for use by the Gemini model.

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -82,17 +82,26 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     that can be executed.
 
 - **`toolPermissions`** (object):
-  - **Description:** Provides fine-grained control over tool execution approvals, allowing specific tools to bypass manual confirmation.
+  - **Description:** Provides fine-grained control over tool execution approvals, allowing specific tools or shell commands to bypass manual confirmation.
   - **Default:** `{}`
   - **Properties:**
-    - **`alwaysAllow`** (array of strings): A list of tool names that will be executed immediately without requiring user confirmation, even if they would normally prompt for approval.
-  - **Example:**
-    ```json
-    "toolPermissions": {
-      "alwaysAllow": ["ls", "cat", "pwd"]
-    }
-    ```
-  - **Security Note:** This feature is designed for convenience, not as a security boundary. Listing a tool in `alwaysAllow` means it will execute with the same permissions as the Gemini CLI itself. Do not add tools that could perform destructive or unintended actions without understanding the risks.
+    - **`alwaysAllow`** (array of strings): A list of tool names or specific shell commands that will be executed immediately without requiring user confirmation.
+      - **For Tools:** To allow a tool to always run, add its name to the list (e.g., `write_file`).
+      - **For Shell Commands:** To allow a specific shell command, add the command name (e.g., `echo`, `ls`). For chained commands (e.g., `echo "hi" && ls`), every command in the chain must be in the `alwaysAllow` list.
+  - **Examples:**
+    - Allow the `read_file` and `glob` tools:
+      ```json
+      "toolPermissions": {
+        "alwaysAllow": ["read_file", "glob"]
+      }
+      ```
+    - Allow the `ls` and `cat` shell commands:
+      ```json
+      "toolPermissions": {
+        "alwaysAllow": ["ls", "cat"]
+      }
+      ```
+  - **Security Note:** This feature is designed for convenience, not as a security boundary. Listing a tool or command in `alwaysAllow` means it will execute with the same permissions as the Gemini CLI itself. Do not add tools or commands that could perform destructive or unintended actions without understanding the risks. For `run_shell_command`, it is much safer to allow specific, trusted commands than to allow the entire tool. Allowing `run_shell_command` itself would permit _any_ shell command to run without a prompt, which is a significant security risk.
 
 - **`allowMCPServers`** (array of strings):
   - **Description:** Allows you to specify a list of MCP server names that should be made available to the model. This can be used to restrict the set of MCP servers to connect to. Note that this will be ignored if `--allowed-mcp-server-names` is set.

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -479,6 +479,7 @@ export async function loadCliConfig(
     folderTrustFeature,
     folderTrust,
     interactive,
+    toolPermissions: settings.toolPermissions,
   });
 }
 

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -114,6 +114,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        toolPermissions: {
+          alwaysAllow: [],
+        },
       });
       expect(settings.errors.length).toBe(0);
     });
@@ -149,6 +152,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        toolPermissions: {
+          alwaysAllow: [],
+        },
       });
     });
 
@@ -184,6 +190,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        toolPermissions: {
+          alwaysAllow: [],
+        },
       });
     });
 
@@ -217,6 +226,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        toolPermissions: {
+          alwaysAllow: [],
+        },
       });
     });
 
@@ -256,6 +268,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        toolPermissions: {
+          alwaysAllow: [],
+        },
       });
     });
 
@@ -307,6 +322,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        toolPermissions: {
+          alwaysAllow: [],
+        },
       });
     });
 
@@ -828,6 +846,46 @@ describe('Settings Loading and Merging', () => {
       ]);
     });
 
+    it('should merge toolPermissions.alwaysAllow from all scopes', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const systemSettingsContent = {
+        toolPermissions: {
+          alwaysAllow: ['system_tool'],
+        },
+      };
+      const userSettingsContent = {
+        toolPermissions: {
+          alwaysAllow: ['user_tool1', 'user_tool2'],
+        },
+      };
+      const workspaceSettingsContent = {
+        toolPermissions: {
+          alwaysAllow: ['workspace_tool'],
+        },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === getSystemSettingsPath())
+            return JSON.stringify(systemSettingsContent);
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.toolPermissions?.alwaysAllow).toEqual([
+        'system_tool',
+        'user_tool1',
+        'user_tool2',
+        'workspace_tool',
+      ]);
+    });
+
     it('should handle JSON parsing errors gracefully', () => {
       (mockFsExistsSync as Mock).mockReturnValue(true); // Both files "exist"
       const invalidJsonContent = 'invalid json';
@@ -868,6 +926,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        toolPermissions: {
+          alwaysAllow: [],
+        },
       });
 
       // Check that error objects are populated in settings.errors
@@ -1306,6 +1367,9 @@ describe('Settings Loading and Merging', () => {
           mcpServers: {},
           includeDirectories: [],
           chatCompression: {},
+          toolPermissions: {
+            alwaysAllow: [],
+          },
         });
       });
     });

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -128,6 +128,13 @@ export class LoadedSettings {
         ...(user.chatCompression || {}),
         ...(workspace.chatCompression || {}),
       },
+      toolPermissions: {
+        alwaysAllow: [
+          ...(system.toolPermissions?.alwaysAllow || []),
+          ...(user.toolPermissions?.alwaysAllow || []),
+          ...(workspace.toolPermissions?.alwaysAllow || []),
+        ],
+      },
     };
   }
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -503,6 +503,19 @@ export const SETTINGS_SCHEMA = {
     description: 'Show line numbers in the chat.',
     showInDialog: true,
   },
+  toolPermissions: {
+    type: 'object',
+    label: 'Tool Permissions',
+    category: 'Advanced',
+    requiresRestart: false,
+    default: undefined as
+      | {
+          alwaysAllow?: string[];
+        }
+      | undefined,
+    description: 'Granular tool permissions.',
+    showInDialog: false,
+  },
 } as const;
 
 type InferSettings<T extends SettingsSchema> = {

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -53,6 +53,9 @@ const mockConfig = {
   getApprovalMode: vi.fn(() => ApprovalMode.DEFAULT),
   getUsageStatisticsEnabled: () => true,
   getDebugMode: () => false,
+  getToolPermissions: () => ({
+    alwaysAllow: [],
+  }),
 };
 
 class MockTool extends BaseTool<object, ToolResult> {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -198,6 +198,9 @@ export interface ConfigParameters {
   loadMemoryFromIncludeDirectories?: boolean;
   chatCompression?: ChatCompressionSettings;
   interactive?: boolean;
+  toolPermissions?: {
+    alwaysAllow?: string[];
+  };
 }
 
 export class Config {
@@ -262,6 +265,7 @@ export class Config {
   private readonly loadMemoryFromIncludeDirectories: boolean = false;
   private readonly chatCompression: ChatCompressionSettings | undefined;
   private readonly interactive: boolean;
+  private readonly toolPermissions: { alwaysAllow?: string[] } | undefined;
   private initialized: boolean = false;
 
   constructor(params: ConfigParameters) {
@@ -330,6 +334,7 @@ export class Config {
       params.loadMemoryFromIncludeDirectories ?? false;
     this.chatCompression = params.chatCompression;
     this.interactive = params.interactive ?? false;
+    this.toolPermissions = params.toolPermissions;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -694,6 +699,10 @@ export class Config {
 
   getChatCompression(): ChatCompressionSettings | undefined {
     return this.chatCompression;
+  }
+
+  getToolPermissions(): { alwaysAllow?: string[] } | undefined {
+    return this.toolPermissions;
   }
 
   isInteractive(): boolean {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -198,9 +198,7 @@ export interface ConfigParameters {
   loadMemoryFromIncludeDirectories?: boolean;
   chatCompression?: ChatCompressionSettings;
   interactive?: boolean;
-  toolPermissions?: {
-    alwaysAllow?: string[];
-  };
+  toolPermissions?: { alwaysAllow?: string[] };
 }
 
 export class Config {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -893,3 +893,214 @@ describe('CoreToolScheduler with alwaysAllow permission', () => {
     }
   });
 });
+
+describe('CoreToolScheduler with alwaysAllow permission for shell commands', () => {
+  it('should execute a shell command directly if the command is in the alwaysAllow list', async () => {
+    // Arrange
+    const mockShellTool = new MockTool('run_shell_command');
+    mockShellTool.executeFn.mockReturnValue({
+      llmContent: 'Shell command executed',
+      returnDisplay: 'Shell command executed',
+    });
+    // This tool would normally require confirmation.
+    mockShellTool.shouldConfirm = true;
+    const declarativeTool = mockShellTool;
+
+    const toolRegistry = {
+      getTool: () => declarativeTool,
+      getToolByName: () => declarativeTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {} as any,
+      registerTool: () => {},
+      getToolByDisplayName: () => declarativeTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    };
+
+    const onAllToolCallsComplete = vi.fn();
+    const onToolCallsUpdate = vi.fn();
+
+    // Configure the scheduler to always allow 'echo'.
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT, // Not YOLO mode
+      getToolPermissions: () => ({
+        alwaysAllow: ['echo'], // The command is in the allow list
+      }),
+    } as unknown as Config;
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      toolRegistry: Promise.resolve(toolRegistry as any),
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const abortController = new AbortController();
+    const request = {
+      callId: '1',
+      name: 'run_shell_command',
+      args: { command: 'echo "hello"' },
+      isClientInitiated: false,
+      prompt_id: 'prompt-id-always-allow-shell',
+    };
+
+    // Act
+    await scheduler.schedule([request], abortController.signal);
+
+    // Assert
+    expect(mockShellTool.executeFn).toHaveBeenCalledWith({
+      command: 'echo "hello"',
+    });
+    const statusUpdates = onToolCallsUpdate.mock.calls
+      .map((call) => (call[0][0] as ToolCall)?.status)
+      .filter(Boolean);
+    expect(statusUpdates).not.toContain('awaiting_approval');
+    expect(onAllToolCallsComplete).toHaveBeenCalled();
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls[0].status).toBe('success');
+  });
+
+  it('should require confirmation for a shell command if the command is not in the alwaysAllow list', async () => {
+    // Arrange
+    const mockShellTool = new MockTool('run_shell_command');
+    mockShellTool.shouldConfirm = true;
+    const declarativeTool = mockShellTool;
+
+    const toolRegistry = {
+      getTool: () => declarativeTool,
+      getToolByName: () => declarativeTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {} as any,
+      registerTool: () => {},
+      getToolByDisplayName: () => declarativeTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    };
+
+    const onAllToolCallsComplete = vi.fn();
+    const onToolCallsUpdate = vi.fn();
+
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+      getToolPermissions: () => ({
+        alwaysAllow: ['echo'], // 'rm' is not in the allow list
+      }),
+    } as unknown as Config;
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      toolRegistry: Promise.resolve(toolRegistry as any),
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const abortController = new AbortController();
+    const request = {
+      callId: '1',
+      name: 'run_shell_command',
+      args: { command: 'rm -rf /' },
+      isClientInitiated: false,
+      prompt_id: 'prompt-id-needs-approval-shell',
+    };
+
+    // Act
+    await scheduler.schedule([request], abortController.signal);
+
+    // Assert
+    const statusUpdates = onToolCallsUpdate.mock.calls
+      .map((call) => (call[0][0] as ToolCall)?.status)
+      .filter(Boolean);
+    expect(statusUpdates).toContain('awaiting_approval');
+  });
+
+  it('should execute a chained shell command directly if all commands are in the alwaysAllow list', async () => {
+    // Arrange
+    const mockShellTool = new MockTool('run_shell_command');
+    mockShellTool.executeFn.mockReturnValue({
+      llmContent: 'Shell command executed',
+      returnDisplay: 'Shell command executed',
+    });
+    // This tool would normally require confirmation.
+    mockShellTool.shouldConfirm = true;
+    const declarativeTool = mockShellTool;
+
+    const toolRegistry = {
+      getTool: () => declarativeTool,
+      getToolByName: () => declarativeTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {} as any,
+      registerTool: () => {},
+      getToolByDisplayName: () => declarativeTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    };
+
+    const onAllToolCallsComplete = vi.fn();
+    const onToolCallsUpdate = vi.fn();
+
+    // Configure the scheduler to always allow 'echo' and 'ls'.
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT, // Not YOLO mode
+      getToolPermissions: () => ({
+        alwaysAllow: ['echo', 'ls'], // The commands are in the allow list
+      }),
+    } as unknown as Config;
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      toolRegistry: Promise.resolve(toolRegistry as any),
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const abortController = new AbortController();
+    const request = {
+      callId: '1',
+      name: 'run_shell_command',
+      args: { command: 'echo "hello" && ls -la' },
+      isClientInitiated: false,
+      prompt_id: 'prompt-id-always-allow-shell-chained',
+    };
+
+    // Act
+    await scheduler.schedule([request], abortController.signal);
+
+    // Assert
+    expect(mockShellTool.executeFn).toHaveBeenCalledWith({
+      command: 'echo "hello" && ls -la',
+    });
+    const statusUpdates = onToolCallsUpdate.mock.calls
+      .map((call) => (call[0][0] as ToolCall)?.status)
+      .filter(Boolean);
+    expect(statusUpdates).not.toContain('awaiting_approval');
+    expect(onAllToolCallsComplete).toHaveBeenCalled();
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls[0].status).toBe('success');
+  });
+});

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -98,6 +98,9 @@ describe('CoreToolScheduler', () => {
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
       getApprovalMode: () => ApprovalMode.DEFAULT,
+      getToolPermissions: () => ({
+        alwaysAllow: [],
+      }),
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -169,6 +172,9 @@ describe('CoreToolScheduler with payload', () => {
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
       getApprovalMode: () => ApprovalMode.DEFAULT,
+      getToolPermissions: () => ({
+        alwaysAllow: [],
+      }),
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -446,6 +452,9 @@ describe('CoreToolScheduler edit cancellation', () => {
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
       getApprovalMode: () => ApprovalMode.DEFAULT,
+      getToolPermissions: () => ({
+        alwaysAllow: [],
+      }),
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -541,6 +550,9 @@ describe('CoreToolScheduler YOLO mode', () => {
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
       getApprovalMode: () => ApprovalMode.YOLO,
+      getToolPermissions: () => ({
+        alwaysAllow: [],
+      }),
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -626,6 +638,9 @@ describe('CoreToolScheduler request queueing', () => {
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
       getApprovalMode: () => ApprovalMode.YOLO, // Use YOLO to avoid confirmation prompts
+      getToolPermissions: () => ({
+        alwaysAllow: [],
+      }),
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -735,6 +750,9 @@ describe('CoreToolScheduler request queueing', () => {
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
       getApprovalMode: () => ApprovalMode.YOLO,
+      getToolPermissions: () => ({
+        alwaysAllow: [],
+      }),
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -782,5 +800,96 @@ describe('CoreToolScheduler request queueing', () => {
 
     // Ensure completion callbacks were called twice.
     expect(onAllToolCallsComplete).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('CoreToolScheduler with alwaysAllow permission', () => {
+  it('should execute a tool directly if it is in the alwaysAllow list, even if it requires confirmation', async () => {
+    // Arrange
+    const mockTool = new MockTool();
+    mockTool.executeFn.mockReturnValue({
+      llmContent: 'Tool executed',
+      returnDisplay: 'Tool executed',
+    });
+    // This tool would normally require confirmation.
+    mockTool.shouldConfirm = true;
+    const declarativeTool = mockTool;
+
+    const toolRegistry = {
+      getTool: () => declarativeTool,
+      getToolByName: () => declarativeTool,
+      // Other properties are not needed for this test but are included for type consistency.
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {} as any,
+      registerTool: () => {},
+      getToolByDisplayName: () => declarativeTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    };
+
+    const onAllToolCallsComplete = vi.fn();
+    const onToolCallsUpdate = vi.fn();
+
+    // Configure the scheduler to always allow 'mockTool'.
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT, // Not YOLO mode
+      getToolPermissions: () => ({
+        alwaysAllow: ['mockTool'], // The tool is in the allow list
+      }),
+    } as unknown as Config;
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      toolRegistry: Promise.resolve(toolRegistry as any),
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const abortController = new AbortController();
+    const request = {
+      callId: '1',
+      name: 'mockTool',
+      args: { param: 'value' },
+      isClientInitiated: false,
+      prompt_id: 'prompt-id-always-allow',
+    };
+
+    // Act
+    await scheduler.schedule([request], abortController.signal);
+
+    // Assert
+    // 1. The tool's execute method was called directly.
+    expect(mockTool.executeFn).toHaveBeenCalledWith({ param: 'value' });
+
+    // 2. The tool call status never entered 'awaiting_approval'.
+    const statusUpdates = onToolCallsUpdate.mock.calls
+      .map((call) => (call[0][0] as ToolCall)?.status)
+      .filter(Boolean);
+    expect(statusUpdates).not.toContain('awaiting_approval');
+    expect(statusUpdates).toEqual([
+      'validating',
+      'scheduled',
+      'executing',
+      'success',
+    ]);
+
+    // 3. The final callback indicates the tool call was successful.
+    expect(onAllToolCallsComplete).toHaveBeenCalled();
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls).toHaveLength(1);
+    const completedCall = completedCalls[0];
+    expect(completedCall.status).toBe('success');
+    if (completedCall.status === 'success') {
+      expect(completedCall.response.resultDisplay).toBe('Tool executed');
+    }
   });
 });

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -591,7 +591,11 @@ export class CoreToolScheduler {
         const { request: reqInfo, invocation } = toolCall;
 
         try {
-          if (this.config.getApprovalMode() === ApprovalMode.YOLO) {
+          const toolPermissions = this.config.getToolPermissions();
+          if (
+            toolPermissions?.alwaysAllow?.includes(reqInfo.name) ||
+            this.config.getApprovalMode() === ApprovalMode.YOLO
+          ) {
             this.setToolCallOutcome(
               reqInfo.callId,
               ToolConfirmationOutcome.ProceedAlways,

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -24,6 +24,7 @@ import {
 } from '../index.js';
 import { Part, PartListUnion } from '@google/genai';
 import { getResponseTextFromParts } from '../utils/generateContentResponseUtilities.js';
+import { getCommandRoots } from '../utils/shell-utils.js';
 import {
   isModifiableDeclarativeTool,
   ModifyContext,
@@ -522,6 +523,30 @@ export class CoreToolScheduler {
     return this._schedule(request, signal);
   }
 
+  private _shouldSkipConfirmation(reqInfo: ToolCallRequestInfo): boolean {
+    const alwaysAllow = this.config.getToolPermissions()?.alwaysAllow ?? [];
+
+    if (
+      alwaysAllow.includes(reqInfo.name) ||
+      this.config.getApprovalMode() === ApprovalMode.YOLO
+    ) {
+      return true;
+    }
+
+    if (
+      reqInfo.name !== 'run_shell_command' ||
+      typeof reqInfo.args.command !== 'string'
+    ) {
+      return false;
+    }
+
+    const commandRoots = getCommandRoots(reqInfo.args.command);
+    return (
+      commandRoots.length > 0 &&
+      commandRoots.every((root) => alwaysAllow.includes(root))
+    );
+  }
+
   private async _schedule(
     request: ToolCallRequestInfo | ToolCallRequestInfo[],
     signal: AbortSignal,
@@ -591,11 +616,7 @@ export class CoreToolScheduler {
         const { request: reqInfo, invocation } = toolCall;
 
         try {
-          const toolPermissions = this.config.getToolPermissions();
-          if (
-            toolPermissions?.alwaysAllow?.includes(reqInfo.name) ||
-            this.config.getApprovalMode() === ApprovalMode.YOLO
-          ) {
+          if (this._shouldSkipConfirmation(reqInfo)) {
             this.setToolCallOutcome(
               reqInfo.callId,
               ToolConfirmationOutcome.ProceedAlways,


### PR DESCRIPTION
## TLDR

This change introduces the alwaysAllow functionality as part of a new, more granular tool permission model. This addresses user feedback for a more flexible and convenient CLI experience.

## Dive Deeper

A new toolPermissions object can now be added to settings.json. Tools listed in the alwaysAllow array within this object will be executed without requiring user confirmation, bypassing the usual prompt. This is particularly useful for safe, read-only commands that users trust.

The implementation involves:
  - Updating the settings schema to include toolPermissions.alwaysAllow.
  - Modifying the settings loader to merge alwaysAllow arrays from user, workspace, and system configurations.
  - Adjusting the CoreToolScheduler to check this list before prompting for tool execution.
  - Updating relevant unit tests to account for the new configuration and behavior.

Note: This is one of the 3 settings as proposed in https://github.com/google-gemini/gemini-cli/issues/4340#issuecomment-3173395850.

## Reviewer Test Plan

Step 1: Verify a Tool Requires Approval by Default

1. First, identify a tool that performs a sensitive action and requires user confirmation. The echo tool is a good
      example.
2. Run a prompt that will invoke this tool. For example:
 ``` write the text 'hello world' to a file named 'test-file.txt' using echo command```

3. **Expected Result:** The CLI should pause and present you with a confirmation dialog, asking for your approval before writing the file. You can cancel the operation.

Step 2: Verify the `alwaysAllow` Setting Bypasses Approval

1. Now, configure the CLI to always allow the echo tool. Open your project's .gemini/settings.json file (or your global ~/.gemini/settings.json) and add the following configuration:

```
{
  "toolPermissions": {
    "alwaysAllow": ["echo"]
  }
}
```
2. Run the exact same prompt again:

 ``` write the text 'hello world' to a file named 'test-file.txt' using echo command```

3. **Expected Result:** The CLI should execute the `echo` tool **without** pausing for confirmation. A new file named `test-file.txt` containing "hello world" should be created in your directory instantly.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | Y  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

Related to #4340 