### PR TITLE
Added the strictSchemeValidation setting for MCP server parameters. 

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -133,6 +133,8 @@ export class MCPServerConfig {
     // OAuth configuration
     readonly oauth?: MCPOAuthConfig,
     readonly authProviderType?: AuthProviderType,
+    // Enable strict validation of the scheme if needed
+    readonly strictSchemeValidation?: boolean,
   ) {}
 }
 

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -180,6 +180,7 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
     override readonly parameterSchema: unknown,
     readonly timeout?: number,
     readonly trust?: boolean,
+    readonly strictSchemeValidation?: boolean,
     nameOverride?: string,
   ) {
     super(
@@ -202,6 +203,7 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
       this.parameterSchema,
       this.timeout,
       this.trust,
+      this.strictSchemeValidation,
       `${this.serverName}__${this.serverToolName}`,
     );
   }


### PR DESCRIPTION
Added the strictSchemeValidation setting for MCP server parameters. 

Defaults to false; if true, it enforces strict validation rules for the tools (current rules)

strictSchemeValidation: 
- **undefined, false :** it's the default in the [MCP Protocol](https://modelcontextprotocol.io/docs/getting-started/intro).
- **true :** if a subSchema has not types, it skips the tool (current policy)


`
    "my_mcp": {
      "url": "https://xxx",
      "strictSchemeValidation" : false/true
    }
`
## Linked issues / bugs
Resolves #6632
