### PR TITLE
refactor(editor): use const assertion for editor types with single source of truth

### DIFF
--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -15,6 +15,7 @@ import {
   isNodeError,
   parseAndFormatApiError,
   safeLiteralReplace,
+  DEFAULT_GUI_EDITOR,
   type AnyDeclarativeTool,
   type ToolCall,
   type ToolConfirmationPayload,
@@ -435,7 +436,7 @@ export class Task {
       outputUpdateHandler: this._schedulerOutputUpdate.bind(this),
       onAllToolCallsComplete: this._schedulerAllToolCallsComplete.bind(this),
       onToolCallsUpdate: this._schedulerToolCallsUpdate.bind(this),
-      getPreferredEditor: () => 'vscode',
+      getPreferredEditor: () => DEFAULT_GUI_EDITOR,
       config: this.config,
     });
     return scheduler;

--- a/packages/core/src/tools/modifiable-tool.test.ts
+++ b/packages/core/src/tools/modifiable-tool.test.ts
@@ -13,7 +13,7 @@ import {
   modifyWithEditor,
   isModifiableDeclarativeTool,
 } from './modifiable-tool.js';
-import type { EditorType } from '../utils/editor.js';
+import { DEFAULT_GUI_EDITOR } from '../utils/editor.js';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import os from 'node:os';
@@ -24,9 +24,13 @@ import { debugLogger } from '../utils/debugLogger.js';
 const mockOpenDiff = vi.hoisted(() => vi.fn());
 const mockCreatePatch = vi.hoisted(() => vi.fn());
 
-vi.mock('../utils/editor.js', () => ({
-  openDiff: mockOpenDiff,
-}));
+vi.mock('../utils/editor.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/editor.js')>();
+  return {
+    ...actual,
+    openDiff: mockOpenDiff,
+  };
+});
 
 vi.mock('diff', () => ({
   createPatch: mockCreatePatch,
@@ -103,7 +107,7 @@ describe('modifyWithEditor', () => {
       const result = await modifyWithEditor(
         mockParams,
         mockModifyContext,
-        'vscode' as EditorType,
+        DEFAULT_GUI_EDITOR,
         abortSignal,
       );
 
@@ -169,9 +173,14 @@ describe('modifyWithEditor', () => {
       await modifyWithEditor(
         mockParams,
         mockModifyContext,
-        'vscode' as EditorType,
+        DEFAULT_GUI_EDITOR,
         abortSignal,
       );
+
+      const [oldFilePath] = mockOpenDiff.mock.calls[0];
+      const diffDir = path.dirname(oldFilePath);
+      // Temp directory should be cleaned up after modification
+      await expect(fsp.stat(diffDir)).rejects.toThrow();
     });
   });
 
@@ -184,7 +193,7 @@ describe('modifyWithEditor', () => {
     const result = await modifyWithEditor(
       mockParams,
       mockModifyContext,
-      'vscode' as EditorType,
+      DEFAULT_GUI_EDITOR,
       abortSignal,
     );
 
@@ -212,7 +221,7 @@ describe('modifyWithEditor', () => {
     const result = await modifyWithEditor(
       mockParams,
       mockModifyContext,
-      'vscode' as EditorType,
+      DEFAULT_GUI_EDITOR,
       abortSignal,
     );
 
@@ -241,7 +250,7 @@ describe('modifyWithEditor', () => {
     await modifyWithEditor(
       mockParams,
       mockModifyContext,
-      'vscode' as EditorType,
+      DEFAULT_GUI_EDITOR,
       abortSignal,
       {
         currentContent: overrideCurrent,
@@ -268,7 +277,7 @@ describe('modifyWithEditor', () => {
     await modifyWithEditor(
       mockParams,
       mockModifyContext,
-      'vscode' as EditorType,
+      DEFAULT_GUI_EDITOR,
       abortSignal,
       {
         currentContent: null,
@@ -298,7 +307,7 @@ describe('modifyWithEditor', () => {
       modifyWithEditor(
         mockParams,
         mockModifyContext,
-        'vscode' as EditorType,
+        DEFAULT_GUI_EDITOR,
         abortSignal,
       ),
     ).rejects.toThrow('Editor failed to open');
@@ -327,7 +336,7 @@ describe('modifyWithEditor', () => {
     await modifyWithEditor(
       mockParams,
       mockModifyContext,
-      'vscode' as EditorType,
+      DEFAULT_GUI_EDITOR,
       abortSignal,
     );
 
@@ -353,7 +362,7 @@ describe('modifyWithEditor', () => {
     await modifyWithEditor(
       mockParams,
       mockModifyContext,
-      'vscode' as EditorType,
+      DEFAULT_GUI_EDITOR,
       abortSignal,
     );
 
@@ -374,7 +383,7 @@ describe('modifyWithEditor', () => {
     await modifyWithEditor(
       mockParams,
       mockModifyContext,
-      'vscode' as EditorType,
+      DEFAULT_GUI_EDITOR,
       abortSignal,
     );
 


### PR DESCRIPTION
## TLDR

Refactored editor type definitions to use const arrays as single source of truth,
improving type safety and maintainability by eliminating duplicated editor lists and
hardcoded categorization logic.

## Dive Deeper

**Problem**

The codebase had several issues with editor type management:
- Editor lists were duplicated between EditorType union and isValidEditorType
function
- GUI vs terminal editor categorization was hardcoded in multiple places
- No type-safe way to distinguish between editor categories
- Test files and configuration used hardcoded editor strings

**Solution**

- Introduced GUI_EDITORS and TERMINAL_EDITORS const arrays as the single source of
truth
- Derived all types (EditorType, GuiEditorType, TerminalEditorType) from these arrays
- Added exported type guard functions (isGuiEditor, isTerminalEditor) for safe
categorization
- Created DEFAULT_GUI_EDITOR constant to replace hardcoded 'vscode' strings
- Simplified branching logic throughout the codebase

**Benefits**

- Single source of truth: Adding a new editor only requires updating one array
- Type safety: Const assertions ensure compile-time type checking
- Better maintainability: Clear separation between GUI and terminal editors
- Reduced duplication: No more scattered editor lists across the codebase

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- This PR Resolves #8603 