### PR TITLE
feat(extensions): add support for sso:// protocol

### DIFF
--- a/packages/cli/src/commands/extensions/install.test.ts
+++ b/packages/cli/src/commands/extensions/install.test.ts
@@ -99,6 +99,18 @@ describe('handleInstall', () => {
     expect(processSpy).toHaveBeenCalledWith(1);
   });
 
+  it('should install an extension from a sso source', async () => {
+    mockInstallExtension.mockResolvedValue('sso-extension');
+
+    await handleInstall({
+      source: 'sso://google.com',
+    });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      'Extension "sso-extension" installed successfully and enabled.',
+    );
+  });
+
   it('should install an extension from a local path', async () => {
     mockInstallExtension.mockResolvedValue('local-extension');
 

--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -27,7 +27,8 @@ export async function handleInstall(args: InstallArgs) {
       if (
         source.startsWith('http://') ||
         source.startsWith('https://') ||
-        source.startsWith('git@')
+        source.startsWith('git@') ||
+        source.startsWith('sso://')
       ) {
         installMetadata = {
           source,


### PR DESCRIPTION
## TLDR

This pull request introduces support for installing extensions using the `sso://` protocol. This enables a more streamlined installation flow for extensions that require Single Sign-On (SSO) for authentication, particularly for internal use cases.

## Dive Deeper

The existing extension installation process supports sources like `http(s)://` and `git@`. This change expands the supported protocols to include `sso://`. This is a proprietary protocol that will be used internally to facilitate the installation of extensions that require single sign-on. The implementation is straightforward, simply adding the new protocol to the list of recognized URL-based sources in the `handleInstall` function. A corresponding test case has been added to ensure the new protocol is handled correctly.

## Reviewer Test Plan

To validate this change, a reviewer can run the newly added unit test:

1.  Check out this branch.
2.  Run `npm install` to ensure all dependencies are up to date.
3.  Execute the specific test file: `npm test`
4.  Confirm that the test suite passes, including the new test case "should install an extension from a sso source".

Manual validation can also be performed by running the `install` command with a sample `sso://` URI:
```bash
gemini extensions install sso://google.com/some-extension
```
While this won't perform a real installation without a valid endpoint, you can verify that the command is recognized and proceeds to the installation logic without a protocol-related error.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Resolves #8281