### PR TITLE
fix windows test for new extension installation

### DIFF
--- a/packages/cli/src/commands/extensions/new.test.ts
+++ b/packages/cli/src/commands/extensions/new.test.ts
@@ -54,18 +54,18 @@ describe('extensions new command', () => {
       recursive: true,
     });
     expect(mockedFs.cp).toHaveBeenCalledWith(
-      expect.stringContaining(path.join('context', 'context')),
-      path.join(`${path.sep}some`, 'path', 'context'),
+      expect.stringContaining(path.normalize('context/context')),
+      path.normalize('/some/path/context'),
       { recursive: true },
     );
     expect(mockedFs.cp).toHaveBeenCalledWith(
-      expect.stringContaining(path.join('context', 'custom-commands')),
-      path.join(`${path.sep}some`, 'path', 'custom-commands'),
+      expect.stringContaining(path.normalize('context/custom-commands')),
+      path.normalize('/some/path/custom-commands'),
       { recursive: true },
     );
     expect(mockedFs.cp).toHaveBeenCalledWith(
-      expect.stringContaining(path.join('context', 'mcp-server')),
-      path.join(`${path.sep}some`, 'path', 'mcp-server'),
+      expect.stringContaining(path.normalize('context/mcp-server')),
+      path.normalize('/some/path/mcp-server'),
       { recursive: true },
     );
   });

--- a/packages/cli/src/commands/extensions/new.test.ts
+++ b/packages/cli/src/commands/extensions/new.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { newCommand } from './new.js';
 import yargs from 'yargs';
 import * as fsPromises from 'node:fs/promises';
+import path from 'node:path';
 
 vi.mock('node:fs/promises');
 
@@ -53,18 +54,18 @@ describe('extensions new command', () => {
       recursive: true,
     });
     expect(mockedFs.cp).toHaveBeenCalledWith(
-      expect.stringContaining('context/context'),
-      '/some/path/context',
+      expect.stringContaining(path.join('context', 'context')),
+      path.join(`${path.sep}some`, 'path', 'context'),
       { recursive: true },
     );
     expect(mockedFs.cp).toHaveBeenCalledWith(
-      expect.stringContaining('context/custom-commands'),
-      '/some/path/custom-commands',
+      expect.stringContaining(path.join('context', 'custom-commands')),
+      path.join(`${path.sep}some`, 'path', 'custom-commands'),
       { recursive: true },
     );
     expect(mockedFs.cp).toHaveBeenCalledWith(
-      expect.stringContaining('context/mcp-server'),
-      '/some/path/mcp-server',
+      expect.stringContaining(path.join('context', 'mcp-server')),
+      path.join(`${path.sep}some`, 'path', 'mcp-server'),
       { recursive: true },
     );
   });


### PR DESCRIPTION
## TLDR

Fixes a test that was failing on windows due to path separators

## Reviewer Test Plan

The e2e tests for windows should be passing now

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

