### PR TITLE
bug(core): Fix `Check Bundle Size` github action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,3 +392,4 @@ jobs:
           pattern: './bundle/**/*.{js,sb}'
           minimum-change-threshold: '1000'
           compression: 'none'
+          clean-script: 'clean'


### PR DESCRIPTION
Adds a missing `clean-step` to the `Check Bundle Size` action.