### PR TITLE
Reuse CoreToolScheduler for nonInteractiveToolExecutor

### DIFF
--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -134,7 +134,6 @@ export function useReactToolScheduler(
   const scheduler = useMemo(
     () =>
       new CoreToolScheduler({
-        toolRegistry: config.getToolRegistry(),
         outputUpdateHandler,
         onAllToolCallsComplete: allToolCallsCompleteHandler,
         onToolCallsUpdate: toolCallsUpdateHandler,

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -129,11 +129,11 @@ describe('CoreToolScheduler', () => {
         model: 'test-model',
         authType: 'oauth-personal',
       }),
+      getToolRegistry: () => mockToolRegistry,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
       config: mockConfig,
-      toolRegistry: mockToolRegistry,
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
@@ -189,11 +189,11 @@ describe('CoreToolScheduler with payload', () => {
         model: 'test-model',
         authType: 'oauth-personal',
       }),
+      getToolRegistry: () => mockToolRegistry,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
       config: mockConfig,
-      toolRegistry: mockToolRegistry,
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
@@ -462,15 +462,14 @@ class MockEditTool extends BaseDeclarativeTool<
 describe('CoreToolScheduler edit cancellation', () => {
   it('should preserve diff when an edit is cancelled', async () => {
     const mockEditTool = new MockEditTool();
-    const declarativeTool = mockEditTool;
     const mockToolRegistry = {
-      getTool: () => declarativeTool,
+      getTool: () => mockEditTool,
       getFunctionDeclarations: () => [],
       tools: new Map(),
       discovery: {},
       registerTool: () => {},
-      getToolByName: () => declarativeTool,
-      getToolByDisplayName: () => declarativeTool,
+      getToolByName: () => mockEditTool,
+      getToolByDisplayName: () => mockEditTool,
       getTools: () => [],
       discoverTools: async () => {},
       getAllTools: () => [],
@@ -489,11 +488,11 @@ describe('CoreToolScheduler edit cancellation', () => {
         model: 'test-model',
         authType: 'oauth-personal',
       }),
+      getToolRegistry: () => mockToolRegistry,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
       config: mockConfig,
-      toolRegistry: mockToolRegistry,
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
@@ -581,11 +580,11 @@ describe('CoreToolScheduler YOLO mode', () => {
         model: 'test-model',
         authType: 'oauth-personal',
       }),
+      getToolRegistry: () => mockToolRegistry,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
       config: mockConfig,
-      toolRegistry: mockToolRegistry,
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
@@ -670,11 +669,11 @@ describe('CoreToolScheduler request queueing', () => {
         model: 'test-model',
         authType: 'oauth-personal',
       }),
+      getToolRegistry: () => mockToolRegistry,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
       config: mockConfig,
-      toolRegistry: mockToolRegistry,
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
@@ -783,11 +782,11 @@ describe('CoreToolScheduler request queueing', () => {
         model: 'test-model',
         authType: 'oauth-personal',
       }),
+      getToolRegistry: () => mockToolRegistry,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
       config: mockConfig,
-      toolRegistry: mockToolRegistry,
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
@@ -864,7 +863,9 @@ describe('CoreToolScheduler request queueing', () => {
       getTools: () => [],
       discoverTools: async () => {},
       discovery: {},
-    };
+    } as unknown as ToolRegistry;
+
+    mockConfig.getToolRegistry = () => toolRegistry;
 
     const onAllToolCallsComplete = vi.fn();
     const onToolCallsUpdate = vi.fn();
@@ -874,7 +875,6 @@ describe('CoreToolScheduler request queueing', () => {
 
     const scheduler = new CoreToolScheduler({
       config: mockConfig,
-      toolRegistry: toolRegistry as unknown as ToolRegistry,
       onAllToolCallsComplete,
       onToolCallsUpdate: (toolCalls) => {
         onToolCallsUpdate(toolCalls);

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -226,12 +226,11 @@ const createErrorResponse = (
 });
 
 interface CoreToolSchedulerOptions {
-  toolRegistry: ToolRegistry;
+  config: Config;
   outputUpdateHandler?: OutputUpdateHandler;
   onAllToolCallsComplete?: AllToolCallsCompleteHandler;
   onToolCallsUpdate?: ToolCallsUpdateHandler;
   getPreferredEditor: () => EditorType | undefined;
-  config: Config;
   onEditorClose: () => void;
 }
 
@@ -255,7 +254,7 @@ export class CoreToolScheduler {
 
   constructor(options: CoreToolSchedulerOptions) {
     this.config = options.config;
-    this.toolRegistry = options.toolRegistry;
+    this.toolRegistry = options.config.getToolRegistry();
     this.outputUpdateHandler = options.outputUpdateHandler;
     this.onAllToolCallsComplete = options.onAllToolCallsComplete;
     this.onToolCallsUpdate = options.onToolCallsUpdate;

--- a/packages/core/src/core/nonInteractiveToolExecutor.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.ts
@@ -4,166 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  FileDiff,
-  logToolCall,
-  ToolCallRequestInfo,
-  ToolCallResponseInfo,
-  ToolErrorType,
-  ToolResult,
-} from '../index.js';
-import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
-import { Config } from '../config/config.js';
-import { convertToFunctionResponse } from './coreToolScheduler.js';
-import { ToolCallDecision } from '../telemetry/tool-call-decision.js';
+import { ToolCallRequestInfo, ToolCallResponseInfo, Config } from '../index.js';
+import { CoreToolScheduler } from './coreToolScheduler.js';
 
 /**
- * Executes a single tool call non-interactively.
- * It does not handle confirmations, multiple calls, or live updates.
+ * Executes a single tool call non-interactively by leveraging the CoreToolScheduler.
  */
 export async function executeToolCall(
   config: Config,
   toolCallRequest: ToolCallRequestInfo,
-  abortSignal?: AbortSignal,
+  abortSignal: AbortSignal,
 ): Promise<ToolCallResponseInfo> {
-  const tool = config.getToolRegistry().getTool(toolCallRequest.name);
-
-  const startTime = Date.now();
-  if (!tool) {
-    const error = new Error(
-      `Tool "${toolCallRequest.name}" not found in registry.`,
-    );
-    const durationMs = Date.now() - startTime;
-    logToolCall(config, {
-      'event.name': 'tool_call',
-      'event.timestamp': new Date().toISOString(),
-      function_name: toolCallRequest.name,
-      function_args: toolCallRequest.args,
-      duration_ms: durationMs,
-      success: false,
-      error: error.message,
-      prompt_id: toolCallRequest.prompt_id,
-      tool_type: 'native',
-    });
-    // Ensure the response structure matches what the API expects for an error
-    return {
-      callId: toolCallRequest.callId,
-      responseParts: [
-        {
-          functionResponse: {
-            id: toolCallRequest.callId,
-            name: toolCallRequest.name,
-            response: { error: error.message },
-          },
-        },
-      ],
-      resultDisplay: error.message,
-      error,
-      errorType: ToolErrorType.TOOL_NOT_REGISTERED,
-    };
-  }
-
-  try {
-    // Directly execute without confirmation or live output handling
-    const effectiveAbortSignal = abortSignal ?? new AbortController().signal;
-    const toolResult: ToolResult = await tool.validateBuildAndExecute(
-      toolCallRequest.args,
-      effectiveAbortSignal,
-      // No live output callback for non-interactive mode
-    );
-
-    const tool_output = toolResult.llmContent;
-
-    const tool_display = toolResult.returnDisplay;
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let metadata: { [key: string]: any } = {};
-    if (
-      toolResult.error === undefined &&
-      typeof tool_display === 'object' &&
-      tool_display !== null &&
-      'diffStat' in tool_display
-    ) {
-      const diffStat = (tool_display as FileDiff).diffStat;
-      if (diffStat) {
-        metadata = {
-          ai_added_lines: diffStat.ai_added_lines,
-          ai_removed_lines: diffStat.ai_removed_lines,
-          user_added_lines: diffStat.user_added_lines,
-          user_removed_lines: diffStat.user_removed_lines,
-        };
-      }
-    }
-    const durationMs = Date.now() - startTime;
-    logToolCall(config, {
-      'event.name': 'tool_call',
-      'event.timestamp': new Date().toISOString(),
-      function_name: toolCallRequest.name,
-      function_args: toolCallRequest.args,
-      duration_ms: durationMs,
-      success: toolResult.error === undefined,
-      error:
-        toolResult.error === undefined ? undefined : toolResult.error.message,
-      error_type:
-        toolResult.error === undefined ? undefined : toolResult.error.type,
-      prompt_id: toolCallRequest.prompt_id,
-      metadata,
-      decision: ToolCallDecision.AUTO_ACCEPT,
-      tool_type:
-        typeof tool !== 'undefined' && tool instanceof DiscoveredMCPTool
-          ? 'mcp'
-          : 'native',
-    });
-
-    const response = convertToFunctionResponse(
-      toolCallRequest.name,
-      toolCallRequest.callId,
-      tool_output,
-    );
-
-    return {
-      callId: toolCallRequest.callId,
-      responseParts: response,
-      resultDisplay: tool_display,
-      error:
-        toolResult.error === undefined
-          ? undefined
-          : new Error(toolResult.error.message),
-      errorType:
-        toolResult.error === undefined ? undefined : toolResult.error.type,
-    };
-  } catch (e) {
-    const error = e instanceof Error ? e : new Error(String(e));
-    const durationMs = Date.now() - startTime;
-    logToolCall(config, {
-      'event.name': 'tool_call',
-      'event.timestamp': new Date().toISOString(),
-      function_name: toolCallRequest.name,
-      function_args: toolCallRequest.args,
-      duration_ms: durationMs,
-      success: false,
-      error: error.message,
-      error_type: ToolErrorType.UNHANDLED_EXCEPTION,
-      prompt_id: toolCallRequest.prompt_id,
-      tool_type:
-        typeof tool !== 'undefined' && tool instanceof DiscoveredMCPTool
-          ? 'mcp'
-          : 'native',
-    });
-    return {
-      callId: toolCallRequest.callId,
-      responseParts: [
-        {
-          functionResponse: {
-            id: toolCallRequest.callId,
-            name: toolCallRequest.name,
-            response: { error: error.message },
-          },
-        },
-      ],
-      resultDisplay: error.message,
-      error,
-      errorType: ToolErrorType.UNHANDLED_EXCEPTION,
-    };
-  }
+  return new Promise<ToolCallResponseInfo>((resolve, reject) => {
+    new CoreToolScheduler({
+      config,
+      getPreferredEditor: () => undefined,
+      onEditorClose: () => {},
+      onAllToolCallsComplete: async (completedToolCalls) => {
+        resolve(completedToolCalls[0].response);
+      },
+    })
+      .schedule(toolCallRequest, abortSignal)
+      .catch(reject);
+  });
 }


### PR DESCRIPTION
## TLDR

Reuse CoreToolScheduler in nonInteractiveToolExecutor. This makes the interactive and noninteractive code paths more similar.

## Reviewer Test Plan

Ran non interactive mode with:

```
npm start -- --prompt "This is a test of your ability to make multiple tool calls at once. Please make two separate requests to read two different files using the read_file tool (DO NOT use read_many_files). Tell me which files your read and what you learned from their contents"
```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
