### PR TITLE
feat: add /model command and dialog

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -24,6 +24,7 @@ import { ideCommand } from '../ui/commands/ideCommand.js';
 import { initCommand } from '../ui/commands/initCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
+import { modelCommand } from '../ui/commands/modelCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
@@ -68,6 +69,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       initCommand,
       mcpCommand,
       memoryCommand,
+      modelCommand,
       privacyCommand,
       quitCommand,
       restoreCommand(this.config),

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -48,6 +48,7 @@ import { loadHierarchicalGeminiMemory } from '../config/config.js';
 import process from 'node:process';
 import { useHistory } from './hooks/useHistoryManager.js';
 import { useThemeCommand } from './hooks/useThemeCommand.js';
+import { useModelCommand } from './hooks/useModelCommand.js';
 import { useAuthCommand } from './auth/useAuth.js';
 import { useQuotaAndFallback } from './hooks/useQuotaAndFallback.js';
 import { useEditorSettings } from './hooks/useEditorSettings.js';
@@ -300,6 +301,9 @@ export const AppContainer = (props: AppContainerProps) => {
     initializationResult.themeError,
   );
 
+  const { isModelDialogOpen, openModelDialog, closeModelDialog } =
+    useModelCommand();
+
   const { authState, setAuthState, authError, onAuthError } = useAuthCommand(
     settings,
     config,
@@ -414,6 +418,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       openAuthDialog: () => setAuthState(AuthState.Updating),
       openThemeDialog,
       openEditorDialog,
+      openModelDialog,
       openPrivacyNotice: () => setShowPrivacyNotice(true),
       openSettingsDialog,
       quit: (messages: HistoryItem[]) => {
@@ -431,6 +436,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       setAuthState,
       openThemeDialog,
       openEditorDialog,
+      openModelDialog,
       openSettingsDialog,
       setQuittingMessages,
       setDebugMessage,
@@ -991,6 +997,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     () => ({
       history: historyManager.history,
       isThemeDialogOpen,
+      isModelDialogOpen,
       themeError,
       isAuthenticating,
       isConfigInitialized,
@@ -1067,6 +1074,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     [
       historyManager.history,
       isThemeDialogOpen,
+      isModelDialogOpen,
       themeError,
       isAuthenticating,
       isConfigInitialized,
@@ -1146,6 +1154,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     () => ({
       handleThemeSelect,
       handleThemeHighlight,
+      closeModelDialog,
       handleAuthSelect,
       setAuthState,
       onAuthError,
@@ -1169,6 +1178,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     [
       handleThemeSelect,
       handleThemeHighlight,
+      closeModelDialog,
       handleAuthSelect,
       setAuthState,
       onAuthError,

--- a/packages/cli/src/ui/commands/modelCommand.tsx
+++ b/packages/cli/src/ui/commands/modelCommand.tsx
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { OpenDialogActionReturn, SlashCommand } from './types.js';
+import { CommandKind } from './types.js';
+
+export const modelCommand: SlashCommand = {
+  name: 'model',
+  description: 'Select a model to use for the session.',
+  kind: CommandKind.BUILT_IN,
+  action: (): OpenDialogActionReturn => ({
+    type: 'dialog',
+    dialog: 'model',
+  }),
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -108,7 +108,14 @@ export interface MessageActionReturn {
 export interface OpenDialogActionReturn {
   type: 'dialog';
 
-  dialog: 'help' | 'auth' | 'theme' | 'editor' | 'privacy' | 'settings';
+  dialog:
+    | 'help'
+    | 'auth'
+    | 'theme'
+    | 'editor'
+    | 'privacy'
+    | 'settings'
+    | 'model';
 }
 
 /**

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -18,6 +18,7 @@ import { EditorSettingsDialog } from './EditorSettingsDialog.js';
 import { PrivacyNotice } from '../privacy/PrivacyNotice.js';
 import { WorkspaceMigrationDialog } from './WorkspaceMigrationDialog.js';
 import { ProQuotaDialog } from './ProQuotaDialog.js';
+import { ModelDialog } from './ModelDialog.js';
 import { theme } from '../semantic-colors.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useUIActions } from '../contexts/UIActionsContext.js';
@@ -44,6 +45,9 @@ export const DialogManager = () => {
         </Text>
       </Box>
     );
+  }
+  if (uiState.isModelDialogOpen) {
+    return <ModelDialog />;
   }
   if (uiState.showWorkspaceMigrationDialog) {
     return (

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { memo } from 'react';
+import { Box, Text } from 'ink';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+import { useUIActions } from '../contexts/UIActionsContext.js';
+
+const items = [
+  {
+    label: 'Default - The default model for your organization',
+    value: 'default',
+  },
+  {
+    label: 'Pro - The most capable model for complex tasks',
+    value: 'pro',
+  },
+  {
+    label: 'Flash - A lighter-weight model for everyday tasks',
+    value: 'flash',
+  },
+  {
+    label: 'Flash light - The lightest-weight model for the simplest tasks',
+    value: 'flash-light',
+  },
+];
+
+const ModelDialog = memo(() => {
+  const { closeModelDialog } = useUIActions();
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold>Select a model</Text>
+      <RadioButtonSelect items={items} onSelect={closeModelDialog} />
+    </Box>
+  );
+});
+
+ModelDialog.displayName = 'ModelDialog';
+
+export { ModelDialog };

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -18,6 +18,7 @@ export interface UIActions {
     scope: SettingScope,
   ) => void;
   handleThemeHighlight: (themeName: string | undefined) => void;
+  closeModelDialog: () => void;
   handleAuthSelect: (
     authType: AuthType | undefined,
     scope: SettingScope,

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -38,6 +38,7 @@ export interface ProQuotaDialogRequest {
 export interface UIState {
   history: HistoryItem[];
   isThemeDialogOpen: boolean;
+  isModelDialogOpen: boolean;
   themeError: string | null;
   isAuthenticating: boolean;
   isConfigInitialized: boolean;

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -40,6 +40,7 @@ interface SlashCommandProcessorActions {
   openAuthDialog: () => void;
   openThemeDialog: () => void;
   openEditorDialog: () => void;
+  openModelDialog: () => void;
   openPrivacyNotice: () => void;
   openSettingsDialog: () => void;
   quit: (messages: HistoryItem[]) => void;
@@ -365,6 +366,9 @@ export const useSlashCommandProcessor = (
                       return { type: 'handled' };
                     case 'settings':
                       actions.openSettingsDialog();
+                      return { type: 'handled' };
+                    case 'model':
+                      actions.openModelDialog();
                       return { type: 'handled' };
                     case 'help':
                       return { type: 'handled' };

--- a/packages/cli/src/ui/hooks/useModelCommand.ts
+++ b/packages/cli/src/ui/hooks/useModelCommand.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useCallback } from 'react';
+
+export function useModelCommand() {
+  const [isModelDialogOpen, setIsModelDialogOpen] = useState(false);
+
+  const openModelDialog = useCallback(() => {
+    setIsModelDialogOpen(true);
+  }, []);
+
+  const closeModelDialog = useCallback(() => {
+    setIsModelDialogOpen(false);
+  }, []);
+
+  return {
+    isModelDialogOpen,
+    openModelDialog,
+    closeModelDialog,
+  };
+}


### PR DESCRIPTION
This PR adds a new /model command that opens a dialog with the following options: 'Default', 'Pro', 'Flash', and 'Flash light', using the standard list component with descriptions, and allowing the dialog to be closed with Enter or Escape.