### PR TITLE
feat(core): Re-download `rg` binary if it is deleted.

### DIFF
--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -20,7 +20,7 @@ import { Storage } from '../config/storage.js';
 
 const DEFAULT_TOTAL_MAX_MATCHES = 20000;
 
-function getRgPath() {
+function getRgPath(): string {
   return path.join(Storage.getGlobalBinDir(), 'rg');
 }
 
@@ -34,6 +34,16 @@ export async function canUseRipgrep(): Promise<boolean> {
 
   await downloadRipGrep(Storage.getGlobalBinDir());
   return await fileExists(getRgPath());
+}
+
+/**
+ * Ensures `rg` is downloaded, or throws.
+ */
+export async function ensureRgPath(): Promise<string> {
+  if (await canUseRipgrep()) {
+    return getRgPath();
+  }
+  throw new Error('Cannot use ripgrep.');
 }
 
 /**
@@ -310,8 +320,9 @@ class GrepToolInvocation extends BaseToolInvocation<
     rgArgs.push(absolutePath);
 
     try {
+      const rgPath = await ensureRgPath();
       const output = await new Promise<string>((resolve, reject) => {
-        const child = spawn(getRgPath(), rgArgs, {
+        const child = spawn(rgPath, rgArgs, {
           windowsHide: true,
         });
 


### PR DESCRIPTION
## TLDR

Re-downloads `rg` if it is deleted at runtime.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | :heavy_check_mark:   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fix to enable #7327
