### PR TITLE
fix(cli): make Ctrl+C UI test less flaky

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -1576,28 +1576,52 @@ describe('App UI', () => {
   describe('Ctrl+C behavior', () => {
     it('should call cancel but only clear the prompt when a tool is executing', async () => {
       const mockCancel = vi.fn();
+      let onCancelSubmitCallback = () => {};
 
       // Simulate a tool in the "Executing" state.
-      vi.mocked(useGeminiStream).mockReturnValue({
-        streamingState: StreamingState.Responding,
-        submitQuery: vi.fn(),
-        initError: null,
-        pendingHistoryItems: [
-          {
-            type: 'tool_group',
-            tools: [
+      vi.mocked(useGeminiStream).mockImplementation(
+        (
+          _client,
+          _history,
+          _addItem,
+          _config,
+          _onDebugMessage,
+          _handleSlashCommand,
+          _shellModeActive,
+          _getPreferredEditor,
+          _onAuthError,
+          _performMemoryRefresh,
+          _modelSwitchedFromQuotaError,
+          _setModelSwitchedFromQuotaError,
+          _onEditorClose,
+          onCancelSubmit, // Capture the cancel callback from App.tsx
+        ) => {
+          onCancelSubmitCallback = onCancelSubmit;
+          return {
+            streamingState: StreamingState.Responding,
+            submitQuery: vi.fn(),
+            initError: null,
+            pendingHistoryItems: [
               {
-                name: 'test_tool',
-                status: 'Executing',
-                result: '',
-                args: {},
+                type: 'tool_group',
+                tools: [
+                  {
+                    name: 'test_tool',
+                    status: 'Executing',
+                    result: '',
+                    args: {},
+                  },
+                ],
               },
             ],
-          },
-        ],
-        thought: null,
-        cancelOngoingRequest: mockCancel,
-      });
+            thought: null,
+            cancelOngoingRequest: () => {
+              mockCancel();
+              onCancelSubmitCallback(); // <--- This is the key change
+            },
+          };
+        },
+      );
 
       const { stdin, lastFrame, unmount } = renderWithProviders(
         <App

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -1624,7 +1624,9 @@ describe('App UI', () => {
 
       // The prompt should now be empty as a result of the cancellation handler's logic.
       // We can't directly test the buffer's state, but we can see the rendered output.
-      expect(lastFrame()).not.toContain('some text');
+      await waitFor(() => {
+        expect(lastFrame()).not.toContain('some text');
+      });
     });
   });
 });


### PR DESCRIPTION
## TLDR

This pull request refactors and fixes a flaky test (`should call cancel but only clear the prompt when a tool is executing`) in `packages/cli/src/ui/App.test.tsx`. The original test was passing for the wrong reason, relying on an internal `Ctrl+C` handler in a child component (`InputPrompt`) rather than testing the intended cancellation logic in `App.tsx`.

This change modifies the test to correctly mock the `useGeminiStream` hook, allowing it to trigger the `onCancelSubmit` callback and verify that the `App.tsx` component properly clears the input buffer when a tool is executing.

## Dive Deeper

The feedback on the initial fix revealed a significant flaw: the test wasn't verifying the correct code path. The prompt clearing was a side effect of the `InputPrompt`'s own keypress handler, not the result of the cancellation flow within the main `App` component.

The core of the problem was that the mock for `useGeminiStream` provided a simple `vi.fn()` for the `cancelOngoingRequest` function. This prevented the test from ever reaching the `cancelHandlerRef` logic in `App.tsx`.

The refactoring addresses this by:
1.  **Improving the `useGeminiStream` mock:** The mock now uses `vi.mocked(useGeminiStream).mockImplementation(...)` to gain access to the props passed by `App.tsx`.
2.  **Capturing the `onCancelSubmit` callback:** The mock captures the `onCancelSubmit` function that `App.tsx` provides.
3.  **Simulating the correct flow:** The mocked `cancelOngoingRequest` function is updated to call the captured `onCancelSubmit` callback. This correctly simulates the hook notifying the `App` component that a cancellation has occurred.
4.  **Verifying the intended logic:** With this change, the test now correctly asserts that the logic within `App.tsx`'s `cancelHandlerRef` is executed, which clears the prompt's text buffer when a tool is running. The `waitFor` is retained to handle the asynchronous nature of the state update.

This ensures the test is no longer flaky and accurately validates the component's cancellation behavior as intended.

## Reviewer Test Plan

A reviewer can validate the change by running the test suite and confirming that the test passes reliably.

1.  Check out the `fix/flaky-ctrl-c-test` branch.
2.  Run the specific test file multiple times to ensure it passes consistently:
    ```bash
    npm run test -- packages/cli/src/ui/App.test.tsx
    ```
3.  Alternatively, run the full preflight check, which includes all tests:
    ```bash
    npm run preflight
    ```
4.  Confirm that the test `should call cancel but only clear the prompt when a tool is executing` passes consistently.
5.  Review the test's implementation to confirm that it now correctly mocks `useGeminiStream` and tests the logic in `App.tsx`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A
