### PR TITLE
Don't log an error about invalid extensions when passing "-e none"

### DIFF
--- a/packages/cli/src/config/extensions/extensionEnablement.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.ts
@@ -121,6 +121,7 @@ export class ExtensionEnablementManager {
 
   validateExtensionOverrides(extensions: Extension[]) {
     for (const name of this.enabledExtensionNamesOverride) {
+      if (name === 'none') continue;
       if (
         !extensions.some(
           (ext) => ext.config.name.toLowerCase() === name.toLowerCase(),


### PR DESCRIPTION
## TLDR

Fixes a bug where `-e none` would log an error about "none" not being a valid extension name.

## Dive Deeper


## Reviewer Test Plan

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
