### PR TITLE
fix(ui): ensure [MCP] tag color matches active state

### DIFF
--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -85,12 +85,7 @@ export function SuggestionsDisplay({
               <Box>
                 {labelElement}
                 {suggestion.commandKind === CommandKind.MCP_PROMPT && (
-                  <Text
-                    color={isActive ? theme.text.accent : theme.text.secondary}
-                  >
-                    {' '}
-                    [MCP]
-                  </Text>
+                  <Text color={textColor}> [MCP]</Text>
                 )}
               </Box>
             </Box>

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -85,7 +85,12 @@ export function SuggestionsDisplay({
               <Box>
                 {labelElement}
                 {suggestion.commandKind === CommandKind.MCP_PROMPT && (
-                  <Text color={theme.text.secondary}> [MCP]</Text>
+                  <Text
+                    color={isActive ? theme.text.accent : theme.text.secondary}
+                  >
+                    {' '}
+                    [MCP]
+                  </Text>
                 )}
               </Box>
             </Box>


### PR DESCRIPTION
## TLDR

This updates the color logic for MCP commands to be highlighted in suggestions:

<img width="600" alt="CleanShot 2025-09-11 at 18 04 22@2x" src="https://github.com/user-attachments/assets/a829b82d-9b07-4b62-8a22-a1127c4ce708" />


## Dive Deeper

Previously, the '[MCP]' tag in the suggestions display had a single color, causing it to remain unchanged when a suggestion was active.

### Before

<img width="600" alt="CleanShot 2025-09-11 at 18 05 58@2x" src="https://github.com/user-attachments/assets/dbca989e-6b09-4c50-97f9-033c02bf9a1f" />


This change updates the color of the '[MCP]' tag to dynamically match the active state of the suggestion item, ensuring a consistent and intuitive user interface.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
