### PR TITLE
Show OpenTelemetry SDK initialization & shutdown in debug mode only

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -143,7 +143,7 @@ export async function runNonInteractive(
   } finally {
     consolePatcher.cleanup();
     if (isTelemetrySdkInitialized()) {
-      await shutdownTelemetry();
+      await shutdownTelemetry(config);
     }
   }
 }

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -125,25 +125,33 @@ export function initializeTelemetry(config: Config): void {
 
   try {
     sdk.start();
-    console.log('OpenTelemetry SDK started successfully.');
+    if (config.getDebugMode()) {
+      console.log('OpenTelemetry SDK started successfully.');
+    }
     telemetryInitialized = true;
     initializeMetrics(config);
   } catch (error) {
     console.error('Error starting OpenTelemetry SDK:', error);
   }
 
-  process.on('SIGTERM', shutdownTelemetry);
-  process.on('SIGINT', shutdownTelemetry);
+  process.on('SIGTERM', () => {
+    shutdownTelemetry(config);
+  });
+  process.on('SIGINT', () => {
+    shutdownTelemetry(config);
+  });
 }
 
-export async function shutdownTelemetry(): Promise<void> {
+export async function shutdownTelemetry(config: Config): Promise<void> {
   if (!telemetryInitialized || !sdk) {
     return;
   }
   try {
     ClearcutLogger.getInstance()?.shutdown();
     await sdk.shutdown();
-    console.log('OpenTelemetry SDK shut down successfully.');
+    if (config.getDebugMode()) {
+      console.log('OpenTelemetry SDK shut down successfully.');
+    }
   } catch (error) {
     console.error('Error shutting down SDK:', error);
   } finally {

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -45,7 +45,7 @@ describe('telemetry', () => {
   afterEach(async () => {
     // Ensure we shut down telemetry even if a test fails.
     if (isTelemetrySdkInitialized()) {
-      await shutdownTelemetry();
+      await shutdownTelemetry(mockConfig);
     }
   });
 
@@ -57,7 +57,7 @@ describe('telemetry', () => {
 
   it('should shutdown the telemetry service', async () => {
     initializeTelemetry(mockConfig);
-    await shutdownTelemetry();
+    await shutdownTelemetry(mockConfig);
 
     expect(mockNodeSdk.shutdown).toHaveBeenCalled();
   });


### PR DESCRIPTION
The telemetry initialization and shutdown messages are now only displayed when the debug mode is enabled in the configuration. This reduces noise for regular users while still providing valuable information for debugging.