### PR TITLE
ci(release): Skip tests by default in scheduled nightly workflow

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -57,7 +57,7 @@ jobs:
           echo "${{ toJSON(github.event.inputs) }}"
 
       - name: 'Run Tests'
-        if: "${{github.event.inputs.force_skip_tests != 'true'}}"
+        if: github.event.inputs.force_skip_tests == 'false'
         uses: './.github/actions/run-tests'
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -57,7 +57,7 @@ jobs:
           echo "${{ toJSON(github.event.inputs) }}"
 
       - name: 'Run Tests'
-        if: github.event.inputs.force_skip_tests == 'false'
+        if: "${{github.event.inputs.force_skip_tests == 'false'}}"
         uses: './.github/actions/run-tests'
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'


### PR DESCRIPTION
## TLDR

This pull request fixes an issue in the scheduled nightly release workflow where tests were being run unintentionally. The `if` condition for the test step was corrected to ensure that tests are skipped by default for all scheduled runs.

## Dive Deeper

The root cause of the issue was how GitHub Actions handles the `github.event.inputs` context for different trigger types. For workflows initiated by a `schedule`, this context is empty.

The previous condition, `if: "${{github.event.inputs.force_skip_tests != 'true'}}"`, would evaluate to `true` during a scheduled run because an empty string (`''`) is not equal to the string `'true'`. This caused the tests to execute every night.

The updated condition, `if: github.event.inputs.force_skip_tests == 'false'`, correctly handles this scenario. For a scheduled run, `'' == 'false'` evaluates to `false`, skipping the tests. Tests will now only run when the "force_skip_tests" input is explicitly set to `false` during a manual `workflow_dispatch` run.

## Linked Issues
Fixes #10170