### PR TITLE
fix(bug): correct /about command in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,9 +34,12 @@ body:
       description: 'Please paste the full text from the `/about` command run from Gemini CLI. Also include which platform (macOS, Windows, Linux).'
       value: |-
         <details>
+        <summary>Client Information</summary>
+
+        Run `gemini` to enter the interactive CLI, then run the `/about` command.
 
         ```console
-        $ gemini /about
+        /about
         # paste output here
         ```
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,7 +39,7 @@ body:
         Run `gemini` to enter the interactive CLI, then run the `/about` command.
 
         ```console
-        /about
+        > /about
         # paste output here
         ```
 


### PR DESCRIPTION
The bug report template incorrectly instructed users to run `gemini /about` which does not work in non-interactive mode.

This change updates the template to instruct users to first launch `gemini` and then run the `/about` command.

Fixes #7111
