### PR TITLE
fix: unstable value cause unnecessary rerender

### DIFF
--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -21,7 +21,7 @@ import type {
   EditorType,
 } from '@google/gemini-cli-core';
 import { CoreToolScheduler } from '@google/gemini-cli-core';
-import { useCallback, useState, useMemo } from 'react';
+import { useCallback, useState, useMemo, useRef } from 'react';
 import type {
   HistoryItemToolGroup,
   IndividualToolCallDisplay,
@@ -71,6 +71,10 @@ export function useReactToolScheduler(
   getPreferredEditor: () => EditorType | undefined,
   onEditorClose: () => void,
 ): [TrackedToolCall[], ScheduleFn, MarkToolsAsSubmittedFn] {
+  const onCompleteRef = useRef(onComplete);
+
+  onCompleteRef.current = onComplete;
+
   const [toolCallsForDisplay, setToolCallsForDisplay] = useState<
     TrackedToolCall[]
   >([]);
@@ -107,9 +111,9 @@ export function useReactToolScheduler(
 
   const allToolCallsCompleteHandler: AllToolCallsCompleteHandler = useCallback(
     async (completedToolCalls) => {
-      await onComplete(completedToolCalls);
+      await onCompleteRef.current(completedToolCalls);
     },
-    [onComplete],
+    [],
   );
 
   const toolCallsUpdateHandler: ToolCallsUpdateHandler = useCallback(


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->
Today, while working on the code, I encountered an unexpected dependency issue that caused unnecessary re-renders in the `gemini-cli`. This PR aims to fix the problem

## Dive Deeper

There are so many `useCallback` hooks with dependencies. If any of these dependencies change on every render, it will cause unexpected re-renders.

> source
<img width="1566" height="1394" alt="image" src="https://github.com/user-attachments/assets/e3a5600e-b2e2-47e1-83e7-020647bc244d" />

> target
<img width="1546" height="1550" alt="image" src="https://github.com/user-attachments/assets/eeec1c72-85c7-479a-8df5-8b1986687a21" />

Unfortunately, we cannot simply optimize this by adding new callbacks, so i just create `useRef` in `useReactToolScheduler` to reference this `onComplete` function to make the `allToolCallsCompleteHandler` function are stable


<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
