### PR TITLE
feat(config): add shell.inheritEnv option

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -73,6 +73,7 @@ export interface CliArgs {
   listExtensions: boolean | undefined;
   proxy: string | undefined;
   includeDirectories: string[] | undefined;
+  shellInheritEnv: boolean | undefined;
 }
 
 export async function parseArguments(): Promise<CliArgs> {
@@ -228,6 +229,10 @@ export async function parseArguments(): Promise<CliArgs> {
           coerce: (dirs: string[]) =>
             // Handle comma-separated values
             dirs.flatMap((dir) => dir.split(',').map((d) => d.trim())),
+        })
+        .option('shell-inherit-env', {
+          type: 'boolean',
+          description: 'Inherit environment variables in the shell tool.',
         })
         .check((argv) => {
           if (argv.prompt && argv.promptInteractive) {
@@ -539,6 +544,9 @@ export async function loadCliConfig(
     folderTrust,
     interactive,
     trustedFolder,
+    shell: {
+      inheritEnv: argv.shellInheritEnv ?? settings.shell?.inheritEnv ?? true,
+    },
   });
 }
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -277,6 +277,26 @@ export const SETTINGS_SCHEMA = {
     description: 'The currently selected authentication type.',
     showInDialog: false,
   },
+  shell: {
+    type: 'object',
+    label: 'Shell',
+    category: 'Advanced',
+    requiresRestart: true,
+    default: {},
+    description: 'Shell tool settings.',
+    showInDialog: false,
+    properties: {
+      inheritEnv: {
+        type: 'boolean',
+        label: 'Inherit Environment Variables',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: true,
+        description: 'Inherit environment variables in the shell tool.',
+        showInDialog: false,
+      },
+    },
+  },
   useExternalAuth: {
     type: 'boolean',
     label: 'Use External Auth',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -199,6 +199,9 @@ export interface ConfigParameters {
   chatCompression?: ChatCompressionSettings;
   interactive?: boolean;
   trustedFolder?: boolean;
+  shell?: {
+    inheritEnv?: boolean;
+  };
 }
 
 export class Config {
@@ -263,6 +266,7 @@ export class Config {
   private readonly chatCompression: ChatCompressionSettings | undefined;
   private readonly interactive: boolean;
   private readonly trustedFolder: boolean | undefined;
+  private readonly shell: { inheritEnv: boolean };
   private initialized: boolean = false;
 
   constructor(params: ConfigParameters) {
@@ -329,6 +333,7 @@ export class Config {
     this.chatCompression = params.chatCompression;
     this.interactive = params.interactive ?? false;
     this.trustedFolder = params.trustedFolder;
+    this.shell = { inheritEnv: params.shell?.inheritEnv ?? true };
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -614,6 +619,10 @@ export class Config {
 
   getProxy(): string | undefined {
     return this.proxy;
+  }
+
+  getShellInheritEnv(): boolean {
+    return this.shell.inheritEnv;
   }
 
   getWorkingDir(): string {


### PR DESCRIPTION
Adds a new configuration setting, `shell.inheritEnv`, to control whether the shell tool inherits environment variables from the Gemini CLI process.

This setting is `true` by default to maintain the existing behavior. It can be controlled via the `--shell-inherit-env` command-line flag.

This PR exposes the configuration but does not yet implement the business logic.

## Dive Deeper

This change, after full implemented, will make it safer to use Gemini CLI against untrusted inputs.