### PR TITLE
improve performance of shell commands with lots of output

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -133,7 +133,7 @@ describe('ShellExecutionService', () => {
 
       expect(onOutputEventMock).toHaveBeenCalledWith({
         type: 'data',
-        chunk: 'file1.txt',
+        chunk: 'file1.txt\n',
       });
     });
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -348,7 +348,6 @@ export class ShellExecutionService {
         });
         let processingChain = Promise.resolve();
         let decoder: TextDecoder | null = null;
-        let output = '';
         const outputChunks: Buffer[] = [];
         const error: Error | null = null;
         let exited = false;
@@ -385,9 +384,10 @@ export class ShellExecutionService {
                 if (isStreamingRawContent) {
                   const decodedChunk = decoder.decode(data, { stream: true });
                   headlessTerminal.write(decodedChunk, () => {
-                    const newStrippedOutput = getFullText(headlessTerminal);
-                    output = newStrippedOutput;
-                    onOutputEvent({ type: 'data', chunk: newStrippedOutput });
+                    onOutputEvent({
+                      type: 'data',
+                      chunk: stripAnsi(decodedChunk),
+                    });
                     resolve();
                   });
                 } else {
@@ -420,7 +420,7 @@ export class ShellExecutionService {
 
               resolve({
                 rawOutput: finalBuffer,
-                output,
+                output: getFullText(headlessTerminal),
                 exitCode,
                 signal: signal ?? null,
                 error,

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -313,7 +313,7 @@ describe('ShellTool', () => {
         // Send a second chunk. THIS event triggers the update with the CUMULATIVE content.
         mockShellOutputCallback({
           type: 'data',
-          chunk: 'hello world',
+          chunk: 'world',
         });
 
         // It should have been called once now with the combined output.

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -149,7 +149,7 @@ class ShellToolInvocation extends BaseToolInvocation<
           switch (event.type) {
             case 'data':
               if (isBinaryStream) break;
-              cumulativeOutput = event.chunk;
+              cumulativeOutput += event.chunk;
               currentDisplayOutput = cumulativeOutput;
               if (Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS) {
                 shouldUpdate = true;

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -132,6 +132,7 @@ class ShellToolInvocation extends BaseToolInvocation<
       );
 
       let cumulativeOutput = '';
+      let outputChunks: string[] = [cumulativeOutput];
       let lastUpdateTime = Date.now();
       let isBinaryStream = false;
 
@@ -149,9 +150,11 @@ class ShellToolInvocation extends BaseToolInvocation<
           switch (event.type) {
             case 'data':
               if (isBinaryStream) break;
-              cumulativeOutput += event.chunk;
-              currentDisplayOutput = cumulativeOutput;
+              outputChunks.push(event.chunk);
               if (Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS) {
+                cumulativeOutput = outputChunks.join('');
+                outputChunks = [cumulativeOutput];
+                currentDisplayOutput = cumulativeOutput;
                 shouldUpdate = true;
               }
               break;


### PR DESCRIPTION
## TLDR

Fix the performance of the pty code path for shell commands.

## Dive Deeper

Previously, on each chunk of output received from the terminal we would then re-compute the entire terminal output from its buffer, which was very inefficient.

Now, we just send each chunk as an event instead of the entire thing, and accumulate the total output on the receiving end of those events. Note that this is still potentially slow though, since we are still re-creating the full output string when we go to update the display (if there are new chunks) - although it should be a fair bit better than it was.

The behavior between the pty and fallback modes should also be more consistent now (that mode already was sending chunks, and I think was likely somewhat broken since the entire output was being bashed over instead of concatenated).

~This could be further improved by collecting the chunks and only concatenating them when we decide to do a UI update (see the checks for OUTPUT_UPDATE_INTERVAL_MS).~ implemented this as well

## Reviewer Test Plan

You can ask gemini to run a command with lots of shell output and watch the CPU usage of gemini cli, or measure it in some other manner, with and without this change.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #5411