### PR TITLE
fix(telemetry): disable OTLP when telemetry-outfile is set

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -51,15 +51,15 @@ observability framework — Gemini CLI's observability system provides:
 All telemetry behavior is controlled through your `.gemini/settings.json` file
 and can be overridden with CLI flags:
 
-| Setting        | Values            | Default                 | CLI Override                                             | Description                                          |
-| -------------- | ----------------- | ----------------------- | -------------------------------------------------------- | ---------------------------------------------------- |
-| `enabled`      | `true`/`false`    | `false`                 | `--telemetry` / `--no-telemetry`                         | Enable or disable telemetry                          |
-| `target`       | `"gcp"`/`"local"` | `"local"`               | `--telemetry-target <local\|gcp>`                        | Where to send telemetry data                         |
-| `otlpEndpoint` | URL string        | `http://localhost:4317` | `--telemetry-otlp-endpoint <URL>`                        | OTLP collector endpoint                              |
-| `otlpProtocol` | `"grpc"`/`"http"` | `"grpc"`                | `--telemetry-otlp-protocol <grpc\|http>`                 | OTLP transport protocol                              |
-| `outfile`      | file path         | -                       | `--telemetry-outfile <path>`                             | Save telemetry to file (requires `otlpEndpoint: ""`) |
-| `logPrompts`   | `true`/`false`    | `true`                  | `--telemetry-log-prompts` / `--no-telemetry-log-prompts` | Include prompts in telemetry logs                    |
-| `useCollector` | `true`/`false`    | `false`                 | -                                                        | Use external OTLP collector (advanced)               |
+| Setting        | Values            | Default                 | CLI Override                                             | Description                                       |
+| -------------- | ----------------- | ----------------------- | -------------------------------------------------------- | ------------------------------------------------- |
+| `enabled`      | `true`/`false`    | `false`                 | `--telemetry` / `--no-telemetry`                         | Enable or disable telemetry                       |
+| `target`       | `"gcp"`/`"local"` | `"local"`               | `--telemetry-target <local\|gcp>`                        | Where to send telemetry data                      |
+| `otlpEndpoint` | URL string        | `http://localhost:4317` | `--telemetry-otlp-endpoint <URL>`                        | OTLP collector endpoint                           |
+| `otlpProtocol` | `"grpc"`/`"http"` | `"grpc"`                | `--telemetry-otlp-protocol <grpc\|http>`                 | OTLP transport protocol                           |
+| `outfile`      | file path         | -                       | `--telemetry-outfile <path>`                             | Save telemetry to file (overrides `otlpEndpoint`) |
+| `logPrompts`   | `true`/`false`    | `true`                  | `--telemetry-log-prompts` / `--no-telemetry-log-prompts` | Include prompts in telemetry logs                 |
+| `useCollector` | `true`/`false`    | `false`                 | -                                                        | Use external OTLP collector (advanced)            |
 
 For detailed information about all configuration options, see the
 [Configuration Guide](./cli/configuration.md).

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -21,6 +21,9 @@ import {
 } from './gcp-exporters.js';
 import { TelemetryTarget } from './index.js';
 
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 vi.mock('@opentelemetry/exporter-trace-otlp-grpc');
 vi.mock('@opentelemetry/exporter-logs-otlp-grpc');
 vi.mock('@opentelemetry/exporter-metrics-otlp-grpc');
@@ -217,5 +220,20 @@ describe('Telemetry SDK', () => {
         delete process.env['GOOGLE_CLOUD_PROJECT'];
       }
     }
+  });
+
+  it('should not use OTLP exporters when telemetryOutfile is set', () => {
+    vi.spyOn(mockConfig, 'getTelemetryOutfile').mockReturnValue(
+      path.join(os.tmpdir(), 'test.log'),
+    );
+    initializeTelemetry(mockConfig);
+
+    expect(OTLPTraceExporter).not.toHaveBeenCalled();
+    expect(OTLPLogExporter).not.toHaveBeenCalled();
+    expect(OTLPMetricExporter).not.toHaveBeenCalled();
+    expect(OTLPTraceExporterHttp).not.toHaveBeenCalled();
+    expect(OTLPLogExporterHttp).not.toHaveBeenCalled();
+    expect(OTLPMetricExporterHttp).not.toHaveBeenCalled();
+    expect(NodeSDK.prototype.start).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -95,8 +95,8 @@ export function initializeTelemetry(config: Config): void {
   const telemetryTarget = config.getTelemetryTarget();
   const useCollector = config.getTelemetryUseCollector();
   const parsedEndpoint = parseOtlpEndpoint(otlpEndpoint, otlpProtocol);
-  const useOtlp = !!parsedEndpoint;
   const telemetryOutfile = config.getTelemetryOutfile();
+  const useOtlp = !!parsedEndpoint && !telemetryOutfile;
 
   const gcpProjectId =
     process.env['OTLP_GOOGLE_CLOUD_PROJECT'] ||


### PR DESCRIPTION
When `--telemetry-outfile` is used, the CLI still attempts to connect to the default OTLP endpoint (localhost:4317), leading to connection errors. This is because the `useOtlp` flag is set to true if `getTelemetryOtlpEndpoint()` returns a default value, even if file export is intended.

This commit fixes the logic in packages/core/src/telemetry/sdk.ts to explicitly disable OTLP export when `--telemetry-outfile` is provided.

Fixes #5063

Co-authored with @bobcatfish 