### PR TITLE
add tests for extractFile

### DIFF
--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -371,7 +371,15 @@ describe('git extension helpers', () => {
     it('should extract a .tar.gz file', () => {
       const archivePath = path.join(tempDir, 'test.tar.gz');
       // Create tar.gz archive
-      spawnSync('tar', ['-czf', archivePath, '-C', sourceDir, '.']);
+      const result = spawnSync('tar', [
+        '-czf',
+        archivePath,
+        '-C',
+        sourceDir,
+        '.',
+      ]);
+      expect(result.status).toBe(0);
+      expect(result.error).toBeUndefined();
 
       extractFile(archivePath, destDir);
 
@@ -390,10 +398,15 @@ describe('git extension helpers', () => {
 
     it('should extract a .zip file', () => {
       const archivePath = path.join(tempDir, 'test.zip');
-      // Create zip archive
-      spawnSync('zip', ['-r', archivePath, '.'], {
-        cwd: sourceDir,
-      });
+      // On windows, use tar to create zip files.
+      const result =
+        os.platform() === 'win32'
+          ? spawnSync('tar', ['-czf', archivePath, '-C', sourceDir, '.'])
+          : spawnSync('zip', ['-r', archivePath, '.'], {
+              cwd: sourceDir,
+            });
+      expect(result.status).toBe(0);
+      expect(result.error).toBeUndefined();
 
       extractFile(archivePath, destDir);
 

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -405,8 +405,8 @@ describe('git extension helpers', () => {
           : spawnSync('zip', ['-r', archivePath, '.'], {
               cwd: sourceDir,
             });
-      expect(result.status).toBe(0);
       expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
 
       extractFile(archivePath, destDir);
 

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -416,7 +416,7 @@ async function downloadFile(url: string, dest: string): Promise<void> {
   });
 }
 
-function extractFile(file: string, dest: string) {
+export function extractFile(file: string, dest: string) {
   let args: string[];
   let command: 'tar' | 'unzip';
   if (file.endsWith('.tar.gz')) {


### PR DESCRIPTION
## TLDR

Adds tests for the fix in https://github.com/google-gemini/gemini-cli/pull/10253

## Dive Deeper

These tests validate just the behavior of `extractFile`, we are still lacking in general GitHub release install tests for extensions though.

## Reviewer Test Plan

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to https://github.com/google-gemini/gemini-cli/pull/10253