### PR TITLE
feat(cli): Adds the ability to run MCP prompt commands in non-interactive mode

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -59,6 +59,9 @@ vi.mock('./services/CommandService.js', () => ({
   },
 }));
 
+vi.mock('./services/FileCommandLoader.js');
+vi.mock('./services/McpPromptLoader.js');
+
 describe('runNonInteractive', () => {
   let mockConfig: Config;
   let mockSettings: LoadedSettings;
@@ -936,6 +939,46 @@ describe('runNonInteractive', () => {
     expect(mockAction).toHaveBeenCalledWith(expect.any(Object), 'arg1 arg2');
 
     expect(processStdoutSpy).toHaveBeenCalledWith('Acknowledged');
+  });
+
+  it('should instantiate CommandService with correct loaders for slash commands', async () => {
+    // This test indirectly checks that handleSlashCommand is using the right loaders.
+    const { FileCommandLoader } = await import(
+      './services/FileCommandLoader.js'
+    );
+    const { McpPromptLoader } = await import('./services/McpPromptLoader.js');
+
+    mockGetCommands.mockReturnValue([]); // No commands found, so it will fall through
+    const events: ServerGeminiStreamEvent[] = [
+      { type: GeminiEventType.Content, value: 'Acknowledged' },
+      {
+        type: GeminiEventType.Finished,
+        value: { reason: undefined, usageMetadata: { totalTokenCount: 1 } },
+      },
+    ];
+    mockGeminiClient.sendMessageStream.mockReturnValue(
+      createStreamFromEvents(events),
+    );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      '/mycommand',
+      'prompt-id-loaders',
+    );
+
+    // Check that loaders were instantiated with the config
+    expect(FileCommandLoader).toHaveBeenCalledTimes(1);
+    expect(FileCommandLoader).toHaveBeenCalledWith(mockConfig);
+    expect(McpPromptLoader).toHaveBeenCalledTimes(1);
+    expect(McpPromptLoader).toHaveBeenCalledWith(mockConfig);
+
+    // Check that instances were passed to CommandService.create
+    expect(mockCommandServiceCreate).toHaveBeenCalledTimes(1);
+    const loadersArg = mockCommandServiceCreate.mock.calls[0][0];
+    expect(loadersArg).toHaveLength(2);
+    expect(loadersArg[0]).toBe(vi.mocked(McpPromptLoader).mock.instances[0]);
+    expect(loadersArg[1]).toBe(vi.mocked(FileCommandLoader).mock.instances[0]);
   });
 
   it('should allow a normally-excluded tool when --allowed-tools is set', async () => {

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -14,6 +14,7 @@ import {
 } from '@google/gemini-cli-core';
 import { CommandService } from './services/CommandService.js';
 import { FileCommandLoader } from './services/FileCommandLoader.js';
+import { McpPromptLoader } from './services/McpPromptLoader.js';
 import type { CommandContext } from './ui/commands/types.js';
 import { createNonInteractiveUI } from './ui/noninteractive/nonInteractiveUi.js';
 import type { LoadedSettings } from './config/settings.js';
@@ -38,9 +39,8 @@ export const handleSlashCommand = async (
     return;
   }
 
-  // Only custom commands are supported for now.
   const commandService = await CommandService.create(
-    [new FileCommandLoader(config)],
+    [new McpPromptLoader(config), new FileCommandLoader(config)],
     abortController.signal,
   );
   const commands = commandService.getCommands();


### PR DESCRIPTION
## TLDR

Adds the ability to run MCP prompts (i.e. MCP slash commands) in non-interactive mode https://github.com/google-gemini/gemini-cli/issues/10177

Note that #8305 added support for custom commands (e.g. extension .toml) but not MCP prompts.

## Dive Deeper

`CommandService` was designed in such a way to make this very easy to add.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

Make sure  1) custom commands and 2) MCP prompts work e.g.

For https://github.com/gemini-cli-extensions/security
`node gemini-cli/packages/cli -p "/security:analyze" --yolo`

For https://github.com/GoogleCloudPlatform/cloud-run-mcp
`node gemini-cli/packages/cli -p "/deploy" --yolo`
`node gemini-cli/packages/cli -p "/deploy"` (when `trust` is `true`)

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | X  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | X  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
Fixes #10177
