### PR TITLE
fix(ui): shell mode command output handles CR properly

### DIFF
--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
@@ -179,7 +179,7 @@ describe('useShellCommandProcessor', () => {
 
     act(() => {
       result.current.handleShellCommand(
-        'echo "test\rme\nand\ryou"',
+        'echo -e "test\rme\nand\ryou"',
         new AbortController().signal,
       );
     });


### PR DESCRIPTION
# NOTE
This PR is closed because of CLA issues. I did not realize that I committed with my school email account, which did not sign CLA.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->
In shell mode, command outputs with carriage returns now renders properly.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->
For example, Python's tqdm progress bar output can deform as in #2752. This PR fixes such issues, and carriage returns properly overwrites existing lines when not in `note-pty` mode.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->
Toggle gemini-cli to shell mode. Run `echo -e "test\rme"` and verify that the output is identical to the terminal's.
 
## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Fixes #2752 


*Example: `This PR makes progress on #456` or `Related to #789`*
-->

- Fixes #2752 
