### PR TITLE
Update isNarrowWidth

### DIFF
--- a/packages/cli/src/ui/components/ContextSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.test.tsx
@@ -60,13 +60,13 @@ describe('<ContextSummaryDisplay />', () => {
     expect(actualLines).toEqual(expectedLines);
   });
 
-  it('should switch layout at the 80-column breakpoint', () => {
-    // At 80 columns, should be on one line
-    const { lastFrame: wideFrame } = renderWithWidth(80, baseProps);
+  it('should switch layout at the 70-column breakpoint', () => {
+    // At 70 columns, should be on one line
+    const { lastFrame: wideFrame } = renderWithWidth(70, baseProps);
     expect(wideFrame().includes('\n')).toBe(false);
 
-    // At 79 columns, should be on multiple lines
-    const { lastFrame: narrowFrame } = renderWithWidth(79, baseProps);
+    // At 69 columns, should be on multiple lines
+    const { lastFrame: narrowFrame } = renderWithWidth(69, baseProps);
     expect(narrowFrame().includes('\n')).toBe(true);
     expect(narrowFrame().split('\n').length).toBe(4);
   });

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.test.tsx
@@ -9,6 +9,7 @@ import { render } from 'ink-testing-library';
 import { describe, it, expect, vi } from 'vitest';
 import { ContextSummaryDisplay } from './ContextSummaryDisplay.js';
 import * as useTerminalSize from '../hooks/useTerminalSize.js';
+import { NARROW_WIDTH_BREAKPOINT } from '../utils/isNarrowWidth.js';
 
 vi.mock('../hooks/useTerminalSize.js', () => ({
   useTerminalSize: vi.fn(),
@@ -62,11 +63,17 @@ describe('<ContextSummaryDisplay />', () => {
 
   it('should switch layout at the 70-column breakpoint', () => {
     // At 70 columns, should be on one line
-    const { lastFrame: wideFrame } = renderWithWidth(70, baseProps);
+    const { lastFrame: wideFrame } = renderWithWidth(
+      NARROW_WIDTH_BREAKPOINT,
+      baseProps,
+    );
     expect(wideFrame().includes('\n')).toBe(false);
 
     // At 69 columns, should be on multiple lines
-    const { lastFrame: narrowFrame } = renderWithWidth(69, baseProps);
+    const { lastFrame: narrowFrame } = renderWithWidth(
+      NARROW_WIDTH_BREAKPOINT - 1,
+      baseProps,
+    );
     expect(narrowFrame().includes('\n')).toBe(true);
     expect(narrowFrame().split('\n').length).toBe(4);
   });

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -7,6 +7,7 @@
 import { render } from 'ink-testing-library';
 import { describe, it, expect, vi } from 'vitest';
 import { Footer } from './Footer.js';
+import { NARROW_WIDTH_BREAKPOINT } from '../utils/isNarrowWidth.js';
 import * as useTerminalSize from '../hooks/useTerminalSize.js';
 import { tildeifyPath } from '@google/gemini-cli-core';
 import path from 'node:path';
@@ -62,23 +63,26 @@ describe('<Footer />', () => {
       expect(lastFrame()).toContain(expectedPath);
     });
 
-    it('should display only the base directory name on a narrow terminal', () => {
-      const { lastFrame } = renderWithWidth(69);
+    it('should display base name on a narrow terminal', () => {
+      const { lastFrame } = renderWithWidth(NARROW_WIDTH_BREAKPOINT - 1);
       const expectedPath = path.basename(defaultProps.targetDir);
       expect(lastFrame()).toContain(expectedPath);
     });
 
     it('should use wide layout at 70 columns', () => {
-      const { lastFrame } = renderWithWidth(70);
+      const { lastFrame } = renderWithWidth(NARROW_WIDTH_BREAKPOINT);
       const tildePath = tildeifyPath(defaultProps.targetDir);
-      const pathLength = Math.max(20, Math.floor(70 * 0.4));
+      const pathLength = Math.max(
+        20,
+        Math.floor(NARROW_WIDTH_BREAKPOINT * 0.4),
+      );
       const expectedPath =
         '...' + tildePath.slice(tildePath.length - pathLength + 3);
       expect(lastFrame()).toContain(expectedPath);
     });
 
-    it('should use narrow layout at 69 columns', () => {
-      const { lastFrame } = renderWithWidth(69);
+    it('should use narrow layout at NARROW_WIDTH_BREAKPOINT - 1 columns', () => {
+      const { lastFrame } = renderWithWidth(NARROW_WIDTH_BREAKPOINT - 1);
       const expectedPath = path.basename(defaultProps.targetDir);
       expect(lastFrame()).toContain(expectedPath);
       const tildePath = tildeifyPath(defaultProps.targetDir);
@@ -201,7 +205,7 @@ describe('<Footer />', () => {
     });
 
     it('renders complete footer in narrow terminal (baseline narrow)', () => {
-      const { lastFrame } = renderWithWidth(69, {
+      const { lastFrame } = renderWithWidth(NARROW_WIDTH_BREAKPOINT - 1, {
         ...defaultProps,
         hideCWD: false,
         hideSandboxStatus: false,

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -56,38 +56,44 @@ describe('<Footer />', () => {
   });
 
   describe('path display', () => {
-    it('should display shortened path on a wide terminal', () => {
+    it('should display a shortened path on a wide terminal', () => {
       const { lastFrame } = renderWithWidth(120);
-      const tildePath = tildeifyPath(defaultProps.targetDir);
-      const expectedPath = '...' + tildePath.slice(tildePath.length - 48 + 3);
-      expect(lastFrame()).toContain(expectedPath);
+      const fullPath = tildeifyPath(defaultProps.targetDir);
+      const output = lastFrame();
+
+      // Behavior: Path is shortened with an ellipsis.
+      expect(output).toContain('...');
+      // Behavior: The full path is NOT displayed.
+      expect(output).not.toContain(fullPath);
+      // Behavior: The end of the path is visible.
+      expect(output).toContain(path.basename(fullPath));
     });
 
-    it('should display base name on a narrow terminal', () => {
+    it('should display only the base name on a narrow terminal', () => {
       const { lastFrame } = renderWithWidth(NARROW_WIDTH_BREAKPOINT - 1);
       const expectedPath = path.basename(defaultProps.targetDir);
-      expect(lastFrame()).toContain(expectedPath);
+      const output = lastFrame();
+
+      // Behavior: Only the basename is displayed.
+      expect(output).toContain(expectedPath);
+      // Behavior: The path is not shortened with an ellipsis.
+      expect(output).not.toContain('...');
     });
 
-    it('should use wide layout at 70 columns', () => {
+    it('should use wide layout at the breakpoint', () => {
       const { lastFrame } = renderWithWidth(NARROW_WIDTH_BREAKPOINT);
-      const tildePath = tildeifyPath(defaultProps.targetDir);
-      const pathLength = Math.max(
-        20,
-        Math.floor(NARROW_WIDTH_BREAKPOINT * 0.4),
-      );
-      const expectedPath =
-        '...' + tildePath.slice(tildePath.length - pathLength + 3);
-      expect(lastFrame()).toContain(expectedPath);
+      const output = lastFrame();
+      // Behavior: Path is shortened (wide layout), so it's not just the basename.
+      expect(output).toContain('...');
+      expect(output).not.toEqual(path.basename(defaultProps.targetDir));
     });
 
-    it('should use narrow layout at NARROW_WIDTH_BREAKPOINT - 1 columns', () => {
+    it('should use narrow layout just below the breakpoint', () => {
       const { lastFrame } = renderWithWidth(NARROW_WIDTH_BREAKPOINT - 1);
-      const expectedPath = path.basename(defaultProps.targetDir);
-      expect(lastFrame()).toContain(expectedPath);
-      const tildePath = tildeifyPath(defaultProps.targetDir);
-      const unexpectedPath = '...' + tildePath.slice(tildePath.length - 31 + 3);
-      expect(lastFrame()).not.toContain(unexpectedPath);
+      const output = lastFrame();
+      // Behavior: Path is just the basename (narrow layout).
+      expect(output).toContain(path.basename(defaultProps.targetDir));
+      expect(output).not.toContain('...');
     });
   });
 

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -63,20 +63,22 @@ describe('<Footer />', () => {
     });
 
     it('should display only the base directory name on a narrow terminal', () => {
-      const { lastFrame } = renderWithWidth(79);
+      const { lastFrame } = renderWithWidth(69);
       const expectedPath = path.basename(defaultProps.targetDir);
       expect(lastFrame()).toContain(expectedPath);
     });
 
-    it('should use wide layout at 80 columns', () => {
-      const { lastFrame } = renderWithWidth(80);
+    it('should use wide layout at 70 columns', () => {
+      const { lastFrame } = renderWithWidth(70);
       const tildePath = tildeifyPath(defaultProps.targetDir);
-      const expectedPath = '...' + tildePath.slice(tildePath.length - 32 + 3);
+      const pathLength = Math.max(20, Math.floor(70 * 0.4));
+      const expectedPath =
+        '...' + tildePath.slice(tildePath.length - pathLength + 3);
       expect(lastFrame()).toContain(expectedPath);
     });
 
-    it('should use narrow layout at 79 columns', () => {
-      const { lastFrame } = renderWithWidth(79);
+    it('should use narrow layout at 69 columns', () => {
+      const { lastFrame } = renderWithWidth(69);
       const expectedPath = path.basename(defaultProps.targetDir);
       expect(lastFrame()).toContain(expectedPath);
       const tildePath = tildeifyPath(defaultProps.targetDir);
@@ -199,7 +201,7 @@ describe('<Footer />', () => {
     });
 
     it('renders complete footer in narrow terminal (baseline narrow)', () => {
-      const { lastFrame } = renderWithWidth(79, {
+      const { lastFrame } = renderWithWidth(69, {
         ...defaultProps,
         hideCWD: false,
         hideSandboxStatus: false,

--- a/packages/cli/src/ui/components/LoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.test.tsx
@@ -242,7 +242,7 @@ describe('<LoadingIndicator />', () => {
         }
       />,
       StreamingState.Responding,
-      80,
+      70,
     );
 
     expect(lastFrame()).toMatchSnapshot();
@@ -273,7 +273,7 @@ describe('<LoadingIndicator />', () => {
           rightContent={<Text>Right</Text>}
         />,
         StreamingState.Responding,
-        79,
+        69,
       );
       const output = lastFrame();
       const lines = output?.split('\n');
@@ -290,20 +290,20 @@ describe('<LoadingIndicator />', () => {
       }
     });
 
-    it('should use wide layout at 80 columns', () => {
+    it('should use wide layout at 70 columns', () => {
       const { lastFrame } = renderWithContext(
         <LoadingIndicator {...defaultProps} />,
         StreamingState.Responding,
-        80,
+        70,
       );
       expect(lastFrame()?.includes('\n')).toBe(false);
     });
 
-    it('should use narrow layout at 79 columns', () => {
+    it('should use narrow layout at 69 columns', () => {
       const { lastFrame } = renderWithContext(
         <LoadingIndicator {...defaultProps} />,
         StreamingState.Responding,
-        79,
+        69,
       );
       expect(lastFrame()?.includes('\n')).toBe(true);
     });

--- a/packages/cli/src/ui/components/LoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.test.tsx
@@ -11,6 +11,7 @@ import { LoadingIndicator } from './LoadingIndicator.js';
 import { StreamingContext } from '../contexts/StreamingContext.js';
 import { StreamingState } from '../types.js';
 import { vi } from 'vitest';
+import { NARROW_WIDTH_BREAKPOINT } from '../utils/isNarrowWidth.js';
 import * as useTerminalSize from '../hooks/useTerminalSize.js';
 
 // Mock GeminiRespondingSpinner
@@ -242,7 +243,7 @@ describe('<LoadingIndicator />', () => {
         }
       />,
       StreamingState.Responding,
-      70,
+      NARROW_WIDTH_BREAKPOINT,
     );
 
     expect(lastFrame()).toMatchSnapshot();
@@ -273,7 +274,7 @@ describe('<LoadingIndicator />', () => {
           rightContent={<Text>Right</Text>}
         />,
         StreamingState.Responding,
-        69,
+        NARROW_WIDTH_BREAKPOINT - 1,
       );
       const output = lastFrame();
       const lines = output?.split('\n');
@@ -294,7 +295,7 @@ describe('<LoadingIndicator />', () => {
       const { lastFrame } = renderWithContext(
         <LoadingIndicator {...defaultProps} />,
         StreamingState.Responding,
-        70,
+        NARROW_WIDTH_BREAKPOINT,
       );
       expect(lastFrame()?.includes('\n')).toBe(false);
     });
@@ -303,7 +304,7 @@ describe('<LoadingIndicator />', () => {
       const { lastFrame } = renderWithContext(
         <LoadingIndicator {...defaultProps} />,
         StreamingState.Responding,
-        69,
+        NARROW_WIDTH_BREAKPOINT - 1,
       );
       expect(lastFrame()?.includes('\n')).toBe(true);
     });

--- a/packages/cli/src/ui/utils/isNarrowWidth.ts
+++ b/packages/cli/src/ui/utils/isNarrowWidth.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export const NARROW_WIDTH_BREAKPOINT = 70;
+
 export function isNarrowWidth(width: number): boolean {
-  return width < 70;
+  return width < NARROW_WIDTH_BREAKPOINT;
 }

--- a/packages/cli/src/ui/utils/isNarrowWidth.ts
+++ b/packages/cli/src/ui/utils/isNarrowWidth.ts
@@ -5,5 +5,5 @@
  */
 
 export function isNarrowWidth(width: number): boolean {
-  return width < 80;
+  return width < 70;
 }


### PR DESCRIPTION
## TLDR

Reduces `isNarrowWidth` from 80 to 70 to place nicer with default terminal sizes

## Dive Deeper

Given that the CLI doesn't use 100% of the horizontal space, 80 seemed a little high for default terminals (iTerm 2) and looking at the available space, it seems there is plenty space to increase it.

### Before
<img width="570" alt="CleanShot 2025-09-26 at 13 02 03@2x" src="https://github.com/user-attachments/assets/66fc6887-ebe1-4472-a52d-1807573e7956" />


### After
<img width="570" height="467" alt="image" src="https://github.com/user-attachments/assets/02ba66d3-ede6-47ee-86b6-6c6b1cfc7d0d" />



## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
