### PR TITLE
Add support for trustedFolders.json config file

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1368,6 +1368,7 @@ describe('loadCliConfig trustedFolder', () => {
     vi.resetAllMocks();
     vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
     process.env.GEMINI_API_KEY = 'test-api-key';
+    process.argv = ['node', 'script.js']; // Reset argv for each test
   });
 
   afterEach(() => {
@@ -1376,30 +1377,102 @@ describe('loadCliConfig trustedFolder', () => {
     vi.restoreAllMocks();
   });
 
-  it('should set trustedFolder to true when isWorkspaceTrusted returns true', async () => {
-    (isWorkspaceTrusted as vi.Mock).mockReturnValue(true);
-    process.argv = ['node', 'script.js'];
-    const argv = await parseArguments();
-    const settings: Settings = {};
-    const config = await loadCliConfig(settings, [], 'test-session', argv);
-    expect(config.isTrustedFolder()).toBe(true);
-  });
+  const testCases = [
+    // Cases where folderTrustFeature is false (feature disabled)
+    {
+      folderTrustFeature: false,
+      folderTrust: true,
+      isWorkspaceTrusted: true,
+      expectedFolderTrust: false,
+      expectedIsTrustedFolder: true,
+      description:
+        'feature disabled, folderTrust true, workspace trusted -> behave as trusted',
+    },
+    {
+      folderTrustFeature: false,
+      folderTrust: true,
+      isWorkspaceTrusted: false,
+      expectedFolderTrust: false,
+      expectedIsTrustedFolder: true,
+      description:
+        'feature disabled, folderTrust true, workspace not trusted -> behave as trusted',
+    },
+    {
+      folderTrustFeature: false,
+      folderTrust: false,
+      isWorkspaceTrusted: true,
+      expectedFolderTrust: false,
+      expectedIsTrustedFolder: true,
+      description:
+        'feature disabled, folderTrust false, workspace trusted -> behave as trusted',
+    },
 
-  it('should set trustedFolder to false when isWorkspaceTrusted returns false', async () => {
-    (isWorkspaceTrusted as vi.Mock).mockReturnValue(false);
-    process.argv = ['node', 'script.js'];
-    const argv = await parseArguments();
-    const settings: Settings = {};
-    const config = await loadCliConfig(settings, [], 'test-session', argv);
-    expect(config.isTrustedFolder()).toBe(false);
-  });
+    // Cases where folderTrustFeature is true but folderTrust setting is false
+    {
+      folderTrustFeature: true,
+      folderTrust: false,
+      isWorkspaceTrusted: true,
+      expectedFolderTrust: false,
+      expectedIsTrustedFolder: true,
+      description:
+        'feature on, folderTrust false, workspace trusted -> behave as trusted',
+    },
+    {
+      folderTrustFeature: true,
+      folderTrust: false,
+      isWorkspaceTrusted: false,
+      expectedFolderTrust: false,
+      expectedIsTrustedFolder: true,
+      description:
+        'feature on, folderTrust false, workspace not trusted -> behave as trusted',
+    },
 
-  it('should set trustedFolder to undefined when isWorkspaceTrusted returns undefined', async () => {
-    (isWorkspaceTrusted as vi.Mock).mockReturnValue(undefined);
-    process.argv = ['node', 'script.js'];
-    const argv = await parseArguments();
-    const settings: Settings = {};
-    const config = await loadCliConfig(settings, [], 'test-session', argv);
-    expect(config.isTrustedFolder()).toBeUndefined();
-  });
+    // Cases where feature is fully enabled (folderTrustFeature and folderTrust are true)
+    {
+      folderTrustFeature: true,
+      folderTrust: true,
+      isWorkspaceTrusted: true,
+      expectedFolderTrust: true,
+      expectedIsTrustedFolder: true,
+      description:
+        'feature on, folderTrust on, workspace trusted -> is trusted',
+    },
+    {
+      folderTrustFeature: true,
+      folderTrust: true,
+      isWorkspaceTrusted: false,
+      expectedFolderTrust: true,
+      expectedIsTrustedFolder: false,
+      description:
+        'feature on, folderTrust on, workspace NOT trusted -> is NOT trusted',
+    },
+    {
+      folderTrustFeature: true,
+      folderTrust: true,
+      isWorkspaceTrusted: undefined,
+      expectedFolderTrust: true,
+      expectedIsTrustedFolder: undefined,
+      description:
+        'feature on, folderTrust on, workspace trust unknown -> is unknown',
+    },
+  ];
+
+  for (const {
+    folderTrustFeature,
+    folderTrust,
+    isWorkspaceTrusted: mockTrustValue,
+    expectedFolderTrust,
+    expectedIsTrustedFolder,
+    description,
+  } of testCases) {
+    it(`should be correct for: ${description}`, async () => {
+      (isWorkspaceTrusted as vi.Mock).mockReturnValue(mockTrustValue);
+      const argv = await parseArguments();
+      const settings: Settings = { folderTrustFeature, folderTrust };
+      const config = await loadCliConfig(settings, [], 'test-session', argv);
+
+      expect(config.getFolderTrust()).toBe(expectedFolderTrust);
+      expect(config.isTrustedFolder()).toBe(expectedIsTrustedFolder);
+    });
+  }
 });

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -13,10 +13,10 @@ import { loadCliConfig, parseArguments } from './config.js';
 import { Settings } from './settings.js';
 import { Extension } from './extension.js';
 import * as ServerConfig from '@google/gemini-cli-core';
-import { isCurrentDirectoryTrusted } from './trustedFolders.js';
+import { isWorkspaceTrusted } from './trustedFolders.js';
 
 vi.mock('./trustedFolders.js', () => ({
-  isCurrentDirectoryTrusted: vi.fn(),
+  isWorkspaceTrusted: vi.fn(),
 }));
 
 vi.mock('os', async (importOriginal) => {
@@ -1376,8 +1376,8 @@ describe('loadCliConfig trustedFolder', () => {
     vi.restoreAllMocks();
   });
 
-  it('should set trustedFolder to true when isCurrentDirectoryTrusted returns true', async () => {
-    (isCurrentDirectoryTrusted as vi.Mock).mockReturnValue(true);
+  it('should set trustedFolder to true when isWorkspaceTrusted returns true', async () => {
+    (isWorkspaceTrusted as vi.Mock).mockReturnValue(true);
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const settings: Settings = {};
@@ -1385,8 +1385,8 @@ describe('loadCliConfig trustedFolder', () => {
     expect(config.isTrustedFolder()).toBe(true);
   });
 
-  it('should set trustedFolder to false when isCurrentDirectoryTrusted returns false', async () => {
-    (isCurrentDirectoryTrusted as vi.Mock).mockReturnValue(false);
+  it('should set trustedFolder to false when isWorkspaceTrusted returns false', async () => {
+    (isWorkspaceTrusted as vi.Mock).mockReturnValue(false);
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const settings: Settings = {};
@@ -1394,8 +1394,8 @@ describe('loadCliConfig trustedFolder', () => {
     expect(config.isTrustedFolder()).toBe(false);
   });
 
-  it('should set trustedFolder to undefined when isCurrentDirectoryTrusted returns undefined', async () => {
-    (isCurrentDirectoryTrusted as vi.Mock).mockReturnValue(undefined);
+  it('should set trustedFolder to undefined when isWorkspaceTrusted returns undefined', async () => {
+    (isWorkspaceTrusted as vi.Mock).mockReturnValue(undefined);
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const settings: Settings = {};

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1633,6 +1633,7 @@ describe('loadCliConfig approval mode', () => {
     vi.resetAllMocks();
     vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
     process.env.GEMINI_API_KEY = 'test-api-key';
+    process.argv = ['node', 'script.js']; // Reset argv for each test
   });
 
   afterEach(() => {

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1710,6 +1710,7 @@ describe('loadCliConfig trustedFolder', () => {
     vi.resetAllMocks();
     vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
     process.env.GEMINI_API_KEY = 'test-api-key';
+    process.argv = ['node', 'script.js']; // Reset argv for each test
   });
 
   afterEach(() => {
@@ -1718,30 +1719,102 @@ describe('loadCliConfig trustedFolder', () => {
     vi.restoreAllMocks();
   });
 
-  it('should set trustedFolder to true when isWorkspaceTrusted returns true', async () => {
-    (isWorkspaceTrusted as vi.Mock).mockReturnValue(true);
-    process.argv = ['node', 'script.js'];
-    const argv = await parseArguments();
-    const settings: Settings = {};
-    const config = await loadCliConfig(settings, [], 'test-session', argv);
-    expect(config.isTrustedFolder()).toBe(true);
-  });
+  const testCases = [
+    // Cases where folderTrustFeature is false (feature disabled)
+    {
+      folderTrustFeature: false,
+      folderTrust: true,
+      isWorkspaceTrusted: true,
+      expectedFolderTrust: false,
+      expectedIsTrustedFolder: true,
+      description:
+        'feature disabled, folderTrust true, workspace trusted -> behave as trusted',
+    },
+    {
+      folderTrustFeature: false,
+      folderTrust: true,
+      isWorkspaceTrusted: false,
+      expectedFolderTrust: false,
+      expectedIsTrustedFolder: true,
+      description:
+        'feature disabled, folderTrust true, workspace not trusted -> behave as trusted',
+    },
+    {
+      folderTrustFeature: false,
+      folderTrust: false,
+      isWorkspaceTrusted: true,
+      expectedFolderTrust: false,
+      expectedIsTrustedFolder: true,
+      description:
+        'feature disabled, folderTrust false, workspace trusted -> behave as trusted',
+    },
 
-  it('should set trustedFolder to false when isWorkspaceTrusted returns false', async () => {
-    (isWorkspaceTrusted as vi.Mock).mockReturnValue(false);
-    process.argv = ['node', 'script.js'];
-    const argv = await parseArguments();
-    const settings: Settings = {};
-    const config = await loadCliConfig(settings, [], 'test-session', argv);
-    expect(config.isTrustedFolder()).toBe(false);
-  });
+    // Cases where folderTrustFeature is true but folderTrust setting is false
+    {
+      folderTrustFeature: true,
+      folderTrust: false,
+      isWorkspaceTrusted: true,
+      expectedFolderTrust: false,
+      expectedIsTrustedFolder: true,
+      description:
+        'feature on, folderTrust false, workspace trusted -> behave as trusted',
+    },
+    {
+      folderTrustFeature: true,
+      folderTrust: false,
+      isWorkspaceTrusted: false,
+      expectedFolderTrust: false,
+      expectedIsTrustedFolder: true,
+      description:
+        'feature on, folderTrust false, workspace not trusted -> behave as trusted',
+    },
 
-  it('should set trustedFolder to undefined when isWorkspaceTrusted returns undefined', async () => {
-    (isWorkspaceTrusted as vi.Mock).mockReturnValue(undefined);
-    process.argv = ['node', 'script.js'];
-    const argv = await parseArguments();
-    const settings: Settings = {};
-    const config = await loadCliConfig(settings, [], 'test-session', argv);
-    expect(config.isTrustedFolder()).toBeUndefined();
-  });
+    // Cases where feature is fully enabled (folderTrustFeature and folderTrust are true)
+    {
+      folderTrustFeature: true,
+      folderTrust: true,
+      isWorkspaceTrusted: true,
+      expectedFolderTrust: true,
+      expectedIsTrustedFolder: true,
+      description:
+        'feature on, folderTrust on, workspace trusted -> is trusted',
+    },
+    {
+      folderTrustFeature: true,
+      folderTrust: true,
+      isWorkspaceTrusted: false,
+      expectedFolderTrust: true,
+      expectedIsTrustedFolder: false,
+      description:
+        'feature on, folderTrust on, workspace NOT trusted -> is NOT trusted',
+    },
+    {
+      folderTrustFeature: true,
+      folderTrust: true,
+      isWorkspaceTrusted: undefined,
+      expectedFolderTrust: true,
+      expectedIsTrustedFolder: undefined,
+      description:
+        'feature on, folderTrust on, workspace trust unknown -> is unknown',
+    },
+  ];
+
+  for (const {
+    folderTrustFeature,
+    folderTrust,
+    isWorkspaceTrusted: mockTrustValue,
+    expectedFolderTrust,
+    expectedIsTrustedFolder,
+    description,
+  } of testCases) {
+    it(`should be correct for: ${description}`, async () => {
+      (isWorkspaceTrusted as vi.Mock).mockReturnValue(mockTrustValue);
+      const argv = await parseArguments();
+      const settings: Settings = { folderTrustFeature, folderTrust };
+      const config = await loadCliConfig(settings, [], 'test-session', argv);
+
+      expect(config.getFolderTrust()).toBe(expectedFolderTrust);
+      expect(config.isTrustedFolder()).toBe(expectedIsTrustedFolder);
+    });
+  }
 });

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -13,10 +13,10 @@ import { loadCliConfig, parseArguments } from './config.js';
 import { Settings } from './settings.js';
 import { Extension } from './extension.js';
 import * as ServerConfig from '@google/gemini-cli-core';
-import { isCurrentDirectoryTrusted } from './trustedFolders.js';
+import { isWorkspaceTrusted } from './trustedFolders.js';
 
 vi.mock('./trustedFolders.js', () => ({
-  isCurrentDirectoryTrusted: vi.fn(),
+  isWorkspaceTrusted: vi.fn(),
 }));
 
 vi.mock('os', async (importOriginal) => {
@@ -1718,8 +1718,8 @@ describe('loadCliConfig trustedFolder', () => {
     vi.restoreAllMocks();
   });
 
-  it('should set trustedFolder to true when isCurrentDirectoryTrusted returns true', async () => {
-    (isCurrentDirectoryTrusted as vi.Mock).mockReturnValue(true);
+  it('should set trustedFolder to true when isWorkspaceTrusted returns true', async () => {
+    (isWorkspaceTrusted as vi.Mock).mockReturnValue(true);
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const settings: Settings = {};
@@ -1727,8 +1727,8 @@ describe('loadCliConfig trustedFolder', () => {
     expect(config.isTrustedFolder()).toBe(true);
   });
 
-  it('should set trustedFolder to false when isCurrentDirectoryTrusted returns false', async () => {
-    (isCurrentDirectoryTrusted as vi.Mock).mockReturnValue(false);
+  it('should set trustedFolder to false when isWorkspaceTrusted returns false', async () => {
+    (isWorkspaceTrusted as vi.Mock).mockReturnValue(false);
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const settings: Settings = {};
@@ -1736,8 +1736,8 @@ describe('loadCliConfig trustedFolder', () => {
     expect(config.isTrustedFolder()).toBe(false);
   });
 
-  it('should set trustedFolder to undefined when isCurrentDirectoryTrusted returns undefined', async () => {
-    (isCurrentDirectoryTrusted as vi.Mock).mockReturnValue(undefined);
+  it('should set trustedFolder to undefined when isWorkspaceTrusted returns undefined', async () => {
+    (isWorkspaceTrusted as vi.Mock).mockReturnValue(undefined);
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const settings: Settings = {};

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -13,6 +13,11 @@ import { loadCliConfig, parseArguments } from './config.js';
 import { Settings } from './settings.js';
 import { Extension } from './extension.js';
 import * as ServerConfig from '@google/gemini-cli-core';
+import { isCurrentDirectoryTrusted } from './trustedFolders.js';
+
+vi.mock('./trustedFolders.js', () => ({
+  isCurrentDirectoryTrusted: vi.fn(),
+}));
 
 vi.mock('os', async (importOriginal) => {
   const actualOs = await importOriginal<typeof os>();
@@ -1694,5 +1699,49 @@ describe('loadCliConfig approval mode', () => {
     const argv = await parseArguments();
     const config = await loadCliConfig({}, [], 'test-session', argv);
     expect(config.getApprovalMode()).toBe(ServerConfig.ApprovalMode.YOLO);
+  });
+});
+
+describe('loadCliConfig trustedFolder', () => {
+  const originalArgv = process.argv;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    process.env.GEMINI_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('should set trustedFolder to true when isCurrentDirectoryTrusted returns true', async () => {
+    (isCurrentDirectoryTrusted as vi.Mock).mockReturnValue(true);
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.isTrustedFolder()).toBe(true);
+  });
+
+  it('should set trustedFolder to false when isCurrentDirectoryTrusted returns false', async () => {
+    (isCurrentDirectoryTrusted as vi.Mock).mockReturnValue(false);
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.isTrustedFolder()).toBe(false);
+  });
+
+  it('should set trustedFolder to undefined when isCurrentDirectoryTrusted returns undefined', async () => {
+    (isCurrentDirectoryTrusted as vi.Mock).mockReturnValue(undefined);
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.isTrustedFolder()).toBeUndefined();
   });
 });

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -35,6 +35,8 @@ import { getCliVersion } from '../utils/version.js';
 import { loadSandboxConfig } from './sandboxConfig.js';
 import { resolvePath } from '../utils/resolvePath.js';
 
+import { isCurrentDirectoryTrusted } from './trustedFolders.js';
+
 // Simple console logger for now - replace with actual logger if available
 const logger = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -408,6 +410,7 @@ export async function loadCliConfig(
   }
 
   const sandboxConfig = await loadSandboxConfig(settings, argv);
+  const trustedFolder = isCurrentDirectoryTrusted();
 
   return new Config({
     sessionId,
@@ -479,6 +482,7 @@ export async function loadCliConfig(
     folderTrustFeature,
     folderTrust,
     interactive,
+    trustedFolder,
   });
 }
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -313,8 +313,9 @@ export async function loadCliConfig(
     argv.ideModeFeature ?? settings.ideModeFeature ?? false;
 
   const folderTrustFeature = settings.folderTrustFeature ?? false;
-  const folderTrustSetting = settings.folderTrust ?? false;
+  const folderTrustSetting = settings.folderTrust ?? true;
   const folderTrust = folderTrustFeature && folderTrustSetting;
+  const trustedFolder = folderTrust ? isWorkspaceTrusted() : true;
 
   const allExtensions = annotateActiveExtensions(
     extensions,
@@ -410,7 +411,6 @@ export async function loadCliConfig(
   }
 
   const sandboxConfig = await loadSandboxConfig(settings, argv);
-  const trustedFolder = isWorkspaceTrusted();
 
   return new Config({
     sessionId,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -35,7 +35,7 @@ import { getCliVersion } from '../utils/version.js';
 import { loadSandboxConfig } from './sandboxConfig.js';
 import { resolvePath } from '../utils/resolvePath.js';
 
-import { isCurrentDirectoryTrusted } from './trustedFolders.js';
+import { isWorkspaceTrusted } from './trustedFolders.js';
 
 // Simple console logger for now - replace with actual logger if available
 const logger = {
@@ -410,7 +410,7 @@ export async function loadCliConfig(
   }
 
   const sandboxConfig = await loadSandboxConfig(settings, argv);
-  const trustedFolder = isCurrentDirectoryTrusted();
+  const trustedFolder = isWorkspaceTrusted();
 
   return new Config({
     sessionId,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -319,8 +319,9 @@ export async function loadCliConfig(
   const ideMode = settings.ideMode ?? false;
 
   const folderTrustFeature = settings.folderTrustFeature ?? false;
-  const folderTrustSetting = settings.folderTrust ?? false;
+  const folderTrustSetting = settings.folderTrust ?? true;
   const folderTrust = folderTrustFeature && folderTrustSetting;
+  const trustedFolder = folderTrust ? isWorkspaceTrusted() : true;
 
   const allExtensions = annotateActiveExtensions(
     extensions,
@@ -455,7 +456,6 @@ export async function loadCliConfig(
   }
 
   const sandboxConfig = await loadSandboxConfig(settings, argv);
-  const trustedFolder = isWorkspaceTrusted();
 
   return new Config({
     sessionId,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -35,7 +35,7 @@ import { getCliVersion } from '../utils/version.js';
 import { loadSandboxConfig } from './sandboxConfig.js';
 import { resolvePath } from '../utils/resolvePath.js';
 
-import { isCurrentDirectoryTrusted } from './trustedFolders.js';
+import { isWorkspaceTrusted } from './trustedFolders.js';
 
 // Simple console logger for now - replace with actual logger if available
 const logger = {
@@ -455,7 +455,7 @@ export async function loadCliConfig(
   }
 
   const sandboxConfig = await loadSandboxConfig(settings, argv);
-  const trustedFolder = isCurrentDirectoryTrusted();
+  const trustedFolder = isWorkspaceTrusted();
 
   return new Config({
     sessionId,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -35,6 +35,8 @@ import { getCliVersion } from '../utils/version.js';
 import { loadSandboxConfig } from './sandboxConfig.js';
 import { resolvePath } from '../utils/resolvePath.js';
 
+import { isCurrentDirectoryTrusted } from './trustedFolders.js';
+
 // Simple console logger for now - replace with actual logger if available
 const logger = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -453,6 +455,7 @@ export async function loadCliConfig(
   }
 
   const sandboxConfig = await loadSandboxConfig(settings, argv);
+  const trustedFolder = isCurrentDirectoryTrusted();
 
   return new Config({
     sessionId,
@@ -523,6 +526,7 @@ export async function loadCliConfig(
     folderTrustFeature,
     folderTrust,
     interactive,
+    trustedFolder,
   });
 }
 

--- a/packages/cli/src/config/trustedFolders.test.ts
+++ b/packages/cli/src/config/trustedFolders.test.ts
@@ -1,0 +1,289 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Mock 'os' first.
+import * as osActual from 'os';
+vi.mock('os', async (importOriginal) => {
+  const actualOs = await importOriginal<typeof osActual>();
+  return {
+    ...actualOs,
+    homedir: vi.fn(() => '/mock/home/user'),
+    platform: vi.fn(() => 'linux'),
+  };
+});
+
+// Mock './trustedFolders.js' to ensure it uses the mocked 'os.homedir()' for its internal constants.
+vi.mock('./trustedFolders.js', async (importActual) => {
+  const originalModule =
+    await importActual<typeof import('./trustedFolders.js')>();
+  return {
+    __esModule: true,
+    ...originalModule,
+  };
+});
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mocked,
+  type Mock,
+} from 'vitest';
+import * as fs from 'fs';
+import stripJsonComments from 'strip-json-comments';
+import * as path from 'path';
+
+import {
+  loadTrustedFolders,
+  USER_TRUSTED_FOLDERS_PATH,
+  getSystemTrustedFoldersPath,
+  TrustLevel,
+  isCurrentDirectoryTrusted,
+} from './trustedFolders.js';
+import { SettingScope } from './settings.js';
+
+vi.mock('fs', async (importOriginal) => {
+  const actualFs = await importOriginal<typeof fs>();
+  return {
+    ...actualFs,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  };
+});
+
+vi.mock('strip-json-comments', () => ({
+  default: vi.fn((content) => content),
+}));
+
+describe('Trusted Folders Loading', () => {
+  let mockFsExistsSync: Mocked<typeof fs.existsSync>;
+  let mockStripJsonComments: Mocked<typeof stripJsonComments>;
+  let mockFsWriteFileSync: Mocked<typeof fs.writeFileSync>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockFsExistsSync = vi.mocked(fs.existsSync);
+    mockStripJsonComments = vi.mocked(stripJsonComments);
+    mockFsWriteFileSync = vi.mocked(fs.writeFileSync);
+    vi.mocked(osActual.homedir).mockReturnValue('/mock/home/user');
+    (mockStripJsonComments as unknown as Mock).mockImplementation(
+      (jsonString: string) => jsonString,
+    );
+    (mockFsExistsSync as Mock).mockReturnValue(false);
+    (fs.readFileSync as Mock).mockReturnValue('{}');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should load empty rules if no files exist', () => {
+    const { rules, errors } = loadTrustedFolders();
+    expect(rules).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  it('should load system rules if only system file exists', () => {
+    const systemPath = getSystemTrustedFoldersPath();
+    (mockFsExistsSync as Mock).mockImplementation((p) => p === systemPath);
+    const systemContent = {
+      '/system/folder': TrustLevel.TRUST_PARENT,
+    };
+    (fs.readFileSync as Mock).mockImplementation((p) => {
+      if (p === systemPath) return JSON.stringify(systemContent);
+      return '{}';
+    });
+
+    const { rules, errors } = loadTrustedFolders();
+    expect(rules).toEqual([
+      { path: '/system/folder', trustLevel: TrustLevel.TRUST_PARENT },
+    ]);
+    expect(errors).toEqual([]);
+  });
+
+  it('should load user rules if only user file exists', () => {
+    const userPath = USER_TRUSTED_FOLDERS_PATH;
+    (mockFsExistsSync as Mock).mockImplementation((p) => p === userPath);
+    const userContent = {
+      '/user/folder': TrustLevel.TRUST_FOLDER,
+    };
+    (fs.readFileSync as Mock).mockImplementation((p) => {
+      if (p === userPath) return JSON.stringify(userContent);
+      return '{}';
+    });
+
+    const { rules, errors } = loadTrustedFolders();
+    expect(rules).toEqual([
+      { path: '/user/folder', trustLevel: TrustLevel.TRUST_FOLDER },
+    ]);
+    expect(errors).toEqual([]);
+  });
+
+  it('should merge system and user rules, with system taking precedence', () => {
+    const systemPath = getSystemTrustedFoldersPath();
+    const userPath = USER_TRUSTED_FOLDERS_PATH;
+    (mockFsExistsSync as Mock).mockImplementation(
+      (p) => p === systemPath || p === userPath,
+    );
+
+    const systemContent = {
+      '/shared/folder': TrustLevel.DO_NOT_TRUST,
+      '/system/folder': TrustLevel.TRUST_PARENT,
+    };
+    const userContent = {
+      '/shared/folder': TrustLevel.TRUST_FOLDER, // This should be overridden
+      '/user/folder': TrustLevel.TRUST_FOLDER,
+    };
+
+    (fs.readFileSync as Mock).mockImplementation((p) => {
+      if (p === systemPath) return JSON.stringify(systemContent);
+      if (p === userPath) return JSON.stringify(userContent);
+      return '{}';
+    });
+
+    const { rules, errors } = loadTrustedFolders();
+    expect(errors).toEqual([]);
+    expect(rules).toHaveLength(3);
+    expect(rules).toEqual(
+      expect.arrayContaining([
+        { path: '/shared/folder', trustLevel: TrustLevel.DO_NOT_TRUST },
+        { path: '/system/folder', trustLevel: TrustLevel.TRUST_PARENT },
+        { path: '/user/folder', trustLevel: TrustLevel.TRUST_FOLDER },
+      ]),
+    );
+  });
+
+  it('should handle JSON parsing errors gracefully', () => {
+    const systemPath = getSystemTrustedFoldersPath();
+    (mockFsExistsSync as Mock).mockImplementation((p) => p === systemPath);
+    (fs.readFileSync as Mock).mockImplementation((p) => {
+      if (p === systemPath) return 'invalid json';
+      return '{}';
+    });
+
+    const { rules, errors } = loadTrustedFolders();
+    expect(rules).toEqual([]);
+    expect(errors.length).toBe(1);
+    expect(errors[0].path).toBe(systemPath);
+    expect(errors[0].message).toContain('Unexpected token');
+  });
+
+  it('setValue should update the user config and save it', () => {
+    const loadedFolders = loadTrustedFolders();
+    loadedFolders.setValue(
+      SettingScope.User,
+      '/new/path',
+      TrustLevel.TRUST_FOLDER,
+    );
+
+    expect(loadedFolders.user.config['/new/path']).toBe(
+      TrustLevel.TRUST_FOLDER,
+    );
+    expect(mockFsWriteFileSync).toHaveBeenCalledWith(
+      USER_TRUSTED_FOLDERS_PATH,
+      JSON.stringify({ '/new/path': TrustLevel.TRUST_FOLDER }, null, 2),
+      'utf-8',
+    );
+  });
+
+  it('setValue should update the system config and save it', () => {
+    const loadedFolders = loadTrustedFolders();
+    loadedFolders.setValue(
+      SettingScope.System,
+      '/new/system/path',
+      TrustLevel.DO_NOT_TRUST,
+    );
+
+    expect(loadedFolders.system.config['/new/system/path']).toBe(
+      TrustLevel.DO_NOT_TRUST,
+    );
+    expect(mockFsWriteFileSync).toHaveBeenCalledWith(
+      getSystemTrustedFoldersPath(),
+      JSON.stringify({ '/new/system/path': TrustLevel.DO_NOT_TRUST }, null, 2),
+      'utf-8',
+    );
+  });
+});
+
+describe('isCurrentDirectoryTrusted', () => {
+  let mockCwd: string;
+  const mockRules: Record<string, TrustLevel> = {};
+
+  beforeEach(() => {
+    vi.spyOn(process, 'cwd').mockImplementation(() => mockCwd);
+    vi.spyOn(fs, 'readFileSync').mockImplementation((p) => {
+      if (p === USER_TRUSTED_FOLDERS_PATH) {
+        return JSON.stringify(mockRules);
+      }
+      return '{}';
+    });
+    vi.spyOn(fs, 'existsSync').mockImplementation(
+      (p) => p === USER_TRUSTED_FOLDERS_PATH,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // Clear the object
+    Object.keys(mockRules).forEach((key) => delete mockRules[key]);
+  });
+
+  it('should return true for a directly trusted folder', () => {
+    mockCwd = '/home/user/projectA';
+    mockRules['/home/user/projectA'] = TrustLevel.TRUST_FOLDER;
+    expect(isCurrentDirectoryTrusted()).toBe(true);
+  });
+
+  it('should return true for a child of a trusted folder', () => {
+    mockCwd = '/home/user/projectA/src';
+    mockRules['/home/user/projectA'] = TrustLevel.TRUST_FOLDER;
+    expect(isCurrentDirectoryTrusted()).toBe(true);
+  });
+
+  it('should return true for a child of a trusted parent folder', () => {
+    mockCwd = '/home/user/projectB';
+    mockRules['/home/user/projectB/somefile.txt'] = TrustLevel.TRUST_PARENT;
+    expect(isCurrentDirectoryTrusted()).toBe(true);
+  });
+
+  it('should return false for a directly untrusted folder', () => {
+    mockCwd = '/home/user/untrusted';
+    mockRules['/home/user/untrusted'] = TrustLevel.DO_NOT_TRUST;
+    expect(isCurrentDirectoryTrusted()).toBe(false);
+  });
+
+  it('should return undefined for a child of an untrusted folder', () => {
+    mockCwd = '/home/user/untrusted/src';
+    mockRules['/home/user/untrusted'] = TrustLevel.DO_NOT_TRUST;
+    expect(isCurrentDirectoryTrusted()).toBeUndefined();
+  });
+
+  it('should return undefined when no rules match', () => {
+    mockCwd = '/home/user/other';
+    mockRules['/home/user/projectA'] = TrustLevel.TRUST_FOLDER;
+    mockRules['/home/user/untrusted'] = TrustLevel.DO_NOT_TRUST;
+    expect(isCurrentDirectoryTrusted()).toBeUndefined();
+  });
+
+  it('should prioritize trust over distrust', () => {
+    mockCwd = '/home/user/projectA/untrusted';
+    mockRules['/home/user/projectA'] = TrustLevel.TRUST_FOLDER;
+    mockRules['/home/user/projectA/untrusted'] = TrustLevel.DO_NOT_TRUST;
+    expect(isCurrentDirectoryTrusted()).toBe(true);
+  });
+
+  it('should handle path normalization', () => {
+    mockCwd = '/home/user/projectA';
+    mockRules[`/home/user/../user/${path.basename('/home/user/projectA')}`] =
+      TrustLevel.TRUST_FOLDER;
+    expect(isCurrentDirectoryTrusted()).toBe(true);
+  });
+});

--- a/packages/cli/src/config/trustedFolders.test.ts
+++ b/packages/cli/src/config/trustedFolders.test.ts
@@ -15,16 +15,6 @@ vi.mock('os', async (importOriginal) => {
   };
 });
 
-// Mock './trustedFolders.js' to ensure it uses the mocked 'os.homedir()' for its internal constants.
-vi.mock('./trustedFolders.js', async (importActual) => {
-  const originalModule =
-    await importActual<typeof import('./trustedFolders.js')>();
-  return {
-    __esModule: true,
-    ...originalModule,
-  };
-});
-
 import {
   describe,
   it,
@@ -42,11 +32,9 @@ import * as path from 'path';
 import {
   loadTrustedFolders,
   USER_TRUSTED_FOLDERS_PATH,
-  getSystemTrustedFoldersPath,
   TrustLevel,
-  isCurrentDirectoryTrusted,
+  isWorkspaceTrusted,
 } from './trustedFolders.js';
-import { SettingScope } from './settings.js';
 
 vi.mock('fs', async (importOriginal) => {
   const actualFs = await importOriginal<typeof fs>();
@@ -91,24 +79,6 @@ describe('Trusted Folders Loading', () => {
     expect(errors).toEqual([]);
   });
 
-  it('should load system rules if only system file exists', () => {
-    const systemPath = getSystemTrustedFoldersPath();
-    (mockFsExistsSync as Mock).mockImplementation((p) => p === systemPath);
-    const systemContent = {
-      '/system/folder': TrustLevel.TRUST_PARENT,
-    };
-    (fs.readFileSync as Mock).mockImplementation((p) => {
-      if (p === systemPath) return JSON.stringify(systemContent);
-      return '{}';
-    });
-
-    const { rules, errors } = loadTrustedFolders();
-    expect(rules).toEqual([
-      { path: '/system/folder', trustLevel: TrustLevel.TRUST_PARENT },
-    ]);
-    expect(errors).toEqual([]);
-  });
-
   it('should load user rules if only user file exists', () => {
     const userPath = USER_TRUSTED_FOLDERS_PATH;
     (mockFsExistsSync as Mock).mockImplementation((p) => p === userPath);
@@ -127,62 +97,24 @@ describe('Trusted Folders Loading', () => {
     expect(errors).toEqual([]);
   });
 
-  it('should merge system and user rules, with system taking precedence', () => {
-    const systemPath = getSystemTrustedFoldersPath();
-    const userPath = USER_TRUSTED_FOLDERS_PATH;
-    (mockFsExistsSync as Mock).mockImplementation(
-      (p) => p === systemPath || p === userPath,
-    );
-
-    const systemContent = {
-      '/shared/folder': TrustLevel.DO_NOT_TRUST,
-      '/system/folder': TrustLevel.TRUST_PARENT,
-    };
-    const userContent = {
-      '/shared/folder': TrustLevel.TRUST_FOLDER, // This should be overridden
-      '/user/folder': TrustLevel.TRUST_FOLDER,
-    };
-
-    (fs.readFileSync as Mock).mockImplementation((p) => {
-      if (p === systemPath) return JSON.stringify(systemContent);
-      if (p === userPath) return JSON.stringify(userContent);
-      return '{}';
-    });
-
-    const { rules, errors } = loadTrustedFolders();
-    expect(errors).toEqual([]);
-    expect(rules).toHaveLength(3);
-    expect(rules).toEqual(
-      expect.arrayContaining([
-        { path: '/shared/folder', trustLevel: TrustLevel.DO_NOT_TRUST },
-        { path: '/system/folder', trustLevel: TrustLevel.TRUST_PARENT },
-        { path: '/user/folder', trustLevel: TrustLevel.TRUST_FOLDER },
-      ]),
-    );
-  });
-
   it('should handle JSON parsing errors gracefully', () => {
-    const systemPath = getSystemTrustedFoldersPath();
-    (mockFsExistsSync as Mock).mockImplementation((p) => p === systemPath);
+    const userPath = USER_TRUSTED_FOLDERS_PATH;
+    (mockFsExistsSync as Mock).mockImplementation((p) => p === userPath);
     (fs.readFileSync as Mock).mockImplementation((p) => {
-      if (p === systemPath) return 'invalid json';
+      if (p === userPath) return 'invalid json';
       return '{}';
     });
 
     const { rules, errors } = loadTrustedFolders();
     expect(rules).toEqual([]);
     expect(errors.length).toBe(1);
-    expect(errors[0].path).toBe(systemPath);
+    expect(errors[0].path).toBe(userPath);
     expect(errors[0].message).toContain('Unexpected token');
   });
 
   it('setValue should update the user config and save it', () => {
     const loadedFolders = loadTrustedFolders();
-    loadedFolders.setValue(
-      SettingScope.User,
-      '/new/path',
-      TrustLevel.TRUST_FOLDER,
-    );
+    loadedFolders.setValue('/new/path', TrustLevel.TRUST_FOLDER);
 
     expect(loadedFolders.user.config['/new/path']).toBe(
       TrustLevel.TRUST_FOLDER,
@@ -193,27 +125,9 @@ describe('Trusted Folders Loading', () => {
       'utf-8',
     );
   });
-
-  it('setValue should update the system config and save it', () => {
-    const loadedFolders = loadTrustedFolders();
-    loadedFolders.setValue(
-      SettingScope.System,
-      '/new/system/path',
-      TrustLevel.DO_NOT_TRUST,
-    );
-
-    expect(loadedFolders.system.config['/new/system/path']).toBe(
-      TrustLevel.DO_NOT_TRUST,
-    );
-    expect(mockFsWriteFileSync).toHaveBeenCalledWith(
-      getSystemTrustedFoldersPath(),
-      JSON.stringify({ '/new/system/path': TrustLevel.DO_NOT_TRUST }, null, 2),
-      'utf-8',
-    );
-  });
 });
 
-describe('isCurrentDirectoryTrusted', () => {
+describe('isWorkspaceTrusted', () => {
   let mockCwd: string;
   const mockRules: Record<string, TrustLevel> = {};
 
@@ -239,51 +153,51 @@ describe('isCurrentDirectoryTrusted', () => {
   it('should return true for a directly trusted folder', () => {
     mockCwd = '/home/user/projectA';
     mockRules['/home/user/projectA'] = TrustLevel.TRUST_FOLDER;
-    expect(isCurrentDirectoryTrusted()).toBe(true);
+    expect(isWorkspaceTrusted()).toBe(true);
   });
 
   it('should return true for a child of a trusted folder', () => {
     mockCwd = '/home/user/projectA/src';
     mockRules['/home/user/projectA'] = TrustLevel.TRUST_FOLDER;
-    expect(isCurrentDirectoryTrusted()).toBe(true);
+    expect(isWorkspaceTrusted()).toBe(true);
   });
 
   it('should return true for a child of a trusted parent folder', () => {
     mockCwd = '/home/user/projectB';
     mockRules['/home/user/projectB/somefile.txt'] = TrustLevel.TRUST_PARENT;
-    expect(isCurrentDirectoryTrusted()).toBe(true);
+    expect(isWorkspaceTrusted()).toBe(true);
   });
 
   it('should return false for a directly untrusted folder', () => {
     mockCwd = '/home/user/untrusted';
     mockRules['/home/user/untrusted'] = TrustLevel.DO_NOT_TRUST;
-    expect(isCurrentDirectoryTrusted()).toBe(false);
+    expect(isWorkspaceTrusted()).toBe(false);
   });
 
   it('should return undefined for a child of an untrusted folder', () => {
     mockCwd = '/home/user/untrusted/src';
     mockRules['/home/user/untrusted'] = TrustLevel.DO_NOT_TRUST;
-    expect(isCurrentDirectoryTrusted()).toBeUndefined();
+    expect(isWorkspaceTrusted()).toBeUndefined();
   });
 
   it('should return undefined when no rules match', () => {
     mockCwd = '/home/user/other';
     mockRules['/home/user/projectA'] = TrustLevel.TRUST_FOLDER;
     mockRules['/home/user/untrusted'] = TrustLevel.DO_NOT_TRUST;
-    expect(isCurrentDirectoryTrusted()).toBeUndefined();
+    expect(isWorkspaceTrusted()).toBeUndefined();
   });
 
   it('should prioritize trust over distrust', () => {
     mockCwd = '/home/user/projectA/untrusted';
     mockRules['/home/user/projectA'] = TrustLevel.TRUST_FOLDER;
     mockRules['/home/user/projectA/untrusted'] = TrustLevel.DO_NOT_TRUST;
-    expect(isCurrentDirectoryTrusted()).toBe(true);
+    expect(isWorkspaceTrusted()).toBe(true);
   });
 
   it('should handle path normalization', () => {
     mockCwd = '/home/user/projectA';
     mockRules[`/home/user/../user/${path.basename('/home/user/projectA')}`] =
       TrustLevel.TRUST_FOLDER;
-    expect(isCurrentDirectoryTrusted()).toBe(true);
+    expect(isWorkspaceTrusted()).toBe(true);
   });
 });

--- a/packages/cli/src/config/trustedFolders.ts
+++ b/packages/cli/src/config/trustedFolders.ts
@@ -1,0 +1,217 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { homedir, platform } from 'os';
+import { getErrorMessage } from '@google/gemini-cli-core';
+import stripJsonComments from 'strip-json-comments';
+import { SettingScope } from './settings.js';
+
+export const TRUSTED_FOLDERS_FILENAME = 'trustedFolders.json';
+export const SETTINGS_DIRECTORY_NAME = '.gemini';
+export const USER_SETTINGS_DIR = path.join(homedir(), SETTINGS_DIRECTORY_NAME);
+export const USER_TRUSTED_FOLDERS_PATH = path.join(
+  USER_SETTINGS_DIR,
+  TRUSTED_FOLDERS_FILENAME,
+);
+
+export function getSystemTrustedFoldersPath(): string {
+  if (process.env.GEMINI_CLI_SYSTEM_TRUSTED_FOLDERS_PATH) {
+    return process.env.GEMINI_CLI_SYSTEM_TRUSTED_FOLDERS_PATH;
+  }
+  if (platform() === 'darwin') {
+    return `/Library/Application Support/GeminiCli/${TRUSTED_FOLDERS_FILENAME}`;
+  } else if (platform() === 'win32') {
+    return `C:/ProgramData/gemini-cli/${TRUSTED_FOLDERS_FILENAME}`;
+  } else {
+    return `/etc/gemini-cli/${TRUSTED_FOLDERS_FILENAME}`;
+  }
+}
+
+export enum TrustLevel {
+  TRUST_FOLDER = 'TRUST_FOLDER',
+  TRUST_PARENT = 'TRUST_PARENT',
+  DO_NOT_TRUST = 'DO_NOT_TRUST',
+}
+
+export interface TrustRule {
+  path: string;
+  trustLevel: TrustLevel;
+}
+
+export interface TrustedFoldersError {
+  message: string;
+  path: string;
+}
+
+export interface TrustedFoldersFile {
+  config: Record<string, TrustLevel>;
+  path: string;
+}
+
+export class LoadedTrustedFolders {
+  constructor(
+    public system: TrustedFoldersFile,
+    public user: TrustedFoldersFile,
+    public errors: TrustedFoldersError[],
+  ) {}
+
+  get rules(): TrustRule[] {
+    const mergedConfig = { ...this.user.config, ...this.system.config };
+    return Object.entries(mergedConfig).map(([path, trustLevel]) => ({
+      path,
+      trustLevel,
+    }));
+  }
+
+  forScope(scope: SettingScope): TrustedFoldersFile {
+    switch (scope) {
+      case SettingScope.User:
+        return this.user;
+      case SettingScope.System:
+        return this.system;
+      default:
+        throw new Error(`Invalid scope: ${scope}`);
+    }
+  }
+
+  setValue(scope: SettingScope, path: string, trustLevel: TrustLevel): void {
+    const fileToUpdate = this.forScope(scope);
+    fileToUpdate.config[path] = trustLevel;
+    saveTrustedFolders(fileToUpdate);
+  }
+}
+
+export function loadTrustedFolders(): LoadedTrustedFolders {
+  const errors: TrustedFoldersError[] = [];
+  const systemConfig: Record<string, TrustLevel> = {};
+  const userConfig: Record<string, TrustLevel> = {};
+
+  const systemPath = getSystemTrustedFoldersPath();
+  const userPath = USER_TRUSTED_FOLDERS_PATH;
+
+  // Load system trusted folders
+  try {
+    if (fs.existsSync(systemPath)) {
+      const content = fs.readFileSync(systemPath, 'utf-8');
+      const parsed = JSON.parse(stripJsonComments(content)) as Record<
+        string,
+        TrustLevel
+      >;
+      if (parsed) {
+        Object.assign(systemConfig, parsed);
+      }
+    }
+  } catch (error: unknown) {
+    errors.push({
+      message: getErrorMessage(error),
+      path: systemPath,
+    });
+  }
+
+  // Load user trusted folders
+  try {
+    if (fs.existsSync(userPath)) {
+      const content = fs.readFileSync(userPath, 'utf-8');
+      const parsed = JSON.parse(stripJsonComments(content)) as Record<
+        string,
+        TrustLevel
+      >;
+      if (parsed) {
+        Object.assign(userConfig, parsed);
+      }
+    }
+  } catch (error: unknown) {
+    errors.push({
+      message: getErrorMessage(error),
+      path: userPath,
+    });
+  }
+
+  return new LoadedTrustedFolders(
+    { path: systemPath, config: systemConfig },
+    { path: userPath, config: userConfig },
+    errors,
+  );
+}
+
+export function saveTrustedFolders(
+  trustedFoldersFile: TrustedFoldersFile,
+): void {
+  try {
+    // Ensure the directory exists
+    const dirPath = path.dirname(trustedFoldersFile.path);
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath, { recursive: true });
+    }
+
+    fs.writeFileSync(
+      trustedFoldersFile.path,
+      JSON.stringify(trustedFoldersFile.config, null, 2),
+      'utf-8',
+    );
+  } catch (error) {
+    console.error('Error saving trusted folders file:', error);
+  }
+}
+
+export function isCurrentDirectoryTrusted(): boolean | undefined {
+  const { rules, errors } = loadTrustedFolders();
+
+  if (errors.length > 0) {
+    for (const error of errors) {
+      console.error(
+        `Error loading trusted folders config from ${error.path}: ${error.message}`,
+      );
+    }
+  }
+
+  const trustedPaths: string[] = [];
+  const untrustedPaths: string[] = [];
+
+  for (const rule of rules) {
+    switch (rule.trustLevel) {
+      case TrustLevel.TRUST_FOLDER:
+        trustedPaths.push(rule.path);
+        break;
+      case TrustLevel.TRUST_PARENT:
+        trustedPaths.push(path.dirname(rule.path));
+        break;
+      case TrustLevel.DO_NOT_TRUST:
+        untrustedPaths.push(rule.path);
+        break;
+      default:
+        // Do nothing for unknown trust levels.
+        break;
+    }
+  }
+
+  const cwd = process.cwd();
+  const normalizedCwd = path.normalize(cwd);
+
+  for (const trustedPath of trustedPaths) {
+    const normalizedTrustedPath = path.normalize(trustedPath);
+    if (normalizedCwd === normalizedTrustedPath) {
+      return true;
+    }
+    const trustedPathWithSep = normalizedTrustedPath.endsWith(path.sep)
+      ? normalizedTrustedPath
+      : `${normalizedTrustedPath}${path.sep}`;
+    if (normalizedCwd.startsWith(trustedPathWithSep)) {
+      return true;
+    }
+  }
+
+  for (const untrustedPath of untrustedPaths) {
+    const normalizedUntrustedPath = path.normalize(untrustedPath);
+    if (normalizedCwd === normalizedUntrustedPath) {
+      return false;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -252,8 +252,10 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   const { isSettingsDialogOpen, openSettingsDialog, closeSettingsDialog } =
     useSettingsCommand();
 
-  const { isFolderTrustDialogOpen, handleFolderTrustSelect } =
-    useFolderTrust(settings);
+  const { isFolderTrustDialogOpen, handleFolderTrustSelect } = useFolderTrust(
+    settings,
+    config,
+  );
 
   const {
     isAuthDialogOpen,

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -251,8 +251,10 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   const { isSettingsDialogOpen, openSettingsDialog, closeSettingsDialog } =
     useSettingsCommand();
 
-  const { isFolderTrustDialogOpen, handleFolderTrustSelect } =
-    useFolderTrust(settings);
+  const { isFolderTrustDialogOpen, handleFolderTrustSelect } = useFolderTrust(
+    settings,
+    config,
+  );
 
   const {
     isAuthDialogOpen,

--- a/packages/cli/src/ui/hooks/useFolderTrust.test.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.test.ts
@@ -4,15 +4,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { renderHook, act } from '@testing-library/react';
 import { vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
 import { useFolderTrust } from './useFolderTrust.js';
+import { type Config } from '@google/gemini-cli-core';
 import { LoadedSettings, SettingScope } from '../../config/settings.js';
 import { FolderTrustChoice } from '../components/FolderTrustDialog.js';
+import { loadTrustedFolders, TrustLevel } from '../../config/trustedFolders.js';
+import * as process from 'process';
+
+// Mock dependencies
+vi.mock('../../config/trustedFolders.js', () => ({
+  loadTrustedFolders: vi.fn(),
+  TrustLevel: {
+    TRUST_FOLDER: 'trust_folder',
+    TRUST_PARENT: 'trust_parent',
+    DO_NOT_TRUST: 'do_not_trust',
+  },
+}));
+
+vi.mock('process', () => ({
+  cwd: vi.fn(),
+  platform: 'linux',
+}));
 
 describe('useFolderTrust', () => {
-  it('should set isFolderTrustDialogOpen to true when folderTrustFeature is true and folderTrust is undefined', () => {
-    const settings = {
+  let mockSettings: LoadedSettings;
+  let mockConfig: Config;
+  let mockTrustedFolders: { setValue: vi.Mock };
+
+  beforeEach(() => {
+    mockSettings = {
       merged: {
         folderTrustFeature: true,
         folderTrust: undefined,
@@ -20,59 +42,123 @@ describe('useFolderTrust', () => {
       setValue: vi.fn(),
     } as unknown as LoadedSettings;
 
-    const { result } = renderHook(() => useFolderTrust(settings));
+    mockConfig = {
+      isTrustedFolder: vi.fn().mockReturnValue(undefined),
+    } as unknown as Config;
 
+    mockTrustedFolders = {
+      setValue: vi.fn(),
+    };
+
+    (loadTrustedFolders as vi.Mock).mockReturnValue(mockTrustedFolders);
+    (process.cwd as vi.Mock).mockReturnValue('/test/path');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should open dialog when feature is enabled and trust is not set', () => {
+    const { result } = renderHook(() =>
+      useFolderTrust(mockSettings, mockConfig),
+    );
     expect(result.current.isFolderTrustDialogOpen).toBe(true);
   });
 
-  it('should set isFolderTrustDialogOpen to false when folderTrustFeature is false', () => {
-    const settings = {
-      merged: {
-        folderTrustFeature: false,
-        folderTrust: undefined,
-      },
-      setValue: vi.fn(),
-    } as unknown as LoadedSettings;
-
-    const { result } = renderHook(() => useFolderTrust(settings));
-
+  it('should not open dialog when feature is disabled', () => {
+    mockSettings.merged.folderTrustFeature = false;
+    const { result } = renderHook(() =>
+      useFolderTrust(mockSettings, mockConfig),
+    );
     expect(result.current.isFolderTrustDialogOpen).toBe(false);
   });
 
-  it('should set isFolderTrustDialogOpen to false when folderTrust is defined', () => {
-    const settings = {
-      merged: {
-        folderTrustFeature: true,
-        folderTrust: true,
-      },
-      setValue: vi.fn(),
-    } as unknown as LoadedSettings;
-
-    const { result } = renderHook(() => useFolderTrust(settings));
-
+  it('should not open dialog when folder trust is explicitly false', () => {
+    mockSettings.merged.folderTrust = false;
+    const { result } = renderHook(() =>
+      useFolderTrust(mockSettings, mockConfig),
+    );
     expect(result.current.isFolderTrustDialogOpen).toBe(false);
   });
 
-  it('should call setValue and set isFolderTrustDialogOpen to false on handleFolderTrustSelect', () => {
-    const settings = {
-      merged: {
-        folderTrustFeature: true,
-        folderTrust: undefined,
-      },
-      setValue: vi.fn(),
-    } as unknown as LoadedSettings;
+  it('should not open dialog when folder is already trusted', () => {
+    (mockConfig.isTrustedFolder as vi.Mock).mockReturnValue(true);
+    const { result } = renderHook(() =>
+      useFolderTrust(mockSettings, mockConfig),
+    );
+    expect(result.current.isFolderTrustDialogOpen).toBe(false);
+  });
 
-    const { result } = renderHook(() => useFolderTrust(settings));
+  it('should handle TRUST_FOLDER choice', () => {
+    const { result } = renderHook(() =>
+      useFolderTrust(mockSettings, mockConfig),
+    );
 
     act(() => {
       result.current.handleFolderTrustSelect(FolderTrustChoice.TRUST_FOLDER);
     });
 
-    expect(settings.setValue).toHaveBeenCalledWith(
+    expect(loadTrustedFolders).toHaveBeenCalled();
+    expect(mockTrustedFolders.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      '/test/path',
+      TrustLevel.TRUST_FOLDER,
+    );
+    expect(mockSettings.setValue).toHaveBeenCalledWith(
       SettingScope.User,
       'folderTrust',
       true,
     );
     expect(result.current.isFolderTrustDialogOpen).toBe(false);
+  });
+
+  it('should handle TRUST_PARENT choice', () => {
+    const { result } = renderHook(() =>
+      useFolderTrust(mockSettings, mockConfig),
+    );
+
+    act(() => {
+      result.current.handleFolderTrustSelect(FolderTrustChoice.TRUST_PARENT);
+    });
+
+    expect(mockTrustedFolders.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      '/test/path',
+      TrustLevel.TRUST_PARENT,
+    );
+    expect(result.current.isFolderTrustDialogOpen).toBe(false);
+  });
+
+  it('should handle DO_NOT_TRUST choice', () => {
+    const { result } = renderHook(() =>
+      useFolderTrust(mockSettings, mockConfig),
+    );
+
+    act(() => {
+      result.current.handleFolderTrustSelect(FolderTrustChoice.DO_NOT_TRUST);
+    });
+
+    expect(mockTrustedFolders.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      '/test/path',
+      TrustLevel.DO_NOT_TRUST,
+    );
+    expect(result.current.isFolderTrustDialogOpen).toBe(false);
+  });
+
+  it('should do nothing for default choice', () => {
+    const { result } = renderHook(() =>
+      useFolderTrust(mockSettings, mockConfig),
+    );
+
+    act(() => {
+      result.current.handleFolderTrustSelect(
+        'invalid_choice' as FolderTrustChoice,
+      );
+    });
+
+    expect(mockTrustedFolders.setValue).not.toHaveBeenCalled();
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+    expect(result.current.isFolderTrustDialogOpen).toBe(true);
   });
 });

--- a/packages/cli/src/ui/hooks/useFolderTrust.test.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.test.ts
@@ -56,35 +56,28 @@ describe('useFolderTrust', () => {
     vi.clearAllMocks();
   });
 
-  it('should open dialog when feature is enabled and trust is not set', () => {
-    const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, mockConfig),
-    );
-    expect(result.current.isFolderTrustDialogOpen).toBe(true);
-  });
-
-  it('should not open dialog when feature is disabled', () => {
-    mockSettings.merged.folderTrustFeature = false;
-    const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, mockConfig),
-    );
-    expect(result.current.isFolderTrustDialogOpen).toBe(false);
-  });
-
-  it('should not open dialog when folder trust is explicitly false', () => {
-    mockSettings.merged.folderTrust = false;
-    const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, mockConfig),
-    );
-    expect(result.current.isFolderTrustDialogOpen).toBe(false);
-  });
-
   it('should not open dialog when folder is already trusted', () => {
     (mockConfig.isTrustedFolder as vi.Mock).mockReturnValue(true);
     const { result } = renderHook(() =>
       useFolderTrust(mockSettings, mockConfig),
     );
     expect(result.current.isFolderTrustDialogOpen).toBe(false);
+  });
+
+  it('should not open dialog when folder is already untrusted', () => {
+    (mockConfig.isTrustedFolder as vi.Mock).mockReturnValue(false);
+    const { result } = renderHook(() =>
+      useFolderTrust(mockSettings, mockConfig),
+    );
+    expect(result.current.isFolderTrustDialogOpen).toBe(false);
+  });
+
+  it('should open dialog when folder trust is undefined', () => {
+    (mockConfig.isTrustedFolder as vi.Mock).mockReturnValue(undefined);
+    const { result } = renderHook(() =>
+      useFolderTrust(mockSettings, mockConfig),
+    );
+    expect(result.current.isFolderTrustDialogOpen).toBe(true);
   });
 
   it('should handle TRUST_FOLDER choice', () => {

--- a/packages/cli/src/ui/hooks/useFolderTrust.test.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.test.ts
@@ -8,7 +8,7 @@ import { vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useFolderTrust } from './useFolderTrust.js';
 import { type Config } from '@google/gemini-cli-core';
-import { LoadedSettings, SettingScope } from '../../config/settings.js';
+import { LoadedSettings } from '../../config/settings.js';
 import { FolderTrustChoice } from '../components/FolderTrustDialog.js';
 import {
   LoadedTrustedFolders,
@@ -56,35 +56,28 @@ describe('useFolderTrust', () => {
     vi.clearAllMocks();
   });
 
-  it('should open dialog when feature is enabled and trust is not set', () => {
-    const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, mockConfig),
-    );
-    expect(result.current.isFolderTrustDialogOpen).toBe(true);
-  });
-
-  it('should not open dialog when feature is disabled', () => {
-    mockSettings.merged.folderTrustFeature = false;
-    const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, mockConfig),
-    );
-    expect(result.current.isFolderTrustDialogOpen).toBe(false);
-  });
-
-  it('should not open dialog when folder trust is explicitly false', () => {
-    mockSettings.merged.folderTrust = false;
-    const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, mockConfig),
-    );
-    expect(result.current.isFolderTrustDialogOpen).toBe(false);
-  });
-
   it('should not open dialog when folder is already trusted', () => {
     (mockConfig.isTrustedFolder as vi.Mock).mockReturnValue(true);
     const { result } = renderHook(() =>
       useFolderTrust(mockSettings, mockConfig),
     );
     expect(result.current.isFolderTrustDialogOpen).toBe(false);
+  });
+
+  it('should not open dialog when folder is already untrusted', () => {
+    (mockConfig.isTrustedFolder as vi.Mock).mockReturnValue(false);
+    const { result } = renderHook(() =>
+      useFolderTrust(mockSettings, mockConfig),
+    );
+    expect(result.current.isFolderTrustDialogOpen).toBe(false);
+  });
+
+  it('should open dialog when folder trust is undefined', () => {
+    (mockConfig.isTrustedFolder as vi.Mock).mockReturnValue(undefined);
+    const { result } = renderHook(() =>
+      useFolderTrust(mockSettings, mockConfig),
+    );
+    expect(result.current.isFolderTrustDialogOpen).toBe(true);
   });
 
   it('should handle TRUST_FOLDER choice', () => {
@@ -100,11 +93,6 @@ describe('useFolderTrust', () => {
     expect(mockTrustedFolders.setValue).toHaveBeenCalledWith(
       '/test/path',
       TrustLevel.TRUST_FOLDER,
-    );
-    expect(mockSettings.setValue).toHaveBeenCalledWith(
-      SettingScope.User,
-      'folderTrust',
-      true,
     );
     expect(result.current.isFolderTrustDialogOpen).toBe(false);
   });

--- a/packages/cli/src/ui/hooks/useFolderTrust.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.ts
@@ -13,10 +13,7 @@ import * as process from 'process';
 
 export const useFolderTrust = (settings: LoadedSettings, config: Config) => {
   const [isFolderTrustDialogOpen, setIsFolderTrustDialogOpen] = useState(
-    !!settings.merged.folderTrustFeature &&
-      (settings.merged.folderTrust === undefined ||
-        settings.merged.folderTrust === true) &&
-      config.isTrustedFolder() === undefined,
+    config.isTrustedFolder() === undefined,
   );
 
   const handleFolderTrustSelect = useCallback(

--- a/packages/cli/src/ui/hooks/useFolderTrust.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.ts
@@ -39,7 +39,7 @@ export const useFolderTrust = (settings: LoadedSettings, config: Config) => {
           return;
       }
 
-      trustedFolders.setValue(SettingScope.User, cwd, trustLevel);
+      trustedFolders.setValue(cwd, trustLevel);
       settings.setValue(SettingScope.User, 'folderTrust', true);
       setIsFolderTrustDialogOpen(false);
     },

--- a/packages/cli/src/ui/hooks/useFolderTrust.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.ts
@@ -5,19 +5,41 @@
  */
 
 import { useState, useCallback } from 'react';
+import { type Config } from '@google/gemini-cli-core';
 import { LoadedSettings, SettingScope } from '../../config/settings.js';
 import { FolderTrustChoice } from '../components/FolderTrustDialog.js';
+import { loadTrustedFolders, TrustLevel } from '../../config/trustedFolders.js';
+import * as process from 'process';
 
-export const useFolderTrust = (settings: LoadedSettings) => {
+export const useFolderTrust = (settings: LoadedSettings, config: Config) => {
   const [isFolderTrustDialogOpen, setIsFolderTrustDialogOpen] = useState(
     !!settings.merged.folderTrustFeature &&
-      // TODO: Update to avoid showing dialog for folders that are trusted.
-      settings.merged.folderTrust === undefined,
+      (settings.merged.folderTrust === undefined ||
+        settings.merged.folderTrust === true) &&
+      config.isTrustedFolder() === undefined,
   );
 
   const handleFolderTrustSelect = useCallback(
-    (_choice: FolderTrustChoice) => {
-      // TODO: Store folderPath in the trusted folders config file based on the choice.
+    (choice: FolderTrustChoice) => {
+      const trustedFolders = loadTrustedFolders();
+      const cwd = process.cwd();
+      let trustLevel: TrustLevel;
+
+      switch (choice) {
+        case FolderTrustChoice.TRUST_FOLDER:
+          trustLevel = TrustLevel.TRUST_FOLDER;
+          break;
+        case FolderTrustChoice.TRUST_PARENT:
+          trustLevel = TrustLevel.TRUST_PARENT;
+          break;
+        case FolderTrustChoice.DO_NOT_TRUST:
+          trustLevel = TrustLevel.DO_NOT_TRUST;
+          break;
+        default:
+          return;
+      }
+
+      trustedFolders.setValue(SettingScope.User, cwd, trustLevel);
       settings.setValue(SettingScope.User, 'folderTrust', true);
       setIsFolderTrustDialogOpen(false);
     },

--- a/packages/cli/src/ui/hooks/useFolderTrust.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.ts
@@ -6,45 +6,38 @@
 
 import { useState, useCallback } from 'react';
 import { type Config } from '@google/gemini-cli-core';
-import { LoadedSettings, SettingScope } from '../../config/settings.js';
+import { LoadedSettings } from '../../config/settings.js';
 import { FolderTrustChoice } from '../components/FolderTrustDialog.js';
 import { loadTrustedFolders, TrustLevel } from '../../config/trustedFolders.js';
 import * as process from 'process';
 
 export const useFolderTrust = (settings: LoadedSettings, config: Config) => {
   const [isFolderTrustDialogOpen, setIsFolderTrustDialogOpen] = useState(
-    !!settings.merged.folderTrustFeature &&
-      (settings.merged.folderTrust === undefined ||
-        settings.merged.folderTrust === true) &&
-      config.isTrustedFolder() === undefined,
+    config.isTrustedFolder() === undefined,
   );
 
-  const handleFolderTrustSelect = useCallback(
-    (choice: FolderTrustChoice) => {
-      const trustedFolders = loadTrustedFolders();
-      const cwd = process.cwd();
-      let trustLevel: TrustLevel;
+  const handleFolderTrustSelect = useCallback((choice: FolderTrustChoice) => {
+    const trustedFolders = loadTrustedFolders();
+    const cwd = process.cwd();
+    let trustLevel: TrustLevel;
 
-      switch (choice) {
-        case FolderTrustChoice.TRUST_FOLDER:
-          trustLevel = TrustLevel.TRUST_FOLDER;
-          break;
-        case FolderTrustChoice.TRUST_PARENT:
-          trustLevel = TrustLevel.TRUST_PARENT;
-          break;
-        case FolderTrustChoice.DO_NOT_TRUST:
-          trustLevel = TrustLevel.DO_NOT_TRUST;
-          break;
-        default:
-          return;
-      }
+    switch (choice) {
+      case FolderTrustChoice.TRUST_FOLDER:
+        trustLevel = TrustLevel.TRUST_FOLDER;
+        break;
+      case FolderTrustChoice.TRUST_PARENT:
+        trustLevel = TrustLevel.TRUST_PARENT;
+        break;
+      case FolderTrustChoice.DO_NOT_TRUST:
+        trustLevel = TrustLevel.DO_NOT_TRUST;
+        break;
+      default:
+        return;
+    }
 
-      trustedFolders.setValue(cwd, trustLevel);
-      settings.setValue(SettingScope.User, 'folderTrust', true);
-      setIsFolderTrustDialogOpen(false);
-    },
-    [settings],
-  );
+    trustedFolders.setValue(cwd, trustLevel);
+    setIsFolderTrustDialogOpen(false);
+  }, []);
 
   return {
     isFolderTrustDialogOpen,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -197,6 +197,7 @@ export interface ConfigParameters {
   loadMemoryFromIncludeDirectories?: boolean;
   chatCompression?: ChatCompressionSettings;
   interactive?: boolean;
+  trustedFolder?: boolean;
 }
 
 export class Config {
@@ -260,6 +261,7 @@ export class Config {
   private readonly loadMemoryFromIncludeDirectories: boolean = false;
   private readonly chatCompression: ChatCompressionSettings | undefined;
   private readonly interactive: boolean;
+  private readonly trustedFolder: boolean | undefined;
   private initialized: boolean = false;
 
   constructor(params: ConfigParameters) {
@@ -324,6 +326,7 @@ export class Config {
       params.loadMemoryFromIncludeDirectories ?? false;
     this.chatCompression = params.chatCompression;
     this.interactive = params.interactive ?? false;
+    this.trustedFolder = params.trustedFolder;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -662,6 +665,10 @@ export class Config {
 
   getFolderTrust(): boolean {
     return this.folderTrust;
+  }
+
+  isTrustedFolder(): boolean | undefined {
+    return this.trustedFolder;
   }
 
   setIdeMode(value: boolean): void {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -198,6 +198,7 @@ export interface ConfigParameters {
   loadMemoryFromIncludeDirectories?: boolean;
   chatCompression?: ChatCompressionSettings;
   interactive?: boolean;
+  trustedFolder?: boolean;
 }
 
 export class Config {
@@ -262,6 +263,7 @@ export class Config {
   private readonly loadMemoryFromIncludeDirectories: boolean = false;
   private readonly chatCompression: ChatCompressionSettings | undefined;
   private readonly interactive: boolean;
+  private readonly trustedFolder: boolean | undefined;
   private initialized: boolean = false;
 
   constructor(params: ConfigParameters) {
@@ -326,6 +328,7 @@ export class Config {
       params.loadMemoryFromIncludeDirectories ?? false;
     this.chatCompression = params.chatCompression;
     this.interactive = params.interactive ?? false;
+    this.trustedFolder = params.trustedFolder;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -668,6 +671,10 @@ export class Config {
 
   getFolderTrust(): boolean {
     return this.folderTrust;
+  }
+
+  isTrustedFolder(): boolean | undefined {
+    return this.trustedFolder;
   }
 
   setIdeMode(value: boolean): void {


### PR DESCRIPTION
## TLDR

A new JSON config file called trustedFolders.json will be created on launch when a user chooses whether they trust the current folder or not. Eg contents:
**{
  "/Users/padamata/Documents/git/du4/gemini-cli": "TRUST_FOLDER",
  "/Users/padamata/Documents/git/du4/gemini-cli/packages/cli": "DO_NOT_TRUST"
}**

## Dive Deeper

- Child folders inherit the trust for "trusted" folders but not for "untrusted" folders, mimicking the behavior in VSCode.
- The config file is supported at system and user scope, with system scope taking precedence over user scope config.
- In case of errors in the config file, the next write will overwrite the file.
- In case of duplicate entries, the last entry will be taken and the previous entries will be overwritten on the next write.

## Reviewer Test Plan

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to https://github.com/google-gemini/maintainers-gemini-cli/issues/641
