### PR TITLE
[ide-mode] Use command to detect IDE

### DIFF
--- a/integration-tests/ide-client.test.ts
+++ b/integration-tests/ide-client.test.ts
@@ -9,25 +9,13 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as net from 'node:net';
 import { IdeClient } from '../packages/core/src/ide/ide-client.js';
-import { getIdeProcess } from '../packages/core/src/ide/process-utils.js';
+import { getIdeProcessId } from '../packages/core/src/ide/process-utils.js';
 import { spawn, ChildProcess } from 'child_process';
-import { DetectedIde } from '../packages/core/src/ide/detect-ide.js';
-
-vi.mock('../packages/core/src/ide/process-utils.js', async (importOriginal) => {
-  const original =
-    await importOriginal<
-      typeof import('../packages/core/src/ide/process-utils.js')
-    >();
-  return {
-    ...original,
-    getIdeProcess: vi.fn(),
-  };
-});
 
 describe('IdeClient', () => {
   it('reads port from file and connects', async () => {
     const port = 12345;
-    const { pid } = await getIdeProcess();
+    const pid = await getIdeProcessId();
     const portFile = path.join(os.tmpdir(), `gemini-ide-server-${pid}.json`);
     fs.writeFileSync(portFile, JSON.stringify({ port }));
 
@@ -35,26 +23,6 @@ describe('IdeClient', () => {
     await ideClient.connect();
 
     expect(ideClient.getConnectionStatus().status).not.toBe('disconnected');
-
-    fs.unlinkSync(portFile);
-  });
-
-  it('detects vscode fork', async () => {
-    const port = 12345;
-    const pid = 123;
-    const portFile = path.join(os.tmpdir(), `gemini-ide-server-${pid}.json`);
-    fs.writeFileSync(portFile, JSON.stringify({ port }));
-
-    const mockedGetIdeProcess = vi.mocked(getIdeProcess);
-    mockedGetIdeProcess.mockResolvedValue({
-      pid,
-      command: 'some-vscode-fork',
-    });
-
-    const ideClient = IdeClient.getInstance();
-    await ideClient.connect();
-
-    expect(ideClient.getCurrentIde()).toBe(DetectedIde.VSCodeFork);
 
     fs.unlinkSync(portFile);
   });
@@ -81,7 +49,7 @@ describe('IdeClient fallback connection logic', () => {
   let portFile: string;
 
   beforeEach(async () => {
-    ({ pid } = await getIdeProcess());
+    pid = await getIdeProcessId();
     portFile = path.join(os.tmpdir(), `gemini-ide-server-${pid}.json`);
     envPort = await getFreePort();
     server = net.createServer().listen(envPort);
@@ -124,7 +92,7 @@ describe('IdeClient fallback connection logic', () => {
   });
 });
 
-describe('getIdeProcess', () => {
+describe('getIdeProcessId', () => {
   let child: ChildProcess;
 
   afterEach(() => {
@@ -135,7 +103,7 @@ describe('getIdeProcess', () => {
 
   it('should return the pid of the parent process', async () => {
     // We need to spawn a child process that will run the test
-    // so that we can check that getIdeProcess returns the pid of the parent
+    // so that we can check that getIdeProcessId returns the pid of the parent
     const parentPid = process.pid;
     const output = await new Promise<string>((resolve, reject) => {
       child = spawn(
@@ -143,8 +111,8 @@ describe('getIdeProcess', () => {
         [
           '-e',
           `
-        const { getIdeProcess } = require('../packages/core/src/ide/process-utils.js');
-        getIdeProcess().then(info => console.log(info.pid));
+        const { getIdeProcessId } = require('../packages/core/src/ide/process-utils.js');
+        getIdeProcessId().then(pid => console.log(pid));
       `,
         ],
         {

--- a/packages/core/src/ide/detect-ide.ts
+++ b/packages/core/src/ide/detect-ide.ts
@@ -8,6 +8,7 @@ export enum DetectedIde {
   Devin = 'devin',
   Replit = 'replit',
   VSCode = 'vscode',
+  VSCodeFork = 'vscode-fork',
   Cursor = 'cursor',
   CloudShell = 'cloudshell',
   Codespaces = 'codespaces',
@@ -30,6 +31,7 @@ export function getIdeInfo(ide: DetectedIde): IdeInfo {
         displayName: 'Replit',
       };
     case DetectedIde.VSCode:
+    case DetectedIde.VSCodeFork:
       return {
         displayName: 'VS Code',
       };
@@ -61,11 +63,8 @@ export function getIdeInfo(ide: DetectedIde): IdeInfo {
   }
 }
 
-export function detectIde(): DetectedIde | undefined {
-  // Only VSCode-based integrations are currently supported.
-  if (process.env.TERM_PROGRAM !== 'vscode') {
-    return undefined;
-  }
+// Detects the current IDE using only environment variables.
+export function detectIdeByEnvVar(): DetectedIde | undefined {
   if (process.env.__COG_BASHRC_SOURCED) {
     return DetectedIde.Devin;
   }
@@ -87,5 +86,20 @@ export function detectIde(): DetectedIde | undefined {
   if (process.env.FIREBASE_DEPLOY_AGENT || process.env.MONOSPACE_ENV) {
     return DetectedIde.FirebaseStudio;
   }
-  return DetectedIde.VSCode;
+  if (process.env.TERM_PROGRAM === 'vscode') {
+    return DetectedIde.VSCode;
+  }
+  return;
+}
+
+// More precise-- detects the current IDE using environment variables and the current command.
+export function detectIde(command: string): DetectedIde | undefined {
+  const ide = detectIdeByEnvVar();
+  if (ide === DetectedIde.VSCode) {
+    if (command && command.toLowerCase().includes('vscode')) {
+      return DetectedIde.VSCode;
+    }
+    return DetectedIde.VSCodeFork;
+  }
+  return ide;
 }

--- a/packages/core/src/ide/process-utils.ts
+++ b/packages/core/src/ide/process-utils.ts
@@ -10,53 +10,86 @@ import os from 'os';
 
 const execAsync = promisify(exec);
 
+interface IdeProcess {
+  pid: number;
+  command: string;
+}
+
+let ideProcessCache: Promise<IdeProcess> | undefined;
+
 /**
- * Traverses up the process tree from the current process to find the top-level ancestor process ID.
- * This is useful for identifying the main application process that spawned the current script,
- * such as the main VS Code window process.
+ * Traverses up the process tree from the current process to find the
+ * top-level ancestor process, and returns its PID and command.
+ * This is useful for identifying the main application process that spawned the
+ * current script, such as the main VS Code window process.
  *
- * @returns A promise that resolves to the numeric PID of the top-level process.
- * @throws Will throw an error if the underlying shell commands fail unexpectedly.
+ * @returns A promise that resolves to an object containing the PID and command
+ * of the top-level process.
+ * @throws Will throw an error if the underlying shell commands fail
+ * unexpectedly.
  */
-export async function getIdeProcessId(): Promise<number> {
-  const platform = os.platform();
-  let currentPid = process.pid;
-
-  // Loop upwards through the process tree, with a depth limit to prevent infinite loops.
-  const MAX_TRAVERSAL_DEPTH = 32;
-  for (let i = 0; i < MAX_TRAVERSAL_DEPTH; i++) {
-    let parentPid: number;
-
-    try {
-      // Use wmic for Windows
-      if (platform === 'win32') {
-        const command = `wmic process where "ProcessId=${currentPid}" get ParentProcessId /value`;
-        const { stdout } = await execAsync(command);
-        const match = stdout.match(/ParentProcessId=(\d+)/);
-        parentPid = match ? parseInt(match[1], 10) : 0; // Top of the tree is 0
-      }
-      // Use ps for macOS, Linux, and other Unix-like systems
-      else {
-        const command = `ps -o ppid= -p ${currentPid}`;
-        const { stdout } = await execAsync(command);
-        const ppid = parseInt(stdout.trim(), 10);
-        parentPid = isNaN(ppid) ? 1 : ppid; // Top of the tree is 1
-      }
-    } catch (_) {
-      // This can happen if a process in the chain dies during execution.
-      // We'll break the loop and return the last valid PID we found.
-      break;
-    }
-
-    // Define the root PID for the current OS
-    const rootPid = platform === 'win32' ? 0 : 1;
-
-    // If the parent is the root process or invalid, we've found our target.
-    if (parentPid === rootPid || parentPid <= 0) {
-      break;
-    }
-    // Move one level up the tree for the next iteration.
-    currentPid = parentPid;
+export function getIdeProcess(): Promise<IdeProcess> {
+  if (ideProcessCache) {
+    return ideProcessCache;
   }
-  return currentPid;
+  ideProcessCache = (async () => {
+    const platform = os.platform();
+    let currentPid = process.pid;
+
+    // Loop upwards through the process tree, with a depth limit to prevent infinite loops.
+    const MAX_TRAVERSAL_DEPTH = 32;
+    for (let i = 0; i < MAX_TRAVERSAL_DEPTH; i++) {
+      let parentPid: number;
+
+      try {
+        // Use wmic for Windows
+        if (platform === 'win32') {
+          const command = `wmic process where "ProcessId=${currentPid}" get ParentProcessId /value`;
+          const { stdout } = await execAsync(command);
+          const match = stdout.match(/ParentProcessId=(\d+)/);
+          parentPid = match ? parseInt(match[1], 10) : 0; // Top of the tree is 0
+        }
+        // Use ps for macOS, Linux, and other Unix-like systems
+        else {
+          const command = `ps -o ppid= -p ${currentPid}`;
+          const { stdout } = await execAsync(command);
+          const ppid = parseInt(stdout.trim(), 10);
+          parentPid = isNaN(ppid) ? 1 : ppid; // Top of the tree is 1
+        }
+      } catch (_) {
+        // This can happen if a process in the chain dies during execution.
+        // We'll break the loop and return the last valid PID we found.
+        break;
+      }
+
+      // Define the root PID for the current OS
+      const rootPid = platform === 'win32' ? 0 : 1;
+
+      // If the parent is the root process or invalid, we've found our target.
+      if (parentPid === rootPid || parentPid <= 0) {
+        break;
+      }
+      // Move one level up the tree for the next iteration.
+      currentPid = parentPid;
+    }
+
+    let command = '';
+    try {
+      if (platform === 'win32') {
+        const { stdout } = await execAsync(
+          `wmic process where "ProcessId=${currentPid}" get CommandLine /value`,
+        );
+        const match = stdout.match(/CommandLine=(.*)/);
+        command = (match ? match[1] : '').trim();
+      } else {
+        const { stdout } = await execAsync(`ps -o command= -p ${currentPid}`);
+        command = stdout.trim();
+      }
+    } catch (e) {
+      // Ignore if getting command fails.
+    }
+
+    return { pid: currentPid, command };
+  })();
+  return ideProcessCache;
 }

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -31,7 +31,12 @@ import {
 import { getInstallationId } from '../../utils/user_id.js';
 import { FixedDeque } from 'mnemonist';
 import { GIT_COMMIT_INFO, CLI_VERSION } from '../../generated/git-commit.js';
-import { DetectedIde, detectIde } from '../../ide/detect-ide.js';
+import {
+  DetectedIde,
+  detectIdeByEnvVar,
+  ideDetector,
+} from '../../ide/detect-ide.js';
+import { IdeClient } from '../../ide/ide-client.js';
 
 const start_session_event_name = 'start_session';
 const new_prompt_event_name = 'new_prompt';
@@ -92,7 +97,7 @@ function determineSurface(): string {
   } else if (process.env.GITHUB_SHA) {
     return 'GitHub';
   } else if (process.env.TERM_PROGRAM === 'vscode') {
-    return detectIde() || DetectedIde.VSCode;
+    return detectIdeByEnvVar() || DetectedIde.VSCode;
   } else {
     return 'SURFACE_NOT_SET';
   }


### PR DESCRIPTION
## TLDR

Introduce an IDE type for VSCode forks-- this will ensure we only install the VSCode extension on VSCode.

This ended up being a lot more involved than expected bc of the logging dependency. IIUC we want that to function even when not in IDE mode, so it seemed weird to be reliant on the IDE client for that. Interested to hear thoughts.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
