### PR TITLE
Downgrade version of ripgrep to the version from 7 months ago without a node 22 dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@lvce-editor/ripgrep": "^2.1.0",
+        "@lvce-editor/ripgrep": "^1.6.0",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0"
       },
@@ -1470,9 +1470,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/ripgrep": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-2.1.0.tgz",
-      "integrity": "sha512-pZObE9Y4x9Prn1c5cmTqHMv4ezHUaYi1qex9TD7YSXtkmoXUyDpYaDUWg56GBpeMUCprtPAhw9u26n6u8AKJyA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-1.6.0.tgz",
+      "integrity": "sha512-880taWBVULNXmcPHXdxnFUI0FvLErBOjY9OigMXEsLZ2Q1rjcm6LixOkaccKWC8qFMpzm/ldkO7WOMK+ZRfk5Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1480,13 +1480,10 @@
         "execa": "^9.5.2",
         "extract-zip": "^2.0.1",
         "fs-extra": "^11.3.0",
-        "got": "^14.4.7",
+        "got": "^14.4.5",
         "path-exists": "^5.0.0",
         "tempy": "^3.1.0",
         "xdg-basedir": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@lvce-editor/ripgrep/node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "@lvce-editor/ripgrep": "^2.1.0",
+    "@lvce-editor/ripgrep": "^1.6.0",
     "simple-git": "^3.28.0",
     "strip-ansi": "^7.1.0"
   },


### PR DESCRIPTION
## TLDR

the version of the lvce-editor/ripgrep package used when the setting to enable ripgrep is enabled accidentally had a node 22 dependency (although doubt it really needs it).
Switched to the version of this package from 7 months ago without the dependency.
As a follow up, we should add a test that verifies we do not add any node dependencies that require a later node version than we intend to support.

## Testing

Set `  "useRipgrep": true` in your settings.json

Ask Gemini CLI to find all files for text

For example "what files include the term help"
