### PR TITLE
feat(cli): Add /reset command and modify /clear command

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -123,7 +123,7 @@ Slash commands provide meta-level control over the CLI itself.
 - **`/privacy`**
   - **Description:** Display the Privacy Notice and allow users to select whether they consent to the collection of their data for service improvement purposes.
 
-- **`/quit`** (or **` /exit`**)
+- **`/quit`** (or **`/exit`**)
   - **Description:** Exit Gemini CLI.
 
 - **`/reset`**

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -123,8 +123,11 @@ Slash commands provide meta-level control over the CLI itself.
 - **`/privacy`**
   - **Description:** Display the Privacy Notice and allow users to select whether they consent to the collection of their data for service improvement purposes.
 
-- **`/quit`** (or **`/exit`**)
+- **`/quit`** (or **` /exit`**)
   - **Description:** Exit Gemini CLI.
+
+- **`/restart`**
+  - **Description:** Restart the session. This is equivalent to the `/clear` command.
 
 - **`/vim`**
   - **Description:** Toggle vim mode on or off. When vim mode is enabled, the input area supports vim-style navigation and editing commands in both NORMAL and INSERT modes.

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -35,7 +35,7 @@ Slash commands provide meta-level control over the CLI itself.
       - **Usage** `/chat share file.md` or `/chat share file.json`. If no filename is provided, then the CLI will generate one.
 
 - **`/clear`**
-  - **Description:** Clear the terminal screen, including the visible session history and scrollback within the CLI. The underlying session data (for history recall) might be preserved depending on the exact implementation, but the visual display is cleared.
+  - **Description:** Clear the terminal screen. This does not clear the conversation history.
   - **Keyboard shortcut:** Press **Ctrl+L** at any time to perform a clear action.
 
 - **`/compress`**
@@ -126,8 +126,8 @@ Slash commands provide meta-level control over the CLI itself.
 - **`/quit`** (or **` /exit`**)
   - **Description:** Exit Gemini CLI.
 
-- **`/restart`**
-  - **Description:** Restart the session. This is equivalent to the `/clear` command.
+- **`/reset`**
+  - **Description:** Clears the conversation history and resets the session. This is useful when you want to start a fresh conversation.
 
 - **`/vim`**
   - **Description:** Toggle vim mode on or off. When vim mode is enabled, the input area supports vim-style navigation and editing commands in both NORMAL and INSERT modes.

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -28,6 +28,7 @@ import { modelCommand } from '../ui/commands/modelCommand.js';
 import { permissionsCommand } from '../ui/commands/permissionsCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
+import { resetCommand } from '../ui/commands/resetCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
@@ -74,6 +75,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       ...(this.config?.getFolderTrust() ? [permissionsCommand] : []),
       privacyCommand,
       quitCommand,
+      resetCommand,
       restoreCommand(this.config),
       statsCommand,
       themeCommand,

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -4,27 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { uiTelemetryService } from '@google/gemini-cli-core';
 import type { SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 
 export const clearCommand: SlashCommand = {
   name: 'clear',
-  description: 'clear the screen and conversation history',
+  description: 'clear the screen',
   kind: CommandKind.BUILT_IN,
   action: async (context, _args) => {
-    const geminiClient = context.services.config?.getGeminiClient();
-
-    if (geminiClient) {
-      context.ui.setDebugMessage('Clearing terminal and resetting chat.');
-      // If resetChat fails, the exception will propagate and halt the command,
-      // which is the correct behavior to signal a failure to the user.
-      await geminiClient.resetChat();
-    } else {
-      context.ui.setDebugMessage('Clearing terminal.');
-    }
-
-    uiTelemetryService.setLastPromptTokenCount(0);
+    context.ui.setDebugMessage('Clearing terminal.');
     context.ui.clear();
   },
 };

--- a/packages/cli/src/ui/commands/resetCommand.test.ts
+++ b/packages/cli/src/ui/commands/resetCommand.test.ts
@@ -74,7 +74,7 @@ describe('resetCommand', () => {
     await resetCommand.action(nullConfigContext, '');
 
     expect(nullConfigContext.ui.setDebugMessage).toHaveBeenCalledWith(
-      'Resetting terminal.',
+      'Could not find an active session to reset.',
     );
     expect(mockResetChat).not.toHaveBeenCalled();
     expect(uiTelemetryService.setLastPromptTokenCount).toHaveBeenCalledWith(0);

--- a/packages/cli/src/ui/commands/resetCommand.test.ts
+++ b/packages/cli/src/ui/commands/resetCommand.test.ts
@@ -77,7 +77,6 @@ describe('resetCommand', () => {
       'Could not find an active session to reset.',
     );
     expect(mockResetChat).not.toHaveBeenCalled();
-    expect(uiTelemetryService.setLastPromptTokenCount).toHaveBeenCalledWith(0);
-    expect(uiTelemetryService.setLastPromptTokenCount).toHaveBeenCalledTimes(1);
+    expect(uiTelemetryService.setLastPromptTokenCount).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/ui/commands/resetCommand.test.ts
+++ b/packages/cli/src/ui/commands/resetCommand.test.ts
@@ -51,7 +51,7 @@ describe('resetCommand', () => {
     await resetCommand.action(mockContext, '');
 
     expect(mockContext.ui.setDebugMessage).toHaveBeenCalledWith(
-      'Resetting terminal and resetting chat.',
+      'Resetting chat session.',
     );
     expect(mockContext.ui.setDebugMessage).toHaveBeenCalledTimes(1);
 

--- a/packages/cli/src/ui/commands/resetCommand.test.ts
+++ b/packages/cli/src/ui/commands/resetCommand.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { clearCommand } from './clearCommand.js';
+import { resetCommand } from './resetCommand.js';
 import { type CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 
@@ -13,7 +13,7 @@ import { createMockCommandContext } from '../../test-utils/mockCommandContext.js
 
 import type { GeminiClient } from '@google/gemini-cli-core';
 
-describe('clearCommand', () => {
+describe('resetCommand', () => {
   let mockContext: CommandContext;
   let mockResetChat: ReturnType<typeof vi.fn>;
 
@@ -33,23 +33,24 @@ describe('clearCommand', () => {
     });
   });
 
-  it('should set debug message and clear UI', async () => {
-    if (!clearCommand.action) {
-      throw new Error('clearCommand must have an action.');
+  it('should set debug message, reset chat, and reset telemetry when config is available', async () => {
+    if (!resetCommand.action) {
+      throw new Error('resetCommand must have an action.');
     }
 
-    await clearCommand.action(mockContext, '');
+    await resetCommand.action(mockContext, '');
 
     expect(mockContext.ui.setDebugMessage).toHaveBeenCalledWith(
-      'Clearing terminal.',
+      'Restarting terminal and resetting chat.',
     );
     expect(mockContext.ui.setDebugMessage).toHaveBeenCalledTimes(1);
-    expect(mockContext.ui.clear).toHaveBeenCalledTimes(1);
+
+    expect(mockResetChat).toHaveBeenCalledTimes(1);
   });
 
-  it('should still clear UI if config service is not available', async () => {
-    if (!clearCommand.action) {
-      throw new Error('clearCommand must have an action.');
+  it('should not attempt to reset chat if config service is not available', async () => {
+    if (!resetCommand.action) {
+      throw new Error('resetCommand must have an action.');
     }
 
     const nullConfigContext = createMockCommandContext({
@@ -58,12 +59,11 @@ describe('clearCommand', () => {
       },
     });
 
-    await clearCommand.action(nullConfigContext, '');
+    await resetCommand.action(nullConfigContext, '');
 
     expect(nullConfigContext.ui.setDebugMessage).toHaveBeenCalledWith(
-      'Clearing terminal.',
+      'Restarting terminal.',
     );
     expect(mockResetChat).not.toHaveBeenCalled();
-    expect(nullConfigContext.ui.clear).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/ui/commands/resetCommand.ts
+++ b/packages/cli/src/ui/commands/resetCommand.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SlashCommand } from './types.js';
+import { CommandKind } from './types.js';
+
+export const resetCommand: SlashCommand = {
+  name: 'reset',
+  description: 'clear the conversation history and restart the session',
+  kind: CommandKind.BUILT_IN,
+  action: async (context, _args) => {
+    const geminiClient = context.services.config?.getGeminiClient();
+
+    if (geminiClient) {
+      context.ui.setDebugMessage('Restarting terminal and resetting chat.');
+      // If resetChat fails, the exception will propagate and halt the command,
+      // which is the correct behavior to signal a failure to the user.
+      await geminiClient.resetChat();
+    } else {
+      context.ui.setDebugMessage('Restarting terminal.');
+    }
+  },
+};

--- a/packages/cli/src/ui/commands/resetCommand.ts
+++ b/packages/cli/src/ui/commands/resetCommand.ts
@@ -20,10 +20,9 @@ export const resetCommand: SlashCommand = {
       // If resetChat fails, the exception will propagate and halt the command,
       // which is the correct behavior to signal a failure to the user.
       await geminiClient.resetChat();
+      uiTelemetryService.setLastPromptTokenCount(0);
     } else {
       context.ui.setDebugMessage('Could not find an active session to reset.');
     }
-
-    uiTelemetryService.setLastPromptTokenCount(0);
   },
 };

--- a/packages/cli/src/ui/commands/resetCommand.ts
+++ b/packages/cli/src/ui/commands/resetCommand.ts
@@ -16,12 +16,12 @@ export const resetCommand: SlashCommand = {
     const geminiClient = context.services.config?.getGeminiClient();
 
     if (geminiClient) {
-      context.ui.setDebugMessage('Resetting terminal and resetting chat.');
+      context.ui.setDebugMessage('Resetting chat session.');
       // If resetChat fails, the exception will propagate and halt the command,
       // which is the correct behavior to signal a failure to the user.
       await geminiClient.resetChat();
     } else {
-      context.ui.setDebugMessage('Resetting terminal.');
+      context.ui.setDebugMessage('Could not find an active session to reset.');
     }
 
     uiTelemetryService.setLastPromptTokenCount(0);

--- a/packages/cli/src/ui/commands/resetCommand.ts
+++ b/packages/cli/src/ui/commands/resetCommand.ts
@@ -4,23 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { uiTelemetryService } from '@google/gemini-cli-core';
 import type { SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 
 export const resetCommand: SlashCommand = {
   name: 'reset',
-  description: 'clear the conversation history and restart the session',
+  description: 'clear the conversation history and reset the session',
   kind: CommandKind.BUILT_IN,
   action: async (context, _args) => {
     const geminiClient = context.services.config?.getGeminiClient();
 
     if (geminiClient) {
-      context.ui.setDebugMessage('Restarting terminal and resetting chat.');
+      context.ui.setDebugMessage('Resetting terminal and resetting chat.');
       // If resetChat fails, the exception will propagate and halt the command,
       // which is the correct behavior to signal a failure to the user.
       await geminiClient.resetChat();
     } else {
-      context.ui.setDebugMessage('Restarting terminal.');
+      context.ui.setDebugMessage('Resetting terminal.');
     }
+
+    uiTelemetryService.setLastPromptTokenCount(0);
   },
 };


### PR DESCRIPTION

## TLDR

   * /clear: This command will clear all the text from your terminal 
     screen, but it will not affect your conversation history. You can 
     still scroll up to see the previous parts of your conversation.
   * /reset: This command will start a new conversation, clearing all the 
     previous messages from the chat history.

## Dive Deeper

Adds a new `/reset` command to the Gemini CLI. This command resets the chat session, providing a quick way to start a fresh conversation.

Also, modifies `/clear` to just make the command clear the screen.

This makes it easier for developers to clear their terminal when wanting to refresh the screen, and when wanting to reset the gemini session, they now have a dedicated command for that.

## Reviewer Test Plan

Running /clear, and /reset.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
