### PR TITLE
fix: unset GEMINI_API_KEY env var if empty

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -232,6 +232,10 @@ export async function main() {
     delete process.env['GEMINI_API_KEY'];
   }
 
+  if (process.env['GOOGLE_API_KEY']?.trim() === '') {
+    delete process.env['GOOGLE_API_KEY'];
+  }
+
   setMaxSizedBoxDebugging(config.getDebugMode());
 
   await config.initialize();

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -227,6 +227,10 @@ export async function main() {
       );
     }
   }
+  // Empty key causes issues with the GoogleGenAI package.
+  if (process.env['GEMINI_API_KEY']?.trim() === '') {
+    delete process.env['GEMINI_API_KEY'];
+  }
 
   setMaxSizedBoxDebugging(config.getDebugMode());
 


### PR DESCRIPTION
## TLDR
If the `GEMINI_API_KEY` env var is set to empty string and Vertex AI env vars are set, then the `GoogleGenAI` client is initialized with `{"apiKey":"","vertexai":true}` which fails to use Vertex AI.
```
[API Error: {"error":{"code":401,"message":"Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED","details":[{"@type":"type.googleapis.com/google.rpc.DebugInfo","detail":"Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project."},{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"CREDENTIALS_MISSING","domain":"googleapis.com","metadata":{"method":"google.cloud.aiplatform.v1beta1.PredictionService.CountTokens","service":"aiplatform.googleapis.com"}}]}}]
```
This is causing failures for Github Action runtimes. 
<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

Will submit a fix upstream, but handling it here directly.

Fixes: #5747 