### PR TITLE
fix(tests): Fix Firebase Studio IDE detection tests

### DIFF
--- a/packages/core/src/ide/detect-ide.test.ts
+++ b/packages/core/src/ide/detect-ide.test.ts
@@ -76,11 +76,15 @@ describe('detectIde', () => {
 
   it('should detect VSCode when no other IDE is detected and command includes "code"', () => {
     vi.stubEnv('TERM_PROGRAM', 'vscode');
+    vi.stubEnv('FIREBASE_DEPLOY_AGENT', '');
+    vi.stubEnv('MONOSPACE_ENV', '');
     expect(detectIde(ideProcessInfo)).toBe(DetectedIde.VSCode);
   });
 
   it('should detect VSCodeFork when no other IDE is detected and command does not include "code"', () => {
     vi.stubEnv('TERM_PROGRAM', 'vscode');
+    vi.stubEnv('FIREBASE_DEPLOY_AGENT', '');
+    vi.stubEnv('MONOSPACE_ENV', '');
     expect(detectIde(ideProcessInfoNoCode)).toBe(DetectedIde.VSCodeFork);
   });
 

--- a/packages/core/src/ide/detect-ide.test.ts
+++ b/packages/core/src/ide/detect-ide.test.ts
@@ -62,12 +62,6 @@ describe('detectIde', () => {
     expect(detectIde(ideProcessInfo)).toBe(DetectedIde.Trae);
   });
 
-  it('should detect Firebase Studio via FIREBASE_DEPLOY_AGENT', () => {
-    vi.stubEnv('TERM_PROGRAM', 'vscode');
-    vi.stubEnv('FIREBASE_DEPLOY_AGENT', 'true');
-    expect(detectIde(ideProcessInfo)).toBe(DetectedIde.FirebaseStudio);
-  });
-
   it('should detect Firebase Studio via MONOSPACE_ENV', () => {
     vi.stubEnv('TERM_PROGRAM', 'vscode');
     vi.stubEnv('MONOSPACE_ENV', 'true');
@@ -76,14 +70,12 @@ describe('detectIde', () => {
 
   it('should detect VSCode when no other IDE is detected and command includes "code"', () => {
     vi.stubEnv('TERM_PROGRAM', 'vscode');
-    vi.stubEnv('FIREBASE_DEPLOY_AGENT', '');
     vi.stubEnv('MONOSPACE_ENV', '');
     expect(detectIde(ideProcessInfo)).toBe(DetectedIde.VSCode);
   });
 
   it('should detect VSCodeFork when no other IDE is detected and command does not include "code"', () => {
     vi.stubEnv('TERM_PROGRAM', 'vscode');
-    vi.stubEnv('FIREBASE_DEPLOY_AGENT', '');
     vi.stubEnv('MONOSPACE_ENV', '');
     expect(detectIde(ideProcessInfoNoCode)).toBe(DetectedIde.VSCodeFork);
   });

--- a/packages/core/src/ide/detect-ide.ts
+++ b/packages/core/src/ide/detect-ide.ts
@@ -85,7 +85,7 @@ export function detectIdeFromEnv(): DetectedIde {
   if (process.env['TERM_PRODUCT'] === 'Trae') {
     return DetectedIde.Trae;
   }
-  if (process.env['FIREBASE_DEPLOY_AGENT'] || process.env['MONOSPACE_ENV']) {
+  if (process.env['MONOSPACE_ENV']) {
     return DetectedIde.FirebaseStudio;
   }
   return DetectedIde.VSCode;

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -277,6 +277,7 @@ describe('ClearcutLogger', () => {
         env: {
           CURSOR_TRACE_ID: 'abc123',
           GITHUB_SHA: undefined,
+          TERM_PROGRAM: 'vscode',
         },
         expectedValue: 'cursor',
       },
@@ -292,6 +293,7 @@ describe('ClearcutLogger', () => {
         env: {
           MONOSPACE_ENV: 'true',
           GITHUB_SHA: undefined,
+          TERM_PROGRAM: 'vscode',
         },
         expectedValue: 'firebasestudio',
       },
@@ -299,6 +301,7 @@ describe('ClearcutLogger', () => {
         env: {
           __COG_BASHRC_SOURCED: 'true',
           GITHUB_SHA: undefined,
+          TERM_PROGRAM: 'vscode',
         },
         expectedValue: 'devin',
       },
@@ -306,6 +309,7 @@ describe('ClearcutLogger', () => {
         env: {
           CLOUD_SHELL: 'true',
           GITHUB_SHA: undefined,
+          TERM_PROGRAM: 'vscode',
         },
         expectedValue: 'cloudshell',
       },

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -284,6 +284,8 @@ describe('ClearcutLogger', () => {
         env: {
           TERM_PROGRAM: 'vscode',
           GITHUB_SHA: undefined,
+          MONOSPACE_ENV: '',
+          FIREBASE_DEPLOY_AGENT: '',
         },
         expectedValue: 'vscode',
       },
@@ -315,7 +317,6 @@ describe('ClearcutLogger', () => {
         for (const [key, value] of Object.entries(env)) {
           vi.stubEnv(key, value);
         }
-        vi.stubEnv('TERM_PROGRAM', 'vscode');
         const event = logger?.createLogEvent(EventNames.API_ERROR, []);
         expect(event?.event_metadata[0][3]).toEqual({
           gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -285,7 +285,6 @@ describe('ClearcutLogger', () => {
           TERM_PROGRAM: 'vscode',
           GITHUB_SHA: undefined,
           MONOSPACE_ENV: '',
-          FIREBASE_DEPLOY_AGENT: '',
         },
         expectedValue: 'vscode',
       },


### PR DESCRIPTION
## TLDR
Adds Firebase Studio to IDE detection and fixes IDE detection test cases when running in Firebase Studio.

This commit fixes the tests by unsetting the environment variables that are used to detect Firebase Studio in the tests that are specifically checking for VS Code.

This update focuses detection on `MONOSPACE_ENV`, the official environment variable. Previously the tests checked for `FIREBASE_DEPLOY_AGENT` which is not an official environment variable for checking for Firebase Studio.

## Dive Deeper

IDE detection tests failed when running in Firebase Studio because the test environment was not fully isolated. This caused the tests to incorrectly identify the IDE as Firebase Studio instead of VS Code.

This commit fixes the tests by unsetting the environment variables that are used to detect Firebase Studio in the tests that are specifically checking for VS Code.

```
 │    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯                                                                                                                                                         │
 │                                                                                                                                                                                           │
 │     FAIL  src/ide/detect-ide.test.ts > detectIde > should detect VSCode when no other IDE is detected and command includes "code"                                                         │
 │    AssertionError: expected 'firebasestudio' to be 'vscode' // Object.is equality                                                                                                         │
 │                                                                                                                                                                                           │
 │    Expected: "vscode"                                                                                                                                                                     │
 │    Received: "firebasestudio"                                                                                                                                                             │
 │                                                                                                                                                                                           │
 │     ❯ src/ide/detect-ide.test.ts:79:39                                                                                                                                                    │
 │         77|   it('should detect VSCode when no other IDE is detected and command i…                                                                                                       │
 │         78|     vi.stubEnv('TERM_PROGRAM', 'vscode');                                                                                                                                     │
 │         79|     expect(detectIde(ideProcessInfo)).toBe(DetectedIde.VSCode);                                                                                                               │
 │           |                                       ^                                                                                                                                       │
 │         80|   });                                                                                                                                                                         │
 │         81|                                                                                                                                                                               │
 │                                                                                                                                                                                           │
 │    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯                                                                                                                                                         │
 │                                                                                                                                                                                           │
 │     FAIL  src/ide/detect-ide.test.ts > detectIde > should detect VSCodeFork when no other IDE is detected and command does not include "code"                                             │
 │    AssertionError: expected 'firebasestudio' to be 'vscodefork' // Object.is equality                                                                                                     │
 │                                                                                                                                                                                           │
 │    Expected: "vscodefork"                                                                                                                                                                 │
 │    Received: "firebasestudio"                                                                                                                                                             │
 │                                                                                                                                                                                           │
 │     ❯ src/ide/detect-ide.test.ts:84:45                                                                                                                                                    │
 │         82|   it('should detect VSCodeFork when no other IDE is detected and comma…                                                                                                       │
 │         83|     vi.stubEnv('TERM_PROGRAM', 'vscode');                                                                                                                                     │
 │         84|     expect(detectIde(ideProcessInfoNoCode)).toBe(DetectedIde.VSCodeFor…                                                                                                       │
 │           |                                             ^                                                                                                                                 │
 │         85|   });                                                                                                                                                                         │
 │         86|                                                                                                                                                                               │
 │                                                                                                                                                                                           │
 │    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯                                                                                                                                                         │
 │                                                                                                                                                                                           │
 │     FAIL  src/telemetry/clearcut-logger/clearcut-logger.test.ts > ClearcutLogger > createLogEvent > logs the current surface as 'vscode', preempting vscode detection                     │
 │    AssertionError: expected { gemini_cli_key: 39, …(1) } to deeply equal { gemini_cli_key: 39, value: 'vscode' }                                                                          │
 │                                                                                                                                                                                           │
 │    - Expected                                                                                                                                                                             │
 │    + Received                                                                                                                                                                             │
 │                                                                                                                                                                                           │
 │      {                                                                                                                                                                                    │
 │        "gemini_cli_key": 39,                                                                                                                                                              │
 │    -   "value": "vscode",                                                                                                                                                                 │
 │    +   "value": "firebasestudio",                                                                                                                                                         │
 │      }                                                                                                                                                                                    │
 │                                                                                                                                                                                           │
 │     ❯ src/telemetry/clearcut-logger/clearcut-logger.test.ts:320:45                                                                                                                        │
 │        318|         vi.stubEnv('TERM_PROGRAM', 'vscode');                                                                                                                                 │
 │        319|         const event = logger?.createLogEvent(EventNames.API_ERROR, []);                                                                                                       │
 │        320|         expect(event?.event_metadata[0][3]).toEqual({                                                                                                                         │
 │           |                                             ^                                                                                                                                 │
 │        321|           gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,                                                                                                                │
 │        322|           value: expectedValue,                                                                                                                                               │
 │                                                                                                                                                                                           │
 │    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯     
 ```

## Reviewer Test Plan
1. Open @davideast's fork of the Gemini CLI in Firebase Studio.
2. Run `git checkout fix/failing-tests-firebasestudio`
3. Run `npm run preflight` and verify tests pass:
   - `src/telemetry/clearcut-logger/clearcut-logger.test.ts`
   - `src/ide/detect-ide.test.ts`
   
<a href="https://studio.firebase.google.com/import?url=https%3A%2F%2Fgithub.com%2Fdavideast%2Fgemini-cli">
  <picture>
    <source
      media="(prefers-color-scheme: dark)"
      srcset="https://cdn.firebasestudio.dev/btn/open_dark_32.svg">
    <source
      media="(prefers-color-scheme: light)"
      srcset="https://cdn.firebasestudio.dev/btn/open_light_32.svg">
    <img
      height="32"
      alt="Open in Firebase Studio"
      src="https://cdn.firebasestudio.dev/btn/open_blue_32.svg">
  </picture>
</a>


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ✅  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
