### PR TITLE
docs(readme): fix 'quick examples' code block formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ gemini -p "Explain the architecture of this codebase"
 cd new-project/
 gemini
 > Write me a Discord bot that answers questions using a FAQ.md file I will provide
+````
 
 #### Analyze existing code
 ```bash


### PR DESCRIPTION
## TLDR
Fixes Markdown formatting in the Quick Examples section of README.md by properly closing the “Start a new project” code block and starting a new one for “Analyze existing code”. 
## Reviewer Test Plan
- Open the updated README.md in GitHub’s preview.
- Confirm that “Start a new project” and “Analyze existing code” now render as two separate code blocks.
- Verify no other sections of the README are affected.

## Linked issues / bugs
Resolves #6490 
