### PR TITLE
feat(routing): Initialize model routing architecture

### DIFF
--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -132,7 +132,7 @@ export class Task {
       id: this.id,
       contextId: this.contextId,
       taskState: this.taskState,
-      model: this.config.getContentGeneratorConfig().model,
+      model: this.config.getModel(),
       mcpServers: servers,
       availableTools,
     };

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -57,7 +57,6 @@ describe('useQuotaAndFallback', () => {
     // Spy on the method that requires the private field and mock its return.
     // This is cleaner than modifying the config class for tests.
     vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
-      model: 'gemini-pro',
       authType: AuthType.LOGIN_WITH_GOOGLE,
     });
 
@@ -128,7 +127,6 @@ describe('useQuotaAndFallback', () => {
     it('should return null and take no action if authType is not LOGIN_WITH_GOOGLE', async () => {
       // Override the default mock from beforeEach for this specific test
       vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
-        model: 'gemini-pro',
         authType: AuthType.USE_GEMINI,
       });
 

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -255,6 +255,7 @@ class Session {
 
       try {
         const responseStream = await chat.sendMessageStream(
+          this.config.getModel(),
           {
             message: nextMessage?.parts ?? [],
             config: {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -206,9 +206,7 @@ describe('Server Config (config.ts)', () => {
     it('should refresh auth and update config', async () => {
       const config = new Config(baseParams);
       const authType = AuthType.USE_GEMINI;
-      const newModel = 'gemini-flash';
       const mockContentConfig = {
-        model: newModel,
         apiKey: 'test-key',
       };
 
@@ -226,10 +224,8 @@ describe('Server Config (config.ts)', () => {
         config,
         authType,
       );
-      // Verify that contentGeneratorConfig is updated with the new model
+      // Verify that contentGeneratorConfig is updated
       expect(config.getContentGeneratorConfig()).toEqual(mockContentConfig);
-      expect(config.getContentGeneratorConfig().model).toBe(newModel);
-      expect(config.getModel()).toBe(newModel); // getModel() should return the updated model
       expect(GeminiClient).toHaveBeenCalledWith(config);
       // Verify that fallback mode is reset
       expect(config.isInFallbackMode()).toBe(false);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -524,7 +524,7 @@ export class Config {
 
   setModel(newModel: string): void {
     // Do not allow Pro usage if the user is in fallback mode.
-    if (newModel === DEFAULT_GEMINI_MODEL && this.isInFallbackMode()) {
+    if (newModel.includes('pro') && this.isInFallbackMode()) {
       return;
     }
 

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getEffectiveModel,
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_GEMINI_FLASH_MODEL,
+  DEFAULT_GEMINI_FLASH_LITE_MODEL,
+} from './models.js';
+
+describe('getEffectiveModel', () => {
+  describe('When NOT in fallback mode', () => {
+    const isInFallbackMode = false;
+
+    it('should return the Pro model when Pro is requested', () => {
+      const model = getEffectiveModel(isInFallbackMode, DEFAULT_GEMINI_MODEL);
+      expect(model).toBe(DEFAULT_GEMINI_MODEL);
+    });
+
+    it('should return the Flash model when Flash is requested', () => {
+      const model = getEffectiveModel(
+        isInFallbackMode,
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
+      expect(model).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+    });
+
+    it('should return the Lite model when Lite is requested', () => {
+      const model = getEffectiveModel(
+        isInFallbackMode,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
+      );
+      expect(model).toBe(DEFAULT_GEMINI_FLASH_LITE_MODEL);
+    });
+
+    it('should return a custom model name when requested', () => {
+      const customModel = 'custom-model-v1';
+      const model = getEffectiveModel(isInFallbackMode, customModel);
+      expect(model).toBe(customModel);
+    });
+  });
+
+  describe('When IN fallback mode', () => {
+    const isInFallbackMode = true;
+
+    it('should downgrade the Pro model to the Flash model', () => {
+      const model = getEffectiveModel(isInFallbackMode, DEFAULT_GEMINI_MODEL);
+      expect(model).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+    });
+
+    it('should return the Flash model when Flash is requested', () => {
+      const model = getEffectiveModel(
+        isInFallbackMode,
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
+      expect(model).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+    });
+
+    it('should HONOR the Lite model when Lite is requested', () => {
+      const model = getEffectiveModel(
+        isInFallbackMode,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
+      );
+      expect(model).toBe(DEFAULT_GEMINI_FLASH_LITE_MODEL);
+    });
+
+    it('should HONOR any model with "lite" in its name', () => {
+      const customLiteModel = 'gemini-2.5-custom-lite-vNext';
+      const model = getEffectiveModel(isInFallbackMode, customLiteModel);
+      expect(model).toBe(customLiteModel);
+    });
+
+    it('should downgrade any other custom model to the Flash model', () => {
+      const customModel = 'custom-model-v1-unlisted';
+      const model = getEffectiveModel(isInFallbackMode, customModel);
+      expect(model).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+    });
+  });
+});

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -12,3 +12,35 @@ export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';
 
 // Some thinking models do not default to dynamic thinking which is done by a value of -1
 export const DEFAULT_THINKING_MODE = -1;
+
+/**
+ * Determines the effective model to use, applying fallback logic if necessary.
+ *
+ * When fallback mode is active, this function enforces the use of the standard
+ * fallback model. However, it makes an exception for "lite" models (any model
+ * with "lite" in its name), allowing them to be used to preserve cost savings.
+ * This ensures that "pro" models are always downgraded, while "lite" model
+ * requests are honored.
+ *
+ * @param isInFallbackMode Whether the application is in fallback mode.
+ * @param requestedModel The model that was originally requested.
+ * @returns The effective model name.
+ */
+export function getEffectiveModel(
+  isInFallbackMode: boolean,
+  requestedModel: string,
+): string {
+  // If we are not in fallback mode, simply use the requested model.
+  if (!isInFallbackMode) {
+    return requestedModel;
+  }
+
+  // If a "lite" model is requested, honor it. This allows for variations of
+  // lite models without needing to list them all as constants.
+  if (requestedModel.includes('lite')) {
+    return requestedModel;
+  }
+
+  // Default fallback for Gemini CLI.
+  return DEFAULT_GEMINI_FLASH_MODEL;
+}

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -41,6 +41,7 @@ import { setSimulate429 } from '../utils/testUtils.js';
 import { tokenLimit } from './tokenLimits.js';
 import { ideContext } from '../ide/ideContext.js';
 import { ClearcutLogger } from '../telemetry/clearcut-logger/clearcut-logger.js';
+import type { ModelRouterService } from '../routing/modelRouterService.js';
 
 // Mock fs module to prevent actual file system operations during tests
 const mockFileSystem = new Map<string, string>();
@@ -234,7 +235,7 @@ describe('Gemini Client (client.ts)', () => {
     mockContentGenerator = {
       generateContent: mockGenerateContentFn,
       generateContentStream: vi.fn(),
-      countTokens: vi.fn(),
+      countTokens: vi.fn().mockResolvedValue({ totalTokens: 100 }),
       embedContent: vi.fn(),
       batchEmbedContents: vi.fn(),
     } as unknown as ContentGenerator;
@@ -248,7 +249,6 @@ describe('Gemini Client (client.ts)', () => {
     };
     const fileService = new FileDiscoveryService('/test/dir');
     const contentGeneratorConfig: ContentGeneratorConfig = {
-      model: 'test-model',
       apiKey: 'test-key',
       vertexai: false,
       authType: AuthType.USE_GEMINI,
@@ -281,6 +281,9 @@ describe('Gemini Client (client.ts)', () => {
         getDirectories: vi.fn().mockReturnValue(['/test/dir']),
       }),
       getGeminiClient: vi.fn(),
+      getModelRouterService: vi.fn().mockReturnValue({
+        route: vi.fn().mockResolvedValue({ model: 'default-routed-model' }),
+      }),
       isInFallbackMode: vi.fn().mockReturnValue(false),
       setFallbackMode: vi.fn(),
       getChatCompression: vi.fn().mockReturnValue(undefined),
@@ -1116,7 +1119,12 @@ ${JSON.stringify(
 
       // Assert
       expect(ideContext.getIdeContext).toHaveBeenCalled();
+      // The `turn.run` method is now called with the model name as the first
+      // argument. We use `expect.any(String)` because this test is
+      // concerned with the IDE context logic, not the model routing,
+      // which is tested in its own dedicated suite.
       expect(mockTurnRunFn).toHaveBeenCalledWith(
+        expect.any(String),
         initialRequest,
         expect.any(Object),
       );
@@ -1504,6 +1512,173 @@ ${JSON.stringify(
         `Infinite loop protection working: checkNextSpeaker called ${callCount} times, ` +
           `${eventCount} events generated (properly bounded by MAX_TURNS)`,
       );
+    });
+
+    describe('Model Routing', () => {
+      let mockRouterService: { route: Mock };
+
+      beforeEach(() => {
+        mockRouterService = {
+          route: vi
+            .fn()
+            .mockResolvedValue({ model: 'routed-model', reason: 'test' }),
+        };
+        vi.mocked(mockConfig.getModelRouterService).mockReturnValue(
+          mockRouterService as unknown as ModelRouterService,
+        );
+
+        mockTurnRunFn.mockReturnValue(
+          (async function* () {
+            yield { type: 'content', value: 'Hello' };
+          })(),
+        );
+      });
+
+      it('should use the model router service to select a model on the first turn', async () => {
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-1',
+        );
+        await fromAsync(stream); // consume stream
+
+        expect(mockConfig.getModelRouterService).toHaveBeenCalled();
+        expect(mockRouterService.route).toHaveBeenCalled();
+        expect(mockTurnRunFn).toHaveBeenCalledWith(
+          'routed-model', // The model from the router
+          [{ text: 'Hi' }],
+          expect.any(Object),
+        );
+      });
+
+      it('should use the same model for subsequent turns in the same prompt (stickiness)', async () => {
+        // First turn
+        let stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-1',
+        );
+        await fromAsync(stream);
+
+        expect(mockRouterService.route).toHaveBeenCalledTimes(1);
+        expect(mockTurnRunFn).toHaveBeenCalledWith(
+          'routed-model',
+          [{ text: 'Hi' }],
+          expect.any(Object),
+        );
+
+        // Second turn
+        stream = client.sendMessageStream(
+          [{ text: 'Continue' }],
+          new AbortController().signal,
+          'prompt-1',
+        );
+        await fromAsync(stream);
+
+        // Router should not be called again
+        expect(mockRouterService.route).toHaveBeenCalledTimes(1);
+        // Should stick to the first model
+        expect(mockTurnRunFn).toHaveBeenCalledWith(
+          'routed-model',
+          [{ text: 'Continue' }],
+          expect.any(Object),
+        );
+      });
+
+      it('should reset the sticky model and re-route when the prompt_id changes', async () => {
+        // First prompt
+        let stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-1',
+        );
+        await fromAsync(stream);
+
+        expect(mockRouterService.route).toHaveBeenCalledTimes(1);
+        expect(mockTurnRunFn).toHaveBeenCalledWith(
+          'routed-model',
+          [{ text: 'Hi' }],
+          expect.any(Object),
+        );
+
+        // New prompt
+        mockRouterService.route.mockResolvedValue({
+          model: 'new-routed-model',
+          reason: 'test',
+        });
+        stream = client.sendMessageStream(
+          [{ text: 'A new topic' }],
+          new AbortController().signal,
+          'prompt-2',
+        );
+        await fromAsync(stream);
+
+        // Router should be called again for the new prompt
+        expect(mockRouterService.route).toHaveBeenCalledTimes(2);
+        // Should use the newly routed model
+        expect(mockTurnRunFn).toHaveBeenCalledWith(
+          'new-routed-model',
+          [{ text: 'A new topic' }],
+          expect.any(Object),
+        );
+      });
+
+      it('should use the fallback model and bypass routing when in fallback mode', async () => {
+        vi.mocked(mockConfig.isInFallbackMode).mockReturnValue(true);
+
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-1',
+        );
+        await fromAsync(stream);
+
+        expect(mockRouterService.route).not.toHaveBeenCalled();
+        expect(mockTurnRunFn).toHaveBeenCalledWith(
+          DEFAULT_GEMINI_FLASH_MODEL,
+          [{ text: 'Hi' }],
+          expect.any(Object),
+        );
+      });
+
+      it('should stick to the fallback model for the entire sequence even if fallback mode ends', async () => {
+        // Start the sequence in fallback mode
+        vi.mocked(mockConfig.isInFallbackMode).mockReturnValue(true);
+        let stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-fallback-stickiness',
+        );
+        await fromAsync(stream);
+
+        // First call should use fallback model
+        expect(mockRouterService.route).not.toHaveBeenCalled();
+        expect(mockTurnRunFn).toHaveBeenCalledWith(
+          DEFAULT_GEMINI_FLASH_MODEL,
+          [{ text: 'Hi' }],
+          expect.any(Object),
+        );
+
+        // End fallback mode
+        vi.mocked(mockConfig.isInFallbackMode).mockReturnValue(false);
+
+        // Second call in the same sequence
+        stream = client.sendMessageStream(
+          [{ text: 'Continue' }],
+          new AbortController().signal,
+          'prompt-fallback-stickiness',
+        );
+        await fromAsync(stream);
+
+        // Router should still not be called, and it should stick to the fallback model
+        expect(mockRouterService.route).not.toHaveBeenCalled();
+        expect(mockTurnRunFn).toHaveBeenCalledTimes(2); // Ensure it was called again
+        expect(mockTurnRunFn).toHaveBeenLastCalledWith(
+          DEFAULT_GEMINI_FLASH_MODEL, // Still the fallback model
+          [{ text: 'Continue' }],
+          expect.any(Object),
+        );
+      });
     });
 
     describe('Editor context delta', () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1625,6 +1625,10 @@ ${JSON.stringify(
 
       it('should use the fallback model and bypass routing when in fallback mode', async () => {
         vi.mocked(mockConfig.isInFallbackMode).mockReturnValue(true);
+        mockRouterService.route.mockResolvedValue({
+          model: DEFAULT_GEMINI_FLASH_MODEL,
+          reason: 'fallback',
+        });
 
         const stream = client.sendMessageStream(
           [{ text: 'Hi' }],
@@ -1633,7 +1637,6 @@ ${JSON.stringify(
         );
         await fromAsync(stream);
 
-        expect(mockRouterService.route).not.toHaveBeenCalled();
         expect(mockTurnRunFn).toHaveBeenCalledWith(
           DEFAULT_GEMINI_FLASH_MODEL,
           [{ text: 'Hi' }],
@@ -1644,6 +1647,10 @@ ${JSON.stringify(
       it('should stick to the fallback model for the entire sequence even if fallback mode ends', async () => {
         // Start the sequence in fallback mode
         vi.mocked(mockConfig.isInFallbackMode).mockReturnValue(true);
+        mockRouterService.route.mockResolvedValue({
+          model: DEFAULT_GEMINI_FLASH_MODEL,
+          reason: 'fallback',
+        });
         let stream = client.sendMessageStream(
           [{ text: 'Hi' }],
           new AbortController().signal,
@@ -1652,7 +1659,6 @@ ${JSON.stringify(
         await fromAsync(stream);
 
         // First call should use fallback model
-        expect(mockRouterService.route).not.toHaveBeenCalled();
         expect(mockTurnRunFn).toHaveBeenCalledWith(
           DEFAULT_GEMINI_FLASH_MODEL,
           [{ text: 'Hi' }],
@@ -1671,7 +1677,6 @@ ${JSON.stringify(
         await fromAsync(stream);
 
         // Router should still not be called, and it should stick to the fallback model
-        expect(mockRouterService.route).not.toHaveBeenCalled();
         expect(mockTurnRunFn).toHaveBeenCalledTimes(2); // Ensure it was called again
         expect(mockTurnRunFn).toHaveBeenLastCalledWith(
           DEFAULT_GEMINI_FLASH_MODEL, // Still the fallback model

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -493,7 +493,6 @@ export class GeminiClient {
       history: this.getChat().getHistory(/*curated=*/ true),
       request,
       signal,
-      explicitModel: '',
     };
 
     let modelToUse: string;
@@ -502,13 +501,9 @@ export class GeminiClient {
     if (this.currentSequenceModel) {
       modelToUse = this.currentSequenceModel;
     } else {
-      if (this.config.isInFallbackMode()) {
-        modelToUse = DEFAULT_GEMINI_FLASH_MODEL;
-      } else {
-        const router = this.config.getModelRouterService();
-        const decision = await router.route(routingContext);
-        modelToUse = decision.model;
-      }
+      const router = await this.config.getModelRouterService();
+      const decision = await router.route(routingContext);
+      modelToUse = decision.model;
       // Lock the model for the rest of the sequence
       this.currentSequenceModel = modelToUse;
     }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -49,6 +49,7 @@ import {
 } from '../telemetry/types.js';
 import type { IdeContext, File } from '../ide/types.js';
 import { handleFallback } from '../fallback/handler.js';
+import type { RoutingContext } from '../routing/routingStrategy.js';
 
 export function isThinkingSupported(model: string) {
   if (model.startsWith('gemini-2.5')) return true;
@@ -118,6 +119,7 @@ export class GeminiClient {
 
   private readonly loopDetector: LoopDetectionService;
   private lastPromptId: string;
+  private currentSequenceModel: string | null = null;
   private lastSentIdeContext: IdeContext | undefined;
   private forceFullIdeContext = true;
 
@@ -426,11 +428,11 @@ export class GeminiClient {
     signal: AbortSignal,
     prompt_id: string,
     turns: number = MAX_TURNS,
-    originalModel?: string,
   ): AsyncGenerator<ServerGeminiStreamEvent, Turn> {
     if (this.lastPromptId !== prompt_id) {
       this.loopDetector.reset(prompt_id);
       this.lastPromptId = prompt_id;
+      this.currentSequenceModel = null;
     }
     this.sessionTurnCount++;
     if (
@@ -445,9 +447,6 @@ export class GeminiClient {
     if (!boundedTurns) {
       return new Turn(this.getChat(), prompt_id);
     }
-
-    // Track the original model from the first call to detect model switching
-    const initialModel = originalModel || this.config.getModel();
 
     const compressed = await this.tryCompressChat(prompt_id);
 
@@ -490,7 +489,31 @@ export class GeminiClient {
       return turn;
     }
 
-    const resultStream = turn.run(request, signal);
+    const routingContext: RoutingContext = {
+      history: this.getChat().getHistory(/*curated=*/ true),
+      request,
+      signal,
+      explicitModel: '',
+    };
+
+    let modelToUse: string;
+
+    // Determine Model (Stickiness vs. Routing)
+    if (this.currentSequenceModel) {
+      modelToUse = this.currentSequenceModel;
+    } else {
+      if (this.config.isInFallbackMode()) {
+        modelToUse = DEFAULT_GEMINI_FLASH_MODEL;
+      } else {
+        const router = this.config.getModelRouterService();
+        const decision = await router.route(routingContext);
+        modelToUse = decision.model;
+      }
+      // Lock the model for the rest of the sequence
+      this.currentSequenceModel = modelToUse;
+    }
+
+    const resultStream = turn.run(modelToUse, request, signal);
     for await (const event of resultStream) {
       if (this.loopDetector.addAndCheck(event)) {
         yield { type: GeminiEventType.LoopDetected };
@@ -502,11 +525,8 @@ export class GeminiClient {
       }
     }
     if (!turn.pendingToolCalls.length && signal && !signal.aborted) {
-      // Check if model was switched during the call (likely due to quota error)
-      const currentModel = this.config.getModel();
-      if (currentModel !== initialModel) {
-        // Model was switched (likely due to quota error fallback)
-        // Don't continue with recursive call to prevent unwanted Flash execution
+      // Check if next speaker check is needed
+      if (this.config.getQuotaErrorOccurred()) {
         return turn;
       }
 
@@ -536,7 +556,6 @@ export class GeminiClient {
           signal,
           prompt_id,
           boundedTurns - 1,
-          initialModel,
         );
       }
     }

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -29,7 +29,6 @@ describe('createContentGenerator', () => {
     );
     const generator = await createContentGenerator(
       {
-        model: 'test-model',
         authType: AuthType.LOGIN_WITH_GOOGLE,
       },
       mockConfig,
@@ -51,7 +50,6 @@ describe('createContentGenerator', () => {
     vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
     const generator = await createContentGenerator(
       {
-        model: 'test-model',
         apiKey: 'test-api-key',
         authType: AuthType.USE_GEMINI,
       },
@@ -85,7 +83,6 @@ describe('createContentGenerator', () => {
     vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
     const generator = await createContentGenerator(
       {
-        model: 'test-model',
         apiKey: 'test-api-key',
         authType: AuthType.USE_GEMINI,
       },

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -14,7 +14,6 @@ import type {
 } from '@google/genai';
 import { GoogleGenAI } from '@google/genai';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
-import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
 import type { Config } from '../config/config.js';
 
 import type { UserTierId } from '../code_assist/types.js';
@@ -50,7 +49,6 @@ export enum AuthType {
 }
 
 export type ContentGeneratorConfig = {
-  model: string;
   apiKey?: string;
   vertexai?: boolean;
   authType?: AuthType;
@@ -66,11 +64,7 @@ export function createContentGeneratorConfig(
   const googleCloudProject = process.env['GOOGLE_CLOUD_PROJECT'] || undefined;
   const googleCloudLocation = process.env['GOOGLE_CLOUD_LOCATION'] || undefined;
 
-  // Use runtime model from config if available; otherwise, fall back to parameter or default
-  const effectiveModel = config.getModel() || DEFAULT_GEMINI_MODEL;
-
   const contentGeneratorConfig: ContentGeneratorConfig = {
-    model: effectiveModel,
     authType,
     proxy: config?.getProxy(),
   };

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -4,15 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  describe,
-  it,
-  expect,
-  vi,
-  beforeEach,
-  afterEach,
-  type Mock,
-} from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type {
   Content,
   GenerateContentConfig,
@@ -933,7 +925,7 @@ describe('GeminiChat', () => {
       );
 
       const stream = await chat.sendMessageStream(
-          'test-model',
+        'test-model',
         { message: 'test' },
         'prompt-id-retry-fail',
       );
@@ -1328,6 +1320,7 @@ describe('GeminiChat', () => {
       mockHandleFallback.mockResolvedValue(false);
 
       const stream = await chat.sendMessageStream(
+        'test-model',
         { message: 'test stop' },
         'prompt-id-fb2',
       );

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -19,7 +19,10 @@ import { toParts } from '../code_assist/converter.js';
 import { createUserContent } from '@google/genai';
 import { retryWithBackoff } from '../utils/retry.js';
 import type { Config } from '../config/config.js';
-import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
+import {
+  DEFAULT_GEMINI_FLASH_MODEL,
+  getEffectiveModel,
+} from '../config/models.js';
 import { hasCycleInSchema } from '../tools/tools.js';
 import type { StructuredError } from './turn.js';
 import type { CompletedToolCall } from './coreToolScheduler.js';
@@ -326,9 +329,10 @@ export class GeminiChat {
     userContent: Content,
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
     const apiCall = () => {
-      const modelToUse = this.config.isInFallbackMode()
-        ? DEFAULT_GEMINI_FLASH_MODEL
-        : model;
+      const modelToUse = getEffectiveModel(
+        this.config.isInFallbackMode(),
+        model,
+      );
 
       if (
         this.config.getQuotaErrorOccurred() &&

--- a/packages/core/src/core/subagent.test.ts
+++ b/packages/core/src/core/subagent.test.ts
@@ -499,7 +499,7 @@ describe('subagent.ts', () => {
         expect(scope.output.emitted_vars).toEqual({});
         expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
         // Check the initial message
-        expect(mockSendMessageStream.mock.calls[0][0].message).toEqual([
+        expect(mockSendMessageStream.mock.calls[0][1].message).toEqual([
           { text: 'Get Started!' },
         ]);
       });
@@ -543,7 +543,7 @@ describe('subagent.ts', () => {
         expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
 
         // Check the tool response sent back in the second call
-        const secondCallArgs = mockSendMessageStream.mock.calls[0][0];
+        const secondCallArgs = mockSendMessageStream.mock.calls[0][1];
         expect(secondCallArgs.message).toEqual([{ text: 'Get Started!' }]);
       });
 
@@ -605,7 +605,7 @@ describe('subagent.ts', () => {
         );
 
         // Check the response sent back to the model
-        const secondCallArgs = mockSendMessageStream.mock.calls[1][0];
+        const secondCallArgs = mockSendMessageStream.mock.calls[1][1];
         expect(secondCallArgs.message).toEqual([
           { text: 'file1.txt\nfile2.ts' },
         ]);
@@ -653,7 +653,7 @@ describe('subagent.ts', () => {
         await scope.runNonInteractive(new ContextState());
 
         // The agent should send the specific error message from responseParts.
-        const secondCallArgs = mockSendMessageStream.mock.calls[1][0];
+        const secondCallArgs = mockSendMessageStream.mock.calls[1][1];
 
         expect(secondCallArgs.message).toEqual([
           {
@@ -699,7 +699,7 @@ describe('subagent.ts', () => {
         await scope.runNonInteractive(new ContextState());
 
         // Check the nudge message sent in Turn 2
-        const secondCallArgs = mockSendMessageStream.mock.calls[1][0];
+        const secondCallArgs = mockSendMessageStream.mock.calls[1][1];
 
         // We check that the message contains the required variable name and the nudge phrasing.
         expect(secondCallArgs.message[0].text).toContain('required_var');

--- a/packages/core/src/core/subagent.ts
+++ b/packages/core/src/core/subagent.ts
@@ -430,6 +430,7 @@ export class SubAgentScope {
         };
 
         const responseStream = await chat.sendMessageStream(
+          this.modelConfig.model,
           messageParams,
           promptId,
         );

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -97,6 +97,7 @@ describe('Turn', () => {
       const events = [];
       const reqParts: Part[] = [{ text: 'Hi' }];
       for await (const event of turn.run(
+        'test-model',
         reqParts,
         new AbortController().signal,
       )) {
@@ -104,6 +105,7 @@ describe('Turn', () => {
       }
 
       expect(mockSendMessageStream).toHaveBeenCalledWith(
+        'test-model',
         {
           message: reqParts,
           config: { abortSignal: expect.any(AbortSignal) },
@@ -144,6 +146,7 @@ describe('Turn', () => {
       const events = [];
       const reqParts: Part[] = [{ text: 'Use tools' }];
       for await (const event of turn.run(
+        'test-model',
         reqParts,
         new AbortController().signal,
       )) {
@@ -206,7 +209,11 @@ describe('Turn', () => {
 
       const events = [];
       const reqParts: Part[] = [{ text: 'Test abort' }];
-      for await (const event of turn.run(reqParts, abortController.signal)) {
+      for await (const event of turn.run(
+        'test-model',
+        reqParts,
+        abortController.signal,
+      )) {
         events.push(event);
       }
       expect(events).toEqual([
@@ -227,6 +234,7 @@ describe('Turn', () => {
       mockMaybeIncludeSchemaDepthContext.mockResolvedValue(undefined);
       const events = [];
       for await (const event of turn.run(
+        'test-model',
         reqParts,
         new AbortController().signal,
       )) {
@@ -267,6 +275,7 @@ describe('Turn', () => {
 
       const events = [];
       for await (const event of turn.run(
+        'test-model',
         [{ text: 'Test undefined tool parts' }],
         new AbortController().signal,
       )) {
@@ -323,6 +332,7 @@ describe('Turn', () => {
 
       const events = [];
       for await (const event of turn.run(
+        'test-model',
         [{ text: 'Test finish reason' }],
         new AbortController().signal,
       )) {
@@ -370,6 +380,7 @@ describe('Turn', () => {
       const events = [];
       const reqParts: Part[] = [{ text: 'Generate long text' }];
       for await (const event of turn.run(
+        'test-model',
         reqParts,
         new AbortController().signal,
       )) {
@@ -407,6 +418,7 @@ describe('Turn', () => {
       const events = [];
       const reqParts: Part[] = [{ text: 'Test safety' }];
       for await (const event of turn.run(
+        'test-model',
         reqParts,
         new AbortController().signal,
       )) {
@@ -443,6 +455,7 @@ describe('Turn', () => {
       const events = [];
       const reqParts: Part[] = [{ text: 'Test no finish reason' }];
       for await (const event of turn.run(
+        'test-model',
         reqParts,
         new AbortController().signal,
       )) {
@@ -487,6 +500,7 @@ describe('Turn', () => {
       const events = [];
       const reqParts: Part[] = [{ text: 'Test multiple responses' }];
       for await (const event of turn.run(
+        'test-model',
         reqParts,
         new AbortController().signal,
       )) {
@@ -529,6 +543,7 @@ describe('Turn', () => {
 
       const events = [];
       for await (const event of turn.run(
+        'test-model',
         [{ text: 'Test citations' }],
         new AbortController().signal,
       )) {
@@ -578,6 +593,7 @@ describe('Turn', () => {
 
       const events = [];
       for await (const event of turn.run(
+        'test-model',
         [{ text: 'test' }],
         new AbortController().signal,
       )) {
@@ -624,6 +640,7 @@ describe('Turn', () => {
 
       const events = [];
       for await (const event of turn.run(
+        'test-model',
         [{ text: 'test' }],
         new AbortController().signal,
       )) {
@@ -669,6 +686,7 @@ describe('Turn', () => {
 
       const events = [];
       for await (const event of turn.run(
+        'test-model',
         [{ text: 'test' }],
         new AbortController().signal,
       )) {
@@ -705,7 +723,11 @@ describe('Turn', () => {
       const events = [];
       const reqParts: Part[] = [{ text: 'Test malformed error handling' }];
 
-      for await (const event of turn.run(reqParts, abortController.signal)) {
+      for await (const event of turn.run(
+        'test-model',
+        reqParts,
+        abortController.signal,
+      )) {
         events.push(event);
       }
 
@@ -727,7 +749,11 @@ describe('Turn', () => {
       mockSendMessageStream.mockResolvedValue(mockResponseStream);
 
       const events = [];
-      for await (const event of turn.run([], new AbortController().signal)) {
+      for await (const event of turn.run(
+        'test-model',
+        [],
+        new AbortController().signal,
+      )) {
         events.push(event);
       }
 
@@ -752,7 +778,11 @@ describe('Turn', () => {
       })();
       mockSendMessageStream.mockResolvedValue(mockResponseStream);
       const reqParts: Part[] = [{ text: 'Hi' }];
-      for await (const _ of turn.run(reqParts, new AbortController().signal)) {
+      for await (const _ of turn.run(
+        'test-model',
+        reqParts,
+        new AbortController().signal,
+      )) {
         // consume stream
       }
       expect(turn.getDebugResponses()).toEqual([resp1, resp2]);

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -210,6 +210,7 @@ export class Turn {
   ) {}
   // The run method yields simpler events suitable for server logic
   async *run(
+    model: string,
     req: PartListUnion,
     signal: AbortSignal,
   ): AsyncGenerator<ServerGeminiStreamEvent> {
@@ -217,6 +218,7 @@ export class Turn {
       // Note: This assumes `sendMessageStream` yields events like
       // { type: StreamEventType.RETRY } or { type: StreamEventType.CHUNK, value: GenerateContentResponse }
       const responseStream = await this.chat.sendMessageStream(
+        model,
         {
           message: req,
           config: {

--- a/packages/core/src/routing/modelRouterService.test.ts
+++ b/packages/core/src/routing/modelRouterService.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ModelRouterService } from './modelRouterService.js';
+import { Config } from '../config/config.js';
+import type { BaseLlmClient } from '../core/baseLlmClient.js';
+import type {
+  RoutingContext,
+  RoutingDecision,
+  RoutingStrategy,
+} from './routingStrategy.js';
+import { DefaultStrategy } from './strategies/defaultStrategy.js';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
+
+// Mock the dependencies
+vi.mock('../config/config.js');
+vi.mock('../core/baseLlmClient.js');
+vi.mock('./strategies/defaultStrategy.js');
+
+describe('ModelRouterService', () => {
+  let service: ModelRouterService;
+  let mockConfig: Config;
+  let mockBaseLlmClient: BaseLlmClient;
+  let mockStrategy: RoutingStrategy;
+  let mockContext: RoutingContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Create mock instances
+    mockConfig = new Config({} as never);
+    mockBaseLlmClient = {} as BaseLlmClient;
+    vi.spyOn(mockConfig, 'getBaseLlmClient').mockReturnValue(mockBaseLlmClient);
+
+    // Mock the strategy that the service will instantiate
+    mockStrategy = new DefaultStrategy();
+    vi.mocked(DefaultStrategy).mockImplementation(() => mockStrategy);
+
+    // Instantiate the service to be tested
+    service = new ModelRouterService(mockConfig);
+
+    // Create a default context for tests
+    mockContext = {
+      history: [],
+      request: [{ text: 'test prompt' }],
+      signal: new AbortController().signal,
+    };
+  });
+
+  it('should initialize with DefaultStrategy by default', () => {
+    expect(DefaultStrategy).toHaveBeenCalled();
+    expect(service['strategy']).toBeInstanceOf(DefaultStrategy);
+  });
+
+  describe('route()', () => {
+    it('should return the Flash model if in fallback mode', async () => {
+      vi.spyOn(mockConfig, 'isInFallbackMode').mockReturnValue(true);
+      const strategySpy = vi.spyOn(mockStrategy, 'route');
+
+      const decision = await service.route(mockContext);
+
+      expect(strategySpy).not.toHaveBeenCalled();
+      expect(decision.model).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+      expect(decision.reason).toContain('In fallback mode');
+      expect(decision.metadata.source).toBe('Fallback');
+    });
+
+    it('should bypass strategy and use explicitModel if provided', async () => {
+      vi.spyOn(mockConfig, 'isInFallbackMode').mockReturnValue(false);
+      const explicitModel = 'explicit-test-model';
+      mockContext.explicitModel = explicitModel;
+
+      const strategySpy = vi.spyOn(mockStrategy, 'route');
+
+      const decision = await service.route(mockContext);
+
+      expect(strategySpy).not.toHaveBeenCalled();
+      expect(decision.model).toBe(explicitModel);
+      expect(decision.reason).toContain(
+        'Routing bypassed by forced model directive',
+      );
+      expect(decision.metadata.source).toBe('Explicit');
+    });
+
+    it('should delegate to the strategy when no override is present', async () => {
+      vi.spyOn(mockConfig, 'isInFallbackMode').mockReturnValue(false);
+      const strategyDecision: RoutingDecision = {
+        model: 'strategy-chosen-model',
+        reason: 'Strategy reasoning',
+        metadata: {
+          source: 'Default',
+          latencyMs: 0,
+        },
+      };
+      const strategySpy = vi
+        .spyOn(mockStrategy, 'route')
+        .mockResolvedValue(strategyDecision);
+
+      const decision = await service.route(mockContext);
+
+      expect(strategySpy).toHaveBeenCalledWith(mockContext, mockBaseLlmClient);
+      expect(decision).toEqual(strategyDecision);
+    });
+  });
+});

--- a/packages/core/src/routing/modelRouterService.ts
+++ b/packages/core/src/routing/modelRouterService.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../config/config.js';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
+import type {
+  RoutingContext,
+  RoutingDecision,
+  RoutingStrategy,
+} from './routingStrategy.js';
+import { DefaultStrategy } from './strategies/defaultStrategy.js';
+
+/**
+ * A centralized service for making model routing decisions.
+ */
+export class ModelRouterService {
+  private config: Config;
+  private strategy: RoutingStrategy;
+
+  constructor(config: Config) {
+    this.config = config;
+    this.strategy = new DefaultStrategy();
+  }
+
+  /**
+   * Determines which model to use for a given request context.
+   *
+   * @param context The full context of the request.
+   * @returns A promise that resolves to a RoutingDecision.
+   */
+  async route(context: RoutingContext): Promise<RoutingDecision> {
+    // Return fallback model if in fallback mode.
+    if (this.config.isInFallbackMode()) {
+      return {
+        model: DEFAULT_GEMINI_FLASH_MODEL,
+        reason: `In fallback mode. Using: ${DEFAULT_GEMINI_FLASH_MODEL}`,
+        metadata: {
+          source: 'Fallback',
+          latencyMs: 0,
+        },
+      };
+    }
+
+    // Honor the override mechanism.
+    if (context.explicitModel) {
+      const decision: RoutingDecision = {
+        model: context.explicitModel,
+        reason: `Routing bypassed by forced model directive. Using: ${context.explicitModel}`,
+        metadata: {
+          source: 'Explicit',
+          latencyMs: 0,
+        },
+      };
+
+      return decision;
+    }
+
+    return this.strategy.route(context, this.config.getBaseLlmClient());
+  }
+}

--- a/packages/core/src/routing/routingStrategy.ts
+++ b/packages/core/src/routing/routingStrategy.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Content, PartListUnion } from '@google/genai';
+import type { BaseLlmClient } from '../core/baseLlmClient.js';
+
+/**
+ * The output of a routing decision. It specifies which model to use and why.
+ */
+export interface RoutingDecision {
+  /** The model identifier string to use for the next API call (e.g., 'gemini-2.5-pro'). */
+  model: string;
+  /** A brief, loggable explanation of why this model was chosen. */
+  reason: string;
+  /**
+   * Metadata about the routing decision for logging purposes.
+   */
+  metadata: {
+    source: 'Default' | 'Explicit' | 'Fallback';
+    latencyMs: number;
+    reasoning?: string;
+    error?: string;
+  };
+}
+
+/**
+ * The context provided to the router for making a decision.
+ */
+export interface RoutingContext {
+  /** The full history of the conversation. */
+  history: Content[];
+  /** The immediate request parts to be processed. */
+  request: PartListUnion;
+  /** An abort signal to cancel an LLM call during routing. */
+  signal: AbortSignal;
+  /**
+   * If provided, the router will be bypassed and this model will be used directly.
+   * This is the override mechanism for specific internal tasks or user settings.
+   */
+  explicitModel?: string;
+}
+
+/**
+ * The core interface that all routing strategies must implement.
+ */
+export interface RoutingStrategy {
+  /**
+   * Determines which model to use for a given request context.
+   * @param context The full context of the request.
+   * @param client A reference to the GeminiClient, allowing the strategy to make its own API calls if needed.
+   * @returns A promise that resolves to a RoutingDecision.
+   */
+  route(
+    context: RoutingContext,
+    baseLlmClient: BaseLlmClient,
+  ): Promise<RoutingDecision>;
+}

--- a/packages/core/src/routing/routingStrategy.ts
+++ b/packages/core/src/routing/routingStrategy.ts
@@ -6,6 +6,7 @@
 
 import type { Content, PartListUnion } from '@google/genai';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
+import type { Config } from '../config/config.js';
 
 /**
  * The output of a routing decision. It specifies which model to use and why.
@@ -13,15 +14,13 @@ import type { BaseLlmClient } from '../core/baseLlmClient.js';
 export interface RoutingDecision {
   /** The model identifier string to use for the next API call (e.g., 'gemini-2.5-pro'). */
   model: string;
-  /** A brief, loggable explanation of why this model was chosen. */
-  reason: string;
   /**
    * Metadata about the routing decision for logging purposes.
    */
   metadata: {
-    source: 'Default' | 'Explicit' | 'Fallback';
+    source: string;
     latencyMs: number;
-    reasoning?: string;
+    reasoning: string;
     error?: string;
   };
 }
@@ -36,25 +35,42 @@ export interface RoutingContext {
   request: PartListUnion;
   /** An abort signal to cancel an LLM call during routing. */
   signal: AbortSignal;
-  /**
-   * If provided, the router will be bypassed and this model will be used directly.
-   * This is the override mechanism for specific internal tasks or user settings.
-   */
-  explicitModel?: string;
 }
 
 /**
  * The core interface that all routing strategies must implement.
+ * Strategies implementing this interface may decline a request by returning null.
  */
 export interface RoutingStrategy {
+  /** The name of the strategy (e.g., 'fallback', 'override', 'composite'). */
+  readonly name: string;
+
   /**
    * Determines which model to use for a given request context.
    * @param context The full context of the request.
+   * @param config The current configuration.
    * @param client A reference to the GeminiClient, allowing the strategy to make its own API calls if needed.
+   * @returns A promise that resolves to a RoutingDecision, or null if the strategy is not applicable.
+   */
+  route(
+    context: RoutingContext,
+    config: Config,
+    baseLlmClient: BaseLlmClient,
+  ): Promise<RoutingDecision | null>;
+}
+
+/**
+ * A strategy that is guaranteed to return a decision. It must not return null.
+ * This is used to ensure that a composite chain always terminates.
+ */
+export interface TerminalStrategy extends RoutingStrategy {
+  /**
+   * Determines which model to use for a given request context.
    * @returns A promise that resolves to a RoutingDecision.
    */
   route(
     context: RoutingContext,
+    config: Config,
     baseLlmClient: BaseLlmClient,
   ): Promise<RoutingDecision>;
 }

--- a/packages/core/src/routing/strategies/compositeStrategy.test.ts
+++ b/packages/core/src/routing/strategies/compositeStrategy.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CompositeStrategy } from './compositeStrategy.js';
+import type {
+  RoutingContext,
+  RoutingDecision,
+  RoutingStrategy,
+  TerminalStrategy,
+} from '../routingStrategy.js';
+import type { Config } from '../../config/config.js';
+import type { BaseLlmClient } from '../../core/baseLlmClient.js';
+
+describe('CompositeStrategy', () => {
+  let mockContext: RoutingContext;
+  let mockConfig: Config;
+  let mockBaseLlmClient: BaseLlmClient;
+  let mockStrategy1: RoutingStrategy;
+  let mockStrategy2: RoutingStrategy;
+  let mockTerminalStrategy: TerminalStrategy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockContext = {} as RoutingContext;
+    mockConfig = {} as Config;
+    mockBaseLlmClient = {} as BaseLlmClient;
+
+    mockStrategy1 = {
+      name: 'strategy1',
+      route: vi.fn().mockResolvedValue(null),
+    };
+
+    mockStrategy2 = {
+      name: 'strategy2',
+      route: vi.fn().mockResolvedValue(null),
+    };
+
+    mockTerminalStrategy = {
+      name: 'terminal',
+      route: vi.fn().mockResolvedValue({
+        model: 'terminal-model',
+        metadata: {
+          source: 'terminal',
+          latencyMs: 10,
+          reasoning: 'Terminal decision',
+        },
+      }),
+    };
+  });
+
+  it('should try strategies in order and return the first successful decision', async () => {
+    const decision: RoutingDecision = {
+      model: 'strategy2-model',
+      metadata: {
+        source: 'strategy2',
+        latencyMs: 20,
+        reasoning: 'Strategy 2 decided',
+      },
+    };
+    vi.spyOn(mockStrategy2, 'route').mockResolvedValue(decision);
+
+    const composite = new CompositeStrategy(
+      [mockStrategy1, mockStrategy2, mockTerminalStrategy],
+      'test-router',
+    );
+
+    const result = await composite.route(
+      mockContext,
+      mockConfig,
+      mockBaseLlmClient,
+    );
+
+    expect(mockStrategy1.route).toHaveBeenCalledWith(
+      mockContext,
+      mockConfig,
+      mockBaseLlmClient,
+    );
+    expect(mockStrategy2.route).toHaveBeenCalledWith(
+      mockContext,
+      mockConfig,
+      mockBaseLlmClient,
+    );
+    expect(mockTerminalStrategy.route).not.toHaveBeenCalled();
+
+    expect(result.model).toBe('strategy2-model');
+    expect(result.metadata.source).toBe('test-router/strategy2');
+  });
+
+  it('should fall back to the terminal strategy if no other strategy provides a decision', async () => {
+    const composite = new CompositeStrategy(
+      [mockStrategy1, mockStrategy2, mockTerminalStrategy],
+      'test-router',
+    );
+
+    const result = await composite.route(
+      mockContext,
+      mockConfig,
+      mockBaseLlmClient,
+    );
+
+    expect(mockStrategy1.route).toHaveBeenCalledTimes(1);
+    expect(mockStrategy2.route).toHaveBeenCalledTimes(1);
+    expect(mockTerminalStrategy.route).toHaveBeenCalledTimes(1);
+
+    expect(result.model).toBe('terminal-model');
+    expect(result.metadata.source).toBe('test-router/terminal');
+  });
+
+  it('should handle errors in non-terminal strategies and continue', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    vi.spyOn(mockStrategy1, 'route').mockRejectedValue(
+      new Error('Strategy 1 failed'),
+    );
+
+    const composite = new CompositeStrategy(
+      [mockStrategy1, mockTerminalStrategy],
+      'test-router',
+    );
+
+    const result = await composite.route(
+      mockContext,
+      mockConfig,
+      mockBaseLlmClient,
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[Routing] Strategy 'strategy1' failed. Continuing to next strategy. Error:",
+      expect.any(Error),
+    );
+    expect(result.model).toBe('terminal-model');
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should re-throw an error from the terminal strategy', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const terminalError = new Error('Terminal strategy failed');
+    vi.spyOn(mockTerminalStrategy, 'route').mockRejectedValue(terminalError);
+
+    const composite = new CompositeStrategy([mockTerminalStrategy]);
+
+    await expect(
+      composite.route(mockContext, mockConfig, mockBaseLlmClient),
+    ).rejects.toThrow(terminalError);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[Routing] Critical Error: Terminal strategy 'terminal' failed. Routing cannot proceed. Error:",
+      terminalError,
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should correctly finalize the decision metadata', async () => {
+    const decision: RoutingDecision = {
+      model: 'some-model',
+      metadata: {
+        source: 'child-source',
+        latencyMs: 50,
+        reasoning: 'Child reasoning',
+      },
+    };
+    vi.spyOn(mockStrategy1, 'route').mockResolvedValue(decision);
+
+    const composite = new CompositeStrategy(
+      [mockStrategy1, mockTerminalStrategy],
+      'my-composite',
+    );
+
+    const result = await composite.route(
+      mockContext,
+      mockConfig,
+      mockBaseLlmClient,
+    );
+
+    expect(result.model).toBe('some-model');
+    expect(result.metadata.source).toBe('my-composite/child-source');
+    expect(result.metadata.reasoning).toBe('Child reasoning');
+    // It should keep the child's latency
+    expect(result.metadata.latencyMs).toBe(50);
+  });
+
+  it('should calculate total latency if child latency is not provided', async () => {
+    const decision: RoutingDecision = {
+      model: 'some-model',
+      metadata: {
+        source: 'child-source',
+        // No latencyMs here
+        latencyMs: 0,
+        reasoning: 'Child reasoning',
+      },
+    };
+    vi.spyOn(mockStrategy1, 'route').mockResolvedValue(decision);
+
+    const composite = new CompositeStrategy(
+      [mockStrategy1, mockTerminalStrategy],
+      'my-composite',
+    );
+
+    const result = await composite.route(
+      mockContext,
+      mockConfig,
+      mockBaseLlmClient,
+    );
+
+    expect(result.metadata.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/core/src/routing/strategies/compositeStrategy.ts
+++ b/packages/core/src/routing/strategies/compositeStrategy.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../../config/config.js';
+import type { BaseLlmClient } from '../../core/baseLlmClient.js';
+import type {
+  RoutingContext,
+  RoutingDecision,
+  RoutingStrategy,
+  TerminalStrategy,
+} from '../routingStrategy.js';
+
+/**
+ * A strategy that attempts a list of child strategies in order (Chain of Responsibility).
+ */
+export class CompositeStrategy implements TerminalStrategy {
+  readonly name: string;
+
+  private strategies: [...RoutingStrategy[], TerminalStrategy];
+
+  /**
+   * Initializes the CompositeStrategy.
+   * @param strategies The strategies to try, in order of priority. The last strategy must be terminal.
+   * @param name The name of this composite configuration (e.g., 'router' or 'composite').
+   */
+  constructor(
+    strategies: [...RoutingStrategy[], TerminalStrategy],
+    name: string = 'composite',
+  ) {
+    this.strategies = strategies;
+    this.name = name;
+  }
+
+  async route(
+    context: RoutingContext,
+    config: Config,
+    baseLlmClient: BaseLlmClient,
+  ): Promise<RoutingDecision> {
+    const startTime = performance.now();
+
+    // Separate non-terminal strategies from the terminal one.
+    // This separation allows TypeScript to understand the control flow guarantees.
+    const nonTerminalStrategies = this.strategies.slice(
+      0,
+      -1,
+    ) as RoutingStrategy[];
+    const terminalStrategy = this.strategies[
+      this.strategies.length - 1
+    ] as TerminalStrategy;
+
+    // Try non-terminal strategies, allowing them to fail gracefully.
+    for (const strategy of nonTerminalStrategies) {
+      try {
+        const decision = await strategy.route(context, config, baseLlmClient);
+        if (decision) {
+          return this.finalizeDecision(decision, startTime);
+        }
+      } catch (error) {
+        console.error(
+          `[Routing] Strategy '${strategy.name}' failed. Continuing to next strategy. Error:`,
+          error,
+        );
+      }
+    }
+
+    // If no other strategy matched, execute the terminal strategy.
+    try {
+      const decision = await terminalStrategy.route(
+        context,
+        config,
+        baseLlmClient,
+      );
+
+      return this.finalizeDecision(decision, startTime);
+    } catch (error) {
+      console.error(
+        `[Routing] Critical Error: Terminal strategy '${terminalStrategy.name}' failed. Routing cannot proceed. Error:`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Helper function to enhance the decision metadata with composite information.
+   */
+  private finalizeDecision(
+    decision: RoutingDecision,
+    startTime: number,
+  ): RoutingDecision {
+    const endTime = performance.now();
+    const totalLatency = endTime - startTime;
+
+    // Combine the source paths: composite_name/child_source (e.g. 'router/default')
+    const compositeSource = `${this.name}/${decision.metadata.source}`;
+
+    return {
+      ...decision,
+      metadata: {
+        ...decision.metadata,
+        source: compositeSource,
+        latencyMs: decision.metadata.latencyMs || totalLatency,
+      },
+    };
+  }
+}

--- a/packages/core/src/routing/strategies/defaultStrategy.test.ts
+++ b/packages/core/src/routing/strategies/defaultStrategy.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DefaultStrategy } from './defaultStrategy.js';
+import type { RoutingContext } from '../routingStrategy.js';
+import type { BaseLlmClient } from '../../core/baseLlmClient.js';
+import { DEFAULT_GEMINI_MODEL } from '../../config/models.js';
+
+describe('DefaultStrategy', () => {
+  it('should always route to the default Gemini model', async () => {
+    const strategy = new DefaultStrategy();
+    const mockContext = {} as RoutingContext;
+    const mockClient = {} as BaseLlmClient;
+
+    const decision = await strategy.route(mockContext, mockClient);
+
+    expect(decision).toEqual({
+      model: DEFAULT_GEMINI_MODEL,
+      reason: `Routing to default model: ${DEFAULT_GEMINI_MODEL}`,
+      metadata: {
+        source: 'Default',
+        latencyMs: 0,
+      },
+    });
+  });
+});

--- a/packages/core/src/routing/strategies/defaultStrategy.test.ts
+++ b/packages/core/src/routing/strategies/defaultStrategy.test.ts
@@ -9,21 +9,23 @@ import { DefaultStrategy } from './defaultStrategy.js';
 import type { RoutingContext } from '../routingStrategy.js';
 import type { BaseLlmClient } from '../../core/baseLlmClient.js';
 import { DEFAULT_GEMINI_MODEL } from '../../config/models.js';
+import type { Config } from '../../config/config.js';
 
 describe('DefaultStrategy', () => {
   it('should always route to the default Gemini model', async () => {
     const strategy = new DefaultStrategy();
     const mockContext = {} as RoutingContext;
+    const mockConfig = {} as Config;
     const mockClient = {} as BaseLlmClient;
 
-    const decision = await strategy.route(mockContext, mockClient);
+    const decision = await strategy.route(mockContext, mockConfig, mockClient);
 
     expect(decision).toEqual({
       model: DEFAULT_GEMINI_MODEL,
-      reason: `Routing to default model: ${DEFAULT_GEMINI_MODEL}`,
       metadata: {
-        source: 'Default',
+        source: 'default',
         latencyMs: 0,
+        reasoning: `Routing to default model: ${DEFAULT_GEMINI_MODEL}`,
       },
     });
   });

--- a/packages/core/src/routing/strategies/defaultStrategy.ts
+++ b/packages/core/src/routing/strategies/defaultStrategy.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { BaseLlmClient } from '../../core/baseLlmClient.js';
+import type {
+  RoutingContext,
+  RoutingDecision,
+  RoutingStrategy,
+} from '../routingStrategy.js';
+import { DEFAULT_GEMINI_MODEL } from '../../config/models.js';
+
+export class DefaultStrategy implements RoutingStrategy {
+  async route(
+    _context: RoutingContext,
+    _baseLlmClient: BaseLlmClient,
+  ): Promise<RoutingDecision> {
+    // Return the default model for Gemini CLI
+    return {
+      model: DEFAULT_GEMINI_MODEL,
+      reason: `Routing to default model: ${DEFAULT_GEMINI_MODEL}`,
+      metadata: {
+        source: 'Default',
+        latencyMs: 0,
+      },
+    };
+  }
+}

--- a/packages/core/src/routing/strategies/defaultStrategy.ts
+++ b/packages/core/src/routing/strategies/defaultStrategy.ts
@@ -4,26 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { Config } from '../../config/config.js';
 import type { BaseLlmClient } from '../../core/baseLlmClient.js';
 import type {
   RoutingContext,
   RoutingDecision,
-  RoutingStrategy,
+  TerminalStrategy,
 } from '../routingStrategy.js';
 import { DEFAULT_GEMINI_MODEL } from '../../config/models.js';
 
-export class DefaultStrategy implements RoutingStrategy {
+export class DefaultStrategy implements TerminalStrategy {
+  readonly name = 'default';
+
   async route(
     _context: RoutingContext,
+    _config: Config,
     _baseLlmClient: BaseLlmClient,
   ): Promise<RoutingDecision> {
-    // Return the default model for Gemini CLI
     return {
       model: DEFAULT_GEMINI_MODEL,
-      reason: `Routing to default model: ${DEFAULT_GEMINI_MODEL}`,
       metadata: {
-        source: 'Default',
+        source: this.name,
         latencyMs: 0,
+        reasoning: `Routing to default model: ${DEFAULT_GEMINI_MODEL}`,
       },
     };
   }

--- a/packages/core/src/routing/strategies/fallbackStrategy.test.ts
+++ b/packages/core/src/routing/strategies/fallbackStrategy.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FallbackStrategy } from './fallbackStrategy.js';
+import type { RoutingContext } from '../routingStrategy.js';
+import type { BaseLlmClient } from '../../core/baseLlmClient.js';
+import type { Config } from '../../config/config.js';
+import {
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_GEMINI_FLASH_MODEL,
+  DEFAULT_GEMINI_FLASH_LITE_MODEL,
+} from '../../config/models.js';
+
+describe('FallbackStrategy', () => {
+  const strategy = new FallbackStrategy();
+  const mockContext = {} as RoutingContext;
+  const mockClient = {} as BaseLlmClient;
+
+  it('should return null when not in fallback mode', async () => {
+    const mockConfig = {
+      isInFallbackMode: () => false,
+      getModel: () => DEFAULT_GEMINI_MODEL,
+    } as Config;
+
+    const decision = await strategy.route(mockContext, mockConfig, mockClient);
+    expect(decision).toBeNull();
+  });
+
+  describe('when in fallback mode', () => {
+    it('should downgrade a pro model to the flash model', async () => {
+      const mockConfig = {
+        isInFallbackMode: () => true,
+        getModel: () => DEFAULT_GEMINI_MODEL,
+      } as Config;
+
+      const decision = await strategy.route(
+        mockContext,
+        mockConfig,
+        mockClient,
+      );
+
+      expect(decision).not.toBeNull();
+      expect(decision?.model).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+      expect(decision?.metadata.source).toBe('fallback');
+      expect(decision?.metadata.reasoning).toContain('In fallback mode');
+    });
+
+    it('should honor a lite model request', async () => {
+      const mockConfig = {
+        isInFallbackMode: () => true,
+        getModel: () => DEFAULT_GEMINI_FLASH_LITE_MODEL,
+      } as Config;
+
+      const decision = await strategy.route(
+        mockContext,
+        mockConfig,
+        mockClient,
+      );
+
+      expect(decision).not.toBeNull();
+      expect(decision?.model).toBe(DEFAULT_GEMINI_FLASH_LITE_MODEL);
+      expect(decision?.metadata.source).toBe('fallback');
+    });
+
+    it('should use the flash model if flash is requested', async () => {
+      const mockConfig = {
+        isInFallbackMode: () => true,
+        getModel: () => DEFAULT_GEMINI_FLASH_MODEL,
+      } as Config;
+
+      const decision = await strategy.route(
+        mockContext,
+        mockConfig,
+        mockClient,
+      );
+
+      expect(decision).not.toBeNull();
+      expect(decision?.model).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+      expect(decision?.metadata.source).toBe('fallback');
+    });
+  });
+});

--- a/packages/core/src/routing/strategies/fallbackStrategy.ts
+++ b/packages/core/src/routing/strategies/fallbackStrategy.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../../config/config.js';
+import { getEffectiveModel } from '../../config/models.js';
+import type { BaseLlmClient } from '../../core/baseLlmClient.js';
+import type {
+  RoutingContext,
+  RoutingDecision,
+  RoutingStrategy,
+} from '../routingStrategy.js';
+
+export class FallbackStrategy implements RoutingStrategy {
+  readonly name = 'fallback';
+
+  async route(
+    _context: RoutingContext,
+    config: Config,
+    _baseLlmClient: BaseLlmClient,
+  ): Promise<RoutingDecision | null> {
+    const isInFallbackMode: boolean = config.isInFallbackMode();
+
+    if (!isInFallbackMode) {
+      return null;
+    }
+
+    const effectiveModel = getEffectiveModel(
+      isInFallbackMode,
+      config.getModel(),
+    );
+    return {
+      model: effectiveModel,
+      metadata: {
+        source: this.name,
+        latencyMs: 0,
+        reasoning: `In fallback mode. Using: ${effectiveModel}`,
+      },
+    };
+  }
+}

--- a/packages/core/src/routing/strategies/overrideStrategy.test.ts
+++ b/packages/core/src/routing/strategies/overrideStrategy.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { OverrideStrategy } from './overrideStrategy.js';
+import type { RoutingContext } from '../routingStrategy.js';
+import type { BaseLlmClient } from '../../core/baseLlmClient.js';
+import type { Config } from '../../config/config.js';
+
+describe('OverrideStrategy', () => {
+  const strategy = new OverrideStrategy();
+  const mockContext = {} as RoutingContext;
+  const mockClient = {} as BaseLlmClient;
+
+  it('should return null when no override model is specified', async () => {
+    const mockConfig = {
+      getModel: () => '', // Simulate no model override
+    } as Config;
+
+    const decision = await strategy.route(mockContext, mockConfig, mockClient);
+    expect(decision).toBeNull();
+  });
+
+  it('should return a decision with the override model when one is specified', async () => {
+    const overrideModel = 'gemini-2.5-pro-custom';
+    const mockConfig = {
+      getModel: () => overrideModel,
+    } as Config;
+
+    const decision = await strategy.route(mockContext, mockConfig, mockClient);
+
+    expect(decision).not.toBeNull();
+    expect(decision?.model).toBe(overrideModel);
+    expect(decision?.metadata.source).toBe('override');
+    expect(decision?.metadata.reasoning).toContain(
+      'Routing bypassed by forced model directive',
+    );
+    expect(decision?.metadata.reasoning).toContain(overrideModel);
+  });
+
+  it('should handle different override model names', async () => {
+    const overrideModel = 'gemini-2.5-flash-experimental';
+    const mockConfig = {
+      getModel: () => overrideModel,
+    } as Config;
+
+    const decision = await strategy.route(mockContext, mockConfig, mockClient);
+
+    expect(decision).not.toBeNull();
+    expect(decision?.model).toBe(overrideModel);
+  });
+});

--- a/packages/core/src/routing/strategies/overrideStrategy.ts
+++ b/packages/core/src/routing/strategies/overrideStrategy.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../../config/config.js';
+import type { BaseLlmClient } from '../../core/baseLlmClient.js';
+import type {
+  RoutingContext,
+  RoutingDecision,
+  RoutingStrategy,
+} from '../routingStrategy.js';
+
+/**
+ * Handles cases where the user explicitly specifies a model (override).
+ */
+export class OverrideStrategy implements RoutingStrategy {
+  readonly name = 'override';
+
+  async route(
+    _context: RoutingContext,
+    config: Config,
+    _baseLlmClient: BaseLlmClient,
+  ): Promise<RoutingDecision | null> {
+    const overrideModel = config.getModel();
+    if (overrideModel) {
+      return {
+        model: overrideModel,
+        metadata: {
+          source: this.name,
+          latencyMs: 0,
+          reasoning: `Routing bypassed by forced model directive. Using: ${overrideModel}`,
+        },
+      };
+    }
+    // No override specified, pass to the next strategy.
+    return null;
+  }
+}


### PR DESCRIPTION
## TLDR

This PR introduces a foundational model routing architecture to enable dynamic model selection for user prompts.

**NOTE:** This PR does not make any functional changes to actually implement dynamic model routing. It only adds the architecture to do so.

- **What:** A `ModelRouterService` is introduced, which is responsible for deciding which model (e.g., Gemini Pro, Gemini Flash) to use for a given conversation.
- **Why:** This architecture paves the way for more intelligent, cost-effective, and performant model usage. In the future, we can implement strategies to route simple queries to faster, cheaper models and complex queries to more powerful models.
- **How:**
    - The `GeminiClient` now orchestrates model selection. For the first turn of a new prompt, it calls the `ModelRouterService`.
    - The chosen model is then made "sticky" for the entire duration of that multi-turn prompt to ensure a consistent and coherent user experience.
    - Lower-level components (`GeminiChat`, `Turn`) have been refactored to accept the chosen model as a parameter, rather than looking it up in the config.
- A new `ModelRouterService` that uses a chain-of-responsibility pattern with different strategies.
- Strategies for handling fallback mode, user overrides, and a default model selection.

The core logic changes are in `packages/core/src/core/client.ts` and the new `packages/core/src/routing/` directory.

## Dive Deeper

This change introduces a more sophisticated approach to model management. Previously, the model was a static configuration value. Now, it's a dynamic decision made at the start of each conversational sequence (identified by a `prompt_id`).

### Model Stickiness

A key concept here is "model stickiness." Once the router selects a model for a prompt, that same model is used for all subsequent turns within that prompt. This is crucial for maintaining conversational context and preventing jarring shifts in tone or capability that could occur if the model changed mid-conversation. The `GeminiClient` now manages this state via the `currentSequenceModel` property.

### Inversion of Control

This refactor also improves the overall architecture by applying an inversion of control pattern. Instead of lower-level modules like `GeminiChat` pulling the model from the `Config` service, the high-level `GeminiClient` now *pushes* the selected model down as a parameter. This makes the downstream components more modular, predictable, and easier to test in isolation.

### Strategies
The initial order of strategies is:
1.  **`FallbackStrategy`**: If the client is in fallback mode (e.g., due to a previous quota error), this strategy immediately takes over. It intelligently downgrades "pro" models to "flash" while honoring requests for "lite" models to preserve cost-saving intentions.
2.  **`OverrideStrategy`**: If a model is explicitly set in the user's configuration, this strategy ensures that the user's choice is respected, bypassing any other logic.
3.  **`DefaultStrategy`**: This is the terminal strategy in the chain. If no other strategy makes a decision, it ensures that we always fall back to the default `gemini-2.5-pro` model.

### Future Possibilities

Although this PR does not introduce functional changes, it unlocks the ability to build more advanced routing strategies in the future, such as:
- **Cost-based routing:** Use Flash for prompts that don't require complex reasoning.
- **Capability-based routing:** Detect if a prompt requires advanced tool use or reasoning and route to Pro.
- **Content-based routing:** Analyze the prompt content (e.g., code generation vs. summarization) to select the best-suited model.

**NOTE**
The Default strategy is not used b/c the override mechanism is greedy. This is in preparation for how we will explicitly set the model once we introduce an actual dynamic router.

## Reviewer Test Plan

The most effective way to validate this change is by reviewing the new unit tests, which thoroughly cover the routing and stickiness logic.

- **Primary Test Files:**
    - `packages/core/src/core/client.test.ts`: See the new "Model Routing" `describe` block.
    - `packages/core/src/routing/modelRouterService.test.ts`: Validates the new service logic.

### Manual Validation (Optional)

Since the `DefaultStrategy` preserves the existing behavior, the CLI should function identically from a user's perspective. To see the new architecture in action, a reviewer can add logging:

1.  **Add logs:**
    - In `packages/core/src/routing/modelRouterService.ts`, log the decision in the `route` method.
    - In `packages/core/src/core/client.ts`, log when the router is being called vs. when a sticky model is being used.
2.  **Run the CLI and start a chat.**
3.  **First Turn:** On your first message, you should see the log from the `ModelRouterService` indicating it's making a decision.
4.  **Second Turn:** On your follow-up message in the same chat, you should *not* see the router log. Instead, you should see a log indicating that the sticky model is being used.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |

## Linked issues / bugs

This PR makes progress on #6079
