### PR TITLE
Add vi globals to fix integration tests.

### DIFF
--- a/integration-tests/replace.test.ts
+++ b/integration-tests/replace.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { TestRig, printDebugInfo, validateModelOutput } from './test-helper.js';
 
 describe('replace', () => {

--- a/integration-tests/write_file.test.ts
+++ b/integration-tests/write_file.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   TestRig,
   createToolCallErrorMessage,


### PR DESCRIPTION
Fixes integration tests which were broken by the use of `vi.stubEnv` in #6255.