### PR TITLE
feat: Add `-o` as alias for `--output-format`

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -232,6 +232,7 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           default: false,
         })
         .option('output-format', {
+          alias: 'o',
           type: 'string',
           description: 'The format of the CLI output.',
           choices: ['text', 'json'],


### PR DESCRIPTION

## TLDR

Add `-o json` as a way to invoke output format json

## Dive Deeper

-o is such a common command line option that when i tried to just Gemini CLI to generate a command for Gemini CLI (haha!) it tried to use `-o json` which didn't work

## Reviewer Test Plan

Well you probably don't need to, but if you're really excited about it you could do:

```
gemini -p "hey there" -o json
```

## Testing Matrix

n/a

## Linked issues / bugs

n/a