### PR TITLE
fix: ensure consistent English error messages in yargs configuration

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -257,7 +257,8 @@ export async function parseArguments(): Promise<CliArgs> {
     .help()
     .alias('h', 'help')
     .strict()
-    .demandCommand(0, 0); // Allow base command to run with no subcommands
+    .demandCommand(0, 0) // Allow base command to run with no subcommands
+    .locale('en'); // Ensure consistent English error messages regardless of system locale
 
   yargsInstance.wrap(yargsInstance.terminalWidth());
   const result = await yargsInstance.parse();


### PR DESCRIPTION
## TLDR

Fix test failures caused by locale-dependent error messages in yargs by adding `.locale('en')` to the configuration. This ensures consistent English error messages regardless of system locale settings.

## Dive Deeper

The yargs library automatically localizes error messages based on the system environment variables. When running tests in non-English locales (like Chinese), error messages appear in the local language ("无效的选项值" instead of "Invalid values:"), causing test assertions to fail.

This fix adds `.locale('en')` to the yargs configuration in the `parseArguments()` function to force English error messages regardless of the system locale.

## Reviewer Test Plan

1. Run the existing tests in a non-English locale environment
2. Verify that the following tests now pass:
   - `parseArguments > should reject invalid --approval-mode values`  
   - `loadCliConfig telemetry > should reject invalid --telemetry-otlp-protocol values`
3. Confirm error messages appear in English format (e.g., "Invalid values:")

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ✅  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes google-gemini/gemini-cli#6824