### PR TITLE
fix(cli): support comma separated values for extensions and allowed mcp server names

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -307,6 +307,28 @@ describe('parseArguments', () => {
     const argv = await parseArguments({} as Settings);
     expect(argv.allowedTools).toEqual(['read_file', 'ShellTool(git status)']);
   });
+
+  it('should support comma-separated values for --allowed-mcp-server-names', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--allowed-mcp-server-names',
+      'server1,server2',
+    ];
+    const argv = await parseArguments({} as Settings);
+    expect(argv.allowedMcpServerNames).toEqual(['server1,server2']);
+  });
+
+    it('should support comma-separated values for --extensions', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--extensions',
+      'ext1,ext2',
+    ];
+    const argv = await parseArguments({} as Settings);
+    expect(argv.extensions).toEqual(['ext1,ext2']);
+  });
 });
 
 describe('loadCliConfig', () => {

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -316,13 +316,13 @@ describe('parseArguments', () => {
       'server1,server2',
     ];
     const argv = await parseArguments({} as Settings);
-    expect(argv.allowedMcpServerNames).toEqual(['server1,server2']);
+    expect(argv.allowedMcpServerNames).toEqual(['server1', 'server2']);
   });
 
   it('should support comma-separated values for --extensions', async () => {
     process.argv = ['node', 'script.js', '--extensions', 'ext1,ext2'];
     const argv = await parseArguments({} as Settings);
-    expect(argv.extensions).toEqual(['ext1,ext2']);
+    expect(argv.extensions).toEqual(['ext1', 'ext2']);
   });
 });
 

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -319,13 +319,8 @@ describe('parseArguments', () => {
     expect(argv.allowedMcpServerNames).toEqual(['server1,server2']);
   });
 
-    it('should support comma-separated values for --extensions', async () => {
-    process.argv = [
-      'node',
-      'script.js',
-      '--extensions',
-      'ext1,ext2',
-    ];
+  it('should support comma-separated values for --extensions', async () => {
+    process.argv = ['node', 'script.js', '--extensions', 'ext1,ext2'];
     const argv = await parseArguments({} as Settings);
     expect(argv.extensions).toEqual(['ext1,ext2']);
   });

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -231,7 +231,9 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           description: 'Allowed MCP server names',
           coerce: (mcpServerNames: string[]) =>
             // Handle comma-separated values
-            mcpServerNames.flatMap((mcpServerName) => mcpServerName.split(',').map((m) => m.trim())),
+            mcpServerNames.flatMap((mcpServerName) =>
+              mcpServerName.split(',').map((m) => m.trim()),
+            ),
         })
         .option('allowed-tools', {
           type: 'array',
@@ -249,7 +251,9 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
             'A list of extensions to use. If not provided, all extensions are used.',
           coerce: (extensions: string[]) =>
             // Handle comma-separated values
-            extensions.flatMap((extension) => extension.split(',').map((e) => e.trim())),
+            extensions.flatMap((extension) =>
+              extension.split(',').map((e) => e.trim()),
+            ),
         })
         .option('list-extensions', {
           alias: 'l',

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -229,6 +229,9 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           type: 'array',
           string: true,
           description: 'Allowed MCP server names',
+          coerce: (mcpServers: string[]) =>
+            // Handle comma-separated values
+            mcpServers.flatMap((mcpServer) => mcpServer.split(',').map((m) => m.trim())),
         })
         .option('allowed-tools', {
           type: 'array',
@@ -244,6 +247,9 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           string: true,
           description:
             'A list of extensions to use. If not provided, all extensions are used.',
+          coerce: (extensions: string[]) =>
+            // Handle comma-separated values
+            extensions.flatMap((extension) => extension.split(',').map((e) => e.trim())),
         })
         .option('list-extensions', {
           alias: 'l',

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -229,9 +229,9 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           type: 'array',
           string: true,
           description: 'Allowed MCP server names',
-          coerce: (mcpServers: string[]) =>
+          coerce: (mcpServerNames: string[]) =>
             // Handle comma-separated values
-            mcpServers.flatMap((mcpServer) => mcpServer.split(',').map((m) => m.trim())),
+            mcpServerNames.flatMap((mcpServerName) => mcpServerName.split(',').map((m) => m.trim())),
         })
         .option('allowed-tools', {
           type: 'array',


### PR DESCRIPTION
## TLDR

Support comma-separated lists for extensions and allowed mcp server names in the same way we support allowed tools and directories.

## Dive Deeper

N/A

## Reviewer Test Plan

Provide comma separated lists for --extensions and --allowed-mcp-server-names.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #9008.
