### PR TITLE
zed integration: Load MCP servers over HTTP/SSE

### DIFF
--- a/packages/cli/src/zed-integration/schema.ts
+++ b/packages/cli/src/zed-integration/schema.ts
@@ -265,12 +265,31 @@ export const envVariableSchema = z.object({
   value: z.string(),
 });
 
-export const mcpServerSchema = z.object({
-  args: z.array(z.string()),
-  command: z.string(),
-  env: z.array(envVariableSchema),
+export const httpHeaderSchema = z.object({
   name: z.string(),
+  value: z.string(),
 });
+
+export const mcpServerSchema = z.union([
+  z.object({
+    headers: z.array(httpHeaderSchema),
+    name: z.string(),
+    type: z.literal('http'),
+    url: z.string(),
+  }),
+  z.object({
+    headers: z.array(httpHeaderSchema),
+    name: z.string(),
+    type: z.literal('sse'),
+    url: z.string(),
+  }),
+  z.object({
+    args: z.array(z.string()),
+    command: z.string(),
+    env: z.array(envVariableSchema),
+    name: z.string(),
+  }),
+]);
 
 export const promptCapabilitiesSchema = z.object({
   audio: z.boolean().optional(),
@@ -278,9 +297,15 @@ export const promptCapabilitiesSchema = z.object({
   image: z.boolean().optional(),
 });
 
+export const mcpCapabilitiesSchema = z.object({
+  http: z.boolean().optional(),
+  sse: z.boolean().optional(),
+});
+
 export const agentCapabilitiesSchema = z.object({
   loadSession: z.boolean().optional(),
   promptCapabilities: promptCapabilitiesSchema.optional(),
+  mcpCapabilities: mcpCapabilitiesSchema.optional(),
 });
 
 export const authMethodSchema = z.object({

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -197,30 +197,27 @@ class GeminiAgent {
           headers[header.name] = header.value;
         }
 
+        let sseUrl: string | undefined;
+        let httpUrl: string | undefined;
+
         if (mcpServer.type === 'sse') {
-          mergedMcpServers[mcpServer.name] = new MCPServerConfig(
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            mcpServer.url,
-            undefined,
-            headers,
-          );
+          sseUrl = mcpServer.url;
         } else if (mcpServer.type === 'http') {
-          mergedMcpServers[mcpServer.name] = new MCPServerConfig(
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            mcpServer.url,
-            headers,
-          );
+          httpUrl = mcpServer.url;
         } else {
           const unreachable: never = mcpServer;
           throw new Error(`Unexpected MCP server type: ${unreachable}`);
         }
+
+        mergedMcpServers[mcpServer.name] = new MCPServerConfig(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          sseUrl,
+          httpUrl,
+          headers,
+        );
       }
     }
 


### PR DESCRIPTION
## TLDR

The Zed integration supported connecting to MCP servers, but until now it only supported the stdio transport. This PR allows the Client to include HTTP and SSE server configurations as well.

## Dive Deeper

When a new session is created via the Zed integration, the Client sends a list of MCP servers that Gemini CLI should connect to. Still, the existing schema only supported stdio servers. 

Now the config object may include a `type` field that can be set to either `http` or `sse`. This field is optional, defaulting to stdio for backwards compatibility.


