### PR TITLE
Extensions update command

### DIFF
--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -145,8 +145,8 @@ describe('extensionsCommand', () => {
         {
           type: MessageType.INFO,
           text:
-            'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1.\n' +
-            'Extension "ext-two" successfully updated: 2.0.0 → 2.0.1.',
+            'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1. Restart gemini-cli to see the changes.\n' +
+            'Extension "ext-two" successfully updated: 2.0.0 → 2.0.1. Restart gemini-cli to see the changes.',
         },
         expect.any(Number),
       );
@@ -176,7 +176,7 @@ describe('extensionsCommand', () => {
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
           type: MessageType.INFO,
-          text: 'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1.',
+          text: 'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1. Restart gemini-cli to see the changes.',
         },
         expect.any(Number),
       );
@@ -213,14 +213,14 @@ describe('extensionsCommand', () => {
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
           type: MessageType.INFO,
-          text: 'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1.',
+          text: 'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1. Restart gemini-cli to see the changes.',
         },
         expect.any(Number),
       );
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
           type: MessageType.INFO,
-          text: 'Extension "ext-two" successfully updated: 2.0.0 → 2.0.1.',
+          text: 'Extension "ext-two" successfully updated: 2.0.0 → 2.0.1. Restart gemini-cli to see the changes.',
         },
         expect.any(Number),
       );

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -145,8 +145,9 @@ describe('extensionsCommand', () => {
         {
           type: MessageType.INFO,
           text:
-            'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1. Restart gemini-cli to see the changes.\n' +
-            'Extension "ext-two" successfully updated: 2.0.0 → 2.0.1. Restart gemini-cli to see the changes.',
+            'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1.\n' +
+            'Extension "ext-two" successfully updated: 2.0.0 → 2.0.1.\n' +
+            'Restart gemini-cli to see the changes.',
         },
         expect.any(Number),
       );
@@ -176,7 +177,9 @@ describe('extensionsCommand', () => {
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
           type: MessageType.INFO,
-          text: 'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1. Restart gemini-cli to see the changes.',
+          text:
+            'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1.\n' +
+            'Restart gemini-cli to see the changes.',
         },
         expect.any(Number),
       );
@@ -213,14 +216,10 @@ describe('extensionsCommand', () => {
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
           type: MessageType.INFO,
-          text: 'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1. Restart gemini-cli to see the changes.',
-        },
-        expect.any(Number),
-      );
-      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
-        {
-          type: MessageType.INFO,
-          text: 'Extension "ext-two" successfully updated: 2.0.0 → 2.0.1. Restart gemini-cli to see the changes.',
+          text:
+            'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1.\n' +
+            'Extension "ext-two" successfully updated: 2.0.0 → 2.0.1.\n' +
+            'Restart gemini-cli to see the changes.',
         },
         expect.any(Number),
       );

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -4,16 +4,42 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
-import { extensionsCommand } from './extensionsCommand.js';
-import { type CommandContext } from './types.js';
+import {
+  updateAllUpdatableExtensions,
+  updateExtensionByName,
+} from '../../config/extension.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { MessageType } from '../types.js';
+import { extensionsCommand } from './extensionsCommand.js';
+import { type CommandContext } from './types.js';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  type MockedFunction,
+} from 'vitest';
+
+vi.mock('../../config/extension.js', () => ({
+  updateExtensionByName: vi.fn(),
+  updateAllUpdatableExtensions: vi.fn(),
+}));
+
+const mockUpdateExtensionByName = updateExtensionByName as MockedFunction<
+  typeof updateExtensionByName
+>;
+
+const mockUpdateAllUpdatableExtensions =
+  updateAllUpdatableExtensions as MockedFunction<
+    typeof updateAllUpdatableExtensions
+  >;
 
 describe('extensionsCommand', () => {
   let mockContext: CommandContext;
 
-  it('should display "No active extensions." when none are found', async () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
     mockContext = createMockCommandContext({
       services: {
         config: {
@@ -21,47 +47,183 @@ describe('extensionsCommand', () => {
         },
       },
     });
-
-    if (!extensionsCommand.action) throw new Error('Action not defined');
-    await extensionsCommand.action(mockContext, '');
-
-    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
-      {
-        type: MessageType.INFO,
-        text: 'No active extensions.',
-      },
-      expect.any(Number),
-    );
   });
 
-  it('should list active extensions when they are found', async () => {
-    const mockExtensions = [
-      { name: 'ext-one', version: '1.0.0', isActive: true },
-      { name: 'ext-two', version: '2.1.0', isActive: true },
-      { name: 'ext-three', version: '3.0.0', isActive: false },
-    ];
-    mockContext = createMockCommandContext({
-      services: {
-        config: {
-          getExtensions: () => mockExtensions,
+  describe('list', () => {
+    it('should display "No active extensions." when none are found', async () => {
+      if (!extensionsCommand.action) throw new Error('Action not defined');
+      await extensionsCommand.action(mockContext, '');
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'No active extensions.',
         },
-      },
+        expect.any(Number),
+      );
     });
 
-    if (!extensionsCommand.action) throw new Error('Action not defined');
-    await extensionsCommand.action(mockContext, '');
+    it('should list active extensions when they are found', async () => {
+      const mockExtensions = [
+        { name: 'ext-one', version: '1.0.0', isActive: true },
+        { name: 'ext-two', version: '2.1.0', isActive: true },
+        { name: 'ext-three', version: '3.0.0', isActive: false },
+      ];
+      mockContext = createMockCommandContext({
+        services: {
+          config: {
+            getExtensions: () => mockExtensions,
+          },
+        },
+      });
 
-    const expectedMessage =
-      'Active extensions:\n\n' +
-      `  - \u001b[36mext-one (v1.0.0)\u001b[0m\n` +
-      `  - \u001b[36mext-two (v2.1.0)\u001b[0m\n`;
+      if (!extensionsCommand.action) throw new Error('Action not defined');
+      await extensionsCommand.action(mockContext, '');
 
-    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
-      {
-        type: MessageType.INFO,
-        text: expectedMessage,
-      },
-      expect.any(Number),
-    );
+      const expectedMessage =
+        'Active extensions:\n\n' +
+        `  - \u001b[36mext-one (v1.0.0)\u001b[0m\n` +
+        `  - \u001b[36mext-two (v2.1.0)\u001b[0m\n`;
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: expectedMessage,
+        },
+        expect.any(Number),
+      );
+    });
+  });
+
+  describe('update', () => {
+    const updateAction = extensionsCommand.subCommands?.find(
+      (cmd) => cmd.name === 'update',
+    )?.action;
+
+    if (!updateAction) {
+      throw new Error('Update action not found');
+    }
+
+    it('should show usage if no args are provided', async () => {
+      await updateAction(mockContext, '');
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.ERROR,
+          text: 'Usage: /extensions update <extension-names>|--all',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should inform user if there are no extensions to update with --all', async () => {
+      mockUpdateAllUpdatableExtensions.mockResolvedValue([]);
+      await updateAction(mockContext, '--all');
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'No extensions to update.',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should update all extensions with --all', async () => {
+      mockUpdateAllUpdatableExtensions.mockResolvedValue([
+        {
+          name: 'ext-one',
+          originalVersion: '1.0.0',
+          updatedVersion: '1.0.1',
+        },
+        {
+          name: 'ext-two',
+          originalVersion: '2.0.0',
+          updatedVersion: '2.0.1',
+        },
+      ]);
+      await updateAction(mockContext, '--all');
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text:
+            'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1.\n' +
+            'Extension "ext-two" successfully updated: 2.0.0 → 2.0.1.',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should handle errors when updating all extensions', async () => {
+      mockUpdateAllUpdatableExtensions.mockRejectedValue(
+        new Error('Something went wrong'),
+      );
+      await updateAction(mockContext, '--all');
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.ERROR,
+          text: 'Something went wrong',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should update a single extension by name', async () => {
+      mockUpdateExtensionByName.mockResolvedValue({
+        name: 'ext-one',
+        originalVersion: '1.0.0',
+        updatedVersion: '1.0.1',
+      });
+      await updateAction(mockContext, 'ext-one');
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1.',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should handle errors when updating a single extension', async () => {
+      mockUpdateExtensionByName.mockRejectedValue(
+        new Error('Extension not found'),
+      );
+      await updateAction(mockContext, 'ext-one');
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.ERROR,
+          text: 'Extension not found',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should update multiple extensions by name', async () => {
+      mockUpdateExtensionByName
+        .mockResolvedValueOnce({
+          name: 'ext-one',
+          originalVersion: '1.0.0',
+          updatedVersion: '1.0.1',
+        })
+        .mockResolvedValueOnce({
+          name: 'ext-two',
+          originalVersion: '2.0.0',
+          updatedVersion: '2.0.1',
+        });
+      await updateAction(mockContext, 'ext-one ext-two');
+      expect(mockUpdateExtensionByName).toHaveBeenCalledTimes(2);
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'Extension "ext-one" successfully updated: 1.0.0 → 1.0.1.',
+        },
+        expect.any(Number),
+      );
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'Extension "ext-two" successfully updated: 2.0.0 → 2.0.1.',
+        },
+        expect.any(Number),
+      );
+    });
   });
 });

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -69,6 +69,7 @@ async function updateAction(context: CommandContext, args: string) {
         },
         Date.now(),
       );
+      return;
     }
 
     // Filter to the actually updated ones.

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -47,7 +47,7 @@ async function listAction(context: CommandContext) {
 }
 
 const updateOutput = (info: ExtensionUpdateInfo) =>
-  `Extension "${info.name}" successfully updated: ${info.originalVersion} → ${info.updatedVersion}.`;
+  `Extension "${info.name}" successfully updated: ${info.originalVersion} → ${info.updatedVersion}. Restart gemini-cli to see the changes.`;
 
 async function updateAction(context: CommandContext, args: string) {
   const updateArgs = args.split(' ').filter((value) => value.length > 0);

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -5,42 +5,136 @@
  */
 
 import {
+  updateExtensionByName,
+  updateAllUpdatableExtensions,
+  type ExtensionUpdateInfo,
+} from '../../config/extension.js';
+import { getErrorMessage } from '../../utils/errors.js';
+import { MessageType } from '../types.js';
+import {
   type CommandContext,
   type SlashCommand,
   CommandKind,
 } from './types.js';
-import { MessageType } from '../types.js';
 
-export const extensionsCommand: SlashCommand = {
-  name: 'extensions',
-  description: 'list active extensions',
-  kind: CommandKind.BUILT_IN,
-  action: async (context: CommandContext): Promise<void> => {
-    const activeExtensions = context.services.config
-      ?.getExtensions()
-      .filter((ext) => ext.isActive);
-    if (!activeExtensions || activeExtensions.length === 0) {
-      context.ui.addItem(
-        {
-          type: MessageType.INFO,
-          text: 'No active extensions.',
-        },
-        Date.now(),
-      );
-      return;
-    }
-
-    const extensionLines = activeExtensions.map(
-      (ext) => `  - \u001b[36m${ext.name} (v${ext.version})\u001b[0m`,
-    );
-    const message = `Active extensions:\n\n${extensionLines.join('\n')}\n`;
-
+async function listAction(context: CommandContext) {
+  const activeExtensions = context.services.config
+    ?.getExtensions()
+    .filter((ext) => ext.isActive);
+  if (!activeExtensions || activeExtensions.length === 0) {
     context.ui.addItem(
       {
         type: MessageType.INFO,
-        text: message,
+        text: 'No active extensions.',
       },
       Date.now(),
     );
-  },
+    return;
+  }
+
+  const extensionLines = activeExtensions.map(
+    (ext) => `  - \u001b[36m${ext.name} (v${ext.version})\u001b[0m`,
+  );
+  const message = `Active extensions:\n\n${extensionLines.join('\n')}\n`;
+
+  context.ui.addItem(
+    {
+      type: MessageType.INFO,
+      text: message,
+    },
+    Date.now(),
+  );
+}
+
+const updateOutput = (info: ExtensionUpdateInfo) =>
+  `Extension "${info.name}" successfully updated: ${info.originalVersion} → ${info.updatedVersion}.`;
+
+async function updateAction(context: CommandContext, args: string) {
+  const updateArgs = args.split(' ').filter((value) => value.length > 0);
+  const all = updateArgs.length === 1 && updateArgs[0] === '--all';
+  const names = all ? undefined : updateArgs;
+
+  if (all) {
+    try {
+      const updateInfos = await updateAllUpdatableExtensions();
+      if (updateInfos.length === 0) {
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text: 'No extensions to update.',
+          },
+          Date.now(),
+        );
+        return;
+      }
+      context.ui.addItem(
+        {
+          type: MessageType.INFO,
+          text: updateInfos.map((info) => updateOutput(info)).join('\n'),
+        },
+        Date.now(),
+      );
+    } catch (error) {
+      context.ui.addItem(
+        {
+          type: MessageType.ERROR,
+          text: getErrorMessage(error),
+        },
+        Date.now(),
+      );
+    }
+  } else if (names?.length) {
+    for (const name of names) {
+      try {
+        const updatedExtensionInfo = await updateExtensionByName(name);
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text: updateOutput(updatedExtensionInfo),
+          },
+          Date.now(),
+        );
+      } catch (error) {
+        context.ui.addItem(
+          {
+            type: MessageType.ERROR,
+            text: getErrorMessage(error),
+          },
+          Date.now(),
+        );
+      }
+    }
+  } else {
+    context.ui.addItem(
+      {
+        type: MessageType.ERROR,
+        text: 'Usage: /extensions update <extension-names>|--all',
+      },
+      Date.now(),
+    );
+  }
+}
+
+const listExtensionsCommand: SlashCommand = {
+  name: 'list',
+  description: 'List active extensions',
+  kind: CommandKind.BUILT_IN,
+  action: listAction,
+};
+
+const updateExtensionsCommand: SlashCommand = {
+  name: 'update',
+  description: 'Update extensions. Usage: update <extension-names>|--all',
+  kind: CommandKind.BUILT_IN,
+  action: updateAction,
+};
+
+export const extensionsCommand: SlashCommand = {
+  name: 'extensions',
+  description: 'Manage extensions',
+  kind: CommandKind.BUILT_IN,
+  subCommands: [listExtensionsCommand, updateExtensionsCommand],
+  action: (context, args) =>
+    // Default to list if no subcommand is provided
+    listExtensionsCommand.action!(context, args),
 };


### PR DESCRIPTION
## TLDR

Adds `/extensions update` and `/extensions list`, although `/extensions` will still default to just the list command as well.

Can pass `--all` to update all extensions or a list of named extensions.

## Reviewer Test Plan

Install a git extension, then update the remote repo and run `/extensions update <extension-name>`.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Part of #8018
Works in combination with #7009 although they are independently updated