### PR TITLE
feat(deps): automate NOTICES.txt generation and improve license detection

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@google/gemini-cli",
       "version": "0.7.0-nightly.20250918.2722473a",
+      "hasInstallScript": true,
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "typecheck": "npm run typecheck --workspaces --if-present",
     "preflight": "npm run clean && npm ci && npm run format && npm run lint:ci && npm run build && npm run typecheck && npm run test:ci",
     "prepare": "npm run bundle",
+    "postinstall": "npm run generate:notices --workspace=gemini-cli-vscode-ide-companion",
     "prepare:package": "node scripts/prepare-package.js",
     "release:version": "node scripts/version.js",
     "telemetry": "node scripts/telemetry.js",

--- a/packages/vscode-ide-companion/NOTICES.txt
+++ b/packages/vscode-ide-companion/NOTICES.txt
@@ -1760,7 +1760,28 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 cookie-signature@1.0.6
 (https://github.com/visionmedia/node-cookie-signature.git)
 
-License text not found.
+(The MIT License)
+
+Copyright (c) 2012 LearnBoost &lt;tj@learnboost.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ============================================================
 encodeurl@2.0.0

--- a/packages/vscode-ide-companion/scripts/generate-notices.js
+++ b/packages/vscode-ide-companion/scripts/generate-notices.js
@@ -50,6 +50,8 @@ async function getDependencyLicense(depName, depVersion) {
       'LICENSE.md',
       'LICENSE.txt',
       'LICENSE-MIT.txt',
+      'README.md',
+      'Readme.md',
     ].filter(Boolean);
 
     let licenseFile;
@@ -63,7 +65,16 @@ async function getDependencyLicense(depName, depVersion) {
 
     if (licenseFile) {
       try {
-        licenseContent = await fs.readFile(licenseFile, 'utf-8');
+        let fileContent = await fs.readFile(licenseFile, 'utf-8');
+        if (path.basename(licenseFile).toLowerCase().startsWith('readme')) {
+          const licenseSection = fileContent.match(
+            /(#+ license\s*|(?:\(the )?mit license\)?\s*)((?:.|\n)*)/i,
+          );
+          if (licenseSection && licenseSection[2]) {
+            fileContent = licenseSection[2].trim();
+          }
+        }
+        licenseContent = fileContent;
       } catch (e) {
         console.warn(
           `Warning: Failed to read license file for ${depName}: ${e.message}`,

--- a/packages/vscode-ide-companion/scripts/generate-notices.js
+++ b/packages/vscode-ide-companion/scripts/generate-notices.js
@@ -68,7 +68,7 @@ async function getDependencyLicense(depName, depVersion) {
         let fileContent = await fs.readFile(licenseFile, 'utf-8');
         if (path.basename(licenseFile).toLowerCase().startsWith('readme')) {
           const licenseSection = fileContent.match(
-            /(#+ license\s*|(?:\(the )?mit license\)?\s*)((?:.|\n)*)/i,
+            /(#+\s*license\s*|(?:\(the )?mit license\)?\s*)([\s\S]+?)(?=\n#|$)/i,
           );
           if (licenseSection && licenseSection[2]) {
             fileContent = licenseSection[2].trim();


### PR DESCRIPTION
## TLDR

This pull request automates the generation of the `NOTICES.txt` file for the VS Code extension by adding a `postinstall` script. It also enhances the license detection logic to correctly find and parse licenses embedded in `README.md` files, ensuring the notices are always accurate and up-to-date.

## Dive Deeper

Previously, the `NOTICES.txt` file was only generated when explicitly running a script, meaning it could easily become stale as dependencies changed. Additionally, the script failed to find licenses for packages like `cookie-signature` that include their license text within their `README.md` instead of a dedicated `LICENSE` file.

This PR introduces two key improvements:
1.  **Automation:** A `postinstall` script has been added to the root `package.json`. This script triggers the `generate-notices.js` script for the `vscode-ide-companion` package after every `npm install`, guaranteeing the `NOTICES.txt` file reflects the current state of dependencies.
2.  **Smarter License Detection:** The `generate-notices.js` script has been updated to:
    *   Include `README.md` and `Readme.md` in its search for license files.
    *   Intelligently extract only the license portion from `README` files, preventing the entire file's content from being dumped into the `NOTICES.txt` file.

These changes fix the issue for the `cookie-signature` dependency and make the overall process more robust.
