### PR TITLE
Rationalize different Extension typings

### DIFF
--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -20,16 +20,16 @@ import {
   GEMINI_CONFIG_DIR,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_GEMINI_MODEL,
+  type GeminiCLIExtension,
 } from '@google/gemini-cli-core';
 
 import { logger } from '../utils/logger.js';
 import type { Settings } from './settings.js';
-import type { Extension } from './extension.js';
 import { type AgentSettings, CoderAgentEvent } from '../types.js';
 
 export async function loadConfig(
   settings: Settings,
-  extensions: Extension[],
+  extensions: GeminiCLIExtension[],
   taskId: string,
 ): Promise<Config> {
   const mcpServers = mergeMcpServers(settings, extensions);
@@ -118,20 +118,21 @@ export async function loadConfig(
   return config;
 }
 
-export function mergeMcpServers(settings: Settings, extensions: Extension[]) {
+export function mergeMcpServers(
+  settings: Settings,
+  extensions: GeminiCLIExtension[],
+) {
   const mcpServers = { ...(settings.mcpServers || {}) };
   for (const extension of extensions) {
-    Object.entries(extension.config.mcpServers || {}).forEach(
-      ([key, server]) => {
-        if (mcpServers[key]) {
-          console.warn(
-            `Skipping extension MCP config for server with key "${key}" as it already exists.`,
-          );
-          return;
-        }
-        mcpServers[key] = server;
-      },
-    );
+    Object.entries(extension.mcpServers || {}).forEach(([key, server]) => {
+      if (mcpServers[key]) {
+        console.warn(
+          `Skipping extension MCP config for server with key "${key}" as it already exists.`,
+        );
+        return;
+      }
+      mcpServers[key] = server;
+    });
   }
   return mcpServers;
 }

--- a/packages/a2a-server/src/config/extension.ts
+++ b/packages/a2a-server/src/config/extension.ts
@@ -6,7 +6,11 @@
 
 // Copied exactly from packages/cli/src/config/extension.ts, last PR #1026
 
-import type { MCPServerConfig } from '@google/gemini-cli-core';
+import type {
+  MCPServerConfig,
+  ExtensionInstallMetadata,
+  GeminiCLIExtension,
+} from '@google/gemini-cli-core';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -14,47 +18,51 @@ import { logger } from '../utils/logger.js';
 
 export const EXTENSIONS_DIRECTORY_NAME = path.join('.gemini', 'extensions');
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
+export const INSTALL_METADATA_FILENAME = '.gemini-extension-install.json';
 
-export interface Extension {
-  config: ExtensionConfig;
-  contextFiles: string[];
-}
-
-export interface ExtensionConfig {
+/**
+ * Extension definition as written to disk in gemini-extension.json files.
+ * This should *not* be referenced outside of the logic for reading files.
+ * If information is required for manipulating extensions (load, unload, update)
+ * outside of the loading process that data needs to be stored on the
+ * GeminiCLIExtension class defined in Core.
+ */
+interface ExtensionConfig {
   name: string;
   version: string;
   mcpServers?: Record<string, MCPServerConfig>;
   contextFileName?: string | string[];
+  excludeTools?: string[];
 }
 
-export function loadExtensions(workspaceDir: string): Extension[] {
+export function loadExtensions(workspaceDir: string): GeminiCLIExtension[] {
   const allExtensions = [
     ...loadExtensionsFromDir(workspaceDir),
     ...loadExtensionsFromDir(os.homedir()),
   ];
 
-  const uniqueExtensions: Extension[] = [];
+  const uniqueExtensions: GeminiCLIExtension[] = [];
   const seenNames = new Set<string>();
   for (const extension of allExtensions) {
-    if (!seenNames.has(extension.config.name)) {
+    if (!seenNames.has(extension.name)) {
       logger.info(
-        `Loading extension: ${extension.config.name} (version: ${extension.config.version})`,
+        `Loading extension: ${extension.name} (version: ${extension.version})`,
       );
       uniqueExtensions.push(extension);
-      seenNames.add(extension.config.name);
+      seenNames.add(extension.name);
     }
   }
 
   return uniqueExtensions;
 }
 
-function loadExtensionsFromDir(dir: string): Extension[] {
+function loadExtensionsFromDir(dir: string): GeminiCLIExtension[] {
   const extensionsDir = path.join(dir, EXTENSIONS_DIRECTORY_NAME);
   if (!fs.existsSync(extensionsDir)) {
     return [];
   }
 
-  const extensions: Extension[] = [];
+  const extensions: GeminiCLIExtension[] = [];
   for (const subdir of fs.readdirSync(extensionsDir)) {
     const extensionDir = path.join(extensionsDir, subdir);
 
@@ -66,7 +74,7 @@ function loadExtensionsFromDir(dir: string): Extension[] {
   return extensions;
 }
 
-function loadExtension(extensionDir: string): Extension | null {
+function loadExtension(extensionDir: string): GeminiCLIExtension | null {
   if (!fs.statSync(extensionDir).isDirectory()) {
     logger.error(
       `Warning: unexpected file ${extensionDir} in extensions directory.`,
@@ -92,14 +100,22 @@ function loadExtension(extensionDir: string): Extension | null {
       return null;
     }
 
+    const installMetadata = loadInstallMetadata(extensionDir);
+
     const contextFiles = getContextFileNames(config)
       .map((contextFileName) => path.join(extensionDir, contextFileName))
       .filter((contextFilePath) => fs.existsSync(contextFilePath));
 
     return {
-      config,
+      name: config.name,
+      version: config.version,
+      path: extensionDir,
       contextFiles,
-    };
+      installMetadata,
+      mcpServers: config.mcpServers,
+      excludeTools: config.excludeTools,
+      isActive: true, // Barring any other signals extensions should be considered Active.
+    } as GeminiCLIExtension;
   } catch (e) {
     logger.error(
       `Warning: error parsing extension config in ${configFilePath}: ${e}`,
@@ -115,4 +131,20 @@ function getContextFileNames(config: ExtensionConfig): string[] {
     return [config.contextFileName];
   }
   return config.contextFileName;
+}
+
+export function loadInstallMetadata(
+  extensionDir: string,
+): ExtensionInstallMetadata | undefined {
+  const metadataFilePath = path.join(extensionDir, INSTALL_METADATA_FILENAME);
+  try {
+    const configContent = fs.readFileSync(metadataFilePath, 'utf-8');
+    const metadata = JSON.parse(configContent) as ExtensionInstallMetadata;
+    return metadata;
+  } catch (e) {
+    logger.warn(
+      `Failed to load or parse extension install metadata at ${metadataFilePath}: ${e}`,
+    );
+    return undefined;
+  }
 }

--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -153,10 +153,8 @@ describe('mcp list command', () => {
 
     mockedLoadExtensions.mockReturnValue([
       {
-        config: {
-          name: 'test-extension',
-          mcpServers: { 'extension-server': { command: '/ext/server' } },
-        },
+        name: 'test-extension',
+        mcpServers: { 'extension-server': { command: '/ext/server' } },
       },
     ]);
 

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -27,17 +27,15 @@ async function getMcpServersFromConfig(): Promise<
   );
   const mcpServers = { ...(settings.merged.mcpServers || {}) };
   for (const extension of extensions) {
-    Object.entries(extension.config.mcpServers || {}).forEach(
-      ([key, server]) => {
-        if (mcpServers[key]) {
-          return;
-        }
-        mcpServers[key] = {
-          ...server,
-          extensionName: extension.config.name,
-        };
-      },
-    );
+    Object.entries(extension.mcpServers || {}).forEach(([key, server]) => {
+      if (mcpServers[key]) {
+        return;
+      }
+      mcpServers[key] = {
+        ...server,
+        extensionName: extension.name,
+      };
+    });
   }
   return mcpServers;
 }

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -14,10 +14,11 @@ import {
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_MODEL_AUTO,
   OutputFormat,
+  type GeminiCLIExtension,
 } from '@google/gemini-cli-core';
 import { loadCliConfig, parseArguments, type CliArgs } from './config.js';
 import type { Settings } from './settings.js';
-import { ExtensionStorage, type Extension } from './extension.js';
+import { ExtensionStorage } from './extension.js';
 import * as ServerConfig from '@google/gemini-cli-core';
 import { isWorkspaceTrusted } from './trustedFolders.js';
 import { ExtensionEnablementManager } from './extensions/extensionEnablement.js';
@@ -1094,33 +1095,30 @@ describe('Hierarchical Memory Loading (config.ts) - Placeholder Suite', () => {
   it('should pass extension context file paths to loadServerHierarchicalMemory', async () => {
     process.argv = ['node', 'script.js'];
     const settings: Settings = {};
-    const extensions: Extension[] = [
+    const extensions: GeminiCLIExtension[] = [
       {
         path: '/path/to/ext1',
-        config: {
-          name: 'ext1',
-          version: '1.0.0',
-        },
+        name: 'ext1',
+        version: '1.0.0',
         contextFiles: ['/path/to/ext1/GEMINI.md'],
+        isActive: true,
       },
       {
         path: '/path/to/ext2',
-        config: {
-          name: 'ext2',
-          version: '1.0.0',
-        },
+        name: 'ext2',
+        version: '1.0.0',
         contextFiles: [],
+        isActive: true,
       },
       {
         path: '/path/to/ext3',
-        config: {
-          name: 'ext3',
-          version: '1.0.0',
-        },
+        name: 'ext3',
+        version: '1.0.0',
         contextFiles: [
           '/path/to/ext3/context1.md',
           '/path/to/ext3/context2.md',
         ],
+        isActive: true,
       },
     ];
     const argv = await parseArguments({} as Settings);
@@ -1191,19 +1189,18 @@ describe('mergeMcpServers', () => {
         },
       },
     };
-    const extensions: Extension[] = [
+    const extensions: GeminiCLIExtension[] = [
       {
         path: '/path/to/ext1',
-        config: {
-          name: 'ext1',
-          version: '1.0.0',
-          mcpServers: {
-            'ext1-server': {
-              url: 'http://localhost:8081',
-            },
+        name: 'ext1',
+        version: '1.0.0',
+        mcpServers: {
+          'ext1-server': {
+            url: 'http://localhost:8081',
           },
         },
         contextFiles: [],
+        isActive: true,
       },
     ];
     const originalSettings = JSON.parse(JSON.stringify(settings));
@@ -1237,24 +1234,22 @@ describe('mergeExcludeTools', () => {
 
   it('should merge excludeTools from settings and extensions', async () => {
     const settings: Settings = { tools: { exclude: ['tool1', 'tool2'] } };
-    const extensions: Extension[] = [
+    const extensions: GeminiCLIExtension[] = [
       {
         path: '/path/to/ext1',
-        config: {
-          name: 'ext1',
-          version: '1.0.0',
-          excludeTools: ['tool3', 'tool4'],
-        },
+        name: 'ext1',
+        version: '1.0.0',
+        excludeTools: ['tool3', 'tool4'],
         contextFiles: [],
+        isActive: true,
       },
       {
         path: '/path/to/ext2',
-        config: {
-          name: 'ext2',
-          version: '1.0.0',
-          excludeTools: ['tool5'],
-        },
+        name: 'ext2',
+        version: '1.0.0',
+        excludeTools: ['tool5'],
         contextFiles: [],
+        isActive: true,
       },
     ];
     process.argv = ['node', 'script.js'];
@@ -1277,15 +1272,14 @@ describe('mergeExcludeTools', () => {
 
   it('should handle overlapping excludeTools between settings and extensions', async () => {
     const settings: Settings = { tools: { exclude: ['tool1', 'tool2'] } };
-    const extensions: Extension[] = [
+    const extensions: GeminiCLIExtension[] = [
       {
         path: '/path/to/ext1',
-        config: {
-          name: 'ext1',
-          version: '1.0.0',
-          excludeTools: ['tool2', 'tool3'],
-        },
+        name: 'ext1',
+        version: '1.0.0',
+        excludeTools: ['tool2', 'tool3'],
         contextFiles: [],
+        isActive: true,
       },
     ];
     process.argv = ['node', 'script.js'];
@@ -1308,24 +1302,22 @@ describe('mergeExcludeTools', () => {
 
   it('should handle overlapping excludeTools between extensions', async () => {
     const settings: Settings = { tools: { exclude: ['tool1'] } };
-    const extensions: Extension[] = [
+    const extensions: GeminiCLIExtension[] = [
       {
         path: '/path/to/ext1',
-        config: {
-          name: 'ext1',
-          version: '1.0.0',
-          excludeTools: ['tool2', 'tool3'],
-        },
+        name: 'ext1',
+        version: '1.0.0',
+        excludeTools: ['tool2', 'tool3'],
         contextFiles: [],
+        isActive: true,
       },
       {
         path: '/path/to/ext2',
-        config: {
-          name: 'ext2',
-          version: '1.0.0',
-          excludeTools: ['tool3', 'tool4'],
-        },
+        name: 'ext2',
+        version: '1.0.0',
+        excludeTools: ['tool3', 'tool4'],
         contextFiles: [],
+        isActive: true,
       },
     ];
     process.argv = ['node', 'script.js'];
@@ -1349,7 +1341,7 @@ describe('mergeExcludeTools', () => {
   it('should return an empty array when no excludeTools are specified and it is interactive', async () => {
     process.stdin.isTTY = true;
     const settings: Settings = {};
-    const extensions: Extension[] = [];
+    const extensions: GeminiCLIExtension[] = [];
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments({} as Settings);
     const config = await loadCliConfig(
@@ -1368,7 +1360,7 @@ describe('mergeExcludeTools', () => {
   it('should return default excludes when no excludeTools are specified and it is not interactive', async () => {
     process.stdin.isTTY = false;
     const settings: Settings = {};
-    const extensions: Extension[] = [];
+    const extensions: GeminiCLIExtension[] = [];
     process.argv = ['node', 'script.js', '-p', 'test'];
     const argv = await parseArguments({} as Settings);
     const config = await loadCliConfig(
@@ -1388,7 +1380,7 @@ describe('mergeExcludeTools', () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments({} as Settings);
     const settings: Settings = { tools: { exclude: ['tool1', 'tool2'] } };
-    const extensions: Extension[] = [];
+    const extensions: GeminiCLIExtension[] = [];
     const config = await loadCliConfig(
       settings,
       extensions,
@@ -1407,15 +1399,14 @@ describe('mergeExcludeTools', () => {
 
   it('should handle extensions with excludeTools but no settings', async () => {
     const settings: Settings = {};
-    const extensions: Extension[] = [
+    const extensions: GeminiCLIExtension[] = [
       {
         path: '/path/to/ext',
-        config: {
-          name: 'ext1',
-          version: '1.0.0',
-          excludeTools: ['tool1', 'tool2'],
-        },
+        name: 'ext1',
+        version: '1.0.0',
+        excludeTools: ['tool1', 'tool2'],
         contextFiles: [],
+        isActive: true,
       },
     ];
     process.argv = ['node', 'script.js'];
@@ -1438,15 +1429,14 @@ describe('mergeExcludeTools', () => {
 
   it('should not modify the original settings object', async () => {
     const settings: Settings = { tools: { exclude: ['tool1'] } };
-    const extensions: Extension[] = [
+    const extensions: GeminiCLIExtension[] = [
       {
         path: '/path/to/ext',
-        config: {
-          name: 'ext1',
-          version: '1.0.0',
-          excludeTools: ['tool2'],
-        },
+        name: 'ext1',
+        version: '1.0.0',
+        excludeTools: ['tool2'],
         contextFiles: [],
+        isActive: true,
       },
     ];
     const originalSettings = JSON.parse(JSON.stringify(settings));
@@ -1482,7 +1472,7 @@ describe('Approval mode tool exclusion logic', () => {
     process.argv = ['node', 'script.js', '-p', 'test'];
     const argv = await parseArguments({} as Settings);
     const settings: Settings = {};
-    const extensions: Extension[] = [];
+    const extensions: GeminiCLIExtension[] = [];
 
     const config = await loadCliConfig(
       settings,
@@ -1512,7 +1502,7 @@ describe('Approval mode tool exclusion logic', () => {
     ];
     const argv = await parseArguments({} as Settings);
     const settings: Settings = {};
-    const extensions: Extension[] = [];
+    const extensions: GeminiCLIExtension[] = [];
 
     const config = await loadCliConfig(
       settings,
@@ -1542,7 +1532,7 @@ describe('Approval mode tool exclusion logic', () => {
     ];
     const argv = await parseArguments({} as Settings);
     const settings: Settings = {};
-    const extensions: Extension[] = [];
+    const extensions: GeminiCLIExtension[] = [];
 
     const config = await loadCliConfig(
       settings,
@@ -1572,7 +1562,7 @@ describe('Approval mode tool exclusion logic', () => {
     ];
     const argv = await parseArguments({} as Settings);
     const settings: Settings = {};
-    const extensions: Extension[] = [];
+    const extensions: GeminiCLIExtension[] = [];
 
     const config = await loadCliConfig(
       settings,
@@ -1595,7 +1585,7 @@ describe('Approval mode tool exclusion logic', () => {
     process.argv = ['node', 'script.js', '--yolo', '-p', 'test'];
     const argv = await parseArguments({} as Settings);
     const settings: Settings = {};
-    const extensions: Extension[] = [];
+    const extensions: GeminiCLIExtension[] = [];
 
     const config = await loadCliConfig(
       settings,
@@ -1629,7 +1619,7 @@ describe('Approval mode tool exclusion logic', () => {
       process.argv = testCase.args;
       const argv = await parseArguments({} as Settings);
       const settings: Settings = {};
-      const extensions: Extension[] = [];
+      const extensions: GeminiCLIExtension[] = [];
 
       const config = await loadCliConfig(
         settings,
@@ -1660,7 +1650,7 @@ describe('Approval mode tool exclusion logic', () => {
     ];
     const argv = await parseArguments({} as Settings);
     const settings: Settings = { tools: { exclude: ['custom_tool'] } };
-    const extensions: Extension[] = [];
+    const extensions: GeminiCLIExtension[] = [];
 
     const config = await loadCliConfig(
       settings,
@@ -1690,7 +1680,7 @@ describe('Approval mode tool exclusion logic', () => {
     };
 
     const settings: Settings = {};
-    const extensions: Extension[] = [];
+    const extensions: GeminiCLIExtension[] = [];
     await expect(
       loadCliConfig(
         settings,
@@ -1972,16 +1962,20 @@ describe('loadCliConfig with allowed-mcp-server-names', () => {
 });
 
 describe('loadCliConfig extensions', () => {
-  const mockExtensions: Extension[] = [
+  const mockExtensions: GeminiCLIExtension[] = [
     {
       path: '/path/to/ext1',
-      config: { name: 'ext1', version: '1.0.0' },
+      name: 'ext1',
+      version: '1.0.0',
       contextFiles: ['/path/to/ext1.md'],
+      isActive: true,
     },
     {
       path: '/path/to/ext2',
-      config: { name: 'ext2', version: '1.0.0' },
+      name: 'ext2',
+      version: '1.0.0',
       contextFiles: ['/path/to/ext2.md'],
+      isActive: true,
     },
   ];
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -15,6 +15,7 @@ import type {
   FileFilteringOptions,
   MCPServerConfig,
   OutputFormat,
+  GeminiCLIExtension,
 } from '@google/gemini-cli-core';
 import { extensionsCommand } from '../commands/extensions.js';
 import {
@@ -36,7 +37,6 @@ import {
 } from '@google/gemini-cli-core';
 import type { Settings } from './settings.js';
 
-import type { Extension } from './extension.js';
 import { annotateActiveExtensions } from './extension.js';
 import { getCliVersion } from '../utils/version.js';
 import { loadSandboxConfig } from './sandboxConfig.js';
@@ -441,7 +441,7 @@ export function isDebugMode(argv: CliArgs): boolean {
 
 export async function loadCliConfig(
   settings: Settings,
-  extensions: Extension[],
+  extensions: GeminiCLIExtension[],
   extensionEnablementManager: ExtensionEnablementManager,
   sessionId: string,
   argv: CliArgs,
@@ -745,30 +745,28 @@ function allowedMcpServers(
   return mcpServers;
 }
 
-function mergeMcpServers(settings: Settings, extensions: Extension[]) {
+function mergeMcpServers(settings: Settings, extensions: GeminiCLIExtension[]) {
   const mcpServers = { ...(settings.mcpServers || {}) };
   for (const extension of extensions) {
-    Object.entries(extension.config.mcpServers || {}).forEach(
-      ([key, server]) => {
-        if (mcpServers[key]) {
-          logger.warn(
-            `Skipping extension MCP config for server with key "${key}" as it already exists.`,
-          );
-          return;
-        }
-        mcpServers[key] = {
-          ...server,
-          extensionName: extension.config.name,
-        };
-      },
-    );
+    Object.entries(extension.mcpServers || {}).forEach(([key, server]) => {
+      if (mcpServers[key]) {
+        logger.warn(
+          `Skipping extension MCP config for server with key "${key}" as it already exists.`,
+        );
+        return;
+      }
+      mcpServers[key] = {
+        ...server,
+        extensionName: extension.name,
+      };
+    });
   }
   return mcpServers;
 }
 
 function mergeExcludeTools(
   settings: Settings,
-  extensions: Extension[],
+  extensions: GeminiCLIExtension[],
   extraExcludes?: string[] | undefined,
 ): string[] {
   const allExcludeTools = new Set([
@@ -776,7 +774,7 @@ function mergeExcludeTools(
     ...(extraExcludes || []),
   ]);
   for (const extension of extensions) {
-    for (const tool of extension.config.excludeTools || []) {
+    for (const tool of extension.excludeTools || []) {
       allExcludeTools.add(tool);
     }
   }

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -45,14 +45,14 @@ export const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
 export const INSTALL_METADATA_FILENAME = '.gemini-extension-install.json';
 
-export interface Extension {
-  path: string;
-  config: ExtensionConfig;
-  contextFiles: string[];
-  installMetadata?: ExtensionInstallMetadata | undefined;
-}
-
-export interface ExtensionConfig {
+/**
+ * Extension definition as written to disk in gemini-extension.json files.
+ * This should *not* be referenced outside of the logic for reading files.
+ * If information is required for manipulating extensions (load, unload, update)
+ * outside of the loading process that data needs to be stored on the
+ * GeminiCLIExtension class defined in Core.
+ */
+interface ExtensionConfig {
   name: string;
   version: string;
   mcpServers?: Record<string, MCPServerConfig>;
@@ -96,7 +96,9 @@ export class ExtensionStorage {
   }
 }
 
-export function getWorkspaceExtensions(workspaceDir: string): Extension[] {
+export function getWorkspaceExtensions(
+  workspaceDir: string,
+): GeminiCLIExtension[] {
   // If the workspace dir is the user extensions dir, there are no workspace extensions.
   if (path.resolve(workspaceDir) === path.resolve(os.homedir())) {
     return [];
@@ -112,7 +114,7 @@ export async function copyExtension(
 }
 
 export async function performWorkspaceExtensionMigration(
-  extensions: Extension[],
+  extensions: GeminiCLIExtension[],
   requestConsent: (consent: string) => Promise<boolean>,
 ): Promise<string[]> {
   const failedInstallNames: string[] = [];
@@ -125,7 +127,7 @@ export async function performWorkspaceExtensionMigration(
       };
       await installExtension(installMetadata, requestConsent);
     } catch (_) {
-      failedInstallNames.push(extension.config.name);
+      failedInstallNames.push(extension.name);
     }
   }
   return failedInstallNames;
@@ -148,7 +150,7 @@ function getTelemetryConfig(cwd: string) {
 export function loadExtensions(
   extensionEnablementManager: ExtensionEnablementManager,
   workspaceDir: string = process.cwd(),
-): Extension[] {
+): GeminiCLIExtension[] {
   const settings = loadSettings(workspaceDir).merged;
   const allExtensions = [...loadUserExtensions()];
 
@@ -160,41 +162,41 @@ export function loadExtensions(
     allExtensions.push(...getWorkspaceExtensions(workspaceDir));
   }
 
-  const uniqueExtensions = new Map<string, Extension>();
+  const uniqueExtensions = new Map<string, GeminiCLIExtension>();
 
   for (const extension of allExtensions) {
     if (
-      !uniqueExtensions.has(extension.config.name) &&
-      extensionEnablementManager.isEnabled(extension.config.name, workspaceDir)
+      !uniqueExtensions.has(extension.name) &&
+      extensionEnablementManager.isEnabled(extension.name, workspaceDir)
     ) {
-      uniqueExtensions.set(extension.config.name, extension);
+      uniqueExtensions.set(extension.name, extension);
     }
   }
 
   return Array.from(uniqueExtensions.values());
 }
 
-export function loadUserExtensions(): Extension[] {
+export function loadUserExtensions(): GeminiCLIExtension[] {
   const userExtensions = loadExtensionsFromDir(os.homedir());
 
-  const uniqueExtensions = new Map<string, Extension>();
+  const uniqueExtensions = new Map<string, GeminiCLIExtension>();
   for (const extension of userExtensions) {
-    if (!uniqueExtensions.has(extension.config.name)) {
-      uniqueExtensions.set(extension.config.name, extension);
+    if (!uniqueExtensions.has(extension.name)) {
+      uniqueExtensions.set(extension.name, extension);
     }
   }
 
   return Array.from(uniqueExtensions.values());
 }
 
-export function loadExtensionsFromDir(dir: string): Extension[] {
+export function loadExtensionsFromDir(dir: string): GeminiCLIExtension[] {
   const storage = new Storage(dir);
   const extensionsDir = storage.getExtensionsDir();
   if (!fs.existsSync(extensionsDir)) {
     return [];
   }
 
-  const extensions: Extension[] = [];
+  const extensions: GeminiCLIExtension[] = [];
   for (const subdir of fs.readdirSync(extensionsDir)) {
     const extensionDir = path.join(extensionsDir, subdir);
 
@@ -206,7 +208,9 @@ export function loadExtensionsFromDir(dir: string): Extension[] {
   return extensions;
 }
 
-export function loadExtension(context: LoadExtensionContext): Extension | null {
+export function loadExtension(
+  context: LoadExtensionContext,
+): GeminiCLIExtension | null {
   const { extensionDir, workspaceDir } = context;
   if (!fs.statSync(extensionDir).isDirectory()) {
     return null;
@@ -243,10 +247,14 @@ export function loadExtension(context: LoadExtensionContext): Extension | null {
       .filter((contextFilePath) => fs.existsSync(contextFilePath));
 
     return {
+      name: config.name,
+      version: config.version,
       path: effectiveExtensionPath,
-      config,
       contextFiles,
       installMetadata,
+      mcpServers: config.mcpServers,
+      excludeTools: config.excludeTools,
+      isActive: true, // Barring any other signals extensions should be considered Active.
     };
   } catch (e) {
     console.error(
@@ -261,7 +269,7 @@ export function loadExtension(context: LoadExtensionContext): Extension | null {
 export function loadExtensionByName(
   name: string,
   workspaceDir: string = process.cwd(),
-): Extension | null {
+): GeminiCLIExtension | null {
   const userExtensionsDir = ExtensionStorage.getUserExtensionsDir();
   if (!fs.existsSync(userExtensionsDir)) {
     return null;
@@ -273,10 +281,7 @@ export function loadExtensionByName(
       continue;
     }
     const extension = loadExtension({ extensionDir, workspaceDir });
-    if (
-      extension &&
-      extension.config.name.toLowerCase() === name.toLowerCase()
-    ) {
+    if (extension && extension.name.toLowerCase() === name.toLowerCase()) {
       return extension;
     }
   }
@@ -320,17 +325,14 @@ function getContextFileNames(config: ExtensionConfig): string[] {
  * @param workspaceDir The current workspace directory.
  */
 export function annotateActiveExtensions(
-  extensions: Extension[],
+  extensions: GeminiCLIExtension[],
   workspaceDir: string,
   manager: ExtensionEnablementManager,
 ): GeminiCLIExtension[] {
   manager.validateExtensionOverrides(extensions);
   return extensions.map((extension) => ({
-    name: extension.config.name,
-    version: extension.config.version,
-    isActive: manager.isEnabled(extension.config.name, workspaceDir),
-    path: extension.path,
-    installMetadata: extension.installMetadata,
+    ...extension,
+    isActive: manager.isEnabled(extension.name, workspaceDir),
   }));
 }
 
@@ -489,7 +491,7 @@ export async function installExtension(
       const installedExtensions = loadUserExtensions();
       if (
         installedExtensions.some(
-          (installed) => installed.config.name === newExtensionName,
+          (installed) => installed.name === newExtensionName,
         )
       ) {
         throw new Error(
@@ -672,11 +674,10 @@ export async function uninstallExtension(
   const installedExtensions = loadUserExtensions();
   const extensionName = installedExtensions.find(
     (installed) =>
-      installed.config.name.toLowerCase() ===
-        extensionIdentifier.toLowerCase() ||
+      installed.name.toLowerCase() === extensionIdentifier.toLowerCase() ||
       installed.installMetadata?.source.toLowerCase() ===
         extensionIdentifier.toLowerCase(),
-  )?.config.name;
+  )?.name;
   if (!extensionName) {
     throw new Error(`Extension not found.`);
   }
@@ -698,20 +699,17 @@ export async function uninstallExtension(
 }
 
 export function toOutputString(
-  extension: Extension,
+  extension: GeminiCLIExtension,
   workspaceDir: string,
 ): string {
   const manager = new ExtensionEnablementManager(
     ExtensionStorage.getUserExtensionsDir(),
   );
-  const userEnabled = manager.isEnabled(extension.config.name, os.homedir());
-  const workspaceEnabled = manager.isEnabled(
-    extension.config.name,
-    workspaceDir,
-  );
+  const userEnabled = manager.isEnabled(extension.name, os.homedir());
+  const workspaceEnabled = manager.isEnabled(extension.name, workspaceDir);
 
   const status = workspaceEnabled ? chalk.green('✓') : chalk.red('✗');
-  let output = `${status} ${extension.config.name} (${extension.config.version})`;
+  let output = `${status} ${extension.name} (${extension.version})`;
   output += `\n Path: ${extension.path}`;
   if (extension.installMetadata) {
     output += `\n Source: ${extension.installMetadata.source} (Type: ${extension.installMetadata.type})`;
@@ -730,15 +728,15 @@ export function toOutputString(
       output += `\n  ${contextFile}`;
     });
   }
-  if (extension.config.mcpServers) {
+  if (extension.mcpServers) {
     output += `\n MCP servers:`;
-    Object.keys(extension.config.mcpServers).forEach((key) => {
+    Object.keys(extension.mcpServers).forEach((key) => {
       output += `\n  ${key}`;
     });
   }
-  if (extension.config.excludeTools) {
+  if (extension.excludeTools) {
     output += `\n Excluded tools:`;
-    extension.config.excludeTools.forEach((tool) => {
+    extension.excludeTools.forEach((tool) => {
       output += `\n  ${tool}`;
     });
   }

--- a/packages/cli/src/config/extensions/extensionEnablement.test.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.test.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ExtensionEnablementManager, Override } from './extensionEnablement.js';
-import type { Extension } from '../extension.js';
+import type { GeminiCLIExtension } from '@google/gemini-cli-core';
 
 // Helper to create a temporary directory for testing
 function createTestDir() {
@@ -286,9 +286,9 @@ describe('ExtensionEnablementManager', () => {
         'ext-two',
       ]);
       const extensions = [
-        { config: { name: 'ext-one' } },
-        { config: { name: 'ext-two' } },
-      ] as Extension[];
+        { name: 'ext-one' },
+        { name: 'ext-two' },
+      ] as GeminiCLIExtension[];
       manager.validateExtensionOverrides(extensions);
       expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
@@ -300,9 +300,9 @@ describe('ExtensionEnablementManager', () => {
         'ext-another-invalid',
       ]);
       const extensions = [
-        { config: { name: 'ext-one' } },
-        { config: { name: 'ext-two' } },
-      ] as Extension[];
+        { name: 'ext-one' },
+        { name: 'ext-two' },
+      ] as GeminiCLIExtension[];
       manager.validateExtensionOverrides(extensions);
       expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
       expect(consoleErrorSpy).toHaveBeenCalledWith(

--- a/packages/cli/src/config/extensions/extensionEnablement.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.ts
@@ -6,7 +6,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { type Extension } from '../extension.js';
+import type { GeminiCLIExtension } from '@google/gemini-cli-core';
 
 export interface ExtensionEnablementConfig {
   overrides: string[];
@@ -119,13 +119,11 @@ export class ExtensionEnablementManager {
       enabledExtensionNames?.map((name) => name.toLowerCase()) ?? [];
   }
 
-  validateExtensionOverrides(extensions: Extension[]) {
+  validateExtensionOverrides(extensions: GeminiCLIExtension[]) {
     for (const name of this.enabledExtensionNamesOverride) {
       if (name === 'none') continue;
       if (
-        !extensions.some(
-          (ext) => ext.config.name.toLowerCase() === name.toLowerCase(),
-        )
+        !extensions.some((ext) => ext.name.toLowerCase() === name.toLowerCase())
       ) {
         console.error(`Extension not found: ${name}`);
       }

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -131,6 +131,7 @@ describe('git extension helpers', () => {
           type: 'link',
           source: '',
         },
+        contextFiles: [],
       };
       let result: ExtensionUpdateState | undefined = undefined;
       await checkForExtensionUpdate(
@@ -150,6 +151,7 @@ describe('git extension helpers', () => {
           type: 'git',
           source: '',
         },
+        contextFiles: [],
       };
       mockGit.getRemotes.mockResolvedValue([]);
       let result: ExtensionUpdateState | undefined = undefined;
@@ -170,6 +172,7 @@ describe('git extension helpers', () => {
           type: 'git',
           source: 'my/ext',
         },
+        contextFiles: [],
       };
       mockGit.getRemotes.mockResolvedValue([
         { name: 'origin', refs: { fetch: 'http://my-repo.com' } },
@@ -195,6 +198,7 @@ describe('git extension helpers', () => {
           type: 'git',
           source: 'my/ext',
         },
+        contextFiles: [],
       };
       mockGit.getRemotes.mockResolvedValue([
         { name: 'origin', refs: { fetch: 'http://my-repo.com' } },
@@ -220,6 +224,7 @@ describe('git extension helpers', () => {
           type: 'git',
           source: 'my/ext',
         },
+        contextFiles: [],
       };
       mockGit.getRemotes.mockRejectedValue(new Error('git error'));
 

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -136,7 +136,7 @@ export async function checkForExtensionUpdate(
       setExtensionUpdateState(ExtensionUpdateState.ERROR);
       return;
     }
-    if (newExtension.config.version !== extension.version) {
+    if (newExtension.version !== extension.version) {
       setExtensionUpdateState(ExtensionUpdateState.UPDATE_AVAILABLE);
       return;
     }

--- a/packages/cli/src/config/extensions/update.ts
+++ b/packages/cli/src/config/extensions/update.ts
@@ -90,7 +90,7 @@ export async function updateExtension(
       });
       throw new Error('Updated extension not found after installation.');
     }
-    const updatedVersion = updatedExtension.config.version;
+    const updatedVersion = updatedExtension.version;
     dispatchExtensionStateUpdate({
       type: 'SET_STATE',
       payload: {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -354,7 +354,7 @@ export async function main() {
     if (config.getListExtensions()) {
       console.log('Installed extensions:');
       for (const extension of extensions) {
-        console.log(`- ${extension.config.name}`);
+        console.log(`- ${extension.name}`);
       }
       process.exit(0);
     }

--- a/packages/cli/src/ui/components/WorkspaceMigrationDialog.tsx
+++ b/packages/cli/src/ui/components/WorkspaceMigrationDialog.tsx
@@ -5,16 +5,14 @@
  */
 
 import { Box, Text, useInput } from 'ink';
-import {
-  type Extension,
-  performWorkspaceExtensionMigration,
-} from '../../config/extension.js';
+import type { GeminiCLIExtension } from '@google/gemini-cli-core';
+import { performWorkspaceExtensionMigration } from '../../config/extension.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import { theme } from '../semantic-colors.js';
 import { useState } from 'react';
 
 export function WorkspaceMigrationDialog(props: {
-  workspaceExtensions: Extension[];
+  workspaceExtensions: GeminiCLIExtension[];
   onOpen: () => void;
   onClose: () => void;
 }) {
@@ -92,7 +90,7 @@ export function WorkspaceMigrationDialog(props: {
 
       <Box flexDirection="column" marginTop={1} marginLeft={2}>
         {workspaceExtensions.map((extension) => (
-          <Text key={extension.config.name}>- {extension.config.name}</Text>
+          <Text key={extension.name}>- {extension.name}</Text>
         ))}
       </Box>
       <Box marginTop={1}>

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.test.ts
@@ -70,6 +70,7 @@ describe('useExtensionUpdates', () => {
           source: 'https://some/repo',
           autoUpdate: false,
         },
+        contextFiles: [],
       },
     ];
     const addItem = vi.fn();
@@ -262,6 +263,7 @@ describe('useExtensionUpdates', () => {
           source: 'https://some/repo1',
           autoUpdate: false,
         },
+        contextFiles: [],
       },
       {
         name: 'test-extension-2',
@@ -274,6 +276,7 @@ describe('useExtensionUpdates', () => {
           source: 'https://some/repo2',
           autoUpdate: false,
         },
+        contextFiles: [],
       },
     ];
     const addItem = vi.fn();

--- a/packages/cli/src/ui/hooks/useWorkspaceMigration.ts
+++ b/packages/cli/src/ui/hooks/useWorkspaceMigration.ts
@@ -5,19 +5,17 @@
  */
 
 import { useState, useEffect } from 'react';
-import {
-  type Extension,
-  getWorkspaceExtensions,
-} from '../../config/extension.js';
+import type { GeminiCLIExtension } from '@google/gemini-cli-core';
+import { getWorkspaceExtensions } from '../../config/extension.js';
 import { type LoadedSettings, SettingScope } from '../../config/settings.js';
 import process from 'node:process';
 
 export function useWorkspaceMigration(settings: LoadedSettings) {
   const [showWorkspaceMigrationDialog, setShowWorkspaceMigrationDialog] =
     useState(false);
-  const [workspaceExtensions, setWorkspaceExtensions] = useState<Extension[]>(
-    [],
-  );
+  const [workspaceExtensions, setWorkspaceExtensions] = useState<
+    GeminiCLIExtension[]
+  >([]);
 
   useEffect(() => {
     // Default to true if not set.

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -11,6 +11,7 @@ import type {
   GeminiChat,
   ToolResult,
   ToolCallConfirmationDetails,
+  GeminiCLIExtension,
 } from '@google/gemini-cli-core';
 import {
   AuthType,
@@ -40,7 +41,7 @@ import * as path from 'node:path';
 import { z } from 'zod';
 
 import { randomUUID } from 'node:crypto';
-import { ExtensionStorage, type Extension } from '../config/extension.js';
+import { ExtensionStorage } from '../config/extension.js';
 import type { CliArgs } from '../config/config.js';
 import { loadCliConfig } from '../config/config.js';
 import { ExtensionEnablementManager } from '../config/extensions/extensionEnablement.js';
@@ -61,7 +62,7 @@ export function resolveModel(model: string, isInFallbackMode: boolean): string {
 export async function runZedIntegration(
   config: Config,
   settings: LoadedSettings,
-  extensions: Extension[],
+  extensions: GeminiCLIExtension[],
   argv: CliArgs,
 ) {
   const stdout = Writable.toWeb(process.stdout) as WritableStream;
@@ -88,7 +89,7 @@ class GeminiAgent {
   constructor(
     private config: Config,
     private settings: LoadedSettings,
-    private extensions: Extension[],
+    private extensions: GeminiCLIExtension[],
     private argv: CliArgs,
     private client: acp.Client,
   ) {}

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -116,12 +116,21 @@ export interface OutputSettings {
   format?: OutputFormat;
 }
 
+/**
+ * All information required in CLI to handle an extension. Defined in Core so
+ * that the collection of loaded, active, and inactive extensions can be passed
+ * around on the config object though Core does not use this information
+ * directly.
+ */
 export interface GeminiCLIExtension {
   name: string;
   version: string;
   isActive: boolean;
   path: string;
   installMetadata?: ExtensionInstallMetadata;
+  mcpServers?: Record<string, MCPServerConfig>;
+  contextFiles: string[];
+  excludeTools?: string[];
 }
 
 export interface ExtensionInstallMetadata {


### PR DESCRIPTION
## TLDR

Effectively just typing updates to pave the way for more easily handling extensions during dynamic loading/unloading within a session

## Dive Deeper

Extension and GeminiGLIExtension had drifted and there were references to the internal file type of the extension json file. Collapsed the two typings into one and ensured the internal file structure was not accessed outside of loading the extension.  Also updated the logic copied into the a2a package to use the new typing (though still duplicates the loading logic)

This is a preparation for being able to keep all extensions loaded but just marked as active or inactive (which will then enable dynamic activation)  This was mostly because both the GeminiCLIExtension in Core and the Extension type in CLI both didn’t have enough information on them to individually support dynamic enablement.  It made sense to standardize on GeminiCLIExtension

This included adding an “IsActive” bit into the core typing.

## Reviewer Test Plan

Core tests pass, running locally extensions are still loaded as expected and report status as expected

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Internal discussion about paving the way to support dynamic loading (okay to consider during a period of cleanup)