### PR TITLE
feat(triage): add status/bot-triaged label after triage

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -288,17 +288,19 @@ jobs:
 
             const issueNumber = parseInt(process.env.ISSUE_NUMBER);
             const explanation = parsedLabels.explanation || '';
+            const labelsToSet = parsedLabels.labels_to_set || [];
+            labelsToSet.push('status/bot-triaged');
 
             // Set labels based on triage result
-            if (parsedLabels.labels_to_set && parsedLabels.labels_to_set.length > 0) {
+            if (labelsToSet.length > 0) {
               await github.rest.issues.setLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issueNumber,
-                labels: parsedLabels.labels_to_set
+                labels: labelsToSet
               });
               const explanationInfo = explanation ? ` - ${explanation}` : '';
-              core.info(`Successfully set labels for #${issueNumber}: ${parsedLabels.labels_to_set.join(', ')}${explanationInfo}`);
+              core.info(`Successfully set labels for #${issueNumber}: ${labelsToSet.join(', ')}${explanationInfo}`);
             } else {
               // If no labels to set, leave the issue as is
               const explanationInfo = explanation ? ` - ${explanation}` : '';

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -286,15 +286,18 @@ jobs:
                 continue;
               }
 
-              if (entry.labels_to_add && entry.labels_to_add.length > 0) {
+              const labelsToAdd = entry.labels_to_add || [];
+              labelsToAdd.push('status/bot-triaged');
+
+              if (labelsToAdd.length > 0) {
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issueNumber,
-                  labels: entry.labels_to_add
+                  labels: labelsToAdd
                 });
                 const explanation = entry.explanation ? ` - ${entry.explanation}` : '';
-                core.info(`Successfully added labels for #${issueNumber}: ${entry.labels_to_add.join(', ')}${explanation}`);
+                core.info(`Successfully added labels for #${issueNumber}: ${labelsToAdd.join(', ')}${explanation}`);
               }
 
               if (entry.labels_to_remove && entry.labels_to_remove.length > 0) {


### PR DESCRIPTION
Adds the `status/bot-triaged` label to issues after they have been successfully triaged by the automated and scheduled workflows.

This provides a clear indicator that the bot has processed the issue.