### PR TITLE
Move settings error throwing to loadSettings

### DIFF
--- a/packages/cli/src/commands/mcp/add.ts
+++ b/packages/cli/src/commands/mcp/add.ts
@@ -38,7 +38,7 @@ async function addMcpServer(
   } = options;
   const settingsScope =
     scope === 'user' ? SettingScope.User : SettingScope.Workspace;
-  const settings = loadSettings(process.cwd());
+  const settings = loadSettings();
 
   let newServer: Partial<MCPServerConfig> = {};
 

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -20,8 +20,8 @@ const RESET_COLOR = '\u001b[0m';
 async function getMcpServersFromConfig(): Promise<
   Record<string, MCPServerConfig>
 > {
-  const settings = loadSettings(process.cwd());
-  const extensions = loadExtensions(process.cwd());
+  const settings = loadSettings();
+  const extensions = loadExtensions();
   const mcpServers = { ...(settings.merged.mcpServers || {}) };
   for (const extension of extensions) {
     Object.entries(extension.config.mcpServers || {}).forEach(

--- a/packages/cli/src/commands/mcp/remove.ts
+++ b/packages/cli/src/commands/mcp/remove.ts
@@ -17,7 +17,7 @@ async function removeMcpServer(
   const { scope } = options;
   const settingsScope =
     scope === 'user' ? SettingScope.User : SettingScope.Workspace;
-  const settings = loadSettings(process.cwd());
+  const settings = loadSettings();
 
   const existingSettings = settings.forScope(settingsScope).settings;
   const mcpServers = existingSettings.mcpServers || {};

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -8,7 +8,7 @@ import { AuthType } from '@google/gemini-cli-core';
 import { loadEnvironment, loadSettings } from './settings.js';
 
 export function validateAuthMethod(authMethod: string): string | null {
-  loadEnvironment(loadSettings(process.cwd()).merged);
+  loadEnvironment(loadSettings().merged);
   if (
     authMethod === AuthType.LOGIN_WITH_GOOGLE ||
     authMethod === AuthType.CLOUD_SHELL

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -110,7 +110,9 @@ export async function performWorkspaceExtensionMigration(
   return failedInstallNames;
 }
 
-export function loadExtensions(workspaceDir: string): Extension[] {
+export function loadExtensions(
+  workspaceDir: string = process.cwd(),
+): Extension[] {
   const settings = loadSettings(workspaceDir).merged;
   const disabledExtensions = settings.extensions?.disabled ?? [];
   const allExtensions = [...loadUserExtensions()];

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -10,6 +10,7 @@ import { homedir, platform } from 'node:os';
 import * as dotenv from 'dotenv';
 import process from 'node:process';
 import {
+  FatalConfigError,
   GEMINI_CONFIG_DIR as GEMINI_DIR,
   getErrorMessage,
   Storage,
@@ -412,7 +413,6 @@ export class LoadedSettings {
     systemDefaults: SettingsFile,
     user: SettingsFile,
     workspace: SettingsFile,
-    errors: SettingsError[],
     isTrusted: boolean,
     migratedInMemorScopes: Set<SettingScope>,
   ) {
@@ -420,7 +420,6 @@ export class LoadedSettings {
     this.systemDefaults = systemDefaults;
     this.user = user;
     this.workspace = workspace;
-    this.errors = errors;
     this.isTrusted = isTrusted;
     this.migratedInMemorScopes = migratedInMemorScopes;
     this._merged = this.computeMergedSettings();
@@ -430,7 +429,6 @@ export class LoadedSettings {
   readonly systemDefaults: SettingsFile;
   readonly user: SettingsFile;
   readonly workspace: SettingsFile;
-  readonly errors: SettingsError[];
   readonly isTrusted: boolean;
   readonly migratedInMemorScopes: Set<SettingScope>;
 
@@ -570,7 +568,9 @@ export function loadEnvironment(settings: Settings): void {
  * Loads settings from user and workspace directories.
  * Project settings override user settings.
  */
-export function loadSettings(workspaceDir: string): LoadedSettings {
+export function loadSettings(
+  workspaceDir: string = process.cwd(),
+): LoadedSettings {
   let systemSettings: Settings = {};
   let systemDefaultSettings: Settings = {};
   let userSettings: Settings = {};
@@ -703,7 +703,17 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
   workspaceSettings = resolveEnvVarsInObject(workspaceSettings);
 
   // Create LoadedSettings first
-  const loadedSettings = new LoadedSettings(
+
+  if (settingsErrors.length > 0) {
+    const errorMessages = settingsErrors.map(
+      (error) => `Error in ${error.path}: ${error.message}`,
+    );
+    throw new FatalConfigError(
+      `${errorMessages.join('\n')}\nPlease fix the configuration file(s) and try again.`,
+    );
+  }
+
+  return new LoadedSettings(
     {
       path: systemSettingsPath,
       settings: systemSettings,
@@ -720,12 +730,9 @@ export function loadSettings(workspaceDir: string): LoadedSettings {
       path: workspaceSettingsPath,
       settings: workspaceSettings,
     },
-    settingsErrors,
     isTrusted,
     migratedInMemorScopes,
   );
-
-  return loadedSettings;
 }
 
 export function saveSettings(settingsFile: SettingsFile): void {

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -6,16 +6,13 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
-  main,
   setupUnhandledRejectionHandler,
   validateDnsResolutionOrder,
   startInteractiveUI,
 } from './gemini.js';
-import type { SettingsFile } from './config/settings.js';
-import { LoadedSettings, loadSettings } from './config/settings.js';
+import { type LoadedSettings } from './config/settings.js';
 import { appEvents, AppEvent } from './utils/events.js';
 import type { Config } from '@google/gemini-cli-core';
-import { FatalConfigError } from '@google/gemini-cli-core';
 
 // Custom error to identify mock process.exit calls
 class MockProcessExitError extends Error {
@@ -75,7 +72,6 @@ vi.mock('./utils/sandbox.js', () => ({
 }));
 
 describe('gemini.tsx main function', () => {
-  let loadSettingsMock: ReturnType<typeof vi.mocked<typeof loadSettings>>;
   let originalEnvGeminiSandbox: string | undefined;
   let originalEnvSandbox: string | undefined;
   let initialUnhandledRejectionListeners: NodeJS.UnhandledRejectionListener[] =
@@ -88,8 +84,6 @@ describe('gemini.tsx main function', () => {
     });
 
   beforeEach(() => {
-    loadSettingsMock = vi.mocked(loadSettings);
-
     // Store and clear sandbox-related env variables to ensure a consistent test environment
     originalEnvGeminiSandbox = process.env['GEMINI_SANDBOX'];
     originalEnvSandbox = process.env['SANDBOX'];
@@ -122,42 +116,6 @@ describe('gemini.tsx main function', () => {
       process.removeListener('unhandledRejection', addedListener);
     }
     vi.restoreAllMocks();
-  });
-
-  it('should throw InvalidConfigurationError if settings have errors', async () => {
-    const settingsError = {
-      message: 'Test settings error',
-      path: '/test/settings.json',
-    };
-    const userSettingsFile: SettingsFile = {
-      path: '/user/settings.json',
-      settings: {},
-    };
-    const workspaceSettingsFile: SettingsFile = {
-      path: '/workspace/.gemini/settings.json',
-      settings: {},
-    };
-    const systemSettingsFile: SettingsFile = {
-      path: '/system/settings.json',
-      settings: {},
-    };
-    const systemDefaultsFile: SettingsFile = {
-      path: '/system/system-defaults.json',
-      settings: {},
-    };
-    const mockLoadedSettings = new LoadedSettings(
-      systemSettingsFile,
-      systemDefaultsFile,
-      userSettingsFile,
-      workspaceSettingsFile,
-      [settingsError],
-      true,
-      new Set(),
-    );
-
-    loadSettingsMock.mockReturnValue(mockLoadedSettings);
-
-    await expect(main()).rejects.toThrow(FatalConfigError);
   });
 
   it('should log unhandled promise rejections and open debug console on first error', async () => {

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -336,7 +336,6 @@ describe('App UI', () => {
       systemDefaultsFile,
       userSettingsFile,
       workspaceSettingsFile,
-      [],
       true,
       new Set(),
     );

--- a/packages/cli/src/ui/components/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.test.tsx
@@ -52,7 +52,6 @@ describe('AuthDialog', () => {
         settings: { ui: { customThemes: {} }, mcpServers: {} },
         path: '',
       },
-      [],
       true,
       new Set(),
     );
@@ -95,7 +94,6 @@ describe('AuthDialog', () => {
           settings: { ui: { customThemes: {} }, mcpServers: {} },
           path: '',
         },
-        [],
         true,
         new Set(),
       );
@@ -134,7 +132,6 @@ describe('AuthDialog', () => {
           settings: { ui: { customThemes: {} }, mcpServers: {} },
           path: '',
         },
-        [],
         true,
         new Set(),
       );
@@ -173,7 +170,6 @@ describe('AuthDialog', () => {
           settings: { ui: { customThemes: {} }, mcpServers: {} },
           path: '',
         },
-        [],
         true,
         new Set(),
       );
@@ -213,7 +209,6 @@ describe('AuthDialog', () => {
           settings: { ui: { customThemes: {} }, mcpServers: {} },
           path: '',
         },
-        [],
         true,
         new Set(),
       );
@@ -248,7 +243,6 @@ describe('AuthDialog', () => {
           settings: { ui: { customThemes: {} }, mcpServers: {} },
           path: '',
         },
-        [],
         true,
         new Set(),
       );
@@ -285,7 +279,6 @@ describe('AuthDialog', () => {
           settings: { ui: { customThemes: {} }, mcpServers: {} },
           path: '',
         },
-        [],
         true,
         new Set(),
       );
@@ -326,7 +319,6 @@ describe('AuthDialog', () => {
         settings: { ui: { customThemes: {} }, mcpServers: {} },
         path: '',
       },
-      [],
       true,
       new Set(),
     );
@@ -371,7 +363,6 @@ describe('AuthDialog', () => {
         settings: { ui: { customThemes: {} }, mcpServers: {} },
         path: '',
       },
-      [],
       true,
       new Set(),
     );
@@ -419,7 +410,6 @@ describe('AuthDialog', () => {
         settings: { ui: { customThemes: {} }, mcpServers: {} },
         path: '',
       },
-      [],
       true,
       new Set(),
     );

--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -63,7 +63,6 @@ const createMockSettings = (
       },
       path: '/workspace/settings.json',
     },
-    [],
     true,
     new Set(),
   );
@@ -188,7 +187,6 @@ describe('SettingsDialog', () => {
         },
         path: '/workspace/settings.json',
       },
-      [],
       true,
       new Set(),
     );

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -23,7 +23,6 @@ describe('<MarkdownDisplay />', () => {
     { path: '', settings: {} },
     { path: '', settings: {} },
     { path: '', settings: {} },
-    [],
     true,
     new Set(),
   );
@@ -227,7 +226,6 @@ Another paragraph.
       { path: '', settings: {} },
       { path: '', settings: { ui: { showLineNumbers: false } } },
       { path: '', settings: {} },
-      [],
       true,
       new Set(),
     );

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -60,7 +60,7 @@ const WARNING_CHECKS: readonly WarningCheck[] = [
 ];
 
 export async function getUserStartupWarnings(
-  workspaceRoot: string,
+  workspaceRoot: string = process.cwd(),
 ): Promise<string[]> {
   const results = await Promise.all(
     WARNING_CHECKS.map((check) => check.check(workspaceRoot)),


### PR DESCRIPTION
## TLDR

Simplifies gemini.tsx by moving loadSettings error creation into loadSettings.

## Dive Deeper

This will cause certain commands (like adding an MCP server) to fail noisily on corrupted settings.json instead of silently elide the error and proceed anyways. But it's probably a good thing to change that. We shouldn't be saving settings files when your settings files are broken.

## Reviewer Test Plan

Attempt to start up with and without a corrupted settings file.
Attempt to add mcp server with and without a corrupted settings file.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

For #4544