### PR TITLE
Fix: Only log message bus debug info when feature is enabled

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1031,7 +1031,7 @@ export class Config {
         // This first implementation is only focused on the general case of
         // the tool registry.
         const messageBusEnabled = this.getEnableMessageBusIntegration();
-        if (this.debugMode) {
+        if (this.debugMode && messageBusEnabled) {
           console.log(
             `[DEBUG] enableMessageBusIntegration setting: ${messageBusEnabled}`,
           );
@@ -1039,7 +1039,7 @@ export class Config {
         const toolArgs = messageBusEnabled
           ? [...args, this.getMessageBus()]
           : args;
-        if (this.debugMode) {
+        if (this.debugMode && messageBusEnabled) {
           console.log(
             `[DEBUG] Registering ${className} with messageBus: ${messageBusEnabled ? 'YES' : 'NO'}`,
           );


### PR DESCRIPTION
## Summary
- Fixed console logging in message bus integration to only output debug messages when `enableMessageBusIntegration` flag is true
- Prevents unnecessary console output when the message bus feature is disabled

## Changes
- Modified `config.ts` to check both `debugMode` and `messageBusEnabled` before logging message bus debug information
- Affected logs:
  - "enableMessageBusIntegration setting" message
  - "Registering [ToolName] with messageBus" messages

## Test Plan
- When `enableMessageBusIntegration` is false: No message bus debug logs appear
- When `enableMessageBusIntegration` is true and `debugMode` is true: Message bus debug logs appear as expected