### PR TITLE
Add CTRL+D as alternate shortcut to clear line in Gemini CLI #10155

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -8,7 +8,7 @@ This document lists the available keyboard shortcuts in the Gemini CLI.
 | -------- | --------------------------------------------------------------------------------------------------------------------- |
 | `Esc`    | Close dialogs and suggestions.                                                                                        |
 | `Ctrl+C` | Cancel the ongoing request and clear the input. Press twice to exit the application.                                  |
-| `Ctrl+D` | Exit the application if the input is empty. Press twice to confirm.                                                   |
+| `Ctrl+D` | Clear the input if not empty. Exit the application if the input is empty (press twice to confirm).                    |
 | `Ctrl+L` | Clear the screen.                                                                                                     |
 | `Ctrl+O` | Toggle the display of the debug console.                                                                              |
 | `Ctrl+S` | Allows long responses to print fully, disabling truncation. Use your terminal's scrollback to view the entire output. |
@@ -30,7 +30,7 @@ This document lists the available keyboard shortcuts in the Gemini CLI.
 | `Ctrl+B` / `Left Arrow`                            | Move the cursor one character to the left.                                                                                          |
 | `Ctrl+C`                                           | Clear the input prompt                                                                                                              |
 | `Esc` (double press)                               | Clear the input prompt.                                                                                                             |
-| `Ctrl+D` / `Delete`                                | Delete the character to the right of the cursor.                                                                                    |
+| `Ctrl+D` / `Delete`                                | Clear the input if not empty. If empty, exit application (press twice to confirm). Delete key deletes the character to the right.   |
 | `Ctrl+E` / `End`                                   | Move the cursor to the end of the line.                                                                                             |
 | `Ctrl+F` / `Right Arrow`                           | Move the cursor one character to the right.                                                                                         |
 | `Ctrl+H` / `Backspace`                             | Delete the character to the left of the cursor.                                                                                     |

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -909,6 +909,8 @@ Logging in with Google... Please restart Gemini CLI to continue.
         return;
       } else if (keyMatchers[Command.EXIT](key)) {
         if (buffer.text.length > 0) {
+          //Clear the current input instead of exiting
+          buffer.setText('');
           return;
         }
         handleExit(ctrlDPressedOnce, setCtrlDPressedOnce, ctrlDTimerRef);

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -757,6 +757,34 @@ describe('InputPrompt', () => {
     unmount();
   });
 
+  it('should clear the buffer on Ctrl+D if it has text', async () => {
+    props.buffer.setText('some text to clear');
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\x04'); // Ctrl+D character
+    await wait();
+
+    expect(props.buffer.setText).toHaveBeenCalledWith('');
+    expect(mockCommandCompletion.resetCompletionState).toHaveBeenCalled();
+    expect(props.onSubmit).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should NOT clear the buffer on Ctrl+D if it is empty', async () => {
+    props.buffer.text = '';
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\x04'); // Ctrl+D character
+    await wait();
+
+    expect(props.buffer.setText).not.toHaveBeenCalled();
+    expect(mockCommandCompletion.resetCompletionState).not.toHaveBeenCalled();
+    expect(props.onSubmit).not.toHaveBeenCalled();
+    unmount();
+  });
+
   describe('cursor-based completion trigger', () => {
     it('should trigger completion when cursor is after @ without spaces', async () => {
       // Set up buffer state

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -628,6 +628,16 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return;
       }
 
+      // Ctrl+D (Clear input if buffer has text)
+      if (keyMatchers[Command.EXIT](key)) {
+        if (buffer.text.length > 0) {
+          buffer.setText('');
+          resetCompletionState();
+          return;
+        }
+        // If buffer is empty, let AppContainer handle exit
+      }
+
       // Kill line commands
       if (keyMatchers[Command.KILL_LINE_RIGHT](key)) {
         buffer.killLineRight();


### PR DESCRIPTION
## TLDR

This PR adds support for using CTRL+D as an alternate shortcut to clear the current line buffer in the Gemini CLI.

First CTRL+D: clears the input line (same effect as CTRL+U).

Second & third CTRL+D: exits the CLI as before.

This provides a smoother UX for users who instinctively use CTRL+D to abandon input, while preserving existing behavior.


## Dive Deeper

Current behavior:

CTRL+U clears the line.

CTRL+D on empty buffer exits (double press to confirm).

CTRL+D on non-empty buffer does nothing.

Change introduced:

If the input buffer contains text, the first CTRL+D now clears it.

Exit flow remains unchanged: pressing CTRL+D two more times will still exit the CLI.

Why:

Many developers expect CTRL+D to reset their input.

This mirrors familiar REPL patterns (Python, Node.js, SQLite).

It is low-risk: does not break CTRL+U, nor alter exit semantics.


## Reviewer Test Plan

Start the CLI.

Type any text (e.g., hello world).

Press CTRL+D: the line should clear.

Press CTRL+D twice more: CLI should exit.

Confirm that CTRL+U still clears the line as before.

Confirm that pressing CTRL+D twice on an empty line still exits.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

  | 🍏 | 🪟 | 🐧
-- | -- | -- | --
npm run | ✅ | ✅ | ✅
npx | ✅ | ✅ | ✅
Docker | ✅ | ✅ | ✅
Podman | ✅ | - | -
Seatbelt | ✅ | - | -


## Linked issues / bugs


- Closes #10155 
