### PR TITLE
feat(events): Implement custom event handlers.

### DIFF
--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -24,6 +24,7 @@ describe('SettingsSchema', () => {
         'telemetry',
         'model',
         'context',
+        'events',
         'tools',
         'mcp',
         'security',
@@ -329,6 +330,15 @@ describe('SettingsSchema', () => {
       expect(
         getSettingsSchema().experimental.properties.useModelRouter.default,
       ).toBe(false);
+    });
+
+    it('should have events setting in schema', () => {
+      expect(getSettingsSchema().events).toBeDefined();
+      expect(getSettingsSchema().events.type).toBe('array');
+      expect(getSettingsSchema().events.category).toBe('UI');
+      expect(getSettingsSchema().events.default).toEqual([]);
+      expect(getSettingsSchema().events.requiresRestart).toBe(false);
+      expect(getSettingsSchema().events.showInDialog).toBe(false);
     });
   });
 });

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -393,6 +393,16 @@ const SETTINGS_SCHEMA = {
     },
   },
 
+  events: {
+    type: 'array',
+    label: 'Events',
+    category: 'UI',
+    requiresRestart: false,
+    default: [],
+    description: 'Event handlers.',
+    showInDialog: false,
+  },
+
   ide: {
     type: 'object',
     label: 'IDE',

--- a/packages/cli/src/ui/hooks/useEventManager.test.ts
+++ b/packages/cli/src/ui/hooks/useEventManager.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook } from '@testing-library/react';
+import { vi } from 'vitest';
+import type { LoadedSettings } from '../../config/settings.js';
+import { useEvents, Event } from './useEventManager.js';
+
+const spawnMock = vi.fn();
+const onMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  default: {
+    spawn: (...args: unknown[]) => {
+      spawnMock(...args);
+      return {
+        on: onMock,
+      };
+    },
+  },
+}));
+
+describe('useEvents', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should do nothing if events are not configured', () => {
+    const settings = { merged: {} } as LoadedSettings;
+    const { result } = renderHook(() => useEvents(settings));
+
+    result.current.notify(Event.Confirm);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should do nothing if the event is not configured to be handled', () => {
+    const settings = {
+      merged: {
+        events: [{ on: [Event.Idle], spawn: ['echo', 'hello'] }],
+      },
+    } as unknown as LoadedSettings;
+    const { result } = renderHook(() => useEvents(settings));
+
+    result.current.notify(Event.Confirm);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should spawn a process when the event is configured', () => {
+    const settings = {
+      merged: {
+        events: [{ on: [Event.Confirm], spawn: ['echo', 'hello'] }],
+      },
+    } as unknown as LoadedSettings;
+    const { result } = renderHook(() => useEvents(settings));
+
+    result.current.notify(Event.Confirm);
+
+    expect(spawnMock).toHaveBeenCalledWith('echo', ['hello'], {
+      stdio: 'inherit',
+    });
+  });
+
+  it('should handle spawn errors', () => {
+    const settings = {
+      merged: {
+        events: [{ on: [Event.Confirm], spawn: ['echo', 'hello'] }],
+      },
+    } as unknown as LoadedSettings;
+    const { result } = renderHook(() => useEvents(settings));
+    const consoleErrorMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    onMock.mockImplementation((event, callback) => {
+      if (event === 'error') {
+        callback(new Error('spawn error'));
+      }
+    });
+
+    result.current.notify(Event.Confirm);
+
+    expect(spawnMock).toHaveBeenCalled();
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      'Failed to spawn process:',
+      new Error('spawn error'),
+    );
+  });
+
+  it('should not spawn a process if spawn is not configured', () => {
+    const settings = {
+      merged: {
+        events: [{ on: [Event.Confirm] }],
+      },
+    } as unknown as LoadedSettings;
+    const { result } = renderHook(() => useEvents(settings));
+    const consoleErrorMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    result.current.notify(Event.Confirm);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      'No command configured to handle event',
+      'confirm',
+    );
+  });
+
+  it('should not spawn a process if spawn is empty', () => {
+    const settings = {
+      merged: {
+        events: [{ on: [Event.Confirm], spawn: [] }],
+      },
+    } as unknown as LoadedSettings;
+    const { result } = renderHook(() => useEvents(settings));
+    const consoleErrorMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    result.current.notify(Event.Confirm);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      'No command configured to handle event',
+      'confirm',
+    );
+  });
+
+  it('should handle multiple event handlers', () => {
+    const settings = {
+      merged: {
+        events: [
+          { on: [Event.Confirm], spawn: ['echo', 'hello'] },
+          { on: [Event.Confirm], spawn: ['npm', 'test'] },
+        ],
+      },
+    } as unknown as LoadedSettings;
+    const { result } = renderHook(() => useEvents(settings));
+
+    result.current.notify(Event.Confirm);
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(spawnMock).toHaveBeenCalledWith('echo', ['hello'], {
+      stdio: 'inherit',
+    });
+    expect(spawnMock).toHaveBeenCalledWith('npm', ['test'], {
+      stdio: 'inherit',
+    });
+  });
+});

--- a/packages/cli/src/ui/hooks/useEventManager.ts
+++ b/packages/cli/src/ui/hooks/useEventManager.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback } from 'react';
+import { spawn } from 'node:child_process';
+import type { LoadedSettings } from '../../config/settings.js';
+
+export enum Event {
+  Idle = 'idle',
+  Confirm = 'confirm',
+}
+
+interface EventHandler {
+  on?: Event[];
+  spawn?: string[];
+}
+
+export interface UseEventManagerReturn {
+  notify: (event: Event) => void;
+}
+
+/**
+ * Custom hook to manage events.
+ *
+ * Encapsulates the code to fire an event and execute a configured command.
+ */
+export function useEvents(settings: LoadedSettings): UseEventManagerReturn {
+  const notify = useCallback(
+    (event: Event) => {
+      const events = settings?.merged?.events as EventHandler[];
+      if (!events) {
+        return;
+      }
+
+      for (const eventHandler of events) {
+        if (!eventHandler.on?.includes(event)) {
+          continue;
+        }
+
+        const spawnArgs = eventHandler.spawn;
+        if (!spawnArgs || spawnArgs.length === 0) {
+          console.error('No command configured to handle event', event);
+          continue;
+        }
+
+        const [command, ...args] = spawnArgs;
+        const child = spawn(command, args, {
+          stdio: 'inherit',
+        });
+
+        child.on('error', (err) => {
+          console.error('Failed to spawn process:', err);
+        });
+      }
+    },
+    [settings?.merged?.events],
+  );
+
+  return {
+    notify,
+  };
+}


### PR DESCRIPTION
## TLDR

This PR introduces a new configuration file section that allows setting up
custom event handlers. An example:

```json
"events": [
    {
        "on": ["idle", "confirm"],
        "spawn": ["echo", "-e", "\\a"]
    }
],
```

## Dive Deeper

For now, only two events are exposed and they map 1-to-1 to the corresponding streaming states: `idle`: `StreamingState.Idle` and `confirm`: `StreamingState.WaitingForConfirmation`. More events can be added later if need be.

The configuration allows spawning the configured program when any of the events in the `on` array is received. There may be more than one handler for a single event.

Note that `spawn` itself is an array where the first item is the program to run and the following items are its arguments. The configured program does not run in a shell. This is a deliberate choice to avoid unnecessary escaping. Otherwise, the example in `TLDR` would look like this: `"spawn": "echo -e \\\\a"`, since the characters would need to be escaped twice: once for JSON and once for the shell.

## Reviewer Test Plan

Use the example in `TLDR` and any prompt. Once the model is done responding your terminal should receive a notification (if it's properly configured to handle bell characters). Alternatively, replace the command with one of your choice.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | x |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

One use case for that is sending a notification when Gemini CLI needs user input.

- Fixes #4310
