### PR TITLE
fix(core): Skip loop check for dividers

### DIFF
--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -558,6 +558,30 @@ describe('LoopDetectionService', () => {
     });
   });
 
+  describe('Divider Content Detection', () => {
+    it('should not detect a loop for repeating divider-like content', () => {
+      service.reset('');
+      const dividerContent = '-'.repeat(CONTENT_CHUNK_SIZE);
+      let isLoop = false;
+      for (let i = 0; i < CONTENT_LOOP_THRESHOLD + 5; i++) {
+        isLoop = service.addAndCheck(createContentEvent(dividerContent));
+        expect(isLoop).toBe(false);
+      }
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+
+    it('should not detect a loop for repeating complex box-drawing dividers', () => {
+      service.reset('');
+      const dividerContent = '╭─'.repeat(CONTENT_CHUNK_SIZE / 2);
+      let isLoop = false;
+      for (let i = 0; i < CONTENT_LOOP_THRESHOLD + 5; i++) {
+        isLoop = service.addAndCheck(createContentEvent(dividerContent));
+        expect(isLoop).toBe(false);
+      }
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Reset Functionality', () => {
     it('tool call should reset content count', () => {
       const contentEvent = createContentEvent('Some content.');

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -171,7 +171,14 @@ export class LoopDetectionService {
     const hasBlockquote = /(^|\n)>\s/.test(content);
     const isDivider = /^[|+-s\u2500-\u257F]+$/.test(content);
 
-    if (numFences || hasTable || hasListItem || hasHeading || hasBlockquote || isDivider) {
+    if (
+      numFences ||
+      hasTable ||
+      hasListItem ||
+      hasHeading ||
+      hasBlockquote ||
+      isDivider
+    ) {
       // Reset tracking when different content elements are detected to avoid analyzing content
       // that spans across different element boundaries.
       this.resetContentTracking();

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -169,8 +169,9 @@ export class LoopDetectionService {
       /(^|\n)\s*[*-+]\s/.test(content) || /(^|\n)\s*\d+\.\s/.test(content);
     const hasHeading = /(^|\n)#+\s/.test(content);
     const hasBlockquote = /(^|\n)>\s/.test(content);
+    const isDivider = /^[|+-s\u2500-\u257F]+$/.test(content);
 
-    if (numFences || hasTable || hasListItem || hasHeading || hasBlockquote) {
+    if (numFences || hasTable || hasListItem || hasHeading || hasBlockquote || isDivider) {
       // Reset tracking when different content elements are detected to avoid analyzing content
       // that spans across different element boundaries.
       this.resetContentTracking();
@@ -179,7 +180,7 @@ export class LoopDetectionService {
     const wasInCodeBlock = this.inCodeBlock;
     this.inCodeBlock =
       numFences % 2 === 0 ? this.inCodeBlock : !this.inCodeBlock;
-    if (wasInCodeBlock || this.inCodeBlock) {
+    if (wasInCodeBlock || this.inCodeBlock || isDivider) {
       return false;
     }
 

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -169,7 +169,7 @@ export class LoopDetectionService {
       /(^|\n)\s*[*-+]\s/.test(content) || /(^|\n)\s*\d+\.\s/.test(content);
     const hasHeading = /(^|\n)#+\s/.test(content);
     const hasBlockquote = /(^|\n)>\s/.test(content);
-    const isDivider = /^[|+-s\u2500-\u257F]+$/.test(content);
+    const isDivider = /^[+-_=*\u2500-\u257F]+$/.test(content);
 
     if (
       numFences ||


### PR DESCRIPTION
## TLDR

This pull request improves the content loop detection algorithm to prevent it from incorrectly identifying Markdown table dividers and other decorative text-based lines as repetitive loops. This was causing the CLI to prematurely terminate valid responses that contained tables or text-based UI elements.

## Dive Deeper

The core of the change is within the `LoopDetectionService`. The previous algorithm would sometimes hash chunks of text consisting of repeating characters (like `---` or `| | |`) and flag them as a "chanting" loop.

This PR introduces a regular expression (`DIVIDER_CHUNK_REGEX`) that specifically identifies these patterns, including:
-   Simple Markdown table dividers (`|`, `+`, `-`).
-   Unicode box-drawing characters (`\u2500-\u257F`) used for more complex text UIs (e.g., `╭───╮`).

Before a content chunk is analyzed for looping, it's now tested against this regex. If it matches, the chunk is skipped, effectively ignoring these legitimate formatting elements and preventing false positives. This makes the loop detection more accurate and robust.

## Reviewer Test Plan

To validate this change, you can test prompts that are likely to generate output with repeating divider patterns.

1.  **Run a prompt that generates a large Markdown table:**
    ```bash
    repeat after me ╭───────────────────────────────────────────────────────────────────╮
    ```
    **Expected behavior:** The entire table should be printed without being cut off by a false loop detection.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |


## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
#6883