### PR TITLE
fix(ui): fix space after info symbol in InfoMessage

### DIFF
--- a/packages/cli/src/ui/components/messages/InfoMessage.tsx
+++ b/packages/cli/src/ui/components/messages/InfoMessage.tsx
@@ -15,7 +15,7 @@ interface InfoMessageProps {
 
 export const InfoMessage: React.FC<InfoMessageProps> = ({ text }) => {
   const prefix = 'ℹ ';
-  const prefixWidth = prefix.length;
+  const prefixWidth = 3;
 
   return (
     <Box flexDirection="row" marginTop={1}>


### PR DESCRIPTION
## TLDR

Fixes #9790

## Dive Deeper

The hardcoded value for `prefixWidth` follows from how warning messages are rendered;
https://github.com/google-gemini/gemini-cli/blob/2aa2ab878b82b7813c340748ee7711fe6c936530/packages/cli/src/ui/components/messages/WarningMessage.tsx#L18
which seems to work for info messages as well.