### PR TITLE
[ide-mode] Show folder picker for runGeminiCLI in multi-root workspaces

### DIFF
--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -112,7 +112,9 @@ export async function activate(context: vscode.ExtensionContext) {
       const workspaceFolders = vscode.workspace.workspaceFolders;
 
       let targetFolder: vscode.WorkspaceFolder | undefined;
-      if (workspaceFolders && workspaceFolders.length > 1) {
+      if (workspaceFolders?.length === 1) {
+        targetFolder = workspaceFolders[0];
+      } else if (workspaceFolders?.length > 1) {
         const picks = workspaceFolders.map((folder) => ({
           label: folder.name,
           description: folder.uri.fsPath,
@@ -125,8 +127,6 @@ export async function activate(context: vscode.ExtensionContext) {
           return; // User cancelled
         }
         targetFolder = selection.folder;
-      } else if (workspaceFolders && workspaceFolders.length === 1) {
-        targetFolder = workspaceFolders[0];
       }
 
       const terminal = vscode.window.createTerminal({

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -112,9 +112,7 @@ export async function activate(context: vscode.ExtensionContext) {
       const workspaceFolders = vscode.workspace.workspaceFolders;
 
       let targetFolder: vscode.WorkspaceFolder | undefined;
-      if (workspaceFolders?.length === 1) {
-        targetFolder = workspaceFolders[0];
-      } else if (workspaceFolders?.length > 1) {
+      if (workspaceFolders && workspaceFolders.length > 1) {
         const picks = workspaceFolders.map((folder) => ({
           label: folder.name,
           description: folder.uri.fsPath,
@@ -127,6 +125,8 @@ export async function activate(context: vscode.ExtensionContext) {
           return; // User cancelled
         }
         targetFolder = selection.folder;
+      } else if (workspaceFolders && workspaceFolders.length === 1) {
+        targetFolder = workspaceFolders[0];
       }
 
       const terminal = vscode.window.createTerminal({


### PR DESCRIPTION
## TLDR

https://github.com/google-gemini/gemini-cli/pull/6177 added support for multi-root workspaces, but the runGeminiCLI command will execute gemini in the workspace directory. This is not ideal because workspaces can be located in any directory not necessarily within one of the folders of the workspace. This PR introduces a folder picker when runGeminiCLI is executed in a multi-root workspace - the chosen folder is used as the CWD for the terminal that runs gemini.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

There are tests which assert that the picker is shown with the correct options and that the terminal is launched with the correct CWD.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | Y  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

Related to https://github.com/google-gemini/gemini-cli/issues/6209