### PR TITLE
feat(mcp-client): add support for JSON Schema  references

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -846,10 +846,7 @@ describe('mcp-client', () => {
 
       it('should handle circular references in anyOf', () => {
         const schema = {
-          anyOf: [
-            { $ref: '#/definitions/NodeA' },
-            { type: 'string' },
-          ],
+          anyOf: [{ $ref: '#/definitions/NodeA' }, { type: 'string' }],
           definitions: {
             NodeA: {
               type: 'object',

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -151,220 +151,6 @@ describe('mcp-client', () => {
       const consoleErrorSpy = vi
         .spyOn(console, 'error')
         .mockImplementation(() => {});
-      vi.mocked(GenAiLib.mcpToTool).mockReturnValue({
-        tool: () =>
-          Promise.resolve({
-            functionDeclarations: [
-              {
-                name: 'validTool',
-                parametersJsonSchema: {
-                  type: 'object',
-                  properties: {},
-                },
-              },
-            ],
-          }),
-      } as unknown as GenAiLib.CallableTool);
-
-      const tools = await discoverTools('test-server', {}, mockedClient);
-
-      expect(tools.length).toBe(1);
-      expect(vi.mocked(DiscoveredMCPTool).mock.calls[0][2]).toBe('validTool');
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      consoleWarnSpy.mockRestore();
-    });
-
-    it('should discover tool with $ref references in schema', async () => {
-      const mockedClient = {} as unknown as ClientLib.Client;
-      const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
-      vi.mocked(GenAiLib.mcpToTool).mockReturnValue({
-        tool: () =>
-          Promise.resolve({
-            functionDeclarations: [
-              {
-                name: 'toolWithRef',
-                parametersJsonSchema: {
-                  type: 'object',
-                  properties: {
-                    user: { $ref: '#/definitions/User' },
-                    address: { $ref: '#/definitions/Address' },
-                  },
-                  definitions: {
-                    User: {
-                      type: 'object',
-                      properties: {
-                        name: { type: 'string' },
-                        age: { type: 'number' },
-                      },
-                    },
-                    Address: {
-                      type: 'object',
-                      properties: {
-                        street: { type: 'string' },
-                        city: { type: 'string' },
-                      },
-                    },
-                  },
-                },
-              },
-            ],
-          }),
-      } as unknown as GenAiLib.CallableTool);
-
-      const tools = await discoverTools('test-server', {}, mockedClient);
-
-      expect(tools.length).toBe(1);
-      expect(vi.mocked(DiscoveredMCPTool).mock.calls[0][2]).toBe('toolWithRef');
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      consoleWarnSpy.mockRestore();
-    });
-
-    it('should discover tool with complex $ref schema including arrays', async () => {
-      const mockedClient = {} as unknown as ClientLib.Client;
-      const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
-      vi.mocked(GenAiLib.mcpToTool).mockReturnValue({
-        tool: () =>
-          Promise.resolve({
-            functionDeclarations: [
-              {
-                name: 'complexTool',
-                parametersJsonSchema: {
-                  type: 'object',
-                  properties: {
-                    users: {
-                      type: 'array',
-                      items: { $ref: '#/definitions/User' },
-                    },
-                    metadata: {
-                      type: 'object',
-                      additionalProperties: { $ref: '#/definitions/Metadata' },
-                    },
-                  },
-                  definitions: {
-                    User: {
-                      type: 'object',
-                      properties: {
-                        id: { type: 'string' },
-                        profile: { $ref: '#/definitions/Profile' },
-                      },
-                    },
-                    Profile: {
-                      type: 'object',
-                      properties: {
-                        name: { type: 'string' },
-                        email: { type: 'string' },
-                      },
-                    },
-                    Metadata: {
-                      type: 'string',
-                    },
-                  },
-                },
-              },
-            ],
-          }),
-      } as unknown as GenAiLib.CallableTool);
-
-      const tools = await discoverTools('test-server', {}, mockedClient);
-
-      expect(tools.length).toBe(1);
-      expect(vi.mocked(DiscoveredMCPTool).mock.calls[0][2]).toBe('complexTool');
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      consoleWarnSpy.mockRestore();
-    });
-
-    it('should discover tool with $defs instead of definitions', async () => {
-      const mockedClient = {} as unknown as ClientLib.Client;
-      const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
-      vi.mocked(GenAiLib.mcpToTool).mockReturnValue({
-        tool: () =>
-          Promise.resolve({
-            functionDeclarations: [
-              {
-                name: 'toolWithDefs',
-                parametersJsonSchema: {
-                  type: 'object',
-                  properties: {
-                    config: { $ref: '#/$defs/Config' },
-                  },
-                  $defs: {
-                    Config: {
-                      type: 'object',
-                      properties: {
-                        timeout: { type: 'number' },
-                        retries: { type: 'integer' },
-                      },
-                    },
-                  },
-                },
-              },
-            ],
-          }),
-      } as unknown as GenAiLib.CallableTool);
-
-      const tools = await discoverTools('test-server', {}, mockedClient);
-
-      expect(tools.length).toBe(1);
-      expect(vi.mocked(DiscoveredMCPTool).mock.calls[0][2]).toBe(
-        'toolWithDefs',
-      );
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      consoleWarnSpy.mockRestore();
-    });
-
-    it('should discover tool with components/schemas structure', async () => {
-      const mockedClient = {} as unknown as ClientLib.Client;
-      const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
-      vi.mocked(GenAiLib.mcpToTool).mockReturnValue({
-        tool: () =>
-          Promise.resolve({
-            functionDeclarations: [
-              {
-                name: 'apiTool',
-                parametersJsonSchema: {
-                  type: 'object',
-                  properties: {
-                    request: { $ref: '#/components/schemas/ApiRequest' },
-                  },
-                  components: {
-                    schemas: {
-                      ApiRequest: {
-                        type: 'object',
-                        properties: {
-                          endpoint: { type: 'string' },
-                          method: {
-                            type: 'string',
-                            enum: ['GET', 'POST', 'PUT', 'DELETE'],
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            ],
-          }),
-      } as unknown as GenAiLib.CallableTool);
-
-      const tools = await discoverTools('test-server', {}, mockedClient);
-
-      expect(tools.length).toBe(1);
-      expect(vi.mocked(DiscoveredMCPTool).mock.calls[0][2]).toBe('apiTool');
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      consoleWarnSpy.mockRestore();
-    });
-  });
-
-  describe('connectToMcpServer', () => {
-    it('should register a roots/list handler', async () => {
       const mockedClient = {
         connect: vi.fn(),
         discover: vi.fn(),
@@ -404,6 +190,7 @@ describe('mcp-client', () => {
       consoleErrorSpy.mockRestore();
     });
   });
+
   describe('appendMcpServerCommand', () => {
     it('should do nothing if no MCP servers or command are configured', () => {
       const out = populateMcpServerCommand({}, undefined);
@@ -987,6 +774,88 @@ describe('mcp-client', () => {
             },
             Tag: {
               type: 'string',
+            },
+          },
+        };
+        expect(hasValidTypes(schema)).toBe(true);
+      });
+
+      it('should handle circular references without infinite recursion', () => {
+        const schema = {
+          type: 'object',
+          properties: {
+            user: { $ref: '#/definitions/User' },
+          },
+          definitions: {
+            User: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                friend: { $ref: '#/definitions/User' }, // circular reference
+              },
+            },
+          },
+        };
+        expect(hasValidTypes(schema)).toBe(true);
+      });
+
+      it('should handle complex circular references', () => {
+        const schema = {
+          type: 'object',
+          properties: {
+            nodeA: { $ref: '#/definitions/NodeA' },
+          },
+          definitions: {
+            NodeA: {
+              type: 'object',
+              properties: {
+                value: { type: 'string' },
+                nodeB: { $ref: '#/definitions/NodeB' },
+              },
+            },
+            NodeB: {
+              type: 'object',
+              properties: {
+                value: { type: 'number' },
+                nodeA: { $ref: '#/definitions/NodeA' }, // circular reference back to NodeA
+              },
+            },
+          },
+        };
+        expect(hasValidTypes(schema)).toBe(true);
+      });
+
+      it('should handle self-referencing schema', () => {
+        const schema = {
+          $ref: '#/definitions/Tree',
+          definitions: {
+            Tree: {
+              type: 'object',
+              properties: {
+                value: { type: 'string' },
+                children: {
+                  type: 'array',
+                  items: { $ref: '#/definitions/Tree' }, // self-reference
+                },
+              },
+            },
+          },
+        };
+        expect(hasValidTypes(schema)).toBe(true);
+      });
+
+      it('should handle circular references in anyOf', () => {
+        const schema = {
+          anyOf: [
+            { $ref: '#/definitions/NodeA' },
+            { type: 'string' },
+          ],
+          definitions: {
+            NodeA: {
+              type: 'object',
+              properties: {
+                next: { $ref: '#/definitions/NodeA' }, // circular reference
+              },
             },
           },
         };

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -629,14 +629,14 @@ describe('mcp-client', () => {
       const schema = {
         anyOf: [{ type: 'string' }, { type: 'number' }],
       };
-      expect(hasValidTypes(schema, schema)).toBe(true);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return false for an invalid schema with anyOf', () => {
       const schema = {
         anyOf: [{ type: 'string' }, { description: 'no type' }],
       };
-      expect(hasValidTypes(schema, schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(false);
     });
 
     it('should return true for a valid schema with allOf', () => {
@@ -646,28 +646,28 @@ describe('mcp-client', () => {
           { type: 'object', properties: { foo: { type: 'string' } } },
         ],
       };
-      expect(hasValidTypes(schema, schema)).toBe(true);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return false for an invalid schema with allOf', () => {
       const schema = {
         allOf: [{ type: 'string' }, { description: 'no type' }],
       };
-      expect(hasValidTypes(schema, schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(false);
     });
 
     it('should return true for a valid schema with oneOf', () => {
       const schema = {
         oneOf: [{ type: 'string' }, { type: 'number' }],
       };
-      expect(hasValidTypes(schema, schema)).toBe(true);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return false for an invalid schema with oneOf', () => {
       const schema = {
         oneOf: [{ type: 'string' }, { description: 'no type' }],
       };
-      expect(hasValidTypes(schema, schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(false);
     });
 
     it('should return true for a valid schema with nested subschemas', () => {
@@ -682,7 +682,7 @@ describe('mcp-client', () => {
           },
         ],
       };
-      expect(hasValidTypes(schema, schema)).toBe(true);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return false for an invalid schema with nested subschemas', () => {
@@ -697,7 +697,7 @@ describe('mcp-client', () => {
           },
         ],
       };
-      expect(hasValidTypes(schema, schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(false);
     });
 
     it('should return true for a schema with a type and subschemas', () => {
@@ -705,14 +705,14 @@ describe('mcp-client', () => {
         type: 'string',
         anyOf: [{ minLength: 1 }, { maxLength: 5 }],
       };
-      expect(hasValidTypes(schema, schema)).toBe(true);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return false for a schema with no type and no subschemas', () => {
       const schema = {
         description: 'a schema with no type',
       };
-      expect(hasValidTypes(schema, schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(false);
     });
 
     it('should return true for a valid schema', () => {
@@ -722,7 +722,7 @@ describe('mcp-client', () => {
           param1: { type: 'string' },
         },
       };
-      expect(hasValidTypes(schema, schema)).toBe(true);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return false if a parameter is missing a type', () => {
@@ -732,7 +732,7 @@ describe('mcp-client', () => {
           param1: { description: 'a param with no type' },
         },
       };
-      expect(hasValidTypes(schema, schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(false);
     });
 
     it('should return false if a nested parameter is missing a type', () => {
@@ -749,7 +749,7 @@ describe('mcp-client', () => {
           },
         },
       };
-      expect(hasValidTypes(schema, schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(false);
     });
 
     it('should return false if an array item is missing a type', () => {
@@ -764,14 +764,14 @@ describe('mcp-client', () => {
           },
         },
       };
-      expect(hasValidTypes(schema, schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(false);
     });
 
     it('should return true for a schema with no properties', () => {
       const schema = {
         type: 'object',
       };
-      expect(hasValidTypes(schema, schema)).toBe(true);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return true for a schema with an empty properties object', () => {
@@ -779,15 +779,34 @@ describe('mcp-client', () => {
         type: 'object',
         properties: {},
       };
-      expect(hasValidTypes(schema, schema)).toBe(true);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     describe('$ref handling', () => {
-      it('should return true for a schema with local $ref reference', () => {
+      it('should return true for a schema with definitions containing types', () => {
+        const schema = {
+          type: 'object',
+          properties: {
+            user: { $ref: '#/definitions/User' },
+          },
+          definitions: {
+            User: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                age: { type: 'number' },
+              },
+            },
+          },
+        };
+        expect(hasValidTypes(schema)).toBe(true);
+      });
+
+      it('should return false for a schema with invalid reference', () => {
         const schema = {
           $ref: '#/definitions/User',
         };
-        expect(hasValidTypes(schema, schema)).toBe(true);
+        expect(hasValidTypes(schema)).toBe(false);
       });
 
       it('should return false for a schema with local $ref reference has no type', () => {
@@ -803,14 +822,14 @@ describe('mcp-client', () => {
             },
           },
         };
-        expect(hasValidTypes(schema, schema)).toBe(false);
+        expect(hasValidTypes(schema)).toBe(false);
       });
 
-      it('should return true for a schema with external $ref reference', () => {
+      it('should return false for a schema with external $ref reference', () => {
         const schema = {
           $ref: 'https://example.com/schema.json#/definitions/User',
         };
-        expect(hasValidTypes(schema, schema)).toBe(true);
+        expect(hasValidTypes(schema)).toBe(false);
       });
 
       it('should return true for a schema with nested $ref in properties', () => {
@@ -820,16 +839,23 @@ describe('mcp-client', () => {
             user: { $ref: '#/definitions/User' },
             address: { $ref: '#/definitions/Address' },
           },
+          definitions: {
+            User: { type: 'object' },
+            Address: { type: 'object' },
+          },
         };
-        expect(hasValidTypes(schema, schema)).toBe(true);
+        expect(hasValidTypes(schema)).toBe(true);
       });
 
       it('should return true for a schema with $ref in array items', () => {
         const schema = {
           type: 'array',
           items: { $ref: '#/definitions/User' },
+          definitions: {
+            User: { type: 'object' },
+          },
         };
-        expect(hasValidTypes(schema, schema)).toBe(true);
+        expect(hasValidTypes(schema)).toBe(true);
       });
 
       it('should return true for a schema with $ref in anyOf', () => {
@@ -838,8 +864,12 @@ describe('mcp-client', () => {
             { $ref: '#/definitions/StringType' },
             { $ref: '#/definitions/NumberType' },
           ],
+          definitions: {
+            StringType: { type: 'string' },
+            NumberType: { type: 'number' },
+          },
         };
-        expect(hasValidTypes(schema, schema)).toBe(true);
+        expect(hasValidTypes(schema)).toBe(true);
       });
 
       it('should return true for a schema with $ref in allOf', () => {
@@ -848,8 +878,12 @@ describe('mcp-client', () => {
             { $ref: '#/definitions/BaseUser' },
             { $ref: '#/definitions/ExtendedUser' },
           ],
+          definitions: {
+            BaseUser: { type: 'object' },
+            ExtendedUser: { type: 'object' },
+          },
         };
-        expect(hasValidTypes(schema, schema)).toBe(true);
+        expect(hasValidTypes(schema)).toBe(true);
       });
 
       it('should return true for a schema with $ref in oneOf', () => {
@@ -858,8 +892,12 @@ describe('mcp-client', () => {
             { $ref: '#/definitions/Admin' },
             { $ref: '#/definitions/User' },
           ],
+          definitions: {
+            Admin: { type: 'object' },
+            User: { type: 'object' },
+          },
         };
-        expect(hasValidTypes(schema, schema)).toBe(true);
+        expect(hasValidTypes(schema)).toBe(true);
       });
 
       it('should return true for a schema with definitions containing types', () => {
@@ -878,7 +916,7 @@ describe('mcp-client', () => {
             },
           },
         };
-        expect(hasValidTypes(schema, schema)).toBe(true);
+        expect(hasValidTypes(schema)).toBe(true);
       });
 
       it('should return true for a schema with $defs containing types', () => {
@@ -897,7 +935,7 @@ describe('mcp-client', () => {
             },
           },
         };
-        expect(hasValidTypes(schema, schema)).toBe(true);
+        expect(hasValidTypes(schema)).toBe(true);
       });
 
       it('should return true for a schema with components containing types', () => {
@@ -918,7 +956,7 @@ describe('mcp-client', () => {
             },
           },
         };
-        expect(hasValidTypes(schema, schema)).toBe(true);
+        expect(hasValidTypes(schema)).toBe(true);
       });
 
       it('should return true for a complex schema with mixed $ref and inline types', () => {
@@ -952,7 +990,7 @@ describe('mcp-client', () => {
             },
           },
         };
-        expect(hasValidTypes(schema, schema)).toBe(true);
+        expect(hasValidTypes(schema)).toBe(true);
       });
     });
   });
@@ -1007,6 +1045,21 @@ describe('mcp-client', () => {
       });
     });
 
+    it('should return null for external reference path', () => {
+      const schema = {
+        definitions: {
+          User: {
+            type: 'object',
+          },
+        },
+      };
+      const result = getRefDefinition(
+        'https://example.com/profile#/definitions/User',
+        schema,
+      );
+      expect(result).toBeNull();
+    });
+
     it('should return null for non-existent path', () => {
       const schema = {
         definitions: {
@@ -1027,7 +1080,7 @@ describe('mcp-client', () => {
           },
         },
       };
-      const result = getRefDefinition('#/invalid/path', schema);
+      const result = getRefDefinition('invalid/path', schema);
       expect(result).toBeNull();
     });
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -579,10 +579,7 @@ export async function connectAndDiscover(
  * // Returns: { type: "object", properties: { name: { type: "string" } } }
  * ```
  */
-export function getRefDefinition(
-  path: string,
-  rootSchema: unknown,
-): unknown {
+export function getRefDefinition(path: string, rootSchema: unknown): unknown {
   // only support internal references
   if (!path.startsWith('#/')) {
     return null;


### PR DESCRIPTION
## TLDR

 Add getRefDefinition function to resolve JSON Schema reference paths
  - Enhance hasValidTypes to handle $ref references in schema validation                                                                                                                                                      
  - Support various reference formats: #/definitions, #/$defs, #/components/schemas                                                                                                                                          
  - Add comprehensive test coverage for $ref handling scenarios                                                                                                                                                                
  - Update existing tests to pass root schema context for proper $ref resolution
## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
