### PR TITLE
feat(chat): Enable non-blocking chat input

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -580,12 +580,16 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   // Input handling
   const handleFinalSubmit = useCallback(
     (submittedValue: string) => {
+      // Guard against submission if the AI is streaming OR a slash command is processing.
+      if (streamingState !== StreamingState.Idle || isProcessing) {
+        return;
+      }
       const trimmedValue = submittedValue.trim();
       if (trimmedValue.length > 0) {
         submitQuery(trimmedValue);
       }
     },
-    [submitQuery],
+    [submitQuery, streamingState, isProcessing],
   );
 
   const handleIdePromptComplete = useCallback(
@@ -760,8 +764,8 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     fetchUserMessages();
   }, [history, logger]);
 
-  const isInputActive =
-    streamingState === StreamingState.Idle && !initError && !isProcessing;
+  const isBusy =
+    streamingState !== StreamingState.Idle || isProcessing || !!initError;
 
   const handleClearScreen = useCallback(() => {
     clearItems();
@@ -1139,25 +1143,23 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
                 </OverflowProvider>
               )}
 
-              {isInputActive && (
-                <InputPrompt
-                  buffer={buffer}
-                  inputWidth={inputWidth}
-                  suggestionsWidth={suggestionsWidth}
-                  onSubmit={handleFinalSubmit}
-                  userMessages={userMessages}
-                  onClearScreen={handleClearScreen}
-                  config={config}
-                  slashCommands={slashCommands}
-                  commandContext={commandContext}
-                  shellModeActive={shellModeActive}
-                  setShellModeActive={setShellModeActive}
-                  onEscapePromptChange={handleEscapePromptChange}
-                  focus={isFocused}
-                  vimHandleInput={vimHandleInput}
-                  placeholder={placeholder}
-                />
-              )}
+              <InputPrompt
+                buffer={buffer}
+                inputWidth={inputWidth}
+                suggestionsWidth={suggestionsWidth}
+                onSubmit={handleFinalSubmit}
+                userMessages={userMessages}
+                onClearScreen={handleClearScreen}
+                config={config}
+                slashCommands={slashCommands}
+                commandContext={commandContext}
+                shellModeActive={shellModeActive}
+                setShellModeActive={setShellModeActive}
+                onEscapePromptChange={handleEscapePromptChange}
+                focus={isFocused && !isBusy}
+                vimHandleInput={vimHandleInput}
+                placeholder={placeholder}
+              />
             </>
           )}
 


### PR DESCRIPTION
This commit resolves the 'stop-and-wait' user experience in the chat interface.

The input prompt is now always visible, allowing users to type their next message while the AI is generating a response.

This is achieved by:
1. Guarding the submission handler against new inputs while the app is busy (either streaming from the API or processing a slash command).
2. Removing the conditional rendering that previously made the input component disappear.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
