### PR TITLE
feat: Update GitHub workflow configurations

### DIFF
--- a/packages/cli/src/ui/commands/setupGithubCommand.test.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.test.ts
@@ -10,7 +10,11 @@ import fs from 'node:fs/promises';
 
 import { vi, describe, expect, it, afterEach, beforeEach } from 'vitest';
 import * as gitUtils from '../../utils/gitUtils.js';
-import { setupGithubCommand, updateGitignore } from './setupGithubCommand.js';
+import {
+  setupGithubCommand,
+  updateGitignore,
+  GITHUB_WORKFLOW_PATHS,
+} from './setupGithubCommand.js';
 import { CommandContext, ToolActionReturn } from './types.js';
 import * as commandUtils from '../utils/commandUtils.js';
 
@@ -51,12 +55,7 @@ describe('setupGithubCommand', async () => {
     const fakeRepoRoot = scratchDir;
     const fakeReleaseVersion = 'v1.2.3';
 
-    const workflows = [
-      'gemini-cli.yml',
-      'gemini-issue-automated-triage.yml',
-      'gemini-issue-scheduled-triage.yml',
-      'gemini-pr-review.yml',
-    ];
+    const workflows = GITHUB_WORKFLOW_PATHS.map((p) => path.basename(p));
     for (const workflow of workflows) {
       vi.mocked(global.fetch).mockReturnValueOnce(
         Promise.resolve(new Response(workflow)),

--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -24,6 +24,14 @@ import {
 } from './types.js';
 import { getUrlOpenCommand } from '../../ui/utils/commandUtils.js';
 
+export const GITHUB_WORKFLOW_PATHS = [
+  'gemini-dispatch/gemini-dispatch.yml',
+  'gemini-assistant/gemini-invoke.yml',
+  'issue-triage/gemini-triage.yml',
+  'issue-triage/gemini-scheduled-triage.yml',
+  'pr-review/gemini-review.yml',
+];
+
 // Generate OS-specific commands to open the GitHub pages needed for setup.
 function getOpenUrlsCommands(readmeUrl: string): string[] {
   // Determine the OS-specific command to open URLs, ex: 'open', 'xdg-open', etc
@@ -131,15 +139,8 @@ export const setupGithubCommand: SlashCommand = {
 
     // Download each workflow in parallel - there aren't enough files to warrant
     // a full workerpool model here.
-    const workflows = [
-      'gemini-cli/gemini-cli.yml',
-      'issue-triage/gemini-issue-automated-triage.yml',
-      'issue-triage/gemini-issue-scheduled-triage.yml',
-      'pr-review/gemini-pr-review.yml',
-    ];
-
     const downloads = [];
-    for (const workflow of workflows) {
+    for (const workflow of GITHUB_WORKFLOW_PATHS) {
       downloads.push(
         (async () => {
           const endpoint = `https://raw.githubusercontent.com/google-github-actions/run-gemini-cli/refs/tags/${releaseTag}/examples/workflows/${workflow}`;
@@ -193,7 +194,7 @@ export const setupGithubCommand: SlashCommand = {
     const commands = [];
     commands.push('set -eEuo pipefail');
     commands.push(
-      `echo "Successfully downloaded ${workflows.length} workflows and updated .gitignore. Follow the steps in ${readmeUrl} (skipping the /setup-github step) to complete setup."`,
+      `echo "Successfully downloaded ${GITHUB_WORKFLOW_PATHS.length} workflows and updated .gitignore. Follow the steps in ${readmeUrl} (skipping the /setup-github step) to complete setup."`,
     );
     commands.push(...getOpenUrlsCommands(readmeUrl));
 


### PR DESCRIPTION
This commit synchronizes the GitHub workflow configurations with the `google-github-actions/run-gemini-cli` repository.

Key changes include:
- Introduction of `gemini-dispatch.yml` to handle routing.
- Renaming of `gemini-cli.yml` to `gemini-invoke.yml`.
- Renaming of `gemini-issue-automated-triage.yml` to `gemini-triage.yml`.
- Renaming of `gemini-issue-scheduled-triage.yml` to `gemini-scheduled-triage.yml`.
- Renaming of `gemini-pr-review.yml` to `gemini-review.yml`.

These updates ensure that the CLI is aligned with the latest workflow structure in the `google-github-actions/run-gemini-cli` repository.
