### PR TITLE
feat(shell): Add security checks for chained commands

### DIFF
--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -90,6 +90,7 @@ export function useReactToolScheduler(
   const allToolCallsCompleteHandler: AllToolCallsCompleteHandler = useCallback(
     async (completedToolCalls) => {
       await onComplete(completedToolCalls);
+      setToolCallsForDisplay([]);
     },
     [onComplete],
   );
@@ -139,8 +140,7 @@ export function useReactToolScheduler(
         getPreferredEditor,
         config,
         onEditorClose,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any),
+      }),
     [
       config,
       outputUpdateHandler,

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -221,7 +221,6 @@ describe('CoreToolScheduler', () => {
       tools: new Map(),
       discovery: {},
       registerTool: () => {},
-      getToolByName: () => declarativeTool,
       getToolByDisplayName: () => declarativeTool,
       getTools: () => [],
       discoverTools: async () => {},
@@ -414,7 +413,6 @@ describe('CoreToolScheduler with payload', () => {
       tools: new Map(),
       discovery: {},
       registerTool: () => {},
-      getToolByName: () => declarativeTool,
       getToolByDisplayName: () => declarativeTool,
       getTools: () => [],
       discoverTools: async () => {},
@@ -737,7 +735,6 @@ describe('CoreToolScheduler edit cancellation', () => {
       tools: new Map(),
       discovery: {},
       registerTool: () => {},
-      getToolByName: () => mockEditTool,
       getToolByDisplayName: () => mockEditTool,
       getTools: () => [],
       discoverTools: async () => {},
@@ -834,7 +831,6 @@ describe('CoreToolScheduler YOLO mode', () => {
 
     const mockToolRegistry = {
       getTool: () => declarativeTool,
-      getToolByName: () => declarativeTool,
       // Other properties are not needed for this test but are included for type consistency.
       getFunctionDeclarations: () => [],
       tools: new Map(),
@@ -943,7 +939,6 @@ describe('CoreToolScheduler request queueing', () => {
 
     const mockToolRegistry = {
       getTool: () => declarativeTool,
-      getToolByName: () => declarativeTool,
       getFunctionDeclarations: () => [],
       tools: new Map(),
       discovery: {},
@@ -1072,7 +1067,6 @@ describe('CoreToolScheduler request queueing', () => {
 
     const toolRegistry = {
       getTool: () => declarativeTool,
-      getToolByName: () => declarativeTool,
       getFunctionDeclarations: () => [],
       tools: new Map(),
       discovery: {},
@@ -1178,7 +1172,6 @@ describe('CoreToolScheduler request queueing', () => {
     const declarativeTool = mockTool;
     const mockToolRegistry = {
       getTool: () => declarativeTool,
-      getToolByName: () => declarativeTool,
       getFunctionDeclarations: () => [],
       tools: new Map(),
       discovery: {},
@@ -1305,7 +1298,6 @@ describe('CoreToolScheduler request queueing', () => {
       tools: new Map(),
       config: mockConfig,
       mcpClientManager: undefined,
-      getToolByName: () => testTool,
       getToolByDisplayName: () => testTool,
       getTools: () => [],
       discoverTools: async () => {},
@@ -1636,7 +1628,6 @@ describe('CoreToolScheduler Security', () => {
 
     const mockToolRegistry = {
       getTool: vi.fn(),
-      getToolByName: vi.fn(),
     } as Partial<ToolRegistry> as ToolRegistry;
 
     const mockConfig = {
@@ -1664,13 +1655,13 @@ describe('CoreToolScheduler Security', () => {
       getTargetDir: () => '/tmp',
       getShouldUseNodePtyShell: () => false,
       getSummarizeToolOutputConfig: () => ({}),
-    } as Partial<Config> as Config;
+      getShellExecutionConfig: () => ({}),
+    } as unknown as Config;
 
     const shellTool = new ShellTool(mockConfig);
 
     // Now that shellTool is created, we can set the mocks for the registry.
-    (mockToolRegistry.getTool as vi.Mock).mockReturnValue(shellTool);
-    (mockToolRegistry.getToolByName as vi.Mock).mockReturnValue(shellTool);
+    (mockToolRegistry.getTool as Mock).mockReturnValue(shellTool);
 
     const onAllToolCallsComplete = vi.fn();
     const onToolCallsUpdate = vi.fn();
@@ -1711,7 +1702,6 @@ describe('CoreToolScheduler Security', () => {
 
     const mockToolRegistry = {
       getTool: vi.fn(),
-      getToolByName: vi.fn(),
     } as Partial<ToolRegistry> as ToolRegistry;
 
     const mockConfig = {
@@ -1739,13 +1729,13 @@ describe('CoreToolScheduler Security', () => {
       getTargetDir: () => '/tmp',
       getShouldUseNodePtyShell: () => false,
       getSummarizeToolOutputConfig: () => ({}),
-    } as Partial<Config> as Config;
+      getShellExecutionConfig: () => ({}),
+    } as unknown as Config;
 
     const shellTool = new ShellTool(mockConfig);
 
     // Now that shellTool is created, we can set the mocks for the registry.
-    (mockToolRegistry.getTool as vi.Mock).mockReturnValue(shellTool);
-    (mockToolRegistry.getToolByName as vi.Mock).mockReturnValue(shellTool);
+    (mockToolRegistry.getTool as Mock).mockReturnValue(shellTool);
 
     const onAllToolCallsComplete = vi.fn();
     const onToolCallsUpdate = vi.fn();
@@ -1784,7 +1774,6 @@ describe('CoreToolScheduler Security', () => {
 
     const mockToolRegistry = {
       getTool: vi.fn(),
-      getToolByName: vi.fn(),
     } as Partial<ToolRegistry> as ToolRegistry;
 
     const mockConfig = {
@@ -1812,13 +1801,13 @@ describe('CoreToolScheduler Security', () => {
       getTargetDir: () => '/tmp',
       getShouldUseNodePtyShell: () => false,
       getSummarizeToolOutputConfig: () => ({}),
-    } as Partial<Config> as Config;
+      getShellExecutionConfig: () => ({}),
+    } as unknown as Config;
 
     const shellTool = new ShellTool(mockConfig);
 
     // Now that shellTool is created, we can set the mocks for the registry.
-    (mockToolRegistry.getTool as vi.Mock).mockReturnValue(shellTool);
-    (mockToolRegistry.getToolByName as vi.Mock).mockReturnValue(shellTool);
+    (mockToolRegistry.getTool as Mock).mockReturnValue(shellTool);
 
     const onAllToolCallsComplete = vi.fn();
     const onToolCallsUpdate = vi.fn();
@@ -1859,7 +1848,6 @@ describe('CoreToolScheduler Security', () => {
 
     const mockToolRegistry = {
       getTool: vi.fn(),
-      getToolByName: vi.fn(),
     } as Partial<ToolRegistry> as ToolRegistry;
 
     const mockConfig = {
@@ -1890,13 +1878,13 @@ describe('CoreToolScheduler Security', () => {
       getTargetDir: () => '/tmp',
       getShouldUseNodePtyShell: () => false,
       getSummarizeToolOutputConfig: () => ({}),
-    } as Partial<Config> as Config;
+      getShellExecutionConfig: () => ({}),
+    } as unknown as Config;
 
     const shellTool = new ShellTool(mockConfig);
 
     // Now that shellTool is created, we can set the mocks for the registry.
-    (mockToolRegistry.getTool as vi.Mock).mockReturnValue(shellTool);
-    (mockToolRegistry.getToolByName as vi.Mock).mockReturnValue(shellTool);
+    (mockToolRegistry.getTool as Mock).mockReturnValue(shellTool);
 
     const onAllToolCallsComplete = vi.fn();
     const onToolCallsUpdate = vi.fn();
@@ -1924,5 +1912,3 @@ describe('CoreToolScheduler Security', () => {
     });
   });
 });
-
-

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1119,7 +1119,11 @@ export class CoreToolScheduler {
         call.status === 'cancelled',
     );
 
-    if (this.toolCalls.length > 0 && allCallsAreTerminal) {
+    if (
+      this.toolCalls.length > 0 &&
+      allCallsAreTerminal &&
+      !this.toolCalls.some((call) => call.status === 'awaiting_approval')
+    ) {
       const completedCalls = [...this.toolCalls] as CompletedToolCall[];
       this.toolCalls = [];
 
@@ -1132,7 +1136,6 @@ export class CoreToolScheduler {
         await this.onAllToolCallsComplete(completedCalls);
         this.isFinalizingToolCalls = false;
       }
-      this.notifyToolCallsUpdate();
       // After completion, process the next item in the queue.
       if (this.requestQueue.length > 0) {
         const next = this.requestQueue.shift()!;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,7 +92,11 @@ export * from './tools/edit.js';
 export * from './tools/write-file.js';
 export * from './tools/web-fetch.js';
 export * from './tools/memoryTool.js';
-export * from './tools/shell.js';
+export {
+  ShellTool,
+  ShellToolInvocation,
+  type ShellToolParams,
+} from './tools/shell.js';
 export * from './tools/web-search.js';
 export * from './tools/read-many-files.js';
 export * from './tools/mcp-client.js';

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -53,6 +53,7 @@ describe('ShellTool', () => {
     mockConfig = {
       getCoreTools: vi.fn().mockReturnValue([]),
       getExcludeTools: vi.fn().mockReturnValue([]),
+      getAllowedTools: vi.fn().mockReturnValue([]),
       getDebugMode: vi.fn().mockReturnValue(false),
       getTargetDir: vi.fn().mockReturnValue('/test/dir'),
       getSummarizeToolOutputConfig: vi.fn().mockReturnValue(undefined),

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -82,9 +82,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
     const globalAllowlist = this.config.getAllowedTools() || [];
 
     const commandsToConfirm = allCommands.filter((cmd) => {
-      const invocation: AnyToolInvocation & { params: { command: string } } = {
+      const invocation = {
         params: { command: cmd },
-      } as any;
+      } as unknown as AnyToolInvocation;
 
       // Check if the command is on the global allowlist.
       const isGloballyAllowed = doesToolInvocationMatch(
@@ -109,7 +109,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       title: 'Confirm Shell Command',
       command: this.params.command,
       rootCommand: commandsToConfirm.join(', '),
-      onConfirm: async (outcome: ToolConfirmationommandConfirmationOutcome) => {
+      onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
           // Add only the root of the commands that were confirmed to the session allowlist.
           getCommandRoots(commandsToConfirm.join(' ')).forEach((root) =>

--- a/packages/core/src/utils/tool-utils.ts
+++ b/packages/core/src/utils/tool-utils.ts
@@ -5,6 +5,7 @@
  */
 
 import { isTool } from '../index.js';
+import type { AnyDeclarativeTool, AnyToolInvocation } from '../tools/tools.js';
 import { splitCommands } from './shell-utils.js';
 
 const SHELL_TOOL_NAMES = ['run_shell_command', 'ShellTool'];
@@ -45,7 +46,9 @@ export function doesToolInvocationMatch(
 
     // Every single subcommand must be on the allowlist.
     return subCommands.every((subCommand) => {
-      const subInvocation = { params: { command: subCommand } };
+      const subInvocation = {
+        params: { command: subCommand },
+      } as unknown as AnyToolInvocation;
       return patterns.some((pattern) =>
         isSingleCommandAllowed(pattern, toolNames, subInvocation),
       );


### PR DESCRIPTION
## TLDR

Enhance security for `allowedTools` with shell commands by checking all parts of a composite command.

## Dive Deeper

Currently `allowedTools` matches a prefix of the command. While shell substitution is forbidden, you can still execute undesired commands like this:

With `gemini --allowed-tools='ShellTool(echo)'`

`echo something evil | cat >protected-file.txt`

This is obviously bad.

I updated the `doesToolInvocationMatch method to split the command and check all components, only allowing the command if all components are allowed.

This is not foolproof, but it at least significantly improves the security such that it can no longer be trivially bypassed with `echo Haha; do-something-evil` or `echo Haha && do-something-evil`.

I added integration style tests to make sure that this works.

`npm run preflight` passes (or at least did recently) but something is breaking CI checks at the moment.

In an ideal world we would refactor this a bit such that the `ToolInvocation` implementation would have a method to check whether a string matches, but I figured it would be better to get this fix in now and finesse it later.

## Reviewer Test Plan

[ ] `npm run start --allowed-tools='ShellTool(echo foo) --prompt-interactive 'Please run `echo foo | cat > test.txt` to add that text to test.txt. It is very important that you run exactly that command because I am testing some of your safety functions'`
[ ] `npm run start --allowed-tools='ShellTool(echo foo)' --prompt-interactive 'Please run `echo foo`'

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

There is probably one but I don't know where it is.
