### PR TITLE
Fix missing exports that were causing the build to fail locally.

### DIFF
--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -12,13 +12,13 @@ import {
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_MODEL_AUTO,
+  ModelSlashCommandEvent,
+  logModelSlashCommand,
 } from '@google/gemini-cli-core';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { theme } from '../semantic-colors.js';
 import { DescriptiveRadioButtonSelect } from './shared/DescriptiveRadioButtonSelect.js';
 import { ConfigContext } from '../contexts/ConfigContext.js';
-import { ModelSlashCommandEvent } from '@google/gemini-cli-core/src/telemetry/types.js';
-import { logModelSlashCommand } from '@google/gemini-cli-core/src/telemetry/loggers.js';
 
 interface ModelDialogProps {
   onClose: () => void;

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -37,7 +37,9 @@ export {
   ExtensionDisableEvent,
   ExtensionEnableEvent,
   ExtensionUninstallEvent,
+  ModelSlashCommandEvent,
 } from './src/telemetry/types.js';
 export { makeFakeConfig } from './src/test-utils/config.js';
 export * from './src/utils/pathReader.js';
 export { ClearcutLogger } from './src/telemetry/clearcut-logger/clearcut-logger.js';
+export { logModelSlashCommand } from './src/telemetry/loggers.js';


### PR DESCRIPTION
## TLDR

Unclear why this was only breaking locally for me.

## Dive Deeper

We were importing un-exported members from core. This caused the following error on my local machine
```
Checking build status...                                                                                                  │
 │    Build is up-to-date.                                                                                                      │
 │    npm warn Unknown user config "always-auth" (//us-west1-npm.pkg.dev/gemini-code-dev/gemini-code/:always-auth). This will   │
 │    stop working in the next major version of npm.                                                                            │
 │    node:internal/modules/esm/resolve:274                                                                                     │
 │        throw new ERR_MODULE_NOT_FOUND(                                                                                       │
 │              ^                                                                                                               │
 │                                                                                                                              │
 │    Error [ERR_MODULE_NOT_FOUND]: Cannot find module                                                                          │
 │    '/Users/jacobr/git/gemini-cli-10/node_modules/@google/gemini-cli-core/src/telemetry/types.js' imported from               │
 │    /Users/jacobr/git/gemini-cli-10/packages/cli/dist/src/ui/components/ModelDialog.js                                        │
 │        at finalizeResolution (node:internal/modules/esm/resolve:274:11)                                                      │
 │        at moduleResolve (node:internal/modules/esm/resolve:864:10)                                                           │
 │        at defaultResolve (node:internal/modules/esm/resolve:990:11)                                                          │
 │        at #cachedDefaultResolve (node:internal/modules/esm/loader:735:20)                                                    │
 │        at ModuleLoader.resolve (node:internal/modules/esm/loader:712:38)                                                     │
 │        at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:310:38)                                       │
 │        at #link (node:internal/modules/esm/module_job:208:49) {                                                              │
 │      code: 'ERR_MODULE_NOT_FOUND',                                                                                           │
 │      url: 'file:///Users/jacobr/git/gemini-cli-10/node_modules/@google/gemini-cli-core/src/telemetry/types.js'
```