### PR TITLE
feat: VSCode multi-root workspace support

### DIFF
--- a/packages/core/src/ide/ide-client.test.ts
+++ b/packages/core/src/ide/ide-client.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { IdeClient, IDEConnectionStatus } from './ide-client.js';
+import * as detectIde from '../ide/detect-ide.js';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// Mock dependencies
+vi.mock('node:fs');
+vi.mock('../ide/detect-ide.js');
+
+describe('IdeClient', () => {
+  let originalProcess: NodeJS.Process;
+
+  beforeEach(() => {
+    // Mock process.cwd and process.env
+    originalProcess = process;
+    vi.stubGlobal('process', {
+      ...originalProcess,
+      cwd: vi.fn(),
+      env: { ...originalProcess.env },
+    });
+
+    // Mock detectIde to simulate being in VSCode
+    vi.mocked(detectIde.detectIde).mockReturnValue(detectIde.DetectedIde.VSCode);
+    vi.mocked(detectIde.getIdeInfo).mockReturnValue({
+      displayName: 'VSCode',
+    });
+
+    // Mock fs.realpathSync to return the path itself
+    vi.mocked(fs.realpathSync).mockImplementation((p) => p.toString());
+
+    // Reset singleton instance before each test
+    (IdeClient as any).instance = undefined;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetAllMocks();
+    (IdeClient as any).instance = undefined;
+  });
+
+  describe('connect', () => {
+    it('should set state to Disconnected if GEMINI_CLI_IDE_WORKSPACE_PATH is not set', async () => {
+      const ideClient = IdeClient.getInstance();
+      delete process.env['GEMINI_CLI_IDE_WORKSPACE_PATH'];
+      await ideClient.connect();
+      const state = ideClient.getConnectionStatus();
+      expect(state.status).toBe(IDEConnectionStatus.Disconnected);
+      expect(state.details).toContain(
+        'Failed to connect to IDE companion extension',
+      );
+    });
+
+    it('should set state to Disconnected if GEMINI_CLI_IDE_WORKSPACE_PATH is empty', async () => {
+      const ideClient = IdeClient.getInstance();
+      process.env['GEMINI_CLI_IDE_WORKSPACE_PATH'] = '';
+      await ideClient.connect();
+      const state = ideClient.getConnectionStatus();
+      expect(state.status).toBe(IDEConnectionStatus.Disconnected);
+      expect(state.details).toContain('please open a folder or workspace');
+    });
+
+    it('should set state to Connected if cwd is within a single workspace root', async () => {
+      const ideClient = IdeClient.getInstance();
+      const workspaceRoot = '/path/to/workspace';
+      process.env['GEMINI_CLI_IDE_WORKSPACE_PATH'] = workspaceRoot;
+      process.env['GEMINI_CLI_IDE_SERVER_PORT'] = '12345';
+      vi.mocked(process.cwd).mockReturnValue('/path/to/workspace/project');
+      const establishConnectionSpy = vi
+        .spyOn(ideClient as any, 'establishConnection')
+        .mockImplementation(async () => {
+          (ideClient as any).setState(IDEConnectionStatus.Connected);
+        });
+
+      await ideClient.connect();
+
+      const state = ideClient.getConnectionStatus();
+      expect(state.status).toBe(IDEConnectionStatus.Connected);
+      expect(establishConnectionSpy).toHaveBeenCalled();
+    });
+
+    it('should set state to Connected if cwd is the same as the single workspace root', async () => {
+      const ideClient = IdeClient.getInstance();
+      const workspaceRoot = '/path/to/workspace';
+      process.env['GEMINI_CLI_IDE_WORKSPACE_PATH'] = workspaceRoot;
+      process.env['GEMINI_CLI_IDE_SERVER_PORT'] = '12345';
+      vi.mocked(process.cwd).mockReturnValue(workspaceRoot);
+      const establishConnectionSpy = vi
+        .spyOn(ideClient as any, 'establishConnection')
+        .mockImplementation(async () => {
+          (ideClient as any).setState(IDEConnectionStatus.Connected);
+        });
+
+      await ideClient.connect();
+
+      const state = ideClient.getConnectionStatus();
+      expect(state.status).toBe(IDEConnectionStatus.Connected);
+      expect(establishConnectionSpy).toHaveBeenCalled();
+    });
+
+    it('should set state to Disconnected if cwd is outside a single workspace root', async () => {
+      const ideClient = IdeClient.getInstance();
+      const workspaceRoot = '/path/to/workspace';
+      process.env['GEMINI_CLI_IDE_WORKSPACE_PATH'] = workspaceRoot;
+      vi.mocked(process.cwd).mockReturnValue('/path/to/another/project');
+      await ideClient.connect();
+      const state = ideClient.getConnectionStatus();
+      expect(state.status).toBe(IDEConnectionStatus.Disconnected);
+      expect(state.details).toContain('Directory mismatch');
+    });
+
+    it('should set state to Connected if cwd is within one of multiple workspace roots', async () => {
+      const ideClient = IdeClient.getInstance();
+      const workspaceRoots = ['/path/to/workspace1', '/path/to/workspace2'];
+      process.env['GEMINI_CLI_IDE_WORKSPACE_PATH'] = workspaceRoots.join(
+        path.delimiter,
+      );
+      process.env['GEMINI_CLI_IDE_SERVER_PORT'] = '12345';
+      vi.mocked(process.cwd).mockReturnValue('/path/to/workspace2/project');
+      const establishConnectionSpy = vi
+        .spyOn(ideClient as any, 'establishConnection')
+        .mockImplementation(async () => {
+          (ideClient as any).setState(IDEConnectionStatus.Connected);
+        });
+
+      await ideClient.connect();
+
+      const state = ideClient.getConnectionStatus();
+      expect(state.status).toBe(IDEConnectionStatus.Connected);
+      expect(establishConnectionSpy).toHaveBeenCalled();
+    });
+
+    it('should set state to Connected if cwd is the same as one of multiple workspace roots', async () => {
+      const ideClient = IdeClient.getInstance();
+      const workspaceRoots = ['/path/to/workspace1', '/path/to/workspace2'];
+      process.env['GEMINI_CLI_IDE_WORKSPACE_PATH'] = workspaceRoots.join(
+        path.delimiter,
+      );
+      process.env['GEMINI_CLI_IDE_SERVER_PORT'] = '12345';
+      vi.mocked(process.cwd).mockReturnValue('/path/to/workspace1');
+      const establishConnectionSpy = vi
+        .spyOn(ideClient as any, 'establishConnection')
+        .mockImplementation(async () => {
+          (ideClient as any).setState(IDEConnectionStatus.Connected);
+        });
+
+      await ideClient.connect();
+
+      const state = ideClient.getConnectionStatus();
+      expect(state.status).toBe(IDEConnectionStatus.Connected);
+      expect(establishConnectionSpy).toHaveBeenCalled();
+    });
+
+    it('should set state to Disconnected if cwd is outside all multiple workspace roots', async () => {
+      const ideClient = IdeClient.getInstance();
+      const workspaceRoots = ['/path/to/workspace1', '/path/to/workspace2'];
+      process.env['GEMINI_CLI_IDE_WORKSPACE_PATH'] = workspaceRoots.join(
+        path.delimiter,
+      );
+      vi.mocked(process.cwd).mockReturnValue('/path/to/another/project');
+      await ideClient.connect();
+      const state = ideClient.getConnectionStatus();
+      expect(state.status).toBe(IDEConnectionStatus.Disconnected);
+      expect(state.details).toContain('Directory mismatch');
+    });
+
+    it('should be case-insensitive when comparing paths', async () => {
+      const ideClient = IdeClient.getInstance();
+      const workspaceRoot = '/Path/To/Workspace';
+      process.env['GEMINI_CLI_IDE_WORKSPACE_PATH'] = workspaceRoot;
+      process.env['GEMINI_CLI_IDE_SERVER_PORT'] = '12345';
+      vi.mocked(process.cwd).mockReturnValue('/path/to/workspace/project');
+      const establishConnectionSpy = vi
+        .spyOn(ideClient as any, 'establishConnection')
+        .mockImplementation(async () => {
+          (ideClient as any).setState(IDEConnectionStatus.Connected);
+        });
+
+      await ideClient.connect();
+
+      const state = ideClient.getConnectionStatus();
+      expect(state.status).toBe(IDEConnectionStatus.Connected);
+      expect(establishConnectionSpy).toHaveBeenCalled();
+    });
+
+    it('should handle non-existent paths gracefully by falling back to original path', async () => {
+      const ideClient = IdeClient.getInstance();
+      const workspaceRoot = '/path/to/non-existent';
+      process.env['GEMINI_CLI_IDE_WORKSPACE_PATH'] = workspaceRoot;
+      process.env['GEMINI_CLI_IDE_SERVER_PORT'] = '12345';
+      vi.mocked(process.cwd).mockReturnValue('/path/to/non-existent/project');
+      vi.mocked(fs.realpathSync).mockImplementation((p) => {
+        if (p.toString().includes('non-existent')) {
+          throw new Error('ENOENT');
+        }
+        return p.toString();
+      });
+      const establishConnectionSpy = vi
+        .spyOn(ideClient as any, 'establishConnection')
+        .mockImplementation(async () => {
+          (ideClient as any).setState(IDEConnectionStatus.Connected);
+        });
+
+      await ideClient.connect();
+
+      const state = ideClient.getConnectionStatus();
+      expect(state.status).toBe(IDEConnectionStatus.Connected);
+      expect(establishConnectionSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/ide/ide-client.test.ts
+++ b/packages/core/src/ide/ide-client.test.ts
@@ -14,6 +14,16 @@ import * as path from 'node:path';
 vi.mock('node:fs');
 vi.mock('../ide/detect-ide.js');
 
+type IdeClientTestApi = {
+  instance: IdeClient | undefined;
+  establishConnection: (port: string) => Promise<void>;
+  setState: (
+    status: IDEConnectionStatus,
+    details?: string,
+    logToConsole?: boolean,
+  ) => void;
+};
+
 describe('IdeClient', () => {
   let originalProcess: NodeJS.Process;
 
@@ -27,7 +37,9 @@ describe('IdeClient', () => {
     });
 
     // Mock detectIde to simulate being in VSCode
-    vi.mocked(detectIde.detectIde).mockReturnValue(detectIde.DetectedIde.VSCode);
+    vi.mocked(detectIde.detectIde).mockReturnValue(
+      detectIde.DetectedIde.VSCode,
+    );
     vi.mocked(detectIde.getIdeInfo).mockReturnValue({
       displayName: 'VSCode',
     });
@@ -36,13 +48,13 @@ describe('IdeClient', () => {
     vi.mocked(fs.realpathSync).mockImplementation((p) => p.toString());
 
     // Reset singleton instance before each test
-    (IdeClient as any).instance = undefined;
+    (IdeClient as unknown as IdeClientTestApi).instance = undefined;
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.resetAllMocks();
-    (IdeClient as any).instance = undefined;
+    (IdeClient as unknown as IdeClientTestApi).instance = undefined;
   });
 
   describe('connect', () => {
@@ -73,9 +85,11 @@ describe('IdeClient', () => {
       process.env['GEMINI_CLI_IDE_SERVER_PORT'] = '12345';
       vi.mocked(process.cwd).mockReturnValue('/path/to/workspace/project');
       const establishConnectionSpy = vi
-        .spyOn(ideClient as any, 'establishConnection')
+        .spyOn(ideClient as unknown as IdeClientTestApi, 'establishConnection')
         .mockImplementation(async () => {
-          (ideClient as any).setState(IDEConnectionStatus.Connected);
+          (ideClient as unknown as IdeClientTestApi).setState(
+            IDEConnectionStatus.Connected,
+          );
         });
 
       await ideClient.connect();
@@ -92,9 +106,11 @@ describe('IdeClient', () => {
       process.env['GEMINI_CLI_IDE_SERVER_PORT'] = '12345';
       vi.mocked(process.cwd).mockReturnValue(workspaceRoot);
       const establishConnectionSpy = vi
-        .spyOn(ideClient as any, 'establishConnection')
+        .spyOn(ideClient as unknown as IdeClientTestApi, 'establishConnection')
         .mockImplementation(async () => {
-          (ideClient as any).setState(IDEConnectionStatus.Connected);
+          (ideClient as unknown as IdeClientTestApi).setState(
+            IDEConnectionStatus.Connected,
+          );
         });
 
       await ideClient.connect();
@@ -124,9 +140,11 @@ describe('IdeClient', () => {
       process.env['GEMINI_CLI_IDE_SERVER_PORT'] = '12345';
       vi.mocked(process.cwd).mockReturnValue('/path/to/workspace2/project');
       const establishConnectionSpy = vi
-        .spyOn(ideClient as any, 'establishConnection')
+        .spyOn(ideClient as unknown as IdeClientTestApi, 'establishConnection')
         .mockImplementation(async () => {
-          (ideClient as any).setState(IDEConnectionStatus.Connected);
+          (ideClient as unknown as IdeClientTestApi).setState(
+            IDEConnectionStatus.Connected,
+          );
         });
 
       await ideClient.connect();
@@ -145,9 +163,11 @@ describe('IdeClient', () => {
       process.env['GEMINI_CLI_IDE_SERVER_PORT'] = '12345';
       vi.mocked(process.cwd).mockReturnValue('/path/to/workspace1');
       const establishConnectionSpy = vi
-        .spyOn(ideClient as any, 'establishConnection')
+        .spyOn(ideClient as unknown as IdeClientTestApi, 'establishConnection')
         .mockImplementation(async () => {
-          (ideClient as any).setState(IDEConnectionStatus.Connected);
+          (ideClient as unknown as IdeClientTestApi).setState(
+            IDEConnectionStatus.Connected,
+          );
         });
 
       await ideClient.connect();
@@ -177,9 +197,11 @@ describe('IdeClient', () => {
       process.env['GEMINI_CLI_IDE_SERVER_PORT'] = '12345';
       vi.mocked(process.cwd).mockReturnValue('/path/to/workspace/project');
       const establishConnectionSpy = vi
-        .spyOn(ideClient as any, 'establishConnection')
+        .spyOn(ideClient as unknown as IdeClientTestApi, 'establishConnection')
         .mockImplementation(async () => {
-          (ideClient as any).setState(IDEConnectionStatus.Connected);
+          (ideClient as unknown as IdeClientTestApi).setState(
+            IDEConnectionStatus.Connected,
+          );
         });
 
       await ideClient.connect();
@@ -202,9 +224,11 @@ describe('IdeClient', () => {
         return p.toString();
       });
       const establishConnectionSpy = vi
-        .spyOn(ideClient as any, 'establishConnection')
+        .spyOn(ideClient as unknown as IdeClientTestApi, 'establishConnection')
         .mockImplementation(async () => {
-          (ideClient as any).setState(IDEConnectionStatus.Connected);
+          (ideClient as unknown as IdeClientTestApi).setState(
+            IDEConnectionStatus.Connected,
+          );
         });
 
       await ideClient.connect();

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -248,7 +248,7 @@ export class IdeClient {
     }
 
     const workspaceRoots = ideWorkspacePath
-      .split(path.delimiter)
+      .split(path.delimiter).filter(Boolean)
       .map((root) => getRealPath(root).toLocaleLowerCase());
     const cwd = getRealPath(process.cwd()).toLocaleLowerCase();
 

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -248,7 +248,8 @@ export class IdeClient {
     }
 
     const workspaceRoots = ideWorkspacePath
-      .split(path.delimiter).filter(Boolean)
+      .split(path.delimiter)
+      .filter(Boolean)
       .map((root) => getRealPath(root).toLocaleLowerCase());
     const cwd = getRealPath(process.cwd()).toLocaleLowerCase();
 

--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -171,9 +171,7 @@ describe('multi-root workspace handling', () => {
     });
 
     it('should set an empty workspace path env var for no folders', async () => {
-      vi.spyOn(vscode.workspace, 'workspaceFolders', 'get').mockReturnValue(
-        [],
-      );
+      vi.spyOn(vscode.workspace, 'workspaceFolders', 'get').mockReturnValue([]);
       await activate(context);
       expect(
         context.environmentVariableCollection.replace,
@@ -183,9 +181,7 @@ describe('multi-root workspace handling', () => {
 
   describe('gemini-cli.runGeminiCLI command', () => {
     it('should create a terminal with no CWD if no workspace folder is open', async () => {
-      vi.spyOn(vscode.workspace, 'workspaceFolders', 'get').mockReturnValue(
-        [],
-      );
+      vi.spyOn(vscode.workspace, 'workspaceFolders', 'get').mockReturnValue([]);
       await activate(context);
       const command = commandMap.get('gemini-cli.runGeminiCLI');
       await (command as () => Promise<void>)();

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -22,9 +22,7 @@ let log: (message: string) => void = () => {};
 function updateWorkspacePath(context: vscode.ExtensionContext) {
   const workspaceFolders = vscode.workspace.workspaceFolders;
   if (workspaceFolders && workspaceFolders.length > 0) {
-    const workspacePaths = workspaceFolders.map(
-      (folder) => folder.uri.fsPath,
-    );
+    const workspacePaths = workspaceFolders.map((folder) => folder.uri.fsPath);
     context.environmentVariableCollection.replace(
       IDE_WORKSPACE_PATH_ENV_VAR,
       workspacePaths.join(path.delimiter),


### PR DESCRIPTION
## TLDR

The primary goal is to allow developers to use the Gemini CLI seamlessly when they have multiple project folders open in a single VSCode window (a "multi-root workspace").

## Dive Deeper

### 1. VSCode Extension Responsibilities

- **Environment Variable:** The extension is responsible for communicating the complete workspace structure to the CLI. It does this by setting the `GEMINI_CLI_IDE_WORKSPACE_PATH` environment variable.
- **Path Serialization:** When one or more workspace folders are open, the extension gets the full path of each folder, joins them into a single string using the OS-native path delimiter (`:` for macOS/Linux, `;` for Windows), and sets this string as the value for the environment variable.
- **Global Availability:** This variable is applied to the global VSCode environment using the `environmentVariableCollection` API, ensuring it's available to any terminal created within VSCode. It is updated automatically whenever a folder is added or removed from the workspace.
- **User-Selected Context:** When the user explicitly launches the Gemini CLI via the "Run Gemini CLI" command in a multi-root workspace, the extension prompts them to select which of the open folders they wish to work in. The new terminal is then created with its current working directory (`cwd`) set to the path of the selected folder.

### 2. Gemini CLI Core Responsibilities

- **Context Validation:** The CLI's `IdeClient` is responsible for validating that it is running in a valid IDE context before enabling integration features.
- **Workspace Verification:** On startup, the `IdeClient` reads the `GEMINI_CLI_IDE_WORKSPACE_PATH` environment variable. It splits the value into a list of all workspace root paths.
- **CWD Check:** It then verifies that the CLI's current working directory (`process.cwd()`) is a child directory of at least one of the paths in the list. If this check passes, the IDE integration is enabled. If it fails, the integration remains disabled, and the user is notified of the directory mismatch.

This design ensures that the CLI is only active when it's confident it's running within a folder that the user has explicitly opened in their IDE, thereby supporting multi-root setups without any ambiguity.

## Implementation

### `packages/vscode-ide-companion/src/extension.ts`

- The `updateWorkspacePath` function was modified to gather all folder paths from `vscode.workspace.workspaceFolders`, join them with `path.delimiter`, and set the result in the `environmentVariableCollection`. If no folders are open, the variable is deleted.
- The `gemini-cli.runGeminiCLI` command was updated to check for multiple workspace folders. If more than one is present, it uses `vscode.window.showQuickPick` to prompt the user for a folder, which is then used as the `cwd` for the new terminal.

### `packages/core/src/ide/ide-client.ts`

- The `validateWorkspacePath` method was rewritten.
- It now splits the `GEMINI_CLI_IDE_WORKSPACE_PATH` environment variable into an array of `workspaceRoots`.
- It checks if the current working directory is a subdirectory of *any* of the `workspaceRoots`.
- The error message for an empty `GEMINI_CLI_IDE_WORKSPACE_PATH` was updated to be more generic, prompting the user to open a folder.

### Tests

- Unit tests were added for `packages/core/src/ide/ide-client.ts` to verify the new workspace validation logic.
- Unit tests were added for `packages/vscode-ide-companion/src/extension.ts` to verify the new multi-root workspace functionality, including prompting the user to select a folder.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

I have tested this on macOS with my Chromium VSCode workspace. To test, you need to install the extension separately by building it in `packages/vscode-ide-companion` and installing the VSIX in VSCode. Then you can test the CLI with `node ~/path/to/gemini-cli/packages/cli`. Note that the "Run Gemini CLI" extension command will just execute `gemini` in the CLI so be sure to alias it or link to the development build, otherwise it will run the global installed `gemini`.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | Y  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #6209

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
