### PR TITLE
Log all parts of a streaming response

### DIFF
--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -149,9 +149,12 @@ export class LoggingContentGenerator implements ContentGenerator {
     userPromptId: string,
   ): AsyncGenerator<GenerateContentResponse> {
     let lastResponse: GenerateContentResponse | undefined;
+    const responses: GenerateContentResponse[] = [];
+
     let lastUsageMetadata: GenerateContentResponseUsageMetadata | undefined;
     try {
       for await (const response of stream) {
+        responses.push(response);
         lastResponse = response;
         if (response.usageMetadata) {
           lastUsageMetadata = response.usageMetadata;
@@ -169,7 +172,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         durationMs,
         userPromptId,
         lastUsageMetadata,
-        JSON.stringify(lastResponse),
+        JSON.stringify(responses),
       );
     }
   }


### PR DESCRIPTION
## TLDR

It seems that this behavior changed with: https://github.com/google-gemini/gemini-cli/commit/60bde58f29815edba365daf04c07080e8d1b24d8

Notice that with this change, we are only logging the last response of the stream of responses (those were called **chunks**  and aggregated before being logged in chatGemini.ts). 

Having those full logs help us debug what is going within the agent's trajectory. 

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

Run gcli and enable telemetry. An easy way to test is logging the telemetry to files: 

```
 npm start -- --debug -y --telemetry --telemetry-otlp-endpoint=no --telemetry-target=local --telemetry-outfile=/tmp/cli_logs.txt --sandbox=false
```

Then examine the file created (in this case, /tmp/cli_logs.txt). In my case I see multiple content-parts that are part of the respone, such as "thought", "text" and function calls. 



## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #6755 

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
