### PR TITLE
remove extraction of the first dir into the top level for github release extensions

### DIFF
--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -273,24 +273,6 @@ export async function downloadFromGitHubRelease(
 
     extractFile(downloadedAssetPath, destination);
 
-    const files = await fs.promises.readdir(destination);
-    const extractedDirName = files.find((file) => {
-      const filePath = path.join(destination, file);
-      return fs.statSync(filePath).isDirectory();
-    });
-
-    if (extractedDirName) {
-      const extractedDirPath = path.join(destination, extractedDirName);
-      const extractedDirFiles = await fs.promises.readdir(extractedDirPath);
-      for (const file of extractedDirFiles) {
-        await fs.promises.rename(
-          path.join(extractedDirPath, file),
-          path.join(destination, file),
-        );
-      }
-      await fs.promises.rmdir(extractedDirPath);
-    }
-
     await fs.promises.unlink(downloadedAssetPath);
     return {
       tagName: releaseData.tag_name,


### PR DESCRIPTION
## TLDR

Previously when downloading a release archive, we would look for the first directory and move all its files into the top level directory.

This PR just removes that functionality entirely, it is not documented and the reason for the behavior is not clear. Release archives should match exactly a standard gemini extension layout.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

After this, installing the flutter extension (https://github.com/flutter/gemini-cli-extension) should work. Prior to this, all commands in the `/commands` dir would get moved to the top level.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #9239
