### PR TITLE
Extension update confirm dialog

### DIFF
--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -898,8 +898,8 @@ describe('extension tests', () => {
       ).resolves.toBe('my-local-extension');
 
       expect(consoleInfoSpy).toHaveBeenCalledWith(
-        `Extensions may introduce unexpected behavior.
-Ensure you have investigated the extension source and trust the author.
+        `Installing extension "my-local-extension".
+**Extensions may introduce unexpected behavior. Ensure you have investigated the extension source and trust the author.**
 This extension will run the following MCP servers:
   * test-server (local): node server.js
   * test-server-2 (remote): https://google.com`,

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -954,7 +954,7 @@ This extension will run the following MCP servers:
           { source: sourceExtDir, type: 'local' },
           requestConsentNonInteractive,
         ),
-      ).rejects.toThrow('Installation cancelled.');
+      ).rejects.toThrow('Installation cancelled for "my-local-extension".');
 
       expect(mockQuestion).toHaveBeenCalledWith(
         expect.stringContaining('Do you want to continue? [Y/n]: '),

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -364,13 +364,11 @@ export async function requestConsentNonInteractive(
  */
 export async function requestConsentInteractive(
   consentDescription: string,
-  setExtensionUpdateConfirmationRequest: (
-    value: ConfirmationRequest | null,
-  ) => void,
+  addExtensionUpdateConfirmationRequest: (value: ConfirmationRequest) => void,
 ): Promise<boolean> {
   return await promptForConsentInteractive(
     consentDescription + '\n\nDo you want to continue?',
-    setExtensionUpdateConfirmationRequest,
+    addExtensionUpdateConfirmationRequest,
   );
 }
 
@@ -410,15 +408,12 @@ async function promptForConsentNonInteractive(
  */
 async function promptForConsentInteractive(
   prompt: string,
-  setExtensionUpdateConfirmationRequest: (
-    value: ConfirmationRequest | null,
-  ) => void,
+  addExtensionUpdateConfirmationRequest: (value: ConfirmationRequest) => void,
 ): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
-    setExtensionUpdateConfirmationRequest({
+    addExtensionUpdateConfirmationRequest({
       prompt,
       onConfirm: (resolvedConfirmed) => {
-        setExtensionUpdateConfirmationRequest(null);
         resolve(resolvedConfirmed);
       },
     });

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -579,7 +579,7 @@ function extensionConsentString(extensionConfig: ExtensionConfig): string {
   );
 
   if (mcpServerEntries.length) {
-    output.push(`This extension will run the following MCP servers:`);
+    output.push('This extension will run the following MCP servers:');
     for (const [key, mcpServer] of mcpServerEntries) {
       const isLocal = !!mcpServer.command;
       const source =

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -347,7 +347,7 @@ export async function requestConsentNonInteractive(
   consentDescription: string,
 ): Promise<boolean> {
   console.info(consentDescription);
-  const result = await promptForContinuationNonInteractive(
+  const result = await promptForConsentNonInteractive(
     'Do you want to continue? [Y/n]: ',
   );
   return result;
@@ -359,6 +359,7 @@ export async function requestConsentNonInteractive(
  * This should not be called from non-interactive mode as it will not work.
  *
  * @param consentDescription The description of the thing they will be consenting to.
+ * @param setExtensionUpdateConfirmationRequest A function to actually add a prompt to the UI.
  * @returns boolean, whether they consented or not.
  */
 export async function requestConsentInteractive(
@@ -367,15 +368,10 @@ export async function requestConsentInteractive(
     value: ConfirmationRequest | null,
   ) => void,
 ): Promise<boolean> {
-  return await new Promise<boolean>((resolve) => {
-    setExtensionUpdateConfirmationRequest({
-      prompt: consentDescription,
-      onConfirm: (resolvedConfirmed) => {
-        setExtensionUpdateConfirmationRequest(null);
-        resolve(resolvedConfirmed);
-      },
-    });
-  });
+  return await promptForConsentInteractive(
+    consentDescription + '\n\nDo you want to continue?',
+    setExtensionUpdateConfirmationRequest,
+  );
 }
 
 /**
@@ -386,7 +382,7 @@ export async function requestConsentInteractive(
  * @param prompt A yes/no prompt to ask the user
  * @returns Whether or not the user answers 'y' (yes). Defaults to 'yes' on enter.
  */
-async function promptForContinuationNonInteractive(
+async function promptForConsentNonInteractive(
   prompt: string,
 ): Promise<boolean> {
   const readline = await import('node:readline');
@@ -399,6 +395,32 @@ async function promptForContinuationNonInteractive(
     rl.question(prompt, (answer) => {
       rl.close();
       resolve(['y', ''].includes(answer.trim().toLowerCase()));
+    });
+  });
+}
+
+/**
+ * Asks users an interactive yes/no prompt.
+ *
+ * This should not be called from non-interactive mode as it will break the CLI.
+ *
+ * @param prompt A markdown prompt to ask the user
+ * @param setExtensionUpdateConfirmationRequest Function to update the UI state with the confirmation request.
+ * @returns Whether or not the user answers yes.
+ */
+async function promptForConsentInteractive(
+  prompt: string,
+  setExtensionUpdateConfirmationRequest: (
+    value: ConfirmationRequest | null,
+  ) => void,
+): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    setExtensionUpdateConfirmationRequest({
+      prompt,
+      onConfirm: (resolvedConfirmed) => {
+        setExtensionUpdateConfirmationRequest(null);
+        resolve(resolvedConfirmed);
+      },
     });
   });
 }
@@ -603,7 +625,7 @@ async function maybeRequestConsentOrFail(
     }
   }
   if (!(await requestConsent(extensionConsent))) {
-    throw new Error('Installation cancelled.');
+    throw new Error(`Installation cancelled for "${extensionConfig.name}".`);
   }
 }
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -551,13 +551,13 @@ export async function installExtension(
 function extensionConsentString(extensionConfig: ExtensionConfig): string {
   const output: string[] = [];
   const mcpServerEntries = Object.entries(extensionConfig.mcpServers || {});
-  output.push('Extensions may introduce unexpected behavior.');
+  output.push(`Installing extension "${extensionConfig.name}".`);
   output.push(
-    'Ensure you have investigated the extension source and trust the author.',
+    '**Extensions may introduce unexpected behavior. Ensure you have investigated the extension source and trust the author.**',
   );
 
   if (mcpServerEntries.length) {
-    output.push('This extension will run the following MCP servers:');
+    output.push(`This extension will run the following MCP servers:`);
     for (const [key, mcpServer] of mcpServerEntries) {
       const isLocal = !!mcpServer.command;
       const source =

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -156,8 +156,8 @@ export const AppContainer = (props: AppContainerProps) => {
   const {
     extensionsUpdateState,
     setExtensionsUpdateState,
-    confirmUpdateExtensionRequest,
-    setConfirmUpdateExtensionRequest,
+    confirmUpdateExtensionRequests,
+    addConfirmUpdateExtensionRequest,
   } = useExtensionUpdates(
     extensions,
     historyManager.addItem,
@@ -460,7 +460,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       setDebugMessage,
       toggleCorgiMode: () => setCorgiMode((prev) => !prev),
       setExtensionsUpdateState,
-      setConfirmUpdateExtensionRequest,
+      addConfirmUpdateExtensionRequest,
     }),
     [
       setAuthState,
@@ -474,7 +474,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       setCorgiMode,
       setExtensionsUpdateState,
       openPermissionsDialog,
-      setConfirmUpdateExtensionRequest,
+      addConfirmUpdateExtensionRequest,
     ],
   );
 
@@ -1048,7 +1048,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     isFolderTrustDialogOpen ||
     !!shellConfirmationRequest ||
     !!confirmationRequest ||
-    !!confirmUpdateExtensionRequest ||
+    confirmUpdateExtensionRequests.length > 0 ||
     !!loopDetectionConfirmationRequest ||
     isThemeDialogOpen ||
     isSettingsDialogOpen ||
@@ -1089,7 +1089,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       commandContext,
       shellConfirmationRequest,
       confirmationRequest,
-      confirmUpdateExtensionRequest,
+      confirmUpdateExtensionRequests,
       loopDetectionConfirmationRequest,
       geminiMdFileCount,
       streamingState,
@@ -1167,7 +1167,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       commandContext,
       shellConfirmationRequest,
       confirmationRequest,
-      confirmUpdateExtensionRequest,
+      confirmUpdateExtensionRequests,
       loopDetectionConfirmationRequest,
       geminiMdFileCount,
       streamingState,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -153,12 +153,16 @@ export const AppContainer = (props: AppContainerProps) => {
   );
 
   const extensions = config.getExtensions();
-  const { extensionsUpdateState, setExtensionsUpdateState } =
-    useExtensionUpdates(
-      extensions,
-      historyManager.addItem,
-      config.getWorkingDir(),
-    );
+  const {
+    extensionsUpdateState,
+    setExtensionsUpdateState,
+    confirmUpdateExtensionRequest,
+    setConfirmUpdateExtensionRequest,
+  } = useExtensionUpdates(
+    extensions,
+    historyManager.addItem,
+    config.getWorkingDir(),
+  );
 
   const [isPermissionsDialogOpen, setPermissionsDialogOpen] = useState(false);
   const openPermissionsDialog = useCallback(
@@ -456,6 +460,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       setDebugMessage,
       toggleCorgiMode: () => setCorgiMode((prev) => !prev),
       setExtensionsUpdateState,
+      setConfirmUpdateExtensionRequest,
     }),
     [
       setAuthState,
@@ -469,6 +474,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       setCorgiMode,
       setExtensionsUpdateState,
       openPermissionsDialog,
+      setConfirmUpdateExtensionRequest,
     ],
   );
 
@@ -995,7 +1001,9 @@ Logging in with Google... Please restart Gemini CLI to continue.
     if (streamingState === StreamingState.Idle) {
       title = originalTitleRef.current;
     } else {
-      const statusText = thought?.subject?.replace(/[\r\n]+/g, ' ').substring(0, 80);
+      const statusText = thought?.subject
+        ?.replace(/[\r\n]+/g, ' ')
+        .substring(0, 80);
       title = statusText || originalTitleRef.current;
     }
 
@@ -1040,6 +1048,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     isFolderTrustDialogOpen ||
     !!shellConfirmationRequest ||
     !!confirmationRequest ||
+    !!confirmUpdateExtensionRequest ||
     !!loopDetectionConfirmationRequest ||
     isThemeDialogOpen ||
     isSettingsDialogOpen ||
@@ -1080,6 +1089,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       commandContext,
       shellConfirmationRequest,
       confirmationRequest,
+      confirmUpdateExtensionRequest,
       loopDetectionConfirmationRequest,
       geminiMdFileCount,
       streamingState,
@@ -1157,6 +1167,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       commandContext,
       shellConfirmationRequest,
       confirmationRequest,
+      confirmUpdateExtensionRequest,
       loopDetectionConfirmationRequest,
       geminiMdFileCount,
       streamingState,

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -56,7 +56,7 @@ async function updateAction(context: CommandContext, args: string) {
         (description) =>
           requestConsentInteractive(
             description,
-            context.ui.setConfirmUpdateExtensionRequest,
+            context.ui.addConfirmUpdateExtensionRequest,
           ),
         context.services.config!.getExtensions(),
         context.ui.extensionsUpdateState,
@@ -85,7 +85,7 @@ async function updateAction(context: CommandContext, args: string) {
           (description) =>
             requestConsentInteractive(
               description,
-              context.ui.setConfirmUpdateExtensionRequest,
+              context.ui.addConfirmUpdateExtensionRequest,
             ),
           context.ui.extensionsUpdateState.get(extension.name) ??
             ExtensionUpdateState.UNKNOWN,

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -54,7 +54,10 @@ async function updateAction(context: CommandContext, args: string) {
         context.services.config!.getWorkingDir(),
         // We don't have the ability to prompt for consent yet in this flow.
         (description) =>
-          requestConsentInteractive(description, context.ui.addItem),
+          requestConsentInteractive(
+            description,
+            context.ui.setConfirmUpdateExtensionRequest,
+          ),
         context.services.config!.getExtensions(),
         context.ui.extensionsUpdateState,
         context.ui.setExtensionsUpdateState,
@@ -80,7 +83,10 @@ async function updateAction(context: CommandContext, args: string) {
           extension,
           workingDir,
           (description) =>
-            requestConsentInteractive(description, context.ui.addItem),
+            requestConsentInteractive(
+              description,
+              context.ui.setConfirmUpdateExtensionRequest,
+            ),
           context.ui.extensionsUpdateState.get(extension.name) ??
             ExtensionUpdateState.UNKNOWN,
           (updateState) => {

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -6,7 +6,11 @@
 
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
 import type { Content, PartListUnion } from '@google/genai';
-import type { HistoryItemWithoutId, HistoryItem } from '../types.js';
+import type {
+  HistoryItemWithoutId,
+  HistoryItem,
+  ConfirmationRequest,
+} from '../types.js';
 import type { Config, GitService, Logger } from '@google/gemini-cli-core';
 import type { LoadedSettings } from '../../config/settings.js';
 import type { UseHistoryManagerReturn } from '../hooks/useHistoryManager.js';
@@ -66,6 +70,9 @@ export interface CommandContext {
     setExtensionsUpdateState: Dispatch<
       SetStateAction<Map<string, ExtensionUpdateState>>
     >;
+    setConfirmUpdateExtensionRequest: (
+      value: ConfirmationRequest | null,
+    ) => void;
   };
   // Session-specific data
   session: {

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -70,9 +70,7 @@ export interface CommandContext {
     setExtensionsUpdateState: Dispatch<
       SetStateAction<Map<string, ExtensionUpdateState>>
     >;
-    setConfirmUpdateExtensionRequest: (
-      value: ConfirmationRequest | null,
-    ) => void;
+    addConfirmUpdateExtensionRequest: (value: ConfirmationRequest) => void;
   };
   // Session-specific data
   session: {

--- a/packages/cli/src/ui/components/ConsentPrompt.test.tsx
+++ b/packages/cli/src/ui/components/ConsentPrompt.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Text } from 'ink';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import { ConsentPrompt } from './ConsentPrompt.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+import { MarkdownDisplay } from '../utils/MarkdownDisplay.js';
+
+vi.mock('./shared/RadioButtonSelect.js', () => ({
+  RadioButtonSelect: vi.fn(() => null),
+}));
+
+vi.mock('../utils/MarkdownDisplay.js', () => ({
+  MarkdownDisplay: vi.fn(() => null),
+}));
+
+const MockedRadioButtonSelect = vi.mocked(RadioButtonSelect);
+const MockedMarkdownDisplay = vi.mocked(MarkdownDisplay);
+
+describe('ConsentPrompt', () => {
+  const onConfirm = vi.fn();
+  const terminalWidth = 80;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a string prompt with MarkdownDisplay', () => {
+    const prompt = 'Are you sure?';
+    render(
+      <ConsentPrompt
+        prompt={prompt}
+        onConfirm={onConfirm}
+        terminalWidth={terminalWidth}
+      />,
+    );
+
+    expect(MockedMarkdownDisplay).toHaveBeenCalledWith(
+      {
+        isPending: true,
+        text: prompt,
+        terminalWidth,
+      },
+      undefined,
+    );
+  });
+
+  it('renders a ReactNode prompt directly', () => {
+    const prompt = <Text>Are you sure?</Text>;
+    const { lastFrame } = render(
+      <ConsentPrompt
+        prompt={prompt}
+        onConfirm={onConfirm}
+        terminalWidth={terminalWidth}
+      />,
+    );
+
+    expect(MockedMarkdownDisplay).not.toHaveBeenCalled();
+    expect(lastFrame()).toContain('Are you sure?');
+  });
+
+  it('calls onConfirm with true when "Yes" is selected', () => {
+    const prompt = 'Are you sure?';
+    render(
+      <ConsentPrompt
+        prompt={prompt}
+        onConfirm={onConfirm}
+        terminalWidth={terminalWidth}
+      />,
+    );
+
+    const onSelect = MockedRadioButtonSelect.mock.calls[0][0].onSelect;
+    onSelect(true);
+
+    expect(onConfirm).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onConfirm with false when "No" is selected', () => {
+    const prompt = 'Are you sure?';
+    render(
+      <ConsentPrompt
+        prompt={prompt}
+        onConfirm={onConfirm}
+        terminalWidth={terminalWidth}
+      />,
+    );
+
+    const onSelect = MockedRadioButtonSelect.mock.calls[0][0].onSelect;
+    onSelect(false);
+
+    expect(onConfirm).toHaveBeenCalledWith(false);
+  });
+
+  it('passes correct items to RadioButtonSelect', () => {
+    const prompt = 'Are you sure?';
+    render(
+      <ConsentPrompt
+        prompt={prompt}
+        onConfirm={onConfirm}
+        terminalWidth={terminalWidth}
+      />,
+    );
+
+    expect(MockedRadioButtonSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [
+          { label: 'Yes', value: true, key: 'Yes' },
+          { label: 'No', value: false, key: 'No' },
+        ],
+      }),
+      undefined,
+    );
+  });
+});

--- a/packages/cli/src/ui/components/ConsentPrompt.tsx
+++ b/packages/cli/src/ui/components/ConsentPrompt.tsx
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box } from 'ink';
+import { type ReactNode } from 'react';
+import { theme } from '../semantic-colors.js';
+import { MarkdownDisplay } from '../utils/MarkdownDisplay.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+
+type ConsentPromptProps = {
+  // If a simple string is given, it will render using markdown by default.
+  prompt: ReactNode;
+  onConfirm: (value: boolean) => void;
+  terminalWidth: number;
+};
+
+export const ConsentPrompt = (props: ConsentPromptProps) => {
+  const { prompt, onConfirm, terminalWidth } = props;
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={theme.border.default}
+      flexDirection="column"
+      paddingY={1}
+      paddingX={2}
+    >
+      {typeof prompt === 'string' ? (
+        <MarkdownDisplay
+          isPending={true}
+          text={prompt}
+          terminalWidth={terminalWidth}
+        />
+      ) : (
+        prompt
+      )}
+      <Box marginTop={1}>
+        <RadioButtonSelect
+          items={[
+            { label: 'Yes', value: true, key: 'Yes' },
+            { label: 'No', value: false, key: 'No' },
+          ]}
+          onSelect={onConfirm}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -111,11 +111,12 @@ export const DialogManager = ({
       />
     );
   }
-  if (uiState.confirmUpdateExtensionRequest) {
+  if (uiState.confirmUpdateExtensionRequests.length > 0) {
+    const request = uiState.confirmUpdateExtensionRequests[0];
     return (
       <ConsentPrompt
-        prompt={uiState.confirmUpdateExtensionRequest.prompt}
-        onConfirm={uiState.confirmUpdateExtensionRequest.onConfirm}
+        prompt={request.prompt}
+        onConfirm={request.onConfirm}
         terminalWidth={terminalWidth}
       />
     );

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -27,13 +27,18 @@ import { useConfig } from '../contexts/ConfigContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import process from 'node:process';
 import { type UseHistoryManagerReturn } from '../hooks/useHistoryManager.js';
+import { MarkdownDisplay } from '../utils/MarkdownDisplay.js';
 
 interface DialogManagerProps {
   addItem: UseHistoryManagerReturn['addItem'];
+  terminalWidth: number;
 }
 
 // Props for DialogManager
-export const DialogManager = ({ addItem }: DialogManagerProps) => {
+export const DialogManager = ({
+  addItem,
+  terminalWidth,
+}: DialogManagerProps) => {
   const config = useConfig();
   const settings = useSettings();
 
@@ -118,9 +123,19 @@ export const DialogManager = ({ addItem }: DialogManagerProps) => {
   }
   if (uiState.confirmUpdateExtensionRequest) {
     return (
-      <Box flexDirection="column">
-        <Text>{uiState.confirmUpdateExtensionRequest.prompt}</Text>
-        <Box paddingY={1}>
+      <Box
+        borderStyle="round"
+        borderColor={theme.border.default}
+        flexDirection="column"
+        paddingY={1}
+        paddingX={2}
+      >
+        <MarkdownDisplay
+          isPending={true}
+          text={uiState.confirmUpdateExtensionRequest.prompt as string}
+          terminalWidth={terminalWidth}
+        ></MarkdownDisplay>
+        <Box marginTop={1}>
           <RadioButtonSelect
             items={[
               { label: 'Yes', value: true, key: 'Yes' },

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -116,6 +116,24 @@ export const DialogManager = ({ addItem }: DialogManagerProps) => {
       </Box>
     );
   }
+  if (uiState.confirmUpdateExtensionRequest) {
+    return (
+      <Box flexDirection="column">
+        <Text>{uiState.confirmUpdateExtensionRequest.prompt}</Text>
+        <Box paddingY={1}>
+          <RadioButtonSelect
+            items={[
+              { label: 'Yes', value: true, key: 'Yes' },
+              { label: 'No', value: false, key: 'No' },
+            ]}
+            onSelect={(value: boolean) => {
+              uiState.confirmUpdateExtensionRequest!.onConfirm(value);
+            }}
+          />
+        </Box>
+      </Box>
+    );
+  }
   if (uiState.isThemeDialogOpen) {
     return (
       <Box flexDirection="column">

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -9,7 +9,7 @@ import { IdeIntegrationNudge } from '../IdeIntegrationNudge.js';
 import { LoopDetectionConfirmation } from './LoopDetectionConfirmation.js';
 import { FolderTrustDialog } from './FolderTrustDialog.js';
 import { ShellConfirmationDialog } from './ShellConfirmationDialog.js';
-import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+import { ConsentPrompt } from './ConsentPrompt.js';
 import { ThemeDialog } from './ThemeDialog.js';
 import { SettingsDialog } from './SettingsDialog.js';
 import { AuthInProgress } from '../auth/AuthInProgress.js';
@@ -27,7 +27,6 @@ import { useConfig } from '../contexts/ConfigContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import process from 'node:process';
 import { type UseHistoryManagerReturn } from '../hooks/useHistoryManager.js';
-import { MarkdownDisplay } from '../utils/MarkdownDisplay.js';
 
 interface DialogManagerProps {
   addItem: UseHistoryManagerReturn['addItem'];
@@ -105,48 +104,20 @@ export const DialogManager = ({
   }
   if (uiState.confirmationRequest) {
     return (
-      <Box flexDirection="column">
-        {uiState.confirmationRequest.prompt}
-        <Box paddingY={1}>
-          <RadioButtonSelect
-            items={[
-              { label: 'Yes', value: true, key: 'Yes' },
-              { label: 'No', value: false, key: 'No' },
-            ]}
-            onSelect={(value: boolean) => {
-              uiState.confirmationRequest!.onConfirm(value);
-            }}
-          />
-        </Box>
-      </Box>
+      <ConsentPrompt
+        prompt={uiState.confirmationRequest.prompt}
+        onConfirm={uiState.confirmationRequest.onConfirm}
+        terminalWidth={terminalWidth}
+      />
     );
   }
   if (uiState.confirmUpdateExtensionRequest) {
     return (
-      <Box
-        borderStyle="round"
-        borderColor={theme.border.default}
-        flexDirection="column"
-        paddingY={1}
-        paddingX={2}
-      >
-        <MarkdownDisplay
-          isPending={true}
-          text={uiState.confirmUpdateExtensionRequest.prompt as string}
-          terminalWidth={terminalWidth}
-        ></MarkdownDisplay>
-        <Box marginTop={1}>
-          <RadioButtonSelect
-            items={[
-              { label: 'Yes', value: true, key: 'Yes' },
-              { label: 'No', value: false, key: 'No' },
-            ]}
-            onSelect={(value: boolean) => {
-              uiState.confirmUpdateExtensionRequest!.onConfirm(value);
-            }}
-          />
-        </Box>
-      </Box>
+      <ConsentPrompt
+        prompt={uiState.confirmUpdateExtensionRequest.prompt}
+        onConfirm={uiState.confirmUpdateExtensionRequest.onConfirm}
+        terminalWidth={terminalWidth}
+      />
     );
   }
   if (uiState.isThemeDialogOpen) {

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -60,6 +60,7 @@ export interface UIState {
   commandContext: CommandContext;
   shellConfirmationRequest: ShellConfirmationRequest | null;
   confirmationRequest: ConfirmationRequest | null;
+  confirmUpdateExtensionRequest: ConfirmationRequest | null;
   loopDetectionConfirmationRequest: LoopDetectionConfirmationRequest | null;
   geminiMdFileCount: number;
   streamingState: StreamingState;

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -60,7 +60,7 @@ export interface UIState {
   commandContext: CommandContext;
   shellConfirmationRequest: ShellConfirmationRequest | null;
   confirmationRequest: ConfirmationRequest | null;
-  confirmUpdateExtensionRequest: ConfirmationRequest | null;
+  confirmUpdateExtensionRequests: ConfirmationRequest[];
   loopDetectionConfirmationRequest: LoopDetectionConfirmationRequest | null;
   geminiMdFileCount: number;
   streamingState: StreamingState;

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -32,6 +32,7 @@ import type {
   HistoryItemWithoutId,
   SlashCommandProcessorResult,
   HistoryItem,
+  ConfirmationRequest,
 } from '../types.js';
 import { MessageType } from '../types.js';
 import type { LoadedSettings } from '../../config/settings.js';
@@ -56,6 +57,9 @@ interface SlashCommandProcessorActions {
   toggleCorgiMode: () => void;
   setExtensionsUpdateState: Dispatch<
     SetStateAction<Map<string, ExtensionUpdateState>>
+  >;
+  setConfirmUpdateExtensionRequest: Dispatch<
+    SetStateAction<ConfirmationRequest | null>
   >;
 }
 
@@ -206,6 +210,8 @@ export const useSlashCommandProcessor = (
         reloadCommands,
         extensionsUpdateState,
         setExtensionsUpdateState: actions.setExtensionsUpdateState,
+        setConfirmUpdateExtensionRequest:
+          actions.setConfirmUpdateExtensionRequest,
       },
       session: {
         stats: session.stats,

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -58,9 +58,7 @@ interface SlashCommandProcessorActions {
   setExtensionsUpdateState: Dispatch<
     SetStateAction<Map<string, ExtensionUpdateState>>
   >;
-  setConfirmUpdateExtensionRequest: Dispatch<
-    SetStateAction<ConfirmationRequest | null>
-  >;
+  addConfirmUpdateExtensionRequest: (request: ConfirmationRequest) => void;
 }
 
 /**
@@ -210,8 +208,8 @@ export const useSlashCommandProcessor = (
         reloadCommands,
         extensionsUpdateState,
         setExtensionsUpdateState: actions.setExtensionsUpdateState,
-        setConfirmUpdateExtensionRequest:
-          actions.setConfirmUpdateExtensionRequest,
+        addConfirmUpdateExtensionRequest:
+          actions.addConfirmUpdateExtensionRequest,
       },
       session: {
         stats: session.stats,

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -79,8 +79,12 @@ export const useExtensionUpdates = (
               );
             })
             .catch((error) => {
-              console.error(
-                `Error updating extension "${extension.name}": ${getErrorMessage(error)}.`,
+              addItem(
+                {
+                  type: MessageType.ERROR,
+                  text: getErrorMessage(error),
+                },
+                Date.now(),
               );
             });
         } else {

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -7,7 +7,7 @@
 import type { GeminiCLIExtension } from '@google/gemini-cli-core';
 import { getErrorMessage } from '../../utils/errors.js';
 import { ExtensionUpdateState } from '../state/extensions.js';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { MessageType, type ConfirmationRequest } from '../types.js';
 import {
@@ -32,19 +32,22 @@ export const useExtensionUpdates = (
         onConfirm: (confirmed: boolean) => void;
       }>
     >([]);
-  const addConfirmUpdateExtensionRequest = (original: ConfirmationRequest) => {
-    const wrappedRequest = {
-      prompt: original.prompt,
-      onConfirm: (confirmed: boolean) => {
-        // Remove it from the outstanding list of requests by identity.
-        setConfirmUpdateExtensionRequests((prev) =>
-          prev.filter((r) => r !== wrappedRequest),
-        );
-        original.onConfirm(confirmed);
-      },
-    };
-    setConfirmUpdateExtensionRequests((prev) => [...prev, wrappedRequest]);
-  };
+  const addConfirmUpdateExtensionRequest = useCallback(
+    (original: ConfirmationRequest) => {
+      const wrappedRequest = {
+        prompt: original.prompt,
+        onConfirm: (confirmed: boolean) => {
+          // Remove it from the outstanding list of requests by identity.
+          setConfirmUpdateExtensionRequests((prev) =>
+            prev.filter((r) => r !== wrappedRequest),
+          );
+          original.onConfirm(confirmed);
+        },
+      };
+      setConfirmUpdateExtensionRequests((prev) => [...prev, wrappedRequest]);
+    },
+    [setConfirmUpdateExtensionRequests],
+  );
 
   (async () => {
     if (isChecking) return;

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -25,6 +25,11 @@ export const useExtensionUpdates = (
     new Map<string, ExtensionUpdateState>(),
   );
   const [isChecking, setIsChecking] = useState(false);
+  const [confirmUpdateExtensionRequest, setConfirmUpdateExtensionRequest] =
+    useState<null | {
+      prompt: React.ReactNode;
+      onConfirm: (confirmed: boolean) => void;
+    }>(null);
 
   (async () => {
     if (isChecking) return;
@@ -49,7 +54,11 @@ export const useExtensionUpdates = (
           updateExtension(
             extension,
             cwd,
-            (description) => requestConsentInteractive(description, addItem),
+            (description) =>
+              requestConsentInteractive(
+                description,
+                setConfirmUpdateExtensionRequest,
+              ),
             currentState,
             (newState) => {
               setExtensionsUpdateState((prev) => {
@@ -96,5 +105,7 @@ export const useExtensionUpdates = (
   return {
     extensionsUpdateState,
     setExtensionsUpdateState,
+    confirmUpdateExtensionRequest,
+    setConfirmUpdateExtensionRequest,
   };
 };

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
@@ -24,7 +24,10 @@ export const DefaultAppLayout: React.FC = () => {
         <Notifications />
 
         {uiState.dialogsVisible ? (
-          <DialogManager addItem={uiState.historyManager.addItem} />
+          <DialogManager
+            terminalWidth={uiState.terminalWidth}
+            addItem={uiState.historyManager.addItem}
+          />
         ) : (
           <Composer />
         )}

--- a/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
@@ -25,7 +25,10 @@ export const ScreenReaderAppLayout: React.FC = () => {
         <MainContent />
       </Box>
       {uiState.dialogsVisible ? (
-        <DialogManager addItem={uiState.historyManager.addItem} />
+        <DialogManager
+          terminalWidth={uiState.terminalWidth}
+          addItem={uiState.historyManager.addItem}
+        />
       ) : (
         <Composer />
       )}

--- a/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
+++ b/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
@@ -25,6 +25,6 @@ export function createNonInteractiveUI(): CommandContext['ui'] {
     reloadCommands: () => {},
     extensionsUpdateState: new Map(),
     setExtensionsUpdateState: (_updateState) => {},
-    setConfirmUpdateExtensionRequest: (_request) => {},
+    addConfirmUpdateExtensionRequest: (_request) => {},
   };
 }

--- a/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
+++ b/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
@@ -25,5 +25,6 @@ export function createNonInteractiveUI(): CommandContext['ui'] {
     reloadCommands: () => {},
     extensionsUpdateState: new Map(),
     setExtensionsUpdateState: (_updateState) => {},
+    setConfirmUpdateExtensionRequest: (_request) => {},
   };
 }


### PR DESCRIPTION
## TLDR

Adds a consent flow dialog for installing extensions inside the CLI. This allows auto-updating to function when consent is needed (text of the consent has changed), and allows `/extensions update` to function. Also paves the way for `/extensions install` if we want that later on.

New UX for consenting to install of an extension (only happens on first install or if an update changes the text):

<img width="1450" height="384" alt="image" src="https://github.com/user-attachments/assets/e5722816-103c-4e5a-be4e-c576fe5a456f" />

## Dive Deeper

This was done by creating a new shared component for consent dialogs, and re-using that for the slash command consent flow as well. This slightly alters the UX for confirming slash commands because of the shared component:

<img width="1454" height="290" alt="image" src="https://github.com/user-attachments/assets/65c5d5e6-b680-4ffa-bead-ec222b6321d9" />

This new component is also now separately unit tested.

## Reviewer Test Plan

Install an extension which has an available update which has a change that will involve re-consent, and update it with `/extensions update` (or enable auto updating) from the CLI.

You should get one of these dialogs.

If you have multiple extensions that need an update you should see the dialogs each get displayed sequentially and not all at once.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/gemini-cli/issues/9522.
