### PR TITLE
feat(ci): Add some very basic smoke testing to CI.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,12 @@ jobs:
           NO_COLOR: true
         run: 'npm run test:ci'
 
+      - name: 'Bundle'
+        run: 'npm run bundle'
+
+      - name: 'Smoke test bundle'
+        run: 'node ./bundle/gemini.js --version'
+
       - name: 'Wait for file system sync'
         run: 'sleep 2'
 
@@ -185,6 +191,12 @@ jobs:
         env:
           NO_COLOR: true
         run: 'npm run test:ci -- --coverage.enabled=false'
+
+      - name: 'Bundle'
+        run: 'npm run bundle'
+
+      - name: 'Smoke test bundle'
+        run: 'node ./bundle/gemini.js --version'
 
       - name: 'Wait for file system sync'
         run: 'sleep 2'
@@ -320,6 +332,14 @@ jobs:
           UV_THREADPOOL_SIZE: '32'
           NODE_ENV: 'test'
         run: 'npm run test:ci -- --coverage.enabled=false'
+        shell: 'pwsh'
+
+      - name: 'Bundle'
+        run: 'npm run bundle'
+        shell: 'pwsh'
+
+      - name: 'Smoke test bundle'
+        run: 'node ./bundle/gemini.js --version'
         shell: 'pwsh'
 
   ci:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -8,16 +8,19 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'The branch, tag, or SHA to release from.'
+        description: 'The branch, tag, or SHA to test on.'
         required: false
         type: 'string'
         default: 'main'
       dry-run:
         description: 'Run a dry-run of the smoke test; No bug will be created'
+        required: true
+        type: 'boolean'
+        default: true
 
 jobs:
   smoke-test:
-    runs-on: 'ubuntu-latest'
+    runs-on: 'self-hosted'
     permissions:
       contents: 'read'
       issues: 'write'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,46 @@
+name: 'On Merge Smoke Test'
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'The branch, tag, or SHA to release from.'
+        required: false
+        type: 'string'
+        default: 'main'
+      dry-run:
+        description: 'Run a dry-run of the smoke test; No bug will be created'
+
+jobs:
+  smoke-test:
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      issues: 'write'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
+        with:
+          ref: '${{ github.event.inputs.ref || github.sha }}'
+          fetch-depth: 0
+      - name: 'Install Dependencies'
+        run: 'npm ci'
+      - name: 'Build bundle'
+        run: 'npm run bundle'
+      - name: 'Smoke test bundle'
+        run: 'node ./bundle/gemini.js --version'
+      - name: 'Create Issue on Failure'
+        if: '${{ failure() && github.event.inputs.dry-run == false }}'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          DETAILS_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          REF: '${{ github.event.inputs.ref }}'
+        run: |
+          gh issue create \
+            --title 'Smoke test failed on ${REF} @ $(date +'%Y-%m-%d')' \
+            --body 'Smoke test build failed. See the full run for details: ${DETAILS_URL}' \
+            --label 'kind/bug,priority/p0'


### PR DESCRIPTION
## TLDR

- Add a very basic smoke test to CI.YML to ensure that Gemini CLI binary can fire up.
- Add an on-main-merge smoke test.

Commentary: We could potentially recycle this bundle+run action, but I didn't really feel like the juice was worth the squeeze. If you feel strongly, I could be convinced to push this out as an action.

## Reviewer Test Plan

- CI.yml Run @ https://github.com/google-gemini/gemini-cli/actions/runs/18202341344/job/51824236216
- Smoke-test.yml run (from my fork) @ https://github.com/richieforeman/gemini-cli/actions/runs/18206615280/job/51838417836

## Testing Matrix

N/A

## Linked issues / bugs

Related: https://github.com/google-gemini/gemini-cli/issues/3696