### PR TITLE
bug(core): Do not throw validation errors when building tools in `nonInteractiveToolExecutor`.

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -12,7 +12,6 @@ import {
   shutdownTelemetry,
   isTelemetrySdkInitialized,
   GeminiEventType,
-  ToolErrorType,
   parseAndFormatApiError,
 } from '@google/gemini-cli-core';
 import { Content, Part, FunctionCall } from '@google/genai';
@@ -109,8 +108,6 @@ export async function runNonInteractive(
             console.error(
               `Error executing tool ${fc.name}: ${toolResponse.resultDisplay || toolResponse.error.message}`,
             );
-            if (toolResponse.errorType === ToolErrorType.UNHANDLED_EXCEPTION)
-              process.exit(1);
           }
 
           if (toolResponse.responseParts) {

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -11,6 +11,7 @@ import {
   ToolCallRequestInfo,
   ToolResult,
   Config,
+  ToolErrorType,
 } from '../index.js';
 import { Part } from '@google/genai';
 import { MockTool } from '../test-utils/tools.js';
@@ -50,7 +51,7 @@ describe('executeToolCall', () => {
       returnDisplay: 'Success!',
     };
     vi.mocked(mockToolRegistry.getTool).mockReturnValue(mockTool);
-    vi.spyOn(mockTool, 'buildAndExecute').mockResolvedValue(toolResult);
+    vi.spyOn(mockTool, 'validateBuildAndExecute').mockResolvedValue(toolResult);
 
     const response = await executeToolCall(
       mockConfig,
@@ -60,7 +61,7 @@ describe('executeToolCall', () => {
     );
 
     expect(mockToolRegistry.getTool).toHaveBeenCalledWith('testTool');
-    expect(mockTool.buildAndExecute).toHaveBeenCalledWith(
+    expect(mockTool.validateBuildAndExecute).toHaveBeenCalledWith(
       request.args,
       abortController.signal,
     );
@@ -112,17 +113,26 @@ describe('executeToolCall', () => {
     ]);
   });
 
-  it('should return an error if tool execution fails', async () => {
+  it('should return an error if tool validation fails', async () => {
     const request: ToolCallRequestInfo = {
       callId: 'call3',
       name: 'testTool',
-      args: { param1: 'value1' },
+      args: { param1: 'invalid' },
       isClientInitiated: false,
       prompt_id: 'prompt-id-3',
     };
-    const executionError = new Error('Tool execution failed');
+    const validationErrorResult: ToolResult = {
+      llmContent: 'Error: Invalid parameters',
+      returnDisplay: 'Invalid parameters',
+      error: {
+        message: 'Invalid parameters',
+        type: ToolErrorType.INVALID_TOOL_PARAMS,
+      },
+    };
     vi.mocked(mockToolRegistry.getTool).mockReturnValue(mockTool);
-    vi.spyOn(mockTool, 'buildAndExecute').mockRejectedValue(executionError);
+    vi.spyOn(mockTool, 'validateBuildAndExecute').mockResolvedValue(
+      validationErrorResult,
+    );
 
     const response = await executeToolCall(
       mockConfig,
@@ -130,22 +140,24 @@ describe('executeToolCall', () => {
       mockToolRegistry,
       abortController.signal,
     );
-
-    expect(response.callId).toBe('call3');
-    expect(response.error).toBe(executionError);
-    expect(response.resultDisplay).toBe('Tool execution failed');
-    expect(response.responseParts).toEqual([
-      {
+    expect(response).toStrictEqual({
+      callId: 'call3',
+      error: new Error('Invalid parameters'),
+      errorType: ToolErrorType.INVALID_TOOL_PARAMS,
+      responseParts: {
         functionResponse: {
-          name: 'testTool',
           id: 'call3',
-          response: { error: 'Tool execution failed' },
+          name: 'testTool',
+          response: {
+            output: 'Error: Invalid parameters',
+          },
         },
       },
-    ]);
+      resultDisplay: 'Invalid parameters',
+    });
   });
 
-  it('should handle cancellation during tool execution', async () => {
+  it('should return an error if tool execution fails', async () => {
     const request: ToolCallRequestInfo = {
       callId: 'call4',
       name: 'testTool',
@@ -153,32 +165,56 @@ describe('executeToolCall', () => {
       isClientInitiated: false,
       prompt_id: 'prompt-id-4',
     };
-    const cancellationError = new Error('Operation cancelled');
-    vi.mocked(mockToolRegistry.getTool).mockReturnValue(mockTool);
-
-    vi.spyOn(mockTool, 'buildAndExecute').mockImplementation(
-      async (_args, signal) => {
-        if (signal?.aborted) {
-          return Promise.reject(cancellationError);
-        }
-        return new Promise((_resolve, reject) => {
-          signal?.addEventListener('abort', () => {
-            reject(cancellationError);
-          });
-          // Simulate work that might happen if not aborted immediately
-          const timeoutId = setTimeout(
-            () =>
-              reject(
-                new Error('Should have been cancelled if not aborted prior'),
-              ),
-            100,
-          );
-          signal?.addEventListener('abort', () => clearTimeout(timeoutId));
-        });
+    const executionErrorResult: ToolResult = {
+      llmContent: 'Error: Execution failed',
+      returnDisplay: 'Execution failed',
+      error: {
+        message: 'Execution failed',
+        type: ToolErrorType.EXECUTION_FAILED,
       },
+    };
+    vi.mocked(mockToolRegistry.getTool).mockReturnValue(mockTool);
+    vi.spyOn(mockTool, 'validateBuildAndExecute').mockResolvedValue(
+      executionErrorResult,
     );
 
-    abortController.abort(); // Abort before calling
+    const response = await executeToolCall(
+      mockConfig,
+      request,
+      mockToolRegistry,
+      abortController.signal,
+    );
+    expect(response).toStrictEqual({
+      callId: 'call4',
+      error: new Error('Execution failed'),
+      errorType: ToolErrorType.EXECUTION_FAILED,
+      responseParts: {
+        functionResponse: {
+          id: 'call4',
+          name: 'testTool',
+          response: {
+            output: 'Error: Execution failed',
+          },
+        },
+      },
+      resultDisplay: 'Execution failed',
+    });
+  });
+
+  it('should return an unhandled exception error if execution throws', async () => {
+    const request: ToolCallRequestInfo = {
+      callId: 'call5',
+      name: 'testTool',
+      args: { param1: 'value1' },
+      isClientInitiated: false,
+      prompt_id: 'prompt-id-5',
+    };
+    const executionError = new Error('Something went very wrong');
+    vi.mocked(mockToolRegistry.getTool).mockReturnValue(mockTool);
+    vi.spyOn(mockTool, 'validateBuildAndExecute').mockRejectedValue(
+      executionError,
+    );
+
     const response = await executeToolCall(
       mockConfig,
       request,
@@ -186,18 +222,28 @@ describe('executeToolCall', () => {
       abortController.signal,
     );
 
-    expect(response.callId).toBe('call4');
-    expect(response.error?.message).toBe(cancellationError.message);
-    expect(response.resultDisplay).toBe('Operation cancelled');
+    expect(response.callId).toBe('call5');
+    expect(response.error).toBe(executionError);
+    expect(response.errorType).toBe(ToolErrorType.UNHANDLED_EXCEPTION);
+    expect(response.resultDisplay).toBe('Something went very wrong');
+    expect(response.responseParts).toEqual([
+      {
+        functionResponse: {
+          name: 'testTool',
+          id: 'call5',
+          response: { error: 'Something went very wrong' },
+        },
+      },
+    ]);
   });
 
   it('should correctly format llmContent with inlineData', async () => {
     const request: ToolCallRequestInfo = {
-      callId: 'call5',
+      callId: 'call6',
       name: 'testTool',
       args: {},
       isClientInitiated: false,
-      prompt_id: 'prompt-id-5',
+      prompt_id: 'prompt-id-6',
     };
     const imageDataPart: Part = {
       inlineData: { mimeType: 'image/png', data: 'base64data' },
@@ -207,7 +253,7 @@ describe('executeToolCall', () => {
       returnDisplay: 'Image processed',
     };
     vi.mocked(mockToolRegistry.getTool).mockReturnValue(mockTool);
-    vi.spyOn(mockTool, 'buildAndExecute').mockResolvedValue(toolResult);
+    vi.spyOn(mockTool, 'validateBuildAndExecute').mockResolvedValue(toolResult);
 
     const response = await executeToolCall(
       mockConfig,
@@ -221,7 +267,7 @@ describe('executeToolCall', () => {
       {
         functionResponse: {
           name: 'testTool',
-          id: 'call5',
+          id: 'call6',
           response: {
             output: 'Binary content of type image/png was processed.',
           },

--- a/packages/core/src/core/nonInteractiveToolExecutor.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.ts
@@ -66,7 +66,7 @@ export async function executeToolCall(
   try {
     // Directly execute without confirmation or live output handling
     const effectiveAbortSignal = abortSignal ?? new AbortController().signal;
-    const toolResult: ToolResult = await tool.buildAndExecute(
+    const toolResult: ToolResult = await tool.validateBuildAndExecute(
       toolCallRequest.args,
       effectiveAbortSignal,
       // No live output callback for non-interactive mode

--- a/packages/core/src/tools/tool-error.ts
+++ b/packages/core/src/tools/tool-error.ts
@@ -13,6 +13,7 @@ export enum ToolErrorType {
   UNKNOWN = 'unknown',
   UNHANDLED_EXCEPTION = 'unhandled_exception',
   TOOL_NOT_REGISTERED = 'tool_not_registered',
+  EXECUTION_FAILED = 'execution_failed',
 
   // File System Errors
   FILE_NOT_FOUND = 'file_not_found',

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -200,6 +200,20 @@ export abstract class DeclarativeTool<
     const invocation = this.build(params);
     return invocation.execute(signal, updateOutput);
   }
+
+  async validateBuildAndExecute(
+    args: TParams,
+    abortSignal: AbortSignal,
+  ): Promise<ToolResult> {
+    const validationError = this.validateToolParams(args);
+    if (validationError) {
+      return {
+        llmContent: `Error: Invalid parameters provided. Reason: ${validationError}`,
+        returnDisplay: validationError,
+      };
+    }
+    return this.buildAndExecute(args, abortSignal);
+  }
 }
 
 /**

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -201,18 +201,59 @@ export abstract class DeclarativeTool<
     return invocation.execute(signal, updateOutput);
   }
 
+  /**
+   * Similar to `build` but never throws.
+   * @param params The raw, untrusted parameters from the model.
+   * @returns A `ToolInvocation` instance.
+   */
+  silentBuild(params: TParams): ToolInvocation<TParams, TResult> | Error {
+    try {
+      return this.build(params);
+    } catch (e) {
+      if (e instanceof Error) {
+        return e;
+      }
+      return new Error(String(e));
+    }
+  }
+
+  /**
+   * A convenience method that builds and executes the tool in one step.
+   * Never throws.
+   * @param params The raw, untrusted parameters from the model.
+   * @params abortSignal a signal to abort.
+   * @returns The result of the tool execution.
+   */
   async validateBuildAndExecute(
-    args: TParams,
+    params: TParams,
     abortSignal: AbortSignal,
   ): Promise<ToolResult> {
-    const validationError = this.validateToolParams(args);
-    if (validationError) {
+    try {
+      const invocationOrError = this.silentBuild(params);
+      if (invocationOrError instanceof Error) {
+        const errorMessage = invocationOrError.message;
+        return {
+          llmContent: `Error: Invalid parameters provided. Reason: ${errorMessage}`,
+          returnDisplay: errorMessage,
+          error: {
+            message: errorMessage,
+            type: ToolErrorType.INVALID_TOOL_PARAMS,
+          },
+        };
+      }
+      return await invocationOrError.execute(abortSignal);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
       return {
-        llmContent: `Error: Invalid parameters provided. Reason: ${validationError}`,
-        returnDisplay: validationError,
+        llmContent: `Error: Tool call execution failed. Reason: ${errorMessage}`,
+        returnDisplay: errorMessage,
+        error: {
+          message: errorMessage,
+          type: ToolErrorType.EXECUTION_FAILED,
+        },
       };
     }
-    return this.buildAndExecute(args, abortSignal);
   }
 }
 


### PR DESCRIPTION
1) Fixes a bug introduced in https://github.com/google-gemini/gemini-cli/pull/5613 
2) adds extensive tests of the corrected behavior to ensure against backsliding.
3) Also stops terminating on caught UNHANDLED_EXCEPTIONs when run non-interactively. This ensures alignment between how subagents and the non-interactive CLI treat these errors.