### PR TITLE
fix(release): correctly parse channel argument in patch workflow

### DIFF
--- a/.github/workflows/release-patch-from-comment.yml
+++ b/.github/workflows/release-patch-from-comment.yml
@@ -55,8 +55,7 @@ jobs:
         uses: 'actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325'
         with:
           script: |
-            const argsStr = '${{ steps.slash_command.outputs.command-arguments }}';
-            const args = argsStr ? JSON.parse(argsStr) : {};
+            const args = ${{ fromJSON(steps.slash_command.outputs.command-arguments) }};
             github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## TLDR

This pull request fixes a bug in the `release-patch-from-comment.yml` workflow where the `channel` argument from a `/patch` command was ignored, causing all patches to default to the `stable` channel. The workflow now correctly parses the command arguments.

## Dive Deeper

The `peter-evans/slash-command-dispatch` action outputs command arguments as a JSON-formatted string. The previous implementation passed this string directly into the `actions/github-script`, which resulted in incorrect parsing.

The fix replaces the manual string parsing (`JSON.parse`) with the `fromJSON()` expression function. This ensures the arguments from the slash command are correctly deserialized into a JavaScript object, allowing the `channel` parameter (e.g., `preview`) to be properly read and passed to the downstream `release-patch-1-create-pr.yml` workflow.

## Reviewer Test Plan

1.  Create and merge a test pull request.
2.  After the PR is merged, add a comment to it: `/patch channel=preview`
3.  Navigate to the "Actions" tab and find the workflow run triggered by your comment.
4.  Verify that the `release-patch-1-create-pr` workflow was dispatched with the `channel` input set to `preview`.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |