### PR TITLE
refac: remove static method from storage.ts

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -26,7 +26,8 @@ export type { Settings, MemoryImportFormat };
 
 export const SETTINGS_DIRECTORY_NAME = '.gemini';
 
-export const USER_SETTINGS_PATH = Storage.getGlobalSettingsPath();
+const storage = new Storage(process.cwd());
+export const USER_SETTINGS_PATH = storage.getGlobalSettingsPath();
 export const USER_SETTINGS_DIR = path.dirname(USER_SETTINGS_PATH);
 export const DEFAULT_EXCLUDED_ENV_VARS = ['DEBUG', 'DEBUG_MODE'];
 

--- a/packages/cli/src/services/FileCommandLoader.test.ts
+++ b/packages/cli/src/services/FileCommandLoader.test.ts
@@ -72,6 +72,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
 
 describe('FileCommandLoader', () => {
   const signal: AbortSignal = new AbortController().signal;
+  const storage = new Storage(process.cwd());
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -105,7 +106,7 @@ describe('FileCommandLoader', () => {
   });
 
   it('loads a single command from a file', async () => {
-    const userCommandsDir = Storage.getUserCommandsDir();
+    const userCommandsDir = storage.getUserCommandsDir();
     mock({
       [userCommandsDir]: {
         'test.toml': 'prompt = "This is a test prompt"',
@@ -146,7 +147,7 @@ describe('FileCommandLoader', () => {
   itif(process.platform !== 'win32')(
     'loads commands from a symlinked directory',
     async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       const realCommandsDir = '/real/commands';
       mock({
         [realCommandsDir]: {
@@ -171,7 +172,7 @@ describe('FileCommandLoader', () => {
   itif(process.platform !== 'win32')(
     'loads commands from a symlinked subdirectory',
     async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       const realNamespacedDir = '/real/namespaced-commands';
       mock({
         [userCommandsDir]: {
@@ -195,7 +196,7 @@ describe('FileCommandLoader', () => {
   );
 
   it('loads multiple commands', async () => {
-    const userCommandsDir = Storage.getUserCommandsDir();
+    const userCommandsDir = storage.getUserCommandsDir();
     mock({
       [userCommandsDir]: {
         'test1.toml': 'prompt = "Prompt 1"',
@@ -210,7 +211,7 @@ describe('FileCommandLoader', () => {
   });
 
   it('creates deeply nested namespaces correctly', async () => {
-    const userCommandsDir = Storage.getUserCommandsDir();
+    const userCommandsDir = storage.getUserCommandsDir();
 
     mock({
       [userCommandsDir]: {
@@ -234,7 +235,7 @@ describe('FileCommandLoader', () => {
   });
 
   it('creates namespaces from nested directories', async () => {
-    const userCommandsDir = Storage.getUserCommandsDir();
+    const userCommandsDir = storage.getUserCommandsDir();
     mock({
       [userCommandsDir]: {
         git: {
@@ -253,7 +254,7 @@ describe('FileCommandLoader', () => {
   });
 
   it('returns both user and project commands in order', async () => {
-    const userCommandsDir = Storage.getUserCommandsDir();
+    const userCommandsDir = storage.getUserCommandsDir();
     const projectCommandsDir = new Storage(
       process.cwd(),
     ).getProjectCommandsDir();
@@ -309,7 +310,7 @@ describe('FileCommandLoader', () => {
   });
 
   it('ignores files with TOML syntax errors', async () => {
-    const userCommandsDir = Storage.getUserCommandsDir();
+    const userCommandsDir = storage.getUserCommandsDir();
     mock({
       [userCommandsDir]: {
         'invalid.toml': 'this is not valid toml',
@@ -325,7 +326,7 @@ describe('FileCommandLoader', () => {
   });
 
   it('ignores files that are semantically invalid (missing prompt)', async () => {
-    const userCommandsDir = Storage.getUserCommandsDir();
+    const userCommandsDir = storage.getUserCommandsDir();
     mock({
       [userCommandsDir]: {
         'no_prompt.toml': 'description = "This file is missing a prompt"',
@@ -341,7 +342,7 @@ describe('FileCommandLoader', () => {
   });
 
   it('handles filename edge cases correctly', async () => {
-    const userCommandsDir = Storage.getUserCommandsDir();
+    const userCommandsDir = storage.getUserCommandsDir();
     mock({
       [userCommandsDir]: {
         'test.v1.toml': 'prompt = "Test prompt"',
@@ -363,7 +364,7 @@ describe('FileCommandLoader', () => {
   });
 
   it('uses a default description if not provided', async () => {
-    const userCommandsDir = Storage.getUserCommandsDir();
+    const userCommandsDir = storage.getUserCommandsDir();
     mock({
       [userCommandsDir]: {
         'test.toml': 'prompt = "Test prompt"',
@@ -378,7 +379,7 @@ describe('FileCommandLoader', () => {
   });
 
   it('uses the provided description', async () => {
-    const userCommandsDir = Storage.getUserCommandsDir();
+    const userCommandsDir = storage.getUserCommandsDir();
     mock({
       [userCommandsDir]: {
         'test.toml': 'prompt = "Test prompt"\ndescription = "My test command"',
@@ -393,7 +394,7 @@ describe('FileCommandLoader', () => {
   });
 
   it('should sanitize colons in filenames to prevent namespace conflicts', async () => {
-    const userCommandsDir = Storage.getUserCommandsDir();
+    const userCommandsDir = storage.getUserCommandsDir();
     mock({
       [userCommandsDir]: {
         'legacy:command.toml': 'prompt = "This is a legacy command"',
@@ -413,7 +414,7 @@ describe('FileCommandLoader', () => {
 
   describe('Processor Instantiation Logic', () => {
     it('instantiates only DefaultArgumentProcessor if no {{args}} or !{} are present', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'simple.toml': `prompt = "Just a regular prompt"`,
@@ -428,7 +429,7 @@ describe('FileCommandLoader', () => {
     });
 
     it('instantiates only ShellProcessor if {{args}} is present (but not !{})', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'args.toml': `prompt = "Prompt with {{args}}"`,
@@ -443,7 +444,7 @@ describe('FileCommandLoader', () => {
     });
 
     it('instantiates ShellProcessor and DefaultArgumentProcessor if !{} is present (but not {{args}})', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'shell.toml': `prompt = "Prompt with !{cmd}"`,
@@ -458,7 +459,7 @@ describe('FileCommandLoader', () => {
     });
 
     it('instantiates only ShellProcessor if both {{args}} and !{} are present', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'both.toml': `prompt = "Prompt with {{args}} and !{cmd}"`,
@@ -473,7 +474,7 @@ describe('FileCommandLoader', () => {
     });
 
     it('instantiates AtFileProcessor and DefaultArgumentProcessor if @{} is present', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'at-file.toml': `prompt = "Context: @{./my-file.txt}"`,
@@ -489,7 +490,7 @@ describe('FileCommandLoader', () => {
     });
 
     it('instantiates ShellProcessor and AtFileProcessor if !{} and @{} are present', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'shell-and-at.toml': `prompt = "Run !{cmd} with @{file.txt}"`,
@@ -505,7 +506,7 @@ describe('FileCommandLoader', () => {
     });
 
     it('instantiates only ShellProcessor and AtFileProcessor if {{args}} and @{} are present', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'args-and-at.toml': `prompt = "Run {{args}} with @{file.txt}"`,
@@ -523,7 +524,7 @@ describe('FileCommandLoader', () => {
 
   describe('Extension Command Loading', () => {
     it('loads commands from active extensions', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       const projectCommandsDir = new Storage(
         process.cwd(),
       ).getProjectCommandsDir();
@@ -576,7 +577,7 @@ describe('FileCommandLoader', () => {
     });
 
     it('extension commands have extensionName metadata for conflict resolution', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       const projectCommandsDir = new Storage(
         process.cwd(),
       ).getProjectCommandsDir();
@@ -831,7 +832,7 @@ describe('FileCommandLoader', () => {
 
   describe('Argument Handling Integration (via ShellProcessor)', () => {
     it('correctly processes a command with {{args}}', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'shorthand.toml':
@@ -865,7 +866,7 @@ describe('FileCommandLoader', () => {
 
   describe('Default Argument Processor Integration', () => {
     it('correctly processes a command without {{args}}', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'model_led.toml':
@@ -899,7 +900,7 @@ describe('FileCommandLoader', () => {
 
   describe('Shell Processor Integration', () => {
     it('instantiates ShellProcessor if {{args}} is present (even without shell trigger)', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'args_only.toml': `prompt = "Hello {{args}}"`,
@@ -912,7 +913,7 @@ describe('FileCommandLoader', () => {
       expect(ShellProcessor).toHaveBeenCalledWith('args_only');
     });
     it('instantiates ShellProcessor if the trigger is present', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'shell.toml': `prompt = "Run this: ${SHELL_INJECTION_TRIGGER}echo hello}"`,
@@ -926,7 +927,7 @@ describe('FileCommandLoader', () => {
     });
 
     it('does not instantiate ShellProcessor if no triggers ({{args}} or !{}) are present', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'regular.toml': `prompt = "Just a regular prompt"`,
@@ -940,7 +941,7 @@ describe('FileCommandLoader', () => {
     });
 
     it('returns a "submit_prompt" action if shell processing succeeds', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'shell.toml': `prompt = "Run !{echo 'hello'}"`,
@@ -967,7 +968,7 @@ describe('FileCommandLoader', () => {
     });
 
     it('returns a "confirm_shell_commands" action if shell processing requires it', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       const rawInvocation = '/shell rm -rf /';
       mock({
         [userCommandsDir]: {
@@ -1001,7 +1002,7 @@ describe('FileCommandLoader', () => {
     });
 
     it('re-throws other errors from the processor', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'shell.toml': `prompt = "Run !{something}"`,
@@ -1026,7 +1027,7 @@ describe('FileCommandLoader', () => {
       ).rejects.toThrow('Something else went wrong');
     });
     it('assembles the processor pipeline in the correct order (AtFile -> Shell -> Default)', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           // This prompt uses !{}, @{}, but NOT {{args}}, so all processors should be active.
@@ -1128,7 +1129,7 @@ describe('FileCommandLoader', () => {
 
   describe('@-file Processor Integration', () => {
     it('correctly processes a command with @{file}', async () => {
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'at-file.toml':
@@ -1192,7 +1193,7 @@ describe('FileCommandLoader', () => {
         getFolderTrustFeature: vi.fn(() => true),
         getFolderTrust: vi.fn(() => true),
       } as unknown as Config;
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'test1.toml': 'prompt = "Prompt 1"',
@@ -1213,7 +1214,7 @@ describe('FileCommandLoader', () => {
         getFolderTrustFeature: vi.fn(() => true),
         getFolderTrust: vi.fn(() => false),
       } as unknown as Config;
-      const userCommandsDir = Storage.getUserCommandsDir();
+      const userCommandsDir = storage.getUserCommandsDir();
       mock({
         [userCommandsDir]: {
           'test1.toml': 'prompt = "Prompt 1"',

--- a/packages/cli/src/services/FileCommandLoader.ts
+++ b/packages/cli/src/services/FileCommandLoader.ts
@@ -143,7 +143,7 @@ export class FileCommandLoader implements ICommandLoader {
     const storage = this.config?.storage ?? new Storage(this.projectRoot);
 
     // 1. User commands
-    dirs.push({ path: Storage.getUserCommandsDir() });
+    dirs.push({ path: storage.getUserCommandsDir() });
 
     // 2. Project commands (override user commands)
     dirs.push({ path: storage.getProjectCommandsDir() });

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -348,8 +348,9 @@ export function getAvailablePort(): Promise<number> {
 }
 
 async function loadCachedCredentials(client: OAuth2Client): Promise<boolean> {
+  const storage = new Storage(process.cwd());
   const pathsToTry = [
-    Storage.getOAuthCredsPath(),
+    storage.getOAuthCredsPath(),
     process.env['GOOGLE_APPLICATION_CREDENTIALS'],
   ].filter((p): p is string => !!p);
 
@@ -377,7 +378,8 @@ async function loadCachedCredentials(client: OAuth2Client): Promise<boolean> {
 }
 
 async function cacheCredentials(credentials: Credentials) {
-  const filePath = Storage.getOAuthCredsPath();
+  const storage = new Storage(process.cwd());
+  const filePath = storage.getOAuthCredsPath();
   await fs.mkdir(path.dirname(filePath), { recursive: true });
 
   const credString = JSON.stringify(credentials, null, 2);
@@ -395,7 +397,8 @@ export function clearOauthClientCache() {
 
 export async function clearCachedCredentialFile() {
   try {
-    await fs.rm(Storage.getOAuthCredsPath(), { force: true });
+    const storage = new Storage(process.cwd());
+    await fs.rm(storage.getOAuthCredsPath(), { force: true });
     // Clear the Google Account ID cache when credentials are cleared
     await userAccountManager.clearCachedGoogleAccount();
     // Clear the in-memory OAuth client cache to force re-authentication

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -19,9 +19,11 @@ vi.mock('fs', async (importOriginal) => {
 import { Storage } from './storage.js';
 
 describe('Storage – getGlobalSettingsPath', () => {
+  const storage = new Storage('test');
+
   it('returns path to ~/.gemini/settings.json', () => {
     const expected = path.join(os.homedir(), '.gemini', 'settings.json');
-    expect(Storage.getGlobalSettingsPath()).toBe(expected);
+    expect(storage.getGlobalSettingsPath()).toBe(expected);
   });
 });
 
@@ -36,7 +38,7 @@ describe('Storage – additional helpers', () => {
 
   it('getUserCommandsDir returns ~/.gemini/commands', () => {
     const expected = path.join(os.homedir(), '.gemini', 'commands');
-    expect(Storage.getUserCommandsDir()).toBe(expected);
+    expect(storage.getUserCommandsDir()).toBe(expected);
   });
 
   it('getProjectCommandsDir returns project/.gemini/commands', () => {
@@ -50,6 +52,6 @@ describe('Storage – additional helpers', () => {
       '.gemini',
       'mcp-oauth-tokens.json',
     );
-    expect(Storage.getMcpOAuthTokensPath()).toBe(expected);
+    expect(storage.getMcpOAuthTokensPath()).toBe(expected);
   });
 });

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -15,45 +15,36 @@ const TMP_DIR_NAME = 'tmp';
 
 export class Storage {
   private readonly targetDir: string;
+  private readonly globalGeminiDir: string;
 
-  constructor(targetDir: string) {
+
+  constructor(targetDir: string, globalGeminiDir: string = Storage.getDefaultGlobalGeminiDir()) {
     this.targetDir = targetDir;
+    this.globalGeminiDir = globalGeminiDir;
   }
 
-  static getGlobalGeminiDir(): string {
-    const homeDir = os.homedir();
-    if (!homeDir) {
-      return path.join(os.tmpdir(), '.gemini');
-    }
-    return path.join(homeDir, GEMINI_DIR);
+  getMcpOAuthTokensPath(): string {
+    return path.join(this.globalGeminiDir, 'mcp-oauth-tokens.json');
   }
 
-  static getMcpOAuthTokensPath(): string {
-    return path.join(Storage.getGlobalGeminiDir(), 'mcp-oauth-tokens.json');
+  getGlobalSettingsPath(): string {
+    return path.join(this.globalGeminiDir, 'settings.json');
   }
 
-  static getGlobalSettingsPath(): string {
-    return path.join(Storage.getGlobalGeminiDir(), 'settings.json');
+  getInstallationIdPath(): string {
+    return path.join(this.globalGeminiDir, 'installation_id');
   }
 
-  static getInstallationIdPath(): string {
-    return path.join(Storage.getGlobalGeminiDir(), 'installation_id');
+  getGoogleAccountsPath(): string {
+    return path.join(this.globalGeminiDir, GOOGLE_ACCOUNTS_FILENAME);
   }
 
-  static getGoogleAccountsPath(): string {
-    return path.join(Storage.getGlobalGeminiDir(), GOOGLE_ACCOUNTS_FILENAME);
+  getUserCommandsDir(): string {
+    return path.join(this.globalGeminiDir, 'commands');
   }
 
-  static getUserCommandsDir(): string {
-    return path.join(Storage.getGlobalGeminiDir(), 'commands');
-  }
-
-  static getGlobalMemoryFilePath(): string {
-    return path.join(Storage.getGlobalGeminiDir(), 'memory.md');
-  }
-
-  static getGlobalTempDir(): string {
-    return path.join(Storage.getGlobalGeminiDir(), TMP_DIR_NAME);
+  getOAuthCredsPath(): string {
+    return path.join(this.globalGeminiDir, 'oauth_creds.json');
   }
 
   getGeminiDir(): string {
@@ -62,7 +53,7 @@ export class Storage {
 
   getProjectTempDir(): string {
     const hash = this.getFilePathHash(this.getProjectRoot());
-    const tempDir = Storage.getGlobalTempDir();
+    const tempDir = this.getGlobalTempDir();
     return path.join(tempDir, hash);
   }
 
@@ -70,21 +61,13 @@ export class Storage {
     fs.mkdirSync(this.getProjectTempDir(), { recursive: true });
   }
 
-  static getOAuthCredsPath(): string {
-    return path.join(Storage.getGlobalGeminiDir(), 'oauth_creds.json');
-  }
-
   getProjectRoot(): string {
     return this.targetDir;
   }
 
-  private getFilePathHash(filePath: string): string {
-    return crypto.createHash('sha256').update(filePath).digest('hex');
-  }
-
   getHistoryDir(): string {
     const hash = this.getFilePathHash(this.getProjectRoot());
-    const historyDir = path.join(Storage.getGlobalGeminiDir(), 'history');
+    const historyDir = path.join(this.globalGeminiDir, 'history');
     return path.join(historyDir, hash);
   }
 
@@ -110,5 +93,21 @@ export class Storage {
 
   getHistoryFilePath(): string {
     return path.join(this.getProjectTempDir(), 'shell_history');
+  }
+
+  private getFilePathHash(filePath: string): string {
+    return crypto.createHash('sha256').update(filePath).digest('hex');
+  }
+
+  private getGlobalTempDir(): string {
+    return path.join(this.globalGeminiDir, TMP_DIR_NAME);
+  }
+
+  static getDefaultGlobalGeminiDir(): string {
+    const homeDir = os.homedir();
+    if (!homeDir) {
+      return path.join(os.tmpdir(), '.gemini');
+    }
+    return path.join(homeDir, GEMINI_DIR);
   }
 }

--- a/packages/core/src/mcp/oauth-token-storage.ts
+++ b/packages/core/src/mcp/oauth-token-storage.ts
@@ -20,7 +20,8 @@ export class MCPOAuthTokenStorage {
    * @returns The full path to the token storage file
    */
   private static getTokenFilePath(): string {
-    return Storage.getMcpOAuthTokensPath();
+    const storage = new Storage(process.cwd());
+    return storage.getMcpOAuthTokensPath();
   }
 
   /**

--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -99,7 +99,7 @@ interface SaveMemoryParams {
 }
 
 function getGlobalMemoryFilePath(): string {
-  return path.join(Storage.getGlobalGeminiDir(), getCurrentGeminiMdFilename());
+  return path.join(Storage.getDefaultGlobalGeminiDir(), getCurrentGeminiMdFilename());
 }
 
 /**

--- a/packages/core/src/utils/installationManager.ts
+++ b/packages/core/src/utils/installationManager.ts
@@ -11,7 +11,8 @@ import { Storage } from '../config/storage.js';
 
 export class InstallationManager {
   private getInstallationIdPath(): string {
-    return Storage.getInstallationIdPath();
+    const storage = new Storage(process.cwd());
+    return storage.getInstallationIdPath();
   }
 
   private readInstallationIdFromFile(): string | null {

--- a/packages/core/src/utils/userAccountManager.ts
+++ b/packages/core/src/utils/userAccountManager.ts
@@ -15,7 +15,8 @@ interface UserAccounts {
 
 export class UserAccountManager {
   private getGoogleAccountsCachePath(): string {
-    return Storage.getGoogleAccountsPath();
+    const storage = new Storage(process.cwd());
+    return storage.getGoogleAccountsPath();
   }
 
   /**


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->
As [commented](https://github.com/google-gemini/gemini-cli/pull/4078#discussion_r2286659733) by @NTaylorMullen , remove static methods in storage.ts and inject a global directory from outside. For now, the configuration for the global directory isn't supported, so it's using the default global directory configured at storage.ts

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->
The same as TLDR

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->
Run test

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.
Resolves #3986 

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
