### PR TITLE
Support JSON schema formats using ajv-formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3576,6 +3576,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -13365,6 +13404,7 @@
         "@types/html-to-text": "^9.0.4",
         "@xterm/headless": "5.5.0",
         "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.0",
         "chardet": "^2.1.0",
         "diff": "^7.0.0",
         "dotenv": "^17.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "@types/glob": "^8.1.0",
     "@types/html-to-text": "^9.0.4",
     "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.0",
     "chardet": "^2.1.0",
     "diff": "^7.0.0",
     "dotenv": "^17.1.0",

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -5,10 +5,14 @@
  */
 
 import AjvPkg from 'ajv';
+import * as addFormats from 'ajv-formats';
 // Ajv's ESM/CJS interop: use 'any' for compatibility as recommended by Ajv docs
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const AjvClass = (AjvPkg as any).default || AjvPkg;
 const ajValidator = new AjvClass();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const addFormatsFunc = (addFormats as any).default || addFormats;
+addFormatsFunc(ajValidator);
 
 /**
  * Simple utility to validate objects against JSON Schemas


### PR DESCRIPTION
## TLDR

Add support for JSON formats in MCP tool schemas

## Dive Deeper

Some MCP servers define schemas that use formats not supported currently in Gemini CLI. An example parameter that failed validation:

```
          "properties": {
            "issueId": {
              "description": "The numerical ID of the issue.",
              "format": "int64",
              "type": "string"
            },
```

OpenAPI 3.0 supports this as a type/format pair: https://spec.openapis.org/registry/format/int64

I suspect our validation in general is too strict, and I wonder if we should just be sending whatever the MCP servers provide directly to the Gemini API. See #5388  and #6632 and #6219 for examples.

## Linked issues / bugs

Fixes #6948