### PR TITLE
feat: add instruction queue for better user experience

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -25,6 +25,7 @@ import {
   saveClipboardImage,
   cleanupOldClipboardImages,
 } from '../utils/clipboardUtils.js';
+import { InstructionQueue } from '../types.js';
 import * as path from 'path';
 
 export interface InputPromptProps {
@@ -43,6 +44,8 @@ export interface InputPromptProps {
   setShellModeActive: (value: boolean) => void;
   onEscapePromptChange?: (showPrompt: boolean) => void;
   vimHandleInput?: (key: Key) => boolean;
+  instructionQueue?: InstructionQueue;
+  hasQueuedInstructions?: boolean;
 }
 
 export const InputPrompt: React.FC<InputPromptProps> = ({
@@ -61,6 +64,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   setShellModeActive,
   onEscapePromptChange,
   vimHandleInput,
+  instructionQueue,
+  hasQueuedInstructions,
 }) => {
   const [justNavigatedHistory, setJustNavigatedHistory] = useState(false);
   const [escPressCount, setEscPressCount] = useState(0);
@@ -630,6 +635,67 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           />
         </Box>
       )}
+      {instructionQueue &&
+        (instructionQueue.pending.length > 0 ||
+          instructionQueue.processing) && (
+          <Box
+            marginTop={1}
+            paddingX={1}
+            borderStyle="single"
+            borderColor={theme.border.default}
+          >
+            <Box flexDirection="column" paddingY={1}>
+              <Box marginBottom={1}>
+                <Text color={theme.text.accent}>⏳ Instruction Queue</Text>
+                <Text color={theme.text.secondary}>
+                  {' '}
+                  ({instructionQueue.pending.length} pending
+                  {instructionQueue.processing && ', 1 processing'})
+                </Text>
+              </Box>
+
+              {/* Show current processing instruction */}
+              {instructionQueue.processing && (
+                <Box marginBottom={instructionQueue.pending.length > 0 ? 1 : 0}>
+                  <Text color={theme.status.success}>▶ </Text>
+                  <Text color={theme.text.primary}>
+                    {instructionQueue.processing.content.length > 60
+                      ? `${instructionQueue.processing.content.substring(0, 60)}...`
+                      : instructionQueue.processing.content}
+                  </Text>
+                </Box>
+              )}
+
+              {/* Show pending instructions */}
+              {instructionQueue.pending
+                .slice(0, 3)
+                .map((instruction, index) => (
+                  <Box
+                    key={instruction.id}
+                    marginBottom={
+                      index < Math.min(instructionQueue.pending.length - 1, 2)
+                        ? 0.5
+                        : 0
+                    }
+                  >
+                    <Text color={theme.text.secondary}>{index + 1}. </Text>
+                    <Text color={theme.text.secondary}>
+                      {instruction.content.length > 60
+                        ? `${instruction.content.substring(0, 60)}...`
+                        : instruction.content}
+                    </Text>
+                  </Box>
+                ))}
+
+              {/* Show "and X more" if there are more than 3 pending */}
+              {instructionQueue.pending.length > 3 && (
+                <Text color={theme.text.secondary}>
+                  ... and {instructionQueue.pending.length - 3} more
+                </Text>
+              )}
+            </Box>
+          </Box>
+        )}
     </>
   );
 };

--- a/packages/cli/src/ui/hooks/useInstructionQueue.ts
+++ b/packages/cli/src/ui/hooks/useInstructionQueue.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useCallback, useRef, useMemo } from 'react';
+import { QueuedInstruction, InstructionQueue } from '../types.js';
+
+export interface UseInstructionQueueReturn {
+  queue: InstructionQueue;
+  addInstruction: (content: string) => string;
+  getNextInstruction: () => QueuedInstruction | null;
+  markInstructionProcessing: (instruction: QueuedInstruction) => void;
+  markInstructionComplete: () => void;
+  clearQueue: () => void;
+  hasQueuedInstructions: boolean;
+}
+
+export const useInstructionQueue = (): UseInstructionQueueReturn => {
+  const [queue, setQueue] = useState<InstructionQueue>({
+    pending: [],
+    processing: null,
+  });
+  const idCounterRef = useRef(0);
+
+  const addInstruction = useCallback((content: string): string => {
+    const id = `instruction-${++idCounterRef.current}`;
+    const instruction: QueuedInstruction = {
+      id,
+      content: content.trim(),
+      timestamp: Date.now(),
+    };
+
+    setQueue((prev) => ({
+      ...prev,
+      pending: [...prev.pending, instruction],
+    }));
+
+    return id;
+  }, []);
+
+  const getNextInstruction = useCallback((): QueuedInstruction | null => {
+    return queue.pending[0] || null;
+  }, [queue.pending]);
+
+  const markInstructionProcessing = useCallback(
+    (instruction: QueuedInstruction) => {
+      setQueue((prev) => ({
+        pending: prev.pending.filter((item) => item.id !== instruction.id),
+        processing: instruction,
+      }));
+    },
+    [],
+  );
+
+  const markInstructionComplete = useCallback(() => {
+    setQueue((prev) => ({
+      ...prev,
+      processing: null,
+    }));
+  }, []);
+
+  const clearQueue = useCallback(() => {
+    setQueue({
+      pending: [],
+      processing: null,
+    });
+  }, []);
+
+  const hasQueuedInstructions = useMemo(
+    () => queue.pending.length > 0 || queue.processing !== null,
+    [queue.pending.length, queue.processing],
+  );
+
+  return {
+    queue,
+    addInstruction,
+    getNextInstruction,
+    markInstructionProcessing,
+    markInstructionComplete,
+    clearQueue,
+    hasQueuedInstructions,
+  };
+};

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -16,6 +16,18 @@ export enum StreamingState {
   WaitingForConfirmation = 'waiting_for_confirmation',
 }
 
+// New types for concurrent instruction handling
+export interface QueuedInstruction {
+  id: string;
+  content: string;
+  timestamp: number;
+}
+
+export interface InstructionQueue {
+  pending: QueuedInstruction[];
+  processing: QueuedInstruction | null;
+}
+
 // Copied from server/src/core/turn.ts for CLI usage
 export enum GeminiEventType {
   Content = 'content',


### PR DESCRIPTION
## TLDR

Provide new instructions while it's still running a command.

## Dive Deeper

For example, a command to perform a build may take a while. Right now, if I want to add further instructions ("once the build finishes, do this"), I have to interrupt the build and even if gemini resumes it, will still take some time to restart, making the total iteration time slower.

## Reviewer Test Plan

run the cli and you'll be able to queue up messages and view the queue 

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Resolves #6387
