### PR TITLE
Fix broken icon on force_skip_tests option in "Release: Manual"

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -44,11 +44,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: '📝 Print Inputs'
-      shell: 'bash'
-      run: |
-        echo "${{ toJSON(inputs) }}"
-
     - name: '👤 Configure Git User'
       working-directory: '${{ inputs.working-directory }}'
       shell: 'bash'

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -2,11 +2,6 @@ name: 'Run Tests'
 description: 'Runs the preflight checks and integration tests.'
 
 inputs:
-  force_skip_tests:
-    description: 'Whether to force skip the tests.'
-    required: false
-    type: 'string'
-    default: 'false'
   gemini_api_key:
     description: 'The API key for running integration tests.'
     required: true
@@ -19,7 +14,6 @@ runs:
   using: 'composite'
   steps:
     - name: 'Run Tests'
-      if: "${{ inputs.force_skip_tests != 'true' }}"
       env:
         GEMINI_API_KEY: '${{ inputs.gemini_api_key }}'
       working-directory: '${{ inputs.working-directory }}'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -71,9 +71,9 @@ jobs:
           echo "PREVIOUS_TAG=$(git describe --tags --abbrev=0)" >> "${GITHUB_OUTPUT}"
 
       - name: 'Run Tests'
+        if: "${{github.event.inputs.force_skip_tests != 'true'}}"
         uses: './.github/actions/run-tests'
         with:
-          force_skip_tests: '${{ github.event.inputs.force_skip_tests }}'
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
 
       - name: 'Publish Release'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -46,9 +46,9 @@ jobs:
         run: 'npm ci'
 
       - name: 'Run Tests'
+        if: "${{github.event.inputs.force_skip_tests != 'true'}}"
         uses: './.github/actions/run-tests'
         with:
-          force_skip_tests: '${{ github.event.inputs.force_skip_tests }}'
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
 
       - name: 'Get Nightly Version'

--- a/.github/workflows/release-patch-3-release.yml
+++ b/.github/workflows/release-patch-3-release.yml
@@ -144,9 +144,9 @@ jobs:
           echo "  Previous Tag: ${{ steps.patch_version.outputs.PREVIOUS_TAG }}"
 
       - name: 'Run Tests'
+        if: "${{github.event.inputs.force_skip_tests != 'true'}}"
         uses: './.github/actions/run-tests'
         with:
-          force_skip_tests: '${{ github.event.inputs.force_skip_tests }}'
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           working-directory: './release'
 

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -141,9 +141,9 @@ jobs:
         run: 'npm ci'
 
       - name: 'Run Tests'
+        if: "${{github.event.inputs.force_skip_tests != 'true'}}"
         uses: './.github/actions/run-tests'
         with:
-          force_skip_tests: '${{ github.event.inputs.force_skip_tests }}'
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           working-directory: './release'
 


### PR DESCRIPTION
## TLDR

Fixes it so that the icon for `Run Tests` properly shows when it is skipped.
<img width="604" height="370" alt="ARuyqAKUa33xGhp" src="https://github.com/user-attachments/assets/a7410d2b-f5a0-4456-a6f0-9ae915a8e573" />

## Dive Deeper

Currently we skip the only step in the "Run Tests" Action so the icon always shows it running. Instead, we should skip the entire action so it's clear in the UI that the tests were not run.

## Reviewer Test Plan

Run the actions in dry run mode.

Release: manual
* skip test = true: https://github.com/google-gemini/gemini-cli/actions/runs/17960594418/job/51082803716
* skip tests= false: https://github.com/google-gemini/gemini-cli/actions/runs/17960496364/job/51082517750

Release: nightly
* skip test = true: https://github.com/google-gemini/gemini-cli/actions/runs/17960594418/job/51082803716
* skip tests= false: https://github.com/google-gemini/gemini-cli/actions/runs/17960590083/job/51082792390

Release patch (3) release
* skip test = true: https://github.com/google-gemini/gemini-cli/actions/runs/17960687426/job/51083084821
* skip tests= false: https://github.com/google-gemini/gemini-cli/actions/runs/17960663218/job/51083010998

Release: Promote
* skip test = true: https://github.com/google-gemini/gemini-cli/actions/runs/17960712990/job/51083205296
* skip tests= false: https://github.com/google-gemini/gemini-cli/actions/runs/17960703204/job/51083172242

## Linked issues / bugs

For #9200