### PR TITLE
fix(ide companion extension): Don't show the installation confirmation message in Firebase Studio

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -16,7 +16,7 @@ export {
   DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
   DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
 } from './src/config/config.js';
-export { getIdeInfo } from './src/ide/detect-ide.js';
+export { detectIdeFromEnv, getIdeInfo } from './src/ide/detect-ide.js';
 export { logIdeConnection } from './src/telemetry/loggers.js';
 export {
   IdeConnectionEvent,

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -9,6 +9,7 @@ import { IDEServer } from './ide-server.js';
 import semver from 'semver';
 import { DiffContentProvider, DiffManager } from './diff-manager.js';
 import { createLogger } from './utils/logger.js';
+import { detectIdeFromEnv, DetectedIde } from '@google/gemini-cli-core';
 
 const CLI_IDE_COMPANION_IDENTIFIER = 'Google.gemini-cli-vscode-ide-companion';
 const INFO_MESSAGE_SHOWN_KEY = 'geminiCliInfoMessageShown';
@@ -133,7 +134,11 @@ export async function activate(context: vscode.ExtensionContext) {
     log(`Failed to start IDE server: ${message}`);
   }
 
-  if (!context.globalState.get(INFO_MESSAGE_SHOWN_KEY)) {
+  const infoMessageEnabled =
+    // the plugin is native to Firebase Studio, don't show the message
+    detectIdeFromEnv() !== DetectedIde.FirebaseStudio;
+
+  if (!context.globalState.get(INFO_MESSAGE_SHOWN_KEY) && infoMessageEnabled) {
     void vscode.window.showInformationMessage(
       'Gemini CLI Companion extension successfully installed.',
     );


### PR DESCRIPTION
## TLDR

Don't show the installation confirmation message in Firebase Studio. This is because we preinstall the CLI companion in many new workspace templates now, and the user immediately sees the message on first run of the workspace.

## Dive Deeper

Checks an environment variable set in Firebase Studio (already available in the core package as `detectIdeFromEnv`) and conditionally disables the popup message.

## Reviewer Test Plan

1. Outside Firebase Studio (e.g. in VSCode, etc) nothing should be different
2. When installing the extension in Firebase Studio, you should NOT see the "Gemini CLI Companion extension successfully installed." message.

## Testing Matrix

N/A - this is for the VSCode companion extension

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A