### PR TITLE
fix: Create notification issues for manual release failures

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -80,3 +80,15 @@ jobs:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           dry-run: '${{ github.event.inputs.dry_run }}'
           previous-tag: '${{ steps.release_info.outputs.PREVIOUS_TAG }}'
+
+      - name: 'Create Issue on Failure'
+        if: '${{ failure() && github.event.inputs.dry_run == false }}'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          RELEASE_TAG: '${{ github.event.inputs.version }}'
+          DETAILS_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        run: |
+          gh issue create \
+            --title 'Manual Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')' \
+            --body 'The nightly-manual workflow failed. See the full run for details: ${DETAILS_URL}' \
+            --label 'kind/bug,release-failure,priority/p0'


### PR DESCRIPTION
## TLDR

Notify consistently (via issue and chat) for release failures.

## Dive Deeper

On the one hand we may think that if someone is running this manually, they'll notice it failing on their own; on the other hand, we create issues for patch release failures (which are also triggered somewhat manually), so at least this way we're consistent. Alternatively we could remove the issue creation from the patch workflow and only create the issue for periodic failures.

## Reviewer Test Plan

I wouldn't recommend it

## Testing Matrix

Did not test the change to the issue creation on release failure; in the worst case if it fails, the workflow has already failed. And it IS triggered manually, so we'll notice.

## Linked issues / bugs

Part of #7565