### PR TITLE
Add ability to skip GitHub release creation in manual release

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -27,6 +27,11 @@ inputs:
   previous-tag:
     description: 'The previous tag to use for generating release notes.'
     required: true
+  skip_github_release:
+    description: 'Whether to skip creating a GitHub release.'
+    type: 'boolean'
+    required: false
+    default: false
   working-directory:
     description: 'The working directory to run the steps in.'
     required: false
@@ -138,7 +143,7 @@ runs:
 
     - name: '🎉 Create GitHub Release'
       working-directory: '${{ inputs.working-directory }}'
-      if: "${{ inputs.dry-run == 'false' }}"
+      if: "${{ inputs.dry-run == 'false' && inputs.skip_github_release == 'false' }}"
       env:
         GITHUB_TOKEN: '${{ inputs.github-token }}'
       shell: 'bash'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -29,6 +29,11 @@ on:
         required: false
         type: 'boolean'
         default: false
+      skip_github_release:
+        description: 'Select to skip creating a GitHub release and create a npm release only.'
+        required: false
+        type: 'boolean'
+        default: false
 
 jobs:
   release:
@@ -78,3 +83,4 @@ jobs:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           dry-run: '${{ github.event.inputs.dry_run }}'
           previous-tag: '${{ steps.release_info.outputs.PREVIOUS_TAG }}'
+          skip_github_release: '${{ github.event.inputs.skip_github_release }}'


### PR DESCRIPTION
## TLDR

Adds an option to skip creating a github release.

## Dive Deeper

For manual test releases we probably don't want to do a github release.

## Reviewer Test Plan

I tested this manually.
