### PR TITLE
chore(docs): adds GitHub action to rebuild docs on change

### DIFF
--- a/.github/workflows/docs-rebuild.yml
+++ b/.github/workflows/docs-rebuild.yml
@@ -1,0 +1,19 @@
+name: Trigger Docs Rebuild
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+
+jobs:
+  trigger-rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger rebuild
+        run: |
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            "${{ secrets.DOCS_REBUILD_URL }}"

--- a/.github/workflows/docs-rebuild.yml
+++ b/.github/workflows/docs-rebuild.yml
@@ -1,17 +1,15 @@
-name: Trigger Docs Rebuild
-
+name: 'Trigger Docs Rebuild'
 on:
   push:
     branches:
-      - main
+      - 'main'
     paths:
       - 'docs/**'
-
 jobs:
   trigger-rebuild:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-latest'
     steps:
-      - name: Trigger rebuild
+      - name: 'Trigger rebuild'
         run: |
           curl -X POST \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
## TLDR

Adds a GitHub action to trigger a docs rebuild when docs content changes by calling a Cloud Build webhook stored in a secret.

**Important:** `DOCS_REBUILD_URL` secret will need to be added to GitHub Actions before merging.

## Dive Deeper

This will ensure that upcoming documentation efforts are always rebuilt when docs content changes in the main repo.

## Reviewer Test Plan

Since it's a GitHub Action, not easy to test before-hand. After merging, should confirm that changing a file in `docs/**` does indeed successfully trigger the webhook.