### PR TITLE
Broaden PR Approval Process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,15 @@
-# By default, require reviews from the release approvers for all files.
-* @google-gemini/gemini-cli-askmode-approvers
+# By default, require reviews from the maintainers for all files.
+* @google-gemini/gemini-cli-maintainers
 
-# The following files don't need reviews from the release approvers.
+# Require reviews from the release approvers for critical files.
 # These patterns override the rule above.
-**/*.md
-/docs/
+/package.json @google-gemini/gemini-cli-askmode-approvers
+/package-lock.json @google-gemini/gemini-cli-askmode-approvers
+/GEMINI.md @google-gemini/gemini-cli-askmode-approvers
+/SECURITY.md @google-gemini/gemini-cli-askmode-approvers
+/LICENSE @google-gemini/gemini-cli-askmode-approvers
+/.github/workflows/ @google-gemini/gemini-cli-askmode-approvers
+/packages/cli/package.json @google-gemini/gemini-cli-askmode-approvers
+/packages/cli/package-lock.json @google-gemini/gemini-cli-askmode-approvers
+/packages/core/package.json @google-gemini/gemini-cli-askmode-approvers
+/packages/core/package-lock.json @google-gemini/gemini-cli-askmode-approvers


### PR DESCRIPTION
This broadens the approvers group. Keeping ask mode for some of the more critical changes. Feel free to suggest if there are others to add/remove from the list. 

https://github.com/orgs/google-gemini/teams/gemini-cli-maintainers