### PR TITLE
Add hidden property to slash commands

### DIFF
--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -349,4 +349,36 @@ describe('CommandService', () => {
     expect(deployExtension).toBeDefined();
     expect(deployExtension?.description).toBe('[gcp] Deploy to Google Cloud');
   });
+
+  it('should filter out hidden commands', async () => {
+    const visibleCommand = createMockCommand('visible', CommandKind.BUILT_IN);
+    const hiddenCommand = {
+      ...createMockCommand('hidden', CommandKind.BUILT_IN),
+      hidden: true,
+    };
+    const initiallyVisibleCommand = createMockCommand(
+      'initially-visible',
+      CommandKind.BUILT_IN,
+    );
+    const hiddenOverrideCommand = {
+      ...createMockCommand('initially-visible', CommandKind.FILE),
+      hidden: true,
+    };
+
+    const mockLoader = new MockCommandLoader([
+      visibleCommand,
+      hiddenCommand,
+      initiallyVisibleCommand,
+      hiddenOverrideCommand,
+    ]);
+
+    const service = await CommandService.create(
+      [mockLoader],
+      new AbortController().signal,
+    );
+
+    const commands = service.getCommands();
+    expect(commands).toHaveLength(1);
+    expect(commands[0].name).toBe('visible');
+  });
 });

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -85,7 +85,9 @@ export class CommandService {
       });
     }
 
-    const finalCommands = Object.freeze(Array.from(commandMap.values()));
+    const finalCommands = Object.freeze(
+      Array.from(commandMap.values()).filter((cmd) => !cmd.hidden),
+    );
     return new CommandService(finalCommands);
   }
 

--- a/packages/cli/src/ui/commands/corgiCommand.ts
+++ b/packages/cli/src/ui/commands/corgiCommand.ts
@@ -10,6 +10,7 @@ export const corgiCommand: SlashCommand = {
   name: 'corgi',
   description: 'Toggles corgi mode.',
   kind: CommandKind.BUILT_IN,
+  hidden: true,
   action: (context, _args) => {
     context.ui.toggleCorgiMode();
   },

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -170,6 +170,7 @@ export interface SlashCommand {
   name: string;
   altNames?: string[];
   description: string;
+  hidden?: boolean;
 
   kind: CommandKind;
 

--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -64,29 +64,27 @@ export const Help: React.FC<Help> = ({ commands }) => (
     <Text bold color={Colors.Foreground}>
       Commands:
     </Text>
-    {commands
-      .filter((command) => command.description && !command.hidden)
-      .map((command: SlashCommand) => (
-        <Box key={command.name} flexDirection="column">
-          <Text color={Colors.Foreground}>
-            <Text bold color={Colors.AccentPurple}>
-              {' '}
-              /{command.name}
-            </Text>
-            {command.description && ' - ' + command.description}
+    {commands.map((command: SlashCommand) => (
+      <Box key={command.name} flexDirection="column">
+        <Text color={Colors.Foreground}>
+          <Text bold color={Colors.AccentPurple}>
+            {' '}
+            /{command.name}
           </Text>
-          {command.subCommands &&
-            command.subCommands.map((subCommand) => (
-              <Text key={subCommand.name} color={Colors.Foreground}>
-                <Text bold color={Colors.AccentPurple}>
-                  {'   '}
-                  {subCommand.name}
-                </Text>
-                {subCommand.description && ' - ' + subCommand.description}
+          {command.description && ' - ' + command.description}
+        </Text>
+        {command.subCommands &&
+          command.subCommands.map((subCommand) => (
+            <Text key={subCommand.name} color={Colors.Foreground}>
+              <Text bold color={Colors.AccentPurple}>
+                {'   '}
+                {subCommand.name}
               </Text>
-            ))}
-        </Box>
-      ))}
+              {subCommand.description && ' - ' + subCommand.description}
+            </Text>
+          ))}
+      </Box>
+    ))}
     <Text color={Colors.Foreground}>
       <Text bold color={Colors.AccentPurple}>
         {' '}

--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -65,7 +65,7 @@ export const Help: React.FC<Help> = ({ commands }) => (
       Commands:
     </Text>
     {commands
-      .filter((command) => command.description)
+      .filter((command) => command.description && !command.hidden)
       .map((command: SlashCommand) => (
         <Box key={command.name} flexDirection="column">
           <Text color={Colors.Foreground}>

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -220,6 +220,18 @@ describe('useSlashCommandProcessor', () => {
       expect(fileAction).toHaveBeenCalledTimes(1);
       expect(builtinAction).not.toHaveBeenCalled();
     });
+
+    it('should not include hidden commands in the command list', async () => {
+      const visibleCommand = createTestCommand({ name: 'visible' });
+      const hiddenCommand = createTestCommand({ name: 'hidden', hidden: true });
+      const result = setupProcessorHook([visibleCommand, hiddenCommand]);
+
+      await waitFor(() => {
+        expect(result.current.slashCommands).toHaveLength(1);
+      });
+
+      expect(result.current.slashCommands[0].name).toBe('visible');
+    });
   });
 
   describe('Command Execution Logic', () => {

--- a/packages/cli/src/ui/hooks/useSlashCompletion.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.ts
@@ -225,7 +225,7 @@ function useCommandSuggestions(
         if (partial === '') {
           // If no partial query, show all available commands
           potentialSuggestions = commandsToSearch.filter(
-            (cmd) => cmd.description,
+            (cmd) => cmd.description && !cmd.hidden,
           );
         } else {
           // Use fuzzy search for non-empty partial queries with fallback
@@ -399,7 +399,7 @@ export function useSlashCompletion(props: UseSlashCompletionProps): {
       const commandMap = new Map<string, SlashCommand>();
 
       commands.forEach((cmd) => {
-        if (cmd.description) {
+        if (cmd.description && !cmd.hidden) {
           commandItems.push(cmd.name);
           commandMap.set(cmd.name, cmd);
 
@@ -443,6 +443,7 @@ export function useSlashCompletion(props: UseSlashCompletionProps): {
       commands.filter(
         (cmd) =>
           cmd.description &&
+          !cmd.hidden &&
           (cmd.name.toLowerCase().startsWith(partial.toLowerCase()) ||
             cmd.altNames?.some((alt) =>
               alt.toLowerCase().startsWith(partial.toLowerCase()),

--- a/packages/cli/src/ui/hooks/useSlashCompletion.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.ts
@@ -225,7 +225,7 @@ function useCommandSuggestions(
         if (partial === '') {
           // If no partial query, show all available commands
           potentialSuggestions = commandsToSearch.filter(
-            (cmd) => cmd.description && !cmd.hidden,
+            (cmd) => cmd.description,
           );
         } else {
           // Use fuzzy search for non-empty partial queries with fallback
@@ -399,7 +399,7 @@ export function useSlashCompletion(props: UseSlashCompletionProps): {
       const commandMap = new Map<string, SlashCommand>();
 
       commands.forEach((cmd) => {
-        if (cmd.description && !cmd.hidden) {
+        if (cmd.description) {
           commandItems.push(cmd.name);
           commandMap.set(cmd.name, cmd);
 

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -158,6 +158,7 @@ describe('createContentGeneratorConfig', () => {
   });
 
   it('should configure for Vertex AI using GCP project and location when set', async () => {
+    vi.stubEnv('GOOGLE_API_KEY', undefined);
     vi.stubEnv('GOOGLE_CLOUD_PROJECT', 'env-gcp-project');
     vi.stubEnv('GOOGLE_CLOUD_LOCATION', 'env-gcp-location');
     const config = await createContentGeneratorConfig(


### PR DESCRIPTION
## TLDR

Allow for slash commands to opt-out of autocompletion and /help discovery.

## Dive Deeper

As slash commands become more numerous allow for a command to opt out if it's unnecessary to advertise them on a case-by-case basis.

## Reviewer Test Plan

Type / and see if hidden slash commands are auto-completed.
Enter /help and see if hidden slash commands are included.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #7796