### PR TITLE
Fix(core): Log exact model version from API response

### DIFF
--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -60,6 +60,7 @@ export class LoggingContentGenerator implements ContentGenerator {
 
   private _logApiResponse(
     durationMs: number,
+    model: string,
     prompt_id: string,
     usageMetadata?: GenerateContentResponseUsageMetadata,
     responseText?: string,
@@ -67,7 +68,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     logApiResponse(
       this.config,
       new ApiResponseEvent(
-        this.config.getModel(),
+        model,
         durationMs,
         prompt_id,
         this.config.getContentGeneratorConfig()?.authType,
@@ -112,6 +113,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       const durationMs = Date.now() - startTime;
       this._logApiResponse(
         durationMs,
+        response.modelVersion || '',
         userPromptId,
         response.usageMetadata,
         JSON.stringify(response),
@@ -171,6 +173,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       this._logApiResponse(
         durationMs,
         userPromptId,
+        responses[0].modelVersion || '',
         lastUsageMetadata,
         JSON.stringify(responses),
       );

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -173,7 +173,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       this._logApiResponse(
         durationMs,
         userPromptId,
-        responses[0].modelVersion || '',
+        responses[0]?.modelVersion || '',
         lastUsageMetadata,
         JSON.stringify(responses),
       );


### PR DESCRIPTION
## TLDR

It was logging config.getModel() which is always gemini-2.5-pro.

## TLDR

This pull request updates the API response logging to use the precise model version returned from the backend (`response.modelVersion`) rather than the model specified in the local configuration. This enhances the accuracy of our telemetry data.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
