### PR TITLE
feat(cli): Add --with-thoughts flag to /chat save command

### DIFF
--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -254,6 +254,26 @@ describe('chatCommand', () => {
         content: `Conversation checkpoint saved with tag: ${tag}.`,
       });
     });
+
+    it('should strip thoughts by default when saving a chat', async () => {
+      const history: Content[] = [
+        { role: 'user', parts: [{ text: 'hello' }] },
+        { role: 'model', parts: [{ text: 'Hi there!' }] },
+      ];
+      mockGetHistory.mockReturnValue(history);
+      await saveCommand?.action?.(mockContext, tag);
+      expect(mockGetHistory).toHaveBeenCalledWith({ stripThoughts: true });
+    });
+
+    it('should include thoughts when saving a chat if --with-thoughts is passed', async () => {
+      const history: Content[] = [
+        { role: 'user', parts: [{ text: 'hello' }] },
+        { role: 'model', parts: [{ text: 'Hi there!' }] },
+      ];
+      mockGetHistory.mockReturnValue(history);
+      await saveCommand?.action?.(mockContext, `${tag} --with-thoughts`);
+      expect(mockGetHistory).toHaveBeenCalledWith({ stripThoughts: false });
+    });
   });
 
   describe('resume subcommand', () => {

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -102,10 +102,12 @@ const listCommand: SlashCommand = {
 const saveCommand: SlashCommand = {
   name: 'save',
   description:
-    'Save the current conversation as a checkpoint. Usage: /chat save <tag>',
+    'Save the current conversation as a checkpoint. Usage: /chat save <tag> [--with-thoughts]',
   kind: CommandKind.BUILT_IN,
   action: async (context, args): Promise<SlashCommandActionReturn | void> => {
-    const tag = args.trim();
+    const [tag, ...rest] = args.split(' ');
+    const withThoughts = rest.includes('--with-thoughts');
+
     if (!tag) {
       return {
         type: 'message',
@@ -145,13 +147,15 @@ const saveCommand: SlashCommand = {
       };
     }
 
-    const history = chat.getHistory();
+    const history = chat.getHistory({ stripThoughts: !withThoughts });
     if (history.length > 2) {
       await logger.saveCheckpoint(history, tag);
       return {
         type: 'message',
         messageType: 'info',
-        content: `Conversation checkpoint saved with tag: ${decodeTagName(tag)}.`,
+        content: `Conversation checkpoint saved with tag: ${decodeTagName(
+          tag,
+        )}.`,
       };
     } else {
       return {

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -105,8 +105,8 @@ const saveCommand: SlashCommand = {
     'Save the current conversation as a checkpoint. Usage: /chat save <tag> [--with-thoughts]',
   kind: CommandKind.BUILT_IN,
   action: async (context, args): Promise<SlashCommandActionReturn | void> => {
-    const [tag, ...rest] = args.split(' ');
-    const withThoughts = rest.includes('--with-thoughts');
+    const withThoughts = args.includes('--with-thoughts');
+    const tag = args.replace('--with-thoughts', '').trim();
 
     if (!tag) {
       return {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -780,7 +780,7 @@ export class GeminiClient {
     prompt_id: string,
     force: boolean = false,
   ): Promise<ChatCompressionInfo> {
-    const curatedHistory = this.getChat().getHistory(true);
+    const curatedHistory = this.getChat().getHistory({ curated: true });
 
     // Regardless of `force`, don't do anything if the history is empty.
     if (

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -528,8 +528,11 @@ export class GeminiChat {
 
     if (stripThoughts) {
       history = history.map((content) => {
-        const visibleParts = content.parts?.filter((part) => !part.thought);
-        return { ...content, parts: visibleParts || [] };
+        if (!content.parts) {
+          return content;
+        }
+        const visibleParts = content.parts.filter((part) => !part.thought);
+        return { ...content, parts: visibleParts };
       });
     }
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -528,8 +528,8 @@ export class GeminiChat {
 
     if (stripThoughts) {
       history = history.map((content) => {
-        const visibleParts = content.parts.filter((part) => !part.thought);
-        return { ...content, parts: visibleParts };
+        const visibleParts = content.parts?.filter((part) => !part.thought);
+        return { ...content, parts: visibleParts || [] };
       });
     }
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -500,19 +500,23 @@ export class GeminiChat {
    * chat session.
    */
   getHistory(curated?: boolean): Content[];
-  getHistory(options?: { curated?: boolean; stripThoughts?: boolean }): Content[];
+  getHistory(options?: {
+    curated?: boolean;
+    stripThoughts?: boolean;
+  }): Content[];
   getHistory(
-    optionsOrCurated?:
-      | boolean
-      | { curated?: boolean; stripThoughts?: boolean },
+    optionsOrCurated?: boolean | { curated?: boolean; stripThoughts?: boolean },
   ): Content[] {
-    const defaultOptions = { curated: false, stripThoughts: false };
+    const defaultOptions = { curated: false, stripThoughts: true };
 
     let finalOptions;
 
     if (typeof optionsOrCurated === 'boolean') {
       finalOptions = { ...defaultOptions, curated: optionsOrCurated };
-    } else if (typeof optionsOrCurated === 'object' && optionsOrCurated !== null) {
+    } else if (
+      typeof optionsOrCurated === 'object' &&
+      optionsOrCurated !== null
+    ) {
       finalOptions = { ...defaultOptions, ...optionsOrCurated };
     } else {
       finalOptions = defaultOptions;
@@ -520,9 +524,7 @@ export class GeminiChat {
 
     const { curated, stripThoughts } = finalOptions;
 
-    let history = curated
-      ? extractCuratedHistory(this.history)
-      : this.history;
+    let history = curated ? extractCuratedHistory(this.history) : this.history;
 
     if (stripThoughts) {
       history = history.map((content) => {

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -290,7 +290,7 @@ export class Turn {
         throw error;
       }
 
-      const contextForReport = [...this.chat.getHistory(/*curated*/ true), req];
+      const contextForReport = [...this.chat.getHistory({ curated: true }), req];
       await reportError(
         error,
         'Error when talking to Gemini API',

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -290,7 +290,10 @@ export class Turn {
         throw error;
       }
 
-      const contextForReport = [...this.chat.getHistory({ curated: true }), req];
+      const contextForReport = [
+        ...this.chat.getHistory({ curated: true }),
+        req,
+      ];
       await reportError(
         error,
         'Error when talking to Gemini API',

--- a/packages/core/src/utils/nextSpeakerChecker.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.ts
@@ -48,7 +48,7 @@ export async function checkNextSpeaker(
   // that when passed back up to the endpoint will break subsequent calls. An example of this is when the model decides
   // to respond with an empty part collection if you were to send that message back to the server it will respond with
   // a 400 indicating that model part collections MUST have content.
-  const curatedHistory = chat.getHistory(/* curated */ true);
+  const curatedHistory = chat.getHistory({ curated: true });
 
   // Ensure there's a model response to analyze
   if (curatedHistory.length === 0) {


### PR DESCRIPTION
## TLDR

Adds a `--with-thoughts` flag to the `/chat save` command. This flag saves the complete chat history, including the model's internal "thought" process, which is stripped out by default. This is primarily a debugging feature to help understand the model's reasoning.

## Dive Deeper

It's really helpful to inspect the `thought` parts of the model's output to understand its reasoning chain.

This PR addresses:
1.  Adding a `--with-thoughts` flag to the `/chat save` command.
2.  Overloading the `GeminiChat.getHistory` method to accept a `stripThoughts` option in a backward-compatible way.
3.  Updating all internal calls to `getHistory` to use the new, more explicit options object where appropriate.
4.  Adding new tests to verify that the flag correctly controls the inclusion of thoughts in the saved history.

## Reviewer Test Plan

1.  Start the CLI (`npm start`).
2.  Have a short conversation with the model.
3.  Run the save command **without** the flag: `/chat save test-no-thoughts`
4.  Inspect the saved file at `.gemini/tmp/checkpoints/checkpoint-test-no-thoughts.json`. Verify that the `parts` arrays for the model's responses **do not** contain any `"thought"` keys.
5.  Run the save command **with** the flag: `/chat save test-with-thoughts --with-thoughts`
6.  Inspect the saved file at `.gemini/tmp/checkpoints/checkpoint-test-with-thoughts.json`. Verify that the `parts` arrays for the model's responses **do** contain `"thought"` keys with corresponding reasoning strings.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #7265 