### PR TITLE
fix(release) - make release failures p0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,4 +228,4 @@ jobs:
           gh issue create \
             --title "Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')" \
             --body "The release workflow failed. See the full run for details: ${DETAILS_URL}" \
-            --label "kind/bug,release-failure"
+            --label "kind/bug,release-failure,priority/p0"


### PR DESCRIPTION
Release failures should be labeled as p0 to make sure it is triaged correctly.