### PR TITLE
feat(core): Copy `downloadRipGrep` with license.

### DIFF
--- a/third_party/get-ripgrep/LICENSE
+++ b/third_party/get-ripgrep/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Lvce Editor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/get-ripgrep/package.json
+++ b/third_party/get-ripgrep/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@lvce-editor/ripgrep",
+  "version": "0.0.0-dev",
+  "description": "A module for using ripgrep in a Node project",
+  "main": "src/index.js",
+  "typings": "src/index.d.ts",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lvce-editor/ripgrep"
+  },
+  "scripts": {
+    "postinstall": "node ./src/postinstall.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
+    "format": "prettier --write ."
+  },
+  "keywords": [
+    "lvce-editor",
+    "ripgrep"
+  ],
+  "author": "Lvce Editor",
+  "license": "MIT",
+  "dependencies": {
+    "@lvce-editor/verror": "^1.6.0",
+    "execa": "^9.5.2",
+    "extract-zip": "^2.0.1",
+    "fs-extra": "^11.3.0",
+    "got": "^14.4.5",
+    "path-exists": "^5.0.0",
+    "tempy": "^3.1.0",
+    "xdg-basedir": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^11.0.4",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.13.0",
+    "jest": "^29.7.0",
+    "prettier": "^3.4.2",
+    "typescript": "^5.7.3"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
+  }
+}

--- a/third_party/get-ripgrep/src/downloadRipGrep.js
+++ b/third_party/get-ripgrep/src/downloadRipGrep.js
@@ -1,0 +1,123 @@
+/* eslint-disable */
+/**
+ * @license
+ * Copyright 2023 Lvce Editor
+ * SPDX-License-Identifier: MIT
+ */
+import { VError } from '@lvce-editor/verror'
+import { execa } from 'execa'
+import extractZip from 'extract-zip'
+import fsExtra from 'fs-extra'
+import got from 'got'
+import * as os from 'node:os'
+import { dirname, join } from 'node:path'
+import { pathExists } from 'path-exists'
+import { pipeline } from 'node:stream/promises'
+import { temporaryFile } from 'tempy'
+import { fileURLToPath } from 'node:url'
+import { xdgCache } from 'xdg-basedir'
+
+const { mkdir, createWriteStream, move } = fsExtra
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const REPOSITORY = `microsoft/ripgrep-prebuilt`
+const VERSION = process.env.RIPGREP_VERSION || 'v13.0.0-10'
+console.log({ VERSION })
+const BIN_PATH = join(__dirname, '../bin')
+
+const getTarget = () => {
+  const arch = process.env.npm_config_arch || os.arch()
+  const platform = process.env.platform || os.platform()
+  switch (platform) {
+    case 'darwin':
+      switch (arch) {
+        case 'arm64':
+          return 'aarch64-apple-darwin.tar.gz'
+        default:
+          return 'x86_64-apple-darwin.tar.gz'
+      }
+    case 'win32':
+      switch (arch) {
+        case 'x64':
+          return 'x86_64-pc-windows-msvc.zip'
+        case 'arm':
+          return 'aarch64-pc-windows-msvc.zip'
+        default:
+          return 'i686-pc-windows-msvc.zip'
+      }
+    case 'linux':
+      switch (arch) {
+        case 'x64':
+          return 'x86_64-unknown-linux-musl.tar.gz'
+        case 'arm':
+        case 'armv7l':
+          return 'arm-unknown-linux-gnueabihf.tar.gz'
+        case 'arm64':
+          return 'aarch64-unknown-linux-gnu.tar.gz'
+        case 'ppc64':
+          return 'powerpc64le-unknown-linux-gnu.tar.gz'
+        case 's390x':
+          return 's390x-unknown-linux-gnu.tar.gz'
+        default:
+          return 'i686-unknown-linux-musl.tar.gz'
+      }
+    default:
+      throw new VError('Unknown platform: ' + platform)
+  }
+}
+
+export const downloadFile = async (url, outFile) => {
+  try {
+    const tmpFile = temporaryFile()
+    await pipeline(got.stream(url), createWriteStream(tmpFile))
+    await mkdir(dirname(outFile), { recursive: true })
+    await move(tmpFile, outFile)
+  } catch (error) {
+    throw new VError(error, `Failed to download "${url}"`)
+  }
+}
+
+/**
+ * @param {string} inFile
+ * @param {string} outDir
+ */
+const unzip = async (inFile, outDir) => {
+  try {
+    await mkdir(outDir, { recursive: true })
+    await extractZip(inFile, { dir: outDir })
+  } catch (error) {
+    throw new VError(error, `Failed to unzip "${inFile}"`)
+  }
+}
+
+/**
+ * @param {string} inFile
+ * @param {string} outDir
+ */
+const untarGz = async (inFile, outDir) => {
+  try {
+    await mkdir(outDir, { recursive: true })
+    await execa('tar', ['xvf', inFile, '-C', outDir])
+  } catch (error) {
+    throw new VError(error, `Failed to extract "${inFile}"`)
+  }
+}
+
+export const downloadRipGrep = async () => {
+  const target = getTarget()
+  const url = `https://github.com/${REPOSITORY}/releases/download/${VERSION}/ripgrep-${VERSION}-${target}`
+  const downloadPath = `${xdgCache}/vscode-ripgrep/ripgrep-${VERSION}-${target}`
+  if (!(await pathExists(downloadPath))) {
+    await downloadFile(url, downloadPath)
+  } else {
+    console.info(`File ${downloadPath} has been cached`)
+  }
+  if (downloadPath.endsWith('.tar.gz')) {
+    await untarGz(downloadPath, BIN_PATH)
+  } else if (downloadPath.endsWith('.zip')) {
+    await unzip(downloadPath, BIN_PATH)
+  } else {
+    throw new VError(`Invalid downloadPath ${downloadPath}`)
+  }
+}

--- a/third_party/get-ripgrep/src/index.js
+++ b/third_party/get-ripgrep/src/index.js
@@ -1,0 +1,17 @@
+/* eslint-disable */
+/**
+ * @license
+ * Copyright 2023 Lvce Editor
+ * SPDX-License-Identifier: MIT
+ */
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export const rgPath = join(
+  __dirname,
+  '..',
+  'bin',
+  `rg${process.platform === 'win32' ? '.exe' : ''}`,
+)


### PR DESCRIPTION
## TLDR

Copies `downloadRipGrep` into the repo along with its license.

## Dive Deeper

This CL just copies the code. In the follow-up, we can add tests and wire this code up.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | :heavy_check_mark:   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Necessary for #7327 