### PR TITLE
feat(core): mitigate Flash API early chat bug & enable model router by default

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2061,7 +2061,7 @@ describe('loadCliConfig model selection', () => {
       argv,
     );
 
-    expect(config.getModel()).toBe(DEFAULT_GEMINI_MODEL);
+    expect(config.getModel()).toBe(DEFAULT_GEMINI_MODEL_AUTO);
   });
 
   it('always prefers model from argvs', async () => {
@@ -2483,7 +2483,7 @@ describe('loadCliConfig useRipgrep', () => {
   });
 
   describe('loadCliConfig useModelRouter', () => {
-    it('should be false by default when useModelRouter is not set in settings', async () => {
+    it('should be true by default when useModelRouter is not set in settings', async () => {
       process.argv = ['node', 'script.js'];
       const argv = await parseArguments({} as Settings);
       const settings: Settings = {};
@@ -2497,7 +2497,7 @@ describe('loadCliConfig useRipgrep', () => {
         'test-session',
         argv,
       );
-      expect(config.getUseModelRouter()).toBe(false);
+      expect(config.getUseModelRouter()).toBe(true);
     });
 
     it('should be true when useModelRouter is set to true in settings', async () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -621,7 +621,7 @@ export async function loadCliConfig(
     );
   }
 
-  const useModelRouter = settings.experimental?.useModelRouter ?? false;
+  const useModelRouter = settings.experimental?.useModelRouter ?? true;
   const defaultModel = useModelRouter
     ? DEFAULT_GEMINI_MODEL_AUTO
     : DEFAULT_GEMINI_MODEL;

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -328,7 +328,7 @@ describe('SettingsSchema', () => {
       ).toBe('Experimental');
       expect(
         getSettingsSchema().experimental.properties.useModelRouter.default,
-      ).toBe(false);
+      ).toBe(true);
     });
   });
 });

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -996,7 +996,7 @@ const SETTINGS_SCHEMA = {
         label: 'Use Model Router',
         category: 'Experimental',
         requiresRestart: true,
-        default: false,
+        default: true,
         description:
           'Enable model routing to route requests to the best model based on complexity.',
         showInDialog: true,


### PR DESCRIPTION
## TLDR

This PR implements a mitigation in the core client for an issue where Gemini 2.5 Flash returns empty responses when using tools early in a conversation (history length < 3).

With this mitigation in place, we are also re-enabling the `useModelRouter` experimental setting by default in the CLI.

## Dive Deeper

### The Issue
There is a known API issue where Gemini 2.5 Flash can return an empty response error when processing function calls during the first few turns of a chat (specifically when history length is less than 3).

### The Mitigation (`packages/core`)
Modified `GeminiClient.sendMessageStream` to intercept requests meeting the problematic criteria:
1.  Chat history length is < 3.
2.  The selected model (by routing or configuration) is Gemini 2.5 Flash.

If these conditions are met, the client temporarily switches the model for that turn:
*   **Fallback Mode:** Switches to **Flash Lite** to ensure functionality.
*   **Auto Mode:** Switches to **Pro** to provide a better experience for the initial interaction.

Comprehensive tests were added to `client.test.ts` to verify this behavior, ensuring chat compression doesn't interfere with the history length checks during testing.

### Re-enabling Model Router (`packages/cli`)
Previously, `useModelRouter` was disabled by default as a temporary workaround for this Flash issue. Now that the core client handles this specific edge case, we have reverted the default value of `useModelRouter` to `true` in `config.ts` and `settingsSchema.ts`. Relevant config tests have been updated.

## Reviewer Test Plan

1.  **Verify Mitigation (Fresh Session):**
    Start a new CLI session and immediately use a prompt that triggers a tool (e.g., read readme).
    ```bash
    gemini -i "read the readme"
    ```
    *   **Expected:** The command should succeed without an "empty response" error.
    *   **Observation:** Use `/stats` to see there will be 3 requests (1 flash lite for routing, 1 pro for the initial function request, and then 1 flash for the response after we cross the 3 turn threshold.

3.  **Verify Long Context (No Mitigation):**
    Have a longer conversation (>= 3 turns).
    Ask a question requiring a tool.
    *   **Expected:** The router should be able to use Flash (if appropriate for the query complexity) without the client overriding it.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |
