### PR TITLE
docs: fix OAuth redirectUri documentation - port 7777 is hardcoded

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -167,6 +167,7 @@ The Gemini CLI uses a dedicated OAuth callback server that listens on port 7777.
 
 **For MCP Server Developers:**
 When configuring OAuth for your MCP server, please ensure your OAuth provider includes this redirect URI:
+
 ```
 http://localhost:7777/oauth/callback
 ```

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -161,6 +161,16 @@ When connecting to an OAuth-enabled server:
 - Open a web browser for authentication
 - Receive redirects on `http://localhost:7777/oauth/callback`
 
+#### OAuth Callback Port Requirement
+
+The Gemini CLI uses a dedicated OAuth callback server that listens on port 7777. This port is hardcoded in the CLI's implementation to ensure consistent OAuth flows across different environments.
+
+**For MCP Server Developers:**
+When configuring OAuth for your MCP server, please ensure your OAuth provider includes this redirect URI:
+```
+http://localhost:7777/oauth/callback
+```
+
 This feature will not work in:
 
 - Headless environments without browser access
@@ -190,7 +200,7 @@ Use the `/mcp auth` command to manage OAuth authentication:
 - **`authorizationUrl`** (string): OAuth authorization endpoint (auto-discovered if omitted)
 - **`tokenUrl`** (string): OAuth token endpoint (auto-discovered if omitted)
 - **`scopes`** (string[]): Required OAuth scopes
-- **`redirectUri`** (string): Custom redirect URI (defaults to `http://localhost:7777/oauth/callback`)
+- **`redirectUri`** (string): OAuth redirect URI. The Gemini CLI uses `http://localhost:7777/oauth/callback` by default and this cannot be customized.
 - **`tokenParamName`** (string): Query parameter name for tokens in SSE URLs
 - **`audiences`** (string[]): Audiences the token is valid for
 


### PR DESCRIPTION
## Summary

Fixes documentation bug where OAuth `redirectUri` property was incorrectly described as customizable when the implementation hardcodes port 7777.

## Problem

The MCP server documentation states that `redirectUri` is a "Custom redirect URI" that "defaults to" localhost:7777, implying it can be configured. However, the actual implementation in `packages/core/src/mcp/oauth-provider.ts` hardcodes both the port and path:

```typescript
private static readonly REDIRECT_PORT = 7777;
private static readonly REDIRECT_PATH = '/oauth/callback';
```

This documentation discrepancy causes authentication failures when developers configure their OAuth providers with different redirect URIs.

## Changes

1. **Corrected OAuth Configuration Properties**: Updated the `redirectUri` description to accurately reflect that it cannot be customized
2. **Added OAuth Callback Port Requirement section**: Provides clear explanation of the hardcoded port 7777 requirement
3. **Enhanced developer guidance**: Explicit instructions for MCP server developers on OAuth provider configuration

## Impact

- Prevents OAuth authentication failures caused by incorrect redirect URI configuration
- Reduces developer confusion about OAuth setup requirements  
- Aligns documentation with actual implementation behavior

## Testing

Validated against real-world MCP server OAuth integration where this documentation discrepancy caused authentication issues.