### PR TITLE
fix(release): Fix promotion workflow

### DIFF
--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -86,13 +86,23 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          echo "PREVIEW_SHA=$(git ls-remote origin '${{ github.event.inputs.ref }}' | awk '{print $1}')" >> "${GITHUB_OUTPUT}"
+          REF="${{ github.event.inputs.ref }}"
+          SHA=$(git ls-remote origin "$REF" | awk '{print $1}')
+          if [ -z "$SHA" ]; then
+            if [[ "$REF" =~ ^[0-9a-f]{7,40}$ ]]; then
+              SHA="$REF"
+            else
+              echo "::error::Could not resolve ref '$REF' to a commit SHA."
+              exit 1
+            fi
+          fi
+          echo "PREVIEW_SHA=$SHA" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           CURRENT_NIGHTLY_TAG=$(git describe --tags --abbrev=0 --match="*nightly*")
           echo "CURRENT_NIGHTLY_TAG=${CURRENT_NIGHTLY_TAG}" >> "${GITHUB_OUTPUT}"
-          echo "NEXT_SHA=$(git ls-remote origin '${{ github.event.inputs.ref }}' | awk '{print $1}')" >> "${GITHUB_OUTPUT}"
+          echo "NEXT_SHA=$SHA" >> "${GITHUB_OUTPUT}"
 
       - name: 'Display Pending Updates'
         run: |

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -83,7 +83,7 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          echo "PREVIEW_SHA=$(git rev-parse '${{ github.event.inputs.ref }}'^{commit})" >> "${GITHUB_OUTPUT}"
+          echo "PREVIEW_SHA=$(git rev-parse '${{ github.event.inputs.ref }}')" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -88,7 +88,7 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          echo "PREVIEW_SHA=$(git rev-parse --verify --quiet ${{ github.event.inputs.ref }}^{commit} || git rev-parse --verify ${{ github.event.inputs.ref }})" >> "${GITHUB_OUTPUT}"
+          echo "PREVIEW_SHA=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -86,7 +86,7 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          echo "PREVIEW_SHA=$(git rev-parse --verify --quiet '${{ github.event.inputs.ref }}^{commit}' || git rev-parse --verify '${{ github.event.inputs.ref }}')" >> "${GITHUB_OUTPUT}"
+          echo "PREVIEW_SHA=$(git rev-list -n 1 '${{ github.event.inputs.ref }}')" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -103,11 +103,11 @@ jobs:
           echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_STABLE_TAG }}"
           echo ""
           echo "Preview Release: ${{ steps.versions.outputs.PREVIEW_VERSION }}"
-          echo "  - Commit: ${{ steps.versions.outputs.PREVIEW_SHA }}"
+          echo "  - Commit: ${{ steps.versions.outputs.PREVIEW_SHA }} (${{ github.event.inputs.ref }})"
           echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_PREVIEW_TAG }}"
           echo ""
           echo "Next Nightly Release: ${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}"
-          echo "  - Commit: ${{ steps.versions.outputs.NEXT_SHA }}"
+          echo "  - Commit: ${{ steps.versions.outputs.NEXT_SHA }} (${{ github.event.inputs.ref }})"
           echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}"
 
   test:

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -38,7 +38,7 @@ jobs:
       PREVIEW_VERSION: '${{ steps.versions.outputs.PREVIEW_VERSION }}'
       PREVIEW_SHA: '${{ steps.versions.outputs.PREVIEW_SHA }}'
       PREVIOUS_PREVIEW_TAG: '${{ steps.versions.outputs.PREVIOUS_PREVIEW_TAG }}'
-      NIGHTLY_VERSION: '${{ steps.versions.outputs.NIGHTLY_VERSION }}'
+      NEXT_NIGHTLY_VERSION: '${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}'
       PREVIOUS_NIGHTLY_TAG: '${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}'
 
     steps:
@@ -88,11 +88,11 @@ jobs:
           # shellcheck disable=SC1083
           echo "PREVIEW_SHA=$(git rev-parse '${{ github.event.inputs.ref }}'^{commit})" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
-          echo "NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
+          echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           CURRENT_NIGHTLY_TAG=$(git describe --tags --abbrev=0 --match="*nightly*")
           echo "CURRENT_NIGHTLY_TAG=${CURRENT_NIGHTLY_TAG}" >> "${GITHUB_OUTPUT}"
-          echo "NIGHTLY_SHA=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+          echo "NEXT_SHA=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
 
       - name: 'Display Pending Updates'
         run: |
@@ -106,8 +106,8 @@ jobs:
           echo "  - Commit: ${{ steps.versions.outputs.PREVIEW_SHA }}"
           echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_PREVIEW_TAG }}"
           echo ""
-          echo "Next Nightly Release: ${{ steps.versions.outputs.NIGHTLY_VERSION }}"
-          echo "  - Commit: ${{ steps.versions.outputs.NIGHTLY_SHA }}"
+          echo "Next Nightly Release: ${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}"
+          echo "  - Commit: ${{ steps.versions.outputs.NEXT_SHA }}"
           echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}"
 
   test:
@@ -299,12 +299,12 @@ jobs:
       - name: 'Create and switch to a new branch'
         id: 'release_branch'
         run: |
-          BRANCH_NAME="chore/nightly-version-bump-${{ needs.calculate-versions.outputs.NIGHTLY_VERSION }}"
+          BRANCH_NAME="chore/nightly-version-bump-${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}"
           git switch -c "${BRANCH_NAME}"
           echo "BRANCH_NAME=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Update package versions'
-        run: 'npm run release:version "${{ needs.calculate-versions.outputs.NIGHTLY_VERSION }}"'
+        run: 'npm run release:version "${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}"'
 
       - name: 'Commit and Push package versions'
         env:
@@ -315,7 +315,7 @@ jobs:
           if [ -f package-lock.json ]; then
             git add package-lock.json
           fi
-          git commit -m "chore(release): bump version to ${{ needs.calculate-versions.outputs.NIGHTLY_VERSION }}"
+          git commit -m "chore(release): bump version to ${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}"
           if [[ "${DRY_RUN}" == "false" ]]; then
             echo "Pushing release branch to remote..."
             git push --set-upstream origin "${BRANCH_NAME}"
@@ -327,7 +327,7 @@ jobs:
         uses: './.github/actions/create-pull-request'
         with:
           branch-name: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
-          pr-title: 'chore(release): bump version to ${{ needs.calculate-versions.outputs.NIGHTLY_VERSION }}'
+          pr-title: 'chore(release): bump version to ${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}'
           pr-body: 'Automated version bump to prepare for the next nightly release.'
           github-token: '${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}'
           dry-run: '${{ github.event.inputs.dry_run }}'
@@ -336,7 +336,7 @@ jobs:
         if: '${{ failure() && github.event.inputs.dry_run == false }}'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          RELEASE_TAG: 'v${{ needs.calculate-versions.outputs.NIGHTLY_VERSION }}'
+          RELEASE_TAG: 'v${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}'
           DETAILS_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: |
           gh issue create \

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -40,8 +40,6 @@ jobs:
       PREVIOUS_PREVIEW_TAG: '${{ steps.versions.outputs.PREVIOUS_PREVIEW_TAG }}'
       NEXT_NIGHTLY_VERSION: '${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}'
       PREVIOUS_NIGHTLY_TAG: '${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}'
-      CURRENT_NIGHTLY_TAG: '${{ steps.versions.outputs.CURRENT_NIGHTLY_TAG }}'
-      NIGHTLY_SHA: '${{ steps.versions.outputs.NIGHTLY_SHA }}'
 
     steps:
       - name: 'Checkout'
@@ -88,7 +86,7 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          echo "PREVIEW_SHA=$(git rev-parse '${{ github.event.inputs.ref }}'^{commit})" >> "${GITHUB_OUTPUT}"          echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
+          echo "PREVIEW_SHA=$(git rev-parse '${{ github.event.inputs.ref }}'^{commit})" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -83,7 +83,7 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          echo "PREVIEW_SHA=$(git rev-parse '${{ github.event.inputs.ref }}')" >> "${GITHUB_OUTPUT}"
+          echo "PREVIEW_SHA=$(git rev-parse --verify --quiet '${{ github.event.inputs.ref }}^{commit}' || git rev-parse --verify '${{ github.event.inputs.ref }}')" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -88,7 +88,7 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          echo "PREVIEW_SHA=$(git rev-parse --verify --quiet '${{ github.event.inputs.ref }}^{commit}' || git rev-parse --verify '${{ github.event.inputs.ref }}')" >> "${GITHUB_OUTPUT}"
+          echo "PREVIEW_SHA=$(git rev-parse --verify --quiet ${{ github.event.inputs.ref }}^{commit} || git rev-parse --verify ${{ github.event.inputs.ref }})" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -68,12 +68,15 @@ jobs:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           set -e
-          STABLE_JSON=$(node scripts/get-release-version.js --type=stable ${{ github.event.inputs.stable_version_override && format('--stable_version_override={0}', github.event.inputs.stable_version_override) || '' }})
-          PREVIEW_JSON=$(node scripts/get-release-version.js --type=preview ${{ github.event.inputs.preview_version_override && format('--preview_version_override={0}', github.event.inputs.preview_version_override) || '' }})
-          NIGHTLY_JSON=$(node scripts/get-release-version.js --type=promote-nightly)
-          echo "STABLE_JSON_COMMAND=node scripts/get-release-version.js --type=stable ${{ github.event.inputs.stable_version_override && format('--stable_version_override={0}', github.event.inputs.stable_version_override) || '' }}"
-          echo "PREVIEW_JSON_COMMAND=node scripts/get-release-version.js --type=preview ${{ github.event.inputs.preview_version_override && format('--preview_version_override={0}', github.event.inputs.preview_version_override) || '' }}"
-          echo "NIGHTLY_JSON_COMMAND=node scripts/get-release-version.js --type=promote-nightly"
+          STABLE_COMMAND="node scripts/get-release-version.js --type=stable ${{ github.event.inputs.stable_version_override && format('--stable_version_override={0}', github.event.inputs.stable_version_override) || '' }}"
+          PREVIEW_COMMAND="node scripts/get-release-version.js --type=preview ${{ github.event.inputs.preview_version_override && format('--preview_version_override={0}', github.event.inputs.preview_version_override) || '' }}"
+          NIGHTLY_COMMAND="node scripts/get-release-version.js --type=promote-nightly"
+          STABLE_JSON=$(${STABLE_COMMAND})
+          PREVIEW_JSON=$(${PREVIEW_COMMAND})
+          NIGHTLY_JSON=$(${NIGHTLY_COMMAND})
+          echo "STABLE_JSON_COMMAND=${STABLE_COMMAND}"
+          echo "PREVIEW_JSON_COMMAND=${PREVIEW_COMMAND}"
+          echo "NIGHTLY_JSON_COMMAND=${NIGHTLY_COMMAND}"
           echo "STABLE_JSON: ${STABLE_JSON}"
           echo "PREVIEW_JSON: ${PREVIEW_JSON}"
           echo "NIGHTLY_JSON: ${NIGHTLY_JSON}"
@@ -93,15 +96,19 @@ jobs:
 
       - name: 'Display Pending Updates'
         run: |
-          echo "Pending Changes, Next Versions:"
-          echo "  Nightly: ${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}"
-          echo "  Preview: ${{ steps.versions.outputs.PREVIEW_VERSION }}"
-          echo "  Stable: ${{ steps.versions.outputs.STABLE_VERSION }}"
+          echo "Release Plan:"
+          echo "-----------"
+          echo "Stable Release: ${{ steps.versions.outputs.STABLE_VERSION }}"
+          echo "  - Commit: ${{ steps.versions.outputs.STABLE_SHA }}"
+          echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_STABLE_TAG }}"
           echo ""
-          echo "Relevant SHAs:"
-          echo "  Stable: Will be cut from:  : ${{ steps.versions.outputs.STABLE_SHA }} / ${{ steps.versions.outputs.PREVIOUS_STABLE_TAG }}"
-          echo "  Preview will be cut from:  : ${{ steps.versions.outputs.PREVIEW_SHA }} (${{ github.event.inputs.ref }})". Users last saw preview as: ${{ steps.versions.outputs.PREVIOUS_PREVIEW_TAG }}
-          echo "  Nightly will be udpated in : ${{ steps.versions.outputs.NEXT_SHA }} (${{ github.event.inputs.ref }}). Previous nightly tag: ${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}"
+          echo "Preview Release: ${{ steps.versions.outputs.PREVIEW_VERSION }}"
+          echo "  - Commit: ${{ steps.versions.outputs.PREVIEW_SHA }}"
+          echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_PREVIEW_TAG }}"
+          echo ""
+          echo "Next Nightly Release: ${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}"
+          echo "  - Commit: ${{ steps.versions.outputs.NEXT_SHA }}"
+          echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}"
 
   test:
     name: 'Test ${{ matrix.channel }}'

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -38,7 +38,7 @@ jobs:
       PREVIEW_VERSION: '${{ steps.versions.outputs.PREVIEW_VERSION }}'
       PREVIEW_SHA: '${{ steps.versions.outputs.PREVIEW_SHA }}'
       PREVIOUS_PREVIEW_TAG: '${{ steps.versions.outputs.PREVIOUS_PREVIEW_TAG }}'
-      NEXT_NIGHTLY_VERSION: '${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}'
+      NIGHTLY_VERSION: '${{ steps.versions.outputs.NIGHTLY_VERSION }}'
       PREVIOUS_NIGHTLY_TAG: '${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}'
 
     steps:
@@ -88,7 +88,7 @@ jobs:
           # shellcheck disable=SC1083
           echo "PREVIEW_SHA=$(git rev-parse '${{ github.event.inputs.ref }}'^{commit})" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
-          echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
+          echo "NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           CURRENT_NIGHTLY_TAG=$(git describe --tags --abbrev=0 --match="*nightly*")
           echo "CURRENT_NIGHTLY_TAG=${CURRENT_NIGHTLY_TAG}" >> "${GITHUB_OUTPUT}"
@@ -106,7 +106,7 @@ jobs:
           echo "  - Commit: ${{ steps.versions.outputs.PREVIEW_SHA }}"
           echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_PREVIEW_TAG }}"
           echo ""
-          echo "Next Nightly Release: ${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}"
+          echo "Next Nightly Release: ${{ steps.versions.outputs.NIGHTLY_VERSION }}"
           echo "  - Commit: ${{ steps.versions.outputs.NIGHTLY_SHA }}"
           echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}"
 
@@ -299,12 +299,12 @@ jobs:
       - name: 'Create and switch to a new branch'
         id: 'release_branch'
         run: |
-          BRANCH_NAME="chore/nightly-version-bump-${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}"
+          BRANCH_NAME="chore/nightly-version-bump-${{ needs.calculate-versions.outputs.NIGHTLY_VERSION }}"
           git switch -c "${BRANCH_NAME}"
           echo "BRANCH_NAME=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Update package versions'
-        run: 'npm run release:version "${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}"'
+        run: 'npm run release:version "${{ needs.calculate-versions.outputs.NIGHTLY_VERSION }}"'
 
       - name: 'Commit and Push package versions'
         env:
@@ -315,7 +315,7 @@ jobs:
           if [ -f package-lock.json ]; then
             git add package-lock.json
           fi
-          git commit -m "chore(release): bump version to ${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}"
+          git commit -m "chore(release): bump version to ${{ needs.calculate-versions.outputs.NIGHTLY_VERSION }}"
           if [[ "${DRY_RUN}" == "false" ]]; then
             echo "Pushing release branch to remote..."
             git push --set-upstream origin "${BRANCH_NAME}"
@@ -327,7 +327,7 @@ jobs:
         uses: './.github/actions/create-pull-request'
         with:
           branch-name: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
-          pr-title: 'chore(release): bump version to ${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}'
+          pr-title: 'chore(release): bump version to ${{ needs.calculate-versions.outputs.NIGHTLY_VERSION }}'
           pr-body: 'Automated version bump to prepare for the next nightly release.'
           github-token: '${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}'
           dry-run: '${{ github.event.inputs.dry_run }}'
@@ -336,7 +336,7 @@ jobs:
         if: '${{ failure() && github.event.inputs.dry_run == false }}'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          RELEASE_TAG: 'v${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}'
+          RELEASE_TAG: 'v${{ needs.calculate-versions.outputs.NIGHTLY_VERSION }}'
           DETAILS_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: |
           gh issue create \

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -88,13 +88,13 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          echo "PREVIEW_SHA=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+          echo "PREVIEW_SHA=$(git rev-parse origin/main)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           CURRENT_NIGHTLY_TAG=$(git describe --tags --abbrev=0 --match="*nightly*")
           echo "CURRENT_NIGHTLY_TAG=${CURRENT_NIGHTLY_TAG}" >> "${GITHUB_OUTPUT}"
-          echo "NEXT_SHA=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+          echo "NEXT_SHA=$(git rev-parse origin/main)" >> "${GITHUB_OUTPUT}"
 
       - name: 'Display Pending Updates'
         run: |

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -41,7 +41,7 @@ jobs:
       NEXT_NIGHTLY_VERSION: '${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}'
       PREVIOUS_NIGHTLY_TAG: '${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}'
       CURRENT_NIGHTLY_TAG: '${{ steps.versions.outputs.CURRENT_NIGHTLY_TAG }}'
-      NEXT_SHA: '${{ steps.versions.outputs.NEXT_SHA }}'
+      NIGHTLY_SHA: '${{ steps.versions.outputs.NIGHTLY_SHA }}'
 
     steps:
       - name: 'Checkout'
@@ -88,13 +88,13 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          echo "PREVIEW_SHA=$(git rev-parse origin/main)" >> "${GITHUB_OUTPUT}"
+          echo "PREVIEW_SHA=$(git rev-parse '${{ github.event.inputs.ref }}'^{commit})" >> "${GITHUB_OUTPUT}"          echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           CURRENT_NIGHTLY_TAG=$(git describe --tags --abbrev=0 --match="*nightly*")
           echo "CURRENT_NIGHTLY_TAG=${CURRENT_NIGHTLY_TAG}" >> "${GITHUB_OUTPUT}"
-          echo "NEXT_SHA=$(git rev-parse origin/main)" >> "${GITHUB_OUTPUT}"
+          echo "NIGHTLY_SHA=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
 
       - name: 'Display Pending Updates'
         run: |
@@ -109,7 +109,7 @@ jobs:
           echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_PREVIEW_TAG }}"
           echo ""
           echo "Next Nightly Release: ${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}"
-          echo "  - Commit: ${{ steps.versions.outputs.NEXT_SHA }}"
+          echo "  - Commit: ${{ steps.versions.outputs.NIGHTLY_SHA }}"
           echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}"
 
   test:

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -86,7 +86,7 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          echo "PREVIEW_SHA=$(git rev-list -n 1 '${{ github.event.inputs.ref }}')" >> "${GITHUB_OUTPUT}"
+          echo "PREVIEW_SHA=$(git rev-list -n 1 'origin/${{ github.event.inputs.ref }}')" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -86,7 +86,7 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          echo "PREVIEW_SHA=$(git rev-parse '${{ github.event.inputs.ref }}'^{commit})" >> "${GITHUB_OUTPUT}"
+          echo "PREVIEW_SHA=$(git rev-parse --verify --quiet '${{ github.event.inputs.ref }}^{commit}' || git rev-parse --verify '${{ github.event.inputs.ref }}')" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -40,6 +40,8 @@ jobs:
       PREVIOUS_PREVIEW_TAG: '${{ steps.versions.outputs.PREVIOUS_PREVIEW_TAG }}'
       NEXT_NIGHTLY_VERSION: '${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}'
       PREVIOUS_NIGHTLY_TAG: '${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}'
+      CURRENT_NIGHTLY_TAG: '${{ steps.versions.outputs.CURRENT_NIGHTLY_TAG }}'
+      NEXT_SHA: '${{ steps.versions.outputs.NEXT_SHA }}'
 
     steps:
       - name: 'Checkout'

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -86,7 +86,7 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          echo "PREVIEW_SHA=$(git rev-list -n 1 'origin/${{ github.event.inputs.ref }}')" >> "${GITHUB_OUTPUT}"
+          echo "PREVIEW_SHA=$(git ls-remote origin '${{ github.event.inputs.ref }}' | awk '{print $1}')" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_PREVIEW_TAG=$(echo "${PREVIEW_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "NEXT_NIGHTLY_VERSION=$(echo "${NIGHTLY_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -92,7 +92,7 @@ jobs:
           echo "PREVIOUS_NIGHTLY_TAG=$(echo "${NIGHTLY_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           CURRENT_NIGHTLY_TAG=$(git describe --tags --abbrev=0 --match="*nightly*")
           echo "CURRENT_NIGHTLY_TAG=${CURRENT_NIGHTLY_TAG}" >> "${GITHUB_OUTPUT}"
-          echo "NEXT_SHA=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+          echo "NEXT_SHA=$(git ls-remote origin '${{ github.event.inputs.ref }}' | awk '{print $1}')" >> "${GITHUB_OUTPUT}"
 
       - name: 'Display Pending Updates'
         run: |

--- a/scripts/get-release-version.js
+++ b/scripts/get-release-version.js
@@ -84,7 +84,7 @@ function isVersionDeprecated(version) {
     return output.length > 0;
   } catch (error) {
     // This command shouldn't fail for existing versions, but as a safeguard:
-    console.warn(
+    console.error(
       `Failed to check deprecation status for ${version}: ${error.message}`,
     );
     return false; // Assume not deprecated on error to avoid breaking the release.
@@ -136,7 +136,7 @@ function detectRollbackAndGetBaseline(npmDistTag) {
       highestExistingVersion = version;
       break; // Found the one we want
     } else {
-      console.log(`Ignoring deprecated version: ${version}`);
+      console.error(`Ignoring deprecated version: ${version}`);
     }
   }
 
@@ -162,7 +162,7 @@ function doesVersionExist(version) {
     const command = `npm view @google/gemini-cli@${version} version 2>/dev/null`;
     const output = execSync(command).toString().trim();
     if (output === version) {
-      console.warn(`Version ${version} already exists on NPM.`);
+      console.error(`Version ${version} already exists on NPM.`);
       return true;
     }
   } catch (_error) {
@@ -174,11 +174,11 @@ function doesVersionExist(version) {
     const command = `git tag -l 'v${version}'`;
     const tagOutput = execSync(command).toString().trim();
     if (tagOutput === `v${version}`) {
-      console.warn(`Git tag v${version} already exists.`);
+      console.error(`Git tag v${version} already exists.`);
       return true;
     }
   } catch (error) {
-    console.warn(`Failed to check git tags for conflicts: ${error.message}`);
+    console.error(`Failed to check git tags for conflicts: ${error.message}`);
   }
 
   // Check GitHub releases
@@ -186,7 +186,7 @@ function doesVersionExist(version) {
     const command = `gh release view "v${version}" --json tagName --jq .tagName 2>/dev/null`;
     const output = execSync(command).toString().trim();
     if (output === `v${version}`) {
-      console.warn(`GitHub release v${version} already exists.`);
+      console.error(`GitHub release v${version} already exists.`);
       return true;
     }
   } catch (error) {
@@ -196,7 +196,7 @@ function doesVersionExist(version) {
       error.message.includes('not found') ||
       error.status === 1;
     if (!isExpectedNotFound) {
-      console.warn(
+      console.error(
         `Failed to check GitHub releases for conflicts: ${error.message}`,
       );
     }
@@ -216,7 +216,7 @@ function getAndVerifyTags(npmDistTag, _gitTagPattern) {
 
   if (rollbackInfo.isRollback) {
     // Rollback scenario: warn about the rollback but don't fail
-    console.warn(
+    console.error(
       `Rollback detected! NPM ${npmDistTag} tag is ${rollbackInfo.distTagVersion}, but using ${baselineVersion} as baseline for next version calculation (highest existing version).`,
     );
   }
@@ -414,7 +414,7 @@ export function getVersion(options = {}) {
   if (type === 'stable' || type === 'preview' || type === 'patch') {
     let releaseVersion = versionData.releaseVersion;
     while (doesVersionExist(releaseVersion)) {
-      console.log(`Version ${releaseVersion} exists, incrementing.`);
+      console.error(`Version ${releaseVersion} exists, incrementing.`);
       if (releaseVersion.includes('-preview.')) {
         // Increment preview number: 0.6.0-preview.2 -> 0.6.0-preview.3
         const [version, prereleasePart] = releaseVersion.split('-');


### PR DESCRIPTION
## TLDR

This PR fixes several bugs in the `release-promote` workflow to improve its reliability and makes its output easier to understand.

Key changes:
- The workflow now uses `git ls-remote` to reliably resolve commit SHAs for branches and tags that are not checked out, fixing the "unknown revision" error
- Changes all important status messages and warnings in the release script to print to `stderr` instead of `stdout`, making them much more visible in CI logs
- Cleans up the "Release Plan" output in the workflow for better readability