### PR TITLE
[ide-mode] Update installation logic and nudge

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -61,6 +61,7 @@ import {
   AuthType,
   type IdeContext,
   ideContext,
+  getIdeInfo,
 } from '@google/gemini-cli-core';
 import {
   IdeIntegrationNudge,
@@ -577,7 +578,15 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   const handleIdePromptComplete = useCallback(
     (result: IdeIntegrationNudgeResult) => {
       if (result === 'yes') {
-        handleSlashCommand('/ide install');
+        if (!currentIDE) {
+          return;
+        }
+        const ideInfo = getIdeInfo(currentIDE);
+        if (ideInfo.isExtensionInstalledByDefault) {
+          handleSlashCommand('/ide enable');
+        } else {
+          handleSlashCommand('/ide install');
+        }
         settings.setValue(
           SettingScope.User,
           'hasSeenIdeIntegrationNudge',
@@ -592,7 +601,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
       }
       setIdePromptAnswered(true);
     },
-    [handleSlashCommand, settings],
+    [handleSlashCommand, settings, currentIDE],
   );
 
   const { handleInput: vimHandleInput } = useVim(buffer, handleFinalSubmit);

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -61,7 +61,6 @@ import {
   AuthType,
   type IdeContext,
   ideContext,
-  getIdeInfo,
 } from '@google/gemini-cli-core';
 import {
   IdeIntegrationNudge,
@@ -577,12 +576,8 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
 
   const handleIdePromptComplete = useCallback(
     (result: IdeIntegrationNudgeResult) => {
-      if (result === 'yes') {
-        if (!currentIDE) {
-          return;
-        }
-        const ideInfo = getIdeInfo(currentIDE);
-        if (ideInfo.isExtensionInstalledByDefault) {
+      if (result.userSelection === 'yes') {
+        if (result.isExtensionPreInstalled) {
           handleSlashCommand('/ide enable');
         } else {
           handleSlashCommand('/ide install');
@@ -592,7 +587,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
           'hasSeenIdeIntegrationNudge',
           true,
         );
-      } else if (result === 'dismiss') {
+      } else if (result.userSelection === 'dismiss') {
         settings.setValue(
           SettingScope.User,
           'hasSeenIdeIntegrationNudge',
@@ -601,7 +596,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
       }
       setIdePromptAnswered(true);
     },
-    [handleSlashCommand, settings, currentIDE],
+    [handleSlashCommand, settings],
   );
 
   const { handleInput: vimHandleInput } = useVim(buffer, handleFinalSubmit);

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -942,9 +942,9 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
             </Box>
           )}
 
-          {shouldShowIdePrompt ? (
+          {shouldShowIdePrompt && currentIDE ? (
             <IdeIntegrationNudge
-              ideName={config.getIdeClient().getDetectedIdeDisplayName()}
+              ide={currentIDE}
               onComplete={handleIdePromptComplete}
             />
           ) : isFolderTrustDialogOpen ? (

--- a/packages/cli/src/ui/IdeIntegrationNudge.tsx
+++ b/packages/cli/src/ui/IdeIntegrationNudge.tsx
@@ -11,7 +11,10 @@ import {
   RadioSelectItem,
 } from './components/shared/RadioButtonSelect.js';
 
-export type IdeIntegrationNudgeResult = 'yes' | 'no' | 'dismiss';
+export type IdeIntegrationNudgeResult = {
+  userSelection: 'yes' | 'no' | 'dismiss';
+  isExtensionPreInstalled: boolean;
+};
 
 interface IdeIntegrationNudgeProps {
   ide: DetectedIde;
@@ -24,7 +27,10 @@ export function IdeIntegrationNudge({
 }: IdeIntegrationNudgeProps) {
   useInput((_input, key) => {
     if (key.escape) {
-      onComplete('no');
+      onComplete({
+        userSelection: 'no',
+        isExtensionPreInstalled: false,
+      });
     }
   });
 
@@ -37,15 +43,24 @@ export function IdeIntegrationNudge({
   const OPTIONS: Array<RadioSelectItem<IdeIntegrationNudgeResult>> = [
     {
       label: 'Yes',
-      value: 'yes',
+      value: {
+        userSelection: 'yes',
+        isExtensionPreInstalled,
+      },
     },
     {
       label: 'No (esc)',
-      value: 'no',
+      value: {
+        userSelection: 'no',
+        isExtensionPreInstalled,
+      },
     },
     {
       label: "No, don't ask again",
-      value: 'dismiss',
+      value: {
+        userSelection: 'dismiss',
+        isExtensionPreInstalled,
+      },
     },
   ];
 

--- a/packages/cli/src/ui/IdeIntegrationNudge.tsx
+++ b/packages/cli/src/ui/IdeIntegrationNudge.tsx
@@ -65,7 +65,7 @@ export function IdeIntegrationNudge({
   ];
 
   const installText = isExtensionPreInstalled
-    ? `If you select Yes, the CLI will have access to access your open files and display diffs directly in ${
+    ? `If you select Yes, the CLI will have access to your open files and display diffs directly in ${
         ideName ?? 'your editor'
       }.`
     : `If you select Yes, we'll install an extension that allows the CLI to access your open files and display diffs directly in ${

--- a/packages/cli/src/ui/IdeIntegrationNudge.tsx
+++ b/packages/cli/src/ui/IdeIntegrationNudge.tsx
@@ -47,7 +47,7 @@ export function IdeIntegrationNudge({
   ];
 
   const installText = isExtensionInstalledByDefault
-    ? `If you select Yes, we'll enable an extension that allows the CLI to access your open files and display diffs directly in ${
+    ? `If you select Yes, the CLI will have access to access your open files and display diffs directly in ${
         ideName ?? 'your editor'
       }.`
     : `If you select Yes, we'll install an extension that allows the CLI to access your open files and display diffs directly in ${
@@ -66,7 +66,7 @@ export function IdeIntegrationNudge({
       <Box marginBottom={1} flexDirection="column">
         <Text>
           <Text color="yellow">{'> '}</Text>
-          {`Do you want to connect your ${ideName ?? 'your'} editor to Gemini CLI?`}
+          {`Do you want to connect ${ideName ?? 'your'} editor to Gemini CLI?`}
         </Text>
         <Text dimColor>{installText}</Text>
       </Box>

--- a/packages/cli/src/ui/IdeIntegrationNudge.tsx
+++ b/packages/cli/src/ui/IdeIntegrationNudge.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DetectedIde, getIdeInfo } from '@google/gemini-cli-core';
 import { Box, Text, useInput } from 'ink';
 import {
   RadioButtonSelect,
@@ -13,12 +14,12 @@ import {
 export type IdeIntegrationNudgeResult = 'yes' | 'no' | 'dismiss';
 
 interface IdeIntegrationNudgeProps {
-  ideName?: string;
+  ide: DetectedIde;
   onComplete: (result: IdeIntegrationNudgeResult) => void;
 }
 
 export function IdeIntegrationNudge({
-  ideName,
+  ide,
   onComplete,
 }: IdeIntegrationNudgeProps) {
   useInput((_input, key) => {
@@ -26,6 +27,9 @@ export function IdeIntegrationNudge({
       onComplete('no');
     }
   });
+
+  const { displayName: ideName, isExtensionInstalledByDefault } =
+    getIdeInfo(ide);
 
   const OPTIONS: Array<RadioSelectItem<IdeIntegrationNudgeResult>> = [
     {
@@ -42,6 +46,14 @@ export function IdeIntegrationNudge({
     },
   ];
 
+  const installText = isExtensionInstalledByDefault
+    ? `If you select Yes, we'll enable an extension that allows the CLI to access your open files and display diffs directly in ${
+        ideName ?? 'your editor'
+      }.`
+    : `If you select Yes, we'll install an extension that allows the CLI to access your open files and display diffs directly in ${
+        ideName ?? 'your editor'
+      }.`;
+
   return (
     <Box
       flexDirection="column"
@@ -56,9 +68,7 @@ export function IdeIntegrationNudge({
           <Text color="yellow">{'> '}</Text>
           {`Do you want to connect your ${ideName ?? 'your'} editor to Gemini CLI?`}
         </Text>
-        <Text
-          dimColor
-        >{`If you select Yes, we'll install an extension that allows the CLI to access your open files and display diffs directly in ${ideName ?? 'your editor'}.`}</Text>
+        <Text dimColor>{installText}</Text>
       </Box>
       <RadioButtonSelect
         items={OPTIONS}

--- a/packages/cli/src/ui/IdeIntegrationNudge.tsx
+++ b/packages/cli/src/ui/IdeIntegrationNudge.tsx
@@ -28,8 +28,11 @@ export function IdeIntegrationNudge({
     }
   });
 
-  const { displayName: ideName, isExtensionInstalledByDefault } =
-    getIdeInfo(ide);
+  const { displayName: ideName } = getIdeInfo(ide);
+  // Assume extension is already installed if the env variables are set.
+  const isExtensionPreInstalled =
+    !!process.env.GEMINI_CLI_IDE_SERVER_PORT &&
+    !!process.env.GEMINI_CLI_IDE_WORKSPACE_PATH;
 
   const OPTIONS: Array<RadioSelectItem<IdeIntegrationNudgeResult>> = [
     {
@@ -46,7 +49,7 @@ export function IdeIntegrationNudge({
     },
   ];
 
-  const installText = isExtensionInstalledByDefault
+  const installText = isExtensionPreInstalled
     ? `If you select Yes, the CLI will have access to access your open files and display diffs directly in ${
         ideName ?? 'your editor'
       }.`

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -8,7 +8,7 @@ import {
   Config,
   DetectedIde,
   IDEConnectionStatus,
-  getIdeDisplayName,
+  getIdeInfo,
   getIdeInstaller,
   IdeClient,
   type File,
@@ -132,7 +132,7 @@ export const ideCommand = (config: Config | null): SlashCommand | null => {
           content: `IDE integration is not supported in your current environment. To use this feature, run Gemini CLI in one of these supported IDEs: ${Object.values(
             DetectedIde,
           )
-            .map((ide) => getIdeDisplayName(ide))
+            .map((ide) => getIdeInfo(ide).displayName)
             .join(', ')}`,
         }) as const,
     };

--- a/packages/core/src/ide/detect-ide.ts
+++ b/packages/core/src/ide/detect-ide.ts
@@ -15,24 +15,53 @@ export enum DetectedIde {
   Trae = 'trae',
 }
 
-export function getIdeDisplayName(ide: DetectedIde): string {
+export interface IdeInfo {
+  displayName: string;
+  isExtensionInstalledByDefault: boolean;
+}
+
+export function getIdeInfo(ide: DetectedIde): IdeInfo {
   switch (ide) {
     case DetectedIde.VSCode:
-      return 'VS Code';
+      return {
+        displayName: 'VS Code',
+        isExtensionInstalledByDefault: false,
+      };
     case DetectedIde.VSCodium:
-      return 'VSCodium';
+      return {
+        displayName: 'VSCodium',
+        isExtensionInstalledByDefault: false,
+      };
     case DetectedIde.Cursor:
-      return 'Cursor';
+      return {
+        displayName: 'Cursor',
+        isExtensionInstalledByDefault: false,
+      };
     case DetectedIde.CloudShell:
-      return 'Cloud Shell';
+      return {
+        displayName: 'Cloud Shell',
+        isExtensionInstalledByDefault: true,
+      };
     case DetectedIde.Codespaces:
-      return 'GitHub Codespaces';
+      return {
+        displayName: 'GitHub Codespaces',
+        isExtensionInstalledByDefault: false,
+      };
     case DetectedIde.Windsurf:
-      return 'Windsurf';
+      return {
+        displayName: 'Windsurf',
+        isExtensionInstalledByDefault: false,
+      };
     case DetectedIde.FirebaseStudio:
-      return 'Firebase Studio';
+      return {
+        displayName: 'Firebase Studio',
+        isExtensionInstalledByDefault: true,
+      };
     case DetectedIde.Trae:
-      return 'Trae';
+      return {
+        displayName: 'Trae',
+        isExtensionInstalledByDefault: false,
+      };
     default: {
       // This ensures that if a new IDE is added to the enum, we get a compile-time error.
       const exhaustiveCheck: never = ide;

--- a/packages/core/src/ide/detect-ide.ts
+++ b/packages/core/src/ide/detect-ide.ts
@@ -6,18 +6,15 @@
 
 export enum DetectedIde {
   VSCode = 'vscode',
-  VSCodium = 'vscodium',
   Cursor = 'cursor',
   CloudShell = 'cloudshell',
   Codespaces = 'codespaces',
-  Windsurf = 'windsurf',
   FirebaseStudio = 'firebasestudio',
   Trae = 'trae',
 }
 
 export interface IdeInfo {
   displayName: string;
-  isExtensionInstalledByDefault: boolean;
 }
 
 export function getIdeInfo(ide: DetectedIde): IdeInfo {
@@ -25,42 +22,26 @@ export function getIdeInfo(ide: DetectedIde): IdeInfo {
     case DetectedIde.VSCode:
       return {
         displayName: 'VS Code',
-        isExtensionInstalledByDefault: false,
-      };
-    case DetectedIde.VSCodium:
-      return {
-        displayName: 'VSCodium',
-        isExtensionInstalledByDefault: false,
       };
     case DetectedIde.Cursor:
       return {
         displayName: 'Cursor',
-        isExtensionInstalledByDefault: false,
       };
     case DetectedIde.CloudShell:
       return {
         displayName: 'Cloud Shell',
-        isExtensionInstalledByDefault: true,
       };
     case DetectedIde.Codespaces:
       return {
         displayName: 'GitHub Codespaces',
-        isExtensionInstalledByDefault: false,
-      };
-    case DetectedIde.Windsurf:
-      return {
-        displayName: 'Windsurf',
-        isExtensionInstalledByDefault: false,
       };
     case DetectedIde.FirebaseStudio:
       return {
         displayName: 'Firebase Studio',
-        isExtensionInstalledByDefault: true,
       };
     case DetectedIde.Trae:
       return {
         displayName: 'Trae',
-        isExtensionInstalledByDefault: false,
       };
     default: {
       // This ensures that if a new IDE is added to the enum, we get a compile-time error.

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -6,11 +6,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {
-  detectIde,
-  DetectedIde,
-  getIdeDisplayName,
-} from '../ide/detect-ide.js';
+import { detectIde, DetectedIde, getIdeInfo } from '../ide/detect-ide.js';
 import {
   ideContext,
   IdeContextNotificationSchema,
@@ -68,7 +64,7 @@ export class IdeClient {
   private constructor() {
     this.currentIde = detectIde();
     if (this.currentIde) {
-      this.currentIdeDisplayName = getIdeDisplayName(this.currentIde);
+      this.currentIdeDisplayName = getIdeInfo(this.currentIde).displayName;
     }
   }
 
@@ -86,7 +82,7 @@ export class IdeClient {
         `IDE integration is not supported in your current environment. To use this feature, run Gemini CLI in one of these supported IDEs: ${Object.values(
           DetectedIde,
         )
-          .map((ide) => getIdeDisplayName(ide))
+          .map((ide) => getIdeInfo(ide).displayName)
           .join(', ')}`,
         false,
       );

--- a/packages/core/src/ide/ide-installer.test.ts
+++ b/packages/core/src/ide/ide-installer.test.ts
@@ -23,31 +23,6 @@ describe('ide-installer', () => {
       // A more specific check might be needed if we export the class
       expect(installer).toBeInstanceOf(Object);
     });
-
-    it('should return a DefaultInstaller for "vscodium"', () => {
-      const installer = getIdeInstaller(DetectedIde.VSCodium);
-      expect(installer).not.toBeNull();
-      expect(installer).toBeInstanceOf(Object);
-    });
-
-    it('should return a DefaultInstaller for an unknown IDE', () => {
-      const installer = getIdeInstaller('unknown' as DetectedIde);
-      // Assuming DefaultInstaller is the fallback
-      expect(installer).not.toBeNull();
-      expect(installer).toBeInstanceOf(Object);
-    });
-
-    it('should return a CloudIdeInstaller for "cloudshell"', () => {
-      const installer = getIdeInstaller(DetectedIde.CloudShell);
-      expect(installer).not.toBeNull();
-      expect(installer).toBeInstanceOf(Object);
-    });
-
-    it('should return a CloudIdeInstaller for "firebasestudio"', () => {
-      const installer = getIdeInstaller(DetectedIde.FirebaseStudio);
-      expect(installer).not.toBeNull();
-      expect(installer).toBeInstanceOf(Object);
-    });
   });
 
   describe('VsCodeInstaller', () => {

--- a/packages/core/src/ide/ide-installer.test.ts
+++ b/packages/core/src/ide/ide-installer.test.ts
@@ -24,15 +24,27 @@ describe('ide-installer', () => {
       expect(installer).toBeInstanceOf(Object);
     });
 
-    it('should return an OpenVSXInstaller for "vscodium"', () => {
+    it('should return a DefaultInstaller for "vscodium"', () => {
       const installer = getIdeInstaller(DetectedIde.VSCodium);
       expect(installer).not.toBeNull();
       expect(installer).toBeInstanceOf(Object);
     });
 
-    it('should return a DefaultIDEInstaller for an unknown IDE', () => {
+    it('should return a DefaultInstaller for an unknown IDE', () => {
       const installer = getIdeInstaller('unknown' as DetectedIde);
-      // Assuming DefaultIDEInstaller is the fallback
+      // Assuming DefaultInstaller is the fallback
+      expect(installer).not.toBeNull();
+      expect(installer).toBeInstanceOf(Object);
+    });
+
+    it('should return a CloudIdeInstaller for "cloudshell"', () => {
+      const installer = getIdeInstaller(DetectedIde.CloudShell);
+      expect(installer).not.toBeNull();
+      expect(installer).toBeInstanceOf(Object);
+    });
+
+    it('should return a CloudIdeInstaller for "firebasestudio"', () => {
+      const installer = getIdeInstaller(DetectedIde.FirebaseStudio);
       expect(installer).not.toBeNull();
       expect(installer).toBeInstanceOf(Object);
     });
@@ -64,46 +76,6 @@ describe('ide-installer', () => {
         const result = await installer.install();
         expect(result.success).toBe(false);
         expect(result.message).toContain('VS Code CLI not found');
-      });
-    });
-  });
-
-  describe('OpenVSXInstaller', () => {
-    let installer: IdeInstaller;
-
-    beforeEach(() => {
-      installer = getIdeInstaller(DetectedIde.VSCodium)!;
-    });
-
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
-    describe('install', () => {
-      it('should call execSync with the correct command and return success', async () => {
-        const execSyncSpy = vi
-          .spyOn(child_process, 'execSync')
-          .mockImplementation(() => '');
-        const result = await installer.install();
-        expect(execSyncSpy).toHaveBeenCalledWith(
-          'npx ovsx get google.gemini-cli-vscode-ide-companion',
-          { stdio: 'pipe' },
-        );
-        expect(result.success).toBe(true);
-        expect(result.message).toContain(
-          'VS Code companion extension was installed successfully from OpenVSX',
-        );
-      });
-
-      it('should return a failure message on failed installation', async () => {
-        vi.spyOn(child_process, 'execSync').mockImplementation(() => {
-          throw new Error('Command failed');
-        });
-        const result = await installer.install();
-        expect(result.success).toBe(false);
-        expect(result.message).toContain(
-          'Failed to install VS Code companion extension from OpenVSX',
-        );
       });
     });
   });

--- a/packages/core/src/ide/ide-installer.ts
+++ b/packages/core/src/ide/ide-installer.ts
@@ -147,20 +147,11 @@ class VsCodeInstaller implements IdeInstaller {
   }
 }
 
-class DefaultInstaller implements IdeInstaller {
-  async install(): Promise<InstallResult> {
-    return {
-      success: false,
-      message: `Install the Gemini Code Assist Companion Extension manually from the extension marketplace.`,
-    };
-  }
-}
-
 export function getIdeInstaller(ide: DetectedIde): IdeInstaller | null {
   switch (ide) {
     case DetectedIde.VSCode:
       return new VsCodeInstaller();
     default:
-      return new DefaultInstaller();
+      return null;
   }
 }

--- a/packages/core/src/ide/ide-installer.ts
+++ b/packages/core/src/ide/ide-installer.ts
@@ -147,23 +147,12 @@ class VsCodeInstaller implements IdeInstaller {
   }
 }
 
-class OpenVSXInstaller implements IdeInstaller {
+class DefaultInstaller implements IdeInstaller {
   async install(): Promise<InstallResult> {
-    // TODO: Use the correct extension path.
-    const command = `npx ovsx get google.gemini-cli-vscode-ide-companion`;
-    try {
-      child_process.execSync(command, { stdio: 'pipe' });
-      return {
-        success: true,
-        message:
-          'VS Code companion extension was installed successfully from OpenVSX. Please restart your terminal to complete the setup.',
-      };
-    } catch (_error) {
-      return {
-        success: false,
-        message: `Failed to install VS Code companion extension from OpenVSX. Please try installing it manually.`,
-      };
-    }
+    return {
+      success: false,
+      message: `Install the Gemini Code Assist Companion Extension manually from the extension marketplace.`,
+    };
   }
 }
 
@@ -172,6 +161,6 @@ export function getIdeInstaller(ide: DetectedIde): IdeInstaller | null {
     case DetectedIde.VSCode:
       return new VsCodeInstaller();
     default:
-      return new OpenVSXInstaller();
+      return new DefaultInstaller();
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,7 +50,7 @@ export * from './services/gitService.js';
 export * from './ide/ide-client.js';
 export * from './ide/ideContext.js';
 export * from './ide/ide-installer.js';
-export { getIdeDisplayName, DetectedIde } from './ide/detect-ide.js';
+export { getIdeInfo, DetectedIde, IdeInfo } from './ide/detect-ide.js';
 
 // Export Shell Execution Service
 export * from './services/shellExecutionService.js';


### PR DESCRIPTION
## TLDR

1. For known non-vscode IDEs (this does not include e.g., Windsurf, which we cannot differentiate from VS Code), prompt the user to install the extension using the marketplace
2. For IDEs where the extension comes pre-installed, the initial nudge is now to enable IDE mode rather than to install the extension

## Dive Deeper
<img width="908" height="362" alt="Screenshot 2025-08-12 at 1 42 36 PM" src="https://github.com/user-attachments/assets/c2d9dd23-c817-46ad-b7a9-8e2a17fe3f79" />

https://github.com/user-attachments/assets/904a0aa5-9604-416e-bf39-37a7adc4bb96



## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
