### PR TITLE
Fix dry run.

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -112,10 +112,11 @@ runs:
         NODE_AUTH_TOKEN: '${{ inputs.wombat-token-core }}'
       shell: 'bash'
       run: |
-        npm publish \
-          --dry-run="${{ inputs.dry-run }}" \
-          --workspace="@google/gemini-cli-core" \
-          --no-tag
+        if [ "${{ inputs.dry-run }}" == "true" ]; then
+          npm publish --dry-run --workspace="@google/gemini-cli-core" --no-tag
+        else
+          npm publish --workspace="@google/gemini-cli-core" --no-tag
+        fi
 
     - name: '🔗 Install latest core package'
       working-directory: '${{ inputs.working-directory }}'
@@ -132,10 +133,11 @@ runs:
         NODE_AUTH_TOKEN: '${{ inputs.wombat-token-cli }}'
       shell: 'bash'
       run: |
-        npm publish \
-          --dry-run="${{ inputs.dry-run }}" \
-          --workspace="@google/gemini-cli" \
-          --no-tag
+        if [ "${{ inputs.dry-run }}" == "true" ]; then
+          npm publish --dry-run --workspace="@google/gemini-cli" --no-tag
+        else
+          npm publish --workspace="@google/gemini-cli" --no-tag
+        fi
 
     - name: '🔬 Verify NPM release by version'
       uses: './.github/actions/verify-release'

--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -74,7 +74,7 @@ runs:
         echo "uri=$(cat final_image_uri.txt)" >> $GITHUB_OUTPUT
     - name: 'publish'
       shell: 'bash'
-      if: "${{ inputs.dry-run == 'false' }}"
+      if: "${{ inputs.dry-run != 'true' }}"
       run: |-
         docker push "${{ steps.docker_build.outputs.uri }}"
     - name: 'Create issue on failure'

--- a/.github/actions/tag-npm-release/action.yml
+++ b/.github/actions/tag-npm-release/action.yml
@@ -29,7 +29,7 @@ runs:
 
     - name: 'Change tag for @google/gemini-cli-core'
       if: |-
-        ${{ inputs.dry-run == 'false' }}
+        ${{ inputs.dry-run != 'true' }}
       env:
         NODE_AUTH_TOKEN: '${{ inputs.wombat-token-core }}'
       shell: 'bash'
@@ -38,7 +38,7 @@ runs:
 
     - name: 'Change tag for @google/gemini-cli'
       if: |-
-        ${{ inputs.dry-run == 'false' }}
+        ${{ inputs.dry-run != 'true' }}
       env:
         NODE_AUTH_TOKEN: '${{ inputs.wombat-token-cli }}'
       shell: 'bash'


### PR DESCRIPTION
## TLDR

Dry run workflow wasn't working properly because it wasn't accounting for empty string values.

## Dive Deeper

the `npm --dry-run` flag treats empty-string as "true" therefore, we can't pass it and trust it'll be treated correctly.

In other locations, we followed the adage of "test against the non-default value".

## Reviewer Test Plan

I ran this command to simulate a scheduled execution (where all inputs are empty string)

```
gh workflow run release-nightly.yml -f dry_run= -f force_skip_tests= -f ref=tomm_fix_dry_run
```

It completed successfully: https://github.com/google-gemini/gemini-cli/actions/runs/18150418445

##Links

Fixes #10279
