### PR TITLE
Log metrics and event for when the chat history is invalid when sendMessageStream is invoked

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -455,7 +455,11 @@ export class GeminiChat {
     if (!valid) {
       logInvalidHistory(
         this.config,
-        new InvalidHistoryEvent(error!, requestContents.length),
+        new InvalidHistoryEvent(
+          error!,
+          requestContents.length,
+          JSON.stringify(requestContents),
+        ),
       );
     }
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -146,12 +146,7 @@ export function checkHistory(history: Content[]): HistoryValidationResult {
     if (turn.role !== expectedRole) {
       return {
         valid: false,
-        error:
-          'Invalid history: expected a ' +
-          expectedRole +
-          ' turn but got a ' +
-          turn.role +
-          ' turn.',
+        error: `Invalid history: expected a ${expectedRole} turn but got a ${turn.role} turn.`,
       };
     }
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -101,7 +101,7 @@ type HistoryValidationResult = {
 /**
  * Visible for testing.
  */
-export function checkHistory(history: Content[]): HistoryValidationResult {
+export function validateHistory(history: Content[]): HistoryValidationResult {
   if (history.length === 0) {
     return { valid: true, error: null };
   }
@@ -186,26 +186,6 @@ export function checkHistory(history: Content[]): HistoryValidationResult {
 }
 
 /**
- * Validates the history array to ensure it follows the required alternating
- * role structure and correctly handles tool-related turns.
- *
- * @remarks
- * The validation enforces the following rules:
- * 1. The history must begin with a `user` role.
- * 2. Roles must alternate between `user` and `model`.
- * 3. A `model` turn with N `functionCall` parts must be followed by a `user`
- *    turn with N `functionResponse` parts.
- *
- * @throws {Error} If the history violates any of the validation rules.
- */
-function validateHistory(history: Content[]) {
-  const { valid, error } = checkHistory(history);
-  if (!valid) {
-    throw new Error(error!);
-  }
-}
-
-/**
  * Extracts the curated (valid) history from a comprehensive history.
  *
  * @remarks
@@ -271,7 +251,10 @@ export class GeminiChat {
     private readonly generationConfig: GenerateContentConfig = {},
     private history: Content[] = [],
   ) {
-    validateHistory(history);
+      const { valid, error } = validateHistory(history);
+      if (!valid) {
+        throw new Error(error!);
+      }
   }
 
   /**
@@ -468,7 +451,7 @@ export class GeminiChat {
     this.history.push(userContent);
     const requestContents = this.getHistory(true);
 
-    const { valid, error } = checkHistory(requestContents);
+    const { valid, error } = validateHistory(requestContents);
     if (!valid) {
       logInvalidHistory(
         this.config,

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -251,10 +251,10 @@ export class GeminiChat {
     private readonly generationConfig: GenerateContentConfig = {},
     private history: Content[] = [],
   ) {
-      const { valid, error } = validateHistory(history);
-      if (!valid) {
-        throw new Error(error!);
-      }
+    const { valid, error } = validateHistory(history);
+    if (!valid) {
+      throw new Error(error!);
+    }
   }
 
   /**

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -114,7 +114,7 @@ function validateHistory(history: Content[]) {
     if (expectFunctionResponse) {
       if (turn.role !== 'user' || !hasFunctionResponse) {
         throw new Error(
-          `Invalid history: expected a user turn with a functionResponse.`,
+          'Invalid history: expected a user turn with a functionResponse.',
         );
       }
       expectFunctionResponse = false;
@@ -131,7 +131,7 @@ function validateHistory(history: Content[]) {
     if (turn.role === 'user') {
       if (hasFunctionResponse) {
         throw new Error(
-          `Invalid history: got a user turn with a functionResponse when none was expected.`,
+          'Invalid history: got a user turn with a functionResponse when none was expected.',
         );
       }
       expectedRole = 'model';
@@ -148,7 +148,7 @@ function validateHistory(history: Content[]) {
   // the history is incomplete.
   if (expectFunctionResponse) {
     throw new Error(
-      `Invalid history: ended with a model turn with a functionCall, but no functionResponse followed.`,
+      'Invalid history: ended with a model turn with a functionCall, but no functionResponse followed.',
     );
   }
 }

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -23,7 +23,11 @@ import { EventMetadataKey } from './event-metadata-key.js';
 import { makeFakeConfig } from '../../test-utils/config.js';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../mocks/msw.js';
-import { UserPromptEvent, makeChatCompressionEvent } from '../types.js';
+import {
+  UserPromptEvent,
+  makeChatCompressionEvent,
+  InvalidHistoryEvent,
+} from '../types.js';
 import { GIT_COMMIT_INFO, CLI_VERSION } from '../../generated/git-commit.js';
 import { UserAccountManager } from '../../utils/userAccountManager.js';
 import { InstallationManager } from '../../utils/installationManager.js';
@@ -364,6 +368,27 @@ describe('ClearcutLogger', () => {
       expect(events[0]).toHaveMetadataValue([
         EventMetadataKey.GEMINI_CLI_COMPRESSION_TOKENS_AFTER,
         '8000',
+      ]);
+    });
+  });
+
+  describe('logInvalidHistoryEvent', () => {
+    it('logs an event with proper fields', () => {
+      const { logger } = setup();
+      logger?.logInvalidHistoryEvent(
+        new InvalidHistoryEvent('some error', 123),
+      );
+
+      const events = getEvents(logger!);
+      expect(events.length).toBe(1);
+      expect(events[0]).toHaveEventName(EventNames.INVALID_HISTORY);
+      expect(events[0]).toHaveMetadataValue([
+        EventMetadataKey.GEMINI_CLI_CHAT_HISTORY_VALIDATION_ERROR_MESSAGE,
+        'some error',
+      ]);
+      expect(events[0]).toHaveMetadataValue([
+        EventMetadataKey.GEMINI_CLI_CHAT_HISTORY_SIZE,
+        '123',
       ]);
     });
   });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -387,7 +387,7 @@ describe('ClearcutLogger', () => {
         'some error',
       ]);
       expect(events[0]).toHaveMetadataValue([
-        EventMetadataKey.GEMINI_CLI_CHAT_HISTORY_SIZE,
+        EventMetadataKey.GEMINI_CLI_CHAT_HISTORY_LENGTH,
         '123',
       ]);
     });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -786,8 +786,8 @@ export class ClearcutLogger {
         value: event.error_message,
       },
       {
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_CHAT_HISTORY_SIZE,
-        value: String(event.history_size),
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_CHAT_HISTORY_LENGTH,
+        value: String(event.history_length),
       },
     ];
 

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -24,6 +24,7 @@ import type {
   InvalidChunkEvent,
   ContentRetryEvent,
   ContentRetryFailureEvent,
+  InvalidHistoryEvent,
 } from '../types.js';
 import { EventMetadataKey } from './event-metadata-key.js';
 import type { Config } from '../../config/config.js';
@@ -55,6 +56,7 @@ export enum EventNames {
   INVALID_CHUNK = 'invalid_chunk',
   CONTENT_RETRY = 'content_retry',
   CONTENT_RETRY_FAILURE = 'content_retry_failure',
+  INVALID_HISTORY = 'invalid_history',
 }
 
 export interface LogResponse {
@@ -773,6 +775,23 @@ export class ClearcutLogger {
     }
 
     this.enqueueLogEvent(this.createLogEvent(EventNames.INVALID_CHUNK, data));
+    this.flushIfNeeded();
+  }
+
+  logInvalidHistoryEvent(event: InvalidHistoryEvent): void {
+    const data: EventValue[] = [
+      {
+        gemini_cli_key:
+          EventMetadataKey.GEMINI_CLI_CHAT_HISTORY_VALIDATION_ERROR_MESSAGE,
+        value: event.error_message,
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_CHAT_HISTORY_SIZE,
+        value: String(event.history_size),
+      },
+    ];
+
+    this.enqueueLogEvent(this.createLogEvent(EventNames.INVALID_HISTORY, data));
     this.flushIfNeeded();
   }
 

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -328,4 +328,11 @@ export enum EventMetadataKey {
 
   // Logs the current nodejs version
   GEMINI_CLI_NODE_VERSION = 83,
+
+  // ==========================================================================
+  // Chat History Validation Check Event Keys
+  // ===========================================================================
+  GEMINI_CLI_CHAT_HISTORY_VALIDATION_ERROR_MESSAGE = 84,
+
+  GEMINI_CLI_CHAT_HISTORY_SIZE = 85,
 }

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -334,5 +334,5 @@ export enum EventMetadataKey {
   // ===========================================================================
   GEMINI_CLI_CHAT_HISTORY_VALIDATION_ERROR_MESSAGE = 84,
 
-  GEMINI_CLI_CHAT_HISTORY_SIZE = 85,
+  GEMINI_CLI_CHAT_HISTORY_LENGTH = 85,
 }

--- a/packages/core/src/telemetry/constants.ts
+++ b/packages/core/src/telemetry/constants.ts
@@ -36,3 +36,7 @@ export const METRIC_INVALID_CHUNK_COUNT = 'gemini_cli.chat.invalid_chunk.count';
 export const METRIC_CONTENT_RETRY_COUNT = 'gemini_cli.chat.content_retry.count';
 export const METRIC_CONTENT_RETRY_FAILURE_COUNT =
   'gemini_cli.chat.content_retry_failure.count';
+
+export const EVENT_INVALID_HISTORY = 'gemini_cli.chat.invalid_history';
+export const METRIC_INVALID_HISTORY_COUNT =
+  'gemini_cli.chat.invalid_history.count';

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -924,5 +924,28 @@ describe('loggers', () => {
 
       expect(metrics.recordInvalidHistory).toHaveBeenCalledWith(mockConfig);
     });
+
+    it('logs the history_text when provided', () => {
+      const mockConfig = makeFakeConfig();
+      const historyText = JSON.stringify([
+        { role: 'user', parts: [{ text: 'hello' }] },
+      ]);
+      const event = new InvalidHistoryEvent('some error', 123, historyText);
+
+      logInvalidHistory(mockConfig, event);
+
+      expect(mockLogger.emit).toHaveBeenCalledWith({
+        body: 'Invalid history detected.',
+        attributes: {
+          'session.id': 'test-session-id',
+          'user.email': 'test-user@example.com',
+          'event.name': EVENT_INVALID_HISTORY,
+          'event.timestamp': '2025-01-01T00:00:00.000Z',
+          'error.message': 'some error',
+          'history.length': 123,
+          'history.text': historyText,
+        },
+      });
+    });
   });
 });

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -918,7 +918,7 @@ describe('loggers', () => {
           'event.name': EVENT_INVALID_HISTORY,
           'event.timestamp': '2025-01-01T00:00:00.000Z',
           'error.message': 'some error',
-          'history.size': 123,
+          'history.length': 123,
         },
       });
 

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -26,6 +26,7 @@ import {
   EVENT_INVALID_CHUNK,
   EVENT_CONTENT_RETRY,
   EVENT_CONTENT_RETRY_FAILURE,
+  EVENT_INVALID_HISTORY,
 } from './constants.js';
 import type {
   ApiErrorEvent,
@@ -47,6 +48,7 @@ import type {
   InvalidChunkEvent,
   ContentRetryEvent,
   ContentRetryFailureEvent,
+  InvalidHistoryEvent,
 } from './types.js';
 import {
   recordApiErrorMetrics,
@@ -58,6 +60,7 @@ import {
   recordInvalidChunk,
   recordContentRetry,
   recordContentRetryFailure,
+  recordInvalidHistory,
 } from './metrics.js';
 import { isTelemetrySdkInitialized } from './sdk.js';
 import type { UiEvent } from './uiTelemetry.js';
@@ -583,4 +586,28 @@ export function logContentRetryFailure(
   };
   logger.emit(logRecord);
   recordContentRetryFailure(config);
+}
+
+export function logInvalidHistory(
+  config: Config,
+  event: InvalidHistoryEvent,
+): void {
+  ClearcutLogger.getInstance(config)?.logInvalidHistoryEvent(event);
+  if (!isTelemetrySdkInitialized()) return;
+
+  const attributes: LogAttributes = {
+    ...getCommonAttributes(config),
+    'event.name': EVENT_INVALID_HISTORY,
+    'event.timestamp': event['event.timestamp'],
+    'error.message': event.error_message,
+    'history.size': event.history_size,
+  };
+
+  const logger = logs.getLogger(SERVICE_NAME);
+  const logRecord: LogRecord = {
+    body: `Invalid history detected.`,
+    attributes,
+  };
+  logger.emit(logRecord);
+  recordInvalidHistory(config);
 }

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -603,6 +603,10 @@ export function logInvalidHistory(
     'history.length': event.history_length,
   };
 
+  if (event.history_text) {
+    attributes['history.text'] = event.history_text;
+  }
+
   const logger = logs.getLogger(SERVICE_NAME);
   const logRecord: LogRecord = {
     body: `Invalid history detected.`,

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -600,7 +600,7 @@ export function logInvalidHistory(
     'event.name': EVENT_INVALID_HISTORY,
     'event.timestamp': event['event.timestamp'],
     'error.message': event.error_message,
-    'history.size': event.history_size,
+    'history.length': event.history_length,
   };
 
   const logger = logs.getLogger(SERVICE_NAME);

--- a/packages/core/src/telemetry/metrics.test.ts
+++ b/packages/core/src/telemetry/metrics.test.ts
@@ -63,6 +63,7 @@ describe('Telemetry Metrics', () => {
   let recordTokenUsageMetricsModule: typeof import('./metrics.js').recordTokenUsageMetrics;
   let recordFileOperationMetricModule: typeof import('./metrics.js').recordFileOperationMetric;
   let recordChatCompressionMetricsModule: typeof import('./metrics.js').recordChatCompressionMetrics;
+  let recordInvalidHistoryModule: typeof import('./metrics.js').recordInvalidHistory;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -78,6 +79,7 @@ describe('Telemetry Metrics', () => {
     recordFileOperationMetricModule = metricsJsModule.recordFileOperationMetric;
     recordChatCompressionMetricsModule =
       metricsJsModule.recordChatCompressionMetrics;
+    recordInvalidHistoryModule = metricsJsModule.recordInvalidHistory;
 
     const otelApiModule = await import('@opentelemetry/api');
 
@@ -313,6 +315,28 @@ describe('Telemetry Metrics', () => {
       expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
         'session.id': 'test-session-id',
         operation: FileOperation.UPDATE,
+      });
+    });
+  });
+
+  describe('recordInvalidHistory', () => {
+    it('does not record metrics if not initialized', () => {
+      const config = makeFakeConfig({});
+
+      recordInvalidHistoryModule(config);
+
+      expect(mockCounterAddFn).not.toHaveBeenCalled();
+    });
+
+    it('records invalid history with the correct attributes', () => {
+      const config = makeFakeConfig({});
+      initializeMetricsModule(config);
+      mockCounterAddFn.mockClear();
+
+      recordInvalidHistoryModule(config);
+
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
+        'session.id': 'test-session-id',
       });
     });
   });

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -19,6 +19,7 @@ import {
   METRIC_INVALID_CHUNK_COUNT,
   METRIC_CONTENT_RETRY_COUNT,
   METRIC_CONTENT_RETRY_FAILURE_COUNT,
+  METRIC_INVALID_HISTORY_COUNT,
 } from './constants.js';
 import type { Config } from '../config/config.js';
 
@@ -39,6 +40,7 @@ let chatCompressionCounter: Counter | undefined;
 let invalidChunkCounter: Counter | undefined;
 let contentRetryCounter: Counter | undefined;
 let contentRetryFailureCounter: Counter | undefined;
+let invalidHistoryCounter: Counter | undefined;
 let isMetricsInitialized = false;
 
 function getCommonAttributes(config: Config): Attributes {
@@ -110,6 +112,11 @@ export function initializeMetrics(config: Config): void {
       valueType: ValueType.INT,
     },
   );
+
+  invalidHistoryCounter = meter.createCounter(METRIC_INVALID_HISTORY_COUNT, {
+    description: 'Counts invalid history events.',
+    valueType: ValueType.INT,
+  });
 
   const sessionCounter = meter.createCounter(METRIC_SESSION_COUNT, {
     description: 'Count of CLI sessions started.',
@@ -266,4 +273,12 @@ export function recordContentRetry(config: Config): void {
 export function recordContentRetryFailure(config: Config): void {
   if (!contentRetryFailureCounter || !isMetricsInitialized) return;
   contentRetryFailureCounter.add(1, getCommonAttributes(config));
+}
+
+/**
+ * Records a metric for when an invalid history is detected.
+ */
+export function recordInvalidHistory(config: Config): void {
+  if (!invalidHistoryCounter || !isMetricsInitialized) return;
+  invalidHistoryCounter.add(1, getCommonAttributes(config));
 }

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -502,13 +502,13 @@ export class InvalidHistoryEvent implements BaseTelemetryEvent {
   'event.name': 'invalid_history';
   'event.timestamp': string;
   error_message: string;
-  history_size: number;
+  history_length: number;
 
-  constructor(error_message: string, history_size: number) {
+  constructor(error_message: string, history_length: number) {
     this['event.name'] = 'invalid_history';
     this['event.timestamp'] = new Date().toISOString();
     this.error_message = error_message;
-    this.history_size = history_size;
+    this.history_length = history_length;
   }
 }
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -503,12 +503,18 @@ export class InvalidHistoryEvent implements BaseTelemetryEvent {
   'event.timestamp': string;
   error_message: string;
   history_length: number;
+  history_text?: string;
 
-  constructor(error_message: string, history_length: number) {
+  constructor(
+    error_message: string,
+    history_length: number,
+    history_text?: string,
+  ) {
     this['event.name'] = 'invalid_history';
     this['event.timestamp'] = new Date().toISOString();
     this.error_message = error_message;
     this.history_length = history_length;
+    this.history_text = history_text;
   }
 }
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -498,6 +498,20 @@ export class ContentRetryFailureEvent implements BaseTelemetryEvent {
   }
 }
 
+export class InvalidHistoryEvent implements BaseTelemetryEvent {
+  'event.name': 'invalid_history';
+  'event.timestamp': string;
+  error_message: string;
+  history_size: number;
+
+  constructor(error_message: string, history_size: number) {
+    this['event.name'] = 'invalid_history';
+    this['event.timestamp'] = new Date().toISOString();
+    this.error_message = error_message;
+    this.history_size = history_size;
+  }
+}
+
 export type TelemetryEvent =
   | StartSessionEvent
   | EndSessionEvent
@@ -517,4 +531,5 @@ export type TelemetryEvent =
   | FileOperationEvent
   | InvalidChunkEvent
   | ContentRetryEvent
-  | ContentRetryFailureEvent;
+  | ContentRetryFailureEvent
+  | InvalidHistoryEvent;


### PR DESCRIPTION
## TLDR

Correctly structured conversation history is critical for the model's performance and for preventing API errors.

Before submitting a fix (and after) for https://github.com/google-gemini/gemini-cli/issues/7003, we want to start logging when the chat history is invalid so we know how prevalent the problem is. 


For the events, I am adding the error_message and how big the chat history is when the error happened. 

**Question: i also added history_text to the opentelemetry logging. I think that's ok, right? It will only log for the user, not sent to google.** 


## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

Added new test cases 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/google-gemini/gemini-cli/issues/7145
