### PR TITLE
Feat/correct preflight script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint:ci": "eslint . --ext .ts,.tsx --max-warnings 0 && eslint integration-tests --max-warnings 0",
     "format": "prettier --experimental-cli --write .",
     "typecheck": "npm run typecheck --workspaces --if-present",
-    "preflight": "npm run clean && npm ci && npm run format && npm run lint:ci && npm run build && npm run typecheck && npm run test:ci",
+    "preflight": "npm run clean && npm ci && npm run format && concurrently \"npm run lint:ci\" \"npm run typecheck\" && npm run build && npm run test:ci",
     "prepare": "npm run bundle",
     "prepare:package": "node scripts/prepare-package.js",
     "release:version": "node scripts/version.js",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint:ci": "eslint . --ext .ts,.tsx --max-warnings 0 && eslint integration-tests --max-warnings 0",
     "format": "prettier --experimental-cli --write .",
     "typecheck": "npm run typecheck --workspaces --if-present",
-    "preflight": "npm run clean && npm ci && npm run format && concurrently \"npm run lint:ci\" \"npm run typecheck\" && npm run build && npm run test:ci",
+    "preflight": "npm run clean && npm ci && npm run format && npm run build && concurrently \"npm run lint:ci\" \"npm run typecheck\" && npm run test:ci",
     "prepare": "npm run bundle",
     "prepare:package": "node scripts/prepare-package.js",
     "release:version": "node scripts/version.js",


### PR DESCRIPTION
## TLDR

Fixes a bug in the preflight script by adjusting the task execution order. The `npm run typecheck` script was running before `npm run build`, causing an error. This Pull Request (PR) ensures the build is complete before type checking starts, while still keeping the parallel execution of the lint and type check tasks.



## Dive Deeper

The preflight script has been updated to respect the command dependency chain. The previous version of the script ran `npm run typecheck` in parallel with `npm run lint:ci`, but typecheck needs files generated by the `npm run build` command.


## Reviewer Test Plan

To validate this change, run the preflight script on this PR's branch. The script should run to completion without any type errors.

`npm run preflight`