### PR TITLE
fix(highlight): Fix backslash handling in file path highlighting and text buffer

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -570,6 +570,26 @@ describe('useTextBuffer', () => {
       act(() => result.current.insert(shortText, { paste: true }));
       expect(getBufferState(result).text).toBe(shortText);
     });
+
+    it('should handle file paths with backslashes', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({ viewport, isValidPath: () => true }),
+      );
+      const backslashPath = '/path/to/\\backslash-file.txt';
+      act(() => result.current.insert(backslashPath, { paste: true }));
+      expect(getBufferState(result).text).toBe(`@${backslashPath} `);
+    });
+
+    it('should fix shell-escaped backslashes in dragged paths', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({ viewport, isValidPath: () => true }),
+      );
+      const escapedPath = '/path/to/\\\\backslash-file.txt';
+      act(() => result.current.insert(escapedPath, { paste: true }));
+      expect(getBufferState(result).text).toBe(
+        '@/path/to/\\backslash-file.txt ',
+      );
+    });
   });
 
   describe('Shell Mode Behavior', () => {

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1531,9 +1531,11 @@ export function useTextBuffer({
           potentialPath = quoteMatch[1];
         }
 
-        potentialPath = potentialPath.trim();
-        if (isValidPath(unescapePath(potentialPath))) {
-          ch = `@${potentialPath} `;
+        // Fix shell-escaped backslashes
+        const fixedPath = potentialPath.trim().replace(/\\\\/g, '\\');
+
+        if (isValidPath(unescapePath(fixedPath))) {
+          ch = `@${fixedPath} `;
         }
       }
 

--- a/packages/cli/src/ui/utils/highlight.test.ts
+++ b/packages/cli/src/ui/utils/highlight.test.ts
@@ -101,4 +101,54 @@ describe('parseInputForHighlighting', () => {
       { text: ' now', type: 'default' },
     ]);
   });
+
+  it('should handle file paths with backslashes', () => {
+    const text = 'Check @/Users/test/\\backslash-file-test.txt for details';
+    expect(parseInputForHighlighting(text)).toEqual([
+      { text: 'Check ', type: 'default' },
+      { text: '@/Users/test/\\backslash-file-test.txt', type: 'file' },
+      { text: ' for details', type: 'default' },
+    ]);
+  });
+
+  it('should handle file paths with multiple backslashes', () => {
+    const text = 'Check @/Users/test/\\\\backslash-file-test.txt';
+    expect(parseInputForHighlighting(text)).toEqual([
+      { text: 'Check ', type: 'default' },
+      { text: '@/Users/test/\\\\backslash-file-test.txt', type: 'file' },
+    ]);
+  });
+
+  it('should handle file paths starting with backslash', () => {
+    const text = '@\\new-backslash-test.txt for testing';
+    expect(parseInputForHighlighting(text)).toEqual([
+      { text: '@\\new-backslash-test.txt', type: 'file' },
+      { text: ' for testing', type: 'default' },
+    ]);
+  });
+
+  it('should handle file paths with full path containing backslashes', () => {
+    const text = '@/Users/test/\\new-backslash-test.txt and more text';
+    expect(parseInputForHighlighting(text)).toEqual([
+      { text: '@/Users/test/\\new-backslash-test.txt', type: 'file' },
+      { text: ' and more text', type: 'default' },
+    ]);
+  });
+
+  it('should handle complex backslash patterns', () => {
+    const text = '@\\\\\\\\backslash-file-test.txt for testing';
+    expect(parseInputForHighlighting(text)).toEqual([
+      { text: '@\\\\\\\\backslash-file-test.txt', type: 'file' },
+      { text: ' for testing', type: 'default' },
+    ]);
+  });
+
+  it('should handle backslashes in middle of filename', () => {
+    const text = 'Check @bac\\k\\slash-file-test.txt here';
+    expect(parseInputForHighlighting(text)).toEqual([
+      { text: 'Check ', type: 'default' },
+      { text: '@bac\\k\\slash-file-test.txt', type: 'file' },
+      { text: ' here', type: 'default' },
+    ]);
+  });
 });

--- a/packages/cli/src/ui/utils/highlight.ts
+++ b/packages/cli/src/ui/utils/highlight.ts
@@ -9,7 +9,7 @@ export type HighlightToken = {
   type: 'default' | 'command' | 'file';
 };
 
-const HIGHLIGHT_REGEX = /(\/[a-zA-Z0-9_-]+|@[a-zA-Z0-9_./-]+)/g;
+const HIGHLIGHT_REGEX = /(\/[a-zA-Z0-9_-]+|@[a-zA-Z0-9_.\\/\\\\-]+)/g;
 
 export function parseInputForHighlighting(
   text: string,

--- a/packages/cli/src/ui/utils/highlight.ts
+++ b/packages/cli/src/ui/utils/highlight.ts
@@ -9,7 +9,7 @@ export type HighlightToken = {
   type: 'default' | 'command' | 'file';
 };
 
-const HIGHLIGHT_REGEX = /(\/[a-zA-Z0-9_-]+|@[a-zA-Z0-9_.\\/\\\\-]+)/g;
+const HIGHLIGHT_REGEX = /(\/[a-zA-Z0-9_-]+|@[a-zA-Z0-9_./\\-]+)/g;
 
 export function parseInputForHighlighting(
   text: string,


### PR DESCRIPTION
## TLDR

Fixed file path rendering issue where backslash characters in filenames caused syntax highlighting to break, addressing the visual display problem when dragging files with backslashes into gemini-cli.

## Dive Deeper

This PR addresses issue #7791 where file paths containing backslash characters (like `/Users/xxx/\\backslash-file-test.txt`) were not rendering with proper syntax highlighting in the terminal interface.

**Root cause**: The regex pattern in `highlight.ts` was not properly handling backslashes in file paths, and the text buffer logic needed updates to correctly process these characters.


The issue manifested when users dragged files with backslashes in their names into gemini-cli - the paths would appear without proper coloring/highlighting, making them less readable and potentially confusing.

## Reviewer Test Plan

1. Run `npm run test:ci` to verify all tests pass, including new backslash handling tests
2. Test drag-and-drop functionality with files containing backslashes:
   - Create a file with backslashes in the name: `touch "\\backslash-file-test.txt"`
   - Drag the file into gemini-cli terminal
   - Verify that the file path displays with proper syntax highlighting

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |

## Linked issues / bugs

Fixes #7791
