### PR TITLE
fix(metrics) - Remove the error field from ApiResponseEvent

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -552,10 +552,6 @@ export class ClearcutLogger {
         value: JSON.stringify(event.duration_ms),
       },
       {
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_API_ERROR_MESSAGE,
-        value: JSON.stringify(event.error),
-      },
-      {
         gemini_cli_key:
           EventMetadataKey.GEMINI_CLI_API_RESPONSE_INPUT_TOKEN_COUNT,
         value: JSON.stringify(event.input_token_count),

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -6,6 +6,8 @@
 
 // Defines valid event metadata keys for Clearcut logging.
 export enum EventMetadataKey {
+  // Deleted enums: 24
+
   GEMINI_CLI_KEY_UNKNOWN = 0,
 
   // ==========================================================================

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -97,9 +97,6 @@ export enum EventMetadataKey {
   // Logs the duration of the API call in milliseconds.
   GEMINI_CLI_API_RESPONSE_DURATION_MS = 23,
 
-  // @deprecated Logs the error message of the API call, if any.
-  GEMINI_CLI_API_ERROR_MESSAGE = 24,
-
   // Logs the input token count of the API call.
   GEMINI_CLI_API_RESPONSE_INPUT_TOKEN_COUNT = 25,
 

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -97,7 +97,7 @@ export enum EventMetadataKey {
   // Logs the duration of the API call in milliseconds.
   GEMINI_CLI_API_RESPONSE_DURATION_MS = 23,
 
-  // Logs the error message of the API call, if any.
+  // @deprecated Logs the error message of the API call, if any.
   GEMINI_CLI_API_ERROR_MESSAGE = 24,
 
   // Logs the input token count of the API call.

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -315,7 +315,6 @@ describe('loggers', () => {
           response_text: 'test-response',
           prompt_id: 'prompt-id-1',
           auth_type: 'oauth-personal',
-          error: undefined,
         },
       });
 
@@ -324,7 +323,6 @@ describe('loggers', () => {
         'test-model',
         100,
         200,
-        undefined,
       );
 
       expect(mockMetrics.recordTokenUsageMetrics).toHaveBeenCalledWith(
@@ -341,7 +339,7 @@ describe('loggers', () => {
       });
     });
 
-    it('should log an API response with an error', () => {
+    it('should log an API response without an error', () => {
       const usageData: GenerateContentResponseUsageMetadata = {
         promptTokenCount: 17,
         candidatesTokenCount: 50,
@@ -356,7 +354,6 @@ describe('loggers', () => {
         AuthType.USE_GEMINI,
         usageData,
         'test-response',
-        'test-error',
       );
 
       logApiResponse(mockConfig, event);
@@ -369,7 +366,7 @@ describe('loggers', () => {
           ...event,
           'event.name': EVENT_API_RESPONSE,
           'event.timestamp': '2025-01-01T00:00:00.000Z',
-          'error.message': 'test-error',
+          [SemanticAttributes.HTTP_STATUS_CODE]: 200,
         },
       });
 

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -338,44 +338,6 @@ describe('loggers', () => {
         'event.timestamp': '2025-01-01T00:00:00.000Z',
       });
     });
-
-    it('should log an API response without an error', () => {
-      const usageData: GenerateContentResponseUsageMetadata = {
-        promptTokenCount: 17,
-        candidatesTokenCount: 50,
-        cachedContentTokenCount: 10,
-        thoughtsTokenCount: 5,
-        toolUsePromptTokenCount: 2,
-      };
-      const event = new ApiResponseEvent(
-        'test-model',
-        100,
-        'prompt-id-1',
-        AuthType.USE_GEMINI,
-        usageData,
-        'test-response',
-      );
-
-      logApiResponse(mockConfig, event);
-
-      expect(mockLogger.emit).toHaveBeenCalledWith({
-        body: 'API response from test-model. Status: 200. Duration: 100ms.',
-        attributes: {
-          'session.id': 'test-session-id',
-          'user.email': 'test-user@example.com',
-          ...event,
-          'event.name': EVENT_API_RESPONSE,
-          'event.timestamp': '2025-01-01T00:00:00.000Z',
-          [SemanticAttributes.HTTP_STATUS_CODE]: 200,
-        },
-      });
-
-      expect(mockUiEvent.addEvent).toHaveBeenCalledWith({
-        ...event,
-        'event.name': EVENT_API_RESPONSE,
-        'event.timestamp': '2025-01-01T00:00:00.000Z',
-      });
-    });
   });
 
   describe('logApiRequest', () => {

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -352,9 +352,7 @@ export function logApiResponse(config: Config, event: ApiResponseEvent): void {
   if (event.response_text) {
     attributes['response_text'] = event.response_text;
   }
-  if (event.error) {
-    attributes['error.message'] = event.error;
-  } else if (event.status_code) {
+  if (event.status_code) {
     if (typeof event.status_code === 'number') {
       attributes[SemanticAttributes.HTTP_STATUS_CODE] = event.status_code;
     }
@@ -371,7 +369,6 @@ export function logApiResponse(config: Config, event: ApiResponseEvent): void {
     event.model,
     event.duration_ms,
     event.status_code,
-    event.error,
   );
   recordTokenUsageMetrics(
     config,

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -174,7 +174,6 @@ export function recordApiResponseMetrics(
   model: string,
   durationMs: number,
   statusCode?: number | string,
-  error?: string,
 ): void {
   if (
     !apiRequestCounter ||
@@ -185,7 +184,7 @@ export function recordApiResponseMetrics(
   const metricAttributes: Attributes = {
     ...getCommonAttributes(config),
     model,
-    status_code: statusCode ?? (error ? 'error' : 'ok'),
+    status_code: statusCode ?? 'ok',
   };
   apiRequestCounter.add(1, metricAttributes);
   apiRequestLatencyHistogram.record(durationMs, {

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -231,7 +231,6 @@ export class ApiResponseEvent implements BaseTelemetryEvent {
   model: string;
   status_code?: number | string;
   duration_ms: number;
-  error?: string;
   input_token_count: number;
   output_token_count: number;
   cached_content_token_count: number;
@@ -249,7 +248,6 @@ export class ApiResponseEvent implements BaseTelemetryEvent {
     auth_type?: string,
     usage_data?: GenerateContentResponseUsageMetadata,
     response_text?: string,
-    error?: string,
   ) {
     this['event.name'] = 'api_response';
     this['event.timestamp'] = new Date().toISOString();
@@ -263,7 +261,6 @@ export class ApiResponseEvent implements BaseTelemetryEvent {
     this.tool_token_count = usage_data?.toolUsePromptTokenCount ?? 0;
     this.total_token_count = usage_data?.totalTokenCount ?? 0;
     this.response_text = response_text;
-    this.error = error;
     this.prompt_id = prompt_id;
     this.auth_type = auth_type;
   }


### PR DESCRIPTION
## TLDR

We log our errors with ApiErrorEvent, the error field is not used at all

## Dive Deeper

None of our events have this metadata logged, as seen from https://github.com/google-gemini/maintainers-gemini-cli/issues/733

When we have an error, we log it as `ApiErrorEvent`: https://github.com/google-gemini/gemini-cli/blob/b9b6fe1f739145861f40b744389c185b92cea3c9/packages/core/src/core/loggingContentGenerator.ts#L125

## Reviewer Test Plan

run build and preflight

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | x  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/733