### PR TITLE
fix(#4645): checkpointing not recognizing local repo on French envs

### DIFF
--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -70,7 +70,7 @@ describe('GitService', () => {
     vi.clearAllMocks();
     hoistedIsGitRepositoryMock.mockReturnValue(true);
     hoistedMockExec.mockImplementation((command, callback) => {
-      if (command === 'git --version') {
+      if (command === 'LANG=C git --version') {
         callback(null, 'git version 2.0.0');
       } else {
         callback(new Error('Command not mocked'));
@@ -148,7 +148,7 @@ describe('GitService', () => {
       const service = new GitService(projectRoot, storage);
       const setupSpy = vi
         .spyOn(service, 'setupShadowGitRepository')
-        .mockResolvedValue(undefined);
+        .mockResolvedValue();
 
       await service.initialize();
       expect(setupSpy).toHaveBeenCalled();
@@ -187,6 +187,14 @@ describe('GitService', () => {
       await service.setupShadowGitRepository();
       expect(hoistedMockSimpleGit).toHaveBeenCalledWith(repoDir);
       expect(hoistedMockInit).toHaveBeenCalled();
+    });
+
+    it('should initialize git repo with LANG=C', async () => {
+      hoistedMockCheckIsRepo.mockResolvedValue(false);
+      const service = new GitService(projectRoot, storage);
+      await service.setupShadowGitRepository();
+      expect(hoistedMockSimpleGit).toHaveBeenCalledWith(repoDir);
+      expect(hoistedMockEnv).toHaveBeenCalledWith({ LANG: 'C' });
     });
 
     it('should not initialize git repo if already initialized', async () => {

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -36,7 +36,7 @@ export class GitService {
 
   verifyGitAvailability(): Promise<boolean> {
     return new Promise((resolve) => {
-      exec('git --version', (error) => {
+      exec('LANG=C git --version', (error) => {
         if (error) {
           resolve(false);
         } else {
@@ -62,7 +62,9 @@ export class GitService {
       '[user]\n  name = Gemini CLI\n  email = gemini-cli@google.com\n[commit]\n  gpgsign = false\n';
     await fs.writeFile(gitConfigPath, gitConfigContent);
 
-    const repo = simpleGit(repoDir);
+    const repo = simpleGit(repoDir).env({
+      LANG: 'C',
+    });
     const isRepoDefined = await repo.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
 
     if (!isRepoDefined) {
@@ -91,6 +93,7 @@ export class GitService {
   private get shadowGitRepository(): SimpleGit {
     const repoDir = this.getHistoryDir();
     return simpleGit(this.projectRoot).env({
+      LANG: 'C',
       GIT_DIR: path.join(repoDir, '.git'),
       GIT_WORK_TREE: this.projectRoot,
       // Prevent git from using the user's global git config.


### PR DESCRIPTION
It fixes the issue about the `-c` or `--checkpointing` option not recognizing users' local repos when their environment is in French (or in other languages I assume) by setting `C` to the `LANG` environment variable which forces git to _always_ communicate in English, ensuring that `simple-git` can always understand its output, regardless of the user's system language settings.

## Dive Deeper

I could not successfully reproduce the issue. I tried many different things, but it did not happen to me. However, if the language setting is indeed the issue as the user stated, this should fix it.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | x  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This PR attempts to fix: https://github.com/google-gemini/gemini-cli/issues/4645
