### PR TITLE
fix(mcp): Fix dynamic client registration for Auth Servers with path components

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -165,6 +165,7 @@ Use the `/mcp auth` command to manage OAuth authentication:
 - **`clientId`** (string): OAuth client identifier (optional with dynamic registration)
 - **`clientSecret`** (string): OAuth client secret (optional for public clients)
 - **`authorizationUrl`** (string): OAuth authorization endpoint (auto-discovered if omitted)
+- **`registrationUrl`** (string): OAuth client registration endpoint (auto-discovered if omitted)
 - **`tokenUrl`** (string): OAuth token endpoint (auto-discovered if omitted)
 - **`scopes`** (string[]): Required OAuth scopes
 - **`redirectUri`** (string): Custom redirect URI (defaults to `http://localhost:7777/oauth/callback`)

--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -95,6 +95,7 @@ describe('MCPOAuthProvider', () => {
     clientId: 'test-client-id',
     clientSecret: 'test-client-secret',
     authorizationUrl: 'https://auth.example.com/authorize',
+    registrationUrl: 'https://auth.example.com/register',
     tokenUrl: 'https://auth.example.com/token',
     scopes: ['read', 'write'],
     redirectUri: 'http://localhost:7777/oauth/callback',
@@ -317,6 +318,7 @@ describe('MCPOAuthProvider', () => {
     it('should perform dynamic client registration when no client ID provided', async () => {
       const configWithoutClient = { ...mockConfig };
       delete configWithoutClient.clientId;
+      delete configWithoutClient.registrationUrl; // to test auto-discover
 
       const mockRegistrationResponse: OAuthClientRegistrationResponse = {
         client_id: 'dynamic_client_id',

--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -142,6 +142,74 @@ describe('OAuthUtils', () => {
     });
   });
 
+  describe('discoverAuthorizationServerMetadata', () => {
+    const mockAuthServerMetadata: OAuthAuthorizationServerMetadata = {
+      issuer: 'https://auth.example.com',
+      authorization_endpoint: 'https://auth.example.com/authorize',
+      token_endpoint: 'https://auth.example.com/token',
+      scopes_supported: ['read', 'write'],
+    };
+
+    it('should handle URLs without path components correctly', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockAuthServerMetadata),
+        });
+
+      const result = await OAuthUtils.discoverAuthorizationServerMetadata(
+        'https://auth.example.com/',
+      );
+
+      expect(result).toEqual(mockAuthServerMetadata);
+
+      expect(mockFetch).nthCalledWith(
+        1,
+        'https://auth.example.com/.well-known/oauth-authorization-server',
+      );
+      expect(mockFetch).nthCalledWith(
+        2,
+        'https://auth.example.com/.well-known/openid-configuration',
+      );
+    });
+
+    it('should handle URLs with path components correctly', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockAuthServerMetadata),
+        });
+
+      const result = await OAuthUtils.discoverAuthorizationServerMetadata(
+        'https://auth.example.com/mcp',
+      );
+
+      expect(result).toEqual(mockAuthServerMetadata);
+
+      expect(mockFetch).nthCalledWith(
+        1,
+        'https://auth.example.com/.well-known/oauth-authorization-server/mcp',
+      );
+      expect(mockFetch).nthCalledWith(
+        2,
+        'https://auth.example.com/.well-known/openid-configuration/mcp',
+      );
+      expect(mockFetch).nthCalledWith(
+        3,
+        'https://auth.example.com/mcp/.well-known/openid-configuration',
+      );
+    });
+  });
+
   describe('metadataToOAuthConfig', () => {
     it('should convert metadata to OAuth config', () => {
       const metadata: OAuthAuthorizationServerMetadata = {

--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -215,6 +215,7 @@ describe('OAuthUtils', () => {
       const metadata: OAuthAuthorizationServerMetadata = {
         issuer: 'https://auth.example.com',
         authorization_endpoint: 'https://auth.example.com/authorize',
+        registration_endpoint: 'https://auth.example.com/register',
         token_endpoint: 'https://auth.example.com/token',
         scopes_supported: ['read', 'write'],
       };
@@ -223,6 +224,7 @@ describe('OAuthUtils', () => {
 
       expect(config).toEqual({
         authorizationUrl: 'https://auth.example.com/authorize',
+        registrationUrl: 'https://auth.example.com/register',
         tokenUrl: 'https://auth.example.com/token',
         scopes: ['read', 'write'],
       });

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -135,6 +135,7 @@ export class OAuthUtils {
   ): MCPOAuthConfig {
     return {
       authorizationUrl: metadata.authorization_endpoint,
+      registrationUrl: metadata.registration_endpoint,
       tokenUrl: metadata.token_endpoint,
       scopes: metadata.scopes_supported || [],
     };


### PR DESCRIPTION
## TLDR

1. Enhance metadata discovery to handle URLs with path components more robustly
2. Add a registrationUrl field to OAuth config

This PR is a sequel to #6863 

## Dive Deeper

In oauth-provider.ts: `authenticate()` when no client ID is provided, the original code uses `config.AuthorizationUrl` to construct well-known endpoints to fetch metadata for registration endpoint. This doesn't work well with Auth Servers that have path components in their URL. For example, GitHub's authorization URL is https://github.com/login/oauth/authorize, while its metadata is located at https://github.com/.well-known/oauth-authorization-server/login/oauth. That being said, GitHub doesn't support dynamic client registration anyways, so this hasn't raised a concern.

To address this issue, a minor refactoring was done to utilize registration endpoint that was discovered in the previous step, instead of trying to discover auth server metadata for a second time. A `registrationUrl` field was added to OAuth config to help with this refactoring.

Scenarios that this change should make work while existing code doesn't:
1. An authorization server has its metadata stored in a well-known endpoint consisting of a path component, supports dynamic client registration, and clientID was not provided in settings.json.
2. No client ID but an authorizationUrl is provided in settings.json, and metadata discovery fails with the provided authorizationUrl. This can now work if a valid registrationUrl is also provided.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✔️  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |