### PR TITLE
Show /ide enable & /ide disable commands based on connection status

### DIFF
--- a/packages/cli/src/ui/commands/ideCommand.test.ts
+++ b/packages/cli/src/ui/commands/ideCommand.test.ts
@@ -69,6 +69,9 @@ describe('ideCommand', () => {
     vi.mocked(mockConfig.getIdeClient).mockReturnValue({
       getCurrentIde: () => DetectedIde.VSCode,
       getDetectedIdeDisplayName: () => 'VS Code',
+      getConnectionStatus: () => ({
+        status: core.IDEConnectionStatus.Disconnected,
+      }),
     } as ReturnType<Config['getIdeClient']>);
     const command = ideCommand(mockConfig);
     expect(command).not.toBeNull();
@@ -161,7 +164,9 @@ describe('ideCommand', () => {
       vi.mocked(mockConfig.getIdeMode).mockReturnValue(true);
       vi.mocked(mockConfig.getIdeClient).mockReturnValue({
         getCurrentIde: () => DetectedIde.VSCode,
-        getConnectionStatus: vi.fn(),
+        getConnectionStatus: () => ({
+          status: core.IDEConnectionStatus.Disconnected,
+        }),
         getDetectedIdeDisplayName: () => 'VS Code',
       } as unknown as ReturnType<Config['getIdeClient']>);
       vi.mocked(core.getIdeInstaller).mockReturnValue({

--- a/packages/cli/src/ui/commands/ideCommand.test.ts
+++ b/packages/cli/src/ui/commands/ideCommand.test.ts
@@ -70,7 +70,7 @@ describe('ideCommand', () => {
       getCurrentIde: () => DetectedIde.VSCode,
       getDetectedIdeDisplayName: () => 'VS Code',
       getConnectionStatus: () => ({
-        status: core.IDEConnectionStatus.Disconnected,
+        status: core.IDEConnectionStatus.Connected,
       }),
     } as ReturnType<Config['getIdeClient']>);
     const command = ideCommand(mockConfig);

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -237,8 +237,8 @@ export const ideCommand = (config: Config | null): SlashCommand | null => {
     },
   };
 
-  const ideModeEnabled = config.getIdeMode();
-  if (ideModeEnabled) {
+  const connectionStatus = ideClient.getConnectionStatus().status;
+  if (connectionStatus === IDEConnectionStatus.Connected) {
     ideSlashCommand.subCommands = [
       disableCommand,
       statusCommand,


### PR DESCRIPTION
Previously, we would show /ide enable & /ide disable commands based on whether ideMode = true. This is confusing for users in cases where ideMode was enabled but we were unable to create a connection with the IDE server. 