### PR TITLE
feat(core): Support configuring Gemini API base URL via environment variable

### DIFF
--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -109,6 +109,7 @@ export async function createContentGenerator(
 ): Promise<ContentGenerator> {
   const version = process.env.CLI_VERSION || process.version;
   const httpOptions = {
+    baseUrl: process.env.GEMINI_BASEURL || undefined,
     headers: {
       'User-Agent': `GeminiCLI/${version} (${process.platform}; ${process.arch})`,
     },


### PR DESCRIPTION
  This pull request adds support for overriding the default Gemini API endpoint by using the GEMINI_BASEURL environment variable.

  This change allows users to specify a custom base URL, which is useful for scenarios such as:
   - Connecting to the Gemini API through a corporate proxy.
   - Using a different API endpoint for testing or development purposes.
   - Accessing regionally specific or private Gemini API instances.

  The implementation retrieves the baseUrl from process.env.GEMINI_BASEURL and passes it into the httpOptions for the GoogleGenAI client. If the environment variable is not set, it defaults to undefined, ensuring no change in the existing behavior.

  Thank you for considering this contribution. I would be very grateful if you could merge this change.