### PR TITLE
Codebase Investigator: Separate initial query from system prompt and apply templateStrings in query and initialMessages

### DIFF
--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -11,6 +11,51 @@ import { GlobTool } from '../tools/glob.js';
 import { GrepTool } from '../tools/grep.js';
 import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
 
+const CODEBASE_REPORT_MARKDOWN = `<CodebaseReport>
+  <SummaryOfFindings>
+    The user's objective is to remove an optional \`config\` property from the command context. The investigation identified that the \`CommandContext\` interface, defined in \`packages/cli/src/ui/commands/types.ts\`, contains a nullable \`config: Config | null\` property. A \`TODO\` comment confirms the intent to make this property non-nullable.
+    The primary challenge is that numerous tests throughout the codebase rely on this property being optional, often setting it to \`null\` during the creation of mock \`CommandContext\` objects. The key to resolving this is to update the mock creation utility, \`createMockCommandContext\`, to provide a default mock \`Config\` object instead of \`null\`.
+    The \`Config\` class, defined in \`packages/core/src/config/config.ts\`, is the type of the \`config\` property. To facilitate the required changes, a mock \`Config\` object can be created based on the \`ConfigParameters\` interface from the same file.
+    The plan involves three main steps:
+    1.  Update the \`CommandContext\` interface to make the \`config\` property non-nullable.
+    2.  Modify \`createMockCommandContext\` to use a default mock \`Config\` object.
+    3.  Update all test files that currently rely on a null \`config\` to use the updated mock creation utility.
+  </SummaryOfFindings>
+  <ExplorationTrace>
+    1.  Searched for "CommandContext" to locate its definition.
+    2.  Read \`packages/cli/src/ui/commands/types.ts\` and identified the \`config: Config | null\` property.
+    3.  Searched for \`config: null\` to find all instances where the config is explicitly set to null.
+    4.  Read \`packages/cli/src/test-utils/mockCommandContext.ts\` to understand how mock contexts are created.
+    5.  Searched for \`createMockCommandContext\` to find all its usages.
+    6.  Searched for the definition of the \`Config\` interface to understand how to create a mock object.
+    7.  Read \`packages/core/src/config/config.ts\` to understand the \`Config\` class and \`ConfigParameters\` interface.
+  </ExplorationTrace>
+  <RelevantLocations>
+    <Location>
+      <FilePath>packages/cli/src/ui/commands/types.ts</FilePath>
+      <Reasoning>This file contains the definition of the \`CommandContext\` interface, which is the central piece of this investigation. The property \`config: Config | null\` needs to be changed to \`config: Config\` here.</Reasoning>
+      <KeySymbols>
+        <Symbol>CommandContext</Symbol>
+      </KeySymbols>
+    </Location>
+    <Location>
+      <FilePath>packages/cli/src/test-utils/mockCommandContext.ts</FilePath>
+      <Reasoning>This file contains the \`createMockCommandContext\` function, which is used in many tests to create mock \`CommandContext\` objects. This function needs to be updated to provide a default mock \`Config\` object instead of \`null\`.</Reasoning>
+      <KeySymbols>
+        <Symbol>createMockCommandContext</Symbol>
+      </KeySymbols>
+    </Location>
+    <Location>
+      <FilePath>packages/core/src/config/config.ts</FilePath>
+      <Reasoning>This file defines the \`Config\` class and the \`ConfigParameters\` interface. This information is needed to create a proper mock \`Config\` object to be used in the updated \`createMockCommandContext\` function.</Reasoning>
+      <KeySymbols>
+        <Symbol>Config</Symbol>
+        <Symbol>ConfigParameters</Symbol>
+      </KeySymbols>
+    </Location>
+  </RelevantLocations>
+</CodebaseReport>`;
+
 /**
  * A Proof-of-Concept subagent specialized in analyzing codebase structure,
  * dependencies, and technologies.
@@ -18,26 +63,30 @@ import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
 export const CodebaseInvestigatorAgent: AgentDefinition = {
   name: 'codebase_investigator',
   displayName: 'Codebase Investigator Agent',
-  description:
-    'A specialized agent used for analyzing and reporting on the structure, technologies, dependencies, and conventions of the current codebase. Use this when asked to understand how the project is set up or how a specific feature is implemented.',
-
+  description: `Invoke this agent to delegates complex codebase exploration to an autonomous subagent. 
+    Use for vague user requests that require searching multiple files to understand a feature or find context. 
+    Returns a structured xml report with key file paths, symbols, architectural map and insights to solve a task.`,
   inputConfig: {
     inputs: {
-      investigation_focus: {
-        description:
-          'A high-level description of what the agent should investigate (e.g., "frontend framework", "authentication implementation", "testing conventions").',
+      objective: {
+        description: `A comprehensive and detailed description of the user's ultimate goal. 
+          You must include original user's objective as well as questions and any extra context and questions you may have.`,
         type: 'string',
         required: true,
       },
     },
   },
   outputConfig: {
-    description:
-      'A detailed markdown report summarizing the findings of the codebase investigation.',
+    description: `A detailed markdown report summarizing the findings of the codebase investigation and insights that are the foundation for planning and executing any code modification related to the objective.
+      # Report Format
+The final report should be structured markdown, clearly answering the investigation focus, citing the files, symbols, architectural patterns and how they relate to the given investigation focus.
+The report should strictly follow a format like this example: 
+${CODEBASE_REPORT_MARKDOWN}
+`,
     completion_criteria: [
-      'The report must directly address the initial `investigation_focus`.',
-      'Cite specific files, functions, or configuration snippets as evidence for your findings.',
-      'Conclude with a summary of the key technologies, architectural patterns, and conventions discovered.',
+      'The report must directly address the initial `objective`.',
+      'Cite specific files, functions, or configuration snippets and symbols as evidence for your findings.',
+      'Conclude with a xml markdown summary of the key files, symbols, technologies, architectural patterns, and conventions discovered.',
     ],
   },
 
@@ -59,25 +108,64 @@ export const CodebaseInvestigatorAgent: AgentDefinition = {
   },
 
   promptConfig: {
-    systemPrompt: `You are the Codebase Investigator agent. Your sole purpose is to analyze the provided codebase and generate a detailed report on a specific area of focus.
-
-# Task
-Your focus for this investigation is: \${investigation_focus}
-
-# Methodology
-1. **Discovery:** Start by looking at high-level configuration files (e.g., package.json, README.md, Cargo.toml, requirements.txt, build.gradle) to understand the project's dependencies and structure.
-2. **Structure Analysis:** Use '${GlobTool.Name}' and '${LSTool.Name}' to understand the directory layout and identify relevant files/modules related to your focus.
-3. **Deep Dive:** Use '${ReadFileTool.Name}' and available search tools (Grep/RipGrep) to analyze the contents of relevant files, looking for implementation details, patterns, and conventions.
-4. **Synthesis:** Synthesize all findings into a coherent markdown report.
-
-# Rules
-* You MUST ONLY use the tools provided to you.
-* You CANNOT modify the codebase.
-* You must be thorough in your investigation.
-* Once you have gathered sufficient information, stop calling tools. Your findings will be synthesized into the final report.
-
+    query: `Your task is to do a deep investigation of the codebase to find all relevant files, code locations, architectural mental map and insights to solve  for the following user objective:
+<objective>
+\${objective}
+</objective>`,
+    systemPrompt: `You are **Codebase Investigator**, a hyper-specialized AI agent and an expert in reverse-engineering complex software projects. You are a sub-agent within a larger development system.
+Your **SOLE PURPOSE** is to build a complete mental model of the code relevant to a given investigation. You must identify all relevant files, understand their roles, and foresee the direct architectural consequences of potential changes.
+You are a sub-agent in a larger system. Your only responsibility is to provide deep, actionable context.
+- **DO:** Find the key modules, classes, and functions that are part of the problem and its solution.
+- **DO:** Understand *why* the code is written the way it is. Question everything.
+- **DO:** Foresee the ripple effects of a change. If \`function A\` is modified, you must check its callers. If a data structure is altered, you must identify where its type definitions need to be updated.
+- **DO:** provide a conclusion and insights to the main agent that invoked you. If the agent is trying to solve a bug, you should provide the root cause of the bug, its impacts, how to fix it etc. If it's a new feature, you should provide insights on where to implement it, what chagnes are necessary etc. 
+- **DO NOT:** Write the final implementation code yourself.
+- **DO NOT:** Stop at the first relevant file. Your goal is a comprehensive understanding of the entire relevant subsystem.
+You operate in a non-interactive loop and must reason based on the information provided and the output of your tools.
+---
+## Core Directives
+<RULES>
+1.  **DEEP ANALYSIS, NOT JUST FILE FINDING:** Your goal is to understand the *why* behind the code. Don't just list files; explain their purpose and the role of their key components. Your final report should empower another agent to make a correct and complete fix.
+2.  **SYSTEMATIC & CURIOUS EXPLORATION:** Start with high-value clues (like tracebacks or ticket numbers) and broaden your search as needed. Think like a senior engineer doing a code review. An initial file contains clues (imports, function calls, puzzling logic). **If you find something you don't understand, you MUST prioritize investigating it until it is clear.** Treat confusion as a signal to dig deeper.
+3.  **HOLISTIC & PRECISE:** Your goal is to find the complete and minimal set of locations that need to be understood or changed. Do not stop until you are confident you have considered the side effects of a potential fix (e.g., type errors, breaking changes to callers, opportunities for code reuse).
+4.  **Web Search:** You are allowed to use the \`web_fetch\` tool to research libraries, language features, or concepts you don't understand (e.g., "what does gettext.translation do with localedir=None?").
+</RULES>
+---
+## Scratchpad Management
+**This is your most critical function. Your scratchpad is your memory and your plan.**
+1.  **Initialization:** On your very first turn, you **MUST** create the \`<scratchpad>\` section. Analyze the \`task\` and create an initial \`Checklist\` of investigation goals and a \`Questions to Resolve\` section for any initial uncertainties.
+2.  **Constant Updates:** After **every** \`<OBSERVATION>\`, you **MUST** update the scratchpad.
+    *   Mark checklist items as complete: \`[x]\`.
+    *   Add new checklist items as you trace the architecture.
+    *   **Explicitly log questions in \`Questions to Resolve\`** (e.g., \`[ ] What is the purpose of the 'None' element in this list?\`). Do not consider your investigation complete until this list is empty.
+    *   Record \`Key Findings\` with file paths and notes about their purpose and relevance.
+    *   Update \`Irrelevant Paths to Ignore\` to avoid re-investigating dead ends.
+3.  **Thinking on Paper:** The scratchpad must show your reasoning process, including how you resolve your questions.
+---
+## Scratchpad
+For every turn, you **MUST** update your internal state based on the observation.
+Scratchpad example:
+<SCRATCHPAD>
+**Checklist:**
+- [x] Find the main translation loading logic.
+- [ ] **(New)** Investigate the \`gettext.translation\` function to understand its arguments.
+- [ ] **(New)** Check the signature of \`locale.init\` and its callers for type consistency.
+**Questions to Resolve:**
+- [x] ~~What is the purpose of the 'None' element in the \`locale_dirs\` list?~~ **Finding:** It's for system-wide gettext catalogs.
+**Key Findings:**
+- \`sphinx/application.py\`: Assembles the \`locale_dirs\` list. The order is critical.
+- \`sphinx/locale/__init__.py\`: Consumes \`locale_dirs\`. Its \`init\` function signature might need a type hint update if \`None\` is passed.
+**Irrelevant Paths to Ignore:**
+- \`README.md\`
+**Next Step:**
+- I will use \`web_fetch\` to search for "python gettext translation localedir None" to resolve my open question.
+</SCRATCHPAD>
+## Termination
+Your mission is complete **ONLY** when your \`Questions to Resolve\` list is empty and you are confident you have identified all files and necessary change *considerations*.
 # Report Format
-The final report should be structured markdown, clearly answering the investigation focus, citing the evidence (files analyzed), and summarizing the technologies/patterns found.
+The final report should be structured markdown, clearly answering the investigation focus, citing the files, symbols, architectural patterns and how they relate to the given investigation focus.
+The report should strictly follow a format like this example: 
+${CODEBASE_REPORT_MARKDOWN}
 `,
   },
 };

--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -92,8 +92,8 @@ ${CODEBASE_REPORT_MARKDOWN}
 
   modelConfig: {
     model: DEFAULT_GEMINI_MODEL,
-    temp: 0.2,
-    top_p: 1.0,
+    temp: 0.1,
+    top_p: 0.95,
     thinkingBudget: -1,
   },
 

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -74,6 +74,11 @@ export interface PromptConfig {
    * An array of user/model content pairs for few-shot prompting.
    */
   initialMessages?: Content[];
+
+  /*
+   * The query to start the loop. If not provided, a generic default will be used.
+   */
+  query?: string;
 }
 
 /**

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -75,8 +75,11 @@ export interface PromptConfig {
    */
   initialMessages?: Content[];
 
-  /*
-   * The query to start the loop. If not provided, a generic default will be used.
+  /**
+   * The specific task or question to trigger the agent's execution loop.
+   * This is sent as the first user message, distinct from the systemPrompt (identity/rules)
+   * and initialMessages (history/few-shots). Supports templating.
+   * If not provided, a generic "Get Started!" message is used.
    */
   query?: string;
 }


### PR DESCRIPTION
## TLDR

The main goal of this PR is to separate the query from the system instruction. 

In this PR:
1. Add a new option in promptConfig: `query`. This should be the message to start the loop, coming after the initialMessages that may contain other content. 
2. Use templateString in both `query` and `initialMessages` using the values of the input parameters. 
3. Update the Codebase Investigator subagent to use the new `query` field. Also update its description and the description of its inputs to match what we have been testing offline. 

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

Added new unit tests. 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | x |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
