### PR TITLE
fix(keyboard): Implement Tab and Backspace handling for Kitty Protocol

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -22,8 +22,10 @@ import { PassThrough } from 'stream';
 import {
   BACKSLASH_ENTER_DETECTION_WINDOW_MS,
   KITTY_CTRL_C,
+  KITTY_KEYCODE_BACKSPACE,
   KITTY_KEYCODE_ENTER,
   KITTY_KEYCODE_NUMPAD_ENTER,
+  KITTY_KEYCODE_TAB,
   MAX_KITTY_SEQUENCE_LENGTH,
 } from '../utils/platformConstants.js';
 
@@ -127,6 +129,30 @@ export function KeypressProvider({
       if (keyCode === 27) {
         return {
           name: 'escape',
+          ctrl,
+          meta: alt,
+          shift,
+          paste: false,
+          sequence,
+          kittyProtocol: true,
+        };
+      }
+
+      if (keyCode === KITTY_KEYCODE_TAB) {
+        return {
+          name: 'tab',
+          ctrl,
+          meta: alt,
+          shift,
+          paste: false,
+          sequence,
+          kittyProtocol: true,
+        };
+      }
+
+      if (keyCode === KITTY_KEYCODE_BACKSPACE) {
+        return {
+          name: 'backspace',
           ctrl,
           meta: alt,
           shift,

--- a/packages/cli/src/ui/utils/platformConstants.ts
+++ b/packages/cli/src/ui/utils/platformConstants.ts
@@ -22,6 +22,8 @@ export const KITTY_CTRL_C = '[99;5u';
  */
 export const KITTY_KEYCODE_ENTER = 13;
 export const KITTY_KEYCODE_NUMPAD_ENTER = 57414;
+export const KITTY_KEYCODE_TAB = 9;
+export const KITTY_KEYCODE_BACKSPACE = 127;
 
 /**
  * Timing constants for terminal interactions


### PR DESCRIPTION
## TLDR

This PR fixes a bug where `Shift+Tab` and `Option+Backspace` (Alt+Backspace) were not working in terminals that support the Kitty Keyboard Protocol (e.g., Ghostty, Kitty, WezTerm).

The root cause was an incomplete implementation of the protocol parser, which did not recognize the keycodes for `Tab` (9) and `Backspace` (127). This change adds the necessary logic to correctly parse these key events and their modifiers, restoring the expected keybinding functionality.

## Dive Deeper

During debugging, it was confirmed that compliant terminals were correctly sending the specified Kitty protocol escape sequences (e.g., `\x1B[9;2u` for Shift+Tab), but our application's input layer was discarding them as unrecognized sequences. This resulted in the keypresses being "swallowed."

This fix is low-risk and specifically targeted, as it only affects the input handling path that is active when the `kittyProtocolEnabled` flag is true. Terminals that do not support the protocol, such as the default VS Code integrated terminal or the native macOS Terminal, are unaffected as they use a separate legacy input path.

The implementation was validated against the [official Kitty protocol documentation](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) to ensure the keycodes and modifier logic are correct.

## Reviewer Test Plan

1.  Pull down this branch and run `npm install && npm run build`.
2.  Launch the Gemini CLI (`gemini` or `npm start`) in a **Kitty-protocol-compliant terminal** (e.g., Ghostty, Kitty, WezTerm, Alacritty). I have tested on Ghostty, so please test in the other possible terminals as well.
3.  In the input prompt, type a few words, like `hello world example`.
4.  **Test `Option+Backspace`**: Press `Option+Backspace` (or `Alt+Backspace`). The word "example" should be deleted. Press it again; "world" should be deleted.
5.  **Test `Shift+Tab`**: This key combination should toggle auto-accepting edits in interactive mode.
6.  Verify that regular `Tab` (for completion) and `Backspace` (for single character deletion) still work as expected.
7.  **Confirm no regressions**: Launch the Gemini CLI in a **non-compliant terminal** (like the default integrated terminal in VS Code). Repeat the steps above to confirm that all keybindings still work as they did previously.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |
