### PR TITLE
feat: Handle large pastes in the input prompt

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -111,6 +111,8 @@ import { WorkspaceMigrationDialog } from './components/WorkspaceMigrationDialog.
 const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
 // Maximum number of queued messages to display in UI to prevent performance issues
 const MAX_DISPLAYED_QUEUED_MESSAGES = 3;
+const LARGE_PASTE_THRESHOLD_CHARS = 1000;
+const LARGE_PASTE_THRESHOLD_LINES = 50;
 
 interface AppProps {
   config: Config;
@@ -152,6 +154,10 @@ export const AppWrapper = (props: AppProps) => {
 const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   const isFocused = useFocus();
   useBracketedPaste();
+  const [pastes, setPastes] = useState<string[]>([]);
+  const handleLargePaste = (pastedText: string) => {
+    setPastes((prevPastes) => [...prevPastes, pastedText]);
+  };
   const [updateInfo, setUpdateInfo] = useState<UpdateObject | null>(null);
   const { stdout } = useStdout();
   const nightly = version.includes('nightly');
@@ -620,6 +626,9 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     setRawMode,
     isValidPath,
     shellModeActive,
+    onLargePaste: handleLargePaste,
+    largePasteThresholdChars: LARGE_PASTE_THRESHOLD_CHARS,
+    largePasteThresholdLines: LARGE_PASTE_THRESHOLD_LINES,
   });
 
   const [userMessages, setUserMessages] = useState<string[]>([]);
@@ -1344,6 +1353,8 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
                   focus={isFocused}
                   vimHandleInput={vimHandleInput}
                   placeholder={placeholder}
+                  pastes={pastes}
+                  setPastes={setPastes}
                 />
               )}
             </>

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -114,6 +114,7 @@ const MAX_DISPLAYED_QUEUED_MESSAGES = 3;
 const LARGE_PASTE_THRESHOLD_CHARS = 1000;
 const LARGE_PASTE_THRESHOLD_LINES = 50;
 
+
 interface AppProps {
   config: Config;
   settings: LoadedSettings;
@@ -154,10 +155,6 @@ export const AppWrapper = (props: AppProps) => {
 const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   const isFocused = useFocus();
   useBracketedPaste();
-  const [pastes, setPastes] = useState<string[]>([]);
-  const handleLargePaste = (pastedText: string) => {
-    setPastes((prevPastes) => [...prevPastes, pastedText]);
-  };
   const [updateInfo, setUpdateInfo] = useState<UpdateObject | null>(null);
   const { stdout } = useStdout();
   const nightly = version.includes('nightly');
@@ -626,7 +623,6 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     setRawMode,
     isValidPath,
     shellModeActive,
-    onLargePaste: handleLargePaste,
     largePasteThresholdChars: LARGE_PASTE_THRESHOLD_CHARS,
     largePasteThresholdLines: LARGE_PASTE_THRESHOLD_LINES,
   });
@@ -1353,8 +1349,6 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
                   focus={isFocused}
                   vimHandleInput={vimHandleInput}
                   placeholder={placeholder}
-                  pastes={pastes}
-                  setPastes={setPastes}
                 />
               )}
             </>

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -95,6 +95,7 @@ describe('InputPrompt', () => {
 
     mockBuffer = {
       text: '',
+      pastes: new Map(),
       cursor: [0, 0],
       lines: [''],
       setText: vi.fn((newText: string) => {
@@ -187,8 +188,6 @@ describe('InputPrompt', () => {
       inputWidth: 80,
       suggestionsWidth: 80,
       focus: true,
-      pastes: [],
-      setPastes: vi.fn(),
     };
   });
 

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -187,6 +187,8 @@ describe('InputPrompt', () => {
       inputWidth: 80,
       suggestionsWidth: 80,
       focus: true,
+      pastes: [],
+      setPastes: vi.fn(),
     };
   });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -31,18 +31,19 @@ import {
 import * as path from 'node:path';
 import { SCREEN_READER_USER_PREFIX } from '../textConstants.js';
 
-const PASTED_CONTENT_REGEX = /\[Pasted Content (\d+) chars\]/g;
 
-const reconstructInput = (text: string, storedPastes: string[]): string => {
-  if (storedPastes.length === 0) {
+const PASTED_CONTENT_REGEX = /\[Pasted Content ID: (paste-\d+)\]/g;
+
+const reconstructInput = (
+  text: string,
+  storedPastes: Map<string, string>,
+): string => {
+  if (storedPastes.size === 0) {
     return text;
   }
 
-  let pasteIndex = 0;
-  return text.replace(PASTED_CONTENT_REGEX, () => {
-    const fullText = storedPastes[pasteIndex] || '';
-    pasteIndex++;
-    return fullText;
+  return text.replace(PASTED_CONTENT_REGEX, (match, pasteId) => {
+    return storedPastes.get(pasteId) || match;
   });
 };
 
@@ -62,8 +63,6 @@ export interface InputPromptProps {
   setShellModeActive: (value: boolean) => void;
   onEscapePromptChange?: (showPrompt: boolean) => void;
   vimHandleInput?: (key: Key) => boolean;
-  pastes: string[];
-  setPastes: (pastes: string[]) => void;
 }
 
 export const InputPrompt: React.FC<InputPromptProps> = ({
@@ -82,8 +81,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   setShellModeActive,
   onEscapePromptChange,
   vimHandleInput,
-  pastes,
-  setPastes,
 }) => {
   const [justNavigatedHistory, setJustNavigatedHistory] = useState(false);
   const [escPressCount, setEscPressCount] = useState(0);
@@ -154,7 +151,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const handleSubmitAndClear = useCallback(
     (submittedValue: string) => {
-      const fullText = reconstructInput(submittedValue, pastes);
+      const fullText = reconstructInput(submittedValue, buffer.pastes);
       if (shellModeActive) {
         shellHistory.addCommandToHistory(fullText);
       }
@@ -162,7 +159,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       // if onSubmit triggers a re-render while the buffer still holds the old value.
       buffer.setText('');
       onSubmit(fullText);
-      setPastes([]); // clear pastes
       resetCompletionState();
       resetReverseSearchCompletionState();
     },
@@ -173,8 +169,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       shellModeActive,
       shellHistory,
       resetReverseSearchCompletionState,
-      pastes,
-      setPastes,
     ],
   );
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -31,6 +31,21 @@ import {
 import * as path from 'node:path';
 import { SCREEN_READER_USER_PREFIX } from '../textConstants.js';
 
+const PASTED_CONTENT_REGEX = /\[Pasted Content (\d+) chars\]/g;
+
+const reconstructInput = (text: string, storedPastes: string[]): string => {
+  if (storedPastes.length === 0) {
+    return text;
+  }
+
+  let pasteIndex = 0;
+  return text.replace(PASTED_CONTENT_REGEX, () => {
+    const fullText = storedPastes[pasteIndex] || '';
+    pasteIndex++;
+    return fullText;
+  });
+};
+
 export interface InputPromptProps {
   buffer: TextBuffer;
   onSubmit: (value: string) => void;
@@ -47,6 +62,8 @@ export interface InputPromptProps {
   setShellModeActive: (value: boolean) => void;
   onEscapePromptChange?: (showPrompt: boolean) => void;
   vimHandleInput?: (key: Key) => boolean;
+  pastes: string[];
+  setPastes: (pastes: string[]) => void;
 }
 
 export const InputPrompt: React.FC<InputPromptProps> = ({
@@ -65,6 +82,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   setShellModeActive,
   onEscapePromptChange,
   vimHandleInput,
+  pastes,
+  setPastes,
 }) => {
   const [justNavigatedHistory, setJustNavigatedHistory] = useState(false);
   const [escPressCount, setEscPressCount] = useState(0);
@@ -135,13 +154,15 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const handleSubmitAndClear = useCallback(
     (submittedValue: string) => {
+      const fullText = reconstructInput(submittedValue, pastes);
       if (shellModeActive) {
-        shellHistory.addCommandToHistory(submittedValue);
+        shellHistory.addCommandToHistory(fullText);
       }
       // Clear the buffer *before* calling onSubmit to prevent potential re-submission
       // if onSubmit triggers a re-render while the buffer still holds the old value.
       buffer.setText('');
-      onSubmit(submittedValue);
+      onSubmit(fullText);
+      setPastes([]); // clear pastes
       resetCompletionState();
       resetReverseSearchCompletionState();
     },
@@ -152,6 +173,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       shellModeActive,
       shellHistory,
       resetReverseSearchCompletionState,
+      pastes,
+      setPastes,
     ],
   );
 

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1584,7 +1584,13 @@ export function useTextBuffer({
         dispatch({ type: 'insert', payload: currentText });
       }
     },
-    [isValidPath, shellModeActive],
+    [
+      isValidPath,
+      shellModeActive,
+      largePasteThresholdChars,
+      largePasteThresholdLines,
+      onLargePaste,
+    ],
   );
 
   const newline = useCallback((): void => {

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -20,6 +20,19 @@ import {
 import type { VimAction } from './vim-buffer-actions.js';
 import { handleVimAction } from './vim-buffer-actions.js';
 
+function isLargePaste(
+  pastedText: string,
+  thresholdChars: number,
+  thresholdLines: number,
+): boolean {
+  if (!pastedText) {
+    return false;
+  }
+  const charCount = pastedText.length;
+  const lineCount = pastedText.split('\n').length;
+  return charCount > thresholdChars || lineCount > thresholdLines;
+}
+
 export type Direction =
   | 'left'
   | 'right'
@@ -518,6 +531,9 @@ interface UseTextBufferProps {
   onChange?: (text: string) => void; // Callback for when text changes
   isValidPath: (path: string) => boolean;
   shellModeActive?: boolean; // Whether the text buffer is in shell mode
+  onLargePaste: (pastedText: string) => void;
+  largePasteThresholdChars: number;
+  largePasteThresholdLines: number;
 }
 
 interface UndoHistoryEntry {
@@ -1455,6 +1471,9 @@ export function useTextBuffer({
   onChange,
   isValidPath,
   shellModeActive = false,
+  onLargePaste,
+  largePasteThresholdChars,
+  largePasteThresholdLines,
 }: UseTextBufferProps): TextBuffer {
   const initialState = useMemo((): TextBufferState => {
     const lines = initialText.split('\n');
@@ -1517,6 +1536,15 @@ export function useTextBuffer({
 
   const insert = useCallback(
     (ch: string, { paste = false }: { paste?: boolean } = {}): void => {
+      if (
+        paste &&
+        isLargePaste(ch, largePasteThresholdChars, largePasteThresholdLines)
+      ) {
+        onLargePaste(ch);
+        const summary = `[Pasted Content ${ch.length} chars]`;
+        dispatch({ type: 'insert', payload: summary });
+        return;
+      }
       if (/[\n\r]/.test(ch)) {
         dispatch({ type: 'insert', payload: ch });
         return;

--- a/packages/cli/src/ui/hooks/useReverseSearchCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useReverseSearchCompletion.test.tsx
@@ -19,6 +19,9 @@ describe('useReverseSearchCompletion', () => {
       viewport: { width: 80, height: 20 },
       isValidPath: () => false,
       onChange: () => {},
+      onLargePaste: () => {},
+      largePasteThresholdChars: 1000,
+      largePasteThresholdLines: 50,
     });
   }
 

--- a/packages/cli/src/ui/hooks/useReverseSearchCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useReverseSearchCompletion.test.tsx
@@ -19,7 +19,6 @@ describe('useReverseSearchCompletion', () => {
       viewport: { width: 80, height: 20 },
       isValidPath: () => false,
       onChange: () => {},
-      onLargePaste: () => {},
       largePasteThresholdChars: 1000,
       largePasteThresholdLines: 50,
     });


### PR DESCRIPTION
## TLDR

This PR implements a large paste handling feature for the input prompt that improves UI performance when users paste large amounts of text (>1000 characters or >50 lines). The text is replaced with a placeholder `[Pasted Content X chars]` in the UI while the full content is stored in memory and sent to the model when submitted.

## Dive Deeper

When users paste large blocks of code, logs, or other text content into the gemini-cli prompt, the UI can become sluggish due to rendering performance. This change addresses that by:

1. **Detection**: Monitoring paste operations for content that exceeds 1000 characters or 50 lines
2. **UI Optimization**: Replacing large pasted content with a compact placeholder showing the character count
3. **Preservation**: Storing the full content in memory so it's available when the prompt is submitted
4. **Transparency**: The model receives the complete original content, maintaining functionality

The implementation modifies the text buffer component's paste handling logic in `packages/cli/src/ui/components/shared/text-buffer.ts` to include new dependencies for large paste thresholds and callback handling.

## Reviewer Test Plan

To validate this change:

1. **Install and link the local version**:
   ```bash
   npm install
   npm link
   ```

2. **Test large paste scenarios**:
   - Copy a file with >1000 characters (e.g., a large code file, log output, or documentation)
   - Paste into the gemini-cli prompt
   - Verify the UI shows `[Pasted Content X chars]` placeholder
   - Submit the prompt and verify the model receives the full content

3. **Test normal paste scenarios**:
   - Copy small text snippets (<1000 chars and <50 lines)
   - Verify normal paste behavior is unchanged
   - Confirm no placeholders appear for small content

4. **Edge case testing**:
   - Test content exactly at thresholds (1000 chars, 50 lines)
   - Test multi-line content that exceeds line threshold but not character threshold
   - Test single-line content that exceeds character threshold

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This feature addresses UI performance issues when pasting large content into the prompt. While there may not be a specific linked issue, this improves the user experience for common workflows involving:
- Pasting large code files for analysis
- Including log output for debugging
- Sharing configuration files or documentation

<!-- 
If there are related issues, reference them here:
Related to #[issue_number] - UI performance with large input
-->