### PR TITLE
feat(vscode-ide-companion): add auth token validation to IDE server

### DIFF
--- a/docs/ide-companion-spec.md
+++ b/docs/ide-companion-spec.md
@@ -35,7 +35,17 @@ For Gemini CLI to connect, it needs to discover which IDE instance it's running 
   - `workspacePath` (string): A list of all open workspace root paths, delimited by the OS-specific path separator (`:` for Linux/macOS, `;` for Windows). The CLI uses this path to ensure it's running in the same project folder that's open in the IDE. If the CLI's current working directory is not a sub-directory of `workspacePath`, the connection will be rejected. Your extension **MUST** provide the correct, absolute path(s) to the root of the open workspace(s).
 - **Tie-Breaking with Environment Variables (Recommended):** For the most reliable experience, your extension **SHOULD** both create the discovery file and set the `GEMINI_CLI_IDE_SERVER_PORT` and `GEMINI_CLI_IDE_WORKSPACE_PATH` environment variables in the integrated terminal. The file serves as the primary discovery mechanism, but the environment variables are crucial for tie-breaking. If a user has multiple IDE windows open for the same workspace, the CLI uses the `GEMINI_CLI_IDE_SERVER_PORT` variable to identify and connect to the correct window's server.
   - For prototyping, you may opt to _only_ set the environment variables. However, this is not a robust solution for a production extension, as environment variables may not be reliably set in all terminal sessions (e.g., restored terminals), which can lead to connection failures.
-- **Authentication:** (TBD)
+- **Authentication:** To secure the connection, the extension **SHOULD** generate a unique, secret token and include it in the discovery file. The CLI will then include this token in all requests to the MCP server.
+  - **Token Generation:** The extension should generate a random string to be used as a bearer token.
+  - **Discovery File Content:** The `authToken` field must be added to the JSON object in the discovery file:
+    ```json
+    {
+      "port": 12345,
+      "workspacePath": "/path/to/project",
+      "authToken": "a-very-secret-token"
+    }
+    ```
+  - **Request Authorization:** The CLI will read the `authToken` from the file and include it in the `Authorization` header for all HTTP requests to the MCP server (e.g., `Authorization: Bearer a-very-secret-token`). Your server **MUST** validate this token on every request and reject any that are unauthorized.
 
 ## II. The Context Interface
 

--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -414,5 +414,32 @@ describe('IDEServer', () => {
       const body = await response.text();
       expect(body).toBe('Unauthorized');
     });
+
+    it('should reject request with malformed auth token', async () => {
+      const malformedHeaders = [
+        'Bearer',
+        'invalid-token',
+        'Bearer token extra',
+      ];
+
+      for (const header of malformedHeaders) {
+        const response = await fetch(`http://localhost:${port}/mcp`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: header,
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'initialize',
+            params: {},
+            id: 1,
+          }),
+        });
+        expect(response.status, `Failed for header: ${header}`).toBe(401);
+        const body = await response.text();
+        expect(body, `Failed for header: ${header}`).toBe('Unauthorized');
+      }
+    });
   });
 });

--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('node:fs/promises', () => ({
   writeFile: vi.fn(() => Promise.resolve(undefined)),
   unlink: vi.fn(() => Promise.resolve(undefined)),
+  chmod: vi.fn(() => Promise.resolve(undefined)),
 }));
 
 vi.mock('node:os', async (importOriginal) => {
@@ -148,6 +149,8 @@ describe('IDEServer', () => {
       expectedPpidPortFile,
       expectedContent,
     );
+    expect(fs.chmod).toHaveBeenCalledWith(expectedPortFile, 0o600);
+    expect(fs.chmod).toHaveBeenCalledWith(expectedPpidPortFile, 0o600);
   });
 
   it('should set a single folder path', async () => {
@@ -184,6 +187,8 @@ describe('IDEServer', () => {
       expectedPpidPortFile,
       expectedContent,
     );
+    expect(fs.chmod).toHaveBeenCalledWith(expectedPortFile, 0o600);
+    expect(fs.chmod).toHaveBeenCalledWith(expectedPpidPortFile, 0o600);
   });
 
   it('should set an empty string if no folders are open', async () => {
@@ -220,6 +225,8 @@ describe('IDEServer', () => {
       expectedPpidPortFile,
       expectedContent,
     );
+    expect(fs.chmod).toHaveBeenCalledWith(expectedPortFile, 0o600);
+    expect(fs.chmod).toHaveBeenCalledWith(expectedPpidPortFile, 0o600);
   });
 
   it('should update the path when workspace folders change', async () => {
@@ -270,6 +277,8 @@ describe('IDEServer', () => {
       expectedPpidPortFile,
       expectedContent,
     );
+    expect(fs.chmod).toHaveBeenCalledWith(expectedPortFile, 0o600);
+    expect(fs.chmod).toHaveBeenCalledWith(expectedPpidPortFile, 0o600);
 
     // Simulate removing a folder
     vscodeMock.workspace.workspaceFolders = [{ uri: { fsPath: '/baz/qux' } }];
@@ -293,6 +302,8 @@ describe('IDEServer', () => {
       expectedPpidPortFile,
       expectedContent2,
     );
+    expect(fs.chmod).toHaveBeenCalledWith(expectedPortFile, 0o600);
+    expect(fs.chmod).toHaveBeenCalledWith(expectedPpidPortFile, 0o600);
   });
 
   it('should clear env vars and delete port file on stop', async () => {
@@ -354,6 +365,8 @@ describe('IDEServer', () => {
         expectedPpidPortFile,
         expectedContent,
       );
+      expect(fs.chmod).toHaveBeenCalledWith(expectedPortFile, 0o600);
+      expect(fs.chmod).toHaveBeenCalledWith(expectedPpidPortFile, 0o600);
     },
   );
 

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -121,10 +121,6 @@ export class IDEServer {
       const app = express();
       app.use(express.json({ limit: '10mb' }));
 
-      // The CLI will send the token in the authorization header.
-      // Older CLIs will not send this header.
-      // To maintain backwards compatibility, we only validate the token
-      // if the header is present.
       app.use((req, res, next) => {
         const authHeader = req.headers.authorization;
         if (authHeader) {

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -71,8 +71,10 @@ async function writePortAndWorkspace({
 
   try {
     await Promise.all([
-      fs.writeFile(portFile, content, { mode: 0o600 }),
-      fs.writeFile(ppidPortFile, content, { mode: 0o600 }),
+      fs.writeFile(portFile, content).then(() => fs.chmod(portFile, 0o600)),
+      fs
+        .writeFile(ppidPortFile, content)
+        .then(() => fs.chmod(ppidPortFile, 0o600)),
     ]);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -27,14 +27,23 @@ const MCP_SESSION_ID_HEADER = 'mcp-session-id';
 const IDE_SERVER_PORT_ENV_VAR = 'GEMINI_CLI_IDE_SERVER_PORT';
 const IDE_WORKSPACE_PATH_ENV_VAR = 'GEMINI_CLI_IDE_WORKSPACE_PATH';
 
-async function writePortAndWorkspace(
-  context: vscode.ExtensionContext,
-  port: number,
-  portFile: string,
-  ppidPortFile: string,
-  authToken: string,
-  log: (message: string) => void,
-): Promise<void> {
+interface WritePortAndWorkspaceArgs {
+  context: vscode.ExtensionContext;
+  port: number;
+  portFile: string;
+  ppidPortFile: string;
+  authToken: string;
+  log: (message: string) => void;
+}
+
+async function writePortAndWorkspace({
+  context,
+  port,
+  portFile,
+  ppidPortFile,
+  authToken,
+  log,
+}: WritePortAndWorkspaceArgs): Promise<void> {
   const workspaceFolders = vscode.workspace.workspaceFolders;
   const workspacePath =
     workspaceFolders && workspaceFolders.length > 0
@@ -62,8 +71,8 @@ async function writePortAndWorkspace(
 
   try {
     await Promise.all([
-      fs.writeFile(portFile, content),
-      fs.writeFile(ppidPortFile, content),
+      fs.writeFile(portFile, content, { mode: 0o600 }),
+      fs.writeFile(ppidPortFile, content, { mode: 0o600 }),
     ]);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -278,14 +287,14 @@ export class IDEServer {
           this.log(`IDE server listening on port ${this.port}`);
 
           if (this.authToken) {
-            await writePortAndWorkspace(
+            await writePortAndWorkspace({
               context,
-              this.port,
-              this.portFile,
-              this.ppidPortFile,
-              this.authToken,
-              this.log,
-            );
+              port: this.port,
+              portFile: this.portFile,
+              ppidPortFile: this.ppidPortFile,
+              authToken: this.authToken,
+              log: this.log,
+            });
           }
         }
         resolve();
@@ -315,14 +324,14 @@ export class IDEServer {
       this.ppidPortFile &&
       this.authToken
     ) {
-      await writePortAndWorkspace(
-        this.context,
-        this.port,
-        this.portFile,
-        this.ppidPortFile,
-        this.authToken,
-        this.log,
-      );
+      await writePortAndWorkspace({
+        context: this.context,
+        port: this.port,
+        portFile: this.portFile,
+        ppidPortFile: this.ppidPortFile,
+        authToken: this.authToken,
+        log: this.log,
+      });
       this.broadcastIdeContextUpdate();
     }
   }


### PR DESCRIPTION
## TLDR

This pull request enhances the security of the IDE companion by adding a bearer token authentication mechanism to the IDE server. The server now generates a unique token on startup, writes it to the discovery file, and validates this token on incoming requests from the CLI. The implementation is backward compatible, allowing older CLIs that don't send the token to continue functioning.