### PR TITLE
fix: handle extra text in gemini output for dedup workflow

### DIFF
--- a/.github/workflows/gemini-automated-issue-dedup.yml
+++ b/.github/workflows/gemini-automated-issue-dedup.yml
@@ -185,8 +185,13 @@ jobs:
             core.info(`Raw duplicates JSON: ${rawJson}`);
             let parsedJson;
             try {
-              const trimmedJson = rawJson.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '').trim();
-              parsedJson = JSON.parse(trimmedJson);
+              const jsonStringMatch = rawJson.match(/{[\s\S]*}/);
+              if (!jsonStringMatch) {
+                core.setFailed(`Could not find JSON object in the output.\nRaw output: ${rawJson}`);
+                return;
+              }
+              const jsonString = jsonStringMatch[0];
+              parsedJson = JSON.parse(jsonString);
               core.info(`Parsed duplicates JSON: ${JSON.stringify(parsedJson)}`);
             } catch (err) {
               core.setFailed(`Failed to parse duplicates JSON from Gemini output: ${err.message}\nRaw output: ${rawJson}`);


### PR DESCRIPTION
The CLI is occasionally outputting extra sentences like:
```
Raw duplicates JSON: Data collection is disabled.
Accessing resource attributes before async attributes settled
Invalid attribute value set for key: metadata
Invalid attribute value set for key: metadata
{"duplicate_issues": []}
```

This PR updates the parsing logic in the issue deduplication workflow to handle extra text.