### PR TITLE
fix(ide): fix crash on windows when null command is returned

### DIFF
--- a/packages/core/src/ide/process-utils.ts
+++ b/packages/core/src/ide/process-utils.ts
@@ -42,13 +42,20 @@ async function getProcessInfo(pid: number): Promise<{
       const {
         Name = '',
         ParentProcessId = 0,
-        CommandLine = '',
+        CommandLine,
       } = JSON.parse(output);
-      return { parentPid: ParentProcessId, name: Name, command: CommandLine };
+      return {
+        parentPid: ParentProcessId,
+        name: Name,
+        command: CommandLine ?? '',
+      };
     } else {
       const command = `ps -o ppid=,command= -p ${pid}`;
       const { stdout } = await execAsync(command);
       const trimmedStdout = stdout.trim();
+      if (!trimmedStdout) {
+        return { parentPid: 0, name: '', command: '' };
+      }
       const ppidString = trimmedStdout.split(/\s+/)[0];
       const parentPid = parseInt(ppidString, 10);
       const fullCommand = trimmedStdout.substring(ppidString.length).trim();

--- a/packages/core/src/ide/process-utils.ts
+++ b/packages/core/src/ide/process-utils.ts
@@ -42,7 +42,7 @@ async function getProcessInfo(pid: number): Promise<{
       const {
         Name = '',
         ParentProcessId = 0,
-        CommandLine,
+        CommandLine = '',
       } = JSON.parse(output);
       return {
         parentPid: ParentProcessId,


### PR DESCRIPTION
## TLDR
Unfortunately I'm unable to repro the bug on my windows machine so I can't actually confirm if this fixes the issue but based on the stack trace from #7834, seems like process-utils was returning a null command. 

## Linked issues / bugs
#7834