### PR TITLE
Markdown

### DIFF
--- a/packages/cli/src/ui/components/messages/GeminiMessage.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessage.tsx
@@ -23,7 +23,8 @@ export const GeminiMessage: React.FC<GeminiMessageProps> = ({
   availableTerminalHeight,
   terminalWidth,
 }) => {
-  const { isRawMode, toggleComponent } = useRawMode();
+  const isMarkdown = text && /[`*_[\\\]()#~|]/.test(text);
+  const { isRawMode, toggleComponent } = useRawMode(isMarkdown);
   const prefix = '✦ ';
   const prefixWidth = prefix.length;
 

--- a/packages/cli/src/ui/components/messages/GeminiMessage.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessage.tsx
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
-import { Text, Box, useInput } from 'ink';
+import React from 'react';
+import { Text, Box } from 'ink';
 import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
 import { Colors } from '../../colors.js';
+import { useRawMode } from '../../hooks/useRawMode.js';
 
 interface GeminiMessageProps {
   text: string;
@@ -22,15 +23,9 @@ export const GeminiMessage: React.FC<GeminiMessageProps> = ({
   availableTerminalHeight,
   terminalWidth,
 }) => {
-  const [isRawMode, setIsRawMode] = useState(false);
+  const { isRawMode, toggleComponent } = useRawMode();
   const prefix = '✦ ';
   const prefixWidth = prefix.length;
-
-  useInput((input) => {
-    if (input.toLowerCase() === 'r') {
-      setIsRawMode((prev) => !prev);
-    }
-  });
 
   return (
     <Box flexDirection="row">
@@ -38,11 +33,7 @@ export const GeminiMessage: React.FC<GeminiMessageProps> = ({
         <Text color={Colors.AccentPurple}>{prefix}</Text>
       </Box>
       <Box flexGrow={1} flexDirection="column">
-        <Box alignSelf="flex-end">
-          <Text dimColor>
-            {isRawMode ? 'Press `r` to see rendered' : 'Press `r` to see raw'}
-          </Text>
-        </Box>
+        {toggleComponent}
         <MarkdownDisplay
           text={text}
           isPending={isPending}

--- a/packages/cli/src/ui/components/messages/GeminiMessage.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessage.tsx
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { Text, Box } from 'ink';
+import React, { useState } from 'react';
+import { Text, Box, useInput } from 'ink';
 import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
 import { Colors } from '../../colors.js';
 
@@ -22,8 +22,15 @@ export const GeminiMessage: React.FC<GeminiMessageProps> = ({
   availableTerminalHeight,
   terminalWidth,
 }) => {
+  const [isRawMode, setIsRawMode] = useState(false);
   const prefix = '✦ ';
   const prefixWidth = prefix.length;
+
+  useInput((input) => {
+    if (input.toLowerCase() === 'r') {
+      setIsRawMode((prev) => !prev);
+    }
+  });
 
   return (
     <Box flexDirection="row">
@@ -31,11 +38,17 @@ export const GeminiMessage: React.FC<GeminiMessageProps> = ({
         <Text color={Colors.AccentPurple}>{prefix}</Text>
       </Box>
       <Box flexGrow={1} flexDirection="column">
+        <Box alignSelf="flex-end">
+          <Text dimColor>
+            {isRawMode ? 'Press `r` to see rendered' : 'Press `r` to see raw'}
+          </Text>
+        </Box>
         <MarkdownDisplay
           text={text}
           isPending={isPending}
           availableTerminalHeight={availableTerminalHeight}
           terminalWidth={terminalWidth}
+          isRawMode={isRawMode}
         />
       </Box>
     </Box>

--- a/packages/cli/src/ui/components/messages/GeminiMessageContent.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessageContent.tsx
@@ -28,7 +28,8 @@ export const GeminiMessageContent: React.FC<GeminiMessageContentProps> = ({
   availableTerminalHeight,
   terminalWidth,
 }) => {
-  const { isRawMode, toggleComponent } = useRawMode();
+  const isMarkdown = text && /[`*_[\\\]()#~|]/.test(text);
+  const { isRawMode, toggleComponent } = useRawMode(isMarkdown);
   const originalPrefix = '✦ ';
   const prefixWidth = originalPrefix.length;
 

--- a/packages/cli/src/ui/components/messages/GeminiMessageContent.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessageContent.tsx
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
-import { Box, Text, useInput } from 'ink';
+import React from 'react';
+import { Box } from 'ink';
 import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
+import { useRawMode } from '../../hooks/useRawMode.js';
 
 interface GeminiMessageContentProps {
   text: string;
@@ -27,23 +28,13 @@ export const GeminiMessageContent: React.FC<GeminiMessageContentProps> = ({
   availableTerminalHeight,
   terminalWidth,
 }) => {
-  const [isRawMode, setIsRawMode] = useState(false);
+  const { isRawMode, toggleComponent } = useRawMode();
   const originalPrefix = '✦ ';
   const prefixWidth = originalPrefix.length;
 
-  useInput((input) => {
-    if (input.toLowerCase() === 'r') {
-      setIsRawMode((prev) => !prev);
-    }
-  });
-
   return (
     <Box flexDirection="column" paddingLeft={prefixWidth}>
-      <Box alignSelf="flex-end">
-        <Text dimColor>
-          {isRawMode ? 'Press `r` to see rendered' : 'Press `r` to see raw'}
-        </Text>
-      </Box>
+      {toggleComponent}
       <MarkdownDisplay
         text={text}
         isPending={isPending}

--- a/packages/cli/src/ui/components/messages/GeminiMessageContent.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessageContent.tsx
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { Box } from 'ink';
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
 import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
 
 interface GeminiMessageContentProps {
@@ -27,16 +27,29 @@ export const GeminiMessageContent: React.FC<GeminiMessageContentProps> = ({
   availableTerminalHeight,
   terminalWidth,
 }) => {
+  const [isRawMode, setIsRawMode] = useState(false);
   const originalPrefix = '✦ ';
   const prefixWidth = originalPrefix.length;
 
+  useInput((input) => {
+    if (input.toLowerCase() === 'r') {
+      setIsRawMode((prev) => !prev);
+    }
+  });
+
   return (
     <Box flexDirection="column" paddingLeft={prefixWidth}>
+      <Box alignSelf="flex-end">
+        <Text dimColor>
+          {isRawMode ? 'Press `r` to see rendered' : 'Press `r` to see raw'}
+        </Text>
+      </Box>
       <MarkdownDisplay
         text={text}
         isPending={isPending}
         availableTerminalHeight={availableTerminalHeight}
         terminalWidth={terminalWidth}
+        isRawMode={isRawMode}
       />
     </Box>
   );

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -41,7 +41,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   emphasis = 'medium',
   renderOutputAsMarkdown = true,
 }) => {
-  const { isRawMode, toggleComponent } = useRawMode();
+  const { isRawMode, toggleComponent } = useRawMode(showToggle);
   const availableHeight = availableTerminalHeight
     ? Math.max(
         availableTerminalHeight - STATIC_HEIGHT - RESERVED_LINE_COUNT,

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -4,14 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
-import { Box, Text, useInput } from 'ink';
+import React from 'react';
+import { Box, Text } from 'ink';
 import { IndividualToolCallDisplay, ToolCallStatus } from '../../types.js';
 import { DiffRenderer } from './DiffRenderer.js';
 import { Colors } from '../../colors.js';
 import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
 import { GeminiRespondingSpinner } from '../GeminiRespondingSpinner.js';
 import { MaxSizedBox } from '../shared/MaxSizedBox.js';
+import { useRawMode } from '../../hooks/useRawMode.js';
 
 const STATIC_HEIGHT = 1;
 const RESERVED_LINE_COUNT = 5; // for tool name, status, padding etc.
@@ -40,19 +41,13 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   emphasis = 'medium',
   renderOutputAsMarkdown = true,
 }) => {
-  const [isRawMode, setIsRawMode] = useState(false);
+  const { isRawMode, toggleComponent } = useRawMode();
   const availableHeight = availableTerminalHeight
     ? Math.max(
         availableTerminalHeight - STATIC_HEIGHT - RESERVED_LINE_COUNT,
         MIN_LINES_SHOWN + 1, // enforce minimum lines shown
       )
     : undefined;
-
-  useInput((input) => {
-    if (input.toLowerCase() === 'r') {
-      setIsRawMode((prev) => !prev);
-    }
-  });
 
   // Long tool call response in MarkdownDisplay doesn't respect availableTerminalHeight properly,
   // we're forcing it to not render as markdown when the response is too long, it will fallback
@@ -69,6 +64,10 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
         '...' + resultDisplay.slice(-MAXIMUM_RESULT_DISPLAY_CHARACTERS);
     }
   }
+
+  const showToggle =
+    typeof resultDisplay === 'string' && renderOutputAsMarkdown;
+
   return (
     <Box paddingX={1} paddingY={0} flexDirection="column">
       <Box minHeight={1}>
@@ -84,12 +83,8 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
       {resultDisplay && (
         <Box paddingLeft={STATUS_INDICATOR_WIDTH} width="100%" marginTop={1}>
           <Box flexDirection="column">
-            <Box alignSelf="flex-end">
-              <Text dimColor>
-                {isRawMode ? 'Press `r` to see rendered' : 'Press `r` to see raw'}
-              </Text>
-            </Box>
-            {isRawMode ? (
+            {showToggle && toggleComponent}
+            {isRawMode && showToggle ? (
               <MarkdownDisplay
                 text={resultDisplay as string}
                 isPending={false}

--- a/packages/cli/src/ui/hooks/useRawMode.ts
+++ b/packages/cli/src/ui/hooks/useRawMode.ts
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+
+export function useRawMode() {
+  const [isRawMode, setIsRawMode] = useState(false);
+
+  useInput((input) => {
+    if (input.toLowerCase() === 'r') {
+      setIsRawMode((prev) => !prev);
+    }
+  });
+
+  const toggleComponent = (
+    <Box alignSelf="flex-end">
+      <Text dimColor>
+        {isRawMode ? 'Press `r` to see rendered' : 'Press `r` to see raw'}
+      </Text>
+    </Box>
+  );
+
+  return { isRawMode, toggleComponent };
+}

--- a/packages/cli/src/ui/hooks/useRawMode.tsx
+++ b/packages/cli/src/ui/hooks/useRawMode.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 
 export function useRawMode() {

--- a/packages/cli/src/ui/hooks/useRawMode.tsx
+++ b/packages/cli/src/ui/hooks/useRawMode.tsx
@@ -1,22 +1,22 @@
 import { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 
-export function useRawMode() {
+export function useRawMode(enabled: boolean) {
   const [isRawMode, setIsRawMode] = useState(false);
 
   useInput((input) => {
-    if (input.toLowerCase() === 'r') {
+    if (enabled && input.toLowerCase() === 'r') {
       setIsRawMode((prev) => !prev);
     }
   });
 
-  const toggleComponent = (
+  const toggleComponent = enabled ? (
     <Box alignSelf="flex-end">
       <Text dimColor>
         {isRawMode ? 'Press `r` to see rendered' : 'Press `r` to see raw'}
       </Text>
     </Box>
-  );
+  ) : null;
 
   return { isRawMode, toggleComponent };
 }

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -17,6 +17,7 @@ interface MarkdownDisplayProps {
   isPending: boolean;
   availableTerminalHeight?: number;
   terminalWidth: number;
+  isRawMode?: boolean;
 }
 
 // Constants for Markdown parsing and rendering
@@ -31,8 +32,21 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   isPending,
   availableTerminalHeight,
   terminalWidth,
+  isRawMode,
 }) => {
   if (!text) return <></>;
+
+  if (isRawMode) {
+    return (
+      <RenderCodeBlock
+        content={text.split('\n')}
+        lang="markdown"
+        isPending={isPending}
+        availableTerminalHeight={availableTerminalHeight}
+        terminalWidth={terminalWidth}
+      />
+    );
+  }
 
   const lines = text.split('\n');
   const headerRegex = /^ *(#{1,4}) +(.*)/;


### PR DESCRIPTION
## TLDR


This PR introduces the ability to toggle between rendered and raw (syntax-highlighted) markdown views for AI and tool responses. Users can simply press the r key to switch between the two modes. This provides an immediate way to view the original source for complex markdown (like tables) and makes it easy to copy the raw content.



## Dive Deeper

Terminal markdown rendering, while powerful, has inherent limitations. Complex elements like tables can suffer from truncation or formatting issues, and occasional rendering glitches can occur. Furthermore, users often want to copy the exact markdown source to use in other applications, such as documentation or GitHub comments.

This feature provides a user-friendly "escape hatch" to address these issues. By pressing r, the user can instantly switch from the pretty-printed, rendered output to a syntax-highlighted view of the raw markdown source.

The implementation is encapsulated in a clean, reusable way:

A new custom hook, useRawMode, was created to manage the state and handle the keyboard input for the toggle.

This hook is implemented in the GeminiMessage, GeminiMessageContent, and ToolMessage components, ensuring consistent behavior across different message types.

The MarkdownDisplay component was updated with an isRawMode prop, allowing it to conditionally display either the rendered output or the raw, highlighted source.

This approach improves the user experience by giving them more control over the output, and it reduces the pressure to create a "perfect" terminal renderer for every possible markdown structure.

## Reviewer Test Plan

Generate Complex Markdown: Start by asking the model for a response that includes complex markdown.

Example Prompt 1 (Tables): Create a markdown table comparing three different cloud providers (AWS, Azure, GCP) on services like Compute, Storage, and Database.

Example Prompt 2 (Mixed Elements): Generate a list of three popular JavaScript frameworks with **bold** and *italic* text, and include a code block for each.

Test the Toggle:

Once the response is displayed in its rendered form, press the r key.

Verify: The view should switch to the raw markdown source. You should see the markdown syntax (e.g., |, ---, **, *, ```).

Verify: The raw markdown text should be syntax-highlighted for readability.

Test Toggling Back:

While in raw mode, press the r key again.

Verify: The view should return to the original, fully rendered markdown output.

Test on Different Messages:

If possible, trigger a model response that involves a tool call to ensure the toggle works on ToolMessage components as well.

Test Edge Cases:

Generate a simple text response with no markdown (e.g., Hello). Pressing r should have no effect or behave gracefully.

Rapidly press r multiple times to ensure the state remains stable.



## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs


[Link to any related issues or bugs.](https://github.com/google-gemini/gemini-cli/issues/6499)

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #6499 
- Resolves #6499 

