### PR TITLE
fix(ci): allow release branches to run (#7060)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - 'main'
-      - 'release'
+      - 'release/**'
   pull_request:
     branches:
       - 'main'
-      - 'release'
+      - 'release/**'
   merge_group:
 
 concurrency:


### PR DESCRIPTION
Fixes an issue where the CI workflow was not being triggered for release branches.