### PR TITLE
fix(tests): look for json in thrown from json-output test

### DIFF
--- a/integration-tests/json-output.test.ts
+++ b/integration-tests/json-output.test.ts
@@ -55,9 +55,24 @@ describe('JSON output', () => {
 
     expect(thrown).toBeDefined();
     const message = (thrown as Error).message;
-    const jsonStart = message.indexOf('{');
-    expect(jsonStart).toBeGreaterThan(-1);
-    const payload = JSON.parse(message.slice(jsonStart));
+    
+    // Use a regex to find the first complete JSON object in the string
+    const jsonMatch = message.match(/{[\s\S]*}/);
+    
+    // Fail if no JSON-like text was found
+    expect(jsonMatch, 'Expected to find a JSON object in the error output').toBeTruthy();
+
+    let payload;
+    try {
+      // Parse the matched JSON string
+      payload = JSON.parse(jsonMatch![0]);
+    } catch (parseError) {
+      console.error("Failed to parse the following JSON:", jsonMatch![0]);
+      throw new Error(
+        `Test failed: Could not parse JSON from error message. Details: ${parseError}`,
+      );
+    }
+
     expect(payload.error).toBeDefined();
     expect(payload.error.type).toBe('Error');
     expect(payload.error.code).toBe(1);

--- a/integration-tests/json-output.test.ts
+++ b/integration-tests/json-output.test.ts
@@ -55,19 +55,22 @@ describe('JSON output', () => {
 
     expect(thrown).toBeDefined();
     const message = (thrown as Error).message;
-    
+
     // Use a regex to find the first complete JSON object in the string
     const jsonMatch = message.match(/{[\s\S]*}/);
-    
+
     // Fail if no JSON-like text was found
-    expect(jsonMatch, 'Expected to find a JSON object in the error output').toBeTruthy();
+    expect(
+      jsonMatch,
+      'Expected to find a JSON object in the error output',
+    ).toBeTruthy();
 
     let payload;
     try {
       // Parse the matched JSON string
       payload = JSON.parse(jsonMatch![0]);
     } catch (parseError) {
-      console.error("Failed to parse the following JSON:", jsonMatch![0]);
+      console.error('Failed to parse the following JSON:', jsonMatch![0]);
       throw new Error(
         `Test failed: Could not parse JSON from error message. Details: ${parseError}`,
       );


### PR DESCRIPTION
## TLDR

In our json output tests, we look for a json object to be thrown and fail the test if any other text is returned. However, prefixes such as deprecation warnings can cause the test to fail. This PR updates the test to look for the JSON object in thrown. We should have a separate discussion on whether or not messages like deprecation warnings should be part of the JSON output.

This is currently impeding our ability to cut releases, see example failure here:

https://github.com/google-gemini/gemini-cli/actions/runs/17780954745/job/50539624476

## Dive Deeper

Here is an example of the issue, where the thrown error contains deprecation warning strings prior to returning the json object for the test case:

```
(node:66438) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.

(Use `node --trace-deprecation ...` to show where the warning was created)

(node:66438) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.

{

  "error": {

    "type": "Error",

    "message": "The configured auth type is gemini-api-key, but the current auth type is oauth-personal. Please re-authenticate with the correct type.",

    "code": 1

  }

}
```

## Reviewer Test Plan

```
npx vitest run integration-tests/json-output.test.ts -t 'should return a JSON error for enforced auth mismatch before running'
```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This fixes #8602 