### PR TITLE
Properly publish npm-shrinkwrap.json.

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit"
   },
   "files": [
-    "dist"
+    "dist",
+    "npm-shrinkwrap.json"
   ],
   "config": {
     "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.7.0-nightly.20250917.0b10ba2c"

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -46,6 +46,7 @@ copyFiles('core', {
 copyFiles('cli', {
   'README.md': 'README.md',
   LICENSE: 'LICENSE',
+  'npm-shrinkwrap.json': 'npm-shrinkwrap.json',
 });
 
 console.log('Successfully prepared all packages.');


### PR DESCRIPTION
## TLDR

updates scripts to make sure shrinkwrap file makes it to the release.

## Dive Deeper

Testing revealed that `npm i -g @google/gemini-cli@preview` was not copying the shrinkwrap to the node_modules dir and we believe the reason is that we weren't copying it in these scripts as we should have.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
