### PR TITLE
feat(mcp): log include MCP request with error

### DIFF
--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -14,6 +14,7 @@ import {
   afterEach,
   Mocked,
 } from 'vitest';
+import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 import { DiscoveredMCPTool, generateValidName } from './mcp-tool.js'; // Added getStringifiedResultForDisplay
 import { ToolResult, ToolConfirmationOutcome } from './tools.js'; // Added ToolConfirmationOutcome
 import { CallableTool, Part } from '@google/genai';
@@ -200,6 +201,10 @@ describe('DiscoveredMCPTool', () => {
           inputSchema,
         );
         const params = { param: 'isErrorTrueCase' };
+        const functionCall = {
+          name: serverToolName,
+          args: params,
+        };
 
         const errorResponse = { isError: isErrorValue };
         const mockMcpToolResponseParts: Part[] = [
@@ -211,10 +216,11 @@ describe('DiscoveredMCPTool', () => {
           },
         ];
         mockCallTool.mockResolvedValue(mockMcpToolResponseParts);
-        const expectedErrorMessage = `MCP tool '${serverToolName}' reported tool error with response: ${JSON.stringify(
-          mockMcpToolResponseParts,
-        )}`;
-
+        const expectedErrorMessage = `MCP tool '${
+          serverToolName
+        }' reported tool error for function call: ${safeJsonStringify(
+          functionCall,
+        )} with response: ${safeJsonStringify(mockMcpToolResponseParts)}`;
         const invocation = tool.build(params);
         const result = await invocation.execute(new AbortController().signal);
 

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -142,9 +142,9 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     if (this.isMCPToolError(rawResponseParts)) {
       const errorMessage = `MCP tool '${
         this.serverToolName
-      }' reported tool error with response: ${JSON.stringify(
-        rawResponseParts,
-      )}`;
+      }' reported tool error for function call: ${safeJsonStringify(
+        functionCalls[0],
+      )} with response: ${safeJsonStringify(rawResponseParts)}`;
       return {
         llmContent: errorMessage,
         returnDisplay: `Error: MCP tool '${this.serverToolName}' reported an error.`,


### PR DESCRIPTION
## TLDR

This improves error logging for MCP servers, as part of #5306, to allows users to better debug why an MCP tool call received a `toolError`, by including the request inline. 

## Dive Deeper

Example response with the changes:
```
 │    MCP tool 'create_pending_pull_request_review' reported tool error for function call:                                 │
 │    {"name":"create_pending_pull_request_review","args":{"pullNumber":3,"owner":"leehagoodjames","repo":"fake_repo"}}    │
 │    with response:                                                                                                       │
 │    [{"functionResponse":{"name":"create_pending_pull_request_review","response":{"error":{"content":[{"type":"text","t  │
 │    ext":"failed to get pull request: Could not resolve to a Repository with the name                                    │
 │    'leehagoodjames/fake_repo'."}],"isError":true}}}}]
 ```

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
- Related to #5306, by making MCP failures easier to debug
-->
