### PR TITLE
doc: Add docs on release failure chat notifications

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -397,3 +397,26 @@ graph TD
 
 This process ensures that the final published artifact is a purpose-built, clean, and efficient representation of the
 project, rather than a direct copy of the development workspace.
+
+## Notifications
+
+Failing release workflows will automatically create an issue with the label
+`release-failure`.
+
+A notification will be posted to the maintainer's chat channel when issues with
+this type are created.
+
+### Modifying chat notifications
+
+Notifications use [GitHub for Google Chat](https://workspace.google.com/marketplace/app/github_for_google_chat/536184076190). To modify the notifications, use `/github-settings` within the chat space.
+
+> [!WARNING]
+> The following instructions describe a fragile workaround that depends on the internal structure of the chat application's UI. It is likely to break with future updates.
+
+The list of available labels is not currently populated correctly. If you want to add a label that does not appear alphabetically in the first 30 labels in the repo, you must use your browser's developer tools to manually modify the UI:
+
+1. Open your browser's developer tools (e.g., Chrome DevTools).
+2. In the `/github-settings` dialog, inspect the list of labels.
+3. Locate one of the `<li>` elements representing a label.
+4. In the HTML, modify the `data-option-value` attribute of that `<li>` element to the desired label name (e.g., `release-failure`).
+5. Click on your modified label in the UI to select it, then save your settings.


### PR DESCRIPTION
## TLDR

Release workflow failures --> issues with `release-failure` tag --> chat notifications

## Dive Deeper

### doc: Add docs on chat notifications
It's kinda gross but it felt like it needed to be written down. If the
label population bug in the chat app isnt fixed soon i'm not sure we
should continue using it cuz it's quite a thing to pull this off.
## Reviewer Test Plan

n/a

## Testing Matrix

n/a

## Linked issues / bugs

Fixes #7565 