### PR TITLE
fix: allow re-auth with another google account

### DIFF
--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -391,11 +391,17 @@ function getCachedCredentialPath(): string {
   return path.join(os.homedir(), GEMINI_DIR, CREDENTIAL_FILENAME);
 }
 
+export function clearOauthClientCache() {
+  oauthClientPromises.clear();
+}
+
 export async function clearCachedCredentialFile() {
   try {
     await fs.rm(getCachedCredentialPath(), { force: true });
     // Clear the Google Account ID cache when credentials are cleared
     await clearCachedGoogleAccount();
+    // Clear the in-memory OAuth client cache to force re-authentication
+    clearOauthClientCache();
   } catch (_) {
     /* empty */
   }

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -402,8 +402,8 @@ export async function clearCachedCredentialFile() {
     await clearCachedGoogleAccount();
     // Clear the in-memory OAuth client cache to force re-authentication
     clearOauthClientCache();
-  } catch (_) {
-    /* empty */
+  } catch (e) {
+    console.error('Failed to clear cached credentials:', e);
   }
 }
 


### PR DESCRIPTION
## TLDR

You can switch to a different Google account via Google Auth when you type /auth.

## Dive Deeper

When you start with Google Auth, if you try to use /auth to change Google accounts, you currently cannot, as it automatically logs you back into the same account.

## Reviewer Test Plan

Type /auth and select login with Google account, and you should be able to log in with another account.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Fixes #6522