### PR TITLE
Add permissions specs to token generation.

### DIFF
--- a/.github/workflows/community-report.yml
+++ b/.github/workflows/community-report.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           app-id: '${{ secrets.APP_ID }}'
           private-key: '${{ secrets.PRIVATE_KEY }}'
+          permission-issues: 'write'
+          permission-pull-requests: 'read'
+          permission-discussions: 'read'
+          permission-contents: 'read'
 
       - name: 'Generate Report 📜'
         id: 'report'

--- a/.github/workflows/gemini-automated-issue-dedup.yml
+++ b/.github/workflows/gemini-automated-issue-dedup.yml
@@ -172,6 +172,7 @@ jobs:
         with:
           app-id: '${{ secrets.APP_ID }}'
           private-key: '${{ secrets.PRIVATE_KEY }}'
+          permission-issues: 'write'
 
       - name: 'Comment and Label Duplicate Issue'
         uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'

--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           app-id: '${{ secrets.APP_ID }}'
           private-key: '${{ secrets.PRIVATE_KEY }}'
+          permission-issues: 'write'
 
       - name: 'Get Repository Labels'
         id: 'get_labels'

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -14,11 +14,8 @@ defaults:
     shell: 'bash'
 
 permissions:
-  contents: 'read'
   id-token: 'write'
   issues: 'write'
-  statuses: 'write'
-  packages: 'read'
 
 jobs:
   triage-issues:
@@ -36,6 +33,7 @@ jobs:
         with:
           app-id: '${{ secrets.APP_ID }}'
           private-key: '${{ secrets.PRIVATE_KEY }}'
+          permission-issues: 'write'
 
       - name: 'Find untriaged issues'
         id: 'find_issues'

--- a/.github/workflows/gemini-scheduled-pr-triage.yml
+++ b/.github/workflows/gemini-scheduled-pr-triage.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           app-id: '${{ secrets.APP_ID }}'
           private-key: '${{ secrets.PRIVATE_KEY }}'
+          permission-issues: 'write'
+          permission-pull-requests: 'write'
 
       - name: 'Run PR Triage Script'
         id: 'run_triage'


### PR DESCRIPTION
Following GitHub best practices: https://github.com/actions/create-github-app-token?tab=readme-ov-file#permission-permission-name