### PR TITLE
refactor(ide): extract IDE context types into a separate file

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -47,7 +47,7 @@ import {
   MalformedJsonResponseEvent,
   NextSpeakerCheckEvent,
 } from '../telemetry/types.js';
-import type { IdeContext, File } from '../ide/ideContext.js';
+import type { IdeContext, File } from '../ide/types.js';
 import { handleFallback } from '../fallback/handler.js';
 
 export function isThinkingSupported(model: string) {

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -7,14 +7,14 @@
 import * as fs from 'node:fs';
 import { isSubpath } from '../utils/paths.js';
 import { detectIde, type DetectedIde, getIdeInfo } from '../ide/detect-ide.js';
-import type { DiffUpdateResult } from '../ide/ideContext.js';
 import {
   ideContext,
-  IdeContextNotificationSchema,
   IdeDiffAcceptedNotificationSchema,
   IdeDiffClosedNotificationSchema,
   CloseDiffResponseSchema,
-} from '../ide/ideContext.js';
+  type DiffUpdateResult,
+} from './ideContext.js';
+import { IdeContextNotificationSchema } from './types.js';
 import { getIdeProcessInfo } from './process-utils.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';

--- a/packages/core/src/ide/ideContext.test.ts
+++ b/packages/core/src/ide/ideContext.test.ts
@@ -5,11 +5,8 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import {
-  createIdeContextStore,
-  FileSchema,
-  IdeContextSchema,
-} from './ideContext.js';
+import { createIdeContextStore } from './ideContext.js';
+import { FileSchema, IdeContextSchema } from './types.js';
 
 describe('ideContext', () => {
   describe('createIdeContextStore', () => {

--- a/packages/core/src/ide/ideContext.ts
+++ b/packages/core/src/ide/ideContext.ts
@@ -5,42 +5,7 @@
  */
 
 import { z } from 'zod';
-
-/**
- * Zod schema for validating a file context from the IDE.
- */
-export const FileSchema = z.object({
-  path: z.string(),
-  timestamp: z.number(),
-  isActive: z.boolean().optional(),
-  selectedText: z.string().optional(),
-  cursor: z
-    .object({
-      line: z.number(),
-      character: z.number(),
-    })
-    .optional(),
-});
-export type File = z.infer<typeof FileSchema>;
-
-export const IdeContextSchema = z.object({
-  workspaceState: z
-    .object({
-      openFiles: z.array(FileSchema).optional(),
-      isTrusted: z.boolean().optional(),
-    })
-    .optional(),
-});
-export type IdeContext = z.infer<typeof IdeContextSchema>;
-
-/**
- * Zod schema for validating the 'ide/contextUpdate' notification from the IDE.
- */
-export const IdeContextNotificationSchema = z.object({
-  jsonrpc: z.literal('2.0'),
-  method: z.literal('ide/contextUpdate'),
-  params: IdeContextSchema,
-});
+import type { IdeContext } from './types.js';
 
 export const IdeDiffAcceptedNotificationSchema = z.object({
   jsonrpc: z.literal('2.0'),

--- a/packages/core/src/ide/types.ts
+++ b/packages/core/src/ide/types.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod';
+
+/**
+ * A file that is open in the IDE.
+ */
+export const FileSchema = z.object({
+  /**
+   * The absolute path to the file.
+   */
+  path: z.string(),
+  /**
+   * The timestamp of when the file was last focused.
+   */
+  timestamp: z.number(),
+  /**
+   * Whether the file is the currently active file. Only one file can be active at a time.
+   */
+  isActive: z.boolean().optional(),
+  /**
+   * The text that is currently selected in the active file.
+   */
+  selectedText: z.string().optional(),
+  /**
+   * The cursor position in the active file.
+   */
+  cursor: z
+    .object({
+      /**
+       * The 1-based line number.
+       */
+      line: z.number(),
+      /**
+       * The 1-based character offset.
+       */
+      character: z.number(),
+    })
+    .optional(),
+});
+export type File = z.infer<typeof FileSchema>;
+
+/**
+ * The context of the IDE.
+ */
+export const IdeContextSchema = z.object({
+  workspaceState: z
+    .object({
+      /**
+       * The list of files that are currently open.
+       */
+      openFiles: z.array(FileSchema).optional(),
+      /**
+       * Whether the workspace is trusted.
+       */
+      isTrusted: z.boolean().optional(),
+    })
+    .optional(),
+});
+export type IdeContext = z.infer<typeof IdeContextSchema>;
+
+export const IdeContextNotificationSchema = z.object({
+  jsonrpc: z.literal('2.0'),
+  method: z.literal('ide/contextUpdate'),
+  params: IdeContextSchema,
+});

--- a/packages/core/src/ide/types.ts
+++ b/packages/core/src/ide/types.ts
@@ -15,7 +15,7 @@ export const FileSchema = z.object({
    */
   path: z.string(),
   /**
-   * The timestamp of when the file was last focused.
+   * The unix timestamp of when the file was last focused.
    */
   timestamp: z.number(),
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,7 @@ export * from './ide/ide-installer.js';
 export { getIdeInfo, DetectedIde } from './ide/detect-ide.js';
 export { type IdeInfo } from './ide/detect-ide.js';
 export * from './ide/constants.js';
+export * from './ide/types.js';
 
 // Export Shell Execution Service
 export * from './services/shellExecutionService.js';


### PR DESCRIPTION
## TLDR
This PR refactors IDE-related type definitions, extracting them into a new, dedicated file at packages/core/src/ide/types.ts. This move separates static type definitions from runtime logic, improving code organization and setting a clearer foundation for future extensibility.

## Dive Deeper

The primary motivation for this refactor is to improve the structure and maintainability of our IDE integration. By centralizing all IDE-related Zod schemas and TypeScript types into a single file, we establish a clear source of truth for these data structures.

This change is purely organizational and introduces no functional changes.

## Linked issues / bugs
#4800 
