### PR TITLE
fix(ui): fix drag-and-drop file feature for macOS terminal

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -261,37 +261,42 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return;
       }
 
-      // Collect characters in drag mode
-      if (isDragModeRef.current && key.sequence && key.sequence.length === 1) {
-        setDragBuffer((prevBuffer) => {
-          const newDragBuffer = prevBuffer + key.sequence;
+      if (isDragModeRef.current) {
+        // Collect characters in drag mode
+        if (key.sequence && key.sequence.length === 1) {
+          setDragBuffer((prevBuffer) => {
+            const newDragBuffer = prevBuffer + key.sequence;
 
-          // Reset timeout for each new character
+            // Reset timeout for each new character
+            if (dragTimeoutRef.current) {
+              clearTimeout(dragTimeoutRef.current);
+            }
+            dragTimeoutRef.current = setTimeout(() => {
+              // Process complete path when character collection is done
+              if (newDragBuffer.trim()) {
+                buffer.insert(newDragBuffer.trim(), { paste: true });
+              }
+              setIsDragMode(false);
+              isDragModeRef.current = false;
+              setDragBuffer('');
+            }, 100);
+
+            return newDragBuffer;
+          });
+        } else {
           if (dragTimeoutRef.current) {
             clearTimeout(dragTimeoutRef.current);
+            dragTimeoutRef.current = null;
           }
-          dragTimeoutRef.current = setTimeout(() => {
-            // Process complete path when character collection is done
-            if (newDragBuffer.trim()) {
-              buffer.insert(newDragBuffer.trim(), { paste: true });
-            }
-            setIsDragMode(false);
-            isDragModeRef.current = false;
-            setDragBuffer('');
-          }, 100);
-
-          return newDragBuffer;
-        });
-
+          setIsDragMode(false);
+          isDragModeRef.current = false;
+          setDragBuffer('');
+        }
         return;
       }
 
-      const isDragDrop = key.paste;
-      const isFocusEvent = key.sequence === '\u001b[I';
-
       /// We want to handle paste even when not focused to support drag and drop.
-      /// Also handle focus events which indicate drag & drop operations.
-      if (!focus && !key.paste && !isDragDrop && !isFocusEvent) {
+      if (!focus && !key.paste) {
         return;
       }
 


### PR DESCRIPTION
## TLDR

Fixes drag-and-drop file functionality in macOS terminal that was only working when debugger was paused. The issue was caused by macOS sending focus events followed by individual characters instead of complete file paths, combined with React's asynchronous state updates preventing proper character collection.

## Dive Deeper

The drag-and-drop functionality had a critical timing issue on macOS:

1. **Root Cause**: macOS terminal drag events send a focus event (`\u001b[I`) followed by individual path characters, not complete file paths like other platforms
2. **React State Issue**: Asynchronous `useState` updates prevented immediate access to drag state in event handlers, causing character collection to fail
3. **Debugger Masking**: When debugger was paused, the artificial timing delay allowed the async state updates to complete, making drag functionality appear to work

**Solution Implementation**:
- **Dual State Management**: Uses both `useState` (for React rendering) and `useRef` (for immediate access in event handlers)
- **Character Collection**: Accumulates individual drag characters using functional state updates to avoid closure issues
- **Timeout Strategy**: 2-second protection timeout for drag mode + 100ms completion timeout for character collection
- **Focus Event Handling**: Properly detects and processes focus events even when terminal lacks focus

This approach maintains React best practices while solving the timing-sensitive nature of macOS drag events.

## Reviewer Test Plan

**Prerequisites**: macOS system with terminal access

**Test Steps**:
1. Build and run Gemini CLI: `npm run build && npm start`
2. Open Finder and navigate to a directory with files
3. **Primary Test**: Drag a file from Finder directly into the Gemini CLI terminal
   - ✅ Expected: File path should appear in the input prompt
   - ❌ Before fix: Nothing happens or partial characters appear
4. **Edge Cases**:
   - Drag multiple files simultaneously
   - Drag files with spaces or special characters in names
   - Drag files while typing (should not interfere with existing input)
   - Test drag functionality in shell mode vs normal mode

**Example Test Files**:
- `test file with spaces.txt`
- `file-with-dashes.js`
- `file_with_underscores.py`
- Files in nested directories

**Validation Points**:
- Complete file paths appear correctly
- No partial or corrupted paths
- Existing input is preserved when drag occurs
- No console errors during drag operations

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

**Note**: This fix specifically targets macOS drag behavior. Windows and Linux drag functionality should remain unchanged but requires validation to ensure no regressions.

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
- Fixes #6386 
- Fixes #6449
- Fixes #5729