### PR TITLE
Add 'zedit' command to zed editor configuration

### DIFF
--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -69,7 +69,7 @@ describe('editor utils', () => {
       { editor: 'cursor', commands: ['cursor'], win32Commands: ['cursor'] },
       { editor: 'vim', commands: ['vim'], win32Commands: ['vim'] },
       { editor: 'neovim', commands: ['nvim'], win32Commands: ['nvim'] },
-      { editor: 'zed', commands: ['zed', 'zeditor'], win32Commands: ['zed'] },
+      { editor: 'zed', commands: ['zed', 'zeditor', 'zedit'], win32Commands: ['zed'] },
       { editor: 'emacs', commands: ['emacs'], win32Commands: ['emacs.exe'] },
     ];
 
@@ -169,7 +169,7 @@ describe('editor utils', () => {
         win32Commands: ['windsurf'],
       },
       { editor: 'cursor', commands: ['cursor'], win32Commands: ['cursor'] },
-      { editor: 'zed', commands: ['zed', 'zeditor'], win32Commands: ['zed'] },
+      { editor: 'zed', commands: ['zed', 'zeditor', 'zedit'], win32Commands: ['zed'] },
     ];
 
     for (const { editor, commands, win32Commands } of guiEditors) {

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -60,7 +60,7 @@ const editorCommands: Record<
   cursor: { win32: ['cursor'], default: ['cursor'] },
   vim: { win32: ['vim'], default: ['vim'] },
   neovim: { win32: ['nvim'], default: ['nvim'] },
-  zed: { win32: ['zed'], default: ['zed', 'zeditor'] },
+  zed: { win32: ['zed'], default: ['zed', 'zeditor', 'zedit'] },
   emacs: { win32: ['emacs.exe'], default: ['emacs'] },
 };
 


### PR DESCRIPTION
Introduce the 'zedit' command to the zed editor configuration, enhancing command options for users. Fixes #7190