### PR TITLE
support Authorization Server Metadata with path appending

### DIFF
--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -185,6 +185,9 @@ describe('OAuthUtils', () => {
           ok: false,
         })
         .mockResolvedValueOnce({
+          ok: false,
+        })
+        .mockResolvedValueOnce({
           ok: true,
           json: () => Promise.resolve(mockAuthServerMetadata),
         });
@@ -205,6 +208,10 @@ describe('OAuthUtils', () => {
       );
       expect(mockFetch).nthCalledWith(
         3,
+        'https://auth.example.com/mcp/.well-known/oauth-authorization-server',
+      );
+      expect(mockFetch).nthCalledWith(
+        4,
         'https://auth.example.com/mcp/.well-known/openid-configuration',
       );
     });

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -174,7 +174,15 @@ export class OAuthUtils {
         ).toString(),
       );
 
-      // 3. OpenID Connect Discovery 1.0 with path appending
+      // 3. OAuth 2.0 Authorization Server Metadata with path appending
+      endpointsToTry.push(
+        new URL(
+          `${authServerUrlObj.pathname}/.well-known/oauth-authorization-server`,
+          base,
+        ).toString(),
+      );
+
+      // 4. OpenID Connect Discovery 1.0 with path appending
       endpointsToTry.push(
         new URL(
           `${authServerUrlObj.pathname}/.well-known/openid-configuration`,

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -177,7 +177,7 @@ export class OAuthUtils {
       // 3. OAuth 2.0 Authorization Server Metadata with path appending
       endpointsToTry.push(
         new URL(
-          `${authServerUrlObj.pathname}/.well-known/oauth-authorization-server`,
+          `${authServerUrlObj.pathname.replace(/\/$/, '')}/.well-known/oauth-authorization-server`,
           base,
         ).toString(),
       );


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

Some authorization servers include a path prefix in their well-known endpoint. For example, Keycloak uses:

```
 http://localhost:8080/realms/master/.well-known/oauth-authorization-server
 ```
 Adding support for this form would enable Gemini to work with these authorization servers.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
