### PR TITLE
Support all content types in prompts from Zed

### DIFF
--- a/packages/cli/src/zed-integration/schema.ts
+++ b/packages/cli/src/zed-integration/schema.ts
@@ -84,6 +84,8 @@ export type AgentCapabilities = z.infer<typeof agentCapabilitiesSchema>;
 
 export type AuthMethod = z.infer<typeof authMethodSchema>;
 
+export type PromptCapabilities = z.infer<typeof promptCapabilitiesSchema>;
+
 export type ClientResponse = z.infer<typeof clientResponseSchema>;
 
 export type ClientNotification = z.infer<typeof clientNotificationSchema>;
@@ -270,8 +272,15 @@ export const mcpServerSchema = z.object({
   name: z.string(),
 });
 
+export const promptCapabilitiesSchema = z.object({
+  audio: z.boolean().optional(),
+  embeddedContext: z.boolean().optional(),
+  image: z.boolean().optional(),
+});
+
 export const agentCapabilitiesSchema = z.object({
-  loadSession: z.boolean(),
+  loadSession: z.boolean().optional(),
+  promptCapabilities: promptCapabilitiesSchema.optional(),
 });
 
 export const authMethodSchema = z.object({

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -710,12 +710,13 @@ class Session {
 
     const processedQueryParts: Part[] = [{ text: initialQueryText }];
 
-    if (atPathCommandParts.length > 0) {
-      if (pathSpecsToRead.length === 0 && embeddedContext.length === 0) {
-        // Fallback for lone "@" or completely invalid @-commands resulting in empty initialQueryText
-        console.warn('No valid file paths found in @ commands to read.');
-        return [{ text: initialQueryText }];
-      }
+    if (pathSpecsToRead.length === 0 && embeddedContext.length === 0) {
+      // Fallback for lone "@" or completely invalid @-commands resulting in empty initialQueryText
+      console.warn('No valid file paths found in @ commands to read.');
+      return [{ text: initialQueryText }];
+    }
+
+    if (pathSpecsToRead.length > 0) {
       const toolArgs = {
         paths: pathSpecsToRead,
         respectGitIgnore, // Use configuration setting

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -99,6 +99,11 @@ class GeminiAgent {
       authMethods,
       agentCapabilities: {
         loadSession: false,
+        promptCapabilities: {
+          image: false,
+          audio: false,
+          embeddedContext: true,
+        },
       },
     };
   }
@@ -488,26 +493,30 @@ class Session {
     message: acp.ContentBlock[],
     abortSignal: AbortSignal,
   ): Promise<Part[]> {
+    const FILE_URI_SCHEME = 'file://';
+
+    const embeddedContext: acp.EmbeddedResourceResource[] = [];
+
     const parts = message.map((part) => {
       switch (part.type) {
         case 'text':
           return { text: part.text };
-        case 'resource_link':
-          return {
-            fileData: {
-              mimeData: part.mimeType,
-              name: part.name,
-              fileUri: part.uri,
-            },
-          };
+        case 'resource_link': {
+          if (part.uri.startsWith(FILE_URI_SCHEME)) {
+            return {
+              fileData: {
+                mimeData: part.mimeType,
+                name: part.name,
+                fileUri: part.uri.slice(FILE_URI_SCHEME.length),
+              },
+            };
+          } else {
+            return { text: `@${part.uri}` };
+          }
+        }
         case 'resource': {
-          return {
-            fileData: {
-              mimeData: part.resource.mimeType,
-              name: part.resource.uri,
-              fileUri: part.resource.uri,
-            },
-          };
+          embeddedContext.push(part.resource);
+          return { text: `@${part.resource.uri}` };
         }
         default: {
           throw new Error(`Unexpected chunk type: '${part.type}'`);
@@ -517,16 +526,17 @@ class Session {
 
     const atPathCommandParts = parts.filter((part) => 'fileData' in part);
 
-    if (atPathCommandParts.length === 0) {
+    if (atPathCommandParts.length === 0 && embeddedContext.length === 0) {
       return parts;
     }
+
+    const atPathToResolvedSpecMap = new Map<string, string>();
 
     // Get centralized file discovery service
     const fileDiscovery = this.config.getFileService();
     const respectGitIgnore = this.config.getFileFilteringRespectGitIgnore();
 
     const pathSpecsToRead: string[] = [];
-    const atPathToResolvedSpecMap = new Map<string, string>();
     const contentLabelsForDisplay: string[] = [];
     const ignoredPaths: string[] = [];
 
@@ -634,6 +644,7 @@ class Session {
         contentLabelsForDisplay.push(pathName);
       }
     }
+
     // Construct the initial part of the query for the LLM
     let initialQueryText = '';
     for (let i = 0; i < parts.length; i++) {
@@ -687,93 +698,122 @@ class Session {
         `Ignored ${ignoredPaths.length} ${ignoreType} files: ${ignoredPaths.join(', ')}`,
       );
     }
-    // Fallback for lone "@" or completely invalid @-commands resulting in empty initialQueryText
-    if (pathSpecsToRead.length === 0) {
-      console.warn('No valid file paths found in @ commands to read.');
-      return [{ text: initialQueryText }];
-    }
+
     const processedQueryParts: Part[] = [{ text: initialQueryText }];
-    const toolArgs = {
-      paths: pathSpecsToRead,
-      respectGitIgnore, // Use configuration setting
-    };
 
-    const callId = `${readManyFilesTool.name}-${Date.now()}`;
-
-    try {
-      const invocation = readManyFilesTool.build(toolArgs);
-
-      await this.sendUpdate({
-        sessionUpdate: 'tool_call',
-        toolCallId: callId,
-        status: 'in_progress',
-        title: invocation.getDescription(),
-        content: [],
-        locations: invocation.toolLocations(),
-        kind: readManyFilesTool.kind,
-      });
-
-      const result = await invocation.execute(abortSignal);
-      const content = toToolCallContent(result) || {
-        type: 'content',
-        content: {
-          type: 'text',
-          text: `Successfully read: ${contentLabelsForDisplay.join(', ')}`,
-        },
-      };
-      await this.sendUpdate({
-        sessionUpdate: 'tool_call_update',
-        toolCallId: callId,
-        status: 'completed',
-        content: content ? [content] : [],
-      });
-      if (Array.isArray(result.llmContent)) {
-        const fileContentRegex = /^--- (.*?) ---\n\n([\s\S]*?)\n\n$/;
-        processedQueryParts.push({
-          text: '\n--- Content from referenced files ---',
-        });
-        for (const part of result.llmContent) {
-          if (typeof part === 'string') {
-            const match = fileContentRegex.exec(part);
-            if (match) {
-              const filePathSpecInContent = match[1]; // This is a resolved pathSpec
-              const fileActualContent = match[2].trim();
-              processedQueryParts.push({
-                text: `\nContent from @${filePathSpecInContent}:\n`,
-              });
-              processedQueryParts.push({ text: fileActualContent });
-            } else {
-              processedQueryParts.push({ text: part });
-            }
-          } else {
-            // part is a Part object.
-            processedQueryParts.push(part);
-          }
-        }
-      } else {
-        console.warn(
-          'read_many_files tool returned no content or empty content.',
-        );
+    if (atPathCommandParts.length > 0) {
+      if (pathSpecsToRead.length === 0 && embeddedContext.length === 0) {
+        // Fallback for lone "@" or completely invalid @-commands resulting in empty initialQueryText
+        console.warn('No valid file paths found in @ commands to read.');
+        return [{ text: initialQueryText }];
       }
-      return processedQueryParts;
-    } catch (error: unknown) {
-      await this.sendUpdate({
-        sessionUpdate: 'tool_call_update',
-        toolCallId: callId,
-        status: 'failed',
-        content: [
-          {
-            type: 'content',
-            content: {
-              type: 'text',
-              text: `Error reading files (${contentLabelsForDisplay.join(', ')}): ${getErrorMessage(error)}`,
-            },
+      const toolArgs = {
+        paths: pathSpecsToRead,
+        respectGitIgnore, // Use configuration setting
+      };
+
+      const callId = `${readManyFilesTool.name}-${Date.now()}`;
+
+      try {
+        const invocation = readManyFilesTool.build(toolArgs);
+
+        await this.sendUpdate({
+          sessionUpdate: 'tool_call',
+          toolCallId: callId,
+          status: 'in_progress',
+          title: invocation.getDescription(),
+          content: [],
+          locations: invocation.toolLocations(),
+          kind: readManyFilesTool.kind,
+        });
+
+        const result = await invocation.execute(abortSignal);
+        const content = toToolCallContent(result) || {
+          type: 'content',
+          content: {
+            type: 'text',
+            text: `Successfully read: ${contentLabelsForDisplay.join(', ')}`,
           },
-        ],
+        };
+        await this.sendUpdate({
+          sessionUpdate: 'tool_call_update',
+          toolCallId: callId,
+          status: 'completed',
+          content: content ? [content] : [],
+        });
+        if (Array.isArray(result.llmContent)) {
+          const fileContentRegex = /^--- (.*?) ---\n\n([\s\S]*?)\n\n$/;
+          processedQueryParts.push({
+            text: '\n--- Content from referenced files ---',
+          });
+          for (const part of result.llmContent) {
+            if (typeof part === 'string') {
+              const match = fileContentRegex.exec(part);
+              if (match) {
+                const filePathSpecInContent = match[1]; // This is a resolved pathSpec
+                const fileActualContent = match[2].trim();
+                processedQueryParts.push({
+                  text: `\nContent from @${filePathSpecInContent}:\n`,
+                });
+                processedQueryParts.push({ text: fileActualContent });
+              } else {
+                processedQueryParts.push({ text: part });
+              }
+            } else {
+              // part is a Part object.
+              processedQueryParts.push(part);
+            }
+          }
+        } else {
+          console.warn(
+            'read_many_files tool returned no content or empty content.',
+          );
+        }
+      } catch (error: unknown) {
+        await this.sendUpdate({
+          sessionUpdate: 'tool_call_update',
+          toolCallId: callId,
+          status: 'failed',
+          content: [
+            {
+              type: 'content',
+              content: {
+                type: 'text',
+                text: `Error reading files (${contentLabelsForDisplay.join(', ')}): ${getErrorMessage(error)}`,
+              },
+            },
+          ],
+        });
+
+        throw error;
+      }
+    }
+
+    if (embeddedContext.length > 0) {
+      processedQueryParts.push({
+        text: '\n--- Content from referenced context ---',
       });
 
-      throw error;
+      for (const contextPart of embeddedContext) {
+        processedQueryParts.push({
+          text: `\nContent from @${contextPart.uri}:\n`,
+        });
+        if ('text' in contextPart) {
+          processedQueryParts.push({
+            text: contextPart.text,
+          });
+        } else {
+          processedQueryParts.push({
+            inlineData: {
+              mimeType: contextPart.mimeType ?? 'application/octet-stream',
+              data: contextPart.blob,
+            },
+          });
+        }
+      }
     }
+
+    return processedQueryParts;
   }
 
   debug(msg: string) {

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -101,7 +101,7 @@ class GeminiAgent {
         loadSession: false,
         promptCapabilities: {
           image: true,
-          audio: false,
+          audio: true,
           embeddedContext: true,
         },
       },
@@ -502,6 +502,7 @@ class Session {
         case 'text':
           return { text: part.text };
         case 'image':
+        case 'audio':
           return {
             inlineData: {
               mimeType: part.mimeType,
@@ -526,7 +527,8 @@ class Session {
           return { text: `@${part.resource.uri}` };
         }
         default: {
-          throw new Error(`Unexpected chunk type: '${part.type}'`);
+          const unreachable: never = part;
+          throw new Error(`Unexpected chunk type: '${unreachable}'`);
         }
       }
     });

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -100,7 +100,7 @@ class GeminiAgent {
       agentCapabilities: {
         loadSession: false,
         promptCapabilities: {
-          image: false,
+          image: true,
           audio: false,
           embeddedContext: true,
         },
@@ -501,6 +501,13 @@ class Session {
       switch (part.type) {
         case 'text':
           return { text: part.text };
+        case 'image':
+          return {
+            inlineData: {
+              mimeType: part.mimeType,
+              data: part.data,
+            },
+          };
         case 'resource_link': {
           if (part.uri.startsWith(FILE_URI_SCHEME)) {
             return {

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -834,6 +834,10 @@ class Session {
 }
 
 function toToolCallContent(toolResult: ToolResult): acp.ToolCallContent | null {
+  if (toolResult.error?.message) {
+    throw new Error(toolResult.error.message);
+  }
+
   if (toolResult.returnDisplay) {
     if (typeof toolResult.returnDisplay === 'string') {
       return {


### PR DESCRIPTION
## TLDR

The Zed integration now supports including images and new types of at-mentions such as LSP symbols, previous conversations, web content, etc. 

## Dive Deeper

The existing implementation supported text and file at-mentions in prompts. Zed now allows external agents to opt in to all types of content that can be used with the native agent. The `PromptCapabilities` object is used to enable these types individually, so Zed can gracefully degrade the experience for existing versions.

Images and audio are mapped to `Part.inlineData`, and at-mentions are appended at the end of the message just like before. Zed now includes the content for all at-mention kinds in the request, which saves a round-trip and allows the message to include context from arbitrary sources the agent may not have access to.

Example interactions:

<table>
<tr>
<td>
<img width="400" alt="CleanShot 2025-08-21 at 11 57 52@2x" src="https://github.com/user-attachments/assets/6814d21a-ecf7-4693-a7d4-cc0ff89e4a7b" />
</td>
<td>
<img width="1176" height="568" alt="CleanShot 2025-08-21 at 12 04 13@2x" src="https://github.com/user-attachments/assets/a6981d47-af61-4d56-8ab8-cef77fa2d9d8" />
</td>
</tr>
<tr>
<td>
<img width="1294" height="528" alt="CleanShot 2025-08-21 at 12 02 43@2x" src="https://github.com/user-attachments/assets/d62ce181-af3f-4ea0-bce5-ebe6d5359389" />
</td>
<td>
<img width="1298" height="834" alt="CleanShot 2025-08-21 at 12 06 33@2x" src="https://github.com/user-attachments/assets/37bf619b-a862-4bc9-b4a1-8c32a5dc800f" />
</td>
</tr>
</table>


## Reviewer Test Plan

To fully test the integration, you'll need to [build Zed from source](https://github.com/zed-industries/zed?tab=readme-ov-file#developing-zed), and add the following to your settings:

```json
{
  "agent_servers": {
    "gemini": {
      "command": "node",
      "args": ["/<PATH>/<TO>/gemini-cli/packages/cli"]
    }
  },
}
```

Feel free to ask @agu-z or @ConradIrwin  for any help getting set up.
