### PR TITLE
fix(ide): preserve focus when showing diff view

### DIFF
--- a/packages/vscode-ide-companion/src/diff-manager.ts
+++ b/packages/vscode-ide-companion/src/diff-manager.ts
@@ -121,6 +121,7 @@ export class DiffManager {
       diffTitle,
       {
         preview: false,
+        preserveFocus: true,
       },
     );
     await vscode.commands.executeCommand(


### PR DESCRIPTION
## TLDR

This change sets `preserveFocus: true` when opening a diff view. This prevents the editor from automatically shifting focus to the diff tab, allowing the user to remain in their current context without interruption.

## Dive Deeper

This is a quality-of-life improvement that enhances the user experience. By preserving focus, we avoid disrupting the developer's workflow when a diff is displayed as a result of a command.