### PR TITLE
feat(cli): add spinner to update notification

### DIFF
--- a/packages/cli/src/ui/components/Notifications.tsx
+++ b/packages/cli/src/ui/components/Notifications.tsx
@@ -25,7 +25,9 @@ export const Notifications = () => {
 
   return (
     <>
-      {updateInfo && <UpdateNotification message={updateInfo.message} />}
+      {updateInfo && (
+        <UpdateNotification message={updateInfo.message} showSpinner={true} />
+      )}
       {showStartupWarnings && (
         <Box
           borderStyle="round"

--- a/packages/cli/src/ui/components/UpdateNotification.tsx
+++ b/packages/cli/src/ui/components/UpdateNotification.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Box, Text } from 'ink';
+import Spinner from 'ink-spinner';
 import { Colors } from '../colors.js';
 
 interface UpdateNotificationProps {
@@ -18,6 +19,8 @@ export const UpdateNotification = ({ message }: UpdateNotificationProps) => (
     paddingX={1}
     marginY={1}
   >
-    <Text color={Colors.AccentYellow}>{message}</Text>
+    <Text color={Colors.AccentYellow}>
+      <Spinner type="dots" /> {message}
+    </Text>
   </Box>
 );

--- a/packages/cli/src/ui/components/UpdateNotification.tsx
+++ b/packages/cli/src/ui/components/UpdateNotification.tsx
@@ -10,9 +10,13 @@ import { Colors } from '../colors.js';
 
 interface UpdateNotificationProps {
   message: string;
+  showSpinner?: boolean;
 }
 
-export const UpdateNotification = ({ message }: UpdateNotificationProps) => (
+export const UpdateNotification = ({
+  message,
+  showSpinner = false,
+}: UpdateNotificationProps) => (
   <Box
     borderStyle="round"
     borderColor={Colors.AccentYellow}
@@ -20,7 +24,12 @@ export const UpdateNotification = ({ message }: UpdateNotificationProps) => (
     marginY={1}
   >
     <Text color={Colors.AccentYellow}>
-      <Spinner type="dots" /> {message}
+      {showSpinner && (
+        <>
+          <Spinner type="dots" />{' '}
+        </>
+      )}
+      {message}
     </Text>
   </Box>
 );


### PR DESCRIPTION
<h2>TL;DR</h2>
<p>This pull request adds a <strong>spinner</strong> to the update notification message, providing visual feedback to users while the auto-update process is running.</p>
<hr>
<h2>Dive Deeper</h2>
<p>The <code>UpdateNotification</code> component (<code>packages/cli/src/ui/components/UpdateNotification.tsx</code>) has been updated to include the <code>Spinner</code> component from <strong>ink-spinner</strong>.</p>
<p>This improves the user experience by making it clear that the CLI is actively handling the update process, rather than appearing idle.</p>
<hr>
<h2>Reviewer Test Plan</h2>
<p>To verify this change:</p>
<ol>
<li>
<p>Manually trigger the update notification.</p>
</li>
<li>
<p>Observe that a <strong>spinner appears next to the update message</strong> while the process is in progress.</p>
</li>
</ol>
<hr>
<h2>Testing Matrix</h2>

Platform | 🍏 macOS | 🪟 Windows | 🐧 Linux
-- | -- | -- | --
npm run | ❓ | ❓ | ✅
npx | ❓ | ❓ | ✅
Docker | ❓ | ❓ | ❓
Podman | ❓ | - | -
Seatbelt | ❓ | - | -

related issue #8064

