### PR TITLE
Fix: ctrl+c tip fix

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -799,12 +799,13 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
         if (isAuthenticating) {
           return;
         }
+
         if (!ctrlCPressedOnce) {
+          const hadText = buffer.text.length > 0;
           cancelOngoingRequest?.();
-        }
-        // Only show the exit tip if the input is empty and we are not streaming.
-        if (buffer.text.length > 0 || streamingState !== StreamingState.Idle) {
-          return;
+          if (hadText) {
+            return; // Don't show tip if buffer had text before cancelling.
+          }
         }
         handleExit(ctrlCPressedOnce, setCtrlCPressedOnce, ctrlCTimerRef);
       } else if (keyMatchers[Command.EXIT](key)) {
@@ -831,7 +832,6 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
       ctrlCPressedOnce,
       setCtrlCPressedOnce,
       ctrlCTimerRef,
-      buffer.text.length,
       ctrlDPressedOnce,
       setCtrlDPressedOnce,
       ctrlDTimerRef,
@@ -839,7 +839,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
       isAuthenticating,
       cancelOngoingRequest,
       settings.merged.general?.debugKeystrokeLogging,
-      streamingState,
+      buffer,
     ],
   );
 

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -802,6 +802,10 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
         if (!ctrlCPressedOnce) {
           cancelOngoingRequest?.();
         }
+        // Only show the exit tip if the input is empty and we are not streaming.
+        if (buffer.text.length > 0 || streamingState !== StreamingState.Idle) {
+          return;
+        }
         handleExit(ctrlCPressedOnce, setCtrlCPressedOnce, ctrlCTimerRef);
       } else if (keyMatchers[Command.EXIT](key)) {
         if (buffer.text.length > 0) {
@@ -835,6 +839,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
       isAuthenticating,
       cancelOngoingRequest,
       settings.merged.general?.debugKeystrokeLogging,
+      streamingState,
     ],
   );
 


### PR DESCRIPTION
## TLDR

This PR refines the behavior of the `ctrl+c` tip and stream cancellation flow.  
Previously, pressing `ctrl+c` to cancel a stream would always show the tip *“Press ctrl+c again to exit”*, even though the second `ctrl+c` only cleared the input. This caused confusion and inconsistency.  

Now, the tip and behavior are aligned:  
- The first `ctrl+c` cancels the stream and restores the previous prompt.  
- While the tip is visible, pressing `ctrl+c` again will **exit immediately**.  
- If no second `ctrl+c` is pressed, the tip disappears, leaving the restored input for editing or resubmission.  

## Dive Deeper

- **Old behavior:**  
  - Cancel stream with `ctrl+c` → tip shown unconditionally.  
  - Second `ctrl+c` only cleared input, not exit.  

- **New behavior:**  
  - Cancel stream with `ctrl+c` → previous prompt is restored and tip briefly shown.  
  - If `ctrl+c` is pressed again while the tip is visible → CLI exits.  
  - If no second `ctrl+c` occurs → tip disappears, input remains for editing/submission, and later `ctrl+c` works as normal to clear input.  

- This change improves UX by making the tip accurate and giving users an intuitive way to either exit quickly or continue editing.  

## Reviewer Test Plan

1. Start a stream and cancel it with `ctrl+c`.  
   - Verify that the previous prompt is restored in the input field.  
   - Verify that the tip *“Press ctrl+c again to exit”* appears briefly.  
2. Press `ctrl+c` again while the tip is visible.  
   - Verify that the CLI exits immediately.  
3. Cancel a stream and **do not press `ctrl+c` again**.  
   - Verify that the tip disappears after the timeout.  
   - Verify that the restored input remains editable.  
   - Verify that pressing `ctrl+c` later clears the input as usual.  

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ✅  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #7534
