### PR TITLE
test(integration-tests): isolate user memory from test runs

### DIFF
--- a/integration-tests/globalSetup.ts
+++ b/integration-tests/globalSetup.ts
@@ -9,16 +9,32 @@ if (process.env.NO_COLOR !== undefined) {
   delete process.env.NO_COLOR;
 }
 
-import { mkdir, readdir, rm } from 'fs/promises';
+import { mkdir, readdir, rm, readFile, writeFile, unlink } from 'fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import * as os from 'os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
 const integrationTestsDir = join(rootDir, '.integration-tests');
 let runDir = ''; // Make runDir accessible in teardown
 
+const GEMINI_CONFIG_DIR = '.gemini';
+const DEFAULT_CONTEXT_FILENAME = 'GEMINI.md';
+const memoryFilePath = join(
+  os.homedir(),
+  GEMINI_CONFIG_DIR,
+  DEFAULT_CONTEXT_FILENAME,
+);
+let originalMemoryContent: string | null = null;
+
 export async function setup() {
+  try {
+    originalMemoryContent = await readFile(memoryFilePath, 'utf-8');
+  } catch {
+    // File doesn't exist, which is fine.
+  }
+
   runDir = join(integrationTestsDir, `${Date.now()}`);
   await mkdir(runDir, { recursive: true });
 
@@ -56,5 +72,15 @@ export async function teardown() {
   // Cleanup the test run directory unless KEEP_OUTPUT is set
   if (process.env.KEEP_OUTPUT !== 'true' && runDir) {
     await rm(runDir, { recursive: true, force: true });
+  }
+
+  if (originalMemoryContent !== null) {
+    await writeFile(memoryFilePath, originalMemoryContent, 'utf-8');
+  } else {
+    try {
+      await unlink(memoryFilePath);
+    } catch {
+      // File might not exist if the test failed before creating it.
+    }
   }
 }

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -4,5 +4,6 @@
     "noEmit": true,
     "allowJs": true
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts"],
+  "references": [{ "path": "../packages/core" }]
 }


### PR DESCRIPTION
## TLDR

This PR isolates the integration test environment from the user's global `~/.gemini/GEMINI.md` file. This prevents tests from accidentally reading, modifying, or deleting a user's memory data, leading to more reliable and predictable test runs.

## Dive Deeper

The integration tests could previously interact with the user's global `~/.gemini/GEMINI.md` file. This could lead to unpredictable test outcomes based on the user's existing memory content and could accidentally modify or delete the user's data.

This change isolates the test environment by:
- Backing up the user's `GEMINI.md` file content before the test suite runs.
- Restoring the original content after the tests are complete.
- Ensuring any memory file created during a test is removed if it did not exist initially.

## Reviewer Test Plan

1. Ensure you have a `~/.gemini/GEMINI.md` file with some content.
2. Run the integration tests via `npm run test:e2e`.
3. Verify that the tests pass and that your `~/.gemini/GEMINI.md` file is unchanged after the test run.
4. Remove the `~/.gemini/GEMINI.md` file.
5. Run the integration tests again.
6. Verify that the tests still pass and that no `~/.gemini/GEMINI.md` file is present after the run.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A
