### PR TITLE
feat: handle nested gitignore files

### DIFF
--- a/packages/core/src/utils/gitIgnoreParser.test.ts
+++ b/packages/core/src/utils/gitIgnoreParser.test.ts
@@ -193,6 +193,80 @@ src/*.tmp
     });
   });
 
+  describe('nested .gitignore files', () => {
+    beforeEach(async () => {
+      await setupGitRepo();
+      // Root .gitignore
+      await createTestFile('.gitignore', 'root-ignored.txt');
+      // Nested .gitignore 1
+      await createTestFile('a/.gitignore', '/b\nc');
+      // Nested .gitignore 2
+      await createTestFile('a/d/.gitignore', 'e.txt\nf/g');
+    });
+
+    it('should handle nested .gitignore files correctly', async () => {
+      parser.loadGitRepoPatterns();
+
+      // From root .gitignore
+      expect(parser.isIgnored('root-ignored.txt')).toBe(true);
+      expect(parser.isIgnored('a/root-ignored.txt')).toBe(true);
+
+      // From a/.gitignore: /b
+      expect(parser.isIgnored('a/b')).toBe(true);
+      expect(parser.isIgnored('b')).toBe(false);
+      expect(parser.isIgnored('a/x/b')).toBe(false);
+
+      // From a/.gitignore: c
+      expect(parser.isIgnored('a/c')).toBe(true);
+      expect(parser.isIgnored('a/x/y/c')).toBe(true);
+      expect(parser.isIgnored('c')).toBe(false);
+
+      // From a/d/.gitignore: e.txt
+      expect(parser.isIgnored('a/d/e.txt')).toBe(true);
+      expect(parser.isIgnored('a/d/x/e.txt')).toBe(true);
+      expect(parser.isIgnored('a/e.txt')).toBe(false);
+
+      // From a/d/.gitignore: f/g
+      expect(parser.isIgnored('a/d/f/g')).toBe(true);
+      expect(parser.isIgnored('a/f/g')).toBe(false);
+    });
+
+    it('should correctly transform patterns from nested gitignore files', () => {
+      parser.loadGitRepoPatterns();
+      const patterns = parser.getPatterns();
+
+      // From root .gitignore
+      expect(patterns).toContain('root-ignored.txt');
+
+      // From a/.gitignore
+      expect(patterns).toContain('/a/b'); // /b becomes /a/b
+      expect(patterns).toContain('/a/**/c'); // c becomes /a/**/c
+
+      // From a/d/.gitignore
+      expect(patterns).toContain('/a/d/**/e.txt'); // e.txt becomes /a/d/**/e.txt
+      expect(patterns).toContain('/a/d/f/g'); // f/g becomes /a/d/f/g
+    });
+  });
+
+  describe('precedence rules', () => {
+    it('should prioritize root .gitignore over .git/info/exclude', async () => {
+      await setupGitRepo();
+      // Exclude all .log files
+      await createTestFile(path.join('.git', 'info', 'exclude'), '*.log');
+      // But make an exception in the root .gitignore
+      await createTestFile('.gitignore', '!important.log');
+
+      parser.loadGitRepoPatterns();
+
+      expect(parser.isIgnored('some.log')).toBe(true);
+      expect(parser.isIgnored('important.log')).toBe(false);
+      expect(parser.isIgnored(path.join('subdir', 'some.log'))).toBe(true);
+      expect(parser.isIgnored(path.join('subdir', 'important.log'))).toBe(
+        false,
+      );
+    });
+  });
+
   describe('getIgnoredPatterns', () => {
     it('should return the raw patterns added', async () => {
       await setupGitRepo();

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -52,7 +52,7 @@ export class GitIgnoreParser implements GitIgnoreFilter {
     try {
       const entries = fs.readdirSync(dir, { withFileTypes: true });
       for (const entry of entries) {
-        if (entry.name === '.git' || entry.name === 'node_modules') {
+        if (entry.name === '.git') {
           continue;
         }
         if (entry.isDirectory()) {

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -29,9 +29,38 @@ export class GitIgnoreParser implements GitIgnoreFilter {
     // Always ignore .git directory regardless of .gitignore content
     this.addPatterns(['.git']);
 
-    const patternFiles = ['.gitignore', path.join('.git', 'info', 'exclude')];
-    for (const pf of patternFiles) {
-      this.loadPatterns(pf);
+    this.loadPatterns(path.join('.git', 'info', 'exclude'));
+    this.findAndLoadGitignoreFiles(this.projectRoot);
+  }
+
+  private findAndLoadGitignoreFiles(dir: string): void {
+    const relativeDir = path.relative(this.projectRoot, dir);
+
+    // For sub-directories, check if they are ignored before proceeding.
+    // The root directory (relativeDir === '') should not be checked.
+    if (relativeDir && this.isIgnored(relativeDir)) {
+      return;
+    }
+
+    // Load patterns from .gitignore in the current directory
+    const gitignorePath = path.join(dir, '.gitignore');
+    if (fs.existsSync(gitignorePath)) {
+      this.loadPatterns(path.relative(this.projectRoot, gitignorePath));
+    }
+
+    // Recurse into subdirectories
+    try {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.name === '.git' || entry.name === 'node_modules') {
+          continue;
+        }
+        if (entry.isDirectory()) {
+          this.findAndLoadGitignoreFiles(path.join(dir, entry.name));
+        }
+      }
+    } catch (_error) {
+      // ignore readdir errors
     }
   }
 
@@ -44,10 +73,72 @@ export class GitIgnoreParser implements GitIgnoreFilter {
       // ignore file not found
       return;
     }
+
+    // .git/info/exclude file patterns are relative to project root and not file directory
+    const isExcludeFile =
+      patternsFileName.replace(/\\/g, '/') === '.git/info/exclude';
+    const relativeBaseDir = isExcludeFile
+      ? '.'
+      : path.dirname(patternsFileName);
+
     const patterns = (content ?? '')
       .split('\n')
       .map((p) => p.trim())
-      .filter((p) => p !== '' && !p.startsWith('#'));
+      .filter((p) => p !== '' && !p.startsWith('#'))
+      .map((p) => {
+        const isNegative = p.startsWith('!');
+        if (isNegative) {
+          p = p.substring(1);
+        }
+
+        const isAnchoredInFile = p.startsWith('/');
+        if (isAnchoredInFile) {
+          p = p.substring(1);
+        }
+
+        // An empty pattern can result from a negated pattern like `!`,
+        // which we can ignore.
+        if (p === '') {
+          return '';
+        }
+
+        let newPattern = p;
+        if (relativeBaseDir && relativeBaseDir !== '.') {
+          // Only in nested .gitignore files, the patterns need to be modified according to:
+          // - If `a/b/.gitignore` defines `/c` then it needs to be changed to `/a/b/c`
+          // - If `a/b/.gitignore` defines `c` then it needs to be changed to `/a/b/**/c`
+          // - If `a/b/.gitignore` defines `c/d` then it needs to be changed to `/a/b/c/d`
+
+          if (!isAnchoredInFile && !p.includes('/')) {
+            // If no slash and not anchored in file, it matches files in any
+            // subdirectory.
+            newPattern = path.join('**', p);
+          }
+
+          // Prepend the .gitignore file's directory.
+          newPattern = path.join(relativeBaseDir, newPattern);
+
+          // Anchor the pattern to a nested gitignore directory.
+          if (!newPattern.startsWith('/')) {
+            newPattern = '/' + newPattern;
+          }
+        }
+
+        // Anchor the pattern if originally anchored
+        if (isAnchoredInFile && !newPattern.startsWith('/')) {
+          newPattern = '/' + newPattern;
+        }
+
+        if (isNegative) {
+          newPattern = '!' + newPattern;
+        }
+
+        // Even in windows, Ignore expects forward slashes.
+        newPattern = newPattern.replace(/\\/g, '/');
+
+        return newPattern;
+      })
+      .filter((p) => p !== '');
     this.addPatterns(patterns);
   }
 


### PR DESCRIPTION
## TLDR

This PR enhances the GitIgnoreParser to correctly  process .gitignore files located in subdirectories.  Previously, only the root .gitignore was considered.  Now, rules defined in nested .gitignore files are  properly applied relative to their location within the  project structure.

##  Dive Deeper

 The primary motivation for this change is to align the  tool's behavior with standard Git functionality, where  .gitignore files can be placed in any directory to  specify ignore patterns for that part of the tree.

The key modifications are within  packages/core/src/utils/gitIgnoreParser.ts:
   - A new findAndLoadGitignoreFiles method recursively scans the project directory for .gitignore files.
   - The logic in loadPatterns has been updated to transform patterns from these nested files. For instance, a pattern like build/ in a .gitignore located at src/component/ will be correctly interpreted to ignore src/component/build/ and not the root build/ directory.

   - The parser now correctly handles pattern precedence, ensuring that rules in nested .gitignore files are
     applied correctly alongside the root .gitignore and .git/info/exclude.

  Comprehensive unit tests have been added in packages/core/src/utils/gitIgnoreParser.test.ts to  validate the new functionality, including tests for nested patterns and precedence rules.

##  Reviewer Test Plan

   1. Setup test project:
```
 # Create a root directory for the test project and enter it
 mkdir test_gitignore_project && cd test_gitignore_project
 
 # Initialize a Git repository
 git init
 
 # Create a nested directory structure
 mkdir -p dir1/dir2/dir3
 mkdir -p dir4
 
 # Create various files to test against the ignore rules
 touch root_file.txt
 touch root_file.log
 touch dir1/file_in_dir1.txt
 touch dir1/file_in_dir1.log
 touch dir1/file_to_keep.tmp
 touch dir1/file_to_ignore.tmp
 touch dir1/dir2/file_in_dir2.txt
 touch dir1/dir2/dir3/file_in_dir3.txt
 touch dir4/file_in_dir4.log
 
 # Create .gitignore files at different levels
 
 # Root .gitignore: ignores all .log files
 echo "*.log" > .gitignore
 
 # Nested .gitignore in dir1: ignores .tmp files, but negates the rule for a specific file
 echo -e "*.tmp\n!file_to_keep.tmp" > dir1/.gitignore
 
 # Nested .gitignore in dir1/dir2: ignores everything inside, but un-ignores dir3
 echo -e "*\n!/dir3/" > dir1/dir2/.gitignore
 
 # Add all files to staging to see the effect of the .gitignore rules
 git add .
 
 # Check the git status to see which files are tracked and which are ignored
 echo "\n--- Git Status ---"
 git status --short
```
2. Should see this output:
```
A  .gitignore
A  dir1/.gitignore
A  dir1/file_in_dir1.txt
A  dir1/file_to_keep.tmp
A  root_file.txt
```

3. Now run this command in Gemini built from this branch:
<img width="1115" height="495" alt="image" src="https://github.com/user-attachments/assets/8ef999d4-bd01-4e89-905a-8e225bcd6a72" />

##  Testing Matrix


|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
Fixes #3072