### PR TITLE
Fix diff rendering in windows.

### DIFF
--- a/packages/cli/src/ui/components/messages/DiffRenderer.test.tsx
+++ b/packages/cli/src/ui/components/messages/DiffRenderer.test.tsx
@@ -9,7 +9,6 @@ import { render } from 'ink-testing-library';
 import { DiffRenderer } from './DiffRenderer.js';
 import * as CodeColorizer from '../../utils/CodeColorizer.js';
 import { vi } from 'vitest';
-import { EOL } from 'node:os';
 
 describe('<OverflowProvider><DiffRenderer /></OverflowProvider>', () => {
   const mockColorizeCode = vi.spyOn(CodeColorizer, 'colorizeCode');
@@ -30,7 +29,7 @@ index 0000000..e69de29
 +++ b/test.py
 @@ -0,0 +1 @@
 +print("hello world")
-`.replace(/\n/g, EOL);
+`;
     render(
       <OverflowProvider>
         <DiffRenderer
@@ -58,7 +57,7 @@ index 0000000..e69de29
 +++ b/test.unknown
 @@ -0,0 +1 @@
 +some content
-`.replace(/\n/g, EOL);
+`;
     render(
       <OverflowProvider>
         <DiffRenderer
@@ -86,7 +85,7 @@ index 0000000..e69de29
 +++ b/test.txt
 @@ -0,0 +1 @@
 +some text content
-`.replace(/\n/g, EOL);
+`;
     render(
       <OverflowProvider>
         <DiffRenderer diffContent={newFileDiffContent} terminalWidth={80} />
@@ -110,7 +109,7 @@ index 0000001..0000002 100644
 @@ -1 +1 @@
 -old line
 +new line
-`.replace(/\n/g, EOL);
+`;
     const { lastFrame } = render(
       <OverflowProvider>
         <DiffRenderer
@@ -140,7 +139,7 @@ index 0000001..0000002 100644
 index 1234567..1234567 100644
 --- a/file.txt
 +++ b/file.txt
-`.replace(/\n/g, EOL);
+`;
     const { lastFrame } = render(
       <OverflowProvider>
         <DiffRenderer
@@ -177,7 +176,7 @@ index 123..456 100644
 @@ -10,2 +10,2 @@
  context line 10
  context line 11
-`.replace(/\n/g, EOL);
+`;
     const { lastFrame } = render(
       <OverflowProvider>
         <DiffRenderer
@@ -214,7 +213,7 @@ index abc..def 100644
  context line 13
  context line 14
  context line 15
-`.replace(/\n/g, EOL);
+`;
     const { lastFrame } = render(
       <OverflowProvider>
         <DiffRenderer
@@ -248,7 +247,7 @@ index 123..789 100644
 -const anotherOld = 'test';
 +const anotherNew = 'test';
  console.log('end of second hunk');
-`.replace(/\n/g, EOL);
+`;
 
     it.each([
       {
@@ -318,7 +317,7 @@ fileDiff Index: file.txt
 -const anotherOld = 'test';
 +const anotherNew = 'test';
 \\ No newline at end of file  
-`.replace(/\n/g, EOL);
+`;
     const { lastFrame } = render(
       <OverflowProvider>
         <DiffRenderer
@@ -348,7 +347,7 @@ fileDiff Index: Dockerfile
 +RUN npm install
 +RUN npm run build
 \\ No newline at end of file  
-`.replace(/\n/g, EOL);
+`;
     const { lastFrame } = render(
       <OverflowProvider>
         <DiffRenderer

--- a/packages/cli/src/ui/components/messages/DiffRenderer.tsx
+++ b/packages/cli/src/ui/components/messages/DiffRenderer.tsx
@@ -6,7 +6,6 @@
 
 import type React from 'react';
 import { Box, Text } from 'ink';
-import { EOL } from 'node:os';
 import { Colors } from '../../colors.js';
 import crypto from 'node:crypto';
 import { colorizeCode, colorizeLine } from '../../utils/CodeColorizer.js';
@@ -21,7 +20,7 @@ interface DiffLine {
 }
 
 function parseDiffWithLineNumbers(diffContent: string): DiffLine[] {
-  const lines = diffContent.split(EOL);
+  const lines = diffContent.split('\n');
   const result: DiffLine[] = [];
   let currentOldLine = 0;
   let currentNewLine = 0;


### PR DESCRIPTION
## TLDR

Fix diff renderer to always look for /n regardless of OS since that's what diff outputs.

## Reviewer Test Plan

Start up on windows and ask it to make an edit.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | x  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes: https://github.com/google-gemini/gemini-cli/issues/4617