### PR TITLE
Re-request consent if necessary when updating extensions

### DIFF
--- a/packages/cli/src/commands/extensions/install.test.ts
+++ b/packages/cli/src/commands/extensions/install.test.ts
@@ -9,9 +9,11 @@ import { handleInstall, installCommand } from './install.js';
 import yargs from 'yargs';
 
 const mockInstallExtension = vi.hoisted(() => vi.fn());
+const mockRequestConsentNonInteractive = vi.hoisted(() => vi.fn());
 
 vi.mock('../../config/extension.js', () => ({
   installExtension: mockInstallExtension,
+  requestConsentNonInteractive: mockRequestConsentNonInteractive,
 }));
 
 vi.mock('../../utils/errors.js', () => ({
@@ -64,6 +66,7 @@ describe('handleInstall', () => {
 
   afterEach(() => {
     mockInstallExtension.mockClear();
+    mockRequestConsentNonInteractive.mockClear();
     vi.resetAllMocks();
   });
 

--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -5,7 +5,10 @@
  */
 
 import type { CommandModule } from 'yargs';
-import { installExtension } from '../../config/extension.js';
+import {
+  installExtension,
+  requestConsentNonInteractive,
+} from '../../config/extension.js';
 import type { ExtensionInstallMetadata } from '@google/gemini-cli-core';
 
 import { getErrorMessage } from '../../utils/errors.js';
@@ -48,7 +51,10 @@ export async function handleInstall(args: InstallArgs) {
       throw new Error('Either --source or --path must be provided.');
     }
 
-    const name = await installExtension(installMetadata, true);
+    const name = await installExtension(
+      installMetadata,
+      requestConsentNonInteractive,
+    );
     console.log(`Extension "${name}" installed successfully and enabled.`);
   } catch (error) {
     console.error(getErrorMessage(error));

--- a/packages/cli/src/commands/extensions/link.ts
+++ b/packages/cli/src/commands/extensions/link.ts
@@ -5,7 +5,10 @@
  */
 
 import type { CommandModule } from 'yargs';
-import { installExtension } from '../../config/extension.js';
+import {
+  installExtension,
+  requestConsentNonInteractive,
+} from '../../config/extension.js';
 import type { ExtensionInstallMetadata } from '@google/gemini-cli-core';
 
 import { getErrorMessage } from '../../utils/errors.js';
@@ -20,7 +23,10 @@ export async function handleLink(args: InstallArgs) {
       source: args.path,
       type: 'link',
     };
-    const extensionName = await installExtension(installMetadata);
+    const extensionName = await installExtension(
+      installMetadata,
+      requestConsentNonInteractive,
+    );
     console.log(
       `Extension "${extensionName}" linked successfully and enabled.`,
     );

--- a/packages/cli/src/commands/extensions/update.ts
+++ b/packages/cli/src/commands/extensions/update.ts
@@ -62,6 +62,7 @@ export async function handleUpdate(args: UpdateArgs) {
       const updatedExtensionInfo = (await updateExtension(
         extension,
         workingDir,
+        true, // Always ask for consent if the extension has changed.
         updateState,
         () => {},
       ))!;
@@ -83,6 +84,8 @@ export async function handleUpdate(args: UpdateArgs) {
     try {
       let updateInfos = await updateAllUpdatableExtensions(
         workingDir,
+        // Always ask for consent if the extension has changed when on the command line.
+        true,
         extensions,
         await checkForAllExtensionUpdates(extensions, new Map(), (_) => {}),
         () => {},

--- a/packages/cli/src/commands/extensions/update.ts
+++ b/packages/cli/src/commands/extensions/update.ts
@@ -8,6 +8,7 @@ import type { CommandModule } from 'yargs';
 import {
   loadExtensions,
   annotateActiveExtensions,
+  requestConsentNonInteractive,
 } from '../../config/extension.js';
 import {
   updateAllUpdatableExtensions,
@@ -62,7 +63,7 @@ export async function handleUpdate(args: UpdateArgs) {
       const updatedExtensionInfo = (await updateExtension(
         extension,
         workingDir,
-        true, // Always ask for consent if the extension has changed.
+        requestConsentNonInteractive,
         updateState,
         () => {},
       ))!;
@@ -84,8 +85,7 @@ export async function handleUpdate(args: UpdateArgs) {
     try {
       let updateInfos = await updateAllUpdatableExtensions(
         workingDir,
-        // Always ask for consent if the extension has changed when on the command line.
-        true,
+        requestConsentNonInteractive,
         extensions,
         await checkForAllExtensionUpdates(extensions, new Map(), (_) => {}),
         () => {},

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -260,10 +260,13 @@ describe('extension tests', () => {
       });
       fs.writeFileSync(path.join(sourceExtDir, 'context.md'), 'linked context');
 
-      const extensionName = await installExtension({
-        source: sourceExtDir,
-        type: 'link',
-      });
+      const extensionName = await installExtension(
+        {
+          source: sourceExtDir,
+          type: 'link',
+        },
+        async (_) => true,
+      );
 
       expect(extensionName).toEqual('my-linked-extension');
       const extensions = loadExtensions();

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -16,8 +16,10 @@ import {
   enableExtension,
   installExtension,
   loadExtension,
+  loadExtensionConfig,
   loadExtensions,
   performWorkspaceExtensionMigration,
+  requestConsentNonInteractive,
   uninstallExtension,
   type Extension,
 } from './extension.js';
@@ -627,7 +629,10 @@ describe('extension tests', () => {
       const targetExtDir = path.join(userExtensionsDir, 'my-local-extension');
       const metadataPath = path.join(targetExtDir, INSTALL_METADATA_FILENAME);
 
-      await installExtension({ source: sourceExtDir, type: 'local' });
+      await installExtension(
+        { source: sourceExtDir, type: 'local' },
+        async (_) => true,
+      );
 
       expect(fs.existsSync(targetExtDir)).toBe(true);
       expect(fs.existsSync(metadataPath)).toBe(true);
@@ -645,9 +650,15 @@ describe('extension tests', () => {
         name: 'my-local-extension',
         version: '1.0.0',
       });
-      await installExtension({ source: sourceExtDir, type: 'local' });
+      await installExtension(
+        { source: sourceExtDir, type: 'local' },
+        async (_) => true,
+      );
       await expect(
-        installExtension({ source: sourceExtDir, type: 'local' }),
+        installExtension(
+          { source: sourceExtDir, type: 'local' },
+          async (_) => true,
+        ),
       ).rejects.toThrow(
         'Extension "my-local-extension" is already installed. Please uninstall it first.',
       );
@@ -659,7 +670,10 @@ describe('extension tests', () => {
       const configPath = path.join(sourceExtDir, EXTENSIONS_CONFIG_FILENAME);
 
       await expect(
-        installExtension({ source: sourceExtDir, type: 'local' }),
+        installExtension(
+          { source: sourceExtDir, type: 'local' },
+          async (_) => true,
+        ),
       ).rejects.toThrow(`Configuration file not found at ${configPath}`);
 
       const targetExtDir = path.join(userExtensionsDir, 'bad-extension');
@@ -673,7 +687,10 @@ describe('extension tests', () => {
       fs.writeFileSync(configPath, '{ "name": "bad-json", "version": "1.0.0"'); // Malformed JSON
 
       await expect(
-        installExtension({ source: sourceExtDir, type: 'local' }),
+        installExtension(
+          { source: sourceExtDir, type: 'local' },
+          async (_) => true,
+        ),
       ).rejects.toThrow(
         new RegExp(
           `^Failed to load extension config from ${configPath.replace(
@@ -695,7 +712,10 @@ describe('extension tests', () => {
       fs.writeFileSync(configPath, JSON.stringify({ version: '1.0.0' }));
 
       await expect(
-        installExtension({ source: sourceExtDir, type: 'local' }),
+        installExtension(
+          { source: sourceExtDir, type: 'local' },
+          async (_) => true,
+        ),
       ).rejects.toThrow(
         `Invalid configuration in ${configPath}: missing "name"`,
       );
@@ -718,7 +738,10 @@ describe('extension tests', () => {
       });
       mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
 
-      await installExtension({ source: gitUrl, type: 'git' });
+      await installExtension(
+        { source: gitUrl, type: 'git' },
+        async (_) => true,
+      );
 
       expect(fs.existsSync(targetExtDir)).toBe(true);
       expect(fs.existsSync(metadataPath)).toBe(true);
@@ -740,7 +763,10 @@ describe('extension tests', () => {
       const metadataPath = path.join(targetExtDir, INSTALL_METADATA_FILENAME);
       const configPath = path.join(targetExtDir, EXTENSIONS_CONFIG_FILENAME);
 
-      await installExtension({ source: sourceExtDir, type: 'link' });
+      await installExtension(
+        { source: sourceExtDir, type: 'link' },
+        async (_) => true,
+      );
 
       expect(fs.existsSync(targetExtDir)).toBe(true);
       expect(fs.existsSync(metadataPath)).toBe(true);
@@ -762,7 +788,10 @@ describe('extension tests', () => {
         version: '1.0.0',
       });
 
-      await installExtension({ source: sourceExtDir, type: 'local' });
+      await installExtension(
+        { source: sourceExtDir, type: 'local' },
+        async (_) => true,
+      );
 
       expect(mockLogExtensionInstallEvent).toHaveBeenCalled();
     });
@@ -789,7 +818,10 @@ describe('extension tests', () => {
       mockQuestion.mockImplementation((_query, callback) => callback('y'));
 
       await expect(
-        installExtension({ source: sourceExtDir, type: 'local' }, true),
+        installExtension(
+          { source: sourceExtDir, type: 'local' },
+          requestConsentNonInteractive,
+        ),
       ).resolves.toBe('my-local-extension');
 
       expect(consoleInfoSpy).toHaveBeenCalledWith(
@@ -817,7 +849,10 @@ This extension will run the following MCP servers:
       mockQuestion.mockImplementation((_query, callback) => callback('y'));
 
       await expect(
-        installExtension({ source: sourceExtDir, type: 'local' }, true),
+        installExtension(
+          { source: sourceExtDir, type: 'local' },
+          requestConsentNonInteractive,
+        ),
       ).resolves.toBe('my-local-extension');
 
       expect(mockQuestion).toHaveBeenCalledWith(
@@ -842,7 +877,10 @@ This extension will run the following MCP servers:
       mockQuestion.mockImplementation((_query, callback) => callback('n'));
 
       await expect(
-        installExtension({ source: sourceExtDir, type: 'local' }, true),
+        installExtension(
+          { source: sourceExtDir, type: 'local' },
+          requestConsentNonInteractive,
+        ),
       ).rejects.toThrow('Installation cancelled by user.');
 
       expect(mockQuestion).toHaveBeenCalledWith(
@@ -860,11 +898,14 @@ This extension will run the following MCP servers:
       const targetExtDir = path.join(userExtensionsDir, 'my-local-extension');
       const metadataPath = path.join(targetExtDir, INSTALL_METADATA_FILENAME);
 
-      await installExtension({
-        source: sourceExtDir,
-        type: 'local',
-        autoUpdate: true,
-      });
+      await installExtension(
+        {
+          source: sourceExtDir,
+          type: 'local',
+          autoUpdate: true,
+        },
+        async (_) => true,
+      );
 
       expect(fs.existsSync(targetExtDir)).toBe(true);
       expect(fs.existsSync(metadataPath)).toBe(true);
@@ -890,9 +931,22 @@ This extension will run the following MCP servers:
         },
       });
 
+      const mockRequestConsent = vi.fn();
+
       await expect(
-        installExtension({ source: sourceExtDir, type: 'local' }, false),
+        installExtension(
+          { source: sourceExtDir, type: 'local' },
+          mockRequestConsent,
+          process.cwd(),
+          // Provide its own existing config as the previous config.
+          await loadExtensionConfig({
+            extensionDir: sourceExtDir,
+            workspaceDir: process.cwd(),
+          }),
+        ),
       ).resolves.toBe('my-local-extension');
+
+      expect(mockRequestConsent).not.toHaveBeenCalled();
     });
   });
 
@@ -1028,12 +1082,15 @@ This extension will run the following MCP servers:
           version: '1.0.0',
         });
 
-        await performWorkspaceExtensionMigration([
-          loadExtension({
-            extensionDir: ext1Path,
-            workspaceDir: tempWorkspaceDir,
-          })!,
-        ]);
+        await performWorkspaceExtensionMigration(
+          [
+            loadExtension({
+              extensionDir: ext1Path,
+              workspaceDir: tempWorkspaceDir,
+            })!,
+          ],
+          async (_) => true,
+        );
 
         const userExtensionsDir = path.join(
           tempHomeDir,
@@ -1051,12 +1108,15 @@ This extension will run the following MCP servers:
           version: '1.0.0',
         });
 
-        await performWorkspaceExtensionMigration([
-          loadExtension({
-            extensionDir: ext1Path,
-            workspaceDir: tempWorkspaceDir,
-          })!,
-        ]);
+        await performWorkspaceExtensionMigration(
+          [
+            loadExtension({
+              extensionDir: ext1Path,
+              workspaceDir: tempWorkspaceDir,
+            })!,
+          ],
+          async (_) => true,
+        );
         const extensions = loadExtensions();
 
         expect(extensions).toEqual([]);
@@ -1084,8 +1144,10 @@ This extension will run the following MCP servers:
           workspaceDir: tempWorkspaceDir,
         })!,
       ];
-      const failed =
-        await performWorkspaceExtensionMigration(extensionsToMigrate);
+      const failed = await performWorkspaceExtensionMigration(
+        extensionsToMigrate,
+        async (_) => true,
+      );
 
       expect(failed).toEqual([]);
 
@@ -1126,7 +1188,10 @@ This extension will run the following MCP servers:
         },
       ];
 
-      const failed = await performWorkspaceExtensionMigration(extensions);
+      const failed = await performWorkspaceExtensionMigration(
+        extensions,
+        async (_) => true,
+      );
       expect(failed).toEqual(['ext2']);
     });
   });

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -884,7 +884,7 @@ This extension will run the following MCP servers:
           { source: sourceExtDir, type: 'local' },
           requestConsentNonInteractive,
         ),
-      ).rejects.toThrow('Installation cancelled by user.');
+      ).rejects.toThrow('Installation cancelled.');
 
       expect(mockQuestion).toHaveBeenCalledWith(
         expect.stringContaining('Do you want to continue? [Y/n]: '),

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -369,9 +369,10 @@ export async function requestConsentNonInteractive(
   consentDescription: string,
 ): Promise<boolean> {
   console.info(consentDescription);
-  return await promptForContinuationNonInteractive(
-    'Do you want to continue? [Y/n]:',
+  const result = await promptForContinuationNonInteractive(
+    'Do you want to continue? [Y/n]: ',
   );
+  return result;
 }
 
 /**
@@ -622,7 +623,7 @@ async function maybeRequestConsentOrFail(
       return;
     }
   }
-  if (!requestConsent(extensionConsent)) {
+  if (!(await requestConsent(extensionConsent))) {
     throw new Error('Installation cancelled by user.');
   }
 }

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -623,7 +623,7 @@ async function maybeRequestConsentOrFail(
     }
   }
   if (!(await requestConsent(extensionConsent))) {
-    throw new Error('Installation cancelled by user.');
+    throw new Error('Installation cancelled.');
   }
 }
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -384,15 +384,13 @@ export async function requestConsentNonInteractive(
  * @returns boolean, whether they consented or not.
  */
 export async function requestConsentInteractive(
-  consentDescription: string,
+  _consentDescription: string,
   addHistoryItem: UseHistoryManagerReturn['addItem'],
 ): Promise<boolean> {
   addHistoryItem(
     {
       type: 'info',
-      text:
-        consentDescription +
-        '\n\nConsenting to updates not implemented in interactive mode, please use `gemini extensions update <extension>` to update this extension.',
+      text: 'Tried to update an extension but it has some changes that require consent, please use `gemini extensions update`.',
     },
     Date.now(),
   );

--- a/packages/cli/src/config/extensions/update.test.ts
+++ b/packages/cli/src/config/extensions/update.test.ts
@@ -140,6 +140,7 @@ describe('update tests', () => {
       const updateInfo = await updateExtension(
         extension,
         tempHomeDir,
+        false,
         ExtensionUpdateState.UPDATE_AVAILABLE,
         () => {},
       );
@@ -197,6 +198,7 @@ describe('update tests', () => {
       await updateExtension(
         extension,
         tempHomeDir,
+        false,
         ExtensionUpdateState.UPDATE_AVAILABLE,
         setExtensionUpdateState,
       );
@@ -239,6 +241,7 @@ describe('update tests', () => {
         updateExtension(
           extension,
           tempHomeDir,
+          false,
           ExtensionUpdateState.UPDATE_AVAILABLE,
           setExtensionUpdateState,
         ),

--- a/packages/cli/src/config/extensions/update.test.ts
+++ b/packages/cli/src/config/extensions/update.test.ts
@@ -140,7 +140,7 @@ describe('update tests', () => {
       const updateInfo = await updateExtension(
         extension,
         tempHomeDir,
-        false,
+        async (_) => true,
         ExtensionUpdateState.UPDATE_AVAILABLE,
         () => {},
       );
@@ -198,7 +198,7 @@ describe('update tests', () => {
       await updateExtension(
         extension,
         tempHomeDir,
-        false,
+        async (_) => true,
         ExtensionUpdateState.UPDATE_AVAILABLE,
         setExtensionUpdateState,
       );
@@ -241,7 +241,7 @@ describe('update tests', () => {
         updateExtension(
           extension,
           tempHomeDir,
-          false,
+          async (_) => true,
           ExtensionUpdateState.UPDATE_AVAILABLE,
           setExtensionUpdateState,
         ),

--- a/packages/cli/src/config/extensions/update.ts
+++ b/packages/cli/src/config/extensions/update.ts
@@ -29,7 +29,7 @@ export interface ExtensionUpdateInfo {
 export async function updateExtension(
   extension: GeminiCLIExtension,
   cwd: string = process.cwd(),
-  askConsentIfChanged: boolean,
+  requestConsent: (consent: string) => Promise<boolean>,
   currentState: ExtensionUpdateState,
   setExtensionUpdateState: (updateState: ExtensionUpdateState) => void,
 ): Promise<ExtensionUpdateInfo | undefined> {
@@ -61,7 +61,7 @@ export async function updateExtension(
     await uninstallExtension(extension.name, cwd);
     await installExtension(
       installMetadata,
-      askConsentIfChanged,
+      requestConsent,
       cwd,
       previousExtensionConfig,
     );
@@ -96,7 +96,7 @@ export async function updateExtension(
 
 export async function updateAllUpdatableExtensions(
   cwd: string = process.cwd(),
-  askConsentIfChanged: boolean,
+  requestConsent: (consent: string) => Promise<boolean>,
   extensions: GeminiCLIExtension[],
   extensionsState: Map<string, ExtensionUpdateState>,
   setExtensionsUpdateState: Dispatch<
@@ -115,7 +115,7 @@ export async function updateAllUpdatableExtensions(
           updateExtension(
             extension,
             cwd,
-            askConsentIfChanged,
+            requestConsent,
             extensionsState.get(extension.name)!,
             (updateState) => {
               setExtensionsUpdateState((prev) => {

--- a/packages/cli/src/config/extensions/update.ts
+++ b/packages/cli/src/config/extensions/update.ts
@@ -53,11 +53,11 @@ export async function updateExtension(
 
   const tempDir = await ExtensionStorage.createTmpDir();
   try {
+    await copyExtension(extension.path, tempDir);
     const previousExtensionConfig = await loadExtensionConfig({
       extensionDir: extension.path,
       workspaceDir: cwd,
     });
-    await copyExtension(extension.path, tempDir);
     await uninstallExtension(extension.name, cwd);
     await installExtension(
       installMetadata,

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -153,11 +153,14 @@ describe('extensionsCommand', () => {
     it('should update a single extension by name', async () => {
       const extension: GeminiCLIExtension = {
         name: 'ext-one',
-        type: 'git',
         version: '1.0.0',
         isActive: true,
         path: '/test/dir/ext-one',
-        autoUpdate: false,
+        installMetadata: {
+          type: 'git',
+          autoUpdate: false,
+          source: 'https://github.com/some/extension.git',
+        },
       };
       mockUpdateExtension.mockResolvedValue({
         name: extension.name,
@@ -173,6 +176,7 @@ describe('extensionsCommand', () => {
       expect(mockUpdateExtension).toHaveBeenCalledWith(
         extension,
         '/test/dir',
+        expect.any(Function),
         ExtensionUpdateState.UPDATE_AVAILABLE,
         expect.any(Function),
       );
@@ -194,19 +198,25 @@ describe('extensionsCommand', () => {
     it('should update multiple extensions by name', async () => {
       const extensionOne: GeminiCLIExtension = {
         name: 'ext-one',
-        type: 'git',
         version: '1.0.0',
         isActive: true,
         path: '/test/dir/ext-one',
-        autoUpdate: false,
+        installMetadata: {
+          type: 'git',
+          autoUpdate: false,
+          source: 'https://github.com/some/extension.git',
+        },
       };
       const extensionTwo: GeminiCLIExtension = {
         name: 'ext-two',
-        type: 'git',
         version: '1.0.0',
         isActive: true,
         path: '/test/dir/ext-two',
-        autoUpdate: false,
+        installMetadata: {
+          type: 'git',
+          autoUpdate: false,
+          source: 'https://github.com/some/extension.git',
+        },
       };
       mockGetExtensions.mockReturnValue([extensionOne, extensionTwo]);
       mockContext.ui.extensionsUpdateState.set(

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -51,6 +51,8 @@ async function updateAction(context: CommandContext, args: string) {
     if (all) {
       updateInfos = await updateAllUpdatableExtensions(
         context.services.config!.getWorkingDir(),
+        // We don't have the ability to prompt for consent yet in this flow.
+        false,
         context.services.config!.getExtensions(),
         context.ui.extensionsUpdateState,
         context.ui.setExtensionsUpdateState,
@@ -75,6 +77,7 @@ async function updateAction(context: CommandContext, args: string) {
         const updateInfo = await updateExtension(
           extension,
           workingDir,
+          false, // We don't have the ability to prompt for consent in this flow.
           context.ui.extensionsUpdateState.get(extension.name) ??
             ExtensionUpdateState.UNKNOWN,
           (updateState) => {

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { requestConsentInteractive } from '../../config/extension.js';
 import {
   updateAllUpdatableExtensions,
   type ExtensionUpdateInfo,
@@ -52,7 +53,8 @@ async function updateAction(context: CommandContext, args: string) {
       updateInfos = await updateAllUpdatableExtensions(
         context.services.config!.getWorkingDir(),
         // We don't have the ability to prompt for consent yet in this flow.
-        false,
+        (description) =>
+          requestConsentInteractive(description, context.ui.addItem),
         context.services.config!.getExtensions(),
         context.ui.extensionsUpdateState,
         context.ui.setExtensionsUpdateState,
@@ -77,7 +79,8 @@ async function updateAction(context: CommandContext, args: string) {
         const updateInfo = await updateExtension(
           extension,
           workingDir,
-          false, // We don't have the ability to prompt for consent in this flow.
+          (description) =>
+            requestConsentInteractive(description, context.ui.addItem),
           context.ui.extensionsUpdateState.get(extension.name) ??
             ExtensionUpdateState.UNKNOWN,
           (updateState) => {

--- a/packages/cli/src/ui/components/WorkspaceMigrationDialog.tsx
+++ b/packages/cli/src/ui/components/WorkspaceMigrationDialog.tsx
@@ -23,8 +23,11 @@ export function WorkspaceMigrationDialog(props: {
   const [failedExtensions, setFailedExtensions] = useState<string[]>([]);
   onOpen();
   const onMigrate = async () => {
-    const failed =
-      await performWorkspaceExtensionMigration(workspaceExtensions);
+    const failed = await performWorkspaceExtensionMigration(
+      workspaceExtensions,
+      // We aren't updating extensions, just moving them around, don't need to ask for consent.
+      async (_) => true,
+    );
     setFailedExtensions(failed);
     setMigrationComplete(true);
   };

--- a/packages/cli/src/ui/components/views/ExtensionsList.test.tsx
+++ b/packages/cli/src/ui/components/views/ExtensionsList.test.tsx
@@ -91,7 +91,7 @@ describe('<ExtensionsList />', () => {
     },
     {
       state: ExtensionUpdateState.ERROR,
-      expectedText: '(error checking for updates)',
+      expectedText: '(error)',
     },
     {
       state: ExtensionUpdateState.UP_TO_DATE,

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -14,6 +14,7 @@ import {
   checkForAllExtensionUpdates,
   updateExtension,
 } from '../../config/extensions/update.js';
+import { requestConsentInteractive } from '../../config/extension.js';
 
 export const useExtensionUpdates = (
   extensions: GeminiCLIExtension[],
@@ -43,7 +44,7 @@ export const useExtensionUpdates = (
           updateExtension(
             extension,
             cwd,
-            false, // We don't have the ability to prompt for consent yet for this flow
+            (description) => requestConsentInteractive(description, addItem),
             currentState,
             (newState) => {
               setExtensionsUpdateState((prev) => {

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -40,13 +40,19 @@ export const useExtensionUpdates = (
           continue;
         }
         if (extension.installMetadata?.autoUpdate) {
-          updateExtension(extension, cwd, currentState, (newState) => {
-            setExtensionsUpdateState((prev) => {
-              const finalState = new Map(prev);
-              finalState.set(extension.name, newState);
-              return finalState;
-            });
-          })
+          updateExtension(
+            extension,
+            cwd,
+            false, // We don't have the ability to prompt for consent yet for this flow
+            currentState,
+            (newState) => {
+              setExtensionsUpdateState((prev) => {
+                const finalState = new Map(prev);
+                finalState.set(extension.name, newState);
+                return finalState;
+              });
+            },
+          )
             .then((result) => {
               if (!result) return;
               addItem(

--- a/packages/cli/src/ui/state/extensions.ts
+++ b/packages/cli/src/ui/state/extensions.ts
@@ -10,7 +10,7 @@ export enum ExtensionUpdateState {
   UPDATING = 'updating',
   UPDATE_AVAILABLE = 'update available',
   UP_TO_DATE = 'up to date',
-  ERROR = 'error checking for updates',
+  ERROR = 'error',
   NOT_UPDATABLE = 'not updatable',
   UNKNOWN = 'unknown',
 }


### PR DESCRIPTION
## TLDR

When updating an extension, we compare the old consent text to the new consent text, and if they are different then we require the user to consent again.

## Dive Deeper

There is no consent flow in interactive mode, so we default today to giving an error and just telling the user to run it on the command line. This is what that looks like:

<img width="1082" height="218" alt="image" src="https://github.com/user-attachments/assets/b8b5b7f1-727a-45dc-aa92-85d6a2e38639" />

## Reviewer Test Plan

Try to update an extension which has added some new feature that requires consent both on the command line and in interactive mode.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/gemini-cli/issues/9400
