### PR TITLE
Make compression algo slightly more aggressive

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -131,7 +131,7 @@ async function fromAsync<T>(promise: AsyncGenerator<T>): Promise<readonly T[]> {
   return results;
 }
 
-describe('findIndexAfterFraction', () => {
+describe('findCompressSplitPoint', () => {
   it('should throw an error for non-positive numbers', () => {
     expect(() => findCompressSplitPoint([], 0)).toThrow(
       'Fraction must be between 0 and 1',
@@ -156,7 +156,7 @@ describe('findIndexAfterFraction', () => {
       { role: 'model', parts: [{ text: 'This is the fourth message.' }] }, // JSON length: 68 (80%)
       { role: 'user', parts: [{ text: 'This is the fifth message.' }] }, // JSON length: 65 (100%)
     ];
-    expect(findCompressSplitPoint(history, 0.5)).toBe(2);
+    expect(findCompressSplitPoint(history, 0.5)).toBe(4);
   });
 
   it('should handle a fraction of last index', () => {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -83,7 +83,6 @@ export function findCompressSplitPoint(
   let lastSplitPoint = 0; // 0 is always valid (compress nothing)
   let cumulativeCharCount = 0;
   for (let i = 0; i < contents.length; i++) {
-    cumulativeCharCount += charCounts[i];
     const content = contents[i];
     if (
       content.role === 'user' &&
@@ -94,6 +93,7 @@ export function findCompressSplitPoint(
       }
       lastSplitPoint = i;
     }
+    cumulativeCharCount += charCounts[i];
   }
 
   // We found no split points after targetCharCount.


### PR DESCRIPTION
## TLDR

The algo was being less aggressive in picking a split point than it should have been. We should pick a split point large enough to compress _at least_ 70% instead of _at most_ 70%.


## Reviewer Test Plan

Write:

```
tell me about @packages/core/
```
then
```
how do you feel about it?
```

Verify that it compresses the context a lot (like compressed from: 836387 to 2641 tokens)

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

#9033
