### PR TITLE
fix(cli): Handle formatting errors in trustedFolders.json similar to settings file

### DIFF
--- a/packages/cli/src/config/trustedFolders.ts
+++ b/packages/cli/src/config/trustedFolders.ts
@@ -208,7 +208,7 @@ function getWorkspaceTrustFromLocalConfig(
       (error) => `Error in ${error.path}: ${error.message}`,
     );
     throw new FatalConfigError(
-      `${errorMessages.join('\n')}\nPlease fix the configuration file(s) and try again.`,
+      `${errorMessages.join('\n')}\nPlease fix the configuration file and try again.`,
     );
   }
 

--- a/packages/cli/src/config/trustedFolders.ts
+++ b/packages/cli/src/config/trustedFolders.ts
@@ -8,6 +8,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { homedir } from 'node:os';
 import {
+  FatalConfigError,
   getErrorMessage,
   isWithinRoot,
   ideContextStore,
@@ -114,9 +115,23 @@ export class LoadedTrustedFolders {
   }
 }
 
+let loadedTrustedFolders: LoadedTrustedFolders | undefined;
+
+/**
+ * FOR TESTING PURPOSES ONLY.
+ * Resets the in-memory cache of the trusted folders configuration.
+ */
+export function resetTrustedFoldersForTesting(): void {
+  loadedTrustedFolders = undefined;
+}
+
 export function loadTrustedFolders(): LoadedTrustedFolders {
+  if (loadedTrustedFolders) {
+    return loadedTrustedFolders;
+  }
+
   const errors: TrustedFoldersError[] = [];
-  const userConfig: Record<string, TrustLevel> = {};
+  let userConfig: Record<string, TrustLevel> = {};
 
   const userPath = getTrustedFoldersPath();
 
@@ -124,12 +139,19 @@ export function loadTrustedFolders(): LoadedTrustedFolders {
   try {
     if (fs.existsSync(userPath)) {
       const content = fs.readFileSync(userPath, 'utf-8');
-      const parsed = JSON.parse(stripJsonComments(content)) as Record<
-        string,
-        TrustLevel
-      >;
-      if (parsed) {
-        Object.assign(userConfig, parsed);
+      const parsed: unknown = JSON.parse(stripJsonComments(content));
+
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        errors.push({
+          message: 'Trusted folders file is not a valid JSON object.',
+          path: userPath,
+        });
+      } else {
+        userConfig = parsed as Record<string, TrustLevel>;
       }
     }
   } catch (error: unknown) {
@@ -139,10 +161,11 @@ export function loadTrustedFolders(): LoadedTrustedFolders {
     });
   }
 
-  return new LoadedTrustedFolders(
+  loadedTrustedFolders = new LoadedTrustedFolders(
     { path: userPath, config: userConfig },
     errors,
   );
+  return loadedTrustedFolders;
 }
 
 export function saveTrustedFolders(
@@ -181,11 +204,12 @@ function getWorkspaceTrustFromLocalConfig(
   }
 
   if (folders.errors.length > 0) {
-    for (const error of folders.errors) {
-      console.error(
-        `Error loading trusted folders config from ${error.path}: ${error.message}`,
-      );
-    }
+    const errorMessages = folders.errors.map(
+      (error) => `Error in ${error.path}: ${error.message}`,
+    );
+    throw new FatalConfigError(
+      `${errorMessages.join('\n')}\nPlease fix the configuration file(s) and try again.`,
+    );
   }
 
   const isTrusted = folders.isPathTrusted(process.cwd());


### PR DESCRIPTION
Added a Fatal error on first read that should happen during launch.

Subsequently, if the user introduces new errors, they will be ignored if trust level modifications happen which will rewrite the file. This is similar to how settings update works.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/805
