### PR TITLE
fix(cli, core): enhance tool exclusion logic to respect explicitly al…

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1013,7 +1013,17 @@ export class Config {
         (tool) => tool === toolName || tool === normalizedClassName,
       );
 
-      if (isExcluded) {
+      // NEW: Check if tool is explicitly allowed via --allowed-tools
+      const isExplicitlyAllowed = this.getAllowedTools()?.some(
+        (allowedTool) =>
+          // Handle both exact matches and pattern matches like "ShellTool(wc)"
+          allowedTool === toolName ||
+          allowedTool === normalizedClassName ||
+          allowedTool.startsWith(`${toolName}(`) ||
+          allowedTool.startsWith(`${normalizedClassName}(`),
+      );
+
+      if (isExcluded && !isExplicitlyAllowed) {
         isEnabled = false;
       }
 


### PR DESCRIPTION
…lowed tools via --allowed-tools

## TLDR

This PR attempts to fix the issue where the --allowed-tools flag wasn't properly overriding tool exclusion logic. Previously, tools specified in --allowed-tools would still be blocked if they were in the exclude list, making the flag ineffective. The fix ensures that explicitly allowed tools bypass exclusion rules, providing users with the expected granular control over tool availability.

## Dive Deeper

The issue stemmed from the tool exclusion logic not considering the --allowed-tools parameter when determining which tools to exclude. The system had multiple layers of tool exclusion:

1. Settings-based exclusions (settings.tools.exclude)
2. Extension-based exclusions (extension.config.excludeTools)
3. Non-interactive mode exclusions (automatically excluding tools like ShellTool, EditTool, WriteFileTool in non-interactive mode)
4. Policy engine exclusions (handled separately in the policy engine)

The --allowed-tools flag was designed to bypass confirmation dialogs, but it wasn't integrated with the exclusion logic. This meant that even if a user explicitly allowed a tool via --allowed-tools, it would still be excluded by other mechanisms.

Impact of the changes made : 
- Users can now effectively use --allowed-tools to override any exclusion rules
- Non-interactive mode can now selectively allow specific tools while keeping others excluded
- The fix maintains backward compatibility and doesn't affect existing exclusion behavior for non-allowed tools

**Current Implementation Limitation :**
This PR includes a hardcoded mapping for `ShellTool` → `run_shell_command` which is specific to this use case. We need a systematic way to map tool class names to their actual tool call names across all tools. The current approach solves the immediate problem for the given use case only.

**Future Work Needed : **
We need to create a mapping system for all tool class names to tool call names if one does not exist already. I've tried looking for finding a logic in the existing codebase but couldn't. It would be very helpful if you could guide me as to how to approach this problem and implement a fix. Thank you!

## Reviewer Test Plan

Test Basic Functionality : 

1. `gemini --allowed-tools "ShellTool(ls)" --prompt "list files in current directory"`
2. `gemini --allowed-tools "ShellTool(git)" -p "what is the git status?"`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅ | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This PR makes progress on #9011 
