### PR TITLE
feat: detect and use parent shell on Windows

### DIFF
--- a/docs/tools/shell.md
+++ b/docs/tools/shell.md
@@ -4,7 +4,19 @@ This document describes the `run_shell_command` tool for the Gemini CLI.
 
 ## Description
 
-Use `run_shell_command` to interact with the underlying system, run scripts, or perform command-line operations. `run_shell_command` executes a given shell command. On Windows, the command will be executed with `cmd.exe /c`. On other platforms, the command will be executed with `bash -c`.
+Use `run_shell_command` to interact with the underlying system, run scripts, or perform command-line operations. `run_shell_command` executes a given shell command using your current shell environment.
+
+## Shell Detection
+
+The Gemini CLI automatically detects and uses the shell you're running it from:
+
+- **Unix-like systems**: Uses the `SHELL` environment variable or defaults to bash
+- **Windows Priority Order**:
+  1. **SHELL variable**: Respects your preferred shell (Git Bash, MSYS2, WSL, zsh, etc.)
+  2. **LOGINSHELL variable**: Fallback if SHELL is not set  
+  3. **PowerShell detection**: When PSModulePath environment variable exists
+  4. **PowerShell via ComSpec**: When ComSpec points to powershell/pwsh
+  5. **Final fallback**: cmd.exe
 
 ### Arguments
 

--- a/docs/tools/shell.md
+++ b/docs/tools/shell.md
@@ -8,15 +8,15 @@ Use `run_shell_command` to interact with the underlying system, run scripts, or 
 
 ## Shell Detection
 
-The Gemini CLI automatically detects and uses the shell you're running it from:
+The Gemini CLI automatically detects your shell in this order:
 
-- **Unix-like systems**: Uses the `SHELL` environment variable or defaults to bash
-- **Windows Priority Order**:
-  1. **SHELL variable**: Respects your preferred shell (Git Bash, MSYS2, WSL, zsh, etc.)
-  2. **LOGINSHELL variable**: Fallback if SHELL is not set  
-  3. **PowerShell detection**: When PSModulePath environment variable exists
-  4. **PowerShell via ComSpec**: When ComSpec points to powershell/pwsh
-  5. **Final fallback**: cmd.exe
+1. **SHELL environment variable** (all platforms)
+2. **LOGINSHELL environment variable** (all platforms)
+3. **PowerShell via ComSpec** (Windows only)
+4. **PowerShell via process title** (Windows only)
+5. **Default shell**: `bash` on Unix/Linux/macOS, `cmd.exe` on Windows
+
+Supports PowerShell Core (`pwsh`) on all platforms.
 
 ### Arguments
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -357,11 +357,9 @@ export class ShellExecutionService {
       const rows = shellExecutionConfig.terminalHeight ?? 30;
       const shellConfig = getShellConfiguration();
 
-      // Use the detected shell configuration
+      // Use the detected shell configuration consistently for all shells
       const shell = shellConfig.executable;
-      const args = shellConfig.shell === 'cmd'
-        ? ['/c', commandToExecute]
-        : shellConfig.argsPrefix.concat([commandToExecute]);
+      const args = shellConfig.argsPrefix.concat([commandToExecute]);
 
       const ptyProcess = ptyInfo.module.spawn(shell, args, {
         cwd,

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -528,6 +528,45 @@ describe('getShellConfiguration', () => {
       process.title = originalTitle;
     });
 
+    it('should detect PowerShell Core via process.title containing "pwsh"', () => {
+      const originalTitle = process.title;
+      process.title = 'pwsh';
+      delete process.env['ComSpec'];
+      
+      const config = getShellConfiguration();
+      expect(config.executable).toBe('pwsh.exe');
+      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.shell).toBe('powershell');
+      
+      process.title = originalTitle;
+    });
+
+    it('should detect PowerShell Core via process.title case-insensitive', () => {
+      const originalTitle = process.title;
+      process.title = 'PWSH';
+      delete process.env['ComSpec'];
+      
+      const config = getShellConfiguration();
+      expect(config.executable).toBe('pwsh.exe');
+      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.shell).toBe('powershell');
+      
+      process.title = originalTitle;
+    });
+
+    it('should prioritize pwsh over powershell when both are in process.title', () => {
+      const originalTitle = process.title;
+      process.title = 'PowerShell Core pwsh';
+      delete process.env['ComSpec'];
+      
+      const config = getShellConfiguration();
+      expect(config.executable).toBe('pwsh.exe'); // Should prefer pwsh
+      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
+      expect(config.shell).toBe('powershell');
+      
+      process.title = originalTitle;
+    });
+
     it('should NOT detect PowerShell when process.title is cmd-like', () => {
       const originalTitle = process.title;
       process.title = 'Command Prompt - node test.js';

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -87,7 +87,7 @@ function getShellTypeFromPath(shellPath: string): ShellType {
   if (shellName.includes('powershell') || shellName.includes('pwsh')) {
     return 'powershell';
   }
-  if (shellName.includes('cmd') || shellName.endsWith('cmd.exe')) {
+  if (/(^|\\|\/)cmd(\.exe)?$/.test(shellName)) {
     return 'cmd';
   }
   return 'bash';

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -65,11 +65,11 @@ function detectParentShell(): ShellConfiguration {
 
   // Process.title is the only reliable way to distinguish cmd.exe from PowerShell on Windows.
   // Environment variables are identical, and PowerShell variables aren't exported as env vars.
-  // PowerShell: "Windows PowerShell" vs cmd.exe: "Command Prompt - node <script>"
-  const isPowerShellFromTitle = !!(process.title && process.title.toLowerCase().includes('powershell'));
-  if (isPowerShellFromTitle) {
+  // PowerShell: "Windows PowerShell" vs PowerShell Core: "pwsh" vs cmd.exe: "Command Prompt - node <script>"
+  const lowerCaseTitle = process.title?.toLowerCase();
+  if (lowerCaseTitle?.includes('pwsh') || lowerCaseTitle?.includes('powershell')) {
     return {
-      executable: 'powershell.exe',
+      executable: lowerCaseTitle.includes('pwsh') ? 'pwsh.exe' : 'powershell.exe',
       argsPrefix: getArgsForShellType('powershell'),
       shell: 'powershell',
     };

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -58,7 +58,7 @@ function detectParentShell(): ShellConfiguration {
   }
 
   // Priority 2: Check LOGINSHELL if SHELL is not set
-  if (loginShell && loginShell.includes('bash')) {
+  if (loginShell) {
     return {
       executable: loginShell,
       argsPrefix: ['-c'],

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -60,7 +60,7 @@ function detectParentShell(): ShellConfiguration {
   // Priority 2: Check LOGINSHELL if SHELL is not set
   if (loginShell && loginShell.includes('bash')) {
     return {
-      executable: 'bash',
+      executable: loginShell,
       argsPrefix: ['-c'],
       shell: 'bash',
     };

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -67,12 +67,24 @@ function detectParentShell(): ShellConfiguration {
   // Environment variables are identical, and PowerShell variables aren't exported as env vars.
   // PowerShell: "Windows PowerShell" vs PowerShell Core: "pwsh" vs cmd.exe: "Command Prompt - node <script>"
   const lowerCaseTitle = process.title?.toLowerCase();
-  if (lowerCaseTitle?.includes('pwsh') || lowerCaseTitle?.includes('powershell')) {
-    return {
-      executable: lowerCaseTitle.includes('pwsh') ? 'pwsh.exe' : 'powershell.exe',
-      argsPrefix: getArgsForShellType('powershell'),
-      shell: 'powershell',
-    };
+  if (lowerCaseTitle) {
+    // Look for "Windows PowerShell" (traditional PowerShell)
+    if (lowerCaseTitle.includes('windows powershell')) {
+      return {
+        executable: 'powershell.exe',
+        argsPrefix: getArgsForShellType('powershell'),
+        shell: 'powershell',
+      };
+    }
+    // Look for "pwsh" as executable name (PowerShell Core)
+    // Match when pwsh appears at start/end or surrounded by spaces (not in file paths)
+    if (/(?:^|\s)pwsh(?:\s|$)/.test(lowerCaseTitle)) {
+      return {
+        executable: 'pwsh.exe',
+        argsPrefix: getArgsForShellType('powershell'),
+        shell: 'powershell',
+      };
+    }
   }
 
   return {
@@ -84,7 +96,7 @@ function detectParentShell(): ShellConfiguration {
 
 function getShellTypeFromPath(shellPath: string): ShellType {
   const shellName = shellPath.toLowerCase();
-  if (shellName.includes('powershell') || shellName.includes('pwsh')) {
+  if (/(^|\\|\/)(powershell|pwsh)(\.exe)?$/.test(shellName)) {
     return 'powershell';
   }
   if (/(^|\\|\/)cmd(\.exe)?$/.test(shellName)) {


### PR DESCRIPTION
Closes #2353  
Closes #3126
Closes #6413

Enable Windows users to use their preferred shell (Git Bash, PowerShell, MSYS2) instead of being forced to use cmd.exe. Gemini CLI now detects the shell that launched it and uses the same shell for command execution.

## Problem
Previously, Gemini CLI would always use cmd.exe on Windows regardless of what shell the user actually preferred. This caused several issues:

- **Limited shell capabilities**: cmd.exe is less capable than PowerShell (as noted in #2353)
- **Poor user experience**: Users who prefer Git Bash, PowerShell, or MSYS2 had commands executed in a different environment (#3126)
- **Agent confusion**: The AI would try Linux syntax, then PowerShell, then cmd syntax due to shell uncertainty (#2353)
- **Unpredictable behavior**: Relying on `spawn({ shell: true })` defaults to cmd.exe even when better shells are available (#6413)

## Solution
- **Priority-Based Shell Detection**: Prioritize user's SHELL preferences over system defaults
- **Smart Environment Analysis**: Analyze environment variables (`SHELL`, `PSModulePath`, `ComSpec`, `LOGINSHELL`) to detect the parent shell
- **Cross-Platform Consistency**: Use the detected shell configuration consistently across both PTY and child_process execution methods
- **Robust Fallbacks**: Graceful fallback to cmd.exe when detection fails

## Detection Logic
**Windows Priority Order:**
1. **SHELL variable**: Respects user's preferred shell (Git Bash, MSYS2, WSL, zsh, etc.)
2. **LOGINSHELL variable**: Fallback if SHELL is not set  
3. **PowerShell detection**: When `PSModulePath` environment variable exists
4. **PowerShell via ComSpec**: When `ComSpec` points to powershell/pwsh
5. **Final fallback**: cmd.exe

**Unix-like systems:** Uses `SHELL` environment variable or defaults to bash

## Changes Made
1. **Enhanced `detectParentShell()`** in `shell-utils.ts` to intelligently detect the parent shell
2. **Updated `getShellConfiguration()`** to use parent shell detection as primary method
3. **Simplified shell execution** in `ShellExecutionService` by removing redundant platform checks
4. **Added comprehensive tests** covering all detection scenarios
5. **Updated documentation** with new shell detection behavior

## Benefits
- **Better UX**: Commands execute in the user's preferred shell environment
- **Reduced AI confusion**: Shell detection enables more accurate command syntax
- **Platform Support**: Works with all major Windows shell environments (Git Bash, PowerShell, MSYS2)
- **Backward Compatibility**: Maintains existing behavior with fallback to cmd.exe
- **Addresses comparison with Claude Code**: Now uses Git Bash when available, like Claude Code does

## Related Issues
This change may also help with issues related to shell command execution and path handling like #4104, #8267, and #2488 by providing better shell environment detection, though those may require additional specific fixes.