### PR TITLE
fix(chat): add confirmation prompt before deleting conversation check

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -28,7 +28,7 @@ Slash commands provide meta-level control over the CLI itself.
     - **`list`**
       - **Description:** Lists available tags for chat state resumption.
     - **`delete`**
-      - **Description:** Deletes a saved conversation checkpoint.
+      - **Description:** Deletes a saved conversation checkpoint. A confirmation prompt is shown before deletion to prevent accidental data loss.
       - **Usage:** `/chat delete <tag>`
     - **`share`**
       - **Description** Writes the current conversation to a provided Markdown or JSON file.

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -239,13 +239,33 @@ const deleteCommand: SlashCommand = {
   name: 'delete',
   description: 'Delete a conversation checkpoint. Usage: /chat delete <tag>',
   kind: CommandKind.BUILT_IN,
-  action: async (context, args): Promise<MessageActionReturn> => {
+  action: async (context, args): Promise<SlashCommandActionReturn> => {
     const tag = args.trim();
     if (!tag) {
       return {
         type: 'message',
         messageType: 'error',
         content: 'Missing tag. Usage: /chat delete <tag>',
+      };
+    }
+
+    if (!context.overwriteConfirmed) {
+      return {
+        type: 'confirm_action',
+        prompt: React.createElement(
+          Text,
+          null,
+          'Are you sure you want to permanently delete checkpoint ',
+          React.createElement(
+            Text,
+            { color: theme.text.accent },
+            decodeTagName(tag),
+          ),
+          '?',
+        ),
+        originalInvocation: {
+          raw: context.invocation?.raw || `/chat delete ${tag}`,
+        },
       };
     }
 


### PR DESCRIPTION

## TLDR
- Add a confirmation prompt to `/chat delete <tag>` to prevent accidental data loss.
- First invocation now shows a Yes/No confirmation; on Yes, the command re-runs and deletes the checkpoint; on No, it cancels.
- Aligns destructive behavior with existing confirmation patterns used elsewhere in the CLI.

## Dive Deeper
- Implements confirmation via the existing `confirm_action` flow handled in `slashCommandProcessor`, keeping UI consistent and changes minimal.
- The prompt clearly names the checkpoint being deleted and only proceeds when the user confirms.
- Tests updated to cover:
  - Returning `confirm_action` on initial delete call.
  - Proceeding and deleting after a confirmed rerun.
  - Graceful handling when no matching checkpoint exists.
- Documentation for `/chat delete` updated to mention the confirmation step.

Key files:
- chatCommand.ts: Adds confirmation before deletion.
- chatCommand.test.ts: New/updated tests for confirmation and deletion flows.
- commands.md: Notes that deletion prompts for confirmation.

## Reviewer Test Plan
- Pull branch `feat/chat-delete-confirmation`.
- Build and run unit tests:
  - npm:
    ```bash
    npm ci
    npm run test
    npm run build
    ```
- Manual verification:
  - Start the CLI and run `/chat save test-del`
  - Run `/chat delete test-del`
    - Verify confirmation prompt appears.
    - Choose “No” → operation is cancelled, checkpoint remains.
    - Run `/chat delete test-del` again and choose “Yes” → checkpoint is deleted.
    - Run `/chat delete test-del` again → error indicating no checkpoint found.
- Edge cases:
  - Attempt to delete a non-existent tag → error message without prompting after the confirmed rerun.
  - Tab-complete with `/chat delete t<Tab>` and verify prompt still protects against accidental delete.

## Testing Matrix
|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ✅  | ✅  |
| npx      | ✅  | ✅  | ✅  |
| Docker   | ✅  | ✅  | ✅  |
| Podman   | ✅  | -   | -   |
| Seatbelt | ✅  | -   | -   |

Notes:
- Confirm dialog works the same across environments due to shared UI flow.
- If using sandboxing (Docker/Podman/Seatbelt), no additional configuration needed for this change.

## Linked issues / bugs
- Closes #9018 (Add a confirmation step to `/chat delete` to prevent accidental deletion)
