### PR TITLE
fix(telemetry): Exclude tool tokens from prompt token count

### DIFF
--- a/packages/core/src/telemetry/uiTelemetry.test.ts
+++ b/packages/core/src/telemetry/uiTelemetry.test.ts
@@ -133,7 +133,7 @@ describe('UiTelemetryService', () => {
     expect(spy).toHaveBeenCalledOnce();
     const { metrics, lastPromptTokenCount } = spy.mock.calls[0][0];
     expect(metrics).toBeDefined();
-    expect(lastPromptTokenCount).toBe(10);
+    expect(lastPromptTokenCount).toBe(7);
   });
 
   describe('API Response Event Processing', () => {
@@ -168,7 +168,7 @@ describe('UiTelemetryService', () => {
           tool: 3,
         },
       });
-      expect(service.getLastPromptTokenCount()).toBe(10);
+      expect(service.getLastPromptTokenCount()).toBe(7);
     });
 
     it('should aggregate multiple ApiResponseEvents for the same model', () => {
@@ -218,7 +218,7 @@ describe('UiTelemetryService', () => {
           tool: 9,
         },
       });
-      expect(service.getLastPromptTokenCount()).toBe(15);
+      expect(service.getLastPromptTokenCount()).toBe(9);
     });
 
     it('should handle ApiResponseEvents for different models', () => {
@@ -257,7 +257,25 @@ describe('UiTelemetryService', () => {
       expect(metrics.models['gemini-2.5-flash']).toBeDefined();
       expect(metrics.models['gemini-2.5-pro'].api.totalRequests).toBe(1);
       expect(metrics.models['gemini-2.5-flash'].api.totalRequests).toBe(1);
-      expect(service.getLastPromptTokenCount()).toBe(100);
+      expect(service.getLastPromptTokenCount()).toBe(70);
+    });
+
+    it('should subtract tool_token_count from input_token_count for lastPromptTokenCount', () => {
+      const event = {
+        'event.name': EVENT_API_RESPONSE,
+        model: 'gemini-2.5-pro',
+        duration_ms: 500,
+        input_token_count: 100,
+        output_token_count: 20,
+        total_token_count: 120,
+        cached_content_token_count: 5,
+        thoughts_token_count: 2,
+        tool_token_count: 30,
+      } as ApiResponseEvent & { 'event.name': typeof EVENT_API_RESPONSE };
+
+      service.addEvent(event);
+
+      expect(service.getLastPromptTokenCount()).toBe(70);
     });
   });
 
@@ -534,7 +552,7 @@ describe('UiTelemetryService', () => {
       } as ApiResponseEvent & { 'event.name': typeof EVENT_API_RESPONSE };
 
       service.addEvent(event);
-      expect(service.getLastPromptTokenCount()).toBe(100);
+      expect(service.getLastPromptTokenCount()).toBe(70);
 
       // Now reset the token count
       service.resetLastPromptTokenCount();
@@ -616,7 +634,7 @@ describe('UiTelemetryService', () => {
       } as ApiResponseEvent & { 'event.name': typeof EVENT_API_RESPONSE };
 
       service.addEvent(event);
-      expect(service.getLastPromptTokenCount()).toBe(100);
+      expect(service.getLastPromptTokenCount()).toBe(70);
 
       // Reset once
       service.resetLastPromptTokenCount();

--- a/packages/core/src/telemetry/uiTelemetry.ts
+++ b/packages/core/src/telemetry/uiTelemetry.ts
@@ -160,7 +160,8 @@ export class UiTelemetryService extends EventEmitter {
     modelMetrics.tokens.thoughts += event.thoughts_token_count;
     modelMetrics.tokens.tool += event.tool_token_count;
 
-    this.#lastPromptTokenCount = event.input_token_count;
+    this.#lastPromptTokenCount =
+      event.input_token_count - event.tool_token_count;
   }
 
   private processApiError(event: ApiErrorEvent) {


### PR DESCRIPTION
Fixes #6106

This change corrects the calculation of the lastPromptTokenCount in the UI telemetry service.

Previously, the token count displayed in the footer included tokens from tool calls, which was not the intended behavior.

This commit modifies the processApiResponse method in UiTelemetryService to subtract the tool_token_count from the input_token_count, ensuring that the displayed prompt token count only reflects the user's input and not the context from tool executions.

Updated relevant test cases and added a new one to verify the fix.

## TLDR

This PR corrects the prompt token count displayed in the footer by excluding tokens from tool calls. This ensures the metric accurately reflects user-provided context, not the internal context generated by tools.

## Dive Deeper

The core of this change is to improve the user experience of the context window indicator. The footer percentage should provide users with a clear and predictable measure of *their* context usage, helping them manage their conversation length and file attachments.

By including token counts from tool executions (e.g., the content of a file read by a tool), the previous implementation would cause the percentage to jump unexpectedly, creating confusion. This fix isolates the **user context** (prompts, chat history) from the **tool context** (internal, system-generated information), making the displayed metric meaningful and actionable for the user.

## Reviewer Test Plan

A reviewer can manually validate this change with the following steps:

1.  Build and run the CLI: `npm run build && npm start`.
2.  Give a prompt that will trigger a file-reading tool. A good example is asking about a large file:
    ```
    @README.md what is this file about?
    ```
3.  Observe the `Context: X%` in the footer as the model responds.
4.  **Expected Behavior**: The context percentage should **not** jump significantly after the file content is processed by the tool. The final increase in percentage should only be proportional to the model's text answer, not the entire size of the `README.md` file.
5.  **For comparison (old behavior)**: Before this change, running the same prompt would cause the context percentage to increase dramatically, reflecting the full token count of the `README.md` file.

## Testing Matrix

*Note: This matrix should be completed by the contributor based on their testing environments.*

|          | 🍏 macOS | 🪟 Windows | 🐧 Linux |
| -------- | :---: | :---: | :---: |
| npm run  |   ✅   |   ❓   |   ❓   |
| npx      |   ❓   |   ❓   |   ❓   |
| Docker   |   ❓   |   ❓   |   ❓   |
| Podman   |   ❓   |   -   |   -   |
| Seatbelt |   ✅   |   -   |   -   |

- The ✅ for macOS indicates that the automated test suite (`npm run preflight`) was successfully run in this environment.

## Linked issues / bugs

Fixes #6106
