### PR TITLE
fix(#5605): .env file loaded after settings are parsed

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -339,10 +339,7 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
   try {
     if (fs.existsSync(systemSettingsPath)) {
       const systemContent = fs.readFileSync(systemSettingsPath, 'utf-8');
-      const parsedSystemSettings = JSON.parse(
-        stripJsonComments(systemContent),
-      ) as Settings;
-      systemSettings = resolveEnvVarsInObject(parsedSystemSettings);
+      systemSettings = JSON.parse(stripJsonComments(systemContent)) as Settings;
     }
   } catch (error: unknown) {
     settingsErrors.push({
@@ -355,10 +352,7 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
   try {
     if (fs.existsSync(USER_SETTINGS_PATH)) {
       const userContent = fs.readFileSync(USER_SETTINGS_PATH, 'utf-8');
-      const parsedUserSettings = JSON.parse(
-        stripJsonComments(userContent),
-      ) as Settings;
-      userSettings = resolveEnvVarsInObject(parsedUserSettings);
+      userSettings = JSON.parse(stripJsonComments(userContent)) as Settings;
       // Support legacy theme names
       if (userSettings.theme && userSettings.theme === 'VS') {
         userSettings.theme = DefaultLight.name;
@@ -378,10 +372,9 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
     try {
       if (fs.existsSync(workspaceSettingsPath)) {
         const projectContent = fs.readFileSync(workspaceSettingsPath, 'utf-8');
-        const parsedWorkspaceSettings = JSON.parse(
+        workspaceSettings = JSON.parse(
           stripJsonComments(projectContent),
         ) as Settings;
-        workspaceSettings = resolveEnvVarsInObject(parsedWorkspaceSettings);
         if (workspaceSettings.theme && workspaceSettings.theme === 'VS') {
           workspaceSettings.theme = DefaultLight.name;
         } else if (
@@ -398,6 +391,22 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
       });
     }
   }
+
+  // Create a temporary merged settings object to pass to loadEnvironment.
+  const tempMergedSettings = {
+    ...userSettings,
+    ...workspaceSettings,
+    ...systemSettings,
+  };
+
+  // Load environment with merged settings so that variables are available for
+  // resolution.
+  loadEnvironment(tempMergedSettings);
+
+  // Now that the environment is loaded, resolve variables in the settings.
+  systemSettings = resolveEnvVarsInObject(systemSettings);
+  userSettings = resolveEnvVarsInObject(userSettings);
+  workspaceSettings = resolveEnvVarsInObject(workspaceSettings);
 
   // Create LoadedSettings first
   const loadedSettings = new LoadedSettings(
@@ -428,9 +437,6 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
     );
     delete loadedSettings.merged.chatCompression;
   }
-
-  // Load environment with merged settings
-  loadEnvironment(loadedSettings.merged);
 
   return loadedSettings;
 }

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -70,6 +70,7 @@ export interface SettingsFile {
   settings: Settings;
   path: string;
 }
+
 function mergeSettings(
   system: Settings,
   user: Settings,
@@ -407,8 +408,8 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
     workspaceSettings,
   );
 
-  // Load environment with merged settings so that variables are available for
-  // resolution.
+  // loadEnviroment depends on settings so we have to create a temp version of
+  // the settings to avoid a cycle
   loadEnvironment(tempMergedSettings);
 
   // Now that the environment is loaded, resolve variables in the settings.


### PR DESCRIPTION
It fixes the issue about `.env` files being loaded after settings are parsed causing the variables in the `settings.json` not being replaced correctly by the values in `.env`.

## TLDR

This PR loads the environment before calling the `resolveEnvVarsInObject` method. It also refactores the tests related to that.

## Reviewer Test Plan

I tried reproducing this on my end by using Ollama, and the ollama3 model. I used this `.env` file from my `.gemini/` directory:
```
OLLAMA_MODEL="llama3"
OLLAMA_HOST="127.0.0.1"
OLLAMA_PORT="11434"
MCP_TEST_VAR="it_worked"
```

And in my `settings.json` from my `.gemini/` folder:
```
{
  "selectedAuthType": "gemini-api-key",
  "theme": "ANSI Light",
  "preferredEditor": "vscode",
  "mcpServers": {
    "ollama-test": {
      "command": "sh",
      "args": [
        "-c",
        "prompt=\"$2\"; echo \"$prompt\" | /usr/local/bin/ollama run \"$1\"",
        "${OLLAMA_MODEL}"
      ],
      "description": "Runs a local Ollama model."
    }
  }
}
```

I then ran this prompt:
`npm run start -- -p '@ollama-test "Why is the sky blue? And what model are you?"'`

And this is what I got:
```
> @google/gemini-cli@0.1.21 start
> node scripts/start.js -p @ollama-test "Why is the sky blue? And what model are you?"

Checking build status...
Build is up-to-date.
Error connecting to MCP server 'ollama-test': Connection failed for 'ollama-test': MCP error -32000: Connection closed
Both GOOGLE_API_KEY and GEMINI_API_KEY are set. Using GOOGLE_API_KEY.
The sky appears blue because of a phenomenon called Rayleigh scattering. Sunlight is made up of a spectrum of colors, and when it enters Earth's atmosphere, the gas molecules in the air scatter the blue light waves more than the other colors because blue light travels in shorter, smaller waves.

I am a large language model, trained by Google
```
The last part makes me question wheter Ollama was used or not. I'm also hessitant about whether `-- -p` is the right way for running a prompt.

Also, if I run `npm start`, I see an attempt of using the Ollama MCP but it fails:
<img width="1338" height="608" alt="image" src="https://github.com/user-attachments/assets/8e7d4837-8d35-4cdc-947d-5f5d22bcaa51" />

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Fixes: https://github.com/google-gemini/gemini-cli/issues/5605
