### PR TITLE
fix(auth): improve Google OAuth error handling and prevent empty error messages

### DIFF
--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -497,20 +497,12 @@ async function fetchAndCacheUserInfo(client: OAuth2Client): Promise<void> {
     );
 
     if (!response.ok) {
-      const errorDetails = `HTTP ${response.status} ${response.statusText}`;
-      console.error('Failed to fetch user info:', errorDetails);
-
-      // Provide specific guidance for common authentication issues
-      if (response.status === 401) {
-        throw new Error(
-          'Authentication token expired or invalid. Please try logging in again.',
-        );
-      } else if (response.status === 403) {
-        throw new Error(
-          'Access denied when fetching user information. This might indicate a permission issue with your Google account.',
-        );
-      }
-      throw new Error(`Failed to fetch user info: ${errorDetails}`);
+      console.error(
+        'Failed to fetch user info:',
+        response.status,
+        response.statusText,
+      );
+      return;
     }
 
     const userInfo = await response.json();

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -97,8 +97,9 @@ async function initOauthClient(
     if (!userAccountManager.getCachedGoogleAccount()) {
       try {
         await fetchAndCacheUserInfo(client);
-      } catch {
+      } catch (error) {
         // Non-fatal, continue with existing auth.
+        console.warn('Failed to fetch user info:', getErrorMessage(error));
       }
     }
     console.log('Loaded cached credentials.');
@@ -164,23 +165,35 @@ async function initOauthClient(
       // Without this, if `open` fails to spawn a process (e.g., `xdg-open` is not found
       // in a minimal Docker container), it will emit an unhandled 'error' event,
       // causing the entire Node.js process to crash.
-      childProcess.on('error', (_) => {
+      childProcess.on('error', (error) => {
         console.error(
           'Failed to open browser automatically. Please try running again with NO_BROWSER=true set.',
         );
-        throw new FatalAuthenticationError('Failed to open browser.');
+        console.error('Browser error details:', getErrorMessage(error));
       });
     } catch (err) {
       console.error(
         'An unexpected error occurred while trying to open the browser:',
-        err,
-        '\nPlease try running again with NO_BROWSER=true set.',
+        getErrorMessage(err),
+        '\nThis might be due to browser compatibility issues or system configuration.',
+        '\nPlease try running again with NO_BROWSER=true set for manual authentication.',
       );
-      throw new FatalAuthenticationError('Failed to open browser.');
+      throw new FatalAuthenticationError(`Failed to open browser: ${getErrorMessage(err)}`);
     }
     console.log('Waiting for authentication...');
 
-    await webLogin.loginCompletePromise;
+    // Add timeout to prevent infinite waiting when browser tab gets stuck
+    const authTimeout = 5 * 60 * 1000; // 5 minutes timeout
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        reject(new FatalAuthenticationError(
+          'Authentication timed out after 5 minutes. The browser tab may have gotten stuck in a loading state. ' +
+          'Please try again or use NO_BROWSER=true for manual authentication.'
+        ));
+      }, authTimeout);
+    });
+
+    await Promise.race([webLogin.loginCompletePromise, timeoutPromise]);
   }
 
   return client;
@@ -236,7 +249,8 @@ async function authWithUserCode(client: OAuth2Client): Promise<boolean> {
       redirect_uri: redirectUri,
     });
     client.setCredentials(tokens);
-  } catch (_error) {
+  } catch (error) {
+    console.error('Failed to authenticate with authorization code:', getErrorMessage(error));
     return false;
   }
   return true;
@@ -265,7 +279,7 @@ async function authWithWeb(client: OAuth2Client): Promise<OauthWebLogin> {
         if (req.url!.indexOf('/oauth2callback') === -1) {
           res.writeHead(HTTP_REDIRECT, { Location: SIGN_IN_FAILURE_URL });
           res.end();
-          reject(new Error('Unexpected request: ' + req.url));
+          reject(new FatalAuthenticationError('OAuth callback not received. Unexpected request: ' + req.url));
         }
         // acquire the code from the querystring, and close the web server.
         const qs = new url.URL(req.url!, 'http://localhost:3000').searchParams;
@@ -273,41 +287,62 @@ async function authWithWeb(client: OAuth2Client): Promise<OauthWebLogin> {
           res.writeHead(HTTP_REDIRECT, { Location: SIGN_IN_FAILURE_URL });
           res.end();
 
-          reject(new Error(`Error during authentication: ${qs.get('error')}`));
+          const errorCode = qs.get('error');
+          const errorDescription = qs.get('error_description') || 'No additional details provided';
+          reject(new FatalAuthenticationError(`Google OAuth error: ${errorCode}. ${errorDescription}`));
         } else if (qs.get('state') !== state) {
           res.end('State mismatch. Possible CSRF attack');
 
-          reject(new Error('State mismatch. Possible CSRF attack'));
+          reject(new FatalAuthenticationError('OAuth state mismatch. Possible CSRF attack or browser session issue.'));
         } else if (qs.get('code')) {
-          const { tokens } = await client.getToken({
-            code: qs.get('code')!,
-            redirect_uri: redirectUri,
-          });
-          client.setCredentials(tokens);
-          // Retrieve and cache Google Account ID during authentication
           try {
-            await fetchAndCacheUserInfo(client);
-          } catch (error) {
-            console.error(
-              'Failed to retrieve Google Account ID during authentication:',
-              error,
-            );
-            // Don't fail the auth flow if Google Account ID retrieval fails
-          }
+            const { tokens } = await client.getToken({
+              code: qs.get('code')!,
+              redirect_uri: redirectUri,
+            });
+            client.setCredentials(tokens);
+            
+            // Retrieve and cache Google Account ID during authentication
+            try {
+              await fetchAndCacheUserInfo(client);
+            } catch (error) {
+              console.warn(
+                'Failed to retrieve Google Account ID during authentication:',
+                getErrorMessage(error),
+              );
+              // Don't fail the auth flow if Google Account ID retrieval fails
+            }
 
-          res.writeHead(HTTP_REDIRECT, { Location: SIGN_IN_SUCCESS_URL });
-          res.end();
-          resolve();
+            res.writeHead(HTTP_REDIRECT, { Location: SIGN_IN_SUCCESS_URL });
+            res.end();
+            resolve();
+          } catch (error) {
+            res.writeHead(HTTP_REDIRECT, { Location: SIGN_IN_FAILURE_URL });
+            res.end();
+            reject(new FatalAuthenticationError(`Failed to exchange authorization code for tokens: ${getErrorMessage(error)}`));
+          }
         } else {
-          reject(new Error('No code found in request'));
+          reject(new FatalAuthenticationError('No authorization code received from Google OAuth. Please try authenticating again.'));
         }
       } catch (e) {
-        reject(e);
+        // Provide more specific error message for unexpected errors during OAuth flow
+        if (e instanceof FatalAuthenticationError) {
+          reject(e);
+        } else {
+          reject(new FatalAuthenticationError(`Unexpected error during OAuth authentication: ${getErrorMessage(e)}`));
+        }
       } finally {
         server.close();
       }
     });
-    server.listen(port, host);
+    
+    server.listen(port, host, () => {
+      // Server started successfully
+    });
+    
+    server.on('error', (err) => {
+      reject(new FatalAuthenticationError(`OAuth callback server error: ${getErrorMessage(err)}`));
+    });
   });
 
   return {
@@ -368,8 +403,9 @@ async function loadCachedCredentials(client: OAuth2Client): Promise<boolean> {
       await client.getTokenInfo(token);
 
       return true;
-    } catch (_) {
-      // Ignore and try next path.
+    } catch (error) {
+      // Log specific error for debugging, but continue trying other paths
+      console.debug(`Failed to load credentials from ${keyFile}:`, getErrorMessage(error));
     }
   }
 
@@ -422,12 +458,16 @@ async function fetchAndCacheUserInfo(client: OAuth2Client): Promise<void> {
     );
 
     if (!response.ok) {
-      console.error(
-        'Failed to fetch user info:',
-        response.status,
-        response.statusText,
-      );
-      return;
+      const errorDetails = `HTTP ${response.status} ${response.statusText}`;
+      console.error('Failed to fetch user info:', errorDetails);
+      
+      // Provide specific guidance for common authentication issues
+      if (response.status === 401) {
+        throw new Error('Authentication token expired or invalid. Please try logging in again.');
+      } else if (response.status === 403) {
+        throw new Error('Access denied when fetching user information. This might indicate a permission issue with your Google account.');
+      }
+      throw new Error(`Failed to fetch user info: ${errorDetails}`);
     }
 
     const userInfo = await response.json();


### PR DESCRIPTION
## Dive Deeper

Addresses an issue where users experienced "Failed to login. reason: (empty)" during Google authentication.

Key improvements:
- Enhanced error propagation throughout OAuth flow to prevent silent failures
- Added specific error messages for different failure scenarios:
  - OAuth callback errors with detailed descriptions
  - Token exchange failures with specific error details
  - Browser opening failures with troubleshooting guidance
- Added authentication timeout (5 minutes) to prevent infinite waiting
- Improved error handling for user info fetching with HTTP status codes
- Added debug logging for credential loading failures
- Enhanced server error handling during OAuth callback setup

The changes ensure users receive meaningful error messages instead of empty reasons, helping with troubleshooting authentication issues across different browsers and system configurations.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Fixes #6973