### PR TITLE
Log config.useSmartEdit to Clearcut

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -199,6 +199,7 @@ describe('useGeminiStream', () => {
       getContentGeneratorConfig: vi
         .fn()
         .mockReturnValue(contentGeneratorConfig),
+      getUseSmartEdit: () => false,
     } as unknown as Config;
     mockOnDebugMessage = vi.fn();
     mockHandleSlashCommand = vi.fn().mockResolvedValue(false);

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -59,6 +59,7 @@ const mockConfig = {
     model: 'test-model',
     authType: 'oauth-personal',
   }),
+  getUseSmartEdit: () => false,
 } as unknown as Config;
 
 const mockTool = new MockTool({

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -278,6 +278,7 @@ describe('Gemini Client (client.ts)', () => {
       setFallbackMode: vi.fn(),
       getChatCompression: vi.fn().mockReturnValue(undefined),
       getSkipNextSpeakerCheck: vi.fn().mockReturnValue(false),
+      getUseSmartEdit: vi.fn().mockReturnValue(false),
     };
     const MockedConfig = vi.mocked(Config, true);
     MockedConfig.mockImplementation(

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -168,6 +168,7 @@ describe('CoreToolScheduler', () => {
         authType: 'oauth-personal',
       }),
       getToolRegistry: () => mockToolRegistry,
+      getUseSmartEdit: () => false,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -201,6 +202,7 @@ describe('CoreToolScheduler', () => {
       // Create mocked tool registry
       const mockConfig = {
         getToolRegistry: () => mockToolRegistry,
+        getUseSmartEdit: () => false,
       } as unknown as Config;
       const mockToolRegistry = {
         getAllToolNames: () => ['list_files', 'read_file', 'write_file'],
@@ -265,6 +267,7 @@ describe('CoreToolScheduler with payload', () => {
         authType: 'oauth-personal',
       }),
       getToolRegistry: () => mockToolRegistry,
+      getUseSmartEdit: () => false,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -571,6 +574,7 @@ describe('CoreToolScheduler edit cancellation', () => {
         authType: 'oauth-personal',
       }),
       getToolRegistry: () => mockToolRegistry,
+      getUseSmartEdit: () => false,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -662,6 +666,7 @@ describe('CoreToolScheduler YOLO mode', () => {
         authType: 'oauth-personal',
       }),
       getToolRegistry: () => mockToolRegistry,
+      getUseSmartEdit: () => false,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -752,6 +757,7 @@ describe('CoreToolScheduler request queueing', () => {
         authType: 'oauth-personal',
       }),
       getToolRegistry: () => mockToolRegistry,
+      getUseSmartEdit: () => false,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -868,6 +874,7 @@ describe('CoreToolScheduler request queueing', () => {
         model: 'test-model',
         authType: 'oauth-personal',
       }),
+      getUseSmartEdit: () => false,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -948,6 +955,7 @@ describe('CoreToolScheduler request queueing', () => {
         authType: 'oauth-personal',
       }),
       getToolRegistry: () => mockToolRegistry,
+      getUseSmartEdit: () => false,
     } as unknown as Config;
 
     const scheduler = new CoreToolScheduler({
@@ -1007,6 +1015,7 @@ describe('CoreToolScheduler request queueing', () => {
       setApprovalMode: (mode: ApprovalMode) => {
         approvalMode = mode;
       },
+      getUseSmartEdit: () => false,
     } as unknown as Config;
 
     const testTool = new TestApprovalTool(mockConfig);

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -41,6 +41,7 @@ describe('executeToolCall', () => {
         model: 'test-model',
         authType: 'oauth-personal',
       }),
+      getUseSmartEdit: () => false,
     } as unknown as Config;
 
     abortController = new AbortController();

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -27,6 +27,7 @@ import { UserPromptEvent, makeChatCompressionEvent } from '../types.js';
 import { GIT_COMMIT_INFO, CLI_VERSION } from '../../generated/git-commit.js';
 import { UserAccountManager } from '../../utils/userAccountManager.js';
 import { InstallationManager } from '../../utils/installationManager.js';
+import { safeJsonStringify } from '../../utils/safeJsonStringify.js';
 
 interface CustomMatchers<R = unknown> {
   toHaveMetadataValue: ([key, value]: [EventMetadataKey, string]) => R;
@@ -208,6 +209,9 @@ describe('ClearcutLogger', () => {
       const cli_version = CLI_VERSION;
       const git_commit_hash = GIT_COMMIT_INFO;
       const prompt_id = 'my-prompt-123';
+      const user_settings = safeJsonStringify([
+        {'smart_edit_enabled': false}
+      ]);
 
       // Setup logger with expected values
       const { logger, loggerConfig } = setup({
@@ -258,6 +262,10 @@ describe('ClearcutLogger', () => {
             gemini_cli_key: EventMetadataKey.GEMINI_CLI_OS,
             value: process.platform,
           },
+          {
+            gemini_cli_key: EventMetadataKey.GEMINI_CLI_USER_SETTINGS,
+            value: user_settings,
+          }
         ]),
       );
     });
@@ -284,6 +292,26 @@ describe('ClearcutLogger', () => {
       expect(event?.event_metadata[0]).toContainEqual({
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
         value: 'ide-1234',
+      });
+    });
+
+    it('logs the value of config.useSmartEdit', () => {
+      const user_settings = safeJsonStringify([
+        {'smart_edit_enabled': true}
+      ]);
+
+      const { logger } = setup({
+        config: { useSmartEdit: true },
+      });
+
+      vi.stubEnv('TERM_PROGRAM', 'vscode');
+      vi.stubEnv('SURFACE', 'ide-1234');
+
+      const event = logger?.createLogEvent(EventNames.TOOL_CALL, []);
+
+      expect(event?.event_metadata[0]).toContainEqual({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_USER_SETTINGS,
+        value: user_settings,
       });
     });
 

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -209,9 +209,7 @@ describe('ClearcutLogger', () => {
       const cli_version = CLI_VERSION;
       const git_commit_hash = GIT_COMMIT_INFO;
       const prompt_id = 'my-prompt-123';
-      const user_settings = safeJsonStringify([
-        {'smart_edit_enabled': false}
-      ]);
+      const user_settings = safeJsonStringify([{ smart_edit_enabled: false }]);
 
       // Setup logger with expected values
       const { logger, loggerConfig } = setup({
@@ -265,7 +263,7 @@ describe('ClearcutLogger', () => {
           {
             gemini_cli_key: EventMetadataKey.GEMINI_CLI_USER_SETTINGS,
             value: user_settings,
-          }
+          },
         ]),
       );
     });
@@ -296,9 +294,7 @@ describe('ClearcutLogger', () => {
     });
 
     it('logs the value of config.useSmartEdit', () => {
-      const user_settings = safeJsonStringify([
-        {'smart_edit_enabled': true}
-      ]);
+      const user_settings = safeJsonStringify([{ smart_edit_enabled: true }]);
 
       const { logger } = setup({
         config: { useSmartEdit: true },

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -874,7 +874,7 @@ export class ClearcutLogger {
       {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_USER_SETTINGS,
         value: safeJsonStringify([
-          {"smart_edit_enabled": this.config?.getUseSmartEdit() ?? false }
+          { smart_edit_enabled: this.config?.getUseSmartEdit() ?? false },
         ]),
       },
     ];

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -871,6 +871,12 @@ export class ClearcutLogger {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_NODE_VERSION,
         value: process.versions.node,
       },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_USER_SETTINGS,
+        value: safeJsonStringify([
+          {"smart_edit_enabled": this.config?.getUseSmartEdit() ?? false }
+        ]),
+      },
     ];
     return [...data, ...defaultLogMetadata];
   }

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -166,6 +166,9 @@ export enum EventMetadataKey {
   // Logs the Gemini CLI OS
   GEMINI_CLI_OS = 82,
 
+  // Logs active user settings
+  GEMINI_CLI_USER_SETTINGS = 84,
+
   // ==========================================================================
   // Loop Detected Event Keys
   // ===========================================================================


### PR DESCRIPTION
## TLDR

Log config.useSmartEdit to a new event metadata key, GEMINI_CLI_USER_SETTINGS.

## Dive Deeper

This new metadata is logged as an array of JSON string: string pairs so it can be used to log additional user settings without adding new event metadata keys going forward.

Concord changes: cl/802304386

## Reviewer Test Plan

Unit tests should suffice 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | y  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/maintainers-gemini-cli/issues/684
