### PR TITLE
fix: Stream parsing for Windows Zed integration

### DIFF
--- a/packages/cli/src/zed-integration/acp.ts
+++ b/packages/cli/src/zed-integration/acp.ts
@@ -7,7 +7,6 @@
 /* ACP defines a schema for a simple (experimental) JSON-RPC protocol that allows GUI applications to interact with agents. */
 
 import { z } from 'zod';
-import { EOL } from 'node:os';
 import * as schema from './schema.js';
 export * from './schema.js';
 
@@ -173,7 +172,7 @@ class Connection {
     const decoder = new TextDecoder();
     for await (const chunk of output) {
       content += decoder.decode(chunk, { stream: true });
-      const lines = content.split(EOL);
+      const lines = content.split('\n');
       content = lines.pop() || '';
 
       for (const line of lines) {


### PR DESCRIPTION
## TLDR

The stream of JSON RPC calls is newline delimited, and it seems this got updated in a previous commit by accident. This should solve the issue we're seeing where Gemini CLI never responds on Windows.

## Reviewer Test Plan

We've tested that the change works for us on Windows, everything is running happily again!

## Linked issues / bugs

Closes: https://github.com/google-gemini/gemini-cli/issues/7880
