### PR TITLE
Add a2a agents to config object

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -379,6 +379,7 @@ export async function loadCliConfig(
   );
 
   let mcpServers = mergeMcpServers(settings, activeExtensions);
+  const a2aAgents = mergeA2aAgents(settings);
   const question = argv.promptInteractive || argv.prompt || '';
 
   // Determine approval mode with backward compatibility
@@ -482,6 +483,7 @@ export async function loadCliConfig(
     toolCallCommand: settings.toolCallCommand,
     mcpServerCommand: settings.mcpServerCommand,
     mcpServers,
+    a2aAgents,
     userMemory: memoryContent,
     geminiMdFileCount: fileCount,
     approvalMode,
@@ -595,6 +597,12 @@ function mergeMcpServers(settings: Settings, extensions: Extension[]) {
     );
   }
   return mcpServers;
+}
+
+function mergeA2aAgents(settings: Settings) {
+  const a2aAgents = { ...(settings.a2aAgents || {}) };
+  // Add functionality to merge agents from extensions, similar to mergeMcpServers
+  return a2aAgents;
 }
 
 function mergeExcludeTools(

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -112,6 +112,7 @@ describe('Settings Loading and Merging', () => {
       expect(settings.merged).toEqual({
         customThemes: {},
         mcpServers: {},
+        a2aAgents: {},
         includeDirectories: [],
         chatCompression: {},
       });
@@ -147,6 +148,7 @@ describe('Settings Loading and Merging', () => {
         ...systemSettingsContent,
         customThemes: {},
         mcpServers: {},
+        a2aAgents: {},
         includeDirectories: [],
         chatCompression: {},
       });
@@ -182,6 +184,7 @@ describe('Settings Loading and Merging', () => {
         ...userSettingsContent,
         customThemes: {},
         mcpServers: {},
+        a2aAgents: {},
         includeDirectories: [],
         chatCompression: {},
       });
@@ -215,6 +218,7 @@ describe('Settings Loading and Merging', () => {
         ...workspaceSettingsContent,
         customThemes: {},
         mcpServers: {},
+        a2aAgents: {},
         includeDirectories: [],
         chatCompression: {},
       });
@@ -254,6 +258,7 @@ describe('Settings Loading and Merging', () => {
         contextFileName: 'WORKSPACE_CONTEXT.md',
         customThemes: {},
         mcpServers: {},
+        a2aAgents: {},
         includeDirectories: [],
         chatCompression: {},
       });
@@ -305,6 +310,7 @@ describe('Settings Loading and Merging', () => {
         allowMCPServers: ['server1', 'server2'],
         customThemes: {},
         mcpServers: {},
+        a2aAgents: {},
         includeDirectories: [],
         chatCompression: {},
       });
@@ -866,6 +872,7 @@ describe('Settings Loading and Merging', () => {
       expect(settings.merged).toEqual({
         customThemes: {},
         mcpServers: {},
+        a2aAgents: {},
         includeDirectories: [],
         chatCompression: {},
       });
@@ -1238,6 +1245,7 @@ describe('Settings Loading and Merging', () => {
           ...systemSettingsContent,
           customThemes: {},
           mcpServers: {},
+          a2aAgents: {},
           includeDirectories: [],
           chatCompression: {},
         });

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -92,6 +92,11 @@ function mergeSettings(
       ...(workspace.mcpServers || {}),
       ...(system.mcpServers || {}),
     },
+    a2aAgents: {
+      ...(user.a2aAgents || {}),
+      ...(workspace.a2aAgents || {}),
+      ...(system.a2aAgents || {}),
+    },
     includeDirectories: [
       ...(system.includeDirectories || []),
       ...(user.includeDirectories || []),

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -39,6 +39,7 @@ describe('SettingsSchema', () => {
         'toolCallCommand',
         'mcpServerCommand',
         'mcpServers',
+        'a2aAgents',
         'allowMCPServers',
         'excludeMCPServers',
         'telemetry',
@@ -193,6 +194,7 @@ describe('SettingsSchema', () => {
       expect(SETTINGS_SCHEMA.selectedAuthType.showInDialog).toBe(false);
       expect(SETTINGS_SCHEMA.coreTools.showInDialog).toBe(false);
       expect(SETTINGS_SCHEMA.mcpServers.showInDialog).toBe(false);
+      expect(SETTINGS_SCHEMA.a2aAgents.showInDialog).toBe(false);
       expect(SETTINGS_SCHEMA.telemetry.showInDialog).toBe(false);
 
       // Check that some settings are appropriately hidden

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -6,6 +6,7 @@
 
 import {
   MCPServerConfig,
+  A2AAgentConfig,
   BugCommandSettings,
   TelemetrySettings,
   AuthType,
@@ -386,6 +387,15 @@ export const SETTINGS_SCHEMA = {
     requiresRestart: true,
     default: undefined as string[] | undefined,
     description: 'A blacklist of MCP servers to exclude.',
+    showInDialog: false,
+  },
+  a2aAgents: {
+    type: 'object',
+    label: 'A2A Agents',
+    category: 'Advanced',
+    requiresRestart: true,
+    default: {} as Record<string, A2AAgentConfig>,
+    description: 'Configuration for A2A agents.',
     showInDialog: false,
   },
   telemetry: {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -536,7 +536,7 @@ export class Config {
     return this.mcpServers;
   }
 
-   getA2AAgents(): Record<string, A2AAgentConfig> | undefined {
+  getA2AAgents(): Record<string, A2AAgentConfig> | undefined {
     return this.a2aAgents;
   }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -133,6 +133,11 @@ export class MCPServerConfig {
   ) {}
 }
 
+export interface A2AAgentConfig {
+  url: string;
+  accessToken: string; // Temporary, to help develop and prototype
+}
+
 export enum AuthProviderType {
   DYNAMIC_DISCOVERY = 'dynamic_discovery',
   GOOGLE_CREDENTIALS = 'google_credentials',
@@ -163,6 +168,7 @@ export interface ConfigParameters {
   toolCallCommand?: string;
   mcpServerCommand?: string;
   mcpServers?: Record<string, MCPServerConfig>;
+  a2aAgents?: Record<string, A2AAgentConfig>;
   userMemory?: string;
   geminiMdFileCount?: number;
   approvalMode?: ApprovalMode;
@@ -221,6 +227,7 @@ export class Config {
   private readonly toolCallCommand: string | undefined;
   private readonly mcpServerCommand: string | undefined;
   private readonly mcpServers: Record<string, MCPServerConfig> | undefined;
+  private readonly a2aAgents: Record<string, A2AAgentConfig> | undefined;
   private userMemory: string;
   private geminiMdFileCount: number;
   private approvalMode: ApprovalMode;
@@ -290,6 +297,7 @@ export class Config {
     this.toolCallCommand = params.toolCallCommand;
     this.mcpServerCommand = params.mcpServerCommand;
     this.mcpServers = params.mcpServers;
+    this.a2aAgents = params.a2aAgents;
     this.userMemory = params.userMemory ?? '';
     this.geminiMdFileCount = params.geminiMdFileCount ?? 0;
     this.approvalMode = params.approvalMode ?? ApprovalMode.DEFAULT;
@@ -526,6 +534,10 @@ export class Config {
 
   getMcpServers(): Record<string, MCPServerConfig> | undefined {
     return this.mcpServers;
+  }
+
+   getA2AAgents(): Record<string, A2AAgentConfig> | undefined {
+    return this.a2aAgents;
   }
 
   getUserMemory(): string {

--- a/packages/core/src/tools/a2a-client-manager.ts
+++ b/packages/core/src/tools/a2a-client-manager.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export class A2AClientManager {
+  constructor() {}
+
+  async initialize(): Promise<void> {
+    // TODO: load agents and register tools
+  }
+}

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -167,7 +167,7 @@ export class ToolRegistry {
   private tools: Map<string, AnyDeclarativeTool> = new Map();
   private config: Config;
   private mcpClientManager: McpClientManager;
-  private a2aClientManager: A2AClientManager
+  private a2aClientManager: A2AClientManager;
 
   constructor(config: Config) {
     this.config = config;

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -18,6 +18,7 @@ import { spawn } from 'node:child_process';
 import { StringDecoder } from 'node:string_decoder';
 import { connectAndDiscover } from './mcp-client.js';
 import { McpClientManager } from './mcp-client-manager.js';
+import { A2AClientManager } from './a2a-client-manager.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import { parse } from 'shell-quote';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
@@ -166,6 +167,7 @@ export class ToolRegistry {
   private tools: Map<string, AnyDeclarativeTool> = new Map();
   private config: Config;
   private mcpClientManager: McpClientManager;
+  private a2aClientManager: A2AClientManager
 
   constructor(config: Config) {
     this.config = config;
@@ -177,6 +179,7 @@ export class ToolRegistry {
       this.config.getDebugMode(),
       this.config.getWorkspaceContext(),
     );
+    this.a2aClientManager = new A2AClientManager();
   }
 
   /**
@@ -232,6 +235,8 @@ export class ToolRegistry {
 
     // discover tools using MCP servers, if configured
     await this.mcpClientManager.discoverAllMcpTools();
+
+    await this.a2aClientManager.initialize();
   }
 
   /**


### PR DESCRIPTION
## TLDR

Parses a2aAgents from settings.json

## Dive Deeper

Follow up PRs will implement the a2a-client-manager, etc

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

[673](https://github.com/google-gemini/maintainers-gemini-cli/issues/673)