### PR TITLE
restore case insensitivity for extension enablement and add tests

### DIFF
--- a/packages/cli/src/config/extensions/extensionEnablement.test.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.test.ts
@@ -255,7 +255,8 @@ describe('ExtensionEnablementManager', () => {
     it('none disables all extensions', () => {
       manager = new ExtensionEnablementManager(configDir, ['none']);
       manager.enable('ext-test', true, '/');
-      expect(manager.isEnabled('ext-test', '/path/to/dir')).toBe(false); // Double check that it would have been enabled otherwise
+      expect(manager.isEnabled('ext-test', '/path/to/dir')).toBe(false);
+      // Double check that it would have been enabled otherwise
       expect(
         new ExtensionEnablementManager(configDir).isEnabled('ext-test', '/'),
       ).toBe(true);

--- a/packages/cli/src/config/extensions/extensionEnablement.test.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.test.ts
@@ -225,6 +225,41 @@ describe('ExtensionEnablementManager', () => {
       true,
     );
   });
+
+  describe('extension overrides (-e <name>)', () => {
+    beforeEach(() => {
+      manager = new ExtensionEnablementManager(configDir, ['ext-test']);
+    });
+
+    it('can enable extensions, case-insensitive', () => {
+      manager.disable('ext-test', true, '/');
+      expect(manager.isEnabled('ext-test', '/')).toBe(true);
+      expect(manager.isEnabled('Ext-Test', '/')).toBe(true);
+      // Double check that it would have been disabled otherwise
+      expect(
+        new ExtensionEnablementManager(configDir).isEnabled('ext-test', '/'),
+      ).toBe(false);
+    });
+
+    it('disable all other extensions', () => {
+      manager = new ExtensionEnablementManager(configDir, ['ext-test']);
+      manager.enable('ext-test-2', true, '/');
+      expect(manager.isEnabled('ext-test-2', '/')).toBe(false);
+      // Double check that it would have been enabled otherwise
+      expect(
+        new ExtensionEnablementManager(configDir).isEnabled('ext-test-2', '/'),
+      ).toBe(true);
+    });
+
+    it('none disables all extensions', () => {
+      manager = new ExtensionEnablementManager(configDir, ['none']);
+      manager.enable('ext-test', true, '/');
+      expect(manager.isEnabled('ext-test', '/path/to/dir')).toBe(false); // Double check that it would have been enabled otherwise
+      expect(
+        new ExtensionEnablementManager(configDir).isEnabled('ext-test', '/'),
+      ).toBe(true);
+    });
+  });
 });
 
 describe('Override', () => {

--- a/packages/cli/src/config/extensions/extensionEnablement.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.ts
@@ -144,14 +144,18 @@ export class ExtensionEnablementManager {
     // Typically, this comes from the user passing `-e none`.
     if (
       this.enabledExtensionNamesOverride.length === 1 &&
-      this.enabledExtensionNamesOverride[0] === 'none'
+      this.enabledExtensionNamesOverride[0].toLowerCase() === 'none'
     ) {
       return false;
     }
 
     // If we have explicit overrides, only enable those extensions.
     if (this.enabledExtensionNamesOverride.length > 0) {
-      return this.enabledExtensionNamesOverride.includes(extensionName);
+      // When checking against overrides ONLY, we use a case insensitive match.
+      // The override names are already lowercased in the constructor.
+      return this.enabledExtensionNamesOverride.includes(
+        extensionName.toLocaleLowerCase(),
+      );
     }
 
     // Otherwise, we use the configuration settings

--- a/packages/cli/src/config/extensions/extensionEnablement.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.ts
@@ -145,7 +145,7 @@ export class ExtensionEnablementManager {
     // Typically, this comes from the user passing `-e none`.
     if (
       this.enabledExtensionNamesOverride.length === 1 &&
-      this.enabledExtensionNamesOverride[0].toLowerCase() === 'none'
+      this.enabledExtensionNamesOverride[0] === 'none'
     ) {
       return false;
     }


### PR DESCRIPTION
## TLDR

Restores the behavior where `-e <name>` is a case-insensitive match.

## Dive Deeper

## Reviewer Test Plan

Pass `-e <some-extension>` with any case for the name

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/gemini-cli/issues/10241