### PR TITLE
fix(routing): Disable model router by default

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2061,7 +2061,7 @@ describe('loadCliConfig model selection', () => {
       argv,
     );
 
-    expect(config.getModel()).toBe(DEFAULT_GEMINI_MODEL_AUTO);
+    expect(config.getModel()).toBe(DEFAULT_GEMINI_MODEL);
   });
 
   it('always prefers model from argvs', async () => {
@@ -2497,7 +2497,7 @@ describe('loadCliConfig useRipgrep', () => {
         'test-session',
         argv,
       );
-      expect(config.getUseModelRouter()).toBe(true);
+      expect(config.getUseModelRouter()).toBe(false);
     });
 
     it('should be true when useModelRouter is set to true in settings', async () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -621,7 +621,7 @@ export async function loadCliConfig(
     );
   }
 
-  const useModelRouter = settings.experimental?.useModelRouter ?? true;
+  const useModelRouter = settings.experimental?.useModelRouter ?? false;
   const defaultModel = useModelRouter
     ? DEFAULT_GEMINI_MODEL_AUTO
     : DEFAULT_GEMINI_MODEL;

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -328,7 +328,7 @@ describe('SettingsSchema', () => {
       ).toBe('Experimental');
       expect(
         getSettingsSchema().experimental.properties.useModelRouter.default,
-      ).toBe(true);
+      ).toBe(false);
     });
   });
 });

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -996,7 +996,7 @@ const SETTINGS_SCHEMA = {
         label: 'Use Model Router',
         category: 'Experimental',
         requiresRestart: true,
-        default: true,
+        default: false,
         description:
           'Enable model routing to route requests to the best model based on complexity.',
         showInDialog: true,


### PR DESCRIPTION
## TLDR

This pull request disables the experimental model router (`useModelRouter`) by default to address a critical bug causing empty model responses. The default value for this setting is now `false`.

## Dive Deeper

While the underlying issue is being investigated, this PR acts as an immediate mitigation by changing the default behavior. By setting `useModelRouter` to `false` out-of-the-box, we ensure that users do not encounter this bug unless they explicitly opt into the experimental feature via their settings.

This change reverts the default configuration to a more stable state, prioritizing a reliable user experience over the experimental routing feature for now. The schema, configuration loading logic, and relevant tests have all been updated to reflect this new default.

## Reviewer Test Plan

1.  Pull the branch and build the project (`npm install && npm run build`).
2.  Run the CLI with a standard prompt (e.g., `gemini -i "what does the readme say"`).
3.  **Verify** that the command completes successfully and provides a valid response. You should not see 'auto' in the footer **and** when you run `/stats` you should not see a flash lite request
4. (Optional) To confirm the feature can still be enabled, manually set `experimental.useModelRouter` to `true` in your global `.gemini/settings.json`. Run a prompt again and observe that the router is now used (the original bug may reappear, which is expected).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |
