### PR TITLE
fix(release): prevent validation error in patch-from-comment workflow

### DIFF
--- a/.github/workflows/release-patch-from-comment.yml
+++ b/.github/workflows/release-patch-from-comment.yml
@@ -55,7 +55,7 @@ jobs:
         uses: 'actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325'
         with:
           script: |
-            const args = ${{ fromJSON(steps.slash_command.outputs.command-arguments) }};
+            const args = ${{ fromJSON(steps.slash_command.outputs.command-arguments || '{}') }};
             github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## TLDR

This PR fixes a validation error in the `release-patch-from-comment.yml` GitHub Actions workflow. The workflow was failing before execution because it didn't correctly handle cases where a pull request comment did not contain a slash command, leading to an invalid input for the `fromJSON` function. This change ensures the workflow is always valid by providing a default empty JSON object.

## Dive Deeper

The `Release: Patch from Comment` workflow uses the `peter-evans/slash-command-dispatch` action to parse comments for commands. If a comment is posted that does not contain a recognized command, the action's `command-arguments` output is an empty string.

The workflow was passing this output directly to `fromJSON()`. The GitHub Actions runner validates workflow expressions before execution, and it correctly identified that `fromJSON('')` is an invalid operation. This caused the entire workflow to be marked as invalid, preventing it from running at all, even when triggered by a valid `/patch` command.

This fix addresses the issue by using the expression `fromJSON(steps.slash_command.outputs.command-arguments || '{}')`. This provides a fallback empty JSON object (`{}`), ensuring that `fromJSON` always receives a valid string to parse. This makes the workflow structurally valid and allows it to run as intended.

## Reviewer Test Plan

The primary way to test this is to confirm the GitHub Action workflow no longer fails during the validation phase.

1. Open a pull request with these changes.
2. On the pull request, add a comment that is *not* a patch command (e.g., "Testing workflow validity.").
3. Check the "Actions" tab to ensure no validation errors occur for the `Release: Patch from Comment` workflow.
4. On the same pull request, add a comment with the patch command (e.g., `/patch`).
5. Verify that the `Release: Patch from Comment` workflow now triggers and starts executing its steps. The workflow is expected to fail later if the PR is not merged, but the key is that it should no longer fail on the initial validation error.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
