### PR TITLE
fix(vscode): target originating window for diff display

### DIFF
--- a/packages/vscode-ide-companion/src/diff-manager.ts
+++ b/packages/vscode-ide-companion/src/diff-manager.ts
@@ -122,6 +122,7 @@ export class DiffManager {
       {
         preview: false,
         preserveFocus: true,
+        viewColumn: vscode.ViewColumn.Active,
       },
     );
     await vscode.commands.executeCommand(


### PR DESCRIPTION
## Summary

- Fixed VS Code extension targeting wrong window when showing diffs with multiple VS Code instances running
- Added explicit `viewColumn: vscode.ViewColumn.Active` parameter to `vscode.diff` command  
- Ensures diffs always open in the originating VS Code window instead of the currently focused one

## Test plan

- [x] Verified TypeScript compilation passes
- [x] Verified ESLint passes  
- [x] Verified build completes successfully
- [ ] Manual testing with multiple VS Code instances (requires reviewer testing)

Fixes google-gemini/gemini-cli#6848