### PR TITLE
fix: resolve @eslint/plugin-kit ReDoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -951,13 +951,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.1",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -965,9 +965,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Updated `@eslint/plugin-kit` from 0.3.1 to 0.3.5 to fix a low-severity security vulnerability

## Details
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in the `@eslint/plugin-kit` package:
- **Vulnerability**: GHSA-xffm-g5w8-qvg7
- **Severity**: Low
- **Component**: ConfigCommentParser in @eslint/plugin-kit
- **Fix**: Updated to version 0.3.5 which includes the security patch

## Changes
- Updated `package-lock.json` via `npm audit fix`
- No code changes required
- Build completes successfully

## Testing
- ✅ `npm audit` now reports 0 vulnerabilities
- ✅ `npm run build` completes successfully
- ✅ No functional changes to the codebase

This is a security maintenance update with no expected impact on functionality.