### PR TITLE
chore: bundle a2a-server

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -31,34 +31,42 @@ const external = [
   '@lydell/node-pty-win32-arm64',
   '@lydell/node-pty-win32-x64',
 ];
+const baseConfig = {
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  external,
+  define: {
+    'process.env.CLI_VERSION': JSON.stringify(pkg.version),
+  },
+  banner: {
+    js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url); globalThis.__filename = require('url').fileURLToPath(import.meta.url); globalThis.__dirname = require('path').dirname(globalThis.__filename);`,
+  },
+  loader: { '.node': 'file' },
+  write: true,
+};
 
-esbuild
-  .build({
-    entryPoints: ['packages/cli/index.ts'],
-    bundle: true,
-    outfile: 'bundle/gemini.js',
-    platform: 'node',
-    format: 'esm',
-    external,
-    alias: {
-      'is-in-ci': path.resolve(
-        __dirname,
-        'packages/cli/src/patches/is-in-ci.ts',
-      ),
-    },
-    define: {
-      'process.env.CLI_VERSION': JSON.stringify(pkg.version),
-    },
-    banner: {
-      js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url); globalThis.__filename = require('url').fileURLToPath(import.meta.url); globalThis.__dirname = require('path').dirname(globalThis.__filename);`,
-    },
-    loader: { '.node': 'file' },
-    metafile: true,
-    write: true,
-  })
-  .then(({ metafile }) => {
+const cliConfig = {
+  ...baseConfig,
+  entryPoints: ['packages/cli/index.ts'],
+  outfile: 'bundle/gemini.js',
+  alias: {
+    'is-in-ci': path.resolve(__dirname, 'packages/cli/src/patches/is-in-ci.ts'),
+  },
+  metafile: true,
+};
+
+const a2aServerConfig = {
+  ...baseConfig,
+  entryPoints: ['packages/a2a-server/src/http/server.ts'],
+  outfile: 'bundle/a2a-server.mjs',
+};
+
+Promise.all([
+  esbuild.build(cliConfig).then(({ metafile }) => {
     if (process.env.DEV === 'true') {
       writeFileSync('./bundle/esbuild.json', JSON.stringify(metafile, null, 2));
     }
-  })
-  .catch(() => process.exit(1));
+  }),
+  esbuild.build(a2aServerConfig),
+]).catch(() => process.exit(1));

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -31,20 +31,21 @@ const external = [
   '@lydell/node-pty-win32-arm64',
   '@lydell/node-pty-win32-x64',
 ];
+
 const baseConfig = {
   bundle: true,
   platform: 'node',
   format: 'esm',
   external,
-  banner: {
-    js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url); globalThis.__filename = require('url').fileURLToPath(import.meta.url); globalThis.__dirname = require('path').dirname(globalThis.__filename);`,
-  },
   loader: { '.node': 'file' },
   write: true,
 };
 
 const cliConfig = {
   ...baseConfig,
+  banner: {
+    js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url); globalThis.__filename = require('url').fileURLToPath(import.meta.url); globalThis.__dirname = require('path').dirname(globalThis.__filename);`,
+  },
   entryPoints: ['packages/cli/index.ts'],
   outfile: 'bundle/gemini.js',
   define: {
@@ -58,8 +59,11 @@ const cliConfig = {
 
 const a2aServerConfig = {
   ...baseConfig,
+  banner: {
+    js: `const require = (await import('module')).createRequire(import.meta.url); globalThis.__filename = require('url').fileURLToPath(import.meta.url); globalThis.__dirname = require('path').dirname(globalThis.__filename);`,
+  },
   entryPoints: ['packages/a2a-server/src/http/server.ts'],
-  outfile: 'bundle/a2a-server.mjs',
+  outfile: 'packages/a2a-server/dist/a2a-server.mjs',
   define: {
     'process.env.CLI_VERSION': JSON.stringify(pkg.version),
   },


### PR DESCRIPTION
## TLDR

Creates the a2a-server.mjs on `npm run bundle`

## Dive Deeper

This is the first in a series of changes to publish the a2a-server as its own package on npm.
If the a2a-server fails to bundle it is non-blocking for the gemini.js bundle.

## Reviewer Test Plan

run `npm ci`, `npm run bundle`, `node packages/a2a-server/dist/a2a-server.mjs` and confirm the agent server starts correctly

- Run `npm run bundle` with this change and on main. Compare the two files with `diff old_gemini.js new_gemini.js` and compare there is no difference.
- (run `npm link` within root directory), then `npx gemini -s -p "whats the most popular dog breed according to the web"`. (French Bulldog).

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes: https://github.com/google-gemini/gemini-cli/issues/9207
