### PR TITLE
fix(core): ensure retry sets defaults for nullish values passed into options

### DIFF
--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -116,6 +116,23 @@ describe('retryWithBackoff', () => {
     expect(mockFn).toHaveBeenCalledTimes(5);
   });
 
+  it('should default to 5 maxAttempts if options.maxAttempts is undefined', async () => {
+    // This function will fail more than 5 times to ensure all retries are used.
+    const mockFn = createFailingFunction(10);
+
+    const promise = retryWithBackoff(mockFn, { maxAttempts: undefined });
+
+    // Expect it to fail with the error from the 5th attempt.
+    // eslint-disable-next-line vitest/valid-expect
+    const assertionPromise = expect(promise).rejects.toThrow(
+      'Simulated error attempt 5',
+    );
+    await vi.runAllTimersAsync();
+    await assertionPromise;
+
+    expect(mockFn).toHaveBeenCalledTimes(5);
+  });
+
   it('should not retry if shouldRetry returns false', async () => {
     const mockFn = vi.fn(async () => {
       throw new NonRetryableError('Non-retryable error');

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -78,13 +78,21 @@ export async function retryWithBackoff<T>(
     throw new Error('maxAttempts must be a positive number.');
   }
 
-  const maxAttempts = options?.maxAttempts ?? DEFAULT_RETRY_OPTIONS.maxAttempts;
-  const initialDelayMs =
-    options?.initialDelayMs ?? DEFAULT_RETRY_OPTIONS.initialDelayMs;
-  const maxDelayMs = options?.maxDelayMs ?? DEFAULT_RETRY_OPTIONS.maxDelayMs;
-  const onPersistent429 = options?.onPersistent429;
-  const authType = options?.authType;
-  const shouldRetry = options?.shouldRetry ?? DEFAULT_RETRY_OPTIONS.shouldRetry;
+  const cleanOptions = options
+    ? Object.fromEntries(Object.entries(options).filter(([_, v]) => v != null))
+    : {};
+
+  const {
+    maxAttempts,
+    initialDelayMs,
+    maxDelayMs,
+    onPersistent429,
+    authType,
+    shouldRetry,
+  } = {
+    ...DEFAULT_RETRY_OPTIONS,
+    ...cleanOptions,
+  };
 
   let attempt = 0;
   let currentDelay = initialDelayMs;

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -78,17 +78,13 @@ export async function retryWithBackoff<T>(
     throw new Error('maxAttempts must be a positive number.');
   }
 
-  const {
-    maxAttempts,
-    initialDelayMs,
-    maxDelayMs,
-    onPersistent429,
-    authType,
-    shouldRetry,
-  } = {
-    ...DEFAULT_RETRY_OPTIONS,
-    ...options,
-  };
+  const maxAttempts = options?.maxAttempts ?? DEFAULT_RETRY_OPTIONS.maxAttempts;
+  const initialDelayMs =
+    options?.initialDelayMs ?? DEFAULT_RETRY_OPTIONS.initialDelayMs;
+  const maxDelayMs = options?.maxDelayMs ?? DEFAULT_RETRY_OPTIONS.maxDelayMs;
+  const onPersistent429 = options?.onPersistent429;
+  const authType = options?.authType;
+  const shouldRetry = options?.shouldRetry ?? DEFAULT_RETRY_OPTIONS.shouldRetry;
 
   let attempt = 0;
   let currentDelay = initialDelayMs;


### PR DESCRIPTION
## TLDR

This PR filters out null or undefined option values that may get passed in to `retryWithBackoff` and ensures that in these cases, the defaults from `DEFAULT_RETRY_OPTIONS` kick in.

## Dive Deeper

We add `cleanOptions` to filter out null/undefined values for any of the option fields that get passed in, ensuring that the spread syntax merges in default values for the null/undefined values.

## Reviewer Test Plan

N/A

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Progress on #4137, #9030