### PR TITLE
feat: Allow user to hide MCP tool response display

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -80,6 +80,7 @@ export interface CliArgs {
   screenReader: boolean | undefined;
   useSmartEdit: boolean | undefined;
   sessionSummary: string | undefined;
+  hideMcpToolResponse: boolean | undefined;
 }
 
 export async function parseArguments(settings: Settings): Promise<CliArgs> {
@@ -232,6 +233,11 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
         .option('session-summary', {
           type: 'string',
           description: 'File to write session summary to.',
+        })
+        .option('hide-mcp-tool-response', {
+          type: 'boolean',
+          description: 'Hide MCP tool response from display.',
+          default: false,
         })
         .deprecateOption(
           'telemetry',
@@ -539,6 +545,10 @@ export async function loadCliConfig(
     argv.screenReader !== undefined
       ? argv.screenReader
       : (settings.ui?.accessibility?.screenReader ?? false);
+  const hideMcpToolResponse =
+    argv.hideMcpToolResponse !== undefined
+      ? argv.hideMcpToolResponse
+      : (settings.mcp?.hideMcpToolResponse ?? false);
   return new Config({
     sessionId,
     embeddingModel: DEFAULT_GEMINI_EMBEDDING_MODEL,
@@ -623,6 +633,7 @@ export async function loadCliConfig(
     enablePromptCompletion: settings.general?.enablePromptCompletion ?? false,
     eventEmitter: appEvents,
     useSmartEdit: argv.useSmartEdit ?? settings.useSmartEdit,
+    hideMcpToolResponse,
   });
 }
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -611,6 +611,15 @@ export const SETTINGS_SCHEMA = {
         description: 'A blacklist of MCP servers to exclude.',
         showInDialog: false,
       },
+      hideMcpToolResponse: {
+        type: 'boolean',
+        label: 'Hide MCP Tool Response',
+        category: 'MCP',
+        requiresRestart: false,
+        default: false,
+        description: 'Hide MCP tool response from display.',
+        showInDialog: true,
+      },
     },
   },
   useSmartEdit: {

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -179,6 +179,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
         getScreenReader: vi.fn(() => false),
         getFolderTrustFeature: vi.fn(() => false),
         getFolderTrust: vi.fn(() => false),
+        getHideMcpToolResponse: vi.fn(() => false),
       };
     });
 

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -23,14 +23,14 @@ vi.mock('./ToolMessage.js', () => ({
     description,
     status,
     emphasis,
-    hideMcpToolResponse,
+    _hideMcpToolResponse,
   }: {
     callId: string;
     name: string;
     description: string;
     status: ToolCallStatus;
     emphasis: string;
-    hideMcpToolResponse?: boolean;
+    _hideMcpToolResponse?: boolean;
   }) {
     // Use the same constants as the real component
     const statusSymbolMap: Record<ToolCallStatus, string> = {

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -23,12 +23,14 @@ vi.mock('./ToolMessage.js', () => ({
     description,
     status,
     emphasis,
+    hideMcpToolResponse,
   }: {
     callId: string;
     name: string;
     description: string;
     status: ToolCallStatus;
     emphasis: string;
+    hideMcpToolResponse?: boolean;
   }) {
     // Use the same constants as the real component
     const statusSymbolMap: Record<ToolCallStatus, string> = {
@@ -63,7 +65,9 @@ vi.mock('./ToolConfirmationMessage.js', () => ({
 }));
 
 describe('<ToolGroupMessage />', () => {
-  const mockConfig: Config = {} as Config;
+  const mockConfig: Config = {
+    getHideMcpToolResponse: () => false,
+  } as unknown as Config;
 
   const createToolCall = (
     overrides: Partial<IndividualToolCallDisplay> = {},

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -106,6 +106,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
                       : 'medium'
                 }
                 renderOutputAsMarkdown={tool.renderOutputAsMarkdown}
+                hideMcpToolResponse={config.getHideMcpToolResponse()}
               />
             </Box>
             {tool.status === ToolCallStatus.Confirming &&

--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -64,7 +64,17 @@ describe('<ToolMessage />', () => {
     terminalWidth: 80,
     confirmationDetails: undefined,
     emphasis: 'medium',
+    hideMcpToolResponse: false,
   };
+
+  it('hides tool response when hideMcpToolResponse is true', () => {
+    const { lastFrame } = renderWithContext(
+      <ToolMessage {...baseProps} hideMcpToolResponse={true} />,
+      StreamingState.Idle,
+    );
+    const output = lastFrame();
+    expect(output).not.toContain('MockMarkdown:Test result');
+  });
 
   it('renders basic tool information', () => {
     const { lastFrame } = renderWithContext(

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -30,6 +30,7 @@ export interface ToolMessageProps extends IndividualToolCallDisplay {
   terminalWidth: number;
   emphasis?: TextEmphasis;
   renderOutputAsMarkdown?: boolean;
+  hideMcpToolResponse?: boolean;
 }
 
 export const ToolMessage: React.FC<ToolMessageProps> = ({
@@ -41,6 +42,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   terminalWidth,
   emphasis = 'medium',
   renderOutputAsMarkdown = true,
+  hideMcpToolResponse,
 }) => {
   const availableHeight = availableTerminalHeight
     ? Math.max(
@@ -76,7 +78,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
         />
         {emphasis === 'high' && <TrailingIndicator />}
       </Box>
-      {resultDisplay && (
+      {resultDisplay && !hideMcpToolResponse && (
         <Box paddingLeft={STATUS_INDICATOR_WIDTH} width="100%" marginTop={1}>
           <Box flexDirection="column">
             {typeof resultDisplay === 'string' && renderOutputAsMarkdown && (

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -211,6 +211,7 @@ export interface ConfigParameters {
   enablePromptCompletion?: boolean;
   eventEmitter?: EventEmitter;
   useSmartEdit?: boolean;
+  hideMcpToolResponse?: boolean;
 }
 
 export class Config {
@@ -288,6 +289,7 @@ export class Config {
   private readonly fileExclusions: FileExclusions;
   private readonly eventEmitter?: EventEmitter;
   private readonly useSmartEdit: boolean;
+  private readonly hideMcpToolResponse: boolean;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -364,6 +366,7 @@ export class Config {
     this.enablePromptCompletion = params.enablePromptCompletion ?? false;
     this.fileExclusions = new FileExclusions(this);
     this.eventEmitter = params.eventEmitter;
+    this.hideMcpToolResponse = params.hideMcpToolResponse ?? false;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -814,6 +817,10 @@ export class Config {
 
   getUseSmartEdit(): boolean {
     return this.useSmartEdit;
+  }
+
+  getHideMcpToolResponse(): boolean {
+    return this.hideMcpToolResponse;
   }
 
   async getGitService(): Promise<GitService> {


### PR DESCRIPTION
Adds a new setting `hideMcpToolResponse` to allow the user to hide the MCP tool response from the display. This is useful for reducing noise in the CLI output and hiding sensitive information which the MCP tool response may contain.

The setting can be configured via the `--hide-mcp-tool-response` command-line flag or in the settings file.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Resolves #3904
