### PR TITLE
Better parsing of github extension source uris

### DIFF
--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -9,7 +9,7 @@ import {
   checkForExtensionUpdate,
   cloneFromGit,
   findReleaseAsset,
-  parseGitHubRepo,
+  parseGitHubRepoForReleases,
 } from './github.js';
 import { simpleGit, type SimpleGit } from 'simple-git';
 import { ExtensionUpdateState } from '../../ui/state/extensions.js';
@@ -233,52 +233,52 @@ describe('git extension helpers', () => {
     });
   });
 
-  describe('parseGitHubRepo', () => {
+  describe('parseGitHubRepoForReleases', () => {
     it('should parse owner and repo from a full GitHub URL', () => {
       const source = 'https://github.com/owner/repo.git';
-      const { owner, repo } = parseGitHubRepo(source);
+      const { owner, repo } = parseGitHubRepoForReleases(source);
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
 
     it('should parse owner and repo from a full GitHub UR without .git', () => {
       const source = 'https://github.com/owner/repo';
-      const { owner, repo } = parseGitHubRepo(source);
+      const { owner, repo } = parseGitHubRepoForReleases(source);
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
 
     it('should fail on a GitHub SSH URL', () => {
       const source = 'git@github.com:owner/repo.git';
-      expect(() => parseGitHubRepo(source)).toThrow(
+      expect(() => parseGitHubRepoForReleases(source)).toThrow(
         'Invalid GitHub repository source: git@github.com:owner/repo.git. Github releases extensions are not supported with ssh uris, you must use an https uri with a personal access token.',
       );
     });
 
     it('should parse owner and repo from a shorthand string', () => {
       const source = 'owner/repo';
-      const { owner, repo } = parseGitHubRepo(source);
+      const { owner, repo } = parseGitHubRepoForReleases(source);
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
 
     it('should handle .git suffix in repo name', () => {
       const source = 'owner/repo.git';
-      const { owner, repo } = parseGitHubRepo(source);
+      const { owner, repo } = parseGitHubRepoForReleases(source);
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
 
     it('should throw error for invalid source format', () => {
       const source = 'invalid-format';
-      expect(() => parseGitHubRepo(source)).toThrow(
+      expect(() => parseGitHubRepoForReleases(source)).toThrow(
         'Invalid GitHub repository source: invalid-format. Expected "owner/repo" or a github repo uri.',
       );
     });
 
     it('should throw error for source with too many parts', () => {
       const source = 'https://github.com/owner/repo/extra';
-      expect(() => parseGitHubRepo(source)).toThrow(
+      expect(() => parseGitHubRepoForReleases(source)).toThrow(
         'Invalid GitHub repository source: https://github.com/owner/repo/extra. Expected "owner/repo" or a github repo uri.',
       );
     });

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -248,11 +248,11 @@ describe('git extension helpers', () => {
       expect(repo).toBe('repo');
     });
 
-    it('should parse owner and repo from a full GitHub sso URL', () => {
+    it('should fail on a GitHub SSH URL', () => {
       const source = 'git@github.com:owner/repo.git';
-      const { owner, repo } = parseGitHubRepo(source);
-      expect(owner).toBe('owner');
-      expect(repo).toBe('repo');
+      expect(() => parseGitHubRepo(source)).toThrow(
+        'Invalid GitHub repository source: git@github.com:owner/repo.git. Github releases extensions are not supported with ssh uris, you must use an https uri with a personal access token.',
+      );
     });
 
     it('should parse owner and repo from a shorthand string', () => {

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -251,7 +251,7 @@ describe('git extension helpers', () => {
     it('should fail on a GitHub SSH URL', () => {
       const source = 'git@github.com:owner/repo.git';
       expect(() => parseGitHubRepoForReleases(source)).toThrow(
-        'Invalid GitHub repository source: git@github.com:owner/repo.git. Github releases extensions are not supported with ssh uris, you must use an https uri with a personal access token.',
+        'GitHub release-based extensions are not supported for SSH. You must use an HTTPS URI with a personal access token to download releases from private repositories. You can set your personal access token in the GITHUB_TOKEN environment variable and install the extension via SSH.',
       );
     });
 

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -88,10 +88,14 @@ export function parseGitHubRepo(source: string): {
       `Invalid GitHub repository source: ${source}. Expected "owner/repo" or a github repo uri.`,
     );
   }
-
-  // SSH uris when parsed come through in the first path segment
-  const owner = parts[0].replace('git@github.com:', '');
+  const owner = parts[0];
   const repo = parts[1].replace('.git', '');
+
+  if (owner.startsWith('git@github.com')) {
+    throw new Error(
+      `Invalid GitHub repository source: ${source}. Github releases extensions are not supported with ssh uris, you must use an https uri with a personal access token.`,
+    );
+  }
 
   if (!owner || !repo) {
     throw new Error(

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -92,15 +92,10 @@ export function parseGitHubRepoForReleases(source: string): {
 
   if (owner.startsWith('git@github.com')) {
     throw new Error(
-      `Invalid GitHub repository source: ${source}. Github releases extensions are not supported with ssh uris, you must use an https uri with a personal access token.`,
+      `GitHub release-based extensions are not supported for SSH. You must use an HTTPS URI with a personal access token to download releases from private repositories. You can set your personal access token in the GITHUB_TOKEN environment variable and install the extension via SSH.`,
     );
   }
 
-  if (!owner || !repo) {
-    throw new Error(
-      `Invalid GitHub repository source: ${source}. Expected "owner/repo" or a github repo uri.`,
-    );
-  }
   return { owner, repo };
 }
 

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -13,7 +13,6 @@ import * as https from 'node:https';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
-import type { K } from 'vitest/dist/chunks/reporters.d.BFLkQcL6.js';
 
 function getGitHubToken(): string | undefined {
   return process.env['GITHUB_TOKEN'];

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -74,7 +74,7 @@ export async function cloneFromGit(
   }
 }
 
-export function parseGitHubRepo(source: string): {
+export function parseGitHubRepoForReleases(source: string): {
   owner: string;
   repo: string;
 } {
@@ -168,7 +168,7 @@ export async function checkForExtensionUpdate(
       if (!source) {
         return ExtensionUpdateState.ERROR;
       }
-      const { owner, repo } = parseGitHubRepo(source);
+      const { owner, repo } = parseGitHubRepoForReleases(source);
 
       const releaseData = await fetchFromGithub(
         owner,
@@ -193,7 +193,7 @@ export async function downloadFromGitHubRelease(
   destination: string,
 ): Promise<string> {
   const { source, ref } = installMetadata;
-  const { owner, repo } = parseGitHubRepo(source);
+  const { owner, repo } = parseGitHubRepoForReleases(source);
 
   try {
     const releaseData = await fetchFromGithub(owner, repo, ref);


### PR DESCRIPTION
## TLDR

See https://github.com/google-gemini/gemini-cli/pull/8498#discussion_r2356509100 - this should more robustly handle github source uris by parsing them as a URL with a default base uri of (https://github.com/<owner>/<repo>).

## Dive Deeper

For SSH uris we just fail - we don't support listing github releases when using SSH.

## Reviewer Test Plan

Run the unit tests.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fix #8656