### PR TITLE
fix(core): harden user account caching

### DIFF
--- a/packages/core/src/utils/user_account.test.ts
+++ b/packages/core/src/utils/user_account.test.ts
@@ -99,13 +99,13 @@ describe('user_account', () => {
     it('should handle corrupted JSON by starting fresh', async () => {
       fs.mkdirSync(path.dirname(accountsFile()), { recursive: true });
       fs.writeFileSync(accountsFile(), 'not valid json');
-      const consoleDebugSpy = vi
-        .spyOn(console, 'debug')
+      const consoleLogSpy = vi
+        .spyOn(console, 'log')
         .mockImplementation(() => {});
 
       await cacheGoogleAccount('test1@google.com');
 
-      expect(consoleDebugSpy).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalled();
       expect(JSON.parse(fs.readFileSync(accountsFile(), 'utf-8'))).toEqual({
         active: 'test1@google.com',
         old: [],
@@ -118,13 +118,13 @@ describe('user_account', () => {
         accountsFile(),
         JSON.stringify({ active: 'test1@google.com', old: 'not-an-array' }),
       );
-      const consoleDebugSpy = vi
-        .spyOn(console, 'debug')
+      const consoleLogSpy = vi
+        .spyOn(console, 'log')
         .mockImplementation(() => {});
 
       await cacheGoogleAccount('test2@google.com');
 
-      expect(consoleDebugSpy).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalled();
       expect(JSON.parse(fs.readFileSync(accountsFile(), 'utf-8'))).toEqual({
         active: 'test2@google.com',
         old: [],
@@ -158,14 +158,14 @@ describe('user_account', () => {
     it('should return null and log if file is corrupted', () => {
       fs.mkdirSync(path.dirname(accountsFile()), { recursive: true });
       fs.writeFileSync(accountsFile(), '{ "active": "test@google.com"'); // Invalid JSON
-      const consoleDebugSpy = vi
-        .spyOn(console, 'debug')
+      const consoleLogSpy = vi
+        .spyOn(console, 'log')
         .mockImplementation(() => {});
 
       const account = getCachedGoogleAccount();
 
       expect(account).toBeNull();
-      expect(consoleDebugSpy).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalled();
     });
 
     it('should return null if active key is missing', () => {
@@ -207,13 +207,13 @@ describe('user_account', () => {
     it('should handle corrupted JSON by creating a fresh file', async () => {
       fs.mkdirSync(path.dirname(accountsFile()), { recursive: true });
       fs.writeFileSync(accountsFile(), 'not valid json');
-      const consoleDebugSpy = vi
-        .spyOn(console, 'debug')
+      const consoleLogSpy = vi
+        .spyOn(console, 'log')
         .mockImplementation(() => {});
 
       await clearCachedGoogleAccount();
 
-      expect(consoleDebugSpy).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalled();
       const stored = JSON.parse(fs.readFileSync(accountsFile(), 'utf-8'));
       expect(stored.active).toBeNull();
       expect(stored.old).toEqual([]);
@@ -269,12 +269,12 @@ describe('user_account', () => {
     it('should return 0 if the file is corrupted', () => {
       fs.mkdirSync(path.dirname(accountsFile()), { recursive: true });
       fs.writeFileSync(accountsFile(), 'invalid json');
-      const consoleDebugSpy = vi
-        .spyOn(console, 'debug')
+      const consoleLogSpy = vi
+        .spyOn(console, 'log')
         .mockImplementation(() => {});
 
       expect(getLifetimeGoogleAccounts()).toBe(0);
-      expect(consoleDebugSpy).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalled();
     });
 
     it('should return 1 if there is only an active account', () => {
@@ -316,12 +316,12 @@ describe('user_account', () => {
         accountsFile(),
         JSON.stringify({ active: null, old: 1 }),
       );
-      const consoleDebugSpy = vi
-        .spyOn(console, 'debug')
+      const consoleLogSpy = vi
+        .spyOn(console, 'log')
         .mockImplementation(() => {});
 
       expect(getLifetimeGoogleAccounts()).toBe(0);
-      expect(consoleDebugSpy).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalled();
     });
 
     it('should not double count if active account is also in old list', () => {

--- a/packages/core/src/utils/user_account.ts
+++ b/packages/core/src/utils/user_account.ts
@@ -33,7 +33,7 @@ function parseAndValidateAccounts(content: string): UserAccounts {
 
   // Inlined validation logic
   if (typeof parsed !== 'object' || parsed === null) {
-    console.debug('Invalid accounts file schema, starting fresh.');
+    console.log('Invalid accounts file schema, starting fresh.');
     return defaultState;
   }
   const { active, old } = parsed as Partial<UserAccounts>;
@@ -43,7 +43,7 @@ function parseAndValidateAccounts(content: string): UserAccounts {
       (Array.isArray(old) && old.every((i) => typeof i === 'string')));
 
   if (!isValid) {
-    console.debug('Invalid accounts file schema, starting fresh.');
+    console.log('Invalid accounts file schema, starting fresh.');
     return defaultState;
   }
 
@@ -62,7 +62,7 @@ function readAccountsSync(filePath: string): UserAccounts {
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
       return defaultState;
     }
-    console.debug('Error during sync read of accounts, starting fresh.', error);
+    console.log('Error during sync read of accounts, starting fresh.', error);
     return defaultState;
   }
 }
@@ -76,7 +76,7 @@ async function readAccounts(filePath: string): Promise<UserAccounts> {
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
       return defaultState;
     }
-    console.debug('Could not parse accounts file, starting fresh.', error);
+    console.log('Could not parse accounts file, starting fresh.', error);
     return defaultState;
   }
 }

--- a/packages/core/src/utils/user_account.ts
+++ b/packages/core/src/utils/user_account.ts
@@ -5,7 +5,7 @@
  */
 
 import path from 'node:path';
-import { promises as fsp, existsSync, readFileSync } from 'node:fs';
+import { promises as fsp, readFileSync } from 'node:fs';
 import * as os from 'os';
 import { GEMINI_DIR, GOOGLE_ACCOUNTS_FILENAME } from './paths.js';
 
@@ -18,21 +18,66 @@ function getGoogleAccountsCachePath(): string {
   return path.join(os.homedir(), GEMINI_DIR, GOOGLE_ACCOUNTS_FILENAME);
 }
 
-async function readAccounts(filePath: string): Promise<UserAccounts> {
+/**
+ * Parses and validates the string content of an accounts file.
+ * @param content The raw string content from the file.
+ * @returns A valid UserAccounts object.
+ */
+function parseAndValidateAccounts(content: string): UserAccounts {
+  const defaultState = { active: null, old: [] };
+  if (!content.trim()) {
+    return defaultState;
+  }
+
+  const parsed = JSON.parse(content);
+
+  // Inlined validation logic
+  if (typeof parsed !== 'object' || parsed === null) {
+    console.debug('Invalid accounts file schema, starting fresh.');
+    return defaultState;
+  }
+  const { active, old } = parsed as Partial<UserAccounts>;
+  const isValid =
+    (active === undefined || active === null || typeof active === 'string') &&
+    (old === undefined ||
+      (Array.isArray(old) && old.every((i) => typeof i === 'string')));
+
+  if (!isValid) {
+    console.debug('Invalid accounts file schema, starting fresh.');
+    return defaultState;
+  }
+
+  return {
+    active: parsed.active ?? null,
+    old: parsed.old ?? [],
+  };
+}
+
+function readAccountsSync(filePath: string): UserAccounts {
+  const defaultState = { active: null, old: [] };
   try {
-    const content = await fsp.readFile(filePath, 'utf-8');
-    if (!content.trim()) {
-      return { active: null, old: [] };
-    }
-    return JSON.parse(content) as UserAccounts;
+    const content = readFileSync(filePath, 'utf-8');
+    return parseAndValidateAccounts(content);
   } catch (error) {
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-      // File doesn't exist, which is fine.
-      return { active: null, old: [] };
+      return defaultState;
     }
-    // File is corrupted or not valid JSON, start with a fresh object.
+    console.debug('Error during sync read of accounts, starting fresh.', error);
+    return defaultState;
+  }
+}
+
+async function readAccounts(filePath: string): Promise<UserAccounts> {
+  const defaultState = { active: null, old: [] };
+  try {
+    const content = await fsp.readFile(filePath, 'utf-8');
+    return parseAndValidateAccounts(content);
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return defaultState;
+    }
     console.debug('Could not parse accounts file, starting fresh.', error);
-    return { active: null, old: [] };
+    return defaultState;
   }
 }
 
@@ -56,52 +101,23 @@ export async function cacheGoogleAccount(email: string): Promise<void> {
 }
 
 export function getCachedGoogleAccount(): string | null {
-  try {
-    const filePath = getGoogleAccountsCachePath();
-    if (existsSync(filePath)) {
-      const content = readFileSync(filePath, 'utf-8').trim();
-      if (!content) {
-        return null;
-      }
-      const accounts: UserAccounts = JSON.parse(content);
-      return accounts.active;
-    }
-    return null;
-  } catch (error) {
-    console.debug('Error reading cached Google Account:', error);
-    return null;
-  }
+  const filePath = getGoogleAccountsCachePath();
+  const accounts = readAccountsSync(filePath);
+  return accounts.active;
 }
 
 export function getLifetimeGoogleAccounts(): number {
-  try {
-    const filePath = getGoogleAccountsCachePath();
-    if (!existsSync(filePath)) {
-      return 0;
-    }
-
-    const content = readFileSync(filePath, 'utf-8').trim();
-    if (!content) {
-      return 0;
-    }
-    const accounts: UserAccounts = JSON.parse(content);
-    let count = accounts.old.length;
-    if (accounts.active) {
-      count++;
-    }
-    return count;
-  } catch (error) {
-    console.debug('Error reading lifetime Google Accounts:', error);
-    return 0;
+  const filePath = getGoogleAccountsCachePath();
+  const accounts = readAccountsSync(filePath);
+  const allAccounts = new Set(accounts.old);
+  if (accounts.active) {
+    allAccounts.add(accounts.active);
   }
+  return allAccounts.size;
 }
 
 export async function clearCachedGoogleAccount(): Promise<void> {
   const filePath = getGoogleAccountsCachePath();
-  if (!existsSync(filePath)) {
-    return;
-  }
-
   const accounts = await readAccounts(filePath);
 
   if (accounts.active) {


### PR DESCRIPTION
Makes the user account caching logic more robust against corruption and invalid schemas.

- Adds comprehensive tests for edge cases, including empty files, corrupt JSON, and invalid data schemas.
- Consolidates file reading and validation logic to remove duplication between sync and async functions.
- Ensures that invalid or corrupt account cache files are safely reset to a default state, preventing crashes.
- Fixes an issue where lifetime account counts could be incorrect if the active user was also in the old user list.

## Reviewer Test Plan

Try corrupting the accounts file (~/.gemini/google_accounts.json) between Gemini CLI runs when logging in with Google.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to #6373; should address the stack trace appearing in that bug report, although the underlying issue is being fixed differently.
