### PR TITLE
Fix maxOutputTokens compression bug.

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -652,34 +652,6 @@ describe('Gemini Client (client.ts)', () => {
       });
     });
 
-    it('attempts to compress with a maxOutputTokens set to the original token count', async () => {
-      vi.mocked(tokenLimit).mockReturnValue(1000);
-      vi.mocked(mockContentGenerator.countTokens).mockResolvedValue({
-        totalTokens: 999,
-      });
-
-      mockGetHistory.mockReturnValue([
-        { role: 'user', parts: [{ text: '...history...' }] },
-      ]);
-
-      // Mock the summary response from the chat
-      mockSendMessage.mockResolvedValue({
-        role: 'model',
-        parts: [{ text: 'This is a summary.' }],
-      });
-
-      await client.tryCompressChat('prompt-id-2', true);
-
-      expect(mockSendMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          config: expect.objectContaining({
-            maxOutputTokens: 999,
-          }),
-        }),
-        'prompt-id-2',
-      );
-    });
-
     it('should not trigger summarization if token count is below threshold', async () => {
       const MOCKED_TOKEN_LIMIT = 1000;
       vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -845,7 +845,6 @@ export class GeminiClient {
         },
         config: {
           systemInstruction: { text: getCompressionPrompt() },
-          maxOutputTokens: originalTokenCount,
         },
       },
       prompt_id,


### PR DESCRIPTION
## TLDR

Don't specify maxOutputTokens to avoid errors when we set it too high.

## Dive Deeper

Setting maxOutputTokens was only introduced two weeks ago in #7047 probably to try to make sure the model didn't output a compression larger than the original context. But each model has a maximum value allowed for `maxOutputTokens` and we don't know what it is.

We could add a max limit to this to make sure we don't send a value that's too large but I think it would be overkill so I'm just taking it out completely.

## Reviewer Test Plan

Load up a context with more than 65537 tokens and try to compress it.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #7784