### PR TITLE
docs: add link to the configuration.md

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -49,6 +49,8 @@ The Gemini CLI supports three MCP transport types:
 
 The Gemini CLI uses the `mcpServers` configuration in your `settings.json` file to locate and connect to MCP servers. This configuration supports multiple servers with different transport mechanisms.
 
+Refer to [Gemini CLI Configuration](../get-started/configuration.md) for more details.
+
 ### Configure the MCP server in settings.json
 
 You can configure MCP servers in your `settings.json` file in two main ways: through the top-level `mcpServers` object for specific server definitions, and through the `mcp` object for global settings that control server discovery and execution.


### PR DESCRIPTION
I'm just adding a link to configuration.md from the mcp-server.md to better guide the develoeprs / users.