### PR TITLE
chore(ci): do not "fail fast" on Node tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       checks: write
       pull-requests: write
     strategy:
+      fail-fast: false # So we can see all test failures
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [20.x, 22.x, 24.x]


### PR DESCRIPTION
## TLDR

It ends up being a lot of back-and-forth for external contributors when they can't see all the CI failures at once. This runs all the tests on all {OS,Node} combinations, even if others fail.

## Dive Deeper

I have no additional thoughts :)

## Reviewer Test Plan

CI changes only

## Testing Matrix

N/A

## Linked issues / bugs

N/A