### PR TITLE
fix(core): update edit tool error type during llm judgements

### DIFF
--- a/packages/core/src/tools/smart-edit.test.ts
+++ b/packages/core/src/tools/smart-edit.test.ts
@@ -390,8 +390,12 @@ describe('SmartEditTool', () => {
       const invocation = tool.build(params);
       const result = await invocation.execute(new AbortController().signal);
 
-      expect(result.error?.type).toBe(ToolErrorType.EDIT_NO_CHANGE);
-      expect(result.llmContent).toMatch(/A secondary check determined/);
+      expect(result.error?.type).toBe(
+        ToolErrorType.EDIT_NO_CHANGE_LLM_JUDGEMENT,
+      );
+      expect(result.llmContent).toMatch(
+        /A secondary check by an LLM determined/,
+      );
       expect(fs.readFileSync(filePath, 'utf8')).toBe(initialContent); // File is unchanged
     });
 

--- a/packages/core/src/tools/smart-edit.ts
+++ b/packages/core/src/tools/smart-edit.ts
@@ -306,7 +306,7 @@ class EditToolInvocation implements ToolInvocation<EditToolParams, ToolResult> {
         error: {
           display: `No changes required. The file already meets the specified conditions.`,
           raw: `A secondary check by an LLM determined that no changes were necessary to fulfill the instruction. Explanation: ${fixedEdit.explanation}. Original error with the parameters given: ${initialError.raw}`,
-          type: ToolErrorType.EDIT_LLM_JUDGEMENT_NO_CHANGE,
+          type: ToolErrorType.EDIT_NO_CHANGE_LLM_JUDGEMENT,
         },
         originalLineEnding,
       };

--- a/packages/core/src/tools/smart-edit.ts
+++ b/packages/core/src/tools/smart-edit.ts
@@ -305,8 +305,8 @@ class EditToolInvocation implements ToolInvocation<EditToolParams, ToolResult> {
         isNewFile: false,
         error: {
           display: `No changes required. The file already meets the specified conditions.`,
-          raw: `A secondary check determined that no changes were necessary to fulfill the instruction. Explanation: ${fixedEdit.explanation}. Original error with the parameters given: ${initialError.raw}`,
-          type: ToolErrorType.EDIT_NO_CHANGE,
+          raw: `A secondary check by an LLM determined that no changes were necessary to fulfill the instruction. Explanation: ${fixedEdit.explanation}. Original error with the parameters given: ${initialError.raw}`,
+          type: ToolErrorType.EDIT_LLM_JUDGEMENT_NO_CHANGE,
         },
         originalLineEnding,
       };

--- a/packages/core/src/tools/tool-error.ts
+++ b/packages/core/src/tools/tool-error.ts
@@ -33,7 +33,7 @@ export enum ToolErrorType {
   EDIT_NO_OCCURRENCE_FOUND = 'edit_no_occurrence_found',
   EDIT_EXPECTED_OCCURRENCE_MISMATCH = 'edit_expected_occurrence_mismatch',
   EDIT_NO_CHANGE = 'edit_no_change',
-  EDIT_LLM_JUDGEMENT_NO_CHANGE = 'edit_llm_judgement_no_change'
+  EDIT_LLM_JUDGEMENT_NO_CHANGE = 'edit_llm_judgement_no_change',
 
   // Glob-specific Errors
   GLOB_EXECUTION_ERROR = 'glob_execution_error',

--- a/packages/core/src/tools/tool-error.ts
+++ b/packages/core/src/tools/tool-error.ts
@@ -33,7 +33,7 @@ export enum ToolErrorType {
   EDIT_NO_OCCURRENCE_FOUND = 'edit_no_occurrence_found',
   EDIT_EXPECTED_OCCURRENCE_MISMATCH = 'edit_expected_occurrence_mismatch',
   EDIT_NO_CHANGE = 'edit_no_change',
-  EDIT_LLM_JUDGEMENT_NO_CHANGE = 'edit_llm_judgement_no_change',
+  EDIT_NO_CHANGE_LLM_JUDGEMENT = 'edit_no_change_llm_judgement',
 
   // Glob-specific Errors
   GLOB_EXECUTION_ERROR = 'glob_execution_error',

--- a/packages/core/src/tools/tool-error.ts
+++ b/packages/core/src/tools/tool-error.ts
@@ -33,6 +33,7 @@ export enum ToolErrorType {
   EDIT_NO_OCCURRENCE_FOUND = 'edit_no_occurrence_found',
   EDIT_EXPECTED_OCCURRENCE_MISMATCH = 'edit_expected_occurrence_mismatch',
   EDIT_NO_CHANGE = 'edit_no_change',
+  EDIT_LLM_JUDGEMENT_NO_CHANGE = 'edit_llm_judgement_no_change'
 
   // Glob-specific Errors
   GLOB_EXECUTION_ERROR = 'glob_execution_error',


### PR DESCRIPTION
## TLDR

We want to be able to distinguish between the occurrences of `EDIT_NO_CHANGE` error type. It can occur currently in two scenarios: one where the old_string and new_string are identical, and [one](https://github.com/google-gemini/gemini-cli/blob/3660d4ecc001702629b968b32ade4e6d5e6717f3/packages/core/src/utils/llm-edit-fixer.ts#L70) where an LLM determines that no changes are required.

## Dive Deeper

When an LLM determines that no changes are required, we want a specific error type signifying this. We introduce in this PR an error type of `EDIT_NO_CHANGE_LLM_JUDGEMENT` This will better help investigations into tool error occurrences.

## Reviewer Test Plan

N/A

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | X  | ❓  | ❓  |
| npx      | X  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Progress on #9030, #4137
Fixes #10131.