### PR TITLE
feat(quality): Skip the next speaker check by default

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -424,7 +424,7 @@ export const SETTINGS_SCHEMA = {
         label: 'Skip Next Speaker Check',
         category: 'Model',
         requiresRestart: false,
-        default: false,
+        default: true,
         description: 'Skip the next speaker check.',
         showInDialog: true,
       },


### PR DESCRIPTION
## TLDR

This pull request changes the default value of the `skipNextSpeakerCheck` setting to `true`.

We found that as the API team fixed upstream issues, the percentage of times we need the next speaker check is down to ~7%. Skipping the next speaker check by default now improves user experience and helps us surface future API issues.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

#4651 