### PR TITLE
fix(build): allow builds to continue when sandbox detection fails

### DIFF
--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -62,7 +62,7 @@ try {
 } catch (e) {
   console.warn('ERROR: could not detect sandbox container command');
   console.error(e);
-  process.exit(1);
+  process.exit(0);
 }
 
 if (sandboxCommand === 'sandbox-exec') {

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -62,7 +62,7 @@ try {
 } catch (e) {
   console.warn('ERROR: could not detect sandbox container command');
   console.error(e);
-  process.exit(0);
+  process.exit(process.env.CI ? 1 : 0);
 }
 
 if (sandboxCommand === 'sandbox-exec') {


### PR DESCRIPTION
## Dive Deeper

Use environment-aware exit codes: fail in CI (exit 1) but continue locally (exit 0) when sandbox container detection fails. This ensures production quality in CI while maintaining developer productivity in local environments.

## Reviewer Test Plan

run npm run build:all and it should work as desired in developer and ci environments

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Resolves #7189 