### PR TITLE
feat(triage): Improve GitHub issue triage workflows

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -55,15 +55,31 @@ jobs:
           app-id: '${{ secrets.APP_ID }}'
           private-key: '${{ secrets.PRIVATE_KEY }}'
 
-      - name: 'Run Gemini Issue Triage'
+      - name: 'Get Repository Labels'
+        id: 'get_labels'
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
+        with:
+          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
+          script: |-
+            const { data: labels } = await github.rest.issues.listLabelsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const labelNames = labels.map(label => label.name);
+            core.setOutput('available_labels', labelNames.join(','));
+            core.info(`Found ${labelNames.length} labels: ${labelNames.join(', ')}`);
+            return labelNames;
+
+      - name: 'Run Gemini Issue Analysis'
         uses: 'google-github-actions/run-gemini-cli@06123c6a203eb7a964ce3be7c48479cc66059f23' # ratchet:google-github-actions/run-gemini-cli@v0
-        id: 'gemini_issue_triage'
+        id: 'gemini_issue_analysis'
         env:
-          GITHUB_TOKEN: '${{ steps.generate_token.outputs.token }}'
+          GITHUB_TOKEN: '' # Do not pass any auth token here since this runs on untrusted inputs
           ISSUE_TITLE: '${{ github.event.issue.title }}'
           ISSUE_BODY: '${{ github.event.issue.body }}'
           ISSUE_NUMBER: '${{ github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'
+          AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
         with:
           gcp_workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           gcp_project_id: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
@@ -76,10 +92,7 @@ jobs:
             {
               "maxSessionTurns": 25,
               "coreTools": [
-                "run_shell_command(echo)",
-                "run_shell_command(gh label list)",
-                "run_shell_command(gh issue edit)",
-                "run_shell_command(gh issue list)"
+                "run_shell_command(echo)"
               ],
               "telemetry": {
                 "enabled": true,
@@ -89,29 +102,42 @@ jobs:
           prompt: |-
             ## Role
 
-            You are an issue triage assistant. Analyze the current GitHub issue and apply the most appropriate existing labels. Use the available
-            tools to gather information; do not ask for information to be provided. Do not remove labels titled help wanted or good first issue.
+            You are an issue triage assistant. Analyze the current GitHub issue
+            and identify the most appropriate existing labels. Use the available
+            tools to gather information; do not ask for information to be
+            provided. Do not remove labels titled help wanted or good first issue.
 
             ## Steps
 
-            1. Run: `gh label list --repo "${REPOSITORY}" --limit 100` to get all available labels.
+            1. Review the available labels in the environment variable: "${AVAILABLE_LABELS}".
             2. Review the issue title and body provided in the environment variables: "${ISSUE_TITLE}" and "${ISSUE_BODY}".
             3. Ignore any existing priorities or tags on the issue. Just report your findings.
             4. Select the most relevant labels from the existing labels, focusing on kind/*, area/*, sub-area/* and priority/*. For area/* and kind/* limit yourself to only the single most applicable label in each case.
-            6. Apply the selected labels to this issue using: `gh issue edit "${ISSUE_NUMBER}" --repo "${REPOSITORY}" --add-label "label1,label2"`.
-            7. For each issue please check if CLI version is present, this is usually in the output of the /about command  and will look like 0.1.5 for anything more than 6 versions older than the most recent should add the status/need-retesting label.
-            8. If you see that the issue doesn't look like it has sufficient information recommend the status/need-information label.
+            5. For each issue please check if CLI version is present, this is usually in the output of the /about command and will look like 0.1.5 for anything more than 6 versions older than the most recent should add the status/need-retesting label.
+            6. If you see that the issue doesn't look like it has sufficient information recommend the status/need-information label.
+            7. Output the appropriate labels for this issue in JSON format with explanation, for example:
+               ```
+               {"labels_to_set": ["kind/bug", "priority/p0"], "explanation": "This is a critical bug report affecting main functionality"}
+               ```
+            8. If the issue cannot be classified using the available labels, output:
+               ```
+               {"labels_to_set": [], "explanation": "Unable to classify this issue with available labels"}
+               ```
             9. Use Area definitions mentioned below to help you narrow down issues.
 
             ## Guidelines
 
-            - Only use labels that already exist in the repository.
-            - Do not add comments or modify the issue content.
-            - Triage only the current issue.
-            - Apply only one area/ label.
-            - Apply only one kind/ label.
-            - Apply all applicable sub-area/* and priority/* labels based on the issue content. It's ok to have multiple of these.
-            - Once you categorize the issue if it needs information bump down the priority by 1 eg.. a p0 would become a p1 a p1 would become a p2. P2 and P3 can stay as is in this scenario.
+            - Only use labels that already exist in the repository
+            - Do not add comments or modify the issue content
+            - Triage only the current issue
+            - Identify only one area/ label
+            - Identify only one kind/ label
+            - Identify all applicable sub-area/* and priority/* labels based on the issue content. It's ok to have multiple of these
+            - Once you categorize the issue if it needs information bump down the priority by 1 eg.. a p0 would become a p1 a p1 would become a p2. P2 and P3 can stay as is in this scenario
+            - Reference all shell variables as "${VAR}" (with quotes and braces)
+            - Output only valid JSON format
+            - Do not include any explanation or additional text, just the JSON
+
             Categorization Guidelines:
             P0: Critical / Blocker
             - A P0 bug is a catastrophic failure that demands immediate attention. It represents a complete showstopper for a significant portion of users or for the development process itself.
@@ -189,21 +215,63 @@ jobs:
             - other general software performance like, memory usage, CPU consumption, and algorithmic efficiency.
             - Switching models from one to the other unexpectedly.
 
-      - name: 'Post Issue Triage Failure Comment'
+      - name: 'Apply Labels to Issue'
         if: |-
-          ${{ failure() && steps.gemini_issue_triage.outcome == 'failure' }}
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
+          ${{ steps.gemini_issue_analysis.outputs.summary != '' }}
         env:
           REPOSITORY: '${{ github.repository }}'
-          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          ISSUE_NUMBER: '${{ github.event.issue.number }}'
+          LABELS_OUTPUT: '${{ steps.gemini_issue_analysis.outputs.summary }}'
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
         with:
-          github-token: '${{ steps.generate_token.outputs.token }}'
+          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
+          script: |-
+            // Strip code block markers if present
+            const rawLabels = process.env.LABELS_OUTPUT;
+            core.info(`Raw labels JSON: ${rawLabels}`);
+            let parsedLabels;
+            try {
+              const trimmedLabels = rawLabels.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '').trim();
+              parsedLabels = JSON.parse(trimmedLabels);
+              core.info(`Parsed labels JSON: ${JSON.stringify(parsedLabels)}`);
+            } catch (err) {
+              core.setFailed(`Failed to parse labels JSON from Gemini output: ${err.message}\nRaw output: ${rawLabels}`);
+              return;
+            }
+
+            const issueNumber = parseInt(process.env.ISSUE_NUMBER);
+
+            // Set labels based on triage result
+            if (parsedLabels.labels_to_set && parsedLabels.labels_to_set.length > 0) {
+              await github.rest.issues.setLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: parsedLabels.labels_to_set
+              });
+              const explanation = parsedLabels.explanation ? ` - ${parsedLabels.explanation}` : '';
+              core.info(`Successfully set labels for #${issueNumber}: ${parsedLabels.labels_to_set.join(', ')}${explanation}`);
+            } else {
+              // If no labels to set, leave the issue as is
+              const explanation = parsedLabels.explanation ? ` - ${parsedLabels.explanation}` : '';
+              core.info(`No labels to set for #${issueNumber}, leaving as is${explanation}`);
+            }
+
+      - name: 'Post Issue Analysis Failure Comment'
+        if: |-
+          ${{ failure() && steps.gemini_issue_analysis.outcome == 'failure' }}
+        env:
+          ISSUE_NUMBER: '${{ github.event.issue.number }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
+        with:
+          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           script: |-
             github.rest.issues.createComment({
-              owner: process.env.REPOSITORY.split('/')[0],
-              repo: process.env.REPOSITORY.split('/')[1],
-              issue_number: '${{ github.event.issue.number }}',
-              body: `There is a problem with the Gemini CLI issue triaging. Please check the [action logs](${process.env.RUN_URL}) for details.`
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt(process.env.ISSUE_NUMBER),
+              body: 'There is a problem with the Gemini CLI issue triaging. Please check the [action logs](${process.env.RUN_URL}) for details.'
             })
 
   deduplicate-issues:

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -62,15 +62,31 @@ jobs:
           ISSUE_COUNT="$(echo "${ISSUES}" | jq 'length')"
           echo "✅ Found ${ISSUE_COUNT} issues to triage! 🎯"
 
-      - name: 'Run Gemini Issue Triage'
+      - name: 'Get Repository Labels'
+        id: 'get_labels'
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
+        with:
+          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
+          script: |-
+            const { data: labels } = await github.rest.issues.listLabelsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const labelNames = labels.map(label => label.name);
+            core.setOutput('available_labels', labelNames.join(','));
+            core.info(`Found ${labelNames.length} labels: ${labelNames.join(', ')}`);
+            return labelNames;
+
+      - name: 'Run Gemini Issue Analysis'
         if: |-
           ${{ steps.find_issues.outputs.issues_to_triage != '[]' }}
         uses: 'google-github-actions/run-gemini-cli@06123c6a203eb7a964ce3be7c48479cc66059f23' # ratchet:google-github-actions/run-gemini-cli@v0
-        id: 'gemini_issue_triage'
+        id: 'gemini_issue_analysis'
         env:
-          GITHUB_TOKEN: '${{ steps.generate_token.outputs.token }}'
+          GITHUB_TOKEN: '' # Do not pass any auth token here since this runs on untrusted inputs
           ISSUES_TO_TRIAGE: '${{ steps.find_issues.outputs.issues_to_triage }}'
           REPOSITORY: '${{ github.repository }}'
+          AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
         with:
           gcp_workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           gcp_project_id: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
@@ -84,10 +100,6 @@ jobs:
               "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command(echo)",
-                "run_shell_command(gh label list)",
-                "run_shell_command(gh issue edit)",
-                "run_shell_command(gh issue view)",
-                "run_shell_command(gh issue list)"
               ],
               "telemetry": {
                 "enabled": true,
@@ -97,46 +109,55 @@ jobs:
           prompt: |-
             ## Role
 
-            You are an issue triage assistant. Analyze issues and apply
+            You are an issue triage assistant. Analyze issues and identify
             appropriate labels. Use the available tools to gather information;
             do not ask for information to be provided.
 
             ## Steps
 
-            1. Run: `gh label list --repo "${REPOSITORY}" --limit 100` to get all available labels.
+            1. Review the available labels in the environment variable: "${AVAILABLE_LABELS}".
             2. Check environment variable for issues to triage: $ISSUES_TO_TRIAGE (JSON array of issues)
             3. Review the issue title, body and any comments provided in the environment variables.
             4. Ignore any existing priorities or tags on the issue.
-            5. Select the most relevant labels from the existing labels, focusing on kind/*, area/*, sub-area/* and priority/*.
-            6. Get the list of labels already on the issue using `gh issue view ISSUE_NUMBER --repo "${REPOSITORY}" --json labels -t '{{range .labels}}{{.name}}{{"\n"}}{{end}}'
+            5. Identify the most relevant labels from the existing labels, focusing on kind/*, area/*, sub-area/* and priority/*.
+            6. Identify other applicable labels based on the issue content, such as status/*, help wanted, good first issue, etc.
             7. For area/* and kind/* limit yourself to only the single most applicable label in each case.
-            8. Give me a single short paragraph about why you are selecting each label in the process. use the format Issue ID: , Title, Label applied:, Label removed, ovearll explanation
-            9. Parse the JSON array from step 2 and for EACH INDIVIDUAL issue, apply appropriate labels using separate commands:
-              - `gh issue edit ISSUE_NUMBER --repo "${REPOSITORY}" --add-label "label1"`
-              - `gh issue edit ISSUE_NUMBER --repo "${REPOSITORY}" --add-label "label2"`
-              - Continue for each label separately
-              - IMPORTANT: Label each issue individually, one command per issue, one label at a time if needed.
-              - Make sure after you apply labels there is only one area/* and one kind/* label per issue.
-              - To do this look for labels found in step 6 that no longer apply remove them one at a time using
-              - `gh issue edit ISSUE_NUMBER --repo "${REPOSITORY}" --remove-label "label-name1"`
-              - `gh issue edit ISSUE_NUMBER --repo "${REPOSITORY}" --remove-label "label-name2"`
-              - IMPORTANT: Remove each label one at a time, one command per issue if needed.
+            8. Give me a single short explanation about why you are selecting each label in the process.
+            9. Output a JSON array of objects, each containing the issue number
+               and the labels to add and remove, along with an explanation. For example:
+               ```
+               [
+                 {
+                   "issue_number": 123,
+                   "labels_to_add": ["kind/bug", "priority/p2"],
+                   "labels_to_remove": ["status/needs-triage"],
+                   "explanation": "This issue is a bug that needs to be addressed with medium priority."
+                 },
+                 {
+                   "issue_number": 456,
+                   "labels_to_add": ["kind/enhancement"],
+                   "labels_to_remove": [],
+                   "explanation": "This issue is an enhancement request that could improve the user experience."
+                 }
+               ]
+               ```
+              If an issue cannot be classified, do not include it in the output array.
             10. For each issue please check if CLI version is present, this is usually in the output of the /about command and will look like 0.1.5
               - Anything more than 6 versions older than the most recent should add the status/need-retesting label
             11. If you see that the issue doesn't look like it has sufficient information recommend the status/need-information label
-              - After applying appropriate labels to an issue, remove the "status/need-triage" label if present: `gh issue edit ISSUE_NUMBER --repo "${REPOSITORY}" --remove-label "status/need-triage"`
-              - Execute one `gh issue edit` command per issue, wait for success before proceeding to the next
-            Process each issue sequentially and confirm each labeling operation before moving to the next issue.
+              - After identifying appropriate labels to an issue, add "status/need-triage" label to labels_to_remove in the output.
 
             ## Guidelines
 
+            - Output only valid JSON format
+            - Do not include any explanation or additional text, just the JSON
             - Only use labels that already exist in the repository.
               - Do not add comments or modify the issue content.
               - Do not remove labels titled help wanted or good first issue.
               - Triage only the current issue.
-              - Apply only one area/ label
-              - Apply only one kind/ label (Do not apply kind/duplicate or kind/parent-issue)
-              - Apply all applicable sub-area/* and priority/* labels based on the issue content. It's ok to have multiple of these.
+              - Identify only one area/ label
+              - Identify only one kind/ label (Do not apply kind/duplicate or kind/parent-issue)
+              - Identify all applicable sub-area/* and priority/* labels based on the issue content. It's ok to have multiple of these.
               - Once you categorize the issue if it needs information bump down the priority by 1 eg.. a p0 would become a p1 a p1 would become a p2. P2 and P3 can stay as is in this scenario.
             Categorization Guidelines:
             P0: Critical / Blocker
@@ -223,6 +244,53 @@ jobs:
               - could also pertain to latency,
               - other general software performance like, memory usage, CPU consumption, and algorithmic efficiency.
               - Switching models from one to the other unexpectedly.
+
+      - name: 'Apply Labels to Issues'
+        if: |-
+          ${{ steps.gemini_issue_analysis.outcome == 'success' &&
+              steps.gemini_issue_analysis.outputs.summary != '[]' }}
+        env:
+          REPOSITORY: '${{ github.repository }}'
+          LABELS_OUTPUT: '${{ steps.gemini_issue_analysis.outputs.summary }}'
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
+        with:
+          github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
+          script: |-
+            // Strip code block markers if present
+            const rawLabels = process.env.LABELS_OUTPUT;
+            core.info(`Raw labels JSON: ${rawLabels}`);
+            let parsedLabels;
+            try {
+              const trimmedLabels = rawLabels.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '').trim();
+              parsedLabels = JSON.parse(trimmedLabels);
+              core.info(`Parsed labels JSON: ${JSON.stringify(parsedLabels)}`);
+            } catch (err) {
+              core.setFailed(`Failed to parse labels JSON from Gemini output: ${err.message}\nRaw output: ${rawLabels}`);
+              return;
+            }
+
+            for (const entry of parsedLabels) {
+              const issueNumber = entry.issue_number;
+              if (!issueNumber) {
+                core.info(`Skipping entry with no issue number: ${JSON.stringify(entry)}`);
+                continue;
+              }
+
+              // Set labels based on triage result
+              if (entry.labels_to_set && entry.labels_to_set.length > 0) {
+                await github.rest.issues.setLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  labels: entry.labels_to_set
+                });
+                const explanation = entry.explanation ? ` - ${entry.explanation}` : '';
+                core.info(`Successfully set labels for #${issueNumber}: ${entry.labels_to_set.join(', ')}${explanation}`);
+              } else {
+                // If no labels to set, leave the issue as is
+                core.info(`No labels to set for #${issueNumber}, leaving as is`);
+              }
+            }
 
   refresh-embeddings:
     if: |-


### PR DESCRIPTION
This commit improves the issue triage process in the GitHub Actions workflows by:

- Fetching all repository labels at the beginning of the workflow and passing them as an environment variable to Gemini CLI. This avoids the need for the `gh` commands in the prompt.
- Updating the prompt for the Gemini CLI to use `AVAILABLE_LABELS` environment variable and to output the labels in JSON format.
- Adding a new step to apply the labels to the issue using the `actions/github-script` action. This script parses the JSON output from Gemini CLI and applies the labels to the issue.

These changes make the issue triage process more robust and reliable.
