### PR TITLE
Move mockTool into test-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14225,6 +14225,7 @@
         "winston": "^3.17.0"
       },
       "devDependencies": {
+        "@google/gemini-cli-test-utils": "file:../test-utils",
         "@types/express": "^5.0.3",
         "@types/fs-extra": "^11.0.4",
         "@types/supertest": "^6.0.3",
@@ -14788,7 +14789,9 @@
       "version": "0.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "typescript": "^5.3.3"
+        "@google/gemini-cli-core": "file:../core",
+        "typescript": "^5.3.3",
+        "vitest": "^3.1.1"
       },
       "engines": {
         "node": ">=20"

--- a/packages/a2a-server/package.json
+++ b/packages/a2a-server/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
+    "@google/gemini-cli-test-utils": "file:../test-utils",
     "@types/fs-extra": "^11.0.4",
     "@types/supertest": "^6.0.3",
     "@types/tar": "^6.1.13",

--- a/packages/a2a-server/src/agent.test.ts
+++ b/packages/a2a-server/src/agent.test.ts
@@ -33,7 +33,7 @@ import {
   assertTaskCreationAndWorkingStatus,
   createStreamMessageRequest,
 } from './testing_utils.js';
-import { MockTool } from '@google/gemini-cli-core';
+import { MockTool } from '@google/gemini-cli-test-utils';
 
 const mockToolConfirmationFn = async () =>
   ({}) as unknown as ToolCallConfirmationDetails;

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -25,13 +25,10 @@ import type {
   AnyDeclarativeTool,
   AnyToolInvocation,
 } from '@google/gemini-cli-core';
-import {
-  ToolConfirmationOutcome,
-  ApprovalMode,
-  MockTool,
-} from '@google/gemini-cli-core';
+import { ToolConfirmationOutcome, ApprovalMode } from '@google/gemini-cli-core';
 import type { HistoryItemWithoutId, HistoryItemToolGroup } from '../types.js';
 import { ToolCallStatus } from '../types.js';
+import { MockTool } from '@google/gemini-cli-test-utils';
 
 // Mocks
 vi.mock('@google/gemini-cli-core', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,3 @@ export * from './telemetry/index.js';
 export { sessionId } from './utils/session.js';
 export * from './utils/browser.js';
 export { Storage } from './config/storage.js';
-
-// Export test utils
-export * from './test-utils/index.js';

--- a/packages/core/src/test-utils/index.ts
+++ b/packages/core/src/test-utils/index.ts
@@ -1,7 +1,0 @@
-/**
- * @license
- * Copyright 2025 Google LLC
- * SPDX-License-Identifier: Apache-2.0
- */
-
-export * from './mock-tool.js';

--- a/packages/test-utils/index.ts
+++ b/packages/test-utils/index.ts
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export * from './src/file-system-test-helpers.js';
+export * from './src/index.js';

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -10,7 +10,9 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "@google/gemini-cli-core": "file:../core",
+    "vitest": "^3.1.1"
   },
   "engines": {
     "node": ">=20"

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -5,3 +5,4 @@
  */
 
 export * from './file-system-test-helpers.js';
+export * from './mock-tool.js';

--- a/packages/test-utils/src/mock-tool.ts
+++ b/packages/test-utils/src/mock-tool.ts
@@ -9,12 +9,12 @@ import type {
   ToolCallConfirmationDetails,
   ToolInvocation,
   ToolResult,
-} from '../tools/tools.js';
+} from '@google/gemini-cli-core';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,
-} from '../tools/tools.js';
+} from '@google/gemini-cli-core';
 
 type MockToolOptions = {
   name: string;


### PR DESCRIPTION
## TLDR

This fixes a production error introduced in https://github.com/google-gemini/gemini-cli/pull/7228, exporting vitest causes crash in npm run start. 

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

Confirm the followig work:
`npm run test`
`npm run start`
`npm run start:a2a-server`

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
