### PR TITLE
fix(ide): prevent race condition when diff accepted through CLI

### DIFF
--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -208,12 +208,16 @@ export class IdeClient {
     });
   }
 
-  async closeDiff(filePath: string): Promise<string | undefined> {
+  async closeDiff(
+    filePath: string,
+    suppressNotifcations: boolean,
+  ): Promise<string | undefined> {
     try {
       const result = await this.client?.callTool({
         name: `closeDiff`,
         arguments: {
           filePath,
+          suppressNotifcations,
         },
       });
 
@@ -230,7 +234,7 @@ export class IdeClient {
   // Closes the diff. Instead of waiting for a notification,
   // manually resolves the diff resolver as the desired outcome.
   async resolveDiffFromCli(filePath: string, outcome: 'accepted' | 'rejected') {
-    const content = await this.closeDiff(filePath);
+    const content = await this.closeDiff(filePath, true);
     const resolver = this.diffResponses.get(filePath);
     if (resolver) {
       if (outcome === 'accepted') {
@@ -247,7 +251,7 @@ export class IdeClient {
       return;
     }
     for (const filePath of this.diffResponses.keys()) {
-      await this.closeDiff(filePath);
+      await this.closeDiff(filePath, false);
     }
     this.diffResponses.clear();
     this.setState(

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -208,16 +208,12 @@ export class IdeClient {
     });
   }
 
-  async closeDiff(
-    filePath: string,
-    suppressNotifcations: boolean,
-  ): Promise<string | undefined> {
+  async closeDiff(filePath: string): Promise<string | undefined> {
     try {
       const result = await this.client?.callTool({
         name: `closeDiff`,
         arguments: {
           filePath,
-          suppressNotifcations,
         },
       });
 
@@ -234,7 +230,7 @@ export class IdeClient {
   // Closes the diff. Instead of waiting for a notification,
   // manually resolves the diff resolver as the desired outcome.
   async resolveDiffFromCli(filePath: string, outcome: 'accepted' | 'rejected') {
-    const content = await this.closeDiff(filePath, true);
+    const content = await this.closeDiff(filePath);
     const resolver = this.diffResponses.get(filePath);
     if (resolver) {
       if (outcome === 'accepted') {
@@ -251,7 +247,7 @@ export class IdeClient {
       return;
     }
     for (const filePath of this.diffResponses.keys()) {
-      await this.closeDiff(filePath, false);
+      await this.closeDiff(filePath);
     }
     this.diffResponses.clear();
     this.setState(

--- a/packages/vscode-ide-companion/src/diff-manager.ts
+++ b/packages/vscode-ide-companion/src/diff-manager.ts
@@ -132,7 +132,7 @@ export class DiffManager {
   /**
    * Closes an open diff view for a specific file.
    */
-  async closeDiff(filePath: string) {
+  async closeDiff(filePath: string, suppressNotification = false) {
     let uriToClose: vscode.Uri | undefined;
     for (const [uriString, diffInfo] of this.diffDocuments.entries()) {
       if (diffInfo.originalFilePath === filePath) {
@@ -145,16 +145,18 @@ export class DiffManager {
       const rightDoc = await vscode.workspace.openTextDocument(uriToClose);
       const modifiedContent = rightDoc.getText();
       await this.closeDiffEditor(uriToClose);
-      this.onDidChangeEmitter.fire(
-        IdeDiffClosedNotificationSchema.parse({
-          jsonrpc: '2.0',
-          method: 'ide/diffClosed',
-          params: {
-            filePath,
-            content: modifiedContent,
-          },
-        }),
-      );
+      if (!suppressNotification) {
+        this.onDidChangeEmitter.fire(
+          IdeDiffClosedNotificationSchema.parse({
+            jsonrpc: '2.0',
+            method: 'ide/diffClosed',
+            params: {
+              filePath,
+              content: modifiedContent,
+            },
+          }),
+        );
+      }
       return modifiedContent;
     }
     return;

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -356,10 +356,20 @@ const createMcpServer = (diffManager: DiffManager) => {
       description: '(IDE Tool) Close an open diff view for a specific file.',
       inputSchema: z.object({
         filePath: z.string(),
+        suppressNotification: z.boolean().optional(),
       }).shape,
     },
-    async ({ filePath }: { filePath: string }) => {
-      const content = await diffManager.closeDiff(filePath);
+    async ({
+      filePath,
+      suppressNotification,
+    }: {
+      filePath: string;
+      suppressNotification?: boolean;
+    }) => {
+      const content = await diffManager.closeDiff(
+        filePath,
+        suppressNotification,
+      );
       const response = { content: content ?? undefined };
       return {
         content: [


### PR DESCRIPTION
## TLDR
This pull request introduces a `suppressNotification` flag to the `closeDiff` functionality. This allows the client to control whether the IDE sends a notification when a diff view is closed. This is primarily used to prevent incorrect notifications when the diff is being resolved directly from the CLI (e.g., via `/accept` or `/reject`), as the client is already handling the resolution manually. 

Note: This PR only contains the VS Code extension changes to ensure backward compatibility. The corresponding CLI-side changes will be released separately after this update is live.

## Linked issues / bugs
#6846 