### PR TITLE
Update shell service integration tests

### DIFF
--- a/integration-tests/shell-service.test.ts
+++ b/integration-tests/shell-service.test.ts
@@ -16,7 +16,7 @@ describe('ShellExecutionService programmatic integration tests', () => {
   beforeAll(async () => {
     // Create a dedicated directory for this test suite to avoid conflicts.
     testDir = path.join(
-      process.env.INTEGRATION_TEST_FILE_DIR!,
+      process.env['INTEGRATION_TEST_FILE_DIR']!,
       'shell-service-tests',
     );
     await fs.mkdir(testDir, { recursive: true });
@@ -27,11 +27,12 @@ describe('ShellExecutionService programmatic integration tests', () => {
     const onOutputEvent = vi.fn();
     const abortController = new AbortController();
 
-    const handle = ShellExecutionService.execute(
+    const handle = await ShellExecutionService.execute(
       command,
       testDir,
       onOutputEvent,
       abortController.signal,
+      false
     );
 
     const result = await handle.result;
@@ -52,11 +53,12 @@ describe('ShellExecutionService programmatic integration tests', () => {
       const onOutputEvent = vi.fn();
       const abortController = new AbortController();
 
-      const handle = ShellExecutionService.execute(
+      const handle = await ShellExecutionService.execute(
         command,
         testDir,
         onOutputEvent,
         abortController.signal,
+        false
       );
 
       const result = await handle.result;
@@ -77,11 +79,12 @@ describe('ShellExecutionService programmatic integration tests', () => {
       const onOutputEvent = vi.fn();
       const abortController = new AbortController();
 
-      const handle = ShellExecutionService.execute(
+      const handle = await ShellExecutionService.execute(
         command,
         testDir,
         onOutputEvent,
         abortController.signal,
+        false,
       );
 
       const result = await handle.result;
@@ -98,11 +101,12 @@ describe('ShellExecutionService programmatic integration tests', () => {
     const onOutputEvent = vi.fn();
     const abortController = new AbortController();
 
-    const handle = ShellExecutionService.execute(
+    const handle = await ShellExecutionService.execute(
       command,
       testDir,
       onOutputEvent,
       abortController.signal,
+      false,
     );
 
     // Abort shortly after starting

--- a/integration-tests/shell-service.test.ts
+++ b/integration-tests/shell-service.test.ts
@@ -32,7 +32,7 @@ describe('ShellExecutionService programmatic integration tests', () => {
       testDir,
       onOutputEvent,
       abortController.signal,
-      false
+      false,
     );
 
     const result = await handle.result;
@@ -58,7 +58,7 @@ describe('ShellExecutionService programmatic integration tests', () => {
         testDir,
         onOutputEvent,
         abortController.signal,
-        false
+        false,
       );
 
       const result = await handle.result;


### PR DESCRIPTION
 Fixing failing e2e tests.
 
The `ShellExecutionService.execute` method has been made asynchronous. This commit updates the integration tests to correctly `await` the method call.

The method signature was also updated to accept a new boolean parameter, which has been set to `false` in the test suite.

