### PR TITLE
fix(release): Use 'npm run bundle' to correctly build package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Build and Prepare Packages
         run: |
-          npm run build:packages
+          npm run bundle
           npm run prepare:package
 
       - name: Configure npm for publishing


### PR DESCRIPTION
## TLDR

This PR fixes a bug in the release workflow that caused the Gemini CLI to report the Node.js version in its User-Agent string instead of its own application version. The fix is to change the Build and Prepare Packages step in .github/workflows/release.yml to run npm run bundle, ensuring the application is correctly packaged and the version is injected before publishing.

## Dive Deeper

Our investigation found that the User-Agent string was incorrectly logging the Node.js version because process.env.CLI_VERSION was undefined at runtime, triggering a fallback in the code. We discovered this was happening because the final bundle/gemini.js artifact was missing from the published npm package. The root cause is in the .github/workflows/release.yml file, where the release job was running a generic npm run build:packages command instead of the required npm run bundle script. This PR corrects the workflow to use npm run bundle, ensuring the application version is properly injected and packaged for all future releases.



## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |


