### PR TITLE
test(integration): Add `"Ctrl + C"` to exit integration test

### DIFF
--- a/integration-tests/ctrl-c-exit.test.ts
+++ b/integration-tests/ctrl-c-exit.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TestRig } from './test-helper.js';
+
+describe('Ctrl+C exit', () => {
+  it('should exit gracefully on second Ctrl+C', async () => {
+    const rig = new TestRig();
+    await rig.setup('should exit gracefully on second Ctrl+C');
+
+    // This test needs to run with a TTY to properly handle Ctrl+C
+    if (process.env['CI']) {
+      console.warn('Skipping Ctrl+C test in CI due to TTY limitations.');
+      return;
+    }
+
+    const { ptyProcess, promise } = rig.runInteractive();
+
+    let output = '';
+    ptyProcess.onData((data) => {
+      output += data;
+    });
+
+    // Wait for the app to be ready by looking for the initial prompt indicator
+    await rig.poll(() => output.includes('▶'), 5000, 100);
+
+    // Send first Ctrl+C
+    ptyProcess.write('\x03');
+
+    // Wait for the exit prompt
+    await rig.poll(
+      () => output.includes('Press Ctrl+C again to exit'),
+      1500,
+      50,
+    );
+
+    // Send second Ctrl+C
+    ptyProcess.write('\x03');
+
+    const result = await promise;
+
+    // Expect a graceful exit (code 0)
+    expect(
+      result.exitCode,
+      `Process exited with code ${result.exitCode}. Output: ${result.output}`,
+    ).toBe(0);
+
+    // Check that the quitting message is displayed
+    const quittingMessage = 'Agent powering down. Goodbye!';
+    // The regex below is intentionally matching the ESC control character (\x1b)
+    // to strip ANSI color codes from the terminal output.
+    // eslint-disable-next-line no-control-regex
+    const cleanOutput = output.replace(/\x1b\[[0-9;]*m/g, '');
+    expect(cleanOutput).toContain(quittingMessage);
+  });
+});

--- a/integration-tests/ctrl-c-exit.test.ts
+++ b/integration-tests/ctrl-c-exit.test.ts
@@ -12,12 +12,6 @@ describe('Ctrl+C exit', () => {
     const rig = new TestRig();
     await rig.setup('should exit gracefully on second Ctrl+C');
 
-    // This test needs to run with a TTY to properly handle Ctrl+C
-    if (process.env['CI']) {
-      console.warn('Skipping Ctrl+C test in CI due to TTY limitations.');
-      return;
-    }
-
     const { ptyProcess, promise } = rig.runInteractive();
 
     let output = '';

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -707,7 +707,7 @@ export class TestRig {
 
     for (const jsonStr of jsonObjects) {
       try {
-        const logData = JSON.Parse(jsonStr);
+        const logData = JSON.parse(jsonStr);
         if (
           logData.attributes &&
           logData.attributes['event.name'] === 'gemini_cli.api_request'

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -10,6 +10,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { env } from 'node:process';
 import fs from 'node:fs';
+import * as pty from '@lydell/node-pty';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -706,7 +707,7 @@ export class TestRig {
 
     for (const jsonStr of jsonObjects) {
       try {
-        const logData = JSON.parse(jsonStr);
+        const logData = JSON.Parse(jsonStr);
         if (
           logData.attributes &&
           logData.attributes['event.name'] === 'gemini_cli.api_request'
@@ -718,5 +719,40 @@ export class TestRig {
       }
     }
     return lastApiRequest;
+  }
+
+  runInteractive(...args: string[]): {
+    ptyProcess: pty.IPty;
+    promise: Promise<{ exitCode: number; signal?: number; output: string }>;
+  } {
+    const commandArgs = [this.bundlePath, '--yolo', ...args];
+
+    const ptyProcess = pty.spawn('node', commandArgs, {
+      name: 'xterm-color',
+      cols: 80,
+      rows: 30,
+      cwd: this.testDir!,
+      env: process.env as { [key: string]: string },
+    });
+
+    let output = '';
+    ptyProcess.onData((data) => {
+      output += data;
+      if (env.KEEP_OUTPUT === 'true' || env.VERBOSE === 'true') {
+        process.stdout.write(data);
+      }
+    });
+
+    const promise = new Promise<{
+      exitCode: number;
+      signal?: number;
+      output: string;
+    }>((resolve) => {
+      ptyProcess.onExit(({ exitCode, signal }) => {
+        resolve({ exitCode, signal, output });
+      });
+    });
+
+    return { ptyProcess, promise };
   }
 }


### PR DESCRIPTION
## TLDR

Adds a new integration test to verify that the Gemini CLI exits gracefully when a user presses `"Ctrl + C"` twice. The test simulates a user's actions in a pseudo-terminal to capture the application's behavior.

## Dive Deeper

The primary concern for this this test is simulating an interactive terminal capable of handling control signals like `"Ctrl + C"`. 

This change adds a `runInteractive` method to the `TestRig` class in `integration-tests/test-helper.ts`. This method uses `@lydell/node-pty` to create a pseudo-terminal for testing interactive features.

The new test file, `integration-tests/ctrl-c-exit.test.ts`, performs the following:
1.  Spawns the CLI process within a pseudo-terminal.
2.  Waits for the application to initialize.
3.  Sends the first `Ctrl+C` signal and asserts that the "Press Ctrl+C again to exit" prompt is displayed.
4.  Sends the second `Ctrl+C` signal and confirms that the application exits gracefully with the correct message.

## Reviewer Test Plan

To validate the changes, please follow these steps:

1.  Pull this branch.
2.  Run `npm install` to ensure all dependencies are correctly installed.
3.  Execute the integration test suite with the following command:
    ```bash
    npm run test:integration:sandbox:none
    ```
4.  Confirm that the new test, `ctrl-c-exit.test.ts`, passes along with the rest of the test suite. No manual testing is required as the automated test fully covers the intended functionality.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

#9127
