### PR TITLE
Fixed the issue where Gemini writes text files without a trailing newline character. Modified StandardFileSystemService and AcpFileSystemService to automatically append a newline character to text file content when missing, ensuring POSIX compliance.

### DIFF
--- a/packages/cli/src/zed-integration/fileSystemService.ts
+++ b/packages/cli/src/zed-integration/fileSystemService.ts
@@ -38,9 +38,11 @@ export class AcpFileSystemService implements FileSystemService {
       return this.fallback.writeTextFile(filePath, content);
     }
 
+    // Ensure text files end with a newline character (POSIX standard)
+    const contentWithEOL = content.endsWith('\n') ? content : content + '\n';
     await this.client.writeTextFile({
       path: filePath,
-      content,
+      content: contentWithEOL,
       sessionId: this.sessionId,
     });
   }

--- a/packages/core/src/services/fileSystemService.test.ts
+++ b/packages/core/src/services/fileSystemService.test.ts
@@ -51,7 +51,31 @@ describe('StandardFileSystemService', () => {
 
       expect(fs.writeFile).toHaveBeenCalledWith(
         '/test/file.txt',
-        'Hello, World!',
+        'Hello, World!\n',
+        'utf-8',
+      );
+    });
+
+    it('should not add extra newline if content already ends with one', async () => {
+      vi.mocked(fs.writeFile).mockResolvedValue();
+
+      await fileSystem.writeTextFile('/test/file.txt', 'Hello, World!\n');
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        '/test/file.txt',
+        'Hello, World!\n',
+        'utf-8',
+      );
+    });
+
+    it('should handle empty content by adding newline', async () => {
+      vi.mocked(fs.writeFile).mockResolvedValue();
+
+      await fileSystem.writeTextFile('/test/file.txt', '');
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        '/test/file.txt',
+        '\n',
         'utf-8',
       );
     });

--- a/packages/core/src/services/fileSystemService.ts
+++ b/packages/core/src/services/fileSystemService.ts
@@ -47,7 +47,9 @@ export class StandardFileSystemService implements FileSystemService {
   }
 
   async writeTextFile(filePath: string, content: string): Promise<void> {
-    await fs.writeFile(filePath, content, 'utf-8');
+    // Ensure text files end with a newline character (POSIX standard)
+    const contentWithEOL = content.endsWith('\n') ? content : content + '\n';
+    await fs.writeFile(filePath, contentWithEOL, 'utf-8');
   }
 
   findFiles(fileName: string, searchPaths: readonly string[]): string[] {


### PR DESCRIPTION
## TLDR

Fixed missing EOL (End of Line) characters in generated text files by updating StandardFileSystemService to automatically append newlines when writing text content. This ensures POSIX compliance and resolves the issue where files created via write_file tool were missing trailing newlines.

## Dive Deeper

When users requested Gemini to create text files (e.g., "Write 10 lines description of what does Linux do into the file linux.txt"), the generated files would end abruptly without a newline character. This violates the POSIX standard that text files should end with a newline character and can cause issues with various Unix tools and text editors.
Root Cause
The StandardFileSystemService.writeTextFile() method was directly calling fs.writeFile() with the exact content provided, without ensuring proper EOL formatting. Since AI-generated content doesn't automatically include trailing newlines, files were left without proper endings.

Solution
Modified both file system service implementations to automatically ensure text files end with newline characters:

StandardFileSystemService: Added logic to check if content ends with \n, appending one if missing
AcpFileSystemService: Applied the same fix for consistency across all file system implementations
Maintained backward compatibility: No extra newlines are added if content already ends with one
Edge case handling: Empty content gets a single newline

## Reviewer Test Plan

Manual Testing Steps

Basic functionality test:
Ask Gemini: "Write a simple hello world message to hello.txt"
Verify the created file ends with a newline using: cat -e hello.txt

Multi-line content test:
Ask Gemini: "Write 5 lines describing cats into cats.txt"
Check file ending: hexdump -C cats.txt | tail -1

Edge cases:
Ask Gemini: "Create an empty file called empty.txt"
Verify it has a newline: wc -l empty.txt

Automated Testing

Run the existing test suite which now includes comprehensive EOL validation:
npm test -- --testPathPattern=fileSystemService.test.ts



## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅ | ✅  | ❓  |
| npx      | ✅  | ✅  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Fixes #10137

