### PR TITLE
Make 'source' a positional argument in extensions install and set flag to true

### DIFF
--- a/packages/cli/src/commands/extensions/install.test.ts
+++ b/packages/cli/src/commands/extensions/install.test.ts
@@ -17,14 +17,14 @@ describe('extensions install command', () => {
   it('should fail if no source is provided', () => {
     const validationParser = yargs([]).command(installCommand).fail(false);
     expect(() => validationParser.parse('install')).toThrow(
-      'Either --source or --path must be provided.',
+      'Either source or --path must be provided.',
     );
   });
 
   it('should fail if both git source and local path are provided', () => {
     const validationParser = yargs([]).command(installCommand).fail(false);
     expect(() =>
-      validationParser.parse('install --source some-url --path /some/path'),
+      validationParser.parse('install some-url --path /some/path'),
     ).toThrow('Arguments source and path are mutually exclusive');
   });
 });

--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -65,12 +65,12 @@ export async function handleInstall(args: InstallArgs) {
 }
 
 export const installCommand: CommandModule = {
-  command: 'install [--source | --path ]',
+  command: 'install [source]',
   describe:
     'Installs an extension from a git repository (URL or "org/repo") or a local path.',
   builder: (yargs) =>
     yargs
-      .option('source', {
+      .positional('source', {
         describe: 'The git URL or "org/repo" of the extension to install.',
         type: 'string',
       })
@@ -81,7 +81,7 @@ export const installCommand: CommandModule = {
       .conflicts('source', 'path')
       .check((argv) => {
         if (!argv.source && !argv.path) {
-          throw new Error('Either --source or --path must be provided.');
+          throw new Error('Either source or --path must be provided.');
         }
         return true;
       }),

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -305,7 +305,7 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
     // Register MCP subcommands
     .command(mcpCommand);
 
-  if (settings?.experimental?.extensionManagement ?? false) {
+  if (settings?.experimental?.extensionManagement ?? true) {
     yargsInstance.command(extensionsCommand);
   }
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -119,7 +119,8 @@ export function loadExtensions(
 
   if (
     (isWorkspaceTrusted(settings) ?? true) &&
-    !settings.experimental?.extensionManagement
+    // Default management setting to true
+    !(settings.experimental?.extensionManagement ?? true)
   ) {
     allExtensions.push(...getWorkspaceExtensions(workspaceDir));
   }

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -76,7 +76,7 @@ const MIGRATION_MAP: Record<string, string> = {
   excludeTools: 'tools.exclude',
   excludeMCPServers: 'mcp.excluded',
   excludedProjectEnvVars: 'advanced.excludedEnvVars',
-  extensionManagement: 'advanced.extensionManagement',
+  extensionManagement: 'experimental.extensionManagement',
   extensions: 'extensions',
   fileFiltering: 'context.fileFiltering',
   folderTrustFeature: 'security.folderTrust.featureEnabled',

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -838,7 +838,7 @@ export const SETTINGS_SCHEMA = {
         label: 'Extension Management',
         category: 'Experimental',
         requiresRestart: true,
-        default: false,
+        default: true,
         description: 'Enable extension management features.',
         showInDialog: false,
       },

--- a/packages/cli/src/ui/hooks/useWorkspaceMigration.ts
+++ b/packages/cli/src/ui/hooks/useWorkspaceMigration.ts
@@ -20,7 +20,8 @@ export function useWorkspaceMigration(settings: LoadedSettings) {
   );
 
   useEffect(() => {
-    if (!settings.merged.experimental?.extensionManagement) {
+    // Default to true if not set.
+    if (!(settings.merged.experimental?.extensionManagement ?? true)) {
       return;
     }
     const cwd = process.cwd();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -282,7 +282,7 @@ export class Config {
   private readonly useRipgrep: boolean;
   private readonly shouldUseNodePtyShell: boolean;
   private readonly skipNextSpeakerCheck: boolean;
-  private readonly extensionManagement: boolean;
+  private readonly extensionManagement: boolean = true;
   private readonly enablePromptCompletion: boolean = false;
   private initialized: boolean = false;
   readonly storage: Storage;
@@ -360,7 +360,7 @@ export class Config {
     this.shouldUseNodePtyShell = params.shouldUseNodePtyShell ?? false;
     this.skipNextSpeakerCheck = params.skipNextSpeakerCheck ?? false;
     this.useSmartEdit = params.useSmartEdit ?? true;
-    this.extensionManagement = params.extensionManagement ?? false;
+    this.extensionManagement = params.extensionManagement ?? true;
     this.storage = new Storage(this.targetDir);
     this.enablePromptCompletion = params.enablePromptCompletion ?? false;
     this.fileExclusions = new FileExclusions(this);


### PR DESCRIPTION
## TLDR

Doing this in lieu of removing the flag and removing all deprecated behavior to make rollbacks easier. https://github.com/google-gemini/gemini-cli/pull/7723

Also updating the tests to remove the workspace dependencies. This shouldn't be affected if we decide to rollback the true default value.

Also, ideally we set this at a higher level but our new settings setup makes that difficult.



## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
