### PR TITLE
fix(ide): polyfill import.meta.url for cjs build

### DIFF
--- a/packages/vscode-ide-companion/esbuild.js
+++ b/packages/vscode-ide-companion/esbuild.js
@@ -43,6 +43,12 @@ async function main() {
     outfile: 'dist/extension.cjs',
     external: ['vscode'],
     logLevel: 'silent',
+    banner: {
+      js: `const import_meta = { url: require('url').pathToFileURL(__filename).href };`,
+    },
+    define: {
+      'import.meta.url': 'import_meta.url',
+    },
     plugins: [
       /* add to the end of plugins array */
       esbuildProblemMatcherPlugin,


### PR DESCRIPTION
## TLDR

This change fixes a runtime error that prevented the VSCode extension from activating. The error `TypeError: The "path" argument must be of type string or an instance of URL` was caused by the use of `import.meta.url` in a CommonJS environment where it is not natively supported.

This PR configures the esbuild process to inject a polyfill for `import.meta.url`, resolving the crash on startup.

## Linked issues / bugs
Fixes #7125
