### PR TITLE
docs(config): update documentation for  settings structure

### DIFF
--- a/docs/checkpointing.md
+++ b/docs/checkpointing.md
@@ -38,8 +38,10 @@ Add the following key to your `settings.json`:
 
 ```json
 {
-  "checkpointing": {
-    "enabled": true
+  "general": {
+    "checkpointing": {
+      "enabled": true
+    }
   }
 }
 ```

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -9,7 +9,7 @@ Slash commands provide meta-level control over the CLI itself.
 ### Built-in Commands
 
 - **`/bug`**
-  - **Description:** File an issue about Gemini CLI. By default, the issue is filed within the GitHub repository for Gemini CLI. The string you enter after `/bug` will become the headline for the bug being filed. The default `/bug` behavior can be modified using the `bugCommand` setting in your `.gemini/settings.json` files.
+  - **Description:** File an issue about Gemini CLI. By default, the issue is filed within the GitHub repository for Gemini CLI. The string you enter after `/bug` will become the headline for the bug being filed. The default `/bug` behavior can be modified using the `advanced.bugCommand` setting in your `.gemini/settings.json` files.
 
 - **`/chat`**
   - **Description:** Save and resume conversation history for branching conversation state interactively, or resuming a previous state from a later session.
@@ -395,7 +395,7 @@ At commands are used to include the content of files or directories as part of y
     - If a path to a directory is provided, the command attempts to read the content of files within that directory and any subdirectories.
     - Spaces in paths should be escaped with a backslash (e.g., `@My\ Documents/file.txt`).
     - The command uses the `read_many_files` tool internally. The content is fetched and then inserted into your query before being sent to the Gemini model.
-    - **Git-aware filtering:** By default, git-ignored files (like `node_modules/`, `dist/`, `.env`, `.git/`) are excluded. This behavior can be changed via the `fileFiltering` settings.
+    - **Git-aware filtering:** By default, git-ignored files (like `node_modules/`, `dist/`, `.env`, `.git/`) are excluded. This behavior can be changed via the `context.fileFiltering` settings.
     - **File types:** The command is intended for text-based files. While it might attempt to read any file, binary files or very large files might be skipped or truncated by the underlying `read_many_files` tool to ensure performance and relevance. The tool indicates if files were skipped.
   - **Output:** The CLI will show a tool call message indicating that `read_many_files` was used, along with a message detailing the status and the path(s) that were processed.
 

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -41,117 +41,225 @@ In addition to a project settings file, a project's `.gemini` directory can cont
 
 - [Custom sandbox profiles](#sandboxing) (e.g., `.gemini/sandbox-macos-custom.sb`, `.gemini/sandbox.Dockerfile`).
 
-### Available settings in `settings.json`:
+### Available settings in `settings.json`
 
-- **`contextFileName`** (string or array of strings):
-  - **Description:** Specifies the filename for context files (e.g., `GEMINI.md`, `AGENTS.md`). Can be a single filename or a list of accepted filenames.
-  - **Default:** `GEMINI.md`
-  - **Example:** `"contextFileName": "AGENTS.md"`
+Settings are organized into categories. All settings should be placed within their corresponding top-level category object in your `settings.json` file.
 
-- **`bugCommand`** (object):
-  - **Description:** Overrides the default URL for the `/bug` command.
-  - **Default:** `"urlTemplate": "https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml&title={title}&info={info}"`
-  - **Properties:**
-    - **`urlTemplate`** (string): A URL that can contain `{title}` and `{info}` placeholders.
-  - **Example:**
-    ```json
-    "bugCommand": {
-      "urlTemplate": "https://bug.example.com/new?title={title}&info={info}"
-    }
-    ```
+#### `general`
 
-- **`fileFiltering`** (object):
-  - **Description:** Controls git-aware file filtering behavior for @ commands and file discovery tools.
-  - **Default:** `"respectGitIgnore": true, "enableRecursiveFileSearch": true`
-  - **Properties:**
-    - **`respectGitIgnore`** (boolean): Whether to respect .gitignore patterns when discovering files. When set to `true`, git-ignored files (like `node_modules/`, `dist/`, `.env`) are automatically excluded from @ commands and file listing operations.
-    - **`enableRecursiveFileSearch`** (boolean): Whether to enable searching recursively for filenames under the current tree when completing @ prefixes in the prompt.
-    - **`disableFuzzySearch`** (boolean): When `true`, disables the fuzzy search capabilities when searching for files, which can improve performance on projects with a large number of files.
-  - **Example:**
-    ```json
-    "fileFiltering": {
-      "respectGitIgnore": true,
-      "enableRecursiveFileSearch": false,
-      "disableFuzzySearch": true
-    }
-    ```
-
-### Troubleshooting File Search Performance
-
-If you are experiencing performance issues with file searching (e.g., with `@` completions), especially in projects with a very large number of files, here are a few things you can try in order of recommendation:
-
-1.  **Use `.geminiignore`:** Create a `.geminiignore` file in your project root to exclude directories that contain a large number of files that you don't need to reference (e.g., build artifacts, logs, `node_modules`). Reducing the total number of files crawled is the most effective way to improve performance.
-
-2.  **Disable Fuzzy Search:** If ignoring files is not enough, you can disable fuzzy search by setting `disableFuzzySearch` to `true` in your `settings.json` file. This will use a simpler, non-fuzzy matching algorithm, which can be faster.
-
-3.  **Disable Recursive File Search:** As a last resort, you can disable recursive file search entirely by setting `enableRecursiveFileSearch` to `false`. This will be the fastest option as it avoids a recursive crawl of your project. However, it means you will need to type the full path to files when using `@` completions.
-
-- **`coreTools`** (array of strings):
-  - **Description:** Allows you to specify a list of core tool names that should be made available to the model. This can be used to restrict the set of built-in tools. See [Built-in Tools](../core/tools-api.md#built-in-tools) for a list of core tools. You can also specify command-specific restrictions for tools that support it, like the `ShellTool`. For example, `"coreTools": ["ShellTool(ls -l)"]` will only allow the `ls -l` command to be executed.
-  - **Default:** All tools available for use by the Gemini model.
-  - **Example:** `"coreTools": ["ReadFileTool", "GlobTool", "ShellTool(ls)"]`.
-
-- **`allowedTools`** (array of strings):
+- **`general.preferredEditor`** (string):
+  - **Description:** The preferred editor to open files in.
   - **Default:** `undefined`
-  - **Description:** A list of tool names that will bypass the confirmation dialog. This is useful for tools that you trust and use frequently. The match semantics are the same as `coreTools`.
-  - **Example:** `"allowedTools": ["ShellTool(git status)"]`.
 
-- **`excludeTools`** (array of strings):
-  - **Description:** Allows you to specify a list of core tool names that should be excluded from the model. A tool listed in both `excludeTools` and `coreTools` is excluded. You can also specify command-specific restrictions for tools that support it, like the `ShellTool`. For example, `"excludeTools": ["ShellTool(rm -rf)"]` will block the `rm -rf` command.
-  - **Default**: No tools excluded.
-  - **Example:** `"excludeTools": ["run_shell_command", "findFiles"]`.
-  - **Security Note:** Command-specific restrictions in
-    `excludeTools` for `run_shell_command` are based on simple string matching and can be easily bypassed. This feature is **not a security mechanism** and should not be relied upon to safely execute untrusted code. It is recommended to use `coreTools` to explicitly select commands
-    that can be executed.
-
-- **`allowMCPServers`** (array of strings):
-  - **Description:** Allows you to specify a list of MCP server names that should be made available to the model. This can be used to restrict the set of MCP servers to connect to. Note that this will be ignored if `--allowed-mcp-server-names` is set.
-  - **Default:** All MCP servers are available for use by the Gemini model.
-  - **Example:** `"allowMCPServers": ["myPythonServer"]`.
-  - **Security Note:** This uses simple string matching on MCP server names, which can be modified. If you're a system administrator looking to prevent users from bypassing this, consider configuring the `mcpServers` at the system settings level such that the user will not be able to configure any MCP servers of their own. This should not be used as an airtight security mechanism.
-
-- **`excludeMCPServers`** (array of strings):
-  - **Description:** Allows you to specify a list of MCP server names that should be excluded from the model. A server listed in both `excludeMCPServers` and `allowMCPServers` is excluded. Note that this will be ignored if `--allowed-mcp-server-names` is set.
-  - **Default**: No MCP servers excluded.
-  - **Example:** `"excludeMCPServers": ["myNodeServer"]`.
-  - **Security Note:** This uses simple string matching on MCP server names, which can be modified. If you're a system administrator looking to prevent users from bypassing this, consider configuring the `mcpServers` at the system settings level such that the user will not be able to configure any MCP servers of their own. This should not be used as an airtight security mechanism.
-
-- **`autoAccept`** (boolean):
-  - **Description:** Controls whether the CLI automatically accepts and executes tool calls that are considered safe (e.g., read-only operations) without explicit user confirmation. If set to `true`, the CLI will bypass the confirmation prompt for tools deemed safe.
+- **`general.vimMode`** (boolean):
+  - **Description:** Enable Vim keybindings.
   - **Default:** `false`
-  - **Example:** `"autoAccept": true`
 
-- **`theme`** (string):
-  - **Description:** Sets the visual [theme](./themes.md) for Gemini CLI.
-  - **Default:** `"Default"`
-  - **Example:** `"theme": "GitHub"`
-
-- **`vimMode`** (boolean):
-  - **Description:** Enables or disables vim mode for input editing. When enabled, the input area supports vim-style navigation and editing commands with NORMAL and INSERT modes. The vim mode status is displayed in the footer and persists between sessions.
+- **`general.disableAutoUpdate`** (boolean):
+  - **Description:** Disable automatic updates.
   - **Default:** `false`
-  - **Example:** `"vimMode": true`
 
-- **`sandbox`** (boolean or string):
-  - **Description:** Controls whether and how to use sandboxing for tool execution. If set to `true`, Gemini CLI uses a pre-built `gemini-cli-sandbox` Docker image. For more information, see [Sandboxing](#sandboxing).
+- **`general.disableUpdateNag`** (boolean):
+  - **Description:** Disable update notification prompts.
   - **Default:** `false`
-  - **Example:** `"sandbox": "docker"`
 
-- **`toolDiscoveryCommand`** (string):
-  - **Description:** Defines a custom shell command for discovering tools from your project. The shell command must return on `stdout` a JSON array of [function declarations](https://ai.google.dev/gemini-api/docs/function-calling#function-declarations). Tool wrappers are optional.
-  - **Default:** Empty
-  - **Example:** `"toolDiscoveryCommand": "bin/get_tools"`
+- **`general.checkpointing.enabled`** (boolean):
+  - **Description:** Enable session checkpointing for recovery.
+  - **Default:** `false`
 
-- **`toolCallCommand`** (string):
-  - **Description:** Defines a custom shell command for calling a specific tool that was discovered using `toolDiscoveryCommand`. The shell command must meet the following criteria:
-    - It must take function `name` (exactly as in [function declaration](https://ai.google.dev/gemini-api/docs/function-calling#function-declarations)) as first command line argument.
-    - It must read function arguments as JSON on `stdin`, analogous to [`functionCall.args`](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#functioncall).
-    - It must return function output as JSON on `stdout`, analogous to [`functionResponse.response.content`](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#functionresponse).
-  - **Default:** Empty
-  - **Example:** `"toolCallCommand": "bin/call_tool"`
+#### `ui`
+
+- **`ui.theme`** (string):
+  - **Description:** The color theme for the UI. See [Themes](./themes.md) for available options.
+  - **Default:** `undefined`
+
+- **`ui.customThemes`** (object):
+  - **Description:** Custom theme definitions.
+  - **Default:** `{}`
+
+- **`ui.hideWindowTitle`** (boolean):
+  - **Description:** Hide the window title bar.
+  - **Default:** `false`
+
+- **`ui.hideTips`** (boolean):
+  - **Description:** Hide helpful tips in the UI.
+  - **Default:** `false`
+
+- **`ui.hideBanner`** (boolean):
+  - **Description:** Hide the application banner.
+  - **Default:** `false`
+
+- **`ui.hideFooter`** (boolean):
+  - **Description:** Hide the footer from the UI.
+  - **Default:** `false`
+
+- **`ui.showMemoryUsage`** (boolean):
+  - **Description:** Display memory usage information in the UI.
+  - **Default:** `false`
+
+- **`ui.showLineNumbers`** (boolean):
+  - **Description:** Show line numbers in the chat.
+  - **Default:** `false`
+
+- **`ui.accessibility.disableLoadingPhrases`** (boolean):
+  - **Description:** Disable loading phrases for accessibility.
+  - **Default:** `false`
+
+#### `ide`
+
+- **`ide.enabled`** (boolean):
+  - **Description:** Enable IDE integration mode.
+  - **Default:** `false`
+
+- **`ide.hasSeenNudge`** (boolean):
+  - **Description:** Whether the user has seen the IDE integration nudge.
+  - **Default:** `false`
+
+#### `privacy`
+
+- **`privacy.usageStatisticsEnabled`** (boolean):
+  - **Description:** Enable collection of usage statistics.
+  - **Default:** `true`
+
+#### `model`
+
+- **`model.name`** (string):
+  - **Description:** The Gemini model to use for conversations.
+  - **Default:** `undefined`
+
+- **`model.maxSessionTurns`** (number):
+  - **Description:** Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.
+  - **Default:** `-1`
+
+- **`model.summarizeToolOutput`** (object):
+  - **Description:** Settings for summarizing tool output.
+  - **Default:** `undefined`
+
+- **`model.chatCompression`** (object):
+  - **Description:** Chat compression settings.
+  - **Default:** `undefined`
+
+- **`model.skipNextSpeakerCheck`** (boolean):
+  - **Description:** Skip the next speaker check.
+  - **Default:** `false`
+
+#### `context`
+
+- **`context.fileName`** (string or array of strings):
+  - **Description:** The name of the context file(s).
+  - **Default:** `undefined`
+
+- **`context.importFormat`** (string):
+  - **Description:** The format to use when importing memory.
+  - **Default:** `undefined`
+
+- **`context.discoveryMaxDirs`** (number):
+  - **Description:** Maximum number of directories to search for memory.
+  - **Default:** `200`
+
+- **`context.includeDirectories`** (array):
+  - **Description:** Additional directories to include in the workspace context. Missing directories will be skipped with a warning.
+  - **Default:** `[]`
+
+- **`context.loadFromIncludeDirectories`** (boolean):
+  - **Description:** Whether to load memory files from include directories.
+  - **Default:** `false`
+
+- **`context.fileFiltering.respectGitIgnore`** (boolean):
+  - **Description:** Respect .gitignore files when searching.
+  - **Default:** `true`
+
+- **`context.fileFiltering.respectGeminiIgnore`** (boolean):
+  - **Description:** Respect .geminiignore files when searching.
+  - **Default:** `true`
+
+- **`context.fileFiltering.enableRecursiveFileSearch`** (boolean):
+  - **Description:** Enable recursive file search functionality.
+  - **Default:** `true`
+
+#### `tools`
+
+- **`tools.sandbox`** (boolean or string):
+  - **Description:** Sandbox execution environment (can be a boolean or a path string).
+  - **Default:** `undefined`
+
+- **`tools.usePty`** (boolean):
+  - **Description:** Use node-pty for shell command execution. Fallback to child_process still applies.
+  - **Default:** `false`
+
+- **`tools.core`** (array of strings):
+  - **Description:** Paths to core tool definitions.
+  - **Default:** `undefined`
+
+- **`tools.exclude`** (array of strings):
+  - **Description:** Tool names to exclude from discovery.
+  - **Default:** `undefined`
+
+- **`tools.discoveryCommand`** (string):
+  - **Description:** Command to run for tool discovery.
+  - **Default:** `undefined`
+
+- **`tools.callCommand`** (string):
+  - **Description:** Command to run for tool calls.
+  - **Default:** `undefined`
+
+#### `mcp`
+
+- **`mcp.serverCommand`** (string):
+  - **Description:** Command to start an MCP server.
+  - **Default:** `undefined`
+
+- **`mcp.allowed`** (array of strings):
+  - **Description:** A whitelist of MCP servers to allow.
+  - **Default:** `undefined`
+
+- **`mcp.excluded`** (array of strings):
+  - **Description:** A blacklist of MCP servers to exclude.
+  - **Default:** `undefined`
+
+#### `security`
+
+- **`security.folderTrust.featureEnabled`** (boolean):
+  - **Description:** Enable folder trust feature for enhanced security.
+  - **Default:** `false`
+
+- **`security.folderTrust.enabled`** (boolean):
+  - **Description:** Setting to track whether Folder trust is enabled.
+  - **Default:** `false`
+
+- **`security.auth.selectedType`** (string):
+  - **Description:** The currently selected authentication type.
+  - **Default:** `undefined`
+
+- **`security.auth.useExternal`** (boolean):
+  - **Description:** Whether to use an external authentication flow.
+  - **Default:** `undefined`
+
+#### `advanced`
+
+- **`advanced.autoConfigureMemory`** (boolean):
+  - **Description:** Automatically configure Node.js memory limits.
+  - **Default:** `false`
+
+- **`advanced.dnsResolutionOrder`** (string):
+  - **Description:** The DNS resolution order.
+  - **Default:** `undefined`
+
+- **`advanced.excludedEnvVars`** (array of strings):
+  - **Description:** Environment variables to exclude from project context.
+  - **Default:** `["DEBUG","DEBUG_MODE"]`
+
+- **`advanced.bugCommand`** (object):
+  - **Description:** Configuration for the bug report command.
+  - **Default:** `undefined`
+
+#### Top-Level Settings
+
+The following settings remain at the top level of the `settings.json` file.
 
 - **`mcpServers`** (object):
   - **Description:** Configures connections to one or more Model-Context Protocol (MCP) servers for discovering and using custom tools. Gemini CLI attempts to connect to each configured MCP server to discover available tools. If multiple MCP servers expose a tool with the same name, the tool names will be prefixed with the server alias you defined in the configuration (e.g., `serverAlias__actualToolName`) to avoid conflicts. Note that the system might strip certain schema properties from MCP tool definitions for compatibility. At least one of `command`, `url`, or `httpUrl` must be provided. If multiple are specified, the order of precedence is `httpUrl`, then `url`, then `command`.
-  - **Default:** Empty
+  - **Default:** `{}`
   - **Properties:**
     - **`<SERVER_NAME>`** (object): The server parameters for the named server.
       - `command` (string, optional): The command to execute to start the MCP server via standard I/O.
@@ -166,191 +274,39 @@ If you are experiencing performance issues with file searching (e.g., with `@` c
       - `description` (string, optional): A brief description of the server, which may be used for display purposes.
       - `includeTools` (array of strings, optional): List of tool names to include from this MCP server. When specified, only the tools listed here will be available from this server (whitelist behavior). If not specified, all tools from the server are enabled by default.
       - `excludeTools` (array of strings, optional): List of tool names to exclude from this MCP server. Tools listed here will not be available to the model, even if they are exposed by the server. **Note:** `excludeTools` takes precedence over `includeTools` - if a tool is in both lists, it will be excluded.
-  - **Example:**
-    ```json
-    "mcpServers": {
-      "myPythonServer": {
-        "command": "python",
-        "args": ["mcp_server.py", "--port", "8080"],
-        "cwd": "./mcp_tools/python",
-        "timeout": 5000,
-        "includeTools": ["safe_tool", "file_reader"],
-      },
-      "myNodeServer": {
-        "command": "node",
-        "args": ["mcp_server.js"],
-        "cwd": "./mcp_tools/node",
-        "excludeTools": ["dangerous_tool", "file_deleter"]
-      },
-      "myDockerServer": {
-        "command": "docker",
-        "args": ["run", "-i", "--rm", "-e", "API_KEY", "ghcr.io/foo/bar"],
-        "env": {
-          "API_KEY": "$MY_API_TOKEN"
-        }
-      },
-      "mySseServer": {
-        "url": "http://localhost:8081/events",
-        "headers": {
-          "Authorization": "Bearer $MY_SSE_TOKEN"
-        },
-        "description": "An example SSE-based MCP server."
-      },
-      "myStreamableHttpServer": {
-        "httpUrl": "http://localhost:8082/stream",
-        "headers": {
-          "X-API-Key": "$MY_HTTP_API_KEY"
-        },
-        "description": "An example Streamable HTTP-based MCP server."
-      }
-    }
-    ```
-
-- **`checkpointing`** (object):
-  - **Description:** Configures the checkpointing feature, which allows you to save and restore conversation and file states. See the [Checkpointing documentation](../checkpointing.md) for more details.
-  - **Default:** `{"enabled": false}`
-  - **Properties:**
-    - **`enabled`** (boolean): When `true`, the `/restore` command is available.
-
-- **`preferredEditor`** (string):
-  - **Description:** Specifies the preferred editor to use for viewing diffs.
-  - **Default:** `vscode`
-  - **Example:** `"preferredEditor": "vscode"`
 
 - **`telemetry`** (object)
   - **Description:** Configures logging and metrics collection for Gemini CLI. For more information, see [Telemetry](../telemetry.md).
-  - **Default:** `{"enabled": false, "target": "local", "otlpEndpoint": "http://localhost:4317", "logPrompts": true}`
+  - **Default:** `undefined`
   - **Properties:**
     - **`enabled`** (boolean): Whether or not telemetry is enabled.
     - **`target`** (string): The destination for collected telemetry. Supported values are `local` and `gcp`.
     - **`otlpEndpoint`** (string): The endpoint for the OTLP Exporter.
+    - **`otlpProtocol`** (string): The protocol for the OTLP Exporter (`grpc` or `http`).
     - **`logPrompts`** (boolean): Whether or not to include the content of user prompts in the logs.
-  - **Example:**
-    ```json
-    "telemetry": {
-      "enabled": true,
-      "target": "local",
-      "otlpEndpoint": "http://localhost:16686",
-      "logPrompts": false
-    }
-    ```
-- **`usageStatisticsEnabled`** (boolean):
-  - **Description:** Enables or disables the collection of usage statistics. See [Usage Statistics](#usage-statistics) for more information.
-  - **Default:** `true`
-  - **Example:**
-    ```json
-    "usageStatisticsEnabled": false
-    ```
+    - **`outfile`** (string): The file to write telemetry to when `target` is `local`.
 
-- **`hideTips`** (boolean):
-  - **Description:** Enables or disables helpful tips in the CLI interface.
-  - **Default:** `false`
-  - **Example:**
+### Example `settings.json`
 
-    ```json
-    "hideTips": true
-    ```
-
-- **`hideBanner`** (boolean):
-  - **Description:** Enables or disables the startup banner (ASCII art logo) in the CLI interface.
-  - **Default:** `false`
-  - **Example:**
-
-    ```json
-    "hideBanner": true
-    ```
-
-- **`maxSessionTurns`** (number):
-  - **Description:** Sets the maximum number of turns for a session. If the session exceeds this limit, the CLI will stop processing and start a new chat.
-  - **Default:** `-1` (unlimited)
-  - **Example:**
-    ```json
-    "maxSessionTurns": 10
-    ```
-
-- **`summarizeToolOutput`** (object):
-  - **Description:** Enables or disables the summarization of tool output. You can specify the token budget for the summarization using the `tokenBudget` setting.
-  - Note: Currently only the `run_shell_command` tool is supported.
-  - **Default:** `{}` (Disabled by default)
-  - **Example:**
-    ```json
-    "summarizeToolOutput": {
-      "run_shell_command": {
-        "tokenBudget": 2000
-      }
-    }
-    ```
-
-- **`excludedProjectEnvVars`** (array of strings):
-  - **Description:** Specifies environment variables that should be excluded from being loaded from project `.env` files. This prevents project-specific environment variables (like `DEBUG=true`) from interfering with gemini-cli behavior. Variables from `.gemini/.env` files are never excluded.
-  - **Default:** `["DEBUG", "DEBUG_MODE"]`
-  - **Example:**
-    ```json
-    "excludedProjectEnvVars": ["DEBUG", "DEBUG_MODE", "NODE_ENV"]
-    ```
-
-- **`includeDirectories`** (array of strings):
-  - **Description:** Specifies an array of additional absolute or relative paths to include in the workspace context. Missing directories will be skipped with a warning by default. Paths can use `~` to refer to the user's home directory. This setting can be combined with the `--include-directories` command-line flag.
-  - **Default:** `[]`
-  - **Example:**
-    ```json
-    "includeDirectories": [
-      "/path/to/another/project",
-      "../shared-library",
-      "~/common-utils"
-    ]
-    ```
-
-- **`loadMemoryFromIncludeDirectories`** (boolean):
-  - **Description:** Controls the behavior of the `/memory refresh` command. If set to `true`, `GEMINI.md` files should be loaded from all directories that are added. If set to `false`, `GEMINI.md` should only be loaded from the current directory.
-  - **Default:** `false`
-  - **Example:**
-    ```json
-    "loadMemoryFromIncludeDirectories": true
-    ```
-
-- **`chatCompression`** (object):
-  - **Description:** Controls the settings for chat history compression, both automatic and
-    when manually invoked through the /compress command.
-  - **Properties:**
-    - **`contextPercentageThreshold`** (number): A value between 0 and 1 that specifies the token threshold for compression as a percentage of the model's total token limit. For example, a value of `0.6` will trigger compression when the chat history exceeds 60% of the token limit.
-  - **Example:**
-    ```json
-    "chatCompression": {
-      "contextPercentageThreshold": 0.6
-    }
-    ```
-
-- **`showLineNumbers`** (boolean):
-  - **Description:** Controls whether line numbers are displayed in code blocks in the CLI output.
-  - **Default:** `true`
-  - **Example:**
-    ```json
-    "showLineNumbers": false
-    ```
-
-- **`accessibility`** (object):
-  - **Description:** Configures accessibility features for the CLI.
-  - **Properties:**
-    - **`screenReader`** (boolean): Enables screen reader mode, which adjusts the TUI for better compatibility with screen readers. This can also be enabled with the `--screen-reader` command-line flag, which will take precedence over the setting.
-    - **`disableLoadingPhrases`** (boolean): Disables the display of loading phrases during operations.
-  - **Default:** `{"screenReader": false, "disableLoadingPhrases": false}`
-  - **Example:**
-    ```json
-    "accessibility": {
-      "screenReader": true,
-      "disableLoadingPhrases": true
-    }
-    ```
-
-### Example `settings.json`:
+Here is an example of a `settings.json` file with the new nested structure:
 
 ```json
 {
-  "theme": "GitHub",
-  "sandbox": "docker",
-  "toolDiscoveryCommand": "bin/get_tools",
-  "toolCallCommand": "bin/call_tool",
+  "general": {
+    "vimMode": true,
+    "preferredEditor": "code"
+  },
+  "ui": {
+    "theme": "GitHub",
+    "hideBanner": true,
+    "hideTips": false
+  },
+  "tools": {
+    "sandbox": "docker",
+    "discoveryCommand": "bin/get_tools",
+    "callCommand": "bin/call_tool",
+    "exclude": ["write_file"]
+  },
   "mcpServers": {
     "mainServer": {
       "command": "bin/mcp_server.py"
@@ -366,18 +322,29 @@ If you are experiencing performance issues with file searching (e.g., with `@` c
     "otlpEndpoint": "http://localhost:4317",
     "logPrompts": true
   },
-  "usageStatisticsEnabled": true,
-  "hideTips": false,
-  "hideBanner": false,
-  "maxSessionTurns": 10,
-  "summarizeToolOutput": {
-    "run_shell_command": {
-      "tokenBudget": 100
+  "privacy": {
+    "usageStatisticsEnabled": true
+  },
+  "model": {
+    "name": "gemini-1.5-pro-latest",
+    "maxSessionTurns": 10,
+    "summarizeToolOutput": {
+      "run_shell_command": {
+        "tokenBudget": 100
+      }
     }
   },
-  "excludedProjectEnvVars": ["DEBUG", "DEBUG_MODE", "NODE_ENV"],
-  "includeDirectories": ["path/to/dir1", "~/path/to/dir2", "../path/to/dir3"],
-  "loadMemoryFromIncludeDirectories": true
+  "context": {
+    "fileName": ["CONTEXT.md", "GEMINI.md"],
+    "includeDirectories": ["path/to/dir1", "~/path/to/dir2", "../path/to/dir3"],
+    "loadFromIncludeDirectories": true,
+    "fileFiltering": {
+      "respectGitIgnore": false
+    }
+  },
+  "advanced": {
+    "excludedEnvVars": ["DEBUG", "DEBUG_MODE", "NODE_ENV"]
+  }
 }
 ```
 
@@ -399,7 +366,7 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
 2.  If not found, it searches upwards in parent directories until it finds an `.env` file or reaches the project root (identified by a `.git` folder) or the home directory.
 3.  If still not found, it looks for `~/.env` (in the user's home directory).
 
-**Environment Variable Exclusion:** Some environment variables (like `DEBUG` and `DEBUG_MODE`) are automatically excluded from being loaded from project `.env` files to prevent interference with gemini-cli behavior. Variables from `.gemini/.env` files are never excluded. You can customize this behavior using the `excludedProjectEnvVars` setting in your `settings.json` file.
+**Environment Variable Exclusion:** Some environment variables (like `DEBUG` and `DEBUG_MODE`) are automatically excluded from being loaded from project `.env` files to prevent interference with gemini-cli behavior. Variables from `.gemini/.env` files are never excluded. You can customize this behavior using the `advanced.excludedEnvVars` setting in your `settings.json` file.
 
 - **`GEMINI_API_KEY`**:
   - Your API key for the Gemini API.
@@ -520,7 +487,7 @@ Arguments passed directly when running the CLI can override other configurations
 
 ## Context Files (Hierarchical Instructional Context)
 
-While not strictly configuration for the CLI's _behavior_, context files (defaulting to `GEMINI.md` but configurable via the `contextFileName` setting) are crucial for configuring the _instructional context_ (also referred to as "memory") provided to the Gemini model. This powerful feature allows you to give project-specific instructions, coding style guides, or any relevant background information to the AI, making its responses more tailored and accurate to your needs. The CLI includes UI elements, such as an indicator in the footer showing the number of loaded context files, to keep you informed about the active context.
+While not strictly configuration for the CLI's _behavior_, context files (defaulting to `GEMINI.md` but configurable via the `context.fileName` setting) are crucial for configuring the _instructional context_ (also referred to as "memory") provided to the Gemini model. This powerful feature allows you to give project-specific instructions, coding style guides, or any relevant background information to the AI, making its responses more tailored and accurate to your needs. The CLI includes UI elements, such as an indicator in the footer showing the number of loaded context files, to keep you informed about the active context.
 
 - **Purpose:** These Markdown files contain instructions, guidelines, or context that you want the Gemini model to be aware of during your interactions. The system is designed to manage this instructional context hierarchically.
 
@@ -561,13 +528,13 @@ This example demonstrates how you can provide general project context, specific 
 
 - **Hierarchical Loading and Precedence:** The CLI implements a sophisticated hierarchical memory system by loading context files (e.g., `GEMINI.md`) from several locations. Content from files lower in this list (more specific) typically overrides or supplements content from files higher up (more general). The exact concatenation order and final context can be inspected using the `/memory show` command. The typical loading order is:
   1.  **Global Context File:**
-      - Location: `~/.gemini/<contextFileName>` (e.g., `~/.gemini/GEMINI.md` in your user home directory).
+      - Location: `~/.gemini/<configured-context-filename>` (e.g., `~/.gemini/GEMINI.md` in your user home directory).
       - Scope: Provides default instructions for all your projects.
   2.  **Project Root & Ancestors Context Files:**
       - Location: The CLI searches for the configured context file in the current working directory and then in each parent directory up to either the project root (identified by a `.git` folder) or your home directory.
       - Scope: Provides context relevant to the entire project or a significant portion of it.
   3.  **Sub-directory Context Files (Contextual/Local):**
-      - Location: The CLI also scans for the configured context file in subdirectories _below_ the current working directory (respecting common ignore patterns like `node_modules`, `.git`, etc.). The breadth of this search is limited to 200 directories by default, but can be configured with a `memoryDiscoveryMaxDirs` field in your `settings.json` file.
+      - Location: The CLI also scans for the configured context file in subdirectories _below_ the current working directory (respecting common ignore patterns like `node_modules`, `.git`, etc.). The breadth of this search is limited to 200 directories by default, but can be configured with the `context.discoveryMaxDirs` setting in your `settings.json` file.
       - Scope: Allows for highly specific instructions relevant to a particular component, module, or subsection of your project.
 - **Concatenation & UI Indication:** The contents of all found context files are concatenated (with separators indicating their origin and path) and provided as part of the system prompt to the Gemini model. The CLI footer displays the count of loaded context files, giving you a quick visual cue about the active instructional context.
 - **Importing Content:** You can modularize your context files by importing other Markdown files using the `@path/to/file.md` syntax. For more details, see the [Memory Import Processor documentation](../core/memport.md).
@@ -625,10 +592,12 @@ To help us improve the Gemini CLI, we collect anonymized usage statistics. This 
 
 **How to opt out:**
 
-You can opt out of usage statistics collection at any time by setting the `usageStatisticsEnabled` property to `false` in your `settings.json` file:
+You can opt out of usage statistics collection at any time by setting the `usageStatisticsEnabled` property to `false` under the `privacy` category in your `settings.json` file:
 
 ```json
 {
-  "usageStatisticsEnabled": false
+  "privacy": {
+    "usageStatisticsEnabled": false
+  }
 }
 ```

--- a/docs/cli/enterprise.md
+++ b/docs/cli/enterprise.md
@@ -25,8 +25,12 @@ Here is how settings from different levels are combined.
 
   ```json
   {
-    "theme": "default-corporate-theme",
-    "includeDirectories": ["/etc/gemini-cli/common-context"]
+    "ui": {
+      "theme": "default-corporate-theme"
+    },
+    "context": {
+      "includeDirectories": ["/etc/gemini-cli/common-context"]
+    }
   }
   ```
 
@@ -34,7 +38,9 @@ Here is how settings from different levels are combined.
 
   ```json
   {
-    "theme": "user-preferred-dark-theme",
+    "ui": {
+      "theme": "user-preferred-dark-theme"
+    },
     "mcpServers": {
       "corp-server": {
         "command": "/usr/local/bin/corp-server-dev"
@@ -43,7 +49,9 @@ Here is how settings from different levels are combined.
         "command": "npm start --prefix ~/tools/my-tool"
       }
     },
-    "includeDirectories": ["~/gemini-context"]
+    "context": {
+      "includeDirectories": ["~/gemini-context"]
+    }
   }
   ```
 
@@ -51,26 +59,34 @@ Here is how settings from different levels are combined.
 
   ```json
   {
-    "theme": "project-specific-light-theme",
+    "ui": {
+      "theme": "project-specific-light-theme"
+    },
     "mcpServers": {
       "project-tool": {
         "command": "npm start"
       }
     },
-    "includeDirectories": ["./project-context"]
+    "context": {
+      "includeDirectories": ["./project-context"]
+    }
   }
   ```
 
 - **System Overrides `settings.json`:**
   ```json
   {
-    "theme": "system-enforced-theme",
+    "ui": {
+      "theme": "system-enforced-theme"
+    },
     "mcpServers": {
       "corp-server": {
         "command": "/usr/local/bin/corp-server-prod"
       }
     },
-    "includeDirectories": ["/etc/gemini-cli/global-context"]
+    "context": {
+      "includeDirectories": ["/etc/gemini-cli/global-context"]
+    }
   }
   ```
 
@@ -79,7 +95,9 @@ This results in the following merged configuration:
 - **Final Merged Configuration:**
   ```json
   {
-    "theme": "system-enforced-theme",
+    "ui": {
+      "theme": "system-enforced-theme"
+    },
     "mcpServers": {
       "corp-server": {
         "command": "/usr/local/bin/corp-server-prod"
@@ -91,12 +109,14 @@ This results in the following merged configuration:
         "command": "npm start"
       }
     },
-    "includeDirectories": [
-      "/etc/gemini-cli/common-context",
-      "~/gemini-context",
-      "./project-context",
-      "/etc/gemini-cli/global-context"
-    ]
+    "context": {
+      "includeDirectories": [
+        "/etc/gemini-cli/common-context",
+        "~/gemini-context",
+        "./project-context",
+        "/etc/gemini-cli/global-context"
+      ]
+    }
   }
   ```
 
@@ -117,7 +137,7 @@ By using the system settings file, you can enforce the security and configuratio
 
 ## Restricting Tool Access
 
-You can significantly enhance security by controlling which tools the Gemini model can use. This is achieved through the `coreTools` and `excludeTools` settings. For a list of available tools, see the [Tools documentation](../tools/index.md).
+You can significantly enhance security by controlling which tools the Gemini model can use. This is achieved through the `tools.core` and `tools.exclude` settings. For a list of available tools, see the [Tools documentation](../tools/index.md).
 
 ### Allowlisting with `coreTools`
 
@@ -127,7 +147,9 @@ The most secure approach is to explicitly add the tools and commands that users 
 
 ```json
 {
-  "coreTools": ["ReadFileTool", "GlobTool", "ShellTool(ls)"]
+  "tools": {
+    "core": ["ReadFileTool", "GlobTool", "ShellTool(ls)"]
+  }
 }
 ```
 
@@ -139,7 +161,9 @@ Alternatively, you can add specific tools that are considered dangerous in your 
 
 ```json
 {
-  "excludeTools": ["ShellTool(rm -rf)"]
+  "tools": {
+    "exclude": ["ShellTool(rm -rf)"]
+  }
 }
 ```
 
@@ -172,7 +196,9 @@ Following the principle of least privilege, it is highly recommended to use `inc
 
 ```json
 {
-  "allowMCPServers": ["third-party-analyzer"],
+  "mcp": {
+    "allowed": ["third-party-analyzer"]
+  },
   "mcpServers": {
     "third-party-analyzer": {
       "command": "/usr/local/bin/start-3p-analyzer.sh",
@@ -187,7 +213,7 @@ Following the principle of least privilege, it is highly recommended to use `inc
 To create a secure, centrally-managed catalog of tools, the system administrator **must** do both of the following in the system-level `settings.json` file:
 
 1.  **Define the full configuration** for every approved server in the `mcpServers` object. This ensures that even if a user defines a server with the same name, the secure system-level definition will take precedence.
-2.  **Add the names** of those servers to an allowlist using the `allowMCPServers` setting. This is a critical security step that prevents users from running any servers that are not on this list. If this setting is omitted, the CLI will merge and allow any server defined by the user.
+2.  **Add the names** of those servers to an allowlist using the `mcp.allowed` setting. This is a critical security step that prevents users from running any servers that are not on this list. If this setting is omitted, the CLI will merge and allow any server defined by the user.
 
 **Example System `settings.json`:**
 
@@ -198,7 +224,9 @@ To create a secure, centrally-managed catalog of tools, the system administrator
 
 ```json
 {
-  "allowMCPServers": ["corp-data-api", "source-code-analyzer"],
+  "mcp": {
+    "allowed": ["corp-data-api", "source-code-analyzer"]
+  },
   "mcpServers": {
     "corp-data-api": {
       "command": "/usr/local/bin/start-corp-api.sh",
@@ -211,16 +239,16 @@ To create a secure, centrally-managed catalog of tools, the system administrator
 }
 ```
 
-This pattern is more secure because it uses both definition and an allowlist. Any server a user defines will either be overridden by the system definition (if it has the same name) or blocked because its name is not in the `allowMCPServers` list.
+This pattern is more secure because it uses both definition and an allowlist. Any server a user defines will either be overridden by the system definition (if it has the same name) or blocked because its name is not in the `mcp.allowed` list.
 
 ### Less Secure Pattern: Omitting the Allowlist
 
-If the administrator defines the `mcpServers` object but fails to also specify the `allowMCPServers` allowlist, users may add their own servers.
+If the administrator defines the `mcpServers` object but fails to also specify the `mcp.allowed` allowlist, users may add their own servers.
 
 **Example System `settings.json`:**
 
 This configuration defines servers but does not enforce the allowlist.
-The administrator has NOT included the "allowMCPServers" setting.
+The administrator has NOT included the "mcp.allowed" setting.
 
 ```json
 {
@@ -232,7 +260,7 @@ The administrator has NOT included the "allowMCPServers" setting.
 }
 ```
 
-In this scenario, a user can add their own server in their local `settings.json`. Because there is no `allowMCPServers` list to filter the merged results, the user's server will be added to the list of available tools and allowed to run.
+In this scenario, a user can add their own server in their local `settings.json`. Because there is no `mcp.allowed` list to filter the merged results, the user's server will be added to the list of available tools and allowed to run.
 
 ## Enforcing Sandboxing for Security
 
@@ -242,7 +270,9 @@ To mitigate the risk of potentially harmful operations, you can enforce the use 
 
 ```json
 {
-  "sandbox": "docker"
+  "tools": {
+    "sandbox": "docker"
+  }
 }
 ```
 
@@ -293,36 +323,39 @@ Here is an example of a system `settings.json` file that combines several of the
 
 ```json
 {
-  "sandbox": "docker",
-
-  "coreTools": [
-    "ReadFileTool",
-    "GlobTool",
-    "ShellTool(ls)",
-    "ShellTool(cat)",
-    "ShellTool(grep)"
-  ],
-
+  "tools": {
+    "sandbox": "docker",
+    "core": [
+      "ReadFileTool",
+      "GlobTool",
+      "ShellTool(ls)",
+      "ShellTool(cat)",
+      "ShellTool(grep)"
+    ]
+  },
+  "mcp": {
+    "allowed": ["corp-tools"]
+  },
   "mcpServers": {
     "corp-tools": {
       "command": "/opt/gemini-tools/start.sh",
       "timeout": 5000
     }
   },
-  "allowMCPServers": ["corp-tools"],
-
   "telemetry": {
     "enabled": true,
     "target": "gcp",
     "otlpEndpoint": "https://telemetry-prod.example.com:4317",
     "logPrompts": false
   },
-
-  "bugCommand": {
-    "urlTemplate": "https://servicedesk.example.com/new-ticket?title={title}&details={info}"
+  "advanced": {
+    "bugCommand": {
+      "urlTemplate": "https://servicedesk.example.com/new-ticket?title={title}&details={info}"
+    }
   },
-
-  "usageStatisticsEnabled": false
+  "privacy": {
+    "usageStatisticsEnabled": false
+  }
 }
 ```
 

--- a/docs/cli/themes.md
+++ b/docs/cli/themes.md
@@ -46,25 +46,14 @@ Add a `customThemes` block to your user, project, or system `settings.json` file
 
 ```json
 {
-  "customThemes": {
-    "MyCustomTheme": {
-      "name": "MyCustomTheme",
-      "type": "custom",
-      "Background": "#181818",
-      "Foreground": "#F8F8F2",
-      "LightBlue": "#82AAFF",
-      "AccentBlue": "#61AFEF",
-      "AccentPurple": "#C678DD",
-      "AccentCyan": "#56B6C2",
-      "AccentGreen": "#98C379",
-      "AccentYellow": "#E5C07B",
-      "AccentRed": "#E06C75",
-      "Comment": "#5C6370",
-      "Gray": "#ABB2BF",
-      "DiffAdded": "#A6E3A1",
-      "DiffRemoved": "#F38BA8",
-      "DiffModified": "#89B4FA",
-      "GradientColors": ["#4796E4", "#847ACE", "#C3677F"]
+  "ui": {
+    "customThemes": {
+      "MyCustomTheme": {
+        "name": "MyCustomTheme",
+        "type": "custom",
+        "Background": "#181818",
+        ...
+      }
     }
   }
 }
@@ -115,7 +104,9 @@ To load a theme from a file, set the `theme` property in your `settings.json` to
 
 ```json
 {
-  "theme": "/path/to/your/theme.json"
+  "ui": {
+    "theme": "/path/to/your/theme.json"
+  }
 }
 ```
 
@@ -154,7 +145,7 @@ The theme file must be a valid JSON file that follows the same structure as a cu
 ### Using Your Custom Theme
 
 - Select your custom theme using the `/theme` command in Gemini CLI. Your custom theme will appear in the theme selection dialog.
-- Or, set it as the default by adding `"theme": "MyCustomTheme"` to your `settings.json`.
+- Or, set it as the default by adding `"theme": "MyCustomTheme"` to the `ui` object in your `settings.json`.
 - Custom themes can be set at the user, project, or system level, and follow the same [configuration precedence](./configuration.md) as other settings.
 
 ---

--- a/docs/core/tools-api.md
+++ b/docs/core/tools-api.md
@@ -23,8 +23,8 @@ The Gemini CLI core (`packages/core`) features a robust system for defining, reg
 - **Tool Registry (`tool-registry.ts`):** A class (`ToolRegistry`) responsible for:
   - **Registering Tools:** Holding a collection of all available built-in tools (e.g., `ReadFileTool`, `ShellTool`).
   - **Discovering Tools:** It can also discover tools dynamically:
-    - **Command-based Discovery:** If `toolDiscoveryCommand` is configured in settings, this command is executed. It's expected to output JSON describing custom tools, which are then registered as `DiscoveredTool` instances.
-    - **MCP-based Discovery:** If `mcpServerCommand` is configured, the registry can connect to a Model Context Protocol (MCP) server to list and register tools (`DiscoveredMCPTool`).
+    - **Command-based Discovery:** If `tools.discoveryCommand` is configured in settings, this command is executed. It's expected to output JSON describing custom tools, which are then registered as `DiscoveredTool` instances.
+    - **MCP-based Discovery:** If `mcp.serverCommand` is configured, the registry can connect to a Model Context Protocol (MCP) server to list and register tools (`DiscoveredMCPTool`).
   - **Providing Schemas:** Exposing the `FunctionDeclaration` schemas of all registered tools to the Gemini model, so it knows what tools are available and how to use them.
   - **Retrieving Tools:** Allowing the core to get a specific tool by name for execution.
 
@@ -69,7 +69,7 @@ Each of these tools extends `BaseTool` and implements the required methods for i
 
 While direct programmatic registration of new tools by users isn't explicitly detailed as a primary workflow in the provided files for typical end-users, the architecture supports extension through:
 
-- **Command-based Discovery:** Advanced users or project administrators can define a `toolDiscoveryCommand` in `settings.json`. This command, when run by the Gemini CLI core, should output a JSON array of `FunctionDeclaration` objects. The core will then make these available as `DiscoveredTool` instances. The corresponding `toolCallCommand` would then be responsible for actually executing these custom tools.
+- **Command-based Discovery:** Advanced users or project administrators can define a `tools.discoveryCommand` in `settings.json`. This command, when run by the Gemini CLI core, should output a JSON array of `FunctionDeclaration` objects. The core will then make these available as `DiscoveredTool` instances. The corresponding `tools.callCommand` would then be responsible for actually executing these custom tools.
 - **MCP Server(s):** For more complex scenarios, one or more MCP servers can be set up and configured via the `mcpServers` setting in `settings.json`. The Gemini CLI core can then discover and use tools exposed by these servers. As mentioned, if you have multiple MCP servers, the tool names will be prefixed with the server name from your configuration (e.g., `serverAlias__actualToolName`).
 
 This tool system provides a flexible and powerful way to augment the Gemini model's capabilities, making the Gemini CLI a versatile assistant for a wide range of tasks.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -55,7 +55,9 @@ gemini -p "run the test suite"
 
 # Configure in settings.json
 {
-  "sandbox": "docker"
+  "tools": {
+    "sandbox": "docker"
+  }
 }
 ```
 
@@ -65,7 +67,7 @@ gemini -p "run the test suite"
 
 1. **Command flag**: `-s` or `--sandbox`
 2. **Environment variable**: `GEMINI_SANDBOX=true|docker|podman|sandbox-exec`
-3. **Settings file**: `"sandbox": true` in `settings.json`
+3. **Settings file**: `"sandbox": true` in the `tools` object of your `settings.json` file (e.g., `{"tools": {"sandbox": true}}`).
 
 ### macOS Seatbelt profiles
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -47,7 +47,9 @@ The following code can be added to your workspace (`.gemini/settings.json`) or u
     "enabled": true,
     "target": "gcp"
   },
-  "sandbox": false
+  "tools": {
+    "sandbox": false
+  }
 }
 ```
 

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -51,7 +51,30 @@ The Gemini CLI uses the `mcpServers` configuration in your `settings.json` file 
 
 ### Configure the MCP server in settings.json
 
-You can configure MCP servers at the global level in the `~/.gemini/settings.json` file or in your project's root directory, create or open the `.gemini/settings.json` file. Within the file, add the `mcpServers` configuration block.
+You can configure MCP servers in your `settings.json` file in two main ways: through the top-level `mcpServers` object for specific server definitions, and through the `mcp` object for global settings that control server discovery and execution.
+
+#### Global MCP Settings (`mcp`)
+
+The `mcp` object in your `settings.json` allows you to define global rules for all MCP servers.
+
+- **`mcp.serverCommand`** (string): A global command to start an MCP server.
+- **`mcp.allowed`** (array of strings): A whitelist of MCP server names to allow. If this is set, only servers from this list (matching the keys in the `mcpServers` object) will be connected to.
+- **`mcp.excluded`** (array of strings): A blacklist of MCP server names to exclude. Servers in this list will not be connected to.
+
+**Example:**
+
+```json
+{
+  "mcp": {
+    "allowed": ["my-trusted-server"],
+    "excluded": ["experimental-server"]
+  }
+}
+```
+
+#### Server-Specific Configuration (`mcpServers`)
+
+The `mcpServers` object is where you define each individual MCP server you want the CLI to connect to.
 
 ### Configuration Structure
 
@@ -667,9 +690,13 @@ await server.connect(transport);
 This can be included in `settings.json` under `mcpServers` with:
 
 ```json
-"nodeServer": {
-  "command": "node",
-  "args": ["filename.ts"],
+{
+  "mcpServers": {
+    "nodeServer": {
+      "command": "node",
+      "args": ["filename.ts"]
+    }
+  }
 }
 ```
 

--- a/docs/tools/shell.md
+++ b/docs/tools/shell.md
@@ -66,16 +66,16 @@ When `run_shell_command` executes a command, it sets the `GEMINI_CLI=1` environm
 
 ## Command Restrictions
 
-You can restrict the commands that can be executed by the `run_shell_command` tool by using the `coreTools` and `excludeTools` settings in your configuration file.
+You can restrict the commands that can be executed by the `run_shell_command` tool by using the `tools.core` and `tools.exclude` settings in your configuration file.
 
-- `coreTools`: To restrict `run_shell_command` to a specific set of commands, add entries to the `coreTools` list in the format `run_shell_command(<command>)`. For example, `"coreTools": ["run_shell_command(git)"]` will only allow `git` commands. Including the generic `run_shell_command` acts as a wildcard, allowing any command not explicitly blocked.
-- `excludeTools`: To block specific commands, add entries to the `excludeTools` list in the format `run_shell_command(<command>)`. For example, `"excludeTools": ["run_shell_command(rm)"]` will block `rm` commands.
+- `tools.core`: To restrict `run_shell_command` to a specific set of commands, add entries to the `core` list under the `tools` category in the format `run_shell_command(<command>)`. For example, `"tools": {"core": ["run_shell_command(git)"]}` will only allow `git` commands. Including the generic `run_shell_command` acts as a wildcard, allowing any command not explicitly blocked.
+- `tools.exclude`: To block specific commands, add entries to the `exclude` list under the `tools` category in the format `run_shell_command(<command>)`. For example, `"tools": {"exclude": ["run_shell_command(rm)"]}` will block `rm` commands.
 
 The validation logic is designed to be secure and flexible:
 
 1.  **Command Chaining Disabled**: The tool automatically splits commands chained with `&&`, `||`, or `;` and validates each part separately. If any part of the chain is disallowed, the entire command is blocked.
 2.  **Prefix Matching**: The tool uses prefix matching. For example, if you allow `git`, you can run `git status` or `git log`.
-3.  **Blocklist Precedence**: The `excludeTools` list is always checked first. If a command matches a blocked prefix, it will be denied, even if it also matches an allowed prefix in `coreTools`.
+3.  **Blocklist Precedence**: The `tools.exclude` list is always checked first. If a command matches a blocked prefix, it will be denied, even if it also matches an allowed prefix in `tools.core`.
 
 ### Command Restriction Examples
 
@@ -85,7 +85,9 @@ To allow only `git` and `npm` commands, and block all others:
 
 ```json
 {
-  "coreTools": ["run_shell_command(git)", "run_shell_command(npm)"]
+  "tools": {
+    "core": ["run_shell_command(git)", "run_shell_command(npm)"]
+  }
 }
 ```
 
@@ -99,8 +101,10 @@ To block `rm` and allow all other commands:
 
 ```json
 {
-  "coreTools": ["run_shell_command"],
-  "excludeTools": ["run_shell_command(rm)"]
+  "tools": {
+    "core": ["run_shell_command"],
+    "exclude": ["run_shell_command(rm)"]
+  }
 }
 ```
 
@@ -110,12 +114,14 @@ To block `rm` and allow all other commands:
 
 **Blocklist takes precedence**
 
-If a command prefix is in both `coreTools` and `excludeTools`, it will be blocked.
+If a command prefix is in both `tools.core` and `tools.exclude`, it will be blocked.
 
 ```json
 {
-  "coreTools": ["run_shell_command(git)"],
-  "excludeTools": ["run_shell_command(git push)"]
+  "tools": {
+    "core": ["run_shell_command(git)"],
+    "exclude": ["run_shell_command(git push)"]
+  }
 }
 ```
 
@@ -124,11 +130,13 @@ If a command prefix is in both `coreTools` and `excludeTools`, it will be blocke
 
 **Block all shell commands**
 
-To block all shell commands, add the `run_shell_command` wildcard to `excludeTools`:
+To block all shell commands, add the `run_shell_command` wildcard to `tools.exclude`:
 
 ```json
 {
-  "excludeTools": ["run_shell_command"]
+  "tools": {
+    "exclude": ["run_shell_command"]
+  }
 }
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -72,7 +72,7 @@ This guide provides solutions to common issues and debugging tips, including top
 - **DEBUG mode not working from project .env file**
   - **Issue:** Setting `DEBUG=true` in a project's `.env` file doesn't enable debug mode for gemini-cli.
   - **Cause:** The `DEBUG` and `DEBUG_MODE` variables are automatically excluded from project `.env` files to prevent interference with gemini-cli behavior.
-  - **Solution:** Use a `.gemini/.env` file instead, or configure the `excludedProjectEnvVars` setting in your `settings.json` to exclude fewer variables.
+  - **Solution:** Use a `.gemini/.env` file instead, or configure the `advanced.excludedEnvVars` setting in your `settings.json` to exclude fewer variables.
 
 ## Exit Codes
 


### PR DESCRIPTION
   This commit updates the documentation to reflect the new nested structure for `settings.json`. All examples and references to settings have been updated to use the new format (e.g., `ui.theme`, `tools.sandbox`).

   This change affects documentation for:
   - General configuration
   - Enterprise settings
   - Themes
   - Tools API and individual tools
   - Sandboxing
   - Telemetry

Resolved #6712
