### PR TITLE
fix(diffstats): Fix diff stats to correctly capture the edits

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -507,7 +507,7 @@ describe('EditTool', () => {
     });
 
     it('should successfully replace multiple occurrences when expected_replacements specified', async () => {
-      fs.writeFileSync(filePath, 'old text old text old text', 'utf8');
+      fs.writeFileSync(filePath, 'old text\nold text\nold text', 'utf8');
       const params: EditToolParams = {
         file_path: filePath,
         old_string: 'old',
@@ -520,12 +520,19 @@ describe('EditTool', () => {
 
       expect(result.llmContent).toMatch(/Successfully modified file/);
       expect(fs.readFileSync(filePath, 'utf8')).toBe(
-        'new text new text new text',
+        'new text\nnew text\nnew text',
       );
       const display = result.returnDisplay as FileDiff;
-      expect(display.fileDiff).toMatch(/old text old text old text/);
-      expect(display.fileDiff).toMatch(/new text new text new text/);
+
+      expect(display.fileDiff).toMatch(/-old text\n-old text\n-old text/);
+      expect(display.fileDiff).toMatch(/\+new text\n\+new text\n\+new text/);
       expect(display.fileName).toBe(testFile);
+      expect((result.returnDisplay as FileDiff).diffStat).toStrictEqual({
+        ai_added_lines: 3,
+        ai_removed_lines: 3,
+        user_added_lines: 0,
+        user_removed_lines: 0,
+      });
     });
 
     it('should return error if expected_replacements does not match actual occurrences', async () => {
@@ -562,13 +569,14 @@ describe('EditTool', () => {
     });
 
     it('should include modification message when proposed content is modified', async () => {
-      const initialContent = 'This is some old text.';
+      const initialContent = 'Line 1\nold line\nLine 3\nLine 4\nLine 5\n';
       fs.writeFileSync(filePath, initialContent, 'utf8');
       const params: EditToolParams = {
         file_path: filePath,
         old_string: 'old',
         new_string: 'new',
         modified_by_user: true,
+        ai_proposed_content: 'Line 1\nAI line\nLine 3\nLine 4\nLine 5\n',
       };
 
       (mockConfig.getApprovalMode as Mock).mockReturnValueOnce(
@@ -580,6 +588,12 @@ describe('EditTool', () => {
       expect(result.llmContent).toMatch(
         /User modified the `new_string` content/,
       );
+      expect((result.returnDisplay as FileDiff).diffStat).toStrictEqual({
+        ai_added_lines: 1,
+        ai_removed_lines: 1,
+        user_added_lines: 1,
+        user_removed_lines: 1,
+      });
     });
 
     it('should not include modification message when proposed content is not modified', async () => {

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -86,9 +86,9 @@ export interface EditToolParams {
   modified_by_user?: boolean;
 
   /**
-   * Initially proposed string.
+   * Initially proposed content.
    */
-  ai_proposed_string?: string;
+  ai_proposed_content?: string;
 }
 
 interface CalculatedEdit {
@@ -365,12 +365,12 @@ class EditToolInvocation implements ToolInvocation<EditToolParams, ToolResult> {
       let displayResult: ToolResultDisplay;
       const fileName = path.basename(this.params.file_path);
       const originallyProposedContent =
-        this.params.ai_proposed_string || this.params.new_string;
+        this.params.ai_proposed_content || editData.newContent;
       const diffStat = getDiffStat(
         fileName,
         editData.currentContent ?? '',
         originallyProposedContent,
-        this.params.new_string,
+        editData.newContent,
       );
 
       if (editData.isNewFile) {
@@ -572,16 +572,13 @@ Expectation for required parameters:
         oldContent: string,
         modifiedProposedContent: string,
         originalParams: EditToolParams,
-      ): EditToolParams => {
-        const content = originalParams.new_string;
-        return {
-          ...originalParams,
-          ai_proposed_string: content,
-          old_string: oldContent,
-          new_string: modifiedProposedContent,
-          modified_by_user: true,
-        };
-      },
+      ): EditToolParams => ({
+        ...originalParams,
+        ai_proposed_content: oldContent,
+        old_string: oldContent,
+        new_string: modifiedProposedContent,
+        modified_by_user: true,
+      }),
     };
   }
 }


### PR DESCRIPTION
## TLDR

Fix the diff stat computation by:
- Using the right content for diffing: `EditToolParams.new_string` corresponds to the replacement string and not the new content. New content is stored in `editData.newContent`
- Using the right content for `EditToolParams.ai_proposed_content` in `createUpdatedParams`. This was being set to the previous `EditToolParams.new_string` which is merely the old replacement string

Also, renamed `ai_proposed_string` => `ai_proposed_content`, which is what this variable stores.

## Dive Deeper

Setup for testing the changes:
Created a file `test.txt` with:
```
Line 1
Line 2
Line 3
Line 4
Line 5
Line 6
Line 7
Line 8
```
Prompt: `Replace '7' in the file docs/test.txt with 'S3V3N'`

Without the change:
<img width="3133" height="1432" alt="Before" src="https://github.com/user-attachments/assets/b63d33d9-79bb-4970-bad9-5553d03504f4" />

With the change:
<img width="3141" height="1372" alt="After" src="https://github.com/user-attachments/assets/0fdae1f4-c7f4-4e8e-a0fe-422c425e60ea" />


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options 
as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Fixes #7481 

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
