### PR TITLE
Fix flake due to using wait instead of waitFor

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -1217,17 +1217,18 @@ describe('InputPrompt', () => {
       props.buffer.setText('some text');
 
       const { stdin, unmount } = render(<InputPrompt {...props} />);
-      await wait();
 
       stdin.write('\x1B');
-      await wait();
 
-      expect(onEscapePromptChange).toHaveBeenCalledWith(true);
+      await waitFor(() => {
+        expect(onEscapePromptChange).toHaveBeenCalledWith(true);
+      });
 
       stdin.write('a');
-      await wait();
 
-      expect(onEscapePromptChange).toHaveBeenCalledWith(false);
+      await waitFor(() => {
+        expect(onEscapePromptChange).toHaveBeenCalledWith(false);
+      });
       unmount();
     });
 


### PR DESCRIPTION
## TLDR
Gemini CLI caught and fixed this flake while working on an unrelated PR

using waitFor is the idiomatic way to handle this case as it ensures there cannot be race conditions. Only downside is if a test is broken it will take until waitFor times out for the test to fail.