### PR TITLE
Fix missing import in ide integration tests.

### DIFF
--- a/integration-tests/ide-client.test.ts
+++ b/integration-tests/ide-client.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';


### PR DESCRIPTION
Fix a missing import in the IDE integration tests.

The tests still don't pass but at least they fail in the test logic rather than in scaffolding.