### PR TITLE
Feat(security) - Create a class for Oauth credential

### DIFF
--- a/packages/core/src/code_assist/oauth-credential-storage.test.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.test.ts
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { type Credentials } from 'google-auth-library';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { OAuthCredentialStorage } from './oauth-credential-storage.js';
 import { HybridTokenStorage } from '../mcp/token-storage/hybrid-token-storage.js';
+import type {OAuthCredentials} from '../mcp/token-storage/types.js';
 
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -27,7 +29,7 @@ describe('OAuthCredentialStorage', () => {
   let storage: HybridTokenStorage;
   let oauthStorage: OAuthCredentialStorage;
 
-  const mockCredentials = {
+  const mockCredentials: Credentials = {
     access_token: 'mock_access_token',
     refresh_token: 'mock_refresh_token',
     expiry_date: Date.now() + 3600 * 1000,
@@ -35,14 +37,14 @@ describe('OAuthCredentialStorage', () => {
     scope: 'email profile',
   };
 
-  const mockMcpCredentials = {
+  const mockMcpCredentials: OAuthCredentials = {
     serverName: 'main-account',
     token: {
       accessToken: 'mock_access_token',
       refreshToken: 'mock_refresh_token',
       tokenType: 'Bearer',
       scope: 'email profile',
-      expiresAt: mockCredentials.expiry_date,
+      expiresAt: mockCredentials.expiry_date!,
     },
     updatedAt: expect.any(Number),
   };
@@ -123,7 +125,7 @@ describe('OAuthCredentialStorage', () => {
     });
 
     it('should throw an error if access_token is missing', async () => {
-      const invalidCredentials = {
+      const invalidCredentials: Credentials = {
         ...mockCredentials,
         access_token: undefined,
       };

--- a/packages/core/src/code_assist/oauth-credential-storage.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.ts
@@ -50,7 +50,8 @@ export class OAuthCredentialStorage {
 
       // Fallback: Try to migrate from old file-based storage
       return await this.migrateFromFileStorage();
-    } catch (_error: unknown) {
+    } catch (error: unknown) {
+      console.error(error);
       throw new Error('Failed to load OAuth credentials');
     }
   }
@@ -89,7 +90,8 @@ export class OAuthCredentialStorage {
       // Also try to remove the old file if it exists
       const oldFilePath = path.join(os.homedir(), GEMINI_DIR, OAUTH_FILE);
       await fs.rm(oldFilePath, { force: true }).catch(() => {});
-    } catch (_error: unknown) {
+    } catch (error: unknown) {
+      console.error(error);
       throw new Error('Failed to clear OAuth credentials');
     }
   }

--- a/packages/core/src/code_assist/oauth-credential-storage.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type Credentials } from 'google-auth-library';
+import { HybridTokenStorage } from '../mcp/token-storage/hybrid-token-storage.js';
+import { OAUTH_FILE } from '../config/storage.js';
+import type { OAuthCredentials } from '../mcp/token-storage/types.js';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { promises as fs } from 'node:fs';
+
+const GEMINI_DIR = '.gemini';
+const KEYCHAIN_SERVICE_NAME = 'gemini-cli-oauth';
+const MAIN_ACCOUNT_KEY = 'main-account';
+
+export class OAuthCredentialStorage {
+  constructor(
+    private readonly storage: HybridTokenStorage = new HybridTokenStorage(
+      KEYCHAIN_SERVICE_NAME,
+    ),
+  ) {}
+
+  /**
+   * Load cached OAuth credentials
+   */
+  async loadCredentials(): Promise<Credentials | null> {
+    try {
+      const credentials = await this.storage.getCredentials(MAIN_ACCOUNT_KEY);
+
+      if (credentials?.token) {
+        const { accessToken, refreshToken, expiresAt, tokenType, scope } =
+          credentials.token;
+        // Convert from OAuthCredentials format to Google Credentials format
+        const googleCreds: Credentials = {
+          access_token: accessToken,
+          refresh_token: refreshToken || undefined,
+          token_type: tokenType || undefined,
+          scope: scope || undefined,
+        };
+
+        if (expiresAt) {
+          googleCreds.expiry_date = expiresAt;
+        }
+
+        return googleCreds;
+      }
+
+      // Fallback: Try to migrate from old file-based storage
+      return await this.migrateFromFileStorage();
+    } catch (_error: unknown) {
+      throw new Error('Failed to load OAuth credentials');
+    }
+  }
+
+  /**
+   * Save OAuth credentials
+   */
+  async saveCredentials(credentials: Credentials): Promise<void> {
+    if (!credentials.access_token) {
+      throw new Error('Attempted to save credentials without an access token.');
+    }
+
+    // Convert Google Credentials to OAuthCredentials format
+    const mcpCredentials: OAuthCredentials = {
+      serverName: MAIN_ACCOUNT_KEY,
+      token: {
+        accessToken: credentials.access_token,
+        refreshToken: credentials.refresh_token || undefined,
+        tokenType: credentials.token_type || 'Bearer',
+        scope: credentials.scope || undefined,
+        expiresAt: credentials.expiry_date || undefined,
+      },
+      updatedAt: Date.now(),
+    };
+
+    await this.storage.setCredentials(mcpCredentials);
+  }
+
+  /**
+   * Clear cached OAuth credentials
+   */
+  async clearCredentials(): Promise<void> {
+    try {
+      await this.storage.deleteCredentials(MAIN_ACCOUNT_KEY);
+
+      // Also try to remove the old file if it exists
+      const oldFilePath = path.join(os.homedir(), GEMINI_DIR, OAUTH_FILE);
+      await fs.rm(oldFilePath, { force: true }).catch(() => {});
+    } catch (_error: unknown) {
+      throw new Error('Failed to clear OAuth credentials');
+    }
+  }
+
+  /**
+   * Migrate credentials from old file-based storage to keychain
+   */
+  private async migrateFromFileStorage(): Promise<Credentials | null> {
+    const oldFilePath = path.join(os.homedir(), GEMINI_DIR, OAUTH_FILE);
+
+    let credsJson: string;
+    try {
+      credsJson = await fs.readFile(oldFilePath, 'utf-8');
+    } catch (error: unknown) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        error.code === 'ENOENT'
+      ) {
+        // File doesn't exist, so no migration.
+        return null;
+      }
+      // Other read errors should propagate.
+      throw error;
+    }
+
+    const credentials = JSON.parse(credsJson) as Credentials;
+
+    // Save to new storage
+    await this.saveCredentials(credentials);
+
+    // Remove old file after successful migration
+    await fs.rm(oldFilePath, { force: true }).catch(() => {});
+
+    return credentials;
+  }
+}

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -11,6 +11,7 @@ import * as fs from 'node:fs';
 
 export const GEMINI_DIR = '.gemini';
 export const GOOGLE_ACCOUNTS_FILENAME = 'google_accounts.json';
+export const OAUTH_FILE = 'oauth_creds.json';
 const TMP_DIR_NAME = 'tmp';
 
 export class Storage {
@@ -71,7 +72,7 @@ export class Storage {
   }
 
   static getOAuthCredsPath(): string {
-    return path.join(Storage.getGlobalGeminiDir(), 'oauth_creds.json');
+    return path.join(Storage.getGlobalGeminiDir(), OAUTH_FILE);
   }
 
   getProjectRoot(): string {


### PR DESCRIPTION
## TLDR

Create an oauth credential storage class

## Dive Deeper

This class utilizes the hybrid token storage class to store oauth credentials

## Reviewer Test Plan
`npm run test`

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | x  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Makes progress on https://github.com/google-gemini/maintainers-gemini-cli/issues/698
