### PR TITLE
Separate custom and built in commands in /help

### DIFF
--- a/packages/cli/src/services/McpPromptLoader.test.ts
+++ b/packages/cli/src/services/McpPromptLoader.test.ts
@@ -5,12 +5,167 @@
  */
 
 import { McpPromptLoader } from './McpPromptLoader.js';
-import type { Config } from '@google/gemini-cli-core';
+import type { Config, DiscoveredMCPPrompt } from '@google/gemini-cli-core';
+import { getMCPServerPrompts } from '@google/gemini-cli-core';
 import type { PromptArgument } from '@modelcontextprotocol/sdk/types.js';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CommandKind } from '../ui/commands/types.js';
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    getMCPServerPrompts: vi.fn(),
+  };
+});
 
 describe('McpPromptLoader', () => {
   const mockConfig = {} as Config;
+
+  describe('loadCommands', () => {
+    const mockGetMcpServers = vi.fn();
+    const mockConfigWithServers = {
+      getMcpServers: mockGetMcpServers,
+    } as unknown as Config;
+
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it('should return no commands if no MCP servers are configured', async () => {
+      mockGetMcpServers.mockReturnValue({});
+      const loader = new McpPromptLoader(mockConfigWithServers);
+      const commands = await loader.loadCommands(new AbortController().signal);
+      expect(commands).toEqual([]);
+      expect(mockGetMcpServers).toHaveBeenCalled();
+    });
+
+    it('should load commands from a single server with a single prompt', async () => {
+      mockGetMcpServers.mockReturnValue({ 'test-server': {} });
+      const mockPrompt: DiscoveredMCPPrompt = {
+        name: 'my-prompt',
+        description: 'A test prompt.',
+        arguments: [],
+        serverName: 'test-server',
+        invoke: vi.fn(),
+      };
+      vi.mocked(getMCPServerPrompts).mockReturnValue([mockPrompt]);
+
+      const loader = new McpPromptLoader(mockConfigWithServers);
+      const commands = await loader.loadCommands(new AbortController().signal);
+
+      expect(commands).toHaveLength(1);
+      const command = commands[0];
+      expect(command.name).toBe('my-prompt');
+      expect(command.description).toBe('A test prompt.');
+      expect(command.kind).toBe(CommandKind.MCP_PROMPT);
+      expect(command.mcpServerName).toBe('test-server');
+      expect(command.subCommands).toHaveLength(1);
+      expect(command.subCommands?.[0].name).toBe('help');
+    });
+
+    it('should use a default description if prompt has none', async () => {
+      mockGetMcpServers.mockReturnValue({ 'test-server': {} });
+      const mockPrompt: DiscoveredMCPPrompt = {
+        name: 'my-prompt',
+        // No description
+        arguments: [],
+        serverName: 'test-server',
+        invoke: vi.fn(),
+      };
+      vi.mocked(getMCPServerPrompts).mockReturnValue([mockPrompt]);
+
+      const loader = new McpPromptLoader(mockConfigWithServers);
+      const commands = await loader.loadCommands(new AbortController().signal);
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0].description).toBe('Invoke prompt my-prompt');
+    });
+
+    it('should load commands from multiple servers and prompts', async () => {
+      mockGetMcpServers.mockReturnValue({ server1: {}, server2: {} });
+      const mockPrompt1: DiscoveredMCPPrompt = {
+        name: 'prompt1',
+        description: 'Prompt 1',
+        arguments: [],
+        serverName: 'server1',
+        invoke: vi.fn(),
+      };
+      const mockPrompt2: DiscoveredMCPPrompt = {
+        name: 'prompt2',
+        description: 'Prompt 2',
+        arguments: [],
+        serverName: 'server1',
+        invoke: vi.fn(),
+      };
+      const mockPrompt3: DiscoveredMCPPrompt = {
+        name: 'prompt3',
+        description: 'Prompt 3',
+        arguments: [],
+        serverName: 'server2',
+        invoke: vi.fn(),
+      };
+
+      vi.mocked(getMCPServerPrompts).mockImplementation(
+        (_config, serverName) => {
+          if (serverName === 'server1') {
+            return [mockPrompt1, mockPrompt2];
+          }
+          if (serverName === 'server2') {
+            return [mockPrompt3];
+          }
+          return [];
+        },
+      );
+
+      const loader = new McpPromptLoader(mockConfigWithServers);
+      const commands = await loader.loadCommands(new AbortController().signal);
+
+      expect(commands).toHaveLength(3);
+      expect(commands.map((c) => c.name)).toEqual([
+        'prompt1',
+        'prompt2',
+        'prompt3',
+      ]);
+      expect(commands[0].mcpServerName).toBe('server1');
+      expect(commands[1].mcpServerName).toBe('server1');
+      expect(commands[2].mcpServerName).toBe('server2');
+    });
+
+    it('should handle a server with no prompts and a server with prompts', async () => {
+      mockGetMcpServers.mockReturnValue({
+        'empty-server': {},
+        'full-server': {},
+      });
+      const mockPrompt: DiscoveredMCPPrompt = {
+        name: 'my-prompt',
+        description: 'A test prompt.',
+        arguments: [],
+        serverName: 'full-server',
+        invoke: vi.fn(),
+      };
+
+      vi.mocked(getMCPServerPrompts).mockImplementation(
+        (_config, serverName) => {
+          if (serverName === 'empty-server') {
+            return [];
+          }
+          if (serverName === 'full-server') {
+            return [mockPrompt];
+          }
+          return [];
+        },
+      );
+
+      const loader = new McpPromptLoader(mockConfigWithServers);
+      const commands = await loader.loadCommands(new AbortController().signal);
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0].name).toBe('my-prompt');
+      expect(commands[0].mcpServerName).toBe('full-server');
+    });
+  });
 
   describe('parseArgs', () => {
     it('should handle multi-word positional arguments', () => {

--- a/packages/cli/src/services/McpPromptLoader.ts
+++ b/packages/cli/src/services/McpPromptLoader.ts
@@ -43,6 +43,7 @@ export class McpPromptLoader implements ICommandLoader {
           name: commandName,
           description: prompt.description || `Invoke prompt ${prompt.name}`,
           kind: CommandKind.MCP_PROMPT,
+          mcpServerName: serverName,
           subCommands: [
             {
               name: 'help',

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -173,6 +173,12 @@ export interface SlashCommand {
 
   kind: CommandKind;
 
+  // Optional name of the MCP server this command came from
+  mcpServerName?: string;
+
+  // Optional path to the directory the file command came from
+  originName?: string;
+
   // Optional metadata for extension commands
   extensionName?: string;
 

--- a/packages/cli/src/ui/components/Help.test.tsx
+++ b/packages/cli/src/ui/components/Help.test.tsx
@@ -39,16 +39,15 @@ describe('<Help/>', () => {
     const customCommands: readonly SlashCommand[] = [
       {
         name: 'custom1',
-        description:
-          '[extension-foo] This is a custom command from an extension.',
+        description: 'This is a custom command from an extension.',
         kind: CommandKind.FILE, // or any other non-BUILT_IN kind
         extensionName: 'extension-foo',
       },
       {
         name: 'custom2',
-        description:
-          '[fooMcpServer] This is a custom command from an MCP server.',
+        description: 'This is a custom command from an MCP server.',
         kind: CommandKind.MCP_PROMPT,
+        mcpServerName: 'mcp-server-bar',
       },
     ];
 
@@ -60,14 +59,11 @@ describe('<Help/>', () => {
     expect(output).toContain('Show this help message.');
     expect(output).toContain('/exit');
     expect(output).toContain('Exit the application.');
-    expect(output).toContain('Custom Commands:');
+    expect(output).toContain('Commands from extension extension-foo:');
     expect(output).toContain('/custom1');
-    expect(output).toContain(
-      '[extension-foo] This is a custom command from an extension.',
-    );
+    expect(output).toContain('This is a custom command from an extension.');
+    expect(output).toContain('Commands from MCP server mcp-server-bar:');
     expect(output).toContain('/custom2');
-    expect(output).toContain(
-      '[fooMcpServer] This is a custom command from an MCP server.',
-    );
+    expect(output).toContain('This is a custom command from an MCP server.');
   });
 });

--- a/packages/cli/src/ui/components/Help.test.tsx
+++ b/packages/cli/src/ui/components/Help.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from 'ink-testing-library';
+import { describe, it, expect } from 'vitest';
+import { Help } from './Help.js';
+import type { SlashCommand } from '../commands/types.js';
+import { CommandKind } from '../commands/types.js';
+
+const builtInCommands: readonly SlashCommand[] = [
+  {
+    name: 'help',
+    description: 'Show this help message.',
+    kind: CommandKind.BUILT_IN,
+  },
+  {
+    name: 'exit',
+    description: 'Exit the application.',
+    kind: CommandKind.BUILT_IN,
+  },
+];
+
+describe('<Help/>', () => {
+  it('renders without custom commands section when none are provided', () => {
+    const { lastFrame } = render(<Help commands={builtInCommands} />);
+    const output = lastFrame();
+
+    expect(output).toContain('/help');
+    expect(output).toContain('Show this help message.');
+    expect(output).toContain('/exit');
+    expect(output).toContain('Exit the application.');
+    expect(output).not.toContain('Custom Commands:');
+  });
+
+  it('renders with custom commands section when custom commands are provided', () => {
+    const customCommands: readonly SlashCommand[] = [
+      {
+        name: 'custom1',
+        description:
+          '[extension-foo] This is a custom command from an extension.',
+        kind: CommandKind.FILE, // or any other non-BUILT_IN kind
+        extensionName: 'extension-foo',
+      },
+      {
+        name: 'custom2',
+        description:
+          '[fooMcpServer] This is a custom command from an MCP server.',
+        kind: CommandKind.MCP_PROMPT,
+      },
+    ];
+
+    const allCommands = [...builtInCommands, ...customCommands];
+    const { lastFrame } = render(<Help commands={allCommands} />);
+    const output = lastFrame();
+
+    expect(output).toContain('/help');
+    expect(output).toContain('Show this help message.');
+    expect(output).toContain('/exit');
+    expect(output).toContain('Exit the application.');
+    expect(output).toContain('Custom Commands:');
+    expect(output).toContain('/custom1');
+    expect(output).toContain(
+      '[extension-foo] This is a custom command from an extension.',
+    );
+    expect(output).toContain('/custom2');
+    expect(output).toContain(
+      '[fooMcpServer] This is a custom command from an MCP server.',
+    );
+  });
+});

--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -119,11 +119,39 @@ export const Help: React.FC<Help> = ({ commands }) => {
         </Box>
       </Box>
 
-      {customCommands.length > 0 && (
-        <Box flexDirection="column" paddingTop={1}>
-          <CommandList title={'Custom Commands:'} commands={customCommands} />
-        </Box>
-      )}
+      {/* Custom commands, grouped by origin */}
+      {customCommands.length > 0 &&
+        Object.entries(
+          customCommands.reduce(
+            (acc, command) => {
+              const key =
+                command.mcpServerName ||
+                command.extensionName ||
+                command.originName ||
+                'Unknown Origin';
+              if (!acc[key]) {
+                acc[key] = [];
+              }
+              acc[key].push(command);
+              return acc;
+            },
+            {} as Record<string, SlashCommand[]>,
+          ),
+        ).map(([origin, commands]) => {
+          let title = 'Commands from unknown location:';
+          if (commands[0].mcpServerName !== undefined) {
+            title = `Commands from MCP server ${origin}:`;
+          } else if (commands[0].extensionName !== undefined) {
+            title = `Commands from extension ${origin}:`;
+          } else if (commands[0].originName !== undefined) {
+            title = `Commands from ${origin}:`;
+          }
+          return (
+            <Box key={origin} flexDirection="column" paddingTop={1}>
+              <CommandList title={title} commands={commands} />
+            </Box>
+          );
+        })}
 
       {/* Shortcuts */}
       <Box key={'shortcuts'} flexDirection="column" paddingTop={1}>

--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -8,167 +8,203 @@ import type React from 'react';
 import { Box, Text } from 'ink';
 import { Colors } from '../colors.js';
 import type { SlashCommand } from '../commands/types.js';
+import { CommandKind } from '../commands/types.js';
 
 interface Help {
   commands: readonly SlashCommand[];
 }
 
-export const Help: React.FC<Help> = ({ commands }) => (
-  <Box
-    flexDirection="column"
-    marginBottom={1}
-    borderColor={Colors.Gray}
-    borderStyle="round"
-    padding={1}
-  >
-    {/* Basics */}
+const CommandList: React.FC<{
+  title: string;
+  commands: readonly SlashCommand[];
+}> = ({ title, commands }) => (
+  <>
     <Text bold color={Colors.Foreground}>
-      Basics:
-    </Text>
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        Add context
-      </Text>
-      : Use{' '}
-      <Text bold color={Colors.AccentPurple}>
-        @
-      </Text>{' '}
-      to specify files for context (e.g.,{' '}
-      <Text bold color={Colors.AccentPurple}>
-        @src/myFile.ts
-      </Text>
-      ) to target specific files or folders.
-    </Text>
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        Shell mode
-      </Text>
-      : Execute shell commands via{' '}
-      <Text bold color={Colors.AccentPurple}>
-        !
-      </Text>{' '}
-      (e.g.,{' '}
-      <Text bold color={Colors.AccentPurple}>
-        !npm run start
-      </Text>
-      ) or use natural language (e.g.{' '}
-      <Text bold color={Colors.AccentPurple}>
-        start server
-      </Text>
-      ).
+      {title}
     </Text>
 
-    <Box height={1} />
-
-    {/* Commands */}
-    <Text bold color={Colors.Foreground}>
-      Commands:
-    </Text>
     {commands
       .filter((command) => command.description)
       .map((command: SlashCommand) => (
-        <Box key={command.name} flexDirection="column">
+        <Box key={command.name} flexDirection="column" paddingLeft={1}>
           <Text color={Colors.Foreground}>
             <Text bold color={Colors.AccentPurple}>
-              {' '}
               /{command.name}
             </Text>
             {command.description && ' - ' + command.description}
           </Text>
           {command.subCommands &&
             command.subCommands.map((subCommand) => (
-              <Text key={subCommand.name} color={Colors.Foreground}>
-                <Text bold color={Colors.AccentPurple}>
-                  {'   '}
-                  {subCommand.name}
+              <Box key={subCommand.name} flexDirection="column" paddingLeft={2}>
+                <Text color={Colors.Foreground}>
+                  <Text bold color={Colors.AccentPurple}>
+                    {subCommand.name}
+                  </Text>
+                  {subCommand.description && ' - ' + subCommand.description}
                 </Text>
-                {subCommand.description && ' - ' + subCommand.description}
-              </Text>
+              </Box>
             ))}
         </Box>
       ))}
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        {' '}
-        !{' '}
-      </Text>
-      - shell command
-    </Text>
-
-    <Box height={1} />
-
-    {/* Shortcuts */}
-    <Text bold color={Colors.Foreground}>
-      Keyboard Shortcuts:
-    </Text>
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        Alt+Left/Right
-      </Text>{' '}
-      - Jump through words in the input
-    </Text>
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        Ctrl+C
-      </Text>{' '}
-      - Quit application
-    </Text>
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        {process.platform === 'win32' ? 'Ctrl+Enter' : 'Ctrl+J'}
-      </Text>{' '}
-      {process.platform === 'linux'
-        ? '- New line (Alt+Enter works for certain linux distros)'
-        : '- New line'}
-    </Text>
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        Ctrl+L
-      </Text>{' '}
-      - Clear the screen
-    </Text>
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        {process.platform === 'darwin' ? 'Ctrl+X / Meta+Enter' : 'Ctrl+X'}
-      </Text>{' '}
-      - Open input in external editor
-    </Text>
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        Ctrl+Y
-      </Text>{' '}
-      - Toggle YOLO mode
-    </Text>
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        Enter
-      </Text>{' '}
-      - Send message
-    </Text>
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        Esc
-      </Text>{' '}
-      - Cancel operation / Clear input (double press)
-    </Text>
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        Shift+Tab
-      </Text>{' '}
-      - Toggle auto-accepting edits
-    </Text>
-    <Text color={Colors.Foreground}>
-      <Text bold color={Colors.AccentPurple}>
-        Up/Down
-      </Text>{' '}
-      - Cycle through your prompt history
-    </Text>
-    <Box height={1} />
-    <Text color={Colors.Foreground}>
-      For a full list of shortcuts, see{' '}
-      <Text bold color={Colors.AccentPurple}>
-        docs/keyboard-shortcuts.md
-      </Text>
-    </Text>
-  </Box>
+  </>
 );
+
+export const Help: React.FC<Help> = ({ commands }) => {
+  const builtInCommands: SlashCommand[] = [];
+  const customCommands: SlashCommand[] = [];
+  for (const command of commands) {
+    if (command.kind === CommandKind.BUILT_IN) {
+      builtInCommands.push(command);
+    } else {
+      customCommands.push(command);
+    }
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      marginBottom={1}
+      borderColor={Colors.Gray}
+      borderStyle="round"
+      padding={1}
+    >
+      {/* Basics */}
+      <Text bold color={Colors.Foreground}>
+        Basics:
+      </Text>
+      <Text color={Colors.Foreground}>
+        <Text bold color={Colors.AccentPurple}>
+          Add context
+        </Text>
+        : Use{' '}
+        <Text bold color={Colors.AccentPurple}>
+          @
+        </Text>{' '}
+        to specify files for context (e.g.,{' '}
+        <Text bold color={Colors.AccentPurple}>
+          @src/myFile.ts
+        </Text>
+        ) to target specific files or folders.
+      </Text>
+      <Text color={Colors.Foreground}>
+        <Text bold color={Colors.AccentPurple}>
+          Shell mode
+        </Text>
+        : Execute shell commands via{' '}
+        <Text bold color={Colors.AccentPurple}>
+          !
+        </Text>{' '}
+        (e.g.,{' '}
+        <Text bold color={Colors.AccentPurple}>
+          !npm run start
+        </Text>
+        ) or use natural language (e.g.{' '}
+        <Text bold color={Colors.AccentPurple}>
+          start server
+        </Text>
+        ).
+      </Text>
+
+      {/* Commands */}
+      <Box flexDirection="column" paddingTop={1}>
+        <CommandList title={'Commands:'} commands={builtInCommands} />
+        {/* Special case the shell command */}
+        <Box key={'shellCommand'} flexDirection="column" paddingLeft={1}>
+          <Text color={Colors.Foreground}>
+            <Text bold color={Colors.AccentPurple}>
+              !
+            </Text>
+            {' - shell command'}
+          </Text>
+        </Box>
+      </Box>
+
+      {customCommands.length > 0 && (
+        <Box flexDirection="column" paddingTop={1}>
+          <CommandList title={'Custom Commands:'} commands={customCommands} />
+        </Box>
+      )}
+
+      {/* Shortcuts */}
+      <Box key={'shortcuts'} flexDirection="column" paddingTop={1}>
+        <Text bold color={Colors.Foreground}>
+          Keyboard Shortcuts:
+        </Text>
+        <Box key={'keyboard-shortcuts'} flexDirection="column" paddingLeft={1}>
+          <Text color={Colors.Foreground}>
+            <Text bold color={Colors.AccentPurple}>
+              Alt+Left/Right
+            </Text>{' '}
+            - Jump through words in the input
+          </Text>
+          <Text color={Colors.Foreground}>
+            <Text bold color={Colors.AccentPurple}>
+              Ctrl+C
+            </Text>{' '}
+            - Quit application
+          </Text>
+          <Text color={Colors.Foreground}>
+            <Text bold color={Colors.AccentPurple}>
+              {process.platform === 'win32' ? 'Ctrl+Enter' : 'Ctrl+J'}
+            </Text>{' '}
+            {process.platform === 'linux'
+              ? '- New line (Alt+Enter works for certain linux distros)'
+              : '- New line'}
+          </Text>
+          <Text color={Colors.Foreground}>
+            <Text bold color={Colors.AccentPurple}>
+              Ctrl+L
+            </Text>{' '}
+            - Clear the screen
+          </Text>
+          <Text color={Colors.Foreground}>
+            <Text bold color={Colors.AccentPurple}>
+              {process.platform === 'darwin' ? 'Ctrl+X / Meta+Enter' : 'Ctrl+X'}
+            </Text>{' '}
+            - Open input in external editor
+          </Text>
+          <Text color={Colors.Foreground}>
+            <Text bold color={Colors.AccentPurple}>
+              Ctrl+Y
+            </Text>{' '}
+            - Toggle YOLO mode
+          </Text>
+          <Text color={Colors.Foreground}>
+            <Text bold color={Colors.AccentPurple}>
+              Enter
+            </Text>{' '}
+            - Send message
+          </Text>
+          <Text color={Colors.Foreground}>
+            <Text bold color={Colors.AccentPurple}>
+              Esc
+            </Text>{' '}
+            - Cancel operation / Clear input (double press)
+          </Text>
+          <Text color={Colors.Foreground}>
+            <Text bold color={Colors.AccentPurple}>
+              Shift+Tab
+            </Text>{' '}
+            - Toggle auto-accepting edits
+          </Text>
+          <Text color={Colors.Foreground}>
+            <Text bold color={Colors.AccentPurple}>
+              Up/Down
+            </Text>{' '}
+            - Cycle through your prompt history
+          </Text>
+        </Box>
+      </Box>
+
+      {/* Footer */}
+      <Box paddingTop={1}>
+        <Text color={Colors.Foreground}>
+          For a full list of shortcuts, see{' '}
+          <Text bold color={Colors.AccentPurple}>
+            docs/keyboard-shortcuts.md
+          </Text>
+        </Text>
+      </Box>
+    </Box>
+  );
+};


### PR DESCRIPTION
## TLDR

With the ever growing list of commands it's hard to pick out custom commands from the built in ones when they're intermingled in the same list in `/help`. This PR separates the `/help` text for built in commands and custom commands.

The PR also adds the name of the MCP server a prompt command comes from to the description, matching file based commands that report which extension they come from.

## Reviewer Test Plan

Run `/help` with custom commands setup.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Issues

resolves #6060 partly by adding MCP server names to /help text and separating built in commands from custom commands
