### PR TITLE
[ide-mode] Fix path delimiter for multi-root workspaces on Windows

### DIFF
--- a/packages/core/src/ide/ide-client.test.ts
+++ b/packages/core/src/ide/ide-client.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import * as path from 'path';
 import { IdeClient } from './ide-client.js';
 
 describe('IdeClient.validateWorkspacePath', () => {
@@ -49,7 +50,7 @@ describe('IdeClient.validateWorkspacePath', () => {
 
   it('should handle multiple workspace paths and return valid', () => {
     const result = IdeClient.validateWorkspacePath(
-      '/some/other/path:/Users/person/gemini-cli',
+      ['/some/other/path', '/Users/person/gemini-cli'].join(path.delimiter),
       'VS Code',
       '/Users/person/gemini-cli/sub-dir',
     );
@@ -58,11 +59,20 @@ describe('IdeClient.validateWorkspacePath', () => {
 
   it('should return invalid if cwd is not in any of the multiple workspace paths', () => {
     const result = IdeClient.validateWorkspacePath(
-      '/some/other/path:/another/path',
+      ['/some/other/path', '/another/path'].join(path.delimiter),
       'VS Code',
       '/Users/person/gemini-cli/sub-dir',
     );
     expect(result.isValid).toBe(false);
     expect(result.error).toContain('Directory mismatch');
+  });
+
+  it.skipIf(process.platform !== 'win32')('should handle windows paths', () => {
+    const result = IdeClient.validateWorkspacePath(
+      'c:/some/other/path;d:/Users/person/gemini-cli',
+      'VS Code',
+      'd:/Users/person/gemini-cli/sub-dir',
+    );
+    expect(result.isValid).toBe(true);
   });
 });

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -272,7 +272,7 @@ export class IdeClient {
       };
     }
 
-    const ideWorkspacePaths = ideWorkspacePath.split(':');
+    const ideWorkspacePaths = ideWorkspacePath.split(path.delimiter);
     const realCwd = getRealPath(cwd);
     const isWithinWorkspace = ideWorkspacePaths.some((workspacePath) => {
       const idePath = getRealPath(workspacePath);

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -5,6 +5,7 @@
  */
 
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { IDEServer } from './ide-server.js';
 import { DiffContentProvider, DiffManager } from './diff-manager.js';
 import { createLogger } from './utils/logger.js';
@@ -23,7 +24,7 @@ function updateWorkspacePath(context: vscode.ExtensionContext) {
   if (workspaceFolders && workspaceFolders.length > 0) {
     const workspacePaths = workspaceFolders
       .map((folder) => folder.uri.fsPath)
-      .join(':');
+      .join(path.delimiter);
     context.environmentVariableCollection.replace(
       IDE_WORKSPACE_PATH_ENV_VAR,
       workspacePaths,


### PR DESCRIPTION
## TLDR

https://github.com/google-gemini/gemini-cli/pull/6177 added support for multi-root workspaces, but it uses the POSIX `:` (colon) path delimiter. This doesn't work well for Windows paths which often have `:` for the drive - the convention on Windows is to use `;` i.e. semicolon. Using `path.delimiter` makes this work in a platform neutral way.

## Dive Deeper

Fix the path delimiter on both the VSCode `extension.ts` and core `ide-server.ts` side.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

I added Windows-only tests with `:` in the path names e.g. `c:/some/path`.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | Y  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

Related to https://github.com/google-gemini/gemini-cli/issues/6209
