### PR TITLE
Log all session metadata

### DIFF
--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -55,6 +55,11 @@ const mockConfig = {
   getApprovalMode: vi.fn(() => ApprovalMode.DEFAULT),
   getUsageStatisticsEnabled: () => true,
   getDebugMode: () => false,
+  getSessionId: () => 'test-session-id',
+  getContentGeneratorConfig: () => ({
+    model: 'test-model',
+    authType: 'oauth-personal',
+  }),
 };
 
 class MockToolInvocation extends BaseToolInvocation<object, ToolResult> {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -53,6 +53,10 @@ describe('CoreToolScheduler', () => {
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
       getApprovalMode: () => ApprovalMode.DEFAULT,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'oauth-personal',
+      }),
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -109,6 +113,10 @@ describe('CoreToolScheduler with payload', () => {
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
       getApprovalMode: () => ApprovalMode.DEFAULT,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'oauth-personal',
+      }),
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -405,6 +413,10 @@ describe('CoreToolScheduler edit cancellation', () => {
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
       getApprovalMode: () => ApprovalMode.DEFAULT,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'oauth-personal',
+      }),
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -493,6 +505,10 @@ describe('CoreToolScheduler YOLO mode', () => {
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
       getApprovalMode: () => ApprovalMode.YOLO,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'oauth-personal',
+      }),
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -578,6 +594,10 @@ describe('CoreToolScheduler request queueing', () => {
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
       getApprovalMode: () => ApprovalMode.YOLO, // Use YOLO to avoid confirmation prompts
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'oauth-personal',
+      }),
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -687,6 +707,10 @@ describe('CoreToolScheduler request queueing', () => {
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
       getApprovalMode: () => ApprovalMode.YOLO,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'oauth-personal',
+      }),
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -19,6 +19,10 @@ const mockConfig = {
   getSessionId: () => 'test-session-id',
   getUsageStatisticsEnabled: () => true,
   getDebugMode: () => false,
+  getContentGeneratorConfig: () => ({
+    model: 'test-model',
+    authType: 'oauth-personal',
+  }),
 } as unknown as Config;
 
 describe('executeToolCall', () => {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -192,14 +192,13 @@ describe('ClearcutLogger', () => {
 
       vi.stubEnv('GITHUB_SHA', '8675309');
 
-      const event = logger?.createLogEvent('abc', []);
+      const event = logger?.createLogEvent(EventNames.CHAT_COMPRESSION, []);
 
       expect(event?.event_metadata[0]).toContainEqual({
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
         value: 'GitHub',
       });
     });
-
 
     it('logs the current surface', () => {
       const { logger } = setup({});
@@ -260,7 +259,7 @@ describe('ClearcutLogger', () => {
         }
         vi.stubEnv('TERM_PROGRAM', 'vscode');
         const event = logger?.createLogEvent(EventNames.API_ERROR, []);
-        expect(event?.event_metadata[0][1]).toEqual({
+        expect(event?.event_metadata[0][3]).toEqual({
           gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
           value: expectedValue,
         });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -132,7 +132,7 @@ describe('ClearcutLogger', () => {
 
       const event = logger?.createLogEvent('abc', []);
 
-      expect(event?.event_metadata[0][0]).toEqual({
+      expect(event?.event_metadata[0]).toContainEqual({
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_GOOGLE_ACCOUNTS_COUNT,
         value: '9001',
       });
@@ -145,7 +145,7 @@ describe('ClearcutLogger', () => {
 
       const event = logger?.createLogEvent('abc', []);
 
-      expect(event?.event_metadata[0][1]).toEqual({
+      expect(event?.event_metadata[0]).toContainEqual({
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
         value: 'GitHub',
       });
@@ -159,7 +159,7 @@ describe('ClearcutLogger', () => {
 
       const event = logger?.createLogEvent('abc', []);
 
-      expect(event?.event_metadata[0][1]).toEqual({
+      expect(event?.event_metadata[0]).toContainEqual({
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
         value: 'ide-1234',
       });
@@ -202,7 +202,7 @@ describe('ClearcutLogger', () => {
         expectedValue: 'cloudshell',
       },
     ])(
-      'logs the current surface for as $expectedValue, preempting vscode detection',
+      'logs the current surface as $expectedValue, preempting vscode detection',
       ({ env, expectedValue }) => {
         const { logger } = setup({});
         for (const [key, value] of Object.entries(env)) {
@@ -210,7 +210,7 @@ describe('ClearcutLogger', () => {
         }
         vi.stubEnv('TERM_PROGRAM', 'vscode');
         const event = logger?.createLogEvent('abc', []);
-        expect(event?.event_metadata[0][1]).toEqual({
+        expect(event?.event_metadata[0]).toContainEqual({
           gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
           value: expectedValue,
         });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -204,7 +204,7 @@ export class ClearcutLogger {
   createLogEvent(eventName: EventNames, data: EventValue[] = []): LogEvent {
     const email = getCachedGoogleAccount();
 
-    if (name !== start_session_event_name) {
+    if (eventName !== EventNames.START_SESSION) {
       data.push(...this.sessionData);
     }
     data = this.addDefaultFields(data);
@@ -558,7 +558,7 @@ export class ClearcutLogger {
       this.createLogEvent(EventNames.CHAT_COMPRESSION, data),
     );
   }
-  
+
   logFlashFallbackEvent(): void {
     this.enqueueLogEvent(this.createLogEvent(EventNames.FLASH_FALLBACK, []));
     this.flushToClearcut().catch((error) => {
@@ -669,7 +669,7 @@ export class ClearcutLogger {
 
   logEndSessionEvent(): void {
     // Flush immediately on session end.
-    this.enqueueLogEvent(this.createLogEvent(EventNames.END_SESSION, data));
+    this.enqueueLogEvent(this.createLogEvent(EventNames.END_SESSION, []));
     this.flushToClearcut().catch((error) => {
       console.debug('Error flushing to Clearcut:', error);
     });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -405,10 +405,6 @@ export class ClearcutLogger {
         value: JSON.stringify(event.function_name),
       },
       {
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_PROMPT_ID,
-        value: JSON.stringify(event.prompt_id),
-      },
-      {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_TOOL_CALL_DECISION,
         value: JSON.stringify(event.decision),
       },
@@ -458,10 +454,6 @@ export class ClearcutLogger {
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_API_REQUEST_MODEL,
         value: JSON.stringify(event.model),
-      },
-      {
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_PROMPT_ID,
-        value: JSON.stringify(event.prompt_id),
       },
     ];
 
@@ -523,10 +515,6 @@ export class ClearcutLogger {
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_API_ERROR_MODEL,
         value: JSON.stringify(event.model),
-      },
-      {
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_PROMPT_ID,
-        value: JSON.stringify(event.prompt_id),
       },
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_API_ERROR_TYPE,

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -171,7 +171,7 @@ export function logFlashFallback(
   config: Config,
   event: FlashFallbackEvent,
 ): void {
-  ClearcutLogger.getInstance(config)?.logFlashFallbackEvent(event);
+  ClearcutLogger.getInstance(config)?.logFlashFallbackEvent();
   if (!isTelemetrySdkInitialized()) return;
 
   const attributes: LogAttributes = {


### PR DESCRIPTION
## TLDR

Updated clearcut-logger to log all session-level metadata on every log event.

## Dive Deeper

We've run into problems trying to denormalize the Concord logs due to irregularities most likely introduced by folks in the open source community modifying the logging code for experimental purposes. After discussing options with the DS team, we decided the cleanest solution is to log all the session-level metadata on every event.

## Reviewer Test Plan

Unit tests should suffice.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | y  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/maintainers-gemini-cli/issues/654