### PR TITLE
feat(mcp): Add ODIC fallback to OAuth metadata look up

### DIFF
--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -142,6 +142,74 @@ describe('OAuthUtils', () => {
     });
   });
 
+  describe('discoverAuthorizationServerMetadata', () => {
+    const mockAuthServerMetadata: OAuthAuthorizationServerMetadata = {
+      issuer: 'https://auth.example.com',
+      authorization_endpoint: 'https://auth.example.com/authorize',
+      token_endpoint: 'https://auth.example.com/token',
+      scopes_supported: ['read', 'write'],
+    };
+
+    it('should handle URLs without path components correctly', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockAuthServerMetadata),
+        });
+
+      const result = await OAuthUtils.discoverAuthorizationServerMetadata(
+        'https://auth.example.com/',
+      );
+
+      expect(result).toEqual(mockAuthServerMetadata);
+
+      expect(mockFetch).nthCalledWith(
+        1,
+        'https://auth.example.com/.well-known/oauth-authorization-server',
+      );
+      expect(mockFetch).nthCalledWith(
+        2,
+        'https://auth.example.com/.well-known/openid-configuration',
+      );
+    });
+
+    it('should handle URLs with path components correctly', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockAuthServerMetadata),
+        });
+
+      const result = await OAuthUtils.discoverAuthorizationServerMetadata(
+        'https://auth.example.com/mcp',
+      );
+
+      expect(result).toEqual(mockAuthServerMetadata);
+
+      expect(mockFetch).nthCalledWith(
+        1,
+        'https://auth.example.com/.well-known/oauth-authorization-server/mcp',
+      );
+      expect(mockFetch).nthCalledWith(
+        2,
+        'https://auth.example.com/.well-known/openid-configuration/mcp',
+      );
+      expect(mockFetch).nthCalledWith(
+        3,
+        'https://auth.example.com/mcp/.well-known/openid-configuration',
+      );
+    });
+  });
+
   describe('metadataToOAuthConfig', () => {
     it('should convert metadata to OAuth config', () => {
       const metadata: OAuthAuthorizationServerMetadata = {


### PR DESCRIPTION
## TLDR

Add fallback to /.well-known/openid-configuration paths when discovering authorization server metadata

## Dive Deeper

There were a few places in OAuth code that build and try /.well-known endpoints. This PR extracts that logic out to a function, where it also adds fallback to ODIC endpoints, per specification in https://modelcontextprotocol.io/specification/draft/basic/authorization#server-metadata-discovery. This extends our support for authorization servers that haven't implemented the pure OAuth RFC 8414 metadata endpoint at /.well-known/oauth-authorization-server, with https://accounts.google.com/ being one of them.

There is one place left in oauth-provider.ts: `authenticate()` where /.well-known endpoint is constructed without calling this new util function. This will is fixed in a follow-up PR #7090 .

## Reviewer Test Plan

This should be able to be tested with a MCP server that uses Google as the authorization server. 

A simpler but hacky way to see that the code path executes fine would be to use the following
```
  "mcpServers": {
    "google": {
      "httpUrl": "https://accounts.google.com",
      "oauth": {
        "clientId": {fill in},
        "clientSecret": {fill in}
      }
    }
  }
```
This will not authorize to the end but can somewhat confirm that metadata discovery works on this URL.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✔️  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
