### PR TITLE
docs: Add e2e status badge to main README 🏅

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gemini CLI
 
 [![Gemini CLI CI](https://github.com/google-gemini/gemini-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/google-gemini/gemini-cli/actions/workflows/ci.yml)
+[![Gemini CLI E2E](https://github.com/google-gemini/gemini-cli/actions/workflows/e2e.yml/badge.svg)](https://github.com/google-gemini/gemini-cli/actions/workflows/e2e.yml)
 [![Version](https://img.shields.io/npm/v/@google/gemini-cli)](https://www.npmjs.com/package/@google/gemini-cli)
 [![License](https://img.shields.io/github/license/google-gemini/gemini-cli)](https://github.com/google-gemini/gemini-cli/blob/main/LICENSE)
 


### PR DESCRIPTION
## TLDR

Add e2e status badge to README

## Dive Deeper

e2e tests are run as part of the merge process (and now enforced on PRs before merge as well), so here's a quick place to see their status. Hopefully we can squash down the flakes and keep this green 😎

## Reviewer Test Plan

n/a

## Testing Matrix

n/a

## Linked issues / bugs

Part of #3694
