### PR TITLE
fix(e2e): add missing deps to fix sandbox module not found errors in cli/core

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "open": "^10.1.2",
     "react": "^19.1.0",
     "read-package-up": "^11.0.0",
+    "simple-git": "^3.28.0",
     "shell-quote": "^1.8.3",
     "string-width": "^7.1.0",
     "strip-ansi": "^7.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "@google/genai": "1.13.0",
+    "@lvce-editor/ripgrep": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.11.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-logs-otlp-grpc": "^0.203.0",


### PR DESCRIPTION
## TLDR

Sandbox runs (and e2e tests) are failing due to module not found errors. 

## Dive Deeper

Missing ripgrep and simple-git in cli/core packages.

## Reviewer Test Plan

Run `VERBOSE=true KEEP_OUTPUT=true npm run test:integration:sandbox:docker`.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | Yes  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to:
#7247
#7248
#7249
#7252 