### PR TITLE
fix(auth): Discard thought signatures when switching from API Key to OAuth

### DIFF
--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -53,6 +53,7 @@ const mockConfig = {
   getApprovalMode: vi.fn(() => ApprovalMode.DEFAULT),
   getUsageStatisticsEnabled: () => true,
   getDebugMode: () => false,
+  getProjectTempDir: vi.fn(() => '/tmp/test'),
 };
 
 class MockTool extends BaseTool<object, ToolResult> {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -5,13 +5,17 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   CoreToolScheduler,
   ToolCall,
   ValidatingToolCall,
   convertToFunctionResponse,
+  truncateAndSaveToFile,
 } from './coreToolScheduler.js';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
 import {
   BaseTool,
   ToolCallConfirmationDetails,
@@ -782,5 +786,129 @@ describe('CoreToolScheduler request queueing', () => {
 
     // Ensure completion callbacks were called twice.
     expect(onAllToolCallsComplete).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('truncateAndSaveToFile', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'truncate-test-'));
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tempDir, { recursive: true });
+    } catch (_error) {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('should return content as-is if under threshold', async () => {
+    const content = 'short content';
+    const result = await truncateAndSaveToFile(content, 'test-call', tempDir);
+    expect(result).toBe(content);
+  });
+
+  it('should truncate and save large output content to file', async () => {
+    const largeContent = 'x'.repeat(200000); // 200kb
+    const result = await truncateAndSaveToFile(
+      largeContent,
+      'test-call',
+      tempDir,
+      'output',
+    );
+
+    expect(result).toContain(
+      'Tool output was too large and has been truncated',
+    );
+    expect(result).toContain('The full output has been saved to:');
+    expect(result).toContain('Last 100 lines of output:');
+    expect(result).toContain('test-call');
+
+    // Check that file was created
+    const files = await fs.readdir(tempDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain('test-call');
+
+    // Verify file content
+    const savedContent = await fs.readFile(
+      path.join(tempDir, files[0]),
+      'utf-8',
+    );
+    expect(savedContent).toBe(largeContent);
+  });
+
+  it('should truncate and save large error content with proper messaging', async () => {
+    const largeError = 'error: '.repeat(50000); // Large error message
+    const result = await truncateAndSaveToFile(
+      largeError,
+      'error-call',
+      tempDir,
+      'error',
+    );
+
+    expect(result).toContain(
+      'Tool error message was too large and has been truncated',
+    );
+    expect(result).toContain('The full error message has been saved to:');
+    expect(result).toContain('Last 100 lines of error message:');
+
+    // Check that file was created
+    const files = await fs.readdir(tempDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain('error-call');
+  });
+
+  it('should handle file write failures gracefully', async () => {
+    const largeContent = 'x'.repeat(200000);
+    const invalidDir = '/invalid/path/that/does/not/exist';
+
+    const result = await truncateAndSaveToFile(
+      largeContent,
+      'test-call',
+      invalidDir,
+    );
+
+    expect(result).not.toContain('The full output has been saved to:');
+    expect(result).toContain('[Note: Could not save full output to file]');
+    expect(result.length).toBeLessThan(largeContent.length);
+  });
+
+  it('should handle multiline content correctly', async () => {
+    const lines = Array.from({ length: 200 }, (_, i) => `Line ${i + 1}`);
+    const multilineContent = lines.join('\\n');
+
+    const result = await truncateAndSaveToFile(
+      multilineContent,
+      'multiline-call',
+      tempDir,
+    );
+
+    expect(result).toContain(
+      'Tool output was too large and has been truncated',
+    );
+    expect(result).toContain('Last 100 lines of output:');
+
+    // Should contain the last 100 lines
+    const outputSection = result.split('Last 100 lines of output:\\n...\\n')[1];
+    expect(outputSection).toContain('Line 200');
+    expect(outputSection).toContain('Line 101');
+    expect(outputSection).not.toContain('Line 100');
+  });
+
+  it('should create unique filenames with timestamps', async () => {
+    const largeContent = 'x'.repeat(200000);
+
+    // Create two files quickly
+    const result1 = truncateAndSaveToFile(largeContent, 'call-1', tempDir);
+    const result2 = truncateAndSaveToFile(largeContent, 'call-2', tempDir);
+
+    await Promise.all([result1, result2]);
+
+    const files = await fs.readdir(tempDir);
+    expect(files).toHaveLength(2);
+    expect(files[0]).not.toBe(files[1]); // Should have different names
+    expect(files.every((f) => f.includes('.txt'))).toBe(true);
   });
 });

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -33,7 +33,7 @@ import * as Diff from 'diff';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-const TRUNCATION_THRESHOLD = 100000; // 100kb
+const TRUNCATION_THRESHOLD = 1000000; // 1M
 const TRUNCATION_LINES = 100;
 
 export type ValidatingToolCall = {


### PR DESCRIPTION
## TLDR

This pull request ensures that when a user switches from a GenAI API key to logging in with Google (which uses the Vertex API), any "thought" data from the previous session is stripped from the conversation history. This prevents potential issues when resuming a conversation across different backend services.

## Dive Deeper

When a user authenticates with a GenAI API key, the conversation history may include internal "thought" metadata. However, the Vertex API, which is used when logging in with Google, has incompatible encryption. If a user switches from using a GenAI key to logging in with Google, this metadata could cause errors or unexpected behavior.

This change introduces a `stripThoughts` flag to the `setHistory` method in `GeminiClient`. When a user's authentication method changes from GenAI to Vertex, this flag is set to `true`, and the `setHistory` method removes any `thoughtSignature` properties from the conversation history before setting it on the new client. This ensures a clean transition between the two services. The reverse is not true; when switching from Vertex to GenAI, the history is preserved as-is.

## Reviewer Test Plan

1.  Start the Gemini CLI using a GenAI API key.
2.  Have a short conversation with the model.
3.  Exit the CLI.
4.  Start the Gemini CLI again, but this time log in with Google.
5.  Verify that the previous conversation history is loaded and that there are no errors.
6.  You can also inspect the code changes in `packages/core/src/config/config.ts` and `packages/core/src/core/client.ts` to confirm the logic.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
