### PR TITLE
refactor(agents): implement submit_final_output tool for agent completion

### DIFF
--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -10,6 +10,7 @@ import { ReadFileTool } from '../tools/read-file.js';
 import { GLOB_TOOL_NAME } from '../tools/tool-names.js';
 import { GrepTool } from '../tools/grep.js';
 import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
+import { Type } from '@google/genai';
 
 const CODEBASE_REPORT_MARKDOWN = `<CodebaseReport>
   <SummaryOfFindings>
@@ -77,17 +78,22 @@ export const CodebaseInvestigatorAgent: AgentDefinition = {
     },
   },
   outputConfig: {
-    description: `A detailed markdown report summarizing the findings of the codebase investigation and insights that are the foundation for planning and executing any code modification related to the objective.
+    outputName: 'report',
+    description: 'The final investigation report.',
+    schema: {
+      type: Type.STRING,
+      description: `A detailed markdown report summarizing the findings of the codebase investigation and insights that are the foundation for planning and executing any code modification related to the objective.
       # Report Format
 The final report should be structured markdown, clearly answering the investigation focus, citing the files, symbols, architectural patterns and how they relate to the given investigation focus.
 The report should strictly follow a format like this example: 
 ${CODEBASE_REPORT_MARKDOWN}
+
+Completion Criteria:
+- The report must directly address the initial \`objective\`.
+- Cite specific files, functions, or configuration snippets and symbols as evidence for your findings.
+- Conclude with a xml markdown summary of the key files, symbols, technologies, architectural patterns, and conventions discovered.
 `,
-    completion_criteria: [
-      'The report must directly address the initial `objective`.',
-      'Cite specific files, functions, or configuration snippets and symbols as evidence for your findings.',
-      'Conclude with a xml markdown summary of the key files, symbols, technologies, architectural patterns, and conventions discovered.',
-    ],
+    },
   },
 
   modelConfig: {

--- a/packages/core/src/agents/executor.test.ts
+++ b/packages/core/src/agents/executor.test.ts
@@ -4,20 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  describe,
-  it,
-  expect,
-  vi,
-  beforeEach,
-  afterEach,
-  type MockedClass,
-} from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AgentExecutor, type ActivityCallback } from './executor.js';
 import type {
   AgentDefinition,
   AgentInputs,
   SubagentActivityEvent,
+  OutputConfig,
 } from './types.js';
 import { AgentTerminateMode } from './types.js';
 import { makeFakeConfig } from '../test-utils/config.js';
@@ -34,6 +27,7 @@ import {
   type FunctionCall,
   type Part,
   type GenerateContentResponse,
+  type GenerateContentConfig,
 } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { MockTool } from '../test-utils/mock-tool.js';
@@ -45,9 +39,9 @@ const { mockSendMessageStream, mockExecuteToolCall } = vi.hoisted(() => ({
 }));
 
 vi.mock('../core/geminiChat.js', async (importOriginal) => {
-  const actual = await importOriginal();
+  const actual = await importOriginal<typeof import('../core/geminiChat.js')>();
   return {
-    ...(actual as object),
+    ...actual,
     GeminiChat: vi.fn().mockImplementation(() => ({
       sendMessageStream: mockSendMessageStream,
     })),
@@ -60,20 +54,29 @@ vi.mock('../core/nonInteractiveToolExecutor.js', () => ({
 
 vi.mock('../utils/environmentContext.js');
 
-const MockedGeminiChat = GeminiChat as MockedClass<typeof GeminiChat>;
+const MockedGeminiChat = vi.mocked(GeminiChat);
+const mockedGetDirectoryContextString = vi.mocked(getDirectoryContextString);
 
-// A mock tool that is NOT on the NON_INTERACTIVE_TOOL_ALLOWLIST
-const MOCK_TOOL_NOT_ALLOWED = new MockTool({ name: 'write_file' });
+// Constants for testing
+const TASK_COMPLETE_TOOL_NAME = 'complete_task';
+const MOCK_TOOL_NOT_ALLOWED = new MockTool({ name: 'write_file_interactive' });
 
+/**
+ * Helper to create a mock API response chunk.
+ * Uses conditional spread to handle readonly functionCalls property safely.
+ */
 const createMockResponseChunk = (
   parts: Part[],
   functionCalls?: FunctionCall[],
 ): GenerateContentResponse =>
   ({
     candidates: [{ index: 0, content: { role: 'model', parts } }],
-    functionCalls,
+    ...(functionCalls && functionCalls.length > 0 ? { functionCalls } : {}),
   }) as unknown as GenerateContentResponse;
 
+/**
+ * Helper to mock a single turn of model response in the stream.
+ */
 const mockModelResponse = (
   functionCalls: FunctionCall[],
   thought?: string,
@@ -88,11 +91,7 @@ const mockModelResponse = (
   }
   if (text) parts.push({ text });
 
-  const responseChunk = createMockResponseChunk(
-    parts,
-    // Ensure functionCalls is undefined if the array is empty, matching API behavior
-    functionCalls.length > 0 ? functionCalls : undefined,
-  );
+  const responseChunk = createMockResponseChunk(parts, functionCalls);
 
   mockSendMessageStream.mockImplementationOnce(async () =>
     (async function* () {
@@ -104,30 +103,60 @@ const mockModelResponse = (
   );
 };
 
+/**
+ * Helper to extract the message parameters sent to sendMessageStream.
+ * Provides type safety for inspecting mock calls.
+ */
+const getMockMessageParams = (callIndex: number) => {
+  const call = mockSendMessageStream.mock.calls[callIndex];
+  expect(call).toBeDefined();
+  // Arg 1 of sendMessageStream is the message parameters
+  return call[1] as { message?: Part[]; config?: GenerateContentConfig };
+};
+
 let mockConfig: Config;
 let parentToolRegistry: ToolRegistry;
+
+/**
+ * Type-safe helper to create agent definitions for tests.
+ */
+type OutputConfigMode = 'default' | 'none' | Partial<OutputConfig>;
 
 const createTestDefinition = (
   tools: Array<string | MockTool> = [LSTool.Name],
   runConfigOverrides: Partial<AgentDefinition['runConfig']> = {},
-  outputConfigOverrides: Partial<AgentDefinition['outputConfig']> = {},
-): AgentDefinition => ({
-  name: 'TestAgent',
-  description: 'An agent for testing.',
-  inputConfig: {
-    inputs: { goal: { type: 'string', required: true, description: 'goal' } },
-  },
-  modelConfig: { model: 'gemini-test-model', temp: 0, top_p: 1 },
-  runConfig: { max_time_minutes: 5, max_turns: 5, ...runConfigOverrides },
-  promptConfig: { systemPrompt: 'Achieve the goal: ${goal}.' },
-  toolConfig: { tools },
-  outputConfig: {
-    outputName: 'finalResult',
-    description: 'The final result.',
-    schema: { type: Type.STRING },
-    ...outputConfigOverrides,
-  },
-});
+  outputConfigMode: OutputConfigMode = 'default',
+): AgentDefinition => {
+  let outputConfig: OutputConfig | undefined;
+
+  if (outputConfigMode === 'default') {
+    outputConfig = {
+      outputName: 'finalResult',
+      description: 'The final result.',
+      schema: { type: Type.STRING },
+    };
+  } else if (outputConfigMode !== 'none') {
+    outputConfig = {
+      outputName: 'finalResult',
+      description: 'The final result.',
+      schema: { type: Type.STRING },
+      ...outputConfigMode,
+    };
+  }
+
+  return {
+    name: 'TestAgent',
+    description: 'An agent for testing.',
+    inputConfig: {
+      inputs: { goal: { type: 'string', required: true, description: 'goal' } },
+    },
+    modelConfig: { model: 'gemini-test-model', temp: 0, top_p: 1 },
+    runConfig: { max_time_minutes: 5, max_turns: 5, ...runConfigOverrides },
+    promptConfig: { systemPrompt: 'Achieve the goal: ${goal}.' },
+    toolConfig: { tools },
+    outputConfig,
+  };
+};
 
 describe('AgentExecutor', () => {
   let activities: SubagentActivityEvent[];
@@ -136,11 +165,10 @@ describe('AgentExecutor', () => {
   let signal: AbortSignal;
 
   beforeEach(async () => {
+    vi.resetAllMocks();
     mockSendMessageStream.mockReset();
     mockExecuteToolCall.mockReset();
-    vi.resetAllMocks();
 
-    // Restore the GeminiChat constructor mock
     MockedGeminiChat.mockImplementation(
       () =>
         ({
@@ -148,7 +176,6 @@ describe('AgentExecutor', () => {
         }) as unknown as GeminiChat,
     );
 
-    // Use fake timers for timeout and concurrency testing
     vi.useFakeTimers();
 
     mockConfig = makeFakeConfig();
@@ -161,7 +188,7 @@ describe('AgentExecutor', () => {
       parentToolRegistry,
     );
 
-    vi.mocked(getDirectoryContextString).mockResolvedValue(
+    mockedGetDirectoryContextString.mockResolvedValue(
       'Mocked Environment Context',
     );
 
@@ -190,9 +217,7 @@ describe('AgentExecutor', () => {
       const definition = createTestDefinition([MOCK_TOOL_NOT_ALLOWED.name]);
       await expect(
         AgentExecutor.create(definition, mockConfig, onActivity),
-      ).rejects.toThrow(
-        `Tool "${MOCK_TOOL_NOT_ALLOWED.name}" is not on the allow-list for non-interactive execution`,
-      );
+      ).rejects.toThrow(/not on the allow-list for non-interactive execution/);
     });
 
     it('should create an isolated ToolRegistry for the agent', async () => {
@@ -202,8 +227,8 @@ describe('AgentExecutor', () => {
         mockConfig,
         onActivity,
       );
-      // @ts-expect-error - accessing private property for test validation
-      const agentRegistry = executor.toolRegistry as ToolRegistry;
+
+      const agentRegistry = executor['toolRegistry'] as ToolRegistry;
 
       expect(agentRegistry).not.toBe(parentToolRegistry);
       expect(agentRegistry.getAllToolNames()).toEqual(
@@ -215,7 +240,7 @@ describe('AgentExecutor', () => {
   });
 
   describe('run (Execution Loop and Logic)', () => {
-    it('should execute successfully when model calls submit_final_output (Happy Path)', async () => {
+    it('should execute successfully when model calls complete_task with output (Happy Path with Output)', async () => {
       const definition = createTestDefinition();
       const executor = await AgentExecutor.create(
         definition,
@@ -244,11 +269,11 @@ describe('AgentExecutor', () => {
         error: undefined,
       });
 
-      // Turn 2: Model calls submit_final_output
+      // Turn 2: Model calls complete_task with required output
       mockModelResponse(
         [
           {
-            name: 'submit_final_output',
+            name: TASK_COMPLETE_TOOL_NAME,
             args: { finalResult: 'Found file1.txt' },
             id: 'call2',
           },
@@ -258,41 +283,43 @@ describe('AgentExecutor', () => {
 
       const output = await executor.run(inputs, signal);
 
-      // Should have called the model twice
       expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
-      // Should have executed only the 'ls' tool call externally
-      expect(mockExecuteToolCall).toHaveBeenCalledTimes(1);
-      expect(mockExecuteToolCall).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ name: LSTool.Name }),
-        expect.anything(),
-      );
 
-      // Verify System Prompt contains the new instructions
       const chatConstructorArgs = MockedGeminiChat.mock.calls[0];
       const chatConfig = chatConstructorArgs[1];
       expect(chatConfig?.systemInstruction).toContain(
-        'Achieve the goal: Find files.',
-      );
-      expect(chatConfig?.systemInstruction).toContain(
-        'MUST call the `submit_final_output` tool',
+        `MUST call the \`${TASK_COMPLETE_TOOL_NAME}\` tool`,
       );
 
-      // Verify the tools list passed to the model includes submit_final_output
-      const turn1CallArgs = mockSendMessageStream.mock.calls[0];
-      const turn1Config = turn1CallArgs[1].config;
-      const tools = turn1Config.tools[0].functionDeclarations;
-      expect(tools).toEqual(
+      const turn1Params = getMockMessageParams(0);
+
+      const firstToolGroup = turn1Params.config?.tools?.[0];
+      expect(firstToolGroup).toBeDefined();
+
+      if (!firstToolGroup || !('functionDeclarations' in firstToolGroup)) {
+        throw new Error(
+          'Test expectation failed: Config does not contain functionDeclarations.',
+        );
+      }
+
+      const sentTools = firstToolGroup.functionDeclarations;
+      expect(sentTools).toBeDefined();
+
+      expect(sentTools).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ name: LSTool.Name }),
-          expect.objectContaining({ name: 'submit_final_output' }),
+          expect.objectContaining({ name: TASK_COMPLETE_TOOL_NAME }),
         ]),
       );
+
+      const completeToolDef = sentTools!.find(
+        (t) => t.name === TASK_COMPLETE_TOOL_NAME,
+      );
+      expect(completeToolDef?.parameters?.required).toContain('finalResult');
 
       expect(output.result).toBe('Found file1.txt');
       expect(output.terminate_reason).toBe(AgentTerminateMode.GOAL);
 
-      // Verify Activity Stream
       expect(activities).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -300,44 +327,35 @@ describe('AgentExecutor', () => {
             data: { text: 'T1: Listing' },
           }),
           expect.objectContaining({
-            type: 'TOOL_CALL_START',
-            data: { name: LSTool.Name, args: { path: '.' } },
-          }),
-          expect.objectContaining({
             type: 'TOOL_CALL_END',
             data: { name: LSTool.Name, output: 'file1.txt' },
           }),
           expect.objectContaining({
-            type: 'THOUGHT_CHUNK',
-            data: { text: 'T2: Done' },
-          }),
-          expect.objectContaining({
             type: 'TOOL_CALL_START',
             data: {
-              name: 'submit_final_output',
+              name: TASK_COMPLETE_TOOL_NAME,
               args: { finalResult: 'Found file1.txt' },
             },
           }),
           expect.objectContaining({
             type: 'TOOL_CALL_END',
             data: {
-              name: 'submit_final_output',
-              output: 'Output submitted successfully.',
+              name: TASK_COMPLETE_TOOL_NAME,
+              output: expect.stringContaining('Output submitted'),
             },
           }),
         ]),
       );
     });
 
-    it('should nudge the model if it stops without calling submit_final_output', async () => {
-      const definition = createTestDefinition();
+    it('should execute successfully when model calls complete_task without output (Happy Path No Output)', async () => {
+      const definition = createTestDefinition([LSTool.Name], {}, 'none');
       const executor = await AgentExecutor.create(
         definition,
         mockConfig,
         onActivity,
       );
 
-      // Turn 1: Model calls ls
       mockModelResponse([
         { name: LSTool.Name, args: { path: '.' }, id: 'call1' },
       ]);
@@ -351,34 +369,39 @@ describe('AgentExecutor', () => {
         ],
       });
 
-      // Turn 2: Model stops calling tools (prematurely)
-      mockModelResponse([]);
-
-      // Turn 3: Model responds to the nudge by calling submit_final_output
-      mockModelResponse([
-        {
-          name: 'submit_final_output',
-          args: { finalResult: 'Done after nudge' },
-          id: 'call2',
-        },
-      ]);
-
-      const output = await executor.run({ goal: 'Nudge test' }, signal);
-
-      expect(mockSendMessageStream).toHaveBeenCalledTimes(3);
-
-      // Verify the nudge message was sent in the 3rd call
-      const turn3CallArgs = mockSendMessageStream.mock.calls[2];
-      const turn3Message = turn3CallArgs[1].message as Part[];
-      expect(turn3Message[0].text).toContain(
-        'You have stopped calling tools, but you have not called `submit_final_output`',
+      mockModelResponse(
+        [{ name: TASK_COMPLETE_TOOL_NAME, args: {}, id: 'call2' }],
+        'Task finished.',
       );
 
-      expect(output.result).toBe('Done after nudge');
+      const output = await executor.run({ goal: 'Do work' }, signal);
+
+      const turn1Params = getMockMessageParams(0);
+      const firstToolGroup = turn1Params.config?.tools?.[0];
+
+      expect(firstToolGroup).toBeDefined();
+      if (!firstToolGroup || !('functionDeclarations' in firstToolGroup)) {
+        throw new Error(
+          'Test expectation failed: Config does not contain functionDeclarations.',
+        );
+      }
+
+      const sentTools = firstToolGroup.functionDeclarations;
+      expect(sentTools).toBeDefined();
+
+      const completeToolDef = sentTools!.find(
+        (t) => t.name === TASK_COMPLETE_TOOL_NAME,
+      );
+      expect(completeToolDef?.parameters?.required).toEqual([]);
+      expect(completeToolDef?.description).toContain(
+        'signal that you have completed',
+      );
+
+      expect(output.result).toBe('Task completed successfully.');
       expect(output.terminate_reason).toBe(AgentTerminateMode.GOAL);
     });
 
-    it('should report an error if submit_final_output is called with missing arguments', async () => {
+    it('should error immediately if the model stops tools without calling complete_task (Protocol Violation)', async () => {
       const definition = createTestDefinition();
       const executor = await AgentExecutor.create(
         definition,
@@ -386,19 +409,62 @@ describe('AgentExecutor', () => {
         onActivity,
       );
 
-      // Turn 1: Model calls submit_final_output but forgets the argument
+      mockModelResponse([
+        { name: LSTool.Name, args: { path: '.' }, id: 'call1' },
+      ]);
+      mockExecuteToolCall.mockResolvedValueOnce({
+        callId: 'call1',
+        resultDisplay: 'ok',
+        responseParts: [
+          {
+            functionResponse: { name: LSTool.Name, response: {}, id: 'call1' },
+          },
+        ],
+      });
+
+      mockModelResponse([], 'I think I am done.');
+
+      const output = await executor.run({ goal: 'Strict test' }, signal);
+
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+
+      const expectedError = `Agent stopped calling tools but did not call '${TASK_COMPLETE_TOOL_NAME}' to finalize the session.`;
+
+      expect(output.terminate_reason).toBe(AgentTerminateMode.ERROR);
+      expect(output.result).toBe(expectedError);
+
+      expect(activities).toContainEqual(
+        expect.objectContaining({
+          type: 'ERROR',
+          data: expect.objectContaining({
+            context: 'protocol_violation',
+            error: expectedError,
+          }),
+        }),
+      );
+    });
+
+    it('should report an error if complete_task is called with missing required arguments', async () => {
+      const definition = createTestDefinition();
+      const executor = await AgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+
+      // Turn 1: Missing arg
       mockModelResponse([
         {
-          name: 'submit_final_output',
-          args: {}, // Missing 'finalResult'
+          name: TASK_COMPLETE_TOOL_NAME,
+          args: { wrongArg: 'oops' },
           id: 'call1',
         },
       ]);
 
-      // Turn 2: Model corrects itself
+      // Turn 2: Corrected
       mockModelResponse([
         {
-          name: 'submit_final_output',
+          name: TASK_COMPLETE_TOOL_NAME,
           args: { finalResult: 'Corrected result' },
           id: 'call2',
         },
@@ -408,26 +474,31 @@ describe('AgentExecutor', () => {
 
       expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
 
-      // Verify the error was reported in the activity stream
+      const expectedError =
+        "Missing required argument 'finalResult' for completion.";
+
       expect(activities).toContainEqual(
         expect.objectContaining({
           type: 'ERROR',
           data: {
             context: 'tool_call',
-            name: 'submit_final_output',
-            error: "Missing required argument 'finalResult'.",
+            name: TASK_COMPLETE_TOOL_NAME,
+            error: expectedError,
           },
         }),
       );
 
-      // Verify the error was sent back to the model in the 2nd call
-      const turn2CallArgs = mockSendMessageStream.mock.calls[1];
-      const turn2Message = turn2CallArgs[1].message as Part[];
-      expect(turn2Message[0]).toEqual(
+      const turn2Params = getMockMessageParams(1);
+      const turn2Parts = turn2Params.message;
+      expect(turn2Parts).toBeDefined();
+      expect(turn2Parts).toHaveLength(1);
+
+      expect(turn2Parts![0]).toEqual(
         expect.objectContaining({
           functionResponse: expect.objectContaining({
-            name: 'submit_final_output',
-            response: { error: "Missing required argument 'finalResult'." },
+            name: TASK_COMPLETE_TOOL_NAME,
+            response: { error: expectedError },
+            id: 'call1',
           }),
         }),
       );
@@ -436,53 +507,77 @@ describe('AgentExecutor', () => {
       expect(output.terminate_reason).toBe(AgentTerminateMode.GOAL);
     });
 
-    it('should execute parallel tool calls concurrently', async () => {
-      const definition = createTestDefinition([LSTool.Name, ReadFileTool.Name]);
+    it('should handle multiple calls to complete_task in the same turn (accept first, block rest)', async () => {
+      const definition = createTestDefinition([], {}, 'none');
       const executor = await AgentExecutor.create(
         definition,
         mockConfig,
         onActivity,
       );
 
-      const call1 = {
+      // Turn 1: Duplicate calls
+      mockModelResponse([
+        { name: TASK_COMPLETE_TOOL_NAME, args: {}, id: 'call1' },
+        { name: TASK_COMPLETE_TOOL_NAME, args: {}, id: 'call2' },
+      ]);
+
+      const output = await executor.run({ goal: 'Dup test' }, signal);
+
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+      expect(output.terminate_reason).toBe(AgentTerminateMode.GOAL);
+
+      const completions = activities.filter(
+        (a) =>
+          a.type === 'TOOL_CALL_END' &&
+          a.data['name'] === TASK_COMPLETE_TOOL_NAME,
+      );
+      const errors = activities.filter(
+        (a) => a.type === 'ERROR' && a.data['name'] === TASK_COMPLETE_TOOL_NAME,
+      );
+
+      expect(completions).toHaveLength(1);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].data['error']).toContain(
+        'Task already marked complete in this turn',
+      );
+    });
+
+    it('should execute parallel tool calls and then complete', async () => {
+      const definition = createTestDefinition([LSTool.Name]);
+      const executor = await AgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+
+      const call1: FunctionCall = {
         name: LSTool.Name,
-        args: { path: '/dir1' },
-        id: 'call1',
+        args: { path: '/a' },
+        id: 'c1',
       };
-      // Using LSTool twice for simplicity in mocking standardized responses.
-      const call2 = {
+      const call2: FunctionCall = {
         name: LSTool.Name,
-        args: { path: '/dir2' },
-        id: 'call2',
+        args: { path: '/b' },
+        id: 'c2',
       };
 
-      // Turn 1: Model calls two tools simultaneously
-      mockModelResponse([call1, call2], 'T1: Listing both');
+      // Turn 1: Parallel calls
+      mockModelResponse([call1, call2]);
 
-      // Use concurrency tracking to ensure parallelism
-      let activeCalls = 0;
-      let maxActiveCalls = 0;
+      // Concurrency mock
       let callsStarted = 0;
-      let resolveCallsStarted: () => void;
-      const callsStartedPromise = new Promise<void>((resolve) => {
-        resolveCallsStarted = resolve;
+      let resolveCalls: () => void;
+      const bothStarted = new Promise<void>((r) => {
+        resolveCalls = r;
       });
 
       mockExecuteToolCall.mockImplementation(async (_ctx, reqInfo) => {
-        activeCalls++;
         callsStarted++;
-        maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
-
-        if (callsStarted === 2) {
-          resolveCallsStarted();
-        }
-
-        // Simulate latency. We must advance the fake timers for this to resolve.
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        activeCalls--;
+        if (callsStarted === 2) resolveCalls();
+        await vi.advanceTimersByTimeAsync(100);
         return {
           callId: reqInfo.callId,
-          resultDisplay: `Result for ${reqInfo.name}`,
+          resultDisplay: 'ok',
           responseParts: [
             {
               functionResponse: {
@@ -492,54 +587,48 @@ describe('AgentExecutor', () => {
               },
             },
           ],
-          error: undefined,
         };
       });
 
-      // Turn 2: Model submits output
+      // Turn 2: Completion
       mockModelResponse([
         {
-          name: 'submit_final_output',
-          args: { finalResult: 'Done.' },
-          id: 'call3',
+          name: TASK_COMPLETE_TOOL_NAME,
+          args: { finalResult: 'done' },
+          id: 'c3',
         },
       ]);
 
-      const runPromise = executor.run({ goal: 'Parallel test' }, signal);
+      const runPromise = executor.run({ goal: 'Parallel' }, signal);
 
-      // Kickstart the async process
+      await vi.advanceTimersByTimeAsync(1);
+      await bothStarted;
+      await vi.advanceTimersByTimeAsync(150);
       await vi.advanceTimersByTimeAsync(1);
 
-      // Wait until both calls have started
-      await callsStartedPromise;
-
-      // Advance timers while the parallel calls (Promise.all + setTimeout) are running
-      await vi.advanceTimersByTimeAsync(150);
-
-      await runPromise;
+      const output = await runPromise;
 
       expect(mockExecuteToolCall).toHaveBeenCalledTimes(2);
-      expect(maxActiveCalls).toBe(2);
+      expect(output.terminate_reason).toBe(AgentTerminateMode.GOAL);
 
-      // Verify the input to the next model call (Turn 2) contains both responses
-      const turn2Input = mockSendMessageStream.mock.calls[1][1];
-      const turn2Parts = turn2Input.message as Part[];
-
-      // Promise.all preserves the order of the input array.
-      expect(turn2Parts.length).toBe(2);
-      expect(turn2Parts[0]).toEqual(
-        expect.objectContaining({
-          functionResponse: expect.objectContaining({ id: 'call1' }),
-        }),
-      );
-      expect(turn2Parts[1]).toEqual(
-        expect.objectContaining({
-          functionResponse: expect.objectContaining({ id: 'call2' }),
-        }),
+      // Safe access to message parts
+      const turn2Params = getMockMessageParams(1);
+      const parts = turn2Params.message;
+      expect(parts).toBeDefined();
+      expect(parts).toHaveLength(2);
+      expect(parts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            functionResponse: expect.objectContaining({ id: 'c1' }),
+          }),
+          expect.objectContaining({
+            functionResponse: expect.objectContaining({ id: 'c2' }),
+          }),
+        ]),
       );
     });
 
-    it('should handle tool execution failure gracefully and report error', async () => {
+    it('SECURITY: should block unauthorized tools and provide explicit failure to model', async () => {
       const definition = createTestDefinition([LSTool.Name]);
       const executor = await AgentExecutor.create(
         definition,
@@ -547,77 +636,22 @@ describe('AgentExecutor', () => {
         onActivity,
       );
 
-      // Turn 1: Model calls ls, but it fails
-      mockModelResponse([
-        { name: LSTool.Name, args: { path: '/invalid' }, id: 'call1' },
-      ]);
-
-      const errorMessage = 'Internal failure.';
-      mockExecuteToolCall.mockResolvedValueOnce({
-        callId: 'call1',
-        resultDisplay: `Error: ${errorMessage}`,
-        responseParts: undefined, // Failed tools might return undefined parts
-        error: { message: errorMessage },
-      });
-
-      // Turn 2: Model submits output
-      mockModelResponse([
-        {
-          name: 'submit_final_output',
-          args: { finalResult: 'Failed.' },
-          id: 'call2',
-        },
-      ]);
-
-      await executor.run({ goal: 'Failure test' }, signal);
-
-      // Verify that the error was reported in the activity stream
-      expect(activities).toContainEqual(
-        expect.objectContaining({
-          type: 'ERROR',
-          data: {
-            error: errorMessage,
-            context: 'tool_call',
-            name: LSTool.Name,
-          },
-        }),
-      );
-
-      // Verify the input to the next model call (Turn 2) contains the fallback error message
-      const turn2Input = mockSendMessageStream.mock.calls[1][1];
-      const turn2Parts = turn2Input.message as Part[];
-      expect(turn2Parts).toEqual([
-        {
-          text: 'All tool calls failed or were unauthorized. Please analyze the errors and try an alternative approach.',
-        },
-      ]);
-    });
-
-    it('SECURITY: should block calls to tools not registered for the agent at runtime', async () => {
-      // Agent definition only includes LSTool
-      const definition = createTestDefinition([LSTool.Name]);
-      const executor = await AgentExecutor.create(
-        definition,
-        mockConfig,
-        onActivity,
-      );
-
-      // Turn 1: Model hallucinates a call to ReadFileTool
-      // (ReadFileTool exists in the parent registry but not the agent's isolated registry)
+      // Turn 1: Model tries to use a tool not in its config
+      const badCallId = 'bad_call_1';
       mockModelResponse([
         {
           name: ReadFileTool.Name,
-          args: { path: 'config.txt' },
-          id: 'call_blocked',
+          args: { path: 'secret.txt' },
+          id: badCallId,
         },
       ]);
 
-      // Turn 2: Model submits output
+      // Turn 2: Model gives up and completes
       mockModelResponse([
         {
-          name: 'submit_final_output',
-          args: { finalResult: 'Done.' },
-          id: 'call2',
+          name: TASK_COMPLETE_TOOL_NAME,
+          args: { finalResult: 'Could not read file.' },
+          id: 'c2',
         },
       ]);
 
@@ -625,208 +659,116 @@ describe('AgentExecutor', () => {
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
 
-      await executor.run({ goal: 'Security test' }, signal);
+      await executor.run({ goal: 'Sec test' }, signal);
 
-      // Verify executeToolCall was NEVER called because the tool was unauthorized
+      // Verify external executor was not called (Security held)
       expect(mockExecuteToolCall).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `attempted to call unauthorized tool '${ReadFileTool.Name}'`,
-        ),
-      );
 
+      // 2. Verify console warning
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`[AgentExecutor] Blocked call:`),
+      );
       consoleWarnSpy.mockRestore();
 
-      // Verify the input to the next model call (Turn 2) indicates failure (as the only call was blocked)
-      const turn2Input = mockSendMessageStream.mock.calls[1][1];
-      const turn2Parts = turn2Input.message as Part[];
-      expect(turn2Parts[0].text).toContain('All tool calls failed');
-    });
-
-    it('should handle multiple calls to submit_final_output in the same turn by accepting the first and erroring on the rest', async () => {
-      const definition = createTestDefinition();
-      const executor = await AgentExecutor.create(
-        definition,
-        mockConfig,
-        onActivity,
-      );
-
-      // Turn 1: Model calls submit_final_output TWICE
-      mockModelResponse([
-        {
-          name: 'submit_final_output',
-          args: { finalResult: 'First result' },
-          id: 'call1',
-        },
-        {
-          name: 'submit_final_output',
-          args: { finalResult: 'Second result (should be ignored)' },
-          id: 'call2',
-        },
-      ]);
-
-      const output = await executor.run(
-        { goal: 'Multiple submit test' },
-        signal,
-      );
-
-      expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
-
-      // Verify the result matches the FIRST call
-      expect(output.result).toBe('First result');
-      expect(output.terminate_reason).toBe(AgentTerminateMode.GOAL);
-
-      // Verify activities
-      // 1. TOOL_CALL_START for both
-      expect(activities).toContainEqual(
+      // Verify specific error was sent back to model
+      const turn2Params = getMockMessageParams(1);
+      const parts = turn2Params.message;
+      expect(parts).toBeDefined();
+      expect(parts![0]).toEqual(
         expect.objectContaining({
-          type: 'TOOL_CALL_START',
-          data: expect.objectContaining({
-            name: 'submit_final_output',
-            args: { finalResult: 'First result' },
-          }),
-        }),
-      );
-      expect(activities).toContainEqual(
-        expect.objectContaining({
-          type: 'TOOL_CALL_START',
-          data: expect.objectContaining({
-            name: 'submit_final_output',
-            args: { finalResult: 'Second result (should be ignored)' },
+          functionResponse: expect.objectContaining({
+            id: badCallId,
+            name: ReadFileTool.Name,
+            response: {
+              error: expect.stringContaining('Unauthorized tool call'),
+            },
           }),
         }),
       );
 
-      // 2. TOOL_CALL_END for the first one
-      expect(activities).toContainEqual(
-        expect.objectContaining({
-          type: 'TOOL_CALL_END',
-          data: {
-            name: 'submit_final_output',
-            output: 'Output submitted successfully.',
-          },
-        }),
-      );
-
-      // 3. ERROR for the second one
+      // Verify Activity Stream reported the error
       expect(activities).toContainEqual(
         expect.objectContaining({
           type: 'ERROR',
-          data: {
-            context: 'tool_call',
-            name: 'submit_final_output',
-            error:
-              'Final output has already been submitted in this turn. Ignoring duplicate call.',
-          },
+          data: expect.objectContaining({
+            context: 'tool_call_unauthorized',
+            name: ReadFileTool.Name,
+          }),
         }),
       );
     });
   });
 
   describe('run (Termination Conditions)', () => {
-    const mockKeepAliveResponse = () => {
-      mockModelResponse(
-        [{ name: LSTool.Name, args: { path: '.' }, id: 'loop' }],
-        'Looping',
-      );
-      mockExecuteToolCall.mockResolvedValue({
-        callId: 'loop',
+    const mockWorkResponse = (id: string) => {
+      mockModelResponse([{ name: LSTool.Name, args: { path: '.' }, id }]);
+      mockExecuteToolCall.mockResolvedValueOnce({
+        callId: id,
         resultDisplay: 'ok',
         responseParts: [
-          { functionResponse: { name: LSTool.Name, response: {}, id: 'loop' } },
+          { functionResponse: { name: LSTool.Name, response: {}, id } },
         ],
-        error: undefined,
       });
     };
 
     it('should terminate when max_turns is reached', async () => {
-      const MAX_TURNS = 2;
+      const MAX = 2;
       const definition = createTestDefinition([LSTool.Name], {
-        max_turns: MAX_TURNS,
+        max_turns: MAX,
       });
-      const executor = await AgentExecutor.create(
-        definition,
-        mockConfig,
-        onActivity,
-      );
+      const executor = await AgentExecutor.create(definition, mockConfig);
 
-      // Turn 1
-      mockKeepAliveResponse();
-      // Turn 2
-      mockKeepAliveResponse();
+      mockWorkResponse('t1');
+      mockWorkResponse('t2');
 
-      const output = await executor.run({ goal: 'Termination test' }, signal);
+      const output = await executor.run({ goal: 'Turns test' }, signal);
 
       expect(output.terminate_reason).toBe(AgentTerminateMode.MAX_TURNS);
-      expect(mockSendMessageStream).toHaveBeenCalledTimes(MAX_TURNS);
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(MAX);
     });
 
     it('should terminate if timeout is reached', async () => {
       const definition = createTestDefinition([LSTool.Name], {
-        max_time_minutes: 5,
-        max_turns: 100,
+        max_time_minutes: 1,
       });
-      const executor = await AgentExecutor.create(
-        definition,
-        mockConfig,
-        onActivity,
-      );
+      const executor = await AgentExecutor.create(definition, mockConfig);
 
-      // Turn 1 setup
-      mockModelResponse(
-        [{ name: LSTool.Name, args: { path: '.' }, id: 'loop' }],
-        'Looping',
-      );
+      mockModelResponse([{ name: LSTool.Name, args: { path: '.' }, id: 't1' }]);
 
-      // Mock a tool call that takes a long time, causing the overall timeout
-      mockExecuteToolCall.mockImplementation(async () => {
-        // Advance time past the 5-minute limit during the tool call execution
-        await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
+      // Long running tool
+      mockExecuteToolCall.mockImplementationOnce(async () => {
+        await vi.advanceTimersByTimeAsync(61 * 1000);
         return {
-          callId: 'loop',
+          callId: 't1',
           resultDisplay: 'ok',
-          responseParts: [
-            {
-              functionResponse: { name: LSTool.Name, response: {}, id: 'loop' },
-            },
-          ],
-          error: undefined,
+          responseParts: [],
         };
       });
 
-      const output = await executor.run({ goal: 'Termination test' }, signal);
+      const output = await executor.run({ goal: 'Timeout test' }, signal);
 
       expect(output.terminate_reason).toBe(AgentTerminateMode.TIMEOUT);
-      // Should only have called the model once before the timeout check stopped it
       expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
     });
 
-    it('should terminate when AbortSignal is triggered mid-stream', async () => {
+    it('should terminate when AbortSignal is triggered', async () => {
       const definition = createTestDefinition();
-      const executor = await AgentExecutor.create(
-        definition,
-        mockConfig,
-        onActivity,
-      );
+      const executor = await AgentExecutor.create(definition, mockConfig);
 
-      // Mock the model response stream
-      mockSendMessageStream.mockImplementation(async () =>
+      mockSendMessageStream.mockImplementationOnce(async () =>
         (async function* () {
-          // Yield the first chunk
           yield {
             type: StreamEventType.CHUNK,
             value: createMockResponseChunk([
-              { text: '**Thinking** Step 1', thought: true },
+              { text: 'Thinking...', thought: true },
             ]),
           } as StreamEvent;
-
-          // Simulate abort happening mid-stream
           abortController.abort();
-          // The loop in callModel should break immediately due to signal check.
         })(),
       );
 
-      const output = await executor.run({ goal: 'Termination test' }, signal);
+      const output = await executor.run({ goal: 'Abort test' }, signal);
+
       expect(output.terminate_reason).toBe(AgentTerminateMode.ABORTED);
     });
   });

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -8,7 +8,7 @@
  * @fileoverview Defines the core configuration interfaces and types for the agent architecture.
  */
 
-import type { Content, FunctionDeclaration } from '@google/genai';
+import type { Content, FunctionDeclaration, Schema } from '@google/genai';
 import type { AnyDeclarativeTool } from '../tools/tools.js';
 
 /**
@@ -119,11 +119,22 @@ export interface InputConfig {
  * Configures the expected outputs for the agent.
  */
 export interface OutputConfig {
-  /** Description of what the agent should return when finished. */
+  /**
+   * The name of the final result parameter. This will be the name of the
+   * argument in the `submit_final_output` tool (e.g., "report", "answer").
+   */
+  outputName: string;
+  /**
+   * A description of the expected output. This will be used as the description
+   * for the tool argument.
+   */
   description: string;
-  /** Optional criteria that must be completed before the agent finishes. */
-  completion_criteria?: string[];
-  // TODO(abhipatel12): Add required_outputs if natural completion insufficient
+  /**
+   * Optional JSON schema for the output. If provided, it will be used as the
+   * schema for the tool's argument, allowing for structured output enforcement.
+   * Defaults to { type: 'string' }.
+   */
+  schema?: Schema;
 }
 
 /**


### PR DESCRIPTION
## TLDR

Refactors the `AgentExecutor` to use an explicit `submit_final_output` tool for agent termination and result delivery, replacing the previous two-phase (work followed by extraction) approach. This improves reliability and enables structured, schema-validated outputs defined in `OutputConfig`.

## Dive Deeper

Previously, the `AgentExecutor` ran in two phases: a "work phase" where the agent called tools, and an "extraction phase" where a final prompt asked the model to summarize its findings based on `completion_criteria`. This could be unreliable if the model didn't adhere to the implicit stop condition.

This PR introduces the following changes:

1.  **`OutputConfig` Update (`types.ts`):**
    *   Removed `completion_criteria`.
    *   Added `outputName` (defines the name of the argument in the final tool) and `schema` (Gemini `Schema` object for structured output validation).

2.  **`AgentExecutor` Refactor (`executor.ts`):**
    *   Dynamically injects a `submit_final_output` tool into the agent's available tools if `OutputConfig` is defined.
    *   Updated the system prompt to explicitly instruct the agent that calling this tool is the *only* way to complete the task.
    *   The execution loop now continues until this tool is called successfully (or other termination conditions like timeout/max turns are met).
    *   Implemented a "nudge" mechanism: if the model stops calling tools but hasn't submitted output, it is explicitly prompted to call `submit_final_output`.
    *   Includes error handling for the submit tool (e.g., missing required arguments, duplicate calls in the same turn).

3.  **Agent Updates (`codebase-investigator.ts`):**
    *   Updated the `CodebaseInvestigatorAgent` definition to comply with the new `OutputConfig` interface, moving the previous completion criteria into the schema's description field.

4.  **Testing (`executor.test.ts`):**
    *   Extensively updated and refactored tests to cover the new workflow.
    *   Added test cases for the happy path, nudging behavior, error handling (missing args), and parallel tool calls involving submission.

## Reviewer Test Plan

Ensure that `enableSubagents` is true in `settings.json` and then run a command asking for the main agent to use the codebase investigator.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |
