### PR TITLE
feat(infra)- Extract change tags into an action

### DIFF
--- a/.github/actions/change-tags/action.yml
+++ b/.github/actions/change-tags/action.yml
@@ -17,8 +17,9 @@ inputs:
   token-cli:
     description: 'NPM token for cli package.'
     required: true
+
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: 'Setup Node.js'
       uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
@@ -44,4 +45,5 @@ runs:
     - name: 'Log dry run'
       if: inputs.dry-run == 'true'
       shell: bash
-      run: echo "Dry run: Would have added tag '${{ inputs.channel }}' to version '${{ inputs.version }}' for @google/gemini-cli and @google/gemini-cli-core."
+      run: |
+        echo "Dry run: Would have added tag '${{ inputs.channel }}' to version '${{ inputs.version }}' for @google/gemini-cli and @google/gemini-cli-core."

--- a/.github/actions/change-tags/action.yml
+++ b/.github/actions/change-tags/action.yml
@@ -1,0 +1,47 @@
+name: 'Change npm dist-tag'
+description: 'Changes the npm dist-tag for CLI packages.'
+inputs:
+  version:
+    description: 'The package version to tag.'
+    required: true
+  channel:
+    description: 'The npm dist-tag to apply.'
+    required: true
+  dry-run:
+    description: 'Whether to run in dry-run mode.'
+    required: false
+    default: 'true'
+  token-core:
+    description: 'NPM token for core package.'
+    required: true
+  token-cli:
+    description: 'NPM token for cli package.'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: 'Setup Node.js'
+      uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
+      with:
+        node-version-file: '.nvmrc'
+        registry-url: 'https://wombat-dressing-room.appspot.com'
+        scope: '@google'
+
+    - name: 'Change tag for @google/gemini-cli-core'
+      if: inputs.dry-run == 'false'
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.token-core }}
+      run: npm dist-tag add @google/gemini-cli-core@${{ inputs.version }} ${{ inputs.channel }}
+
+    - name: 'Change tag for @google/gemini-cli'
+      if: inputs.dry-run == 'false'
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.token-cli }}
+      run: npm dist-tag add @google/gemini-cli@${{ inputs.version }} ${{ inputs.channel }}
+
+    - name: 'Log dry run'
+      if: inputs.dry-run == 'true'
+      shell: bash
+      run: echo "Dry run: Would have added tag '${{ inputs.channel }}' to version '${{ inputs.version }}' for @google/gemini-cli and @google/gemini-cli-core."

--- a/.github/workflows/release-change-tags.yml
+++ b/.github/workflows/release-change-tags.yml
@@ -36,34 +36,13 @@ jobs:
       - name: 'Checkout repository'
         uses: 'actions/checkout@v4'
         with:
-          ref: '${{ github.event.inputs.ref }}'
-          fetch-depth: 0
+          ref: '${{ inputs.ref }}'
 
-      - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
+      - name: 'Change Tags'
+        uses: ./.github/actions/change-tags
         with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://wombat-dressing-room.appspot.com'
-          scope: '@google'
-
-      - name: 'Change tag for @google/gemini-cli-core'
-        if: |-
-          ${{ github.event.inputs.dry-run == 'false' }}
-        env:
-          NODE_AUTH_TOKEN: '${{ secrets.WOMBAT_TOKEN_CORE }}'
-        run: |
-          npm dist-tag add @google/gemini-cli-core@${{ github.event.inputs.version }} ${{ github.event.inputs.channel }}
-
-      - name: 'Change tag for @google/gemini-cli'
-        if: |-
-          ${{ github.event.inputs.dry-run == 'false' }}
-        env:
-          NODE_AUTH_TOKEN: '${{ secrets.WOMBAT_TOKEN_CLI }}'
-        run: |
-          npm dist-tag add @google/gemini-cli@${{ github.event.inputs.version }} ${{ github.event.inputs.channel }}
-
-      - name: 'Log dry run'
-        if: |-
-          ${{ github.event.inputs.dry-run == 'true' }}
-        run: |
-          echo "Dry run: Would have added tag '${{ github.event.inputs.channel }}' to version '${{ github.event.inputs.version }}' for @google/gemini-cli and @google/gemini-cli-core."
+          version: ${{ inputs.version }}
+          channel: ${{ inputs.channel }}
+          dry-run: ${{ inputs.dry-run }}
+          token-core: ${{ secrets.WOMBAT_TOKEN_CORE }}
+          token-cli: ${{ secrets.WOMBAT_TOKEN_CLI }}


### PR DESCRIPTION
## TLDR

Make change release tag an action to use later in rollback workflow

## Dive Deeper


## Reviewer Test Plan

Dry run results: https://github.com/google-gemini/gemini-cli/actions/runs/17926846253

I ran `gh workflow run release-change-tags.yml --ref ss/changeTags -f version=0.0.0-test -f channel=preview -f dry-run=true`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Makes progress on #9057 
