### PR TITLE
feat(ci): add ability to publish packages to private github registry for testing

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -51,8 +51,7 @@ inputs:
   registry:
     description: 'The registry to publish to.'
     required: false
-    default: 'npm'
-
+    default: 'npm-wombat'
 runs:
   using: 'composite'
   steps:
@@ -121,7 +120,7 @@ runs:
         node ${{ github.workspace }}/scripts/prepare-github-release.js
 
     - name: 'Configure npm for publishing to npm'
-      if: "inputs.registry == 'npm'"
+      if: "inputs.registry != 'github'"
       uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
       with:
         node-version-file: '${{ inputs.working-directory }}/.nvmrc'
@@ -137,7 +136,7 @@ runs:
         scope: '@google-gemini'
 
     - name: '📦 Publish @google/gemini-cli-core to npm'
-      if: "inputs.registry == 'npm'"
+      if: "inputs.registry != 'github'"
       working-directory: '${{ inputs.working-directory }}'
       env:
         NODE_AUTH_TOKEN: '${{ inputs.wombat-token-core }}'
@@ -163,7 +162,7 @@ runs:
 
     - name: '🔗 Install latest core package'
       working-directory: '${{ inputs.working-directory }}'
-      if: "${{ inputs.dry-run != 'true' && inputs.registry == 'npm' }}"
+      if: "${{ inputs.dry-run != 'true' && inputs.registry != 'github' }}"
       shell: 'bash'
       run: |
         npm install "@google/gemini-cli-core@${{ inputs.release-version }}" \
@@ -171,7 +170,7 @@ runs:
         --save-exact
 
     - name: '📦 Publish @google/gemini-cli to npm'
-      if: "inputs.registry == 'npm'"
+      if: "inputs.registry != 'github'"
       working-directory: '${{ inputs.working-directory }}'
       env:
         NODE_AUTH_TOKEN: '${{ inputs.wombat-token-cli }}'
@@ -197,7 +196,7 @@ runs:
 
     - name: '🔬 Verify NPM release by version'
       uses: './.github/actions/verify-release'
-      if: "${{ inputs.dry-run != 'true' && inputs.force-skip-tests != 'true' && inputs.registry == 'npm' }}"
+      if: "${{ inputs.dry-run != 'true' && inputs.force-skip-tests != 'true' && inputs.registry != 'github' }}"
       with:
         npm-package: '@google/gemini-cli@${{ inputs.release-version }}'
         expected-version: '${{ inputs.release-version }}'
@@ -206,7 +205,7 @@ runs:
 
     - name: '🏷️ Tag release'
       uses: './.github/actions/tag-npm-release'
-      if: "${{ inputs.dry-run != 'true' && inputs.registry == 'npm' }}"
+      if: "${{ inputs.dry-run != 'true' && inputs.registry != 'github' }}"
       with:
         channel: '${{ inputs.npm-tag }}'
         version: '${{ inputs.release-version }}'
@@ -216,7 +215,7 @@ runs:
 
     - name: '🎉 Create GitHub Release'
       working-directory: '${{ inputs.working-directory }}'
-      if: "${{ inputs.dry-run != 'true' && inputs.skip-github-release != 'true' && inputs.npm-tag != 'dev' && inputs.registry == 'npm' }}"
+      if: "${{ inputs.dry-run != 'true' && inputs.skip-github-release != 'true' && inputs.npm-tag != 'dev' && inputs.registry != 'github' }}"
       env:
         GITHUB_TOKEN: '${{ inputs.github-token }}'
       shell: 'bash'

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -48,6 +48,10 @@ inputs:
   gemini_api_key:
     description: 'The API key for running integration tests.'
     required: true
+  registry:
+    description: 'The registry to publish to.'
+    required: false
+    default: 'npm'
 
 runs:
   using: 'composite'
@@ -103,14 +107,37 @@ runs:
         npm run build:packages
         npm run prepare:package
 
-    - name: 'Configure npm for publishing'
+    - name: '🎁 Bundle'
+      working-directory: '${{ inputs.working-directory }}'
+      shell: 'bash'
+      run: |
+        npm run bundle
+
+    - name: '📦 Prepare for GitHub release'
+      if: "inputs.registry == 'github'"
+      working-directory: '${{ inputs.working-directory }}'
+      shell: 'bash'
+      run: |
+        node scripts/prepare-github-release.js
+
+    - name: 'Configure npm for publishing to npm'
+      if: "inputs.registry == 'npm'"
       uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
       with:
         node-version-file: '${{ inputs.working-directory }}/.nvmrc'
         registry-url: 'https://wombat-dressing-room.appspot.com'
         scope: '@google'
 
-    - name: '📦 Publish @google/gemini-cli-core'
+    - name: 'Configure npm for publishing to GitHub'
+      if: "inputs.registry == 'github'"
+      uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
+      with:
+        node-version-file: '${{ inputs.working-directory }}/.nvmrc'
+        registry-url: 'https://npm.pkg.github.com'
+        scope: '@google-gemini'
+
+    - name: '📦 Publish @google/gemini-cli-core to npm'
+      if: "inputs.registry == 'npm'"
       working-directory: '${{ inputs.working-directory }}'
       env:
         NODE_AUTH_TOKEN: '${{ inputs.wombat-token-core }}'
@@ -122,16 +149,29 @@ runs:
           npm publish --workspace="@google/gemini-cli-core" --no-tag
         fi
 
+    - name: '📦 Publish @google-gemini/gemini-cli-core to GitHub'
+      if: "inputs.registry == 'github'"
+      working-directory: '${{ inputs.working-directory }}'
+      env:
+        NODE_AUTH_TOKEN: '${{ inputs.github-token }}'
+      shell: 'bash'
+      run: |
+        npm publish \
+          --dry-run="${{ inputs.dry-run }}" \
+          --workspace="@google-gemini/gemini-cli-core" \
+          --no-tag
+
     - name: '🔗 Install latest core package'
       working-directory: '${{ inputs.working-directory }}'
-      if: "${{ inputs.dry-run != 'true' }}"
+      if: "${{ inputs.dry-run != 'true' && inputs.registry == 'npm' }}"
       shell: 'bash'
       run: |
         npm install "@google/gemini-cli-core@${{ inputs.release-version }}" \
         --workspace="@google/gemini-cli" \
         --save-exact
 
-    - name: '📦 Publish @google/gemini-cli'
+    - name: '📦 Publish @google/gemini-cli to npm'
+      if: "inputs.registry == 'npm'"
       working-directory: '${{ inputs.working-directory }}'
       env:
         NODE_AUTH_TOKEN: '${{ inputs.wombat-token-cli }}'
@@ -143,9 +183,21 @@ runs:
           npm publish --workspace="@google/gemini-cli" --no-tag
         fi
 
+    - name: '📦 Publish @google-gemini/gemini-cli to GitHub'
+      if: "inputs.registry == 'github'"
+      working-directory: '${{ inputs.working-directory }}'
+      env:
+        NODE_AUTH_TOKEN: '${{ inputs.github-token }}'
+      shell: 'bash'
+      run: |
+        npm publish \
+          --dry-run="${{ inputs.dry-run }}" \
+          --workspace="@google-gemini/gemini-cli" \
+          --no-tag
+
     - name: '🔬 Verify NPM release by version'
       uses: './.github/actions/verify-release'
-      if: "${{ inputs.dry-run != 'true' && inputs.force-skip-tests != 'true' }}"
+      if: "${{ inputs.dry-run != 'true' && inputs.force-skip-tests != 'true' && inputs.registry == 'npm' }}"
       with:
         npm-package: '@google/gemini-cli@${{ inputs.release-version }}'
         expected-version: '${{ inputs.release-version }}'
@@ -154,7 +206,7 @@ runs:
 
     - name: '🏷️ Tag release'
       uses: './.github/actions/tag-npm-release'
-      if: "${{ inputs.dry-run != 'true' }}"
+      if: "${{ inputs.dry-run != 'true' && inputs.registry == 'npm' }}"
       with:
         channel: '${{ inputs.npm-tag }}'
         version: '${{ inputs.release-version }}'
@@ -162,15 +214,9 @@ runs:
         wombat-token-core: '${{ inputs.wombat-token-core }}'
         wombat-token-cli: '${{ inputs.wombat-token-cli }}'
 
-    - name: '🎁 Bundle'
-      working-directory: '${{ inputs.working-directory }}'
-      shell: 'bash'
-      run: |
-        npm run bundle
-
     - name: '🎉 Create GitHub Release'
       working-directory: '${{ inputs.working-directory }}'
-      if: "${{ inputs.dry-run != 'true' && inputs.skip-github-release != 'true' && inputs.npm-tag != 'dev' }}"
+      if: "${{ inputs.dry-run != 'true' && inputs.skip-github-release != 'true' && inputs.npm-tag != 'dev' && inputs.registry == 'npm' }}"
       env:
         GITHUB_TOKEN: '${{ inputs.github-token }}'
       shell: 'bash'

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -118,7 +118,7 @@ runs:
       working-directory: '${{ inputs.working-directory }}'
       shell: 'bash'
       run: |
-        node scripts/prepare-github-release.js
+        node ${{ github.workspace }}/scripts/prepare-github-release.js
 
     - name: 'Configure npm for publishing to npm'
       if: "inputs.registry == 'npm'"

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: 'string'
       npm_channel:
-        description: 'The npm channel to publish to.'
+        description: 'The npm channel to publish to (only used when registry is \'npm\').'
         required: true
         type: 'choice'
         options:
@@ -32,10 +32,18 @@ on:
         type: 'boolean'
         default: false
       skip_github_release:
-        description: 'Select to skip creating a GitHub release and create a npm release only.'
+        description: 'Select to skip creating a GitHub release (only used when registry is \'npm\').'
         required: false
         type: 'boolean'
         default: false
+      registry:
+        description: 'The registry to publish to.'
+        required: true
+        type: 'choice'
+        options:
+          - 'npm'
+          - 'github'
+        default: 'npm'
 
 jobs:
   release:
@@ -100,6 +108,7 @@ jobs:
           skip-github-release: '${{ github.event.inputs.skip_github_release }}'
           working-directory: './release'
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
+          registry: '${{ github.event.inputs.registry }}'
 
       - name: 'Create Issue on Failure'
         if: '${{ failure() && github.event.inputs.dry_run == false }}'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -16,11 +16,11 @@ on:
         required: true
         type: 'choice'
         options:
-          - 'npm'
+          - 'npm-wombat'
           - 'github'
-        default: 'npm'
+        default: 'npm-wombat'
       npm_channel:
-        description: 'The npm channel to publish to (only used when registry is npm)'
+        description: 'The npm channel to publish to (only used when registry is npm-wombat)'
         required: true
         type: 'choice'
         options:
@@ -40,7 +40,7 @@ on:
         type: 'boolean'
         default: false
       skip_github_release:
-        description: 'Select to skip creating a GitHub release (only used when registry is npm)'
+        description: 'Select to skip creating a GitHub release (only used when registry is npm-wombat)'
         required: false
         type: 'boolean'
         default: false

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: 'string'
       npm_channel:
-        description: 'The npm channel to publish to (only used when registry is npm)
+        description: 'The npm channel to publish to (only used when registry is npm)'
         required: true
         type: 'choice'
         options:
@@ -32,7 +32,7 @@ on:
         type: 'boolean'
         default: false
       skip_github_release:
-        description: 'Select to skip creating a GitHub release (only used when registry is npm)
+        description: 'Select to skip creating a GitHub release (only used when registry is npm)'
         required: false
         type: 'boolean'
         default: false

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -11,6 +11,14 @@ on:
         description: 'The branch, tag, or SHA to release from.'
         required: true
         type: 'string'
+      registry:
+        description: 'The registry to publish to.'
+        required: true
+        type: 'choice'
+        options:
+          - 'npm'
+          - 'github'
+        default: 'npm'
       npm_channel:
         description: 'The npm channel to publish to (only used when registry is npm)'
         required: true
@@ -36,14 +44,6 @@ on:
         required: false
         type: 'boolean'
         default: false
-      registry:
-        description: 'The registry to publish to.'
-        required: true
-        type: 'choice'
-        options:
-          - 'npm'
-          - 'github'
-        default: 'npm'
 
 jobs:
   release:

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: 'string'
       npm_channel:
-        description: 'The npm channel to publish to (only used when registry is \'npm\').'
+        description: 'The npm channel to publish to (only used when registry is npm)
         required: true
         type: 'choice'
         options:
@@ -32,7 +32,7 @@ on:
         type: 'boolean'
         default: false
       skip_github_release:
-        description: 'Select to skip creating a GitHub release (only used when registry is \'npm\').'
+        description: 'Select to skip creating a GitHub release (only used when registry is npm)
         required: false
         type: 'boolean'
         default: false

--- a/scripts/prepare-github-release.js
+++ b/scripts/prepare-github-release.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const rootDir = path.resolve(__dirname, '..');
+
+function updatePackageJson(packagePath, updateFn) {
+  const packageJsonPath = path.resolve(rootDir, packagePath);
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  updateFn(packageJson);
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+}
+
+// Copy bundle directory into packages/cli
+const sourceBundleDir = path.resolve(rootDir, 'bundle');
+const destBundleDir = path.resolve(rootDir, 'packages/cli/bundle');
+
+if (fs.existsSync(sourceBundleDir)) {
+  fs.rmSync(destBundleDir, { recursive: true, force: true });
+  fs.cpSync(sourceBundleDir, destBundleDir, { recursive: true });
+  console.log('Copied bundle/ directory to packages/cli/');
+} else {
+  console.error(
+    'Error: bundle/ directory not found at project root. Please run `npm run bundle` first.',
+  );
+  process.exit(1);
+}
+
+// Overwrite the .npmrc in the core package to point to the GitHub registry.
+const coreNpmrcPath = path.resolve(rootDir, 'packages/core/.npmrc');
+fs.writeFileSync(
+  coreNpmrcPath,
+  '@google-gemini:registry=https://npm.pkg.github.com/',
+);
+console.log('Wrote .npmrc for @google-gemini scope to packages/core/');
+
+// Update @google/gemini-cli
+updatePackageJson('packages/cli/package.json', (pkg) => {
+  pkg.name = '@google-gemini/gemini-cli';
+  pkg.files = ['bundle/'];
+  pkg.bin = {
+    gemini: 'bundle/gemini.js',
+  };
+
+  // Remove fields that are not relevant to the bundled package.
+  delete pkg.dependencies;
+  delete pkg.devDependencies;
+  delete pkg.scripts;
+  delete pkg.main;
+  delete pkg.config; // Deletes the sandboxImageUri
+});
+
+// Update @google/gemini-cli-core
+updatePackageJson('packages/core/package.json', (pkg) => {
+  pkg.name = '@google-gemini/gemini-cli-core';
+});
+
+console.log('Successfully prepared packages for GitHub release.');

--- a/scripts/prepare-github-release.js
+++ b/scripts/prepare-github-release.js
@@ -6,12 +6,8 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const rootDir = path.resolve(__dirname, '..');
+const rootDir = process.cwd();
 
 function updatePackageJson(packagePath, updateFn) {
   const packageJsonPath = path.resolve(rootDir, packagePath);


### PR DESCRIPTION
## TLDR
Updates manual release workflow to include registry option for publishing to private github registry instead of public.

## Dive Deeper
The following applies when publishing to the github registry, the npm registry publishing flow should be a no-op.

- Github requires packages published to their registry to be named with organization scope so we need to modify the names of the packages from @google/gemini-cli & @google/gemini-cli-core to @google-gemini/gemini-cli & @google-gemini/gemini-cli-core
- Instead of publishing the entire gemini-cli package, we now just publish the bundled code. Therefore, we remove unnecessary metadata from the package.json file
- Successful manual publish to github registry: https://github.com/google-gemini/gemini-cli/actions/runs/18166685616/job/51710727267

## Testing
- Install package from private github registry:
```
npm install @google-gemini/gemini-cli@0.0.3 --@google-gemini:registry=https://npm.pkg.github.com --//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
```

- Run package
```
 ./node_modules/.bin/gemini
```

- Make sure version in /about is 0.0.3

## Linked issues / bugs
#8941