### PR TITLE
fix(ui): Resolve IME composition bug on backspace by adjusting timeout

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -655,16 +655,21 @@ export function KeypressProvider({
     };
 
     let rl: readline.Interface;
+    const IME_ESCAPE_CODE_TIMEOUT_MS = 20;
+
     if (usePassthrough) {
       rl = readline.createInterface({
         input: keypressStream,
-        escapeCodeTimeout: 20,
+        escapeCodeTimeout: IME_ESCAPE_CODE_TIMEOUT_MS,
       });
       readline.emitKeypressEvents(keypressStream, rl);
       keypressStream.on('keypress', handleKeypress);
       stdin.on('data', handleRawKeypress);
     } else {
-      rl = readline.createInterface({ input: stdin, escapeCodeTimeout: 20 });
+      rl = readline.createInterface({
+        input: stdin,
+        escapeCodeTimeout: IME_ESCAPE_CODE_TIMEOUT_MS,
+      });
       readline.emitKeypressEvents(stdin, rl);
       stdin.on('keypress', handleKeypress);
     }

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -658,13 +658,13 @@ export function KeypressProvider({
     if (usePassthrough) {
       rl = readline.createInterface({
         input: keypressStream,
-        escapeCodeTimeout: 0,
+        escapeCodeTimeout: 20,
       });
       readline.emitKeypressEvents(keypressStream, rl);
       keypressStream.on('keypress', handleKeypress);
       stdin.on('data', handleRawKeypress);
     } else {
-      rl = readline.createInterface({ input: stdin, escapeCodeTimeout: 0 });
+      rl = readline.createInterface({ input: stdin, escapeCodeTimeout: 20 });
       readline.emitKeypressEvents(stdin, rl);
       stdin.on('keypress', handleKeypress);
     }

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -23,6 +23,7 @@ import { PassThrough } from 'node:stream';
 import {
   BACKSLASH_ENTER_DETECTION_WINDOW_MS,
   CHAR_CODE_ESC,
+  IME_ESCAPE_CODE_TIMEOUT_MS,
   KITTY_CTRL_C,
   KITTY_KEYCODE_BACKSPACE,
   KITTY_KEYCODE_ENTER,
@@ -655,7 +656,6 @@ export function KeypressProvider({
     };
 
     let rl: readline.Interface;
-    const IME_ESCAPE_CODE_TIMEOUT_MS = 20;
 
     if (usePassthrough) {
       rl = readline.createInterface({

--- a/packages/cli/src/ui/utils/platformConstants.ts
+++ b/packages/cli/src/ui/utils/platformConstants.ts
@@ -56,6 +56,16 @@ export const MODIFIER_CTRL_BIT = 4;
 export const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
 
 /**
+ * The escape code timeout for Node.js's readline interface.
+ * A value of 0 can cause bugs with IME (Input Method Editor) composition,
+ * where backspacing a composing character incorrectly finalizes it.
+ * A small delay (e.g., 20ms) gives the IME and readline enough time to
+ * process the composition correctly without being perceptible to the user or
+ * affecting other escape-based shortcuts.
+ */
+export const IME_ESCAPE_CODE_TIMEOUT_MS = 20;
+
+/**
  * VS Code terminal integration constants
  */
 export const VSCODE_SHIFT_ENTER_SEQUENCE = '\\\r\n';


### PR DESCRIPTION
## TLDR

This PR fixes a frustrating bug for users of IMEs (e.g., Korean, Japanese) where pressing `Backspace` to delete the last component of a composing character would incorrectly finalize the text instead of deleting it.

The fix is a one-line change, increasing Node.js `readline`'s `escapeCodeTimeout` from `0` to `20ms`. This small delay gives the input system enough time to correctly process the backspace within the IME composition, resolving the issue without impacting other functionalities.

## Dive Deeper

The root cause of this bug was the `escapeCodeTimeout` setting in the `readline` interface being set to `0`.

The `escapeCodeTimeout` is the duration `readline` waits to see if multiple key inputs are part of a single complex escape sequence. IME composition, where consonants and vowels are combined to form a single character, can be processed in a way that is analogous to these escape sequences.

With `escapeCodeTimeout: 0`, there was no waiting period. When a user typed `마ㄹ` (in composition) and pressed `Backspace`, `readline` would immediately process the existing buffer as a finalized input (`마ㄹ`) before the IME had a chance to correctly handle the backspace as a composition edit.

By changing the setting to `escapeCodeTimeout: 20`, we introduce a 20-millisecond window. This is a very short, imperceptible delay for the user, but it's sufficient time for the `readline` library and the underlying IME system to correctly interpret the `Backspace` as an instruction to delete the last component of the composing character (`ㄹ`), rather than finalizing the entire buffer. This small change allows the IME to function as expected.

This 20ms delay does not negatively affect other ESC-key functionalities (like command cancellation), which has been verified by ensuring all existing tests pass.

## Reviewer Test Plan

To validate this change, the reviewer will need an environment where they can use an IME (e.g., Korean).

1.  Run the CLI with `npx gemini`.
2.  Switch your input method to an IME (e.g., press the Han/Eng key for Korean).
3.  Type `마` (ma), then `ㄹ` (l). The input should show `마ㄹ` in a composing state (e.g., underlined).
4.  Press **`Backspace`** once.
5.  **Expected Result:** The input should correctly show `마` in a composing state.
6.  **Behavior Before This Fix:** The input would incorrectly show `마ㄹ` as finalized text.
7.  **Additional Verification:** Confirm that quick actions using the `ESC` key, such as closing the suggestions menu, still feel instantaneous.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #7925