### PR TITLE
feat(core): Handle special characters in file search paths

### DIFF
--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -566,6 +566,35 @@ describe('FileSearch', () => {
     expect(limitedResults).toEqual(['file1.js', 'file2.js']);
   });
 
+  it('should handle file paths with special characters that need escaping', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'file with (special) chars.txt': '',
+        'another-file.txt': '',
+      },
+    });
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      useGitignore: false,
+      useGeminiignore: false,
+      ignoreDirs: [],
+      cache: false,
+      cacheTtl: 0,
+      enableRecursiveFileSearch: true,
+    });
+
+    await fileSearch.initialize();
+
+    // Search for the file using a pattern that contains special characters.
+    // The `unescapePath` function should handle the escaped path correctly.
+    const results = await fileSearch.search(
+      'src/file with \\(special\\) chars.txt',
+    );
+
+    expect(results).toEqual(['src/file with (special) chars.txt']);
+  });
+
   describe('DirectoryFileSearch', () => {
     it('should search for files in the current directory', async () => {
       tmpDir = await createTmpDir({

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -10,6 +10,7 @@ import { Ignore, loadIgnoreRules } from './ignore.js';
 import { ResultCache } from './result-cache.js';
 import { crawl } from './crawler.js';
 import { AsyncFzf, FzfResultItem } from 'fzf';
+import { unescapePath } from '../paths.js';
 
 export interface FileSearchOptions {
   projectRoot: string;
@@ -116,7 +117,7 @@ class RecursiveFileSearch implements FileSearch {
       throw new Error('Engine not initialized. Call initialize() first.');
     }
 
-    pattern = pattern || '*';
+    pattern = unescapePath(pattern) || '*';
 
     let filteredCandidates;
     const { files: candidates, isExactMatch } =


### PR DESCRIPTION
## TLDR

This pull request fixes a bug in the file search functionality that prevented it from finding files with special characters (like parentheses) in their paths. The search pattern is now unescaped before being used, ensuring that paths with special characters are resolved correctly.

## Dive Deeper

The `RecursiveFileSearch` implementation was passing the user-provided search pattern directly to the `fzf` engine. This caused issues when a path contained special characters that are typically escaped in a shell environment (e.g., `src/file (special).txt`). A user trying to find this file might provide an escaped pattern like `src/file \\(special\\).txt`.

This change introduces a call to a new `unescapePath` utility function, which normalizes the search pattern by removing shell escapes. This ensures that the search engine looks for the literal file path, allowing it to find files with special characters correctly.

A new unit test has been added to verify this specific scenario, ensuring that a file with a path containing `(special)` can be found using an escaped search pattern.

## Reviewer Test Plan

1. Create a new file in your test project with special characters in its name, for example:
    ```bash
    touch "my-file-(1).log"
    ```
2. Use the Gemini CLI to search for this file using the escaped path:
    ```bash
    look at @my-file-\(
    ```
3. Verify that the CLI correctly shows ``my-file-(1).log`` as a suggestion.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
