### PR TITLE
feat(ui): make accept edits & yolo mode match shell mode styles

### DIFF
--- a/packages/cli/src/ui/components/AutoAcceptIndicator.tsx
+++ b/packages/cli/src/ui/components/AutoAcceptIndicator.tsx
@@ -22,7 +22,7 @@ export const AutoAcceptIndicator: React.FC<AutoAcceptIndicatorProps> = ({
 
   switch (approvalMode) {
     case ApprovalMode.AUTO_EDIT:
-      textColor = theme.status.success;
+      textColor = theme.status.warning;
       textContent = 'accepting edits';
       subText = ' (shift + tab to toggle)';
       break;

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -170,6 +170,7 @@ export const Composer = () => {
           commandContext={uiState.commandContext}
           shellModeActive={uiState.shellModeActive}
           setShellModeActive={uiActions.setShellModeActive}
+          approvalMode={showAutoAcceptIndicator}
           onEscapePromptChange={uiActions.onEscapePromptChange}
           focus={uiState.isFocused}
           vimHandleInput={uiActions.vimHandleInput}

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -138,7 +138,7 @@ export const Footer: React.FC<FooterProps> = ({
         <Box alignItems="center" paddingLeft={2}>
           {corgiMode && (
             <Text>
-              <Text color={theme.ui.symbol}>| </Text>
+              <Text color={theme.ui.comment}>| </Text>
               <Text color={theme.status.error}>▼</Text>
               <Text color={theme.text.primary}>(´</Text>
               <Text color={theme.status.error}>ᴥ</Text>
@@ -148,7 +148,7 @@ export const Footer: React.FC<FooterProps> = ({
           )}
           {!showErrorDetails && errorCount > 0 && (
             <Box>
-              <Text color={theme.ui.symbol}>| </Text>
+              <Text color={theme.ui.comment}>| </Text>
               <ConsoleSummaryDisplay errorCount={errorCount} />
             </Box>
           )}

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -1788,4 +1788,36 @@ describe('InputPrompt', () => {
       unmount();
     });
   });
+
+  describe('snapshots', () => {
+    it('should render correctly in shell mode', async () => {
+      props.shellModeActive = true;
+      const { stdout, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+      expect(stdout.lastFrame()).toMatchSnapshot();
+      unmount();
+    });
+
+    it('should render correctly when accepting edits', async () => {
+      props.approvalMode = ApprovalMode.AUTO_EDIT;
+      const { stdout, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+      expect(stdout.lastFrame()).toMatchSnapshot();
+      unmount();
+    });
+
+    it('should render correctly in yolo mode', async () => {
+      props.approvalMode = ApprovalMode.YOLO;
+      const { stdout, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+      expect(stdout.lastFrame()).toMatchSnapshot();
+      unmount();
+    });
+  });
 });

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -10,6 +10,7 @@ import type { InputPromptProps } from './InputPrompt.js';
 import { InputPrompt } from './InputPrompt.js';
 import type { TextBuffer } from './shared/text-buffer.js';
 import type { Config } from '@google/gemini-cli-core';
+import { ApprovalMode } from '@google/gemini-cli-core';
 import * as path from 'node:path';
 import type { CommandContext, SlashCommand } from '../commands/types.js';
 import { CommandKind } from '../commands/types.js';
@@ -207,6 +208,7 @@ describe('InputPrompt', () => {
       commandContext: mockCommandContext,
       shellModeActive: false,
       setShellModeActive: vi.fn(),
+      approvalMode: ApprovalMode.DEFAULT,
       inputWidth: 80,
       suggestionsWidth: 80,
       focus: true,

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -712,8 +712,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const { inlineGhost, additionalLines } = getGhostTextLines();
 
-  const showAutoAcceptStyling = !shellModeActive && approvalMode === ApprovalMode.AUTO_EDIT;
-  const showYoloStyling = !shellModeActive && approvalMode === ApprovalMode.YOLO;
+  const showAutoAcceptStyling =
+    !shellModeActive && approvalMode === ApprovalMode.AUTO_EDIT;
+  const showYoloStyling =
+    !shellModeActive && approvalMode === ApprovalMode.YOLO;
 
   return (
     <>

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -745,13 +745,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 (r:){' '}
               </Text>
             ) : (
-              '! '
+              '!'
             )
           ) : showYoloStyling ? (
-            '* '
+            '*'
           ) : (
-            '> '
-          )}
+            '>'
+          )}{' '}
         </Text>
         <Box flexGrow={1} flexDirection="column">
           {buffer.text.length === 0 && placeholder ? (

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -713,6 +713,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const { inlineGhost, additionalLines } = getGhostTextLines();
 
   const showAutoAcceptStyling = !shellModeActive && approvalMode === ApprovalMode.AUTO_EDIT;
+  const showYoloStyling = !shellModeActive && approvalMode === ApprovalMode.YOLO;
 
   return (
     <>
@@ -721,9 +722,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         borderColor={
           shellModeActive
             ? theme.status.warning
-            : showAutoAcceptStyling
-              ? theme.status.success
-              : theme.border.focused
+            : showYoloStyling
+              ? theme.status.error
+              : showAutoAcceptStyling
+                ? theme.status.success
+                : theme.border.focused
         }
         paddingX={1}
       >
@@ -731,9 +734,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           color={
             shellModeActive
               ? theme.status.warning
-              : showAutoAcceptStyling
-                ? theme.status.success
-                : theme.text.accent
+              : showYoloStyling
+                ? theme.status.error
+                : showAutoAcceptStyling
+                  ? theme.status.success
+                  : theme.text.accent
           }
         >
           {shellModeActive ? (
@@ -747,6 +752,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             ) : (
               '! '
             )
+          ) : showYoloStyling ? (
+            '* '
           ) : (
             '> '
           )}

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -718,12 +718,16 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     !shellModeActive && approvalMode === ApprovalMode.YOLO;
 
   let statusColor: string | undefined;
+  let statusText = '';
   if (shellModeActive) {
     statusColor = theme.ui.symbol;
+    statusText = 'Shell mode';
   } else if (showYoloStyling) {
     statusColor = theme.status.error;
+    statusText = 'YOLO mode';
   } else if (showAutoAcceptStyling) {
     statusColor = theme.status.warning;
+    statusText = 'Accepting edits';
   }
 
   return (
@@ -735,7 +739,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
         paddingX={1}
       >
-        <Text color={statusColor ?? theme.text.accent}>
+        <Text
+          color={statusColor ?? theme.text.accent}
+          aria-label={statusText || undefined}
+        >
           {shellModeActive ? (
             reverseSearchActive ? (
               <Text

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -719,11 +719,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   let statusColor: string | undefined;
   if (shellModeActive) {
-    statusColor = theme.status.warning;
+    statusColor = theme.ui.symbol;
   } else if (showYoloStyling) {
     statusColor = theme.status.error;
   } else if (showAutoAcceptStyling) {
-    statusColor = theme.status.success;
+    statusColor = theme.status.warning;
   }
 
   return (

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -717,31 +717,24 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const showYoloStyling =
     !shellModeActive && approvalMode === ApprovalMode.YOLO;
 
+  let statusColor: string | undefined;
+  if (shellModeActive) {
+    statusColor = theme.status.warning;
+  } else if (showYoloStyling) {
+    statusColor = theme.status.error;
+  } else if (showAutoAcceptStyling) {
+    statusColor = theme.status.success;
+  }
+
   return (
     <>
       <Box
         borderStyle="round"
-        borderColor={
-          shellModeActive
-            ? theme.status.warning
-            : showYoloStyling
-              ? theme.status.error
-              : showAutoAcceptStyling
-                ? theme.status.success
-                : theme.border.focused
-        }
+        borderColor={statusColor ?? theme.border.focused}
         paddingX={1}
       >
         <Text
-          color={
-            shellModeActive
-              ? theme.status.warning
-              : showYoloStyling
-                ? theme.status.error
-                : showAutoAcceptStyling
-                  ? theme.status.success
-                  : theme.text.accent
-          }
+          color={statusColor ?? theme.text.accent}
         >
           {shellModeActive ? (
             reverseSearchActive ? (

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -23,6 +23,7 @@ import { useKeypress } from '../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../keyMatchers.js';
 import type { CommandContext, SlashCommand } from '../commands/types.js';
 import type { Config } from '@google/gemini-cli-core';
+import { ApprovalMode } from '@google/gemini-cli-core';
 import { parseInputForHighlighting } from '../utils/highlight.js';
 import {
   clipboardHasImage,
@@ -46,6 +47,7 @@ export interface InputPromptProps {
   suggestionsWidth: number;
   shellModeActive: boolean;
   setShellModeActive: (value: boolean) => void;
+  approvalMode: ApprovalMode;
   onEscapePromptChange?: (showPrompt: boolean) => void;
   vimHandleInput?: (key: Key) => boolean;
 }
@@ -64,6 +66,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   suggestionsWidth,
   shellModeActive,
   setShellModeActive,
+  approvalMode,
   onEscapePromptChange,
   vimHandleInput,
 }) => {
@@ -709,17 +712,29 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const { inlineGhost, additionalLines } = getGhostTextLines();
 
+  const showAutoAcceptStyling = !shellModeActive && approvalMode === ApprovalMode.AUTO_EDIT;
+
   return (
     <>
       <Box
         borderStyle="round"
         borderColor={
-          shellModeActive ? theme.status.warning : theme.border.focused
+          shellModeActive
+            ? theme.status.warning
+            : showAutoAcceptStyling
+              ? theme.status.success
+              : theme.border.focused
         }
         paddingX={1}
       >
         <Text
-          color={shellModeActive ? theme.status.warning : theme.text.accent}
+          color={
+            shellModeActive
+              ? theme.status.warning
+              : showAutoAcceptStyling
+                ? theme.status.success
+                : theme.text.accent
+          }
         >
           {shellModeActive ? (
             reverseSearchActive ? (

--- a/packages/cli/src/ui/components/ShellModeIndicator.tsx
+++ b/packages/cli/src/ui/components/ShellModeIndicator.tsx
@@ -10,7 +10,7 @@ import { theme } from '../semantic-colors.js';
 
 export const ShellModeIndicator: React.FC = () => (
   <Box>
-    <Text color={theme.status.warning}>
+    <Text color={theme.ui.symbol}>
       shell mode enabled
       <Text color={theme.text.secondary}> (esc to disable)</Text>
     </Text>

--- a/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
@@ -1,0 +1,19 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`InputPrompt > snapshots > should render correctly in shell mode 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ !   Type your message or @path/to/file                                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`InputPrompt > snapshots > should render correctly in yolo mode 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ *   Type your message or @path/to/file                                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+exports[`InputPrompt > snapshots > should render correctly when accepting edits 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ >   Type your message or @path/to/file                                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;

--- a/packages/cli/src/ui/themes/theme.ts
+++ b/packages/cli/src/ui/themes/theme.ts
@@ -174,8 +174,8 @@ export class Theme {
         focused: this.colors.AccentBlue,
       },
       ui: {
-        comment: this.colors.Comment,
-        symbol: this.colors.Gray,
+        comment: this.colors.Gray,
+        symbol: this.colors.AccentCyan,
         gradient: this.colors.GradientColors,
       },
       status: {


### PR DESCRIPTION
## TLDR

When a user enters shell mode, we display a nice visual cue that they are in this special mode. This PR extends this styling to accept edits & yolo mode.

<img width="600" alt="CleanShot 2025-09-10 at 10 46 21@2x" src="https://github.com/user-attachments/assets/757b5750-1b87-4f91-8f74-29b2f589dc0a" />


## Dive Deeper

Extends the pattern we use for shell mode (see screenshot above). For "accept edits" we'll use the success status and for "yolo mode" we'll use the error status w/ a `*`.

**Note:** the shell/accept/yolo modes will eventually be left-aligned after #8041 is fixed

<img width="600" alt="CleanShot 2025-09-11 at 10 35 17@2x" src="https://github.com/user-attachments/assets/15d0b838-38fe-434a-87bb-b9e5abc26934" />
<img width="600" alt="CleanShot 2025-09-11 at 10 35 29@2x" src="https://github.com/user-attachments/assets/c7f3d193-4645-4479-a5b4-9d8e3122744f" />
<img width="600" alt="CleanShot 2025-09-11 at 10 35 34@2x" src="https://github.com/user-attachments/assets/b728fca1-07aa-478c-835a-2b1b302fd3b2" />




## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
