### PR TITLE
Filter out the 'trust' attribute from extension MCP server configs

### DIFF
--- a/docs/extension.md
+++ b/docs/extension.md
@@ -105,8 +105,9 @@ The `gemini-extension.json` file contains the configuration for the extension. T
 - `name`: The name of the extension. This is used to uniquely identify the extension and for conflict resolution when extension commands have the same name as user or project commands. The name should be lowercase and use dashes instead of underscores or spaces. This is how users will refer to your extension in the CLI. Note that we expect this name to match the extension directory name.
 - `version`: The version of the extension.
 - `mcpServers`: A map of MCP servers to configure. The key is the name of the server, and the value is the server configuration. These servers will be loaded on startup just like MCP servers configured in a [`settings.json` file](./cli/configuration.md). If both an extension and a `settings.json` file configure an MCP server with the same name, the server defined in the `settings.json` file takes precedence.
+  - Note that all MCP server configuration options are supported except for `trust`.
 - `contextFileName`: The name of the file that contains the context for the extension. This will be used to load the context from the extension directory. If this property is not used but a `GEMINI.md` file is present in your extension directory, then that file will be loaded.
-- `excludeTools`: An array of tool names to exclude from the model. You can also specify command-specific restrictions for tools that support it, like the `run_shell_command` tool. For example, `"excludeTools": ["run_shell_command(rm -rf)"]` will block the `rm -rf` command.
+- `excludeTools`: An array of tool names to exclude from the model. You can also specify command-specific restrictions for tools that support it, like the `run_shell_command` tool. For example, `"excludeTools": ["run_shell_command(rm -rf)"]` will block the `rm -rf` command. Note that this differs from the MCP server `excludeTools` functionality, which can be listed in the MCP server config.
 
 When Gemini CLI starts, it loads all the extensions and merges their configurations. If there are any conflicts, the workspace configuration takes precedence.
 

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -372,6 +372,26 @@ describe('extension tests', () => {
       expect(serverConfig.env!.MISSING_VAR).toBe('$UNDEFINED_ENV_VAR');
       expect(serverConfig.env!.MISSING_VAR_BRACES).toBe('${ALSO_UNDEFINED}');
     });
+
+    it('should filter trust out of mcp servers', () => {
+      createExtension({
+        extensionsDir: userExtensionsDir,
+        name: 'test-extension',
+        version: '1.0.0',
+        mcpServers: {
+          'test-server': {
+            command: 'node',
+            args: ['server.js'],
+            trust: true,
+          },
+        },
+      });
+
+      const extensions = loadExtensions();
+      expect(extensions).toHaveLength(1);
+      const loadedConfig = extensions[0].config;
+      expect(loadedConfig.mcpServers?.['test-server'].trust).toBeUndefined();
+    });
   });
 
   describe('annotateActiveExtensions', () => {

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -239,6 +239,15 @@ export function loadExtension(context: LoadExtensionContext): Extension | null {
 
     config = resolveEnvVarsInObject(config);
 
+    if (config.mcpServers) {
+      config.mcpServers = Object.fromEntries(
+        Object.entries(config.mcpServers).map(([key, value]) => [
+          key,
+          filterMcpConfig(value),
+        ]),
+      );
+    }
+
     const contextFiles = getContextFileNames(config)
       .map((contextFileName) =>
         path.join(effectiveExtensionPath, contextFileName),
@@ -259,6 +268,12 @@ export function loadExtension(context: LoadExtensionContext): Extension | null {
     );
     return null;
   }
+}
+
+function filterMcpConfig(original: MCPServerConfig): MCPServerConfig {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { trust, ...rest } = original;
+  return rest;
 }
 
 export function loadInstallMetadata(

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -273,7 +273,7 @@ export function loadExtension(context: LoadExtensionContext): Extension | null {
 function filterMcpConfig(original: MCPServerConfig): MCPServerConfig {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { trust, ...rest } = original;
-  return rest;
+  return Object.freeze(rest);
 }
 
 export function loadInstallMetadata(


### PR DESCRIPTION
## TLDR

This is ultimately useful functionality, but exposes a major vulnerability. An extension could set `trust: true` and get the CLI to call any tool it's exposing without requiring user consent. Eventually this should be something users can configure-- until then, we should remove it. 

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #8731