### PR TITLE
Add log groups to run tests

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -18,8 +18,16 @@ runs:
         GEMINI_API_KEY: '${{ inputs.gemini_api_key }}'
       working-directory: '${{ inputs.working-directory }}'
       run: |-
+        echo "::group::Build"
         npm run build
+        echo "::endgroup::"
+        echo "::group::Unit Tests"
         npm run test:ci
+        echo "::endgroup::"
+        echo "::group::Integration Tests (no sandbox)"
         npm run test:integration:sandbox:none
+        echo "::endgroup::"
+        echo "::group::Integration Tests (docker sandbox)"
         npm run test:integration:sandbox:docker
+        echo "::endgroup::"
       shell: 'bash'


### PR DESCRIPTION
## TLDR

Add log groups to run tests action. 
<img width="741" height="573" alt="7tJUzHr7dNjHQhW" src="https://github.com/user-attachments/assets/47555973-946e-425e-9ff8-7369f13d1934" />

## Reviewer Test Plan

Run the "Release: Manual" workflow and verify the logs are grouped.

## Linked issues / bugs

Fixes #9200