### PR TITLE
Fix integration test.

### DIFF
--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -221,8 +221,8 @@ export class TestRig {
     // Handle stdin if provided
     if (execOptions.input) {
       child.stdin!.write(execOptions.input);
-      child.stdin!.end();
     }
+    child.stdin!.end();
 
     child.stdout!.on('data', (data: Buffer) => {
       stdout += data;


### PR DESCRIPTION
Fixes integration test by closing stdin unconditionally. This might break interactive multi-turn tests, if we have any.