### PR TITLE
feat: add telemetry for output format usage

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -176,6 +176,7 @@ Logs are timestamped records of specific events. The following events are logged
     - `file_filtering_respect_git_ignore` (boolean)
     - `debug_mode` (boolean)
     - `mcp_servers` (string)
+    - `output_format` (string: "text" or "json")
 
 - `gemini_cli.user_prompt`: This event occurs when a user submits a prompt.
   - **Attributes**:

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -18,6 +18,7 @@ import {
   ToolErrorType,
   ToolRegistry,
 } from '../index.js';
+import { OutputFormat } from '../output/types.js';
 import { logs } from '@opentelemetry/api-logs';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import type { Config } from '../config/config.js';
@@ -157,6 +158,7 @@ describe('loggers', () => {
         getQuestion: () => 'test-question',
         getTargetDir: () => 'target-dir',
         getProxy: () => 'http://test.proxy.com:8080',
+        getOutputFormat: () => OutputFormat.JSON,
       } as unknown as Config;
 
       const startSessionEvent = new StartSessionEvent(mockConfig);
@@ -183,6 +185,7 @@ describe('loggers', () => {
           mcp_servers_count: 1,
           mcp_tools: undefined,
           mcp_tools_count: undefined,
+          output_format: 'json',
         },
       });
     });

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -106,6 +106,7 @@ export function logCliConfiguration(
     mcp_servers_count: event.mcp_servers_count,
     mcp_tools: event.mcp_tools,
     mcp_tools_count: event.mcp_tools_count,
+    output_format: event.output_format,
   };
 
   const logger = logs.getLogger(SERVICE_NAME);

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -18,6 +18,7 @@ import {
 import type { FileOperation } from './metrics.js';
 export { ToolCallDecision };
 import type { ToolRegistry } from '../tools/tool-registry.js';
+import type { OutputFormat } from '../output/types.js';
 
 export interface BaseTelemetryEvent {
   'event.name': string;
@@ -45,6 +46,7 @@ export class StartSessionEvent implements BaseTelemetryEvent {
   mcp_servers_count: number;
   mcp_tools_count?: number;
   mcp_tools?: string;
+  output_format: OutputFormat;
 
   constructor(config: Config, toolRegistry?: ToolRegistry) {
     const generatorConfig = config.getContentGeneratorConfig();
@@ -74,6 +76,7 @@ export class StartSessionEvent implements BaseTelemetryEvent {
     this.file_filtering_respect_git_ignore =
       config.getFileFilteringRespectGitIgnore();
     this.mcp_servers_count = mcpServers ? Object.keys(mcpServers).length : 0;
+    this.output_format = config.getOutputFormat();
     if (toolRegistry) {
       const mcpTools = toolRegistry
         .getAllTools()


### PR DESCRIPTION
- Add output_format field to StartSessionEvent to track user's chosen output format ('text' or 'json')
- Update telemetry logger to include the output format in CLI configuration events
- Update test to verify output format tracking functionality
- Update telemetry documentation to describe the new output_format attribute

This metric is now available in OpenTelemetry traces/logs under the gemini_cli.config event, enabling monitoring of output format usage patterns.

Fixes https://github.com/google-gemini/gemini-cli/issues/8222