### PR TITLE
fix(telemetry): Improve Cloud Shell surface type detection for telemetry purposes

### DIFF
--- a/packages/core/src/ide/detect-ide.ts
+++ b/packages/core/src/ide/detect-ide.ts
@@ -21,6 +21,10 @@ export interface IdeInfo {
   displayName: string;
 }
 
+export function isCloudShell(): boolean {
+  return !!(process.env['EDITOR_IN_CLOUD_SHELL'] || process.env['CLOUD_SHELL']);
+}
+
 export function detectIdeFromEnv(): IdeInfo {
   if (process.env['__COG_BASHRC_SOURCED']) {
     return IDE_DEFINITIONS.devin;
@@ -34,7 +38,7 @@ export function detectIdeFromEnv(): IdeInfo {
   if (process.env['CODESPACES']) {
     return IDE_DEFINITIONS.codespaces;
   }
-  if (process.env['EDITOR_IN_CLOUD_SHELL'] || process.env['CLOUD_SHELL']) {
+  if (isCloudShell()) {
     return IDE_DEFINITIONS.cloudshell;
   }
   if (process.env['TERM_PRODUCT'] === 'Trae') {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -221,6 +221,32 @@ describe('ClearcutLogger', () => {
       });
     });
 
+    it('logs the current surface from Cloud Shell via EDITOR_IN_CLOUD_SHELL', () => {
+      const { logger } = setup({});
+
+      vi.stubEnv('EDITOR_IN_CLOUD_SHELL', 'true');
+
+      const event = logger?.createLogEvent(EventNames.CHAT_COMPRESSION, []);
+
+      expect(event?.event_metadata[0]).toContainEqual({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
+        value: 'cloudshell',
+      });
+    });
+
+    it('logs the current surface from Cloud Shell via CLOUD_SHELL', () => {
+      const { logger } = setup({});
+
+      vi.stubEnv('CLOUD_SHELL', 'true');
+
+      const event = logger?.createLogEvent(EventNames.CHAT_COMPRESSION, []);
+
+      expect(event?.event_metadata[0]).toContainEqual({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_SURFACE,
+        value: 'cloudshell',
+      });
+    });
+
     it('logs default metadata', () => {
       // Define expected values
       const session_id = 'my-session-id';

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -39,7 +39,11 @@ import { UserAccountManager } from '../../utils/userAccountManager.js';
 import { safeJsonStringify } from '../../utils/safeJsonStringify.js';
 import { FixedDeque } from 'mnemonist';
 import { GIT_COMMIT_INFO, CLI_VERSION } from '../../generated/git-commit.js';
-import { IDE_DEFINITIONS, detectIdeFromEnv } from '../../ide/detect-ide.js';
+import {
+  IDE_DEFINITIONS,
+  detectIdeFromEnv,
+  isCloudShell,
+} from '../../ide/detect-ide.js';
 
 export enum EventNames {
   START_SESSION = 'start_session',
@@ -114,10 +118,7 @@ export interface LogRequest {
 function determineSurface(): string {
   if (process.env['SURFACE']) {
     return process.env['SURFACE'];
-  } else if (
-    process.env['EDITOR_IN_CLOUD_SHELL'] ||
-    process.env['CLOUD_SHELL']
-  ) {
+  } else if (isCloudShell()) {
     return IDE_DEFINITIONS.cloudshell.name;
   } else if (process.env['GITHUB_SHA']) {
     return 'GitHub';

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -114,6 +114,11 @@ export interface LogRequest {
 function determineSurface(): string {
   if (process.env['SURFACE']) {
     return process.env['SURFACE'];
+  } else if (
+    process.env['EDITOR_IN_CLOUD_SHELL'] ||
+    process.env['CLOUD_SHELL']
+  ) {
+    return IDE_DEFINITIONS.cloudshell.name;
   } else if (process.env['GITHUB_SHA']) {
     return 'GitHub';
   } else if (process.env['TERM_PROGRAM'] === 'vscode') {


### PR DESCRIPTION
## TLDR

This PR fixes the the undercounting of Google Cloud Shell users in Gemini CLI telemetry. It updates the `determineSurface()` function to correctly identify the Cloud Shell environment.

## Dive Deeper

Currently, CLI usage within Cloud Shell is significantly underreported in the telemetry data. The existing environment variable checks within the `determineSurface()` function do not reliably detect the Cloud Shell environment. The `SURFACE` is not set, and `TERM_PROGRAM` is not consistently available or indicative. This causes most Cloud Shell sessions to be logged with `GEMINI_CLI_SURFACE` set to `SURFACE_NOT_SET`.

The environment variable `CLOUD_SHELL` or `EDITOR_IN_CLOUD_SHELL` is consistently present in Cloud Shell sessions.

This change implements the agreed-upon solution by adding a check for this variable:

```typescript
// Inside determineSurface() in packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts

  // ... other checks
  } else if (process.env['EDITOR_IN_CLOUD_SHELL'] || process.env['CLOUD_SHELL']) {
    return IDE_DEFINITIONS.cloudshell.name;
  // ... rest of the function
```

## Reviewer Test Plan

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs