### PR TITLE
docs(extensions): update security extension URL used in installation example

### DIFF
--- a/docs/extension.md
+++ b/docs/extension.md
@@ -19,7 +19,7 @@ You can install an extension using `gemini extensions install` with either a Git
 Note that we create a copy of the installed extension, so you will need to run `gemini extensions update` to pull in changes from both locally-defined extensions and those on GitHub.
 
 ```
-gemini extensions install https://github.com/google-gemini/gemini-cli-security
+gemini extensions install https://github.com/gemini-cli-extensions/security
 ```
 
 This will install the Gemini CLI Security extension, which offers support for a `/security:analyze` command.


### PR DESCRIPTION
## TLDR

The example URL for the security extension was pointing to its previous GitHub organization, but has since moved to the extensions org. This commit updates the URL to the correct `gemini-cli-extensions` organization.

## Dive Deeper

N/A

## Reviewer Test Plan

N/A

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | X  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
