### PR TITLE
feat(highlight): only highlight commands at the start of input

### DIFF
--- a/packages/cli/src/ui/utils/highlight.test.ts
+++ b/packages/cli/src/ui/utils/highlight.test.ts
@@ -37,12 +37,10 @@ describe('parseInputForHighlighting', () => {
     ]);
   });
 
-  it('should highlight a command in the middle', () => {
+  it('should not highlight a command in the middle', () => {
     const text = 'I need /help with this';
     expect(parseInputForHighlighting(text)).toEqual([
-      { text: 'I need ', type: 'default' },
-      { text: '/help', type: 'command' },
-      { text: ' with this', type: 'default' },
+      { text: 'I need /help with this', type: 'default' },
     ]);
   });
 
@@ -55,16 +53,12 @@ describe('parseInputForHighlighting', () => {
     ]);
   });
 
-  it('should highlight multiple commands and files', () => {
+  it('should highlight multiple files but not commands in the middle', () => {
     const text = 'Use /run with @file.js and also /format @another/file.ts';
     expect(parseInputForHighlighting(text)).toEqual([
-      { text: 'Use ', type: 'default' },
-      { text: '/run', type: 'command' },
-      { text: ' with ', type: 'default' },
+      { text: 'Use /run with ', type: 'default' },
       { text: '@file.js', type: 'file' },
-      { text: ' and also ', type: 'default' },
-      { text: '/format', type: 'command' },
-      { text: ' ', type: 'default' },
+      { text: ' and also /format ', type: 'default' },
       { text: '@another/file.ts', type: 'file' },
     ]);
   });
@@ -77,11 +71,10 @@ describe('parseInputForHighlighting', () => {
     ]);
   });
 
-  it('should handle highlights at the end of the string', () => {
+  it('should not highlight a command at the end of the string', () => {
     const text = 'Get help with /help';
     expect(parseInputForHighlighting(text)).toEqual([
-      { text: 'Get help with ', type: 'default' },
-      { text: '/help', type: 'command' },
+      { text: 'Get help with /help', type: 'default' },
     ]);
   });
 
@@ -93,12 +86,10 @@ describe('parseInputForHighlighting', () => {
     ]);
   });
 
-  it('should handle commands with dashes and numbers', () => {
+  it('should not highlight a command with dashes and numbers in the middle', () => {
     const text = 'Run /command-123 now';
     expect(parseInputForHighlighting(text)).toEqual([
-      { text: 'Run ', type: 'default' },
-      { text: '/command-123', type: 'command' },
-      { text: ' now', type: 'default' },
+      { text: 'Run /command-123 now', type: 'default' },
     ]);
   });
 });

--- a/packages/cli/src/ui/utils/highlight.ts
+++ b/packages/cli/src/ui/utils/highlight.ts
@@ -9,7 +9,7 @@ export type HighlightToken = {
   type: 'default' | 'command' | 'file';
 };
 
-const HIGHLIGHT_REGEX = /(\/[a-zA-Z0-9_-]+|@[a-zA-Z0-9_./-]+)/g;
+const HIGHLIGHT_REGEX = /^(\/[a-zA-Z0-9_-]+)|(@[a-zA-Z0-9_./-]+)/g;
 
 export function parseInputForHighlighting(
   text: string,


### PR DESCRIPTION
## TLDR

Only highlights commands at the start of a prompt

<img width="1320" height="564" alt="CleanShot 2025-09-04 at 16 27 26@2x" src="https://github.com/user-attachments/assets/cc2927dc-2d61-4d6a-bdb1-1b238ef0afc1" />


## Dive Deeper

The previous highlighting logic would highlight any word starting with a / as a command, regardless of its position in the input. 

This change adjusts the regular expression to only match commands when they appear at the very beginning of the string.

This also updates the tests to reflect the new behavior.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Fixes #7651
