### PR TITLE
Print error when failing to build sandbox

### DIFF
--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -62,7 +62,7 @@ try {
 } catch (e) {
   console.warn('ERROR: could not detect sandbox container command');
   console.error(e);
-  process.exit(1);
+  process.exit(0);
 }
 
 if (sandboxCommand === 'sandbox-exec') {

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -62,7 +62,7 @@ try {
 } catch (e) {
   console.warn('ERROR: could not detect sandbox container command');
   console.error(e);
-  process.exit(0);
+  process.exit(1);
 }
 
 if (sandboxCommand === 'sandbox-exec') {

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -59,8 +59,9 @@ try {
   sandboxCommand = execSync('node scripts/sandbox_command.js')
     .toString()
     .trim();
-} catch {
+} catch (e) {
   console.warn('ERROR: could not detect sandbox container command');
+  console.error(e);
   process.exit(0);
 }
 


### PR DESCRIPTION
Printing the error will help us diagnose why it's failing in the release action.