### PR TITLE
fix(stats): Use request model as fallback for stats logging

### DIFF
--- a/packages/core/src/code_assist/converter.test.ts
+++ b/packages/core/src/code_assist/converter.test.ts
@@ -299,6 +299,17 @@ describe('converter', () => {
         codeAssistRes.response.automaticFunctionCallingHistory,
       );
     });
+
+    it('should handle modelVersion', () => {
+      const codeAssistRes: CaGenerateContentResponse = {
+        response: {
+          candidates: [],
+          modelVersion: 'gemini-2.5-pro',
+        },
+      };
+      const genaiRes = fromGenerateContentResponse(codeAssistRes);
+      expect(genaiRes.modelVersion).toEqual('gemini-2.5-pro');
+    });
   });
 
   describe('toContents', () => {

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -80,6 +80,7 @@ interface VertexGenerateContentResponse {
   automaticFunctionCallingHistory?: Content[];
   promptFeedback?: GenerateContentResponsePromptFeedback;
   usageMetadata?: GenerateContentResponseUsageMetadata;
+  modelVersion?: string;
 }
 
 export interface CaCountTokenRequest {
@@ -137,6 +138,7 @@ export function fromGenerateContentResponse(
   out.automaticFunctionCallingHistory = inres.automaticFunctionCallingHistory;
   out.promptFeedback = inres.promptFeedback;
   out.usageMetadata = inres.usageMetadata;
+  out.modelVersion = inres.modelVersion;
   return out;
 }
 

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -143,13 +143,19 @@ export class LoggingContentGenerator implements ContentGenerator {
       throw error;
     }
 
-    return this.loggingStreamWrapper(stream, startTime, userPromptId);
+    return this.loggingStreamWrapper(
+      stream,
+      startTime,
+      userPromptId,
+      req.model,
+    );
   }
 
   private async *loggingStreamWrapper(
     stream: AsyncGenerator<GenerateContentResponse>,
     startTime: number,
     userPromptId: string,
+    model: string,
   ): AsyncGenerator<GenerateContentResponse> {
     const responses: GenerateContentResponse[] = [];
 
@@ -166,7 +172,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       const durationMs = Date.now() - startTime;
       this._logApiResponse(
         durationMs,
-        responses[0]?.modelVersion || '',
+        responses[0]?.modelVersion || model,
         userPromptId,
         lastUsageMetadata,
         JSON.stringify(responses),
@@ -176,7 +182,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       this._logApiError(
         durationMs,
         error,
-        responses[0]?.modelVersion || '',
+        responses[0]?.modelVersion || model,
         userPromptId,
       );
       throw error;

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -114,7 +114,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       const durationMs = Date.now() - startTime;
       this._logApiResponse(
         durationMs,
-        response.modelVersion || '',
+        response.modelVersion || req.model,
         userPromptId,
         response.usageMetadata,
         JSON.stringify(response),


### PR DESCRIPTION
## TLDR

This pull request fixes a bug where the model name was not being recorded in usage statistics if the user used `Log In with Google`. Additionally, this also revealed that we did not have a fallback for when the `modelVersion` was missing from the backend response. This change captures the model version for requests made to the code assist server as well as adding a fallback for when the version is missing, guaranteeing that stats always have an associated model.

Key changes:
- The `loggingContentGenerator` now uses the request's model name as a fallback for logging.
- The `converter` has been updated to properly handle the `modelVersion` field from the backend response for code assist.
- A new unit test has been added to `converter.test.ts` to verify the mapping of `modelVersion`.

## Dive Deeper

The `loggingContentGenerator` is responsible for capturing metadata about API calls for statistical analysis. It was observed that the `modelVersion` field, which we relied on for logging the model name, is not always present in the `GenerateContentResponse` from the backend when using Login with Google. This was due to a missing field on the interface that we use. This resulted in empty model names in our stats, making them difficult to analyze.

The `VertexGenerateContentResponse` interface and the `fromGenerateContentResponse` function in the converter were updated to correctly process and pass along the `modelVersion` when it *is* available from the backend.

Additionally, this PR implements a fallback mechanism. The model name from the original `GenerateContentRequest` is now passed down through the `loggingStreamWrapper`. When the response is logged, the code now uses `responses[0]?.modelVersion || model`, ensuring that if the `modelVersion` from the response is missing, we use the model name from the request as a reliable fallback.

## Reviewer Test Plan

1.  Log in with Google.
2.  Run a few commands (e.g., `/new`, `hi`).
3.  Run the `/stats` command.
4.  Verify that the model name is present in the output for each model.
5.  Log out and log in with an API key.
6.  Run a few commands.
7.  Run the `/stats` command.
8.  Verify that the model name is present in the output for each model.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |
