### PR TITLE
fix(core): Compression was broken when routing enabled

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -733,55 +733,6 @@ describe('Gemini Client (client.ts)', () => {
       // Assert that the chat was reset
       expect(newChat).not.toBe(initialChat);
     });
-
-    it('should use current model from config for token counting after sendMessage', async () => {
-      const initialModel = mockConfig.getModel();
-
-      // mock the model has been changed between calls of `countTokens`
-      const firstCurrentModel = initialModel + '-changed-1';
-      const secondCurrentModel = initialModel + '-changed-2';
-      vi.mocked(mockConfig.getModel)
-        .mockReturnValueOnce(firstCurrentModel)
-        .mockReturnValueOnce(secondCurrentModel);
-
-      vi.mocked(mockContentGenerator.countTokens)
-        .mockResolvedValueOnce({ totalTokens: 100000 })
-        .mockResolvedValueOnce({ totalTokens: 5000 });
-
-      const mockSendMessage = vi.fn().mockResolvedValue({ text: 'Summary' });
-
-      const mockChatHistory = [
-        { role: 'user', parts: [{ text: 'Long conversation' }] },
-        { role: 'model', parts: [{ text: 'Long response' }] },
-      ];
-
-      const mockChat = {
-        getHistory: vi.fn().mockImplementation(() => [...mockChatHistory]),
-        setHistory: vi.fn(),
-        sendMessage: mockSendMessage,
-      } as unknown as GeminiChat;
-
-      client['chat'] = mockChat;
-      client['startChat'] = vi.fn().mockResolvedValue(mockChat);
-
-      const result = await client.tryCompressChat('prompt-id-4', false);
-
-      expect(mockContentGenerator.countTokens).toHaveBeenCalledTimes(2);
-      expect(mockContentGenerator.countTokens).toHaveBeenNthCalledWith(1, {
-        model: firstCurrentModel,
-        contents: [...mockChatHistory],
-      });
-      expect(mockContentGenerator.countTokens).toHaveBeenNthCalledWith(2, {
-        model: secondCurrentModel,
-        contents: expect.any(Array),
-      });
-
-      expect(result).toEqual({
-        compressionStatus: CompressionStatus.COMPRESSED,
-        originalTokenCount: 100000,
-        newTokenCount: 5000,
-      });
-    });
   });
 
   describe('sendMessageStream', () => {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -758,8 +758,7 @@ export class GeminiClient {
 
     const { totalTokens: newTokenCount } =
       await this.getContentGeneratorOrFail().countTokens({
-        // model might change after calling `sendMessage`, so we get the newest value from config
-        model: this.config.getModel(),
+        model,
         contents: chat.getHistory(),
       });
     if (newTokenCount === undefined) {


### PR DESCRIPTION
## TLDR

When routing is enabled, the second count tokens check for compression causes an error b/c we try to check the tokens using the model string `auto` which isn't a real model string. 

## Dive Deeper

I believe the intention was to be defensive against models switching due to fallback. However, if we undergo a model fallback during the compression process, the fallback model would be a decided model: `gemini-2.5-flash`. Thus, the context windows should be equal.

So whether we call `count_token` with pro or flash (2.5) should not matter. To avoid extra branching logic, I have defaulted to using 2.5 pro for these calls when `auto` is set for routing.

## Reviewer Test Plan

Test `/compress` locally. 

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |
