### PR TITLE
feat(chat): add completion for chat save command

### DIFF
--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -162,6 +162,12 @@ const saveCommand: SlashCommand = {
       };
     }
   },
+  completion: async (context, partialArg) => {
+    const chatDetails = await getSavedChatTags(context, true);
+    return chatDetails
+      .map((chat) => chat.name)
+      .filter((name) => name.startsWith(partialArg));
+  },
 };
 
 const resumeCommand: SlashCommand = {


### PR DESCRIPTION
## TLDR

- Add completion to the /chat save command

## Dive Deeper

- Reuses existing function `getSavedChatTags` to retrieve all saved conversation checkpoints
- Aligns with the completion behavior of resumeCommand and deleteCommand


## Reviewer Test Plan

- Pull branch: feat/chat-save-completion
- Run gemini and Setting up test data
```
/chat save tag1
/chat save tag2
```
- Test completion
Type` /chat save` and press `Tab` - should show tag1 and tag2

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Closes #10102 
