### PR TITLE
fix(core): Fix a cache collision bug in the edit corrector 

### DIFF
--- a/packages/core/src/utils/editCorrector.ts
+++ b/packages/core/src/utils/editCorrector.ts
@@ -8,6 +8,7 @@ import type { Content, GenerateContentConfig } from '@google/genai';
 import type { GeminiClient } from '../core/client.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
 import type { EditToolParams } from '../tools/edit.js';
+import { createHash } from 'node:crypto';
 import { EditTool } from '../tools/edit.js';
 import { WriteFileTool } from '../tools/write-file.js';
 import { ReadFileTool } from '../tools/read-file.js';
@@ -177,7 +178,15 @@ export async function ensureCorrectEdit(
   baseLlmClient: BaseLlmClient,
   abortSignal: AbortSignal,
 ): Promise<CorrectedEditResult> {
-  const cacheKey = `${currentContent}---${originalParams.old_string}---${originalParams.new_string}`;
+  const cacheKey = createHash('sha256')
+    .update(
+      JSON.stringify([
+        currentContent,
+        originalParams.old_string,
+        originalParams.new_string,
+      ]),
+    )
+    .digest('hex');
   const cachedResult = editCorrectionCache.get(cacheKey);
   if (cachedResult) {
     return cachedResult;

--- a/packages/core/src/utils/editCorrector.ts
+++ b/packages/core/src/utils/editCorrector.ts
@@ -179,13 +179,9 @@ export async function ensureCorrectEdit(
   abortSignal: AbortSignal,
 ): Promise<CorrectedEditResult> {
   const cacheKey = createHash('sha256')
-    .update(
-      JSON.stringify([
-        currentContent,
-        originalParams.old_string,
-        originalParams.new_string,
-      ]),
-    )
+    .update(createHash('sha256').update(currentContent).digest())
+    .update(createHash('sha256').update(originalParams.old_string).digest())
+    .update(createHash('sha256').update(originalParams.new_string).digest())
     .digest('hex');
   const cachedResult = editCorrectionCache.get(cacheKey);
   if (cachedResult) {


### PR DESCRIPTION
## TLDR

Fixed a cache collision bug in the edit corrector that could cause incorrect text replacements. Changed cache key generation from using `---` separators to JSON.stringify() to prevent collisions when code content contains the `---` sequence or any other special characters.

## Dive Deeper

The `ensureCorrectEdit` function uses a cache to avoid redundant LLM calls for edit corrections. The cache key was generated by concatenating `currentContent`, `old_string`, and `new_string` with `---` as a separator:

```javascript
const cacheKey = `${currentContent}---${originalParams.old_string}---${originalParams.new_string}`;
```

This approach had a collision vulnerability when the file content or edit parameters contained the `---` sequence, which is common in:
- YAML frontmatter (`---`)
- Markdown document separators 
- Code comments (`// --- Section ---`)
- Configuration files

**Example collision scenario:**
- Content: `"config = { theme: '---'"`, old: `"default"`, new: `"dark' }"`
- Content: `"config = { theme: '---'---default"`, old: `"dark' }"`, new: `""`
- Both produce the same cache key, causing incorrect cache hits

The fix uses `JSON.stringify()` to serialize the cache key components into an array, which is completely collision-proof and handles any possible content safely:

```javascript
const cacheKey = JSON.stringify([currentContent, originalParams.old_string, originalParams.new_string]);
```

This approach guarantees unique cache keys regardless of what characters appear in the content, including edge cases where LLMs might generate unusual characters.

## Reviewer Test Plan

To validate this fix:

1. **Test edit operations with `---` in content:**
   - Create files containing `---` (YAML, Markdown, comments)
   - Perform multiple edits and verify cache behavior is correct
   - Ensure no incorrect cached results are returned

2. **Verify cache functionality still works:**
   - Perform the same edit operation twice
   - Confirm second operation uses cached result (faster execution)
   - Check cache hit/miss behavior with debug logging

3. **Test edge cases:**
   - Files with various special characters (quotes, backslashes, unicode)
   - Large file content (cache key generation performance)
   - Multiple rapid edit operations
   - Content with JSON-like structures that might interfere with serialization

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
