### PR TITLE
Revert "Move mockTool into test-utils (#7245)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14248,7 +14248,6 @@
         "winston": "^3.17.0"
       },
       "devDependencies": {
-        "@google/gemini-cli-test-utils": "file:../test-utils",
         "@types/express": "^5.0.3",
         "@types/fs-extra": "^11.0.4",
         "@types/supertest": "^6.0.3",
@@ -14814,9 +14813,7 @@
       "version": "0.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@google/gemini-cli-core": "file:../core",
-        "typescript": "^5.3.3",
-        "vitest": "^3.1.1"
+        "typescript": "^5.3.3"
       },
       "engines": {
         "node": ">=20"

--- a/packages/a2a-server/package.json
+++ b/packages/a2a-server/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
-    "@google/gemini-cli-test-utils": "file:../test-utils",
     "@types/fs-extra": "^11.0.4",
     "@types/supertest": "^6.0.3",
     "@types/tar": "^6.1.13",

--- a/packages/a2a-server/src/agent.test.ts
+++ b/packages/a2a-server/src/agent.test.ts
@@ -33,7 +33,7 @@ import {
   assertTaskCreationAndWorkingStatus,
   createStreamMessageRequest,
 } from './testing_utils.js';
-import { MockTool } from '@google/gemini-cli-test-utils';
+import { MockTool } from '@google/gemini-cli-core';
 
 const mockToolConfirmationFn = async () =>
   ({}) as unknown as ToolCallConfirmationDetails;

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -25,10 +25,13 @@ import type {
   AnyDeclarativeTool,
   AnyToolInvocation,
 } from '@google/gemini-cli-core';
-import { ToolConfirmationOutcome, ApprovalMode } from '@google/gemini-cli-core';
+import {
+  ToolConfirmationOutcome,
+  ApprovalMode,
+  MockTool,
+} from '@google/gemini-cli-core';
 import type { HistoryItemWithoutId, HistoryItemToolGroup } from '../types.js';
 import { ToolCallStatus } from '../types.js';
-import { MockTool } from '@google/gemini-cli-test-utils';
 
 // Mocks
 vi.mock('@google/gemini-cli-core', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,3 +106,6 @@ export * from './telemetry/index.js';
 export { sessionId } from './utils/session.js';
 export * from './utils/browser.js';
 export { Storage } from './config/storage.js';
+
+// Export test utils
+export * from './test-utils/index.js';

--- a/packages/core/src/test-utils/index.ts
+++ b/packages/core/src/test-utils/index.ts
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export * from './file-system-test-helpers.js';
+export * from './mock-tool.js';

--- a/packages/core/src/test-utils/mock-tool.ts
+++ b/packages/core/src/test-utils/mock-tool.ts
@@ -9,12 +9,12 @@ import type {
   ToolCallConfirmationDetails,
   ToolInvocation,
   ToolResult,
-} from '@google/gemini-cli-core';
+} from '../tools/tools.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,
-} from '@google/gemini-cli-core';
+} from '../tools/tools.js';
 
 type MockToolOptions = {
   name: string;

--- a/packages/test-utils/index.ts
+++ b/packages/test-utils/index.ts
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export * from './src/index.js';
+export * from './src/file-system-test-helpers.js';

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -10,9 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "typescript": "^5.3.3",
-    "@google/gemini-cli-core": "file:../core",
-    "vitest": "^3.1.1"
+    "typescript": "^5.3.3"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
This reverts commit da7901acaf5d75903bde21c12b9911ae15b27fa0.

This adds a circular dependency for test-util is depending on core, and core is depending on test-util.
