### PR TITLE
Store installed release version as a part of install metadata

### DIFF
--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -594,6 +594,9 @@ export function toOutputString(extension: Extension): string {
     if (extension.installMetadata.ref) {
       output += `\n Ref: ${extension.installMetadata.ref}`;
     }
+    if (extension.installMetadata.releaseTag) {
+      output += `\n Release tag: ${extension.installMetadata.releaseTag}`;
+    }
   }
   if (extension.contextFiles.length > 0) {
     output += `\n Context files:`;

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -406,8 +406,8 @@ export async function installExtension(
           installMetadata,
           tempDir,
         );
-        updateExtensionVersion(tempDir, tagName);
         installMetadata.type = 'github-release';
+        installMetadata.releaseTag = tagName;
       } catch (_error) {
         await cloneFromGit(installMetadata, tempDir);
         installMetadata.type = 'git';
@@ -503,21 +503,6 @@ export async function installExtension(
   }
 }
 
-async function updateExtensionVersion(
-  extensionDir: string,
-  extensionVersion: string,
-) {
-  const configFilePath = path.join(extensionDir, EXTENSIONS_CONFIG_FILENAME);
-  if (fs.existsSync(configFilePath)) {
-    const configContent = await fs.promises.readFile(configFilePath, 'utf-8');
-    const config = JSON.parse(configContent);
-    config.version = extensionVersion;
-    await fs.promises.writeFile(
-      configFilePath,
-      JSON.stringify(config, null, 2),
-    );
-  }
-}
 async function requestConsent(extensionConfig: ExtensionConfig) {
   const mcpServerEntries = Object.entries(extensionConfig.mcpServers || {});
   if (mcpServerEntries.length) {

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -191,7 +191,7 @@ export async function checkForExtensionUpdate(
       setExtensionUpdateState(ExtensionUpdateState.UPDATE_AVAILABLE);
       return;
     } else {
-      const { source, ref } = installMetadata;
+      const { source, releaseTag } = installMetadata;
       if (!source) {
         console.error(`No "source" provided for extension.`);
         setExtensionUpdateState(ExtensionUpdateState.ERROR);
@@ -204,7 +204,7 @@ export async function checkForExtensionUpdate(
         repo,
         installMetadata.ref,
       );
-      if (releaseData.tag_name !== ref) {
+      if (releaseData.tag_name !== releaseTag) {
         setExtensionUpdateState(ExtensionUpdateState.UPDATE_AVAILABLE);
         return;
       }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -124,6 +124,7 @@ export interface GeminiCLIExtension {
 export interface ExtensionInstallMetadata {
   source: string;
   type: 'git' | 'local' | 'link' | 'github-release';
+  releaseTag?: string; // Only present for github-release installs.
   ref?: string;
   autoUpdate?: boolean;
 }


### PR DESCRIPTION
## TLDR

When installing via a GitHub release we now store the tag that was installed on the metadata and use that to compare against when checking for updates.

## Dive Deeper

Previously this tag was being stored, but it was actually overwriting the version number on the primary extension metadata. This resulted in `extensions list` showing the _tag_ instead of the version as advertised by the extension, and we also were not actually using that version number when checking for updates.

This change makes `extensions list` show the actual version number as defined by the extension, fixes the update check, and avoids us overwriting files that are actually a part of the git repo we are cloning.

## Reviewer Test Plan

Install any extension that has GitHub releases, and then do `/extensions list` from within the Gemini CLI. You should see it say "up to date" and not "update available" after this change (unless of course you push a release). 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #9115
