### PR TITLE
fix(cli): restart gemini cli if untrusted folder option selected

### DIFF
--- a/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
@@ -64,28 +64,6 @@ describe('FolderTrustDialog', () => {
     });
   });
 
-  it('should display restart message when isRestarting is true', () => {
-    const { lastFrame } = renderWithProviders(
-      <FolderTrustDialog onSelect={vi.fn()} isRestarting={true} />,
-    );
-
-    expect(lastFrame()).toContain(
-      'To see changes, Gemini CLI must be restarted',
-    );
-  });
-
-  it('should call process.exit when "r" is pressed and isRestarting is true', async () => {
-    const { stdin } = renderWithProviders(
-      <FolderTrustDialog onSelect={vi.fn()} isRestarting={true} />,
-    );
-
-    stdin.write('r');
-
-    await waitFor(() => {
-      expect(mockedExit).toHaveBeenCalledWith(0);
-    });
-  });
-
   it('should not call process.exit when "r" is pressed and isRestarting is false', async () => {
     const { stdin } = renderWithProviders(
       <FolderTrustDialog onSelect={vi.fn()} isRestarting={false} />,

--- a/packages/cli/src/ui/components/FolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.tsx
@@ -37,15 +37,6 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
     { isActive: !isRestarting },
   );
 
-  useKeypress(
-    (key) => {
-      if (key.name === 'r') {
-        process.exit(0);
-      }
-    },
-    { isActive: !!isRestarting },
-  );
-
   const parentFolder = path.basename(path.dirname(process.cwd()));
 
   const options: Array<RadioSelectItem<FolderTrustChoice>> = [
@@ -88,14 +79,6 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
           isFocused={!isRestarting}
         />
       </Box>
-      {isRestarting && (
-        <Box marginLeft={1} marginTop={1}>
-          <Text color={Colors.AccentYellow}>
-            To see changes, Gemini CLI must be restarted. Press r to exit and
-            apply changes now.
-          </Text>
-        </Box>
-      )}
     </Box>
   );
 };


### PR DESCRIPTION
## TLDR

This PR updates the logic in the App container to check on isRestarting state  from the folder trust hook. As soon as the state turns to true the cli is restarted.

## Dive Deeper

The restart is done by spawning a child process and transferring all the controls to the new process while the parent process is moved to background and its  UI is cleared. The parent process is also  hooked to the close event of the child process. Once the child process exits it kills the parent process as well.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes - https://github.com/google-gemini/maintainers-gemini-cli/issues/776