### PR TITLE
feat(logging): add session_id to all logs

### DIFF
--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -55,6 +55,7 @@ const mockConfig = {
   getApprovalMode: vi.fn(() => ApprovalMode.DEFAULT),
   getUsageStatisticsEnabled: () => true,
   getDebugMode: () => false,
+  getSessionId: () => 'my-session-id',
 };
 
 class MockToolInvocation extends BaseToolInvocation<object, ToolResult> {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -132,9 +132,41 @@ describe('ClearcutLogger', () => {
 
       const event = logger?.createLogEvent('abc', []);
 
-      expect(event?.event_metadata[0][0]).toEqual({
+      expect(event?.event_metadata[0]).toContainEqual({
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_GOOGLE_ACCOUNTS_COUNT,
         value: '9001',
+      });
+    });
+
+    it('logs default metadata', () => {
+      const google_accounts = 123;
+      const session_id = 'my-session-id';
+      const surface = 'ide-1234';
+
+      const { logger } = setup({
+        lifetimeGoogleAccounts: google_accounts,
+        config: {
+          sessionId: session_id,
+        },
+      });
+
+      vi.stubEnv('SURFACE', surface);
+
+      const event = logger?.createLogEvent('abc', []);
+
+      expect(event?.event_metadata[0]).toContainEqual({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GOOGLE_ACCOUNTS_COUNT,
+        value: `${google_accounts}`,
+      });
+
+      expect(event?.event_metadata[0]).toContainEqual({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SESSION_ID,
+        value: session_id,
+      });
+
+      expect(event?.event_metadata[0]).toContainEqual({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
+        value: surface,
       });
     });
 
@@ -145,7 +177,7 @@ describe('ClearcutLogger', () => {
 
       const event = logger?.createLogEvent('abc', []);
 
-      expect(event?.event_metadata[0][1]).toEqual({
+      expect(event?.event_metadata[0]).toContainEqual({
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
         value: 'GitHub',
       });
@@ -159,7 +191,7 @@ describe('ClearcutLogger', () => {
 
       const event = logger?.createLogEvent('abc', []);
 
-      expect(event?.event_metadata[0][1]).toEqual({
+      expect(event?.event_metadata[0]).toContainEqual({
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
         value: 'ide-1234',
       });
@@ -210,7 +242,7 @@ describe('ClearcutLogger', () => {
         }
         vi.stubEnv('TERM_PROGRAM', 'vscode');
         const event = logger?.createLogEvent('abc', []);
-        expect(event?.event_metadata[0][1]).toEqual({
+        expect(event?.event_metadata[0]).toContainEqual({
           gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
           value: expectedValue,
         });

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -31,7 +31,6 @@ export {
 } from './loggers.js';
 export {
   StartSessionEvent,
-  EndSessionEvent,
   UserPromptEvent,
   ToolCallEvent,
   ApiRequestEvent,

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -68,18 +68,6 @@ export class StartSessionEvent implements BaseTelemetryEvent {
   }
 }
 
-export class EndSessionEvent implements BaseTelemetryEvent {
-  'event.name': 'end_session';
-  'event.timestamp': string;
-  session_id?: string;
-
-  constructor(config?: Config) {
-    this['event.name'] = 'end_session';
-    this['event.timestamp'] = new Date().toISOString();
-    this.session_id = config?.getSessionId();
-  }
-}
-
 export class UserPromptEvent implements BaseTelemetryEvent {
   'event.name': 'user_prompt';
   'event.timestamp': string;
@@ -362,7 +350,6 @@ export class KittySequenceOverflowEvent {
 
 export type TelemetryEvent =
   | StartSessionEvent
-  | EndSessionEvent
   | UserPromptEvent
   | ToolCallEvent
   | ApiRequestEvent


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->
Adds `session_id` to all logs, to make it easier in downstream processes to enrich by metadata logged in the `StartSessionEvent`.

## Dive Deeper

Key changes:
- Adds `session_id` to default log metadata (which is included with all logs)
- Removes `EndSessionEvent` because it now longer serves a purpose. Logs should still be emitted on shutdown.

Note: some of the changes are self-annotated for context

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
