### PR TITLE
refactor(core): Require model for utility calls

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -434,7 +434,7 @@ describe('Gemini Client (client.ts)', () => {
 
       expect(mockGenerateContentFn).toHaveBeenCalledWith(
         {
-          model: 'test-model', // Should use current model from config
+          model: DEFAULT_GEMINI_FLASH_MODEL,
           config: {
             abortSignal,
             systemInstruction: getCoreSystemPrompt(''),
@@ -2320,7 +2320,7 @@ ${JSON.stringify(
 
       expect(mockGenerateContentFn).toHaveBeenCalledWith(
         {
-          model: 'test-model',
+          model: DEFAULT_GEMINI_FLASH_MODEL,
           config: {
             abortSignal,
             systemInstruction: getCoreSystemPrompt(''),
@@ -2360,7 +2360,7 @@ ${JSON.stringify(
       });
       expect(mockGenerateContentFn).toHaveBeenCalledWith(
         {
-          model: currentModel,
+          model: DEFAULT_GEMINI_FLASH_MODEL,
           config: expect.any(Object),
           contents,
         },

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -425,7 +425,12 @@ describe('Gemini Client (client.ts)', () => {
       };
       client['contentGenerator'] = mockGenerator as ContentGenerator;
 
-      await client.generateJson(contents, schema, abortSignal);
+      await client.generateJson(
+        contents,
+        schema,
+        abortSignal,
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
 
       expect(mockGenerateContentFn).toHaveBeenCalledWith(
         {
@@ -2306,7 +2311,12 @@ ${JSON.stringify(
       };
       client['contentGenerator'] = mockGenerator as ContentGenerator;
 
-      await client.generateContent(contents, generationConfig, abortSignal);
+      await client.generateContent(
+        contents,
+        generationConfig,
+        abortSignal,
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
 
       expect(mockGenerateContentFn).toHaveBeenCalledWith(
         {
@@ -2336,7 +2346,12 @@ ${JSON.stringify(
       };
       client['contentGenerator'] = mockGenerator as ContentGenerator;
 
-      await client.generateContent(contents, {}, new AbortController().signal);
+      await client.generateContent(
+        contents,
+        {},
+        new AbortController().signal,
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
 
       expect(mockGenerateContentFn).not.toHaveBeenCalledWith({
         model: initialModel,

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -582,12 +582,9 @@ export class GeminiClient {
     contents: Content[],
     schema: Record<string, unknown>,
     abortSignal: AbortSignal,
-    model?: string,
+    model: string,
     config: GenerateContentConfig = {},
   ): Promise<Record<string, unknown>> {
-    // Use current model from config instead of hardcoded Flash model
-    const modelToUse =
-      model || this.config.getModel() || DEFAULT_GEMINI_FLASH_MODEL;
     try {
       const userMemory = this.config.getUserMemory();
       const systemInstruction = getCoreSystemPrompt(userMemory);
@@ -600,7 +597,7 @@ export class GeminiClient {
       const apiCall = () =>
         this.getContentGenerator().generateContent(
           {
-            model: modelToUse,
+            model,
             config: {
               ...requestConfig,
               systemInstruction,
@@ -637,7 +634,7 @@ export class GeminiClient {
       if (text.startsWith(prefix) && text.endsWith(suffix)) {
         logMalformedJsonResponse(
           this.config,
-          new MalformedJsonResponseEvent(modelToUse),
+          new MalformedJsonResponseEvent(model),
         );
         text = text
           .substring(prefix.length, text.length - suffix.length)
@@ -691,9 +688,8 @@ export class GeminiClient {
     contents: Content[],
     generationConfig: GenerateContentConfig,
     abortSignal: AbortSignal,
-    model?: string,
+    model: string,
   ): Promise<GenerateContentResponse> {
-    const modelToUse = model ?? this.config.getModel();
     const configToUse: GenerateContentConfig = {
       ...this.generateContentConfig,
       ...generationConfig,
@@ -712,7 +708,7 @@ export class GeminiClient {
       const apiCall = () =>
         this.getContentGenerator().generateContent(
           {
-            model: modelToUse,
+            model,
             config: requestConfig,
             contents,
           },
@@ -732,7 +728,7 @@ export class GeminiClient {
 
       await reportError(
         error,
-        `Error generating content via API with model ${modelToUse}.`,
+        `Error generating content via API with model ${model}.`,
         {
           requestContents: contents,
           requestConfig: configToUse,
@@ -740,7 +736,7 @@ export class GeminiClient {
         'generateContent-api',
       );
       throw new Error(
-        `Failed to generate content with model ${modelToUse}: ${getErrorMessage(error)}`,
+        `Failed to generate content with model ${model}: ${getErrorMessage(error)}`,
       );
     }
   }

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -18,7 +18,7 @@ import {
 import { ToolErrorType } from './tool-error.js';
 import { getErrorMessage } from '../utils/errors.js';
 import type { Config } from '../config/config.js';
-import { ApprovalMode } from '../config/config.js';
+import { ApprovalMode, DEFAULT_GEMINI_FLASH_MODEL } from '../config/config.js';
 import { getResponseText } from '../utils/partUtils.js';
 import { fetchWithTimeout, isPrivateIp } from '../utils/fetch.js';
 import { convert } from 'html-to-text';
@@ -116,6 +116,7 @@ ${textContent}
         [{ role: 'user', parts: [{ text: fallbackPrompt }] }],
         {},
         signal,
+        DEFAULT_GEMINI_FLASH_MODEL,
       );
       const resultText = getResponseText(result) || '';
       return {
@@ -193,6 +194,7 @@ ${textContent}
         [{ role: 'user', parts: [{ text: userPrompt }] }],
         { tools: [{ urlContext: {} }] },
         signal, // Pass signal
+        DEFAULT_GEMINI_FLASH_MODEL,
       );
 
       console.debug(

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -10,7 +10,7 @@ import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 
 import { getErrorMessage } from '../utils/errors.js';
-import type { Config } from '../config/config.js';
+import { DEFAULT_GEMINI_FLASH_MODEL, type Config } from '../config/config.js';
 import { getResponseText } from '../utils/partUtils.js';
 
 interface GroundingChunkWeb {
@@ -78,6 +78,7 @@ class WebSearchToolInvocation extends BaseToolInvocation<
         [{ role: 'user', parts: [{ text: this.params.query }] }],
         { tools: [{ googleSearch: {} }] },
         signal,
+        DEFAULT_GEMINI_FLASH_MODEL,
       );
 
       const responseText = getResponseText(response);

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -10,8 +10,9 @@ import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 
 import { getErrorMessage } from '../utils/errors.js';
-import { DEFAULT_GEMINI_FLASH_MODEL, type Config } from '../config/config.js';
+import { type Config } from '../config/config.js';
 import { getResponseText } from '../utils/partUtils.js';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 
 interface GroundingChunkWeb {
   uri?: string;


### PR DESCRIPTION
## TLDR

This PR refactors `GeminiClient` to require an explicit `model` parameter for the `generateContent` and `generateJson` methods. This change makes our internal API calls more explicit and is a necessary preparatory step for upcoming model routing enhancements.

Calls to these methods from within the tool implementations (`web-fetch`, `web-search`) have been updated to pass a specific model, typically `DEFAULT_GEMINI_FLASH_MODEL`.

## Dive Deeper

The primary motivation for this refactoring is to prepare the codebase for more sophisticated model routing capabilities. Currently, `config.getModel()` serves as a general default. However, the long-term vision is for `config.getModel()` to represent a model that the *user* has explicitly forced for a given session.

By requiring internal utility calls (like those in `web-fetch` and `web-search`) to specify which model they need, we avoid ambiguity and prevent these internal processes from unintentionally using a user-forced model that may not be suitable for the task. This change ensures that we have precise control over which model is used for each specific API call, paving the way for more intelligent and context-aware model selection in the future.

## Reviewer Test Plan

As this is primarily an internal refactoring, the most important validation is ensuring that existing functionality remains unchanged and all checks pass.

1.  Pull down the changes.
2.  Run the full preflight check and ensure it passes:
    ```bash
    npm run preflight
    ```
3.  All tests should pass. To be extra sure, you can run the core package tests specifically:
    ```bash
    npm run test -w @google/gemini-cli-core
    ```
4.  Manually exercise the tools that were modified to ensure they still function as expected. For each, start gemini cli and ask the following:
    *   Test web search: "Do a web search for the latest info/news about gemini and then tell me about it"
    *   Test web fetch: "use web fetch and summarize the info at https://cloud.google.com/blog/topics/developers-practitioners/gemini-cli-custom-slash-commands"

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅ | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅| -   | -   |
