### PR TITLE
fix(ide): Correct IDE client temp dir and port matching

### DIFF
--- a/packages/core/src/ide/ide-client.test.ts
+++ b/packages/core/src/ide/ide-client.test.ts
@@ -330,7 +330,7 @@ describe('IdeClient', () => {
 
       expect(result).toEqual(config);
       expect(fs.promises.readFile).toHaveBeenCalledWith(
-        path.join('/tmp/.gemini/ide', 'gemini-ide-server-12345-123.json'),
+        path.join('/tmp/gemini/ide', 'gemini-ide-server-12345-123.json'),
         'utf8',
       );
     });
@@ -525,11 +525,11 @@ describe('IdeClient', () => {
 
       expect(result).toEqual(validConfig);
       expect(fs.promises.readFile).toHaveBeenCalledWith(
-        path.join('/tmp/.gemini/ide', 'gemini-ide-server-12345-111.json'),
+        path.join('/tmp/gemini/ide', 'gemini-ide-server-12345-111.json'),
         'utf8',
       );
       expect(fs.promises.readFile).not.toHaveBeenCalledWith(
-        path.join('/tmp/.gemini/ide', 'not-a-config-file.txt'),
+        path.join('/tmp/gemini/ide', 'not-a-config-file.txt'),
         'utf8',
       );
     });

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -459,7 +459,7 @@ export class IdeClient {
       // exist.
     }
 
-    const portFileDir = path.join(os.tmpdir(), '.gemini', 'ide');
+    const portFileDir = path.join(os.tmpdir(), 'gemini', 'ide');
     let portFiles;
     try {
       portFiles = await fs.promises.readdir(portFileDir);
@@ -521,7 +521,7 @@ export class IdeClient {
     const portFromEnv = this.getPortFromEnv();
     if (portFromEnv) {
       const matchingPort = validWorkspaces.find(
-        (content) => content.port === portFromEnv,
+        (content) => String(content.port) === portFromEnv,
       );
       if (matchingPort) {
         return matchingPort;


### PR DESCRIPTION
## TLDR

This pull request addresses two issues in the IDE client:
1.  It changes the temporary directory used for storing IDE server connection files from `.../.gemini/ide` to `.../gemini/ide`, removing the leading dot.
2.  It fixes a bug in port matching where a strict equality check (`===`) would fail due to comparing a number (`content.port`) with a string (`portFromEnv`). The port is now cast to a string for a reliable comparison.

## Linked issues / bugs
#4800, #6848 
