### PR TITLE
chore(dedup): Mock tools refix

### DIFF
--- a/packages/a2a-server/src/agent.test.ts
+++ b/packages/a2a-server/src/agent.test.ts
@@ -32,9 +32,9 @@ import {
   assertUniqueFinalEventIsLast,
   assertTaskCreationAndWorkingStatus,
   createStreamMessageRequest,
-  MockTool,
   createMockConfig,
 } from './testing_utils.js';
+import { MockTool } from '@google/gemini-cli-core';
 
 const mockToolConfirmationFn = async () =>
   ({}) as unknown as ToolCallConfirmationDetails;
@@ -175,13 +175,10 @@ describe('E2E Tests', () => {
       yield* [];
     });
 
-    const mockTool = new MockTool(
-      'test-tool',
-      'Test Tool',
-      true,
-      false,
-      mockToolConfirmationFn,
-    );
+    const mockTool = new MockTool({
+      name: 'test-tool',
+      shouldConfirmExecute: vi.fn(mockToolConfirmationFn),
+    });
 
     getToolRegistrySpy.mockReturnValue({
       getAllTools: vi.fn().mockReturnValue([mockTool]),
@@ -270,20 +267,16 @@ describe('E2E Tests', () => {
       yield* [];
     });
 
-    const mockTool1 = new MockTool(
-      'test-tool-1',
-      'Test Tool 1',
-      false,
-      false,
-      mockToolConfirmationFn,
-    );
-    const mockTool2 = new MockTool(
-      'test-tool-2',
-      'Test Tool 2',
-      false,
-      false,
-      mockToolConfirmationFn,
-    );
+    const mockTool1 = new MockTool({
+      name: 'test-tool-1',
+      displayName: 'Test Tool 1',
+      shouldConfirmExecute: vi.fn(mockToolConfirmationFn),
+    });
+    const mockTool2 = new MockTool({
+      name: 'test-tool-2',
+      displayName: 'Test Tool 2',
+      shouldConfirmExecute: vi.fn(mockToolConfirmationFn),
+    });
 
     getToolRegistrySpy.mockReturnValue({
       getAllTools: vi.fn().mockReturnValue([mockTool1, mockTool2]),
@@ -390,13 +383,13 @@ describe('E2E Tests', () => {
       yield* [{ type: 'content', value: 'Tool executed successfully.' }];
     });
 
-    const mockTool = new MockTool(
-      'test-tool-no-approval',
-      'Test Tool No Approval',
-    );
-    mockTool.execute.mockResolvedValue({
-      llmContent: 'Tool executed successfully.',
-      returnDisplay: 'Tool executed successfully.',
+    const mockTool = new MockTool({
+      name: 'test-tool-no-approval',
+      displayName: 'Test Tool No Approval',
+      execute: vi.fn().mockResolvedValue({
+        llmContent: 'Tool executed successfully.',
+        returnDisplay: 'Tool executed successfully.',
+      }),
     });
 
     getToolRegistrySpy.mockReturnValue({
@@ -521,15 +514,13 @@ describe('E2E Tests', () => {
     // Set approval mode to yolo
     getApprovalModeSpy.mockReturnValue(ApprovalMode.YOLO);
 
-    const mockTool = new MockTool(
-      'test-tool-yolo',
-      'Test Tool YOLO',
-      false,
-      false,
-    );
-    mockTool.execute.mockResolvedValue({
-      llmContent: 'Tool executed successfully.',
-      returnDisplay: 'Tool executed successfully.',
+    const mockTool = new MockTool({
+      name: 'test-tool-yolo',
+      displayName: 'Test Tool YOLO',
+      execute: vi.fn().mockResolvedValue({
+        llmContent: 'Tool executed successfully.',
+        returnDisplay: 'Tool executed successfully.',
+      }),
     });
 
     getToolRegistrySpy.mockReturnValue({

--- a/packages/a2a-server/src/testing_utils.ts
+++ b/packages/a2a-server/src/testing_utils.ts
@@ -10,17 +10,7 @@ import type {
   SendStreamingMessageSuccessResponse,
 } from '@a2a-js/sdk';
 import { ApprovalMode } from '@google/gemini-cli-core';
-import {
-  BaseDeclarativeTool,
-  BaseToolInvocation,
-  Kind,
-} from '@google/gemini-cli-core';
-import type {
-  Config,
-  ToolCallConfirmationDetails,
-  ToolResult,
-  ToolInvocation,
-} from '@google/gemini-cli-core';
+import type { Config } from '@google/gemini-cli-core';
 import { expect, vi } from 'vitest';
 
 export function createMockConfig(
@@ -53,79 +43,6 @@ export function createMockConfig(
     ...overrides,
   };
   return mockConfig;
-}
-
-export const mockOnUserConfirmForToolConfirmation = vi.fn();
-
-export class MockToolInvocation extends BaseToolInvocation<object, ToolResult> {
-  constructor(
-    private readonly tool: MockTool,
-    params: object,
-  ) {
-    super(params);
-  }
-
-  getDescription(): string {
-    return JSON.stringify(this.params);
-  }
-
-  override shouldConfirmExecute(
-    abortSignal: AbortSignal,
-  ): Promise<ToolCallConfirmationDetails | false> {
-    return this.tool.shouldConfirmExecute(this.params, abortSignal);
-  }
-
-  execute(
-    signal: AbortSignal,
-    updateOutput?: (output: string) => void,
-    terminalColumns?: number,
-    terminalRows?: number,
-  ): Promise<ToolResult> {
-    return this.tool.execute(
-      this.params,
-      signal,
-      updateOutput,
-      terminalColumns,
-      terminalRows,
-    );
-  }
-}
-
-// TODO: dedup with gemini-cli, add shouldConfirmExecute() support in core
-export class MockTool extends BaseDeclarativeTool<object, ToolResult> {
-  constructor(
-    name: string,
-    displayName: string,
-    canUpdateOutput = false,
-    isOutputMarkdown = false,
-    shouldConfirmExecute?: () => Promise<ToolCallConfirmationDetails | false>,
-  ) {
-    super(
-      name,
-      displayName,
-      'A mock tool for testing',
-      Kind.Other,
-      {},
-      isOutputMarkdown,
-      canUpdateOutput,
-    );
-
-    if (shouldConfirmExecute) {
-      this.shouldConfirmExecute.mockImplementation(shouldConfirmExecute);
-    } else {
-      // Default to no confirmation needed
-      this.shouldConfirmExecute.mockResolvedValue(false);
-    }
-  }
-
-  execute = vi.fn();
-  shouldConfirmExecute = vi.fn();
-
-  protected createInvocation(
-    params: object,
-  ): ToolInvocation<object, ToolResult> {
-    return new MockToolInvocation(this, params);
-  }
 }
 
 export function createStreamMessageRequest(

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -22,16 +22,13 @@ import type {
   ToolCallResponseInfo,
   ToolCall, // Import from core
   Status as ToolCallStatusType,
-  ToolInvocation,
   AnyDeclarativeTool,
   AnyToolInvocation,
 } from '@google/gemini-cli-core';
 import {
   ToolConfirmationOutcome,
   ApprovalMode,
-  Kind,
-  BaseDeclarativeTool,
-  BaseToolInvocation,
+  MockTool,
 } from '@google/gemini-cli-core';
 import type { HistoryItemWithoutId, HistoryItemToolGroup } from '../types.js';
 import { ToolCallStatus } from '../types.js';
@@ -64,96 +61,20 @@ const mockConfig = {
   }),
 } as unknown as Config;
 
-class MockToolInvocation extends BaseToolInvocation<object, ToolResult> {
-  constructor(
-    private readonly tool: MockTool,
-    params: object,
-  ) {
-    super(params);
-  }
-
-  getDescription(): string {
-    return JSON.stringify(this.params);
-  }
-
-  override shouldConfirmExecute(
-    abortSignal: AbortSignal,
-  ): Promise<ToolCallConfirmationDetails | false> {
-    return this.tool.shouldConfirmExecute(this.params, abortSignal);
-  }
-
-  execute(
-    signal: AbortSignal,
-    updateOutput?: (output: string) => void,
-    terminalColumns?: number,
-    terminalRows?: number,
-  ): Promise<ToolResult> {
-    return this.tool.execute(
-      this.params,
-      signal,
-      updateOutput,
-      terminalColumns,
-      terminalRows,
-    );
-  }
-}
-
-class MockTool extends BaseDeclarativeTool<object, ToolResult> {
-  constructor(
-    name: string,
-    displayName: string,
-    canUpdateOutput = false,
-    shouldConfirm = false,
-    isOutputMarkdown = false,
-  ) {
-    super(
-      name,
-      displayName,
-      'A mock tool for testing',
-      Kind.Other,
-      {},
-      isOutputMarkdown,
-      canUpdateOutput,
-    );
-    if (shouldConfirm) {
-      this.shouldConfirmExecute.mockImplementation(
-        async (): Promise<ToolCallConfirmationDetails | false> => ({
-          type: 'edit',
-          title: 'Mock Tool Requires Confirmation',
-          onConfirm: mockOnUserConfirmForToolConfirmation,
-          filePath: 'mock',
-          fileName: 'mockToolRequiresConfirmation.ts',
-          fileDiff: 'Mock tool requires confirmation',
-          originalContent: 'Original content',
-          newContent: 'New content',
-        }),
-      );
-    }
-  }
-
-  execute = vi.fn();
-  shouldConfirmExecute = vi.fn();
-
-  protected createInvocation(
-    params: object,
-  ): ToolInvocation<object, ToolResult> {
-    return new MockToolInvocation(this, params);
-  }
-}
-
-const mockTool = new MockTool('mockTool', 'Mock Tool');
-const mockToolWithLiveOutput = new MockTool(
-  'mockToolWithLiveOutput',
-  'Mock Tool With Live Output',
-  true,
-);
+const mockTool = new MockTool({ name: 'mockTool', displayName: 'Mock Tool' });
+const mockToolWithLiveOutput = new MockTool({
+  name: 'mockToolWithLiveOutput',
+  displayName: 'Mock Tool With Live Output',
+  description: 'A mock tool for testing',
+  params: {},
+  isOutputMarkdown: true,
+  canUpdateOutput: true,
+});
 let mockOnUserConfirmForToolConfirmation: Mock;
-const mockToolRequiresConfirmation = new MockTool(
-  'mockToolRequiresConfirmation',
-  'Mock Tool Requires Confirmation',
-  false,
-  true,
-);
+const mockToolRequiresConfirmation = new MockTool({
+  name: 'mockToolRequiresConfirmation',
+  displayName: 'Mock Tool Requires Confirmation',
+});
 
 describe('useReactToolScheduler in YOLO Mode', () => {
   let onComplete: Mock;
@@ -717,19 +638,23 @@ describe('useReactToolScheduler', () => {
   });
 
   it('should schedule and execute multiple tool calls', async () => {
-    const tool1 = new MockTool('tool1', 'Tool 1');
-    tool1.execute.mockResolvedValue({
-      llmContent: 'Output 1',
-      returnDisplay: 'Display 1',
-    } as ToolResult);
-    tool1.shouldConfirmExecute.mockResolvedValue(null);
+    const tool1 = new MockTool({
+      name: 'tool1',
+      displayName: 'Tool 1',
+      execute: vi.fn().mockResolvedValue({
+        llmContent: 'Output 1',
+        returnDisplay: 'Display 1',
+      } as ToolResult),
+    });
 
-    const tool2 = new MockTool('tool2', 'Tool 2');
-    tool2.execute.mockResolvedValue({
-      llmContent: 'Output 2',
-      returnDisplay: 'Display 2',
-    } as ToolResult);
-    tool2.shouldConfirmExecute.mockResolvedValue(null);
+    const tool2 = new MockTool({
+      name: 'tool2',
+      displayName: 'Tool 2',
+      execute: vi.fn().mockResolvedValue({
+        llmContent: 'Output 2',
+        returnDisplay: 'Display 2',
+      } as ToolResult),
+    });
 
     mockToolRegistry.getTool.mockImplementation((name) => {
       if (name === 'tool1') return tool1;
@@ -870,7 +795,12 @@ describe('mapToDisplay', () => {
     args: { foo: 'bar' },
   } as any;
 
-  const baseTool = new MockTool('testTool', 'Test Tool Display');
+  const baseTool = new MockTool({
+    name: 'testTool',
+    displayName: 'Test Tool Display',
+    execute: vi.fn(),
+    shouldConfirmExecute: vi.fn(),
+  });
 
   const baseResponse: ToolCallResponseInfo = {
     callId: 'testCallId',
@@ -1028,7 +958,7 @@ describe('mapToDisplay', () => {
       expectedStatus: ToolCallStatus.Error,
       expectedResultDisplay: 'Execution failed display',
       expectedName: baseTool.displayName, // Changed from baseTool.name
-      expectedDescription: baseInvocation.getDescription(),
+      expectedDescription: JSON.stringify(baseRequest.args),
     },
     {
       name: 'cancelled',
@@ -1099,13 +1029,13 @@ describe('mapToDisplay', () => {
       invocation: baseTool.build(baseRequest.args),
       response: { ...baseResponse, callId: 'call1' },
     } as ToolCall;
-    const toolForCall2 = new MockTool(
-      baseTool.name,
-      baseTool.displayName,
-      false,
-      false,
-      true,
-    );
+    const toolForCall2 = new MockTool({
+      name: baseTool.name,
+      displayName: baseTool.displayName,
+      isOutputMarkdown: true,
+      execute: vi.fn(),
+      shouldConfirmExecute: vi.fn(),
+    });
     const toolCall2: ToolCall = {
       request: { ...baseRequest, callId: 'call2' },
       status: 'executing',

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -61,7 +61,12 @@ const mockConfig = {
   }),
 } as unknown as Config;
 
-const mockTool = new MockTool({ name: 'mockTool', displayName: 'Mock Tool' });
+const mockTool = new MockTool({
+  name: 'mockTool',
+  displayName: 'Mock Tool',
+  execute: vi.fn(),
+  shouldConfirmExecute: vi.fn(),
+});
 const mockToolWithLiveOutput = new MockTool({
   name: 'mockToolWithLiveOutput',
   displayName: 'Mock Tool With Live Output',
@@ -69,11 +74,15 @@ const mockToolWithLiveOutput = new MockTool({
   params: {},
   isOutputMarkdown: true,
   canUpdateOutput: true,
+  execute: vi.fn(),
+  shouldConfirmExecute: vi.fn(),
 });
 let mockOnUserConfirmForToolConfirmation: Mock;
 const mockToolRequiresConfirmation = new MockTool({
   name: 'mockToolRequiresConfirmation',
   displayName: 'Mock Tool Requires Confirmation',
+  execute: vi.fn(),
+  shouldConfirmExecute: vi.fn(),
 });
 
 describe('useReactToolScheduler in YOLO Mode', () => {

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -154,9 +154,7 @@ describe('useReactToolScheduler in YOLO Mode', () => {
     expect(mockToolRequiresConfirmation.execute).toHaveBeenCalledWith(
       request.args,
       expect.any(AbortSignal),
-      undefined,
-      undefined,
-      undefined,
+      undefined /*updateOutputFn*/,
     );
 
     // Check that onComplete was called with success
@@ -307,9 +305,7 @@ describe('useReactToolScheduler', () => {
     expect(mockTool.execute).toHaveBeenCalledWith(
       request.args,
       expect.any(AbortSignal),
-      undefined,
-      undefined,
-      undefined,
+      undefined /*updateOutputFn*/,
     );
     expect(onComplete).toHaveBeenCalledWith([
       expect.objectContaining({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,3 +108,6 @@ export * from './telemetry/index.js';
 export { sessionId } from './utils/session.js';
 export * from './utils/browser.js';
 export { Storage } from './config/storage.js';
+
+// Export test utils
+export * from './test-utils/index.js';

--- a/packages/core/src/test-utils/index.ts
+++ b/packages/core/src/test-utils/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './mock-tool.js';

--- a/packages/core/src/test-utils/mock-tool.ts
+++ b/packages/core/src/test-utils/mock-tool.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi } from 'vitest';
+import type {
+  ToolCallConfirmationDetails,
+  ToolInvocation,
+  ToolResult,
+} from '../tools/tools.js';
+import {
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+} from '../tools/tools.js';
+
+type MockToolOptions = {
+  name: string;
+  displayName?: string;
+  description?: string;
+  canUpdateOutput?: boolean;
+  isOutputMarkdown?: boolean;
+  shouldConfirmExecute?: (
+    ...args: unknown[]
+  ) => Promise<ToolCallConfirmationDetails | false>;
+  execute?: (...args: unknown[]) => Promise<ToolResult>;
+  params?: object;
+};
+
+class MockToolInvocation extends BaseToolInvocation<
+  { [key: string]: unknown },
+  ToolResult
+> {
+  constructor(
+    private readonly tool: MockTool,
+    params: { [key: string]: unknown },
+  ) {
+    super(params);
+  }
+
+  execute(
+    signal: AbortSignal,
+    updateOutput?: (output: string) => void,
+    terminalColumns?: number,
+    terminalRows?: number,
+  ): Promise<ToolResult> {
+    return this.tool.execute(
+      this.params,
+      signal,
+      updateOutput,
+      terminalColumns,
+      terminalRows,
+    );
+  }
+
+  override shouldConfirmExecute(
+    abortSignal: AbortSignal,
+  ): Promise<ToolCallConfirmationDetails | false> {
+    return this.tool.shouldConfirmExecute(this.params, abortSignal);
+  }
+
+  getDescription(): string {
+    return `A mock tool invocation for ${this.tool.name}`;
+  }
+}
+
+/**
+ * A highly configurable mock tool for testing purposes.
+ */
+export class MockTool extends BaseDeclarativeTool<
+  { [key: string]: unknown },
+  ToolResult
+> {
+  execute: (...args: unknown[]) => Promise<ToolResult>;
+  shouldConfirmExecute: (
+    ...args: unknown[]
+  ) => Promise<ToolCallConfirmationDetails | false>;
+
+  constructor(options: MockToolOptions) {
+    super(
+      options.name,
+      options.displayName ?? options.name,
+      options.description ?? options.name,
+      Kind.Other,
+      options.params,
+      options.isOutputMarkdown ?? false,
+      options.canUpdateOutput ?? false,
+    );
+
+    if (options.shouldConfirmExecute) {
+      this.shouldConfirmExecute = options.shouldConfirmExecute;
+    } else {
+      this.shouldConfirmExecute = vi.fn().mockResolvedValue(false);
+    }
+
+    if (options.execute) {
+      this.execute = options.execute;
+    } else {
+      this.execute = vi.fn();
+    }
+  }
+
+  protected createInvocation(params: {
+    [key: string]: unknown;
+  }): ToolInvocation<{ [key: string]: unknown }, ToolResult> {
+    return new MockToolInvocation(this, params);
+  }
+}

--- a/packages/core/src/test-utils/mock-tool.ts
+++ b/packages/core/src/test-utils/mock-tool.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi } from 'vitest';
 import type {
   ToolCallConfirmationDetails,
   ToolInvocation,
@@ -16,7 +15,7 @@ import {
   Kind,
 } from '../tools/tools.js';
 
-type MockToolOptions = {
+interface MockToolOptions {
   name: string;
   displayName?: string;
   description?: string;
@@ -27,7 +26,7 @@ type MockToolOptions = {
   ) => Promise<ToolCallConfirmationDetails | false>;
   execute?: (...args: unknown[]) => Promise<ToolResult>;
   params?: object;
-};
+}
 
 class MockToolInvocation extends BaseToolInvocation<
   { [key: string]: unknown },
@@ -92,13 +91,17 @@ export class MockTool extends BaseDeclarativeTool<
     if (options.shouldConfirmExecute) {
       this.shouldConfirmExecute = options.shouldConfirmExecute;
     } else {
-      this.shouldConfirmExecute = vi.fn().mockResolvedValue(false);
+      this.shouldConfirmExecute = () => Promise.resolve(false);
     }
 
     if (options.execute) {
       this.execute = options.execute;
     } else {
-      this.execute = vi.fn();
+      this.execute = () =>
+        Promise.resolve({
+          llmContent: `Tool ${this.name} executed successfully.`,
+          returnDisplay: `Tool ${this.name} executed successfully.`,
+        });
     }
   }
 

--- a/packages/core/src/test-utils/mock-tool.ts
+++ b/packages/core/src/test-utils/mock-tool.ts
@@ -22,9 +22,14 @@ interface MockToolOptions {
   canUpdateOutput?: boolean;
   isOutputMarkdown?: boolean;
   shouldConfirmExecute?: (
-    ...args: unknown[]
+    params: { [key: string]: unknown },
+    signal: AbortSignal,
   ) => Promise<ToolCallConfirmationDetails | false>;
-  execute?: (...args: unknown[]) => Promise<ToolResult>;
+  execute?: (
+    params: { [key: string]: unknown },
+    signal: AbortSignal,
+    updateOutput?: (output: string) => void,
+  ) => Promise<ToolResult>;
   params?: object;
 }
 
@@ -42,16 +47,8 @@ class MockToolInvocation extends BaseToolInvocation<
   execute(
     signal: AbortSignal,
     updateOutput?: (output: string) => void,
-    terminalColumns?: number,
-    terminalRows?: number,
   ): Promise<ToolResult> {
-    return this.tool.execute(
-      this.params,
-      signal,
-      updateOutput,
-      terminalColumns,
-      terminalRows,
-    );
+    return this.tool.execute(this.params, signal, updateOutput);
   }
 
   override shouldConfirmExecute(
@@ -72,10 +69,15 @@ export class MockTool extends BaseDeclarativeTool<
   { [key: string]: unknown },
   ToolResult
 > {
-  execute: (...args: unknown[]) => Promise<ToolResult>;
   shouldConfirmExecute: (
-    ...args: unknown[]
+    params: { [key: string]: unknown },
+    signal: AbortSignal,
   ) => Promise<ToolCallConfirmationDetails | false>;
+  execute: (
+    params: { [key: string]: unknown },
+    signal: AbortSignal,
+    updateOutput?: (output: string) => void,
+  ) => Promise<ToolResult>;
 
   constructor(options: MockToolOptions) {
     super(


### PR DESCRIPTION
## TLDR

Reverts #7283 and fixes error (vitest import)

## Dive Deeper

Importing vitest in a file that was exported cause npm run start errors. This removes that dependency by pushing vi.fn() instantiation to the test files. 

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |


### Issues
[669](https://github.com/google-gemini/maintainers-gemini-cli/issues/669)
