### PR TITLE
fix(ux) keyboard input hangs while waiting for keyboard input.

### DIFF
--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -73,12 +73,14 @@ export const renderWithProviders = (
     settings = mockSettings,
     uiState: providedUiState,
     width,
+    kittyProtocolEnabled = true,
     config = configProxy as unknown as Config,
   }: {
     shellFocus?: boolean;
     settings?: LoadedSettings;
     uiState?: Partial<UIState>;
     width?: number;
+    kittyProtocolEnabled?: boolean;
     config?: Config;
   } = {},
 ): ReturnType<typeof render> => {
@@ -115,7 +117,7 @@ export const renderWithProviders = (
         <UIStateContext.Provider value={finalUiState}>
           <VimModeProvider settings={settings}>
             <ShellFocusContext.Provider value={shellFocus}>
-              <KeypressProvider kittyProtocolEnabled={true}>
+              <KeypressProvider kittyProtocolEnabled={kittyProtocolEnabled}>
                 {component}
               </KeypressProvider>
             </ShellFocusContext.Provider>

--- a/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { renderWithProviders } from '../../test-utils/render.js';
-import { waitFor } from '@testing-library/react';
+import { waitFor, act } from '@testing-library/react';
 import { vi } from 'vitest';
 import { FolderTrustDialog } from './FolderTrustDialog.js';
 import * as processUtils from '../../utils/processUtils.js';
@@ -50,7 +50,9 @@ describe('FolderTrustDialog', () => {
       <FolderTrustDialog onSelect={onSelect} isRestarting={false} />,
     );
 
-    stdin.write('\x1b'); // escape key
+    act(() => {
+      stdin.write('\u001b[27u'); // Press kitty escape key
+    });
 
     await waitFor(() => {
       expect(lastFrame()).toContain(
@@ -87,7 +89,9 @@ describe('FolderTrustDialog', () => {
       <FolderTrustDialog onSelect={vi.fn()} isRestarting={false} />,
     );
 
-    stdin.write('r');
+    act(() => {
+      stdin.write('r');
+    });
 
     await waitFor(() => {
       expect(mockedExit).not.toHaveBeenCalled();

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -1616,6 +1616,7 @@ describe('InputPrompt', () => {
 
         const { stdin, unmount } = renderWithProviders(
           <InputPrompt {...props} />,
+          { kittyProtocolEnabled: true },
         );
         await vi.runAllTimersAsync();
 
@@ -1661,6 +1662,7 @@ describe('InputPrompt', () => {
 
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
+        { kittyProtocolEnabled: false },
       );
       await wait();
 
@@ -1682,6 +1684,7 @@ describe('InputPrompt', () => {
 
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
+        { kittyProtocolEnabled: false },
       );
 
       stdin.write('\x1B');
@@ -1703,6 +1706,7 @@ describe('InputPrompt', () => {
 
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
+        { kittyProtocolEnabled: false },
       );
       await wait();
 
@@ -1722,6 +1726,7 @@ describe('InputPrompt', () => {
 
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
+        { kittyProtocolEnabled: false },
       );
       await wait();
 
@@ -1733,23 +1738,27 @@ describe('InputPrompt', () => {
     });
 
     it('should not call onEscapePromptChange when not provided', async () => {
+      vi.useFakeTimers();
       props.onEscapePromptChange = undefined;
       props.buffer.setText('some text');
 
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
+        { kittyProtocolEnabled: false },
       );
-      await wait();
+      await vi.runAllTimersAsync();
 
       stdin.write('\x1B');
-      await wait();
+      await vi.runAllTimersAsync();
 
+      vi.useRealTimers();
       unmount();
     });
 
     it('should not interfere with existing keyboard shortcuts', async () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
+        { kittyProtocolEnabled: false },
       );
       await wait();
 
@@ -1821,6 +1830,7 @@ describe('InputPrompt', () => {
       stdin.write('\x12');
       await wait();
       stdin.write('\x1B');
+      stdin.write('\u001b[27u'); // Press kitty escape key
 
       await waitFor(() => {
         expect(stdout.lastFrame()).not.toContain('(r:)');
@@ -1922,7 +1932,7 @@ describe('InputPrompt', () => {
       stdin.write('\x12');
       await wait();
       expect(stdout.lastFrame()).toContain('(r:)');
-      stdin.write('\x1B');
+      stdin.write('\u001b[27u'); // Press kitty escape key
 
       await waitFor(() => {
         expect(stdout.lastFrame()).not.toContain('(r:)');

--- a/packages/cli/src/ui/components/PermissionsModifyTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/PermissionsModifyTrustDialog.test.tsx
@@ -129,7 +129,7 @@ describe('PermissionsModifyTrustDialog', () => {
     await waitFor(() => expect(lastFrame()).not.toContain('Loading...'));
 
     act(() => {
-      stdin.write('\x1b'); // escape key
+      stdin.write('\u001b[27u'); // Kitty escape key
     });
 
     await waitFor(() => {
@@ -189,7 +189,7 @@ describe('PermissionsModifyTrustDialog', () => {
 
     await waitFor(() => expect(lastFrame()).not.toContain('Loading...'));
 
-    act(() => stdin.write('\x1b')); // Press escape
+    act(() => stdin.write('\u001b[27u')); // Press kitty escape key
 
     await waitFor(() => {
       expect(mockCommitTrustLevelChange).not.toHaveBeenCalled();


### PR DESCRIPTION
## TLDR

We would wait for addition output to complete a kitty protocol response rather than timing out if a kitty protocol response wasn't received in a small number of ms.

This is a problem as some terminals could send responses that looked like kitty protocol but weren't resulting in Google users reporting that Gemini CLI was hanging or not responding to their input.

## Dive Deeper

There are too many cases to enumerate for why terminals could send responses starting with escape codes that looked like they might be kitty but were not kitty.
We now timeout in 50ms if a complete kitty protocol sequence is not sent and abort early if we detect escape sequences that cannot possibly complete as a valid kitty protocol sequence.

## Reviewer Test Plan

Test with iterm2 (terminal google user had an issue with) and other terminals. Test over ssh to make sure the 50ms threshold is not too aggressive. We might need to increase it to 100ms.
Verify that all keys pressed in the terminal are registered successfully. In particular test cases like shift+enter and test performing actions such as entering and leaving the terminal, triggering custom terminal scroll modes and custom keyboard mouse modes to trigger cases that might result in escape codes gemini cli doesn't handle being added to the terminal.

Fixes: #7936