### PR TITLE
feat: Show tip for extra text after command

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -320,6 +320,20 @@ export const useSlashCommandProcessor = (
           const args = parts.slice(pathIndex).join(' ');
 
           if (commandToExecute.action) {
+            // Show a tip if the user provides extra text after a command that doesn't take arguments.
+            if (
+              args.trim().length > 0 &&
+              !commandToExecute.subCommands &&
+              commandToExecute.action !== undefined
+            ) {
+              addItem(
+                {
+                  type: MessageType.INFO,
+                  text: 'Tip: Prompts starting with / are treated as commands. Any text following the command is ignored.',
+                },
+                Date.now(),
+              );
+            }
             const fullCommandContext: CommandContext = {
               ...commandContext,
               invocation: {


### PR DESCRIPTION
## TL;DR

This PR adds a tip that informs users when extra text after a slash command is ignored, making command behavior clearer and reducing confusion.

---

## Dive Deeper

- Slash commands that don’t accept arguments currently ignore extra text without feedback.  
- Users may assume their text is being processed, leading to misunderstanding.  
- This change makes the behavior explicit by showing a short tip, improving UX and transparency.  

---

## Reviewer Test Plan

1. Enter a valid slash command **without extra text** → behavior should remain unchanged.  
2. Enter the same slash command **with extra text after it** → a tip should appear indicating that the extra text is ignored.  
3. Check across platforms (npm run, npx, Docker, etc.) to confirm consistent behavior.  

---

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

---

## Linked Issues / Bugs

Resolves #7542
