### PR TITLE
fix(cli): "Loaded cached credentials" message appears twice during CLI startup

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -34,12 +34,7 @@ import {
 } from './utils/cleanup.js';
 import { getCliVersion } from './utils/version.js';
 import type { Config } from '@google/gemini-cli-core';
-import {
-  sessionId,
-  logUserPrompt,
-  AuthType,
-  getOauthClient,
-} from '@google/gemini-cli-core';
+import { sessionId, logUserPrompt, AuthType } from '@google/gemini-cli-core';
 import {
   initializeApp,
   type InitializationResult,


### PR DESCRIPTION
### TL;DR

This PR fixes a bug where the **"Loaded cached credentials"** message appeared twice during startup. The issue was caused by authentication logic running in both the temporary launcher process and the final application process. The fix ensures authentication runs only once, resulting in a cleaner and more efficient startup experience.

---

### Details

The Gemini CLI uses a **relaunch mechanism** for stability and memory management. On startup, a parent process launches first, whose job is to spawn the final, long-lived child process.

Previously, `initializeApp()` was called too early, before the relaunch logic began. This caused the following flow:

1. The parent process starts.
2. `initializeApp()` runs, performing authentication and printing **"Loaded cached credentials"**.
3. The parent process relaunches the child process.
4. The child process starts fresh, re-running `main()`.
5. `initializeApp()` runs again, printing the same message a second time.

**Fix:**
This PR moves the `initializeApp()` call **after** the sandbox and relaunch block. With this adjustment, authentication only happens once—in the final, stable child process—eliminating the duplicate message and simplifying startup logic.

---

### Reviewer Test Plan

**1. Verify the Original Bug:**

* Checkout `main` branch.
* Run `npm install`.
* Run `npm start -- --prompt-interactive`.
* **Expected:** "Loaded cached credentials" appears twice.

**2. Test the Fix:**

* Checkout `fix/double-auth-message` branch.
* Run `npm install`.
* Run `npm start -- --prompt-interactive`.
* **Expected:** Message appears only once.

---

### Testing Matrix
┌──────────┬────┬────┬────┐
│          │ 🍏 │ 🪟 │ 🐧 │
├──────────┼────┼────┼────┤
│ npm run  │ ❓ │ ❓ │ ✅ │
│ npx      │ ❓ │ ❓ │ ❓ │
│ Docker   │ ❓ │ ❓ │ ❓ │
│ Podman   │ ❓ │ -  │ -  │
│ Seatbelt │ ❓ │ -  │ -  │
└──────────┴────┴────┴────┘
#8860 