### PR TITLE
feat(core): Add skipNextSpeakerCheck setting

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -73,6 +73,7 @@ export interface CliArgs {
   listExtensions: boolean | undefined;
   proxy: string | undefined;
   includeDirectories: string[] | undefined;
+  skipNextSpeakerCheck: boolean | undefined;
 }
 
 export async function parseArguments(): Promise<CliArgs> {
@@ -228,6 +229,11 @@ export async function parseArguments(): Promise<CliArgs> {
           coerce: (dirs: string[]) =>
             // Handle comma-separated values
             dirs.flatMap((dir) => dir.split(',').map((d) => d.trim())),
+        })
+        .option('skip-next-speaker-check', {
+          type: 'boolean',
+          description: 'Skip the next speaker check.',
+          default: false,
         })
         .check((argv) => {
           if (argv.prompt && argv['promptInteractive']) {
@@ -540,6 +546,7 @@ export async function loadCliConfig(
     interactive,
     trustedFolder,
     shouldUseNodePtyShell: settings.shouldUseNodePtyShell,
+    skipNextSpeakerCheck: argv.skipNextSpeakerCheck,
   });
 }
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -73,7 +73,6 @@ export interface CliArgs {
   listExtensions: boolean | undefined;
   proxy: string | undefined;
   includeDirectories: string[] | undefined;
-  skipNextSpeakerCheck: boolean | undefined;
 }
 
 export async function parseArguments(): Promise<CliArgs> {
@@ -230,11 +229,7 @@ export async function parseArguments(): Promise<CliArgs> {
             // Handle comma-separated values
             dirs.flatMap((dir) => dir.split(',').map((d) => d.trim())),
         })
-        .option('skip-next-speaker-check', {
-          type: 'boolean',
-          description: 'Skip the next speaker check.',
-          default: false,
-        })
+        
         .check((argv) => {
           if (argv.prompt && argv['promptInteractive']) {
             throw new Error(
@@ -546,7 +541,7 @@ export async function loadCliConfig(
     interactive,
     trustedFolder,
     shouldUseNodePtyShell: settings.shouldUseNodePtyShell,
-    skipNextSpeakerCheck: argv.skipNextSpeakerCheck,
+    skipNextSpeakerCheck: settings.skipNextSpeakerCheck,
   });
 }
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -229,7 +229,7 @@ export async function parseArguments(): Promise<CliArgs> {
             // Handle comma-separated values
             dirs.flatMap((dir) => dir.split(',').map((d) => d.trim())),
         })
-        
+
         .check((argv) => {
           if (argv.prompt && argv['promptInteractive']) {
             throw new Error(

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -515,6 +515,15 @@ export const SETTINGS_SCHEMA = {
     description: 'Show line numbers in the chat.',
     showInDialog: true,
   },
+  skipNextSpeakerCheck: {
+    type: 'boolean',
+    label: 'Skip Next Speaker Check',
+    category: 'General',
+    requiresRestart: false,
+    default: false,
+    description: 'Skip the next speaker check.',
+    showInDialog: true,
+  },
 } as const;
 
 type InferSettings<T extends SettingsSchema> = {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -203,6 +203,7 @@ export interface ConfigParameters {
   interactive?: boolean;
   trustedFolder?: boolean;
   shouldUseNodePtyShell?: boolean;
+  skipNextSpeakerCheck?: boolean;
 }
 
 export class Config {
@@ -269,6 +270,7 @@ export class Config {
   private readonly interactive: boolean;
   private readonly trustedFolder: boolean | undefined;
   private readonly shouldUseNodePtyShell: boolean;
+  private readonly skipNextSpeakerCheck: boolean;
   private initialized: boolean = false;
 
   constructor(params: ConfigParameters) {
@@ -337,6 +339,7 @@ export class Config {
     this.interactive = params.interactive ?? false;
     this.trustedFolder = params.trustedFolder;
     this.shouldUseNodePtyShell = params.shouldUseNodePtyShell ?? false;
+    this.skipNextSpeakerCheck = params.skipNextSpeakerCheck ?? false;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -733,6 +736,10 @@ export class Config {
 
   getShouldUseNodePtyShell(): boolean {
     return this.shouldUseNodePtyShell;
+  }
+
+  getSkipNextSpeakerCheck(): boolean {
+    return this.skipNextSpeakerCheck;
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -209,6 +209,7 @@ describe('Gemini Client (client.ts)', () => {
       getGeminiClient: vi.fn(),
       setFallbackMode: vi.fn(),
       getChatCompression: vi.fn().mockReturnValue(undefined),
+      getSkipNextSpeakerCheck: vi.fn().mockReturnValue(false),
     };
     const MockedConfig = vi.mocked(Config, true);
     MockedConfig.mockImplementation(

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -527,6 +527,10 @@ export class GeminiClient {
         return turn;
       }
 
+      if (this.config.getSkipNextSpeakerCheck()) {
+        return turn;
+      }
+
       const nextSpeakerCheck = await checkNextSpeaker(
         this.getChat(),
         this,


### PR DESCRIPTION
## TLDR

This pull request introduces a new configuration option, `skipNextSpeakerCheck`, which allows users to bypass the `checkNextSpeaker` function call. This can be useful for developers or power users who want to ensure their input is processed without an intermediate check to see if the model should speak next, potentially speeding up interactions.

## Dive Deeper

The `checkNextSpeaker` function is designed to create a more natural conversational flow by predicting whether the user or the model should provide the next turn. However, in scenarios where a user wants to provide a series of inputs without interruption, or for debugging purposes, this check can be an unnecessary extra step.

This change adds a `skipNextSpeakerCheck` boolean flag to the settings schema, accessible through the `gemini settings` dialog. When enabled, the `GeminiClient` will skip the `checkNextSpeaker` call entirely and proceed directly with processing the user's turn. This provides more direct control over the conversation flow for users who need it.

The changes span:
- `settingsSchema.ts` to define the new setting.
- `config.ts` in both `cli` and `core` to plumb the setting through.
- `client.ts` to implement the conditional skip logic.

## Reviewer Test Plan

1.  Run `gemini settings` and enable the "Skip Next Speaker Check" option in the "General" category.
2.  Start a chat session with `gemini`.
3.  Enter a multi-turn prompt where the model might typically interject.
4.  Observe that the client immediately processes your input without the delay or logic associated with determining the next speaker.
5.  Disable the setting and repeat the process to confirm that the default behavior is restored.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

#4651 