### PR TITLE
Fix skipped tests in useGitBranchName hook

### DIFF
--- a/packages/cli/src/ui/hooks/useGitBranchName.test.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.test.ts
@@ -9,34 +9,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { renderHook } from '@testing-library/react';
 import { useGitBranchName } from './useGitBranchName.js';
-import { fs, vol } from 'memfs'; // For mocking fs
 import { EventEmitter } from 'node:events';
 import { exec as mockExec, type ChildProcess } from 'node:child_process';
-import type { FSWatcher } from 'memfs/lib/volume.js';
+import type { FSWatcher } from 'node:fs';
 
 // Mock child_process
 vi.mock('child_process');
 
-// Mock fs and fs/promises
-vi.mock('node:fs', async () => {
-  const memfs = await vi.importActual<typeof import('memfs')>('memfs');
-  return memfs.fs;
-});
-
-vi.mock('node:fs/promises', async () => {
-  const memfs = await vi.importActual<typeof import('memfs')>('memfs');
-  return memfs.fs.promises;
-});
-
 const CWD = '/test/project';
-const GIT_HEAD_PATH = `${CWD}/.git/HEAD`;
+const GIT_LOGS_HEAD_PATH = `${CWD}/.git/logs/HEAD`;
 
 describe('useGitBranchName', () => {
   beforeEach(() => {
-    vol.reset(); // Reset in-memory filesystem
-    vol.fromJSON({
-      [GIT_HEAD_PATH]: 'ref: refs/heads/main',
-    });
     vi.useFakeTimers(); // Use fake timers for async operations
   });
 
@@ -121,8 +105,25 @@ describe('useGitBranchName', () => {
     expect(result.current).toBeUndefined();
   });
 
-  it('should update branch name when .git/HEAD changes', async ({ skip }) => {
-    skip(); // TODO: fix
+  it('should update branch name when .git/logs/HEAD changes', async () => {
+    let watchCallback: ((eventType: string) => void) | undefined;
+    
+    // Create mock fs dependencies
+    const mockFs = {
+      watch: vi.fn().mockImplementation((path: string, callback: (eventType: string) => void) => {
+        watchCallback = callback;
+        return {
+          close: vi.fn(),
+        } as unknown as FSWatcher;
+      }),
+      constants: { F_OK: 0 },
+    };
+
+    const mockFsPromises = {
+      access: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // Mock initial call to return 'main'
     (mockExec as MockedFunction<typeof mockExec>).mockImplementationOnce(
       (_command, _options, callback) => {
         callback?.(null, 'main\n', '');
@@ -130,15 +131,28 @@ describe('useGitBranchName', () => {
       },
     );
 
-    const { result, rerender } = renderHook(() => useGitBranchName(CWD));
+    const { result, rerender } = renderHook(() => 
+      useGitBranchName(CWD, { fs: mockFs as any, fsPromises: mockFsPromises as any })
+    );
 
+    // Wait for initial branch name to be set
     await act(async () => {
       vi.runAllTimers();
       rerender();
     });
     expect(result.current).toBe('main');
 
-    // Simulate a branch change
+    // Wait for async watcher setup to complete
+    await act(async () => {
+      await Promise.resolve();
+      vi.runAllTimers();
+      rerender();
+    });
+
+    // Verify watcher was set up
+    expect(mockFs.watch).toHaveBeenCalledWith(GIT_LOGS_HEAD_PATH, expect.any(Function));
+
+    // Mock subsequent call for file change to return 'develop'
     (mockExec as MockedFunction<typeof mockExec>).mockImplementationOnce(
       (_command, _options, callback) => {
         callback?.(null, 'develop\n', '');
@@ -146,11 +160,10 @@ describe('useGitBranchName', () => {
       },
     );
 
-    // Simulate file change event
-    // Ensure the watcher is set up before triggering the change
+    // Now simulate the file change event
     await act(async () => {
-      fs.writeFileSync(GIT_HEAD_PATH, 'ref: refs/heads/develop'); // Trigger watcher
-      vi.runAllTimers(); // Process timers for watcher and exec
+      watchCallback?.('change');
+      vi.runAllTimers();
       rerender();
     });
 
@@ -158,8 +171,15 @@ describe('useGitBranchName', () => {
   });
 
   it('should handle watcher setup error silently', async () => {
-    // Remove .git/HEAD to cause an error in fs.watch setup
-    vol.unlinkSync(GIT_HEAD_PATH);
+    // Create mock fs dependencies that fail on access
+    const mockFs = {
+      watch: vi.fn(),
+      constants: { F_OK: 0 },
+    };
+
+    const mockFsPromises = {
+      access: vi.fn().mockRejectedValue(new Error('ENOENT: no such file or directory')),
+    };
 
     (mockExec as MockedFunction<typeof mockExec>).mockImplementation(
       (_command, _options, callback) => {
@@ -168,7 +188,9 @@ describe('useGitBranchName', () => {
       },
     );
 
-    const { result, rerender } = renderHook(() => useGitBranchName(CWD));
+    const { result, rerender } = renderHook(() => 
+      useGitBranchName(CWD, { fs: mockFs as any, fsPromises: mockFsPromises as any })
+    );
 
     await act(async () => {
       vi.runAllTimers();
@@ -177,37 +199,34 @@ describe('useGitBranchName', () => {
 
     expect(result.current).toBe('main'); // Branch name should still be fetched initially
 
-    // Try to trigger a change that would normally be caught by the watcher
-    (mockExec as MockedFunction<typeof mockExec>).mockImplementationOnce(
-      (_command, _options, callback) => {
-        callback?.(null, 'develop\n', '');
-        return new EventEmitter() as ChildProcess;
-      },
-    );
-
-    // This write would trigger the watcher if it was set up
-    // but since it failed, the branch name should not update
-    // We need to create the file again for writeFileSync to not throw
-    vol.fromJSON({
-      [GIT_HEAD_PATH]: 'ref: refs/heads/develop',
-    });
-
+    // Wait for async watcher setup attempt to complete
     await act(async () => {
-      fs.writeFileSync(GIT_HEAD_PATH, 'ref: refs/heads/develop');
+      await Promise.resolve();
       vi.runAllTimers();
       rerender();
     });
 
-    // Branch name should not change because watcher setup failed
+    // Verify that fs.watch was never called because access failed
+    expect(mockFs.watch).not.toHaveBeenCalled();
+    
+    // Branch name should remain the same since no watcher was set up
     expect(result.current).toBe('main');
   });
 
-  it('should cleanup watcher on unmount', async ({ skip }) => {
-    skip(); // TODO: fix
+  it('should cleanup watcher on unmount', async () => {
     const closeMock = vi.fn();
-    const watchMock = vi.spyOn(fs, 'watch').mockReturnValue({
-      close: closeMock,
-    } as unknown as FSWatcher);
+    
+    // Create mock fs dependencies
+    const mockFs = {
+      watch: vi.fn().mockReturnValue({
+        close: closeMock,
+      } as unknown as FSWatcher),
+      constants: { F_OK: 0 },
+    };
+
+    const mockFsPromises = {
+      access: vi.fn().mockResolvedValue(undefined),
+    };
 
     (mockExec as MockedFunction<typeof mockExec>).mockImplementation(
       (_command, _options, callback) => {
@@ -216,15 +235,25 @@ describe('useGitBranchName', () => {
       },
     );
 
-    const { unmount, rerender } = renderHook(() => useGitBranchName(CWD));
+    const { unmount, rerender } = renderHook(() => 
+      useGitBranchName(CWD, { fs: mockFs as any, fsPromises: mockFsPromises as any })
+    );
 
+    // Wait for initial setup
     await act(async () => {
       vi.runAllTimers();
       rerender();
     });
 
+    // Wait for async watcher setup to complete
+    await act(async () => {
+      await Promise.resolve();
+      vi.runAllTimers();
+      rerender();
+    });
+
     unmount();
-    expect(watchMock).toHaveBeenCalledWith(GIT_HEAD_PATH, expect.any(Function));
+    expect(mockFs.watch).toHaveBeenCalledWith(GIT_LOGS_HEAD_PATH, expect.any(Function));
     expect(closeMock).toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -15,9 +15,11 @@ interface FileSystemDeps {
   fsPromises: typeof fsPromises;
 }
 
+const defaultDeps: FileSystemDeps = { fs, fsPromises };
+
 export function useGitBranchName(
   cwd: string,
-  deps: FileSystemDeps = { fs, fsPromises }
+  deps: FileSystemDeps = defaultDeps
 ): string | undefined {
   const [branchName, setBranchName] = useState<string | undefined>(undefined);
 

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -10,7 +10,15 @@ import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 
-export function useGitBranchName(cwd: string): string | undefined {
+interface FileSystemDeps {
+  fs: typeof fs;
+  fsPromises: typeof fsPromises;
+}
+
+export function useGitBranchName(
+  cwd: string,
+  deps: FileSystemDeps = { fs, fsPromises }
+): string | undefined {
   const [branchName, setBranchName] = useState<string | undefined>(undefined);
 
   const fetchBranchName = useCallback(
@@ -53,8 +61,8 @@ export function useGitBranchName(cwd: string): string | undefined {
     const setupWatcher = async () => {
       try {
         // Check if .git/logs/HEAD exists, as it might not in a new repo or orphaned head
-        await fsPromises.access(gitLogsHeadPath, fs.constants.F_OK);
-        watcher = fs.watch(gitLogsHeadPath, (eventType: string) => {
+        await deps.fsPromises.access(gitLogsHeadPath, deps.fs.constants.F_OK);
+        watcher = deps.fs.watch(gitLogsHeadPath, (eventType: string) => {
           // Changes to .git/logs/HEAD (appends) indicate HEAD has likely changed
           if (eventType === 'change' || eventType === 'rename') {
             // Handle rename just in case
@@ -73,7 +81,7 @@ export function useGitBranchName(cwd: string): string | undefined {
     return () => {
       watcher?.close();
     };
-  }, [cwd, fetchBranchName]);
+  }, [cwd, fetchBranchName, deps]);
 
   return branchName;
 }


### PR DESCRIPTION
## What this PR does

Fixes two tests that were previously skipped in the `useGitBranchName` hook. These tests were important for verifying file watching functionality and proper cleanup on unmount, but were disabled due to complex mocking issues.

## The problem

The original tests were trying to mock filesystem modules using memfs, but the async nature of the file watcher setup made this extremely difficult to test properly. The `fsPromises.access()` call wasn't being intercepted correctly, so the file watcher was never being set up in tests.

## The solution

Instead of fighting with complex module mocking, I refactored the hook to use dependency injection. The hook now accepts optional filesystem dependencies as a parameter, while maintaining full backward compatibility.

## Changes made

- Added optional `deps` parameter to `useGitBranchName` hook with default values
- Updated hook to use injected dependencies instead of direct imports
- Completely rewrote the failing tests to use simple mocks via dependency injection
- Removed complex memfs setup that wasn't working properly

## Backward compatibility

Zero breaking changes. All existing code continues to work exactly the same:

```typescript
// This still works identically
const branchName = useGitBranchName('/my/project');
```

The hook uses the real `fs` and `fsPromises` modules by default. Only tests inject mocks.

## Test results

All 7 tests now pass, including the two that were previously skipped:
- ✅ File watching setup and branch name updates
- ✅ Proper cleanup of file watchers on unmount  
- ✅ Error handling when file access fails

This improves test coverage while making the code more testable for future changes.