### PR TITLE
refactor: Centralize and improve model fallback handling

### DIFF
--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -89,11 +89,10 @@ export class Task {
     this.completedToolCalls = [];
     this._resetToolCompletionPromise();
     this.config.setFallbackHandler(
-      async (currentModel: string, fallbackModel: string): Promise<'stop'> => {
-        config.setModel(fallbackModel); // gemini-cli-core sets to DEFAULT_GEMINI_FLASH_MODEL
-        // Switch model for future use but return false to stop current retry
-        return 'stop';
-      },
+      // For a2a-server, we want to automatically switch to the fallback model
+      // for future requests without retrying the current one. The 'stop'
+      // intent achieves this.
+      async () => 'stop',
     );
   }
 

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -88,11 +88,11 @@ export class Task {
     this.eventBus = eventBus;
     this.completedToolCalls = [];
     this._resetToolCompletionPromise();
-    this.config.setFlashFallbackHandler(
-      async (currentModel: string, fallbackModel: string): Promise<boolean> => {
+    this.config.setFallbackHandler(
+      async (currentModel: string, fallbackModel: string): Promise<'stop'> => {
         config.setModel(fallbackModel); // gemini-cli-core sets to DEFAULT_GEMINI_FLASH_MODEL
         // Switch model for future use but return false to stop current retry
-        return false;
+        return 'stop';
       },
     );
   }

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -88,7 +88,7 @@ export class Task {
     this.eventBus = eventBus;
     this.completedToolCalls = [];
     this._resetToolCompletionPromise();
-    this.config.setFallbackHandler(
+    this.config.setFallbackModelHandler(
       // For a2a-server, we want to automatically switch to the fallback model
       // for future requests without retrying the current one. The 'stop'
       // intent achieves this.

--- a/packages/a2a-server/src/utils/testing_utils.ts
+++ b/packages/a2a-server/src/utils/testing_utils.ts
@@ -43,7 +43,7 @@ export function createMockConfig(
     getContentGeneratorConfig: vi.fn().mockReturnValue({ model: 'gemini-pro' }),
     getModel: vi.fn().mockReturnValue('gemini-pro'),
     getUsageStatisticsEnabled: vi.fn().mockReturnValue(false),
-    setFlashFallbackHandler: vi.fn(),
+    setFallbackHandler: vi.fn(),
     initialize: vi.fn().mockResolvedValue(undefined),
     getProxy: vi.fn().mockReturnValue(undefined),
     getHistory: vi.fn().mockReturnValue([]),

--- a/packages/a2a-server/src/utils/testing_utils.ts
+++ b/packages/a2a-server/src/utils/testing_utils.ts
@@ -43,7 +43,7 @@ export function createMockConfig(
     getContentGeneratorConfig: vi.fn().mockReturnValue({ model: 'gemini-pro' }),
     getModel: vi.fn().mockReturnValue('gemini-pro'),
     getUsageStatisticsEnabled: vi.fn().mockReturnValue(false),
-    setFallbackHandler: vi.fn(),
+    setFallbackModelHandler: vi.fn(),
     initialize: vi.fn().mockResolvedValue(undefined),
     getProxy: vi.fn().mockReturnValue(undefined),
     getHistory: vi.fn().mockReturnValue([]),

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -4,31 +4,55 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
 import { render, cleanup } from 'ink-testing-library';
 import { AppContainer } from './AppContainer.js';
 import { type Config, makeFakeConfig } from '@google/gemini-cli-core';
 import type { LoadedSettings } from '../config/settings.js';
 import type { InitializationResult } from '../core/initializer.js';
+import { useQuotaAndFallback } from './hooks/useQuotaAndFallback.js';
+import { UIStateContext, type UIState } from './contexts/UIStateContext.js';
+import {
+  UIActionsContext,
+  type UIActions,
+} from './contexts/UIActionsContext.js';
+import { useContext } from 'react';
 
-// Mock App component to isolate AppContainer testing
+// Helper component will read the context values provided by AppContainer
+// so we can assert against them in our tests.
+let capturedUIState: UIState;
+let capturedUIActions: UIActions;
+function TestContextConsumer() {
+  capturedUIState = useContext(UIStateContext)!;
+  capturedUIActions = useContext(UIActionsContext)!;
+  return null;
+}
+
 vi.mock('./App.js', () => ({
-  App: () => 'App Component',
+  App: TestContextConsumer,
 }));
 
-// Mock all the hooks and utilities
-vi.mock('./hooks/useHistory.js');
+vi.mock('./hooks/useQuotaAndFallback.js');
+vi.mock('./hooks/useHistoryManager.js');
 vi.mock('./hooks/useThemeCommand.js');
-vi.mock('./hooks/useAuthCommand.js');
+vi.mock('./auth/useAuth.js');
 vi.mock('./hooks/useEditorSettings.js');
 vi.mock('./hooks/useSettingsCommand.js');
-vi.mock('./hooks/useSlashCommandProcessor.js');
+vi.mock('./hooks/slashCommandProcessor.js');
 vi.mock('./hooks/useConsoleMessages.js');
 vi.mock('./hooks/useTerminalSize.js', () => ({
   useTerminalSize: vi.fn(() => ({ columns: 80, rows: 24 })),
 }));
 vi.mock('./hooks/useGeminiStream.js');
-vi.mock('./hooks/useVim.js');
+vi.mock('./hooks/vim.js');
 vi.mock('./hooks/useFocus.js');
 vi.mock('./hooks/useBracketedPaste.js');
 vi.mock('./hooks/useKeypress.js');
@@ -40,7 +64,7 @@ vi.mock('./hooks/useWorkspaceMigration.js');
 vi.mock('./hooks/useGitBranchName.js');
 vi.mock('./contexts/VimModeContext.js');
 vi.mock('./contexts/SessionContext.js');
-vi.mock('./hooks/useTextBuffer.js');
+vi.mock('./components/shared/text-buffer.js');
 vi.mock('./hooks/useLogger.js');
 
 // Mock external utilities
@@ -49,13 +73,153 @@ vi.mock('../utils/handleAutoUpdate.js');
 vi.mock('./utils/ConsolePatcher.js');
 vi.mock('../utils/cleanup.js');
 
+// Import the mocked hooks so you can provide implementations
+import { useHistory } from './hooks/useHistoryManager.js';
+import { useThemeCommand } from './hooks/useThemeCommand.js';
+import { useAuthCommand } from './auth/useAuth.js';
+import { useEditorSettings } from './hooks/useEditorSettings.js';
+import { useSettingsCommand } from './hooks/useSettingsCommand.js';
+import { useSlashCommandProcessor } from './hooks/slashCommandProcessor.js';
+import { useConsoleMessages } from './hooks/useConsoleMessages.js';
+import { useGeminiStream } from './hooks/useGeminiStream.js';
+import { useVim } from './hooks/vim.js';
+import { useFolderTrust } from './hooks/useFolderTrust.js';
+import { useMessageQueue } from './hooks/useMessageQueue.js';
+import { useAutoAcceptIndicator } from './hooks/useAutoAcceptIndicator.js';
+import { useWorkspaceMigration } from './hooks/useWorkspaceMigration.js';
+import { useGitBranchName } from './hooks/useGitBranchName.js';
+import { useVimMode } from './contexts/VimModeContext.js';
+import { useSessionStats } from './contexts/SessionContext.js';
+import { useTextBuffer } from './components/shared/text-buffer.js';
+import { useLogger } from './hooks/useLogger.js';
+import { useLoadingIndicator } from './hooks/useLoadingIndicator.js';
+
 describe('AppContainer State Management', () => {
   let mockConfig: Config;
   let mockSettings: LoadedSettings;
   let mockInitResult: InitializationResult;
 
+  // Create typed mocks for all hooks
+  const mockedUseQuotaAndFallback = useQuotaAndFallback as Mock;
+  const mockedUseHistory = useHistory as Mock;
+  const mockedUseThemeCommand = useThemeCommand as Mock;
+  const mockedUseAuthCommand = useAuthCommand as Mock;
+  const mockedUseEditorSettings = useEditorSettings as Mock;
+  const mockedUseSettingsCommand = useSettingsCommand as Mock;
+  const mockedUseSlashCommandProcessor = useSlashCommandProcessor as Mock;
+  const mockedUseConsoleMessages = useConsoleMessages as Mock;
+  const mockedUseGeminiStream = useGeminiStream as Mock;
+  const mockedUseVim = useVim as Mock;
+  const mockedUseFolderTrust = useFolderTrust as Mock;
+  const mockedUseMessageQueue = useMessageQueue as Mock;
+  const mockedUseAutoAcceptIndicator = useAutoAcceptIndicator as Mock;
+  const mockedUseWorkspaceMigration = useWorkspaceMigration as Mock;
+  const mockedUseGitBranchName = useGitBranchName as Mock;
+  const mockedUseVimMode = useVimMode as Mock;
+  const mockedUseSessionStats = useSessionStats as Mock;
+  const mockedUseTextBuffer = useTextBuffer as Mock;
+  const mockedUseLogger = useLogger as Mock;
+  const mockedUseLoadingIndicator = useLoadingIndicator as Mock;
+
   beforeEach(() => {
     vi.clearAllMocks();
+
+    capturedUIState = null!;
+    capturedUIActions = null!;
+
+    // **Provide a default return value for EVERY mocked hook.**
+    mockedUseQuotaAndFallback.mockReturnValue({
+      proQuotaRequest: null,
+      handleProQuotaChoice: vi.fn(),
+    });
+    mockedUseHistory.mockReturnValue({
+      history: [],
+      addItem: vi.fn(),
+      updateItem: vi.fn(),
+      clearItems: vi.fn(),
+      loadHistory: vi.fn(),
+    });
+    mockedUseThemeCommand.mockReturnValue({
+      isThemeDialogOpen: false,
+      openThemeDialog: vi.fn(),
+      handleThemeSelect: vi.fn(),
+      handleThemeHighlight: vi.fn(),
+    });
+    mockedUseAuthCommand.mockReturnValue({
+      authState: 'authenticated',
+      setAuthState: vi.fn(),
+      authError: null,
+      onAuthError: vi.fn(),
+    });
+    mockedUseEditorSettings.mockReturnValue({
+      isEditorDialogOpen: false,
+      openEditorDialog: vi.fn(),
+      handleEditorSelect: vi.fn(),
+      exitEditorDialog: vi.fn(),
+    });
+    mockedUseSettingsCommand.mockReturnValue({
+      isSettingsDialogOpen: false,
+      openSettingsDialog: vi.fn(),
+      closeSettingsDialog: vi.fn(),
+    });
+    mockedUseSlashCommandProcessor.mockReturnValue({
+      handleSlashCommand: vi.fn(),
+      slashCommands: [],
+      pendingHistoryItems: [],
+      commandContext: {},
+      shellConfirmationRequest: null,
+      confirmationRequest: null,
+    });
+    mockedUseConsoleMessages.mockReturnValue({
+      consoleMessages: [],
+      handleNewMessage: vi.fn(),
+      clearConsoleMessages: vi.fn(),
+    });
+    mockedUseGeminiStream.mockReturnValue({
+      streamingState: 'idle',
+      submitQuery: vi.fn(),
+      initError: null,
+      pendingHistoryItems: [],
+      thought: null,
+      cancelOngoingRequest: vi.fn(),
+    });
+    mockedUseVim.mockReturnValue({ handleInput: vi.fn() });
+    mockedUseFolderTrust.mockReturnValue({
+      isFolderTrustDialogOpen: false,
+      handleFolderTrustSelect: vi.fn(),
+      isRestarting: false,
+    });
+    mockedUseMessageQueue.mockReturnValue({
+      messageQueue: [],
+      addMessage: vi.fn(),
+      clearQueue: vi.fn(),
+      getQueuedMessagesText: vi.fn().mockReturnValue(''),
+    });
+    mockedUseAutoAcceptIndicator.mockReturnValue(false);
+    mockedUseWorkspaceMigration.mockReturnValue({
+      showWorkspaceMigrationDialog: false,
+      workspaceExtensions: [],
+      onWorkspaceMigrationDialogOpen: vi.fn(),
+      onWorkspaceMigrationDialogClose: vi.fn(),
+    });
+    mockedUseGitBranchName.mockReturnValue('main');
+    mockedUseVimMode.mockReturnValue({
+      isVimEnabled: false,
+      toggleVimEnabled: vi.fn(),
+    });
+    mockedUseSessionStats.mockReturnValue({ stats: {} });
+    mockedUseTextBuffer.mockReturnValue({
+      text: '',
+      setText: vi.fn(),
+      // Add other properties if AppContainer uses them
+    });
+    mockedUseLogger.mockReturnValue({
+      getPreviousUserMessages: vi.fn().mockResolvedValue([]),
+    });
+    mockedUseLoadingIndicator.mockReturnValue({
+      elapsedTime: '0.0s',
+      currentLoadingPhrase: '',
+    });
 
     // Mock Config
     mockConfig = makeFakeConfig();
@@ -325,7 +489,75 @@ describe('AppContainer State Management', () => {
       expect(() => unmount()).not.toThrow();
     });
   });
+
+  describe('Quota and Fallback Integration', () => {
+    it('passes a null proQuotaRequest to UIStateContext by default', () => {
+      // The default mock from beforeEach already sets proQuotaRequest to null
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      // Assert that the context value is as expected
+      expect(capturedUIState.proQuotaRequest).toBeNull();
+    });
+
+    it('passes a valid proQuotaRequest to UIStateContext when provided by the hook', () => {
+      // Arrange: Create a mock request object that a UI dialog would receive
+      const mockRequest = {
+        failedModel: 'gemini-pro',
+        fallbackModel: 'gemini-flash',
+        resolve: vi.fn(),
+      };
+      mockedUseQuotaAndFallback.mockReturnValue({
+        proQuotaRequest: mockRequest,
+        handleProQuotaChoice: vi.fn(),
+      });
+
+      // Act: Render the container
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      // Assert: The mock request is correctly passed through the context
+      expect(capturedUIState.proQuotaRequest).toEqual(mockRequest);
+    });
+
+    it('passes the handleProQuotaChoice function to UIActionsContext', () => {
+      // Arrange: Create a mock handler function
+      const mockHandler = vi.fn();
+      mockedUseQuotaAndFallback.mockReturnValue({
+        proQuotaRequest: null,
+        handleProQuotaChoice: mockHandler,
+      });
+
+      // Act: Render the container
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      // Assert: The action in the context is the mock handler we provided
+      expect(capturedUIActions.handleProQuotaChoice).toBe(mockHandler);
+
+      // You can even verify that the plumbed function is callable
+      capturedUIActions.handleProQuotaChoice('auth');
+      expect(mockHandler).toHaveBeenCalledWith('auth');
+    });
+  });
 });
 
 // TODO: Add comprehensive integration test once all hook mocks are complete
-// For now, the 14 passing unit tests provide good coverage of AppContainer functionality

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -73,7 +73,6 @@ vi.mock('../utils/handleAutoUpdate.js');
 vi.mock('./utils/ConsolePatcher.js');
 vi.mock('../utils/cleanup.js');
 
-// Import the mocked hooks so you can provide implementations
 import { useHistory } from './hooks/useHistoryManager.js';
 import { useThemeCommand } from './hooks/useThemeCommand.js';
 import { useAuthCommand } from './auth/useAuth.js';
@@ -559,5 +558,3 @@ describe('AppContainer State Management', () => {
     });
   });
 });
-
-// TODO: Add comprehensive integration test once all hook mocks are complete

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -24,18 +24,15 @@ import { MessageType, StreamingState } from './types.js';
 import {
   type EditorType,
   type Config,
-  IdeClient,
   type DetectedIde,
-  ideContext,
   type IdeContext,
+  type UserTierId,
+  DEFAULT_GEMINI_FLASH_MODEL,
+  IdeClient,
+  ideContext,
   getErrorMessage,
   getAllGeminiMdFilenames,
-  UserTierId,
   AuthType,
-  isProQuotaExceededError,
-  isGenericQuotaExceededError,
-  logFlashFallback,
-  FlashFallbackEvent,
   clearCachedCredentialFile,
 } from '@google/gemini-cli-core';
 import { validateAuthMethod } from '../config/auth.js';
@@ -44,6 +41,7 @@ import process from 'node:process';
 import { useHistory } from './hooks/useHistoryManager.js';
 import { useThemeCommand } from './hooks/useThemeCommand.js';
 import { useAuthCommand } from './auth/useAuth.js';
+import { useQuotaAndFallback } from './hooks/useQuotaAndFallback.js';
 import { useEditorSettings } from './hooks/useEditorSettings.js';
 import { useSettingsCommand } from './hooks/useSettingsCommand.js';
 import { useSlashCommandProcessor } from './hooks/slashCommandProcessor.js';
@@ -123,12 +121,18 @@ export const AppContainer = (props: AppContainerProps) => {
   const [isTrustedFolder, setIsTrustedFolder] = useState<boolean | undefined>(
     config.isTrustedFolder(),
   );
-  const [currentModel, setCurrentModel] = useState(config.getModel());
+
+  // Helper to determine the effective model, considering the fallback state.
+  const getEffectiveModel = useCallback(() => {
+    if (config.isInFallbackMode()) {
+      return DEFAULT_GEMINI_FLASH_MODEL;
+    }
+    return config.getModel();
+  }, [config]);
+
+  const [currentModel, setCurrentModel] = useState(getEffectiveModel());
+
   const [userTier, setUserTier] = useState<UserTierId | undefined>(undefined);
-  const [isProQuotaDialogOpen, setIsProQuotaDialogOpen] = useState(false);
-  const [proQuotaDialogResolver, setProQuotaDialogResolver] = useState<
-    ((value: boolean) => void) | null
-  >(null);
 
   // Auto-accept indicator
   const showAutoAcceptIndicator = useAutoAcceptIndicator({
@@ -167,18 +171,17 @@ export const AppContainer = (props: AppContainerProps) => {
   // Watch for model changes (e.g., from Flash fallback)
   useEffect(() => {
     const checkModelChange = () => {
-      const configModel = config.getModel();
-      if (configModel !== currentModel) {
-        setCurrentModel(configModel);
+      const effectiveModel = getEffectiveModel();
+      if (effectiveModel !== currentModel) {
+        setCurrentModel(effectiveModel);
       }
     };
 
-    // Check immediately and then periodically
     checkModelChange();
     const interval = setInterval(checkModelChange, 1000); // Check every second
 
     return () => clearInterval(interval);
-  }, [config, currentModel]);
+  }, [config, currentModel, getEffectiveModel]);
 
   const {
     consoleMessages,
@@ -272,6 +275,14 @@ export const AppContainer = (props: AppContainerProps) => {
     settings,
     config,
   );
+
+  const { proQuotaRequest, handleProQuotaChoice } = useQuotaAndFallback({
+    config,
+    historyManager,
+    userTier,
+    setAuthState,
+    setModelSwitchedFromQuotaError,
+  });
 
   // Derive auth state variables for backward compatibility with UIStateContext
   const isAuthDialogOpen = authState === AuthState.Updating;
@@ -477,132 +488,6 @@ Logging in with Google... Please restart Gemini CLI to continue.
     }
   }, [config, historyManager, settings.merged]);
 
-  // Set up Flash fallback handler
-  useEffect(() => {
-    const flashFallbackHandler = async (
-      currentModel: string,
-      fallbackModel: string,
-      error?: unknown,
-    ): Promise<boolean> => {
-      // Check if we've already switched to the fallback model
-      if (config.isInFallbackMode()) {
-        // If we're already in fallback mode, don't show the dialog again
-        return false;
-      }
-
-      let message: string;
-
-      if (
-        config.getContentGeneratorConfig().authType ===
-        AuthType.LOGIN_WITH_GOOGLE
-      ) {
-        // Use actual user tier if available; otherwise, default to FREE tier behavior (safe default)
-        const isPaidTier =
-          userTier === UserTierId.LEGACY || userTier === UserTierId.STANDARD;
-
-        // Check if this is a Pro quota exceeded error
-        if (error && isProQuotaExceededError(error)) {
-          if (isPaidTier) {
-            message = `⚡ You have reached your daily ${currentModel} quota limit.
-⚡ You can choose to authenticate with a paid API key or continue with the fallback model.
-⚡ To continue accessing the ${currentModel} model today, consider using /auth to switch to using a paid API key from AI Studio at https://aistudio.google.com/apikey`;
-          } else {
-            message = `⚡ You have reached your daily ${currentModel} quota limit.
-⚡ You can choose to authenticate with a paid API key or continue with the fallback model.
-⚡ To increase your limits, upgrade to a Gemini Code Assist Standard or Enterprise plan with higher limits at https://goo.gle/set-up-gemini-code-assist
-⚡ Or you can utilize a Gemini API Key. See: https://goo.gle/gemini-cli-docs-auth#gemini-api-key
-⚡ You can switch authentication methods by typing /auth`;
-          }
-        } else if (error && isGenericQuotaExceededError(error)) {
-          if (isPaidTier) {
-            message = `⚡ You have reached your daily quota limit.
-⚡ Automatically switching from ${currentModel} to ${fallbackModel} for the remainder of this session.
-⚡ To continue accessing the ${currentModel} model today, consider using /auth to switch to using a paid API key from AI Studio at https://aistudio.google.com/apikey`;
-          } else {
-            message = `⚡ You have reached your daily quota limit.
-⚡ Automatically switching from ${currentModel} to ${fallbackModel} for the remainder of this session.
-⚡ To increase your limits, upgrade to a Gemini Code Assist Standard or Enterprise plan with higher limits at https://goo.gle/set-up-gemini-code-assist
-⚡ Or you can utilize a Gemini API Key. See: https://goo.gle/gemini-cli-docs-auth#gemini-api-key
-⚡ You can switch authentication methods by typing /auth`;
-          }
-        } else {
-          if (isPaidTier) {
-            // Default fallback message for other cases (like consecutive 429s)
-            message = `⚡ Automatically switching from ${currentModel} to ${fallbackModel} for faster responses for the remainder of this session.
-⚡ Possible reasons for this are that you have received multiple consecutive capacity errors or you have reached your daily ${currentModel} quota limit
-⚡ To continue accessing the ${currentModel} model today, consider using /auth to switch to using a paid API key from AI Studio at https://aistudio.google.com/apikey`;
-          } else {
-            // Default fallback message for other cases (like consecutive 429s)
-            message = `⚡ Automatically switching from ${currentModel} to ${fallbackModel} for faster responses for the remainder of this session.
-⚡ Possible reasons for this are that you have received multiple consecutive capacity errors or you have reached your daily ${currentModel} quota limit
-⚡ To increase your limits, upgrade to a Gemini Code Assist Standard or Enterprise plan with higher limits at https://goo.gle/set-up-gemini-code-assist
-⚡ Or you can utilize a Gemini API Key. See: https://goo.gle/gemini-cli-docs-auth#gemini-api-key
-⚡ You can switch authentication methods by typing /auth`;
-          }
-        }
-
-        // Add message to UI history
-        historyManager.addItem(
-          {
-            type: MessageType.INFO,
-            text: message,
-          },
-          Date.now(),
-        );
-
-        // For Pro quota errors, show the dialog and wait for user's choice
-        if (error && isProQuotaExceededError(error)) {
-          // Set the flag to prevent tool continuation
-          setModelSwitchedFromQuotaError(true);
-          // Set global quota error flag to prevent Flash model calls
-          config.setQuotaErrorOccurred(true);
-
-          // Show the ProQuotaDialog and wait for user's choice
-          const shouldContinueWithFallback = await new Promise<boolean>(
-            (resolve) => {
-              setIsProQuotaDialogOpen(true);
-              setProQuotaDialogResolver(() => resolve);
-            },
-          );
-
-          // If user chose to continue with fallback, we don't need to stop the current prompt
-          if (shouldContinueWithFallback) {
-            // Switch to fallback model for future use
-            config.setModel(fallbackModel);
-            config.setFallbackMode(true);
-            logFlashFallback(
-              config,
-              new FlashFallbackEvent(
-                config.getContentGeneratorConfig().authType!,
-              ),
-            );
-            return true; // Continue with current prompt using fallback model
-          }
-
-          // If user chose to authenticate, stop current prompt
-          return false;
-        }
-
-        // For other quota errors, automatically switch to fallback model
-        // Set the flag to prevent tool continuation
-        setModelSwitchedFromQuotaError(true);
-        // Set global quota error flag to prevent Flash model calls
-        config.setQuotaErrorOccurred(true);
-      }
-
-      // Switch model for future use but return false to stop current retry
-      config.setModel(fallbackModel);
-      config.setFallbackMode(true);
-      logFlashFallback(
-        config,
-        new FlashFallbackEvent(config.getContentGeneratorConfig().authType!),
-      );
-      return false; // Don't continue with current prompt
-    };
-
-    config.setFlashFallbackHandler(flashFallbackHandler);
-  }, [config, historyManager, userTier]);
-
   const cancelHandlerRef = useRef<() => void>(() => {});
 
   const {
@@ -681,22 +566,6 @@ Logging in with Google... Please restart Gemini CLI to continue.
     refreshStatic();
   }, [historyManager, clearConsoleMessagesState, refreshStatic]);
 
-  const handleProQuotaChoice = useCallback(
-    (choice: 'auth' | 'continue') => {
-      setIsProQuotaDialogOpen(false);
-      if (proQuotaDialogResolver) {
-        if (choice === 'auth') {
-          proQuotaDialogResolver(false); // Don't continue with fallback, show auth dialog
-          setAuthState(AuthState.Updating);
-        } else {
-          proQuotaDialogResolver(true); // Continue with fallback model
-        }
-        setProQuotaDialogResolver(null);
-      }
-    },
-    [proQuotaDialogResolver, setAuthState],
-  );
-
   const { handleInput: vimHandleInput } = useVim(buffer, handleFinalSubmit);
 
   /**
@@ -712,7 +581,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     !isProcessing &&
     (streamingState === StreamingState.Idle ||
       streamingState === StreamingState.Responding) &&
-    !isProQuotaDialogOpen;
+    !proQuotaRequest;
 
   // Compute available terminal height based on controls measurement
   const availableTerminalHeight = useMemo(() => {
@@ -1029,7 +898,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       isAuthDialogOpen ||
       isEditorDialogOpen ||
       showPrivacyNotice ||
-      isProQuotaDialogOpen,
+      !!proQuotaRequest,
     [
       showWorkspaceMigrationDialog,
       shouldShowIdePrompt,
@@ -1042,7 +911,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       isAuthDialogOpen,
       isEditorDialogOpen,
       showPrivacyNotice,
-      isProQuotaDialogOpen,
+      proQuotaRequest,
     ],
   );
 
@@ -1101,11 +970,9 @@ Logging in with Google... Please restart Gemini CLI to continue.
       showAutoAcceptIndicator,
       showWorkspaceMigrationDialog,
       workspaceExtensions,
-      // Use current state values instead of config.getModel()
       currentModel,
       userTier,
-      isProQuotaDialogOpen,
-      // New fields
+      proQuotaRequest,
       contextFileNames,
       errorCount,
       availableTerminalHeight,
@@ -1174,10 +1041,8 @@ Logging in with Google... Please restart Gemini CLI to continue.
       showAutoAcceptIndicator,
       showWorkspaceMigrationDialog,
       workspaceExtensions,
-      // Quota-related state dependencies
       userTier,
-      isProQuotaDialogOpen,
-      // New fields dependencies
+      proQuotaRequest,
       contextFileNames,
       errorCount,
       availableTerminalHeight,
@@ -1196,7 +1061,6 @@ Logging in with Google... Please restart Gemini CLI to continue.
       updateInfo,
       showIdeRestartPrompt,
       isRestarting,
-      // Quota-related dependencies
       currentModel,
     ],
   );

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -22,7 +22,6 @@ import { useUIState } from '../contexts/UIStateContext.js';
 import { useUIActions } from '../contexts/UIActionsContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
-import { DEFAULT_GEMINI_FLASH_MODEL } from '@google/gemini-cli-core';
 import process from 'node:process';
 
 // Props for DialogManager
@@ -54,11 +53,11 @@ export const DialogManager = () => {
       />
     );
   }
-  if (uiState.isProQuotaDialogOpen) {
+  if (uiState.proQuotaRequest) {
     return (
       <ProQuotaDialog
-        currentModel={uiState.currentModel}
-        fallbackModel={DEFAULT_GEMINI_FLASH_MODEL}
+        failedModel={uiState.proQuotaRequest.failedModel}
+        fallbackModel={uiState.proQuotaRequest.fallbackModel}
         onChoice={uiActions.handleProQuotaChoice}
       />
     );

--- a/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.test.tsx
@@ -22,7 +22,7 @@ describe('ProQuotaDialog', () => {
   it('should render with correct title and options', () => {
     const { lastFrame } = render(
       <ProQuotaDialog
-        currentModel="gemini-2.5-pro"
+        failedModel="gemini-2.5-pro"
         fallbackModel="gemini-2.5-flash"
         onChoice={() => {}}
       />,
@@ -53,7 +53,7 @@ describe('ProQuotaDialog', () => {
     const mockOnChoice = vi.fn();
     render(
       <ProQuotaDialog
-        currentModel="gemini-2.5-pro"
+        failedModel="gemini-2.5-pro"
         fallbackModel="gemini-2.5-flash"
         onChoice={mockOnChoice}
       />,
@@ -72,7 +72,7 @@ describe('ProQuotaDialog', () => {
     const mockOnChoice = vi.fn();
     render(
       <ProQuotaDialog
-        currentModel="gemini-2.5-pro"
+        failedModel="gemini-2.5-pro"
         fallbackModel="gemini-2.5-flash"
         onChoice={mockOnChoice}
       />,

--- a/packages/cli/src/ui/components/ProQuotaDialog.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.tsx
@@ -10,13 +10,13 @@ import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import { Colors } from '../colors.js';
 
 interface ProQuotaDialogProps {
-  currentModel: string;
+  failedModel: string;
   fallbackModel: string;
   onChoice: (choice: 'auth' | 'continue') => void;
 }
 
 export function ProQuotaDialog({
-  currentModel,
+  failedModel: currentModel,
   fallbackModel,
   onChoice,
 }: ProQuotaDialogProps): React.JSX.Element {

--- a/packages/cli/src/ui/components/ProQuotaDialog.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.tsx
@@ -16,7 +16,7 @@ interface ProQuotaDialogProps {
 }
 
 export function ProQuotaDialog({
-  failedModel: currentModel,
+  failedModel,
   fallbackModel,
   onChoice,
 }: ProQuotaDialogProps): React.JSX.Element {
@@ -38,7 +38,7 @@ export function ProQuotaDialog({
   return (
     <Box borderStyle="round" flexDirection="column" paddingX={1}>
       <Text bold color={Colors.AccentYellow}>
-        Pro quota limit reached for {currentModel}.
+        Pro quota limit reached for {failedModel}.
       </Text>
       <Box marginTop={1}>
         <RadioButtonSelect

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -21,10 +21,17 @@ import type {
   ApprovalMode,
   UserTierId,
   DetectedIde,
+  FallbackIntent,
 } from '@google/gemini-cli-core';
 import type { DOMElement } from 'ink';
 import type { SessionStatsState } from '../contexts/SessionContext.js';
 import type { UpdateObject } from '../utils/updateCheck.js';
+
+export interface ProQuotaDialogRequest {
+  failedModel: string;
+  fallbackModel: string;
+  resolve: (intent: FallbackIntent) => void;
+}
 
 export interface UIState {
   history: HistoryItem[];
@@ -78,9 +85,8 @@ export interface UIState {
   workspaceExtensions: any[]; // Extension[]
   // Quota-related state
   userTier: UserTierId | undefined;
-  isProQuotaDialogOpen: boolean;
+  proQuotaRequest: ProQuotaDialogRequest | null;
   currentModel: string;
-  // New fields for complete state management
   contextFileNames: string[];
   errorCount: number;
   availableTerminalHeight: number | undefined;

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -1,0 +1,346 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import {
+  type Config,
+  type FallbackHandler,
+  UserTierId,
+  AuthType,
+  isGenericQuotaExceededError,
+  isProQuotaExceededError,
+  makeFakeConfig,
+} from '@google/gemini-cli-core';
+import { useQuotaAndFallback } from './useQuotaAndFallback.js';
+import type { UseHistoryManagerReturn } from './useHistoryManager.js';
+import { AuthState, MessageType } from '../types.js';
+
+// Mock the error checking functions from the core package to control test scenarios
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...original,
+    isGenericQuotaExceededError: vi.fn(),
+    isProQuotaExceededError: vi.fn(),
+  };
+});
+
+// Use a type alias for SpyInstance as it's not directly exported
+type SpyInstance = ReturnType<typeof vi.spyOn>;
+
+describe('useQuotaAndFallback', () => {
+  let mockConfig: Config;
+  let mockHistoryManager: UseHistoryManagerReturn;
+  let mockSetAuthState: Mock;
+  let mockSetModelSwitchedFromQuotaError: Mock;
+  let setFallbackHandlerSpy: SpyInstance;
+
+  const mockedIsGenericQuotaExceededError = isGenericQuotaExceededError as Mock;
+  const mockedIsProQuotaExceededError = isProQuotaExceededError as Mock;
+
+  beforeEach(() => {
+    mockConfig = makeFakeConfig();
+
+    // Spy on the method that requires the private field and mock its return.
+    // This is cleaner than modifying the config class for tests.
+    vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
+      model: 'gemini-pro',
+      authType: AuthType.LOGIN_WITH_GOOGLE,
+    });
+
+    mockHistoryManager = {
+      addItem: vi.fn(),
+      history: [],
+      updateItem: vi.fn(),
+      clearItems: vi.fn(),
+      loadHistory: vi.fn(),
+    };
+    mockSetAuthState = vi.fn();
+    mockSetModelSwitchedFromQuotaError = vi.fn();
+
+    setFallbackHandlerSpy = vi.spyOn(mockConfig, 'setFallbackHandler');
+    vi.spyOn(mockConfig, 'setQuotaErrorOccurred');
+
+    mockedIsGenericQuotaExceededError.mockReturnValue(false);
+    mockedIsProQuotaExceededError.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should register a fallback handler on initialization', () => {
+    renderHook(() =>
+      useQuotaAndFallback({
+        config: mockConfig,
+        historyManager: mockHistoryManager,
+        userTier: UserTierId.FREE,
+        setAuthState: mockSetAuthState,
+        setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+      }),
+    );
+
+    expect(setFallbackHandlerSpy).toHaveBeenCalledTimes(1);
+    expect(setFallbackHandlerSpy.mock.calls[0][0]).toBeInstanceOf(Function);
+  });
+
+  describe('Fallback Handler Logic', () => {
+    // Helper function to render the hook and extract the registered handler
+    const getRegisteredHandler = (
+      userTier: UserTierId = UserTierId.FREE,
+    ): FallbackHandler => {
+      renderHook(
+        (props) =>
+          useQuotaAndFallback({
+            config: mockConfig,
+            historyManager: mockHistoryManager,
+            userTier: props.userTier,
+            setAuthState: mockSetAuthState,
+            setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+          }),
+        { initialProps: { userTier } },
+      );
+      return setFallbackHandlerSpy.mock.calls[0][0] as FallbackHandler;
+    };
+
+    it('should return null and take no action if already in fallback mode', async () => {
+      vi.spyOn(mockConfig, 'isInFallbackMode').mockReturnValue(true);
+      const handler = getRegisteredHandler();
+      const result = await handler('gemini-pro', 'gemini-flash', new Error());
+
+      expect(result).toBeNull();
+      expect(mockHistoryManager.addItem).not.toHaveBeenCalled();
+    });
+
+    it('should return null and take no action if authType is not LOGIN_WITH_GOOGLE', async () => {
+      // Override the default mock from beforeEach for this specific test
+      vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
+        model: 'gemini-pro',
+        authType: AuthType.USE_GEMINI,
+      });
+
+      const handler = getRegisteredHandler();
+      const result = await handler('gemini-pro', 'gemini-flash', new Error());
+
+      expect(result).toBeNull();
+      expect(mockHistoryManager.addItem).not.toHaveBeenCalled();
+    });
+
+    describe('Automatic Fallback Scenarios', () => {
+      const testCases = [
+        {
+          errorType: 'generic',
+          tier: UserTierId.FREE,
+          expectedMessageSnippets: [
+            'Automatically switching from model-A to model-B',
+            'upgrade to a Gemini Code Assist Standard or Enterprise plan',
+          ],
+        },
+        {
+          errorType: 'generic',
+          tier: UserTierId.STANDARD, // Paid tier
+          expectedMessageSnippets: [
+            'Automatically switching from model-A to model-B',
+            'switch to using a paid API key from AI Studio',
+          ],
+        },
+        {
+          errorType: 'other',
+          tier: UserTierId.FREE,
+          expectedMessageSnippets: [
+            'Automatically switching from model-A to model-B for faster responses',
+            'upgrade to a Gemini Code Assist Standard or Enterprise plan',
+          ],
+        },
+        {
+          errorType: 'other',
+          tier: UserTierId.LEGACY, // Paid tier
+          expectedMessageSnippets: [
+            'Automatically switching from model-A to model-B for faster responses',
+            'switch to using a paid API key from AI Studio',
+          ],
+        },
+      ];
+
+      for (const { errorType, tier, expectedMessageSnippets } of testCases) {
+        it(`should handle ${errorType} error for ${tier} tier correctly`, async () => {
+          mockedIsGenericQuotaExceededError.mockReturnValue(
+            errorType === 'generic',
+          );
+
+          const handler = getRegisteredHandler(tier);
+          const result = await handler(
+            'model-A',
+            'model-B',
+            new Error('quota exceeded'),
+          );
+
+          // Automatic fallbacks should return 'stop'
+          expect(result).toBe('stop');
+
+          expect(mockHistoryManager.addItem).toHaveBeenCalledWith(
+            expect.objectContaining({ type: MessageType.INFO }),
+            expect.any(Number),
+          );
+
+          const message = (mockHistoryManager.addItem as Mock).mock.calls[0][0]
+            .text;
+          for (const snippet of expectedMessageSnippets) {
+            expect(message).toContain(snippet);
+          }
+
+          expect(mockSetModelSwitchedFromQuotaError).toHaveBeenCalledWith(true);
+          expect(mockConfig.setQuotaErrorOccurred).toHaveBeenCalledWith(true);
+        });
+      }
+    });
+
+    describe('Interactive Fallback (Pro Quota Error)', () => {
+      beforeEach(() => {
+        mockedIsProQuotaExceededError.mockReturnValue(true);
+      });
+
+      it('should set an interactive request and wait for user choice', async () => {
+        const { result } = renderHook(() =>
+          useQuotaAndFallback({
+            config: mockConfig,
+            historyManager: mockHistoryManager,
+            userTier: UserTierId.FREE,
+            setAuthState: mockSetAuthState,
+            setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+          }),
+        );
+
+        const handler = setFallbackHandlerSpy.mock
+          .calls[0][0] as FallbackHandler;
+
+        // Call the handler but do not await it, to check the intermediate state
+        const promise = handler(
+          'gemini-pro',
+          'gemini-flash',
+          new Error('pro quota'),
+        );
+
+        await act(async () => {});
+
+        // The hook should now have a pending request for the UI to handle
+        expect(result.current.proQuotaRequest).not.toBeNull();
+        expect(result.current.proQuotaRequest?.failedModel).toBe('gemini-pro');
+
+        // Simulate the user choosing to continue with the fallback model
+        act(() => {
+          result.current.handleProQuotaChoice('continue');
+        });
+
+        // The original promise from the handler should now resolve
+        const intent = await promise;
+        expect(intent).toBe('retry');
+
+        // The pending request should be cleared from the state
+        expect(result.current.proQuotaRequest).toBeNull();
+      });
+    });
+  });
+
+  describe('handleProQuotaChoice', () => {
+    beforeEach(() => {
+      mockedIsProQuotaExceededError.mockReturnValue(true);
+    });
+
+    it('should do nothing if there is no pending pro quota request', () => {
+      const { result } = renderHook(() =>
+        useQuotaAndFallback({
+          config: mockConfig,
+          historyManager: mockHistoryManager,
+          userTier: UserTierId.FREE,
+          setAuthState: mockSetAuthState,
+          setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+        }),
+      );
+
+      act(() => {
+        result.current.handleProQuotaChoice('auth');
+      });
+
+      expect(mockSetAuthState).not.toHaveBeenCalled();
+      expect(mockHistoryManager.addItem).not.toHaveBeenCalled();
+    });
+
+    it('should resolve intent to "auth" and trigger auth state update', async () => {
+      const { result } = renderHook(() =>
+        useQuotaAndFallback({
+          config: mockConfig,
+          historyManager: mockHistoryManager,
+          userTier: UserTierId.FREE,
+          setAuthState: mockSetAuthState,
+          setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+        }),
+      );
+
+      const handler = setFallbackHandlerSpy.mock.calls[0][0] as FallbackHandler;
+      const promise = handler(
+        'gemini-pro',
+        'gemini-flash',
+        new Error('pro quota'),
+      );
+      await act(async () => {}); // Allow state to update
+
+      act(() => {
+        result.current.handleProQuotaChoice('auth');
+      });
+
+      const intent = await promise;
+      expect(intent).toBe('auth');
+      expect(mockSetAuthState).toHaveBeenCalledWith(AuthState.Updating);
+      expect(result.current.proQuotaRequest).toBeNull();
+    });
+
+    it('should resolve intent to "retry" and add info message on continue', async () => {
+      const { result } = renderHook(() =>
+        useQuotaAndFallback({
+          config: mockConfig,
+          historyManager: mockHistoryManager,
+          userTier: UserTierId.FREE,
+          setAuthState: mockSetAuthState,
+          setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+        }),
+      );
+
+      const handler = setFallbackHandlerSpy.mock.calls[0][0] as FallbackHandler;
+      // The first `addItem` call is for the initial quota error message
+      const promise = handler(
+        'gemini-pro',
+        'gemini-flash',
+        new Error('pro quota'),
+      );
+      await act(async () => {}); // Allow state to update
+
+      act(() => {
+        result.current.handleProQuotaChoice('continue');
+      });
+
+      const intent = await promise;
+      expect(intent).toBe('retry');
+      expect(result.current.proQuotaRequest).toBeNull();
+
+      // Check for the second "Switched to fallback model" message
+      expect(mockHistoryManager.addItem).toHaveBeenCalledTimes(2);
+      const lastCall = (mockHistoryManager.addItem as Mock).mock.calls[1][0];
+      expect(lastCall.type).toBe(MessageType.INFO);
+      expect(lastCall.text).toContain('Switched to fallback model.');
+    });
+  });
+});

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -16,7 +16,7 @@ import {
 import { act, renderHook } from '@testing-library/react';
 import {
   type Config,
-  type FallbackHandler,
+  type FallbackModelHandler,
   UserTierId,
   AuthType,
   isGenericQuotaExceededError,
@@ -71,7 +71,7 @@ describe('useQuotaAndFallback', () => {
     mockSetAuthState = vi.fn();
     mockSetModelSwitchedFromQuotaError = vi.fn();
 
-    setFallbackHandlerSpy = vi.spyOn(mockConfig, 'setFallbackHandler');
+    setFallbackHandlerSpy = vi.spyOn(mockConfig, 'setFallbackModelHandler');
     vi.spyOn(mockConfig, 'setQuotaErrorOccurred');
 
     mockedIsGenericQuotaExceededError.mockReturnValue(false);
@@ -101,7 +101,7 @@ describe('useQuotaAndFallback', () => {
     // Helper function to render the hook and extract the registered handler
     const getRegisteredHandler = (
       userTier: UserTierId = UserTierId.FREE,
-    ): FallbackHandler => {
+    ): FallbackModelHandler => {
       renderHook(
         (props) =>
           useQuotaAndFallback({
@@ -113,7 +113,7 @@ describe('useQuotaAndFallback', () => {
           }),
         { initialProps: { userTier } },
       );
-      return setFallbackHandlerSpy.mock.calls[0][0] as FallbackHandler;
+      return setFallbackHandlerSpy.mock.calls[0][0] as FallbackModelHandler;
     };
 
     it('should return null and take no action if already in fallback mode', async () => {
@@ -225,7 +225,7 @@ describe('useQuotaAndFallback', () => {
         );
 
         const handler = setFallbackHandlerSpy.mock
-          .calls[0][0] as FallbackHandler;
+          .calls[0][0] as FallbackModelHandler;
 
         // Call the handler but do not await it, to check the intermediate state
         const promise = handler(
@@ -265,7 +265,7 @@ describe('useQuotaAndFallback', () => {
         );
 
         const handler = setFallbackHandlerSpy.mock
-          .calls[0][0] as FallbackHandler;
+          .calls[0][0] as FallbackModelHandler;
 
         const promise1 = handler(
           'gemini-pro',
@@ -333,7 +333,8 @@ describe('useQuotaAndFallback', () => {
         }),
       );
 
-      const handler = setFallbackHandlerSpy.mock.calls[0][0] as FallbackHandler;
+      const handler = setFallbackHandlerSpy.mock
+        .calls[0][0] as FallbackModelHandler;
       const promise = handler(
         'gemini-pro',
         'gemini-flash',
@@ -362,7 +363,8 @@ describe('useQuotaAndFallback', () => {
         }),
       );
 
-      const handler = setFallbackHandlerSpy.mock.calls[0][0] as FallbackHandler;
+      const handler = setFallbackHandlerSpy.mock
+        .calls[0][0] as FallbackModelHandler;
       // The first `addItem` call is for the initial quota error message
       const promise = handler(
         'gemini-pro',

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  AuthType,
+  type Config,
+  type FallbackHandler,
+  type FallbackIntent,
+  isGenericQuotaExceededError,
+  isProQuotaExceededError,
+  UserTierId,
+} from '@google/gemini-cli-core';
+import { useCallback, useEffect, useState } from 'react';
+import { type UseHistoryManagerReturn } from './useHistoryManager.js';
+import { AuthState, MessageType } from '../types.js';
+import { type ProQuotaDialogRequest } from '../contexts/UIStateContext.js';
+
+interface UseQuotaAndFallbackArgs {
+  config: Config;
+  historyManager: UseHistoryManagerReturn;
+  userTier: UserTierId | undefined;
+  setAuthState: (state: AuthState) => void;
+  setModelSwitchedFromQuotaError: (value: boolean) => void;
+}
+
+export function useQuotaAndFallback({
+  config,
+  historyManager,
+  userTier,
+  setAuthState,
+  setModelSwitchedFromQuotaError,
+}: UseQuotaAndFallbackArgs) {
+  const [proQuotaRequest, setProQuotaRequest] =
+    useState<ProQuotaDialogRequest | null>(null);
+
+  // Set up Flash fallback handler
+  useEffect(() => {
+    const fallbackHandler: FallbackHandler = async (
+      failedModel,
+      fallbackModel,
+      error,
+    ): Promise<FallbackIntent | null> => {
+      if (config.isInFallbackMode()) {
+        return null;
+      }
+
+      // Fallbacks are currently only handled for OAuth users.
+      const contentGeneratorConfig = config.getContentGeneratorConfig();
+      if (
+        !contentGeneratorConfig ||
+        contentGeneratorConfig.authType !== AuthType.LOGIN_WITH_GOOGLE
+      ) {
+        return null;
+      }
+
+      // Use actual user tier if available; otherwise, default to FREE tier behavior (safe default)
+      const isPaidTier =
+        userTier === UserTierId.LEGACY || userTier === UserTierId.STANDARD;
+
+      let message: string;
+
+      if (error && isProQuotaExceededError(error)) {
+        // Pro Quota specific messages (Interactive)
+        if (isPaidTier) {
+          message = `⚡ You have reached your daily ${failedModel} quota limit.
+⚡ You can choose to authenticate with a paid API key or continue with the fallback model.
+⚡ To continue accessing the ${failedModel} model today, consider using /auth to switch to using a paid API key from AI Studio at https://aistudio.google.com/apikey`;
+        } else {
+          message = `⚡ You have reached your daily ${failedModel} quota limit.
+⚡ You can choose to authenticate with a paid API key or continue with the fallback model.
+⚡ To increase your limits, upgrade to a Gemini Code Assist Standard or Enterprise plan with higher limits at https://goo.gle/set-up-gemini-code-assist
+⚡ Or you can utilize a Gemini API Key. See: https://goo.gle/gemini-cli-docs-auth#gemini-api-key
+⚡ You can switch authentication methods by typing /auth`;
+        }
+      } else if (error && isGenericQuotaExceededError(error)) {
+        // Generic Quota (Automatic fallback)
+        const actionMessage = `⚡ You have reached your daily quota limit.\n⚡ Automatically switching from ${failedModel} to ${fallbackModel} for the remainder of this session.`;
+
+        if (isPaidTier) {
+          message = `${actionMessage}
+⚡ To continue accessing the ${failedModel} model today, consider using /auth to switch to using a paid API key from AI Studio at https://aistudio.google.com/apikey`;
+        } else {
+          message = `${actionMessage}
+⚡ To increase your limits, upgrade to a Gemini Code Assist Standard or Enterprise plan with higher limits at https://goo.gle/set-up-gemini-code-assist
+⚡ Or you can utilize a Gemini API Key. See: https://goo.gle/gemini-cli-docs-auth#gemini-api-key
+⚡ You can switch authentication methods by typing /auth`;
+        }
+      } else {
+        // Consecutive 429s or other errors (Automatic fallback)
+        const actionMessage = `⚡ Automatically switching from ${failedModel} to ${fallbackModel} for faster responses for the remainder of this session.`;
+
+        if (isPaidTier) {
+          message = `${actionMessage}
+⚡ Possible reasons for this are that you have received multiple consecutive capacity errors or you have reached your daily ${failedModel} quota limit
+⚡ To continue accessing the ${failedModel} model today, consider using /auth to switch to using a paid API key from AI Studio at https://aistudio.google.com/apikey`;
+        } else {
+          message = `${actionMessage}
+⚡ Possible reasons for this are that you have received multiple consecutive capacity errors or you have reached your daily ${failedModel} quota limit
+⚡ To increase your limits, upgrade to a Gemini Code Assist Standard or Enterprise plan with higher limits at https://goo.gle/set-up-gemini-code-assist
+⚡ Or you can utilize a Gemini API Key. See: https://goo.gle/gemini-cli-docs-auth#gemini-api-key
+⚡ You can switch authentication methods by typing /auth`;
+        }
+      }
+
+      // Add message to UI history
+      historyManager.addItem(
+        {
+          type: MessageType.INFO,
+          text: message,
+        },
+        Date.now(),
+      );
+
+      setModelSwitchedFromQuotaError(true);
+      config.setQuotaErrorOccurred(true);
+
+      // Interactive Fallback for Pro quota
+      if (error && isProQuotaExceededError(error)) {
+        const intent: FallbackIntent = await new Promise<FallbackIntent>(
+          (resolve) => {
+            setProQuotaRequest({
+              failedModel,
+              fallbackModel,
+              resolve,
+            });
+          },
+        );
+
+        return intent;
+      }
+
+      return 'stop';
+    };
+
+    config.setFallbackHandler(fallbackHandler);
+  }, [config, historyManager, userTier, setModelSwitchedFromQuotaError]);
+
+  const handleProQuotaChoice = useCallback(
+    (choice: 'auth' | 'continue') => {
+      if (!proQuotaRequest) return;
+
+      const intent: FallbackIntent = choice === 'auth' ? 'auth' : 'retry';
+      proQuotaRequest.resolve(intent);
+      setProQuotaRequest(null);
+
+      if (choice === 'auth') {
+        setAuthState(AuthState.Updating);
+      } else {
+        historyManager.addItem(
+          {
+            type: MessageType.INFO,
+            text: 'Switched to fallback model. Tip: Press Ctrl+P (or Up Arrow) to recall your previous prompt and submit it again if you wish.',
+          },
+          Date.now(),
+        );
+      }
+    },
+    [proQuotaRequest, setAuthState, historyManager],
+  );
+
+  return {
+    proQuotaRequest,
+    handleProQuotaChoice,
+  };
+}

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -7,7 +7,7 @@
 import {
   AuthType,
   type Config,
-  type FallbackHandler,
+  type FallbackModelHandler,
   type FallbackIntent,
   isGenericQuotaExceededError,
   isProQuotaExceededError,
@@ -39,7 +39,7 @@ export function useQuotaAndFallback({
 
   // Set up Flash fallback handler
   useEffect(() => {
-    const fallbackHandler: FallbackHandler = async (
+    const fallbackHandler: FallbackModelHandler = async (
       failedModel,
       fallbackModel,
       error,
@@ -141,7 +141,7 @@ export function useQuotaAndFallback({
       return 'stop';
     };
 
-    config.setFallbackHandler(fallbackHandler);
+    config.setFallbackModelHandler(fallbackHandler);
   }, [config, historyManager, userTier, setModelSwitchedFromQuotaError]);
 
   const handleProQuotaChoice = useCallback(

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -52,6 +52,7 @@ import type { FileSystemService } from '../services/fileSystemService.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
 import { logCliConfiguration, logIdeConnection } from '../telemetry/loggers.js';
 import { IdeConnectionEvent, IdeConnectionType } from '../telemetry/types.js';
+import type { FallbackHandler } from '../fallback/types.js';
 
 // Re-export OAuth config type
 export type { MCPOAuthConfig, AnyToolInvocation };
@@ -156,12 +157,6 @@ export interface SandboxConfig {
   command: 'docker' | 'podman' | 'sandbox-exec';
   image: string;
 }
-
-export type FlashFallbackHandler = (
-  currentModel: string,
-  fallbackModel: string,
-  error?: unknown,
-) => Promise<boolean | string | null>;
 
 export interface ConfigParameters {
   sessionId: string;
@@ -281,7 +276,7 @@ export class Config {
     name: string;
     extensionName: string;
   }>;
-  flashFallbackHandler?: FlashFallbackHandler;
+  fallbackHandler?: FallbackHandler;
   private quotaErrorOccurred: boolean = false;
   private readonly summarizeToolOutput:
     | Record<string, SummarizeToolOutputSettings>
@@ -490,8 +485,8 @@ export class Config {
     this.inFallbackMode = active;
   }
 
-  setFlashFallbackHandler(handler: FlashFallbackHandler): void {
-    this.flashFallbackHandler = handler;
+  setFallbackHandler(handler: FallbackHandler): void {
+    this.fallbackHandler = handler;
   }
 
   getMaxSessionTurns(): number {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -52,7 +52,7 @@ import type { FileSystemService } from '../services/fileSystemService.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
 import { logCliConfiguration, logIdeConnection } from '../telemetry/loggers.js';
 import { IdeConnectionEvent, IdeConnectionType } from '../telemetry/types.js';
-import type { FallbackHandler } from '../fallback/types.js';
+import type { FallbackModelHandler } from '../fallback/types.js';
 
 // Re-export OAuth config type
 export type { MCPOAuthConfig, AnyToolInvocation };
@@ -276,7 +276,7 @@ export class Config {
     name: string;
     extensionName: string;
   }>;
-  fallbackHandler?: FallbackHandler;
+  fallbackModelHandler?: FallbackModelHandler;
   private quotaErrorOccurred: boolean = false;
   private readonly summarizeToolOutput:
     | Record<string, SummarizeToolOutputSettings>
@@ -485,8 +485,8 @@ export class Config {
     this.inFallbackMode = active;
   }
 
-  setFallbackHandler(handler: FallbackHandler): void {
-    this.fallbackHandler = handler;
+  setFallbackModelHandler(handler: FallbackModelHandler): void {
+    this.fallbackModelHandler = handler;
   }
 
   getMaxSessionTurns(): number {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -2260,7 +2260,6 @@ ${JSON.stringify(
         requestedModel,
       );
 
-      // Assert that the Flash model was used, not the requested model
       expect(mockGenerateContentFn).toHaveBeenCalledWith(
         expect.objectContaining({
           model: DEFAULT_GEMINI_FLASH_MODEL,

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -49,6 +49,7 @@ import {
   NextSpeakerCheckEvent,
 } from '../telemetry/types.js';
 import type { IdeContext, File } from '../ide/ideContext.js';
+import { handleFallback } from '../fallback/handler.js';
 
 export function isThinkingSupported(model: string) {
   if (model.startsWith('gemini-2.5')) return true;
@@ -550,6 +551,8 @@ export class GeminiClient {
     model: string,
     config: GenerateContentConfig = {},
   ): Promise<Record<string, unknown>> {
+    let currentAttemptModel: string = model;
+
     try {
       const userMemory = this.config.getUserMemory();
       const systemInstruction = getCoreSystemPrompt(userMemory);
@@ -559,10 +562,15 @@ export class GeminiClient {
         ...config,
       };
 
-      const apiCall = () =>
-        this.getContentGeneratorOrFail().generateContent(
+      const apiCall = () => {
+        const modelToUse = this.config.isInFallbackMode()
+          ? DEFAULT_GEMINI_FLASH_MODEL
+          : model;
+        currentAttemptModel = modelToUse;
+
+        return this.getContentGeneratorOrFail().generateContent(
           {
-            model,
+            model: modelToUse,
             config: {
               ...requestConfig,
               systemInstruction,
@@ -573,10 +581,17 @@ export class GeminiClient {
           },
           this.lastPromptId,
         );
+      };
+
+      const onPersistent429Callback = async (
+        authType?: string,
+        error?: unknown,
+      ) =>
+        // Pass the captured model to the centralized handler.
+        await handleFallback(this.config, currentAttemptModel, authType, error);
 
       const result = await retryWithBackoff(apiCall, {
-        onPersistent429: async (authType?: string, error?: unknown) =>
-          await this.handleFlashFallback(authType, error),
+        onPersistent429: onPersistent429Callback,
         authType: this.config.getContentGeneratorConfig()?.authType,
       });
 
@@ -599,7 +614,7 @@ export class GeminiClient {
       if (text.startsWith(prefix) && text.endsWith(suffix)) {
         logMalformedJsonResponse(
           this.config,
-          new MalformedJsonResponseEvent(model),
+          new MalformedJsonResponseEvent(currentAttemptModel),
         );
         text = text
           .substring(prefix.length, text.length - suffix.length)
@@ -655,6 +670,8 @@ export class GeminiClient {
     abortSignal: AbortSignal,
     model: string,
   ): Promise<GenerateContentResponse> {
+    let currentAttemptModel: string = model;
+
     const configToUse: GenerateContentConfig = {
       ...this.generateContentConfig,
       ...generationConfig,
@@ -670,19 +687,30 @@ export class GeminiClient {
         systemInstruction,
       };
 
-      const apiCall = () =>
-        this.getContentGeneratorOrFail().generateContent(
+      const apiCall = () => {
+        const modelToUse = this.config.isInFallbackMode()
+          ? DEFAULT_GEMINI_FLASH_MODEL
+          : model;
+        currentAttemptModel = modelToUse;
+
+        return this.getContentGeneratorOrFail().generateContent(
           {
-            model,
+            model: modelToUse,
             config: requestConfig,
             contents,
           },
           this.lastPromptId,
         );
+      };
+      const onPersistent429Callback = async (
+        authType?: string,
+        error?: unknown,
+      ) =>
+        // Pass the captured model to the centralized handler.
+        await handleFallback(this.config, currentAttemptModel, authType, error);
 
       const result = await retryWithBackoff(apiCall, {
-        onPersistent429: async (authType?: string, error?: unknown) =>
-          await this.handleFlashFallback(authType, error),
+        onPersistent429: onPersistent429Callback,
         authType: this.config.getContentGeneratorConfig()?.authType,
       });
       return result;
@@ -693,7 +721,7 @@ export class GeminiClient {
 
       await reportError(
         error,
-        `Error generating content via API with model ${model}.`,
+        `Error generating content via API with model ${currentAttemptModel}.`,
         {
           requestContents: contents,
           requestConfig: configToUse,
@@ -701,7 +729,7 @@ export class GeminiClient {
         'generateContent-api',
       );
       throw new Error(
-        `Failed to generate content with model ${model}: ${getErrorMessage(error)}`,
+        `Failed to generate content with model ${currentAttemptModel}: ${getErrorMessage(error)}`,
       );
     }
   }
@@ -879,53 +907,6 @@ export class GeminiClient {
       newTokenCount,
       compressionStatus: CompressionStatus.COMPRESSED,
     };
-  }
-
-  /**
-   * Handles falling back to Flash model when persistent 429 errors occur for OAuth users.
-   * Uses a fallback handler if provided by the config; otherwise, returns null.
-   */
-  private async handleFlashFallback(
-    authType?: string,
-    error?: unknown,
-  ): Promise<string | null> {
-    // Only handle fallback for OAuth users
-    if (authType !== AuthType.LOGIN_WITH_GOOGLE) {
-      return null;
-    }
-
-    const currentModel = this.config.getModel();
-    const fallbackModel = DEFAULT_GEMINI_FLASH_MODEL;
-
-    // Don't fallback if already using Flash model
-    if (currentModel === fallbackModel) {
-      return null;
-    }
-
-    // Check if config has a fallback handler (set by CLI package)
-    const fallbackHandler = this.config.flashFallbackHandler;
-    if (typeof fallbackHandler === 'function') {
-      try {
-        const accepted = await fallbackHandler(
-          currentModel,
-          fallbackModel,
-          error,
-        );
-        if (accepted !== false && accepted !== null) {
-          this.config.setModel(fallbackModel);
-          this.config.setFallbackMode(true);
-          return fallbackModel;
-        }
-        // Check if the model was switched manually in the handler
-        if (this.config.getModel() === fallbackModel) {
-          return null; // Model was switched but don't continue with current prompt
-        }
-      } catch (error) {
-        console.warn('Flash fallback handler failed:', error);
-      }
-    }
-
-    return null;
   }
 }
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -31,7 +31,6 @@ import { isFunctionResponse } from '../utils/messageInspectors.js';
 import { tokenLimit } from './tokenLimits.js';
 import type { ChatRecordingService } from '../services/chatRecordingService.js';
 import type { ContentGenerator } from './contentGenerator.js';
-import { AuthType } from './contentGenerator.js';
 import {
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_THINKING_MODE,

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1669,8 +1669,10 @@ describe('GeminiChat', () => {
   });
 
   it('should discard valid partial content from a failed attempt upon retry', async () => {
+    // Mock the stream to fail on the first attempt after yielding some valid content.
     vi.mocked(mockContentGenerator.generateContentStream)
       .mockImplementationOnce(async () =>
+        // First attempt: yields one valid chunk, then one invalid chunk
         (async function* () {
           yield {
             candidates: [
@@ -1687,6 +1689,7 @@ describe('GeminiChat', () => {
         })(),
       )
       .mockImplementationOnce(async () =>
+        // Second attempt (the retry): succeeds
         (async function* () {
           yield {
             candidates: [
@@ -1701,6 +1704,7 @@ describe('GeminiChat', () => {
         })(),
       );
 
+    // Send a message and consume the stream
     const stream = await chat.sendMessageStream(
       { message: 'test' },
       'prompt-id-discard-test',

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -18,7 +18,6 @@ import type {
 import { toParts } from '../code_assist/converter.js';
 import { createUserContent } from '@google/genai';
 import { retryWithBackoff } from '../utils/retry.js';
-import { AuthType } from './contentGenerator.js';
 import type { Config } from '../config/config.js';
 import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { hasCycleInSchema } from '../tools/tools.js';
@@ -176,6 +175,8 @@ export class GeminiChat {
     private history: Content[] = [],
   ) {
     validateHistory(history);
+    this.chatRecordingService = new ChatRecordingService(config);
+    this.chatRecordingService.initialize();
   }
 
   setSystemInstruction(sysInstr: string) {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -35,6 +35,7 @@ import {
   ContentRetryFailureEvent,
   InvalidChunkEvent,
 } from '../telemetry/types.js';
+import { handleFallback } from '../fallback/handler.js';
 import { isFunctionResponse } from '../utils/messageInspectors.js';
 import { partListUnionToString } from './geminiRequest.js';
 
@@ -175,55 +176,6 @@ export class GeminiChat {
     private history: Content[] = [],
   ) {
     validateHistory(history);
-    this.chatRecordingService = new ChatRecordingService(config);
-    this.chatRecordingService.initialize();
-  }
-
-  /**
-   * Handles falling back to Flash model when persistent 429 errors occur for OAuth users.
-   * Uses a fallback handler if provided by the config; otherwise, returns null.
-   */
-  private async handleFlashFallback(
-    authType?: string,
-    error?: unknown,
-  ): Promise<string | null> {
-    // Only handle fallback for OAuth users
-    if (authType !== AuthType.LOGIN_WITH_GOOGLE) {
-      return null;
-    }
-
-    const currentModel = this.config.getModel();
-    const fallbackModel = DEFAULT_GEMINI_FLASH_MODEL;
-
-    // Don't fallback if already using Flash model
-    if (currentModel === fallbackModel) {
-      return null;
-    }
-
-    // Check if config has a fallback handler (set by CLI package)
-    const fallbackHandler = this.config.flashFallbackHandler;
-    if (typeof fallbackHandler === 'function') {
-      try {
-        const accepted = await fallbackHandler(
-          currentModel,
-          fallbackModel,
-          error,
-        );
-        if (accepted !== false && accepted !== null) {
-          this.config.setModel(fallbackModel);
-          this.config.setFallbackMode(true);
-          return fallbackModel;
-        }
-        // Check if the model was switched manually in the handler
-        if (this.config.getModel() === fallbackModel) {
-          return null; // Model was switched but don't continue with current prompt
-        }
-      } catch (error) {
-        console.warn('Flash fallback handler failed:', error);
-      }
-    }
-
-    return null;
   }
 
   setSystemInstruction(sysInstr: string) {
@@ -272,8 +224,13 @@ export class GeminiChat {
     let response: GenerateContentResponse;
 
     try {
+      let currentAttemptModel: string | undefined;
+
       const apiCall = () => {
-        const modelToUse = this.config.getModel() || DEFAULT_GEMINI_FLASH_MODEL;
+        const modelToUse = this.config.isInFallbackMode()
+          ? DEFAULT_GEMINI_FLASH_MODEL
+          : this.config.getModel();
+        currentAttemptModel = modelToUse;
 
         // Prevent Flash model calls immediately after quota error
         if (
@@ -295,6 +252,19 @@ export class GeminiChat {
         );
       };
 
+      const onPersistent429Callback = async (
+        authType?: string,
+        error?: unknown,
+      ) => {
+        if (!currentAttemptModel) return null;
+        return await handleFallback(
+          this.config,
+          currentAttemptModel,
+          authType,
+          error,
+        );
+      };
+
       response = await retryWithBackoff(apiCall, {
         shouldRetry: (error: unknown) => {
           // Check for known error messages and codes.
@@ -305,8 +275,7 @@ export class GeminiChat {
           }
           return false; // Don't retry other errors by default
         },
-        onPersistent429: async (authType?: string, error?: unknown) =>
-          await this.handleFlashFallback(authType, error),
+        onPersistent429: onPersistent429Callback,
         authType: this.config.getContentGeneratorConfig()?.authType,
       });
 
@@ -484,8 +453,13 @@ export class GeminiChat {
     prompt_id: string,
     userContent: Content,
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
+    let currentAttemptModel: string | undefined;
+
     const apiCall = () => {
-      const modelToUse = this.config.getModel();
+      const modelToUse = this.config.isInFallbackMode()
+        ? DEFAULT_GEMINI_FLASH_MODEL
+        : this.config.getModel();
+      currentAttemptModel = modelToUse;
 
       if (
         this.config.getQuotaErrorOccurred() &&
@@ -506,6 +480,19 @@ export class GeminiChat {
       );
     };
 
+    const onPersistent429Callback = async (
+      authType?: string,
+      error?: unknown,
+    ) => {
+      if (!currentAttemptModel) return null;
+      return await handleFallback(
+        this.config,
+        currentAttemptModel,
+        authType,
+        error,
+      );
+    };
+
     const streamResponse = await retryWithBackoff(apiCall, {
       shouldRetry: (error: unknown) => {
         if (error instanceof Error && error.message) {
@@ -515,8 +502,7 @@ export class GeminiChat {
         }
         return false;
       },
-      onPersistent429: async (authType?: string, error?: unknown) =>
-        await this.handleFlashFallback(authType, error),
+      onPersistent429: onPersistent429Callback,
       authType: this.config.getContentGeneratorConfig()?.authType,
     });
 

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  type Mock,
+  type MockInstance,
+  afterEach,
+} from 'vitest';
+import { handleFallback } from './handler.js';
+import type { Config } from '../config/config.js';
+import { AuthType } from '../core/contentGenerator.js';
+import {
+  DEFAULT_GEMINI_FLASH_MODEL,
+  DEFAULT_GEMINI_MODEL,
+} from '../config/models.js';
+import { logFlashFallback } from '../telemetry/index.js';
+import type { FallbackHandler } from './types.js';
+
+// Mock the telemetry logger and event class
+vi.mock('../telemetry/index.js', () => ({
+  logFlashFallback: vi.fn(),
+  FlashFallbackEvent: class {},
+}));
+
+const MOCK_PRO_MODEL = DEFAULT_GEMINI_MODEL;
+const FALLBACK_MODEL = DEFAULT_GEMINI_FLASH_MODEL;
+const AUTH_OAUTH = AuthType.LOGIN_WITH_GOOGLE;
+const AUTH_API_KEY = AuthType.USE_GEMINI;
+
+const createMockConfig = (overrides: Partial<Config> = {}): Config =>
+  ({
+    isInFallbackMode: vi.fn(() => false),
+    setFallbackMode: vi.fn(),
+    fallbackHandler: undefined,
+    ...overrides,
+  }) as unknown as Config;
+
+describe('handleFallback', () => {
+  let mockConfig: Config;
+  let mockHandler: Mock<FallbackHandler>;
+  let consoleWarnSpy: MockInstance;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHandler = vi.fn();
+    // Default setup: OAuth user, Pro model failed, handler injected
+    mockConfig = createMockConfig({
+      fallbackHandler: mockHandler,
+    });
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should return null immediately if authType is not OAuth', async () => {
+    const result = await handleFallback(
+      mockConfig,
+      MOCK_PRO_MODEL,
+      AUTH_API_KEY,
+    );
+    expect(result).toBeNull();
+    expect(mockHandler).not.toHaveBeenCalled();
+    expect(mockConfig.setFallbackMode).not.toHaveBeenCalled();
+  });
+
+  it('should return null if the failed model is already the fallback model', async () => {
+    const result = await handleFallback(
+      mockConfig,
+      FALLBACK_MODEL, // Failed model is Flash
+      AUTH_OAUTH,
+    );
+    expect(result).toBeNull();
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
+
+  it('should return null if no fallbackHandler is injected in config', async () => {
+    const configWithoutHandler = createMockConfig({
+      fallbackHandler: undefined,
+    });
+    const result = await handleFallback(
+      configWithoutHandler,
+      MOCK_PRO_MODEL,
+      AUTH_OAUTH,
+    );
+    expect(result).toBeNull();
+  });
+
+  describe('when handler returns "retry"', () => {
+    it('should activate fallback mode, log telemetry, and return true', async () => {
+      mockHandler.mockResolvedValue('retry');
+
+      const result = await handleFallback(
+        mockConfig,
+        MOCK_PRO_MODEL,
+        AUTH_OAUTH,
+      );
+
+      expect(result).toBe(true);
+      expect(mockConfig.setFallbackMode).toHaveBeenCalledWith(true);
+      expect(logFlashFallback).toHaveBeenCalled();
+    });
+  });
+
+  describe('when handler returns "stop"', () => {
+    it('should activate fallback mode, log telemetry, and return false', async () => {
+      mockHandler.mockResolvedValue('stop');
+
+      const result = await handleFallback(
+        mockConfig,
+        MOCK_PRO_MODEL,
+        AUTH_OAUTH,
+      );
+
+      expect(result).toBe(false);
+      expect(mockConfig.setFallbackMode).toHaveBeenCalledWith(true);
+      expect(logFlashFallback).toHaveBeenCalled();
+    });
+  });
+
+  describe('when handler returns "auth"', () => {
+    it('should NOT activate fallback mode and return false', async () => {
+      mockHandler.mockResolvedValue('auth');
+
+      const result = await handleFallback(
+        mockConfig,
+        MOCK_PRO_MODEL,
+        AUTH_OAUTH,
+      );
+
+      expect(result).toBe(false);
+      expect(mockConfig.setFallbackMode).not.toHaveBeenCalled();
+      expect(logFlashFallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when handler returns null (default)', () => {
+    it('should NOT activate fallback mode and return false', async () => {
+      mockHandler.mockResolvedValue(null);
+
+      const result = await handleFallback(
+        mockConfig,
+        MOCK_PRO_MODEL,
+        AUTH_OAUTH,
+      );
+
+      // The default case in the switch results in false
+      expect(result).toBe(false);
+      expect(mockConfig.setFallbackMode).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should pass the correct context (failedModel, fallbackModel, error) to the handler', async () => {
+    const mockError = new Error('Quota Exceeded');
+    mockHandler.mockResolvedValue('retry');
+
+    await handleFallback(mockConfig, MOCK_PRO_MODEL, AUTH_OAUTH, mockError);
+
+    expect(mockHandler).toHaveBeenCalledWith(
+      MOCK_PRO_MODEL,
+      FALLBACK_MODEL,
+      mockError,
+    );
+  });
+
+  it('should not call setFallbackMode or log telemetry if already in fallback mode', async () => {
+    // Setup config where fallback mode is already active
+    const activeFallbackConfig = createMockConfig({
+      fallbackHandler: mockHandler,
+      isInFallbackMode: vi.fn(() => true), // Already active
+      setFallbackMode: vi.fn(),
+    });
+
+    mockHandler.mockResolvedValue('retry');
+
+    const result = await handleFallback(
+      activeFallbackConfig,
+      MOCK_PRO_MODEL,
+      AUTH_OAUTH,
+    );
+
+    // Should still return true to allow the retry (which will use the active fallback mode)
+    expect(result).toBe(true);
+    // Should still consult the handler
+    expect(mockHandler).toHaveBeenCalled();
+    // But should not mutate state or log telemetry again
+    expect(activeFallbackConfig.setFallbackMode).not.toHaveBeenCalled();
+    expect(logFlashFallback).not.toHaveBeenCalled();
+  });
+
+  it('should catch errors from the handler, log a warning, and return null', async () => {
+    const handlerError = new Error('UI interaction failed');
+    mockHandler.mockRejectedValue(handlerError);
+
+    const result = await handleFallback(mockConfig, MOCK_PRO_MODEL, AUTH_OAUTH);
+
+    expect(result).toBeNull();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Fallback UI handler failed:',
+      handlerError,
+    );
+    expect(mockConfig.setFallbackMode).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -51,9 +51,11 @@ export async function handleFallback(
   }
 }
 
-function activateFallbackMode(config: Config, authType: string) {
+function activateFallbackMode(config: Config, authType: string | undefined) {
   if (!config.isInFallbackMode()) {
     config.setFallbackMode(true);
-    logFlashFallback(config, new FlashFallbackEvent(authType));
+    if (authType) {
+      logFlashFallback(config, new FlashFallbackEvent(authType));
+    }
   }
 }

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../config/config.js';
+import { AuthType } from '../core/contentGenerator.js';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
+import { logFlashFallback, FlashFallbackEvent } from '../telemetry/index.js';
+
+export async function handleFallback(
+  config: Config,
+  failedModel: string,
+  authType?: string,
+  error?: unknown,
+): Promise<string | boolean | null> {
+  // Applicability Checks
+  if (authType !== AuthType.LOGIN_WITH_GOOGLE) return null;
+
+  const fallbackModel = DEFAULT_GEMINI_FLASH_MODEL;
+
+  if (failedModel === fallbackModel) return null;
+
+  // Consult UI Handler for Intent
+  const fallbackHandler = config.fallbackHandler;
+  if (typeof fallbackHandler !== 'function') return null;
+
+  try {
+    // Pass the specific failed model to the UI handler.
+    const intent = await fallbackHandler(failedModel, fallbackModel, error);
+
+    // Process Intent and Update State
+    switch (intent) {
+      case 'retry':
+        // Activate fallback mode. The NEXT retry attempt will pick this up.
+        activateFallbackMode(config, authType);
+        return true; // Signal retryWithBackoff to continue.
+
+      case 'stop':
+        activateFallbackMode(config, authType);
+        return false;
+
+      case 'auth':
+      default:
+        return false;
+    }
+  } catch (handlerError) {
+    console.warn('Fallback UI handler failed:', handlerError);
+    return null;
+  }
+}
+
+function activateFallbackMode(config: Config, authType: string) {
+  if (!config.isInFallbackMode()) {
+    config.setFallbackMode(true);
+    logFlashFallback(config, new FlashFallbackEvent(authType));
+  }
+}

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -23,12 +23,16 @@ export async function handleFallback(
   if (failedModel === fallbackModel) return null;
 
   // Consult UI Handler for Intent
-  const fallbackHandler = config.fallbackHandler;
-  if (typeof fallbackHandler !== 'function') return null;
+  const fallbackModelHandler = config.fallbackModelHandler;
+  if (typeof fallbackModelHandler !== 'function') return null;
 
   try {
     // Pass the specific failed model to the UI handler.
-    const intent = await fallbackHandler(failedModel, fallbackModel, error);
+    const intent = await fallbackModelHandler(
+      failedModel,
+      fallbackModel,
+      error,
+    );
 
     // Process Intent and Update State
     switch (intent) {
@@ -42,11 +46,15 @@ export async function handleFallback(
         return false;
 
       case 'auth':
-      default:
         return false;
+
+      default:
+        throw new Error(
+          `Unexpected fallback intent received from fallbackModelHandler: "${intent}"`,
+        );
     }
   } catch (handlerError) {
-    console.warn('Fallback UI handler failed:', handlerError);
+    console.error('Fallback UI handler failed:', handlerError);
     return null;
   }
 }

--- a/packages/core/src/fallback/types.ts
+++ b/packages/core/src/fallback/types.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Defines the intent returned by the UI layer during a fallback scenario.
+ */
+export type FallbackIntent =
+  | 'retry' // Immediately retry the current request with the fallback model.
+  | 'stop' // Switch to fallback for future requests, but stop the current request.
+  | 'auth'; // Stop the current request; user intends to change authentication.
+
+/**
+ * The interface for the handler provided by the UI layer (e.g., the CLI)
+ * to interact with the user during a fallback scenario.
+ */
+export type FallbackHandler = (
+  failedModel: string,
+  fallbackModel: string,
+  error?: unknown,
+) => Promise<FallbackIntent | null>;

--- a/packages/core/src/fallback/types.ts
+++ b/packages/core/src/fallback/types.ts
@@ -16,7 +16,7 @@ export type FallbackIntent =
  * The interface for the handler provided by the UI layer (e.g., the CLI)
  * to interact with the user during a fallback scenario.
  */
-export type FallbackHandler = (
+export type FallbackModelHandler = (
   failedModel: string,
   fallbackModel: string,
   error?: unknown,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,8 @@ export * from './core/geminiRequest.js';
 export * from './core/coreToolScheduler.js';
 export * from './core/nonInteractiveToolExecutor.js';
 
+export * from './fallback/types.js';
+
 export * from './code_assist/codeAssist.js';
 export * from './code_assist/oauth2.js';
 export * from './code_assist/server.js';

--- a/packages/core/src/utils/flashFallback.integration.test.ts
+++ b/packages/core/src/utils/flashFallback.integration.test.ts
@@ -17,10 +17,13 @@ import {
 import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { retryWithBackoff } from './retry.js';
 import { AuthType } from '../core/contentGenerator.js';
+// Import the new types (Assuming this test file is in packages/core/src/utils/)
+import type { FallbackHandler } from '../fallback/types.js';
 
 vi.mock('node:fs');
 
-describe('Flash Fallback Integration', () => {
+// Update the description to reflect that this tests the retry utility's integration
+describe('Retry Utility Fallback Integration', () => {
   let config: Config;
 
   beforeEach(() => {
@@ -41,25 +44,28 @@ describe('Flash Fallback Integration', () => {
     resetRequestCounter();
   });
 
-  it('should automatically accept fallback', async () => {
-    // Set up a minimal flash fallback handler for testing
-    const flashFallbackHandler = async (): Promise<boolean> => true;
+  // This test validates the Config's ability to store and execute the handler contract.
+  it('should execute the injected FallbackHandler contract correctly', async () => {
+    // Set up a minimal handler for testing, ensuring it matches the new type.
+    const fallbackHandler: FallbackHandler = async () => 'retry';
 
-    config.setFlashFallbackHandler(flashFallbackHandler);
+    // Use the generalized setter
+    config.setFallbackHandler(fallbackHandler);
 
-    // Call the handler directly to test
-    const result = await config.flashFallbackHandler!(
+    // Call the handler directly via the config property
+    const result = await config.fallbackHandler!(
       'gemini-2.5-pro',
       DEFAULT_GEMINI_FLASH_MODEL,
     );
 
-    // Verify it automatically accepts
-    expect(result).toBe(true);
+    // Verify it returns the correct intent
+    expect(result).toBe('retry');
   });
 
-  it('should trigger fallback after 2 consecutive 429 errors for OAuth users', async () => {
+  // This test validates the retry utility's logic for triggering the callback.
+  it('should trigger onPersistent429 after 2 consecutive 429 errors for OAuth users', async () => {
     let fallbackCalled = false;
-    let fallbackModel = '';
+    // Removed fallbackModel variable as it's no longer relevant here.
 
     // Mock function that simulates exactly 2 429 errors, then succeeds after fallback
     const mockApiCall = vi
@@ -68,11 +74,11 @@ describe('Flash Fallback Integration', () => {
       .mockRejectedValueOnce(createSimulated429Error())
       .mockResolvedValueOnce('success after fallback');
 
-    // Mock fallback handler
-    const mockFallbackHandler = vi.fn(async (_authType?: string) => {
+    // Mock the onPersistent429 callback (this is what client.ts/geminiChat.ts provides)
+    const mockPersistent429Callback = vi.fn(async (_authType?: string) => {
       fallbackCalled = true;
-      fallbackModel = DEFAULT_GEMINI_FLASH_MODEL;
-      return fallbackModel;
+      // Return true to signal retryWithBackoff to reset attempts and continue.
+      return true;
     });
 
     // Test with OAuth personal auth type, with maxAttempts = 2 to ensure fallback triggers
@@ -84,14 +90,13 @@ describe('Flash Fallback Integration', () => {
         const status = (error as Error & { status?: number }).status;
         return status === 429;
       },
-      onPersistent429: mockFallbackHandler,
+      onPersistent429: mockPersistent429Callback,
       authType: AuthType.LOGIN_WITH_GOOGLE,
     });
 
-    // Verify fallback was triggered
+    // Verify fallback mechanism was triggered
     expect(fallbackCalled).toBe(true);
-    expect(fallbackModel).toBe(DEFAULT_GEMINI_FLASH_MODEL);
-    expect(mockFallbackHandler).toHaveBeenCalledWith(
+    expect(mockPersistent429Callback).toHaveBeenCalledWith(
       AuthType.LOGIN_WITH_GOOGLE,
       expect.any(Error),
     );
@@ -100,16 +105,16 @@ describe('Flash Fallback Integration', () => {
     expect(mockApiCall).toHaveBeenCalledTimes(3);
   });
 
-  it('should not trigger fallback for API key users', async () => {
+  it('should not trigger onPersistent429 for API key users', async () => {
     let fallbackCalled = false;
 
     // Mock function that simulates 429 errors
     const mockApiCall = vi.fn().mockRejectedValue(createSimulated429Error());
 
-    // Mock fallback handler
-    const mockFallbackHandler = vi.fn(async () => {
+    // Mock the callback
+    const mockPersistent429Callback = vi.fn(async () => {
       fallbackCalled = true;
-      return DEFAULT_GEMINI_FLASH_MODEL;
+      return true;
     });
 
     // Test with API key auth type - should not trigger fallback
@@ -122,7 +127,7 @@ describe('Flash Fallback Integration', () => {
           const status = (error as Error & { status?: number }).status;
           return status === 429;
         },
-        onPersistent429: mockFallbackHandler,
+        onPersistent429: mockPersistent429Callback,
         authType: AuthType.USE_GEMINI, // API key auth type
       });
     } catch (error) {
@@ -132,10 +137,11 @@ describe('Flash Fallback Integration', () => {
 
     // Verify fallback was NOT triggered for API key users
     expect(fallbackCalled).toBe(false);
-    expect(mockFallbackHandler).not.toHaveBeenCalled();
+    expect(mockPersistent429Callback).not.toHaveBeenCalled();
   });
 
-  it('should properly disable simulation state after fallback', () => {
+  // This test validates the test utilities themselves.
+  it('should properly disable simulation state after fallback (Test Utility)', () => {
     // Enable simulation
     setSimulate429(true);
 

--- a/packages/core/src/utils/flashFallback.test.ts
+++ b/packages/core/src/utils/flashFallback.test.ts
@@ -18,7 +18,7 @@ import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { retryWithBackoff } from './retry.js';
 import { AuthType } from '../core/contentGenerator.js';
 // Import the new types (Assuming this test file is in packages/core/src/utils/)
-import type { FallbackHandler } from '../fallback/types.js';
+import type { FallbackModelHandler } from '../fallback/types.js';
 
 vi.mock('node:fs');
 
@@ -47,13 +47,13 @@ describe('Retry Utility Fallback Integration', () => {
   // This test validates the Config's ability to store and execute the handler contract.
   it('should execute the injected FallbackHandler contract correctly', async () => {
     // Set up a minimal handler for testing, ensuring it matches the new type.
-    const fallbackHandler: FallbackHandler = async () => 'retry';
+    const fallbackHandler: FallbackModelHandler = async () => 'retry';
 
     // Use the generalized setter
-    config.setFallbackHandler(fallbackHandler);
+    config.setFallbackModelHandler(fallbackHandler);
 
     // Call the handler directly via the config property
-    const result = await config.fallbackHandler!(
+    const result = await config.fallbackModelHandler!(
       'gemini-2.5-pro',
       DEFAULT_GEMINI_FLASH_MODEL,
     );


### PR DESCRIPTION
## TLDR

This PR refactors the model fallback mechanism, preparing the architecture for upcoming model routing strategies (e.g., "auto" mode).

The previous implementation suffered from duplicated logic, tight coupling where the CLI package mutated Core state, and ambiguity in the communication contract. This PR resolves these issues by centralizing the logic, introducing explicit intents, and implementing key architectural patterns for decoupling.

**Key changes for reviewers:**
-   `packages/core/src/fallback/`: New centralized handler and types.
-   `packages/cli/src/ui/hooks/useQuotaAndFallback.ts`: New hook encapsulating all UI logic for this feature.
-   `packages/cli/src/ui/AppContainer.tsx`: Significantly simplified by removing the inline fallback handler.
-   `packages/core/src/core/client.ts` & `geminiChat.ts`: Updated to use the new centralized handler.

## Dive Deeper

### Model Resolution

We no longer mutate `config.setModel()` during runtime fallbacks.

In an interim state, until we have a more complex router service, we check `config.isInFallbackMode()`; if true, we return the fallback model (Flash); otherwise, we return the configured model.

### Centralized, Intent-Driven Fallback

The logic previously duplicated in `client.ts` and `geminiChat.ts` is now handled by a single `handleFallback` function.

The new flow is:
1.  An API call fails (e.g., 429). The specific, concrete model used for that attempt (`currentAttemptModel`) is captured via closure.
2.  The `onPersistent429` callback calls `handleFallback(config, currentAttemptModel, ...)`.
3.  `handleFallback` invokes the UI handler (injected via `config.setFallbackHandler`).
4.  The UI (`App.tsx`) handles user interaction (e.g., Pro Quota Dialog) and returns a `FallbackIntent`.
5.  `handleFallback` interprets this intent:
    *   `'retry'`: Calls `config.setFallbackMode(true)` and signals `retryWithBackoff` to immediately retry the request. The Model Resolver ensures the retry uses the fallback model.
    *   `'stop'`: Calls `config.setFallbackMode(true)` but stops the current request.
    *   `'auth'`: Stops the current request without activating fallback mode.

Crucially, the Core package now owns the responsibility of changing the fallback state; the UI only signals intent.

## Reviewer Test Plan

To test this, you will need to simulate quota errors. The easiest way is to temporarily modify `packages/core/src/core/geminiChat.ts` in the `sendMessage` method to always throw an error that looks like a 429.

Find the `apiCall` function and replace its content with:
```typescript
throw Object.assign(new Error('API Error 429: Quota exceeded'), {
  status: 429,
  errors: [{ reason: 'rateLimitExceeded' }] // For generic quota
  // OR
  // errors: [{ reason: 'userRateLimitExceeded' }] // For Pro quota
});
```

**Scenario 1: Generic Quota Fallback (Automatic)**
1.  Use the `rateLimitExceeded` reason in your mock error.
2.  Run the CLI and submit a prompt.
3.  **Expect:** An informational message appears in the chat history, stating that you've been switched to the fallback model. The prompt is **not** retried.
4.  **Expect:** Subsequent prompts are sent to the `gemini-flash` model. The model indicator in the UI should update.

**Scenario 2: Pro Quota Fallback (Interactive)**
1.  Use the `userRateLimitExceeded` reason in your mock error.
2.  Run the CLI and submit a prompt.
3.  **Expect:** The interactive "Pro quota limit reached" dialog appears.

**Scenario 2a: Continue with Fallback**
1.  From the dialog, select "Continue with fallback model".
2.  **Expect:** The dialog closes, an informational message about the switch is added to history, and the original prompt is **successfully retried** using the `gemini-flash` model. You should see a valid response.

**Scenario 2b: Authenticate**
1.  From the dialog, select "Authenticate with a different method".
2.  **Expect:** The dialog closes, and the `/auth` dialog immediately opens. The original prompt is **not** retried.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅ | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅ | -   | -   |

## Linked issues / bugs

Resolves #7810