### PR TITLE
chore(release): v0.1.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@google/gemini-cli",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "workspaces": [
         "packages/*"
       ],
@@ -12307,7 +12307,7 @@
     },
     "packages/cli": {
       "name": "@google/gemini-cli",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "dependencies": {
         "@google/gemini-cli-core": "file:../core",
         "@google/genai": "1.13.0",
@@ -12490,7 +12490,7 @@
     },
     "packages/core": {
       "name": "@google/gemini-cli-core",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "dependencies": {
         "@google/genai": "1.13.0",
         "@modelcontextprotocol/sdk": "^1.11.0",
@@ -12596,7 +12596,7 @@
     },
     "packages/test-utils": {
       "name": "@google/gemini-cli-test-utils",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "engines": {
     "node": ">=20.0.0"
   },
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/google-gemini/gemini-cli.git"
   },
   "config": {
-    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.19"
+    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.21"
   },
   "scripts": {
     "start": "node scripts/start.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "description": "Gemini CLI",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.19"
+    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.21"
   },
   "dependencies": {
     "@google/gemini-cli-core": "file:../core",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli-core",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "description": "Gemini CLI Core",
   "repository": {
     "type": "git",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli-test-utils",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "private": true,
   "main": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## TLDR

Merge release branch into main for break fix relase of 0.1.21.

## Dive Deeper

Mulitple Users reported that we don't have a valid sandbox build for builds 0.1.19 and 0.1.20.

See:

https://github.com/google-gemini/gemini-cli/pull/6207
https://github.com/google-gemini/gemini-cli/issues/6192
https://github.com/google-gemini/gemini-cli/issues/6162

### Root cause
This is due to a clean up effort where the [build file](https://github.com/google-gemini/gemini-cli/pull/6100) and the [docs](https://github.com/google-gemini/gemini-cli/pull/6107) were renamed but the internal google cloud build job was not updated as well. This cause the sandbox image generation to fail with "build file not found". 

While this was the breakage, there were several reasons our code and testing didn't catch the issue. Our integration tests build a fresh sandbox image rather than pulling the acutal docker image. Also we often don't quickly merge the updated version numbers into main so even if a build has failed testing on main would still work as long as the older version number is present.

### Future Remediation

We have multiple items on our immediate backlog that will prevent and catch breakages like this in the future. We will have these gates and validation in place in the next 2 weeks to avoid this impactful but simple breakage in the future. In short we're adding better pre/post release validation, and working to bring both the docker and npm builds in unison so we don't have consistency issues like this. Realted to do's below:

- [x] google-gemini/gemini-cli#3788 
- [x] #3694 
- [x] #3696 
- [x] #3689
- [x] #3722 