### PR TITLE
fix(core): Treat stream chunk with finishReason but no content as valid

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -73,7 +73,14 @@ function isValidResponse(response: GenerateContentResponse): boolean {
   if (response.candidates === undefined || response.candidates.length === 0) {
     return false;
   }
-  const content = response.candidates[0]?.content;
+  const candidate = response.candidates[0];
+  if (candidate === undefined) {
+    return false;
+  }
+  if (candidate.finishReason) {
+    return true;
+  }
+  const content = candidate.content;
   if (content === undefined) {
     return false;
   }


### PR DESCRIPTION
## TLDR

This pull request fixes a bug where the CLI would incorrectly retry valid API responses where the last chunk contains a `finishReason` but no message content. This ensures that even when the model returns no text, the response is processed correctly instead of being treated as an error, which previously caused unnecessary retries.

## Dive Deeper

The `isValidResponse` function was previously too strict, requiring message `content` in all valid API responses. However, the Gemini API can legitimately return a response that includes a `finishReason` (like 'STOP' or 'SAFETY') but has no `content` part. This is a valid final state for a model's turn.

The logic has been updated to first check for the presence of a `finishReason` on the response candidate. If it exists, the response is considered valid, regardless of whether `content` is present. This change prevents the system from incorrectly flagging these responses as invalid and attempting to retry, leading to a more robust and accurate handling of the API's behavior.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
Fixes #7851