### PR TITLE
Fix shell argument parsing in windows

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -290,7 +290,7 @@ describe('ShellExecutionService', () => {
 
       expect(mockPtySpawn).toHaveBeenCalledWith(
         'cmd.exe',
-        ['/c', 'dir "foo bar"'],
+        '/c dir "foo bar"',
         expect.any(Object),
       );
     });

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -141,6 +141,7 @@ export class ShellExecutionService {
       const child = cpSpawn(commandToExecute, [], {
         cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
+        windowsVerbatimArguments: true,
         shell: isWindows ? true : 'bash',
         detached: !isWindows,
         env: {
@@ -322,7 +323,7 @@ export class ShellExecutionService {
       const isWindows = os.platform() === 'win32';
       const shell = isWindows ? 'cmd.exe' : 'bash';
       const args = isWindows
-        ? ['/c', commandToExecute]
+        ? `/c ${commandToExecute}`
         : ['-c', commandToExecute];
 
       const ptyProcess = ptyInfo?.module.spawn(shell, args, {


### PR DESCRIPTION
## TLDR

Fixes shell argument parsing in windows.

## Dive Deeper

We now support shell execution through both child_process spawn() and node_pty. This PR fixes both of them.

## Reviewer Test Plan

I ran it on windows and had it execute the following prompt:

`Create a file called "derp.txt" containing "hello world" and commit it with the comment "foo  #C   bar".`

I ran this both with and without `shouldUseNodePtyShell:true`

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | x  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/gemini-cli/issues/3015