### PR TITLE
feat: Add `enableSubagents` configuration and wire up subagent registration

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2534,6 +2534,59 @@ describe('loadCliConfig useRipgrep', () => {
       expect(config.getUseModelRouter()).toBe(false);
     });
   });
+
+  describe('loadCliConfig enableSubagents', () => {
+    it('should be false by default when enableSubagents is not set in settings', async () => {
+      process.argv = ['node', 'script.js'];
+      const argv = await parseArguments({} as Settings);
+      const settings: Settings = {};
+      const config = await loadCliConfig(
+        settings,
+        [],
+        new ExtensionEnablementManager(
+          ExtensionStorage.getUserExtensionsDir(),
+          argv.extensions,
+        ),
+        'test-session',
+        argv,
+      );
+      expect(config.getEnableSubagents()).toBe(false);
+    });
+
+    it('should be true when enableSubagents is set to true in settings', async () => {
+      process.argv = ['node', 'script.js'];
+      const argv = await parseArguments({} as Settings);
+      const settings: Settings = { experimental: { enableSubagents: true } };
+      const config = await loadCliConfig(
+        settings,
+        [],
+        new ExtensionEnablementManager(
+          ExtensionStorage.getUserExtensionsDir(),
+          argv.extensions,
+        ),
+        'test-session',
+        argv,
+      );
+      expect(config.getEnableSubagents()).toBe(true);
+    });
+
+    it('should be false when enableSubagents is explicitly set to false in settings', async () => {
+      process.argv = ['node', 'script.js'];
+      const argv = await parseArguments({} as Settings);
+      const settings: Settings = { experimental: { enableSubagents: false } };
+      const config = await loadCliConfig(
+        settings,
+        [],
+        new ExtensionEnablementManager(
+          ExtensionStorage.getUserExtensionsDir(),
+          argv.extensions,
+        ),
+        'test-session',
+        argv,
+      );
+      expect(config.getEnableSubagents()).toBe(false);
+    });
+  });
 });
 
 describe('screenReader configuration', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -708,6 +708,7 @@ export async function loadCliConfig(
     useModelRouter,
     enableMessageBusIntegration:
       settings.tools?.enableMessageBusIntegration ?? false,
+    enableSubagents: settings.experimental?.enableSubagents ?? false,
   });
 }
 

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -330,5 +330,24 @@ describe('SettingsSchema', () => {
         getSettingsSchema().experimental.properties.useModelRouter.default,
       ).toBe(false);
     });
+
+    it('should have enableSubagents setting in schema', () => {
+      expect(
+        getSettingsSchema().experimental.properties.enableSubagents,
+      ).toBeDefined();
+      expect(
+        getSettingsSchema().experimental.properties.enableSubagents.type,
+      ).toBe('boolean');
+      expect(
+        getSettingsSchema().experimental.properties.enableSubagents.category,
+      ).toBe('Experimental');
+      expect(
+        getSettingsSchema().experimental.properties.enableSubagents.default,
+      ).toBe(false);
+      expect(
+        getSettingsSchema().experimental.properties.enableSubagents
+          .requiresRestart,
+      ).toBe(true);
+    });
   });
 });

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1001,6 +1001,15 @@ const SETTINGS_SCHEMA = {
           'Enable model routing to route requests to the best model based on complexity.',
         showInDialog: true,
       },
+      enableSubagents: {
+        type: 'boolean',
+        label: 'Enable Subagents',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enable experimental subagents.',
+        showInDialog: false,
+      },
     },
   },
 

--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -7,7 +7,7 @@
 import type { AgentDefinition } from './types.js';
 import { LSTool } from '../tools/ls.js';
 import { ReadFileTool } from '../tools/read-file.js';
-import { GlobTool } from '../tools/glob.js';
+import { GLOB_TOOL_NAME } from '../tools/tool-names.js';
 import { GrepTool } from '../tools/grep.js';
 import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
 
@@ -104,7 +104,7 @@ ${CODEBASE_REPORT_MARKDOWN}
 
   toolConfig: {
     // Grant access only to read-only tools.
-    tools: [LSTool.Name, ReadFileTool.Name, GlobTool.Name, GrepTool.Name],
+    tools: [LSTool.Name, ReadFileTool.Name, GLOB_TOOL_NAME, GrepTool.Name],
   },
 
   promptConfig: {

--- a/packages/core/src/agents/invocation.test.ts
+++ b/packages/core/src/agents/invocation.test.ts
@@ -16,6 +16,7 @@ import { AgentTerminateMode } from './types.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import type { Config } from '../config/config.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
 
 vi.mock('./executor.js');
 
@@ -50,6 +51,21 @@ describe('SubagentInvocation', () => {
     } as unknown as Mocked<AgentExecutor>;
 
     MockAgentExecutor.create.mockResolvedValue(mockExecutorInstance);
+  });
+
+  it('should pass the messageBus to the parent constructor', () => {
+    const mockMessageBus = {} as MessageBus;
+    const params = { task: 'Analyze data' };
+    const invocation = new SubagentInvocation(
+      params,
+      testDefinition,
+      mockConfig,
+      mockMessageBus,
+    );
+
+    // Access the protected messageBus property by casting to any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((invocation as any).messageBus).toBe(mockMessageBus);
   });
 
   describe('getDescription', () => {

--- a/packages/core/src/agents/invocation.ts
+++ b/packages/core/src/agents/invocation.ts
@@ -14,6 +14,7 @@ import type {
   AgentInputs,
   SubagentActivityEvent,
 } from './types.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
 
 const INPUT_PREVIEW_MAX_LENGTH = 50;
 const DESCRIPTION_MAX_LENGTH = 200;
@@ -36,13 +37,15 @@ export class SubagentInvocation extends BaseToolInvocation<
    * @param params The validated input parameters for the agent.
    * @param definition The definition object that configures the agent.
    * @param config The global runtime configuration.
+   * @param messageBus Optional message bus for policy enforcement.
    */
   constructor(
     params: AgentInputs,
     private readonly definition: AgentDefinition,
     private readonly config: Config,
+    messageBus?: MessageBus,
   ) {
-    super(params);
+    super(params, messageBus);
   }
 
   /**

--- a/packages/core/src/agents/subagent-tool-wrapper.test.ts
+++ b/packages/core/src/agents/subagent-tool-wrapper.test.ts
@@ -12,6 +12,7 @@ import { makeFakeConfig } from '../test-utils/config.js';
 import type { AgentDefinition, AgentInputs } from './types.js';
 import type { Config } from '../config/config.js';
 import { Kind } from '../tools/tools.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
 
 // Mock dependencies to isolate the SubagentToolWrapper class
 vi.mock('./invocation.js');
@@ -119,6 +120,26 @@ describe('SubagentToolWrapper', () => {
         params,
         mockDefinition,
         mockConfig,
+        undefined,
+      );
+    });
+
+    it('should pass the messageBus to the SubagentInvocation constructor', () => {
+      const mockMessageBus = {} as MessageBus;
+      const wrapper = new SubagentToolWrapper(
+        mockDefinition,
+        mockConfig,
+        mockMessageBus,
+      );
+      const params: AgentInputs = { goal: 'Test the invocation', priority: 1 };
+
+      wrapper.build(params);
+
+      expect(MockedSubagentInvocation).toHaveBeenCalledWith(
+        params,
+        mockDefinition,
+        mockConfig,
+        mockMessageBus,
       );
     });
 

--- a/packages/core/src/agents/subagent-tool-wrapper.ts
+++ b/packages/core/src/agents/subagent-tool-wrapper.ts
@@ -14,6 +14,7 @@ import type { Config } from '../config/config.js';
 import type { AgentDefinition, AgentInputs } from './types.js';
 import { convertInputConfigToJsonSchema } from './schema-utils.js';
 import { SubagentInvocation } from './invocation.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
 
 /**
  * A tool wrapper that dynamically exposes a subagent as a standard,
@@ -31,10 +32,12 @@ export class SubagentToolWrapper extends BaseDeclarativeTool<
    *
    * @param definition The `AgentDefinition` of the subagent to wrap.
    * @param config The runtime configuration, passed down to the subagent.
+   * @param messageBus Optional message bus for policy enforcement.
    */
   constructor(
     private readonly definition: AgentDefinition,
     private readonly config: Config,
+    messageBus?: MessageBus,
   ) {
     // Dynamically generate the JSON schema required for the tool definition.
     const parameterSchema = convertInputConfigToJsonSchema(
@@ -49,6 +52,7 @@ export class SubagentToolWrapper extends BaseDeclarativeTool<
       parameterSchema,
       /* isOutputMarkdown */ true,
       /* canUpdateOutput */ true,
+      messageBus,
     );
   }
 
@@ -64,6 +68,11 @@ export class SubagentToolWrapper extends BaseDeclarativeTool<
   protected createInvocation(
     params: AgentInputs,
   ): ToolInvocation<AgentInputs, ToolResult> {
-    return new SubagentInvocation(params, this.definition, this.config);
+    return new SubagentInvocation(
+      params,
+      this.definition,
+      this.config,
+      this.messageBus,
+    );
   }
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -76,6 +76,9 @@ import type { PolicyEngineConfig } from '../policy/types.js';
 import type { UserTierId } from '../code_assist/types.js';
 import { ProxyAgent, setGlobalDispatcher } from 'undici';
 
+import { AgentRegistry } from '../agents/registry.js';
+import { SubagentToolWrapper } from '../agents/subagent-tool-wrapper.js';
+
 export enum ApprovalMode {
   DEFAULT = 'default',
   AUTO_EDIT = 'autoEdit',
@@ -255,11 +258,13 @@ export interface ConfigParameters {
   output?: OutputSettings;
   useModelRouter?: boolean;
   enableMessageBusIntegration?: boolean;
+  enableSubagents?: boolean;
 }
 
 export class Config {
   private toolRegistry!: ToolRegistry;
   private promptRegistry!: PromptRegistry;
+  private agentRegistry!: AgentRegistry;
   private readonly sessionId: string;
   private fileSystemService: FileSystemService;
   private contentGeneratorConfig!: ContentGeneratorConfig;
@@ -345,6 +350,7 @@ export class Config {
   private readonly outputSettings: OutputSettings;
   private readonly useModelRouter: boolean;
   private readonly enableMessageBusIntegration: boolean;
+  private readonly enableSubagents: boolean;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -433,6 +439,7 @@ export class Config {
     this.useModelRouter = params.useModelRouter ?? false;
     this.enableMessageBusIntegration =
       params.enableMessageBusIntegration ?? false;
+    this.enableSubagents = params.enableSubagents ?? false;
     this.extensionManagement = params.extensionManagement ?? true;
     this.storage = new Storage(this.targetDir);
     this.enablePromptCompletion = params.enablePromptCompletion ?? false;
@@ -474,6 +481,10 @@ export class Config {
       await this.getGitService();
     }
     this.promptRegistry = new PromptRegistry();
+
+    this.agentRegistry = new AgentRegistry(this);
+    await this.agentRegistry.initialize();
+
     this.toolRegistry = await this.createToolRegistry();
 
     await this.geminiClient.initialize();
@@ -618,6 +629,10 @@ export class Config {
 
   getWorkspaceContext(): WorkspaceContext {
     return this.workspaceContext;
+  }
+
+  getAgentRegistry(): AgentRegistry {
+    return this.agentRegistry;
   }
 
   getToolRegistry(): ToolRegistry {
@@ -996,6 +1011,10 @@ export class Config {
     return this.enableMessageBusIntegration;
   }
 
+  getEnableSubagents(): boolean {
+    return this.enableSubagents;
+  }
+
   async createToolRegistry(): Promise<ToolRegistry> {
     const registry = new ToolRegistry(this, this.eventEmitter);
 
@@ -1085,6 +1104,41 @@ export class Config {
     registerCoreTool(WebSearchTool, this);
     if (this.getUseWriteTodos()) {
       registerCoreTool(WriteTodosTool, this);
+    }
+
+    // Register Subagents as Tools
+    if (this.getEnableSubagents()) {
+      const agentDefinitions = this.agentRegistry.getAllDefinitions();
+      for (const definition of agentDefinitions) {
+        // We must respect the main allowed/exclude lists for agents too.
+        const excludeTools = this.getExcludeTools() || [];
+        const allowedTools = this.getAllowedTools();
+
+        const isExcluded = excludeTools.includes(definition.name);
+        const isAllowed =
+          !allowedTools || allowedTools.includes(definition.name);
+
+        if (isAllowed && !isExcluded) {
+          try {
+            const messageBusEnabled = this.getEnableMessageBusIntegration();
+            const wrapper = new SubagentToolWrapper(
+              definition,
+              this,
+              messageBusEnabled ? this.getMessageBus() : undefined,
+            );
+            registry.registerTool(wrapper);
+          } catch (error) {
+            console.error(
+              `Failed to wrap agent '${definition.name}' as a tool:`,
+              error,
+            );
+          }
+        } else if (this.getDebugMode()) {
+          console.log(
+            `[Config] Skipping registration of agent '${definition.name}' due to allow/exclude configuration.`,
+          );
+        }
+      }
     }
 
     await registry.discoverAllTools();

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -13,6 +13,7 @@ import { shortenPath, makeRelative } from '../utils/paths.js';
 import { type Config } from '../config/config.js';
 import { DEFAULT_FILE_FILTERING_OPTIONS } from '../config/constants.js';
 import { ToolErrorType } from './tool-error.js';
+import { GLOB_TOOL_NAME } from './tool-names.js';
 
 // Subset of 'Path' interface provided by 'glob' that we can implement for testing
 export interface GlobPath {
@@ -259,7 +260,7 @@ class GlobToolInvocation extends BaseToolInvocation<
  * Implementation of the Glob tool logic
  */
 export class GlobTool extends BaseDeclarativeTool<GlobToolParams, ToolResult> {
-  static readonly Name = 'glob';
+  static readonly Name = GLOB_TOOL_NAME;
 
   constructor(private config: Config) {
     super(

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Centralized constants for tool names.
+// This prevents circular dependencies that can occur when other modules (like agents)
+// need to reference a tool's name without importing the tool's implementation.
+
+export const GLOB_TOOL_NAME = 'glob';
+
+// TODO: Migrate other tool names here to follow this pattern and prevent future circular dependencies.
+// Candidates for migration:
+// - LSTool ('list_directory')
+// - ReadFileTool ('read_file')
+// - GrepTool ('search_file_content')


### PR DESCRIPTION
## TLDR

This PR introduces the necessary configuration and wiring to enable the experimental "Subagents" feature. It adds a new `enableSubagents` setting, updates the core `Config` to dynamically register subagents as tools when this setting is enabled, and ensures the `MessageBus` is correctly propagated for policy enforcement. It also resolves a circular dependency that was exposed by these changes.

## Dive Deeper

### Configuration Changes
- Added a new boolean setting `experimental.enableSubagents` to the CLI `settingsSchema`. It defaults to `false` and requires a restart to take effect.
- Updated both the CLI and Core `Config` classes to read and expose this setting.

### Subagent Registration
- In `packages/core/src/config/config.ts`, an `AgentRegistry` is now initialized.
- The `createToolRegistry` method has been updated. If `enableSubagents` is `true`, it retrieves all agent definitions from the registry, wraps them in a `SubagentToolWrapper`, and registers them as tools.
- This registration process respects the existing `allowedTools` and `excludeTools` configuration, allowing users to control which subagents are available.

### Message Bus Propagation
- Updated `SubagentToolWrapper` and `SubagentInvocation` to accept an optional `MessageBus` in their constructors.
- The `Config` class now passes the `MessageBus` when creating the `SubagentToolWrapper`. This ensures that any actions taken by the subagents will still participate in the standard confirmation and policy enforcement flow.

### Circular Dependency Fix
The introduction of `AgentRegistry` into `Config` exposed a circular dependency:
`Config` -> `AgentRegistry` -> `CodebaseInvestigatorAgent` -> `GlobTool` -> `Config`.

This was causing `glob.test.ts` to fail. The fix involved decoupling the tool name from the tool implementation:
- Created `packages/core/src/tools/tool-names.ts` to hold tool name constants.
- Updated `GlobTool` to use the constant `GLOB_TOOL_NAME`.
- Updated `CodebaseInvestigatorAgent` to import the name from `tool-names.ts` instead of importing the `GlobTool` class, thus breaking the import cycle.

## Reviewer Test Plan

### 1. Verify Unit Tests
Run preflight and ensure all tests pass

### 2. Verify Configuration Behavior
1.  Start the CLI without modifying settings. Verify that subagents are **not** loaded (you can check `/tools` to see if you see the example codebase investigator).
2.  Open your settings file and add:
    ```json
    "experimental": {
      "enableSubagents": true
    }
    ```
3.  Restart the CLI. Verify that the codebase investigator is being registered now.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |
