### PR TITLE
fix(cli): return proper errors from loadExtensionConfig

### DIFF
--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -430,13 +430,13 @@ describe('extension tests', () => {
       expect(consoleSpy).toHaveBeenCalledOnce();
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Warning: Skipping extension in ${badExtDir}: Failed to load extension config from ${badConfigPath}: Invalid configuration in ${badConfigPath}: missing "name" or "version"`,
+          `Warning: Skipping extension in ${badExtDir}: Failed to load extension config from ${badConfigPath}: Invalid configuration in ${badConfigPath}: missing "name"`,
         ),
       );
 
       consoleSpy.mockRestore();
     });
-    
+
     it('should filter trust out of mcp servers', () => {
       createExtension({
         extensionsDir: userExtensionsDir,
@@ -691,7 +691,7 @@ describe('extension tests', () => {
       await expect(
         installExtension({ source: sourceExtDir, type: 'local' }),
       ).rejects.toThrow(
-        `Invalid configuration in ${configPath}: missing "name" or "version"`,
+        `Invalid configuration in ${configPath}: missing "name"`,
       );
     });
 

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -372,6 +372,70 @@ describe('extension tests', () => {
       expect(serverConfig.env!.MISSING_VAR).toBe('$UNDEFINED_ENV_VAR');
       expect(serverConfig.env!.MISSING_VAR_BRACES).toBe('${ALSO_UNDEFINED}');
     });
+
+    it('should skip extensions with invalid JSON and log a warning', () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      // Good extension
+      createExtension({
+        extensionsDir: userExtensionsDir,
+        name: 'good-ext',
+        version: '1.0.0',
+      });
+
+      // Bad extension
+      const badExtDir = path.join(userExtensionsDir, 'bad-ext');
+      fs.mkdirSync(badExtDir);
+      const badConfigPath = path.join(badExtDir, EXTENSIONS_CONFIG_FILENAME);
+      fs.writeFileSync(badConfigPath, '{ "name": "bad-ext"'); // Malformed
+
+      const extensions = loadExtensions();
+
+      expect(extensions).toHaveLength(1);
+      expect(extensions[0].config.name).toBe('good-ext');
+      expect(consoleSpy).toHaveBeenCalledOnce();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Warning: Skipping extension in ${badExtDir}: Failed to load extension config from ${badConfigPath}`,
+        ),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should skip extensions with missing name and log a warning', () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      // Good extension
+      createExtension({
+        extensionsDir: userExtensionsDir,
+        name: 'good-ext',
+        version: '1.0.0',
+      });
+
+      // Bad extension
+      const badExtDir = path.join(userExtensionsDir, 'bad-ext-no-name');
+      fs.mkdirSync(badExtDir);
+      const badConfigPath = path.join(badExtDir, EXTENSIONS_CONFIG_FILENAME);
+      fs.writeFileSync(badConfigPath, JSON.stringify({ version: '1.0.0' }));
+
+      const extensions = loadExtensions();
+
+      expect(extensions).toHaveLength(1);
+      expect(extensions[0].config.name).toBe('good-ext');
+      expect(consoleSpy).toHaveBeenCalledOnce();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Warning: Skipping extension in ${badExtDir}: Failed to load extension config from ${badConfigPath}: Invalid configuration in ${badConfigPath}: missing "name" or "version"`,
+        ),
+      );
+
+      consoleSpy.mockRestore();
+    });
   });
 
   describe('annotateActiveExtensions', () => {
@@ -571,15 +635,44 @@ describe('extension tests', () => {
     it('should throw an error and cleanup if gemini-extension.json is missing', async () => {
       const sourceExtDir = path.join(tempHomeDir, 'bad-extension');
       fs.mkdirSync(sourceExtDir, { recursive: true });
+      const configPath = path.join(sourceExtDir, EXTENSIONS_CONFIG_FILENAME);
+
+      await expect(
+        installExtension({ source: sourceExtDir, type: 'local' }),
+      ).rejects.toThrow(`Configuration file not found at ${configPath}`);
+
+      const targetExtDir = path.join(userExtensionsDir, 'bad-extension');
+      expect(fs.existsSync(targetExtDir)).toBe(false);
+    });
+
+    it('should throw an error for invalid JSON in gemini-extension.json', async () => {
+      const sourceExtDir = path.join(tempHomeDir, 'bad-json-ext');
+      fs.mkdirSync(sourceExtDir, { recursive: true });
+      const configPath = path.join(sourceExtDir, EXTENSIONS_CONFIG_FILENAME);
+      fs.writeFileSync(configPath, '{ "name": "bad-json", "version": "1.0.0"'); // Malformed JSON
 
       await expect(
         installExtension({ source: sourceExtDir, type: 'local' }),
       ).rejects.toThrow(
-        `Invalid extension at ${sourceExtDir}. Please make sure it has a valid gemini-extension.json file.`,
+        new RegExp(`^Failed to load extension config from ${configPath}`),
       );
+    });
 
-      const targetExtDir = path.join(userExtensionsDir, 'bad-extension');
-      expect(fs.existsSync(targetExtDir)).toBe(false);
+    it('should throw an error for missing name in gemini-extension.json', async () => {
+      const sourceExtDir = createExtension({
+        extensionsDir: tempHomeDir,
+        name: 'missing-name-ext',
+        version: '1.0.0',
+      });
+      const configPath = path.join(sourceExtDir, EXTENSIONS_CONFIG_FILENAME);
+      // Overwrite with invalid config
+      fs.writeFileSync(configPath, JSON.stringify({ version: '1.0.0' }));
+
+      await expect(
+        installExtension({ source: sourceExtDir, type: 'local' }),
+      ).rejects.toThrow(
+        `Invalid configuration in ${configPath}: missing "name" or "version"`,
+      );
     });
 
     it('should install an extension from a git URL', async () => {

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -674,7 +674,12 @@ describe('extension tests', () => {
       await expect(
         installExtension({ source: sourceExtDir, type: 'local' }),
       ).rejects.toThrow(
-        new RegExp(`^Failed to load extension config from ${configPath}`),
+        new RegExp(
+          `^Failed to load extension config from ${configPath.replace(
+            /\\/g,
+            '\\\\',
+          )}`,
+        ),
       );
     });
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -211,31 +211,11 @@ export function loadExtension(context: LoadExtensionContext): Extension | null {
     effectiveExtensionPath = installMetadata.source;
   }
 
-  const configFilePath = path.join(
-    effectiveExtensionPath,
-    EXTENSIONS_CONFIG_FILENAME,
-  );
-  if (!fs.existsSync(configFilePath)) {
-    console.error(
-      `Warning: extension directory ${effectiveExtensionPath} does not contain a config file ${configFilePath}.`,
-    );
-    return null;
-  }
-
   try {
-    const configContent = fs.readFileSync(configFilePath, 'utf-8');
-    let config = recursivelyHydrateStrings(JSON.parse(configContent), {
-      extensionPath: extensionDir,
-      workspacePath: workspaceDir,
-      '/': path.sep,
-      pathSeparator: path.sep,
-    }) as unknown as ExtensionConfig;
-    if (!config.name || !config.version) {
-      console.error(
-        `Invalid extension config in ${configFilePath}: missing name or version.`,
-      );
-      return null;
-    }
+    let config = loadExtensionConfig({
+      extensionDir: effectiveExtensionPath,
+      workspaceDir,
+    });
 
     config = resolveEnvVarsInObject(config);
 
@@ -253,7 +233,7 @@ export function loadExtension(context: LoadExtensionContext): Extension | null {
     };
   } catch (e) {
     console.error(
-      `Warning: error parsing extension config in ${configFilePath}: ${getErrorMessage(
+      `Warning: Skipping extension in ${effectiveExtensionPath}: ${getErrorMessage(
         e,
       )}`,
     );
@@ -428,15 +408,10 @@ export async function installExtension(
     }
 
     try {
-      newExtensionConfig = await loadExtensionConfig({
+      newExtensionConfig = loadExtensionConfig({
         extensionDir: localSourcePath,
         workspaceDir: cwd,
       });
-      if (!newExtensionConfig) {
-        throw new Error(
-          `Invalid extension at ${installMetadata.source}. Please make sure it has a valid gemini-extension.json file.`,
-        );
-      }
 
       const newExtensionName = newExtensionConfig.name;
       const extensionStorage = new ExtensionStorage(newExtensionName);
@@ -492,10 +467,14 @@ export async function installExtension(
     // Attempt to load config from the source path even if installation fails
     // to get the name and version for logging.
     if (!newExtensionConfig && localSourcePath) {
-      newExtensionConfig = await loadExtensionConfig({
-        extensionDir: localSourcePath,
-        workspaceDir: cwd,
-      });
+      try {
+        newExtensionConfig = loadExtensionConfig({
+          extensionDir: localSourcePath,
+          workspaceDir: cwd,
+        });
+      } catch {
+        // Ignore error, this is just for logging.
+      }
     }
     logger?.logExtensionInstallEvent(
       new ExtensionInstallEvent(
@@ -545,13 +524,13 @@ async function requestConsent(extensionConfig: ExtensionConfig) {
   }
 }
 
-export async function loadExtensionConfig(
+export function loadExtensionConfig(
   context: LoadExtensionContext,
-): Promise<ExtensionConfig | null> {
+): ExtensionConfig {
   const { extensionDir, workspaceDir } = context;
   const configFilePath = path.join(extensionDir, EXTENSIONS_CONFIG_FILENAME);
   if (!fs.existsSync(configFilePath)) {
-    return null;
+    throw new Error(`Configuration file not found at ${configFilePath}`);
   }
   try {
     const configContent = fs.readFileSync(configFilePath, 'utf-8');
@@ -562,11 +541,17 @@ export async function loadExtensionConfig(
       pathSeparator: path.sep,
     }) as unknown as ExtensionConfig;
     if (!config.name || !config.version) {
-      return null;
+      throw new Error(
+        `Invalid configuration in ${configFilePath}: missing "name" or "version"`,
+      );
     }
     return config;
-  } catch (_) {
-    return null;
+  } catch (e) {
+    throw new Error(
+      `Failed to load extension config from ${configFilePath}: ${getErrorMessage(
+        e,
+      )}`,
+    );
   }
 }
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -557,7 +557,7 @@ export function loadExtensionConfig(
     }) as unknown as ExtensionConfig;
     if (!config.name || !config.version) {
       throw new Error(
-        `Invalid configuration in ${configFilePath}: missing "name" or "version"`,
+        `Invalid configuration in ${configFilePath}: missing ${!config.name ? '"name"' : '"version"'}`,
       );
     }
     return config;


### PR DESCRIPTION
## TLDR
Improves error returns with proper messages.
https://github.com/google-gemini/gemini-cli/issues/8703

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes - https://github.com/google-gemini/gemini-cli/issues/8703