### PR TITLE
fix(e2e): skip flaky stdin context test

### DIFF
--- a/integration-tests/stdin-context.test.ts
+++ b/integration-tests/stdin-context.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import { TestRig, printDebugInfo, validateModelOutput } from './test-helper.js';
 
-describe('stdin context', () => {
+describe.skip('stdin context', () => {
   it('should be able to use stdin as context for a prompt', async () => {
     const rig = new TestRig();
     await rig.setup('should be able to use stdin as context for a prompt');


### PR DESCRIPTION
## TLDR

Skip flaky stdin context test.

## Dive Deeper

## Reviewer Test Plan

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | Yes  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to:
https://github.com/google-gemini/gemini-cli/issues/7247
https://github.com/google-gemini/gemini-cli/issues/7248
https://github.com/google-gemini/gemini-cli/issues/7249
https://github.com/google-gemini/gemini-cli/issues/7252
