### PR TITLE
chore: add indicator to extensions list for enable/disable

### DIFF
--- a/packages/cli/src/commands/extensions/list.ts
+++ b/packages/cli/src/commands/extensions/list.ts
@@ -5,7 +5,12 @@
  */
 
 import type { CommandModule } from 'yargs';
-import { loadUserExtensions, toOutputString } from '../../config/extension.js';
+import {
+  loadUserExtensions,
+  toOutputString,
+  ExtensionStorage,
+} from '../../config/extension.js';
+import { ExtensionEnablementManager } from '../../config/extensions/extensionEnablement.js';
 import { getErrorMessage } from '../../utils/errors.js';
 
 export async function handleList() {
@@ -15,9 +20,16 @@ export async function handleList() {
       console.log('No extensions installed.');
       return;
     }
+    const manager = new ExtensionEnablementManager(
+      ExtensionStorage.getUserExtensionsDir(),
+    );
+    const cwd = process.cwd();
     console.log(
       extensions
-        .map((extension, _): string => toOutputString(extension))
+        .map((extension): string => {
+          const isEnabled = manager.isEnabled(extension.config.name, cwd);
+          return toOutputString(extension, isEnabled);
+        })
         .join('\n\n'),
     );
   } catch (error) {

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -37,6 +37,7 @@ import {
 } from './extensions/github.js';
 import type { LoadExtensionContext } from './extensions/variableSchema.js';
 import { ExtensionEnablementManager } from './extensions/extensionEnablement.js';
+import chalk from 'chalk';
 
 export const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
 
@@ -612,8 +613,12 @@ export async function uninstallExtension(
   );
 }
 
-export function toOutputString(extension: Extension): string {
-  let output = `${extension.config.name} (${extension.config.version})`;
+export function toOutputString(
+  extension: Extension,
+  isEnabled: boolean,
+): string {
+  const status = isEnabled ? chalk.green('✓') : chalk.red('✗');
+  let output = `${status} ${extension.config.name} (${extension.config.version})`;
   output += `\n Path: ${extension.path}`;
   if (extension.installMetadata) {
     output += `\n Source: ${extension.installMetadata.source} (Type: ${extension.installMetadata.type})`;


### PR DESCRIPTION
## TLDR

Add ✅  or ❌  to `gemini extensions list` command to visualize which extensions are enabled/disabled.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

<img width="1972" height="878" alt="image" src="https://github.com/user-attachments/assets/0cbd5f24-85ed-422e-b3d8-c42ac2c7dae6" />

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
