### PR TITLE
feat: update pending tool call message to mention Esc and Ctrl+C for cancellation

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -175,7 +175,7 @@ export const ToolConfirmationMessage: React.FC<
         value: ToolConfirmationOutcome.ProceedAlways,
       },
       {
-        label: 'No, suggest changes (esc)',
+        label: 'No, suggest changes (esc or ctrl+c)',
         value: ToolConfirmationOutcome.Cancel,
       },
     );

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -138,7 +138,7 @@ export const ToolConfirmationMessage: React.FC<
     );
     if (config?.getIdeMode()) {
       options.push({
-        label: 'No (esc)',
+        label: 'No (esc or ctrl+c)',
         value: ToolConfirmationOutcome.Cancel,
       });
     } else {
@@ -147,7 +147,7 @@ export const ToolConfirmationMessage: React.FC<
         value: ToolConfirmationOutcome.ModifyWithEditor,
       });
       options.push({
-        label: 'No, suggest changes (esc)',
+        label: 'No, suggest changes (esc or ctrl+c)',
         value: ToolConfirmationOutcome.Cancel,
       });
     }
@@ -215,7 +215,7 @@ export const ToolConfirmationMessage: React.FC<
         value: ToolConfirmationOutcome.ProceedAlways,
       },
       {
-        label: 'No, suggest changes (esc)',
+        label: 'No, suggest changes (esc or ctrl+c)',
         value: ToolConfirmationOutcome.Cancel,
       },
     );
@@ -259,7 +259,7 @@ export const ToolConfirmationMessage: React.FC<
         value: ToolConfirmationOutcome.ProceedAlwaysServer,
       },
       {
-        label: 'No, suggest changes (esc)',
+        label: 'No, suggest changes (esc or ctrl+c)',
         value: ToolConfirmationOutcome.Cancel,
       },
     );


### PR DESCRIPTION
<h2>TLDR</h2>
<p>Updated the pending tool call confirmation label in <strong>Gemini CLI</strong> to mention both <code>Esc</code> and <code>Ctrl+C</code> as cancellation options. Previously, the label only referenced <code>Esc</code>. This aligns the message with the new feature where <code>Ctrl+C</code> can now also be used to cancel.</p>
<h2>Dive Deeper</h2>
<p>In the confirmation dialog for pending tool calls, the “No, suggest changes” option label was:</p>
<pre><code>No, suggest changes (esc)
</code></pre>
<p>Since the latest release added <code>Ctrl+C</code> support for canceling pending tool calls, this label has been updated to:</p>
<pre><code>No, suggest changes (esc or ctrl+c)
</code></pre>
<p>This change improves clarity for users by making both supported cancellation keys visible right in the UI, reducing guesswork and improving discoverability.</p>
<h2>Reviewer Test Plan</h2>
<ol>
<li>
<p>Pull the changes locally.</p>
</li>
<li>
<p>Trigger a pending tool call scenario.</p>
</li>
<li>
<p>In the confirmation dialog, verify the label now reads:</p>
<pre><code>No, suggest changes (esc or ctrl+c)
</code></pre>
</li>
<li>
<p>Test canceling via both <code>Esc</code> and <code>Ctrl+C</code> to confirm they work as intended.</p>
</li>
</ol>
<h2>Testing Matrix</h2>

  | 🍏 | 🪟 | 🐧
-- | -- | -- | --
npm run | ❓ | ❓ | ❓
npx | ❓ | ❓ | ❓
Docker | ❓ | ❓ | ❓
Podman | ❓ | - | -
Seatbelt | ❓ | - | -


<h2>Linked issues / bugs</h2>
<p>Resolves #6123</p>