### PR TITLE
Fix character corruption in unescapeStringForGeminiBug function

### DIFF
--- a/packages/core/src/utils/editCorrector.test.ts
+++ b/packages/core/src/utils/editCorrector.test.ts
@@ -150,6 +150,28 @@ describe('editCorrector', () => {
         'quote"text\nline',
       );
     });
+
+    // Test cases for the character corruption bug fix
+    describe('character corruption prevention', () => {
+      it('should NOT corrupt Windows file paths', () => {
+        // These should remain unchanged - they are legitimate file paths
+        expect(unescapeStringForGeminiBug('C:\\\\Users\\\\name')).toBe('C:\\\\Users\\\\name');
+        expect(unescapeStringForGeminiBug('D:\\\\workspace\\\\project')).toBe('D:\\\\workspace\\\\project');
+      });
+
+      it('should NOT corrupt multi-segment paths', () => {
+        // These should remain unchanged - they are legitimate paths
+        expect(unescapeStringForGeminiBug('path\\\\to\\\\file')).toBe('path\\\\to\\\\file');
+        expect(unescapeStringForGeminiBug('src\\\\components\\\\Button')).toBe('src\\\\components\\\\Button');
+      });
+
+      it('should still handle legitimate escape sequences', () => {
+        // These ARE actual escape sequences that should be unescaped
+        expect(unescapeStringForGeminiBug('Hello\\nWorld')).toBe('Hello\nWorld');
+        expect(unescapeStringForGeminiBug('Tab\\tSeparated')).toBe('Tab\tSeparated');
+        expect(unescapeStringForGeminiBug('Quote\\"Text')).toBe('Quote"Text');
+      });
+    });
   });
 
   describe('ensureCorrectEdit', () => {


### PR DESCRIPTION
##Fix
#8035


## Problem

Fixes a character corruption bug in the `unescapeStringForGeminiBug` function where legitimate file paths and code were being corrupted by over-aggressive regex matching.

**Examples of corruption that this PR fixes:**
- `C:\\Users\\name` → `C:\Users[newline]ame` (\\n converted to newline)
- `path\\to\\file` → `path[tab]o\file` (\\t converted to tab)  
- `monorepo root` → `monopo root` (\\r converted to carriage return)

This was causing data loss and syntax errors when the CLI processed file edits.

## Root Cause

The regex `/\\+(n|t|r|'|"|`|\\|\n)/g` was too aggressive and matched legitimate backslash sequences in file paths, converting them to escape characters instead of preserving them.

## Solution

Enhanced the function with context detection that:

1. **Preserves legitimate file paths:**
   - Windows absolute paths (`C:\Users\name`)
   - UNC paths (`\\server\share`)
   - Multi-segment relative paths (`path\to\file`)

2. **Still properly unescapes legitimate escape sequences:**
   - `Hello\\nWorld` → `Hello\nWorld` (newline)
   - `Tab\\tSeparated` → `Tab\tSeparated` (tab)
   - `Quote\\"Text` → `Quote"Text` (quote)

## Changes

- Enhanced `unescapeStringForGeminiBug` function in `packages/core/src/utils/editCorrector.ts`
- Added context detection logic to distinguish file paths from escape sequences
- Added comprehensive test cases to prevent regression
