### PR TITLE
chore(e2e): Stabilize e2e test by adding a more descriptive prompt

### DIFF
--- a/integration-tests/utf-bom-encoding.test.ts
+++ b/integration-tests/utf-bom-encoding.test.ts
@@ -130,12 +130,13 @@ d('BOM end-to-end integration', () => {
     const imageContent = readFileSync(imagePath);
     const filename = 'gemini-screenshot.png';
     writeFileSync(join(dir, filename), imageContent);
-    const prompt = `describe the image ${filename}`;
+    const prompt = `describe the image ${filename}, what tool is being used and how long has it been running`;
     const output = await rig.run(prompt);
     await rig.waitForToolCall('read_file');
     const lower = output.toLowerCase();
     expect(lower.includes('screenshot')).toBeTruthy();
     expect(lower.includes('gemini cli')).toBeTruthy();
-    expect(lower.includes('terminal')).toBeTruthy();
+    expect(lower.replace(/\s/g, '').includes('googlesearch')).toBeTruthy();
+    expect(lower.includes('21')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## TLDR

This e2e test frequently failed when looking for the `terminal` keyword. 
With the new change the test passed 5 times in a row when run locally.

## Reviewer Test Plan

Run npm run test:e2e -- --test-name-pattern "utf-bom-encoding.test.ts" X number of times locally

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
