### PR TITLE
Switch to a reducer for tracking update state fixing flicker issues due to continuous renders

### DIFF
--- a/packages/cli/src/commands/extensions/update.ts
+++ b/packages/cli/src/commands/extensions/update.ts
@@ -95,7 +95,7 @@ export async function handleUpdate(args: UpdateArgs) {
         workingDir,
         requestConsentNonInteractive,
         extensions,
-        await checkForAllExtensionUpdates(extensions, new Map(), (_) => {}),
+        await checkForAllExtensionUpdates(extensions, new Map(), () => {}),
         () => {},
       );
       updateInfos = updateInfos.filter(

--- a/packages/cli/src/commands/extensions/update.ts
+++ b/packages/cli/src/commands/extensions/update.ts
@@ -91,11 +91,24 @@ export async function handleUpdate(args: UpdateArgs) {
   }
   if (args.all) {
     try {
+      const extensionState = new Map();
+      await checkForAllExtensionUpdates(
+        extensions,
+        extensionState,
+        (action) => {
+          if (action.type === 'SET_STATE') {
+            extensionState.set(action.payload.name, {
+              status: action.payload.state,
+              processed: true, // No need to process as we will force the update.
+            });
+          }
+        },
+      );
       let updateInfos = await updateAllUpdatableExtensions(
         workingDir,
         requestConsentNonInteractive,
         extensions,
-        await checkForAllExtensionUpdates(extensions, new Map(), () => {}),
+        extensionState,
         () => {},
       );
       updateInfos = updateInfos.filter(

--- a/packages/cli/src/commands/extensions/update.ts
+++ b/packages/cli/src/commands/extensions/update.ts
@@ -92,18 +92,14 @@ export async function handleUpdate(args: UpdateArgs) {
   if (args.all) {
     try {
       const extensionState = new Map();
-      await checkForAllExtensionUpdates(
-        extensions,
-        extensionState,
-        (action) => {
-          if (action.type === 'SET_STATE') {
-            extensionState.set(action.payload.name, {
-              status: action.payload.state,
-              processed: true, // No need to process as we will force the update.
-            });
-          }
-        },
-      );
+      await checkForAllExtensionUpdates(extensions, (action) => {
+        if (action.type === 'SET_STATE') {
+          extensionState.set(action.payload.name, {
+            status: action.payload.state,
+            processed: true, // No need to process as we will force the update.
+          });
+        }
+      });
       let updateInfos = await updateAllUpdatableExtensions(
         workingDir,
         requestConsentNonInteractive,

--- a/packages/cli/src/config/extensions/update.test.ts
+++ b/packages/cli/src/config/extensions/update.test.ts
@@ -186,6 +186,12 @@ describe('update tests', () => {
       mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
 
       const setExtensionUpdateState = vi.fn();
+      const dispatch = (action: {
+        type: string;
+        payload: { name: string; state: ExtensionUpdateState };
+      }) => {
+        setExtensionUpdateState(action.payload.state);
+      };
 
       const extension = annotateActiveExtensions(
         [
@@ -202,7 +208,7 @@ describe('update tests', () => {
         tempHomeDir,
         async (_) => true,
         ExtensionUpdateState.UPDATE_AVAILABLE,
-        setExtensionUpdateState,
+        dispatch,
       );
 
       expect(setExtensionUpdateState).toHaveBeenCalledWith(
@@ -229,6 +235,12 @@ describe('update tests', () => {
       mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
 
       const setExtensionUpdateState = vi.fn();
+      const dispatch = (action: {
+        type: string;
+        payload: { name: string; state: ExtensionUpdateState };
+      }) => {
+        setExtensionUpdateState(action.payload.state);
+      };
       const extension = annotateActiveExtensions(
         [
           loadExtension({
@@ -245,7 +257,7 @@ describe('update tests', () => {
           tempHomeDir,
           async (_) => true,
           ExtensionUpdateState.UPDATE_AVAILABLE,
-          setExtensionUpdateState,
+          dispatch,
         ),
       ).rejects.toThrow();
 
@@ -286,17 +298,17 @@ describe('update tests', () => {
       mockGit.listRemote.mockResolvedValue('remoteHash	HEAD');
       mockGit.revparse.mockResolvedValue('localHash');
 
-      let extensionState = new Map();
+      const extensionState = new Map();
+      const dispatch = (action: {
+        type: string;
+        payload: { name: string; state: ExtensionUpdateState };
+      }) => {
+        extensionState.set(action.payload.name, action.payload.state);
+      };
       const results = await checkForAllExtensionUpdates(
         [extension],
         extensionState,
-        (newState) => {
-          if (typeof newState === 'function') {
-            newState(extensionState);
-          } else {
-            extensionState = newState;
-          }
-        },
+        dispatch,
       );
       const result = results.get('test-extension');
       expect(result).toBe(ExtensionUpdateState.UPDATE_AVAILABLE);
@@ -329,17 +341,17 @@ describe('update tests', () => {
       mockGit.listRemote.mockResolvedValue('sameHash	HEAD');
       mockGit.revparse.mockResolvedValue('sameHash');
 
-      let extensionState = new Map();
+      const extensionState = new Map();
+      const dispatch = (action: {
+        type: string;
+        payload: { name: string; state: ExtensionUpdateState };
+      }) => {
+        extensionState.set(action.payload.name, action.payload.state);
+      };
       const results = await checkForAllExtensionUpdates(
         [extension],
         extensionState,
-        (newState) => {
-          if (typeof newState === 'function') {
-            newState(extensionState);
-          } else {
-            extensionState = newState;
-          }
-        },
+        dispatch,
       );
       const result = results.get('test-extension');
       expect(result).toBe(ExtensionUpdateState.UP_TO_DATE);
@@ -369,17 +381,17 @@ describe('update tests', () => {
         process.cwd(),
         new ExtensionEnablementManager(ExtensionStorage.getUserExtensionsDir()),
       )[0];
-      let extensionState = new Map();
+      const extensionState = new Map();
+      const dispatch = (action: {
+        type: string;
+        payload: { name: string; state: ExtensionUpdateState };
+      }) => {
+        extensionState.set(action.payload.name, action.payload.state);
+      };
       const results = await checkForAllExtensionUpdates(
         [extension],
         extensionState,
-        (newState) => {
-          if (typeof newState === 'function') {
-            newState(extensionState);
-          } else {
-            extensionState = newState;
-          }
-        },
+        dispatch,
         tempWorkspaceDir,
       );
       const result = results.get('local-extension');
@@ -410,17 +422,17 @@ describe('update tests', () => {
         process.cwd(),
         new ExtensionEnablementManager(ExtensionStorage.getUserExtensionsDir()),
       )[0];
-      let extensionState = new Map();
+      const extensionState = new Map();
+      const dispatch = (action: {
+        type: string;
+        payload: { name: string; state: ExtensionUpdateState };
+      }) => {
+        extensionState.set(action.payload.name, action.payload.state);
+      };
       const results = await checkForAllExtensionUpdates(
         [extension],
         extensionState,
-        (newState) => {
-          if (typeof newState === 'function') {
-            newState(extensionState);
-          } else {
-            extensionState = newState;
-          }
-        },
+        dispatch,
         tempWorkspaceDir,
       );
       const result = results.get('local-extension');
@@ -450,17 +462,17 @@ describe('update tests', () => {
 
       mockGit.getRemotes.mockRejectedValue(new Error('Git error'));
 
-      let extensionState = new Map();
+      const extensionState = new Map();
+      const dispatch = (action: {
+        type: string;
+        payload: { name: string; state: ExtensionUpdateState };
+      }) => {
+        extensionState.set(action.payload.name, action.payload.state);
+      };
       const results = await checkForAllExtensionUpdates(
         [extension],
         extensionState,
-        (newState) => {
-          if (typeof newState === 'function') {
-            newState(extensionState);
-          } else {
-            extensionState = newState;
-          }
-        },
+        dispatch,
       );
       const result = results.get('error-extension');
       expect(result).toBe(ExtensionUpdateState.ERROR);

--- a/packages/cli/src/config/extensions/update.test.ts
+++ b/packages/cli/src/config/extensions/update.test.ts
@@ -185,14 +185,7 @@ describe('update tests', () => {
       });
       mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
 
-      const setExtensionUpdateState = vi.fn();
-      const dispatch = (action: {
-        type: string;
-        payload: { name: string; state: ExtensionUpdateState };
-      }) => {
-        setExtensionUpdateState(action.payload.state);
-      };
-
+      const dispatch = vi.fn();
       const extension = annotateActiveExtensions(
         [
           loadExtension({
@@ -211,12 +204,20 @@ describe('update tests', () => {
         dispatch,
       );
 
-      expect(setExtensionUpdateState).toHaveBeenCalledWith(
-        ExtensionUpdateState.UPDATING,
-      );
-      expect(setExtensionUpdateState).toHaveBeenCalledWith(
-        ExtensionUpdateState.UPDATED_NEEDS_RESTART,
-      );
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: {
+          name: extensionName,
+          state: ExtensionUpdateState.UPDATING,
+        },
+      });
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: {
+          name: extensionName,
+          state: ExtensionUpdateState.UPDATED_NEEDS_RESTART,
+        },
+      });
     });
 
     it('should call setExtensionUpdateState with ERROR on failure', async () => {
@@ -234,13 +235,7 @@ describe('update tests', () => {
       mockGit.clone.mockRejectedValue(new Error('Git clone failed'));
       mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
 
-      const setExtensionUpdateState = vi.fn();
-      const dispatch = (action: {
-        type: string;
-        payload: { name: string; state: ExtensionUpdateState };
-      }) => {
-        setExtensionUpdateState(action.payload.state);
-      };
+      const dispatch = vi.fn();
       const extension = annotateActiveExtensions(
         [
           loadExtension({
@@ -261,12 +256,20 @@ describe('update tests', () => {
         ),
       ).rejects.toThrow();
 
-      expect(setExtensionUpdateState).toHaveBeenCalledWith(
-        ExtensionUpdateState.UPDATING,
-      );
-      expect(setExtensionUpdateState).toHaveBeenCalledWith(
-        ExtensionUpdateState.ERROR,
-      );
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: {
+          name: extensionName,
+          state: ExtensionUpdateState.UPDATING,
+        },
+      });
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: {
+          name: extensionName,
+          state: ExtensionUpdateState.ERROR,
+        },
+      });
     });
   });
 
@@ -299,19 +302,15 @@ describe('update tests', () => {
       mockGit.revparse.mockResolvedValue('localHash');
 
       const extensionState = new Map();
-      const dispatch = (action: {
-        type: string;
-        payload: { name: string; state: ExtensionUpdateState };
-      }) => {
-        extensionState.set(action.payload.name, action.payload.state);
-      };
-      const results = await checkForAllExtensionUpdates(
-        [extension],
-        extensionState,
-        dispatch,
-      );
-      const result = results.get('test-extension');
-      expect(result).toBe(ExtensionUpdateState.UPDATE_AVAILABLE);
+      const dispatch = vi.fn();
+      await checkForAllExtensionUpdates([extension], extensionState, dispatch);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: {
+          name: 'test-extension',
+          state: ExtensionUpdateState.UPDATE_AVAILABLE,
+        },
+      });
     });
 
     it('should return UpToDate for a git extension with no updates', async () => {
@@ -342,19 +341,15 @@ describe('update tests', () => {
       mockGit.revparse.mockResolvedValue('sameHash');
 
       const extensionState = new Map();
-      const dispatch = (action: {
-        type: string;
-        payload: { name: string; state: ExtensionUpdateState };
-      }) => {
-        extensionState.set(action.payload.name, action.payload.state);
-      };
-      const results = await checkForAllExtensionUpdates(
-        [extension],
-        extensionState,
-        dispatch,
-      );
-      const result = results.get('test-extension');
-      expect(result).toBe(ExtensionUpdateState.UP_TO_DATE);
+      const dispatch = vi.fn();
+      await checkForAllExtensionUpdates([extension], extensionState, dispatch);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: {
+          name: 'test-extension',
+          state: ExtensionUpdateState.UP_TO_DATE,
+        },
+      });
     });
 
     it('should return UpToDate for a local extension with no updates', async () => {
@@ -382,20 +377,20 @@ describe('update tests', () => {
         new ExtensionEnablementManager(ExtensionStorage.getUserExtensionsDir()),
       )[0];
       const extensionState = new Map();
-      const dispatch = (action: {
-        type: string;
-        payload: { name: string; state: ExtensionUpdateState };
-      }) => {
-        extensionState.set(action.payload.name, action.payload.state);
-      };
-      const results = await checkForAllExtensionUpdates(
+      const dispatch = vi.fn();
+      await checkForAllExtensionUpdates(
         [extension],
         extensionState,
         dispatch,
         tempWorkspaceDir,
       );
-      const result = results.get('local-extension');
-      expect(result).toBe(ExtensionUpdateState.UP_TO_DATE);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: {
+          name: 'local-extension',
+          state: ExtensionUpdateState.UP_TO_DATE,
+        },
+      });
     });
 
     it('should return UpdateAvailable for a local extension with updates', async () => {
@@ -423,20 +418,20 @@ describe('update tests', () => {
         new ExtensionEnablementManager(ExtensionStorage.getUserExtensionsDir()),
       )[0];
       const extensionState = new Map();
-      const dispatch = (action: {
-        type: string;
-        payload: { name: string; state: ExtensionUpdateState };
-      }) => {
-        extensionState.set(action.payload.name, action.payload.state);
-      };
-      const results = await checkForAllExtensionUpdates(
+      const dispatch = vi.fn();
+      await checkForAllExtensionUpdates(
         [extension],
         extensionState,
         dispatch,
         tempWorkspaceDir,
       );
-      const result = results.get('local-extension');
-      expect(result).toBe(ExtensionUpdateState.UPDATE_AVAILABLE);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: {
+          name: 'local-extension',
+          state: ExtensionUpdateState.UPDATE_AVAILABLE,
+        },
+      });
     });
 
     it('should return Error when git check fails', async () => {
@@ -463,19 +458,15 @@ describe('update tests', () => {
       mockGit.getRemotes.mockRejectedValue(new Error('Git error'));
 
       const extensionState = new Map();
-      const dispatch = (action: {
-        type: string;
-        payload: { name: string; state: ExtensionUpdateState };
-      }) => {
-        extensionState.set(action.payload.name, action.payload.state);
-      };
-      const results = await checkForAllExtensionUpdates(
-        [extension],
-        extensionState,
-        dispatch,
-      );
-      const result = results.get('error-extension');
-      expect(result).toBe(ExtensionUpdateState.ERROR);
+      const dispatch = vi.fn();
+      await checkForAllExtensionUpdates([extension], extensionState, dispatch);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: {
+          name: 'error-extension',
+          state: ExtensionUpdateState.ERROR,
+        },
+      });
     });
   });
 });

--- a/packages/cli/src/config/extensions/update.test.ts
+++ b/packages/cli/src/config/extensions/update.test.ts
@@ -301,9 +301,8 @@ describe('update tests', () => {
       mockGit.listRemote.mockResolvedValue('remoteHash	HEAD');
       mockGit.revparse.mockResolvedValue('localHash');
 
-      const extensionState = new Map();
       const dispatch = vi.fn();
-      await checkForAllExtensionUpdates([extension], extensionState, dispatch);
+      await checkForAllExtensionUpdates([extension], dispatch);
       expect(dispatch).toHaveBeenCalledWith({
         type: 'SET_STATE',
         payload: {
@@ -340,9 +339,8 @@ describe('update tests', () => {
       mockGit.listRemote.mockResolvedValue('sameHash	HEAD');
       mockGit.revparse.mockResolvedValue('sameHash');
 
-      const extensionState = new Map();
       const dispatch = vi.fn();
-      await checkForAllExtensionUpdates([extension], extensionState, dispatch);
+      await checkForAllExtensionUpdates([extension], dispatch);
       expect(dispatch).toHaveBeenCalledWith({
         type: 'SET_STATE',
         payload: {
@@ -376,14 +374,8 @@ describe('update tests', () => {
         process.cwd(),
         new ExtensionEnablementManager(ExtensionStorage.getUserExtensionsDir()),
       )[0];
-      const extensionState = new Map();
       const dispatch = vi.fn();
-      await checkForAllExtensionUpdates(
-        [extension],
-        extensionState,
-        dispatch,
-        tempWorkspaceDir,
-      );
+      await checkForAllExtensionUpdates([extension], dispatch);
       expect(dispatch).toHaveBeenCalledWith({
         type: 'SET_STATE',
         payload: {
@@ -417,14 +409,8 @@ describe('update tests', () => {
         process.cwd(),
         new ExtensionEnablementManager(ExtensionStorage.getUserExtensionsDir()),
       )[0];
-      const extensionState = new Map();
       const dispatch = vi.fn();
-      await checkForAllExtensionUpdates(
-        [extension],
-        extensionState,
-        dispatch,
-        tempWorkspaceDir,
-      );
+      await checkForAllExtensionUpdates([extension], dispatch);
       expect(dispatch).toHaveBeenCalledWith({
         type: 'SET_STATE',
         payload: {
@@ -457,9 +443,8 @@ describe('update tests', () => {
 
       mockGit.getRemotes.mockRejectedValue(new Error('Git error'));
 
-      const extensionState = new Map();
       const dispatch = vi.fn();
-      await checkForAllExtensionUpdates([extension], extensionState, dispatch);
+      await checkForAllExtensionUpdates([extension], dispatch);
       expect(dispatch).toHaveBeenCalledWith({
         type: 'SET_STATE',
         payload: {

--- a/packages/cli/src/config/extensions/update.ts
+++ b/packages/cli/src/config/extensions/update.ts
@@ -153,33 +153,24 @@ export interface ExtensionUpdateCheckResult {
 
 export async function checkForAllExtensionUpdates(
   extensions: GeminiCLIExtension[],
-  extensionsUpdateState: Map<string, ExtensionUpdateStatus>,
   dispatch: (action: ExtensionUpdateAction) => void,
-  cwd: string = process.cwd(),
 ): Promise<void> {
   for (const extension of extensions) {
-    const initialState = extensionsUpdateState.get(extension.name);
-    if (initialState === undefined) {
-      if (!extension.installMetadata) {
-        dispatch({
-          type: 'SET_STATE',
-          payload: {
-            name: extension.name,
-            state: ExtensionUpdateState.NOT_UPDATABLE,
-          },
-        });
-        continue;
-      }
-      await checkForExtensionUpdate(
-        extension,
-        (updatedState) => {
-          dispatch({
-            type: 'SET_STATE',
-            payload: { name: extension.name, state: updatedState },
-          });
+    if (!extension.installMetadata) {
+      dispatch({
+        type: 'SET_STATE',
+        payload: {
+          name: extension.name,
+          state: ExtensionUpdateState.NOT_UPDATABLE,
         },
-        cwd,
-      );
+      });
+      continue;
     }
+    await checkForExtensionUpdate(extension, (updatedState) => {
+      dispatch({
+        type: 'SET_STATE',
+        payload: { name: extension.name, state: updatedState },
+      });
+    });
   }
 }

--- a/packages/cli/src/config/extensions/update.ts
+++ b/packages/cli/src/config/extensions/update.ts
@@ -34,19 +34,19 @@ export async function updateExtension(
   cwd: string = process.cwd(),
   requestConsent: (consent: string) => Promise<boolean>,
   currentState: ExtensionUpdateState,
-  dispatch: (action: ExtensionUpdateAction) => void,
+  dispatchExtensionStateUpdate: (action: ExtensionUpdateAction) => void,
 ): Promise<ExtensionUpdateInfo | undefined> {
   if (currentState === ExtensionUpdateState.UPDATING) {
     return undefined;
   }
-  dispatch({
+  dispatchExtensionStateUpdate({
     type: 'SET_STATE',
     payload: { name: extension.name, state: ExtensionUpdateState.UPDATING },
   });
   const installMetadata = loadInstallMetadata(extension.path);
 
   if (!installMetadata?.type) {
-    dispatch({
+    dispatchExtensionStateUpdate({
       type: 'SET_STATE',
       payload: { name: extension.name, state: ExtensionUpdateState.ERROR },
     });
@@ -55,7 +55,7 @@ export async function updateExtension(
     );
   }
   if (installMetadata?.type === 'link') {
-    dispatch({
+    dispatchExtensionStateUpdate({
       type: 'SET_STATE',
       payload: { name: extension.name, state: ExtensionUpdateState.UP_TO_DATE },
     });
@@ -84,14 +84,14 @@ export async function updateExtension(
       workspaceDir: cwd,
     });
     if (!updatedExtension) {
-      dispatch({
+      dispatchExtensionStateUpdate({
         type: 'SET_STATE',
         payload: { name: extension.name, state: ExtensionUpdateState.ERROR },
       });
       throw new Error('Updated extension not found after installation.');
     }
     const updatedVersion = updatedExtension.config.version;
-    dispatch({
+    dispatchExtensionStateUpdate({
       type: 'SET_STATE',
       payload: {
         name: extension.name,
@@ -107,7 +107,7 @@ export async function updateExtension(
     console.error(
       `Error updating extension, rolling back. ${getErrorMessage(e)}`,
     );
-    dispatch({
+    dispatchExtensionStateUpdate({
       type: 'SET_STATE',
       payload: { name: extension.name, state: ExtensionUpdateState.ERROR },
     });

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -460,7 +460,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       },
       setDebugMessage,
       toggleCorgiMode: () => setCorgiMode((prev) => !prev),
-      dispatch: dispatchExtensionStateUpdate,
+      dispatchExtensionStateUpdate,
       addConfirmUpdateExtensionRequest,
     }),
     [

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -155,7 +155,7 @@ export const AppContainer = (props: AppContainerProps) => {
   const extensions = config.getExtensions();
   const {
     extensionsUpdateState,
-    setExtensionsUpdateState,
+    dispatchExtensionStateUpdate,
     confirmUpdateExtensionRequests,
     addConfirmUpdateExtensionRequest,
   } = useExtensionUpdates(
@@ -459,7 +459,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       },
       setDebugMessage,
       toggleCorgiMode: () => setCorgiMode((prev) => !prev),
-      setExtensionsUpdateState,
+      dispatch: dispatchExtensionStateUpdate,
       addConfirmUpdateExtensionRequest,
     }),
     [
@@ -472,7 +472,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       setDebugMessage,
       setShowPrivacyNotice,
       setCorgiMode,
-      setExtensionsUpdateState,
+      dispatchExtensionStateUpdate,
       openPermissionsDialog,
       addConfirmUpdateExtensionRequest,
     ],

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -155,6 +155,7 @@ export const AppContainer = (props: AppContainerProps) => {
   const extensions = config.getExtensions();
   const {
     extensionsUpdateState,
+    extensionsUpdateStateInternal,
     dispatchExtensionStateUpdate,
     confirmUpdateExtensionRequests,
     addConfirmUpdateExtensionRequest,
@@ -496,7 +497,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     setIsProcessing,
     setGeminiMdFileCount,
     slashCommandActions,
-    extensionsUpdateState,
+    extensionsUpdateStateInternal,
     isConfigInitialized,
   );
 

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -26,6 +26,7 @@ import { ExtensionUpdateState } from '../state/extensions.js';
 vi.mock('../../config/extensions/update.js', () => ({
   updateExtension: vi.fn(),
   updateAllUpdatableExtensions: vi.fn(),
+  checkForAllExtensionUpdates: vi.fn(),
 }));
 
 const mockUpdateExtension = updateExtension as MockedFunction<
@@ -50,6 +51,9 @@ describe('extensionsCommand', () => {
           getExtensions: mockGetExtensions,
           getWorkingDir: () => '/test/dir',
         },
+      },
+      ui: {
+        dispatchExtensionStateUpdate: vi.fn(),
       },
     });
   });
@@ -168,10 +172,10 @@ describe('extensionsCommand', () => {
         updatedVersion: '1.0.1',
       });
       mockGetExtensions.mockReturnValue([extension]);
-      mockContext.ui.extensionsUpdateState.set(
-        extension.name,
-        ExtensionUpdateState.UPDATE_AVAILABLE,
-      );
+      mockContext.ui.extensionsUpdateState.set(extension.name, {
+        status: ExtensionUpdateState.UPDATE_AVAILABLE,
+        processed: false,
+      });
       await updateAction(mockContext, 'ext-one');
       expect(mockUpdateExtension).toHaveBeenCalledWith(
         extension,

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -60,7 +60,7 @@ async function updateAction(context: CommandContext, args: string) {
           ),
         context.services.config!.getExtensions(),
         context.ui.extensionsUpdateState,
-        context.ui.setExtensionsUpdateState,
+        context.ui.dispatchExtensionStateUpdate,
       );
     } else if (names?.length) {
       const workingDir = context.services.config!.getWorkingDir();
@@ -89,13 +89,7 @@ async function updateAction(context: CommandContext, args: string) {
             ),
           context.ui.extensionsUpdateState.get(extension.name) ??
             ExtensionUpdateState.UNKNOWN,
-          (updateState) => {
-            context.ui.setExtensionsUpdateState((prev) => {
-              const newState = new Map(prev);
-              newState.set(name, updateState);
-              return newState;
-            });
-          },
+          context.ui.dispatchExtensionStateUpdate,
         );
         if (updateInfo) updateInfos.push(updateInfo);
       }

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -9,6 +9,7 @@ import {
   updateAllUpdatableExtensions,
   type ExtensionUpdateInfo,
   updateExtension,
+  checkForAllExtensionUpdates,
 } from '../../config/extensions/update.js';
 import { getErrorMessage } from '../../utils/errors.js';
 import { ExtensionUpdateState } from '../state/extensions.js';
@@ -46,6 +47,10 @@ async function updateAction(context: CommandContext, args: string) {
   }
 
   try {
+    await checkForAllExtensionUpdates(
+      context.services.config!.getExtensions(),
+      context.ui.dispatchExtensionStateUpdate,
+    );
     context.ui.setPendingItem({
       type: MessageType.EXTENSIONS_LIST,
     });

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -87,7 +87,7 @@ async function updateAction(context: CommandContext, args: string) {
               description,
               context.ui.addConfirmUpdateExtensionRequest,
             ),
-          context.ui.extensionsUpdateState.get(extension.name) ??
+          context.ui.extensionsUpdateState.get(extension.name)?.status ??
             ExtensionUpdateState.UNKNOWN,
           context.ui.dispatchExtensionStateUpdate,
         );

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -17,7 +17,7 @@ import type { UseHistoryManagerReturn } from '../hooks/useHistoryManager.js';
 import type { SessionStatsState } from '../contexts/SessionContext.js';
 import type {
   ExtensionUpdateAction,
-  ExtensionUpdateState,
+  ExtensionUpdateStatus,
 } from '../state/extensions.js';
 
 // Grouped dependencies for clarity and easier mocking
@@ -69,7 +69,7 @@ export interface CommandContext {
     toggleVimEnabled: () => Promise<boolean>;
     setGeminiMdFileCount: (count: number) => void;
     reloadCommands: () => void;
-    extensionsUpdateState: Map<string, ExtensionUpdateState>;
+    extensionsUpdateState: Map<string, ExtensionUpdateStatus>;
     dispatchExtensionStateUpdate: (action: ExtensionUpdateAction) => void;
     addConfirmUpdateExtensionRequest: (value: ConfirmationRequest) => void;
   };

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Dispatch, ReactNode, SetStateAction } from 'react';
+import type { ReactNode } from 'react';
 import type { Content, PartListUnion } from '@google/genai';
 import type {
   HistoryItemWithoutId,
@@ -15,7 +15,10 @@ import type { Config, GitService, Logger } from '@google/gemini-cli-core';
 import type { LoadedSettings } from '../../config/settings.js';
 import type { UseHistoryManagerReturn } from '../hooks/useHistoryManager.js';
 import type { SessionStatsState } from '../contexts/SessionContext.js';
-import type { ExtensionUpdateState } from '../state/extensions.js';
+import type {
+  ExtensionUpdateAction,
+  ExtensionUpdateState,
+} from '../state/extensions.js';
 
 // Grouped dependencies for clarity and easier mocking
 export interface CommandContext {
@@ -67,9 +70,7 @@ export interface CommandContext {
     setGeminiMdFileCount: (count: number) => void;
     reloadCommands: () => void;
     extensionsUpdateState: Map<string, ExtensionUpdateState>;
-    setExtensionsUpdateState: Dispatch<
-      SetStateAction<Map<string, ExtensionUpdateState>>
-    >;
+    dispatchExtensionStateUpdate: (action: ExtensionUpdateAction) => void;
     addConfirmUpdateExtensionRequest: (value: ConfirmationRequest) => void;
   };
   // Session-specific data

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -26,8 +26,8 @@ import type {
 } from '@google/gemini-cli-core';
 import type { DOMElement } from 'ink';
 import type { SessionStatsState } from '../contexts/SessionContext.js';
-import type { UpdateObject } from '../utils/updateCheck.js';
 import type { ExtensionUpdateState } from '../state/extensions.js';
+import type { UpdateObject } from '../utils/updateCheck.js';
 
 export interface ProQuotaDialogRequest {
   failedModel: string;

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -37,7 +37,7 @@ import { McpPromptLoader } from '../../services/McpPromptLoader.js';
 import { parseSlashCommand } from '../../utils/commands.js';
 import {
   type ExtensionUpdateAction,
-  type ExtensionUpdateState,
+  type ExtensionUpdateStatus,
 } from '../state/extensions.js';
 
 interface SlashCommandProcessorActions {
@@ -69,7 +69,7 @@ export const useSlashCommandProcessor = (
   setIsProcessing: (isProcessing: boolean) => void,
   setGeminiMdFileCount: (count: number) => void,
   actions: SlashCommandProcessorActions,
-  extensionsUpdateState: Map<string, ExtensionUpdateState>,
+  extensionsUpdateState: Map<string, ExtensionUpdateStatus>,
   isConfigInitialized: boolean,
 ) => {
   const session = useSessionStats();

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -51,7 +51,7 @@ interface SlashCommandProcessorActions {
   quit: (messages: HistoryItem[]) => void;
   setDebugMessage: (message: string) => void;
   toggleCorgiMode: () => void;
-  dispatch: (action: ExtensionUpdateAction) => void;
+  dispatchExtensionStateUpdate: (action: ExtensionUpdateAction) => void;
   addConfirmUpdateExtensionRequest: (request: ConfirmationRequest) => void;
 }
 
@@ -201,7 +201,7 @@ export const useSlashCommandProcessor = (
         setGeminiMdFileCount,
         reloadCommands,
         extensionsUpdateState,
-        dispatchExtensionStateUpdate: actions.dispatch,
+        dispatchExtensionStateUpdate: actions.dispatchExtensionStateUpdate,
         addConfirmUpdateExtensionRequest:
           actions.addConfirmUpdateExtensionRequest,
       },

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -4,14 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  useCallback,
-  useMemo,
-  useEffect,
-  useState,
-  type Dispatch,
-  type SetStateAction,
-} from 'react';
+import { useCallback, useMemo, useEffect, useState } from 'react';
 import { type PartListUnion } from '@google/genai';
 import process from 'node:process';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
@@ -42,7 +35,10 @@ import { BuiltinCommandLoader } from '../../services/BuiltinCommandLoader.js';
 import { FileCommandLoader } from '../../services/FileCommandLoader.js';
 import { McpPromptLoader } from '../../services/McpPromptLoader.js';
 import { parseSlashCommand } from '../../utils/commands.js';
-import type { ExtensionUpdateState } from '../state/extensions.js';
+import {
+  type ExtensionUpdateAction,
+  type ExtensionUpdateState,
+} from '../state/extensions.js';
 
 interface SlashCommandProcessorActions {
   openAuthDialog: () => void;
@@ -55,9 +51,7 @@ interface SlashCommandProcessorActions {
   quit: (messages: HistoryItem[]) => void;
   setDebugMessage: (message: string) => void;
   toggleCorgiMode: () => void;
-  setExtensionsUpdateState: Dispatch<
-    SetStateAction<Map<string, ExtensionUpdateState>>
-  >;
+  dispatch: (action: ExtensionUpdateAction) => void;
   addConfirmUpdateExtensionRequest: (request: ConfirmationRequest) => void;
 }
 
@@ -207,7 +201,7 @@ export const useSlashCommandProcessor = (
         setGeminiMdFileCount,
         reloadCommands,
         extensionsUpdateState,
-        setExtensionsUpdateState: actions.setExtensionsUpdateState,
+        dispatchExtensionStateUpdate: actions.dispatch,
         addConfirmUpdateExtensionRequest:
           actions.addConfirmUpdateExtensionRequest,
       },

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -87,7 +87,6 @@ export const useExtensionUpdates = (
       try {
         await checkForAllExtensionUpdates(
           extensions,
-          extensionsUpdateState,
           dispatchExtensionStateUpdate,
         );
       } finally {

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -6,8 +6,11 @@
 
 import type { GeminiCLIExtension } from '@google/gemini-cli-core';
 import { getErrorMessage } from '../../utils/errors.js';
-import { ExtensionUpdateState } from '../state/extensions.js';
-import { useCallback, useState } from 'react';
+import {
+  ExtensionUpdateState,
+  extensionUpdatesReducer,
+} from '../state/extensions.js';
+import { useCallback, useEffect, useReducer, useState } from 'react';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { MessageType, type ConfirmationRequest } from '../types.js';
 import {
@@ -15,118 +18,149 @@ import {
   updateExtension,
 } from '../../config/extensions/update.js';
 import { requestConsentInteractive } from '../../config/extension.js';
+import { checkExhaustive } from '../../utils/checks.js';
+
+type ConfirmationRequestWrapper = {
+  prompt: React.ReactNode;
+  onConfirm: (confirmed: boolean) => void;
+};
+
+type ConfirmationRequestAction =
+  | { type: 'add'; request: ConfirmationRequestWrapper }
+  | { type: 'remove'; request: ConfirmationRequestWrapper };
+
+function confirmationRequestsReducer(
+  state: ConfirmationRequestWrapper[],
+  action: ConfirmationRequestAction,
+): ConfirmationRequestWrapper[] {
+  switch (action.type) {
+    case 'add':
+      return [...state, action.request];
+    case 'remove':
+      return state.filter((r) => r !== action.request);
+    default:
+      checkExhaustive(action);
+      return state;
+  }
+}
 
 export const useExtensionUpdates = (
   extensions: GeminiCLIExtension[],
   addItem: UseHistoryManagerReturn['addItem'],
   cwd: string,
 ) => {
-  const [extensionsUpdateState, setExtensionsUpdateState] = useState(
+  const [extensionsUpdateState, dispatchExtensionStateUpdate] = useReducer(
+    extensionUpdatesReducer,
     new Map<string, ExtensionUpdateState>(),
   );
   const [isChecking, setIsChecking] = useState(false);
-  const [confirmUpdateExtensionRequests, setConfirmUpdateExtensionRequests] =
-    useState<
-      Array<{
-        prompt: React.ReactNode;
-        onConfirm: (confirmed: boolean) => void;
-      }>
-    >([]);
+  const [
+    confirmUpdateExtensionRequests,
+    dispatchConfirmUpdateExtensionRequests,
+  ] = useReducer(confirmationRequestsReducer, []);
   const addConfirmUpdateExtensionRequest = useCallback(
     (original: ConfirmationRequest) => {
       const wrappedRequest = {
         prompt: original.prompt,
         onConfirm: (confirmed: boolean) => {
           // Remove it from the outstanding list of requests by identity.
-          setConfirmUpdateExtensionRequests((prev) =>
-            prev.filter((r) => r !== wrappedRequest),
-          );
+          dispatchConfirmUpdateExtensionRequests({
+            type: 'remove',
+            request: wrappedRequest,
+          });
           original.onConfirm(confirmed);
         },
       };
-      setConfirmUpdateExtensionRequests((prev) => [...prev, wrappedRequest]);
+      dispatchConfirmUpdateExtensionRequests({
+        type: 'add',
+        request: wrappedRequest,
+      });
     },
-    [setConfirmUpdateExtensionRequests],
+    [dispatchConfirmUpdateExtensionRequests],
   );
 
-  (async () => {
-    if (isChecking) return;
+  useEffect(() => {
+    if (isChecking || extensions.length === 0) return;
     setIsChecking(true);
-    try {
-      const updateState = await checkForAllExtensionUpdates(
-        extensions,
-        extensionsUpdateState,
-        setExtensionsUpdateState,
-      );
-      let extensionsWithUpdatesCount = 0;
-      for (const extension of extensions) {
-        const prevState = extensionsUpdateState.get(extension.name);
-        const currentState = updateState.get(extension.name);
-        if (
-          prevState === currentState ||
-          currentState !== ExtensionUpdateState.UPDATE_AVAILABLE
-        ) {
-          continue;
-        }
-        if (extension.installMetadata?.autoUpdate) {
-          updateExtension(
-            extension,
-            cwd,
-            (description) =>
-              requestConsentInteractive(
-                description,
-                addConfirmUpdateExtensionRequest,
-              ),
-            currentState,
-            (newState) => {
-              setExtensionsUpdateState((prev) => {
-                const finalState = new Map(prev);
-                finalState.set(extension.name, newState);
-                return finalState;
-              });
-            },
-          )
-            .then((result) => {
-              if (!result) return;
-              addItem(
-                {
-                  type: MessageType.INFO,
-                  text: `Extension "${extension.name}" successfully updated: ${result.originalVersion} → ${result.updatedVersion}.`,
-                },
-                Date.now(),
-              );
-            })
-            .catch((error) => {
-              addItem(
-                {
-                  type: MessageType.ERROR,
-                  text: getErrorMessage(error),
-                },
-                Date.now(),
-              );
-            });
-        } else {
-          extensionsWithUpdatesCount++;
-        }
-      }
-      if (extensionsWithUpdatesCount > 0) {
-        const s = extensionsWithUpdatesCount > 1 ? 's' : '';
-        addItem(
-          {
-            type: MessageType.INFO,
-            text: `You have ${extensionsWithUpdatesCount} extension${s} with an update available, run "/extensions list" for more information.`,
-          },
-          Date.now(),
+    (async () => {
+      try {
+        const updateState = await checkForAllExtensionUpdates(
+          extensions,
+          extensionsUpdateState,
+          dispatchExtensionStateUpdate,
         );
+        let extensionsWithUpdatesCount = 0;
+        for (const extension of extensions) {
+          const prevState = extensionsUpdateState.get(extension.name);
+          const currentState = updateState.get(extension.name);
+          if (
+            prevState === currentState ||
+            currentState !== ExtensionUpdateState.UPDATE_AVAILABLE
+          ) {
+            continue;
+          }
+          if (extension.installMetadata?.autoUpdate) {
+            updateExtension(
+              extension,
+              cwd,
+              (description) =>
+                requestConsentInteractive(
+                  description,
+                  addConfirmUpdateExtensionRequest,
+                ),
+              currentState,
+              dispatchExtensionStateUpdate,
+            )
+              .then((result) => {
+                if (!result) return;
+                addItem(
+                  {
+                    type: MessageType.INFO,
+                    text: `Extension "${extension.name}" successfully updated: ${result.originalVersion} → ${result.updatedVersion}.`,
+                  },
+                  Date.now(),
+                );
+              })
+              .catch((error) => {
+                addItem(
+                  {
+                    type: MessageType.ERROR,
+                    text: getErrorMessage(error),
+                  },
+                  Date.now(),
+                );
+              });
+          } else {
+            extensionsWithUpdatesCount++;
+          }
+        }
+        if (extensionsWithUpdatesCount > 0) {
+          const s = extensionsWithUpdatesCount > 1 ? 's' : '';
+          addItem(
+            {
+              type: MessageType.INFO,
+              text: `You have ${extensionsWithUpdatesCount} extension${s} with an update available, run "/extensions list" for more information.`,
+            },
+            Date.now(),
+          );
+        }
+      } finally {
+        setIsChecking(false);
       }
-    } finally {
-      setIsChecking(false);
-    }
-  })();
+    })();
+  }, [
+    addConfirmUpdateExtensionRequest,
+    addItem,
+    cwd,
+    extensions,
+    extensions.length,
+    extensionsUpdateState,
+    isChecking,
+  ]);
 
   return {
     extensionsUpdateState,
-    setExtensionsUpdateState,
+    dispatchExtensionStateUpdate,
     confirmUpdateExtensionRequests,
     addConfirmUpdateExtensionRequest,
   };

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -11,7 +11,7 @@ import {
   ExtensionUpdateState,
   extensionUpdatesReducer,
 } from '../state/extensions.js';
-import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer } from 'react';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { MessageType, type ConfirmationRequest } from '../types.js';
 import {
@@ -54,7 +54,6 @@ export const useExtensionUpdates = (
     extensionUpdatesReducer,
     new Map<string, ExtensionUpdateStatus>(),
   );
-  const [isChecking, setIsChecking] = useState(false);
   const [
     confirmUpdateExtensionRequests,
     dispatchConfirmUpdateExtensionRequests,
@@ -81,25 +80,13 @@ export const useExtensionUpdates = (
   );
 
   useEffect(() => {
-    if (isChecking || extensions.length === 0) return;
-    setIsChecking(true);
     (async () => {
-      try {
-        await checkForAllExtensionUpdates(
-          extensions,
-          dispatchExtensionStateUpdate,
-        );
-      } finally {
-        setIsChecking(false);
-      }
+      await checkForAllExtensionUpdates(
+        extensions,
+        dispatchExtensionStateUpdate,
+      );
     })();
-  }, [
-    extensions,
-    extensions.length,
-    dispatchExtensionStateUpdate,
-    isChecking,
-    extensionsUpdateState,
-  ]);
+  }, [extensions, extensions.length, dispatchExtensionStateUpdate]);
 
   useEffect(() => {
     let extensionsWithUpdatesCount = 0;

--- a/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
+++ b/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
@@ -5,6 +5,7 @@
  */
 
 import type { CommandContext } from '../commands/types.js';
+import type { ExtensionUpdateAction } from '../state/extensions.js';
 
 /**
  * Creates a UI context object with no-op functions.
@@ -24,7 +25,7 @@ export function createNonInteractiveUI(): CommandContext['ui'] {
     setGeminiMdFileCount: (_count) => {},
     reloadCommands: () => {},
     extensionsUpdateState: new Map(),
-    setExtensionsUpdateState: (_updateState) => {},
+    dispatchExtensionStateUpdate: (_action: ExtensionUpdateAction) => {},
     addConfirmUpdateExtensionRequest: (_request) => {},
   };
 }

--- a/packages/cli/src/ui/state/extensions.ts
+++ b/packages/cli/src/ui/state/extensions.ts
@@ -14,3 +14,26 @@ export enum ExtensionUpdateState {
   NOT_UPDATABLE = 'not updatable',
   UNKNOWN = 'unknown',
 }
+
+export type ExtensionUpdateAction = {
+  type: 'SET_STATE';
+  payload: { name: string; state: ExtensionUpdateState };
+};
+
+export function extensionUpdatesReducer(
+  state: Map<string, ExtensionUpdateState>,
+  action: ExtensionUpdateAction,
+): Map<string, ExtensionUpdateState> {
+  switch (action.type) {
+    case 'SET_STATE': {
+      if (state.get(action.payload.name) === action.payload.state) {
+        return state;
+      }
+      const newState = new Map(state);
+      newState.set(action.payload.name, action.payload.state);
+      return newState;
+    }
+    default:
+      return state;
+  }
+}

--- a/packages/cli/src/ui/state/extensions.ts
+++ b/packages/cli/src/ui/state/extensions.ts
@@ -15,22 +15,48 @@ export enum ExtensionUpdateState {
   UNKNOWN = 'unknown',
 }
 
-export type ExtensionUpdateAction = {
-  type: 'SET_STATE';
-  payload: { name: string; state: ExtensionUpdateState };
-};
+export interface ExtensionUpdateStatus {
+  status: ExtensionUpdateState;
+  processed: boolean;
+}
+
+export type ExtensionUpdateAction =
+  | {
+      type: 'SET_STATE';
+      payload: { name: string; state: ExtensionUpdateState };
+    }
+  | {
+      type: 'SET_PROCESSED';
+      payload: { name: string; processed: boolean };
+    };
 
 export function extensionUpdatesReducer(
-  state: Map<string, ExtensionUpdateState>,
+  state: Map<string, ExtensionUpdateStatus>,
   action: ExtensionUpdateAction,
-): Map<string, ExtensionUpdateState> {
+): Map<string, ExtensionUpdateStatus> {
   switch (action.type) {
     case 'SET_STATE': {
-      if (state.get(action.payload.name) === action.payload.state) {
+      const existing = state.get(action.payload.name);
+      if (existing?.status === action.payload.state) {
         return state;
       }
       const newState = new Map(state);
-      newState.set(action.payload.name, action.payload.state);
+      newState.set(action.payload.name, {
+        status: action.payload.state,
+        processed: false,
+      });
+      return newState;
+    }
+    case 'SET_PROCESSED': {
+      const existing = state.get(action.payload.name);
+      if (!existing || existing.processed === action.payload.processed) {
+        return state;
+      }
+      const newState = new Map(state);
+      newState.set(action.payload.name, {
+        ...existing,
+        processed: action.payload.processed,
+      });
       return newState;
     }
     default:

--- a/packages/cli/src/ui/state/extensions.ts
+++ b/packages/cli/src/ui/state/extensions.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { checkExhaustive } from '../../utils/checks.js';
+
 export enum ExtensionUpdateState {
   CHECKING_FOR_UPDATES = 'checking for updates',
   UPDATED_NEEDS_RESTART = 'updated, needs restart',
@@ -60,6 +62,6 @@ export function extensionUpdatesReducer(
       return newState;
     }
     default:
-      return state;
+      checkExhaustive(action);
   }
 }

--- a/packages/cli/src/ui/state/extensions.ts
+++ b/packages/cli/src/ui/state/extensions.ts
@@ -22,6 +22,16 @@ export interface ExtensionUpdateStatus {
   processed: boolean;
 }
 
+export interface ExtensionUpdatesState {
+  extensionStatuses: Map<string, ExtensionUpdateStatus>;
+  batchChecksInProgress: number;
+}
+
+export const initialExtensionUpdatesState: ExtensionUpdatesState = {
+  extensionStatuses: new Map(),
+  batchChecksInProgress: 0,
+};
+
 export type ExtensionUpdateAction =
   | {
       type: 'SET_STATE';
@@ -30,37 +40,49 @@ export type ExtensionUpdateAction =
   | {
       type: 'SET_PROCESSED';
       payload: { name: string; processed: boolean };
-    };
+    }
+  | { type: 'BATCH_CHECK_START' }
+  | { type: 'BATCH_CHECK_END' };
 
 export function extensionUpdatesReducer(
-  state: Map<string, ExtensionUpdateStatus>,
+  state: ExtensionUpdatesState,
   action: ExtensionUpdateAction,
-): Map<string, ExtensionUpdateStatus> {
+): ExtensionUpdatesState {
   switch (action.type) {
     case 'SET_STATE': {
-      const existing = state.get(action.payload.name);
+      const existing = state.extensionStatuses.get(action.payload.name);
       if (existing?.status === action.payload.state) {
         return state;
       }
-      const newState = new Map(state);
-      newState.set(action.payload.name, {
+      const newStatuses = new Map(state.extensionStatuses);
+      newStatuses.set(action.payload.name, {
         status: action.payload.state,
         processed: false,
       });
-      return newState;
+      return { ...state, extensionStatuses: newStatuses };
     }
     case 'SET_PROCESSED': {
-      const existing = state.get(action.payload.name);
+      const existing = state.extensionStatuses.get(action.payload.name);
       if (!existing || existing.processed === action.payload.processed) {
         return state;
       }
-      const newState = new Map(state);
-      newState.set(action.payload.name, {
+      const newStatuses = new Map(state.extensionStatuses);
+      newStatuses.set(action.payload.name, {
         ...existing,
         processed: action.payload.processed,
       });
-      return newState;
+      return { ...state, extensionStatuses: newStatuses };
     }
+    case 'BATCH_CHECK_START':
+      return {
+        ...state,
+        batchChecksInProgress: state.batchChecksInProgress + 1,
+      };
+    case 'BATCH_CHECK_END':
+      return {
+        ...state,
+        batchChecksInProgress: state.batchChecksInProgress - 1,
+      };
     default:
       checkExhaustive(action);
   }


### PR DESCRIPTION
## TLDR

We were triggering calls to setState every frame triggering a classic React render loop issue due to improper react state management.

## Dive Deeper

Refactored from unsafe ways of using setState to using a proper reducer pattern.
Also avoided scary cases we were doing work after an async gap where state might have changed completely.

I will follow up with a proper integration test for this case as well as fixing the frame counter logic to add errors to the output even when ctrl-b has not been pressed warning that there is constant rendering when the app should be idle.

## Reviewer Test Plan

Run with --debug
press ctrl-b to trigger the frame render counter.
Verify that without the change the number goes up continously.
With this change the frame counter only goes up when the user interacts with the app or content is streaming
Manually test that updating extensions still works correctly.
Also verify that you can make large edits, press ctrl-S and not get destroyed by flicker.

## Testing Matrix

Resolves #10242