### PR TITLE
fix: use server-returned project for gca free tier auth

### DIFF
--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -33,38 +33,58 @@ export interface UserData {
  * @returns the user's actual project id
  */
 export async function setupUser(client: OAuth2Client): Promise<UserData> {
-  let projectId = process.env.GOOGLE_CLOUD_PROJECT || undefined;
+  const projectId = process.env.GOOGLE_CLOUD_PROJECT || undefined;
   const caServer = new CodeAssistServer(client, projectId, {}, '', undefined);
-
-  const clientMetadata: ClientMetadata = {
+  const coreClientMetadata: ClientMetadata = {
     ideType: 'IDE_UNSPECIFIED',
     platform: 'PLATFORM_UNSPECIFIED',
     pluginType: 'GEMINI',
-    duetProject: projectId,
   };
 
   const loadRes = await caServer.loadCodeAssist({
     cloudaicompanionProject: projectId,
-    metadata: clientMetadata,
+    metadata: {
+      ...coreClientMetadata,
+      duetProject: projectId,
+    },
   });
 
-  if (!projectId && loadRes.cloudaicompanionProject) {
-    projectId = loadRes.cloudaicompanionProject;
+  if (loadRes.currentTier) {
+    if (!loadRes.cloudaicompanionProject) {
+      if (projectId) {
+        return {
+          projectId,
+          userTier: loadRes.currentTier.id,
+        };
+      }
+      throw new ProjectIdRequiredError();
+    }
+    return {
+      projectId: loadRes.cloudaicompanionProject,
+      userTier: loadRes.currentTier.id,
+    };
   }
 
   const tier = getOnboardTier(loadRes);
 
+  let onboardReq: OnboardUserRequest;
   if (tier.id === UserTierId.FREE) {
     // The free tier uses a managed google cloud project. Setting a project in the `onboardUser` request causes a `Precondition Failed` error.
-    projectId = undefined;
-    clientMetadata.duetProject = undefined;
+    onboardReq = {
+      tierId: tier.id,
+      cloudaicompanionProject: undefined,
+      metadata: coreClientMetadata,
+    };
+  } else {
+    onboardReq = {
+      tierId: tier.id,
+      cloudaicompanionProject: projectId,
+      metadata: {
+        ...coreClientMetadata,
+        duetProject: projectId,
+      },
+    };
   }
-
-  const onboardReq: OnboardUserRequest = {
-    tierId: tier.id,
-    cloudaicompanionProject: projectId,
-    metadata: clientMetadata,
-  };
 
   // Poll onboardUser until long running operation is complete.
   let lroRes = await caServer.onboardUser(onboardReq);
@@ -73,24 +93,23 @@ export async function setupUser(client: OAuth2Client): Promise<UserData> {
     lroRes = await caServer.onboardUser(onboardReq);
   }
 
-  if (lroRes.response?.cloudaicompanionProject?.id) {
-    projectId = lroRes.response.cloudaicompanionProject.id;
-  }
-
-  if (!projectId) {
+  if (!lroRes.response?.cloudaicompanionProject?.id) {
+    if (projectId) {
+      return {
+        projectId,
+        userTier: tier.id,
+      };
+    }
     throw new ProjectIdRequiredError();
   }
 
   return {
-    projectId,
+    projectId: lroRes.response.cloudaicompanionProject.id,
     userTier: tier.id,
   };
 }
 
 function getOnboardTier(res: LoadCodeAssistResponse): GeminiUserTier {
-  if (res.currentTier) {
-    return res.currentTier;
-  }
   for (const tier of res.allowedTiers || []) {
     if (tier.isDefault) {
       return tier;


### PR DESCRIPTION
## TLDR

  This pull request addresses a bug that caused authentication failures for free-tier users who had the
  `GOOGLE_CLOUD_PROJECT` environment variable set. The fix ensures that the client-side logic respects the server-managed project for the free tier, preventing a `Precondition Failed` error.

##  Dive Deeper

  For free-tier users, Gemini Code Assist manages the Google Cloud project on the server side. Previously, if a user had
  the `GOOGLE_CLOUD_PROJECT` environment variable set, the client would erroneously send this project ID in the onboardUser request. This conflicts with the server's expectation for the free tier, leading to a 400 Precondition Failed error. This is a recently enforced behavior on the API which is why it was working earlier.


  This patch corrects the behavior by:
   1. Identifying if the user is on the free tier.
   2. If so, it refrains from sending a projectId in the onboardUser request, even if GOOGLE_CLOUD_PROJECT is set.
   3. It then correctly uses the cloudaicompanionProject.id returned in the onboardUser response as the projectId for the
      remainder of the session.
   4. A new unit test has been added to packages/core/src/code_assist/setup.test.ts to cover this specific scenario and
      prevent regressions.

##  Reviewer Test Plan

  To validate this fix, a reviewer can perform the following steps:

   1. Create an OTA on http://rhea.
   2. Set the `GOOGLE_CLOUD_PROJECT` environment variable in your shell to some value
   3. Run the Gemini CLI and attempt to authenticate with the OTA account.
   4. Expected Result: The authentication process should complete successfully without any Precondition Failed errors. The CLI should be ready to use.


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**


*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
- Fixes #5331 
