### PR TITLE
fix(settings/env): Ensure that `loadEnvironment` is always called with settings.

### DIFF
--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -10,18 +10,18 @@ import { validateAuthMethod } from './auth.js';
 
 vi.mock('./settings.js', () => ({
   loadEnvironment: vi.fn(),
+  loadSettings: vi.fn().mockReturnValue({
+    merged: vi.fn().mockReturnValue({}),
+  }),
 }));
 
 describe('validateAuthMethod', () => {
-  const originalEnv = process.env;
-
   beforeEach(() => {
     vi.resetModules();
-    process.env = {};
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    vi.unstubAllEnvs();
   });
 
   it('should return null for LOGIN_WITH_GOOGLE', () => {
@@ -34,7 +34,7 @@ describe('validateAuthMethod', () => {
 
   describe('USE_GEMINI', () => {
     it('should return null if GEMINI_API_KEY is set', () => {
-      process.env['GEMINI_API_KEY'] = 'test-key';
+      vi.stubEnv('GEMINI_API_KEY', 'test-key');
       expect(validateAuthMethod(AuthType.USE_GEMINI)).toBeNull();
     });
 
@@ -47,13 +47,13 @@ describe('validateAuthMethod', () => {
 
   describe('USE_VERTEX_AI', () => {
     it('should return null if GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION are set', () => {
-      process.env['GOOGLE_CLOUD_PROJECT'] = 'test-project';
-      process.env['GOOGLE_CLOUD_LOCATION'] = 'test-location';
+      vi.stubEnv('GOOGLE_CLOUD_PROJECT', 'test-project');
+      vi.stubEnv('GOOGLE_CLOUD_LOCATION', 'test-location');
       expect(validateAuthMethod(AuthType.USE_VERTEX_AI)).toBeNull();
     });
 
     it('should return null if GOOGLE_API_KEY is set', () => {
-      process.env['GOOGLE_API_KEY'] = 'test-api-key';
+      vi.stubEnv('GOOGLE_API_KEY', 'test-api-key');
       expect(validateAuthMethod(AuthType.USE_VERTEX_AI)).toBeNull();
     });
 

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -5,10 +5,10 @@
  */
 
 import { AuthType } from '@google/gemini-cli-core';
-import { loadEnvironment } from './settings.js';
+import { loadEnvironment, loadSettings } from './settings.js';
 
-export const validateAuthMethod = (authMethod: string): string | null => {
-  loadEnvironment();
+export function validateAuthMethod(authMethod: string): string | null {
+  loadEnvironment(loadSettings(process.cwd()).merged);
   if (
     authMethod === AuthType.LOGIN_WITH_GOOGLE ||
     authMethod === AuthType.CLOUD_SHELL
@@ -40,4 +40,4 @@ export const validateAuthMethod = (authMethod: string): string | null => {
   }
 
   return 'Invalid auth method selected.';
-};
+}

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -553,34 +553,12 @@ export function setUpCloudShellEnvironment(envFilePath: string | null): void {
   }
 }
 
-export function loadEnvironment(settings?: Settings): void {
+export function loadEnvironment(settings: Settings): void {
   const envFilePath = findEnvFile(process.cwd());
 
   // Cloud Shell environment variable handling
   if (process.env['CLOUD_SHELL'] === 'true') {
     setUpCloudShellEnvironment(envFilePath);
-  }
-
-  // If no settings provided, try to load workspace settings for exclusions
-  let resolvedSettings = settings;
-  if (!resolvedSettings) {
-    const workspaceSettingsPath = new Storage(
-      process.cwd(),
-    ).getWorkspaceSettingsPath();
-    try {
-      if (fs.existsSync(workspaceSettingsPath)) {
-        const workspaceContent = fs.readFileSync(
-          workspaceSettingsPath,
-          'utf-8',
-        );
-        const parsedWorkspaceSettings = JSON.parse(
-          stripJsonComments(workspaceContent),
-        ) as Settings;
-        resolvedSettings = resolveEnvVarsInObject(parsedWorkspaceSettings);
-      }
-    } catch (_e) {
-      // Ignore errors loading workspace settings
-    }
   }
 
   if (envFilePath) {
@@ -591,8 +569,7 @@ export function loadEnvironment(settings?: Settings): void {
       const parsedEnv = dotenv.parse(envFileContent);
 
       const excludedVars =
-        resolvedSettings?.advanced?.excludedEnvVars ||
-        DEFAULT_EXCLUDED_ENV_VARS;
+        settings?.advanced?.excludedEnvVars || DEFAULT_EXCLUDED_ENV_VARS;
       const isProjectEnvFile = !envFilePath.includes(GEMINI_DIR);
 
       for (const key in parsedEnv) {


### PR DESCRIPTION
## TLDR

Previously `loadEnvironment` would just load workstation settings if no settings were provided.  There are lots of cases where we'd want to load merged settings.

## Dive Deeper

Update the `loadEnvironment` call in Auth to use the merged settings, which could potentially mean that various .env variables are pulled in.  I'm not sure what the repercussions are of this or if this was intentional.  It feels accidental to me.

## Reviewer Test Plan

## Testing Matrix


|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

In progress of https://github.com/google-gemini/maintainers-gemini-cli/issues/722