### PR TITLE
feat(release): update release process for nightly and preview builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
             PREVIOUS_TAG=$(gh release list --limit 100 --json tagName | jq -r '[.[] | select(.tagName | contains("nightly"))] | .[0].tagName')
           else
             echo "Finding latest STABLE release (excluding pre-releases)..."
-            PREVIOUS_TAG=$(gh release list --limit 100 --json tagName | jq -r '[.[] | select(.tagName | contains("nightly") | not)] | .[0].tagName')
+            PREVIOUS_TAG=$(gh release list --limit 100 --json tagName | jq -r '[.[] | select(.tagName | (contains("nightly") or contains("preview")) | not)] | .[0].tagName')
           fi
           echo "PREVIOUS_TAG=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
             PREVIOUS_TAG=$(gh release list --limit 100 --json tagName | jq -r '[.[] | select(.tagName | contains("nightly"))] | .[0].tagName')
           else
             echo "Finding latest STABLE release (excluding pre-releases)..."
-            PREVIOUS_TAG=$(gh release list --limit 100 --json tagName | jq -r '[.[] | select(.tagName | contains("nightly") | not)] | .[0]..tagName')
+            PREVIOUS_TAG=$(gh release list --limit 100 --json tagName | jq -r '[.[] | select(.tagName | contains("nightly") | not)] | .[0].tagName')
           fi
           echo "PREVIOUS_TAG=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     # Runs every day at midnight UTC for the nightly release.
     - cron: '0 0 * * *'
+    # Runs every Tuesday at 23:59 UTC for the preview release.
+    - cron: '59 23 * * 2'
   workflow_dispatch:
     inputs:
       version:
@@ -58,14 +60,21 @@ jobs:
         env:
           CREATE_NIGHTLY_RELEASE: '${{ github.event.inputs.create_nightly_release }}'
           EVENT_NAME: '${{ github.event_name }}'
+          CRON: '${{ github.event.schedule }}'
           DRY_RUN_INPUT: '${{ github.event.inputs.dry_run }}'
         id: 'vars'
         run: |-
           is_nightly="false"
-          if [[ "${EVENT_NAME}" == "schedule" || "${CREATE_NIGHTLY_RELEASE}" == "true" ]]; then
+          if [[ "${CRON}" == "0 0 * * *" || "${CREATE_NIGHTLY_RELEASE}" == "true" ]]; then
             is_nightly="true"
           fi
           echo "is_nightly=${is_nightly}" >> "${GITHUB_OUTPUT}"
+
+          is_preview="false"
+          if [[ "${CRON}" == "59 23 * * 2" ]]; then
+            is_preview="true"
+          fi
+          echo "is_preview=${is_preview}" >> "${GITHUB_OUTPUT}"
 
           is_dry_run="false"
           if [[ "${DRY_RUN_INPUT}" == "true" ]]; then
@@ -87,6 +96,7 @@ jobs:
         id: 'version'
         env:
           IS_NIGHTLY: '${{ steps.vars.outputs.is_nightly }}'
+          IS_PREVIEW: '${{ steps.vars.outputs.is_preview }}'
           MANUAL_VERSION: '${{ inputs.version }}'
         run: |-
           VERSION_JSON="$(node scripts/get-release-version.js)"
@@ -196,7 +206,7 @@ jobs:
             PREVIOUS_TAG=$(gh release list --limit 100 --json tagName | jq -r '[.[] | select(.tagName | contains("nightly"))] | .[0].tagName')
           else
             echo "Finding latest STABLE release (excluding pre-releases)..."
-            PREVIOUS_TAG=$(gh release list --limit 100 --json tagName | jq -r '[.[] | select(.tagName | contains("nightly") | not)] | .[0].tagName')
+            PREVIOUS_TAG=$(gh release list --limit 100 --json tagName | jq -r '[.[] | select(.tagName | contains("nightly") | not)] | .[0]..tagName')
           fi
           echo "PREVIOUS_TAG=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: 'boolean'
         default: false
+      create_preview_release:
+        description: 'Auto apply the preview release tag, input version is ignored.'
+        required: false
+        type: 'boolean'
+        default: false
       force_skip_tests:
         description: 'Select to skip the "Run Tests" step in testing. Prod releases should run tests'
         required: false
@@ -236,5 +241,8 @@ jobs:
         run: |-
           gh issue create \
             --title "Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')" \
+            --body "The release workflow failed. See the full run for details: ${DETAILS_URL}" \
+            --label "kind/bug,release-failure"
+(date +'%Y-%m-%d')" \
             --body "The release workflow failed. See the full run for details: ${DETAILS_URL}" \
             --label "kind/bug,release-failure"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
       - name: 'Set booleans for simplified logic'
         env:
           CREATE_NIGHTLY_RELEASE: '${{ github.event.inputs.create_nightly_release }}'
+          CREATE_PREVIEW_RELEASE: '${{ github.event.inputs.create_preview_release }}'
           EVENT_NAME: '${{ github.event_name }}'
           CRON: '${{ github.event.schedule }}'
           DRY_RUN_INPUT: '${{ github.event.inputs.dry_run }}'
@@ -76,7 +77,7 @@ jobs:
           echo "is_nightly=${is_nightly}" >> "${GITHUB_OUTPUT}"
 
           is_preview="false"
-          if [[ "${CRON}" == "59 23 * * 2" ]]; then
+          if [[ "${CRON}" == "59 23 * * 2" || "${CREATE_PREVIEW_RELEASE}" == "true" ]]; then
             is_preview="true"
           fi
           echo "is_preview=${is_preview}" >> "${GITHUB_OUTPUT}"
@@ -100,6 +101,7 @@ jobs:
       - name: 'Get the version'
         id: 'version'
         env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           IS_NIGHTLY: '${{ steps.vars.outputs.is_nightly }}'
           IS_PREVIEW: '${{ steps.vars.outputs.is_preview }}'
           MANUAL_VERSION: '${{ inputs.version }}'
@@ -108,6 +110,7 @@ jobs:
           echo "RELEASE_TAG=$(echo "${VERSION_JSON}" | jq -r .releaseTag)" >> "${GITHUB_OUTPUT}"
           echo "RELEASE_VERSION=$(echo "${VERSION_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "NPM_TAG=$(echo "${VERSION_JSON}" | jq -r .npmTag)" >> "${GITHUB_OUTPUT}"
+          echo "PREVIOUS_TAG=$(echo "${VERSION_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
 
       - name: 'Run Tests'
         if: |-
@@ -198,23 +201,6 @@ jobs:
             --workspace="@google/gemini-cli" \
             --tag="${NPM_TAG}"
 
-      - name: 'Get previous release tag'
-        id: 'previous_release'
-        if: |-
-          ${{ steps.vars.outputs.is_dry_run == 'false' }}
-        env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          IS_NIGHTLY: '${{ steps.vars.outputs.is_nightly }}'
-        run: |-
-          if [[ "${IS_NIGHTLY}" == "true" ]]; then
-            echo "Finding latest nightly release..."
-            PREVIOUS_TAG=$(gh release list --limit 100 --json tagName | jq -r '[.[] | select(.tagName | contains("nightly"))] | .[0].tagName')
-          else
-            echo "Finding latest STABLE release (excluding pre-releases)..."
-            PREVIOUS_TAG=$(gh release list --limit 100 --json tagName | jq -r '[.[] | select(.tagName | (contains("nightly") or contains("preview")) | not)] | .[0].tagName')
-          fi
-          echo "PREVIOUS_TAG=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
-
       - name: 'Create GitHub Release and Tag'
         if: |-
           ${{ steps.vars.outputs.is_dry_run == 'false' }}
@@ -222,7 +208,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           RELEASE_BRANCH: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
           RELEASE_TAG: '${{ steps.version.outputs.RELEASE_TAG }}'
-          PREVIOUS_TAG: '${{ steps.previous_release.outputs.PREVIOUS_TAG }}'
+          PREVIOUS_TAG: '${{ steps.version.outputs.PREVIOUS_TAG }}'
         run: |-
           gh release create "${RELEASE_TAG}" \
             bundle/gemini.js \
@@ -241,8 +227,5 @@ jobs:
         run: |-
           gh issue create \
             --title "Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')" \
-            --body "The release workflow failed. See the full run for details: ${DETAILS_URL}" \
-            --label "kind/bug,release-failure"
-(date +'%Y-%m-%d')" \
             --body "The release workflow failed. See the full run for details: ${DETAILS_URL}" \
             --label "kind/bug,release-failure"

--- a/scripts/tests/get-release-version.test.js
+++ b/scripts/tests/get-release-version.test.js
@@ -6,62 +6,98 @@
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getReleaseVersion } from '../get-release-version';
-import { execSync } from 'child_process';
 
+// Mock child_process so we can spy on execSync
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
 }));
 
-describe('getReleaseVersion', () => {
+describe('getReleaseVersion', async () => {
+  // Dynamically import execSync after mocking
+  const { execSync } = await import('child_process');
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
-    vi.resetModules();
+    vi.resetAllMocks();
     process.env = { ...originalEnv };
-    vi.useFakeTimers();
-    // Mock git commands
-    vi.mocked(execSync).mockImplementation((command) => {
-      if (command.startsWith('git tag')) {
-        return 'v1.1.0\nv1.0.0';
-      }
-      if (command.startsWith('git rev-parse')) {
-        return 'abcdef';
-      }
-      return '';
-    });
+    // Mock date to be consistent
+    vi.setSystemTime(new Date('2025-08-20T00:00:00.000Z'));
+    // Provide a default mock for execSync to avoid toString() on undefined
+    vi.mocked(execSync).mockReturnValue('');
   });
 
   afterEach(() => {
     process.env = originalEnv;
-    vi.clearAllMocks();
     vi.useRealTimers();
   });
 
-  it('should calculate nightly version when IS_NIGHTLY is true', () => {
+  it('should generate a nightly version and get previous tag', () => {
     process.env.IS_NIGHTLY = 'true';
-    const knownDate = new Date('2025-07-20T10:00:00.000Z');
-    vi.setSystemTime(knownDate);
 
-    const { releaseTag, releaseVersion, npmTag } = getReleaseVersion();
-    expect(releaseTag).toBe('v1.3.0-nightly.20250720.abcdef');
-    expect(releaseVersion).toBe('1.3.0-nightly.20250720.abcdef');
-    expect(npmTag).toBe('nightly');
+    vi.mocked(execSync).mockImplementation((command) => {
+      if (command.includes('git tag')) {
+        return 'v0.1.0\nv0.0.1';
+      }
+      if (command.includes('git rev-parse')) {
+        return 'abcdef';
+      }
+      if (command.includes('gh release list')) {
+        return 'v0.3.0-nightly.20250819.abcdef';
+      }
+      return '';
+    });
+
+    const result = getReleaseVersion();
+
+    expect(result).toEqual({
+      releaseTag: 'v0.3.0-nightly.20250820.abcdef',
+      releaseVersion: '0.3.0-nightly.20250820.abcdef',
+      npmTag: 'nightly',
+      previousReleaseTag: 'v0.3.0-nightly.20250819.abcdef',
+    });
   });
 
-  it('should calculate preview version when IS_PREVIEW is true', () => {
+  it('should generate a preview version and get previous tag', () => {
     process.env.IS_PREVIEW = 'true';
-    const { releaseTag, releaseVersion, npmTag } = getReleaseVersion();
-    expect(releaseTag).toBe('v1.2.0-preview');
-    expect(releaseVersion).toBe('1.2.0-preview');
-    expect(npmTag).toBe('preview');
+
+    vi.mocked(execSync).mockImplementation((command) => {
+      if (command.includes('git tag')) {
+        return 'v0.1.0\nv0.0.1';
+      }
+      if (command.includes('gh release list')) {
+        return 'v0.1.0'; // Previous stable release
+      }
+      return '';
+    });
+
+    const result = getReleaseVersion();
+
+    expect(result).toEqual({
+      releaseTag: 'v0.2.0-preview',
+      releaseVersion: '0.2.0-preview',
+      npmTag: 'preview',
+      previousReleaseTag: 'v0.1.0',
+    });
   });
 
-  it('should use manual version when provided', () => {
-    process.env.MANUAL_VERSION = '1.2.3';
-    const { releaseTag, releaseVersion, npmTag } = getReleaseVersion();
-    expect(releaseTag).toBe('v1.2.3');
-    expect(releaseVersion).toBe('1.2.3');
-    expect(npmTag).toBe('latest');
+  it('should use the manual version and get previous tag', () => {
+    process.env.MANUAL_VERSION = 'v0.1.1';
+
+    vi.mocked(execSync).mockImplementation((command) => {
+      if (command.includes('gh release list')) {
+        return 'v0.1.0'; // Previous stable release
+      }
+      return '';
+    });
+
+    const result = getReleaseVersion();
+
+    expect(result).toEqual({
+      releaseTag: 'v0.1.1',
+      releaseVersion: '0.1.1',
+      npmTag: 'latest',
+      previousReleaseTag: 'v0.1.0',
+    });
   });
 
   it('should prepend v to manual version if missing', () => {
@@ -85,7 +121,7 @@ describe('getReleaseVersion', () => {
     );
   });
 
-  it('should throw an error if no version is provided for non-nightly release', () => {
+  it('should throw an error if no version is provided for non-nightly/preview release', () => {
     expect(() => getReleaseVersion()).toThrow(
       'Error: No version specified and this is not a nightly or preview release.',
     );
@@ -96,5 +132,23 @@ describe('getReleaseVersion', () => {
     expect(() => getReleaseVersion()).toThrow(
       'Error: Versions with build metadata (+) are not supported for releases.',
     );
+  });
+
+  it('should correctly calculate the next version from a patch release', () => {
+    process.env.IS_PREVIEW = 'true';
+
+    vi.mocked(execSync).mockImplementation((command) => {
+      if (command.includes('git tag')) {
+        return 'v1.1.3\nv1.1.2\nv1.1.1\nv1.1.0\nv1.0.0';
+      }
+      if (command.includes('gh release list')) {
+        return 'v1.1.3';
+      }
+      return '';
+    });
+
+    const result = getReleaseVersion();
+
+    expect(result.releaseTag).toBe('v1.2.0-preview');
   });
 });


### PR DESCRIPTION

## TLDR

- Updates the nightly version calculator to be current version +2 for the minor version number.
- Adds the idea of the preview tag to the release.yml. this will be currrent version +1 for the minor version number.
- Schedules the preview release at utc 2359 on tuesadays

## Dive Deeper


## Reviewer Test Plan

To test this you can run a release in dry run mode and verify the output.

## Testing Matrix

Actions only

## Linked issues / bugs

closes #3729 