### PR TITLE
process: remove hardcoded clientID and clientSecret

### DIFF
--- a/.gcp/release-docker.yml
+++ b/.gcp/release-docker.yml
@@ -39,18 +39,33 @@ steps:
         echo "Determined image tag: $$FINAL_TAG"
         echo "$$FINAL_TAG" > /workspace/image_tag.txt
 
-  # Step 5: Build sandbox container image
+  # Step 5: Inject OAuth2 Secrets
+  - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
+    id: 'Inject OAuth2 Secrets'
+    entrypoint: 'node'
+    args: ['scripts/release/inject_secrets.js']
+    env:
+      - 'OAUTH_CLIENT_ID=$_OAUTH_CLIENT_ID'
+      - 'OAUTH_CLIENT_SECRET=$_OAUTH_CLIENT_SECRET'
+
+  # Step 6: Build sandbox container image
   - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
     id: 'Build sandbox Docker image'
     entrypoint: 'bash'
     args:
       - '-c'
       - |-
-        export GEMINI_SANDBOX_IMAGE_TAG=$$(cat /workspace/image_tag.txt)
-        echo "Using Docker image tag for build: $$GEMINI_SANDBOX_IMAGE_TAG"
+        export GEMINI_SANDBOX_IMAGE_TAG=$(cat /workspace/image_tag.txt)
+        echo "Using Docker image tag for build: $GEMINI_SANDBOX_IMAGE_TAG"
         npm run build:sandbox -- --output-file /workspace/final_image_uri.txt
     env:
       - 'GEMINI_SANDBOX=$_CONTAINER_TOOL'
+
+  # Step 7: Revert OAuth2 Secrets
+  - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
+    id: 'Revert OAuth2 Secrets'
+    entrypoint: 'git'
+    args: ['checkout', '--', 'packages/core/src/code_assist/oauth2_secrets.ts']
 
   # Step 8: Publish sandbox container image
   - name: 'us-west1-docker.pkg.dev/gemini-code-dev/gemini-code-containers/gemini-code-builder'
@@ -73,3 +88,5 @@ options:
 
 substitutions:
   _CONTAINER_TOOL: 'docker'
+  _OAUTH_CLIENT_ID: ''
+  _OAUTH_CLIENT_SECRET: ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,13 @@ jobs:
           npm run build:packages
           npm run prepare:package
 
+      - name: 'Inject OAuth2 Secrets'
+        env:
+          OAUTH_CLIENT_ID: '${{ secrets.OAUTH_CLIENT_ID }}'
+          OAUTH_CLIENT_SECRET: '${{ secrets.OAUTH_CLIENT_SECRET }}'
+        run: |-
+          node scripts/release/inject_secrets.js
+
       - name: 'Configure npm for publishing'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
         with:
@@ -182,6 +189,10 @@ jobs:
             --dry-run="${IS_DRY_RUN}" \
             --workspace="@google/gemini-cli" \
             --tag="${NPM_TAG}"
+
+      - name: 'Revert OAuth2 Secrets'
+        run: |-
+          git checkout -- packages/core/src/code_assist/oauth2_secrets.ts
 
       - name: 'Get previous release tag'
         id: 'previous_release'

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -27,18 +27,7 @@ import {
 } from '../utils/user_account.js';
 import { AuthType } from '../core/contentGenerator.js';
 import readline from 'node:readline';
-
-//  OAuth Client ID used to initiate OAuth2Client class.
-const OAUTH_CLIENT_ID =
-  '681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com';
-
-// OAuth Secret value used to initiate OAuth2Client class.
-// Note: It's ok to save this in git because this is an installed application
-// as described here: https://developers.google.com/identity/protocols/oauth2#installed
-// "The process results in a client ID and, in some cases, a client secret,
-// which you embed in the source code of your application. (In this context,
-// the client secret is obviously not treated as a secret.)"
-const OAUTH_CLIENT_SECRET = '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';
+import { OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET } from './oauth2_secrets.js';
 
 // OAuth Scopes for Cloud Code authorization.
 const OAUTH_SCOPE = [

--- a/packages/core/src/code_assist/oauth2_secrets.ts
+++ b/packages/core/src/code_assist/oauth2_secrets.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This file is a placeholder for OAuth2 secrets.
+// During the release process, this file will be overwritten with the actual
+// client ID and secret.
+
+export const OAUTH_CLIENT_ID =
+  '14228896175-3idqge8muu0ii9g4b9mnnscan33qp4sh.apps.googleusercontent.com';
+export const OAUTH_CLIENT_SECRET = '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';

--- a/scripts/release/inject_secrets.js
+++ b/scripts/release/inject_secrets.js
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const { OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET } = process.env;
+
+if (!OAUTH_CLIENT_ID || !OAUTH_CLIENT_SECRET) {
+  throw new Error(
+    'Missing OAUTH_CLIENT_ID or OAUTH_CLIENT_SECRET environment variables.',
+  );
+}
+
+const secretsFilePath = path.resolve(
+  process.cwd(),
+  'packages/core/src/code_assist/oauth2_secrets.ts',
+);
+
+const content = `/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This file is a placeholder for OAuth2 secrets.
+// During the release process, this file will be overwritten with the actual
+// client ID and secret.
+
+export const OAUTH_CLIENT_ID = '${OAUTH_CLIENT_ID}';
+export const OAUTH_CLIENT_SECRET = '${OAUTH_CLIENT_SECRET}';
+`;
+
+async function injectSecrets() {
+  try {
+    await fs.writeFile(secretsFilePath, content, 'utf8');
+    console.log('Successfully injected OAuth2 secrets.');
+  } catch (error) {
+    console.error('Failed to inject OAuth2 secrets:', error);
+    process.exit(1);
+  }
+}
+
+injectSecrets();


### PR DESCRIPTION
## TLDR

This PR refactors the handling of OAuth2 client secrets by moving them from hardcoded constants to a separate, untracked file. The release workflows for both Docker and NPM have been updated to inject these secrets at build time, ensuring they are available for authentication while keeping them out of source control.

The new hardcoded secrets are callable only by members of the dev team, so it can still be used to test GCA auth locally. However headless oauth (no browser) breaks locally due to not having this test app registered (I think that's ok for local).

##  Dive Deeper

  Previously, the OAuth2 client ID and secret were stored as constants directly in packages/core/src/code_assist/oauth2.ts. This PR introduces the
  following changes to improve security and configurability:

   1. New `oauth2_secrets.ts` file: A new file, packages/core/src/code_assist/oauth2_secrets.ts, is created to hold the OAUTH_CLIENT_ID and
      OAUTH_CLIENT_SECRET constants. This file is intended to be git-ignored (though the ignore entry is not part of this diff).
   2. Dynamic Secret Injection:
       * The GitHub Actions workflow (.github/workflows/release.yml) and the Google Cloud Build pipeline (.gcp/release-docker.yml) are modified to
         include new steps that inject the secrets into oauth2_secrets.ts during the release process.
       * A corresponding "Revert OAuth2 Secrets" step is added to both workflows to ensure the secrets are cleared from the file system after the
         build, preventing them from being accidentally committed.
   3. Code Refactoring: The main oauth2.ts file is updated to import the secrets from the new oauth2_secrets.ts file.

  This approach allows for secure management of secrets while enabling authenticated builds for releases.

##  Reviewer Test Plan

   1. Pull down the branch and run npm run preflight to ensure all tests, linting, and build steps pass.
   2. Manually create the packages/core/src/code_assist/oauth2_secrets.ts file with placeholder values for the client ID and secret.
   3. Run the application locally and verify that authentication-related features still function as expected.
   4. Review the changes in .github/workflows/release.yml and .gcp/release-docker.yml to confirm the logic for injecting and reverting secrets is sound.


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
