### PR TITLE
fix: GCA creds loading order

### DIFF
--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -351,27 +351,32 @@ export function getAvailablePort(): Promise<number> {
 }
 
 async function loadCachedCredentials(client: OAuth2Client): Promise<boolean> {
-  try {
-    const keyFile =
-      process.env['GOOGLE_APPLICATION_CREDENTIALS'] ||
-      getCachedCredentialPath();
+  const pathsToTry = [
+    getCachedCredentialPath(),
+    process.env['GOOGLE_APPLICATION_CREDENTIALS'],
+  ].filter((p): p is string => !!p);
 
-    const creds = await fs.readFile(keyFile, 'utf-8');
-    client.setCredentials(JSON.parse(creds));
+  for (const keyFile of pathsToTry) {
+    try {
+      const creds = await fs.readFile(keyFile, 'utf-8');
+      client.setCredentials(JSON.parse(creds));
 
-    // This will verify locally that the credentials look good.
-    const { token } = await client.getAccessToken();
-    if (!token) {
-      return false;
+      // This will verify locally that the credentials look good.
+      const { token } = await client.getAccessToken();
+      if (!token) {
+        continue;
+      }
+
+      // This will check with the server to see if it hasn't been revoked.
+      await client.getTokenInfo(token);
+
+      return true;
+    } catch (_) {
+      // Ignore and try next path.
     }
-
-    // This will check with the server to see if it hasn't been revoked.
-    await client.getTokenInfo(token);
-
-    return true;
-  } catch (_) {
-    return false;
   }
+
+  return false;
 }
 
 async function cacheCredentials(credentials: Credentials) {


### PR DESCRIPTION
## TLDR

  This pull request modifies the OAuth credential loading logic to prioritize the local Gemini configuration directory (~/.gemini/oauth_creds.json) over the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. This is necessary because any `GOOGLE_APPLICATION_CREDENTIALS` will not work for GCA auth.

##  Dive Deeper

 Previously, the loadCachedCredentials function checked for the `GOOGLE_APPLICATION_CREDENTIALS` environment variable first, which could lead to unintended credentials being used if the user had this variable set for other purposes. The refresh token in this creds file cannot be used to reauthorize on the GCA oauth client app.

The implementation has been refactored try the Gemini-specific path and then falling back to the environment variable. This makes the CLI's authentication mechanism more robust and aligns with user expectations.

The PR https://github.com/google-gemini/gemini-cli/pull/1202 had introduced reading `GOOGLE_APPLICATION_CREDENTIALS` because it's being set by the VSCode IDE GCA extension. That should continue working since the  VSCode IDE GCA extension and Gemini CLI are using the same client ID.

##  Reviewer Test Plan

       * Sign in to gemini-cli with GCA auth, run a few commands and terminate the app.
       * Run `gcloud auth login --update-adc`.
       * Set `GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/application_default_credentials.json` and rerun gemini-cli.
       * With the build from HEAD, it'll open the browser to relogin
       * With the build from this PR it'll reuse the cached creds.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
Fixes:
- #2429
- #6368
- #1901
- #6446
- #5580
-  #6373