### PR TITLE
fix: misaligned right border on tool calls ui and spacing in multiple tool calls ui

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -81,7 +81,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
       borderDimColor={hasPending}
       borderColor={borderColor}
     >
-      {toolCalls.map((tool) => {
+      {toolCalls.map((tool, index) => {
         const isConfirming = toolAwaitingApproval?.callId === tool.callId;
         return (
           <Box key={tool.callId} flexDirection="column" minHeight={1}>
@@ -118,6 +118,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
                   terminalWidth={innerWidth}
                 />
               )}
+            {index < toolCalls.length - 1 && <Box height={1} />}
           </Box>
         );
       })}

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -80,8 +80,9 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
       marginLeft={1}
       borderDimColor={hasPending}
       borderColor={borderColor}
+      gap={1}
     >
-      {toolCalls.map((tool, index) => {
+      {toolCalls.map((tool) => {
         const isConfirming = toolAwaitingApproval?.callId === tool.callId;
         return (
           <Box key={tool.callId} flexDirection="column" minHeight={1}>
@@ -118,7 +119,6 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
                   terminalWidth={innerWidth}
                 />
               )}
-            {index < toolCalls.length - 1 && <Box height={1} />}
           </Box>
         );
       })}

--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -71,19 +71,19 @@ describe('<ToolMessage />', () => {
       StreamingState.Idle,
     );
     const output = lastFrame();
-    expect(output).toContain('✔'); // Success indicator
+    expect(output).toContain('√'); // Success indicator
     expect(output).toContain('test-tool');
     expect(output).toContain('A tool for testing');
     expect(output).toContain('MockMarkdown:Test result');
   });
 
   describe('ToolStatusIndicator rendering', () => {
-    it('shows ✔ for Success status', () => {
+    it('shows √ for Success status', () => {
       const { lastFrame } = renderWithContext(
         <ToolMessage {...baseProps} status={ToolCallStatus.Success} />,
         StreamingState.Idle,
       );
-      expect(lastFrame()).toContain('✔');
+      expect(lastFrame()).toContain('√');
     });
 
     it('shows o for Pending status', () => {
@@ -125,7 +125,7 @@ describe('<ToolMessage />', () => {
       );
       expect(lastFrame()).toContain('⊷');
       expect(lastFrame()).not.toContain('MockRespondingSpinner');
-      expect(lastFrame()).not.toContain('✔');
+      expect(lastFrame()).not.toContain('√');
     });
 
     it('shows paused spinner for Executing status when streamingState is WaitingForConfirmation', () => {
@@ -135,7 +135,7 @@ describe('<ToolMessage />', () => {
       );
       expect(lastFrame()).toContain('⊷');
       expect(lastFrame()).not.toContain('MockRespondingSpinner');
-      expect(lastFrame()).not.toContain('✔');
+      expect(lastFrame()).not.toContain('√');
     });
 
     it('shows MockRespondingSpinner for Executing status when streamingState is Responding', () => {
@@ -144,7 +144,7 @@ describe('<ToolMessage />', () => {
         StreamingState.Responding, // Simulate app still responding
       );
       expect(lastFrame()).toContain('MockRespondingSpinner');
-      expect(lastFrame()).not.toContain('✔');
+      expect(lastFrame()).not.toContain('√');
     });
   });
 

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -127,7 +127,7 @@ const ToolStatusIndicator: React.FC<ToolStatusIndicatorProps> = ({
       />
     )}
     {status === ToolCallStatus.Success && (
-      <Text color={Colors.AccentGreen}>✔</Text>
+      <Text color={Colors.AccentGreen}>√</Text>
     )}
     {status === ToolCallStatus.Confirming && (
       <Text color={Colors.AccentYellow}>?</Text>


### PR DESCRIPTION
## TLDR

- fix previously misaligned right border in successful tool calls
- add space between multiple tool calls in the same box
- the new checkmark is also same type as the x on the failed tool calls

## Dive Deeper
Before:
<img width="1223" height="235" alt="before" src="https://github.com/user-attachments/assets/7ecc63a1-bb50-430e-b57f-2699ed5f13a6" />
After:
<img width="1220" height="273" alt="after" src="https://github.com/user-attachments/assets/3085c74c-889c-48e0-a8cd-f336e4866eaa" />



## Reviewer Test Plan

- make a successful tool calls and notice that the right margin is properly aligned.
- do something that has two tool calls together and notice the spacing isn't congested

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
