### PR TITLE
feat: Introduce Patch tool for applying unified diffs

### DIFF
--- a/packages/cli/src/zed-integration/fileSystemService.ts
+++ b/packages/cli/src/zed-integration/fileSystemService.ts
@@ -44,4 +44,23 @@ export class AcpFileSystemService implements FileSystemService {
       sessionId: this.sessionId,
     });
   }
+
+  async unlink(filePath: string): Promise<void> {
+    if (!this.capabilities.unlink) {
+      return this.fallback.unlink(filePath);
+    }
+    // TODO: acp.Client doesn't have an unlink method yet.
+    return this.fallback.unlink(filePath);
+  }
+
+  async mkdir(
+    dirPath: string,
+    options?: { recursive: boolean },
+  ): Promise<void> {
+    if (!this.capabilities.mkdir) {
+      return this.fallback.mkdir(dirPath, options);
+    }
+    // TODO: acp.Client doesn't have a mkdir method yet.
+    return this.fallback.mkdir(dirPath, options);
+  }
 }

--- a/packages/cli/src/zed-integration/schema.ts
+++ b/packages/cli/src/zed-integration/schema.ts
@@ -258,6 +258,8 @@ export const requestPermissionResponseSchema = z.object({
 export const fileSystemCapabilitySchema = z.object({
   readTextFile: z.boolean(),
   writeTextFile: z.boolean(),
+  unlink: z.boolean(),
+  mkdir: z.boolean(),
 });
 
 export const envVariableSchema = z.object({

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -22,8 +22,6 @@ import { ReadFileTool } from '../tools/read-file.js';
 import { GrepTool } from '../tools/grep.js';
 import { canUseRipgrep, RipGrepTool } from '../tools/ripGrep.js';
 import { GlobTool } from '../tools/glob.js';
-import { EditTool } from '../tools/edit.js';
-import { SmartEditTool } from '../tools/smart-edit.js';
 import { ShellTool } from '../tools/shell.js';
 import { WriteFileTool } from '../tools/write-file.js';
 import { WebFetchTool } from '../tools/web-fetch.js';
@@ -72,6 +70,7 @@ import { FileExclusions } from '../utils/ignorePatterns.js';
 import type { EventEmitter } from 'node:events';
 import type { UserTierId } from '../code_assist/types.js';
 import { ProxyAgent, setGlobalDispatcher } from 'undici';
+import { PatchTool } from '../tools/patch.js';
 
 export enum ApprovalMode {
   DEFAULT = 'default',
@@ -569,6 +568,10 @@ export class Config {
     return this.workspaceContext;
   }
 
+  isPathWithinWorkspace(pathToCheck: string): boolean {
+    return this.workspaceContext.isPathWithinWorkspace(pathToCheck);
+  }
+
   getToolRegistry(): ToolRegistry {
     return this.toolRegistry;
   }
@@ -951,11 +954,7 @@ export class Config {
     }
 
     registerCoreTool(GlobTool, this);
-    if (this.getUseSmartEdit()) {
-      registerCoreTool(SmartEditTool, this);
-    } else {
-      registerCoreTool(EditTool, this);
-    }
+    registerCoreTool(PatchTool, this);
     registerCoreTool(WriteFileTool, this);
     registerCoreTool(WebFetchTool, this);
     registerCoreTool(ReadManyFilesTool, this);

--- a/packages/core/src/services/fileSystemService.ts
+++ b/packages/core/src/services/fileSystemService.ts
@@ -25,6 +25,21 @@ export interface FileSystemService {
    * @param content - The content to write
    */
   writeTextFile(filePath: string, content: string): Promise<void>;
+
+  /**
+   * Deletes a file.
+   *
+   * @param filePath - The path to the file to delete.
+   */
+  unlink(filePath: string): Promise<void>;
+
+  /**
+   * Creates a directory.
+   *
+   * @param dirPath - The path to the directory to create.
+   * @param options - Options, e.g., { recursive: true }.
+   */
+  mkdir(dirPath: string, options?: { recursive: boolean }): Promise<void>;
 }
 
 /**
@@ -37,5 +52,16 @@ export class StandardFileSystemService implements FileSystemService {
 
   async writeTextFile(filePath: string, content: string): Promise<void> {
     await fs.writeFile(filePath, content, 'utf-8');
+  }
+
+  async unlink(filePath: string): Promise<void> {
+    await fs.unlink(filePath);
+  }
+
+  async mkdir(
+    dirPath: string,
+    options?: { recursive: boolean },
+  ): Promise<void> {
+    await fs.mkdir(dirPath, options);
   }
 }

--- a/packages/core/src/tools/patch.test.ts
+++ b/packages/core/src/tools/patch.test.ts
@@ -1,0 +1,297 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { PatchTool, type PatchToolParams } from './patch.js';
+import type { Config } from '../config/config.js';
+import { type GeminiClient } from '../core/client.js';
+import { fixFailedHunk } from '../utils/patch-fixer.js';
+import {
+  StandardFileSystemService,
+  type FileSystemService,
+} from '../services/fileSystemService.js';
+import { ToolErrorType } from './tool-error.js';
+
+describe('PatchTool Direct Invocation Test', () => {
+  vi.mock('../utils/patch-fixer.js');
+
+  let tempDir: string;
+  let fsService: FileSystemService;
+  let mockConfig: Config;
+  let patchTool: PatchTool;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'patch-test-'));
+    fsService = new StandardFileSystemService();
+
+    mockConfig = {
+      getFileSystemService: () => fsService,
+      getTargetDir: () => tempDir,
+      isPathWithinWorkspace: (p: string) => {
+        const relative = path.relative(tempDir, p);
+        return !relative.startsWith('..') && !path.isAbsolute(relative);
+      },
+      getGeminiClient: () => ({}) as unknown as GeminiClient,
+    } as unknown as Config;
+    patchTool = new PatchTool(mockConfig);
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function createTempFile(
+    content: string,
+    filename = 'test.txt',
+  ): Promise<string> {
+    const filePath = path.join(tempDir, filename);
+    await fs.writeFile(filePath, content);
+    return filePath;
+  }
+
+  it('should apply a simple patch to a file', async () => {
+    const initialContent = 'Hello, world!\n';
+    const filePath = 'test.txt';
+    await createTempFile(initialContent, filePath);
+
+    const patch = `--- a/test.txt
++++ b/test.txt
+@@ -1 +1 @@
+-Hello, world!
++Hello, universe!
+`;
+    const params: PatchToolParams = { unified_diff: patch };
+    const invocation = patchTool.build(params);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(result.returnDisplay).toContain('✅ ALL HUNKS APPLIED SUCCESSFULLY');
+    const finalContent = await fs.readFile(
+      path.join(tempDir, filePath),
+      'utf-8',
+    );
+    expect(finalContent).toBe('Hello, universe!\n');
+  });
+
+  it('should create a new file', async () => {
+    const filePath = 'new-file.txt';
+    const patch = `--- /dev/null
++++ b/new-file.txt
+@@ -0,0 +1,3 @@
++This is a new file.
++It has multiple lines.
++The end.
+`.trim();
+    const params: PatchToolParams = { unified_diff: patch };
+    const invocation = patchTool.build(params);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(result.returnDisplay).toContain(
+      '✅ ALL HUNKS APPLIED SUCCESSFULLY for new-file.txt',
+    );
+    const finalContent = await fs.readFile(
+      path.join(tempDir, filePath),
+      'utf-8',
+    );
+    expect(finalContent).toContain('This is a new file.');
+  });
+
+  it('should delete a file', async () => {
+    const filePath = 'to-delete.txt';
+    await createTempFile('This file will be deleted.', filePath);
+    const patch = `--- a/to-delete.txt
++++ /dev/null
+@@ -1,1 +0,0 @@
+-This file will be deleted.
+`.trim();
+    const params: PatchToolParams = { unified_diff: patch };
+    const invocation = patchTool.build(params);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(result.returnDisplay).toContain('Deleted file');
+    await expect(fs.access(path.join(tempDir, filePath))).rejects.toThrow();
+  });
+
+  it('should handle a multi-file patch successfully', async () => {
+    await createTempFile("console.log('one');", 'file1.js');
+    await createTempFile("console.log('two');", 'file2.js');
+
+    const patch = `--- a/file1.js
++++ b/file1.js
+@@ -1 +1 @@
+-console.log('one');
++console.log('ONE');
+--- a/file2.js
++++ b/file2.js
+@@ -1 +1 @@
+-console.log('two');
++console.log('TWO');
+`.trim();
+    const params: PatchToolParams = { unified_diff: patch };
+    const invocation = patchTool.build(params);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(result.returnDisplay).toContain(
+      '📊 PATCH SUMMARY: 2/2 files patched successfully.',
+    );
+    const finalContent1 = await fs.readFile(
+      path.join(tempDir, 'file1.js'),
+      'utf-8',
+    );
+    expect(finalContent1).toBe("console.log('ONE');");
+    const finalContent2 = await fs.readFile(
+      path.join(tempDir, 'file2.js'),
+      'utf-8',
+    );
+    expect(finalContent2).toBe("console.log('TWO');");
+  });
+
+  it('should report partial success when one file fails to patch', async () => {
+    await createTempFile('This part is correct.', 'good.txt');
+    await createTempFile('This content is wrong.', 'bad.txt');
+
+    const patch = `--- a/good.txt
++++ b/good.txt
+@@ -1 +1 @@
+-This part is correct.
++This part is now updated.
+--- a/bad.txt
++++ b/bad.txt
+@@ -1 +1 @@
+-This context does not exist.
++This will fail.
+`.trim();
+
+    const params: PatchToolParams = { unified_diff: patch };
+    const invocation = patchTool.build(params);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(result.returnDisplay).toContain(
+      '✅ ALL HUNKS APPLIED SUCCESSFULLY for good.txt',
+    );
+
+    // Verify file states
+    const finalContentGood = await fs.readFile(
+      path.join(tempDir, 'good.txt'),
+      'utf-8',
+    );
+    expect(finalContentGood).toBe('This part is now updated.');
+    const finalContentBad = await fs.readFile(
+      path.join(tempDir, 'bad.txt'),
+      'utf-8',
+    );
+    expect(finalContentBad).toBe('This content is wrong.');
+  });
+
+  it('should return an error when all hunks for all files fail', async () => {
+    const initialContent = 'original content';
+    await createTempFile(initialContent, 'file.txt');
+
+    const patch = `--- a/file.txt
++++ b/file.txt
+@@ -1,1 +1,1 @@
+-completely wrong content
++new content
+`.trim();
+    const params: PatchToolParams = { unified_diff: patch };
+    const invocation = patchTool.build(params);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toEqual(ToolErrorType.EDIT_NO_OCCURRENCE_FOUND);
+    expect(result.returnDisplay).toContain(
+      'Error: No changes could be applied from the patch',
+    );
+
+    // Ensure the file was not modified
+    const finalContent = await fs.readFile(
+      path.join(tempDir, 'file.txt'),
+      'utf-8',
+    );
+    expect(finalContent).toBe(initialContent);
+  });
+
+  it('should successfully heal a failed hunk', async () => {
+    const initialContent = 'const foo = 1;\nconst bar = 2;\n';
+    await createTempFile(initialContent, 'file.js');
+
+    const failingPatch = `--- a/file.js
++++ b/file.js
+@@ -1,2 +1,2 @@
+THIS IS WRONG CONTEXT
+-const bar = 2;
++const bar = 3;
+`;
+
+    const correctedPatch = `--- a/file.js
++ b/file.js
+@@ -1,2 +1,2 @@
+const foo = 1;
+-const bar = 2;
++const bar = 3;
+`;
+
+    vi.mocked(fixFailedHunk).mockResolvedValue(correctedPatch);
+
+    const params: PatchToolParams = { unified_diff: failingPatch };
+    const invocation = patchTool.build(params);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(fixFailedHunk).toHaveBeenCalledOnce();
+    expect(result.returnDisplay).toContain(
+      '✅ ALL HUNKS APPLIED SUCCESSFULLY for file.js',
+    );
+
+    const finalContent = await fs.readFile(
+      path.join(tempDir, 'file.js'),
+      'utf-8',
+    );
+    expect(finalContent).toBe('const foo = 1;\nconst bar = 3;\n');
+  });
+
+  it('should report a failure if healing also fails', async () => {
+    const initialContent = 'const foo = 1;\nconst bar = 2;\n';
+    await createTempFile(initialContent, 'file.js');
+
+    const failingPatch = `--- a/file.js
++++ b/file.js
+@@ -1,2 +1,2 @@
+THIS IS WRONG CONTEXT
+-const bar = 2;
++const bar = 3;
+`;
+
+    // Simulate the fixer returning another invalid patch
+    vi.mocked(fixFailedHunk).mockResolvedValue(
+      '--- a/file.js\n+++ b/file.js\n@@ -99,1 +99,1 @@\n-invalid\n+truly-invalid',
+    );
+
+    const params: PatchToolParams = { unified_diff: failingPatch };
+    const invocation = patchTool.build(params);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeDefined();
+    expect(fixFailedHunk).toHaveBeenCalledOnce();
+    expect(result.returnDisplay).toContain(
+      'Error: No changes could be applied from the patch.',
+    );
+
+    const finalContent = await fs.readFile(
+      path.join(tempDir, 'file.js'),
+      'utf-8',
+    );
+    expect(finalContent).toBe(initialContent);
+  });
+});

--- a/packages/core/src/tools/patch.ts
+++ b/packages/core/src/tools/patch.ts
@@ -1,0 +1,537 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Diff from 'diff';
+import * as path from 'node:path';
+import type {
+  ToolCallConfirmationDetails,
+  ToolEditConfirmationDetails,
+  ToolInvocation,
+  ToolLocation,
+  ToolResult,
+} from './tools.js';
+import { BaseDeclarativeTool, Kind, ToolConfirmationOutcome } from './tools.js';
+import { ToolErrorType } from './tool-error.js';
+import { makeRelative, shortenPath } from '../utils/paths.js';
+import type { Config } from '../config/config.js';
+import { ApprovalMode } from '../config/config.js';
+import {
+  parse,
+  applyHunksToContent,
+  applyPatchesToFS,
+  isFileDeletionHunk,
+} from '../utils/patcher.js';
+import { DEFAULT_DIFF_OPTIONS } from './diffOptions.js';
+import type { Hunk, PatchError } from '../utils/patcher.js';
+import { IdeClient, IDEConnectionStatus } from '../ide/ide-client.js';
+import { fixFailedHunk } from '../utils/patch-fixer.js';
+
+/**
+ * Parameters for the Patch tool
+ */
+export interface PatchToolParams {
+  /**
+   * A complete, multi-file patch in the standard unified diff format.
+   */
+  unified_diff: string;
+
+  /**
+   * Initially proposed content by the user.
+   */
+  ai_proposed_content?: string;
+}
+
+/**
+ * Data structure to hold the results of the dry-run.
+ */
+interface CalculatedPatch {
+  // Map from filepath to its original content and the new content after applying only successful hunks.
+  fileDiffInfo: Map<string, { originalContent: string; newContent: string }>;
+  // A map of filepaths to just the hunks that were successful in the dry-run.
+  successfulHunks: Map<string, Hunk[]>;
+  // A map of filepaths to hunks that failed the dry-run, including the error.
+  failedHunks: Map<string, Array<{ hunk: Hunk; error: PatchError }>>;
+  // A map of filepaths to hunks that were skipped as no-ops.
+  noOpHunks: Map<string, Hunk[]>;
+  // For fatal errors like parsing failure.
+  error?: { display: string; raw: string; type: ToolErrorType };
+  // The total number of files identified in the original patch.
+  totalFiles: number;
+}
+
+/**
+ * Formats a map of failed hunks back into a unified diff string for the LLM.
+ */
+function formatFailedHunksToDiff(
+  failedHunks: Map<string, Array<{ hunk: Hunk; error: PatchError }>>,
+): string {
+  let diffString = '';
+  for (const [filepath, failures] of failedHunks.entries()) {
+    diffString += `--- a/${filepath}\n`;
+    diffString += `+++ b/${filepath}\n`;
+    for (const { hunk } of failures) {
+      diffString += `${hunk.originalHunk}\n`;
+    }
+  }
+  return diffString.trim();
+}
+
+class PatchToolInvocation
+  implements ToolInvocation<PatchToolParams, ToolResult>
+{
+  private calculatedPatchPromise?: Promise<CalculatedPatch>;
+
+  constructor(
+    private readonly config: Config,
+    public params: PatchToolParams,
+  ) {}
+
+  toolLocations(): ToolLocation[] {
+    try {
+      const fileHunks = parse(this.params.unified_diff);
+      return Array.from(fileHunks.keys()).map((path) => ({ path }));
+    } catch (_e) {
+      return [];
+    }
+  }
+
+  /**
+   * Performs a dry-run of the patch to validate it, separating successful
+   * hunks from failed ones and generating a diff for the successful changes.
+   */
+  private async _calculatePatch(signal: AbortSignal): Promise<CalculatedPatch> {
+    let parsedHunks: Map<string, Hunk[]>;
+    try {
+      parsedHunks = parse(this.params.unified_diff);
+      if (parsedHunks.size === 0) {
+        return {
+          fileDiffInfo: new Map(),
+          successfulHunks: new Map(),
+          failedHunks: new Map(),
+          noOpHunks: new Map(),
+          totalFiles: 0,
+          error: {
+            display: 'The provided diff was empty or invalid.',
+            raw: 'Patch failed: The unified_diff parameter did not contain any valid hunks.',
+            type: ToolErrorType.INVALID_TOOL_PARAMS,
+          },
+        };
+      }
+    } catch (e: unknown) {
+      return {
+        fileDiffInfo: new Map(),
+        successfulHunks: new Map(),
+        failedHunks: new Map(),
+        noOpHunks: new Map(),
+        totalFiles: 0,
+        error: {
+          display: `Failed to parse the diff: ${(e as Error).message}`,
+          raw: `Patch failed during parsing: ${(e as Error).message}`,
+          type: ToolErrorType.INVALID_TOOL_PARAMS,
+        },
+      };
+    }
+
+    const totalFiles = parsedHunks.size;
+    const fileDiffInfo = new Map<
+      string,
+      { originalContent: string; newContent: string }
+    >();
+    const successfulHunks = new Map<string, Hunk[]>();
+    const failedHunks = new Map<
+      string,
+      Array<{ hunk: Hunk; error: PatchError }>
+    >();
+    const noOpHunks = new Map<string, Hunk[]>();
+
+    for (const [filepath, hunks] of parsedHunks.entries()) {
+      // Handle file deletion as a special case first.
+      if (hunks.length > 0 && isFileDeletionHunk(hunks[0])) {
+        try {
+          const absolutePath = path.join(this.config.getTargetDir(), filepath);
+          const originalContent = await this.config
+            .getFileSystemService()
+            .readTextFile(absolutePath);
+          // If successful, mark for deletion and show diff.
+          successfulHunks.set(filepath, hunks);
+          fileDiffInfo.set(filepath, {
+            originalContent: originalContent.replace(/\r\n/g, '\n'),
+            newContent: '',
+          });
+        } catch (err: unknown) {
+          if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            // File doesn't exist, so deletion is a silent success (no-op).
+            successfulHunks.set(filepath, hunks);
+            fileDiffInfo.set(filepath, {
+              originalContent: '',
+              newContent: '',
+            });
+          } else {
+            failedHunks.set(filepath, [
+              { hunk: hunks[0], error: err as PatchError },
+            ]);
+          }
+        }
+        continue; // Move to the next file.
+      }
+
+      let originalContent = '';
+      try {
+        const absolutePath = path.join(this.config.getTargetDir(), filepath);
+        originalContent = await this.config
+          .getFileSystemService()
+          .readTextFile(absolutePath);
+        originalContent = originalContent.replace(/\r\n/g, '\n');
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+
+      const {
+        newContent,
+        failedHunks: firstPassFailures,
+        noOpHunks: firstPassNoOps,
+        appliedHunks: firstPassApplied,
+      } = applyHunksToContent(originalContent, hunks);
+      const finalFailedHunks: Array<{ hunk: Hunk; error: PatchError }> = [];
+      const healedAndAppliedHunks: Hunk[] = [];
+      let contentAfterHealing = newContent;
+
+      if (firstPassFailures.length > 0) {
+        for (const failure of firstPassFailures) {
+          console.log(
+            `Attempting to heal failed hunk for ${filepath}:`,
+            failure.hunk.originalHunk,
+          );
+          try {
+            const correctedPatchString = await fixFailedHunk(
+              failure.hunk,
+              filepath,
+              contentAfterHealing, // Use the latest content for fixing
+              this.config.getGeminiClient(),
+              signal,
+            );
+
+            const newlyHealedHunks = parse(correctedPatchString).get(filepath);
+
+            if (!newlyHealedHunks || newlyHealedHunks.length === 0) {
+              throw new Error('LLM fixer returned an empty or invalid patch.');
+            }
+
+            // Try to apply the newly healed hunk immediately
+            const { newContent: healedContent, failedHunks: healedFailures } =
+              applyHunksToContent(contentAfterHealing, newlyHealedHunks);
+
+            if (healedFailures.length > 0) {
+              throw new Error('Healed hunk failed to apply.');
+            }
+
+            // Success! Update content and track the healed hunk.
+            contentAfterHealing = healedContent;
+            healedAndAppliedHunks.push(...newlyHealedHunks);
+          } catch (_e) {
+            finalFailedHunks.push(failure);
+          }
+        }
+      }
+
+      if (finalFailedHunks.length > 0) {
+        failedHunks.set(filepath, finalFailedHunks);
+      }
+
+      if (firstPassNoOps.length > 0) {
+        noOpHunks.set(filepath, firstPassNoOps);
+      }
+
+      const allSuccessfulHunks = [
+        ...firstPassApplied,
+        ...healedAndAppliedHunks,
+        ...firstPassNoOps, // No-ops are also a form of success
+      ];
+
+      if (allSuccessfulHunks.length > 0) {
+        successfulHunks.set(filepath, allSuccessfulHunks);
+        fileDiffInfo.set(filepath, {
+          originalContent,
+          newContent: contentAfterHealing,
+        });
+      }
+    }
+
+    const changedFileDiffInfo = new Map<
+      string,
+      { originalContent: string; newContent: string }
+    >();
+    const changedSuccessfulHunks = new Map<string, Hunk[]>();
+
+    for (const [filepath, diffInfo] of fileDiffInfo.entries()) {
+      if (diffInfo.originalContent !== diffInfo.newContent) {
+        changedFileDiffInfo.set(filepath, diffInfo);
+        if (successfulHunks.has(filepath)) {
+          changedSuccessfulHunks.set(filepath, successfulHunks.get(filepath)!);
+        }
+      }
+    }
+
+    return {
+      fileDiffInfo: changedFileDiffInfo,
+      successfulHunks: changedSuccessfulHunks,
+      failedHunks,
+      noOpHunks,
+      totalFiles,
+    };
+  }
+
+  private calculatePatch(signal: AbortSignal): Promise<CalculatedPatch> {
+    if (!this.calculatedPatchPromise) {
+      this.calculatedPatchPromise = this._calculatePatch(signal);
+    }
+    return this.calculatedPatchPromise;
+  }
+
+  async shouldConfirmExecute(
+    signal: AbortSignal,
+  ): Promise<ToolCallConfirmationDetails | false> {
+    if (this.config.getApprovalMode() === ApprovalMode.YOLO) {
+      return false;
+    }
+
+    const patchData = await this.calculatePatch(signal);
+
+    if (patchData.error) {
+      console.log(`Error: ${patchData.error.display}`);
+      return false;
+    }
+
+    if (patchData.successfulHunks.size === 0) {
+      const firstError = Array.from(patchData.failedHunks.values())[0]?.[0]
+        ?.error.message;
+      console.log(
+        `Error: No changes could be applied from the patch. First error: ${firstError || 'Unknown error'}`,
+      );
+      return false;
+    }
+
+    let combinedDiff = '';
+    for (const [filepath, contents] of patchData.fileDiffInfo.entries()) {
+      const fileDiff = Diff.createPatch(
+        path.basename(filepath),
+        contents.originalContent,
+        contents.newContent,
+        'Current',
+        'Proposed',
+        DEFAULT_DIFF_OPTIONS,
+      );
+      combinedDiff += fileDiff + '\n';
+    }
+
+    const firstFilePath = Array.from(patchData.fileDiffInfo.keys())[0];
+    const isPartial = patchData.failedHunks.size > 0;
+    const numFiles = patchData.successfulHunks.size;
+    const firstFileContents = patchData.fileDiffInfo.get(firstFilePath);
+
+    const title = isPartial
+      ? `Confirm Partial Patch (${numFiles} file(s), some changes failed)`
+      : `Confirm Patch Application (${numFiles} file(s))`;
+
+    const ideClient = await IdeClient.getInstance();
+    const ideConfirmation =
+      numFiles === 1 &&
+      this.config.getIdeMode() &&
+      ideClient?.getConnectionStatus().status === IDEConnectionStatus.Connected
+        ? ideClient.openDiff(
+            firstFilePath,
+            patchData.fileDiffInfo.get(firstFilePath)!.newContent,
+          )
+        : undefined;
+
+    const confirmationDetails: ToolEditConfirmationDetails = {
+      type: 'edit',
+      title,
+      fileName:
+        numFiles === 1
+          ? path.basename(firstFilePath)
+          : `${numFiles} file(s) will be changed`,
+      filePath: firstFilePath,
+      fileDiff: combinedDiff.trim(),
+      originalContent:
+        numFiles === 1 ? (firstFileContents?.originalContent ?? null) : null,
+      newContent: numFiles === 1 ? (firstFileContents?.newContent ?? '') : '',
+      onConfirm: async (outcome: ToolConfirmationOutcome) => {
+        if (outcome === ToolConfirmationOutcome.ProceedAlways) {
+          this.config.setApprovalMode(ApprovalMode.YOLO);
+        }
+      },
+      ideConfirmation,
+    };
+    return confirmationDetails;
+  }
+
+  getDescription(): string {
+    try {
+      const fileHunks = parse(this.params.unified_diff);
+      const filePaths = Array.from(fileHunks.keys()).map((p) =>
+        shortenPath(makeRelative(p, this.config.getTargetDir())),
+      );
+      if (filePaths.length === 0) return 'Apply an empty patch';
+      if (filePaths.length === 1) return `Apply patch to ${filePaths[0]}`;
+      return `Apply patch to ${filePaths.length} files: ${filePaths
+        .slice(0, 2)
+        .join(', ')}...`;
+    } catch {
+      return 'Apply an invalid patch';
+    }
+  }
+
+  async execute(signal: AbortSignal): Promise<ToolResult> {
+    const patchData = await this.calculatePatch(signal);
+
+    if (patchData.error) {
+      console.log(`Error: Failed to apply patch: ${patchData.error.display}`);
+      return {
+        llmContent: patchData.error.raw,
+        returnDisplay: `Error: ${patchData.error.display}`,
+        error: {
+          message: patchData.error.raw,
+          type: patchData.error.type,
+        },
+      };
+    }
+
+    // Display failed hunks for debugging
+    if (patchData.failedHunks.size > 0) {
+      for (const [filepath, failures] of patchData.failedHunks.entries()) {
+        let originalContent =
+          patchData.fileDiffInfo.get(filepath)?.originalContent;
+        if (originalContent === undefined) {
+          try {
+            const absolutePath = path.join(
+              this.config.getTargetDir(),
+              filepath,
+            );
+            originalContent = await this.config
+              .getFileSystemService()
+              .readTextFile(absolutePath);
+          } catch (readError) {
+            originalContent = `[Content not available: Failed to re-read file during logging. Error: ${(readError as Error).message}]`;
+          }
+        }
+        console.error('Original File Content:\n' + originalContent);
+        console.error(
+          'Failed Hunks:\n' +
+            failures.map((f) => f.hunk.originalHunk).join('\n'),
+        );
+      }
+    }
+
+    if (patchData.successfulHunks.size === 0) {
+      if (patchData.failedHunks.size > 0) {
+        console.error('Error: No hunks could be applied from the patch.');
+        const failedHunksDiff = formatFailedHunksToDiff(patchData.failedHunks);
+        const rawError = `Patch failed. No hunks could be applied. Please correct the following hunks:\n${failedHunksDiff}`;
+        return {
+          llmContent: rawError,
+          returnDisplay: `Error: No changes could be applied from the patch.`,
+          error: {
+            message: rawError,
+            type: ToolErrorType.EDIT_NO_OCCURRENCE_FOUND,
+          },
+        };
+      } else {
+        return {
+          llmContent:
+            'The patch was applied successfully. No changes were needed as the code already matched the patch.',
+          returnDisplay: '✅ All changes from the patch are already present.',
+        };
+      }
+    }
+
+    try {
+      const report = await applyPatchesToFS(
+        patchData.successfulHunks,
+        this.config,
+        patchData.totalFiles,
+        this.config.getFileSystemService(),
+      );
+
+      let llmContent = `Successfully applied some changes.\n${report}`;
+      if (patchData.failedHunks.size > 0) {
+        const failedHunksDiff = formatFailedHunksToDiff(patchData.failedHunks);
+        console.log(`Warning: Some hunks failed to apply:\n${failedHunksDiff}`);
+        llmContent += `\n\nThe following hunks failed to apply:\n${failedHunksDiff}`;
+      }
+
+      if (patchData.noOpHunks.size > 0) {
+        let noOpMessage =
+          '\n\nThe following hunks were skipped as no-ops (the changes were already present):';
+        for (const [filepath, hunks] of patchData.noOpHunks.entries()) {
+          noOpMessage += `\n- ${hunks.length} hunk(s) for ${filepath}`;
+        }
+        llmContent += noOpMessage;
+      }
+
+      return {
+        llmContent,
+        returnDisplay: report.trim(),
+      };
+    } catch (e: unknown) {
+      console.log(`Error: Failed to execute patch: ${(e as Error).message}`);
+      return {
+        llmContent: `Error executing patch: ${(e as Error).message}`,
+        returnDisplay: `Error applying patch: ${(e as Error).message}`,
+        error: {
+          message: (e as Error).message,
+          type: ToolErrorType.EXECUTION_FAILED,
+        },
+      };
+    }
+  }
+}
+
+/**
+ * Implementation of the Patch tool
+ */
+export class PatchTool extends BaseDeclarativeTool<
+  PatchToolParams,
+  ToolResult
+> {
+  static readonly Name = 'patch';
+  constructor(private readonly config: Config) {
+    super(
+      PatchTool.Name,
+      'Patch',
+      `Applies a code change to one or more files using the standard unified diff format.
+
+**MANDATORY WORKFLOW:**
+1. **ALWAYS** read the full, current content of the file(s) you intend to patch *immediately* before creating the \`unified_diff\`. This prevents errors from stale context.
+2. If the patch application fails, **NEVER** manually retry the patch. The tool has already attempted an automatic self-heal.
+3. If self-healing fails, your **ONLY** next step is to use the \`write_file\` tool to overwrite the entire file with the desired changes.
+
+**Key Features:**
+* **Multi-File Operations:** Can create, delete, and modify multiple files in a single operation.
+* **Content-Based Matching:** The patch is applied based on the content of the context lines (' '), not on line numbers.
+* **Partial Success:** The tool will attempt to apply every hunk independently. If some hunks succeed and others fail, the successful changes are kept.
+* **Automatic Self-Healing:** If a hunk fails, the tool automatically tries to fix it.`,
+      Kind.Edit,
+      {
+        properties: {
+          unified_diff: {
+            description:
+              'A string containing the full patch in the standard unified diff format.',
+            type: 'string',
+          },
+        },
+        required: ['unified_diff'],
+        type: 'object',
+      },
+    );
+  }
+
+  protected createInvocation(
+    params: PatchToolParams,
+  ): ToolInvocation<PatchToolParams, ToolResult> {
+    return new PatchToolInvocation(this.config, params);
+  }
+}

--- a/packages/core/src/utils/patch-fixer.test.ts
+++ b/packages/core/src/utils/patch-fixer.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { fixFailedHunk } from './patch-fixer.js';
+import { type Hunk } from './patcher.js';
+import { type GeminiClient } from '../core/client.js';
+
+describe('fixFailedHunk', () => {
+  it('should call the Gemini client with the correct prompt and return the corrected patch', async () => {
+    const mockGeminiClient = {
+      generateJson: vi.fn(),
+    } as unknown as GeminiClient;
+
+    const failedHunk: Hunk = {
+      oldStart: 10,
+      oldCount: 3,
+      newStart: 10,
+      newCount: 3,
+      lines: ['- old line 1', '- old line 2', '+ new line 1', '+ new line 2'],
+      originalHunk:
+        '@@ -10,3 +10,3 @@\n- old line 1\n- old line 2\n+ new line 1\n+ new line 2',
+      header: '@@ -10,3 +10,3 @@',
+    };
+
+    const currentContent =
+      'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nold line 1\nold line 2\nline12\n';
+    const correctedPatch =
+      '@@ -10,2 +10,2 @@\n- old line 1\n- old line 2\n+ new line 1\n+ new line 2';
+
+    vi.mocked(mockGeminiClient.generateJson).mockResolvedValue({
+      patch: correctedPatch,
+    });
+
+    const result = await fixFailedHunk(
+      failedHunk,
+      'file.ts',
+      currentContent,
+      mockGeminiClient,
+      new AbortController().signal,
+    );
+
+    expect(mockGeminiClient.generateJson).toHaveBeenCalledOnce();
+    const [contents] = vi.mocked(mockGeminiClient.generateJson).mock.calls[0];
+    if (!contents?.[0]?.parts?.[0]?.text) {
+      throw new Error('Prompt text not found in mock call');
+    }
+    const prompt = contents[0].parts[0].text;
+
+    expect(prompt).toContain('file.ts');
+    expect(prompt).toContain(currentContent);
+    expect(prompt).toContain(failedHunk.originalHunk);
+    expect(prompt).toContain('You are an automated patch-fixing utility.');
+
+    expect(result).toBe(correctedPatch);
+  });
+});

--- a/packages/core/src/utils/patch-fixer.ts
+++ b/packages/core/src/utils/patch-fixer.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type Content, Type } from '@google/genai';
+import { type GeminiClient } from '../core/client.js';
+import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
+import { type Hunk } from './patcher.js';
+
+const PATCH_FIXER_PROMPT = `
+You are an automated patch-fixing utility. The following hunk failed to apply to the provided source file due to a context mismatch. Your task is to generate a new patch in the **unified diff format** that correctly applies the *exact same substantive change* but with updated context lines that match the source file. You are free to break it into multiple smaller hunks, give more generous context for matching. Your output should be **only the diff content**, starting with --- a/ or @@. Do not add any other explanations or text.
+**Source File:**
+{filepath}
+---
+\
+{currentContent}
+\
+**Failed Hunk:**
+\
+{hunkAsString}
+\
+`;
+
+const CorrectedPatchResponseSchema = {
+  type: Type.OBJECT,
+  properties: {
+    patch: { type: Type.STRING },
+  },
+  required: ['patch'],
+};
+
+/**
+ * Attempts to fix a failed patch hunk by using an LLM to generate a new,
+ * corrected patch with updated context lines.
+ *
+ * @param failedHunk The hunk object that failed to apply.
+ * @param currentContent The current content of the file to be patched.
+ * @param geminiClient The Gemini client to use for the LLM call.
+ * @param abortSignal An abort signal to cancel the operation.
+ * @returns A string containing the new, corrected patch in unified diff format.
+ */
+export async function fixFailedHunk(
+  failedHunk: Hunk,
+  filepath: string,
+  currentContent: string,
+  geminiClient: GeminiClient,
+  abortSignal: AbortSignal,
+): Promise<string> {
+  // The originalHunk property contains the raw string representation of the hunk.
+  const hunkAsString = failedHunk.originalHunk;
+
+  const prompt = PATCH_FIXER_PROMPT.replace('{currentContent}', currentContent)
+    .replace('{hunkAsString}', hunkAsString)
+    .replace('{filepath}', filepath);
+
+  const contents: Content[] = [
+    {
+      role: 'user',
+      parts: [{ text: prompt }],
+    },
+  ];
+
+  const result = (await geminiClient.generateJson(
+    contents,
+    CorrectedPatchResponseSchema,
+    abortSignal,
+    DEFAULT_GEMINI_MODEL,
+  )) as { patch: string };
+
+  // The LLM may wrap the diff in markdown, so we remove it.
+  const cleanedResult = result.patch.replace(/^```diff\n|```$/g, '').trim();
+
+  return cleanedResult;
+}

--- a/packages/core/src/utils/patcher.test.ts
+++ b/packages/core/src/utils/patcher.test.ts
@@ -1,0 +1,446 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Comprehensive test suite for the diff_patch tool.
+ * This suite validates all behaviors, including fuzzy matching, error handling,
+ * file creation, and multi-file patches.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { parse, applyPatchesToFS } from './patcher.js';
+import type { PatcherConfig } from './patcher.js';
+
+describe('TestPatchBehaviors', () => {
+  let tempDir: string;
+  let mockConfig: PatcherConfig;
+
+  // Setup: Create a temporary directory before each test
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'patch-test-'));
+    mockConfig = {
+      getTargetDir: () => tempDir,
+      isPathWithinWorkspace: (p: string) => {
+        const relative = path.relative(tempDir, p);
+        return !relative.startsWith('..') && !path.isAbsolute(relative);
+      },
+    };
+  });
+
+  // Teardown: Clean up the temporary directory after each test
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Helper to create a file within the temporary test directory.
+   * @param content The content of the file.
+   * @param filename The name of the file.
+   * @return The full path to the created file.
+   */
+  async function createTempFile(
+    content: string,
+    filename = 'test.ts',
+  ): Promise<string> {
+    const filePath = path.join(tempDir, filename);
+    await fs.writeFile(filePath, content);
+    return filePath;
+  }
+
+  /**
+   * Applies standard unified diff format patches. It ignores line numbers and uses
+   * content-based matching for high accuracy.
+   *
+   * This is the main entry point for the patcher library.
+   */
+  async function diffPatch(patchesStr: string): Promise<string> {
+    const fileHunks = parse(patchesStr);
+    const ret = await applyPatchesToFS(fileHunks, mockConfig);
+    return ret;
+  }
+
+  it('should completely ignore line numbers', async () => {
+    const content = `function function_a(): string {
+    return "a";
+}
+
+function function_b(): string {
+    return "b";
+}
+
+function function_c(): string {
+    return "c";
+}`;
+    await createTempFile(content, 'test.ts');
+
+    // Patch with completely wrong line numbers (999,999) but GOOD CONTEXT
+    const diffStr = `--- a/test.ts
++++ b/test.ts
+@@ -999,3 +999,3 @@
+ function function_b(): string {
+-    return "b";
++    return "modified_b";
+ }`;
+
+    const result = await diffPatch(diffStr);
+    expect(result).toContain('SUCCESS');
+
+    const modified = await fs.readFile(path.join(tempDir, 'test.ts'), 'utf-8');
+    expect(modified).toContain('return "modified_b";');
+    expect(modified).not.toContain('return "b"');
+  });
+
+  it('should process hunks as atomic units', async () => {
+    const content = `class MyClass {
+    constructor() {
+        this.value = 0;
+        this.name = "test";
+    }
+
+    process() {
+        return this.value;
+    }
+}`;
+    await createTempFile(content);
+
+    const diffStr = `--- a/test.ts
++++ b/test.ts
+@@ -2,5 +2,6 @@
+     constructor() {
+-        this.value = 0;
+-        this.name = "test";
++        this.value = 42;
++        this.name = "modified";
++        this.description = "new field";
+     }
+
+     process() {
+         return this.value;
+`;
+
+    const result = await diffPatch(diffStr);
+    expect(result).toContain('SUCCESS');
+
+    const modified = await fs.readFile(path.join(tempDir, 'test.ts'), 'utf-8');
+    expect(modified).toContain('this.value = 42;');
+    expect(modified).toContain('this.name = "modified";');
+    expect(modified).toContain('this.description = "new field"');
+  });
+
+  it('should create a new file', async () => {
+    const newFileName = 'new_module.ts';
+    const diffStr = `--- /dev/null
++++ b/${newFileName}
+@@ -0,0 +1,5 @@
++/** A new module. */
++export class NewClass {
++  public static run(): string {
++    return 'new';
++  }
++}`;
+    const result = await diffPatch(diffStr);
+    expect(result).toContain('SUCCESS');
+
+    const newFilePath = path.join(tempDir, newFileName);
+    const content = await fs.readFile(newFilePath, 'utf-8');
+    expect(content).toContain('export class NewClass');
+  });
+
+  it('should delete a file', async () => {
+    const content = 'This file should be deleted.';
+    const filePath = await createTempFile(content);
+
+    const diffStr = `--- a/test.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-This file should be deleted.
+`;
+    const result = await diffPatch(diffStr);
+    expect(result).toContain('SUCCESS');
+    expect(result).toContain('Deleted file');
+
+    await expect(fs.access(filePath)).rejects.toThrow();
+  });
+
+  it('should handle multiple files being processed', async () => {
+    await createTempFile('content for file1', 'file1.ts');
+    await createTempFile('content for file2', 'file2.ts');
+
+    const diffStr = `--- a/file1.ts
++++ b/file1.ts
+@@ -1,1 +1,1 @@
+-content for file1
++modified content for file1
+--- a/file2.ts
++++ b/file2.ts
+@@ -1,1 +1,1 @@
+-content for file2
++modified content for file2`;
+
+    const result = await diffPatch(diffStr);
+    expect(result).toContain('2/2 files patched successfully');
+    expect(result).toContain('SUCCESSFULLY for file1.ts');
+    expect(result).toContain('SUCCESSFULLY for file2.ts');
+
+    const content1 = await fs.readFile(path.join(tempDir, 'file1.ts'), 'utf-8');
+    expect(content1).toBe('modified content for file1');
+    const content2 = await fs.readFile(path.join(tempDir, 'file2.ts'), 'utf-8');
+    expect(content2).toBe('modified content for file2');
+  });
+
+  it('should handle graceful failure for unmatchable patches', async () => {
+    const content = `function existing_function() {
+    return "exists";
+}`;
+    await createTempFile(content);
+
+    const diffStr = `--- a/test.ts
++++ b/test.ts
+@@ -1,3 +1,3 @@
+ class CompletelyDifferentClass {
+-    constructor() {
++    constructor(value: any) {
+         this.data = "something";
+ }`;
+    const result = await diffPatch(diffStr);
+    expect(result).toContain('FAILED');
+    expect(result).toContain('Could not locate context');
+
+    const contentAfter = await fs.readFile(
+      path.join(tempDir, 'test.ts'),
+      'utf-8',
+    );
+    expect(contentAfter).toBe(content); // File should be unchanged
+  });
+
+  it('should preserve file structure on partial error', async () => {
+    const content = `function important_function() {
+    // This function must not be corrupted
+    return "critical_data";
+}
+
+function another_function() {
+    return "other_data";
+}`;
+    await createTempFile(content);
+
+    const diffStr = `--- a/test.ts
++++ b/test.ts
+@@ -1,4 +1,5 @@
+ function important_function() {
+     // This function must not be corrupted
++    // Added a comment
+     return "critical_data";
+---
+-a/test.ts
++++ b/test.ts
+@@ -999,3 +999,3 @@
+ def nonexistent_function():
+-    return "this does not exist"
++    return "this also does not exist"`;
+
+    const result = await diffPatch(diffStr);
+    expect(result).toContain('PARTIAL SUCCESS');
+
+    const modified = await fs.readFile(path.join(tempDir, 'test.ts'), 'utf-8');
+    expect(modified).toContain('// Added a comment');
+    expect(modified).toContain('return "critical_data"');
+  });
+
+  it('should reject a patch trying to access outside the working directory', async () => {
+    const diffStr = `--- a/../test.ts
++++ b/../test.ts
+@@ -1,1 +1,1 @@
+-foo
++bar
+`;
+    const result = await diffPatch(diffStr);
+    expect(result).toContain('FAILED: ../test.ts');
+    expect(result).toContain('Security violation');
+  });
+
+  it('should show failed hunks for manual application', async () => {
+    await createTempFile('line one\nline two\nline three\n');
+    const badHunk = `@@ -1,3 +1,3 @@
+ line one
+-something that does not exist
++something new
+ line three`;
+    const diffStr = `--- a/test.ts\n+++ b/test.ts\n${badHunk}`;
+
+    const result = await diffPatch(diffStr);
+
+    expect(result).toContain('FAILED HUNKS FOR MANUAL APPLICATION');
+    expect(result).toContain(badHunk);
+  });
+
+  it('should skip a hunk if it appears to be already applied', async () => {
+    const content = 'const x = 2;';
+    await createTempFile(content);
+
+    const diffStr = `--- a/test.ts
++++ b/test.ts
+@@ -1,1 +1,1 @@
+-const x = 1;
++const x = 2;`;
+
+    const result = await diffPatch(diffStr);
+    // The tool should see 'const x = 2' is already present and skip.
+    expect(result).toContain('SUCCESS');
+    expect(result).not.toContain('FAILED');
+
+    const finalContent = await fs.readFile(
+      path.join(tempDir, 'test.ts'),
+      'utf-8',
+    );
+    expect(finalContent).toBe(content);
+  });
+
+  it('should apply multiple hunks in reverse order', async () => {
+    const content = `// Hunk 2 Target
+function second() {
+    return 'second';
+}
+
+// Hunk 1 Target
+function first() {
+    return 'first';
+}`;
+    await createTempFile(content);
+
+    const diffStr = `--- a/test.ts
++++ b/test.ts
+@@ -6,3 +6,4 @@
+ // Hunk 1 Target
+ function first() {
+-    return 'first';
++    return 'first modified';
++    // Comment added
+}
+@@ -1,4 +1,4 @@
+ // Hunk 2 Target
+ function second() {
+-    return 'second';
++    return 'second modified';
+ }
+`;
+
+    const result = await diffPatch(diffStr);
+    expect(result).toContain('SUCCESS');
+
+    const modified = await fs.readFile(path.join(tempDir, 'test.ts'), 'utf-8');
+    expect(modified).toContain('first modified');
+    expect(modified).toContain('second modified');
+  });
+
+  it('should handle pure insertions with context', async () => {
+    const content = `class DatabaseManager {
+    constructor() {}
+
+    disconnect() {}
+}`;
+    await createTempFile(content);
+
+    const diffStr = `--- a/test.ts
++++ b/test.ts
+@@ -2,3 +2,7 @@
+     constructor() {}
+
++    connect() {
++        // new connection logic
++    }
++
+     disconnect() {}
+ }`;
+
+    const result = await diffPatch(diffStr);
+    expect(result).toContain('SUCCESS');
+
+    const modified = await fs.readFile(path.join(tempDir, 'test.ts'), 'utf-8');
+    expect(modified).toContain('connect()');
+  });
+
+  it('should tolerate whitespace and formatting variations', async () => {
+    const content = `function process(data: any) {
+    if   (data   ===   null) {
+        return false;
+    }
+    return true;
+}`;
+    await createTempFile(content);
+
+    // This patch has normalized whitespace compared to the original content
+    const diffStr = `--- a/test.ts
++++ b/test.ts
+@@ -1,5 +1,6 @@
+ function process(data: any) {
+-    if   (data   ===   null) {
++    if (data === null) {
++        console.log('Data was null');
+         return false;
+     }
+     return true;
+`;
+    const result = await diffPatch(diffStr);
+    expect(result).toContain('SUCCESS');
+
+    const modified = await fs.readFile(path.join(tempDir, 'test.ts'), 'utf-8');
+    expect(modified).toContain("console.log('Data was null')");
+  });
+
+  it('should be compatible with git format-patch output', async () => {
+    const content = `def hello():
+    return "world"
+`;
+    await createTempFile(content);
+
+    const diffStr = `From 1234567890abcdef1234567890abcdef12345678 Mon Sep 17 00:00:00 2001
+From: A. Developer <dev@example.com>
+Date: Tue, 2 Sep 2025 16:00:00 -0700
+Subject: [PATCH] Update hello function
+
+---
+ test.ts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test.ts b/test.ts
+index abc123..def456 100644
+--- a/test.ts
++++ b/test.ts
+@@ -1,2 +1,2 @@
+ def hello():
+-    return "world"
++    return "universe"
+`;
+    const result = await diffPatch(diffStr);
+    expect(result).toContain('SUCCESS');
+
+    const modified = await fs.readFile(path.join(tempDir, 'test.ts'), 'utf-8');
+    expect(modified).toContain('return "universe"');
+  });
+
+  it('should handle empty and no-op patches gracefully', async () => {
+    const content = 'hello world';
+    await createTempFile(content);
+
+    // Test 1: Empty diff string
+    const resultEmpty = await diffPatch('');
+    expect(resultEmpty).toContain('No valid patches found');
+
+    // Test 2: Diff with only context lines (no changes)
+    const noChangeDiff = `--- a/test.ts
++++ b/test.ts
+@@ -1,1 +1,1 @@
+ hello world`;
+    const resultNoChange = await diffPatch(noChangeDiff);
+    // This should fail gracefully because the change results in no modification
+    expect(resultNoChange).toContain('SUCCESS');
+    expect(resultNoChange).toContain('Skipped as no-op');
+  });
+});

--- a/packages/core/src/utils/patcher.ts
+++ b/packages/core/src/utils/patcher.ts
@@ -1,0 +1,576 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview A tool to apply standard unified diff format patches.
+ * This tool is optimized for use by LLMs, featuring content-based matching
+ * that ignores line numbers for a higher success rate. It handles multiple
+ * files, file creation, and file deletion, and provides clear output on
+ * success or failure.
+ */
+
+import * as path from 'node:path';
+import {
+  StandardFileSystemService,
+  type FileSystemService,
+} from '../services/fileSystemService.js';
+
+export interface PatcherConfig {
+  getTargetDir(): string;
+  isPathWithinWorkspace(path: string): boolean;
+}
+
+/**
+ * Custom error class for patch-related failures.
+ */
+export class PatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PatchError';
+  }
+}
+
+/** Interface representing a parsed hunk from a diff file. */
+export interface Hunk {
+  oldStart: number;
+  oldCount: number;
+  newStart: number;
+  newCount: number;
+  originalHunk: string;
+  lines: string[];
+  header: string;
+}
+
+/**
+ * Parses a hunk header to extract line numbers and context.
+ * @param hunkStr The string content of a single hunk.
+ * @returns An object with old start line and a context hint string.
+ */
+function parseHunkHeader(hunkStr: string): Hunk {
+  const lines = hunkStr.split('\n');
+  const headerLine = lines[0];
+  const match = /@@ -(\d+)(,(\d+))? \+(\d+)(,(\d+))? @@/.exec(headerLine);
+  if (!match) {
+    throw new PatchError(`Invalid hunk header: ${headerLine}`);
+  }
+
+  return {
+    oldStart: parseInt(match[1], 10),
+    oldCount: match[3] ? parseInt(match[3], 10) : 1,
+    newStart: parseInt(match[4], 10),
+    newCount: match[6] ? parseInt(match[6], 10) : 1,
+    originalHunk: hunkStr,
+    lines: lines.slice(1),
+    header: headerLine,
+  };
+}
+
+/**
+ * Extracts the filename from a diff header line (e.g., '--- a/foo.ts').
+ * @param headerLine The diff header line.
+ * @return The extracted filename or null for '/dev/null'.
+ */
+function extractFilenameFromDiffHeader(headerLine: string): string | null {
+  // Strip the '--- ' or '+++ ' prefix.
+  let filename = headerLine.substring(4).trim();
+
+  if (filename === '/dev/null') {
+    return null;
+  }
+
+  // Remove standard git diff prefixes 'a/' or 'b/'.
+  if (filename.startsWith('a/') || filename.startsWith('b/')) {
+    filename = filename.substring(2);
+  }
+  return filename;
+}
+
+/**
+ * Parses a unified diff string, which may contain multiple files, and returns a
+ * map where keys are filenames and values are an array of parsed Hunk objects.
+ * @param diffContent The raw unified diff string.
+ * @returns A map from filenames to their Hunks.
+ */
+export function parse(diffContent: string): Map<string, Hunk[]> {
+  const fileHunks = new Map<string, Hunk[]>();
+  let currentFile: string | null = null;
+  let currentHunk: string[] = [];
+
+  const lines = diffContent.split('\n');
+  let i = 0;
+
+  const commitCurrentHunk = () => {
+    if (currentFile && currentHunk.length > 0) {
+      if (!fileHunks.has(currentFile)) {
+        fileHunks.set(currentFile, []);
+      }
+      fileHunks.get(currentFile)!.push(parseHunkHeader(currentHunk.join('\n')));
+    }
+    currentHunk = [];
+  };
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Ignore git format-patch headers and other metadata
+    if (
+      line.startsWith('From ') ||
+      line.startsWith('Date:') ||
+      line.startsWith('Subject:') ||
+      line.startsWith('diff --git') ||
+      line.startsWith('index ') ||
+      line.startsWith('new file mode') ||
+      line.startsWith('deleted file mode') ||
+      line.startsWith('similarity index')
+    ) {
+      i++;
+      continue;
+    }
+
+    if (line.startsWith('---')) {
+      commitCurrentHunk();
+      const oldFile = extractFilenameFromDiffHeader(line);
+      if (oldFile) {
+        // File deletion might set currentFile here
+        currentFile = oldFile;
+      }
+      i++;
+      continue;
+    }
+
+    if (line.startsWith('+++')) {
+      const newFile = extractFilenameFromDiffHeader(line);
+      if (newFile) {
+        currentFile = newFile;
+      }
+      i++;
+      continue;
+    }
+
+    if (line.startsWith('@@')) {
+      commitCurrentHunk();
+      currentHunk = [line];
+    } else if (currentFile) {
+      if (currentHunk.length > 0) {
+        currentHunk.push(line);
+      }
+    }
+    i++;
+  }
+
+  // Save the final hunk
+  commitCurrentHunk();
+
+  return fileHunks;
+}
+
+/**
+ * Extracts the original 'old' block and the new 'target' block from a hunk.
+ * This preserves the exact line structure, including empty lines.
+ * @param hunkStr The string content of a single hunk.
+ * @return A tuple containing [oldBlock, newBlock].
+ */
+function extractOldAndNewBlocksFromHunk(hunkStr: string): [string, string] {
+  const lines = hunkStr.trim().split('\n').slice(1); // Skip @@ header
+  const oldBlockLines: string[] = [];
+  const newBlockLines: string[] = [];
+
+  for (const line of lines) {
+    // Ignore git patch metadata lines
+    if (line.startsWith('-- \n') || /^\d+\.\d+\.\d+/.test(line)) {
+      continue;
+    }
+
+    const content = line.substring(1);
+    switch (line[0]) {
+      case ' ':
+        oldBlockLines.push(content);
+        newBlockLines.push(content);
+        break;
+      case '-':
+        oldBlockLines.push(content);
+        break;
+      case '+':
+        newBlockLines.push(content);
+        break;
+      default:
+        // Handle lines without a prefix (e.g., '\ No newline at end of file')
+        // Treat as context, though it's rare.
+        oldBlockLines.push(line);
+        newBlockLines.push(line);
+    }
+  }
+  return [oldBlockLines.join('\n'), newBlockLines.join('\n')];
+}
+
+/**
+ * Finds the exact start and end line numbers of the old block in the file content.
+ * It first tries an exact match and then falls back to a fuzzy match that
+ * ignores whitespace differences.
+ * @param fileContent The content of the file to search within.
+ * @param oldBlock The block of code to find.
+ * @return A tuple of [startLine, endLine] (1-based), or [-1, -1] if not found.
+ */
+function findOldBlockInFile(
+  fileContent: string,
+  oldBlock: string,
+): [number, number] {
+  const fileLines = fileContent.split('\n');
+  const oldBlockLines = oldBlock.split('\n');
+
+  // An empty old block cannot be located.
+  if (
+    oldBlock.length === 0 ||
+    (oldBlockLines.length === 1 && oldBlockLines[0] === '')
+  )
+    return [-1, -1];
+
+  // Strategy 1: Exact match
+  const exactSearchEnd = fileLines.length - oldBlockLines.length;
+  for (let i = 0; i <= exactSearchEnd; i++) {
+    const candidateBlock = fileLines
+      .slice(i, i + oldBlockLines.length)
+      .join('\n');
+    if (candidateBlock === oldBlock) {
+      return [i + 1, i + oldBlockLines.length];
+    }
+  }
+
+  // Strategy 2: Fuzzy match (ignore ALL whitespace variations)
+  const normalize = (text: string): string =>
+    text
+      .split('\n')
+      .map(
+        (line) =>
+          line
+            .replace(/\s/g, ' ') // Replaces all whitespace types (tabs, non-breaking spaces, etc.) with a regular space
+            .trim(), // Removes all leading AND trailing whitespace
+      )
+      .join('\n');
+  const oldBlockNormalized = normalize(oldBlock);
+
+  if (oldBlockNormalized === '') return [-1, -1];
+
+  // Use a smaller window for fuzzy matching to avoid incorrect matches.
+  const fuzzySearchEnd = fileLines.length - oldBlockLines.length;
+  for (let i = 0; i <= fuzzySearchEnd; i++) {
+    const candidateBlock = fileLines
+      .slice(i, i + oldBlockLines.length)
+      .join('\n');
+    if (normalize(candidateBlock) === oldBlockNormalized) {
+      return [i + 1, i + oldBlockLines.length];
+    }
+  }
+
+  return [-1, -1];
+}
+
+/**
+ * Applies a single hunk to the in-memory content of a file.
+ * @param currentContent The current content of the file.
+ * @param hunk The parsed hunk object to apply.
+ * @return The modified file content.
+ */
+function applySingleHunk(currentContent: string, hunk: Hunk): string {
+  const [oldBlock, newBlock] = extractOldAndNewBlocksFromHunk(
+    hunk.originalHunk,
+  );
+
+  // A no-op hunk is one where the old and new blocks are identical after
+  // removing context. It should not be treated as a failure.
+  if (oldBlock === newBlock) {
+    return currentContent;
+  }
+
+  // For file creation, the first hunk applies to an empty document.
+  if (currentContent === '') {
+    return newBlock;
+  }
+
+  // For pure insertions, the oldBlock consists only of context lines.
+  // For deletions, the newBlock consists only of context lines.
+  const [startLine] = findOldBlockInFile(currentContent, oldBlock);
+
+  if (startLine === -1) {
+    // Before failing, check if the patch has already been applied.
+    const [alreadyAppliedStart] = findOldBlockInFile(currentContent, newBlock);
+    if (alreadyAppliedStart !== -1) {
+      // The new block is already in the file, so we can consider this a success.
+      console.log('INFO: Hunk seems to be already applied. Skipping.');
+      return currentContent;
+    }
+    throw new PatchError(
+      `Could not locate context for hunk:\n${hunk.originalHunk}`,
+    );
+  }
+
+  // Reconstruct file with the replacement using splice for accuracy
+  const fileLines = currentContent.split('\n');
+  const oldBlockLines = oldBlock.split('\n');
+  const newBlockLines = newBlock.split('\n');
+
+  // Replace the old block with the new block.
+  fileLines.splice(startLine - 1, oldBlockLines.length, ...newBlockLines);
+  const newFileContent = fileLines.join('\n');
+
+  // This check is important for no-op hunks or subtle whitespace issues.
+  if (newFileContent === currentContent) {
+    throw new PatchError(
+      'Old block was found, but replacement did not change file content. ' +
+        'This can happen with subtle whitespace differences.',
+    );
+  }
+  return newFileContent;
+}
+
+/**
+ * Checks if a hunk represents a file deletion.
+ * @param hunk The parsed hunk object.
+ * @returns True if it's a file deletion hunk.
+ */
+export function isFileDeletionHunk(hunk: Hunk): boolean {
+  return hunk.newStart === 0 && hunk.newCount === 0;
+}
+
+/**
+ * Applies a series of patch hunks to a single file.
+ * @param filepath The path to the file to be patched.
+ * @param hunks An array of hunk strings for this file.
+ * @param config The secure directory for operations.
+ * @return A summary string of the operations and a list of failed hunks.
+ */
+async function applyHunksToFile(
+  filepath: string,
+  parsedHunks: Hunk[],
+  config: PatcherConfig,
+  fsService: FileSystemService,
+): Promise<{ summary: string; failedHunks: Hunk[] }> {
+  const safeFilepath = path.resolve(config.getTargetDir(), filepath);
+  if (!config.isPathWithinWorkspace(safeFilepath)) {
+    throw new PatchError(
+      `Security violation: Attempted to patch file '${filepath}' ` +
+        `which is outside of the designated working directory.`,
+    );
+  }
+  let originalContent: string;
+  let fileExists = true;
+
+  try {
+    originalContent = await fsService.readTextFile(safeFilepath);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      fileExists = false;
+      originalContent = '';
+    } else {
+      throw error;
+    }
+  }
+
+  // Handle file deletion as a special case.
+  if (parsedHunks.length > 0 && isFileDeletionHunk(parsedHunks[0])) {
+    if (fileExists) {
+      await fsService.unlink(safeFilepath);
+    }
+    const summary = `✅ ALL HUNKS APPLIED SUCCESSFULLY for ${filepath}\n\n✅ Hunk 1: Deleted file.`;
+    return { summary, failedHunks: [] };
+  }
+
+  // Standard hunk application for both existing and new files.
+  // The originalContent will be an empty string for new files.
+  const { newContent, appliedHunks, failedHunks, noOpHunks } =
+    applyHunksToContent(originalContent, parsedHunks);
+
+  const successfulHunks = appliedHunks.length;
+  const localFailedHunks = failedHunks.map((f) => f.hunk);
+  const hunkResults: string[] = [];
+
+  // Generate hunk results for summary
+  parsedHunks.forEach((hunk, i) => {
+    const failure = failedHunks.find(
+      (f) => f.hunk.originalHunk === hunk.originalHunk,
+    );
+    if (failure) {
+      hunkResults.push(
+        `❌ Hunk ${i + 1} (L${hunk.oldStart}): FAILED - ${failure.error.message}`,
+      );
+    } else if (noOpHunks.includes(hunk)) {
+      hunkResults.push(
+        `✅ Hunk ${i + 1} (L${hunk.oldStart}): Skipped as no-op.`,
+      );
+    } else {
+      hunkResults.push(
+        `✅ Hunk ${i + 1} (L${hunk.oldStart}): Applied successfully.`,
+      );
+    }
+  });
+
+  // Write the file back to disk if any changes were successful.
+  if (successfulHunks > 0 && newContent !== originalContent) {
+    // Ensure the directory exists before writing, crucial for new files.
+    await fsService.mkdir(path.dirname(safeFilepath), { recursive: true });
+    await fsService.writeTextFile(safeFilepath, newContent);
+  }
+
+  let status = '❌ ALL HUNKS FAILED';
+  if (successfulHunks > 0 && failedHunks.length === 0) {
+    status = '✅ ALL HUNKS APPLIED SUCCESSFULLY';
+  } else if (successfulHunks > 0 && failedHunks.length > 0) {
+    status = `⚠️ PARTIAL SUCCESS: ${successfulHunks}/${parsedHunks.length} hunks applied`;
+  } else if (
+    successfulHunks === 0 &&
+    failedHunks.length === 0 &&
+    noOpHunks.length > 0
+  ) {
+    status = '✅ ALL HUNKS APPLIED SUCCESSFULLY';
+  }
+
+  const summary = [`${status} for ${filepath}`, '', ...hunkResults].join('\n');
+  return { summary, failedHunks: localFailedHunks };
+}
+
+/**
+ * Applies an array of hunks to a string content. This is a pure function
+ * that operates in-memory.
+ * Takes original file content and an array of hunks to apply. It will return
+ * the fully patched content and an array of any hunks that failed to match and
+ * apply.
+ * @param content The original content of the file.
+ * @param hunks An array of Hunk objects to apply.
+ * @returns An object containing the new content and a list of failed hunks.
+ */
+export function applyHunksToContent(
+  content: string,
+  hunks: Hunk[],
+): {
+  newContent: string;
+  appliedHunks: Hunk[];
+  failedHunks: Array<{ hunk: Hunk; error: PatchError }>;
+  noOpHunks: Hunk[];
+} {
+  let modifiedContent = content;
+  const appliedHunks: Hunk[] = [];
+  const failedHunks: Array<{ hunk: Hunk; error: PatchError }> = [];
+  const noOpHunks: Hunk[] = [];
+
+  const isNewFile = content === '';
+
+  // For new files, hunks must be applied in forward order based on their
+  // position in the new file. For existing files, applying in reverse order
+  // is safer to avoid line number shifts from affecting subsequent hunks.
+  const sortedHunks = isNewFile
+    ? [...hunks].sort((a, b) => a.newStart - b.newStart)
+    : [...hunks].sort((a, b) => b.oldStart - a.oldStart);
+
+  for (const hunk of sortedHunks) {
+    const [oldBlock, newBlock] = extractOldAndNewBlocksFromHunk(
+      hunk.originalHunk,
+    );
+    if (oldBlock === newBlock) {
+      noOpHunks.push(hunk);
+      continue;
+    }
+    try {
+      modifiedContent = applySingleHunk(modifiedContent, hunk);
+      // If applySingleHunk completes without an error, it's a success.
+      appliedHunks.push(hunk);
+    } catch (e: unknown) {
+      // When applying in forward order, we push to the end.
+      // When applying in reverse, we unshift to the front to maintain order.
+      if (isNewFile) {
+        failedHunks.push({ hunk, error: e as PatchError });
+      } else {
+        failedHunks.unshift({ hunk, error: e as PatchError });
+      }
+    }
+  }
+
+  return { newContent: modifiedContent, appliedHunks, failedHunks, noOpHunks };
+}
+
+const defaultFsService = new StandardFileSystemService();
+
+/**
+ * Applies a map of file hunks to the file system.
+ * @param fileHunks A map from filenames to Hunk objects.
+ * @param config The secure base directory for file operations.
+ * @returns A comprehensive summary report of the patching operation.
+ */
+export async function applyPatchesToFS(
+  fileHunks: Map<string, Hunk[]>,
+  config: PatcherConfig,
+  totalFilesOverride?: number,
+  fsService: FileSystemService = defaultFsService,
+): Promise<string> {
+  if (!fileHunks || fileHunks.size === 0) {
+    return 'ERROR: No valid patches found in input. Please provide a standard unified diff.';
+  }
+
+  const results: string[] = [];
+  const allFailedHunks: string[] = [];
+  let successfulFiles = 0;
+  let failedFiles = 0;
+
+  for (const [filepath, hunks] of fileHunks.entries()) {
+    try {
+      const { summary, failedHunks } = await applyHunksToFile(
+        filepath,
+        hunks,
+        config,
+        fsService,
+      );
+      results.push(summary);
+
+      if (failedHunks.length > 0) {
+        failedFiles++;
+        const failedHunkBlock = [
+          `--- a/${filepath}`,
+          `+++ b/${filepath}`,
+          ...failedHunks.map((h) => h.originalHunk),
+        ].join('\n');
+        allFailedHunks.push(failedHunkBlock);
+      } else {
+        successfulFiles++;
+      }
+    } catch (e: unknown) {
+      failedFiles++;
+      results.push(`❌ FAILED: ${filepath}\n   Error: ${(e as Error).message}`);
+      // Add all hunks for this file to the failed list on catastrophic error
+      const failedHunkBlock = [
+        `--- a/${filepath}`,
+        `+++ b/${filepath}`,
+        ...hunks.map((h) => h.originalHunk),
+      ].join('\n');
+      allFailedHunks.push(failedHunkBlock);
+    }
+  }
+
+  // Build the final report string
+  const totalFiles =
+    totalFilesOverride !== undefined
+      ? totalFilesOverride
+      : successfulFiles + failedFiles;
+  let finalReport = '';
+  if (totalFiles > 1) {
+    finalReport += `📊 PATCH SUMMARY: ${successfulFiles}/${totalFiles} files patched successfully.\n`;
+    if (failedFiles > 0) {
+      finalReport += `⚠️  ${failedFiles} files require manual intervention.\n`;
+    }
+    finalReport += '\n';
+  }
+
+  finalReport += results.join('\n\n');
+
+  if (allFailedHunks.length > 0) {
+    finalReport += '\n\n' + '🔧 FAILED HUNKS FOR MANUAL APPLICATION\n';
+    finalReport += `${'='.repeat(60)}\n`;
+    finalReport += `${allFailedHunks.join('\n')}\n`;
+    finalReport += `${'='.repeat(60)}\n`;
+    finalReport +=
+      '💡 TIP: Review the failed hunks, add more context lines from the original file, and try again.\n';
+  }
+
+  return finalReport;
+}


### PR DESCRIPTION
    feat: Introduce Patch tool for applying unified diffs

    For LLM-generated code to converge on large projects, the model must
    make focused changes rather than attempting full rewrites. This patch-based
    approach is key to iterative refinement. LLMs are natively proficient at
    this, as they are trained on vast datasets of code from version control
    repositories, making the generation of a standard unified diff a natural
    and robust capability.

    On the other hand, the existing `replace` tool is fundamentally brittle from an
    engineering perspective. It forces the LLM to simultaneously manage two
    distinct concerns: the complex syntax of the code itself (like Python
    indentation) and the formatting characters of the string literal (like `\n`)
    when composing a single, multi-line string. This dual responsibility is a frequent
    source of correctness errors and is a flawed approach for generating reliable code.

    This commit replaces the existing 'replace' tool with a new `patch` tool that
    applies standard unified diffs directly. This creates a proper separation
    of concerns, allowing the LLM to focus on generating correct code while the
    agent handles the mechanical application.

    Key benefits include:

    * **Improves Correctness**: By using a structured format, it prevents the
        common errors associated with string manipulation and escaping, leading
        to more reliable code generation.
    * **Workflow Efficiency**: Applies complex, multi-file changes
        (including file creation and deletion) in a single operation,
        dramatically reducing the number of LLM interactions.
    * **Robust Application**: Uses a content-based matching algorithm that is
        resilient to line number shifts, resulting in a much higher success
        rate for applying patches.
    * **Self-Healing Patches**: Automatically uses an LLM to fix hunks that
        fail due to context mismatches, further increasing reliability.
    * **Iterative Refinement**: Applies all successful hunks even if others
        fail, returning a clean diff of only the failures. This enables a
        powerful workflow where the LLM only needs to correct what went wrong.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->
Assume I have a Python code snippet like this:
```
def test_multiple_hunks():
  """Original test - kept for compatibility."""
  test_instance = TestPatchBehaviors()
  content = """import os

def func1():
    pass

def func2():
    pass
"""
  file_path = test_instance.create_temp_file(content)

  try:
    diff_str = f"""--- a/test.py
+++ b/test.py
@@ -1,3 +1,4 @@
 import os
+import sys

 def func1():

@@ -3,4 +4,5 @@
 def func1():
+    print("func1")
     pass

"""

    result = diff_patch(diff_str, working_directory=os.getcwd())
    assert "SUCCESS" in result
  finally:
    test_instance.cleanup()
 ```
 Which has strings inside strings, and I want to edit some line inside the string block, while maintain its correctness, any string based solution would be very hard to achieve the correct editing -- this is inherently a work that suitable for a deterministic tool (like the diff patch tool), not for LLM (to acting like an editor), as an intelligent entity.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
