### PR TITLE
Add extension name auto-complete to `/extensions update`

### DIFF
--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -251,5 +251,83 @@ describe('extensionsCommand', () => {
         expect.any(Number),
       );
     });
+
+    describe('completion', () => {
+      const updateCompletion = extensionsCommand.subCommands?.find(
+        (cmd) => cmd.name === 'update',
+      )?.completion;
+
+      if (!updateCompletion) {
+        throw new Error('Update completion not found');
+      }
+
+      it('should return matching extension names', async () => {
+        const extensionOne: GeminiCLIExtension = {
+          name: 'ext-one',
+          version: '1.0.0',
+          isActive: true,
+          path: '/test/dir/ext-one',
+          installMetadata: {
+            type: 'git',
+            autoUpdate: false,
+            source: 'https://github.com/some/extension.git',
+          },
+        };
+        const extensionTwo: GeminiCLIExtension = {
+          name: 'another-ext',
+          version: '1.0.0',
+          isActive: true,
+          path: '/test/dir/another-ext',
+          installMetadata: {
+            type: 'git',
+            autoUpdate: false,
+            source: 'https://github.com/some/extension.git',
+          },
+        };
+        mockGetExtensions.mockReturnValue([extensionOne, extensionTwo]);
+        const suggestions = await updateCompletion(mockContext, 'ext');
+        expect(suggestions).toEqual(['ext-one']);
+      });
+
+      it('should return --all when partialArg matches', async () => {
+        mockGetExtensions.mockReturnValue([]);
+        const suggestions = await updateCompletion(mockContext, '--al');
+        expect(suggestions).toEqual(['--all']);
+      });
+
+      it('should return both extension names and --all when both match', async () => {
+        const extensionOne: GeminiCLIExtension = {
+          name: 'all-ext',
+          version: '1.0.0',
+          isActive: true,
+          path: '/test/dir/all-ext',
+          installMetadata: {
+            type: 'git',
+            autoUpdate: false,
+            source: 'https://github.com/some/extension.git',
+          },
+        };
+        mockGetExtensions.mockReturnValue([extensionOne]);
+        const suggestions = await updateCompletion(mockContext, 'all');
+        expect(suggestions).toEqual(['--all', 'all-ext']);
+      });
+
+      it('should return an empty array if no matches', async () => {
+        const extensionOne: GeminiCLIExtension = {
+          name: 'ext-one',
+          version: '1.0.0',
+          isActive: true,
+          path: '/test/dir/ext-one',
+          installMetadata: {
+            type: 'git',
+            autoUpdate: false,
+            source: 'https://github.com/some/extension.git',
+          },
+        };
+        mockGetExtensions.mockReturnValue([extensionOne]);
+        const suggestions = await updateCompletion(mockContext, 'nomatch');
+        expect(suggestions).toEqual([]);
+      });
+    });
   });
 });

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -261,72 +261,70 @@ describe('extensionsCommand', () => {
         throw new Error('Update completion not found');
       }
 
-      it('should return matching extension names', async () => {
-        const extensionOne: GeminiCLIExtension = {
-          name: 'ext-one',
-          version: '1.0.0',
-          isActive: true,
-          path: '/test/dir/ext-one',
-          installMetadata: {
-            type: 'git',
-            autoUpdate: false,
-            source: 'https://github.com/some/extension.git',
-          },
-        };
-        const extensionTwo: GeminiCLIExtension = {
-          name: 'another-ext',
-          version: '1.0.0',
-          isActive: true,
-          path: '/test/dir/another-ext',
-          installMetadata: {
-            type: 'git',
-            autoUpdate: false,
-            source: 'https://github.com/some/extension.git',
-          },
-        };
-        mockGetExtensions.mockReturnValue([extensionOne, extensionTwo]);
-        const suggestions = await updateCompletion(mockContext, 'ext');
-        expect(suggestions).toEqual(['ext-one']);
-      });
+      const extensionOne: GeminiCLIExtension = {
+        name: 'ext-one',
+        version: '1.0.0',
+        isActive: true,
+        path: '/test/dir/ext-one',
+        installMetadata: {
+          type: 'git',
+          autoUpdate: false,
+          source: 'https://github.com/some/extension.git',
+        },
+      };
+      const extensionTwo: GeminiCLIExtension = {
+        name: 'another-ext',
+        version: '1.0.0',
+        isActive: true,
+        path: '/test/dir/another-ext',
+        installMetadata: {
+          type: 'git',
+          autoUpdate: false,
+          source: 'https://github.com/some/extension.git',
+        },
+      };
+      const allExt: GeminiCLIExtension = {
+        name: 'all-ext',
+        version: '1.0.0',
+        isActive: true,
+        path: '/test/dir/all-ext',
+        installMetadata: {
+          type: 'git',
+          autoUpdate: false,
+          source: 'https://github.com/some/extension.git',
+        },
+      };
 
-      it('should return --all when partialArg matches', async () => {
-        mockGetExtensions.mockReturnValue([]);
-        const suggestions = await updateCompletion(mockContext, '--al');
-        expect(suggestions).toEqual(['--all']);
-      });
-
-      it('should return both extension names and --all when both match', async () => {
-        const extensionOne: GeminiCLIExtension = {
-          name: 'all-ext',
-          version: '1.0.0',
-          isActive: true,
-          path: '/test/dir/all-ext',
-          installMetadata: {
-            type: 'git',
-            autoUpdate: false,
-            source: 'https://github.com/some/extension.git',
-          },
-        };
-        mockGetExtensions.mockReturnValue([extensionOne]);
-        const suggestions = await updateCompletion(mockContext, 'all');
-        expect(suggestions).toEqual(['--all', 'all-ext']);
-      });
-
-      it('should return an empty array if no matches', async () => {
-        const extensionOne: GeminiCLIExtension = {
-          name: 'ext-one',
-          version: '1.0.0',
-          isActive: true,
-          path: '/test/dir/ext-one',
-          installMetadata: {
-            type: 'git',
-            autoUpdate: false,
-            source: 'https://github.com/some/extension.git',
-          },
-        };
-        mockGetExtensions.mockReturnValue([extensionOne]);
-        const suggestions = await updateCompletion(mockContext, 'nomatch');
-        expect(suggestions).toEqual([]);
+      it.each([
+        {
+          description: 'should return matching extension names',
+          extensions: [extensionOne, extensionTwo],
+          partialArg: 'ext',
+          expected: ['ext-one'],
+        },
+        {
+          description: 'should return --all when partialArg matches',
+          extensions: [],
+          partialArg: '--al',
+          expected: ['--all'],
+        },
+        {
+          description:
+            'should return both extension names and --all when both match',
+          extensions: [allExt],
+          partialArg: 'all',
+          expected: ['--all', 'all-ext'],
+        },
+        {
+          description: 'should return an empty array if no matches',
+          extensions: [extensionOne],
+          partialArg: 'nomatch',
+          expected: [],
+        },
+      ])('$description', async ({ extensions, partialArg, expected }) => {
+        mockGetExtensions.mockReturnValue(extensions);
+        const suggestions = await updateCompletion(mockContext, partialArg);
+        expect(suggestions).toEqual(expected);
       });
     });
   });

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -142,6 +142,20 @@ const updateExtensionsCommand: SlashCommand = {
   description: 'Update extensions. Usage: update <extension-names>|--all',
   kind: CommandKind.BUILT_IN,
   action: updateAction,
+  completion: async (context, partialArg) => {
+    const extensions = context.services.config!.getExtensions();
+    const extensionNames = extensions.map((ext) => ext.name);
+    const suggestions = extensionNames.filter((name) =>
+      name.startsWith(partialArg),
+    );
+
+    //
+    if ('--all'.startsWith(partialArg) || 'all'.startsWith(partialArg)) {
+      suggestions.unshift('--all');
+    }
+
+    return suggestions;
+  },
 };
 
 export const extensionsCommand: SlashCommand = {

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -143,7 +143,7 @@ const updateExtensionsCommand: SlashCommand = {
   kind: CommandKind.BUILT_IN,
   action: updateAction,
   completion: async (context, partialArg) => {
-    const extensions = context.services.config!.getExtensions();
+    const extensions = context.services.config?.getExtensions() ?? [];
     const extensionNames = extensions.map((ext) => ext.name);
     const suggestions = extensionNames.filter((name) =>
       name.startsWith(partialArg),

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -149,7 +149,6 @@ const updateExtensionsCommand: SlashCommand = {
       name.startsWith(partialArg),
     );
 
-    //
     if ('--all'.startsWith(partialArg) || 'all'.startsWith(partialArg)) {
       suggestions.unshift('--all');
     }


### PR DESCRIPTION
## TLDR

Adds auto-completion support for the built-in `/extensions update` command.

Will also auto-complete `--all` with or without the leading dashes.

## Dive Deeper


## Reviewer Test Plan

Run `/extensions update` and view the autocomplete list.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

