### PR TITLE
chore: update erroneous model version added by external contrib

### DIFF
--- a/packages/cli/src/utils/commentJson.test.ts
+++ b/packages/cli/src/utils/commentJson.test.ts
@@ -119,7 +119,7 @@ describe('commentJson', () => {
       fs.writeFileSync(testFilePath, complexContent, 'utf-8');
 
       updateSettingsFilePreservingFormat(testFilePath, {
-        model: 'gemini-2.5-flash`',
+        model: 'gemini-2.5-flash',
         mcpServers: {
           context7: {
             headers: {

--- a/packages/cli/src/utils/commentJson.test.ts
+++ b/packages/cli/src/utils/commentJson.test.ts
@@ -41,14 +41,14 @@ describe('commentJson', () => {
       fs.writeFileSync(testFilePath, originalContent, 'utf-8');
 
       updateSettingsFilePreservingFormat(testFilePath, {
-        model: 'gemini-3.0-ultra',
+        model: 'gemini-2.5-flash',
       });
 
       const updatedContent = fs.readFileSync(testFilePath, 'utf-8');
 
       expect(updatedContent).toContain('// Model configuration');
       expect(updatedContent).toContain('// Theme setting');
-      expect(updatedContent).toContain('"model": "gemini-3.0-ultra"');
+      expect(updatedContent).toContain('"model": "gemini-2.5-flash"');
       expect(updatedContent).toContain('"theme": "dark"');
     });
 
@@ -119,7 +119,7 @@ describe('commentJson', () => {
       fs.writeFileSync(testFilePath, complexContent, 'utf-8');
 
       updateSettingsFilePreservingFormat(testFilePath, {
-        model: 'gemini-3.0-ultra',
+        model: 'gemini-2.5-flash`',
         mcpServers: {
           context7: {
             headers: {
@@ -140,7 +140,7 @@ describe('commentJson', () => {
       expect(updatedContent).toContain('// API key');
 
       // Verify updates applied
-      expect(updatedContent).toContain('"model": "gemini-3.0-ultra"');
+      expect(updatedContent).toContain('"model": "gemini-2.5-flash"');
       expect(updatedContent).toContain('"newSection"');
       expect(updatedContent).toContain('"API_KEY": "new-test-key"');
     });
@@ -161,7 +161,7 @@ describe('commentJson', () => {
 
       expect(() => {
         updateSettingsFilePreservingFormat(testFilePath, {
-          model: 'gemini-3.0-ultra',
+          model: 'gemini-2.5-flash',
         });
       }).not.toThrow();
 


### PR DESCRIPTION
## TLDR

An external contributor added a test that has a mis-leading and incorrect model number in the test data.

Removing it to not cause confusion or false speculation. 

To be clear, this was test data added by an external contributor and not a Google employee. 

Not trying to rain on anyone's parade ☔ 😆 
