### PR TITLE
Ignore workspace extensions in user extensions dir

### DIFF
--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -81,6 +81,13 @@ export class ExtensionStorage {
 }
 
 export function getWorkspaceExtensions(workspaceDir: string): Extension[] {
+  // If the workspace dir is the user extensions dir, there are no workspace extensions.
+  if (
+    path.resolve(workspaceDir) ===
+    path.resolve(ExtensionStorage.getUserExtensionsDir())
+  ) {
+    return [];
+  }
   return loadExtensionsFromDir(workspaceDir);
 }
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -82,10 +82,7 @@ export class ExtensionStorage {
 
 export function getWorkspaceExtensions(workspaceDir: string): Extension[] {
   // If the workspace dir is the user extensions dir, there are no workspace extensions.
-  if (
-    path.resolve(workspaceDir) ===
-    path.resolve(ExtensionStorage.getUserExtensionsDir())
-  ) {
+  if (path.resolve(workspaceDir) === path.resolve(os.homedir())) {
     return [];
   }
   return loadExtensionsFromDir(workspaceDir);


### PR DESCRIPTION
## TLDR

This ensures a user-level extension is never treated as a (now deprecated) workspace-level extension.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #8083
