### PR TITLE
fix(ui): disable input prompt during tool confirmation

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -20,7 +20,7 @@ import {
   type HistoryItemWithoutId,
   AuthState,
 } from './types.js';
-import { MessageType } from './types.js';
+import { MessageType, StreamingState } from './types.js';
 import {
   type EditorType,
   type Config,
@@ -699,7 +699,20 @@ Logging in with Google... Please restart Gemini CLI to continue.
 
   const { handleInput: vimHandleInput } = useVim(buffer, handleFinalSubmit);
 
-  const isInputActive = !initError && !isProcessing;
+  /**
+   * Determines if the input prompt should be active and accept user input.
+   * Input is disabled during:
+   * - Initialization errors
+   * - Slash command processing
+   * - Tool confirmations (WaitingForConfirmation state)
+   * - Any future streaming states not explicitly allowed
+   */
+  const isInputActive =
+    !initError &&
+    !isProcessing &&
+    (streamingState === StreamingState.Idle ||
+      streamingState === StreamingState.Responding) &&
+    !isProQuotaDialogOpen;
 
   // Compute available terminal height based on controls measurement
   const availableTerminalHeight = useMemo(() => {


### PR DESCRIPTION
## Overview
This pull request addresses an issue where the user input prompt remained active while the application was awaiting user confirmation for tool actions.

The root cause was the accidental omission of `streamingState` validation from the `isInputActive` flag during a recent refactor. This change restores the original "whitelist" logic, ensuring the input prompt is only enabled when the application is in an `Idle` or `Responding` state.

## Reviewer Test Plan

1. Run a command that requires tool confirmation, for example:
   `Add 3 files named a.txt, b.txt, 3.txt each that contain the words
   "hello world" each using the write file tool.`
2. While the confirmation prompt ("Do you want to run this command?") is
   displayed, attempt to type in the input prompt.
3. Verify that the input prompt is disabled and does not accept any text.
4. Confirm the tool action and verify that the input prompt becomes
   active again once the tool execution is complete.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #7912

