### PR TITLE
JSON errors in non-interactive auth validation

### DIFF
--- a/integration-tests/json-output.test.ts
+++ b/integration-tests/json-output.test.ts
@@ -34,4 +34,38 @@ describe('JSON output', () => {
     expect(parsed).toHaveProperty('stats');
     expect(typeof parsed.stats).toBe('object');
   });
+
+  it('should return a JSON error for enforced auth mismatch before running', async () => {
+    process.env['GOOGLE_GENAI_USE_GCA'] = 'true';
+    await rig.setup('json-output-auth-mismatch', {
+      settings: {
+        security: { auth: { enforcedType: 'gemini-api-key' } },
+      },
+    });
+
+    let thrown: Error | undefined;
+    try {
+      await rig.run('Hello', '--output-format', 'json');
+      expect.fail('Expected process to exit with error');
+    } catch (e) {
+      thrown = e as Error;
+    } finally {
+      delete process.env['GOOGLE_GENAI_USE_GCA'];
+    }
+
+    expect(thrown).toBeDefined();
+    const message = (thrown as Error).message;
+    const jsonStart = message.indexOf('{');
+    expect(jsonStart).toBeGreaterThan(-1);
+    const payload = JSON.parse(message.slice(jsonStart));
+    expect(payload.error).toBeDefined();
+    expect(payload.error.type).toBe('Error');
+    expect(payload.error.code).toBe(1);
+    expect(payload.error.message).toContain(
+      'configured auth type is gemini-api-key',
+    );
+    expect(payload.error.message).toContain(
+      'current auth type is oauth-personal',
+    );
+  });
 });

--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -5,10 +5,11 @@
  */
 
 import type { Config } from '@google/gemini-cli-core';
-import { AuthType } from '@google/gemini-cli-core';
+import { AuthType, OutputFormat } from '@google/gemini-cli-core';
 import { USER_SETTINGS_PATH } from './config/settings.js';
 import { validateAuthMethod } from './config/auth.js';
 import { type LoadedSettings } from './config/settings.js';
+import { handleError } from './utils/errors.js';
 
 function getAuthTypeFromEnv(): AuthType | undefined {
   if (process.env['GOOGLE_GENAI_USE_GCA'] === 'true') {
@@ -29,35 +30,45 @@ export async function validateNonInteractiveAuth(
   nonInteractiveConfig: Config,
   settings: LoadedSettings,
 ) {
-  const enforcedType = settings.merged.security?.auth?.enforcedType;
-  if (enforcedType) {
-    const currentAuthType = getAuthTypeFromEnv();
-    if (currentAuthType !== enforcedType) {
-      console.error(
-        `The configured auth type is ${enforcedType}, but the current auth type is ${currentAuthType}. Please re-authenticate with the correct type.`,
+  try {
+    const enforcedType = settings.merged.security?.auth?.enforcedType;
+    if (enforcedType) {
+      const currentAuthType = getAuthTypeFromEnv();
+      if (currentAuthType !== enforcedType) {
+        const message = `The configured auth type is ${enforcedType}, but the current auth type is ${currentAuthType}. Please re-authenticate with the correct type.`;
+        throw new Error(message);
+      }
+    }
+
+    const effectiveAuthType =
+      enforcedType || getAuthTypeFromEnv() || configuredAuthType;
+
+    if (!effectiveAuthType) {
+      const message = `Please set an Auth method in your ${USER_SETTINGS_PATH} or specify one of the following environment variables before running: GEMINI_API_KEY, GOOGLE_GENAI_USE_VERTEXAI, GOOGLE_GENAI_USE_GCA`;
+      throw new Error(message);
+    }
+
+    const authType: AuthType = effectiveAuthType as AuthType;
+
+    if (!useExternalAuth) {
+      const err = validateAuthMethod(String(authType));
+      if (err != null) {
+        throw new Error(err);
+      }
+    }
+
+    await nonInteractiveConfig.refreshAuth(authType);
+    return nonInteractiveConfig;
+  } catch (error) {
+    if (nonInteractiveConfig.getOutputFormat() === OutputFormat.JSON) {
+      handleError(
+        error instanceof Error ? error : new Error(String(error)),
+        nonInteractiveConfig,
+        1,
       );
+    } else {
+      console.error(error instanceof Error ? error.message : String(error));
       process.exit(1);
     }
   }
-
-  const effectiveAuthType =
-    enforcedType || getAuthTypeFromEnv() || configuredAuthType;
-
-  if (!effectiveAuthType) {
-    console.error(
-      `Please set an Auth method in your ${USER_SETTINGS_PATH} or specify one of the following environment variables before running: GEMINI_API_KEY, GOOGLE_GENAI_USE_VERTEXAI, GOOGLE_GENAI_USE_GCA`,
-    );
-    process.exit(1);
-  }
-
-  if (!useExternalAuth) {
-    const err = validateAuthMethod(effectiveAuthType);
-    if (err != null) {
-      console.error(err);
-      process.exit(1);
-    }
-  }
-
-  await nonInteractiveConfig.refreshAuth(effectiveAuthType);
-  return nonInteractiveConfig;
 }


### PR DESCRIPTION
- Output JSON-formatted errors in non-interactive mode when:
  - Enforced auth type mismatches current environment-provided auth
  - No effective auth type is resolved
  - validateAuthMethod reports an error
- Preserve existing text-mode behavior for non-JSON output.
- Add unit tests for JSON auth errors
- Add JSON auth error case in integration-tests

---
Follow up to #8119
Fixes #8022 