### PR TITLE
fix(commands): Respect YOLO mode in custom slash commands

### DIFF
--- a/packages/cli/src/services/prompt-processors/shellProcessor.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  ApprovalMode,
   checkCommandPermissions,
   escapeShellArg,
   getShellConfiguration,
@@ -107,7 +108,11 @@ export class ShellProcessor implements IPromptProcessor {
             `${this.commandName} cannot be run. Blocked command: "${command}". Reason: ${blockReason || 'Blocked by configuration.'}`,
           );
         }
-        disallowedCommands.forEach((uc) => commandsToConfirm.add(uc));
+
+        // If not a hard denial, respect YOLO mode and auto-approve.
+        if (config.getApprovalMode() !== ApprovalMode.YOLO) {
+          disallowedCommands.forEach((uc) => commandsToConfirm.add(uc));
+        }
       }
     }
 


### PR DESCRIPTION
## TLDR

This pull request fixes a bug where custom slash commands that execute shell scripts (`!{...}`) did not respect YOLO mode (`--yolo` or `--approval-mode=yolo`). Previously, users would still be prompted for confirmation even when YOLO mode was active.

The fix is in the `ShellProcessor`, which now checks the `approvalMode` from the configuration before triggering a confirmation prompt. Importantly, this change still respects "hard deny" rules from the settings, which will block a command even in YOLO mode.

**Key files to review:**
- `packages/cli/src/services/prompt-processors/shellProcessor.ts` (The core logic change)
- `packages/cli/src/services/prompt-processors/shellProcessor.test.ts` (New tests verifying the behavior)

## Dive Deeper

The root cause of this issue was a missing check in the command processing pipeline for custom slash commands. The `ShellProcessor` would ask the `checkCommandPermissions` service if a command was allowed. If the service replied that confirmation was needed, the processor would unconditionally throw a `ConfirmationRequiredError`, which the UI would then use to render a confirmation prompt.

This approach failed to account for the user's configured `approvalMode`.

This PR injects the approval mode check at the correct layer. The flow is now:
1. `ShellProcessor` asks `checkCommandPermissions` for a verdict on a command.
2. `checkCommandPermissions` acts as the "security guard," returning whether the command is allowed, needs confirmation, or is subject to a "hard deny." It remains unaware of UI concepts like YOLO mode.
3. The `ShellProcessor` then acts as the "action taker." It inspects the verdict:
    - If it's a hard deny, execution is stopped (security first).
    - If it requires confirmation, the processor now checks if `approvalMode` is `YOLO`.
    - If it is `YOLO`, the confirmation is bypassed, and the command is executed.
    - Otherwise, the `ConfirmationRequiredError` is thrown as before.

This maintains a clean separation of concerns, ensuring user preferences don't override fundamental security policies (hard denies), while providing the expected user experience for YOLO mode.

## Reviewer Test Plan

You can use the following steps to validate the fix.

### 1. Setup a Test Command

Create a test slash command in your project's `.gemini/commands/` directory.

**File: `.gemini/commands/test-ls.toml`**
```toml
prompt = "List files here: !{ls -l}"
description = "A test command for YOLO mode."
```

### 2. Verify the Original Bug (on `main` branch)

1. Run the command without YOLO mode. It **should** prompt for confirmation when you enter `/test-ls`. (Start interactive mode without yolo mode)

2. Run the command **with** YOLO mode. It will **incorrectly** prompt for confirmation (this is the bug).

### 3. Verify the Fix (on this branch)

1. Run the command with YOLO mode again. It should now execute **without** a confirmation prompt.

### 4. Verify "Hard Deny" is Still Respected

This is a critical security check to ensure YOLO mode doesn't bypass everything.

1. Create or edit your project's `.gemini/settings.json` file and add a "hard deny" rule.
   ```json
   {
     "excludeTools": ["run_shell_command(ls)"]
   }
   ```
3. Now, run the test command again, even with YOLO mode enabled.

4. The command **must be blocked**, and you should see an error message indicating that the command is not allowed. This confirms that the security layer is still effective.


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅ | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅ | -   | -   |
