### PR TITLE
fix(settings): use union merge for excludeTools

### DIFF
--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -428,8 +428,11 @@ describe('Settings Loading and Merging', () => {
         '/workspace/dir',
       ]);
 
-      // Verify excludeTools are overwritten by workspace
-      expect(settings.merged.tools?.exclude).toEqual(['workspace-tool']);
+      // Verify excludeTools are concatenated and de-duped
+      expect(settings.merged.tools?.exclude).toEqual([
+        'user-tool',
+        'workspace-tool',
+      ]);
 
       // Verify excludedProjectEnvVars are concatenated and de-duped
       expect(settings.merged.advanced?.excludedEnvVars).toEqual(

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -662,6 +662,7 @@ const SETTINGS_SCHEMA = {
         default: undefined as string[] | undefined,
         description: 'Tool names to exclude from discovery.',
         showInDialog: false,
+        mergeStrategy: MergeStrategy.UNION,
       },
       discoveryCommand: {
         type: 'string',


### PR DESCRIPTION
## TLDR

Previously, having a system setting for excludeTools would overwrite any user provided value. There is no harm in a user excluding more tools, so a union strategy should work.

## Dive Deeper

If you have a system settings file:
```yaml
{
  "excludeTools": ["web_fetch"]
}
```

And a user file:
```yaml
{
  "excludeTools": ["run_shell_command(git push)"]
}
```

Previously gemini-cli would overwrite the user's desire to block `git push`.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

http://b/442329210

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
