### PR TITLE
fix(vscode): suppress update and install messages in managed IDEs

### DIFF
--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -209,17 +209,34 @@ describe('activate', () => {
         ide: IDE_DEFINITIONS.cloudshell,
       },
       { ide: IDE_DEFINITIONS.firebasestudio },
-    ])('does not show the notification for $ide.name', async ({ ide }) => {
-      vi.mocked(detectIdeFromEnv).mockReturnValue(ide);
-      vi.mocked(context.globalState.get).mockReturnValue(undefined);
-      const showInformationMessageMock = vi.mocked(
-        vscode.window.showInformationMessage,
-      );
+    ])(
+      'does not show install or update messages for $ide.name',
+      async ({ ide }) => {
+        vi.mocked(detectIdeFromEnv).mockReturnValue(ide);
+        vi.mocked(context.globalState.get).mockReturnValue(undefined);
+        vi.spyOn(global, 'fetch').mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            results: [
+              {
+                extensions: [
+                  {
+                    versions: [{ version: '1.2.0' }],
+                  },
+                ],
+              },
+            ],
+          }),
+        } as Response);
+        const showInformationMessageMock = vi.mocked(
+          vscode.window.showInformationMessage,
+        );
 
-      await activate(context);
+        await activate(context);
 
-      expect(showInformationMessageMock).not.toHaveBeenCalled();
-    });
+        expect(showInformationMessageMock).not.toHaveBeenCalled();
+      },
+    );
 
     it('should not show an update notification if the version is older', async () => {
       vi.spyOn(global, 'fetch').mockResolvedValue({


### PR DESCRIPTION
## TLDR

This PR prevents the VS Code extension from showing installation and update notifications when running in "managed" environments like Cloud Shell and Firebase Studio. Since users in these environments don't manage the extension themselves, these pop-ups are confusing and un-actionable.

This change also improves the output of the release check script for better clarity.