### PR TITLE
Fix duplicate info messages for extension updates

### DIFF
--- a/packages/cli/src/config/extensions/update.ts
+++ b/packages/cli/src/config/extensions/update.ts
@@ -130,7 +130,9 @@ export async function checkForAllExtensionUpdates(
   >,
   cwd: string = process.cwd(),
 ): Promise<Map<string, ExtensionUpdateState>> {
-  let newStates: Map<string, ExtensionUpdateState> = new Map();
+  let newStates: Map<string, ExtensionUpdateState> = new Map(
+    extensionsUpdateState,
+  );
   for (const extension of extensions) {
     const initialState = extensionsUpdateState.get(extension.name);
     if (initialState === undefined) {

--- a/packages/cli/src/config/extensions/update.ts
+++ b/packages/cli/src/config/extensions/update.ts
@@ -130,17 +130,15 @@ export async function checkForAllExtensionUpdates(
   >,
   cwd: string = process.cwd(),
 ): Promise<Map<string, ExtensionUpdateState>> {
+  let newStates: Map<string, ExtensionUpdateState> = new Map();
   for (const extension of extensions) {
     const initialState = extensionsUpdateState.get(extension.name);
     if (initialState === undefined) {
       if (!extension.installMetadata) {
         setExtensionsUpdateState((prev) => {
-          extensionsUpdateState = new Map(prev);
-          extensionsUpdateState.set(
-            extension.name,
-            ExtensionUpdateState.NOT_UPDATABLE,
-          );
-          return extensionsUpdateState;
+          newStates = new Map(prev);
+          newStates.set(extension.name, ExtensionUpdateState.NOT_UPDATABLE);
+          return newStates;
         });
         continue;
       }
@@ -148,14 +146,14 @@ export async function checkForAllExtensionUpdates(
         extension,
         (updatedState) => {
           setExtensionsUpdateState((prev) => {
-            extensionsUpdateState = new Map(prev);
-            extensionsUpdateState.set(extension.name, updatedState);
-            return extensionsUpdateState;
+            newStates = new Map(prev);
+            newStates.set(extension.name, updatedState);
+            return newStates;
           });
         },
         cwd,
       );
     }
   }
-  return extensionsUpdateState;
+  return newStates;
 }

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.test.ts
@@ -143,7 +143,7 @@ describe('useExtensionUpdates', () => {
       expect(addItem).toHaveBeenCalledWith(
         {
           type: MessageType.INFO,
-          text: 'Extension test-extension has an update available, run "/extensions update test-extension" to install it.',
+          text: 'You have 1 extensions with updates available, run "/extensions list" for more information.',
         },
         expect.any(Number),
       );

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.test.ts
@@ -143,7 +143,7 @@ describe('useExtensionUpdates', () => {
       expect(addItem).toHaveBeenCalledWith(
         {
           type: MessageType.INFO,
-          text: 'You have 1 extensions with updates available, run "/extensions list" for more information.',
+          text: 'You have 1 extension with an update available, run "/extensions list" for more information.',
         },
         expect.any(Number),
       );

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -7,7 +7,7 @@
 import type { GeminiCLIExtension } from '@google/gemini-cli-core';
 import { getErrorMessage } from '../../utils/errors.js';
 import { ExtensionUpdateState } from '../state/extensions.js';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { MessageType } from '../types.js';
 import {
@@ -23,8 +23,12 @@ export const useExtensionUpdates = (
   const [extensionsUpdateState, setExtensionsUpdateState] = useState(
     new Map<string, ExtensionUpdateState>(),
   );
-  useMemo(() => {
-    const checkUpdates = async () => {
+  const [isChecking, setIsChecking] = useState(false);
+
+  (async () => {
+    if (isChecking) return;
+    setIsChecking(true);
+    try {
       const updateState = await checkForAllExtensionUpdates(
         extensions,
         extensionsUpdateState,
@@ -72,15 +76,11 @@ export const useExtensionUpdates = (
           );
         }
       }
-    };
-    checkUpdates();
-  }, [
-    extensions,
-    extensionsUpdateState,
-    setExtensionsUpdateState,
-    addItem,
-    cwd,
-  ]);
+    } finally {
+      setIsChecking(false);
+    }
+  })();
+
   return {
     extensionsUpdateState,
     setExtensionsUpdateState,

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -72,10 +72,11 @@ export const useExtensionUpdates = (
         }
       }
       if (extensionsWithUpdatesCount > 0) {
+        const s = extensionsWithUpdatesCount > 1 ? 's' : '';
         addItem(
           {
             type: MessageType.INFO,
-            text: `You have ${extensionsWithUpdatesCount} extensions with updates available, run "/extensions list" for more information.`,
+            text: `You have ${extensionsWithUpdatesCount} extension${s} with an update available, run "/extensions list" for more information.`,
           },
           Date.now(),
         );

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -34,6 +34,7 @@ export const useExtensionUpdates = (
         extensionsUpdateState,
         setExtensionsUpdateState,
       );
+      let extensionsWithUpdatesCount = 0;
       for (const extension of extensions) {
         const prevState = extensionsUpdateState.get(extension.name);
         const currentState = updateState.get(extension.name);
@@ -67,14 +68,17 @@ export const useExtensionUpdates = (
               );
             });
         } else {
-          addItem(
-            {
-              type: MessageType.INFO,
-              text: `Extension ${extension.name} has an update available, run "/extensions update ${extension.name}" to install it.`,
-            },
-            Date.now(),
-          );
+          extensionsWithUpdatesCount++;
         }
+      }
+      if (extensionsWithUpdatesCount > 0) {
+        addItem(
+          {
+            type: MessageType.INFO,
+            text: `You have ${extensionsWithUpdatesCount} extensions with updates available, run "/extensions list" for more information.`,
+          },
+          Date.now(),
+        );
       }
     } finally {
       setIsChecking(false);


### PR DESCRIPTION
## TLDR

Previously there was a race condition where you could get zero, one, or multiple possible notifications for updates to extensions. This fixes that so you just get one notification reliably.

I also combined all the info messages into one generic message like this:
<img width="600" height="26" alt="image" src="https://github.com/user-attachments/assets/3b22c7b3-4fe4-458d-9f21-0b46e921564c" />

## Dive Deeper

The primary issue is this useExtensionState function being called many times on startup in quick succession, which was resulting in simultaneous ongoing calls to check the extension update states. These were all mutating the same extension state object and getting in race conditions.

I added a fix to ensure we only have one ongoing check at a time by adding an extra boolean state object to track if we have an ongoing update check already happening.

I also added a fix to not edit the original extension state object but instead return a new one from `checkForAllExtensionUpdates`, this was creating the situation where we would have no log at all sometimes due to the previous and new states being equal (the same object). 

## Reviewer Test Plan

Run the CLI with extensions installed that need updates, you should just see one message to update.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

