### PR TITLE
fix: make `bfsFileSearch` more efficient

### DIFF
--- a/packages/core/src/utils/bfsFileSearch.ts
+++ b/packages/core/src/utils/bfsFileSearch.ts
@@ -99,6 +99,16 @@ export async function bfsFileSearch(
     for (const { currentDir, entries } of results) {
       for (const entry of entries) {
         const fullPath = path.join(currentDir, entry.name);
+        const isDirectory = entry.isDirectory();
+        const isMatchingFile = entry.isFile() && entry.name === fileName;
+
+        if (!isDirectory && !isMatchingFile) {
+          continue;
+        }
+        if (isDirectory && ignoreDirsSet.has(entry.name)) {
+          continue;
+        }
+
         if (
           fileService?.shouldIgnoreFile(fullPath, {
             respectGitIgnore: options.fileFilteringOptions?.respectGitIgnore,
@@ -109,11 +119,9 @@ export async function bfsFileSearch(
           continue;
         }
 
-        if (entry.isDirectory()) {
-          if (!ignoreDirsSet.has(entry.name)) {
-            queue.push(fullPath);
-          }
-        } else if (entry.isFile() && entry.name === fileName) {
+        if (isDirectory) {
+          queue.push(fullPath);
+        } else {
           foundFiles.push(fullPath);
         }
       }


### PR DESCRIPTION
## TLDR

The `bfsFileSearch` is needlessly calling `fileService?.shouldIgnoreFile` for each and every file. It can only call this method for files matching the target file, or for directories. This drastically reduces the number of invocations of `fileService?.shouldIgnoreFile`. This will be relevant after #8172.
