### PR TITLE
Revert "Show /ide enable & /ide disable commands based on connection status"

### DIFF
--- a/packages/cli/src/ui/commands/ideCommand.test.ts
+++ b/packages/cli/src/ui/commands/ideCommand.test.ts
@@ -69,9 +69,6 @@ describe('ideCommand', () => {
     vi.mocked(mockConfig.getIdeClient).mockReturnValue({
       getCurrentIde: () => DetectedIde.VSCode,
       getDetectedIdeDisplayName: () => 'VS Code',
-      getConnectionStatus: () => ({
-        status: core.IDEConnectionStatus.Connected,
-      }),
     } as ReturnType<Config['getIdeClient']>);
     const command = ideCommand(mockConfig);
     expect(command).not.toBeNull();
@@ -164,9 +161,7 @@ describe('ideCommand', () => {
       vi.mocked(mockConfig.getIdeMode).mockReturnValue(true);
       vi.mocked(mockConfig.getIdeClient).mockReturnValue({
         getCurrentIde: () => DetectedIde.VSCode,
-        getConnectionStatus: () => ({
-          status: core.IDEConnectionStatus.Disconnected,
-        }),
+        getConnectionStatus: vi.fn(),
         getDetectedIdeDisplayName: () => 'VS Code',
       } as unknown as ReturnType<Config['getIdeClient']>);
       vi.mocked(core.getIdeInstaller).mockReturnValue({

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -237,8 +237,8 @@ export const ideCommand = (config: Config | null): SlashCommand | null => {
     },
   };
 
-  const connectionStatus = ideClient.getConnectionStatus().status;
-  if (connectionStatus === IDEConnectionStatus.Connected) {
+  const ideModeEnabled = config.getIdeMode();
+  if (ideModeEnabled) {
     ideSlashCommand.subCommands = [
       disableCommand,
       statusCommand,


### PR DESCRIPTION
Reverts google-gemini/gemini-cli#6248

(This introduced a bug where the sub commands were not being reloaded based on connection state. I'll roll-forward with a fix)