### PR TITLE
feat(ui): Add confirmation dialog for disabling loop detection for current session

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -897,37 +897,20 @@ Logging in with Google... Please restart Gemini CLI to continue.
 
   const nightly = props.version.includes('nightly');
 
-  const dialogsVisible = useMemo(
-    () =>
-      showWorkspaceMigrationDialog ||
-      shouldShowIdePrompt ||
-      isFolderTrustDialogOpen ||
-      !!shellConfirmationRequest ||
-      !!confirmationRequest ||
-      !!loopDetectionConfirmationRequest ||
-      isThemeDialogOpen ||
-      isSettingsDialogOpen ||
-      isAuthenticating ||
-      isAuthDialogOpen ||
-      isEditorDialogOpen ||
-      showPrivacyNotice ||
-      !!proQuotaRequest,
-    [
-      showWorkspaceMigrationDialog,
-      shouldShowIdePrompt,
-      isFolderTrustDialogOpen,
-      shellConfirmationRequest,
-      confirmationRequest,
-      loopDetectionConfirmationRequest,
-      isThemeDialogOpen,
-      isSettingsDialogOpen,
-      isAuthenticating,
-      isAuthDialogOpen,
-      isEditorDialogOpen,
-      showPrivacyNotice,
-      proQuotaRequest,
-    ],
-  );
+  const dialogsVisible =
+    showWorkspaceMigrationDialog ||
+    shouldShowIdePrompt ||
+    isFolderTrustDialogOpen ||
+    !!shellConfirmationRequest ||
+    !!confirmationRequest ||
+    !!loopDetectionConfirmationRequest ||
+    isThemeDialogOpen ||
+    isSettingsDialogOpen ||
+    isAuthenticating ||
+    isAuthDialogOpen ||
+    isEditorDialogOpen ||
+    showPrivacyNotice ||
+    !!proQuotaRequest;
 
   const pendingHistoryItems = useMemo(
     () => [...pendingSlashCommandHistoryItems, ...pendingGeminiHistoryItems],

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -505,6 +505,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     pendingHistoryItems: pendingGeminiHistoryItems,
     thought,
     cancelOngoingRequest,
+    loopDetectionConfirmationRequest,
   } = useGeminiStream(
     config.getGeminiClient(),
     historyManager.history,
@@ -903,6 +904,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       isFolderTrustDialogOpen ||
       !!shellConfirmationRequest ||
       !!confirmationRequest ||
+      !!loopDetectionConfirmationRequest ||
       isThemeDialogOpen ||
       isSettingsDialogOpen ||
       isAuthenticating ||
@@ -916,6 +918,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       isFolderTrustDialogOpen,
       shellConfirmationRequest,
       confirmationRequest,
+      loopDetectionConfirmationRequest,
       isThemeDialogOpen,
       isSettingsDialogOpen,
       isAuthenticating,
@@ -952,6 +955,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       commandContext,
       shellConfirmationRequest,
       confirmationRequest,
+      loopDetectionConfirmationRequest,
       geminiMdFileCount,
       streamingState,
       initError,
@@ -1024,6 +1028,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       commandContext,
       shellConfirmationRequest,
       confirmationRequest,
+      loopDetectionConfirmationRequest,
       geminiMdFileCount,
       streamingState,
       initError,

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -6,6 +6,7 @@
 
 import { Box, Text } from 'ink';
 import { IdeIntegrationNudge } from '../IdeIntegrationNudge.js';
+import { LoopDetectionConfirmation } from './LoopDetectionConfirmation.js';
 import { FolderTrustDialog } from './FolderTrustDialog.js';
 import { ShellConfirmationDialog } from './ShellConfirmationDialog.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
@@ -81,6 +82,13 @@ export const DialogManager = () => {
   if (uiState.shellConfirmationRequest) {
     return (
       <ShellConfirmationDialog request={uiState.shellConfirmationRequest} />
+    );
+  }
+  if (uiState.loopDetectionConfirmationRequest) {
+    return (
+      <LoopDetectionConfirmation
+        onComplete={uiState.loopDetectionConfirmationRequest.onComplete}
+      />
     );
   }
   if (uiState.confirmationRequest) {

--- a/packages/cli/src/ui/components/LoopDetectionConfirmation.test.tsx
+++ b/packages/cli/src/ui/components/LoopDetectionConfirmation.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderWithProviders } from '../../test-utils/render.js';
+import { describe, it, expect, vi } from 'vitest';
+import { LoopDetectionConfirmation } from './LoopDetectionConfirmation.js';
+
+describe('LoopDetectionConfirmation', () => {
+  const onComplete = vi.fn();
+
+  it('renders correctly', () => {
+    const { lastFrame } = renderWithProviders(
+      <LoopDetectionConfirmation onComplete={onComplete} />,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+  });
+
+  it('contains the expected options', () => {
+    const { lastFrame } = renderWithProviders(
+      <LoopDetectionConfirmation onComplete={onComplete} />,
+    );
+    const output = lastFrame()!.toString();
+
+    expect(output).toContain('A potential loop was detected');
+    expect(output).toContain('Keep loop detection enabled (esc)');
+    expect(output).toContain('Disable loop detection for this session');
+    expect(output).toContain(
+      'This can happen due to repetitive tool calls or other model behavior',
+    );
+  });
+});

--- a/packages/cli/src/ui/components/LoopDetectionConfirmation.tsx
+++ b/packages/cli/src/ui/components/LoopDetectionConfirmation.tsx
@@ -8,6 +8,7 @@ import { Box, Text } from 'ink';
 import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import { useKeypress } from '../hooks/useKeypress.js';
+import { theme } from '../semantic-colors.js';
 
 export type LoopDetectionConfirmationResult = {
   userSelection: 'disable' | 'keep';
@@ -33,13 +34,13 @@ export function LoopDetectionConfirmation({
 
   const OPTIONS: Array<RadioSelectItem<LoopDetectionConfirmationResult>> = [
     {
-      label: 'No, keep loop detection enabled and stop (esc)',
+      label: 'Keep loop detection enabled (esc)',
       value: {
         userSelection: 'keep',
       },
     },
     {
-      label: 'Yes, disable loop detection for this session',
+      label: 'Disable loop detection for this session',
       value: {
         userSelection: 'disable',
       },
@@ -50,26 +51,38 @@ export function LoopDetectionConfirmation({
     <Box
       flexDirection="column"
       borderStyle="round"
-      borderColor="yellow"
-      padding={1}
+      borderColor={theme.status.warning}
       width="100%"
       marginLeft={1}
     >
-      <Box marginBottom={1} flexDirection="column">
-        <Text>
-          <Text color="yellow">⚠️ </Text>
-          Loop Detection Alert
-        </Text>
-        <Text dimColor>
-          A potential loop was detected. This can happen due to repetitive tool
-          calls or other model behavior patterns.
-        </Text>
-        <Text dimColor>
-          Would you like to disable loop detection for this session and
-          continue?
-        </Text>
+      <Box paddingX={1} paddingY={0} flexDirection="column">
+        <Box minHeight={1}>
+          <Box minWidth={3}>
+            <Text color={theme.status.warning} aria-label="Loop detected:">
+              ?
+            </Text>
+          </Box>
+          <Box>
+            <Text wrap="truncate-end">
+              <Text color={theme.text.primary} bold>
+                A potential loop was detected
+              </Text>{' '}
+            </Text>
+          </Box>
+        </Box>
+        <Box width="100%" marginTop={1}>
+          <Box flexDirection="column">
+            <Text color={theme.text.secondary}>
+              This can happen due to repetitive tool calls or other model
+              behavior. Do you want to keep loop detection enabled or disable it
+              for this session?
+            </Text>
+            <Box marginTop={1}>
+              <RadioButtonSelect items={OPTIONS} onSelect={onComplete} />
+            </Box>
+          </Box>
+        </Box>
       </Box>
-      <RadioButtonSelect items={OPTIONS} onSelect={onComplete} />
     </Box>
   );
 }

--- a/packages/cli/src/ui/components/LoopDetectionConfirmation.tsx
+++ b/packages/cli/src/ui/components/LoopDetectionConfirmation.tsx
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Text } from 'ink';
+import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+
+export type LoopDetectionConfirmationResult = {
+  userSelection: 'disable' | 'keep';
+};
+
+interface LoopDetectionConfirmationProps {
+  onComplete: (result: LoopDetectionConfirmationResult) => void;
+}
+
+export function LoopDetectionConfirmation({
+  onComplete,
+}: LoopDetectionConfirmationProps) {
+  useKeypress(
+    (key) => {
+      if (key.name === 'escape') {
+        onComplete({
+          userSelection: 'keep',
+        });
+      }
+    },
+    { isActive: true },
+  );
+
+  const OPTIONS: Array<RadioSelectItem<LoopDetectionConfirmationResult>> = [
+    {
+      label: 'No, keep loop detection enabled and stop (esc)',
+      value: {
+        userSelection: 'keep',
+      },
+    },
+    {
+      label: 'Yes, disable loop detection for this session',
+      value: {
+        userSelection: 'disable',
+      },
+    },
+  ];
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="yellow"
+      padding={1}
+      width="100%"
+      marginLeft={1}
+    >
+      <Box marginBottom={1} flexDirection="column">
+        <Text>
+          <Text color="yellow">⚠️ </Text>
+          Loop Detection Alert
+        </Text>
+        <Text dimColor>
+          A potential loop was detected. This can happen due to repetitive tool
+          calls or other model behavior patterns.
+        </Text>
+        <Text dimColor>
+          Would you like to disable loop detection for this session and
+          continue?
+        </Text>
+      </Box>
+      <RadioButtonSelect items={OPTIONS} onSelect={onComplete} />
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/components/__snapshots__/LoopDetectionConfirmation.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/LoopDetectionConfirmation.test.tsx.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`LoopDetectionConfirmation > renders correctly 1`] = `
+" ╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+ │ ?  A potential loop was detected                                                                 │
+ │                                                                                                  │
+ │ This can happen due to repetitive tool calls or other model behavior. Do you want to keep loop   │
+ │ detection enabled or disable it for this session?                                                │
+ │                                                                                                  │
+ │ ● 1. Keep loop detection enabled (esc)                                                           │
+ │   2. Disable loop detection for this session                                                     │
+ ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -11,6 +11,7 @@ import type {
   ConsoleMessageItem,
   ShellConfirmationRequest,
   ConfirmationRequest,
+  LoopDetectionConfirmationRequest,
   HistoryItemWithoutId,
   StreamingState,
 } from '../types.js';
@@ -53,6 +54,7 @@ export interface UIState {
   commandContext: CommandContext;
   shellConfirmationRequest: ShellConfirmationRequest | null;
   confirmationRequest: ConfirmationRequest | null;
+  loopDetectionConfirmationRequest: LoopDetectionConfirmationRequest | null;
   geminiMdFileCount: number;
   streamingState: StreamingState;
   initError: string | null;

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1929,7 +1929,7 @@ describe('useGeminiStream', () => {
       expect(mockAddItem).toHaveBeenCalledWith(
         {
           type: 'info',
-          text: 'A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted. Loop detection remains enabled.',
+          text: 'A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted.',
         },
         expect.any(Number),
       );
@@ -1969,7 +1969,7 @@ describe('useGeminiStream', () => {
       expect(mockAddItem).toHaveBeenCalledWith(
         {
           type: 'info',
-          text: 'A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted. Loop detection remains enabled.',
+          text: 'A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted.',
         },
         expect.any(Number),
       );

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1789,4 +1789,262 @@ describe('useGeminiStream', () => {
       );
     });
   });
+
+  describe('Loop Detection Confirmation', () => {
+    beforeEach(() => {
+      // Add mock for getLoopDetectionService to the config
+      const mockLoopDetectionService = {
+        disableForSession: vi.fn(),
+      };
+      mockConfig.getGeminiClient = vi.fn().mockReturnValue({
+        ...new MockedGeminiClientClass(mockConfig),
+        getLoopDetectionService: () => mockLoopDetectionService,
+      });
+    });
+
+    it('should set loopDetectionConfirmationRequest when LoopDetected event is received', async () => {
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'Some content',
+          };
+          yield {
+            type: ServerGeminiEventType.LoopDetected,
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('test query');
+      });
+
+      await waitFor(() => {
+        expect(result.current.loopDetectionConfirmationRequest).not.toBeNull();
+        expect(
+          typeof result.current.loopDetectionConfirmationRequest?.onComplete,
+        ).toBe('function');
+      });
+    });
+
+    it('should disable loop detection and show message when user selects "disable"', async () => {
+      const mockLoopDetectionService = {
+        disableForSession: vi.fn(),
+      };
+      const mockClient = {
+        ...new MockedGeminiClientClass(mockConfig),
+        getLoopDetectionService: () => mockLoopDetectionService,
+      };
+      mockConfig.getGeminiClient = vi.fn().mockReturnValue(mockClient);
+
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.LoopDetected,
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('test query');
+      });
+
+      // Wait for confirmation request to be set
+      await waitFor(() => {
+        expect(result.current.loopDetectionConfirmationRequest).not.toBeNull();
+      });
+
+      // Simulate user selecting "disable"
+      await act(async () => {
+        result.current.loopDetectionConfirmationRequest?.onComplete({
+          userSelection: 'disable',
+        });
+      });
+
+      // Verify loop detection was disabled
+      expect(mockLoopDetectionService.disableForSession).toHaveBeenCalledTimes(
+        1,
+      );
+
+      // Verify confirmation request was cleared
+      expect(result.current.loopDetectionConfirmationRequest).toBeNull();
+
+      // Verify appropriate message was added
+      expect(mockAddItem).toHaveBeenCalledWith(
+        {
+          type: 'info',
+          text: 'Loop detection has been disabled for this session. Please try your request again.',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should keep loop detection enabled and show message when user selects "keep"', async () => {
+      const mockLoopDetectionService = {
+        disableForSession: vi.fn(),
+      };
+      const mockClient = {
+        ...new MockedGeminiClientClass(mockConfig),
+        getLoopDetectionService: () => mockLoopDetectionService,
+      };
+      mockConfig.getGeminiClient = vi.fn().mockReturnValue(mockClient);
+
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.LoopDetected,
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('test query');
+      });
+
+      // Wait for confirmation request to be set
+      await waitFor(() => {
+        expect(result.current.loopDetectionConfirmationRequest).not.toBeNull();
+      });
+
+      // Simulate user selecting "keep"
+      await act(async () => {
+        result.current.loopDetectionConfirmationRequest?.onComplete({
+          userSelection: 'keep',
+        });
+      });
+
+      // Verify loop detection was NOT disabled
+      expect(mockLoopDetectionService.disableForSession).not.toHaveBeenCalled();
+
+      // Verify confirmation request was cleared
+      expect(result.current.loopDetectionConfirmationRequest).toBeNull();
+
+      // Verify appropriate message was added
+      expect(mockAddItem).toHaveBeenCalledWith(
+        {
+          type: 'info',
+          text: 'A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted. Loop detection remains enabled.',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should handle multiple loop detection events properly', async () => {
+      const { result } = renderTestHook();
+
+      // First loop detection - set up fresh mock for first call
+      mockSendMessageStream.mockReturnValueOnce(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.LoopDetected,
+          };
+        })(),
+      );
+
+      // First loop detection
+      await act(async () => {
+        await result.current.submitQuery('first query');
+      });
+
+      await waitFor(() => {
+        expect(result.current.loopDetectionConfirmationRequest).not.toBeNull();
+      });
+
+      // Simulate user selecting "keep" for first request
+      await act(async () => {
+        result.current.loopDetectionConfirmationRequest?.onComplete({
+          userSelection: 'keep',
+        });
+      });
+
+      expect(result.current.loopDetectionConfirmationRequest).toBeNull();
+
+      // Verify first message was added
+      expect(mockAddItem).toHaveBeenCalledWith(
+        {
+          type: 'info',
+          text: 'A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted. Loop detection remains enabled.',
+        },
+        expect.any(Number),
+      );
+
+      // Second loop detection - set up fresh mock for second call
+      mockSendMessageStream.mockReturnValueOnce(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.LoopDetected,
+          };
+        })(),
+      );
+
+      // Second loop detection
+      await act(async () => {
+        await result.current.submitQuery('second query');
+      });
+
+      await waitFor(() => {
+        expect(result.current.loopDetectionConfirmationRequest).not.toBeNull();
+      });
+
+      // Simulate user selecting "disable" for second request
+      await act(async () => {
+        result.current.loopDetectionConfirmationRequest?.onComplete({
+          userSelection: 'disable',
+        });
+      });
+
+      expect(result.current.loopDetectionConfirmationRequest).toBeNull();
+
+      // Verify second message was added
+      expect(mockAddItem).toHaveBeenCalledWith(
+        {
+          type: 'info',
+          text: 'Loop detection has been disabled for this session. Please try your request again.',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should process LoopDetected event after moving pending history to history', async () => {
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'Some response content',
+          };
+          yield {
+            type: ServerGeminiEventType.LoopDetected,
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('test query');
+      });
+
+      // Verify that the content was added to history before the loop detection dialog
+      await waitFor(() => {
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'gemini',
+            text: 'Some response content',
+          }),
+          expect.any(Number),
+        );
+      });
+
+      // Then verify loop detection confirmation request was set
+      await waitFor(() => {
+        expect(result.current.loopDetectionConfirmationRequest).not.toBeNull();
+      });
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -153,6 +153,12 @@ export const useGeminiStream = (
   );
 
   const loopDetectedRef = useRef(false);
+  const [
+    loopDetectionConfirmationRequest,
+    setLoopDetectionConfirmationRequest,
+  ] = useState<{
+    onComplete: (result: { userSelection: 'disable' | 'keep' }) => void;
+  } | null>(null);
 
   const onExec = useCallback(async (done: Promise<void>) => {
     setIsResponding(true);
@@ -588,15 +594,38 @@ export const useGeminiStream = (
     [addItem, config],
   );
 
+  const handleLoopDetectionConfirmation = useCallback(
+    (result: { userSelection: 'disable' | 'keep' }) => {
+      setLoopDetectionConfirmationRequest(null);
+
+      if (result.userSelection === 'disable') {
+        config.getGeminiClient().getLoopDetectionService().disableForSession();
+        addItem(
+          {
+            type: 'info',
+            text: `Loop detection has been disabled for this session. Please try your request again.`,
+          },
+          Date.now(),
+        );
+      } else {
+        addItem(
+          {
+            type: 'info',
+            text: `A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted. Loop detection remains enabled.`,
+          },
+          Date.now(),
+        );
+      }
+    },
+    [config, addItem],
+  );
+
   const handleLoopDetectedEvent = useCallback(() => {
-    addItem(
-      {
-        type: 'info',
-        text: `A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted.`,
-      },
-      Date.now(),
-    );
-  }, [addItem]);
+    // Show the confirmation dialog to choose whether to disable loop detection
+    setLoopDetectionConfirmationRequest({
+      onComplete: handleLoopDetectionConfirmation,
+    });
+  }, [handleLoopDetectionConfirmation]);
 
   const processGeminiStreamEvents = useCallback(
     async (
@@ -1045,5 +1074,6 @@ export const useGeminiStream = (
     pendingHistoryItems,
     thought,
     cancelOngoingRequest,
+    loopDetectionConfirmationRequest,
   };
 };

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -611,7 +611,7 @@ export const useGeminiStream = (
         addItem(
           {
             type: 'info',
-            text: `A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted. Loop detection remains enabled.`,
+            text: `A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted.`,
           },
           Date.now(),
         );

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -284,3 +284,7 @@ export interface ConfirmationRequest {
   prompt: ReactNode;
   onConfirm: (confirm: boolean) => void;
 }
+
+export interface LoopDetectionConfirmationRequest {
+  onComplete: (result: { userSelection: 'disable' | 'keep' }) => void;
+}

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -186,6 +186,10 @@ export class GeminiClient {
     return this.chat?.getChatRecordingService();
   }
 
+  getLoopDetectionService(): LoopDetectionService {
+    return this.loopDetector;
+  }
+
   async addDirectoryContext(): Promise<void> {
     if (!this.chat) {
       return;

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -130,6 +130,15 @@ describe('LoopDetectionService', () => {
       expect(service.addAndCheck(toolCallEvent)).toBe(true);
       expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
     });
+
+    it('should not detect a loop when disabled for session', () => {
+      service.disableForSession();
+      const event = createToolCallRequestEvent('testTool', { param: 'value' });
+      for (let i = 0; i < TOOL_CALL_LOOP_THRESHOLD; i++) {
+        expect(service.addAndCheck(event)).toBe(false);
+      }
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
   });
 
   describe('Content Loop Detection', () => {
@@ -718,5 +727,13 @@ describe('LoopDetectionService LLM Checks', () => {
     const result = await service.turnStarted(abortController.signal);
     expect(result).toBe(false);
     expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger LLM check when disabled for session', async () => {
+    service.disableForSession();
+    await advanceTurns(30);
+    const result = await service.turnStarted(abortController.signal);
+    expect(result).toBe(false);
+    expect(mockGeminiClient.generateJson).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## TLDR

This change introduces a user confirmation dialog when a potential infinite loop is detected. Previously, the CLI would halt the request and there is no way to stop false positives. Now, the user is prompted with a choice: either halt the request (the default) or disable loop detection for the current session and proceed.

Confirmation dialog:
<img width="1034" height="674" alt="image" src="https://github.com/user-attachments/assets/9c5b815b-2846-4576-9b5e-fe2abf06710c" />

After selecting no for the first prompt and yes the second time:
<img width="1072" height="1322" alt="image" src="https://github.com/user-attachments/assets/ef0cae1a-b35d-4010-bcb6-3b848591641f" />


## Dive Deeper

The core goal is to give users more control when the `LoopDetectionService` flags a potential infinite loop. The previous behavior was abrupt and could interrupt a valid, albeit repetitive, workflow.

This PR implements the following:
- A new `LoopDetectionConfirmation.tsx` component is created to present the dialog to the user.
- The `useGeminiStream` hook now listens for the `LoopDetected` event and, instead of just logging a message, it triggers the new confirmation dialog.
- Based on the user's selection ("keep" or "disable"), the hook either halts the stream or calls a new `disableForSession()` method on the `LoopDetectionService`.
- The `LoopDetectionService` was updated to include the `disableForSession` flag, which bypasses all loop checks for the remainder of the CLI session if set.

This provides a much better user experience by preventing the CLI from being overly aggressive in halting user requests, empowering the user to decide if the repetitive behavior is intentional.

## Reviewer Test Plan

To test this, you'll need to trigger the loop detection mechanism.

1.  Start the CLI.
2.  It can be difficult to create a prompt that reliably causes a loop. A more deterministic way to test is to temporarily modify the `TOOL_CALL_LOOP_THRESHOLD` in `packages/core/src/services/loopDetectionService.ts` to a low number, like `2`.
3.  With the threshold lowered, ask the model a prompt that uses the same tool call multiple times, for example: "list the files in the current directory, then tell me what you see, then list them again".
4.  **Verify:** A yellow warning dialog should appear, asking if you want to disable loop detection.
5.  Press `escape` or select the "No, keep loop detection..." option.
6.  **Verify:** The request should be halted, and an informational message should appear stating that a loop was detected and the request was stopped.
7.  Run the same prompt again to trigger the dialog.
8.  This time, select "Yes, disable loop detection...".
9.  **Verify:** An informational message should appear stating that loop detection is disabled for the session, and the model should attempt to continue processing your request. Subsequent repetitive tool calls in the same session should no longer trigger the dialog.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
```