### PR TITLE
Fix references to old name of npm-shrinkwrap.json.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,4 @@
 /LICENSE @google-gemini/gemini-cli-askmode-approvers
 /.github/workflows/ @google-gemini/gemini-cli-askmode-approvers
 /packages/cli/package.json @google-gemini/gemini-cli-askmode-approvers
-/packages/cli/package-lock.json @google-gemini/gemini-cli-askmode-approvers
 /packages/core/package.json @google-gemini/gemini-cli-askmode-approvers
-/packages/core/package-lock.json @google-gemini/gemini-cli-askmode-approvers

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -64,7 +64,7 @@ runs:
         DRY_RUN: '${{ inputs.dry-run }}'
         RELEASE_TAG: '${{ inputs.release-tag }}'
       run: |-
-        git add package.json package-lock.json packages/*/package.json
+        git add package.json npm-shrinkwrap.json packages/*/package.json
         git commit -m "chore(release): ${RELEASE_TAG}"
         if [[ "${DRY_RUN}" == "false" ]]; then
           echo "Pushing release branch to remote..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
           IS_DRY_RUN: '${{ steps.vars.outputs.is_dry_run }}'
           RELEASE_TAG: '${{ steps.version.outputs.RELEASE_TAG }}'
         run: |-
-          git add package.json package-lock.json packages/*/package.json
+          git add package.json npm-shrinkwrap.json packages/*/package.json
           git commit -m "chore(release): ${RELEASE_TAG}"
           if [[ "${IS_DRY_RUN}" == "false" ]]; then
             echo "Pushing release branch to remote..."


### PR DESCRIPTION
## TLDR

Somehow these were missed.

## Dive Deeper

Note that `core` and `cli` don't seem to have independent `package-lock.json` files anymore.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Contributes to  https://github.com/google-gemini/maintainers-gemini-cli/issues/764