### PR TITLE
fix(ui): prevent useSlashCompletion effects from running during @ completion

### DIFF
--- a/packages/cli/src/ui/hooks/useSlashCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.test.ts
@@ -807,4 +807,47 @@ describe('useSlashCompletion', () => {
       });
     });
   });
+
+  it('should not call shared callbacks when disabled', () => {
+    const mockSetSuggestions = vi.fn();
+    const mockSetIsLoadingSuggestions = vi.fn();
+    const mockSetIsPerfectMatch = vi.fn();
+
+    const slashCommands = [
+      createTestCommand({
+        name: 'help',
+        description: 'Show help',
+      }),
+    ];
+
+    const { rerender } = renderHook(
+      ({ enabled, query }) =>
+        useSlashCompletion({
+          enabled,
+          query,
+          slashCommands,
+          commandContext: mockCommandContext,
+          setSuggestions: mockSetSuggestions,
+          setIsLoadingSuggestions: mockSetIsLoadingSuggestions,
+          setIsPerfectMatch: mockSetIsPerfectMatch,
+        }),
+      {
+        initialProps: { enabled: false, query: '@src/file' },
+      },
+    );
+
+    // Clear any initial calls
+    mockSetSuggestions.mockClear();
+    mockSetIsLoadingSuggestions.mockClear();
+    mockSetIsPerfectMatch.mockClear();
+
+    // Change query while disabled (simulating @ completion typing)
+    rerender({ enabled: false, query: '@src/file.ts' });
+    rerender({ enabled: false, query: '@src/file.tsx' });
+
+    // Should not have called shared callbacks during @ completion typing
+    expect(mockSetSuggestions).not.toHaveBeenCalled();
+    expect(mockSetIsLoadingSuggestions).not.toHaveBeenCalled();
+    expect(mockSetIsPerfectMatch).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/ui/hooks/useSlashCompletion.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.ts
@@ -485,14 +485,20 @@ export function useSlashCompletion(props: UseSlashCompletionProps): {
   );
   const { isPerfectMatch } = usePerfectMatch(parserResult);
 
-  // Update external state - this is now much simpler and focused
+  // Clear internal state when disabled
   useEffect(() => {
-    if (!enabled || query === null) {
+    if (!enabled) {
       setSuggestions([]);
       setIsLoadingSuggestions(false);
       setIsPerfectMatch(false);
       setCompletionStart(-1);
       setCompletionEnd(-1);
+    }
+  }, [enabled, setSuggestions, setIsLoadingSuggestions, setIsPerfectMatch]);
+
+  // Update external state only when enabled
+  useEffect(() => {
+    if (!enabled || query === null) {
       return;
     }
 


### PR DESCRIPTION
## TLDR

Fixes @ autocompletion flickering introduced by the fuzzy matching commit. The issue was that `useSlashCompletion`'s `useEffect` was running on every query change, even when typing `@` patterns, interfering with `useAtCompletion`'s anti-flicker mechanism.

## Dive Deeper

After https://github.com/google-gemini/gemini-cli/pull/6633 (fuzzy matching for slash commands), @ autocompletion started flickering when typing rapidly. The root cause was that `useSlashCompletion`'s `useEffect` had `query` in its dependency array, causing it to run on every keystroke even when `enabled: false` (during @ completion).

Both completion systems share the same callback functions (`setSuggestions`, `setIsLoadingSuggestions`, `setIsPerfectMatch`). `useAtCompletion` has a 200ms anti-flicker delay, but `useSlashCompletion`'s effect was running during @ completion and calling these shared callbacks, bypassing the anti-flicker logic.

The fix splits the effect into two separate `useEffect` hooks:

1. One that only runs when `enabled` changes (for cleanup)
2. One that only runs when enabled and has all dependencies (for active completion)

This prevents any interference between the two completion systems while maintaining proper React hooks patterns.

## Reviewer Test Plan

1. Type rapidly after `@` symbol (e.g., `@src/file` or `@packages/cli/src/`)
2. Verify that completion suggestions appear smoothly without flickering
3. Compare with typing after `/` to ensure slash completion still works normally
4. Test switching between `/` and `@` completion modes to ensure proper cleanup

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
Fixes #8955