### PR TITLE
feat(ide): add auth token support to IdeClient

### DIFF
--- a/packages/core/src/ide/ide-client.test.ts
+++ b/packages/core/src/ide/ide-client.test.ts
@@ -656,4 +656,34 @@ describe('IdeClient', () => {
       expect(ideClient.isDiffingEnabled()).toBe(true);
     });
   });
+
+  describe('authentication', () => {
+    it('should connect with an auth token if provided in the discovery file', async () => {
+      const authToken = 'test-auth-token';
+      const config = { port: '8080', authToken };
+      vi.mocked(fs.promises.readFile).mockResolvedValue(JSON.stringify(config));
+      (
+        vi.mocked(fs.promises.readdir) as Mock<
+          (path: fs.PathLike) => Promise<string[]>
+        >
+      ).mockResolvedValue([]);
+
+      const ideClient = await IdeClient.getInstance();
+      await ideClient.connect();
+
+      expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
+        new URL('http://localhost:8080/mcp'),
+        expect.objectContaining({
+          requestInit: {
+            headers: {
+              Authorization: `Bearer ${authToken}`,
+            },
+          },
+        }),
+      );
+      expect(ideClient.getConnectionStatus().status).toBe(
+        IDEConnectionStatus.Connected,
+      );
+    });
+  });
 });


### PR DESCRIPTION
## TLDR

This pull request introduces authentication for the connection between the Gemini CLI and the IDE companion server. The `IdeClient` can now read an `authToken` from the IDE discovery file and send it as a `Bearer` token in the `Authorization` header when establishing a connection. A corresponding unit test has been added to validate this new functionality.