### PR TITLE
Refine stream validation to prevent unnecessary retries

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -566,7 +566,6 @@ export class GeminiChat {
     let hasToolCall = false;
     let lastChunk: GenerateContentResponse | null = null;
 
-    // --- FIX: Restore the overall status flag and initialize all flags ---
     let isStreamInvalid = false;
     let firstInvalidChunkEncountered = false;
     let validChunkAfterInvalidEncountered = false;
@@ -592,8 +591,7 @@ export class GeminiChat {
         logInvalidChunk(
           this.config,
           new InvalidChunkEvent('Invalid chunk received from stream.'),
-        );
-        // --- FIX: Set both flags for an invalid chunk ---
+        );        
         isStreamInvalid = true;
         firstInvalidChunkEncountered = true;
       }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -562,30 +562,69 @@ export class GeminiChat {
     userInput: Content,
   ): AsyncGenerator<GenerateContentResponse> {
     const modelResponseParts: Part[] = [];
-    let isStreamInvalid = false;
     let hasReceivedAnyChunk = false;
+    let hasToolCall = false;
+    let lastChunk: GenerateContentResponse | null = null;
+
+    // --- FIX: Restore the overall status flag and initialize all flags ---
+    let isStreamInvalid = false;
+    let firstInvalidChunkEncountered = false;
+    let validChunkAfterInvalidEncountered = false;
 
     for await (const chunk of streamResponse) {
       hasReceivedAnyChunk = true;
+      lastChunk = chunk;
+
       if (isValidResponse(chunk)) {
+        if (firstInvalidChunkEncountered) {
+          // A valid chunk appeared *after* an invalid one.
+          validChunkAfterInvalidEncountered = true;
+        }
+
         const content = chunk.candidates?.[0]?.content;
         if (content?.parts) {
           modelResponseParts.push(...content.parts);
+          if (content.parts.some((part) => part.functionCall)) {
+            hasToolCall = true;
+          }
         }
       } else {
         logInvalidChunk(
           this.config,
           new InvalidChunkEvent('Invalid chunk received from stream.'),
         );
+        // --- FIX: Set both flags for an invalid chunk ---
         isStreamInvalid = true;
+        firstInvalidChunkEncountered = true;
       }
       yield chunk;
     }
 
-    if (isStreamInvalid || !hasReceivedAnyChunk) {
-      throw new EmptyStreamError(
-        'Model stream was invalid or completed without valid content.',
-      );
+    if (!hasReceivedAnyChunk) {
+      throw new EmptyStreamError('Model stream completed without any chunks.');
+    }
+
+    // --- FIX: The entire validation block was restructured for clarity and correctness ---
+    // Only apply complex validation if an invalid chunk was actually found.
+    if (isStreamInvalid) {
+      // Fail immediately if an invalid chunk was not the absolute last chunk.
+      if (validChunkAfterInvalidEncountered) {
+        throw new EmptyStreamError(
+          'Model stream had invalid intermediate chunks without a tool call.',
+        );
+      }
+
+      if (!hasToolCall) {
+        // If the *only* invalid part was the last chunk, we still check its finish reason.
+        const finishReason = lastChunk?.candidates?.[0]?.finishReason;
+        const isSuccessfulFinish =
+          finishReason === 'STOP' || finishReason === 'MAX_TOKENS';
+        if (!isSuccessfulFinish) {
+          throw new EmptyStreamError(
+            'Model stream ended with an invalid chunk and a failed finish reason.',
+          );
+        }
+      }
     }
 
     // Bundle all streamed parts into a single Content object

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -591,7 +591,7 @@ export class GeminiChat {
         logInvalidChunk(
           this.config,
           new InvalidChunkEvent('Invalid chunk received from stream.'),
-        );        
+        );
         isStreamInvalid = true;
         firstInvalidChunkEncountered = true;
       }


### PR DESCRIPTION
## TLDR
The stream processing logic has been updated to prevent unnecessary retries. It now correctly handles streams that are functionally complete but end with an empty part, such as after a tool call or with a valid finishReason (STOP, MAX_TOKENS).
<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper
The previous implementation of processStreamResponse was too aggressive in its validation. It would trigger a retry by throwing an EmptyStreamError if any chunk in the stream was considered invalid (e.g., contained an empty text part). This led to incorrect failures in two legitimate scenarios:

A model response contains a tool call and is then followed by an empty final chunk.

A model response streams valid text and then ends with an empty chunk but provides a successful finishReason like STOP.

In both cases, the stream had successfully completed its primary task, and the empty final chunk did not signify a failure that required a retry.

The decision to throw an EmptyStreamError is now governed by the following rules:

If the stream contains an invalid chunk but a tool call was present, the stream is considered successful. The tool call is treated as the intended output, and the empty part is ignored.

If the stream contains an invalid chunk and no tool call was present, it is only considered successful if two conditions are met:
a. The invalid chunk was the absolute last one (validChunkAfterInvalidEncountered === false).
b. The lastChunk has a successful finishReason (e.g., STOP or MAX_TOKENS).
<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
