### PR TITLE
Add flag for clearing opentelemetry settings in script

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -100,7 +100,7 @@ Use the `npm run telemetry -- --target=local` command to automate the process of
     - Start a local Jaeger instance.
     - Start an OTEL collector configured to receive data from Gemini CLI.
     - Automatically enable telemetry in your workspace settings.
-    - On exit, disable telemetry.
+    - On exit (Ctrl+C), it will attempt to restore your original sandbox settings.
 
 1.  **View traces**:
     Open your web browser and navigate to **http://localhost:16686** to access the Jaeger UI. Here you can inspect detailed traces of Gemini CLI operations.
@@ -136,7 +136,7 @@ Use the `npm run telemetry -- --target=gcp` command to automate setting up a loc
     - Start an OTEL collector configured to receive data from Gemini CLI and export it to your specified Google Cloud project.
     - Automatically enable telemetry and disable sandbox mode in your workspace settings (`.gemini/settings.json`).
     - Provide direct links to view traces, metrics, and logs in your Google Cloud Console.
-    - On exit (Ctrl+C), it will attempt to restore your original telemetry and sandbox settings.
+    - On exit (Ctrl+C), it will attempt to restore your original sandbox settings.
 
 1.  **Run Gemini CLI:**
     In a separate terminal, run your Gemini CLI commands. This generates telemetry data that the collector captures.

--- a/scripts/telemetry_utils.js
+++ b/scripts/telemetry_utils.js
@@ -295,6 +295,7 @@ export function manageTelemetrySettings(
   oTelEndpoint = 'http://localhost:4317',
   target = 'local',
   originalSandboxSettingToRestore,
+  clearTelemetrySettings = false,
 ) {
   const workspaceSettings = readJsonFile(WORKSPACE_SETTINGS_FILE);
   const currentSandboxSetting = workspaceSettings.sandbox;
@@ -326,23 +327,25 @@ export function manageTelemetrySettings(
       console.log(`🎯 Set telemetry target to ${target}.`);
     }
   } else {
-    if (workspaceSettings.telemetry.enabled === true) {
-      delete workspaceSettings.telemetry.enabled;
-      settingsModified = true;
-      console.log('⚙️  Disabled telemetry in workspace settings.');
-    }
-    if (workspaceSettings.telemetry.otlpEndpoint) {
-      delete workspaceSettings.telemetry.otlpEndpoint;
-      settingsModified = true;
-      console.log('🔧 Cleared telemetry OTLP endpoint.');
-    }
-    if (workspaceSettings.telemetry.target) {
-      delete workspaceSettings.telemetry.target;
-      settingsModified = true;
-      console.log('🎯 Cleared telemetry target.');
-    }
-    if (Object.keys(workspaceSettings.telemetry).length === 0) {
-      delete workspaceSettings.telemetry;
+    if (clearTelemetrySettings) {
+      if (workspaceSettings.telemetry.enabled === true) {
+        delete workspaceSettings.telemetry.enabled;
+        settingsModified = true;
+        console.log('⚙️  Disabled telemetry in workspace settings.');
+      }
+      if (workspaceSettings.telemetry.otlpEndpoint) {
+        delete workspaceSettings.telemetry.otlpEndpoint;
+        settingsModified = true;
+        console.log('🔧 Cleared telemetry OTLP endpoint.');
+      }
+      if (workspaceSettings.telemetry.target) {
+        delete workspaceSettings.telemetry.target;
+        settingsModified = true;
+        console.log('🎯 Cleared telemetry target.');
+      }
+      if (Object.keys(workspaceSettings.telemetry).length === 0) {
+        delete workspaceSettings.telemetry;
+      }
     }
 
     if (
@@ -380,7 +383,7 @@ export function registerCleanup(
 
     console.log('\n👋 Shutting down...');
 
-    manageTelemetrySettings(false, null, originalSandboxSetting);
+    manageTelemetrySettings(false, null, null, originalSandboxSetting);
 
     const processes = getProcesses ? getProcesses() : [];
     processes.forEach((proc) => {


### PR DESCRIPTION
The script automatically clears settings during shutdown of the collector. This change provides a flag to toggle between clearing or not.
