### PR TITLE
feat(cli): Enable model router by default and add to settings dialog

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1485,7 +1485,7 @@ describe('loadCliConfig model selection', () => {
       argv,
     );
 
-    expect(config.getModel()).toBe('gemini-2.5-pro');
+    expect(config.getModel()).toBe(DEFAULT_GEMINI_MODEL_AUTO);
   });
 
   it('always prefers model from argvs', async () => {
@@ -1803,7 +1803,7 @@ describe('loadCliConfig useRipgrep', () => {
       const argv = await parseArguments({} as Settings);
       const settings: Settings = {};
       const config = await loadCliConfig(settings, [], 'test-session', argv);
-      expect(config.getUseModelRouter()).toBe(false);
+      expect(config.getUseModelRouter()).toBe(true);
     });
 
     it('should be true when useModelRouter is set to true in settings', async () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -587,7 +587,7 @@ export async function loadCliConfig(
     );
   }
 
-  const useModelRouter = settings.experimental?.useModelRouter ?? false;
+  const useModelRouter = settings.experimental?.useModelRouter ?? true;
   const defaultModel = useModelRouter
     ? DEFAULT_GEMINI_MODEL_AUTO
     : DEFAULT_GEMINI_MODEL;

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -328,7 +328,7 @@ describe('SettingsSchema', () => {
       ).toBe('Experimental');
       expect(
         getSettingsSchema().experimental.properties.useModelRouter.default,
-      ).toBe(false);
+      ).toBe(true);
     });
   });
 });

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -986,10 +986,10 @@ const SETTINGS_SCHEMA = {
         label: 'Use Model Router',
         category: 'Experimental',
         requiresRestart: true,
-        default: false,
+        default: true,
         description:
           'Enable model routing to route requests to the best model based on complexity.',
-        showInDialog: false,
+        showInDialog: true,
       },
     },
   },

--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -342,7 +342,7 @@ describe('SettingsDialog', () => {
 
       await wait();
 
-      expect(lastFrame()).toContain('● Folder Trust');
+      expect(lastFrame()).toContain('● Use Model Router');
 
       unmount();
     });


### PR DESCRIPTION
## TLDR

This PR enables the Model Router feature by default and adds a toggle for it within the `/settings` dialog. This improves user experience by making it easier for users to opt-out of model routing without needing to manually edit their `settings.json` file.

Key changes for reviewers:
- `packages/cli/src/config/settingsSchema.ts`: The `default` for `useModelRouter` is now `true` and `showInDialog` is set to `true`.
- `packages/cli/src/config/config.ts`: The hardcoded fallback for `useModelRouter` has been updated to `true` to ensure backward compatibility for users without this setting in their config.
- Associated tests in `settingsSchema.test.ts`, `config.test.ts`, and `SettingsDialog.test.tsx` have been updated to reflect the new default behavior.

Ex of Setting:

<img width="799" height="625" alt="Screenshot 2025-09-23 at 3 56 09 PM" src="https://github.com/user-attachments/assets/2d05fcc8-9d4d-43f7-b17f-f4e629eff91d" />

## Dive Deeper

As we move towards making model routing the default behavior, we need to provide users with a straightforward way to disable it if they choose. While a user can force a specific model for a single session with the `/model` command, this preference doesn't persist.

Previously, the only way to permanently disable model routing was to manually find and edit the `settings.json` file, which creates unnecessary friction. By exposing the "Use Model Router" setting in the main settings dialog, we empower users to easily control this feature, improving the overall usability of the CLI.

## Reviewer Test Plan

1.  Pull down this branch and run `npm run preflight` to ensure all checks pass.
2.  Start the Gemini CLI (`npm start`).
3.  Open the settings dialog by running the `/settings` command.
4.  **Verify:** The "Use Model Router" setting is now visible in the "Experimental" category and is enabled (`true`) by default.
5.  Navigate to the setting, toggle it **off** (`false`), and exit the dialog.
6.  Re-open the settings dialog and confirm the setting has persisted as `false`.
7.  Check your user `settings.json` file (`~/.gemini/settings.json`) and verify that `experimental.useModelRouter` is now set to `false`.
8.  Manually remove the entire `experimental` object from your `settings.json` file and save it.
9.  Restart the CLI and open `/settings` again.
10. **Verify:** The "Use Model Router" setting has correctly defaulted back to `true`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt  |✅| -   |

## Linked issues / bugs

This PR makes progress on #6079
