### PR TITLE
feat(auth): Improve Gemini CLI API Key Authentication User Experience

### DIFF
--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -27,22 +27,26 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
       ```
 
 2.  **<a id="gemini-api-key"></a>Gemini API key:**
+    - When you select this option during the initial setup, the CLI will prompt you to enter your API key.
     - Obtain your API key from Google AI Studio: [https://aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey)
-    - Set the `GEMINI_API_KEY` environment variable. In the following methods, replace `YOUR_GEMINI_API_KEY` with the API key you obtained from Google AI Studio:
-      - You can temporarily set the environment variable in your current shell session using the following command:
-        ```bash
-        export GEMINI_API_KEY="YOUR_GEMINI_API_KEY"
-        ```
-      - For repeated use, you can add the environment variable to your [.env file](#persisting-environment-variables-with-env-files).
+    - Paste the key into the CLI prompt. It will be automatically saved to a `.env` file in your project's root directory.
+    - If you need to change the key later, you can edit the `.env` file directly.
 
-      - Alternatively you can export the API key from your shell's configuration file (like `~/.bashrc`, `~/.zshrc`, or `~/.profile`). For example, the following command adds the environment variable to a `~/.bashrc` file:
+    Alternatively, you can set the `GEMINI_API_KEY` environment variable manually. In the following methods, replace `YOUR_GEMINI_API_KEY` with the API key you obtained from Google AI Studio:
+    - You can temporarily set the environment variable in your current shell session using the following command:
+      ```bash
+      export GEMINI_API_KEY="YOUR_GEMINI_API_KEY"
+      ```
+    - For repeated use, you can add the environment variable to your [.env file](#persisting-environment-variables-with-env-files).
 
-        ```bash
-        echo 'export GEMINI_API_KEY="YOUR_GEMINI_API_KEY"' >> ~/.bashrc
-        source ~/.bashrc
-        ```
+    - You can also export the API key from your shell's configuration file (like `~/.bashrc`, `~/.zshrc`, or `~/.profile`). For example, the following command adds the environment variable to a `~/.bashrc` file:
 
-        :warning: Be advised that when you export your API key inside your shell configuration file, any other process executed from the shell can read it.
+      ```bash
+      echo 'export GEMINI_API_KEY="YOUR_GEMINI_API_KEY"' >> ~/.bashrc
+      source ~/.bashrc
+      ```
+
+      :warning: Be advised that when you export your API key inside your shell configuration file, any other process executed from the shell can read it.
 
 3.  **Vertex AI:**
     - **API Key:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8152,6 +8152,25 @@
         "ink": ">=4"
       }
     },
+    "node_modules/ink-link": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ink-link/-/ink-link-4.1.0.tgz",
+      "integrity": "sha512-3nNyJXum0FJIKAXBK8qat2jEOM41nJ1J60NRivwgK9Xh92R5UMN/k4vbz0A9xFzhJVrlf4BQEmmxMgXkCE1Jeg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "terminal-link": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "peerDependencies": {
+        "ink": ">=4"
+      }
+    },
     "node_modules/ink-spinner": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
@@ -12534,6 +12553,31 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -12659,6 +12703,49 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-link": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-3.0.0.tgz",
+      "integrity": "sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^5.0.0",
+        "supports-hyperlinks": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-link/node_modules/ansi-escapes": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-link/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14520,6 +14607,7 @@
         "highlight.js": "^11.11.1",
         "ink": "^6.2.3",
         "ink-gradient": "^3.0.0",
+        "ink-link": "^4.0.0",
         "ink-spinner": "^5.0.0",
         "lodash-es": "^4.17.21",
         "lowlight": "^3.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "highlight.js": "^11.11.1",
     "ink": "^6.2.3",
     "ink-gradient": "^3.0.0",
+    "ink-link": "^4.0.0",
     "ink-spinner": "^5.0.0",
     "lodash-es": "^4.17.21",
     "lowlight": "^3.3.0",

--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -6,73 +6,139 @@
 
 import { AuthType } from '@google/gemini-cli-core';
 import { vi } from 'vitest';
-import { validateAuthMethod } from './auth.js';
+import { saveGeminiApiKeyToEnvFile, validateAuthMethod } from './auth.js';
+import fs from 'node:fs';
+import * as settings from './settings.js';
 
-vi.mock('./settings.js', () => ({
-  loadEnvironment: vi.fn(),
-  loadSettings: vi.fn().mockReturnValue({
-    merged: vi.fn().mockReturnValue({}),
-  }),
-}));
+vi.mock('node:fs');
 
-describe('validateAuthMethod', () => {
+describe('auth', () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.resetAllMocks();
+    vi.spyOn(settings, 'loadSettings').mockReturnValue(
+      new settings.LoadedSettings(
+        { settings: {}, path: '' },
+        { settings: {}, path: '' },
+        { settings: {}, path: '' },
+        { settings: {}, path: '' },
+        [],
+        true,
+        new Set(),
+      ),
+    );
+    vi.spyOn(settings, 'loadEnvironment').mockImplementation(vi.fn());
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it('should return null for LOGIN_WITH_GOOGLE', () => {
-    expect(validateAuthMethod(AuthType.LOGIN_WITH_GOOGLE)).toBeNull();
-  });
-
-  it('should return null for CLOUD_SHELL', () => {
-    expect(validateAuthMethod(AuthType.CLOUD_SHELL)).toBeNull();
-  });
-
-  describe('USE_GEMINI', () => {
-    it('should return null if GEMINI_API_KEY is set', () => {
-      vi.stubEnv('GEMINI_API_KEY', 'test-key');
-      expect(validateAuthMethod(AuthType.USE_GEMINI)).toBeNull();
+  describe('validateAuthMethod', () => {
+    it('should return null for LOGIN_WITH_GOOGLE', () => {
+      expect(validateAuthMethod(AuthType.LOGIN_WITH_GOOGLE)).toBeNull();
     });
 
-    it('should return an error message if GEMINI_API_KEY is not set', () => {
-      vi.stubEnv('GEMINI_API_KEY', undefined);
-      expect(validateAuthMethod(AuthType.USE_GEMINI)).toBe(
-        'GEMINI_API_KEY environment variable not found. Add that to your environment and try again (no reload needed if using .env)!',
+    it('should return null for CLOUD_SHELL', () => {
+      expect(validateAuthMethod(AuthType.CLOUD_SHELL)).toBeNull();
+    });
+
+    describe('USE_GEMINI', () => {
+      it('should return null if GEMINI_API_KEY is set', () => {
+        vi.stubEnv('GEMINI_API_KEY', 'test-key');
+        expect(validateAuthMethod(AuthType.USE_GEMINI)).toBeNull();
+      });
+
+      it('should return an error message if GEMINI_API_KEY is not set', () => {
+        vi.stubEnv('GEMINI_API_KEY', undefined);
+        expect(validateAuthMethod(AuthType.USE_GEMINI)).toBe(
+          'GEMINI_API_KEY environment variable not found. Please provide one to continue.',
+        );
+      });
+    });
+
+    describe('USE_VERTEX_AI', () => {
+      it('should return null if GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION are set', () => {
+        vi.stubEnv('GOOGLE_CLOUD_PROJECT', 'test-project');
+        vi.stubEnv('GOOGLE_CLOUD_LOCATION', 'test-location');
+        expect(validateAuthMethod(AuthType.USE_VERTEX_AI)).toBeNull();
+      });
+
+      it('should return null if GOOGLE_API_KEY is set', () => {
+        vi.stubEnv('GOOGLE_API_KEY', 'test-api-key');
+        expect(validateAuthMethod(AuthType.USE_VERTEX_AI)).toBeNull();
+      });
+
+      it('should return an error message if no required environment variables are set', () => {
+        vi.stubEnv('GOOGLE_CLOUD_PROJECT', undefined);
+        vi.stubEnv('GOOGLE_CLOUD_LOCATION', undefined);
+        expect(validateAuthMethod(AuthType.USE_VERTEX_AI)).toBe(
+          'When using Vertex AI, you must specify either:\n' +
+            '• GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION environment variables.\n' +
+            '• GOOGLE_API_KEY environment variable (if using express mode).\n' +
+            'Update your environment and try again (no reload needed if using .env)!',
+        );
+      });
+    });
+
+    it('should return an error message for an invalid auth method', () => {
+      expect(validateAuthMethod('invalid-method')).toBe(
+        'Invalid auth method selected.',
       );
     });
   });
 
-  describe('USE_VERTEX_AI', () => {
-    it('should return null if GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION are set', () => {
-      vi.stubEnv('GOOGLE_CLOUD_PROJECT', 'test-project');
-      vi.stubEnv('GOOGLE_CLOUD_LOCATION', 'test-location');
-      expect(validateAuthMethod(AuthType.USE_VERTEX_AI)).toBeNull();
-    });
-
-    it('should return null if GOOGLE_API_KEY is set', () => {
-      vi.stubEnv('GOOGLE_API_KEY', 'test-api-key');
-      expect(validateAuthMethod(AuthType.USE_VERTEX_AI)).toBeNull();
-    });
-
-    it('should return an error message if no required environment variables are set', () => {
-      vi.stubEnv('GOOGLE_CLOUD_PROJECT', undefined);
-      vi.stubEnv('GOOGLE_CLOUD_LOCATION', undefined);
-      expect(validateAuthMethod(AuthType.USE_VERTEX_AI)).toBe(
-        'When using Vertex AI, you must specify either:\n' +
-          '• GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION environment variables.\n' +
-          '• GOOGLE_API_KEY environment variable (if using express mode).\n' +
-          'Update your environment and try again (no reload needed if using .env)!',
+  describe('saveGeminiApiKeyToEnvFile', () => {
+    it('should save the key to a new .env file', () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const writeSpy = vi
+        .spyOn(fs, 'writeFileSync')
+        .mockImplementation(() => {});
+      const result = saveGeminiApiKeyToEnvFile('test-key');
+      expect(result).toBe(true);
+      expect(writeSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        'GEMINI_API_KEY="test-key"\n',
+        'utf-8',
       );
     });
-  });
 
-  it('should return an error message for an invalid auth method', () => {
-    expect(validateAuthMethod('invalid-method')).toBe(
-      'Invalid auth method selected.',
-    );
+    it('should add the key to an existing .env file', () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      vi.spyOn(fs, 'readFileSync').mockReturnValue('EXISTING_VAR=true');
+      const writeSpy = vi
+        .spyOn(fs, 'writeFileSync')
+        .mockImplementation(() => {});
+      const result = saveGeminiApiKeyToEnvFile('test-key');
+      expect(result).toBe(true);
+      expect(writeSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        'EXISTING_VAR=true\nGEMINI_API_KEY="test-key"\n',
+        'utf-8',
+      );
+    });
+
+    it('should update an existing key in the .env file', () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      vi.spyOn(fs, 'readFileSync').mockReturnValue('GEMINI_API_KEY="old-key"');
+      const writeSpy = vi
+        .spyOn(fs, 'writeFileSync')
+        .mockImplementation(() => {});
+      const result = saveGeminiApiKeyToEnvFile('new-key');
+      expect(result).toBe(true);
+      expect(writeSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        'GEMINI_API_KEY="new-key"',
+        'utf-8',
+      );
+    });
+
+    it('should return false on error', () => {
+      vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+        throw new Error('FS Error');
+      });
+      const result = saveGeminiApiKeyToEnvFile('test-key');
+      expect(result).toBe(false);
+    });
   });
 });

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -4,8 +4,46 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import fs from 'node:fs';
+import path from 'node:path';
 import { AuthType } from '@google/gemini-cli-core';
 import { loadEnvironment, loadSettings } from './settings.js';
+
+const ENV_PATH = path.resolve(process.cwd(), '.env');
+
+// Save or update GEMINI_API_KEY in .env file.
+export function saveGeminiApiKeyToEnvFile(key: string): boolean {
+  try {
+    // Ensure the directory exists
+    const dirPath = path.dirname(ENV_PATH);
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath, { recursive: true });
+    }
+
+    // Read existing env file content (if exists)
+    let envContent = fs.existsSync(ENV_PATH)
+      ? fs.readFileSync(ENV_PATH, 'utf-8')
+      : '';
+
+    const regex = /^\s*(?:export\s+)?GEMINI_API_KEY\s*=.*$/m;
+    const newLine = `GEMINI_API_KEY="${key}"`;
+
+    if (regex.test(envContent)) {
+      // Replace existing GEMINI_API_KEY
+      envContent = envContent.replace(regex, newLine);
+    } else {
+      // Append GEMINI_API_KEY to the end
+      envContent += (envContent.trim().length ? '\n' : '') + newLine + '\n';
+    }
+
+    // Write back to the .env file
+    fs.writeFileSync(ENV_PATH, envContent, 'utf-8');
+    return true;
+  } catch (error) {
+    console.error(`[Error] Failed to save GEMINI_API_KEY:`, error);
+    return false;
+  }
+}
 
 export function validateAuthMethod(authMethod: string): string | null {
   loadEnvironment(loadSettings(process.cwd()).merged);
@@ -18,7 +56,7 @@ export function validateAuthMethod(authMethod: string): string | null {
 
   if (authMethod === AuthType.USE_GEMINI) {
     if (!process.env['GEMINI_API_KEY']) {
-      return 'GEMINI_API_KEY environment variable not found. Add that to your environment and try again (no reload needed if using .env)!';
+      return 'GEMINI_API_KEY environment variable not found. Please provide one to continue.';
     }
     return null;
   }

--- a/packages/cli/src/ui/components/shared/CustomTextInput.test.tsx
+++ b/packages/cli/src/ui/components/shared/CustomTextInput.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { CustomTextInput } from './CustomTextInput.js';
+import { renderWithProviders } from '../../../test-utils/render.js';
+
+describe('CustomTextInput', () => {
+  const wait = (ms = 50) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  it('should handle input change', async () => {
+    const handleChange = vi.fn();
+    const { stdin, unmount } = renderWithProviders(
+      <CustomTextInput value="" onChange={handleChange} onSubmit={() => {}} />,
+    );
+
+    stdin.write('a');
+    await wait();
+
+    expect(handleChange).toHaveBeenCalledWith('a');
+    unmount();
+  });
+
+  it('should handle submit', async () => {
+    const handleSubmit = vi.fn();
+    const { stdin, unmount } = renderWithProviders(
+      <CustomTextInput value="" onChange={() => {}} onSubmit={handleSubmit} />,
+    );
+
+    stdin.write('\r');
+    await wait();
+
+    expect(handleSubmit).toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should handle backspace', async () => {
+    const handleChange = vi.fn();
+    let value = 'abc';
+    const { stdin, rerender, unmount } = renderWithProviders(
+      <CustomTextInput
+        value={value}
+        onChange={(v) => {
+          value = v;
+          handleChange(v);
+        }}
+        onSubmit={() => {}}
+      />,
+    );
+
+    stdin.write('\u0008'); // backspace
+    await wait();
+    rerender(
+      <CustomTextInput
+        value={value}
+        onChange={handleChange}
+        onSubmit={() => {}}
+      />,
+    );
+
+    expect(handleChange).toHaveBeenCalledWith('ab');
+    unmount();
+  });
+
+  it('should handle paste', async () => {
+    const handleChange = vi.fn();
+    const { stdin, unmount } = renderWithProviders(
+      <CustomTextInput value="" onChange={handleChange} onSubmit={() => {}} />,
+    );
+
+    stdin.write('\x1b[200~pasted text\x1b[201~');
+    await wait();
+
+    expect(handleChange).toHaveBeenCalledWith('pasted text');
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/shared/CustomTextInput.tsx
+++ b/packages/cli/src/ui/components/shared/CustomTextInput.tsx
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState } from 'react';
+import { Text } from 'ink';
+import { useKeypress } from '../../hooks/useKeypress.js';
+
+interface CustomTextInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  mask?: string;
+}
+
+export function CustomTextInput({
+  value,
+  onChange,
+  onSubmit,
+  mask,
+}: CustomTextInputProps) {
+  const [isFocused] = useState(true);
+
+  useKeypress(
+    (key) => {
+      if (key.name === 'return') {
+        onSubmit();
+        return;
+      }
+
+      if (key.name === 'backspace' || key.name === 'delete') {
+        onChange(value.slice(0, -1));
+        return;
+      }
+
+      if (key.paste && key.sequence) {
+        onChange(value + key.sequence);
+        return;
+      }
+
+      // Allow only printable ASCII characters
+      if (
+        key.sequence &&
+        key.sequence.length === 1 &&
+        key.sequence >= ' ' &&
+        key.sequence <= '~'
+      ) {
+        onChange(value + key.sequence);
+      }
+    },
+    { isActive: isFocused },
+  );
+
+  const displayValue = mask ? mask.repeat(value.length) : value;
+
+  return <Text>{displayValue}</Text>;
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -57,6 +57,7 @@
     "src/ui/commands/statsCommand.test.ts",
     "src/ui/commands/terminalSetupCommand.test.ts",
     "src/ui/commands/toolsCommand.test.ts",
+    "src/ui/components/AuthDialog.test.tsx",
     "src/ui/components/ContextSummaryDisplay.test.tsx",
     "src/ui/components/Footer.test.tsx",
     "src/ui/components/InputPrompt.test.tsx",


### PR DESCRIPTION
## TLDR

This PR improves the authentication flow for users of the Gemini API key. It introduces an interactive prompt for the API key if it's not set as an environment variable and updates the documentation accordingly.

## Dive Deeper

This PR introduces a new interactive flow for capturing the user's Gemini API key. The implementation is centered around changes in the `AuthDialog` component and a new helper function for persisting the key.

**File Changes and Implementation:**

*   **`packages/cli/src/config/auth.ts`**:
    *   A new function, `saveGeminiApiKeyToEnvFile`, has been added. This function is responsible for persisting the user's API key to a `.env` file in the project's root directory.
    *   It handles creating the `.env` file if it doesn't exist, appending the `GEMINI_API_KEY` if the file exists but doesn't contain the key, and updating the key if it already exists.

*   **`packages/cli/src/ui/components/AuthDialog.tsx`**:
    *   The `AuthDialog` component now manages a new piece of state, `isEnteringApiKey`, to toggle between the authentication method selection and the API key input view.
    *   When a user selects "Use Gemini API Key" and the key is not already set, the component now renders a new view that prompts the user for their key.
    *   This new view uses a new reusable component, `CustomTextInput`, for the key input, which masks the input for security.
    *   The `handleApiKeySubmit` function calls `saveGeminiApiKeyToEnvFile` to persist the key and then updates the application's state to proceed with the authentication.

*   **`packages/cli/src/ui/components/shared/CustomTextInput.tsx`**:
    *   A new reusable Ink component for text input with masking has been created. This can be used in other parts of the CLI in the future.

*   **Testing (`*.test.tsx`, `*.test.ts`)**:
    *   Comprehensive tests have been added for the new functionality.
    *   `auth.test.ts` now includes tests for `saveGeminiApiKeyToEnvFile`, covering all the file interaction logic.
    *   `AuthDialog.test.tsx` has been updated with tests for the new API key input flow, simulating user input and verifying the component's behavior.
    *   Tests for the new `CustomTextInput` component have also been added.

**Wrong API key input Screenshot**:
<img width="1901" height="857" alt="Screenshot from 2025-08-25 18-35-43" src="https://github.com/user-attachments/assets/9ab5c229-ebfd-4a1b-9cec-3a3f9e9a8345" />

**Screenshots with correct API key input**:
<img width="1901" height="857" alt="Screenshot from 2025-08-25 18-37-19" src="https://github.com/user-attachments/assets/e0e1041d-e967-45f3-8b52-6e4522883c38" />
<img width="1901" height="857" alt="Screenshot from 2025-08-25 18-37-35" src="https://github.com/user-attachments/assets/f869345d-9797-4a3c-af31-31e8ad95591a" />

## Reviewer Test Plan

1.  Pull down this branch.
2.  Ensure you do not have `GEMINI_API_KEY` set as an environment variable.
3.  Run the Gemini CLI (`gemini` or `npx @google/gemini-cli`).
4.  When prompted for the authentication method, select "Use Gemini API Key".
5.  The CLI should now prompt you to enter your API key.
6.  Enter a valid Gemini API key.
7.  The CLI should proceed, and a `.env` file should be created in your project root with the key.
8.  Run the CLI again. It should now use the key from the `.env` file and not prompt you for it again.
9.  Press `escape` to exit the API key prompt and verify that you are returned to the authentication selection screen.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ✅  |
| Docker   | ❓  | ❓  | ✅  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

fixes #4912 #2202 

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
