### PR TITLE
feat(extensions): implement `gemini extensions list`

### DIFF
--- a/packages/cli/src/commands/extensions.ts
+++ b/packages/cli/src/commands/extensions.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule, Argv } from 'yargs';
+import { listCommand } from './extensions/list.js';
+
+export const extensionsCommand: CommandModule = {
+  command: 'extensions',
+  describe: 'Manage extensions',
+  builder: (yargs: Argv) =>
+    yargs
+      .command(listCommand)
+      .demandCommand(1, 'You need at least one command before continuing.')
+      .version(false),
+  handler: () => {
+    // yargs will automatically show help if no subcommand is provided
+  },
+};

--- a/packages/cli/src/commands/extensions/list.test.ts
+++ b/packages/cli/src/commands/extensions/list.test.ts
@@ -49,12 +49,25 @@ describe('extensions list command', () => {
 
   it('should list all installed extensions', () => {
     mockedLoadExtensions.mockReturnValue([
-      { config: { name: 'extension-1', version: '1.0.0' } },
-      { config: { name: 'ext2', version: '2.0.0' } },
+      {
+        config: { name: 'extension-1', version: '1.0.0' },
+        path: '/path/to/extension-1',
+      },
+      { config: { name: 'ext2', version: '2.0.0' }, path: '/path/to/ext2' },
     ]);
     mockedAnnotateActiveExtensions.mockReturnValue([
-      { name: 'extension-1', version: '1.0.0', isActive: true },
-      { name: 'ext2', version: '2.0.0', isActive: true },
+      {
+        name: 'extension-1',
+        version: '1.0.0',
+        isActive: true,
+        path: '/path/to/extension-1',
+      },
+      {
+        name: 'ext2',
+        version: '2.0.0',
+        isActive: true,
+        path: '/path/to/ext2',
+      },
     ]);
 
     if (listCommand.handler) {
@@ -62,9 +75,17 @@ describe('extensions list command', () => {
       handler();
     }
 
-    expect(consoleSpy).toHaveBeenCalledWith('Name        | Enabled');
-    expect(consoleSpy).toHaveBeenCalledWith('----------- | -------');
-    expect(consoleSpy).toHaveBeenCalledWith('extension-1 | true');
-    expect(consoleSpy).toHaveBeenCalledWith('ext2        | true');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Name        | Version | Enabled | Path',
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '----------- | ------- | ------- | ----',
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'extension-1 | 1.0.0   | true    | /path/to/extension-1',
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'ext2        | 2.0.0   | true    | /path/to/ext2',
+    );
   });
 });

--- a/packages/cli/src/commands/extensions/list.test.ts
+++ b/packages/cli/src/commands/extensions/list.test.ts
@@ -27,8 +27,8 @@ describe('extensions list command', () => {
   it('should display message when no extensions are installed', () => {
     mockedLoadExtensions.mockReturnValue([]);
     if (listCommand.handler) {
-        const handler = listCommand.handler as () => void;
-        handler();
+      const handler = listCommand.handler as () => void;
+      handler();
     }
     expect(consoleSpy).toHaveBeenCalledWith('Installed extensions:');
   });
@@ -40,8 +40,8 @@ describe('extensions list command', () => {
     ]);
 
     if (listCommand.handler) {
-        const handler = listCommand.handler as () => void;
-        handler();
+      const handler = listCommand.handler as () => void;
+      handler();
     }
 
     expect(consoleSpy).toHaveBeenCalledWith('Installed extensions:');

--- a/packages/cli/src/commands/extensions/list.test.ts
+++ b/packages/cli/src/commands/extensions/list.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { listCommand } from './list.js';
+import { loadExtensions } from '../../config/extension.js';
+
+vi.mock('../../config/extension.js');
+
+const mockedLoadExtensions = loadExtensions as vi.Mock;
+
+describe('extensions list command', () => {
+  let consoleSpy: vi.SpyInstance;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('should display message when no extensions are installed', () => {
+    mockedLoadExtensions.mockReturnValue([]);
+    if (listCommand.handler) {
+        const handler = listCommand.handler as () => void;
+        handler();
+    }
+    expect(consoleSpy).toHaveBeenCalledWith('Installed extensions:');
+  });
+
+  it('should list all installed extensions', () => {
+    mockedLoadExtensions.mockReturnValue([
+      { config: { name: 'extension-1' } },
+      { config: { name: 'extension-2' } },
+    ]);
+
+    if (listCommand.handler) {
+        const handler = listCommand.handler as () => void;
+        handler();
+    }
+
+    expect(consoleSpy).toHaveBeenCalledWith('Installed extensions:');
+    expect(consoleSpy).toHaveBeenCalledWith('- extension-1');
+    expect(consoleSpy).toHaveBeenCalledWith('- extension-2');
+  });
+});

--- a/packages/cli/src/commands/extensions/list.ts
+++ b/packages/cli/src/commands/extensions/list.ts
@@ -5,16 +5,26 @@
  */
 
 import type { CommandModule } from 'yargs';
-import { loadExtensions } from '../../config/extension.js';
+import {
+  loadExtensions,
+  annotateActiveExtensionsFromDisabled,
+} from '../../config/extension.js';
+import { loadSettings } from '../../config/settings.js';
 
 export const listCommand: CommandModule = {
   command: 'list',
   describe: 'List all available extensions',
   handler: () => {
-    const extensions = loadExtensions(process.cwd());
+    const workspaceRoot = process.cwd();
+    const settings = loadSettings(workspaceRoot);
+    const extensions = loadExtensions(workspaceRoot);
+    const annotatedExtensions = annotateActiveExtensionsFromDisabled(
+      extensions,
+      settings.merged.extensions?.disabled || [],
+    );
     console.log('Installed extensions:');
-    for (const extension of extensions) {
-      console.log(`- ${extension.config.name}`);
+    for (const extension of annotatedExtensions) {
+      console.log(`- ${extension.name}`);
     }
   },
 };

--- a/packages/cli/src/commands/extensions/list.ts
+++ b/packages/cli/src/commands/extensions/list.ts
@@ -22,9 +22,28 @@ export const listCommand: CommandModule = {
       extensions,
       settings.merged.extensions?.disabled || [],
     );
-    console.log('Installed extensions:');
+
+    if (annotatedExtensions.length === 0) {
+      console.log('No extensions installed.');
+      return;
+    }
+
+    const nameHeader = 'Name';
+    const enabledHeader = 'Enabled';
+
+    const nameWidth = Math.max(
+      nameHeader.length,
+      ...annotatedExtensions.map((ext) => ext.name.length),
+    );
+
+    console.log(`${nameHeader.padEnd(nameWidth)} | ${enabledHeader}`);
+    console.log(
+      `${'-'.repeat(nameWidth)} | ${'-'.repeat(enabledHeader.length)}`,
+    );
+
     for (const extension of annotatedExtensions) {
-      console.log(`- ${extension.name}`);
+      const { name, isActive } = extension;
+      console.log(`${name.padEnd(nameWidth)} | ${isActive}`);
     }
   },
 };

--- a/packages/cli/src/commands/extensions/list.ts
+++ b/packages/cli/src/commands/extensions/list.ts
@@ -29,21 +29,37 @@ export const listCommand: CommandModule = {
     }
 
     const nameHeader = 'Name';
+    const versionHeader = 'Version';
     const enabledHeader = 'Enabled';
+    const pathHeader = 'Path';
 
     const nameWidth = Math.max(
       nameHeader.length,
       ...annotatedExtensions.map((ext) => ext.name.length),
     );
+    const versionWidth = Math.max(
+      versionHeader.length,
+      ...annotatedExtensions.map((ext) => ext.version.length),
+    );
 
-    console.log(`${nameHeader.padEnd(nameWidth)} | ${enabledHeader}`);
     console.log(
-      `${'-'.repeat(nameWidth)} | ${'-'.repeat(enabledHeader.length)}`,
+      `${nameHeader.padEnd(nameWidth)} | ${versionHeader.padEnd(
+        versionWidth,
+      )} | ${enabledHeader} | ${pathHeader}`,
+    );
+    console.log(
+      `${'-'.repeat(nameWidth)} | ${'-'.repeat(versionWidth)} | ${'-'.repeat(
+        enabledHeader.length,
+      )} | ${'-'.repeat(pathHeader.length)}`,
     );
 
     for (const extension of annotatedExtensions) {
-      const { name, isActive } = extension;
-      console.log(`${name.padEnd(nameWidth)} | ${isActive}`);
+      const { name, version, isActive, path } = extension;
+      console.log(
+        `${name.padEnd(nameWidth)} | ${version.padEnd(
+          versionWidth,
+        )} | ${isActive.toString().padEnd(enabledHeader.length)} | ${path}`,
+      );
     }
   },
 };

--- a/packages/cli/src/commands/extensions/list.ts
+++ b/packages/cli/src/commands/extensions/list.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import { loadExtensions } from '../../config/extension.js';
+
+export const listCommand: CommandModule = {
+  command: 'list',
+  describe: 'List all available extensions',
+  handler: () => {
+    const extensions = loadExtensions(process.cwd());
+    console.log('Installed extensions:');
+    for (const extension of extensions) {
+      console.log(`- ${extension.config.name}`);
+    }
+  },
+};

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -946,6 +946,40 @@ describe('loadCliConfig extensions', () => {
     );
     expect(config.getExtensionContextFilePaths()).toEqual(['/path/to/ext1.md']);
   });
+
+  it('should disable extensions from settings if --extensions flag is not used', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      extensions: {
+        disabled: ['ext2'],
+      },
+    };
+    const config = await loadCliConfig(
+      settings,
+      mockExtensions,
+      'test-session',
+      argv,
+    );
+    expect(config.getExtensionContextFilePaths()).toEqual(['/path/to/ext1.md']);
+  });
+
+  it('should prioritize --extensions flag over settings.extensions.disabled', async () => {
+    process.argv = ['node', 'script.js', '--extensions', 'ext2'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      extensions: {
+        disabled: ['ext1'],
+      },
+    };
+    const config = await loadCliConfig(
+      settings,
+      mockExtensions,
+      'test-session',
+      argv,
+    );
+    expect(config.getExtensionContextFilePaths()).toEqual(['/path/to/ext2.md']);
+  });
 });
 
 describe('loadCliConfig model selection', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -11,6 +11,7 @@ import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
 import process from 'node:process';
 import { mcpCommand } from '../commands/mcp.js';
+import { extensionsCommand } from '../commands/extensions.js';
 import {
   Config,
   loadServerHierarchicalMemory,
@@ -229,6 +230,7 @@ export async function parseArguments(): Promise<CliArgs> {
     )
     // Register MCP subcommands
     .command(mcpCommand)
+    .command(extensionsCommand)
     .version(await getCliVersion()) // This will enable the --version flag based on package.json
     .alias('v', 'version')
     .help()
@@ -239,9 +241,9 @@ export async function parseArguments(): Promise<CliArgs> {
   yargsInstance.wrap(yargsInstance.terminalWidth());
   const result = await yargsInstance.parse();
 
-  // Handle case where MCP subcommands are executed - they should exit the process
+  // Handle case where MCP and extensions subcommands are executed - they should exit the process
   // and not return to main CLI logic
-  if (result._.length > 0 && result._[0] === 'mcp') {
+  if (result._.length > 0 && (result._[0] === 'mcp' || result._[0] === 'extensions')) {
     // MCP commands handle their own execution and process exit
     process.exit(0);
   }
@@ -536,7 +538,7 @@ function mergeMcpServers(settings: Settings, extensions: Extension[]) {
       ([key, server]) => {
         if (mcpServers[key]) {
           logger.warn(
-            `Skipping extension MCP config for server with key "${key}" as it already exists.`,
+            `Skipping extension MCP config for server with key \"${key}\" as it already exists.`,
           );
           return;
         }

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -247,7 +247,10 @@ export async function parseArguments(): Promise<CliArgs> {
 
   // Handle case where MCP and extensions subcommands are executed - they should exit the process
   // and not return to main CLI logic
-  if (result._.length > 0 && (result._[0] === 'mcp' || result._[0] === 'extensions')) {
+  if (
+    result._.length > 0 &&
+    (result._[0] === 'mcp' || result._[0] === 'extensions')
+  ) {
     // MCP commands handle their own execution and process exit
     process.exit(0);
   }
@@ -530,7 +533,7 @@ function mergeMcpServers(settings: Settings, extensions: Extension[]) {
       ([key, server]) => {
         if (mcpServers[key]) {
           logger.warn(
-            `Skipping extension MCP config for server with key \"${key}\" as it already exists.`,
+            `Skipping extension MCP config for server with key "${key}" as it already exists.`,
           );
           return;
         }

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -314,9 +314,25 @@ export async function loadCliConfig(
   const folderTrustSetting = settings.folderTrust ?? false;
   const folderTrust = folderTrustFeature && folderTrustSetting;
 
+  let enabledExtensions: string[];
+  if (argv.extensions) {
+    // If the CLI flag is used, it takes precedence.
+    enabledExtensions = argv.extensions;
+  } else {
+    // Otherwise, use the settings to determine the enabled list.
+    const allAvailableNames = extensions.map((ext) => ext.config.name);
+    const disabledFromSettings = settings.extensions?.disabled || [];
+    const disabledNamesSet = new Set(
+      disabledFromSettings.map((name) => name.toLowerCase()),
+    );
+    enabledExtensions = allAvailableNames.filter(
+      (name) => !disabledNamesSet.has(name.toLowerCase()),
+    );
+  }
+
   const allExtensions = annotateActiveExtensions(
     extensions,
-    argv.extensions || [],
+    enabledExtensions || [],
   );
 
   const activeExtensions = extensions.filter(

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -38,11 +38,10 @@ function getSystemExtensionsPath(): string {
       'extensions',
     );
   } else if (os.platform() === 'win32') {
-    return path.join(
-      process.env.PROGRAMDATA || 'C:\\ProgramData',
-      'gemini-cli',
-      'extensions',
-    );
+    if (process.env.PROGRAMDATA) {
+      return path.join(process.env.PROGRAMDATA, 'gemini-cli', 'extensions');
+    }
+    return '';
   } else {
     return '/usr/share/gemini-cli/extensions';
   }

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -144,15 +144,6 @@ export function annotateActiveExtensions(
 ): GeminiCLIExtension[] {
   const annotatedExtensions: GeminiCLIExtension[] = [];
 
-  if (enabledExtensionNames.length === 0) {
-    return extensions.map((extension) => ({
-      name: extension.config.name,
-      version: extension.config.version,
-      isActive: true,
-      path: extension.path,
-    }));
-  }
-
   const lowerCaseEnabledExtensions = new Set(
     enabledExtensionNames.map((e) => e.trim().toLowerCase()),
   );

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -193,3 +193,18 @@ export function annotateActiveExtensions(
 
   return annotatedExtensions;
 }
+
+export function annotateActiveExtensionsFromDisabled(
+  extensions: Extension[],
+  disabledExtensionNames: string[],
+): GeminiCLIExtension[] {
+  const allAvailableNames = extensions.map((ext) => ext.config.name);
+  const disabledNamesSet = new Set(
+    disabledExtensionNames.map((name) => name.toLowerCase()),
+  );
+  const enabledExtensions = allAvailableNames.filter(
+    (name) => !disabledNamesSet.has(name.toLowerCase()),
+  );
+
+  return annotateActiveExtensions(extensions, enabledExtensions);
+}

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -114,6 +114,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        extensions: {
+          disabled: [],
+        },
       });
       expect(settings.errors.length).toBe(0);
     });
@@ -149,6 +152,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        extensions: {
+          disabled: [],
+        },
       });
     });
 
@@ -184,6 +190,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        extensions: {
+          disabled: [],
+        },
       });
     });
 
@@ -217,6 +226,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        extensions: {
+          disabled: [],
+        },
       });
     });
 
@@ -256,6 +268,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        extensions: {
+          disabled: [],
+        },
       });
     });
 
@@ -307,6 +322,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        extensions: {
+          disabled: [],
+        },
       });
     });
 
@@ -828,6 +846,46 @@ describe('Settings Loading and Merging', () => {
       ]);
     });
 
+    it('should merge extensions.disabled from all scopes', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const systemSettingsContent = {
+        extensions: { disabled: ['system-ext'] },
+      };
+      const userSettingsContent = {
+        extensions: { disabled: ['user-ext', 'shared-ext'] },
+      };
+      const workspaceSettingsContent = {
+        extensions: { disabled: ['workspace-ext', 'shared-ext'] },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === getSystemSettingsPath())
+            return JSON.stringify(systemSettingsContent);
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // Use a Set to account for duplicates, then convert back to a sorted array for a stable assertion.
+      const expectedDisabled = [
+        'system-ext',
+        'user-ext',
+        'shared-ext',
+        'workspace-ext',
+      ];
+      const actualDisabled = [
+        ...new Set(settings.merged.extensions?.disabled || []),
+      ].sort();
+
+      expect(actualDisabled).toEqual(expectedDisabled.sort());
+    });
+
     it('should handle JSON parsing errors gracefully', () => {
       (mockFsExistsSync as Mock).mockReturnValue(true); // Both files "exist"
       const invalidJsonContent = 'invalid json';
@@ -868,6 +926,9 @@ describe('Settings Loading and Merging', () => {
         mcpServers: {},
         includeDirectories: [],
         chatCompression: {},
+        extensions: {
+          disabled: [],
+        },
       });
 
       // Check that error objects are populated in settings.errors
@@ -1306,6 +1367,9 @@ describe('Settings Loading and Merging', () => {
           mcpServers: {},
           includeDirectories: [],
           chatCompression: {},
+          extensions: {
+            disabled: [],
+          },
         });
       });
     });

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -126,6 +126,13 @@ export class LoadedSettings {
         ...(user.includeDirectories || []),
         ...(workspace.includeDirectories || []),
       ],
+      extensions: {
+        disabled: [
+          ...(system.extensions?.disabled || []),
+          ...(user.extensions?.disabled || []),
+          ...(workspace.extensions?.disabled || []),
+        ],
+      },
       chatCompression: {
         ...(system.chatCompression || {}),
         ...(user.chatCompression || {}),

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -31,7 +31,10 @@ export function getSystemSettingsPath(): string {
   if (platform() === 'darwin') {
     return '/Library/Application Support/GeminiCli/settings.json';
   } else if (platform() === 'win32') {
-    return 'C:\\ProgramData\\gemini-cli\\settings.json';
+    if (process.env.PROGRAMDATA) {
+      return path.join(process.env.PROGRAMDATA, 'gemini-cli', 'settings.json');
+    }
+    return '';
   } else {
     return '/etc/gemini-cli/settings.json';
   }

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -485,6 +485,26 @@ export const SETTINGS_SCHEMA = {
     description: 'Setting to track whether Folder trust is enabled.',
     showInDialog: true,
   },
+  extensions: {
+    type: 'object',
+    label: 'Extensions',
+    category: 'Advanced',
+    requiresRestart: true,
+    default: {},
+    description: 'Extension settings.',
+    showInDialog: false,
+    properties: {
+      disabled: {
+        type: 'array',
+        label: 'Disabled Extensions',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: [] as string[],
+        description: 'A list of extension names to disable.',
+        showInDialog: false,
+      },
+    },
+  },
   chatCompression: {
     type: 'object',
     label: 'Chat Compression',


### PR DESCRIPTION
## TLDR

This pull request introduces a new command, `gemini extensions list`, which displays all installed extensions. The list indicates whether each extension is enabled or disabled, and also shows its version and installed path.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

This depends on #6025 and contains commits from that PR as well.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | x  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #5989
