### PR TITLE
fix: correct context percentage display after /chat resume

### DIFF
--- a/packages/core/src/telemetry/uiTelemetry.ts
+++ b/packages/core/src/telemetry/uiTelemetry.ts
@@ -140,6 +140,14 @@ export class UiTelemetryService extends EventEmitter {
     return this.#lastPromptTokenCount;
   }
 
+  setLastPromptTokenCount(tokenCount: number): void {
+    this.#lastPromptTokenCount = tokenCount;
+    this.emit('update', {
+      metrics: this.#metrics,
+      lastPromptTokenCount: this.#lastPromptTokenCount,
+    });
+  }
+
   resetLastPromptTokenCount(): void {
     this.#lastPromptTokenCount = 0;
     this.emit('update', {


### PR DESCRIPTION
## Summary

Fixes the issue where the context percentage indicator incorrectly shows 100% after using `/chat resume` instead of reflecting the actual context usage from the loaded conversation history.

- Adds `setLastPromptTokenCount()` method to `UiTelemetryService` for manual token count updates
- Updates the `load_history` case in `useSlashCommandProcessor` to calculate and set token count after loading history
- Ensures the context percentage indicator immediately reflects actual usage when resuming conversations

## Test plan

- [x] Build passes without errors
- [x] All existing tests continue to pass  
- [x] Linting and type checking pass
- [x] Manual testing: `/chat resume` now correctly shows context percentage instead of 100%

Fixes google-gemini/gemini-cli#6750