### PR TITLE
Build docker image before testing.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
         run: |-
           npm run preflight
           npm run test:integration:sandbox:none
+          npm run build:sandbox
           npm run test:integration:sandbox:docker
 
       - name: 'Configure Git User'


### PR DESCRIPTION
We need to build the image as it hasn't been pushed to AR at this point in the build process.