### PR TITLE
fix(ui): prevent terminal display shift during IME input in VSCode

### DIFF
--- a/packages/cli/src/ui/hooks/useTerminalSize.ts
+++ b/packages/cli/src/ui/hooks/useTerminalSize.ts
@@ -4,9 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
 const TERMINAL_PADDING_X = 8;
+
+// IME stabilization constants
+const IME_SIZE_CHANGE_THRESHOLD = 5; // Minimum column change to consider significant
+const IME_STABILIZATION_DELAY = 150; // Delay in ms before applying size changes
+const VSCode_TERM_PROGRAM = 'vscode';
 
 export function useTerminalSize(): { columns: number; rows: number } {
   const [size, setSize] = useState({
@@ -14,17 +19,66 @@ export function useTerminalSize(): { columns: number; rows: number } {
     rows: process.stdout.rows || 20,
   });
 
+  const lastStableSize = useRef(size);
+  const pendingUpdate = useRef<NodeJS.Timeout | null>(null);
+
   useEffect(() => {
     function updateSize() {
-      setSize({
-        columns: (process.stdout.columns || 60) - TERMINAL_PADDING_X,
-        rows: process.stdout.rows || 20,
-      });
+      const newColumns = (process.stdout.columns || 60) - TERMINAL_PADDING_X;
+      const newRows = process.stdout.rows || 20;
+      const newSize = { columns: newColumns, rows: newRows };
+
+      // Check if we're running in VSCode or VSCode-based terminal where IME issues occur
+      const isVSCodeFamily = process.env['TERM_PROGRAM'] === VSCode_TERM_PROGRAM ||
+                             process.env['VSCODE_GIT_IPC_HANDLE'] !== undefined ||
+                             process.env['CURSOR_TRACE_ID'] !== undefined ||
+                             process.env['VSCODE_GIT_ASKPASS_MAIN']?.toLowerCase().includes('cursor') ||
+                             process.env['VSCODE_GIT_ASKPASS_MAIN']?.toLowerCase().includes('windsurf');
+
+      if (isVSCodeFamily) {
+        const columnsDiff = Math.abs(newColumns - lastStableSize.current.columns);
+        
+        // If the column change is small (likely IME candidate window), debounce the update
+        if (columnsDiff > 0 && columnsDiff <= IME_SIZE_CHANGE_THRESHOLD) {
+          // Clear any existing pending update
+          if (pendingUpdate.current) {
+            clearTimeout(pendingUpdate.current);
+          }
+
+          // Schedule a delayed update to allow IME operations to complete
+          pendingUpdate.current = setTimeout(() => {
+            // Only update if the size is still the same after the delay
+            const currentColumns = (process.stdout.columns || 60) - TERMINAL_PADDING_X;
+            const currentRows = process.stdout.rows || 20;
+            
+            if (currentColumns === newColumns && currentRows === newRows) {
+              lastStableSize.current = { columns: currentColumns, rows: currentRows };
+              setSize({ columns: currentColumns, rows: currentRows });
+            }
+            pendingUpdate.current = null;
+          }, IME_STABILIZATION_DELAY);
+
+          return; // Don't update immediately for small changes
+        }
+      }
+
+      // For significant size changes or non-VSCode terminals, update immediately
+      lastStableSize.current = newSize;
+      setSize(newSize);
+
+      // Clear any pending delayed update since we're updating now
+      if (pendingUpdate.current) {
+        clearTimeout(pendingUpdate.current);
+        pendingUpdate.current = null;
+      }
     }
 
     process.stdout.on('resize', updateSize);
     return () => {
       process.stdout.off('resize', updateSize);
+      if (pendingUpdate.current) {
+        clearTimeout(pendingUpdate.current);
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes issue where multibyte character input (Japanese, Chinese, Korean) in VSCode integrated terminal causes the entire terminal display to shift left when IME candidate windows appear.

- **Issue**: VSCode terminal display shifts during IME composition for multibyte characters
- **Cause**: IME candidate windows temporarily affect reported terminal width, triggering layout recalculation
- **Solution**: Add IME-aware stabilization to prevent rapid layout changes during composition

## Changes

- Enhanced `useTerminalSize` hook with IME stabilization logic
- Added debouncing for small terminal width changes in VSCode/Cursor/Windsurf terminals  
- Preserved immediate updates for genuine terminal resize events
- Added support for VSCode-based editors (Cursor, Windsurf)

## Test plan

- [x] Verify TypeScript compilation passes
- [x] Confirm all existing tests pass
- [x] Run linting and build successfully  
- [ ] Manual testing with multibyte character input in VSCode terminal
- [x] Verify normal terminal resize behavior still works correctly
- [x] Test in different VSCode-based editors (Cursor, Windsurf)

Fixes google-gemini/gemini-cli#6799