### PR TITLE
support standard github release archives format

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "request": "launch",
       "name": "Build & Launch CLI",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "build-and-start", "extensions", "install", "https://github.com/jakemac53/test-gemini-cli-extension"],
+      "runtimeArgs": ["run", "build-and-start"],
       "skipFiles": ["<node_internals>/**"],
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "request": "launch",
       "name": "Build & Launch CLI",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "build-and-start"],
+      "runtimeArgs": ["run", "build-and-start", "extensions", "install", "https://github.com/jakemac53/test-gemini-cli-extension"],
       "skipFiles": ["<node_internals>/**"],
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -16,7 +16,7 @@ import * as https from 'node:https';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
-import { loadExtension } from '../extension.js';
+import { EXTENSIONS_CONFIG_FILENAME, loadExtension } from '../extension.js';
 import { quote } from 'shell-quote';
 
 function getGitHubToken(): string | undefined {
@@ -275,14 +275,20 @@ export async function downloadFromGitHubRelease(
 
     // For regular github releases, the repository is put inside of a top level
     // directory. In this case we should see exactly two file in the destination
-    // dir, the archive and the directory. If we see that, we move all files
+    // dir, the archive and the directory. If we see that, validate that the
+    // dir has a gemini extension configuration file and then move all files
     // from the directory up one level into the destination directory.
     const entries = await fs.promises.readdir(destination, {
       withFileTypes: true,
     });
     if (entries.length === 2) {
       const lonelyDir = entries.find((entry) => entry.isDirectory());
-      if (lonelyDir) {
+      if (
+        lonelyDir &&
+        fs.existsSync(
+          path.join(destination, lonelyDir.name, EXTENSIONS_CONFIG_FILENAME),
+        )
+      ) {
         const dirPathToExtract = path.join(destination, lonelyDir.name);
         const extractedDirFiles = await fs.promises.readdir(dirPathToExtract);
         for (const file of extractedDirFiles) {

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -277,13 +277,13 @@ export async function downloadFromGitHubRelease(
     // directory. In this case we should see exactly two file in the destination
     // dir, the archive and the directory. If we see that, we move all files
     // from the directory up one level into the destination directory.
-    const files = await fs.promises.readdir(destination);
-    if (files.length === 2) {
-      const lonelyDirName = files.find((file) =>
-        fs.statSync(path.join(destination, file)).isDirectory(),
-      );
-      if (lonelyDirName) {
-        const dirPathToExtract = path.join(destination, lonelyDirName);
+    const entries = await fs.promises.readdir(destination, {
+      withFileTypes: true,
+    });
+    if (entries.length === 2) {
+      const lonelyDir = entries.find((entry) => entry.isDirectory());
+      if (lonelyDir) {
+        const dirPathToExtract = path.join(destination, lonelyDir.name);
         const extractedDirFiles = await fs.promises.readdir(dirPathToExtract);
         for (const file of extractedDirFiles) {
           await fs.promises.rename(


### PR DESCRIPTION
## TLDR

Standard GitHub release archives always have a directory inside them, and then the contents of the repo under that. We need to make sure to actually move those contents up one directory.

This was broken by https://github.com/google-gemini/gemini-cli/pull/9247, I have also now documented why this code exists.

## Dive Deeper

## Reviewer Test Plan

Install an extension using normal GitHub releases with no custom archives attached.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to #9239
