### PR TITLE
Support proper path expansion for chat sharing to file

### DIFF
--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as os from 'node:os';
 import * as fsPromises from 'node:fs/promises';
 import React from 'react';
 import { Text } from 'ink';
@@ -299,6 +300,9 @@ const shareCommand: SlashCommand = {
       filePathArg = `gemini-conversation-${Date.now()}.json`;
     }
 
+    if (filePathArg.startsWith('~/')) {
+      filePathArg = path.join(os.homedir(), filePathArg.slice(2));
+    }
     const filePath = path.resolve(filePathArg);
     const extension = path.extname(filePath);
     if (extension !== '.md' && extension !== '.json') {


### PR DESCRIPTION
## TLDR

Support path expansion of "~" when a user provides this in the file path.

## Reviewer Test Plan

Verify that "~" in the file path resolves to the home directory.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | x  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #8639