### PR TITLE
feat: Add a2a-server to npm run bundle

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -52,7 +52,7 @@ const cliConfig = {
 const a2aServerConfig = {
   ...baseConfig,
   entryPoints: ['packages/a2a-server/src/http/server.ts'],
-  outfile: 'bundle/a2a-server.js',
+  outfile: 'bundle/a2a-server.mjs',
 };
 
 Promise.all([

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -24,17 +24,11 @@ const external = [
   '@lydell/node-pty-win32-arm64',
   '@lydell/node-pty-win32-x64',
 ];
-
-const cliConfig = {
-  entryPoints: ['packages/cli/index.ts'],
+const baseConfig = {
   bundle: true,
-  outfile: 'bundle/gemini.js',
   platform: 'node',
   format: 'esm',
   external,
-  alias: {
-    'is-in-ci': path.resolve(__dirname, 'packages/cli/src/patches/is-in-ci.ts'),
-  },
   define: {
     'process.env.CLI_VERSION': JSON.stringify(pkg.version),
   },
@@ -42,25 +36,23 @@ const cliConfig = {
     js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url); globalThis.__filename = require('url').fileURLToPath(import.meta.url); globalThis.__dirname = require('path').dirname(globalThis.__filename);`,
   },
   loader: { '.node': 'file' },
-  metafile: true,
   write: true,
 };
 
+const cliConfig = {
+  ...baseConfig,
+  entryPoints: ['packages/cli/index.ts'],
+  outfile: 'bundle/gemini.js',
+  alias: {
+    'is-in-ci': path.resolve(__dirname, 'packages/cli/src/patches/is-in-ci.ts'),
+  },
+  metafile: true,
+};
+
 const a2aServerConfig = {
+  ...baseConfig,
   entryPoints: ['packages/a2a-server/src/http/server.ts'],
-  bundle: true,
   outfile: 'bundle/a2a-server.js',
-  platform: 'node',
-  format: 'esm',
-  external,
-  define: {
-    'process.env.CLI_VERSION': JSON.stringify(pkg.version),
-  },
-  banner: {
-    js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url); globalThis.__filename = require('url').fileURLToPath(import.meta.url); globalThis.__dirname = require('path').dirname(globalThis.__filename);`,
-  },
-  loader: { '.node': 'file' },
-  write: true,
 };
 
 Promise.all([


### PR DESCRIPTION
## TLDR

Add a second .js file to the output of `npm run bundle` which contains the a2a-server.

## Dive Deeper

Change the `esbuild.config.js` file to include the a2a-server with the entrypoint at `packages/a2a-server/src/http/server.ts`.

## Reviewer Test Plan

You should be able to install & build and then run `npm run bundle` and verify it outputs an a2a-server.js file. You should be able to `node bundle/a2a-server.js` to start the a2a-server.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓   | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Tested the bundle command on a macos.

## Linked issues / bugs
- Fixes #8382 
