### PR TITLE
feat(core): Enable command substitution in YOLO approval mode

### DIFF
--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -5,7 +5,7 @@
  */
 
 import type { AnyToolInvocation } from '../index.js';
-import type { Config } from '../config/config.js';
+import { type Config, ApprovalMode } from '../config/config.js';
 import os from 'node:os';
 import { quote } from 'shell-quote';
 import { doesToolInvocationMatch } from './tool-utils.js';
@@ -313,7 +313,7 @@ export function checkCommandPermissions(
   isHardDenial?: boolean;
 } {
   // Disallow command substitution for security.
-  if (detectCommandSubstitution(command)) {
+  if (config.getApprovalMode() !== ApprovalMode.YOLO && detectCommandSubstitution(command)) {
     return {
       allAllowed: false,
       disallowedCommands: [command],


### PR DESCRIPTION
## Summary

Enable command substitution (e.g., `$(pwd)`, `$PWD`, `` `command` ``) when running in YOLO approval mode while maintaining security restrictions in stricter approval modes.

### Changes Made

- Modified `checkCommandPermissions()` in `shell-utils.ts` to allow command substitution only when `config.getApprovalMode() === ApprovalMode.YOLO`
- Updated imports to include `ApprovalMode` enum
- Preserved existing security restrictions for all other approval modes

### Benefits

- Enables more flexible shell command execution for users who need command substitution capabilities in their automated workflows
- Maintains backward compatibility and security for users not in YOLO mode
- Follows the principle of least privilege by only relaxing restrictions when explicitly in the most permissive mode

### Test Plan

- [ ] Verify command substitution is blocked in default approval modes
- [ ] Verify command substitution is allowed in YOLO approval mode
- [ ] Confirm existing shell command functionality remains unchanged
- [ ] Run existing test suite to ensure no regressions

This change addresses use cases where users need dynamic command execution with environment variable expansion or command substitution while preserving the security model for conservative usage.