### PR TITLE
feat: Add chat history with --save-chat and --resume-chat

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -428,6 +428,13 @@ Arguments passed directly when running the CLI can override other configurations
   - The prompt is processed within the interactive session, not before it.
   - Cannot be used when piping input from stdin.
   - Example: `gemini -i "explain this code"`
+- **`--save-chat <tag>`** and **`--resume-chat <tag>`**:
+  - **Description:**
+    - `--save-chat`: Saves the chat history of a non-interactive session. This is useful for keeping a record of conversations that are initiated with the `--prompt` flag.
+    - `--resume-chat`: Resumes a previous chat session in non-interactive modes.
+  - **Usage:**
+    - `gemini --prompt "your prompt here" --save-chat my-session`
+    - `gemini --prompt "your follow up here" --resume-chat my-session`
 - **`--sandbox`** (**`-s`**):
   - Enables sandbox mode for this session.
 - **`--sandbox-image`**:

--- a/integration-tests/chat-history.test.ts
+++ b/integration-tests/chat-history.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test, expect, beforeEach, afterEach } from 'vitest';
+import { TestRig } from './test-helper.js';
+
+let rig: TestRig;
+
+beforeEach(() => {
+  rig = new TestRig();
+});
+
+afterEach(async () => {
+  await rig.cleanup();
+});
+
+test('should save and resume chat history using tags', async () => {
+  rig.setup('chat-history-tags');
+  const tag = `test-session-${Date.now()}`;
+
+  // First run: save the history
+  const result1 = await rig.run(
+    'What is the capital of France?',
+    '--save-chat',
+    tag,
+  );
+  expect(result1).toContain('Paris');
+
+  // Second run: resume the history
+  const result2 = await rig.run(
+    'What continent is it located in?',
+    '--resume-chat',
+    tag,
+  );
+  expect(result2).toContain('Europe');
+});

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -53,6 +53,8 @@ export interface CliArgs {
   sandboxImage: string | undefined;
   debug: boolean | undefined;
   prompt: string | undefined;
+  saveChat: string | undefined;
+  resumeChat: string | undefined;
   promptInteractive: string | undefined;
   allFiles: boolean | undefined;
   all_files: boolean | undefined;
@@ -94,12 +96,22 @@ export async function parseArguments(): Promise<CliArgs> {
           type: 'string',
           description: 'Prompt. Appended to input on stdin (if any).',
         })
+        .option('save-chat', {
+          type: 'string',
+          description: 'Save the chat history to a tag.',
+        })
+        .option('resume-chat', {
+          type: 'string',
+          description: 'Resume the chat history from a tag.',
+        })
         .option('prompt-interactive', {
           alias: 'i',
           type: 'string',
           description:
             'Execute the provided prompt and continue in interactive mode',
         })
+        .alias('save-chat', 'saveChat')
+        .alias('resume-chat', 'resumeChat')
         .option('sandbox', {
           alias: 's',
           type: 'boolean',
@@ -542,6 +554,8 @@ export async function loadCliConfig(
     trustedFolder,
     shouldUseNodePtyShell: settings.shouldUseNodePtyShell,
     skipNextSpeakerCheck: settings.skipNextSpeakerCheck,
+    saveChat: argv.saveChat,
+    resumeChat: argv.resumeChat,
   });
 }
 

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -60,6 +60,8 @@ describe('runNonInteractive', () => {
 
     mockGeminiClient = {
       sendMessageStream: vi.fn(),
+      getHistory: vi.fn().mockReturnValue([]),
+      setHistory: vi.fn(),
     };
 
     mockConfig = {
@@ -71,6 +73,10 @@ describe('runNonInteractive', () => {
       getFullContext: vi.fn().mockReturnValue(false),
       getContentGeneratorConfig: vi.fn().mockReturnValue({}),
       getDebugMode: vi.fn().mockReturnValue(false),
+      getSessionId: vi.fn().mockReturnValue('test-session-id'),
+      getResumeChat: vi.fn().mockReturnValue(undefined),
+      getSaveChat: vi.fn().mockReturnValue(undefined),
+      getTargetDir: vi.fn().mockReturnValue('/test/dir'),
     } as unknown as Config;
   });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -200,6 +200,8 @@ export interface ConfigParameters {
   trustedFolder?: boolean;
   shouldUseNodePtyShell?: boolean;
   skipNextSpeakerCheck?: boolean;
+  saveChat?: string;
+  resumeChat?: string;
 }
 
 export class Config {
@@ -267,6 +269,8 @@ export class Config {
   private readonly trustedFolder: boolean | undefined;
   private readonly shouldUseNodePtyShell: boolean;
   private readonly skipNextSpeakerCheck: boolean;
+  private readonly saveChat: string | undefined;
+  private readonly resumeChat: string | undefined;
   private initialized: boolean = false;
   readonly storage: Storage;
 
@@ -337,6 +341,8 @@ export class Config {
     this.trustedFolder = params.trustedFolder;
     this.shouldUseNodePtyShell = params.shouldUseNodePtyShell ?? false;
     this.skipNextSpeakerCheck = params.skipNextSpeakerCheck ?? false;
+    this.saveChat = params.saveChat;
+    this.resumeChat = params.resumeChat;
     this.storage = new Storage(this.targetDir);
 
     if (params.contextFileName) {
@@ -729,6 +735,14 @@ export class Config {
 
   getSkipNextSpeakerCheck(): boolean {
     return this.skipNextSpeakerCheck;
+  }
+
+  getSaveChat(): string | undefined {
+    return this.saveChat;
+  }
+
+  getResumeChat(): string | undefined {
+    return this.resumeChat;
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/core/logger.test.ts
+++ b/packages/core/src/core/logger.test.ts
@@ -516,6 +516,13 @@ describe('Logger', () => {
       expect(decodeTagName(encodedTag)).toBe(tag);
     });
 
+    it('should throw an error for a malicious tag', async () => {
+      const maliciousTag = '../../../../../../../../../../etc/passwd';
+      await expect(logger.loadCheckpoint(maliciousTag)).rejects.toThrow(
+        `Invalid tag: ${maliciousTag}`,
+      );
+    });
+
     it('should return an empty array if a tagged checkpoint file does not exist', async () => {
       const loaded = await logger.loadCheckpoint('nonexistent-tag');
       expect(loaded).toEqual([]);

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -297,6 +297,10 @@ export class Logger {
     }
 
     // 2. Fallback for backward compatibility: check for the old raw path.
+    // Prevent path traversal attacks on the fallback path.
+    if (tag.includes('..')) {
+      throw new Error(`Invalid tag: ${tag}`);
+    }
     const oldPath = path.join(this.geminiDir!, `checkpoint-${tag}.json`);
     try {
       await fs.access(oldPath);


### PR DESCRIPTION
## TLDR

This commit introduces a new feature that allows users to save and resume their chat history in non-interactive mode.

Two new command-line flags have been added:
- `--save-chat <tag>`: Saves the current chat session to the specified tag at session end.
- `--resume-chat <tag>`: Resumes a chat session from the specified tag at session start.

Key changes include:
- Updated the CLI configuration to accept the new flags.
- Integrated the save/resume logic into the main non-interactive CLI flow.
- Added an integration test to validate the new functionality.

## Reviewer Test Plan

Tests 
<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

Example prompts to try:
 ```
> gemini --prompt "What is the capital of Germany?" --save-chat germany
Berlin.
> gemini --prompt "What continent is it in?" --resume-chat germany
Europe.
```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✔️  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Resolves #6587
