### PR TITLE
fix(release): fallback to github.sha when ref is not provided

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
         with:
-          ref: '${{ github.sha }}'
+          ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
       - name: 'Set booleans for simplified logic'


### PR DESCRIPTION
## TLDR

The release action was not respecting the input sha. this caused the .1 patch release of our preview to go out against main.

## Dive Deeper

We correctly checked out the right thing here; https://github.com/google-gemini/gemini-cli/actions/runs/17164239765/job/48700695900