### PR TITLE
fix(trust): Refuse to load extensions from untrusted workspaces

### DIFF
--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -21,9 +21,9 @@ import {
   uninstallExtension,
   updateExtension,
   type Extension,
-  type ExtensionConfig,
 } from './extension.js';
 import {
+  GEMINI_DIR,
   type GeminiCLIExtension,
   type MCPServerConfig,
 } from '@google/gemini-cli-core';
@@ -60,7 +60,7 @@ vi.mock('child_process', async (importOriginal) => {
   };
 });
 
-const EXTENSIONS_DIRECTORY_NAME = path.join('.gemini', 'extensions');
+const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
 
 describe('loadExtensions', () => {
   let tempWorkspaceDir: string;
@@ -175,7 +175,7 @@ describe('loadExtensions', () => {
       version: '2.0.0',
     });
 
-    const settingsDir = path.join(tempWorkspaceDir, '.gemini');
+    const settingsDir = path.join(tempWorkspaceDir, GEMINI_DIR);
     fs.mkdirSync(settingsDir, { recursive: true });
     fs.writeFileSync(
       path.join(settingsDir, 'settings.json'),
@@ -303,7 +303,7 @@ describe('installExtension', () => {
       path.join(os.tmpdir(), 'gemini-cli-test-home-'),
     );
     vi.mocked(os.homedir).mockReturnValue(tempHomeDir);
-    userExtensionsDir = path.join(tempHomeDir, '.gemini', 'extensions');
+    userExtensionsDir = path.join(tempHomeDir, GEMINI_DIR, 'extensions');
     // Clean up before each test
     fs.rmSync(userExtensionsDir, { recursive: true, force: true });
     fs.mkdirSync(userExtensionsDir, { recursive: true });
@@ -403,7 +403,7 @@ describe('uninstallExtension', () => {
       path.join(os.tmpdir(), 'gemini-cli-test-home-'),
     );
     vi.mocked(os.homedir).mockReturnValue(tempHomeDir);
-    userExtensionsDir = path.join(tempHomeDir, '.gemini', 'extensions');
+    userExtensionsDir = path.join(tempHomeDir, GEMINI_DIR, 'extensions');
     // Clean up before each test
     fs.rmSync(userExtensionsDir, { recursive: true, force: true });
     fs.mkdirSync(userExtensionsDir, { recursive: true });
@@ -498,7 +498,7 @@ describe('performWorkspaceExtensionMigration', () => {
 
     expect(failed).toEqual([]);
 
-    const userExtensionsDir = path.join(tempHomeDir, '.gemini', 'extensions');
+    const userExtensionsDir = path.join(tempHomeDir, GEMINI_DIR, 'extensions');
     const userExt1Path = path.join(userExtensionsDir, 'ext1');
     const extensions = loadExtensions(tempWorkspaceDir);
 
@@ -573,7 +573,7 @@ describe('updateExtension', () => {
       path.join(os.tmpdir(), 'gemini-cli-test-home-'),
     );
     vi.mocked(os.homedir).mockReturnValue(tempHomeDir);
-    userExtensionsDir = path.join(tempHomeDir, '.gemini', 'extensions');
+    userExtensionsDir = path.join(tempHomeDir, GEMINI_DIR, 'extensions');
     // Clean up before each test
     fs.rmSync(userExtensionsDir, { recursive: true, force: true });
     fs.mkdirSync(userExtensionsDir, { recursive: true });
@@ -702,7 +702,7 @@ describe('enableExtension', () => {
     tempHomeDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'gemini-cli-test-home-'),
     );
-    userExtensionsDir = path.join(tempHomeDir, '.gemini', 'extensions');
+    userExtensionsDir = path.join(tempHomeDir, GEMINI_DIR, 'extensions');
     vi.mocked(os.homedir).mockReturnValue(tempHomeDir);
     vi.spyOn(process, 'cwd').mockReturnValue(tempWorkspaceDir);
   });

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -540,7 +540,7 @@ describe('performWorkspaceExtensionMigration', () => {
 });
 
 function createExtension({
-  extensionsDir = '',
+  extensionsDir = 'extensions-dir',
   name = 'my-extension',
   version = '1.0.0',
   addContextFile = false,

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -16,6 +16,7 @@ import { simpleGit } from 'simple-git';
 import { SettingScope, loadSettings } from '../config/settings.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { recursivelyHydrateStrings } from './extensions/variables.js';
+import { isWorkspaceTrusted } from './trustedFolders.js';
 
 export const EXTENSIONS_DIRECTORY_NAME = '.gemini/extensions';
 
@@ -112,7 +113,10 @@ export function loadExtensions(workspaceDir: string): Extension[] {
   const disabledExtensions = settings.extensions?.disabled ?? [];
   const allExtensions = [...loadUserExtensions()];
 
-  if (!settings.experimental?.extensionManagement) {
+  if (
+    isWorkspaceTrusted(settings) &&
+    !settings.experimental?.extensionManagement
+  ) {
     allExtensions.push(...getWorkspaceExtensions(workspaceDir));
   }
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -114,7 +114,7 @@ export function loadExtensions(workspaceDir: string): Extension[] {
   const allExtensions = [...loadUserExtensions()];
 
   if (
-    isWorkspaceTrusted(settings) &&
+    (isWorkspaceTrusted(settings) ?? true) &&
     !settings.experimental?.extensionManagement
   ) {
     allExtensions.push(...getWorkspaceExtensions(workspaceDir));

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -327,6 +327,13 @@ export async function installExtension(
   installMetadata: ExtensionInstallMetadata,
   cwd: string = process.cwd(),
 ): Promise<string> {
+  const settings = loadSettings(cwd).merged;
+  if (!isWorkspaceTrusted(settings)) {
+    throw new Error(
+      `Could not install extension from untrusted folder at ${installMetadata.source}`,
+    );
+  }
+
   const extensionsDir = ExtensionStorage.getUserExtensionsDir();
   await fs.promises.mkdir(extensionsDir, { recursive: true });
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -8,7 +8,7 @@ import type {
   MCPServerConfig,
   GeminiCLIExtension,
 } from '@google/gemini-cli-core';
-import { Storage } from '@google/gemini-cli-core';
+import { GEMINI_DIR, Storage } from '@google/gemini-cli-core';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -18,7 +18,7 @@ import { getErrorMessage } from '../utils/errors.js';
 import { recursivelyHydrateStrings } from './extensions/variables.js';
 import { isWorkspaceTrusted } from './trustedFolders.js';
 
-export const EXTENSIONS_DIRECTORY_NAME = '.gemini/extensions';
+export const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
 
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
 export const INSTALL_METADATA_FILENAME = '.gemini-extension-install.json';


### PR DESCRIPTION
## TLDR

Refuse to load extensions from untrusted workspaces.

## Dive Deeper

I also found these tests a little messy, so I took some liberties to tidy them up.  Most of the churn in the tests is due to that. .

## Reviewer Test Plan

- Unit tests cover the functionality quite well.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes https://github.com/google-gemini/maintainers-gemini-cli/issues/721