### PR TITLE
feat: Use Vertex AI for E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,7 +76,9 @@ jobs:
 
       - name: 'Run E2E tests'
         env:
-          GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
+          GOOGLE_API_KEY: '${{ secrets.GOOGLE_API_KEY }}'
+          GOOGLE_GENAI_USE_VERTEXAI: 'true'
+          GOOGLE_CLOUD_PROJECT: '${{ vars.E2E_GOOGLE_CLOUD_PROJECT }}'
           KEEP_OUTPUT: 'true'
           SANDBOX: '${{ matrix.sandbox }}'
           VERBOSE: 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,16 @@ on:
   pull_request_target:
     types: ['labeled']
   merge_group:
+  workflow_dispatch:
+    inputs:
+      auth_method:
+        description: 'Authentication method'
+        required: false
+        type: 'choice'
+        options:
+          - 'vertex'
+          - 'gemini'
+        default: 'vertex'
 
 jobs:
   e2e-test:
@@ -74,11 +84,23 @@ jobs:
           matrix.os == 'ubuntu-latest' && matrix.sandbox == 'sandbox:docker'
         uses: 'docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435' # ratchet:docker/setup-buildx-action@v3
 
-      - name: 'Run E2E tests'
+      - name: 'Run E2E tests with Vertex AI'
+        if: "(github.event.inputs.auth_method || vars.E2E_AUTH_METHOD || 'vertex') == 'vertex'"
         env:
           GOOGLE_API_KEY: '${{ secrets.GOOGLE_API_KEY }}'
           GOOGLE_GENAI_USE_VERTEXAI: 'true'
           GOOGLE_CLOUD_PROJECT: '${{ vars.E2E_GOOGLE_CLOUD_PROJECT }}'
+          KEEP_OUTPUT: 'true'
+          SANDBOX: '${{ matrix.sandbox }}'
+          VERBOSE: 'true'
+        shell: 'bash'
+        run: |-
+          npm run "test:integration:${SANDBOX}"
+
+      - name: 'Run E2E tests with Gemini API'
+        if: "(github.event.inputs.auth_method || vars.E2E_AUTH_METHOD) == 'gemini'"
+        env:
+          GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
           KEEP_OUTPUT: 'true'
           SANDBOX: '${{ matrix.sandbox }}'
           VERBOSE: 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,6 +90,7 @@ jobs:
           GOOGLE_API_KEY: '${{ secrets.GOOGLE_API_KEY }}'
           GOOGLE_GENAI_USE_VERTEXAI: 'true'
           GOOGLE_CLOUD_PROJECT: '${{ vars.E2E_GOOGLE_CLOUD_PROJECT }}'
+          GOOGLE_CLOUD_LOCATION: 'global'
           KEEP_OUTPUT: 'true'
           SANDBOX: '${{ matrix.sandbox }}'
           VERBOSE: 'true'


### PR DESCRIPTION
Updates the e2e workflow to use Vertex AI for authentication instead of the Gemini API.

This change replaces the GEMINI_API_KEY with GOOGLE_API_KEY and sets the necessary environment variables to enable Vertex AI.
