### PR TITLE
fix(#7039): broken IDE integration for multi-edit/multi-write flows

### DIFF
--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -200,6 +200,8 @@ class WriteFileToolInvocation extends BaseToolInvocation<
         ? ideClient.openDiff(this.params.file_path, correctedContent)
         : undefined;
 
+    await ideConfirmation;
+
     const confirmationDetails: ToolEditConfirmationDetails = {
       type: 'edit',
       title: `Confirm Write: ${shortenPath(relativePath)}`,

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -200,8 +200,6 @@ class WriteFileToolInvocation extends BaseToolInvocation<
         ? ideClient.openDiff(this.params.file_path, correctedContent)
         : undefined;
 
-    await ideConfirmation;
-
     const confirmationDetails: ToolEditConfirmationDetails = {
       type: 'edit',
       title: `Confirm Write: ${shortenPath(relativePath)}`,


### PR DESCRIPTION
## TLDR

It fixes the issue about the broken IDE integration for multi-edit/multi-write flows.

## Dive Deeper

Before, when inputting something like this: `Please create two files: a.txt and b.txt`, two vscode diff views would open at the same time. The problem was that, those diff views would open in read-only mode, and sometimes only the first one would be editable, creating inconsistency. IDE integration should function for multi-edit and multi-write flows in the same manner as it does for single-edit and single-write flows. The user should be able to accept or modify changes seamlessly through the CLI or IDE as intended, and that's exactly what this pull request addresses.

The fix involves opening vscode diff views sequentially. It seems like, when opening diff views in quick succession was not giving VSCode enough time to open them up _correctly_ causing them to open in read-only mode. Also, the `WriteFile` tool takes care of requests sequentially, so I don't see any issue replicating that behavior.

## Reviewer Test Plan
Make sure to have the IDE installed and active before testing.

**Multi-Write**
In order to reproduce the multi-write fix we can input something like this:

`Please create three files a.txt, b.txt and c.txt.`

This will summon the `WriteFile` tool, three requests will queue up to create the files, and a _**single**_ vscode diff view will open (before, three vscode diff views would have opened at the same time):
<img width="1554" height="711" alt="image" src="https://github.com/user-attachments/assets/9a07b8b3-6023-42a9-82bf-1c9dc67fc383" />

I am able to write to the file with no problem:
<img width="1505" height="264" alt="image" src="https://github.com/user-attachments/assets/c572ba73-ce1a-490d-931d-ade5fd0f367f" />

And when accepting the changes by clicking the check button from the vscode diff view, the file content gets written correctly:
<img width="284" height="122" alt="image" src="https://github.com/user-attachments/assets/6bd15b61-3c7c-437c-98ac-d540a7392487" />

They all were created successfully:
<img width="1548" height="705" alt="image" src="https://github.com/user-attachments/assets/42bae6d4-e6f5-44ec-8ac0-467483ab2b6e" />

**Multi-Edit**
For multi-edit, we can do something like this:

`Please add "Hello World" to a.txt, b.txt and c.txt`

If I add more text in the vscode diff view like: "\nHere's some extra text":
<img width="1548" height="705" alt="image" src="https://github.com/user-attachments/assets/ca10a7c2-cb8e-4060-b298-c271e6a9c9f4" />

It gets added correctly:
<img width="1548" height="705" alt="image" src="https://github.com/user-attachments/assets/1a6a1313-556c-451d-b8e1-1049d00d5a5e" />

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | x  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes: #https://github.com/google-gemini/gemini-cli/issues/7039
