### PR TITLE
fix(actions): hydrate env vars into nightly failure issue/issue body

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -121,6 +121,6 @@ jobs:
           DETAILS_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: |
           gh issue create \
-            --title 'Nightly Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')' \
-            --body 'The nightly-release workflow failed. See the full run for details: ${DETAILS_URL}' \
+            --title "Nightly Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')" \
+            --body "The nightly-release workflow failed. See the full run for details: ${DETAILS_URL}" \
             --label 'kind/bug,release-failure,priority/p0'


### PR DESCRIPTION
## TLDR

This PR switches to double quotes for strings with env vars when creating github issues when a nightly release fails, preventing issue creation with placeholders like #10085.

## Dive Deeper

## Reviewer Test Plan

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
