### PR TITLE
fix(cli): added directory name to folder trust dialog

### DIFF
--- a/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
@@ -98,7 +98,15 @@ describe('FolderTrustDialog', () => {
     });
   });
 
-  describe('parentFolder display', () => {
+  describe('directory display', () => {
+    it('should correctly display the folder name for a nested directory', () => {
+      mockedCwd.mockReturnValue('/home/user/project');
+      const { lastFrame } = renderWithProviders(
+        <FolderTrustDialog onSelect={vi.fn()} />,
+      );
+      expect(lastFrame()).toContain('Trust folder (project)');
+    });
+
     it('should correctly display the parent folder name for a nested directory', () => {
       mockedCwd.mockReturnValue('/home/user/project');
       const { lastFrame } = renderWithProviders(

--- a/packages/cli/src/ui/components/FolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.tsx
@@ -46,11 +46,12 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
     { isActive: !!isRestarting },
   );
 
+  const dirName = path.basename(process.cwd());
   const parentFolder = path.basename(path.dirname(process.cwd()));
 
   const options: Array<RadioSelectItem<FolderTrustChoice>> = [
     {
-      label: 'Trust folder',
+      label: `Trust folder (${dirName})`,
       value: FolderTrustChoice.TRUST_FOLDER,
     },
     {


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

After the change:
<img width="1300" height="470" alt="image" src="https://github.com/user-attachments/assets/133b5355-c7e3-4489-bc72-29b13c5997e6" />

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes - https://github.com/google-gemini/maintainers-gemini-cli/issues/760