### PR TITLE
feat(cli) Add mime-type validation to MCP tool responses (#9511)

### DIFF
--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -59,6 +59,7 @@ type McpContentBlock =
 
 // This list is based on the supported file formats for Gemini 2.5 Pro.
 // Source: https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro
+//         https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash
 const SUPPORTED_MIME_TYPES = new Set([
   'image/png',
   'image/jpeg',

--- a/packages/core/src/utils/mimeUtils.ts
+++ b/packages/core/src/utils/mimeUtils.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This list is based on the supported file formats for Gemini 2.5 Pro.
+// Source: https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro
+//         https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash
+const SUPPORTED_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'application/pdf',
+  'text/plain',
+  'video/x-flv',
+  'video/quicktime',
+  'video/mpeg',
+  'video/mpegs',
+  'video/mpg',
+  'video/mp4',
+  'video/webm',
+  'video/wmv',
+  'video/3gpp',
+  'audio/x-aac',
+  'audio/flac',
+  'audio/mp3',
+  'audio/m4a',
+  'audio/mpeg',
+  'audio/mpga',
+  'audio/mp4',
+  'audio/opus',
+  'audio/pcm',
+  'audio/wav',
+  'audio/webm',
+]);
+
+/**
+ * Checks if a given MIME type is in the supported set.
+ * @param mimeType The MIME type string to validate.
+ * @returns True if the MIME type is supported, false otherwise.
+ */
+export function isMimeTypeSupported(mimeType: string): boolean {
+  return SUPPORTED_MIME_TYPES.has(mimeType);
+}
+
+/**
+ * Standardized error message for unsupported MIME types.
+ */
+export const UNSUPPORTED_MIME_TYPE_ERROR =
+  'The MIME type of the file is not supported for inline content.';


### PR DESCRIPTION
## TLDR

Add input validation from MCP tool responses and file reads to block mime-types that aren't supported by gemini.

## Dive Deeper

Handing an unsupported mime-type to the gemini api results in a 400 error for unsupported mime-type. Blocking these results before pushing them to the model prevents the agent from crashing when receiving unsupported content types. 

### Before: 
<img width="1183" height="683" alt="image" src="https://github.com/user-attachments/assets/05417d30-ffc5-4021-9821-97dffa4ca67f" />

### After:
<img width="1190" height="609" alt="image" src="https://github.com/user-attachments/assets/d15f8ce0-3aef-4c02-a77d-23c043d9d242" />


## Reviewer Test Plan

### Verifying File sanitization: 
Download an unsupported mimetype, image/tiff is a reasonable example. Ask gemini to read it `Can you read this file? @file_example_TIFF_1MB.tiff` It should result in an API failure without this change and a tool failure with it. 

### Verifying MCP sanitization:
You need an MCP server you expect to return invalid types. You can checkout and install this experimental GCS MCP server at [this commit](https://github.com/googleapis/gcloud-mcp/tree/ba993b78e96a1bd711773b015716bee610aeabdd). You will need a GCP project and an associated GCS Bucket. You can upload any unsupported types (spreadsheet, executable, etc) and ask gemini to read and summarize the object context. 

Without this change you will get a 400 error and the agent session will return to the turn to the user immediately. 

With this change it the model will instead return that it can't process that type of data. 

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓  | ❓  |
| npx      | ✅   | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Closes #9511 