### PR TITLE
fix(tools): Handle special characters in file paths for glob and read_many_files

### DIFF
--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -150,6 +150,34 @@ describe('GlobTool', () => {
       expect(result.returnDisplay).toBe('No files found');
     });
 
+    it('should find files with special characters in the name', async () => {
+      await fs.writeFile(path.join(tempRootDir, 'file[1].txt'), 'content');
+      const params: GlobToolParams = { pattern: 'file[1].txt' };
+      const invocation = globTool.build(params);
+      const result = await invocation.execute(abortSignal);
+      expect(result.llmContent).toContain('Found 1 file(s)');
+      expect(result.llmContent).toContain(
+        path.join(tempRootDir, 'file[1].txt'),
+      );
+    });
+
+    it('should find files with special characters like [] and () in the path', async () => {
+      const filePath = path.join(
+        tempRootDir,
+        'src/app/[test]/(dashboard)/testing/components/code.tsx',
+      );
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, 'content');
+
+      const params: GlobToolParams = {
+        pattern: 'src/app/[test]/(dashboard)/testing/components/code.tsx',
+      };
+      const invocation = globTool.build(params);
+      const result = await invocation.execute(abortSignal);
+      expect(result.llmContent).toContain('Found 1 file(s)');
+      expect(result.llmContent).toContain(filePath);
+    });
+
     it('should correctly sort files by modification time (newest first)', async () => {
       const params: GlobToolParams = { pattern: '*.sortme' };
       const invocation = globTool.build(params);

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -6,7 +6,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { glob } from 'glob';
+import { glob, escape } from 'glob';
 import { SchemaValidator } from '../utils/schemaValidator.js';
 import {
   BaseDeclarativeTool,
@@ -137,7 +137,13 @@ class GlobToolInvocation extends BaseToolInvocation<
       let allEntries: GlobPath[] = [];
 
       for (const searchDir of searchDirectories) {
-        const entries = (await glob(this.params.pattern, {
+        let pattern = this.params.pattern;
+        const fullPath = path.join(searchDir, pattern);
+        if (fs.existsSync(fullPath)) {
+          pattern = escape(pattern);
+        }
+
+        const entries = (await glob(pattern, {
           cwd: searchDir,
           withFileTypes: true,
           nodir: true,

--- a/packages/core/src/tools/read-many-files.test.ts
+++ b/packages/core/src/tools/read-many-files.test.ts
@@ -524,6 +524,43 @@ describe('ReadManyFilesTool', () => {
       expect(truncatedFileContent).toContain('L200');
       expect(truncatedFileContent).not.toContain('L2400');
     });
+
+    it('should read files with special characters like [] and () in the path', async () => {
+      const filePath = 'src/app/[test]/(dashboard)/testing/components/code.tsx';
+      createFile(filePath, 'Content of receive-detail');
+      const params = { paths: [filePath] };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(new AbortController().signal);
+      const expectedPath = path.join(tempRootDir, filePath);
+      expect(result.llmContent).toEqual([
+        `--- ${expectedPath} ---
+
+Content of receive-detail
+
+`,
+      ]);
+      expect(result.returnDisplay).toContain(
+        'Successfully read and concatenated content from **1 file(s)**',
+      );
+    });
+
+    it('should read files with special characters in the name', async () => {
+      createFile('file[1].txt', 'Content of file[1]');
+      const params = { paths: ['file[1].txt'] };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(new AbortController().signal);
+      const expectedPath = path.join(tempRootDir, 'file[1].txt');
+      expect(result.llmContent).toEqual([
+        `--- ${expectedPath} ---
+
+Content of file[1]
+
+`,
+      ]);
+      expect(result.returnDisplay).toContain(
+        'Successfully read and concatenated content from **1 file(s)**',
+      );
+    });
   });
 
   describe('Batch Processing', () => {


### PR DESCRIPTION
## TLDR

This PR fixes a bug in the `glob` and `read-many-files` tools that prevented them from working with file paths containing special characters like `[]` and `()`. The fix ensures these paths are correctly escaped when they refer to existing files, while still allowing glob patterns to be used.

## Dive Deeper

The issue stemmed from the `glob` library interpreting special characters in file paths as part of a glob pattern. To resolve this, we now check if a given path exists on the filesystem before passing it to `glob`.

- If `fs.stat()` confirms the path exists, we treat it as a literal path and escape any special characters using `glob.escape()`.
- If the path does not exist, we assume it's a glob pattern and use it as-is.

This logic has been implemented in both the `GlobTool` and the `ReadManyFilesTool`. Additionally, new unit tests have been added to verify that both tools can now correctly handle file paths and names with special characters, ensuring this bug is resolved and preventing future regressions.

## Reviewer Test Plan

To validate the fix, a reviewer can perform the following steps:

1.  Create a file within a directory structure that includes special characters:
    ```bash
    mkdir -p 'my-dir(v1)/[test]'
    echo "hello world from file1.txt" > 'my-dir(v1)/[test]/file1.txt'
    echo "hello world from file2.txt" > 'my-dir(v1)/[test]/file2.txt'
    ```
2.  Use the `read-many-files` tool to read the content of the newly created file. The tool should successfully read and display the file's content.
    ```bash
    what is in @my-dir(v1)/[test]/file.txt 
    ```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
- Fixes: #5086 