### PR TITLE
docs: Update mcpServers configuration documentation

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -127,7 +127,7 @@ In addition to a project settings file, a project's `.gemini` directory can cont
   - **Example:** `"toolCallCommand": "bin/call_tool"`
 
 - **`mcpServers`** (object):
-  - **Description:** Configures connections to one or more Model-Context Protocol (MCP) servers for discovering and using custom tools. Gemini CLI attempts to connect to each configured MCP server to discover available tools. If multiple MCP servers expose a tool with the same name, the tool names will be prefixed with the server alias you defined in the configuration (e.g., `serverAlias__actualToolName`) to avoid conflicts. Note that the system might strip certain schema properties from MCP tool definitions for compatibility.
+  - **Description:** Configures connections to one or more Model-Context Protocol (MCP) servers for discovering and using custom tools. Gemini CLI attempts to connect to each configured MCP server to discover available tools. If multiple MCP servers expose a tool with the same name, the tool names will be prefixed with the server alias you defined in the configuration (e.g., `serverAlias__actualToolName`) to avoid conflicts. Note that the system might strip certain schema properties from MCP tool definitions for compatibility. At least one of `command`, `url`, or `httpUrl` must be provided. If multiple are specified, the order of precedence is `httpUrl`, then `url`, then `command`.
   - **Default:** Empty
   - **Properties:**
     - **`<SERVER_NAME>`** (object): The server parameters for the named server.
@@ -140,6 +140,7 @@ In addition to a project settings file, a project's `.gemini` directory can cont
       - `headers` (object, optional): A map of HTTP headers to send with requests to `url` or `httpUrl`.
       - `timeout` (number, optional): Timeout in milliseconds for requests to this MCP server.
       - `trust` (boolean, optional): Trust this server and bypass all tool call confirmations.
+      - `description` (string, optional): A brief description of the server, which may be used for display purposes.
       - `includeTools` (array of strings, optional): List of tool names to include from this MCP server. When specified, only the tools listed here will be available from this server (whitelist behavior). If not specified, all tools from the server are enabled by default.
       - `excludeTools` (array of strings, optional): List of tool names to exclude from this MCP server. Tools listed here will not be available to the model, even if they are exposed by the server. **Note:** `excludeTools` takes precedence over `includeTools` - if a tool is in both lists, it will be excluded.
   - **Example:**

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -131,10 +131,13 @@ In addition to a project settings file, a project's `.gemini` directory can cont
   - **Default:** Empty
   - **Properties:**
     - **`<SERVER_NAME>`** (object): The server parameters for the named server.
-      - `command` (string, required): The command to execute to start the MCP server.
+      - `command` (string, optional): The command to execute to start the MCP server via standard I/O.
       - `args` (array of strings, optional): Arguments to pass to the command.
       - `env` (object, optional): Environment variables to set for the server process.
       - `cwd` (string, optional): The working directory in which to start the server.
+      - `url` (string, optional): The URL of an MCP server that uses Server-Sent Events (SSE) for communication.
+      - `httpUrl` (string, optional): The URL of an MCP server that uses streamable HTTP for communication.
+      - `headers` (object, optional): A map of HTTP headers to send with requests to `url` or `httpUrl`.
       - `timeout` (number, optional): Timeout in milliseconds for requests to this MCP server.
       - `trust` (boolean, optional): Trust this server and bypass all tool call confirmations.
       - `includeTools` (array of strings, optional): List of tool names to include from this MCP server. When specified, only the tools listed here will be available from this server (whitelist behavior). If not specified, all tools from the server are enabled by default.
@@ -161,6 +164,20 @@ In addition to a project settings file, a project's `.gemini` directory can cont
         "env": {
           "API_KEY": "$MY_API_TOKEN"
         }
+      },
+      "mySseServer": {
+        "url": "http://localhost:8081/events",
+        "headers": {
+          "Authorization": "Bearer $MY_SSE_TOKEN"
+        },
+        "description": "An example SSE-based MCP server."
+      },
+      "myStreamableHttpServer": {
+        "httpUrl": "http://localhost:8082/stream",
+        "headers": {
+          "X-API-Key": "$MY_HTTP_API_KEY"
+        },
+        "description": "An example Streamable HTTP-based MCP server."
       }
     }
     ```


### PR DESCRIPTION
The documentation for `mcpServers` in `docs/cli/configuration.md` is updated to include configurations for all communication methods.

This change adds descriptions for properties related to SSE and Streamable HTTP, and provides new examples for them.

Fixes #6553

## TLDR

This PR updates the mcpServers documentation to add missing configuration details for SSE and Streamable HTTP communication methods.

## Dive Deeper

The existing documentation only covered the standard I/O method for configuring MCP servers. This could lead users to believe it's the only supported method. By adding details for URL-based connections (SSE and Streamable HTTP), we
provide a complete picture of the CLI's capabilities, improving user experience and preventing potential confusion.

## Reviewer Test Plan

As this is a documentation-only change, no specific testing is required.

Please review the changes in docs/cli/configuration.md to ensure they are clear, accurate, and correctly formatted.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| ---- | ---- | ---- | ---- |
| npm run  | N/A | N/A | N/A |
| npx      | N/A | N/A | N/A |
| Docker   | N/A | N/A | N/A |
| Podman   | -   | -   | -   |
| Seatbelt | N/A | -   | -   |

## Linked issues / bugs

Fixes #6553