### PR TITLE
Fix oauth support for MCP servers

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -12,9 +12,13 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuthProviderType, type Config } from '../config/config.js';
 import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
+import { MCPOAuthProvider } from '../mcp/oauth-provider.js';
+import { MCPOAuthTokenStorage } from '../mcp/oauth-token-storage.js';
+import { OAuthUtils } from '../mcp/oauth-utils.js';
 import type { PromptRegistry } from '../prompts/prompt-registry.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
 import {
+  connectToMcpServer,
   createTransport,
   hasNetworkTransport,
   isEnabled,
@@ -31,6 +35,7 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js');
 vi.mock('@google/genai');
 vi.mock('../mcp/oauth-provider.js');
 vi.mock('../mcp/oauth-token-storage.js');
+vi.mock('../mcp/oauth-utils.js');
 
 describe('mcp-client', () => {
   let workspaceContext: WorkspaceContext;
@@ -447,5 +452,136 @@ describe('mcp-client', () => {
       const config = {};
       expect(hasNetworkTransport(config)).toBe(false);
     });
+  });
+});
+
+describe('connectToMcpServer with OAuth', () => {
+  let mockedClient: ClientLib.Client;
+  let workspaceContext: WorkspaceContext;
+  let testWorkspace: string;
+  let mockAuthProvider: any;
+  let mockTokenStorage: any;
+
+  beforeEach(() => {
+    mockedClient = {
+      connect: vi.fn(),
+      close: vi.fn(),
+      registerCapabilities: vi.fn(),
+      setRequestHandler: vi.fn(),
+      onclose: vi.fn(),
+      notification: vi.fn(),
+    } as unknown as ClientLib.Client;
+    vi.mocked(ClientLib.Client).mockImplementation(() => mockedClient);
+
+    testWorkspace = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'gemini-agent-test-'),
+    );
+    workspaceContext = new WorkspaceContext(testWorkspace);
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    mockAuthProvider = {
+      authenticate: vi.fn().mockResolvedValue(undefined),
+      getValidToken: vi.fn().mockResolvedValue('test-access-token'),
+    };
+    vi.mocked(MCPOAuthProvider).mockReturnValue(mockAuthProvider);
+
+    mockTokenStorage = {
+      getCredentials: vi.fn().mockResolvedValue({ clientId: 'test-client' }),
+    };
+    vi.mocked(MCPOAuthTokenStorage).mockReturnValue(mockTokenStorage);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should handle automatic OAuth flow on 401 with www-authenticate header', async () => {
+    const serverUrl = 'http://test-server.com/';
+    const authUrl = 'http://auth.example.com/auth';
+    const tokenUrl = 'http://auth.example.com/token';
+    const wwwAuthHeader = `Bearer realm="test", resource_metadata="http://test-server.com/.well-known/oauth-protected-resource"`;
+
+    vi.mocked(mockedClient.connect).mockRejectedValueOnce(
+      new Error(`401 Unauthorized\nwww-authenticate: ${wwwAuthHeader}`),
+    );
+
+    vi.mocked(OAuthUtils.discoverOAuthConfig).mockResolvedValue({
+      authorizationUrl: authUrl,
+      tokenUrl,
+      scopes: ['test-scope'],
+    });
+
+    // We need this to be an any type because we dig into its private state.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let capturedTransport: any;
+    vi.mocked(mockedClient.connect).mockImplementationOnce(
+      async (transport) => {
+        capturedTransport = transport;
+        return Promise.resolve();
+      },
+    );
+
+    const client = await connectToMcpServer(
+      'test-server',
+      { httpUrl: serverUrl },
+      false,
+      workspaceContext,
+    );
+
+    expect(client).toBe(mockedClient);
+    expect(mockedClient.connect).toHaveBeenCalledTimes(2);
+    expect(mockAuthProvider.authenticate).toHaveBeenCalledOnce();
+
+    const authHeader =
+      capturedTransport._requestInit?.headers?.['Authorization'];
+    expect(authHeader).toBe('Bearer test-access-token');
+  });
+
+  it('should discover oauth config if not in www-authenticate header', async () => {
+    const serverUrl = 'http://test-server.com';
+    const authUrl = 'http://auth.example.com/auth';
+    const tokenUrl = 'http://auth.example.com/token';
+
+    vi.mocked(mockedClient.connect).mockRejectedValueOnce(
+      new Error('401 Unauthorized'),
+    );
+
+    vi.mocked(OAuthUtils.discoverOAuthConfig).mockResolvedValue({
+      authorizationUrl: authUrl,
+      tokenUrl,
+      scopes: ['test-scope'],
+    });
+    vi.mocked(mockAuthProvider.getValidToken).mockResolvedValue(
+      'test-access-token-from-discovery',
+    );
+
+    // We need this to be an any type because we dig into its private state.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let capturedTransport: any;
+    vi.mocked(mockedClient.connect).mockImplementationOnce(
+      async (transport) => {
+        capturedTransport = transport;
+        return Promise.resolve();
+      },
+    );
+
+    const client = await connectToMcpServer(
+      'test-server',
+      { httpUrl: serverUrl },
+      false,
+      workspaceContext,
+    );
+
+    expect(client).toBe(mockedClient);
+    expect(mockedClient.connect).toHaveBeenCalledTimes(2);
+    expect(mockAuthProvider.authenticate).toHaveBeenCalledOnce();
+    expect(OAuthUtils.discoverOAuthConfig).toHaveBeenCalledWith(serverUrl);
+
+    const authHeader =
+      capturedTransport._requestInit?.headers?.['Authorization'];
+    expect(authHeader).toBe('Bearer test-access-token-from-discovery');
   });
 });

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -546,8 +546,8 @@ describe('connectToMcpServer with OAuth', () => {
   let mockedClient: ClientLib.Client;
   let workspaceContext: WorkspaceContext;
   let testWorkspace: string;
-  let mockAuthProvider: any;
-  let mockTokenStorage: any;
+  let mockAuthProvider: MCPOAuthProvider;
+  let mockTokenStorage: MCPOAuthTokenStorage;
 
   beforeEach(() => {
     mockedClient = {
@@ -569,16 +569,16 @@ describe('connectToMcpServer with OAuth', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
+    mockTokenStorage = {
+      getCredentials: vi.fn().mockResolvedValue({ clientId: 'test-client' }),
+    } as unknown as MCPOAuthTokenStorage;
+    vi.mocked(MCPOAuthTokenStorage).mockReturnValue(mockTokenStorage);
     mockAuthProvider = {
       authenticate: vi.fn().mockResolvedValue(undefined),
       getValidToken: vi.fn().mockResolvedValue('test-access-token'),
-    };
+      tokenStorage: mockTokenStorage,
+    } as unknown as MCPOAuthProvider;
     vi.mocked(MCPOAuthProvider).mockReturnValue(mockAuthProvider);
-
-    mockTokenStorage = {
-      getCredentials: vi.fn().mockResolvedValue({ clientId: 'test-client' }),
-    };
-    vi.mocked(MCPOAuthTokenStorage).mockReturnValue(mockTokenStorage);
   });
 
   afterEach(() => {

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -234,7 +234,7 @@ describe('mcp-client', () => {
         },
         mockedToolRegistry,
         {} as PromptRegistry,
-        {} as WorkspaceContext,
+        workspaceContext,
         false,
       );
       await client.connect();
@@ -282,7 +282,7 @@ describe('mcp-client', () => {
         },
         mockedToolRegistry,
         {} as PromptRegistry,
-        {} as WorkspaceContext,
+        workspaceContext,
         false,
       );
       await client.connect();

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -13,7 +13,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AuthProviderType, type Config } from '../config/config.js';
 import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
 import type { PromptRegistry } from '../prompts/prompt-registry.js';
-import type { WorkspaceContext } from '../utils/workspaceContext.js';
+import { WorkspaceContext } from '../utils/workspaceContext.js';
 import {
   createTransport,
   hasNetworkTransport,
@@ -22,6 +22,9 @@ import {
   populateMcpServerCommand,
 } from './mcp-client.js';
 import type { ToolRegistry } from './tool-registry.js';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 vi.mock('@modelcontextprotocol/sdk/client/stdio.js');
 vi.mock('@modelcontextprotocol/sdk/client/index.js');
@@ -30,6 +33,18 @@ vi.mock('../mcp/oauth-provider.js');
 vi.mock('../mcp/oauth-token-storage.js');
 
 describe('mcp-client', () => {
+  let workspaceContext: WorkspaceContext;
+  let testWorkspace: string;
+
+  beforeEach(() => {
+    // create a tmp dir for this test
+    // Create a unique temporary directory for the workspace to avoid conflicts
+    testWorkspace = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'gemini-agent-test-'),
+    );
+    workspaceContext = new WorkspaceContext(testWorkspace);
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -69,7 +84,7 @@ describe('mcp-client', () => {
         },
         mockedToolRegistry,
         {} as PromptRegistry,
-        {} as WorkspaceContext,
+        workspaceContext,
         false,
       );
       await client.connect();
@@ -131,7 +146,7 @@ describe('mcp-client', () => {
         },
         mockedToolRegistry,
         {} as PromptRegistry,
-        {} as WorkspaceContext,
+        workspaceContext,
         false,
       );
       await client.connect();
@@ -171,7 +186,7 @@ describe('mcp-client', () => {
         },
         {} as ToolRegistry,
         {} as PromptRegistry,
-        {} as WorkspaceContext,
+        workspaceContext,
         false,
       );
       await client.connect();

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -9,7 +9,7 @@ import * as ClientLib from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import * as SdkClientStdioLib from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuthProviderType, type Config } from '../config/config.js';
 import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
 import type { PromptRegistry } from '../prompts/prompt-registry.js';


### PR DESCRIPTION
## TLDR

Previously during tool discovery we would go through a different code path than the standard one to connect to the MCP server, and this code path did not support OAUTH. This caused OAUTH mcp servers to not connect at all.

I changed that logic to use the same top level function that is used by other code paths.

## Dive Deeper

Longer term it seems to me like we are connecting to these servers repeatedly, and through many different code paths which is very confusing. The culprit in this case was the McpClientManager which has a `discoverAllMcpTools` function which calls McpClient.connect, but then we also have a top level `connectAndDiscover` function in mcp-client.ts which this mcp client manager does not use, and that function would do the oauth stuff correctly.

We should try and consolidate all this code into the McpClientManager or something along those lines to reduce duplicate code paths.

## Reviewer Test Plan

Attempt to connect to an MCP server that supports oauth.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/gemini-cli/issues/10165
