### PR TITLE
feat: Add a `--session-summary` flag

### DIFF
--- a/integration-tests/session-summary.test.ts
+++ b/integration-tests/session-summary.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TestRig } from './test-helper.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+describe('session-summary flag', () => {
+  let rig: TestRig;
+
+  beforeEach(function (context) {
+    rig = new TestRig();
+    if (context.task.name) {
+      rig.setup(context.task.name);
+    }
+  });
+
+  afterEach(async () => {
+    await rig.cleanup();
+  });
+
+  it('should write a session summary in non-interactive mode', async () => {
+    const summaryPath = join(rig.testDir!, 'summary.json');
+    await rig.run('Say hello', '--session-summary', summaryPath);
+
+    const summaryContent = readFileSync(summaryPath, 'utf-8');
+    const summary = JSON.parse(summaryContent);
+
+    expect(summary).toBeDefined();
+    expect(summary.models).toBeDefined();
+    expect(summary.tools).toBeDefined();
+  });
+});

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -78,6 +78,7 @@ export interface CliArgs {
   proxy: string | undefined;
   includeDirectories: string[] | undefined;
   screenReader: boolean | undefined;
+  sessionSummary: string | undefined;
 }
 
 export async function parseArguments(settings: Settings): Promise<CliArgs> {
@@ -227,6 +228,10 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           description: 'Enable screen reader mode for accessibility.',
           default: false,
         })
+        .option('session-summary', {
+          type: 'string',
+          description: 'File to write session summary to.',
+        })
         .deprecateOption(
           'telemetry',
           'Use settings.json instead. This flag will be removed in a future version.',
@@ -271,6 +276,7 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           'all-files',
           'Use @ includes in the application instead. This flag will be removed in a future version.',
         )
+
         .check((argv) => {
           if (argv.prompt && argv['promptInteractive']) {
             throw new Error(

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -276,7 +276,6 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           'all-files',
           'Use @ includes in the application instead. This flag will be removed in a future version.',
         )
-
         .check((argv) => {
           if (argv.prompt && argv['promptInteractive']) {
             throw new Error(

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -24,7 +24,11 @@ import { getUserStartupWarnings } from './utils/userStartupWarnings.js';
 import { ConsolePatcher } from './ui/utils/ConsolePatcher.js';
 import { runNonInteractive } from './nonInteractiveCli.js';
 import { loadExtensions } from './config/extension.js';
-import { cleanupCheckpoints, registerCleanup } from './utils/cleanup.js';
+import {
+  cleanupCheckpoints,
+  registerCleanup,
+  runExitCleanup,
+} from './utils/cleanup.js';
 import { getCliVersion } from './utils/version.js';
 import type { Config } from '@google/gemini-cli-core';
 import {
@@ -46,6 +50,7 @@ import { checkForUpdates } from './ui/utils/updateCheck.js';
 import { handleAutoUpdate } from './utils/handleAutoUpdate.js';
 import { appEvents, AppEvent } from './utils/events.js';
 import { SettingsContext } from './ui/contexts/SettingsContext.js';
+import { writeFileSync } from 'node:fs';
 
 export function validateDnsResolutionOrder(
   order: string | undefined,
@@ -141,7 +146,6 @@ const InitializingComponent = ({ initialTotal }: { initialTotal: number }) => {
 };
 
 import { runZedIntegration } from './zed-integration/zedIntegration.js';
-import * as fs from 'node:fs';
 
 export function setupUnhandledRejectionHandler() {
   let unhandledRejectionOccurred = false;
@@ -226,6 +230,16 @@ export async function main() {
     sessionId,
     argv,
   );
+
+  if (argv.sessionSummary) {
+    registerCleanup(() => {
+      const metrics = uiTelemetryService.getMetrics();
+      writeFileSync(
+        argv.sessionSummary!,
+        JSON.stringify({ sessionMetrics: metrics }, null, 2),
+      );
+    });
+  }
 
   const consolePatcher = new ConsolePatcher({
     stderr: true,
@@ -436,12 +450,8 @@ export async function main() {
   }
 
   await runNonInteractive(nonInteractiveConfig, input, prompt_id);
-
-  if (argv.sessionSummary) {
-    const metrics = uiTelemetryService.getMetrics();
-    fs.writeFileSync(argv.sessionSummary, JSON.stringify(metrics, null, 2));
-  }
-
+  // Call cleanup before process.exit, which causes cleanup to not run
+  await runExitCleanup();
   process.exit(0);
 }
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -36,6 +36,7 @@ import {
   IdeConnectionEvent,
   IdeConnectionType,
   FatalConfigError,
+  uiTelemetryService,
 } from '@google/gemini-cli-core';
 import { validateAuthMethod } from './config/auth.js';
 import { setMaxSizedBoxDebugging } from './ui/components/shared/MaxSizedBox.js';
@@ -140,6 +141,7 @@ const InitializingComponent = ({ initialTotal }: { initialTotal: number }) => {
 };
 
 import { runZedIntegration } from './zed-integration/zedIntegration.js';
+import * as fs from 'node:fs';
 
 export function setupUnhandledRejectionHandler() {
   let unhandledRejectionOccurred = false;
@@ -434,6 +436,12 @@ export async function main() {
   }
 
   await runNonInteractive(nonInteractiveConfig, input, prompt_id);
+
+  if (argv.sessionSummary) {
+    const metrics = uiTelemetryService.getMetrics();
+    fs.writeFileSync(argv.sessionSummary, JSON.stringify(metrics, null, 2));
+  }
+
   process.exit(0);
 }
 


### PR DESCRIPTION
## TLDR

Support a `--session-summary` flag that stores summary stats in a json object to evaluate multi-turn runs as well as for stats in nonInteractive mode (such as GitHub Actions). 

## Dive Deeper

Example invocations
```
gemini-cli --yolo --session-summary interactive_test_001.json
gemini-cli --yolo --prompt "Call github.list_issues to list the oldest issues in this repo  (google-gemini/gemini-cli)" --session-summary non_interactive_test_001.json
```

Example JSON file
```
{
  "models": {
    "gemini-2.5-pro": {
      "api": {
        "totalRequests": 3,
        "totalErrors": 0,
        "totalLatencyMs": 11198
      },
      "tokens": {
        "prompt": 96678,
        "candidates": 155,
        "total": 97243,
        "cached": 27213,
        "thoughts": 410,
        "tool": 0
      }
    }
  },
  "tools": {
    "totalCalls": 1,
    "totalSuccess": 1,
    "totalFail": 0,
    "totalDurationMs": 1356,
    "totalDecisions": {
      "accept": 0,
      "reject": 0,
      "modify": 0,
      "auto_accept": 1
    },
    "byName": {
      "list_issues": {
        "count": 1,
        "success": 1,
        "fail": 0,
        "durationMs": 1356,
        "decisions": {
          "accept": 0,
          "reject": 0,
          "modify": 0,
          "auto_accept": 1
        }
      }
    }
  },
  "files": {
    "totalLinesAdded": 0,
    "totalLinesRemoved": 0
  }
}
```

## Reviewer Test Plan

They should ensure `--session-summary` WAI, in interactive and non-interactive modes. 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to #6757
