### PR TITLE
docs: fix links in headless.md after relocation from docs/cli

### DIFF
--- a/docs/headless.md
+++ b/docs/headless.md
@@ -244,7 +244,7 @@ Key command-line options for headless usage:
 | `--yolo`, `-y`          | Auto-approve all actions           | `gemini -p "query" --yolo`                         |
 | `--approval-mode`       | Set approval mode                  | `gemini -p "query" --approval-mode auto_edit`      |
 
-For complete details on all available configuration options, settings files, and environment variables, see the [Configuration Guide](./configuration.md).
+For complete details on all available configuration options, settings files, and environment variables, see the [Configuration Guide](./cli/configuration.md).
 
 ## Examples
 
@@ -317,7 +317,7 @@ tail -5 usage.log
 
 ## Resources
 
-- [CLI Configuration](./configuration.md) - Complete configuration guide
-- [Authentication](./authentication.md) - Setup authentication
-- [Commands](./commands.md) - Interactive commands reference
-- [Tutorials](./tutorials.md) - Step-by-step automation guides
+- [CLI Configuration](./cli/configuration.md) - Complete configuration guide
+- [Authentication](./cli/authentication.md) - Setup authentication
+- [Commands](./cli/commands.md) - Interactive commands reference
+- [Tutorials](./cli/tutorials.md) - Step-by-step automation guides


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

#8593 moved headless.md from `docs/cli` into `docs/` but did not update the references inside. This PR updates the links to reflect the relocation.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

fixes #9053
