### PR TITLE
return the JSON stringified parameters from getDescription for MCP tools and Discovered tools

### DIFF
--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -746,10 +746,10 @@ describe('DiscoveredMCPTool', () => {
 
   describe('DiscoveredMCPToolInvocation', () => {
     it('should return the stringified params from getDescription', () => {
-      const params = { param: 'testValue' };
+      const params = { param: 'testValue', param2: 'anotherOne' };
       const invocation = tool.build(params);
       const description = invocation.getDescription();
-      expect(description).toBe('{"param":"testValue"}');
+      expect(description).toBe('{"param":"testValue","param2":"anotherOne"}');
     });
   });
 });

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -743,4 +743,13 @@ describe('DiscoveredMCPTool', () => {
       }
     });
   });
+
+  describe('DiscoveredMCPToolInvocation', () => {
+    it('should return the stringified params from getDescription', () => {
+      const params = { param: 'testValue' };
+      const invocation = tool.build(params);
+      const description = invocation.getDescription();
+      expect(description).toBe(JSON.stringify(params));
+    });
+  });
 });

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -749,7 +749,7 @@ describe('DiscoveredMCPTool', () => {
       const params = { param: 'testValue' };
       const invocation = tool.build(params);
       const description = invocation.getDescription();
-      expect(description).toBe(JSON.stringify(params));
+      expect(description).toBe('{"param":"testValue"}');
     });
   });
 });

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
@@ -152,7 +153,7 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
   }
 
   getDescription(): string {
-    return JSON.stringify(this.params);
+    return safeJsonStringify(this.params);
   }
 }
 

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -152,7 +152,7 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
   }
 
   getDescription(): string {
-    return this.displayName;
+    return JSON.stringify(this.params);
   }
 }
 

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -332,4 +332,14 @@ describe('ToolRegistry', () => {
       expect(discoverSpy).toHaveBeenCalled();
     });
   });
+
+  describe('DiscoveredToolInvocation', () => {
+    it('should return the stringified params from getDescription', () => {
+      const tool = new DiscoveredTool(config, 'test-tool', 'A test tool', {});
+      const params = { param: 'testValue' };
+      const invocation = tool.build(params);
+      const description = invocation.getDescription();
+      expect(description).toBe(JSON.stringify(params));
+    });
+  });
 });

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -36,7 +36,7 @@ class DiscoveredToolInvocation extends BaseToolInvocation<
   }
 
   getDescription(): string {
-    return `Calling discovered tool: ${this.toolName}`;
+    return JSON.stringify(this.params);
   }
 
   async execute(

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -20,6 +20,7 @@ import { connectAndDiscover } from './mcp-client.js';
 import { McpClientManager } from './mcp-client-manager.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import { parse } from 'shell-quote';
+import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 
 type ToolParams = Record<string, unknown>;
 
@@ -36,7 +37,7 @@ class DiscoveredToolInvocation extends BaseToolInvocation<
   }
 
   getDescription(): string {
-    return JSON.stringify(this.params);
+    return safeJsonStringify(this.params);
   }
 
   async execute(

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -24,6 +24,7 @@ export interface ToolInvocation<
 
   /**
    * Gets a pre-execution description of the tool operation.
+   *
    * @returns A markdown string describing what the tool will do.
    */
   getDescription(): string;


### PR DESCRIPTION
## TLDR

Updates `getDescription()` for MCP tools and Discovered tools to be the JSON stringified parameters instead of just the tool name.

The tool name already appears in the display so this was being duplicated previously, the description is really the details of the invocation.

## Dive Deeper

Ultimately long term we might want to improve the display further here, rendering the arguments in a yaml-ish format or something more human readable, the current format is compact but somewhat hard to decipher and I think it can also get trimmed.

Ultimately this restores the previous behavior though.

## Reviewer Test Plan

Ask Gemini to invoke any discovered or MCP tool and you should now see the arguments displayed instead of the name of the tool duplicated.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/gemini-cli/issues/6531
