### PR TITLE
feat(ide): Allow IDEs to self-identify via discovery file

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -31,7 +31,6 @@ import { MessageType, StreamingState } from './types.js';
 import {
   type EditorType,
   type Config,
-  type DetectedIde,
   type IdeContext,
   type UserTierId,
   DEFAULT_GEMINI_FLASH_MODEL,
@@ -711,16 +710,20 @@ Logging in with Google... Please restart Gemini CLI to continue.
   ]);
 
   const [idePromptAnswered, setIdePromptAnswered] = useState(false);
-  const [currentIDE, setCurrentIDE] = useState<DetectedIde | null>(null);
+  const [currentIDE, setCurrentIDE] = useState<string | null>(null);
 
   useEffect(() => {
     const getIde = async () => {
       const ideClient = await IdeClient.getInstance();
       const currentIde = ideClient.getCurrentIde();
-      if (currentIde && typeof currentIde !== 'string') {
-        setCurrentIDE(currentIde.name as DetectedIde);
+      if (currentIde) {
+        if (typeof currentIde === 'string') {
+          setCurrentIDE(currentIde);
+        } else {
+          setCurrentIDE(currentIde.name);
+        }
       } else {
-        setCurrentIDE(currentIde || null);
+        setCurrentIDE(null);
       }
     };
     getIde();

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -717,7 +717,11 @@ Logging in with Google... Please restart Gemini CLI to continue.
     const getIde = async () => {
       const ideClient = await IdeClient.getInstance();
       const currentIde = ideClient.getCurrentIde();
-      setCurrentIDE(currentIde || null);
+      if (currentIde && typeof currentIde !== 'string') {
+        setCurrentIDE(currentIde.name as DetectedIde);
+      } else {
+        setCurrentIDE(currentIde || null);
+      }
     };
     getIde();
   }, []);

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -144,7 +144,7 @@ export const ideCommand = async (): Promise<SlashCommand> => {
         ({
           type: 'message',
           messageType: 'error',
-          content: `IDE integration is not supported in your current environment. To use this feature, run Gemini CLI in one of these supported IDEs: VS Code or VS Code forks.`,
+          content: `IDE integration is not supported in your current environment. To use this feature, run Gemini CLI in one of the supported IDEs.`,
         }) as const,
     };
   }
@@ -176,6 +176,17 @@ export const ideCommand = async (): Promise<SlashCommand> => {
     description: `install required IDE companion for ${ideClient.getDetectedIdeDisplayName()}`,
     kind: CommandKind.BUILT_IN,
     action: async (context) => {
+      if (!currentIDE) {
+        // This should not happen based on the check above, but it satisfies the compiler.
+        context.ui.addItem(
+          {
+            type: 'error',
+            text: 'Could not determine the current IDE.',
+          },
+          Date.now(),
+        );
+        return;
+      }
       const installer = getIdeInstaller(currentIDE);
       if (!installer) {
         context.ui.addItem(

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -21,7 +21,6 @@ import type {
   IdeContext,
   ApprovalMode,
   UserTierId,
-  DetectedIde,
   FallbackIntent,
 } from '@google/gemini-cli-core';
 import type { DOMElement } from 'ink';
@@ -104,8 +103,8 @@ export interface UIState {
   sessionStats: SessionStatsState;
   terminalWidth: number;
   terminalHeight: number;
-  mainControlsRef: React.MutableRefObject<DOMElement | null>;
-  currentIDE: DetectedIde | null;
+  mainControlsRef: React.RefObject<DOMElement>;
+  currentIDE: string | null;
   updateInfo: UpdateObject | null;
   showIdeRestartPrompt: boolean;
   isRestarting: boolean;

--- a/packages/core/src/ide/detect-ide.test.ts
+++ b/packages/core/src/ide/detect-ide.test.ts
@@ -4,15 +4,44 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { detectIde, DetectedIde, getIdeInfo } from './detect-ide.js';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import {
+  detectIde,
+  DetectedIde,
+  getIdeInfo,
+  type CustomIde,
+} from './detect-ide.js';
 
 describe('detectIde', () => {
   const ideProcessInfo = { pid: 123, command: 'some/path/to/code' };
   const ideProcessInfoNoCode = { pid: 123, command: 'some/path/to/fork' };
 
+  beforeEach(() => {
+    vi.stubEnv('TERM_PROGRAM', 'vscode');
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
+  });
+
+  it('should return the IDE from connectionConfig if provided', () => {
+    const customIde: CustomIde = {
+      name: 'custom-ide',
+      displayName: 'Custom IDE',
+    };
+    expect(detectIde(ideProcessInfo, { ide: customIde })).toBe(customIde);
+  });
+
+  it('should prioritize connectionConfig over environment detection', () => {
+    vi.stubEnv('TERM_PROGRAM', 'vscode');
+    vi.stubEnv('REPLIT_USER', 'testuser');
+    const customIde: CustomIde = {
+      name: 'custom-ide',
+      displayName: 'Custom IDE',
+    };
+    expect(detectIde(ideProcessInfo, { ide: customIde })).toBe(customIde);
+    // And without it, it should detect from env
+    expect(detectIde(ideProcessInfo)).toBe(DetectedIde.Replit);
   });
 
   it('should return undefined if TERM_PROGRAM is not vscode', () => {
@@ -89,44 +118,73 @@ describe('detectIde', () => {
 
 describe('getIdeInfo', () => {
   it('should return correct info for Devin', () => {
-    expect(getIdeInfo(DetectedIde.Devin)).toEqual({ displayName: 'Devin' });
+    expect(getIdeInfo(DetectedIde.Devin)).toEqual({
+      name: DetectedIde.Devin,
+      displayName: 'Devin',
+    });
   });
 
   it('should return correct info for Replit', () => {
-    expect(getIdeInfo(DetectedIde.Replit)).toEqual({ displayName: 'Replit' });
+    expect(getIdeInfo(DetectedIde.Replit)).toEqual({
+      name: DetectedIde.Replit,
+      displayName: 'Replit',
+    });
   });
 
   it('should return correct info for Cursor', () => {
-    expect(getIdeInfo(DetectedIde.Cursor)).toEqual({ displayName: 'Cursor' });
+    expect(getIdeInfo(DetectedIde.Cursor)).toEqual({
+      name: DetectedIde.Cursor,
+      displayName: 'Cursor',
+    });
   });
 
   it('should return correct info for CloudShell', () => {
     expect(getIdeInfo(DetectedIde.CloudShell)).toEqual({
+      name: DetectedIde.CloudShell,
       displayName: 'Cloud Shell',
     });
   });
 
   it('should return correct info for Codespaces', () => {
     expect(getIdeInfo(DetectedIde.Codespaces)).toEqual({
+      name: DetectedIde.Codespaces,
       displayName: 'GitHub Codespaces',
     });
   });
 
   it('should return correct info for FirebaseStudio', () => {
     expect(getIdeInfo(DetectedIde.FirebaseStudio)).toEqual({
+      name: DetectedIde.FirebaseStudio,
       displayName: 'Firebase Studio',
     });
   });
 
   it('should return correct info for Trae', () => {
-    expect(getIdeInfo(DetectedIde.Trae)).toEqual({ displayName: 'Trae' });
+    expect(getIdeInfo(DetectedIde.Trae)).toEqual({
+      name: DetectedIde.Trae,
+      displayName: 'Trae',
+    });
   });
 
   it('should return correct info for VSCode', () => {
-    expect(getIdeInfo(DetectedIde.VSCode)).toEqual({ displayName: 'VS Code' });
+    expect(getIdeInfo(DetectedIde.VSCode)).toEqual({
+      name: DetectedIde.VSCode,
+      displayName: 'VS Code',
+    });
   });
 
   it('should return correct info for VSCodeFork', () => {
-    expect(getIdeInfo(DetectedIde.VSCodeFork)).toEqual({ displayName: 'IDE' });
+    expect(getIdeInfo(DetectedIde.VSCodeFork)).toEqual({
+      name: DetectedIde.VSCodeFork,
+      displayName: 'IDE',
+    });
+  });
+
+  it('should return the same object for a custom IDE', () => {
+    const customIde: CustomIde = {
+      name: 'my-ide',
+      displayName: 'My Custom IDE',
+    };
+    expect(getIdeInfo(customIde)).toBe(customIde);
   });
 });

--- a/packages/core/src/ide/detect-ide.ts
+++ b/packages/core/src/ide/detect-ide.ts
@@ -16,54 +16,69 @@ export enum DetectedIde {
   VSCodeFork = 'vscodefork',
 }
 
-export interface IdeInfo {
+export interface CustomIde {
+  name: string;
   displayName: string;
 }
 
-export function getIdeInfo(ide: DetectedIde): IdeInfo {
-  switch (ide) {
-    case DetectedIde.Devin:
-      return {
-        displayName: 'Devin',
-      };
-    case DetectedIde.Replit:
-      return {
-        displayName: 'Replit',
-      };
-    case DetectedIde.Cursor:
-      return {
-        displayName: 'Cursor',
-      };
-    case DetectedIde.CloudShell:
-      return {
-        displayName: 'Cloud Shell',
-      };
-    case DetectedIde.Codespaces:
-      return {
-        displayName: 'GitHub Codespaces',
-      };
-    case DetectedIde.FirebaseStudio:
-      return {
-        displayName: 'Firebase Studio',
-      };
-    case DetectedIde.Trae:
-      return {
-        displayName: 'Trae',
-      };
-    case DetectedIde.VSCode:
-      return {
-        displayName: 'VS Code',
-      };
-    case DetectedIde.VSCodeFork:
-      return {
-        displayName: 'IDE',
-      };
-    default: {
-      // This ensures that if a new IDE is added to the enum, we get a compile-time error.
-      const exhaustiveCheck: never = ide;
-      return exhaustiveCheck;
+export type DetectedIdeInfo = DetectedIde | CustomIde;
+
+export function getIdeInfo(ide: DetectedIdeInfo): CustomIde {
+  if (typeof ide === 'string') {
+    switch (ide) {
+      case DetectedIde.Devin:
+        return {
+          name: DetectedIde.Devin,
+          displayName: 'Devin',
+        };
+      case DetectedIde.Replit:
+        return {
+          name: DetectedIde.Replit,
+          displayName: 'Replit',
+        };
+      case DetectedIde.Cursor:
+        return {
+          name: DetectedIde.Cursor,
+          displayName: 'Cursor',
+        };
+      case DetectedIde.CloudShell:
+        return {
+          name: DetectedIde.CloudShell,
+          displayName: 'Cloud Shell',
+        };
+      case DetectedIde.Codespaces:
+        return {
+          name: DetectedIde.Codespaces,
+          displayName: 'GitHub Codespaces',
+        };
+      case DetectedIde.FirebaseStudio:
+        return {
+          name: DetectedIde.FirebaseStudio,
+          displayName: 'Firebase Studio',
+        };
+      case DetectedIde.Trae:
+        return {
+          name: DetectedIde.Trae,
+          displayName: 'Trae',
+        };
+      case DetectedIde.VSCode:
+        return {
+          name: DetectedIde.VSCode,
+          displayName: 'VS Code',
+        };
+      case DetectedIde.VSCodeFork:
+        return {
+          name: DetectedIde.VSCodeFork,
+          displayName: 'IDE',
+        };
+      default: {
+        // This ensures that if a new IDE is added to the enum, we get a compile-time error.
+        const exhaustiveCheck: never = ide;
+        return exhaustiveCheck;
+      }
     }
   }
+  return ide;
 }
 
 export function detectIdeFromEnv(): DetectedIde {
@@ -107,7 +122,7 @@ function verifyVSCode(
   return DetectedIde.VSCodeFork;
 }
 
-export function detectIde(ideProcessInfo: {
+export function detectIdeInternal(ideProcessInfo: {
   pid: number;
   command: string;
 }): DetectedIde | undefined {
@@ -118,4 +133,17 @@ export function detectIde(ideProcessInfo: {
 
   const ide = detectIdeFromEnv();
   return verifyVSCode(ide, ideProcessInfo);
+}
+
+export function detectIde(
+  ideProcessInfo: {
+    pid: number;
+    command: string;
+  },
+  connectionConfig?: { ide?: CustomIde },
+): DetectedIdeInfo | undefined {
+  if (connectionConfig?.ide) {
+    return connectionConfig.ide;
+  }
+  return detectIdeInternal(ideProcessInfo);
 }

--- a/packages/core/src/ide/ide-client.test.ts
+++ b/packages/core/src/ide/ide-client.test.ts
@@ -24,7 +24,7 @@ import {
   detectIde,
   DetectedIde,
   getIdeInfo,
-  type IdeInfo,
+  type CustomIde,
 } from './detect-ide.js';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -69,8 +69,9 @@ describe('IdeClient', () => {
     vi.spyOn(process, 'cwd').mockReturnValue('/test/workspace/sub-dir');
     vi.mocked(detectIde).mockReturnValue(DetectedIde.VSCode);
     vi.mocked(getIdeInfo).mockReturnValue({
+      name: DetectedIde.VSCode,
       displayName: 'VS Code',
-    } as IdeInfo);
+    } as CustomIde);
     vi.mocked(getIdeProcessInfo).mockResolvedValue({
       pid: 12345,
       command: 'test-ide',

--- a/packages/core/src/ide/ide-installer.ts
+++ b/packages/core/src/ide/ide-installer.ts
@@ -9,7 +9,12 @@ import * as process from 'node:process';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { DetectedIde, getIdeInfo, type IdeInfo } from './detect-ide.js';
+import {
+  DetectedIde,
+  getIdeInfo,
+  type CustomIde,
+  type DetectedIdeInfo,
+} from './detect-ide.js';
 import { GEMINI_CLI_COMPANION_EXTENSION_NAME } from './constants.js';
 
 function getVsCodeCommand(platform: NodeJS.Platform = process.platform) {
@@ -100,10 +105,10 @@ async function findVsCodeCommand(
 
 class VsCodeInstaller implements IdeInstaller {
   private vsCodeCommand: Promise<string | null>;
-  private readonly ideInfo: IdeInfo;
+  private readonly ideInfo: CustomIde;
 
   constructor(
-    readonly ide: DetectedIde,
+    readonly ide: DetectedIdeInfo,
     readonly platform = process.platform,
   ) {
     this.vsCodeCommand = findVsCodeCommand(platform);
@@ -150,10 +155,11 @@ class VsCodeInstaller implements IdeInstaller {
 }
 
 export function getIdeInstaller(
-  ide: DetectedIde,
+  ide: DetectedIdeInfo,
   platform = process.platform,
 ): IdeInstaller | null {
-  switch (ide) {
+  const ideName = typeof ide === 'string' ? ide : ide.name;
+  switch (ideName) {
     case DetectedIde.VSCode:
     case DetectedIde.FirebaseStudio:
       return new VsCodeInstaller(ide, platform);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,7 +65,7 @@ export * from './ide/ide-client.js';
 export * from './ide/ideContext.js';
 export * from './ide/ide-installer.js';
 export { getIdeInfo, DetectedIde } from './ide/detect-ide.js';
-export { type IdeInfo } from './ide/detect-ide.js';
+export { type DetectedIdeInfo, type CustomIde } from './ide/detect-ide.js';
 export * from './ide/constants.js';
 export * from './ide/types.js';
 


### PR DESCRIPTION
## TLDR

This PR refactors the IDE detection mechanism to allow IDEs to self-identify by providing their name and display name in the discovery file. This shifts the responsibility of identification from the CLI to the IDE companion extension, making it significantly easier to support new IDEs without requiring changes to the CLI's core logic.

The primary change is the addition of an optional `ide` object to the discovery file spec. If this object is present, the CLI will use it to identify the connected IDE.

## Linked Issues
#4800 