### PR TITLE
feat(cli): Add --allowed-tools flag to bypass tool confirmation (#2417)

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -91,6 +91,11 @@ If you are experiencing performance issues with file searching (e.g., with `@` c
   - **Default:** All tools available for use by the Gemini model.
   - **Example:** `"coreTools": ["ReadFileTool", "GlobTool", "ShellTool(ls)"]`.
 
+- **`allowedTools`** (array of strings):
+  - **Default:** `undefined`
+  - **Description:** A list of tool names that will bypass the confirmation dialog. This is useful for tools that you trust and use frequently. The match semantics are the same as `coreTools`.
+  - **Example:** `"allowedTools": ["ShellTool(git status)"]`.
+
 - **`excludeTools`** (array of strings):
   - **Description:** Allows you to specify a list of core tool names that should be excluded from the model. A tool listed in both `excludeTools` and `coreTools` is excluded. You can also specify command-specific restrictions for tools that support it, like the `ShellTool`. For example, `"excludeTools": ["ShellTool(rm -rf)"]` will block the `rm -rf` command.
   - **Default**: No tools excluded.
@@ -479,6 +484,9 @@ Arguments passed directly when running the CLI can override other configurations
     - `yolo`: Automatically approve all tool calls (equivalent to `--yolo`)
   - Cannot be used together with `--yolo`. Use `--approval-mode=yolo` instead of `--yolo` for the new unified approach.
   - Example: `gemini --approval-mode auto_edit`
+- **`--allowed-tools <tool1,tool2,...>`**:
+  - A comma-separated list of tool names that will bypass the confirmation dialog.
+  - Example: `gemini --allowed-tools "ShellTool(git status)"`
 - **`--telemetry`**:
   - Enables [telemetry](../telemetry.md).
 - **`--telemetry-target`**:

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -70,6 +70,7 @@ export interface CliArgs {
   telemetryLogPrompts: boolean | undefined;
   telemetryOutfile: string | undefined;
   allowedMcpServerNames: string[] | undefined;
+  allowedTools: string[] | undefined;
   experimentalAcp: boolean | undefined;
   extensions: string[] | undefined;
   listExtensions: boolean | undefined;
@@ -188,6 +189,11 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           type: 'array',
           string: true,
           description: 'Allowed MCP server names',
+        })
+        .option('allowed-tools', {
+          type: 'array',
+          string: true,
+          description: 'Tools that are allowed to run without confirmation',
         })
         .option('extensions', {
           alias: 'e',
@@ -488,6 +494,7 @@ export async function loadCliConfig(
     question,
     fullContext: argv.allFiles || false,
     coreTools: settings.coreTools || undefined,
+    allowedTools: argv.allowedTools || settings.allowedTools || undefined,
     excludeTools,
     toolDiscoveryCommand: settings.toolDiscoveryCommand,
     toolCallCommand: settings.toolCallCommand,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -344,6 +344,16 @@ export const SETTINGS_SCHEMA = {
     description: 'Paths to core tool definitions.',
     showInDialog: false,
   },
+  allowedTools: {
+    type: 'array',
+    label: 'Allowed Tools',
+    category: 'Advanced',
+    requiresRestart: true,
+    default: undefined as string[] | undefined,
+    description:
+      'A list of tool names that will bypass the confirmation dialog.',
+    showInDialog: false,
+  },
   excludeTools: {
     type: 'array',
     label: 'Exclude Tools',

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -53,14 +53,15 @@ const mockToolRegistry = {
 const mockConfig = {
   getToolRegistry: vi.fn(() => mockToolRegistry as unknown as ToolRegistry),
   getApprovalMode: vi.fn(() => ApprovalMode.DEFAULT),
+  getSessionId: () => 'test-session-id',
   getUsageStatisticsEnabled: () => true,
   getDebugMode: () => false,
-  getSessionId: () => 'test-session-id',
+  getAllowedTools: vi.fn(() => []),
   getContentGeneratorConfig: () => ({
     model: 'test-model',
     authType: 'oauth-personal',
   }),
-};
+} as unknown as Config;
 
 class MockToolInvocation extends BaseToolInvocation<object, ToolResult> {
   constructor(
@@ -217,11 +218,6 @@ describe('useReactToolScheduler in YOLO Mode', () => {
     await act(async () => {
       await vi.runAllTimersAsync(); // Process execution
     });
-
-    // Check that shouldConfirmExecute was NOT called
-    expect(
-      mockToolRequiresConfirmation.shouldConfirmExecute,
-    ).not.toHaveBeenCalled();
 
     // Check that execute WAS called
     expect(mockToolRequiresConfirmation.execute).toHaveBeenCalledWith(

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -32,6 +32,7 @@ describe('executeToolCall', () => {
     mockConfig = {
       getToolRegistry: () => mockToolRegistry,
       getApprovalMode: () => ApprovalMode.DEFAULT,
+      getAllowedTools: () => [],
       getSessionId: () => 'test-session-id',
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -307,6 +307,21 @@ export abstract class BaseDeclarativeTool<
  */
 export type AnyDeclarativeTool = DeclarativeTool<object, ToolResult>;
 
+/**
+ * Type guard to check if an object is a Tool.
+ * @param obj The object to check.
+ * @returns True if the object is a Tool, false otherwise.
+ */
+export function isTool(obj: unknown): obj is AnyDeclarativeTool {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'name' in obj &&
+    'build' in obj &&
+    typeof (obj as AnyDeclarativeTool).build === 'function'
+  );
+}
+
 export interface ToolResult {
   /**
    * Content meant to be included in LLM history.

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -16,11 +16,14 @@ import {
 import type { Config } from '../config/config.js';
 
 const mockPlatform = vi.hoisted(() => vi.fn());
+const mockHomedir = vi.hoisted(() => vi.fn());
 vi.mock('os', () => ({
   default: {
     platform: mockPlatform,
+    homedir: mockHomedir,
   },
   platform: mockPlatform,
+  homedir: mockHomedir,
 }));
 
 const mockQuote = vi.hoisted(() => vi.fn());
@@ -38,6 +41,7 @@ beforeEach(() => {
   config = {
     getCoreTools: () => [],
     getExcludeTools: () => [],
+    getAllowedTools: () => [],
   } as unknown as Config;
 });
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { AnyToolInvocation } from '../index.js';
 import type { Config } from '../config/config.js';
 import os from 'node:os';
 import { quote } from 'shell-quote';
+import { doesToolInvocationMatch } from './tool-utils.js';
+
+const SHELL_TOOL_NAMES = ['run_shell_command', 'ShellTool'];
 
 /**
  * An identifier for the shell type.
@@ -319,32 +323,19 @@ export function checkCommandPermissions(
     };
   }
 
-  const SHELL_TOOL_NAMES = ['run_shell_command', 'ShellTool'];
   const normalize = (cmd: string): string => cmd.trim().replace(/\s+/g, ' ');
-
-  const isPrefixedBy = (cmd: string, prefix: string): boolean => {
-    if (!cmd.startsWith(prefix)) {
-      return false;
-    }
-    return cmd.length === prefix.length || cmd[prefix.length] === ' ';
-  };
-
-  const extractCommands = (tools: string[]): string[] =>
-    tools.flatMap((tool) => {
-      for (const toolName of SHELL_TOOL_NAMES) {
-        if (tool.startsWith(`${toolName}(`) && tool.endsWith(')')) {
-          return [normalize(tool.slice(toolName.length + 1, -1))];
-        }
-      }
-      return [];
-    });
-
-  const coreTools = config.getCoreTools() || [];
-  const excludeTools = config.getExcludeTools() || [];
   const commandsToValidate = splitCommands(command).map(normalize);
+  const invocation: AnyToolInvocation & { params: { command: string } } = {
+    params: { command: '' },
+  } as AnyToolInvocation & { params: { command: string } };
 
   // 1. Blocklist Check (Highest Priority)
-  if (SHELL_TOOL_NAMES.some((name) => excludeTools.includes(name))) {
+  const excludeTools = config.getExcludeTools() || [];
+  const isWildcardBlocked = SHELL_TOOL_NAMES.some((name) =>
+    excludeTools.includes(name),
+  );
+
+  if (isWildcardBlocked) {
     return {
       allAllowed: false,
       disallowedCommands: commandsToValidate,
@@ -352,9 +343,12 @@ export function checkCommandPermissions(
       isHardDenial: true,
     };
   }
-  const blockedCommands = extractCommands(excludeTools);
+
   for (const cmd of commandsToValidate) {
-    if (blockedCommands.some((blocked) => isPrefixedBy(cmd, blocked))) {
+    invocation.params['command'] = cmd;
+    if (
+      doesToolInvocationMatch('run_shell_command', invocation, excludeTools)
+    ) {
       return {
         allAllowed: false,
         disallowedCommands: [cmd],
@@ -364,7 +358,7 @@ export function checkCommandPermissions(
     }
   }
 
-  const globallyAllowedCommands = extractCommands(coreTools);
+  const coreTools = config.getCoreTools() || [];
   const isWildcardAllowed = SHELL_TOOL_NAMES.some((name) =>
     coreTools.includes(name),
   );
@@ -375,18 +369,30 @@ export function checkCommandPermissions(
     return { allAllowed: true, disallowedCommands: [] };
   }
 
+  const disallowedCommands: string[] = [];
+
   if (sessionAllowlist) {
     // "DEFAULT DENY" MODE: A session allowlist is provided.
     // All commands must be in either the session or global allowlist.
-    const disallowedCommands: string[] = [];
+    const normalizedSessionAllowlist = new Set(
+      [...sessionAllowlist].flatMap((cmd) =>
+        SHELL_TOOL_NAMES.map((name) => `${name}(${cmd})`),
+      ),
+    );
+
     for (const cmd of commandsToValidate) {
-      const isSessionAllowed = [...sessionAllowlist].some((allowed) =>
-        isPrefixedBy(cmd, normalize(allowed)),
+      invocation.params['command'] = cmd;
+      const isSessionAllowed = doesToolInvocationMatch(
+        'run_shell_command',
+        invocation,
+        [...normalizedSessionAllowlist],
       );
       if (isSessionAllowed) continue;
 
-      const isGloballyAllowed = globallyAllowedCommands.some((allowed) =>
-        isPrefixedBy(cmd, allowed),
+      const isGloballyAllowed = doesToolInvocationMatch(
+        'run_shell_command',
+        invocation,
+        coreTools,
       );
       if (isGloballyAllowed) continue;
 
@@ -405,12 +411,18 @@ export function checkCommandPermissions(
     }
   } else {
     // "DEFAULT ALLOW" MODE: No session allowlist.
-    const hasSpecificAllowedCommands = globallyAllowedCommands.length > 0;
+    const hasSpecificAllowedCommands =
+      coreTools.filter((tool) =>
+        SHELL_TOOL_NAMES.some((name) => tool.startsWith(`${name}(`)),
+      ).length > 0;
+
     if (hasSpecificAllowedCommands) {
-      const disallowedCommands: string[] = [];
       for (const cmd of commandsToValidate) {
-        const isGloballyAllowed = globallyAllowedCommands.some((allowed) =>
-          isPrefixedBy(cmd, allowed),
+        invocation.params['command'] = cmd;
+        const isGloballyAllowed = doesToolInvocationMatch(
+          'run_shell_command',
+          invocation,
+          coreTools,
         );
         if (!isGloballyAllowed) {
           disallowedCommands.push(cmd);
@@ -420,7 +432,9 @@ export function checkCommandPermissions(
         return {
           allAllowed: false,
           disallowedCommands,
-          blockReason: `Command(s) not in the allowed commands list. Disallowed commands: ${disallowedCommands.map((c) => JSON.stringify(c)).join(', ')}`,
+          blockReason: `Command(s) not in the allowed commands list. Disallowed commands: ${disallowedCommands
+            .map((c) => JSON.stringify(c))
+            .join(', ')}`,
           isHardDenial: false, // This is a soft denial.
         };
       }

--- a/packages/core/src/utils/tool-utils.test.ts
+++ b/packages/core/src/utils/tool-utils.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect, describe, it } from 'vitest';
+import { doesToolInvocationMatch } from './tool-utils.js';
+import type { AnyToolInvocation, Config } from '../index.js';
+import { ReadFileTool } from '../tools/read-file.js';
+
+describe('doesToolInvocationMatch', () => {
+  it('should not match a partial command prefix', () => {
+    const invocation = {
+      params: { command: 'git commitsomething' },
+    } as AnyToolInvocation;
+    const patterns = ['ShellTool(git commit)'];
+    const result = doesToolInvocationMatch(
+      'run_shell_command',
+      invocation,
+      patterns,
+    );
+    expect(result).toBe(false);
+  });
+
+  it('should match an exact command', () => {
+    const invocation = {
+      params: { command: 'git status' },
+    } as AnyToolInvocation;
+    const patterns = ['ShellTool(git status)'];
+    const result = doesToolInvocationMatch(
+      'run_shell_command',
+      invocation,
+      patterns,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should match a command that is a prefix', () => {
+    const invocation = {
+      params: { command: 'git status -v' },
+    } as AnyToolInvocation;
+    const patterns = ['ShellTool(git status)'];
+    const result = doesToolInvocationMatch(
+      'run_shell_command',
+      invocation,
+      patterns,
+    );
+    expect(result).toBe(true);
+  });
+
+  describe('for non-shell tools', () => {
+    const readFileTool = new ReadFileTool({} as Config);
+    const invocation = {
+      params: { file: 'test.txt' },
+    } as AnyToolInvocation;
+
+    it('should match by tool name', () => {
+      const patterns = ['read_file'];
+      const result = doesToolInvocationMatch(
+        readFileTool,
+        invocation,
+        patterns,
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should match by tool class name', () => {
+      const patterns = ['ReadFileTool'];
+      const result = doesToolInvocationMatch(
+        readFileTool,
+        invocation,
+        patterns,
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should not match if neither name is in the patterns', () => {
+      const patterns = ['some_other_tool', 'AnotherToolClass'];
+      const result = doesToolInvocationMatch(
+        readFileTool,
+        invocation,
+        patterns,
+      );
+      expect(result).toBe(false);
+    });
+
+    it('should match by tool name when passed as a string', () => {
+      const patterns = ['read_file'];
+      const result = doesToolInvocationMatch('read_file', invocation, patterns);
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/utils/tool-utils.ts
+++ b/packages/core/src/utils/tool-utils.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AnyDeclarativeTool, AnyToolInvocation } from '../index.js';
+import { isTool } from '../index.js';
+
+const SHELL_TOOL_NAMES = ['run_shell_command', 'ShellTool'];
+
+/**
+ * Checks if a tool invocation matches any of a list of patterns.
+ *
+ * @param toolOrToolName The tool object or the name of the tool being invoked.
+ * @param invocation The invocation object for the tool.
+ * @param patterns A list of patterns to match against.
+ *   Patterns can be:
+ *   - A tool name (e.g., "ReadFileTool") to match any invocation of that tool.
+ *   - A tool name with a prefix (e.g., "ShellTool(git status)") to match
+ *     invocations where the arguments start with that prefix.
+ * @returns True if the invocation matches any pattern, false otherwise.
+ */
+export function doesToolInvocationMatch(
+  toolOrToolName: AnyDeclarativeTool | string,
+  invocation: AnyToolInvocation,
+  patterns: string[],
+): boolean {
+  let toolNames: string[];
+  if (isTool(toolOrToolName)) {
+    toolNames = [toolOrToolName.name, toolOrToolName.constructor.name];
+  } else {
+    toolNames = [toolOrToolName as string];
+  }
+
+  if (toolNames.some((name) => SHELL_TOOL_NAMES.includes(name))) {
+    toolNames = [...new Set([...toolNames, ...SHELL_TOOL_NAMES])];
+  }
+
+  for (const pattern of patterns) {
+    const openParen = pattern.indexOf('(');
+
+    if (openParen === -1) {
+      // No arguments, just a tool name
+      if (toolNames.includes(pattern)) {
+        return true;
+      }
+      continue;
+    }
+
+    const patternToolName = pattern.substring(0, openParen);
+    if (!toolNames.includes(patternToolName)) {
+      continue;
+    }
+
+    if (!pattern.endsWith(')')) {
+      continue;
+    }
+
+    const argPattern = pattern.substring(openParen + 1, pattern.length - 1);
+
+    if (
+      'command' in invocation.params &&
+      toolNames.includes('run_shell_command')
+    ) {
+      const argValue = String(
+        (invocation.params as { command: string }).command,
+      );
+      if (argValue === argPattern || argValue.startsWith(argPattern + ' ')) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
This PR introduces the `--allowed-tools` flag and a corresponding `allowedTools` setting, allowing users to specify tools that can run without confirmation. This is useful for trusted and frequently used commands like `git status`.

I have chosen `--allowed-tools` (instead of `--auto-approved-tools` as I had initially) because at the moment its functionality is quite complementary to `coreTools` (if you are in YOLO/unattended mode, `coreTools` is useful and `allowedTools` is not, and if you're in interactive mode, `coreTools` is not that useful but `allowedTools` is), so we may want to merge `coreTools` into `allowedTools` – and `allowedTools` works well for both use cases.

Addresses #2417

**Key Changes:**

*   **New Feature:**
    *   Adds the `--allowed-tools` command-line flag.
    *   Adds the `allowedTools` setting to the configuration schema.
    *   Updates documentation in `docs/cli/configuration.md`.

*   **Refactoring & Bug Fix:**
    *   To support this feature correctly for shell commands with arguments, the tool filtering logic was refactored.
    *   The core matching logic is now centralized in the `doesToolInvocationMatch` function located in `packages/core/src/utils/shell-utils.ts`.
    *   This refactoring unifies how `coreTools`, `excludedTools`, and the new `allowedTools` are handled, resolving a circular dependency.
    *   The redundant `packages/core/src/utils/tool-utils.ts` file has been removed.
    *   Fixes a bug where matching shell command patterns with arguments (e.g., `run_shell_command(git status)`) was not working correctly.