### PR TITLE
fix(routing): Round latency to integer for telemetry

### DIFF
--- a/packages/core/src/routing/strategies/compositeStrategy.ts
+++ b/packages/core/src/routing/strategies/compositeStrategy.ts
@@ -92,7 +92,9 @@ export class CompositeStrategy implements TerminalStrategy {
     startTime: number,
   ): RoutingDecision {
     const endTime = performance.now();
-    const totalLatency = endTime - startTime;
+    // Round to the nearest millisecond to ensure we send an integer to
+    // telemetry.
+    const totalLatency = Math.round(endTime - startTime);
 
     // Combine the source paths: composite_name/child_source (e.g. 'router/default')
     const compositeSource = `${this.name}/${decision.metadata.source}`;

--- a/packages/core/src/routing/strategies/compositeStrategy.ts
+++ b/packages/core/src/routing/strategies/compositeStrategy.ts
@@ -92,19 +92,18 @@ export class CompositeStrategy implements TerminalStrategy {
     startTime: number,
   ): RoutingDecision {
     const endTime = performance.now();
-    // Round to the nearest millisecond to ensure we send an integer to
-    // telemetry.
-    const totalLatency = Math.round(endTime - startTime);
-
-    // Combine the source paths: composite_name/child_source (e.g. 'router/default')
     const compositeSource = `${this.name}/${decision.metadata.source}`;
+
+    // Use the child's latency if it's a meaningful (non-zero) value,
+    // otherwise use the total time spent in the composite strategy.
+    const latency = decision.metadata.latencyMs || endTime - startTime;
 
     return {
       ...decision,
       metadata: {
         ...decision.metadata,
         source: compositeSource,
-        latencyMs: decision.metadata.latencyMs || totalLatency,
+        latencyMs: Math.round(latency), // Round to ensure int for telemetry.
       },
     };
   }


### PR DESCRIPTION
## TLDR

This change fixes a warning that primarily occurs on Linux systems: `INT value type cannot accept a floating-point value for gemini_cli.model_routing.latency`.

The `CompositeStrategy` uses `performance.now()` to calculate routing latency, which can return a high-precision floating-point number (e.g., `15.234`). Our telemetry backend expects an integer for this value. This PR rounds the calculated latency to the nearest whole number using `Math.round()`, resolving the type mismatch.

A comment has also been added to explain why rounding is necessary, preventing accidental removal in the future.

## Dive Deeper

- **Why `performance.now()`?**: This is the correct, idiomatic API for measuring latency in JavaScript/TypeScript. Unlike `Date.now()`, it provides a high-resolution, monotonic clock, which is essential for accurate and reliable duration measurements that are immune to system time changes.

- **Solution**: By applying `Math.round()`, we ensure the value sent to telemetry is always an integer, regardless of the underlying OS's timer precision. This is the most statistically neutral way to handle the conversion, as it avoids the bias that would be introduced by always rounding up (`Math.ceil`) or down (`Math.floor`).

## Reviewer Test Plan

The validation for this change is straightforward:

1.  **Code Review**: The change is a single line and is logically simple. Verify that `Math.round()` is correctly applied to the latency calculation in `packages/core/src/routing/strategies/compositeStrategy.ts`.
2.  **CI/Preflight Checks**: The most important validation is that all existing tests and checks pass, which they do. This ensures the change has not introduced any regressions.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅| -   | -   |
