### PR TITLE
fix(tests): reduce flakiness in simple mcp server test

### DIFF
--- a/integration-tests/simple-mcp-server.test.ts
+++ b/integration-tests/simple-mcp-server.test.ts
@@ -190,9 +190,7 @@ describe('simple-mcp-server', () => {
       chmodSync(testServerPath, 0o755);
     }
 
-    // Allow a moment for the file system to sync, which can help
-    // prevent race conditions in some CI environments where the test
-    // might run before the script is fully available.
+    // Wait 1s for the file system to sync to prevent race conditions
     await new Promise((resolve) => setTimeout(resolve, 1000));
   });
 

--- a/integration-tests/simple-mcp-server.test.ts
+++ b/integration-tests/simple-mcp-server.test.ts
@@ -189,6 +189,11 @@ describe('simple-mcp-server', () => {
       const { chmodSync } = await import('node:fs');
       chmodSync(testServerPath, 0o755);
     }
+
+    // Allow a moment for the file system to sync, which can help
+    // prevent race conditions in some CI environments where the test
+    // might run before the script is fully available.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
   });
 
   it('should add two numbers', async () => {


### PR DESCRIPTION
## TLDR

This PR introduces a poll to ensure we check that `mcp-server.cjs` exists before running the test; this should reduce flakiness here where the test was dependent on a file that may or may not be present.

## Dive Deeper

## Reviewer Test Plan

Run the following:

```
npm run test:e2e -- integration-tests/simple-mcp-server.test.ts
```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | X  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #8580