### PR TITLE
dont attempt to look up releases on github for non-github git uris

### DIFF
--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -306,6 +306,13 @@ describe('git extension helpers', () => {
       );
     });
 
+    it('should fail on a non-GitHub URL', () => {
+      const source = 'https://example.com/owner/repo.git';
+      expect(() => parseGitHubRepoForReleases(source)).toThrow(
+        'Invalid GitHub repository source: https://example.com/owner/repo.git. Expected "owner/repo" or a github repo uri.',
+      );
+    });
+
     it('should parse owner and repo from a shorthand string', () => {
       const source = 'owner/repo';
       const { owner, repo } = parseGitHubRepoForReleases(source);

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -87,7 +87,7 @@ export function parseGitHubRepoForReleases(source: string): {
   const parsedUrl = URL.parse(source, 'https://github.com');
   // The pathname should be "/owner/repo".
   const parts = parsedUrl?.pathname.substring(1).split('/');
-  if (parts?.length !== 2) {
+  if (parts?.length !== 2 || parsedUrl?.host !== 'github.com') {
     throw new Error(
       `Invalid GitHub repository source: ${source}. Expected "owner/repo" or a github repo uri.`,
     );


### PR DESCRIPTION
## TLDR

If the git URI is not a GitHub one, bail early from the `parseGitHubRepoForReleases` function. This should only return successfully for GitHub URIs.

## Dive Deeper

## Reviewer Test Plan

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
