### PR TITLE
fix(mcp-client): Correct hasValidTypes validation

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -78,7 +78,7 @@ describe('mcp-client', () => {
       expect(mockedMcpToTool).toHaveBeenCalledOnce();
     });
 
-    it('should skip tools if a parameter is missing a type', async () => {
+    it('should not skip tools if a parameter is missing a type', async () => {
       const consoleWarnSpy = vi
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
@@ -137,12 +137,8 @@ describe('mcp-client', () => {
       );
       await client.connect();
       await client.discover({} as Config);
-      expect(mockedToolRegistry.registerTool).toHaveBeenCalledOnce();
-      expect(consoleWarnSpy).toHaveBeenCalledOnce();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        `Skipping tool 'invalidTool' from MCP server 'test-server' because it has ` +
-          `missing types in its parameter schema. Please file an issue with the owner of the MCP server.`,
-      );
+      expect(mockedToolRegistry.registerTool).toHaveBeenCalledTimes(2);
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
       consoleWarnSpy.mockRestore();
     });
 
@@ -417,11 +413,11 @@ describe('mcp-client', () => {
       expect(hasValidTypes(schema)).toBe(true);
     });
 
-    it('should return false for an invalid schema with anyOf', () => {
+    it('should return true for an invalid schema with anyOf', () => {
       const schema = {
         anyOf: [{ type: 'string' }, { description: 'no type' }],
       };
-      expect(hasValidTypes(schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return true for a valid schema with allOf', () => {
@@ -434,11 +430,11 @@ describe('mcp-client', () => {
       expect(hasValidTypes(schema)).toBe(true);
     });
 
-    it('should return false for an invalid schema with allOf', () => {
+    it('should return true for an invalid schema with allOf', () => {
       const schema = {
         allOf: [{ type: 'string' }, { description: 'no type' }],
       };
-      expect(hasValidTypes(schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return true for a valid schema with oneOf', () => {
@@ -448,11 +444,11 @@ describe('mcp-client', () => {
       expect(hasValidTypes(schema)).toBe(true);
     });
 
-    it('should return false for an invalid schema with oneOf', () => {
+    it('should return true for an invalid schema with oneOf', () => {
       const schema = {
         oneOf: [{ type: 'string' }, { description: 'no type' }],
       };
-      expect(hasValidTypes(schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return true for a valid schema with nested subschemas', () => {
@@ -470,7 +466,7 @@ describe('mcp-client', () => {
       expect(hasValidTypes(schema)).toBe(true);
     });
 
-    it('should return false for an invalid schema with nested subschemas', () => {
+    it('should return true for an invalid schema with nested subschemas', () => {
       const schema = {
         anyOf: [
           { type: 'string' },
@@ -482,7 +478,7 @@ describe('mcp-client', () => {
           },
         ],
       };
-      expect(hasValidTypes(schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return true for a schema with a type and subschemas', () => {
@@ -493,11 +489,11 @@ describe('mcp-client', () => {
       expect(hasValidTypes(schema)).toBe(true);
     });
 
-    it('should return false for a schema with no type and no subschemas', () => {
+    it('should return true for a schema with no type and no subschemas', () => {
       const schema = {
         description: 'a schema with no type',
       };
-      expect(hasValidTypes(schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return true for a valid schema', () => {
@@ -510,17 +506,17 @@ describe('mcp-client', () => {
       expect(hasValidTypes(schema)).toBe(true);
     });
 
-    it('should return false if a parameter is missing a type', () => {
+    it('should return true if a parameter is missing a type', () => {
       const schema = {
         type: 'object',
         properties: {
           param1: { description: 'a param with no type' },
         },
       };
-      expect(hasValidTypes(schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
-    it('should return false if a nested parameter is missing a type', () => {
+    it('should return true if a nested parameter is missing a type', () => {
       const schema = {
         type: 'object',
         properties: {
@@ -534,10 +530,10 @@ describe('mcp-client', () => {
           },
         },
       };
-      expect(hasValidTypes(schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
-    it('should return false if an array item is missing a type', () => {
+    it('should return true if an array item is missing a type', () => {
       const schema = {
         type: 'object',
         properties: {
@@ -549,7 +545,7 @@ describe('mcp-client', () => {
           },
         },
       };
-      expect(hasValidTypes(schema)).toBe(false);
+      expect(hasValidTypes(schema)).toBe(true);
     });
 
     it('should return true for a schema with no properties', () => {
@@ -564,6 +560,11 @@ describe('mcp-client', () => {
         type: 'object',
         properties: {},
       };
+      expect(hasValidTypes(schema)).toBe(true);
+    });
+
+    it('should return true for an empty schema', () => {
+      const schema = {};
       expect(hasValidTypes(schema)).toBe(true);
     });
   });

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -575,34 +575,10 @@ export async function connectAndDiscover(
  */
 export function hasValidTypes(schema: unknown): boolean {
   if (typeof schema !== 'object' || schema === null) {
-    // Not a schema object we can validate, or not a schema at all.
-    // Treat as valid as it has no properties to be invalid.
     return true;
   }
 
   const s = schema as Record<string, unknown>;
-
-  if (!s['type']) {
-    // These keywords contain an array of schemas that should be validated.
-    //
-    // If no top level type was given, then they must each have a type.
-    let hasSubSchema = false;
-    const schemaArrayKeywords = ['anyOf', 'allOf', 'oneOf'];
-    for (const keyword of schemaArrayKeywords) {
-      const subSchemas = s[keyword];
-      if (Array.isArray(subSchemas)) {
-        hasSubSchema = true;
-        for (const subSchema of subSchemas) {
-          if (!hasValidTypes(subSchema)) {
-            return false;
-          }
-        }
-      }
-    }
-
-    // If the node itself is missing a type and had no subschemas, then it isn't valid.
-    if (!hasSubSchema) return false;
-  }
 
   if (s['type'] === 'object' && s['properties']) {
     if (typeof s['properties'] === 'object' && s['properties'] !== null) {
@@ -617,6 +593,18 @@ export function hasValidTypes(schema: unknown): boolean {
   if (s['type'] === 'array' && s['items']) {
     if (!hasValidTypes(s['items'])) {
       return false;
+    }
+  }
+
+  const schemaArrayKeywords = ['anyOf', 'allOf', 'oneOf'];
+  for (const keyword of schemaArrayKeywords) {
+    const subSchemas = s[keyword];
+    if (Array.isArray(subSchemas)) {
+      for (const subSchema of subSchemas) {
+        if (!hasValidTypes(subSchema)) {
+          return false;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
The `hasValidTypes` function was previously too strict and would incorrectly flag valid schemas as invalid, particularly when dealing with schemas that use `anyOf`, `allOf`, or `oneOf` without a top-level `type` property.

This change adjusts the validation logic to correctly handle these cases, preventing tools from being unnecessarily skipped. The tests have been updated to reflect the corrected behavior.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
