### PR TITLE
Fix/emoji support

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import stripAnsi from 'strip-ansi';
 import { renderHook, act } from '@testing-library/react';
 import {
   useTextBuffer,
@@ -1277,6 +1278,36 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
         }),
       );
       expect(getBufferState(result).text).toBe('Pasted Text');
+    });
+
+    it('should not strip popular emojis', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({ viewport, isValidPath: () => false }),
+      );
+      const emojis = '🐍🐳🦀🦄';
+      act(() => result.current.handleInput(emojis, {}));
+      expect(getBufferState(result).text).toBe(emojis);
+    });
+  });
+
+  describe('stripAnsi', () => {
+    it('should correctly strip ANSI escape codes', () => {
+      const textWithAnsi = '\x1B[31mHello\x1B[0m World';
+      expect(stripAnsi(textWithAnsi)).toBe('Hello World');
+    });
+
+    it('should handle multiple ANSI codes', () => {
+      const textWithMultipleAnsi = '\x1B[1m\x1B[34mBold Blue\x1B[0m Text';
+      expect(stripAnsi(textWithMultipleAnsi)).toBe('Bold Blue Text');
+    });
+
+    it('should not modify text without ANSI codes', () => {
+      const plainText = 'Plain text';
+      expect(stripAnsi(plainText)).toBe('Plain text');
+    });
+
+    it('should handle empty string', () => {
+      expect(stripAnsi('')).toBe('');
     });
   });
 });

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -1285,7 +1285,16 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
         useTextBuffer({ viewport, isValidPath: () => false }),
       );
       const emojis = '🐍🐳🦀🦄';
-      act(() => result.current.handleInput(emojis, {}));
+      act(() =>
+        result.current.handleInput({
+          name: '',
+          ctrl: false,
+          meta: false,
+          shift: false,
+          paste: false,
+          sequence: emojis,
+        }),
+      );
       expect(getBufferState(result).text).toBe(emojis);
     });
   });

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -5,6 +5,7 @@
  */
 
 import stripAnsi from 'strip-ansi';
+import { stripVTControlCharacters } from 'util';
 import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
@@ -496,21 +497,44 @@ export const replaceRangeInternal = (
 /**
  * Strip characters that can break terminal rendering.
  *
- * Strip ANSI escape codes and control characters except for line breaks.
- * Control characters such as delete break terminal UI rendering.
+ * Uses Node.js built-in stripVTControlCharacters to handle VT sequences,
+ * then filters remaining control characters that can disrupt display.
+ *
+ * Characters stripped:
+ * - ANSI escape sequences (via strip-ansi)
+ * - VT control sequences (via Node.js util.stripVTControlCharacters)
+ * - C0 control chars (0x00-0x1F) except CR/LF which are handled elsewhere
+ * - C1 control chars (0x80-0x9F) that can cause display issues
+ *
+ * Characters preserved:
+ * - All printable Unicode including emojis
+ * - DEL (0x7F) - handled functionally by applyOperations, not a display issue
+ * - CR/LF (0x0D/0x0A) - needed for line breaks
  */
 function stripUnsafeCharacters(str: string): string {
-  const stripped = stripAnsi(str);
-  return toCodePoints(stripped)
+  const strippedAnsi = stripAnsi(str);
+  const strippedVT = stripVTControlCharacters(strippedAnsi);
+
+  return toCodePoints(strippedVT)
     .filter((char) => {
-      if (char.length > 1) return false;
       const code = char.codePointAt(0);
-      if (code === undefined) {
-        return false;
-      }
-      const isUnsafe =
-        code === 127 || (code <= 31 && code !== 13 && code !== 10);
-      return !isUnsafe;
+      if (code === undefined) return false;
+
+      // Preserve CR/LF for line handling
+      if (code === 0x0a || code === 0x0d) return true;
+
+      // Remove C0 control chars (except CR/LF) that can break display
+      // Examples: BELL(0x07) makes noise, BS(0x08) moves cursor, VT(0x0B), FF(0x0C)
+      if (code >= 0x00 && code <= 0x1f) return false;
+
+      // Remove C1 control chars (0x80-0x9F) - legacy 8-bit control codes
+      if (code >= 0x80 && code <= 0x9f) return false;
+
+      // Preserve DEL (0x7F) - it's handled functionally by applyOperations as backspace
+      // and doesn't cause rendering issues when displayed
+
+      // Preserve all other characters including Unicode/emojis
+      return true;
     })
     .join('');
 }


### PR DESCRIPTION
This is a copy of https://github.com/google-gemini/gemini-cli/pull/2074
with an extra fix to resolve the failing test case.
Fyi @elasticdotventures thanks for doing all the hard work here.
You will still show up as credited with the commit.
Unfortunately I wasn't able to push to your branch so had to land this here to commit.

## TLDR

This pull request addresses issue #1920 by modifying the stripUnsafeCharacters function in
  packages/cli/src/ui/components/shared/text-buffer.ts. Previously, this function was overly aggressive in
  stripping characters, inadvertently removing emojis from user input.

 ## Changes:
  The stripUnsafeCharacters function has been updated to allow emojis and other non-ASCII printable characters
   to pass through, while still filtering out actual unsafe control characters that could disrupt terminal
  rendering.


## For Reviewers:
  Please pay close attention to the updated logic within stripUnsafeCharacters. Verify that the new
  filtering mechanism correctly distinguishes between unsafe control characters and valid printable Unicode
  characters (including emojis), and that no new rendering or security issues are introduced.
  
   The goal is to explicitly allow common newline characters, and then explicitly disallow all C0 and C1 control characters,
   as well as the DEL character. This ensures that only truly unsafe characters are removed, while all
  printable Unicode characters (including emojis) are preserved.
  
## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ✅  |
| Docker   | ❓  | ❓  |  ✅ |  
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

  This change ensures that user input, including emojis, is accurately displayed in the CLI, improving the
  user experience and addressing the bug reported in #1920.

