### PR TITLE
fix(ide): remove noisy error log

### DIFF
--- a/packages/core/src/ide/process-utils.ts
+++ b/packages/core/src/ide/process-utils.ts
@@ -99,9 +99,6 @@ async function getIdeProcessInfoForUnix(): Promise<{
     }
   }
 
-  console.error(
-    'Failed to find shell process in the process tree. Falling back to top-level process, which may be inaccurate. If you see this, please file a bug via /bug.',
-  );
   const { command } = await getProcessInfo(currentPid);
   return { pid: currentPid, command };
 }


### PR DESCRIPTION
## TLDR

Currently, the CLI logs a misleading error message when it is run in a non-integrated terminal. This happens because the process is not spawned with a parent PID, which is the expected behavior in this environment.

