### PR TITLE
Treat undefined same as true for isTrustedFolder

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
@@ -136,6 +136,24 @@ describe('ToolConfirmationMessage', () => {
         expect(lastFrame()).toContain(alwaysAllowText);
       });
 
+      it('should show "allow always" when folder trust is undefined', () => {
+        const mockConfig = {
+          isTrustedFolder: () => undefined,
+          getIdeMode: () => false,
+        } as unknown as Config;
+
+        const { lastFrame } = renderWithProviders(
+          <ToolConfirmationMessage
+            confirmationDetails={details}
+            config={mockConfig}
+            availableTerminalHeight={30}
+            terminalWidth={80}
+          />,
+        );
+
+        expect(lastFrame()).toContain(alwaysAllowText);
+      });
+
       it('should NOT show "allow always" when folder is untrusted', () => {
         const mockConfig = {
           isTrustedFolder: () => false,

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -56,6 +56,8 @@ export const ToolConfirmationMessage: React.FC<
     onConfirm(outcome);
   };
 
+  const isTrustedFolder = config?.isTrustedFolder() !== false;
+
   useKeypress(
     (key) => {
       if (!isFocused) return;
@@ -129,7 +131,7 @@ export const ToolConfirmationMessage: React.FC<
       label: 'Yes, allow once',
       value: ToolConfirmationOutcome.ProceedOnce,
     });
-    if (config?.isTrustedFolder()) {
+    if (isTrustedFolder) {
       options.push({
         label: 'Yes, allow always',
         value: ToolConfirmationOutcome.ProceedAlways,
@@ -168,7 +170,7 @@ export const ToolConfirmationMessage: React.FC<
       label: 'Yes, allow once',
       value: ToolConfirmationOutcome.ProceedOnce,
     });
-    if (config?.isTrustedFolder()) {
+    if (isTrustedFolder) {
       options.push({
         label: `Yes, allow always ...`,
         value: ToolConfirmationOutcome.ProceedAlways,
@@ -208,7 +210,7 @@ export const ToolConfirmationMessage: React.FC<
       label: 'Yes, allow once',
       value: ToolConfirmationOutcome.ProceedOnce,
     });
-    if (config?.isTrustedFolder()) {
+    if (isTrustedFolder) {
       options.push({
         label: 'Yes, allow always',
         value: ToolConfirmationOutcome.ProceedAlways,
@@ -253,7 +255,7 @@ export const ToolConfirmationMessage: React.FC<
       label: 'Yes, allow once',
       value: ToolConfirmationOutcome.ProceedOnce,
     });
-    if (config?.isTrustedFolder()) {
+    if (isTrustedFolder) {
       options.push({
         label: `Yes, always allow tool "${mcpProps.toolName}" from server "${mcpProps.serverName}"`,
         value: ToolConfirmationOutcome.ProceedAlwaysTool, // Cast until types are updated

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -685,4 +685,18 @@ describe('setApprovalMode with folder trust', () => {
     expect(() => config.setApprovalMode(ApprovalMode.AUTO_EDIT)).not.toThrow();
     expect(() => config.setApprovalMode(ApprovalMode.DEFAULT)).not.toThrow();
   });
+
+  it('should NOT throw an error when setting any mode if trustedFolder is undefined', () => {
+    const config = new Config({
+      sessionId: 'test',
+      targetDir: '.',
+      debugMode: false,
+      model: 'test-model',
+      cwd: '.',
+      trustedFolder: undefined, // Undefined
+    });
+    expect(() => config.setApprovalMode(ApprovalMode.YOLO)).not.toThrow();
+    expect(() => config.setApprovalMode(ApprovalMode.AUTO_EDIT)).not.toThrow();
+    expect(() => config.setApprovalMode(ApprovalMode.DEFAULT)).not.toThrow();
+  });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -564,7 +564,7 @@ export class Config {
   }
 
   setApprovalMode(mode: ApprovalMode): void {
-    if (!this.isTrustedFolder() && mode !== ApprovalMode.DEFAULT) {
+    if (this.isTrustedFolder() === false && mode !== ApprovalMode.DEFAULT) {
       throw new Error(
         'Cannot enable privileged approval modes in an untrusted folder.',
       );


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to https://github.com/google-gemini/maintainers-gemini-cli/issues/642
