### PR TITLE
update(deps): genai sdk now handles empty GEMINI_API_KEY correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1126,9 +1126,9 @@
       "link": true
     },
     "node_modules/@google/genai": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.13.0.tgz",
-      "integrity": "sha512-BxilXzE8cJ0zt5/lXk6KwuBcIT9P2Lbi2WXhwWMbxf1RNeC68/8DmYQqMrzQP333CieRMdbDXs0eNCphLoScWg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.16.0.tgz",
+      "integrity": "sha512-hdTYu39QgDFxv+FB6BK2zi4UIJGWhx2iPc0pHQ0C5Q/RCi+m+4gsryIzTGO+riqWcUA8/WGYp6hpqckdOBNysw==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.14.2",
@@ -1138,7 +1138,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.0"
+        "@modelcontextprotocol/sdk": "^1.11.4"
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
@@ -14509,7 +14509,7 @@
       "version": "0.2.2",
       "dependencies": {
         "@google/gemini-cli-core": "file:../core",
-        "@google/genai": "1.13.0",
+        "@google/genai": "1.16.0",
         "@iarna/toml": "^2.2.5",
         "@modelcontextprotocol/sdk": "^1.15.1",
         "@types/update-notifier": "^6.0.8",
@@ -14691,7 +14691,7 @@
       "name": "@google/gemini-cli-core",
       "version": "0.2.2",
       "dependencies": {
-        "@google/genai": "1.13.0",
+        "@google/genai": "1.16.0",
         "@lvce-editor/ripgrep": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.11.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@google/gemini-cli-core": "file:../core",
-    "@google/genai": "1.13.0",
+    "@google/genai": "1.16.0",
     "@iarna/toml": "^2.2.5",
     "@modelcontextprotocol/sdk": "^1.15.1",
     "@types/update-notifier": "^6.0.8",

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -261,14 +261,6 @@ export async function main() {
       );
     }
   }
-  // Empty key causes issues with the GoogleGenAI package.
-  if (process.env['GEMINI_API_KEY']?.trim() === '') {
-    delete process.env['GEMINI_API_KEY'];
-  }
-
-  if (process.env['GOOGLE_API_KEY']?.trim() === '') {
-    delete process.env['GOOGLE_API_KEY'];
-  }
 
   setMaxSizedBoxDebugging(config.getDebugMode());
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "dependencies": {
-    "@google/genai": "1.13.0",
+    "@google/genai": "1.16.0",
     "@lvce-editor/ripgrep": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.11.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
## TLDR

Update genai sdk version to 1.16.0 which handles empty string `GEMINI_API_KEY` correctly. Revert the temp fix made in [#7214](https://github.com/google-gemini/gemini-cli/pull/7214)

## Reviewer Test Plan
* Setup auth with Vertex AI and set `GEMINI_API_KEY` to empty:
  ```
  export GEMINI_API_KEY=   
  export GOOGLE_CLOUD_LOCATION=us-central1
  export GOOGLE_CLOUD_PROJECT=gaghosh-project-1           
  ```
* Build from branch and run some query
  ```
  ./bundle/gemini.js -p "what can you do?"
  ```
<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
- Contributes: #5747