### PR TITLE
feat(core): Use lastPromptTokenCount to determine if we need to compress

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -115,6 +115,7 @@ vi.mock('../ide/ideContext.js');
 vi.mock('../telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),
+    getLastPromptTokenCount: vi.fn(),
   },
 }));
 
@@ -261,7 +262,6 @@ describe('Gemini Client (client.ts)', () => {
     mockContentGenerator = {
       generateContent: mockGenerateContentFn,
       generateContentStream: vi.fn(),
-      countTokens: vi.fn().mockResolvedValue({ totalTokens: 100 }),
       batchEmbedContents: vi.fn(),
     } as unknown as ContentGenerator;
 
@@ -402,102 +402,161 @@ describe('Gemini Client (client.ts)', () => {
         { role: 'user', parts: [{ text: 'Long conversation' }] },
         { role: 'model', parts: [{ text: 'Long response' }] },
       ] as Content[],
+      originalTokenCount = 1000,
+      summaryText = 'This is a summary.',
     } = {}) {
-      const mockChat: Partial<GeminiChat> = {
-        getHistory: vi.fn().mockReturnValue(chatHistory),
+      const mockOriginalChat: Partial<GeminiChat> = {
+        getHistory: vi.fn((_curated?: boolean) => chatHistory),
         setHistory: vi.fn(),
       };
-      vi.mocked(mockContentGenerator.countTokens)
-        .mockResolvedValueOnce({ totalTokens: 1000 })
-        .mockResolvedValueOnce({ totalTokens: 5000 });
+      client['chat'] = mockOriginalChat as GeminiChat;
 
-      client['chat'] = mockChat as GeminiChat;
-      client['startChat'] = vi.fn().mockResolvedValue({ ...mockChat });
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        originalTokenCount,
+      );
 
-      return { client, mockChat };
+      mockGenerateContentFn.mockResolvedValue({
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: summaryText }],
+            },
+          },
+        ],
+      } as unknown as GenerateContentResponse);
+
+      // Calculate what the new history will be
+      const splitPoint = findCompressSplitPoint(chatHistory, 0.7); // 1 - 0.3
+      const historyToKeep = chatHistory.slice(splitPoint);
+
+      // This is the history that the new chat will have.
+      // It includes the default startChat history + the extra history from tryCompressChat
+      const newCompressedHistory: Content[] = [
+        // Mocked envParts + canned response from startChat
+        {
+          role: 'user',
+          parts: [{ text: 'Mocked env context' }],
+        },
+        {
+          role: 'model',
+          parts: [{ text: 'Got it. Thanks for the context!' }],
+        },
+        // extraHistory from tryCompressChat
+        {
+          role: 'user',
+          parts: [{ text: summaryText }],
+        },
+        {
+          role: 'model',
+          parts: [{ text: 'Got it. Thanks for the additional context!' }],
+        },
+        ...historyToKeep,
+      ];
+
+      const mockNewChat: Partial<GeminiChat> = {
+        getHistory: vi.fn().mockReturnValue(newCompressedHistory),
+        setHistory: vi.fn(),
+      };
+
+      client['startChat'] = vi
+        .fn()
+        .mockResolvedValue(mockNewChat as GeminiChat);
+
+      const totalChars = newCompressedHistory.reduce(
+        (total, content) => total + JSON.stringify(content).length,
+        0,
+      );
+      const estimatedNewTokenCount = Math.floor(totalChars / 4);
+
+      return {
+        client,
+        mockOriginalChat,
+        mockNewChat,
+        estimatedNewTokenCount,
+      };
     }
 
     describe('when compression inflates the token count', () => {
       it('allows compression to be forced/manual after a failure', async () => {
-        const { client } = setup();
-
-        vi.mocked(mockContentGenerator.countTokens).mockResolvedValue({
-          totalTokens: 1000,
+        // Call 1 (Fails): Setup with a long summary to inflate tokens
+        const longSummary = 'long summary '.repeat(100);
+        const { client, estimatedNewTokenCount: inflatedTokenCount } = setup({
+          originalTokenCount: 100,
+          summaryText: longSummary,
         });
+        expect(inflatedTokenCount).toBeGreaterThan(100); // Ensure setup is correct
+
         await client.tryCompressChat('prompt-id-4', false); // Fails
-        const result = await client.tryCompressChat('prompt-id-4', true);
+
+        // Call 2 (Forced): Re-setup with a short summary
+        const shortSummary = 'short';
+        const { estimatedNewTokenCount: compressedTokenCount } = setup({
+          originalTokenCount: 100,
+          summaryText: shortSummary,
+        });
+        expect(compressedTokenCount).toBeLessThanOrEqual(100); // Ensure setup is correct
+
+        const result = await client.tryCompressChat('prompt-id-4', true); // Forced
 
         expect(result).toEqual({
           compressionStatus: CompressionStatus.COMPRESSED,
-          newTokenCount: 1000,
-          originalTokenCount: 1000,
+          newTokenCount: compressedTokenCount,
+          originalTokenCount: 100,
         });
       });
 
       it('yields the result even if the compression inflated the tokens', async () => {
-        const { client } = setup();
-        vi.mocked(mockContentGenerator.countTokens).mockResolvedValue({
-          totalTokens: 1000,
+        const longSummary = 'long summary '.repeat(100);
+        const { client, estimatedNewTokenCount } = setup({
+          originalTokenCount: 100,
+          summaryText: longSummary,
         });
+        expect(estimatedNewTokenCount).toBeGreaterThan(100); // Ensure setup is correct
+
         const result = await client.tryCompressChat('prompt-id-4', false);
 
         expect(result).toEqual({
           compressionStatus:
             CompressionStatus.COMPRESSION_FAILED_INFLATED_TOKEN_COUNT,
-          newTokenCount: 5000,
-          originalTokenCount: 1000,
+          newTokenCount: estimatedNewTokenCount,
+          originalTokenCount: 100,
         });
-        expect(uiTelemetryService.setLastPromptTokenCount).toHaveBeenCalledWith(
-          5000,
-        );
+        // IMPORTANT: The change in client.ts means setLastPromptTokenCount is NOT called on failure
         expect(
           uiTelemetryService.setLastPromptTokenCount,
-        ).toHaveBeenCalledTimes(1);
+        ).not.toHaveBeenCalled();
       });
 
       it('does not manipulate the source chat', async () => {
-        const { client, mockChat } = setup();
+        const longSummary = 'long summary '.repeat(100);
+        const { client, mockOriginalChat, estimatedNewTokenCount } = setup({
+          originalTokenCount: 100,
+          summaryText: longSummary,
+        });
+        expect(estimatedNewTokenCount).toBeGreaterThan(100); // Ensure setup is correct
+
         await client.tryCompressChat('prompt-id-4', false);
 
-        expect(client['chat']).toBe(mockChat); // a new chat session was not created
-      });
-
-      it('restores the history back to the original', async () => {
-        vi.mocked(tokenLimit).mockReturnValue(1000);
-        vi.mocked(mockContentGenerator.countTokens).mockResolvedValue({
-          totalTokens: 999,
-        });
-
-        const originalHistory: Content[] = [
-          { role: 'user', parts: [{ text: 'what is your wisdom?' }] },
-          { role: 'model', parts: [{ text: 'some wisdom' }] },
-          { role: 'user', parts: [{ text: 'ahh that is a good a wisdom' }] },
-        ];
-
-        const { client } = setup({
-          chatHistory: originalHistory,
-        });
-        const { compressionStatus } = await client.tryCompressChat(
-          'prompt-id-4',
-          false,
-        );
-
-        expect(compressionStatus).toBe(
-          CompressionStatus.COMPRESSION_FAILED_INFLATED_TOKEN_COUNT,
-        );
-        expect(client['chat']?.setHistory).toHaveBeenCalledWith(
-          originalHistory,
-        );
+        // On failure, the chat should NOT be replaced
+        expect(client['chat']).toBe(mockOriginalChat);
       });
 
       it('will not attempt to compress context after a failure', async () => {
-        const { client } = setup();
-        await client.tryCompressChat('prompt-id-4', false);
+        const longSummary = 'long summary '.repeat(100);
+        const { client, estimatedNewTokenCount } = setup({
+          originalTokenCount: 100,
+          summaryText: longSummary,
+        });
+        expect(estimatedNewTokenCount).toBeGreaterThan(100); // Ensure setup is correct
 
+        await client.tryCompressChat('prompt-id-4', false); // This fails and sets hasFailedCompressionAttempt = true
+
+        // This call should now be a NOOP
         const result = await client.tryCompressChat('prompt-id-5', false);
 
-        // it counts tokens for {original, compressed} and then never again
-        expect(mockContentGenerator.countTokens).toHaveBeenCalledTimes(2);
+        // generateContent (for summary) should only have been called once
+        expect(mockGenerateContentFn).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
           compressionStatus: CompressionStatus.NOOP,
           newTokenCount: 0,
@@ -512,9 +571,10 @@ describe('Gemini Client (client.ts)', () => {
       mockGetHistory.mockReturnValue([
         { role: 'user', parts: [{ text: '...history...' }] },
       ]);
-      vi.mocked(mockContentGenerator.countTokens).mockResolvedValue({
-        totalTokens: MOCKED_TOKEN_LIMIT * 0.699, // TOKEN_THRESHOLD_FOR_SUMMARIZATION = 0.7
-      });
+      const originalTokenCount = MOCKED_TOKEN_LIMIT * 0.699;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        originalTokenCount,
+      );
 
       const initialChat = client.getChat();
       const result = await client.tryCompressChat('prompt-id-2', false);
@@ -523,8 +583,8 @@ describe('Gemini Client (client.ts)', () => {
       expect(tokenLimit).toHaveBeenCalled();
       expect(result).toEqual({
         compressionStatus: CompressionStatus.NOOP,
-        newTokenCount: 699,
-        originalTokenCount: 699,
+        newTokenCount: originalTokenCount,
+        originalTokenCount,
       });
       expect(newChat).toBe(initialChat);
     });
@@ -538,17 +598,43 @@ describe('Gemini Client (client.ts)', () => {
       vi.spyOn(client['config'], 'getChatCompression').mockReturnValue({
         contextPercentageThreshold: MOCKED_CONTEXT_PERCENTAGE_THRESHOLD,
       });
-      mockGetHistory.mockReturnValue([
-        { role: 'user', parts: [{ text: '...history...' }] },
-      ]);
+      const history = [{ role: 'user', parts: [{ text: '...history...' }] }];
+      mockGetHistory.mockReturnValue(history);
 
       const originalTokenCount =
         MOCKED_TOKEN_LIMIT * MOCKED_CONTEXT_PERCENTAGE_THRESHOLD;
-      const newTokenCount = 100;
 
-      vi.mocked(mockContentGenerator.countTokens)
-        .mockResolvedValueOnce({ totalTokens: originalTokenCount }) // First call for the check
-        .mockResolvedValueOnce({ totalTokens: newTokenCount }); // Second call for the new history
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        originalTokenCount,
+      );
+
+      // We need to control the estimated new token count.
+      // We mock startChat to return a chat with a known history.
+      const summaryText = 'This is a summary.';
+      const splitPoint = findCompressSplitPoint(history, 0.7);
+      const historyToKeep = history.slice(splitPoint);
+      const newCompressedHistory: Content[] = [
+        { role: 'user', parts: [{ text: 'Mocked env context' }] },
+        { role: 'model', parts: [{ text: 'Got it. Thanks for the context!' }] },
+        { role: 'user', parts: [{ text: summaryText }] },
+        {
+          role: 'model',
+          parts: [{ text: 'Got it. Thanks for the additional context!' }],
+        },
+        ...historyToKeep,
+      ];
+      const mockNewChat: Partial<GeminiChat> = {
+        getHistory: vi.fn().mockReturnValue(newCompressedHistory),
+      };
+      client['startChat'] = vi
+        .fn()
+        .mockResolvedValue(mockNewChat as GeminiChat);
+
+      const totalChars = newCompressedHistory.reduce(
+        (total, content) => total + JSON.stringify(content).length,
+        0,
+      );
+      const newTokenCount = Math.floor(totalChars / 4);
 
       // Mock the summary response from the chat
       mockGenerateContentFn.mockResolvedValue({
@@ -556,7 +642,7 @@ describe('Gemini Client (client.ts)', () => {
           {
             content: {
               role: 'model',
-              parts: [{ text: 'This is a summary.' }],
+              parts: [{ text: summaryText }],
             },
           },
         ],
@@ -587,17 +673,42 @@ describe('Gemini Client (client.ts)', () => {
       vi.spyOn(client['config'], 'getChatCompression').mockReturnValue({
         contextPercentageThreshold: MOCKED_CONTEXT_PERCENTAGE_THRESHOLD,
       });
-      mockGetHistory.mockReturnValue([
-        { role: 'user', parts: [{ text: '...history...' }] },
-      ]);
+      const history = [{ role: 'user', parts: [{ text: '...history...' }] }];
+      mockGetHistory.mockReturnValue(history);
 
       const originalTokenCount =
         MOCKED_TOKEN_LIMIT * MOCKED_CONTEXT_PERCENTAGE_THRESHOLD;
-      const newTokenCount = 100;
 
-      vi.mocked(mockContentGenerator.countTokens)
-        .mockResolvedValueOnce({ totalTokens: originalTokenCount }) // First call for the check
-        .mockResolvedValueOnce({ totalTokens: newTokenCount }); // Second call for the new history
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        originalTokenCount,
+      );
+
+      // Mock summary and new chat
+      const summaryText = 'This is a summary.';
+      const splitPoint = findCompressSplitPoint(history, 0.7);
+      const historyToKeep = history.slice(splitPoint);
+      const newCompressedHistory: Content[] = [
+        { role: 'user', parts: [{ text: 'Mocked env context' }] },
+        { role: 'model', parts: [{ text: 'Got it. Thanks for the context!' }] },
+        { role: 'user', parts: [{ text: summaryText }] },
+        {
+          role: 'model',
+          parts: [{ text: 'Got it. Thanks for the additional context!' }],
+        },
+        ...historyToKeep,
+      ];
+      const mockNewChat: Partial<GeminiChat> = {
+        getHistory: vi.fn().mockReturnValue(newCompressedHistory),
+      };
+      client['startChat'] = vi
+        .fn()
+        .mockResolvedValue(mockNewChat as GeminiChat);
+
+      const totalChars = newCompressedHistory.reduce(
+        (total, content) => total + JSON.stringify(content).length,
+        0,
+      );
+      const newTokenCount = Math.floor(totalChars / 4);
 
       // Mock the summary response from the chat
       mockGenerateContentFn.mockResolvedValue({
@@ -605,7 +716,7 @@ describe('Gemini Client (client.ts)', () => {
           {
             content: {
               role: 'model',
-              parts: [{ text: 'This is a summary.' }],
+              parts: [{ text: summaryText }],
             },
           },
         ],
@@ -632,7 +743,7 @@ describe('Gemini Client (client.ts)', () => {
     it('should not compress across a function call response', async () => {
       const MOCKED_TOKEN_LIMIT = 1000;
       vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
-      mockGetHistory.mockReturnValue([
+      const history: Content[] = [
         { role: 'user', parts: [{ text: '...history 1...' }] },
         { role: 'model', parts: [{ text: '...history 2...' }] },
         { role: 'user', parts: [{ text: '...history 3...' }] },
@@ -649,14 +760,45 @@ describe('Gemini Client (client.ts)', () => {
         { role: 'model', parts: [{ text: '...history 10...' }] },
         // Instead we will break here.
         { role: 'user', parts: [{ text: '...history 10...' }] },
-      ]);
+      ];
+      mockGetHistory.mockReturnValue(history);
 
       const originalTokenCount = 1000 * 0.7;
-      const newTokenCount = 100;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        originalTokenCount,
+      );
 
-      vi.mocked(mockContentGenerator.countTokens)
-        .mockResolvedValueOnce({ totalTokens: originalTokenCount }) // First call for the check
-        .mockResolvedValueOnce({ totalTokens: newTokenCount }); // Second call for the new history
+      // Mock summary and new chat
+      const summaryText = 'This is a summary.';
+      const splitPoint = findCompressSplitPoint(history, 0.7); // This should be 10
+      expect(splitPoint).toBe(10); // Verify split point logic
+      const historyToKeep = history.slice(splitPoint); // Should keep last user message
+      expect(historyToKeep).toEqual([
+        { role: 'user', parts: [{ text: '...history 10...' }] },
+      ]);
+
+      const newCompressedHistory: Content[] = [
+        { role: 'user', parts: [{ text: 'Mocked env context' }] },
+        { role: 'model', parts: [{ text: 'Got it. Thanks for the context!' }] },
+        { role: 'user', parts: [{ text: summaryText }] },
+        {
+          role: 'model',
+          parts: [{ text: 'Got it. Thanks for the additional context!' }],
+        },
+        ...historyToKeep,
+      ];
+      const mockNewChat: Partial<GeminiChat> = {
+        getHistory: vi.fn().mockReturnValue(newCompressedHistory),
+      };
+      client['startChat'] = vi
+        .fn()
+        .mockResolvedValue(mockNewChat as GeminiChat);
+
+      const totalChars = newCompressedHistory.reduce(
+        (total, content) => total + JSON.stringify(content).length,
+        0,
+      );
+      const newTokenCount = Math.floor(totalChars / 4);
 
       // Mock the summary response from the chat
       mockGenerateContentFn.mockResolvedValue({
@@ -664,7 +806,7 @@ describe('Gemini Client (client.ts)', () => {
           {
             content: {
               role: 'model',
-              parts: [{ text: 'This is a summary.' }],
+              parts: [{ text: summaryText }],
             },
           },
         ],
@@ -686,25 +828,49 @@ describe('Gemini Client (client.ts)', () => {
       // Assert that the chat was reset
       expect(newChat).not.toBe(initialChat);
 
-      // 1. standard start context message
-      // 2. standard canned user start message
-      // 3. compressed summary message
-      // 4. standard canned user summary message
-      // 5. The last user message (not the last 3 because that would start with a function response)
+      // 1. standard start context message (env)
+      // 2. standard canned model response
+      // 3. compressed summary message (user)
+      // 4. standard canned model response
+      // 5. The last user message (historyToKeep)
       expect(newChat.getHistory().length).toEqual(5);
     });
 
     it('should always trigger summarization when force is true, regardless of token count', async () => {
-      mockGetHistory.mockReturnValue([
-        { role: 'user', parts: [{ text: '...history...' }] },
-      ]);
+      const history = [{ role: 'user', parts: [{ text: '...history...' }] }];
+      mockGetHistory.mockReturnValue(history);
 
-      const originalTokenCount = 10; // Well below threshold
-      const newTokenCount = 5;
+      const originalTokenCount = 100; // Well below threshold, but > estimated new count
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        originalTokenCount,
+      );
 
-      vi.mocked(mockContentGenerator.countTokens)
-        .mockResolvedValueOnce({ totalTokens: originalTokenCount })
-        .mockResolvedValueOnce({ totalTokens: newTokenCount });
+      // Mock summary and new chat
+      const summaryText = 'This is a summary.';
+      const splitPoint = findCompressSplitPoint(history, 0.7);
+      const historyToKeep = history.slice(splitPoint);
+      const newCompressedHistory: Content[] = [
+        { role: 'user', parts: [{ text: 'Mocked env context' }] },
+        { role: 'model', parts: [{ text: 'Got it. Thanks for the context!' }] },
+        { role: 'user', parts: [{ text: summaryText }] },
+        {
+          role: 'model',
+          parts: [{ text: 'Got it. Thanks for the additional context!' }],
+        },
+        ...historyToKeep,
+      ];
+      const mockNewChat: Partial<GeminiChat> = {
+        getHistory: vi.fn().mockReturnValue(newCompressedHistory),
+      };
+      client['startChat'] = vi
+        .fn()
+        .mockResolvedValue(mockNewChat as GeminiChat);
+
+      const totalChars = newCompressedHistory.reduce(
+        (total, content) => total + JSON.stringify(content).length,
+        0,
+      );
+      const newTokenCount = Math.floor(totalChars / 4);
 
       // Mock the summary response from the chat
       mockGenerateContentFn.mockResolvedValue({
@@ -712,14 +878,14 @@ describe('Gemini Client (client.ts)', () => {
           {
             content: {
               role: 'model',
-              parts: [{ text: 'This is a summary.' }],
+              parts: [{ text: summaryText }],
             },
           },
         ],
       } as unknown as GenerateContentResponse);
 
       const initialChat = client.getChat();
-      const result = await client.tryCompressChat('prompt-id-1', false); // force = true
+      const result = await client.tryCompressChat('prompt-id-1', true); // force = true
       const newChat = client.getChat();
 
       expect(mockGenerateContentFn).toHaveBeenCalled();
@@ -776,10 +942,6 @@ describe('Gemini Client (client.ts)', () => {
           CompressionStatus.COMPRESSION_FAILED_INFLATED_TOKEN_COUNT,
       },
       { compressionStatus: CompressionStatus.NOOP },
-      {
-        compressionStatus:
-          CompressionStatus.COMPRESSION_FAILED_TOKEN_COUNT_ERROR,
-      },
     ])(
       'does not emit a compression event when the status is $compressionStatus',
       async ({ compressionStatus }) => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -115,7 +115,6 @@ vi.mock('../ide/ideContext.js');
 vi.mock('../telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),
-    getLastPromptTokenCount: vi.fn(),
   },
 }));
 
@@ -251,7 +250,6 @@ describe('Gemini Client (client.ts)', () => {
   beforeEach(async () => {
     vi.resetAllMocks();
     vi.mocked(uiTelemetryService.setLastPromptTokenCount).mockClear();
-    vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(1000);
 
     mockGenerateContentFn = vi.fn().mockResolvedValue({
       candidates: [{ content: { parts: [{ text: '{"key": "value"}' }] } }],
@@ -263,6 +261,7 @@ describe('Gemini Client (client.ts)', () => {
     mockContentGenerator = {
       generateContent: mockGenerateContentFn,
       generateContentStream: vi.fn(),
+      countTokens: vi.fn().mockResolvedValue({ totalTokens: 100 }),
       batchEmbedContents: vi.fn(),
     } as unknown as ContentGenerator;
 
@@ -359,12 +358,12 @@ describe('Gemini Client (client.ts)', () => {
     it('should create a new chat session, clearing the old history', async () => {
       // 1. Get the initial chat instance and add some history.
       const initialChat = client.getChat();
-      const initialHistory = client.getHistory();
+      const initialHistory = await client.getHistory();
       await client.addHistory({
         role: 'user',
         parts: [{ text: 'some old message' }],
       });
-      const historyWithOldMessage = client.getHistory();
+      const historyWithOldMessage = await client.getHistory();
       expect(historyWithOldMessage.length).toBeGreaterThan(
         initialHistory.length,
       );
@@ -374,7 +373,7 @@ describe('Gemini Client (client.ts)', () => {
 
       // 3. Get the new chat instance and its history.
       const newChat = client.getChat();
-      const newHistory = client.getHistory();
+      const newHistory = await client.getHistory();
 
       // 4. Assert that the chat instance is new and the history is reset.
       expect(newChat).not.toBe(initialChat);
@@ -403,87 +402,61 @@ describe('Gemini Client (client.ts)', () => {
         { role: 'user', parts: [{ text: 'Long conversation' }] },
         { role: 'model', parts: [{ text: 'Long response' }] },
       ] as Content[],
-      originalTokenCount = 1000,
-      newTokenCount = 5000,
     } = {}) {
       const mockChat: Partial<GeminiChat> = {
         getHistory: vi.fn().mockReturnValue(chatHistory),
         setHistory: vi.fn(),
       };
-
-      // Mock the telemetry service to return the original token count
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        originalTokenCount,
-      );
-
-      // Create mock history that when estimated will result in newTokenCount
-      // We need to account for JSON.stringify overhead
-      const baseStructure = [
-        { role: 'user', parts: [{ text: '' }] },
-        { role: 'model', parts: [{ text: 'Response' }] },
-      ];
-      const baseChars = JSON.stringify(baseStructure).length;
-      const targetChars = newTokenCount * 4;
-      const contentChars = Math.max(1, targetChars - baseChars);
-
-      const mockCompressedHistory = [
-        { role: 'user', parts: [{ text: 'A'.repeat(contentChars) }] },
-        { role: 'model', parts: [{ text: 'Response' }] },
-      ];
+      vi.mocked(mockContentGenerator.countTokens)
+        .mockResolvedValueOnce({ totalTokens: 1000 })
+        .mockResolvedValueOnce({ totalTokens: 5000 });
 
       client['chat'] = mockChat as GeminiChat;
-
-      // Mock startChat to return a chat with the compressed history
-      const mockCompressedChat = {
-        ...mockChat,
-        getHistory: vi.fn().mockReturnValue(mockCompressedHistory),
-      };
-      client['startChat'] = vi.fn().mockResolvedValue(mockCompressedChat);
+      client['startChat'] = vi.fn().mockResolvedValue({ ...mockChat });
 
       return { client, mockChat };
     }
 
     describe('when compression inflates the token count', () => {
       it('allows compression to be forced/manual after a failure', async () => {
-        const { client } = setup({
-          originalTokenCount: 1000,
-          newTokenCount: 1000,
-        });
+        const { client } = setup();
 
+        vi.mocked(mockContentGenerator.countTokens).mockResolvedValue({
+          totalTokens: 1000,
+        });
         await client.tryCompressChat('prompt-id-4', false); // Fails
         const result = await client.tryCompressChat('prompt-id-4', true);
 
         expect(result).toEqual({
-          compressionStatus: CompressionStatus.NOOP,
-          newTokenCount: 0,
-          originalTokenCount: 0,
+          compressionStatus: CompressionStatus.COMPRESSED,
+          newTokenCount: 1000,
+          originalTokenCount: 1000,
         });
       });
 
       it('yields the result even if the compression inflated the tokens', async () => {
-        const { client } = setup({
-          originalTokenCount: 1000,
-          newTokenCount: 5000,
+        const { client } = setup();
+        vi.mocked(mockContentGenerator.countTokens).mockResolvedValue({
+          totalTokens: 1000,
         });
         const result = await client.tryCompressChat('prompt-id-4', false);
 
         expect(result).toEqual({
           compressionStatus:
             CompressionStatus.COMPRESSION_FAILED_INFLATED_TOKEN_COUNT,
-          newTokenCount: 4999, // Character-based estimation gives 4999 instead of 5000
+          newTokenCount: 5000,
           originalTokenCount: 1000,
         });
-        // Telemetry should NOT be updated when compression fails
+        expect(uiTelemetryService.setLastPromptTokenCount).toHaveBeenCalledWith(
+          5000,
+        );
         expect(
           uiTelemetryService.setLastPromptTokenCount,
-        ).not.toHaveBeenCalled();
+        ).toHaveBeenCalledTimes(1);
       });
 
       it('does not manipulate the source chat', async () => {
-        const { client, mockChat } = setup({
-          originalTokenCount: 1000,
-          newTokenCount: 5000,
-        });
+        const { client, mockChat } = setup();
         await client.tryCompressChat('prompt-id-4', false);
 
         expect(client['chat']).toBe(mockChat); // a new chat session was not created
@@ -491,6 +464,9 @@ describe('Gemini Client (client.ts)', () => {
 
       it('restores the history back to the original', async () => {
         vi.mocked(tokenLimit).mockReturnValue(1000);
+        vi.mocked(mockContentGenerator.countTokens).mockResolvedValue({
+          totalTokens: 999,
+        });
 
         const originalHistory: Content[] = [
           { role: 'user', parts: [{ text: 'what is your wisdom?' }] },
@@ -500,8 +476,6 @@ describe('Gemini Client (client.ts)', () => {
 
         const { client } = setup({
           chatHistory: originalHistory,
-          originalTokenCount: 999,
-          newTokenCount: 1200,
         });
         const { compressionStatus } = await client.tryCompressChat(
           'prompt-id-4',
@@ -511,20 +485,19 @@ describe('Gemini Client (client.ts)', () => {
         expect(compressionStatus).toBe(
           CompressionStatus.COMPRESSION_FAILED_INFLATED_TOKEN_COUNT,
         );
-        // After compression failure, the original chat should remain unchanged
-        // (we removed the setHistory call that was incorrectly modifying state on failure)
+        expect(client['chat']?.setHistory).toHaveBeenCalledWith(
+          originalHistory,
+        );
       });
 
       it('will not attempt to compress context after a failure', async () => {
-        const { client } = setup({
-          originalTokenCount: 1000,
-          newTokenCount: 5000,
-        });
+        const { client } = setup();
         await client.tryCompressChat('prompt-id-4', false);
 
         const result = await client.tryCompressChat('prompt-id-5', false);
 
-        // After the first failure, subsequent calls should return NOOP
+        // it counts tokens for {original, compressed} and then never again
+        expect(mockContentGenerator.countTokens).toHaveBeenCalledTimes(2);
         expect(result).toEqual({
           compressionStatus: CompressionStatus.NOOP,
           newTokenCount: 0,
@@ -537,16 +510,11 @@ describe('Gemini Client (client.ts)', () => {
       const MOCKED_TOKEN_LIMIT = 1000;
       vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
       mockGetHistory.mockReturnValue([
-        { role: 'user', parts: [{ text: 'Environment context' }] }, // Initial context (index 0)
-        { role: 'model', parts: [{ text: 'Got it. Thanks for the context!' }] }, // Initial response (index 1)
-        { role: 'user', parts: [{ text: '...history...' }] }, // Real conversation
+        { role: 'user', parts: [{ text: '...history...' }] },
       ]);
-
-      // Mock telemetry service to return token count below threshold
-      const originalTokenCount = MOCKED_TOKEN_LIMIT * 0.699; // TOKEN_THRESHOLD_FOR_SUMMARIZATION = 0.7
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        originalTokenCount,
-      );
+      vi.mocked(mockContentGenerator.countTokens).mockResolvedValue({
+        totalTokens: MOCKED_TOKEN_LIMIT * 0.699, // TOKEN_THRESHOLD_FOR_SUMMARIZATION = 0.7
+      });
 
       const initialChat = client.getChat();
       const result = await client.tryCompressChat('prompt-id-2', false);
@@ -576,12 +544,11 @@ describe('Gemini Client (client.ts)', () => {
 
       const originalTokenCount =
         MOCKED_TOKEN_LIMIT * MOCKED_CONTEXT_PERCENTAGE_THRESHOLD;
-      const newTokenCount = 162; // Character-based estimation gives 162
+      const newTokenCount = 100;
 
-      // Mock telemetry service to return the original token count
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        originalTokenCount,
-      );
+      vi.mocked(mockContentGenerator.countTokens)
+        .mockResolvedValueOnce({ totalTokens: originalTokenCount }) // First call for the check
+        .mockResolvedValueOnce({ totalTokens: newTokenCount }); // Second call for the new history
 
       // Mock the summary response from the chat
       mockGenerateContentFn.mockResolvedValue({
@@ -626,12 +593,11 @@ describe('Gemini Client (client.ts)', () => {
 
       const originalTokenCount =
         MOCKED_TOKEN_LIMIT * MOCKED_CONTEXT_PERCENTAGE_THRESHOLD;
-      const newTokenCount = 162; // Character-based estimation gives 162
+      const newTokenCount = 100;
 
-      // Mock telemetry service to return the original token count
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        originalTokenCount,
-      );
+      vi.mocked(mockContentGenerator.countTokens)
+        .mockResolvedValueOnce({ totalTokens: originalTokenCount }) // First call for the check
+        .mockResolvedValueOnce({ totalTokens: newTokenCount }); // Second call for the new history
 
       // Mock the summary response from the chat
       mockGenerateContentFn.mockResolvedValue({
@@ -686,12 +652,11 @@ describe('Gemini Client (client.ts)', () => {
       ]);
 
       const originalTokenCount = 1000 * 0.7;
-      const newTokenCount = 149; // Character-based estimation gives 149
+      const newTokenCount = 100;
 
-      // Mock telemetry service to return the original token count
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        originalTokenCount,
-      );
+      vi.mocked(mockContentGenerator.countTokens)
+        .mockResolvedValueOnce({ totalTokens: originalTokenCount }) // First call for the check
+        .mockResolvedValueOnce({ totalTokens: newTokenCount }); // Second call for the new history
 
       // Mock the summary response from the chat
       mockGenerateContentFn.mockResolvedValue({
@@ -734,13 +699,12 @@ describe('Gemini Client (client.ts)', () => {
         { role: 'user', parts: [{ text: '...history...' }] },
       ]);
 
-      const originalTokenCount = 200; // Well below threshold but realistic
-      const newTokenCount = 162; // Character-based estimation gives 162
+      const originalTokenCount = 10; // Well below threshold
+      const newTokenCount = 5;
 
-      // Mock telemetry service to return the original token count
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        originalTokenCount,
-      );
+      vi.mocked(mockContentGenerator.countTokens)
+        .mockResolvedValueOnce({ totalTokens: originalTokenCount })
+        .mockResolvedValueOnce({ totalTokens: newTokenCount });
 
       // Mock the summary response from the chat
       mockGenerateContentFn.mockResolvedValue({
@@ -768,143 +732,6 @@ describe('Gemini Client (client.ts)', () => {
 
       // Assert that the chat was reset
       expect(newChat).not.toBe(initialChat);
-    });
-
-    it('should skip initial context messages when determining compression split point', async () => {
-      // Test verifies that the first 2 messages (initial context) are excluded from compression
-      const MOCKED_TOKEN_LIMIT = 1000;
-      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
-
-      // Mock curated history that includes initial context + user messages
-      const fullHistory = [
-        { role: 'user', parts: [{ text: 'Environment context' }] }, // Initial context (index 0)
-        { role: 'model', parts: [{ text: 'Got it. Thanks for the context!' }] }, // Initial response (index 1)
-        { role: 'user', parts: [{ text: 'User message 1' }] }, // First real user message (index 2)
-        { role: 'model', parts: [{ text: 'Model response 1' }] }, // First real model response
-        { role: 'user', parts: [{ text: 'User message 2' }] }, // Second real user message
-        { role: 'model', parts: [{ text: 'Model response 2' }] }, // Second real model response
-      ];
-
-      // getHistory(true) returns curated history, then slice(2) excludes initial context
-      mockGetHistory.mockReturnValue(fullHistory);
-
-      const originalTokenCount = MOCKED_TOKEN_LIMIT * 0.8; // Above compression threshold
-      const newTokenCount = 91; // Character-based estimation gives 91
-
-      // Mock telemetry service to return the original token count
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        originalTokenCount,
-      );
-
-      // Mock the summary response
-      mockGenerateContentFn.mockResolvedValue({
-        candidates: [
-          {
-            content: {
-              role: 'model',
-              parts: [{ text: 'This is a summary.' }],
-            },
-          },
-        ],
-      } as unknown as GenerateContentResponse);
-
-      // Mock startChat to verify the history passed to it
-      const mockNewChat = {
-        getHistory: vi.fn().mockReturnValue([
-          { role: 'user', parts: [{ text: 'Environment context' }] },
-          {
-            role: 'model',
-            parts: [{ text: 'Got it. Thanks for the context!' }],
-          },
-          { role: 'user', parts: [{ text: 'This is a summary.' }] },
-          {
-            role: 'model',
-            parts: [{ text: 'Got it. Thanks for the additional context!' }],
-          },
-          // Only the last messages should be kept, not the initial ones
-          { role: 'user', parts: [{ text: 'User message 2' }] },
-          { role: 'model', parts: [{ text: 'Model response 2' }] },
-        ]),
-        setHistory: vi.fn(),
-      };
-
-      client['startChat'] = vi.fn().mockResolvedValue(mockNewChat);
-
-      const result = await client.tryCompressChat(
-        'prompt-id-initial-context',
-        false,
-      );
-
-      expect(result).toEqual({
-        compressionStatus: CompressionStatus.COMPRESSED,
-        originalTokenCount,
-        newTokenCount,
-      });
-
-      // Verify that the original token count was retrieved from telemetry service
-      expect(uiTelemetryService.getLastPromptTokenCount).toHaveBeenCalled();
-    });
-
-    it('should return NOOP when compression split point is 0', async () => {
-      // Test the early return when findCompressSplitPoint returns 0
-      const MOCKED_TOKEN_LIMIT = 1000;
-      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
-
-      // Create history where all messages would need to be preserved
-      // (e.g., only function responses that can't be split)
-      const historyWithNoSplitPoint = [
-        { role: 'user', parts: [{ text: 'Environment context' }] },
-        { role: 'model', parts: [{ text: 'Got it. Thanks for the context!' }] },
-        {
-          role: 'user',
-          parts: [{ functionResponse: { name: 'tool1', response: {} } }],
-        },
-        {
-          role: 'model',
-          parts: [{ functionCall: { name: 'tool2', args: {} } }],
-        },
-      ];
-
-      mockGetHistory.mockReturnValue(historyWithNoSplitPoint);
-
-      const result = await client.tryCompressChat('prompt-id-no-split', false);
-
-      expect(result).toEqual({
-        originalTokenCount: 0,
-        newTokenCount: 0,
-        compressionStatus: CompressionStatus.NOOP,
-      });
-
-      // Verify generateContent was never called since we returned early
-      expect(mockGenerateContentFn).not.toHaveBeenCalled();
-    });
-
-    it('should handle empty history after slicing initial context', async () => {
-      // Test edge case where history only contains initial context
-      const MOCKED_TOKEN_LIMIT = 1000;
-      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
-
-      // History with only initial context (first 2 messages)
-      const initialContextOnly = [
-        { role: 'user', parts: [{ text: 'Environment context' }] },
-        { role: 'model', parts: [{ text: 'Got it. Thanks for the context!' }] },
-      ];
-
-      mockGetHistory.mockReturnValue(initialContextOnly);
-
-      const result = await client.tryCompressChat(
-        'prompt-id-initial-only',
-        false,
-      );
-
-      expect(result).toEqual({
-        originalTokenCount: 0,
-        newTokenCount: 0,
-        compressionStatus: CompressionStatus.NOOP,
-      });
-
-      // With empty history after slicing, compression should return NOOP
-      expect(mockGenerateContentFn).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -679,21 +679,7 @@ export class GeminiClient {
       };
     }
 
-    const { totalTokens: originalTokenCount } =
-      await this.getContentGeneratorOrFail().countTokens({
-        model,
-        contents: curatedHistory,
-      });
-    if (originalTokenCount === undefined) {
-      console.warn(`Could not determine token count for model ${model}.`);
-      this.hasFailedCompressionAttempt = !force && true;
-      return {
-        originalTokenCount: 0,
-        newTokenCount: 0,
-        compressionStatus:
-          CompressionStatus.COMPRESSION_FAILED_TOKEN_COUNT_ERROR,
-      };
-    }
+    const originalTokenCount = uiTelemetryService.getLastPromptTokenCount();
 
     const contextPercentageThreshold =
       this.config.getChatCompression()?.contextPercentageThreshold;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -743,12 +743,12 @@ export class GeminiClient {
     this.forceFullIdeContext = true;
 
     // Estimate token count 1 token ≈ 4 characters
-    const compressedHistory = chat.getHistory();
-    const totalChars = compressedHistory.reduce(
-      (total, content) => total + JSON.stringify(content).length,
-      0,
+    const newTokenCount = Math.floor(
+      chat
+        .getHistory()
+        .reduce((total, content) => total + JSON.stringify(content).length, 0) /
+        4,
     );
-    const newTokenCount = Math.floor(totalChars / 4);
 
     logChatCompression(
       this.config,


### PR DESCRIPTION
## TLDR

This PR improves the chat history compression logic (`tryCompressChat`) to make it use lastPromptTokenCount to decide if we need to compress.

Previously, compression relied on two `countTokens` API calls to get the token count before and after summarization.  These API calls could be slow or fail.

This change removes those API calls entirely:
1.  The `originalTokenCount` is now read from the `uiTelemetryService`, which caches the last known token count.
2.  The `newTokenCount` (after summarization) is now *estimated* using a string-length heuristic (1 token ≈ 4 characters).

This makes the compression logic more reliable and removes a network dependency, at the trade-off of using an estimated token count instead of an exact one.

## Dive Deeper

The primary motivation for this change was to reduce latency and improve reliability. If the `countTokens` API call failed, compression would be skipped, and the user's large chat history would be sent on the next turn, which could then fail due to exceeding token limits.

By using a cached value for the original count and estimating the new count, we eliminate this failure point.

## Reviewer Test Plan

The goal is to validate that chat compression still triggers correctly and reliably.

1.  Start a new chat session (`gemini -c`).
2.  Have a very long conversation until context used is after 70%. A good way to do this is to include a large directory like packages/cli using @.
3.  Send another message. You should see auto compression works.
4.  Verify that the conversation continues smoothly and the model seems to have a summarized context of the previous conversation.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
#9033