### PR TITLE
refactor(packages): Use structuredClone()

### DIFF
--- a/packages/a2a-server/src/agent/task.test.ts
+++ b/packages/a2a-server/src/agent/task.test.ts
@@ -49,7 +49,7 @@ describe('Task', () => {
       },
     ];
 
-    const originalRequests = JSON.parse(JSON.stringify(requests));
+    const originalRequests = structuredClone(requests);
     const abortController = new AbortController();
 
     await task.scheduleToolCalls(requests, abortController.signal);

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -813,7 +813,7 @@ describe('mergeMcpServers', () => {
         contextFiles: [],
       },
     ];
-    const originalSettings = JSON.parse(JSON.stringify(settings));
+    const originalSettings = structuredClone(settings);
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments({} as Settings);
     await loadCliConfig(settings, extensions, 'test-session', argv);
@@ -1019,7 +1019,7 @@ describe('mergeExcludeTools', () => {
         contextFiles: [],
       },
     ];
-    const originalSettings = JSON.parse(JSON.stringify(settings));
+    const originalSettings = structuredClone(settings);
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments({} as Settings);
     await loadCliConfig(settings, extensions, 'test-session', argv);

--- a/packages/cli/src/utils/deepMerge.test.ts
+++ b/packages/cli/src/utils/deepMerge.test.ts
@@ -87,8 +87,8 @@ describe('customDeepMerge', () => {
   it('should not mutate the original source objects', () => {
     const target = { a: { x: 1 }, b: [1, 2] };
     const source = { a: { y: 2 }, b: [3, 4] };
-    const originalTarget = JSON.parse(JSON.stringify(target));
-    const originalSource = JSON.parse(JSON.stringify(source));
+    const originalTarget = structuredClone(target);
+    const originalSource = structuredClone(source);
     const getMergeStrategy = () => undefined;
 
     customDeepMerge(getMergeStrategy, target, source);
@@ -100,8 +100,8 @@ describe('customDeepMerge', () => {
   it('should not mutate sources when merging multiple levels deep', () => {
     const s1 = { data: { common: { val: 'from s1' }, s1_only: true } };
     const s2 = { data: { common: { val: 'from s2' }, s2_only: true } };
-    const s1_original = JSON.parse(JSON.stringify(s1));
-    const s2_original = JSON.parse(JSON.stringify(s2));
+    const s1_original = structuredClone(s1);
+    const s2_original = structuredClone(s2);
 
     const getMergeStrategy = () => undefined;
     const result = customDeepMerge(getMergeStrategy, s1, s2);

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -347,7 +347,7 @@ export function setPendingSettingValue(
   pendingSettings: Settings,
 ): Settings {
   const path = key.split('.');
-  const newSettings = JSON.parse(JSON.stringify(pendingSettings));
+  const newSettings = structuredClone(pendingSettings);
   setNestedValue(newSettings, path, value);
   return newSettings;
 }


### PR DESCRIPTION
## TLDR

Using structuredClone() instead of JSON.parse(JSON.stringify())

## Dive Deeper

structuredClone() is faster, a native function, and is recommended to use instead of the following pattern that it replaces.


## Reviewer Test Plan

Simple compilation and run. This is a better practice recommended by style guides.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
