### PR TITLE
quote archive names before extraction

### DIFF
--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -404,7 +404,7 @@ async function downloadFile(url: string, dest: string): Promise<void> {
 function extractFile(file: string, dest: string) {
   const safeFile = quote([file]);
   const safeDest = quote([dest]);
-  if (safeFile.endsWith('.tar.gz')) {
+  if (file.endsWith('.tar.gz')) {
     execSync(`tar -xzf ${safeFile} -C ${safeDest}`);
   } else if (file.endsWith('.zip')) {
     execSync(`unzip ${safeFile} -d ${safeDest}`);

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -17,6 +17,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import { loadExtension } from '../extension.js';
+import { quote } from 'shell-quote';
 
 function getGitHubToken(): string | undefined {
   return process.env['GITHUB_TOKEN'];
@@ -401,10 +402,12 @@ async function downloadFile(url: string, dest: string): Promise<void> {
 }
 
 function extractFile(file: string, dest: string) {
-  if (file.endsWith('.tar.gz')) {
-    execSync(`tar -xzf ${file} -C ${dest}`);
+  const safeFile = quote([file]);
+  const safeDest = quote([dest]);
+  if (safeFile.endsWith('.tar.gz')) {
+    execSync(`tar -xzf ${safeFile} -C ${safeDest}`);
   } else if (file.endsWith('.zip')) {
-    execSync(`unzip ${file} -d ${dest}`);
+    execSync(`unzip ${safeFile} -d ${safeDest}`);
   } else {
     throw new Error(`Unsupported file extension for extraction: ${file}`);
   }


### PR DESCRIPTION
## TLDR

Use shell-quote to quote the file/destination prior to passing them to tools, which will allow for things like spaces in file names as well as preventing certain types of attacks.

## Dive Deeper

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs


