### PR TITLE
fix installing extensions from zip files

### DIFF
--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -423,7 +423,7 @@ function extractFile(file: string, dest: string) {
     args = ['-xzf', file, '-C', dest];
     command = 'tar';
   } else if (file.endsWith('.zip')) {
-    args = ['-xf', file, '-C', dest];
+    args = [file, '-d', dest];
     command = 'unzip';
   } else {
     throw new Error(`Unsupported file extension for extraction: ${file}`);

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -418,22 +418,25 @@ async function downloadFile(url: string, dest: string): Promise<void> {
 
 function extractFile(file: string, dest: string) {
   let args: string[];
+  let command: 'tar' | 'unzip';
   if (file.endsWith('.tar.gz')) {
     args = ['-xzf', file, '-C', dest];
+    command = 'tar';
   } else if (file.endsWith('.zip')) {
     args = ['-xf', file, '-C', dest];
+    command = 'unzip';
   } else {
     throw new Error(`Unsupported file extension for extraction: ${file}`);
   }
 
-  const result = spawnSync('tar', args, { stdio: 'pipe' });
+  const result = spawnSync(command, args, { stdio: 'pipe' });
 
   if (result.status !== 0) {
     if (result.error) {
-      throw new Error(`Failed to spawn 'tar': ${result.error.message}`);
+      throw new Error(`Failed to spawn '${command}': ${result.error.message}`);
     }
     throw new Error(
-      `'tar' command failed with exit code ${result.status}: ${result.stderr.toString()}`,
+      `'${command}' command failed with exit code ${result.status}: ${result.stderr.toString()}`,
     );
   }
 }


### PR DESCRIPTION
## TLDR

Fixes installing from GitHub releases which have zip archives attached.

## Dive Deeper

https://github.com/google-gemini/gemini-cli/pull/9512 accidentally added an assumption that all archives are tar files.

## Reviewer Test Plan

Install from an extension with a single custom zip file attached to the latest github release.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

