### PR TITLE
fix(cli): uninstall extensions using their source URL

### DIFF
--- a/packages/cli/src/commands/extensions/uninstall.ts
+++ b/packages/cli/src/commands/extensions/uninstall.ts
@@ -9,13 +9,13 @@ import { uninstallExtension } from '../../config/extension.js';
 import { getErrorMessage } from '../../utils/errors.js';
 
 interface UninstallArgs {
-  name: string;
+  identifier: string; // can be extension name or source URL.
 }
 
 export async function handleUninstall(args: UninstallArgs) {
   try {
-    await uninstallExtension(args.name);
-    console.log(`Extension "${args.name}" successfully uninstalled.`);
+    await uninstallExtension(args.identifier);
+    console.log(`Extension "${args.identifier}" successfully uninstalled.`);
   } catch (error) {
     console.error(getErrorMessage(error));
     process.exit(1);
@@ -23,25 +23,25 @@ export async function handleUninstall(args: UninstallArgs) {
 }
 
 export const uninstallCommand: CommandModule = {
-  command: 'uninstall <name>',
+  command: 'uninstall <identifier>',
   describe: 'Uninstalls an extension.',
   builder: (yargs) =>
     yargs
-      .positional('name', {
-        describe: 'The name of the extension to uninstall.',
+      .positional('identifier', {
+        describe: 'The identifier of the extension to uninstall.',
         type: 'string',
       })
       .check((argv) => {
-        if (!argv.name) {
+        if (!argv.identifier) {
           throw new Error(
-            'Please include the name of the extension to uninstall as a positional argument.',
+            'Please include the identifier of the extension to uninstall as a positional argument.',
           );
         }
         return true;
       }),
   handler: async (argv) => {
     await handleUninstall({
-      name: argv['name'] as string,
+      identifier: argv['identifier'] as string,
     });
   },
 };

--- a/packages/cli/src/commands/extensions/uninstall.ts
+++ b/packages/cli/src/commands/extensions/uninstall.ts
@@ -9,13 +9,13 @@ import { uninstallExtension } from '../../config/extension.js';
 import { getErrorMessage } from '../../utils/errors.js';
 
 interface UninstallArgs {
-  identifier: string; // can be extension name or source URL.
+  name: string; // can be extension name or source URL.
 }
 
 export async function handleUninstall(args: UninstallArgs) {
   try {
-    await uninstallExtension(args.identifier);
-    console.log(`Extension "${args.identifier}" successfully uninstalled.`);
+    await uninstallExtension(args.name);
+    console.log(`Extension "${args.name}" successfully uninstalled.`);
   } catch (error) {
     console.error(getErrorMessage(error));
     process.exit(1);
@@ -23,25 +23,25 @@ export async function handleUninstall(args: UninstallArgs) {
 }
 
 export const uninstallCommand: CommandModule = {
-  command: 'uninstall <identifier>',
+  command: 'uninstall <name>',
   describe: 'Uninstalls an extension.',
   builder: (yargs) =>
     yargs
-      .positional('identifier', {
-        describe: 'The identifier of the extension to uninstall.',
+      .positional('name', {
+        describe: 'The name or source path of the extension to uninstall.',
         type: 'string',
       })
       .check((argv) => {
-        if (!argv.identifier) {
+        if (!argv.name) {
           throw new Error(
-            'Please include the identifier of the extension to uninstall as a positional argument.',
+            'Please include the name of the extension to uninstall as a positional argument.',
           );
         }
         return true;
       }),
   handler: async (argv) => {
     await handleUninstall({
-      identifier: argv['identifier'] as string,
+      name: argv['name'] as string,
     });
   },
 };

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -573,17 +573,18 @@ export async function loadExtensionConfig(
 }
 
 export async function uninstallExtension(
-  extensionName: string,
+  extensionIdentifier: string,
   cwd: string = process.cwd(),
 ): Promise<void> {
   const logger = getClearcutLogger(cwd);
   const installedExtensions = loadUserExtensions();
-  if (
-    !installedExtensions.some(
-      (installed) => installed.config.name === extensionName,
-    )
-  ) {
-    throw new Error(`Extension "${extensionName}" not found.`);
+  const extensionName = installedExtensions.find(
+    (installed) =>
+      installed.config.name === extensionIdentifier ||
+      installed.installMetadata?.source === extensionIdentifier,
+  )?.config.name;
+  if (!extensionName) {
+    throw new Error(`Extension not found.`);
   }
   const manager = new ExtensionEnablementManager(
     ExtensionStorage.getUserExtensionsDir(),

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -580,8 +580,10 @@ export async function uninstallExtension(
   const installedExtensions = loadUserExtensions();
   const extensionName = installedExtensions.find(
     (installed) =>
-      installed.config.name === extensionIdentifier ||
-      installed.installMetadata?.source === extensionIdentifier,
+      installed.config.name.toLowerCase() ===
+        extensionIdentifier.toLowerCase() ||
+      installed.installMetadata?.source.toLowerCase() ===
+        extensionIdentifier.toLowerCase(),
   )?.config.name;
   if (!extensionName) {
     throw new Error(`Extension not found.`);


### PR DESCRIPTION
## TLDR

This change lets user uninstall extensions using extension's source URL if it was captured during installation as installMetaData.

## Dive Deeper


## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes - https://github.com/google-gemini/gemini-cli/issues/8623
