### PR TITLE
fix(config): Correct settings migration to prevent overwrite

### DIFF
--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -2168,12 +2168,12 @@ describe('Settings Loading and Merging', () => {
     });
 
     it('should correctly migrate customWittyPhrases', () => {
-      const v2Settings = {
+      const v2Settings: Partial<Settings> = {
         ui: {
           customWittyPhrases: ['test phrase'],
         },
       };
-      const v1Settings = migrateSettingsToV1(v2Settings);
+      const v1Settings = migrateSettingsToV1(v2Settings as Settings);
       expect(v1Settings).toEqual({
         customWittyPhrases: ['test phrase'],
       });
@@ -2236,7 +2236,7 @@ describe('Settings Loading and Merging', () => {
     });
 
     it('should return false for settings that are already in V2 format', () => {
-      const v2Settings = {
+      const v2Settings: Partial<Settings> = {
         ui: {
           theme: 'dark',
         },

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -2166,6 +2166,18 @@ describe('Settings Loading and Merging', () => {
         allowMCPServers: ['serverA'],
       });
     });
+
+    it('should correctly migrate customWittyPhrases', () => {
+      const v2Settings = {
+        ui: {
+          customWittyPhrases: ['test phrase'],
+        },
+      };
+      const v1Settings = migrateSettingsToV1(v2Settings);
+      expect(v1Settings).toEqual({
+        customWittyPhrases: ['test phrase'],
+      });
+    });
   });
 
   describe('loadEnvironment', () => {

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -28,7 +28,7 @@ import {
   getSettingsSchema,
 } from './settingsSchema.js';
 import { resolveEnvVarsInObject } from '../utils/envVarResolver.js';
-import { customDeepMerge } from '../utils/deepMerge.js';
+import { customDeepMerge, type MergeableObject } from '../utils/deepMerge.js';
 
 function getMergeStrategyForPath(path: string[]): MergeStrategy | undefined {
   let current: SettingDefinition | undefined = undefined;
@@ -258,10 +258,14 @@ function migrateSettingsToV2(
       newValue !== null &&
       !Array.isArray(newValue)
     ) {
-      v2Settings[remainingKey] = {
-        ...(newValue as Record<string, unknown>),
-        ...(existingValue as Record<string, unknown>),
-      };
+      const pathAwareGetStrategy = (path: string[]) =>
+        getMergeStrategyForPath([remainingKey, ...path]);
+      v2Settings[remainingKey] = customDeepMerge(
+        pathAwareGetStrategy,
+        {},
+        newValue as MergeableObject,
+        existingValue as MergeableObject,
+      );
     } else {
       v2Settings[remainingKey] = newValue;
     }

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -67,6 +67,7 @@ const MIGRATION_MAP: Record<string, string> = {
   coreTools: 'tools.core',
   contextFileName: 'context.fileName',
   customThemes: 'ui.customThemes',
+  customWittyPhrases: 'ui.customWittyPhrases',
   debugKeystrokeLogging: 'general.debugKeystrokeLogging',
   disableAutoUpdate: 'general.disableAutoUpdate',
   disableUpdateNag: 'general.disableUpdateNag',
@@ -246,7 +247,24 @@ function migrateSettingsToV2(
 
   // Carry over any unrecognized keys
   for (const remainingKey of flatKeys) {
-    v2Settings[remainingKey] = flatSettings[remainingKey];
+    const existingValue = v2Settings[remainingKey];
+    const newValue = flatSettings[remainingKey];
+
+    if (
+      typeof existingValue === 'object' &&
+      existingValue !== null &&
+      !Array.isArray(existingValue) &&
+      typeof newValue === 'object' &&
+      newValue !== null &&
+      !Array.isArray(newValue)
+    ) {
+      v2Settings[remainingKey] = {
+        ...(newValue as Record<string, unknown>),
+        ...(existingValue as Record<string, unknown>),
+      };
+    } else {
+      v2Settings[remainingKey] = newValue;
+    }
   }
 
   return v2Settings;

--- a/packages/cli/src/utils/deepMerge.ts
+++ b/packages/cli/src/utils/deepMerge.ts
@@ -15,7 +15,7 @@ type Mergeable =
   | object
   | Mergeable[];
 
-type MergeableObject = Record<string, Mergeable>;
+export type MergeableObject = Record<string, Mergeable>;
 
 function isPlainObject(item: unknown): item is MergeableObject {
   return !!item && typeof item === 'object' && !Array.isArray(item);


### PR DESCRIPTION
<h2>TLDR</h2>
<p>While testing, I noticed that <code>customWittyPhrases</code> were effectively being <strong>“Thanos snapped”</strong> (disappearing) after <code>settings.json</code> was updated.</p>
<ul>
<li>
<p>Cause: <code>customWittyPhrases</code> wasn’t properly preserved in the migration, since it was NOT present in the migration map.</p>
</li>
<li>
<p>Effect: after a theme change or file rewrite, <code>customWittyPhrases</code> vanished on the next load.</p>
</li>
</ul>
<p>✅ <strong>Fix:</strong> I changed the migration logic so that objects are <strong>merged instead of replaced</strong>.</p>
<p>Now, just like <code>theme</code>, users can keep <code>customWittyPhrases</code> as a <strong>top-level key</strong> in <code>settings.json</code> without worrying about losing them—even after the file updates.</p>
<hr>
<h2>Dive Deeper</h2>
<ul>
<li>
<p><strong>Old behavior:</strong></p>
<ul>
<li>
<p>Migrating <code>customWittyPhrases</code> into <code>ui</code> worked, but the <code>ui</code> object from V2 would overwrite it during carry-over.</p>
</li>
<li>
<p>This wiped out the migrated phrases.</p>
</li>
</ul>
</li>
<li>
<p><strong>New behavior:</strong></p>
<ul>
<li>
<p>The migration process now deep-merges objects instead of replacing them.</p>
</li>
<li>
<p><code>customWittyPhrases</code> is preserved regardless of settings.json override.</p>
</li>
</ul>
</li>
</ul>
<p><strong>Example top-level settings.json:</strong></p>
<pre><code class="language-json">{
  "theme": "GitHub",
  "customWittyPhrases": [
    "Getting this Before GTA6",
    "Connecting to AGI"
  ]
}
</code></pre>
<p>After migration, these values remain intact—even if <code>settings.json</code> is rewritten after theme changes.</p>
<hr>
<h2>Reviewer Test Plan</h2>
<ol>
<li>
<p>Create a settings file with:</p>
<ul>
<li>
<p>A top-level <code>customWittyPhrases</code> array.</p>
</li>
<li>
<p>Or a nested <code>ui.customWittyPhrases</code>.</p>
</li>
</ul>
</li>
<li>
<p>Trigger a migration (e.g., by changing the theme).</p>
</li>
<li>
<p>Verify that <code>customWittyPhrases</code> remains intact in both cases.</p>
</li>
<li>
<p>Confirm that no other settings are lost.</p>
</li>
</ol>
<hr>
<h2>Testing Matrix</h2>

  | 🍏 | 🪟 | 🐧
-- | -- | -- | --
npm run | ❓ | ❓ | ❓
npx | ❓ | ❓ | ❓
Docker | ❓ | ❓ | ❓
Podman | ❓ | - | -
Seatbelt | ❓ | - | -


<hr>
<h2>Linked issues / bugs</h2>
<ul>
<li>
<p>Resolves #️⃣ (#7781)</p>
</li>
</ul>
