### PR TITLE
Force restart on trust level change to reload settings

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -74,17 +74,13 @@ function mergeSettings(
   system: Settings,
   user: Settings,
   workspace: Settings,
-  isTrusted?: boolean,
+  isTrusted: boolean,
 ): Settings {
+  const safeWorkspace = isTrusted ? workspace : ({} as Settings);
+
   // folderTrust is not supported at workspace level.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { folderTrust, ...workspaceWithoutFolderTrust } = workspace;
-
-  const isSafeWorkspace = isTrusted ?? true;
-  const safeWorkspace = isSafeWorkspace ? workspace : ({} as Settings);
-  const safeWorkspaceWithoutFolderTrust = isSafeWorkspace
-    ? workspaceWithoutFolderTrust
-    : ({} as Settings);
+  const { folderTrust, ...safeWorkspaceWithoutFolderTrust } = safeWorkspace;
 
   return {
     ...user,
@@ -119,7 +115,7 @@ export class LoadedSettings {
     user: SettingsFile,
     workspace: SettingsFile,
     errors: SettingsError[],
-    isTrusted?: boolean,
+    isTrusted: boolean,
   ) {
     this.system = system;
     this.user = user;
@@ -133,7 +129,7 @@ export class LoadedSettings {
   readonly user: SettingsFile;
   readonly workspace: SettingsFile;
   readonly errors: SettingsError[];
-  readonly isTrusted: boolean | undefined;
+  readonly isTrusted: boolean;
 
   private _merged: Settings;
 
@@ -417,7 +413,7 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
 
   // For the initial trust check, we can only use user and system settings.
   const initialTrustCheckSettings = { ...systemSettings, ...userSettings };
-  const isTrusted = isWorkspaceTrusted(initialTrustCheckSettings);
+  const isTrusted = isWorkspaceTrusted(initialTrustCheckSettings) ?? true;
 
   // Create a temporary merged settings object to pass to loadEnvironment.
   const tempMergedSettings = mergeSettings(

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -149,6 +149,7 @@ describe('gemini.tsx main function', () => {
       userSettingsFile,
       workspaceSettingsFile,
       [settingsError],
+      true,
     );
 
     loadSettingsMock.mockReturnValue(mockLoadedSettings);

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -211,6 +211,7 @@ vi.mock('./hooks/useFolderTrust', () => ({
   useFolderTrust: vi.fn(() => ({
     isFolderTrustDialogOpen: false,
     handleFolderTrustSelect: vi.fn(),
+    isRestarting: false,
   })),
 }));
 
@@ -296,6 +297,7 @@ describe('App UI', () => {
       userSettingsFile,
       workspaceSettingsFile,
       [],
+      true,
     );
   };
 

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -267,10 +267,8 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   const { isSettingsDialogOpen, openSettingsDialog, closeSettingsDialog } =
     useSettingsCommand();
 
-  const { isFolderTrustDialogOpen, handleFolderTrustSelect } = useFolderTrust(
-    settings,
-    setIsTrustedFolder,
-  );
+  const { isFolderTrustDialogOpen, handleFolderTrustSelect, isRestarting } =
+    useFolderTrust(settings, setIsTrustedFolder);
 
   const {
     isAuthDialogOpen,
@@ -991,7 +989,11 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
               onComplete={handleIdePromptComplete}
             />
           ) : isFolderTrustDialogOpen ? (
-            <FolderTrustDialog onSelect={handleFolderTrustSelect} />
+            <FolderTrustDialog
+              onSelect={handleFolderTrustSelect}
+              onRestartRequest={() => process.exit(0)}
+              isRestarting={isRestarting}
+            />
           ) : shellConfirmationRequest ? (
             <ShellConfirmationDialog request={shellConfirmationRequest} />
           ) : confirmationRequest ? (

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -991,7 +991,6 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
           ) : isFolderTrustDialogOpen ? (
             <FolderTrustDialog
               onSelect={handleFolderTrustSelect}
-              onRestartRequest={() => process.exit(0)}
               isRestarting={isRestarting}
             />
           ) : shellConfirmationRequest ? (

--- a/packages/cli/src/ui/components/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.test.tsx
@@ -45,6 +45,7 @@ describe('AuthDialog', () => {
         path: '',
       },
       [],
+      true,
     );
 
     const { lastFrame } = renderWithProviders(
@@ -82,6 +83,7 @@ describe('AuthDialog', () => {
           path: '',
         },
         [],
+        true,
       );
 
       const { lastFrame } = renderWithProviders(
@@ -115,6 +117,7 @@ describe('AuthDialog', () => {
           path: '',
         },
         [],
+        true,
       );
 
       const { lastFrame } = renderWithProviders(
@@ -148,6 +151,7 @@ describe('AuthDialog', () => {
           path: '',
         },
         [],
+        true,
       );
 
       const { lastFrame } = renderWithProviders(
@@ -182,6 +186,7 @@ describe('AuthDialog', () => {
           path: '',
         },
         [],
+        true,
       );
 
       const { lastFrame } = renderWithProviders(
@@ -211,6 +216,7 @@ describe('AuthDialog', () => {
           path: '',
         },
         [],
+        true,
       );
 
       const { lastFrame } = renderWithProviders(
@@ -242,6 +248,7 @@ describe('AuthDialog', () => {
           path: '',
         },
         [],
+        true,
       );
 
       const { lastFrame } = renderWithProviders(
@@ -277,6 +284,7 @@ describe('AuthDialog', () => {
         path: '',
       },
       [],
+      true,
     );
 
     const { lastFrame, stdin, unmount } = renderWithProviders(
@@ -316,6 +324,7 @@ describe('AuthDialog', () => {
         path: '',
       },
       [],
+      true,
     );
 
     const { lastFrame, stdin, unmount } = renderWithProviders(
@@ -358,6 +367,7 @@ describe('AuthDialog', () => {
         path: '',
       },
       [],
+      true,
     );
 
     const { stdin, unmount } = renderWithProviders(

--- a/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
@@ -12,7 +12,7 @@ import { FolderTrustDialog, FolderTrustChoice } from './FolderTrustDialog.js';
 describe('FolderTrustDialog', () => {
   it('should render the dialog with title and description', () => {
     const { lastFrame } = renderWithProviders(
-      <FolderTrustDialog onSelect={vi.fn()} />,
+      <FolderTrustDialog onSelect={vi.fn()} onRestartRequest={vi.fn()} />,
     );
 
     expect(lastFrame()).toContain('Do you trust this folder?');
@@ -21,16 +21,85 @@ describe('FolderTrustDialog', () => {
     );
   });
 
-  it('should call onSelect with DO_NOT_TRUST when escape is pressed', async () => {
+  it('should call onSelect with DO_NOT_TRUST when escape is pressed and not restarting', async () => {
     const onSelect = vi.fn();
     const { stdin } = renderWithProviders(
-      <FolderTrustDialog onSelect={onSelect} />,
+      <FolderTrustDialog
+        onSelect={onSelect}
+        onRestartRequest={vi.fn()}
+        isRestarting={false}
+      />,
     );
 
-    stdin.write('\x1b');
+    stdin.write('\x1b'); // escape key
 
     await waitFor(() => {
       expect(onSelect).toHaveBeenCalledWith(FolderTrustChoice.DO_NOT_TRUST);
     });
+  });
+
+  it('should not call onSelect when escape is pressed and is restarting', async () => {
+    const onSelect = vi.fn();
+    const { stdin } = renderWithProviders(
+      <FolderTrustDialog
+        onSelect={onSelect}
+        onRestartRequest={vi.fn()}
+        isRestarting={true}
+      />,
+    );
+
+    stdin.write('\x1b'); // escape key
+
+    // Give it a moment to process, then assert that onSelect was NOT called.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('should display restart message when isRestarting is true', () => {
+    const { lastFrame } = renderWithProviders(
+      <FolderTrustDialog
+        onSelect={vi.fn()}
+        onRestartRequest={vi.fn()}
+        isRestarting={true}
+      />,
+    );
+
+    expect(lastFrame()).toContain(
+      'To see changes, Gemini CLI must be restarted',
+    );
+  });
+
+  it('should call onRestartRequest when "r" is pressed and isRestarting is true', async () => {
+    const onRestartRequest = vi.fn();
+    const { stdin } = renderWithProviders(
+      <FolderTrustDialog
+        onSelect={vi.fn()}
+        onRestartRequest={onRestartRequest}
+        isRestarting={true}
+      />,
+    );
+
+    stdin.write('r');
+
+    await waitFor(() => {
+      expect(onRestartRequest).toHaveBeenCalled();
+    });
+  });
+
+  it('should not call onRestartRequest when "r" is pressed and isRestarting is false', async () => {
+    const onRestartRequest = vi.fn();
+    const { stdin } = renderWithProviders(
+      <FolderTrustDialog
+        onSelect={vi.fn()}
+        onRestartRequest={onRestartRequest}
+        isRestarting={false}
+      />,
+    );
+
+    stdin.write('r');
+
+    // Give it a moment to process, then assert that onRestartRequest was NOT called.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(onRestartRequest).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
@@ -8,11 +8,24 @@ import { renderWithProviders } from '../../test-utils/render.js';
 import { waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { FolderTrustDialog, FolderTrustChoice } from './FolderTrustDialog.js';
+import * as process from 'process';
+
+vi.mock('process', async () => {
+  const actual = await vi.importActual('process');
+  return {
+    ...actual,
+    exit: vi.fn(),
+  };
+});
 
 describe('FolderTrustDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should render the dialog with title and description', () => {
     const { lastFrame } = renderWithProviders(
-      <FolderTrustDialog onSelect={vi.fn()} onRestartRequest={vi.fn()} />,
+      <FolderTrustDialog onSelect={vi.fn()} />,
     );
 
     expect(lastFrame()).toContain('Do you trust this folder?');
@@ -24,11 +37,7 @@ describe('FolderTrustDialog', () => {
   it('should call onSelect with DO_NOT_TRUST when escape is pressed and not restarting', async () => {
     const onSelect = vi.fn();
     const { stdin } = renderWithProviders(
-      <FolderTrustDialog
-        onSelect={onSelect}
-        onRestartRequest={vi.fn()}
-        isRestarting={false}
-      />,
+      <FolderTrustDialog onSelect={onSelect} isRestarting={false} />,
     );
 
     stdin.write('\x1b'); // escape key
@@ -41,27 +50,19 @@ describe('FolderTrustDialog', () => {
   it('should not call onSelect when escape is pressed and is restarting', async () => {
     const onSelect = vi.fn();
     const { stdin } = renderWithProviders(
-      <FolderTrustDialog
-        onSelect={onSelect}
-        onRestartRequest={vi.fn()}
-        isRestarting={true}
-      />,
+      <FolderTrustDialog onSelect={onSelect} isRestarting={true} />,
     );
 
     stdin.write('\x1b'); // escape key
 
-    // Give it a moment to process, then assert that onSelect was NOT called.
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    expect(onSelect).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onSelect).not.toHaveBeenCalled();
+    });
   });
 
   it('should display restart message when isRestarting is true', () => {
     const { lastFrame } = renderWithProviders(
-      <FolderTrustDialog
-        onSelect={vi.fn()}
-        onRestartRequest={vi.fn()}
-        isRestarting={true}
-      />,
+      <FolderTrustDialog onSelect={vi.fn()} isRestarting={true} />,
     );
 
     expect(lastFrame()).toContain(
@@ -69,37 +70,27 @@ describe('FolderTrustDialog', () => {
     );
   });
 
-  it('should call onRestartRequest when "r" is pressed and isRestarting is true', async () => {
-    const onRestartRequest = vi.fn();
+  it('should call process.exit when "r" is pressed and isRestarting is true', async () => {
     const { stdin } = renderWithProviders(
-      <FolderTrustDialog
-        onSelect={vi.fn()}
-        onRestartRequest={onRestartRequest}
-        isRestarting={true}
-      />,
+      <FolderTrustDialog onSelect={vi.fn()} isRestarting={true} />,
     );
 
     stdin.write('r');
 
     await waitFor(() => {
-      expect(onRestartRequest).toHaveBeenCalled();
+      expect(process.exit).toHaveBeenCalledWith(0);
     });
   });
 
-  it('should not call onRestartRequest when "r" is pressed and isRestarting is false', async () => {
-    const onRestartRequest = vi.fn();
+  it('should not call process.exit when "r" is pressed and isRestarting is false', async () => {
     const { stdin } = renderWithProviders(
-      <FolderTrustDialog
-        onSelect={vi.fn()}
-        onRestartRequest={onRestartRequest}
-        isRestarting={false}
-      />,
+      <FolderTrustDialog onSelect={vi.fn()} isRestarting={false} />,
     );
 
     stdin.write('r');
 
-    // Give it a moment to process, then assert that onRestartRequest was NOT called.
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    expect(onRestartRequest).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(process.exit).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/cli/src/ui/components/FolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.tsx
@@ -21,10 +21,14 @@ export enum FolderTrustChoice {
 
 interface FolderTrustDialogProps {
   onSelect: (choice: FolderTrustChoice) => void;
+  onRestartRequest: () => void;
+  isRestarting?: boolean;
 }
 
 export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
   onSelect,
+  onRestartRequest,
+  isRestarting,
 }) => {
   useKeypress(
     (key) => {
@@ -32,7 +36,16 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
         onSelect(FolderTrustChoice.DO_NOT_TRUST);
       }
     },
-    { isActive: true },
+    { isActive: !isRestarting },
+  );
+
+  useKeypress(
+    (key) => {
+      if (key.name === 'r') {
+        onRestartRequest();
+      }
+    },
+    { isActive: !!isRestarting },
   );
 
   const options: Array<RadioSelectItem<FolderTrustChoice>> = [
@@ -51,24 +64,38 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
   ];
 
   return (
-    <Box
-      flexDirection="column"
-      borderStyle="round"
-      borderColor={Colors.AccentYellow}
-      padding={1}
-      width="100%"
-      marginLeft={1}
-    >
-      <Box flexDirection="column" marginBottom={1}>
-        <Text bold>Do you trust this folder?</Text>
-        <Text>
-          Trusting a folder allows Gemini to execute commands it suggests. This
-          is a security feature to prevent accidental execution in untrusted
-          directories.
-        </Text>
-      </Box>
+    <Box flexDirection="column">
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={Colors.AccentYellow}
+        padding={1}
+        width="100%"
+        marginLeft={1}
+      >
+        <Box flexDirection="column" marginBottom={1}>
+          <Text bold>Do you trust this folder?</Text>
+          <Text>
+            Trusting a folder allows Gemini to execute commands it suggests.
+            This is a security feature to prevent accidental execution in
+            untrusted directories.
+          </Text>
+        </Box>
 
-      <RadioButtonSelect items={options} onSelect={onSelect} isFocused />
+        <RadioButtonSelect
+          items={options}
+          onSelect={onSelect}
+          isFocused={!isRestarting}
+        />
+      </Box>
+      {isRestarting && (
+        <Box marginLeft={1} marginTop={1}>
+          <Text color={Colors.AccentYellow}>
+            To see changes, Gemini CLI must be restarted. Press r to exit and
+            apply changes now.
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/FolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.tsx
@@ -12,6 +12,7 @@ import {
   RadioSelectItem,
 } from './shared/RadioButtonSelect.js';
 import { useKeypress } from '../hooks/useKeypress.js';
+import * as process from 'process';
 
 export enum FolderTrustChoice {
   TRUST_FOLDER = 'trust_folder',
@@ -21,13 +22,11 @@ export enum FolderTrustChoice {
 
 interface FolderTrustDialogProps {
   onSelect: (choice: FolderTrustChoice) => void;
-  onRestartRequest: () => void;
   isRestarting?: boolean;
 }
 
 export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
   onSelect,
-  onRestartRequest,
   isRestarting,
 }) => {
   useKeypress(
@@ -42,7 +41,7 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
   useKeypress(
     (key) => {
       if (key.name === 'r') {
-        onRestartRequest();
+        process.exit(0);
       }
     },
     { isActive: !!isRestarting },

--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -140,6 +140,7 @@ describe('SettingsDialog', () => {
         path: '/workspace/settings.json',
       },
       [],
+      true,
     );
 
   describe('Initial Rendering', () => {

--- a/packages/cli/src/ui/hooks/useFolderTrust.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.ts
@@ -20,6 +20,7 @@ export const useFolderTrust = (
 ) => {
   const [isTrusted, setIsTrusted] = useState<boolean | undefined>(undefined);
   const [isFolderTrustDialogOpen, setIsFolderTrustDialogOpen] = useState(false);
+  const [isRestarting, setIsRestarting] = useState(false);
 
   const { folderTrust, folderTrustFeature } = settings.merged;
   useEffect(() => {
@@ -38,6 +39,8 @@ export const useFolderTrust = (
       const cwd = process.cwd();
       let trustLevel: TrustLevel;
 
+      const wasTrusted = isTrusted ?? true;
+
       switch (choice) {
         case FolderTrustChoice.TRUST_FOLDER:
           trustLevel = TrustLevel.TRUST_FOLDER;
@@ -53,20 +56,27 @@ export const useFolderTrust = (
       }
 
       trustedFolders.setValue(cwd, trustLevel);
-      const trusted = isWorkspaceTrusted({
-        folderTrust,
-        folderTrustFeature,
-      } as Settings);
-      setIsTrusted(trusted);
-      setIsFolderTrustDialogOpen(false);
-      onTrustChange(trusted);
+      const newIsTrusted =
+        trustLevel === TrustLevel.TRUST_FOLDER ||
+        trustLevel === TrustLevel.TRUST_PARENT;
+      setIsTrusted(newIsTrusted);
+      onTrustChange(newIsTrusted);
+
+      const needsRestart = wasTrusted !== newIsTrusted;
+      if (needsRestart) {
+        setIsRestarting(true);
+        setIsFolderTrustDialogOpen(true);
+      } else {
+        setIsFolderTrustDialogOpen(false);
+      }
     },
-    [onTrustChange, folderTrust, folderTrustFeature],
+    [onTrustChange, isTrusted],
   );
 
   return {
     isTrusted,
     isFolderTrustDialogOpen,
     handleFolderTrustSelect,
+    isRestarting,
   };
 };

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -22,6 +22,7 @@ describe('<MarkdownDisplay />', () => {
     { path: '', settings: {} },
     { path: '', settings: {} },
     [],
+    true,
   );
 
   beforeEach(() => {
@@ -220,6 +221,7 @@ Another paragraph.
       { path: '', settings: { showLineNumbers: false } },
       { path: '', settings: {} },
       [],
+      true,
     );
 
     const { lastFrame } = render(


### PR DESCRIPTION
## TLDR

Updated settings to ignore workspace settings in untrusted environments and added logic to force restart when trust level changes. Since trust is expected to be the default, we initialize with trusted settings when the trust level is undefined and only force restart for untrusted case. If it's already defined, we force restart when the trusted status flips.

## Dive Deeper

<img width="1041" height="244" alt="image" src="https://github.com/user-attachments/assets/065edbe7-c05f-4e48-a5ed-e55ee502e6bf" />

## Reviewer Test Plan

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to https://github.com/google-gemini/maintainers-gemini-cli/issues/642
