### PR TITLE
chore(vscode): Add eslint as a recommended extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["vitest.explorer", "esbenp.prettier-vscode"]
+  "recommendations": [
+    "vitest.explorer",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
 }


### PR DESCRIPTION
## TLDR

Add Eslint Extension to the recommended list.  This makes eslint errors show up in vscode editor rather than being caught by NPM scripts or github action lint checks!

## Dive Deeper

N/A

## Reviewer Test Plan

N/A
## Testing Matrix
N/A
## Linked issues / bugs
N/A