### PR TITLE
Fix(extension) - Add pid into portFile

### DIFF
--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -124,7 +124,7 @@ describe('IDEServer', () => {
     const port = getPortFromMock(replaceMock);
     const expectedPortFile = path.join(
       '/tmp',
-      `gemini-ide-server-${port}.json`,
+      `gemini-ide-server-${process.ppid}-${port}.json`,
     );
     const expectedPpidPortFile = path.join(
       '/tmp',
@@ -159,7 +159,7 @@ describe('IDEServer', () => {
     const port = getPortFromMock(replaceMock);
     const expectedPortFile = path.join(
       '/tmp',
-      `gemini-ide-server-${port}.json`,
+      `gemini-ide-server-${process.ppid}-${port}.json`,
     );
     const expectedPpidPortFile = path.join(
       '/tmp',
@@ -194,7 +194,7 @@ describe('IDEServer', () => {
     const port = getPortFromMock(replaceMock);
     const expectedPortFile = path.join(
       '/tmp',
-      `gemini-ide-server-${port}.json`,
+      `gemini-ide-server-${process.ppid}-${port}.json`,
     );
     const expectedPpidPortFile = path.join(
       '/tmp',
@@ -243,7 +243,7 @@ describe('IDEServer', () => {
     const port = getPortFromMock(replaceMock);
     const expectedPortFile = path.join(
       '/tmp',
-      `gemini-ide-server-${port}.json`,
+      `gemini-ide-server-${process.ppid}-${port}.json`,
     );
     const expectedPpidPortFile = path.join(
       '/tmp',
@@ -290,7 +290,10 @@ describe('IDEServer', () => {
     await ideServer.start(mockContext);
     const replaceMock = mockContext.environmentVariableCollection.replace;
     const port = getPortFromMock(replaceMock);
-    const portFile = path.join('/tmp', `gemini-ide-server-${port}.json`);
+    const portFile = path.join(
+      '/tmp',
+      `gemini-ide-server-${process.ppid}-${port}.json`,
+    );
     const ppidPortFile = path.join(
       '/tmp',
       `gemini-ide-server-${process.ppid}.json`,
@@ -325,7 +328,7 @@ describe('IDEServer', () => {
       const port = getPortFromMock(replaceMock);
       const expectedPortFile = path.join(
         '/tmp',
-        `gemini-ide-server-${port}.json`,
+        `gemini-ide-server-${process.ppid}-${port}.json`,
       );
       const expectedPpidPortFile = path.join(
         '/tmp',

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -238,7 +238,7 @@ export class IDEServer {
           this.port = address.port;
           this.portFile = path.join(
             os.tmpdir(),
-            `gemini-ide-server-${this.port}.json`,
+            `gemini-ide-server-${process.ppid}-${this.port}.json`,
           );
           this.ppidPortFile = path.join(
             os.tmpdir(),


### PR DESCRIPTION
## TLDR

Add pid into the portFile name

## Dive Deeper

The client does not have access to the port info until the config is read. Adding pid into the portFile names help us reduce the number of configs to filter through when figuring out the current active port.

## Reviewer Test Plan

`npm run test` is the only way to test since port files are not used yet.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | x  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Makes progress on #6848 
