### PR TITLE
feat(core): Cap shell output truncation threshold to the remaining context window size

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -919,7 +919,7 @@ export class Config {
 
   getTruncateToolOutputThreshold(): number {
     return Math.min(
-      // an estimate of remaining context-window size
+      // Estimate remaining context window in characters (1 token ~= 4 chars).
       4 *
         (tokenLimit(this.model) - uiTelemetryService.getLastPromptTokenCount()),
       this.truncateToolOutputThreshold,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -39,7 +39,9 @@ import {
   initializeTelemetry,
   DEFAULT_TELEMETRY_TARGET,
   DEFAULT_OTLP_ENDPOINT,
+  uiTelemetryService,
 } from '../telemetry/index.js';
+import { tokenLimit } from '../core/tokenLimits.js';
 import { StartSessionEvent } from '../telemetry/index.js';
 import {
   DEFAULT_GEMINI_EMBEDDING_MODEL,
@@ -916,7 +918,11 @@ export class Config {
   }
 
   getTruncateToolOutputThreshold(): number {
-    return this.truncateToolOutputThreshold;
+    return Math.min(
+      // an estimate of remaining context-window size
+      4 * (tokenLimit(this.model) - uiTelemetryService.getLastPromptTokenCount()),
+      this.truncateToolOutputThreshold,
+    );
   }
 
   getTruncateToolOutputLines(): number {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -920,7 +920,8 @@ export class Config {
   getTruncateToolOutputThreshold(): number {
     return Math.min(
       // an estimate of remaining context-window size
-      4 * (tokenLimit(this.model) - uiTelemetryService.getLastPromptTokenCount()),
+      4 *
+        (tokenLimit(this.model) - uiTelemetryService.getLastPromptTokenCount()),
       this.truncateToolOutputThreshold,
     );
   }


### PR DESCRIPTION
## TLDR

This pull request introduces a dynamic calculation for the tool output truncation threshold. Instead of using a fixed limit, the threshold is now adjusted based on the estimated remaining tokens in the model's context window. This helps prevent context window overflow errors when tools produce large outputs.

## Dive Deeper

The `getTruncateToolOutputThreshold` method in the `Config` class has been updated. It now calculates the available space in the context window by subtracting the last prompt's token count from the model's total token limit. This remaining token count is then converted to an estimated byte threshold (assuming ~4 chars per token).

The final truncation limit is the *minimum* of this dynamically calculated value and the existing `truncateToolOutputThreshold` (either user-configured or the default). This ensures that we respect any user-defined hard limit while still preventing the tool output from exceeding the available context window, making tool execution more robust.

## Reviewer Test Plan

To validate this change, you can test scenarios where a tool's output could potentially exceed the context window.

1.  Find a large file in your filesystem.
2.  Run a prompt that uses a tool to read that file, for example: `gemini-cli "what are the contents of <large_file_path>?"`
3.  Before this change, if the file size was larger than the available context, the request would fail or trigger a auto-compression (compression would also fail if it's too large). With this change, the tool's output should be intelligently truncated to fit, and the request should complete successfully.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
#4659