### PR TITLE
Retry empty chunks

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -32,7 +32,8 @@ import {
   GeminiClient,
   GeminiEventType as ServerGeminiEventType,
   AnyToolInvocation,
-  ToolErrorType, // <-- Import ToolErrorType
+  UserPromptEvent,
+  ToolErrorType, // FIX: Import ToolErrorType
 } from '@google/gemini-cli-core';
 import { Part, PartListUnion } from '@google/genai';
 import { UseHistoryManagerReturn } from './useHistoryManager.js';

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -611,7 +611,7 @@ export const useGeminiStream = (
             return {
               status: StreamProcessingStatus.UserCancelled,
               geminiMessageBuffer: '',
-              isResponseInvalid: false
+              isResponseInvalid: false,
             };
           case ServerGeminiEventType.Error:
             handleErrorEvent(event.value, userMessageTimestamp);
@@ -619,7 +619,7 @@ export const useGeminiStream = (
             return {
               status: StreamProcessingStatus.Error,
               geminiMessageBuffer: '',
-              isResponseInvalid: false
+              isResponseInvalid: false,
             };
           case ServerGeminiEventType.ChatCompressed:
             handleChatCompressionEvent(event.value);
@@ -653,7 +653,11 @@ export const useGeminiStream = (
         scheduleToolCalls(toolCallRequests, signal);
       }
       // CHANGE 4: Return the status and the final assembled buffer
-      return { status: StreamProcessingStatus.Completed, geminiMessageBuffer, isResponseInvalid: isResponseInvalid };
+      return {
+        status: StreamProcessingStatus.Completed,
+        geminiMessageBuffer,
+        isResponseInvalid: isResponseInvalid,
+      };
     },
     [
       handleContentEvent,


### PR DESCRIPTION
## TLDR
Improves Model API Response Error Handling.


## Dive Deeper

**What:** This PR makes the CLI more resilient to invalid or empty model responses.

**Why:** The CLI would confusingly delete a user's prompt from the history if the model returned an invalid response.

**How:**
1.  **Robust Retries:** Instead of silently deleting user prompts on model error, the CLI now automatically retries the API call up to two times if it receives an invalid or empty response. If retries fail, it displays a clear error message. This handles transient issues without blocking the session or confusing the user.
<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->


## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
