### PR TITLE
fix: Correct typos in comments across multiple files

### DIFF
--- a/packages/a2a-server/development-extension-rfc.md
+++ b/packages/a2a-server/development-extension-rfc.md
@@ -273,7 +273,7 @@ message DevelopmentToolEvent {
   // The tier of the user (optional).
   string user_tier = 3;
 
-  // An unexpected error occured in the agent execution (optional).
+  // An unexpected error occurred in the agent execution (optional).
   string error = 4;
 }
 ```

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -636,7 +636,7 @@ export function loadSettings(
     isTrusted,
   );
 
-  // loadEnviroment depends on settings so we have to create a temp version of
+  // loadEnvironment depends on settings so we have to create a temp version of
   // the settings to avoid a cycle
   loadEnvironment(tempMergedSettings);
 

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -85,7 +85,7 @@ export function setUpdateHandler(
   setUpdateInfo: (info: UpdateObject | null) => void,
 ) {
   let successfullyInstalled = false;
-  const handleUpdateRecieved = (info: UpdateObject) => {
+  const handleUpdateReceived = (info: UpdateObject) => {
     setUpdateInfo(info);
     const savedMessage = info.message;
     setTimeout(() => {
@@ -135,13 +135,13 @@ export function setUpdateHandler(
     );
   };
 
-  updateEventEmitter.on('update-received', handleUpdateRecieved);
+  updateEventEmitter.on('update-received', handleUpdateReceived);
   updateEventEmitter.on('update-failed', handleUpdateFailed);
   updateEventEmitter.on('update-success', handleUpdateSuccess);
   updateEventEmitter.on('update-info', handleUpdateInfo);
 
   return () => {
-    updateEventEmitter.off('update-received', handleUpdateRecieved);
+    updateEventEmitter.off('update-received', handleUpdateReceived);
     updateEventEmitter.off('update-failed', handleUpdateFailed);
     updateEventEmitter.off('update-success', handleUpdateSuccess);
     updateEventEmitter.off('update-info', handleUpdateInfo);

--- a/packages/core/src/test-utils/config.ts
+++ b/packages/core/src/test-utils/config.ts
@@ -21,7 +21,7 @@ export const DEFAULT_CONFIG_PARAMETERS: ConfigParameters = {
 };
 
 /**
- * Produces a config.  Default paramters are set to
+ * Produces a config.  Default parameters are set to
  * {@link DEFAULT_CONFIG_PARAMETERS}, optionally, fields can be specified to
  * override those defaults.
  */


### PR DESCRIPTION
## TLDR

Correct typos in comments across multiple files

## Dive Deeper

Correct typos in comments across multiple files

## Reviewer Test Plan

none

## Testing Matrix

They are just typos: I did a full rebuild without any errors.

## Linked issues / bugs

none
