### PR TITLE
fix(cli): Revert the code to hide tips when showing trust dialog

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -754,7 +754,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
   const [showIdeRestartPrompt, setShowIdeRestartPrompt] = useState(false);
 
   const { isFolderTrustDialogOpen, handleFolderTrustSelect, isRestarting } =
-    useFolderTrust(settings, setIsTrustedFolder, refreshStatic);
+    useFolderTrust(settings, setIsTrustedFolder);
   const { needsRestart: ideNeedsRestart } = useIdeTrustListener();
   const isInitialMount = useRef(true);
 

--- a/packages/cli/src/ui/components/AppHeader.tsx
+++ b/packages/cli/src/ui/components/AppHeader.tsx
@@ -18,18 +18,16 @@ interface AppHeaderProps {
 export const AppHeader = ({ version }: AppHeaderProps) => {
   const settings = useSettings();
   const config = useConfig();
-  const { nightly, isFolderTrustDialogOpen } = useUIState();
-  const showTips =
-    !isFolderTrustDialogOpen &&
-    !settings.merged.ui?.hideTips &&
-    !config.getScreenReader();
+  const { nightly } = useUIState();
 
   return (
     <Box flexDirection="column">
       {!(settings.merged.ui?.hideBanner || config.getScreenReader()) && (
         <Header version={version} nightly={nightly} />
       )}
-      {showTips && <Tips config={config} />}
+      {!(settings.merged.ui?.hideTips || config.getScreenReader()) && (
+        <Tips config={config} />
+      )}
     </Box>
   );
 };

--- a/packages/cli/src/ui/hooks/useFolderTrust.test.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.test.ts
@@ -26,7 +26,6 @@ describe('useFolderTrust', () => {
   let loadTrustedFoldersSpy: vi.SpyInstance;
   let isWorkspaceTrustedSpy: vi.SpyInstance;
   let onTrustChange: (isTrusted: boolean | undefined) => void;
-  let refreshStatic: () => void;
 
   beforeEach(() => {
     mockSettings = {
@@ -50,7 +49,6 @@ describe('useFolderTrust', () => {
     isWorkspaceTrustedSpy = vi.spyOn(trustedFolders, 'isWorkspaceTrusted');
     (process.cwd as vi.Mock).mockReturnValue('/test/path');
     onTrustChange = vi.fn();
-    refreshStatic = vi.fn();
   });
 
   afterEach(() => {
@@ -60,7 +58,7 @@ describe('useFolderTrust', () => {
   it('should not open dialog when folder is already trusted', () => {
     isWorkspaceTrustedSpy.mockReturnValue(true);
     const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, onTrustChange, refreshStatic),
+      useFolderTrust(mockSettings, onTrustChange),
     );
     expect(result.current.isFolderTrustDialogOpen).toBe(false);
     expect(onTrustChange).toHaveBeenCalledWith(true);
@@ -69,7 +67,7 @@ describe('useFolderTrust', () => {
   it('should not open dialog when folder is already untrusted', () => {
     isWorkspaceTrustedSpy.mockReturnValue(false);
     const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, onTrustChange, refreshStatic),
+      useFolderTrust(mockSettings, onTrustChange),
     );
     expect(result.current.isFolderTrustDialogOpen).toBe(false);
     expect(onTrustChange).toHaveBeenCalledWith(false);
@@ -78,7 +76,7 @@ describe('useFolderTrust', () => {
   it('should open dialog when folder trust is undefined', () => {
     isWorkspaceTrustedSpy.mockReturnValue(undefined);
     const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, onTrustChange, refreshStatic),
+      useFolderTrust(mockSettings, onTrustChange),
     );
     expect(result.current.isFolderTrustDialogOpen).toBe(true);
     expect(onTrustChange).toHaveBeenCalledWith(undefined);
@@ -89,7 +87,7 @@ describe('useFolderTrust', () => {
       .mockReturnValueOnce(undefined)
       .mockReturnValueOnce(true);
     const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, onTrustChange, refreshStatic),
+      useFolderTrust(mockSettings, onTrustChange),
     );
 
     isWorkspaceTrustedSpy.mockReturnValue(true);
@@ -111,7 +109,7 @@ describe('useFolderTrust', () => {
       .mockReturnValueOnce(undefined)
       .mockReturnValueOnce(true);
     const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, onTrustChange, refreshStatic),
+      useFolderTrust(mockSettings, onTrustChange),
     );
 
     act(() => {
@@ -131,7 +129,7 @@ describe('useFolderTrust', () => {
       .mockReturnValueOnce(undefined)
       .mockReturnValueOnce(false);
     const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, onTrustChange, refreshStatic),
+      useFolderTrust(mockSettings, onTrustChange),
     );
 
     act(() => {
@@ -150,7 +148,7 @@ describe('useFolderTrust', () => {
   it('should do nothing for default choice', () => {
     isWorkspaceTrustedSpy.mockReturnValue(undefined);
     const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, onTrustChange, refreshStatic),
+      useFolderTrust(mockSettings, onTrustChange),
     );
 
     act(() => {
@@ -168,7 +166,7 @@ describe('useFolderTrust', () => {
   it('should set isRestarting to true when trust status changes from false to true', () => {
     isWorkspaceTrustedSpy.mockReturnValueOnce(false).mockReturnValueOnce(true); // Initially untrusted, then trusted
     const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, onTrustChange, refreshStatic),
+      useFolderTrust(mockSettings, onTrustChange),
     );
 
     act(() => {
@@ -184,7 +182,7 @@ describe('useFolderTrust', () => {
       .mockReturnValueOnce(undefined)
       .mockReturnValueOnce(true); // Initially undefined, then trust
     const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, onTrustChange, refreshStatic),
+      useFolderTrust(mockSettings, onTrustChange),
     );
 
     act(() => {
@@ -193,27 +191,5 @@ describe('useFolderTrust', () => {
 
     expect(result.current.isRestarting).toBe(false);
     expect(result.current.isFolderTrustDialogOpen).toBe(false); // Dialog should close
-  });
-
-  it('should call refreshStatic when dialog opens and closes', () => {
-    isWorkspaceTrustedSpy.mockReturnValue(undefined);
-    const { result } = renderHook(() =>
-      useFolderTrust(mockSettings, onTrustChange, refreshStatic),
-    );
-
-    // The hook runs, isFolderTrustDialogOpen becomes true, useEffect triggers.
-    // It's called once on mount, and once when the dialog state changes.
-    expect(refreshStatic).toHaveBeenCalledTimes(2);
-    expect(result.current.isFolderTrustDialogOpen).toBe(true);
-
-    // Now, simulate closing the dialog
-    isWorkspaceTrustedSpy.mockReturnValue(true); // So the state update works
-    act(() => {
-      result.current.handleFolderTrustSelect(FolderTrustChoice.TRUST_FOLDER);
-    });
-
-    // The state isFolderTrustDialogOpen becomes false, useEffect triggers again
-    expect(refreshStatic).toHaveBeenCalledTimes(3);
-    expect(result.current.isFolderTrustDialogOpen).toBe(false);
   });
 });

--- a/packages/cli/src/ui/hooks/useFolderTrust.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.ts
@@ -17,7 +17,6 @@ import * as process from 'node:process';
 export const useFolderTrust = (
   settings: LoadedSettings,
   onTrustChange: (isTrusted: boolean | undefined) => void,
-  refreshStatic: () => void,
 ) => {
   const [isTrusted, setIsTrusted] = useState<boolean | undefined>(undefined);
   const [isFolderTrustDialogOpen, setIsFolderTrustDialogOpen] = useState(false);
@@ -31,12 +30,6 @@ export const useFolderTrust = (
     setIsFolderTrustDialogOpen(trusted === undefined);
     onTrustChange(trusted);
   }, [folderTrust, onTrustChange, settings.merged]);
-
-  useEffect(() => {
-    // When the folder trust dialog is about to open/close, we need to force a refresh
-    // of the static content to ensure the Tips are hidden/shown correctly.
-    refreshStatic();
-  }, [isFolderTrustDialogOpen, refreshStatic]);
 
   const handleFolderTrustSelect = useCallback(
     (choice: FolderTrustChoice) => {


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/gemini-cli/issues/8914
