### PR TITLE
Check for pending tool calls before appending IDE Context

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -468,6 +468,11 @@ export class GeminiClient {
       yield { type: GeminiEventType.ChatCompressed, value: compressed };
     }
 
+    // Prevent context updates from being sent while a tool call is
+    // waiting for a response. The Gemini API requires that a functionResponse
+    // part from the user immediately follows a functionCall part from the model
+    // in the conversation history . The IDE context is not discarded; it will
+    // be included in the next regular message sent to the model.
     const history = this.getHistory();
     const lastMessage =
       history.length > 0 ? history[history.length - 1] : undefined;
@@ -478,7 +483,7 @@ export class GeminiClient {
 
     if (this.config.getIdeMode() && !hasPendingToolCall) {
       const { contextParts, newIdeContext } = this.getIdeContextParts(
-        this.forceFullIdeContext || this.getHistory().length === 0,
+        this.forceFullIdeContext || history.length === 0,
       );
       if (contextParts.length > 0) {
         this.getChat().addHistory({

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -468,7 +468,15 @@ export class GeminiClient {
       yield { type: GeminiEventType.ChatCompressed, value: compressed };
     }
 
-    if (this.config.getIdeMode()) {
+    const history = this.getHistory();
+    const lastMessage =
+      history.length > 0 ? history[history.length - 1] : undefined;
+    const hasPendingToolCall =
+      !!lastMessage &&
+      lastMessage.role === 'model' &&
+      (lastMessage.parts?.some((p) => 'functionCall' in p) || false);
+
+    if (this.config.getIdeMode() && !hasPendingToolCall) {
       const { contextParts, newIdeContext } = this.getIdeContextParts(
         this.forceFullIdeContext || this.getHistory().length === 0,
       );


### PR DESCRIPTION
## TLDR

  Fixes a bug that caused API errors when using tools in an IDE. The CLI was sometimes sending editor context
  updates in the middle of a tool call, which breaks the required message sequence for the Gemini API. This
  change prevents context updates from being sent while a tool call is waiting for a response.

## Dive Deeper

 ### The Bug:

  The Gemini API requires that a `functionResponse` part from the user immediately follows a `functionCall` part
  from the model in the conversation history. However, when running the Gemini CLI in an IDE, an
  `activeFileChanged` event (or other editor context events) could trigger a new `user` message to be inserted
  into the history.

  If this event fired while a tool was executing (i.e., after the model returned a `functionCall` but before
  the CLI sent the `functionResponse`), the history would become invalid. For example:

   1. `model`: `functionCall(read_file)`
   2. `user`: `(IDE context update)`  <-- Invalid message
   3. `user`: `functionResponse(...)`

  This invalid sequence caused the API to return a `400 Bad Request` error.

This was introduced in https://github.com/google-gemini/gemini-cli/releases/tag/v0.1.21.

  ### The Fix:

  The solution is to prevent the CLI from sending IDE context updates when a tool call is pending.

  In `packages/core/src/core/client.ts`, within the `sendMessageStream` function, I've added a check that
  inspects the last message in the chat history. If the last message is a `model` turn that contains a
  `functionCall`, the logic to add the IDE context is now skipped for that turn.

  This ensures that no other messages can be injected between the `functionCall` and its subsequent
  `functionResponse`, preserving the integrity of the tool-use conversation flow. The IDE context is not
  discarded; it will be included in the next regular message sent to the model.

  Here’s a step-by-step example:

   1. You type: `Read the file foo.ts and tell me what it does.`
   2. *CLI sends to Gemini*: Your prompt *AND* the current IDE context are sent together.
   3. Gemini responds with: `functionCall(read_file, ...)`
   4. The CLI executes the `read_file` tool.
   5. While the tool is running, you click on another file, `bar.ts`. A new IDE context is now available.
   6. *CLI sends to Gemini*: `functionResponse(...)`
       - *This is where the fix applies*. We *skip* sending the new context about `bar.ts` here to avoid breaking the
         API's required `functionCall`/`functionResponse` sequence.
   7. Gemini responds with the summary of `foo.ts`.
   8. You type a new message: `Thanks!`
   9. CLI sends to Gemini: Your new prompt *AND* the latest IDE context (which includes `bar.ts`) are sent together.

## Reviewer Test Plan

An easy way to reproduce is if you click around in IDE files during a tool call, an activeFileChanged event will be inserted between the tool calls causing the error. If run this build and perform that same action, there is no failure.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #6315
Fixes #6271
Fixes #6259
Fixes #6224
Contributes to #6093
