### PR TITLE
Skip bundle_size job for merge_group event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,6 +375,8 @@ jobs:
   # Check for changes in bundle size.
   bundle_size:
     name: 'Check Bundle Size'
+    if: |-
+      ${{ github.event_name != 'merge_group' }}
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read' # For checkout


### PR DESCRIPTION
## TLDR

Don't run bundle size check on merge_group event.

## Dive Deeper

https://github.com/google-gemini/gemini-cli/pull/7395 added the bundle_size job for all CI events, but it turns out that preact/compressed-size-action doesn't support the merge_group event (https://github.com/preactjs/compressed-size-action/blob/2a937a1dd255ef04f3ee3611816b630873f5faa3/src/index.js#L37).

This has been broken since the job was introduced (e.g. here it is failing for the merge of the job itself:
https://github.com/google-gemini/gemini-cli/actions/runs/17476553727/job/49637776974)

## Reviewer Test Plan

n/a

## Testing Matrix

n/a

## Linked issues / bugs

In the interests of #3694 to get main to green.
