### PR TITLE
feat: Make stale bot more aggressive

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,18 +28,18 @@ jobs:
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           stale-issue-message: >-
-            This issue has been automatically marked as stale due to 60 days of inactivity.
-            It will be closed in 14 days if no further activity occurs.
+            This issue has been automatically marked as stale due to 30 days of inactivity.
+            It will be closed in 7 days if no further activity occurs.
           stale-pr-message: >-
-            This pull request has been automatically marked as stale due to 60 days of inactivity.
-            It will be closed in 14 days if no further activity occurs.
+            This pull request has been automatically marked as stale due to 30 days of inactivity.
+            It will be closed in 7 days if no further activity occurs.
           close-issue-message: >-
-            This issue has been closed due to 14 additional days of inactivity after being marked as stale.
+            This issue has been closed due to 7 additional days of inactivity after being marked as stale.
             If you believe this is still relevant, feel free to comment or reopen the issue. Thank you!
           close-pr-message: >-
-            This pull request has been closed due to 14 additional days of inactivity after being marked as stale.
+            This pull request has been closed due to 7 additional days of inactivity after being marked as stale.
             If this is still relevant, you are welcome to reopen or leave a comment. Thanks for contributing!
-          days-before-stale: 60
-          days-before-close: 14
+          days-before-stale: 30
+          days-before-close: 7
           exempt-issue-labels: 'pinned,security'
           exempt-pr-labels: 'pinned,security'


### PR DESCRIPTION
FIX #6894 
Reduces the time before an issue or PR is marked as stale from 60 days to 30 days. Reduces the time before a stale issue or PR is closed from 14 days to 7 days. Updates the messages to reflect the new timeframes.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #6894 
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
