### PR TITLE
Add test for negative includes

### DIFF
--- a/packages/core/src/services/fileDiscoveryService.test.ts
+++ b/packages/core/src/services/fileDiscoveryService.test.ts
@@ -176,6 +176,20 @@ describe('FileDiscoveryService', () => {
         service.shouldGeminiIgnoreFile(path.join(projectRoot, 'src/index.ts')),
       ).toBe(false);
     });
+    it('should respect negative patterns in .geminiignore', async () => {
+      // Overwrite .geminiignore with a negation pattern
+      // Gemini negation patterns should also override .gitignore patterns
+      await createTestFile('.gitignore', '.*log');
+      await createTestFile('.geminiignore', '*.log\n!important.log');
+      const service = new FileDiscoveryService(projectRoot);
+      // Should ignore debug.log but NOT important.log
+      expect(
+        service.shouldGeminiIgnoreFile(path.join(projectRoot, 'debug.log')),
+      ).toBe(true);
+      expect(
+        service.shouldGeminiIgnoreFile(path.join(projectRoot, 'important.log')),
+      ).toBe(false);
+    });
   });
 
   describe('edge cases', () => {


### PR DESCRIPTION
## TLDR

Adds a test to verify that negative includes work in .geminiignore, and that they work properly when combined with rules in .gitignore.

## Dive Deeper

We had no test coverage for this before, although it seems to work properly.

## Reviewer Test Plan

Run the tests (this is purely a test change).

## Testing Matrix

Run unit tests

## Linked issues / bugs

- Fixes: #5259

