### PR TITLE
 add Ctrl+Backspace (KILL_WORD_LEFT) to delete word backwards

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -40,7 +40,7 @@ This document lists the available keyboard shortcuts in the Gemini CLI.
 | `Ctrl+Right Arrow` / `Meta+Right Arrow` / `Meta+F` | Move the cursor one word to the right.                                                                                              |
 | `Ctrl+U`                                           | Delete from the cursor to the beginning of the line.                                                                                |
 | `Ctrl+V`                                           | Paste clipboard content. If the clipboard contains an image, it will be saved and a reference to it will be inserted in the prompt. |
-| `Ctrl+W` / `Meta+Backspace` / `Ctrl+Backspace`     | Delete the word to the left of the cursor.                                                                                          |
+| `Ctrl+W` / `Option+Backspace` / `Ctrl+Backspace`     | Delete the word to the left of the cursor.                                                                                          |
 | `Ctrl+X` / `Meta+Enter`                            | Open the current input in an external editor.                                                                                       |
 
 ## Suggestions

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -19,6 +19,7 @@ export enum Command {
   // Text deletion
   KILL_LINE_RIGHT = 'killLineRight',
   KILL_LINE_LEFT = 'killLineLeft',
+  KILL_WORD_LEFT = 'killWordLeft',
   CLEAR_INPUT = 'clearInput',
 
   // Screen control
@@ -103,6 +104,8 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.KILL_LINE_RIGHT]: [{ key: 'k', ctrl: true }],
   // Original: key.ctrl && key.name === 'u'
   [Command.KILL_LINE_LEFT]: [{ key: 'u', ctrl: true }],
+  // Ctrl+Backspace for deleting a word
+  [Command.KILL_WORD_LEFT]: [{ key: 'backspace', ctrl: true }],
   // Original: key.ctrl && key.name === 'c'
   [Command.CLEAR_INPUT]: [{ key: 'c', ctrl: true }],
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -492,6 +492,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         buffer.killLineLeft();
         return;
       }
+      if (keyMatchers[Command.KILL_WORD_LEFT](key)) {
+        buffer.deleteWordLeft();
+        return;
+      }
 
       // External editor
       if (keyMatchers[Command.OPEN_EXTERNAL_EDITOR](key)) {

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -1029,7 +1029,26 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
       );
       expect(state.cursor).toEqual(expectedCursorPos);
     });
+
+    it('deleteWordLeft: should delete word to the left of cursor', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'some text to delete',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+      
+      // Position cursor at end: "some text to delete|"
+      act(() => result.current.moveToOffset(19));
+      act(() => result.current.deleteWordLeft());
+      
+      const state = getBufferState(result);
+      expect(state.text).toBe('some text to ');
+      expect(state.cursor).toEqual([0, 13]);
+    });
   });
+  
 
   // More tests would be needed for:
   // - setText, replaceRange

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -27,6 +27,8 @@ describe('keyMatchers', () => {
     [Command.END]: (key: Key) => key.ctrl && key.name === 'e',
     [Command.KILL_LINE_RIGHT]: (key: Key) => key.ctrl && key.name === 'k',
     [Command.KILL_LINE_LEFT]: (key: Key) => key.ctrl && key.name === 'u',
+    [Command.KILL_WORD_LEFT]: (key: Key) =>
+      key.ctrl && key.name === 'backspace',
     [Command.CLEAR_INPUT]: (key: Key) => key.ctrl && key.name === 'c',
     [Command.CLEAR_SCREEN]: (key: Key) => key.ctrl && key.name === 'l',
     [Command.HISTORY_UP]: (key: Key) => key.ctrl && key.name === 'p',
@@ -106,6 +108,11 @@ describe('keyMatchers', () => {
       command: Command.KILL_LINE_LEFT,
       positive: [createKey('u', { ctrl: true })],
       negative: [createKey('u'), createKey('k', { ctrl: true })],
+    },
+    {
+      command: Command.KILL_WORD_LEFT,
+      positive: [createKey('backspace', { ctrl: true })],
+      negative: [createKey('backspace'), createKey('w', { ctrl: true })],
     },
     {
       command: Command.CLEAR_INPUT,


### PR DESCRIPTION
## TLDR

Adds support for **Ctrl+Backspace** (`KILL_WORD_LEFT`) in the CLI input prompt to delete the word backwards.

## Dive Deeper

- Introduced a new `KILL_WORD_LEFT` command in `keyBindings.ts`
- Added a key binding for `Ctrl+Backspace` mapped to `KILL_WORD_LEFT`.
- Implemented logic in `InputPrompt.tsx` to correctly delete the word to the left of the cursor.

## Reviewer Test Plan

1. Enter a few words into the text box
2. Press ctrl + backspace
3. The word to the immediate left of the cursor should be deleted

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ✅  | ❓  | ✅  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Closes #6547 

