### PR TITLE
fix(core): Fix bugs in subagent resource mgmt and recovery

### DIFF
--- a/packages/core/src/core/subagent.test.ts
+++ b/packages/core/src/core/subagent.test.ts
@@ -849,17 +849,15 @@ describe('subagent.ts', () => {
         );
 
         // Spy on cleanup methods
-        const mcpStopSpy = vi.spyOn(
-          scope['toolRegistry']['mcpClientManager'],
-          'stop',
+        const toolRegistryCleanupSpy = vi.spyOn(
+          scope['toolRegistry'],
+          'cleanup',
         );
-        const toolsClearSpy = vi.spyOn(scope['toolRegistry']['tools'], 'clear');
 
         await scope.runNonInteractive(new ContextState());
 
         expect(scope.output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
-        expect(mcpStopSpy).toHaveBeenCalledTimes(1);
-        expect(toolsClearSpy).toHaveBeenCalledTimes(1);
+        expect(toolRegistryCleanupSpy).toHaveBeenCalledTimes(1);
         expect(scope['isCleanedUp']).toBe(true);
       });
 
@@ -878,19 +876,17 @@ describe('subagent.ts', () => {
         );
 
         // Spy on cleanup methods
-        const mcpStopSpy = vi.spyOn(
-          scope['toolRegistry']['mcpClientManager'],
-          'stop',
+        const toolRegistryCleanupSpy = vi.spyOn(
+          scope['toolRegistry'],
+          'cleanup',
         );
-        const toolsClearSpy = vi.spyOn(scope['toolRegistry']['tools'], 'clear');
 
         await expect(
           scope.runNonInteractive(new ContextState()),
         ).rejects.toThrow('LLM Error');
 
         expect(scope.output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
-        expect(mcpStopSpy).toHaveBeenCalledTimes(1);
-        expect(toolsClearSpy).toHaveBeenCalledTimes(1);
+        expect(toolRegistryCleanupSpy).toHaveBeenCalledTimes(1);
         expect(scope['isCleanedUp']).toBe(true);
       });
 
@@ -908,8 +904,8 @@ describe('subagent.ts', () => {
         );
 
         // Mock cleanup to throw an error
-        const mcpStopSpy = vi
-          .spyOn(scope['toolRegistry']['mcpClientManager'], 'stop')
+        const toolRegistryCleanupSpy = vi
+          .spyOn(scope['toolRegistry'], 'cleanup')
           .mockRejectedValue(new Error('Cleanup failed'));
         const consoleWarnSpy = vi
           .spyOn(console, 'warn')
@@ -918,7 +914,7 @@ describe('subagent.ts', () => {
         await scope.runNonInteractive(new ContextState());
 
         expect(scope.output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
-        expect(mcpStopSpy).toHaveBeenCalledTimes(1);
+        expect(toolRegistryCleanupSpy).toHaveBeenCalledTimes(1);
         expect(consoleWarnSpy).toHaveBeenCalledWith(
           'Error during subagent cleanup:',
           expect.any(Error),
@@ -939,19 +935,17 @@ describe('subagent.ts', () => {
           defaultRunConfig,
         );
 
-        const mcpStopSpy = vi.spyOn(
-          scope['toolRegistry']['mcpClientManager'],
-          'stop',
+        const toolRegistryCleanupSpy = vi.spyOn(
+          scope['toolRegistry'],
+          'cleanup',
         );
-        const toolsClearSpy = vi.spyOn(scope['toolRegistry']['tools'], 'clear');
 
         // Call cleanup directly multiple times
         await scope.cleanup();
         await scope.cleanup();
         await scope.cleanup();
 
-        expect(mcpStopSpy).toHaveBeenCalledTimes(1);
-        expect(toolsClearSpy).toHaveBeenCalledTimes(1);
+        expect(toolRegistryCleanupSpy).toHaveBeenCalledTimes(1);
         expect(scope['isCleanedUp']).toBe(true);
       });
 
@@ -1019,10 +1013,16 @@ describe('subagent.ts', () => {
         );
 
         const registeredTools = scope['toolRegistry']['tools'];
+        const toolRegistryCleanupSpy = vi.spyOn(
+          scope['toolRegistry'],
+          'cleanup',
+        );
+
         expect(registeredTools.size).toBeGreaterThan(0);
 
         await scope.cleanup();
 
+        expect(toolRegistryCleanupSpy).toHaveBeenCalledTimes(1);
         expect(registeredTools.size).toBe(0);
         expect(scope['isCleanedUp']).toBe(true);
       });

--- a/packages/core/src/core/subagent.ts
+++ b/packages/core/src/core/subagent.ts
@@ -755,11 +755,8 @@ Important Rules:
     this.isCleanedUp = true;
 
     try {
-      // Stop MCP clients to close persistent connections
-      await this.toolRegistry['mcpClientManager'].stop();
-
-      // Clear the tools map to release references
-      this.toolRegistry['tools'].clear();
+      // Delegate cleanup to the ToolRegistry
+      await this.toolRegistry.cleanup();
     } catch (error) {
       console.warn('Error during subagent cleanup:', error);
       // Don't throw - cleanup should be best effort

--- a/packages/core/src/core/subagent.ts
+++ b/packages/core/src/core/subagent.ts
@@ -246,6 +246,7 @@ export class SubAgentScope {
   private readonly outputConfig?: OutputConfig;
   private readonly onMessage?: (message: string) => void;
   private readonly toolRegistry: ToolRegistry;
+  private isCleanedUp = false;
 
   /**
    * Constructs a new SubAgentScope instance.
@@ -367,6 +368,8 @@ export class SubAgentScope {
   async runNonInteractive(context: ContextState): Promise<void> {
     const startTime = Date.now();
     let turnCounter = 0;
+    let abortController: AbortController | undefined;
+
     try {
       const chat = await this.createChatObject(context);
 
@@ -375,7 +378,7 @@ export class SubAgentScope {
         return;
       }
 
-      const abortController = new AbortController();
+      abortController = new AbortController();
 
       // Prepare the list of tools available to the subagent.
       const toolsList: FunctionDeclaration[] = [];
@@ -517,7 +520,16 @@ export class SubAgentScope {
     } catch (error) {
       console.error('Error during subagent execution:', error);
       this.output.terminate_reason = SubagentTerminateMode.ERROR;
+
+      // Abort any pending operations to prevent resource leaks
+      if (abortController && !abortController.signal.aborted) {
+        abortController.abort();
+      }
+
       throw error;
+    } finally {
+      // Always cleanup resources, regardless of success or failure
+      await this.cleanup();
     }
   }
 
@@ -727,5 +739,30 @@ Important Rules:
  * Once you believe all goals have been met and all required outputs have been emitted, stop calling tools.`;
 
     return finalPrompt;
+  }
+
+  /**
+   * Cleans up resources held by this subagent instance.
+   * This includes stopping MCP clients and clearing tool registry resources.
+   * Should be called when the subagent is no longer needed to prevent memory leaks.
+   */
+  async cleanup(): Promise<void> {
+    if (this.isCleanedUp) {
+      return; // Already cleaned up
+    }
+
+    // Always mark as cleaned up, even if cleanup fails
+    this.isCleanedUp = true;
+
+    try {
+      // Stop MCP clients to close persistent connections
+      await this.toolRegistry['mcpClientManager'].stop();
+
+      // Clear the tools map to release references
+      this.toolRegistry['tools'].clear();
+    } catch (error) {
+      console.warn('Error during subagent cleanup:', error);
+      // Don't throw - cleanup should be best effort
+    }
   }
 }

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -476,4 +476,14 @@ export class ToolRegistry {
   getTool(name: string): AnyDeclarativeTool | undefined {
     return this.tools.get(name);
   }
+
+  /**
+   * Cleans up resources held by this ToolRegistry instance.
+   * This includes stopping MCP clients and clearing tool registry resources.
+   * Should be called when the ToolRegistry is no longer needed to prevent memory leaks.
+   */
+  async cleanup(): Promise<void> {
+    await this.mcpClientManager.stop();
+    this.tools.clear();
+  }
 }


### PR DESCRIPTION
## TLDR

Fixed critical memory leaks and resource management issues in the subagent system. Added proper cleanup mechanisms for Tool Registry resources and abort signal handling to prevent hanging operations and memory accumulation.

## Dive Deeper

The subagent system had two critical resource management issues:

### **Memory Leak in Tool Registry**
Each subagent created its own `ToolRegistry` with `McpClientManager` but never cleaned up resources:
- MCP client connections remained open after subagent completion
- Tool maps accumulated references without disposal
- Multiple subagent instances would cause progressive memory growth

### **Missing Abort Signal Cleanup on Error**
When errors occurred during subagent execution:
- `AbortController` was never called to abort pending operations  
- Streaming LLM operations could continue running in background
- Resources weren't properly released on failure paths

### **Solution**
- Added `cleanup()` method to properly dispose Tool Registry resources
- Added `isCleanedUp` flag to prevent double cleanup
- Cleanup is called in `finally` block ensuring it runs regardless of success/failure
- Abort controller is properly aborted in error catch block
- Added comprehensive test suite with 6 new test cases covering all cleanup scenarios

The fixes ensure subagents properly clean up their resources and don't leave hanging connections or memory leaks, making the system robust for long-running applications or scenarios with many subagent instances.

## Reviewer Test Plan

To validate these fixes work correctly:

### **Test Resource Cleanup**
1. **Run the test suite**: `npm test -- subagent.test.ts`
   - Verify all 25 tests pass, including the 6 new "Resource Cleanup" tests
   - Tests verify MCP client shutdown, tool map clearing, and cleanup idempotency

2. **Memory leak verification**:
   ```bash
   # Create multiple subagents in succession
   echo "Create 10 subagents and verify no memory growth" | npx gemini-cli --subagent
   ```

3. **Error path testing**:
   - Trigger subagent errors (invalid tools, network failures)
   - Verify cleanup still occurs and no hanging processes remain

### **Test Abort Signal Handling**
1. **Interrupt subagent execution**:
   - Start a long-running subagent operation
   - Send SIGINT or cause error during execution
   - Verify pending operations are properly aborted

2. **LLM timeout scenarios**:
   - Configure very short timeouts
   - Verify streaming operations are cleanly terminated

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This PR addresses resource management and memory leak issues that could affect long-running applications using subagents. No specific GitHub issues were linked, but this prevents potential production stability problems.