### PR TITLE
fix(async): prevent missed async errors in try/catch with return-await ESLint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -85,6 +85,10 @@ export default tseslint.config(
         ...globals.node,
         ...globals.es2021,
       },
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: projectRoot,
+      },
     },
     rules: {
       // General Best Practice Rules (subset adapted for flat config)
@@ -159,6 +163,8 @@ export default tseslint.config(
       'prefer-const': ['error', { destructuring: 'all' }],
       radix: 'error',
       'default-case': 'error',
+      // Prevent redundant async/await patterns
+      '@typescript-eslint/return-await': ['error', 'in-try-catch'],
     },
   },
   {

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -96,7 +96,7 @@ export class CoderAgentExecutor implements AgentExecutor {
     loadEnvironment(); // Will override any global env with workspace envs
     const settings = loadSettings(workspaceRoot);
     const extensions = loadExtensions(workspaceRoot);
-    return await loadConfig(settings, extensions, taskId);
+    return loadConfig(settings, extensions, taskId);
   }
 
   /**

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -87,7 +87,7 @@ async function getServerStatus(
   server: MCPServerConfig,
 ): Promise<MCPServerStatus> {
   // Test all server types by attempting actual connection
-  return await testMCPConnection(serverName, server);
+  return testMCPConnection(serverName, server);
 }
 
 export async function listMcpServers(): Promise<void> {

--- a/packages/cli/src/config/extensions/consent.ts
+++ b/packages/cli/src/config/extensions/consent.ts
@@ -45,7 +45,7 @@ export async function requestConsentInteractive(
   consentDescription: string,
   addExtensionUpdateConfirmationRequest: (value: ConfirmationRequest) => void,
 ): Promise<boolean> {
-  return await promptForConsentInteractive(
+  return promptForConsentInteractive(
     consentDescription + '\n\nDo you want to continue?',
     addExtensionUpdateConfirmationRequest,
   );
@@ -89,7 +89,7 @@ async function promptForConsentInteractive(
   prompt: string,
   addExtensionUpdateConfirmationRequest: (value: ConfirmationRequest) => void,
 ): Promise<boolean> {
-  return await new Promise<boolean>((resolve) => {
+  return new Promise<boolean>((resolve) => {
     addExtensionUpdateConfirmationRequest({
       prompt,
       onConfirm: (resolvedConfirmed) => {

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -123,7 +123,7 @@ export async function fetchReleaseFromGithub(
   allowPreRelease?: boolean,
 ): Promise<GithubReleaseData | null> {
   if (ref) {
-    return await fetchJson(
+    return fetchJson(
       `https://api.github.com/repos/${owner}/${repo}/releases/tags/${ref}`,
     );
   }

--- a/packages/cli/src/config/extensions/storage.ts
+++ b/packages/cli/src/config/extensions/storage.ts
@@ -40,8 +40,6 @@ export class ExtensionStorage {
   }
 
   static async createTmpDir(): Promise<string> {
-    return await fs.promises.mkdtemp(
-      path.join(os.tmpdir(), 'gemini-extension'),
-    );
+    return fs.promises.mkdtemp(path.join(os.tmpdir(), 'gemini-extension'));
   }
 }

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -339,7 +339,7 @@ export async function start_sandbox(
       sandboxProcess = spawn(config.command, args, {
         stdio: 'inherit',
       });
-      return new Promise((resolve, reject) => {
+      return await new Promise((resolve, reject) => {
         sandboxProcess?.on('error', reject);
         sandboxProcess?.on('close', (code) => {
           process.stdin.resume();
@@ -816,7 +816,7 @@ export async function start_sandbox(
       stdio: 'inherit',
     });
 
-    return new Promise<number>((resolve, reject) => {
+    return await new Promise<number>((resolve, reject) => {
       sandboxProcess.on('error', (err) => {
         console.error('Sandbox process error:', err);
         reject(err);

--- a/packages/cli/src/zed-integration/acp.ts
+++ b/packages/cli/src/zed-integration/acp.ts
@@ -67,7 +67,7 @@ export class AgentSideConnection implements Client {
    * Streams new content to the client including text, tool calls, etc.
    */
   async sessionUpdate(params: schema.SessionNotification): Promise<void> {
-    return await this.#connection.sendNotification(
+    return this.#connection.sendNotification(
       schema.CLIENT_METHODS.session_update,
       params,
     );
@@ -82,7 +82,7 @@ export class AgentSideConnection implements Client {
   async requestPermission(
     params: schema.RequestPermissionRequest,
   ): Promise<schema.RequestPermissionResponse> {
-    return await this.#connection.sendRequest(
+    return this.#connection.sendRequest(
       schema.CLIENT_METHODS.session_request_permission,
       params,
     );
@@ -91,7 +91,7 @@ export class AgentSideConnection implements Client {
   async readTextFile(
     params: schema.ReadTextFileRequest,
   ): Promise<schema.ReadTextFileResponse> {
-    return await this.#connection.sendRequest(
+    return this.#connection.sendRequest(
       schema.CLIENT_METHODS.fs_read_text_file,
       params,
     );
@@ -100,7 +100,7 @@ export class AgentSideConnection implements Client {
   async writeTextFile(
     params: schema.WriteTextFileRequest,
   ): Promise<schema.WriteTextFileResponse> {
-    return await this.#connection.sendRequest(
+    return this.#connection.sendRequest(
       schema.CLIENT_METHODS.fs_write_text_file,
       params,
     );

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -95,10 +95,7 @@ export class CodeAssistServer implements ContentGenerator {
   async onboardUser(
     req: OnboardUserRequest,
   ): Promise<LongRunningOperationResponse> {
-    return await this.requestPost<LongRunningOperationResponse>(
-      'onboardUser',
-      req,
-    );
+    return this.requestPost<LongRunningOperationResponse>('onboardUser', req);
   }
 
   async loadCodeAssist(
@@ -121,7 +118,7 @@ export class CodeAssistServer implements ContentGenerator {
   }
 
   async getCodeAssistGlobalUserSetting(): Promise<CodeAssistGlobalUserSettingResponse> {
-    return await this.requestGet<CodeAssistGlobalUserSettingResponse>(
+    return this.requestGet<CodeAssistGlobalUserSettingResponse>(
       'getCodeAssistGlobalUserSetting',
     );
   }
@@ -129,7 +126,7 @@ export class CodeAssistServer implements ContentGenerator {
   async setCodeAssistGlobalUserSetting(
     req: SetCodeAssistGlobalUserSettingRequest,
   ): Promise<CodeAssistGlobalUserSettingResponse> {
-    return await this.requestPost<CodeAssistGlobalUserSettingResponse>(
+    return this.requestPost<CodeAssistGlobalUserSettingResponse>(
       'setCodeAssistGlobalUserSetting',
       req,
     );

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -702,7 +702,7 @@ My setup is complete. I will provide my first command in the next turn.
         error?: unknown,
       ) =>
         // Pass the captured model to the centralized handler.
-        await handleFallback(this.config, currentAttemptModel, authType, error);
+        handleFallback(this.config, currentAttemptModel, authType, error);
 
       const result = await retryWithBackoff(apiCall, {
         onPersistent429: onPersistent429Callback,

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1477,7 +1477,7 @@ describe('GeminiChat', () => {
             error,
           );
           if (shouldRetry) {
-            return await apiCall();
+            return apiCall();
           }
         }
         throw error; // Stop if callback returns false/null or doesn't exist

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -377,7 +377,7 @@ export class GeminiChat {
     const onPersistent429Callback = async (
       authType?: string,
       error?: unknown,
-    ) => await handleFallback(this.config, model, authType, error);
+    ) => handleFallback(this.config, model, authType, error);
 
     const streamResponse = await retryWithBackoff(apiCall, {
       onPersistent429: onPersistent429Callback,

--- a/packages/core/src/mcp/token-storage/hybrid-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/hybrid-token-storage.ts
@@ -57,7 +57,7 @@ export class HybridTokenStorage extends BaseTokenStorage {
     }
 
     // Wait for initialization to complete
-    return await this.storageInitPromise;
+    return this.storageInitPromise;
   }
 
   async getCredentials(serverName: string): Promise<OAuthCredentials | null> {

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -164,7 +164,7 @@ export class LoopDetectionService {
       this.turnsInCurrentPrompt - this.lastCheckTurn >= this.llmCheckInterval
     ) {
       this.lastCheckTurn = this.turnsInCurrentPrompt;
-      return await this.checkForLoopWithLLM(signal);
+      return this.checkForLoopWithLLM(signal);
     }
 
     return false;

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -578,7 +578,7 @@ Expectation for required parameters:
       getFilePath: (params: EditToolParams) => params.file_path,
       getCurrentContent: async (params: EditToolParams): Promise<string> => {
         try {
-          return this.config
+          return await this.config
             .getFileSystemService()
             .readTextFile(params.file_path);
         } catch (err) {

--- a/packages/core/src/tools/smart-edit.ts
+++ b/packages/core/src/tools/smart-edit.ts
@@ -944,7 +944,7 @@ A good instruction should concisely answer:
       getFilePath: (params: EditToolParams) => params.file_path,
       getCurrentContent: async (params: EditToolParams): Promise<string> => {
         try {
-          return this.config
+          return await this.config
             .getFileSystemService()
             .readTextFile(params.file_path);
         } catch (err) {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -313,7 +313,7 @@ ${textContent}
           this.config,
           new WebFetchFallbackAttemptEvent('primary_failed'),
         );
-        return this.executeFallback(signal);
+        return await this.executeFallback(signal);
       }
 
       const sourceListFormatted: string[] = [];


### PR DESCRIPTION
## TLDR

Added @typescript-eslint/return-await ESLint rule to enforce
proper async/await usage in try-catch blocks, preventing errors
 from bypassing catch handlers. Also cleaned up unnecessary
return await in non-try-catch contexts.

## Dive Deeper

The rule addresses a subtle but important anti-pattern where
returning promises directly in try-catch blocks causes async
errors to escape the catch handler

```typescript
// Before: Error bypasses catch
try {
  return someAsyncFunc();
} catch (e) {
  // Never called for async errors
}
```

```typescript
// After: Error properly caught
try {
  return await someAsyncFunc();
} catch (e) {
  // Handles async errors correctly
}
```

This PR includes:
1. ESLint config update with the new rule
2. Fixed 15 files to add required await in try-catch blocks
3. Removed unnecessary return await in regular async contexts

## Reviewer Test Plan

1. Run `npm run lint` - should pass without errors
2. Check modified files for proper async/await usage

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
|----------|-----|-----|-----|
| npm run  | ✅   | ❓   | ❓   |
| npx      | ✅   | ❓   | ❓   |
| Docker   | ❓   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |

## Linked issues / bugs

- This PR Resolves on #8167 
