### PR TITLE
Remove docs mention from sandbox footer

### DIFF
--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -141,7 +141,7 @@ describe('<Footer />', () => {
         ...defaultProps,
         isTrustedFolder: true,
       });
-      expect(lastFrame()).toContain('no sandbox');
+      expect(lastFrame()).toMatch(/no.*sandbox/s);
       vi.unstubAllEnvs();
     });
 

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -141,7 +141,7 @@ describe('<Footer />', () => {
         ...defaultProps,
         isTrustedFolder: true,
       });
-      expect(lastFrame()).toMatch(/no.*sandbox/s);
+      expect(lastFrame()).toMatch(/\bno sandbox\b/);
       vi.unstubAllEnvs();
     });
 

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -116,9 +116,7 @@ export const Footer: React.FC<FooterProps> = ({
             </Text>
           </Text>
         ) : (
-          <Text color={theme.status.error}>
-            no sandbox
-          </Text>
+          <Text color={theme.status.error}>no sandbox</Text>
         )}
       </Box>
 

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -117,7 +117,7 @@ export const Footer: React.FC<FooterProps> = ({
           </Text>
         ) : (
           <Text color={theme.status.error}>
-            no sandbox <Text color={theme.text.secondary}>(see /docs)</Text>
+            no sandbox
           </Text>
         )}
       </Box>


### PR DESCRIPTION
## TLDR

This removes the blurb `(see /docs)` from the sandbox footer in order to give more space to other items in the footer. Especially in narrower views, this blurb takes up a decent amount of space.

## Dive Deeper

## Before
<img width="1516" height="270" alt="CleanShot 2025-09-08 at 16 59 23@2x" src="https://github.com/user-attachments/assets/4a5125fb-7a91-491c-a83e-adf8e88335ff" />

## After
<img width="1498" height="220" alt="CleanShot 2025-09-08 at 16 57 50@2x" src="https://github.com/user-attachments/assets/19125d8e-d2d2-4f32-83f6-eab9df538a08" />


## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
