### PR TITLE
feat(core): Preload User Memory in New Chat History

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -288,6 +288,14 @@ In addition to a project settings file, a project's `.gemini` directory can cont
     "showLineNumbers": false
     ```
 
+- **`loadUserMemoryInHistory`** (boolean):
+  - **Description:** Controls whether user memory (including GEMINI.md files and other context files) is loaded into the chat history for new or cleared chats. When enabled, the content from your context files is added as a user message at the start of each new conversation, making the AI aware of your project-specific instructions throughout the entire conversation. When disabled, context files are only included in the system prompt.
+  - **Default:** `false`
+  - **Example:**
+    ```json
+    "loadUserMemoryInHistory": true
+    ```
+
 ### Example `settings.json`:
 
 ```json

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -527,6 +527,7 @@ export async function loadCliConfig(
     folderTrust,
     interactive,
     trustedFolder,
+    loadUserMemoryInHistory: settings.loadUserMemoryInHistory ?? false,
   });
 }
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -495,6 +495,16 @@ export const SETTINGS_SCHEMA = {
     description: 'Show line numbers in the chat.',
     showInDialog: true,
   },
+  loadUserMemoryInHistory: {
+    type: 'boolean',
+    label: 'Preload User Memory for New Chats',
+    category: 'General',
+    requiresRestart: false,
+    default: false,
+    description:
+      'Load user memory (including GEMINI.md files) into the chat history for new / cleared chats.',
+    showInDialog: true,
+  },
 } as const;
 
 type InferSettings<T extends SettingsSchema> = {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -221,10 +221,13 @@ export class GeminiClient {
     const toolRegistry = await this.config.getToolRegistry();
     const toolDeclarations = toolRegistry.getFunctionDeclarations();
     const tools: Tool[] = [{ functionDeclarations: toolDeclarations }];
+    const preloadMemory = this.config.getLoadUserMemoryInHistory && this.config.getLoadUserMemoryInHistory();
+    const geminiMemory = preloadMemory ? await this.config.getGeminiMemory() : '';
+    console.log(`Starting chat with memory: ${geminiMemory}`);
     const history: Content[] = [
       {
         role: 'user',
-        parts: envParts,
+        parts: [...envParts, ...(preloadMemory ? [{ text: geminiMemory }] : [])],
       },
       {
         role: 'model',


### PR DESCRIPTION
## TLDR

From my testing Gemini seems to follow instructions better if they are in the actual chat context, so this adds an option to preload user memory (GEMINI.md files and other context files) into the chat history for new / cleared chats. Optional since it sacrifices some of the context window.

## Reviewer Test Plan

"Unit" testing via this prompt with the setting on/off:
> summarize each message we've sent to each other so far in this current chat

When `loadUserMemoryInHistory: true` it shows the default 2 messages plus the user memory content from GEMINI.md files.
When `loadUserMemoryInHistory: false` it shows just the default 2 messages.

As for testing its ability to follow instructions better, that would involve more subjective/circumstantial testing.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

There are definitely a few issues added in the context of Gemini not following instructions, but cannot guarantee that this should close them.