### PR TITLE
Disable failing IDE tests.

### DIFF
--- a/integration-tests/ide-client.test.ts
+++ b/integration-tests/ide-client.test.ts
@@ -14,7 +14,7 @@ import { IdeClient } from '../packages/core/src/ide/ide-client.js';
 
 import { TestMcpServer } from './test-mcp-server.js';
 
-describe('IdeClient', () => {
+describe.skip('IdeClient', () => {
   it('reads port from file and connects', async () => {
     const server = new TestMcpServer();
     const port = await server.start();
@@ -111,7 +111,7 @@ describe('IdeClient fallback connection logic', () => {
   });
 });
 
-describe('getIdeProcessId', () => {
+describe.skip('getIdeProcessId', () => {
   let child: ChildProcess;
 
   afterEach(() => {


### PR DESCRIPTION
Disabling them so that we can make our integration tests required for merge.