### PR TITLE
refactor: centralize tool status symbols in constants

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -10,6 +10,7 @@ import { Text } from 'ink';
 import { ToolGroupMessage } from './ToolGroupMessage.js';
 import { IndividualToolCallDisplay, ToolCallStatus } from '../../types.js';
 import { Config, ToolCallConfirmationDetails } from '@google/gemini-cli-core';
+import { TOOL_STATUS } from '../../constants.js';
 
 // Mock child components to isolate ToolGroupMessage behavior
 vi.mock('./ToolMessage.js', () => ({
@@ -26,14 +27,30 @@ vi.mock('./ToolMessage.js', () => ({
     status: ToolCallStatus;
     emphasis: string;
   }) {
-    const statusSymbol = {
-      [ToolCallStatus.Success]: '✓',
-      [ToolCallStatus.Pending]: 'o',
-      [ToolCallStatus.Executing]: '⊷',
-      [ToolCallStatus.Confirming]: '?',
-      [ToolCallStatus.Canceled]: '-',
-      [ToolCallStatus.Error]: 'x',
-    }[status];
+    // Use the same constants as the real component
+    let statusSymbol: string;
+    switch (status) {
+      case ToolCallStatus.Success:
+        statusSymbol = TOOL_STATUS.SUCCESS;
+        break;
+      case ToolCallStatus.Pending:
+        statusSymbol = TOOL_STATUS.PENDING;
+        break;
+      case ToolCallStatus.Executing:
+        statusSymbol = TOOL_STATUS.EXECUTING;
+        break;
+      case ToolCallStatus.Confirming:
+        statusSymbol = TOOL_STATUS.CONFIRMING;
+        break;
+      case ToolCallStatus.Canceled:
+        statusSymbol = TOOL_STATUS.CANCELED;
+        break;
+      case ToolCallStatus.Error:
+        statusSymbol = TOOL_STATUS.ERROR;
+        break;
+      default:
+        statusSymbol = '?';
+    }
     return (
       <Text>
         MockTool[{callId}]: {statusSymbol} {name} - {description} ({emphasis})

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -28,29 +28,15 @@ vi.mock('./ToolMessage.js', () => ({
     emphasis: string;
   }) {
     // Use the same constants as the real component
-    let statusSymbol: string;
-    switch (status) {
-      case ToolCallStatus.Success:
-        statusSymbol = TOOL_STATUS.SUCCESS;
-        break;
-      case ToolCallStatus.Pending:
-        statusSymbol = TOOL_STATUS.PENDING;
-        break;
-      case ToolCallStatus.Executing:
-        statusSymbol = TOOL_STATUS.EXECUTING;
-        break;
-      case ToolCallStatus.Confirming:
-        statusSymbol = TOOL_STATUS.CONFIRMING;
-        break;
-      case ToolCallStatus.Canceled:
-        statusSymbol = TOOL_STATUS.CANCELED;
-        break;
-      case ToolCallStatus.Error:
-        statusSymbol = TOOL_STATUS.ERROR;
-        break;
-      default:
-        statusSymbol = '?';
-    }
+    const statusSymbolMap: Record<ToolCallStatus, string> = {
+      [ToolCallStatus.Success]: TOOL_STATUS.SUCCESS,
+      [ToolCallStatus.Pending]: TOOL_STATUS.PENDING,
+      [ToolCallStatus.Executing]: TOOL_STATUS.EXECUTING,
+      [ToolCallStatus.Confirming]: TOOL_STATUS.CONFIRMING,
+      [ToolCallStatus.Canceled]: TOOL_STATUS.CANCELED,
+      [ToolCallStatus.Error]: TOOL_STATUS.ERROR,
+    };
+    const statusSymbol = statusSymbolMap[status] || '?';
     return (
       <Text>
         MockTool[{callId}]: {statusSymbol} {name} - {description} ({emphasis})

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -12,6 +12,7 @@ import { Colors } from '../../colors.js';
 import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
 import { GeminiRespondingSpinner } from '../GeminiRespondingSpinner.js';
 import { MaxSizedBox } from '../shared/MaxSizedBox.js';
+import { TOOL_STATUS } from '../../constants.js';
 
 const STATIC_HEIGHT = 1;
 const RESERVED_LINE_COUNT = 5; // for tool name, status, padding etc.
@@ -118,28 +119,28 @@ const ToolStatusIndicator: React.FC<ToolStatusIndicatorProps> = ({
 }) => (
   <Box minWidth={STATUS_INDICATOR_WIDTH}>
     {status === ToolCallStatus.Pending && (
-      <Text color={Colors.AccentGreen}>o</Text>
+      <Text color={Colors.AccentGreen}>{TOOL_STATUS.PENDING}</Text>
     )}
     {status === ToolCallStatus.Executing && (
       <GeminiRespondingSpinner
         spinnerType="toggle"
-        nonRespondingDisplay={'⊷'}
+        nonRespondingDisplay={TOOL_STATUS.EXECUTING}
       />
     )}
     {status === ToolCallStatus.Success && (
-      <Text color={Colors.AccentGreen}>✓</Text>
+      <Text color={Colors.AccentGreen}>{TOOL_STATUS.SUCCESS}</Text>
     )}
     {status === ToolCallStatus.Confirming && (
-      <Text color={Colors.AccentYellow}>?</Text>
+      <Text color={Colors.AccentYellow}>{TOOL_STATUS.CONFIRMING}</Text>
     )}
     {status === ToolCallStatus.Canceled && (
       <Text color={Colors.AccentYellow} bold>
-        -
+        {TOOL_STATUS.CANCELED}
       </Text>
     )}
     {status === ToolCallStatus.Error && (
       <Text color={Colors.AccentRed} bold>
-        x
+        {TOOL_STATUS.ERROR}
       </Text>
     )}
   </Box>

--- a/packages/cli/src/ui/constants.ts
+++ b/packages/cli/src/ui/constants.ts
@@ -19,3 +19,13 @@ export const SHELL_COMMAND_NAME = 'Shell Command';
 export const SCREEN_READER_USER_PREFIX = 'User: ';
 
 export const SCREEN_READER_MODEL_PREFIX = 'Model: ';
+
+// Tool status symbols used in ToolMessage component
+export const TOOL_STATUS = {
+  SUCCESS: '✓',
+  PENDING: 'o',
+  EXECUTING: '⊷',
+  CONFIRMING: '?',
+  CANCELED: '-',
+  ERROR: 'x',
+} as const;


### PR DESCRIPTION
## TLDR

addressed https://github.com/google-gemini/gemini-cli/pull/7037#discussion_r2299168452

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |