### PR TITLE
feat(core): Enable ripgrep by default.

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1645,28 +1645,28 @@ describe('loadCliConfig useRipgrep', () => {
     vi.restoreAllMocks();
   });
 
-  it('should be false by default when useRipgrep is not set in settings', async () => {
+  it('should be true by default when useRipgrep is not set in settings', async () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments({} as Settings);
     const settings: Settings = {};
     const config = await loadCliConfig(settings, [], 'test-session', argv);
-    expect(config.getUseRipgrep()).toBe(false);
-  });
-
-  it('should be true when useRipgrep is set to true in settings', async () => {
-    process.argv = ['node', 'script.js'];
-    const argv = await parseArguments({} as Settings);
-    const settings: Settings = { tools: { useRipgrep: true } };
-    const config = await loadCliConfig(settings, [], 'test-session', argv);
     expect(config.getUseRipgrep()).toBe(true);
   });
 
-  it('should be false when useRipgrep is explicitly set to false in settings', async () => {
+  it('should be false when useRipgrep is set to false in settings', async () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments({} as Settings);
     const settings: Settings = { tools: { useRipgrep: false } };
     const config = await loadCliConfig(settings, [], 'test-session', argv);
     expect(config.getUseRipgrep()).toBe(false);
+  });
+
+  it('should be true when useRipgrep is explicitly set to true in settings', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments({} as Settings);
+    const settings: Settings = { tools: { useRipgrep: true } };
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.getUseRipgrep()).toBe(true);
   });
 });
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -741,7 +741,7 @@ const SETTINGS_SCHEMA = {
         label: 'Use Ripgrep',
         category: 'Tools',
         requiresRestart: false,
-        default: false,
+        default: true,
         description:
           'Use ripgrep for file content search instead of the fallback implementation. Provides faster search performance.',
         showInDialog: true,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -490,21 +490,12 @@ describe('Server Config (config.ts)', () => {
   });
 
   describe('UseRipgrep Configuration', () => {
-    it('should default useRipgrep to false when not provided', () => {
+    it('should default useRipgrep to true when not provided', () => {
       const config = new Config(baseParams);
-      expect(config.getUseRipgrep()).toBe(false);
-    });
-
-    it('should set useRipgrep to true when provided as true', () => {
-      const paramsWithRipgrep: ConfigParameters = {
-        ...baseParams,
-        useRipgrep: true,
-      };
-      const config = new Config(paramsWithRipgrep);
       expect(config.getUseRipgrep()).toBe(true);
     });
 
-    it('should set useRipgrep to false when explicitly provided as false', () => {
+    it('should set useRipgrep to false when provided as false', () => {
       const paramsWithRipgrep: ConfigParameters = {
         ...baseParams,
         useRipgrep: false,
@@ -513,13 +504,22 @@ describe('Server Config (config.ts)', () => {
       expect(config.getUseRipgrep()).toBe(false);
     });
 
-    it('should default useRipgrep to false when undefined', () => {
+    it('should set useRipgrep to true when explicitly provided as true', () => {
+      const paramsWithRipgrep: ConfigParameters = {
+        ...baseParams,
+        useRipgrep: true,
+      };
+      const config = new Config(paramsWithRipgrep);
+      expect(config.getUseRipgrep()).toBe(true);
+    });
+
+    it('should default useRipgrep to true when undefined', () => {
       const paramsWithUndefinedRipgrep: ConfigParameters = {
         ...baseParams,
         useRipgrep: undefined,
       };
       const config = new Config(paramsWithUndefinedRipgrep);
-      expect(config.getUseRipgrep()).toBe(false);
+      expect(config.getUseRipgrep()).toBe(true);
     });
   });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -390,7 +390,7 @@ export class Config {
     this.chatCompression = params.chatCompression;
     this.interactive = params.interactive ?? false;
     this.trustedFolder = params.trustedFolder;
-    this.useRipgrep = params.useRipgrep ?? false;
+    this.useRipgrep = params.useRipgrep ?? true;
     this.shouldUseNodePtyShell = params.shouldUseNodePtyShell ?? false;
     this.skipNextSpeakerCheck = params.skipNextSpeakerCheck ?? true;
     this.shellExecutionConfig = {

--- a/packages/core/src/core/subagent.test.ts
+++ b/packages/core/src/core/subagent.test.ts
@@ -45,6 +45,7 @@ vi.mock('../ide/ide-client.js');
 
 async function createMockConfig(
   toolRegistryMocks = {},
+  configParameters: Partial<ConfigParameters> = {},
 ): Promise<{ config: Config; toolRegistry: ToolRegistry }> {
   const configParams: ConfigParameters = {
     sessionId: 'test-session',
@@ -52,6 +53,7 @@ async function createMockConfig(
     targetDir: '.',
     debugMode: false,
     cwd: process.cwd(),
+    ...configParameters,
   };
   const config = new Config(configParams);
   await config.initialize();
@@ -767,7 +769,7 @@ describe('subagent.ts', () => {
         // Use fake timers to reliably test timeouts
         vi.useFakeTimers();
 
-        const { config } = await createMockConfig();
+        const { config } = await createMockConfig({}, { useRipgrep: false });
         const runConfig: RunConfig = { max_time_minutes: 5, max_turns: 100 };
 
         // We need to control the resolution of the sendMessageStream promise to advance the timer during execution.
@@ -812,7 +814,7 @@ describe('subagent.ts', () => {
       });
 
       it('should terminate with ERROR if the model call throws', async () => {
-        const { config } = await createMockConfig();
+        const { config } = await createMockConfig({}, { useRipgrep: false });
         mockSendMessageStream.mockRejectedValue(new Error('API Failure'));
 
         const scope = await SubAgentScope.create(


### PR DESCRIPTION
## TLDR

Enables ripgrep by default

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | :heavy_check_mark:   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
- Fixes #7327 