### PR TITLE
feat(ui): Render UI to almost 100% of terminal width

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -23,7 +23,7 @@ export const App = () => {
 
   return (
     <StreamingContext.Provider value={uiState.streamingState}>
-      <Box flexDirection="column" width="90%">
+      <Box flexDirection="column" width={uiState.mainAreaWidth}>
         <MainContent />
 
         <Box flexDirection="column" ref={uiState.mainControlsRef}>

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -58,7 +58,10 @@ import { useSlashCommandProcessor } from './hooks/slashCommandProcessor.js';
 import { useVimMode } from './contexts/VimModeContext.js';
 import { useConsoleMessages } from './hooks/useConsoleMessages.js';
 import { useTerminalSize } from './hooks/useTerminalSize.js';
-import { calculatePromptWidths } from './components/InputPrompt.js';
+import {
+  calculatePromptWidths,
+  SCROLLBAR_CLEARANCE,
+} from './components/InputPrompt.js';
 import { useStdin, useStdout } from 'ink';
 import ansiEscapes from 'ansi-escapes';
 import * as fs from 'node:fs';
@@ -252,7 +255,7 @@ export const AppContainer = (props: AppContainerProps) => {
       calculatePromptWidths(terminalWidth);
     return { inputWidth, suggestionsWidth };
   }, [terminalWidth]);
-  const mainAreaWidth = terminalWidth - 2; // Reserve 2 characters for scrollbar/margin
+  const mainAreaWidth = terminalWidth - SCROLLBAR_CLEARANCE;
   const staticAreaMaxItemHeight = Math.max(terminalHeight * 4, 100);
 
   const isValidPath = useCallback((filePath: string): boolean => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -114,7 +114,7 @@ interface AppContainerProps {
  * The fraction of the terminal width to allocate to the shell.
  * This provides horizontal padding.
  */
-const SHELL_WIDTH_FRACTION = 0.89;
+const SHELL_WIDTH_FRACTION = 1.0;
 
 /**
  * The number of lines to subtract from the available terminal height
@@ -252,7 +252,7 @@ export const AppContainer = (props: AppContainerProps) => {
       calculatePromptWidths(terminalWidth);
     return { inputWidth, suggestionsWidth };
   }, [terminalWidth]);
-  const mainAreaWidth = Math.floor(terminalWidth * 0.9);
+  const mainAreaWidth = terminalWidth - 2; // Reserve 2 characters for scrollbar/margin
   const staticAreaMaxItemHeight = Math.max(terminalHeight * 4, 100);
 
   const isValidPath = useCallback((filePath: string): boolean => {

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -57,8 +57,9 @@ export interface InputPromptProps {
 }
 
 // The input content, input container, and input suggestions list may have different widths
+export const SCROLLBAR_CLEARANCE = 2; // Reserve 2 characters for scrollbar/margin
+
 export const calculatePromptWidths = (terminalWidth: number) => {
-  const SCROLLBAR_CLEARANCE = 2; // Reserve 2 characters for scrollbar/margin
   const FRAME_PADDING_AND_BORDER = 4; // Border (2) + padding (2)
   const PROMPT_PREFIX_WIDTH = 2; // '> ' or '! '
   const MIN_CONTENT_WIDTH = 2;

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -58,20 +58,21 @@ export interface InputPromptProps {
 
 // The input content, input container, and input suggestions list may have different widths
 export const calculatePromptWidths = (terminalWidth: number) => {
-  const widthFraction = 0.9;
+  const SCROLLBAR_CLEARANCE = 2; // Reserve 2 characters for scrollbar/margin
   const FRAME_PADDING_AND_BORDER = 4; // Border (2) + padding (2)
   const PROMPT_PREFIX_WIDTH = 2; // '> ' or '! '
   const MIN_CONTENT_WIDTH = 2;
 
   const innerContentWidth =
-    Math.floor(terminalWidth * widthFraction) -
+    terminalWidth -
+    SCROLLBAR_CLEARANCE -
     FRAME_PADDING_AND_BORDER -
     PROMPT_PREFIX_WIDTH;
 
   const inputWidth = Math.max(MIN_CONTENT_WIDTH, innerContentWidth);
   const FRAME_OVERHEAD = FRAME_PADDING_AND_BORDER + PROMPT_PREFIX_WIDTH;
   const containerWidth = inputWidth + FRAME_OVERHEAD;
-  const suggestionsWidth = Math.max(20, Math.floor(terminalWidth * 1.0));
+  const suggestionsWidth = Math.max(20, terminalWidth - SCROLLBAR_CLEARANCE);
 
   return {
     inputWidth,

--- a/packages/cli/src/ui/hooks/useTerminalSize.ts
+++ b/packages/cli/src/ui/hooks/useTerminalSize.ts
@@ -6,7 +6,7 @@
 
 import { useEffect, useState } from 'react';
 
-const TERMINAL_PADDING_X = 8;
+const TERMINAL_PADDING_X = 4;
 
 export function useTerminalSize(): { columns: number; rows: number } {
   const [size, setSize] = useState({


### PR DESCRIPTION
Fixes #4671

This change adjusts the UI layout calculations to utilize the full terminal width, removing the previous 90% constraint.
- The main application container now expands to fill the available horizontal space, with a small reserve for a scrollbar.
- Input prompt and suggestion widths are now calculated based on the full terminal width.
- Horizontal padding has been adjusted to accommodate the wider layout.

## Screenshots
<img width="3492" height="3390" alt="image" src="https://github.com/user-attachments/assets/1528d1ff-5c6d-4fc6-964c-559910b18ce0" />

## Dive Deeper
Ink has layout quirks at the terminal edges, use 100% width leads to more problems than the extra 1-2 characters of width are worth. So I used a simple `terminalWidth - 4` across board to get ~96% width usage (much better than 90%) while avoiding the rendering issues entirely. (Tried other approaches e.g. full width by default and calculate width for specific components, but it caused more responsiveness issues.)  

## Reviewer Test Plan
* Run a simple request to test the width
* Resize window to test responsiveness

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
