### PR TITLE
Fix suggestion alignment

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -211,7 +211,7 @@ export const AppContainer = (props: AppContainerProps) => {
     20,
     Math.floor(terminalWidth * widthFraction) - 3,
   );
-  const suggestionsWidth = Math.max(20, Math.floor(terminalWidth * 0.8));
+  const suggestionsWidth = Math.max(20, Math.floor(terminalWidth * 1.0));
   const mainAreaWidth = Math.floor(terminalWidth * 0.9);
   const staticAreaMaxItemHeight = Math.max(terminalHeight * 4, 100);
 

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -54,6 +54,14 @@ export function SuggestionsDisplay({
   );
   const visibleSuggestions = suggestions.slice(startIndex, endIndex);
 
+  const getFullLabel = (s: Suggestion) =>
+    s.label + (s.commandKind === CommandKind.MCP_PROMPT ? ' [MCP]' : '');
+
+  const maxLabelLength = Math.max(
+    ...suggestions.map((s) => getFullLabel(s).length),
+  );
+  const commandColumnWidth = Math.min(maxLabelLength, Math.floor(width * 0.5));
+
   return (
     <Box flexDirection="column" paddingX={1} width={width}>
       {scrollOffset > 0 && <Text color={theme.text.primary}>▲</Text>}
@@ -72,36 +80,26 @@ export function SuggestionsDisplay({
         );
 
         return (
-          <Box key={`${suggestion.value}-${originalIndex}`} width={width}>
-            <Box flexDirection="row">
-              {(() => {
-                const isSlashCommand = userInput.startsWith('/');
-                return (
-                  <>
-                    {isSlashCommand ? (
-                      <Box flexShrink={0} paddingRight={2}>
-                        {labelElement}
-                        {suggestion.commandKind === CommandKind.MCP_PROMPT && (
-                          <Text color={theme.text.secondary}> [MCP]</Text>
-                        )}
-                      </Box>
-                    ) : (
-                      labelElement
-                    )}
-                    {suggestion.description && (
-                      <Box
-                        flexGrow={1}
-                        paddingLeft={isSlashCommand ? undefined : 1}
-                      >
-                        <Text color={textColor} wrap="truncate">
-                          {suggestion.description}
-                        </Text>
-                      </Box>
-                    )}
-                  </>
-                );
-              })()}
+          <Box
+            key={`${suggestion.value}-${originalIndex}`}
+            flexDirection="row"
+          >
+            <Box width={commandColumnWidth} flexShrink={0}>
+              <Box>
+                {labelElement}
+                {suggestion.commandKind === CommandKind.MCP_PROMPT && (
+                  <Text color={theme.text.secondary}> [MCP]</Text>
+                )}
+              </Box>
             </Box>
+
+            {suggestion.description && (
+              <Box flexGrow={1} paddingLeft={3}>
+                <Text color={textColor} wrap="truncate">
+                  {suggestion.description}
+                </Text>
+              </Box>
+            )}
           </Box>
         );
       })}

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -80,10 +80,7 @@ export function SuggestionsDisplay({
         );
 
         return (
-          <Box
-            key={`${suggestion.value}-${originalIndex}`}
-            flexDirection="row"
-          >
+          <Box key={`${suggestion.value}-${originalIndex}`} flexDirection="row">
             <Box width={commandColumnWidth} flexShrink={0}>
               <Box>
                 {labelElement}


### PR DESCRIPTION
## TLDR

Fixes a bug where the alignment was broken for suggestions. 




## Dive Deeper

The command column will only be as long as the command name, with a cap at 50% of the screen width. I also increased the width of the suggestion box to 100% since it's under the prompt (which already is capped at 80%) and was causing unnecessary truncation of descriptions.

### Before
<img width="600" alt="CleanShot 2025-09-10 at 16 46 19@2x" src="https://github.com/user-attachments/assets/6e39c730-60f4-4ee6-a922-2e115346b6ad" />

### After
<img width="600" alt="CleanShot 2025-09-10 at 16 44 17@2x" src="https://github.com/user-attachments/assets/e8d8ce9a-c272-4306-971b-f47d10466815" />

<img width="600" alt="CleanShot 2025-09-10 at 16 49 09@2x" src="https://github.com/user-attachments/assets/efc9ab2e-7a6d-4132-ac62-b8a4b3a7f8f2" />


## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #8040