### PR TITLE
Streaming retry UI fix

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -30,7 +30,11 @@ import {
   GeminiEventType as ServerGeminiEventType,
   ToolErrorType,
 } from '@google/gemini-cli-core';
-import type { Part, PartListUnion } from '@google/genai';
+import type {
+  GenerateContentResponse,
+  Part,
+  PartListUnion,
+} from '@google/genai';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import type { HistoryItem, SlashCommandProcessorResult } from '../types.js';
 import { MessageType, StreamingState } from '../types.js';
@@ -41,6 +45,22 @@ const mockSendMessageStream = vi
   .fn()
   .mockReturnValue((async function* () {})());
 const mockStartChat = vi.fn();
+
+// Add this mock to your test file
+const mockGenerateContentStream = vi.fn();
+vi.mock('@google/genai', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@google/genai')>();
+  return {
+    ...original,
+    GoogleGenerativeAI: class {
+      getGenerativeModel() {
+        return {
+          generateContentStream: mockGenerateContentStream,
+        };
+      }
+    },
+  };
+});
 
 const MockedGeminiClientClass = vi.hoisted(() =>
   vi.fn().mockImplementation(function (this: any, _config: any) {
@@ -1745,6 +1765,93 @@ describe('useGeminiStream', () => {
         'gemini-2.5-pro',
         'gemini-2.5-flash',
       );
+    });
+  });
+  // Add this new test suite to the end of your file
+  describe('useGeminiStream with Retries', () => {
+    it('should not display duplicate content when a stream retries internally', async () => {
+      // ARRANGE:
+      const mockAddItem = vi.fn();
+      const mockConfig = {
+        getApprovalMode: () => ApprovalMode.DEFAULT,
+        getSessionId: () => 'test-session-id',
+        setQuotaErrorOccurred: vi.fn(),
+        getModel: () => 'gemini-pro',
+        getContentGeneratorConfig: () => ({ model: 'gemini-pro' }),
+        getProxy: () => undefined,
+        getEmbeddingModel: () => undefined,
+        getProjectRoot: () => undefined,
+        getCheckpointingEnabled: () => undefined,
+        getUsageStatisticsEnabled: () => false,
+      } as unknown as Config;
+
+      // 1. First API call: returns an invalid stream (empty text part),
+      //    which triggers the internal retry logic in GeminiChat.
+      mockGenerateContentStream.mockImplementationOnce(async function* () {
+        yield {
+          candidates: [{ content: { parts: [{ text: '' }] } }],
+        } as GenerateContentResponse;
+      });
+
+      // 2. Second API call (the retry): returns a valid, multi-chunk stream.
+      mockGenerateContentStream.mockImplementationOnce(async function* () {
+        yield {
+          candidates: [{ content: { parts: [{ text: 'Hello ' }] } }],
+        } as GenerateContentResponse;
+        yield {
+          candidates: [{ content: { parts: [{ text: 'World!' }] } }],
+        } as GenerateContentResponse;
+      });
+
+      // Temporarily override the global mock to return a REAL client instance
+      const { GeminiClient: RealGeminiClient } = await vi.importActual(
+        '@google/gemini-cli-core',
+      );
+      MockedGeminiClientClass.mockImplementationOnce(
+        (config) => new RealGeminiClient(config),
+      );
+
+      const geminiClient = new (vi.mocked(RealGeminiClient, true))(mockConfig);
+
+      const { result } = renderHook(() =>
+        useGeminiStream(
+          geminiClient,
+          [], // initial history
+          mockAddItem,
+          mockConfig,
+          vi.fn(),
+          vi.fn(),
+          false,
+          vi.fn(),
+          vi.fn(),
+          vi.fn(),
+          false,
+          vi.fn(),
+          vi.fn(),
+          vi.fn(),
+        ),
+      );
+
+      // ACT:
+      await act(async () => {
+        await result.current.submitQuery('test query');
+      });
+
+      await waitFor(() => {
+        expect(result.current.streamingState).toBe(StreamingState.Idle);
+      });
+
+      // ASSERT:
+      const geminiResponseCalls = mockAddItem.mock.calls.filter(
+        (call) => call[0].type === MessageType.GEMINI,
+      );
+
+      const combinedText = geminiResponseCalls.reduce(
+        (acc, call) => acc + call[0].text,
+        '',
+      );
+
+      expect(combinedText).toBe('Hello World!');
     });
   });
 });

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -29,8 +29,7 @@ import {
   ConversationFinishedEvent,
   ApprovalMode,
   parseAndFormatApiError,
-  StreamEventType,
-  type StreamEvent,
+  GeminiEventType,
 } from '@google/gemini-cli-core';
 import { type Part, type PartListUnion, FinishReason } from '@google/genai';
 import type {
@@ -60,6 +59,10 @@ import {
 } from './useReactToolScheduler.js';
 import { useSessionStats } from '../contexts/SessionContext.js';
 import { useKeypress } from './useKeypress.js';
+import {
+  StreamEventType,
+  type StreamEvent,
+} from '@google/gemini-cli-core/src/core/geminiChat.js';
 
 enum StreamProcessingStatus {
   Completed,
@@ -644,7 +647,7 @@ export const useGeminiStream = (
 
       if (lastFinishReason) {
         handleFinishedEvent(
-          { type: 'finished', value: lastFinishReason },
+          { type: GeminiEventType.Finished, value: lastFinishReason },
           userMessageTimestamp,
         );
       }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -566,7 +566,6 @@ export class GeminiChat {
     let hasToolCall = false;
     let lastChunk: GenerateContentResponse | null = null;
 
-    // --- FIX: Restore the overall status flag and initialize all flags ---
     let isStreamInvalid = false;
     let firstInvalidChunkEncountered = false;
     let validChunkAfterInvalidEncountered = false;
@@ -592,8 +591,7 @@ export class GeminiChat {
         logInvalidChunk(
           this.config,
           new InvalidChunkEvent('Invalid chunk received from stream.'),
-        );
-        // --- FIX: Set both flags for an invalid chunk ---
+        );        
         isStreamInvalid = true;
         firstInvalidChunkEncountered = true;
       }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -562,30 +562,69 @@ export class GeminiChat {
     userInput: Content,
   ): AsyncGenerator<GenerateContentResponse> {
     const modelResponseParts: Part[] = [];
-    let isStreamInvalid = false;
     let hasReceivedAnyChunk = false;
+    let hasToolCall = false;
+    let lastChunk: GenerateContentResponse | null = null;
+
+    // --- FIX: Restore the overall status flag and initialize all flags ---
+    let isStreamInvalid = false;
+    let firstInvalidChunkEncountered = false;
+    let validChunkAfterInvalidEncountered = false;
 
     for await (const chunk of streamResponse) {
       hasReceivedAnyChunk = true;
+      lastChunk = chunk;
+
       if (isValidResponse(chunk)) {
+        if (firstInvalidChunkEncountered) {
+          // A valid chunk appeared *after* an invalid one.
+          validChunkAfterInvalidEncountered = true;
+        }
+
         const content = chunk.candidates?.[0]?.content;
         if (content?.parts) {
           modelResponseParts.push(...content.parts);
+          if (content.parts.some((part) => part.functionCall)) {
+            hasToolCall = true;
+          }
         }
       } else {
         logInvalidChunk(
           this.config,
           new InvalidChunkEvent('Invalid chunk received from stream.'),
         );
+        // --- FIX: Set both flags for an invalid chunk ---
         isStreamInvalid = true;
+        firstInvalidChunkEncountered = true;
       }
       yield chunk;
     }
 
-    if (isStreamInvalid || !hasReceivedAnyChunk) {
-      throw new EmptyStreamError(
-        'Model stream was invalid or completed without valid content.',
-      );
+    if (!hasReceivedAnyChunk) {
+      throw new EmptyStreamError('Model stream completed without any chunks.');
+    }
+
+    // --- FIX: The entire validation block was restructured for clarity and correctness ---
+    // Only apply complex validation if an invalid chunk was actually found.
+    if (isStreamInvalid) {
+      // Fail immediately if an invalid chunk was not the absolute last chunk.
+      if (validChunkAfterInvalidEncountered) {
+        throw new EmptyStreamError(
+          'Model stream had invalid intermediate chunks without a tool call.',
+        );
+      }
+
+      if (!hasToolCall) {
+        // If the *only* invalid part was the last chunk, we still check its finish reason.
+        const finishReason = lastChunk?.candidates?.[0]?.finishReason;
+        const isSuccessfulFinish =
+          finishReason === 'STOP' || finishReason === 'MAX_TOKENS';
+        if (!isSuccessfulFinish) {
+          throw new EmptyStreamError(
+            'Model stream ended with an invalid chunk and a failed finish reason.',
+          );
+        }
+      }
     }
 
     // Bundle all streamed parts into a single Content object

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -591,7 +591,7 @@ export class GeminiChat {
         logInvalidChunk(
           this.config,
           new InvalidChunkEvent('Invalid chunk received from stream.'),
-        );        
+        );
         isStreamInvalid = true;
         firstInvalidChunkEncountered = true;
       }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -382,7 +382,7 @@ export class GeminiChat {
             if (attempt > 0) {
               yield { type: StreamEventType.RETRY };
             }
-            
+
             const stream = await self.makeApiCallAndProcessStream(
               requestContents,
               params,

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -352,7 +352,7 @@ export class GeminiChat {
   async sendMessageStream(
     params: SendMessageParameters,
     prompt_id: string,
-  ): Promise<AsyncGenerator<GenerateContentResponse>> {
+  ): Promise<AsyncGenerator<StreamEvent>> {
     await this.sendPromise;
 
     let streamDoneResolver: () => void;


### PR DESCRIPTION
## TLDR
Handle cleaning up the response text in the UI when a response stream retry occurs.

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

`geminiChat.ts` was changed so that `sendMessageStream` returns a new `StreamEvent` which can indicate a retry event. `client.ts` was changed to also return a `StreamEvent`. `useGeminiStream.ts` was changed to clear the response buffer upon receiving a retry event.

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
