### PR TITLE
feat(core): add telemetry for subagent execution

### DIFF
--- a/packages/core/src/agents/executor.test.ts
+++ b/packages/core/src/agents/executor.test.ts
@@ -299,9 +299,8 @@ describe('AgentExecutor', () => {
         mockConfig,
         expect.objectContaining({
           terminate_reason: AgentTerminateMode.ERROR,
-          error_message: expect.stringContaining(
-            'Missing required input parameters',
-          ),
+          // Error message should be sanitized to just the error name for telemetry
+          error_message: 'Error',
         }),
       );
     });

--- a/packages/core/src/agents/executor.test.ts
+++ b/packages/core/src/agents/executor.test.ts
@@ -299,8 +299,6 @@ describe('AgentExecutor', () => {
         mockConfig,
         expect.objectContaining({
           terminate_reason: AgentTerminateMode.ERROR,
-          // Error message should be sanitized to just the error name for telemetry
-          error_message: 'Error',
         }),
       );
     });

--- a/packages/core/src/agents/executor.test.ts
+++ b/packages/core/src/agents/executor.test.ts
@@ -6,13 +6,6 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AgentExecutor, type ActivityCallback } from './executor.js';
-import type {
-  AgentDefinition,
-  AgentInputs,
-  SubagentActivityEvent,
-  OutputConfig,
-} from './types.js';
-import { AgentTerminateMode } from './types.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import { ToolRegistry } from '../tools/tool-registry.js';
 import { LSTool } from '../tools/ls.js';
@@ -32,6 +25,16 @@ import type { Config } from '../config/config.js';
 import { MockTool } from '../test-utils/mock-tool.js';
 import { getDirectoryContextString } from '../utils/environmentContext.js';
 import { z } from 'zod';
+import { promptIdContext } from '../utils/promptIdContext.js';
+import { logAgentStart, logAgentFinish } from '../telemetry/loggers.js';
+import { AgentStartEvent, AgentFinishEvent } from '../telemetry/types.js';
+import type {
+  AgentDefinition,
+  AgentInputs,
+  SubagentActivityEvent,
+  OutputConfig,
+} from './types.js';
+import { AgentTerminateMode } from './types.js';
 
 const { mockSendMessageStream, mockExecuteToolCall } = vi.hoisted(() => ({
   mockSendMessageStream: vi.fn(),
@@ -54,8 +57,29 @@ vi.mock('../core/nonInteractiveToolExecutor.js', () => ({
 
 vi.mock('../utils/environmentContext.js');
 
+vi.mock('../telemetry/loggers.js', () => ({
+  logAgentStart: vi.fn(),
+  logAgentFinish: vi.fn(),
+}));
+
+vi.mock('../utils/promptIdContext.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../utils/promptIdContext.js')>();
+  return {
+    ...actual,
+    promptIdContext: {
+      ...actual.promptIdContext,
+      getStore: vi.fn(),
+      run: vi.fn((_id, fn) => fn()),
+    },
+  };
+});
+
 const MockedGeminiChat = vi.mocked(GeminiChat);
 const mockedGetDirectoryContextString = vi.mocked(getDirectoryContextString);
+const mockedPromptIdContext = vi.mocked(promptIdContext);
+const mockedLogAgentStart = vi.mocked(logAgentStart);
+const mockedLogAgentFinish = vi.mocked(logAgentFinish);
 
 // Constants for testing
 const TASK_COMPLETE_TOOL_NAME = 'complete_task';
@@ -160,6 +184,10 @@ describe('AgentExecutor', () => {
     vi.resetAllMocks();
     mockSendMessageStream.mockReset();
     mockExecuteToolCall.mockReset();
+    mockedLogAgentStart.mockReset();
+    mockedLogAgentFinish.mockReset();
+    mockedPromptIdContext.getStore.mockReset();
+    mockedPromptIdContext.run.mockImplementation((_id, fn) => fn());
 
     MockedGeminiChat.mockImplementation(
       () =>
@@ -229,9 +257,55 @@ describe('AgentExecutor', () => {
       expect(agentRegistry.getAllToolNames()).toHaveLength(2);
       expect(agentRegistry.getTool(MOCK_TOOL_NOT_ALLOWED.name)).toBeUndefined();
     });
+
+    it('should use parentPromptId from context to create agentId', async () => {
+      const parentId = 'parent-id';
+      mockedPromptIdContext.getStore.mockReturnValue(parentId);
+
+      const definition = createTestDefinition();
+      const executor = await AgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+
+      expect(executor['agentId']).toMatch(
+        new RegExp(`^${parentId}-${definition.name}-`),
+      );
+    });
   });
 
   describe('run (Execution Loop and Logic)', () => {
+    it('should log AgentFinish with error if run throws', async () => {
+      const definition = createTestDefinition();
+      // Make the definition invalid to cause an error during run
+      definition.inputConfig.inputs = {
+        goal: { type: 'string', required: true, description: 'goal' },
+      };
+      const executor = await AgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+
+      // Run without inputs to trigger validation error
+      await expect(executor.run({}, signal)).rejects.toThrow(
+        /Missing required input parameters/,
+      );
+
+      expect(mockedLogAgentStart).toHaveBeenCalledTimes(1);
+      expect(mockedLogAgentFinish).toHaveBeenCalledTimes(1);
+      expect(mockedLogAgentFinish).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          terminate_reason: AgentTerminateMode.ERROR,
+          error_message: expect.stringContaining(
+            'Missing required input parameters',
+          ),
+        }),
+      );
+    });
+
     it('should execute successfully when model calls complete_task with output (Happy Path with Output)', async () => {
       const definition = createTestDefinition();
       const executor = await AgentExecutor.create(
@@ -311,6 +385,34 @@ describe('AgentExecutor', () => {
 
       expect(output.result).toBe('Found file1.txt');
       expect(output.terminate_reason).toBe(AgentTerminateMode.GOAL);
+
+      // Telemetry checks
+      expect(mockedLogAgentStart).toHaveBeenCalledTimes(1);
+      expect(mockedLogAgentStart).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(AgentStartEvent),
+      );
+      expect(mockedLogAgentFinish).toHaveBeenCalledTimes(1);
+      expect(mockedLogAgentFinish).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(AgentFinishEvent),
+      );
+      const finishEvent = mockedLogAgentFinish.mock.calls[0][1];
+      expect(finishEvent.terminate_reason).toBe(AgentTerminateMode.GOAL);
+
+      // Context checks
+      expect(mockedPromptIdContext.run).toHaveBeenCalledTimes(2); // Two turns
+      const agentId = executor['agentId'];
+      expect(mockedPromptIdContext.run).toHaveBeenNthCalledWith(
+        1,
+        `${agentId}#0`,
+        expect.any(Function),
+      );
+      expect(mockedPromptIdContext.run).toHaveBeenNthCalledWith(
+        2,
+        `${agentId}#1`,
+        expect.any(Function),
+      );
 
       expect(activities).toEqual(
         expect.arrayContaining([
@@ -424,6 +526,14 @@ describe('AgentExecutor', () => {
 
       expect(output.terminate_reason).toBe(AgentTerminateMode.ERROR);
       expect(output.result).toBe(expectedError);
+
+      // Telemetry check for error
+      expect(mockedLogAgentFinish).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          terminate_reason: AgentTerminateMode.ERROR,
+        }),
+      );
 
       expect(activities).toContainEqual(
         expect.objectContaining({

--- a/packages/core/src/agents/executor.ts
+++ b/packages/core/src/agents/executor.ts
@@ -28,6 +28,9 @@ import { MemoryTool } from '../tools/memoryTool.js';
 import { ReadFileTool } from '../tools/read-file.js';
 import { ReadManyFilesTool } from '../tools/read-many-files.js';
 import { WebSearchTool } from '../tools/web-search.js';
+import { promptIdContext } from '../utils/promptIdContext.js';
+import { logAgentStart, logAgentFinish } from '../telemetry/loggers.js';
+import { AgentStartEvent, AgentFinishEvent } from '../telemetry/types.js';
 import type {
   AgentDefinition,
   AgentInputs,
@@ -104,10 +107,14 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
       await AgentExecutor.validateTools(agentToolRegistry, definition.name);
     }
 
+    // Get the parent prompt ID from context
+    const parentPromptId = promptIdContext.getStore();
+
     return new AgentExecutor(
       definition,
       runtimeContext,
       agentToolRegistry,
+      parentPromptId, // Pass to constructor
       onActivity,
     );
   }
@@ -122,6 +129,7 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
     definition: AgentDefinition<TOutput>,
     runtimeContext: Config,
     toolRegistry: ToolRegistry,
+    parentPromptId: string | undefined, // Pass it in
     onActivity?: ActivityCallback,
   ) {
     this.definition = definition;
@@ -130,7 +138,8 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
     this.onActivity = onActivity;
 
     const randomIdPart = Math.random().toString(36).slice(2, 8);
-    this.agentId = `${this.definition.name}-${randomIdPart}`;
+    const parentPrefix = parentPromptId ? `${parentPromptId}-` : '';
+    this.agentId = `${parentPrefix}${this.definition.name}-${randomIdPart}`;
   }
 
   /**
@@ -143,12 +152,18 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
   async run(inputs: AgentInputs, signal: AbortSignal): Promise<OutputObject> {
     const startTime = Date.now();
     let turnCounter = 0;
+    let terminateReason: AgentTerminateMode = AgentTerminateMode.ERROR;
+    let finalResult: string | null = null;
+    let errorMessage: string | undefined;
+
+    logAgentStart(
+      this.runtimeContext,
+      new AgentStartEvent(this.agentId, this.definition.name),
+    );
 
     try {
       const chat = await this.createChatObject(inputs);
       const tools = this.prepareToolsList();
-      let terminateReason = AgentTerminateMode.ERROR;
-      let finalResult: string | null = null;
 
       const query = this.definition.promptConfig.query
         ? templateString(this.definition.promptConfig.query, inputs)
@@ -167,14 +182,12 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
           break;
         }
 
-        // Call model
-        const promptId = `${this.runtimeContext.getSessionId()}#${this.agentId}#${turnCounter++}`;
-        const { functionCalls } = await this.callModel(
-          chat,
-          currentMessage,
-          tools,
-          signal,
+        const promptId = `${this.agentId}#${turnCounter++}`;
+
+        const { functionCalls } = await promptIdContext.run(
           promptId,
+          async () =>
+            this.callModel(chat, currentMessage, tools, signal, promptId),
         );
 
         if (signal.aborted) {
@@ -218,8 +231,21 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
         terminate_reason: terminateReason,
       };
     } catch (error) {
-      this.emitActivity('ERROR', { error: String(error) });
+      errorMessage = String(error);
+      this.emitActivity('ERROR', { error: errorMessage });
       throw error; // Re-throw the error for the parent context to handle.
+    } finally {
+      logAgentFinish(
+        this.runtimeContext,
+        new AgentFinishEvent(
+          this.agentId,
+          this.definition.name,
+          Date.now() - startTime,
+          turnCounter,
+          terminateReason,
+          errorMessage,
+        ),
+      );
     }
   }
 

--- a/packages/core/src/agents/executor.ts
+++ b/packages/core/src/agents/executor.ts
@@ -156,7 +156,6 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
     let turnCounter = 0;
     let terminateReason: AgentTerminateMode = AgentTerminateMode.ERROR;
     let finalResult: string | null = null;
-    let errorMessage: string | undefined;
 
     logAgentStart(
       this.runtimeContext,
@@ -233,11 +232,6 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
         terminate_reason: terminateReason,
       };
     } catch (error) {
-      // Sanitize the error for telemetry to avoid logging PII.
-      // We only log the error name (e.g. "TypeError") or a generic string.
-      // The full error message might contain sensitive data (e.g. file paths, content).
-      errorMessage = error instanceof Error ? error.name : 'UnknownError';
-
       this.emitActivity('ERROR', { error: String(error) });
       throw error; // Re-throw the error for the parent context to handle.
     } finally {
@@ -249,7 +243,6 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
           Date.now() - startTime,
           turnCounter,
           terminateReason,
-          errorMessage,
         ),
       );
     }

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -32,6 +32,7 @@ import {
   AgentStartEvent,
   AgentFinishEvent,
 } from '../types.js';
+import { AgentTerminateMode } from '../../agents/types.js';
 import { GIT_COMMIT_INFO, CLI_VERSION } from '../../generated/git-commit.js';
 import { UserAccountManager } from '../../utils/userAccountManager.js';
 import { InstallationManager } from '../../utils/installationManager.js';
@@ -752,7 +753,7 @@ describe('ClearcutLogger', () => {
         'TestAgent',
         1000,
         5,
-        'GOAL',
+        AgentTerminateMode.GOAL,
       );
 
       logger?.logAgentFinishEvent(event);
@@ -792,7 +793,7 @@ describe('ClearcutLogger', () => {
         'TestAgent',
         500,
         2,
-        'ERROR',
+        AgentTerminateMode.ERROR,
         'Something went wrong',
       );
 

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -781,9 +781,6 @@ describe('ClearcutLogger', () => {
         EventMetadataKey.GEMINI_CLI_AGENT_TERMINATE_REASON,
         'GOAL',
       ]);
-      expect(events[0]).not.toHaveMetadataKey(
-        EventMetadataKey.GEMINI_CLI_AGENT_ERROR_MESSAGE,
-      );
     });
 
     it('logs an event with proper fields (error)', () => {
@@ -794,7 +791,6 @@ describe('ClearcutLogger', () => {
         500,
         2,
         AgentTerminateMode.ERROR,
-        'Something went wrong',
       );
 
       logger?.logAgentFinishEvent(event);
@@ -805,10 +801,6 @@ describe('ClearcutLogger', () => {
       expect(events[0]).toHaveMetadataValue([
         EventMetadataKey.GEMINI_CLI_AGENT_TERMINATE_REASON,
         'ERROR',
-      ]);
-      expect(events[0]).toHaveMetadataValue([
-        EventMetadataKey.GEMINI_CLI_AGENT_ERROR_MESSAGE,
-        'Something went wrong',
       ]);
     });
   });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.test.ts
@@ -29,6 +29,8 @@ import {
   makeChatCompressionEvent,
   ModelRoutingEvent,
   ToolCallEvent,
+  AgentStartEvent,
+  AgentFinishEvent,
 } from '../types.js';
 import { GIT_COMMIT_INFO, CLI_VERSION } from '../../generated/git-commit.js';
 import { UserAccountManager } from '../../utils/userAccountManager.js';
@@ -716,6 +718,95 @@ describe('ClearcutLogger', () => {
       ]);
       expect(events[0]).toHaveMetadataValue([
         EventMetadataKey.GEMINI_CLI_ROUTING_FAILURE_REASON,
+        'Something went wrong',
+      ]);
+    });
+  });
+
+  describe('logAgentStartEvent', () => {
+    it('logs an event with proper fields', () => {
+      const { logger } = setup();
+      const event = new AgentStartEvent('agent-123', 'TestAgent');
+
+      logger?.logAgentStartEvent(event);
+
+      const events = getEvents(logger!);
+      expect(events.length).toBe(1);
+      expect(events[0]).toHaveEventName(EventNames.AGENT_START);
+      expect(events[0]).toHaveMetadataValue([
+        EventMetadataKey.GEMINI_CLI_AGENT_ID,
+        'agent-123',
+      ]);
+      expect(events[0]).toHaveMetadataValue([
+        EventMetadataKey.GEMINI_CLI_AGENT_NAME,
+        'TestAgent',
+      ]);
+    });
+  });
+
+  describe('logAgentFinishEvent', () => {
+    it('logs an event with proper fields (success)', () => {
+      const { logger } = setup();
+      const event = new AgentFinishEvent(
+        'agent-123',
+        'TestAgent',
+        1000,
+        5,
+        'GOAL',
+      );
+
+      logger?.logAgentFinishEvent(event);
+
+      const events = getEvents(logger!);
+      expect(events.length).toBe(1);
+      expect(events[0]).toHaveEventName(EventNames.AGENT_FINISH);
+      expect(events[0]).toHaveMetadataValue([
+        EventMetadataKey.GEMINI_CLI_AGENT_ID,
+        'agent-123',
+      ]);
+      expect(events[0]).toHaveMetadataValue([
+        EventMetadataKey.GEMINI_CLI_AGENT_NAME,
+        'TestAgent',
+      ]);
+      expect(events[0]).toHaveMetadataValue([
+        EventMetadataKey.GEMINI_CLI_AGENT_DURATION_MS,
+        '1000',
+      ]);
+      expect(events[0]).toHaveMetadataValue([
+        EventMetadataKey.GEMINI_CLI_AGENT_TURN_COUNT,
+        '5',
+      ]);
+      expect(events[0]).toHaveMetadataValue([
+        EventMetadataKey.GEMINI_CLI_AGENT_TERMINATE_REASON,
+        'GOAL',
+      ]);
+      expect(events[0]).not.toHaveMetadataKey(
+        EventMetadataKey.GEMINI_CLI_AGENT_ERROR_MESSAGE,
+      );
+    });
+
+    it('logs an event with proper fields (error)', () => {
+      const { logger } = setup();
+      const event = new AgentFinishEvent(
+        'agent-123',
+        'TestAgent',
+        500,
+        2,
+        'ERROR',
+        'Something went wrong',
+      );
+
+      logger?.logAgentFinishEvent(event);
+
+      const events = getEvents(logger!);
+      expect(events.length).toBe(1);
+      expect(events[0]).toHaveEventName(EventNames.AGENT_FINISH);
+      expect(events[0]).toHaveMetadataValue([
+        EventMetadataKey.GEMINI_CLI_AGENT_TERMINATE_REASON,
+        'ERROR',
+      ]);
+      expect(events[0]).toHaveMetadataValue([
+        EventMetadataKey.GEMINI_CLI_AGENT_ERROR_MESSAGE,
         'Something went wrong',
       ]);
     });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -1107,13 +1107,6 @@ export class ClearcutLogger {
       },
     ];
 
-    if (event.error_message) {
-      data.push({
-        gemini_cli_key: EventMetadataKey.GEMINI_CLI_AGENT_ERROR_MESSAGE,
-        value: event.error_message,
-      });
-    }
-
     this.enqueueLogEvent(this.createLogEvent(EventNames.AGENT_FINISH, data));
     this.flushIfNeeded();
   }

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -33,6 +33,8 @@ import type {
   ExtensionDisableEvent,
   SmartEditStrategyEvent,
   SmartEditCorrectionEvent,
+  AgentStartEvent,
+  AgentFinishEvent,
 } from '../types.js';
 import { EventMetadataKey } from './event-metadata-key.js';
 import type { Config } from '../../config/config.js';
@@ -79,6 +81,8 @@ export enum EventNames {
   MODEL_SLASH_COMMAND = 'model_slash_command',
   SMART_EDIT_STRATEGY = 'smart_edit_strategy',
   SMART_EDIT_CORRECTION = 'smart_edit_correction',
+  AGENT_START = 'agent_start',
+  AGENT_FINISH = 'agent_finish',
 }
 
 export interface LogResponse {
@@ -1060,6 +1064,57 @@ export class ClearcutLogger {
     this.enqueueLogEvent(
       this.createLogEvent(EventNames.SMART_EDIT_CORRECTION, data),
     );
+    this.flushIfNeeded();
+  }
+
+  logAgentStartEvent(event: AgentStartEvent): void {
+    const data: EventValue[] = [
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_AGENT_ID,
+        value: event.agent_id,
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_AGENT_NAME,
+        value: event.agent_name,
+      },
+    ];
+
+    this.enqueueLogEvent(this.createLogEvent(EventNames.AGENT_START, data));
+    this.flushIfNeeded();
+  }
+
+  logAgentFinishEvent(event: AgentFinishEvent): void {
+    const data: EventValue[] = [
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_AGENT_ID,
+        value: event.agent_id,
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_AGENT_NAME,
+        value: event.agent_name,
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_AGENT_DURATION_MS,
+        value: event.duration_ms.toString(),
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_AGENT_TURN_COUNT,
+        value: event.turn_count.toString(),
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_AGENT_TERMINATE_REASON,
+        value: event.terminate_reason,
+      },
+    ];
+
+    if (event.error_message) {
+      data.push({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_AGENT_ERROR_MESSAGE,
+        value: event.error_message,
+      });
+    }
+
+    this.enqueueLogEvent(this.createLogEvent(EventNames.AGENT_FINISH, data));
     this.flushIfNeeded();
   }
 

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -445,7 +445,4 @@ export enum EventMetadataKey {
 
   // Logs the reason for agent termination.
   GEMINI_CLI_AGENT_TERMINATE_REASON = 115,
-
-  // Logs the error message if the agent failed.
-  GEMINI_CLI_AGENT_ERROR_MESSAGE = 116,
 }

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -426,4 +426,26 @@ export enum EventMetadataKey {
 
   // Logs an event when the user uses the /model command.
   GEMINI_CLI_MODEL_SLASH_COMMAND = 108,
+
+  // ==========================================================================
+  // Agent Event Keys
+  // ==========================================================================
+
+  // Logs the name of the agent.
+  GEMINI_CLI_AGENT_NAME = 111,
+
+  // Logs the unique ID of the agent instance.
+  GEMINI_CLI_AGENT_ID = 112,
+
+  // Logs the duration of the agent execution in milliseconds.
+  GEMINI_CLI_AGENT_DURATION_MS = 113,
+
+  // Logs the number of turns the agent took.
+  GEMINI_CLI_AGENT_TURN_COUNT = 114,
+
+  // Logs the reason for agent termination.
+  GEMINI_CLI_AGENT_TERMINATE_REASON = 115,
+
+  // Logs the error message if the agent failed.
+  GEMINI_CLI_AGENT_ERROR_MESSAGE = 116,
 }

--- a/packages/core/src/telemetry/constants.ts
+++ b/packages/core/src/telemetry/constants.ts
@@ -36,6 +36,10 @@ export const EVENT_SMART_EDIT_STRATEGY = 'gemini_cli.smart_edit.strategy';
 export const EVENT_MODEL_ROUTING = 'gemini_cli.model_routing';
 export const EVENT_SMART_EDIT_CORRECTION = 'gemini_cli.smart_edit.correction';
 
+// Agent Events
+export const EVENT_AGENT_START = 'gemini_cli.agent.start';
+export const EVENT_AGENT_FINISH = 'gemini_cli.agent.finish';
+
 // Performance Events
 export const EVENT_STARTUP_PERFORMANCE = 'gemini_cli.startup.performance';
 export const EVENT_MEMORY_USAGE = 'gemini_cli.memory.usage';

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -1485,7 +1485,6 @@ describe('loggers', () => {
           duration_ms: 1000,
           turn_count: 5,
           terminate_reason: 'GOAL',
-          error_message: undefined,
         },
       });
 

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -99,6 +99,7 @@ import * as uiTelemetry from './uiTelemetry.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import { ClearcutLogger } from './clearcut-logger/clearcut-logger.js';
 import { UserAccountManager } from '../utils/userAccountManager.js';
+import { AgentTerminateMode } from '../agents/types.js';
 
 describe('loggers', () => {
   const mockLogger = {
@@ -1463,7 +1464,7 @@ describe('loggers', () => {
         'TestAgent',
         1000,
         5,
-        'GOAL',
+        AgentTerminateMode.GOAL,
       );
 
       logAgentFinish(mockConfig, event);

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -38,6 +38,8 @@ import {
   EVENT_EXTENSION_INSTALL,
   EVENT_EXTENSION_UNINSTALL,
   EVENT_TOOL_OUTPUT_TRUNCATED,
+  EVENT_AGENT_START,
+  EVENT_AGENT_FINISH,
 } from './constants.js';
 import {
   logApiRequest,
@@ -56,6 +58,8 @@ import {
   logExtensionDisable,
   logExtensionInstallEvent,
   logExtensionUninstall,
+  logAgentStart,
+  logAgentFinish,
 } from './loggers.js';
 import { ToolCallDecision } from './tool-call-decision.js';
 import {
@@ -75,6 +79,8 @@ import {
   ExtensionDisableEvent,
   ExtensionInstallEvent,
   ExtensionUninstallEvent,
+  AgentStartEvent,
+  AgentFinishEvent,
 } from './types.js';
 import * as metrics from './metrics.js';
 import {
@@ -1404,6 +1410,88 @@ describe('loggers', () => {
           setting_scope: 'user',
         },
       });
+    });
+  });
+
+  describe('logAgentStart', () => {
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+    } as unknown as Config;
+
+    beforeEach(() => {
+      vi.spyOn(ClearcutLogger.prototype, 'logAgentStartEvent');
+    });
+
+    it('should log agent start event', () => {
+      const event = new AgentStartEvent('agent-123', 'TestAgent');
+
+      logAgentStart(mockConfig, event);
+
+      expect(ClearcutLogger.prototype.logAgentStartEvent).toHaveBeenCalledWith(
+        event,
+      );
+
+      expect(mockLogger.emit).toHaveBeenCalledWith({
+        body: 'Agent TestAgent started. ID: agent-123',
+        attributes: {
+          'session.id': 'test-session-id',
+          'user.email': 'test-user@example.com',
+          'event.name': EVENT_AGENT_START,
+          'event.timestamp': '2025-01-01T00:00:00.000Z',
+          agent_id: 'agent-123',
+          agent_name: 'TestAgent',
+        },
+      });
+    });
+  });
+
+  describe('logAgentFinish', () => {
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+    } as unknown as Config;
+
+    beforeEach(() => {
+      vi.spyOn(ClearcutLogger.prototype, 'logAgentFinishEvent');
+      vi.spyOn(metrics, 'recordAgentRunMetrics');
+    });
+
+    it('should log agent finish event and record metrics', () => {
+      const event = new AgentFinishEvent(
+        'agent-123',
+        'TestAgent',
+        1000,
+        5,
+        'GOAL',
+      );
+
+      logAgentFinish(mockConfig, event);
+
+      expect(ClearcutLogger.prototype.logAgentFinishEvent).toHaveBeenCalledWith(
+        event,
+      );
+
+      expect(mockLogger.emit).toHaveBeenCalledWith({
+        body: 'Agent TestAgent finished. Reason: GOAL. Duration: 1000ms. Turns: 5.',
+        attributes: {
+          'session.id': 'test-session-id',
+          'user.email': 'test-user@example.com',
+          'event.name': EVENT_AGENT_FINISH,
+          'event.timestamp': '2025-01-01T00:00:00.000Z',
+          agent_id: 'agent-123',
+          agent_name: 'TestAgent',
+          duration_ms: 1000,
+          turn_count: 5,
+          terminate_reason: 'GOAL',
+          error_message: undefined,
+        },
+      });
+
+      expect(metrics.recordAgentRunMetrics).toHaveBeenCalledWith(
+        mockConfig,
+        event,
+      );
     });
   });
 });

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -899,7 +899,7 @@ export function logAgentFinish(config: Config, event: AgentFinishEvent): void {
 
   const logger = logs.getLogger(SERVICE_NAME);
   const logRecord: LogRecord = {
-    body: `Agent ${event.agent_name} finished. Reason: ${event.terminate_reason}. Duration: ${event.duration_ms}ms. Turns: ${event.turn_count}.${event.error_message ? ` Error: ${event.error_message}` : ''}`,
+    body: `Agent ${event.agent_name} finished. Reason: ${event.terminate_reason}. Duration: ${event.duration_ms}ms. Turns: ${event.turn_count}.`,
     attributes,
   };
   logger.emit(logRecord);

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -899,7 +899,7 @@ export function logAgentFinish(config: Config, event: AgentFinishEvent): void {
 
   const logger = logs.getLogger(SERVICE_NAME);
   const logRecord: LogRecord = {
-    body: `Agent ${event.agent_name} finished. Reason: ${event.terminate_reason}. Duration: ${event.duration_ms}ms. Turns: ${event.turn_count}.`,
+    body: `Agent ${event.agent_name} finished. Reason: ${event.terminate_reason}. Duration: ${event.duration_ms}ms. Turns: ${event.turn_count}.${event.error_message ? ` Error: ${event.error_message}` : ''}`,
     attributes,
   };
   logger.emit(logRecord);

--- a/packages/core/src/telemetry/metrics.test.ts
+++ b/packages/core/src/telemetry/metrics.test.ts
@@ -21,6 +21,7 @@ import {
 } from './metrics.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import { ModelRoutingEvent, AgentFinishEvent } from './types.js';
+import { AgentTerminateMode } from '../agents/types.js';
 
 const mockCounterAddFn: Mock<
   (value: number, attributes?: Attributes, context?: Context) => void
@@ -453,7 +454,7 @@ describe('Telemetry Metrics', () => {
         'TestAgent',
         1000,
         5,
-        'GOAL',
+        AgentTerminateMode.GOAL,
       );
       recordAgentRunMetricsModule(mockConfig, event);
       expect(mockCounterAddFn).not.toHaveBeenCalled();
@@ -470,7 +471,7 @@ describe('Telemetry Metrics', () => {
         'TestAgent',
         1000,
         5,
-        'GOAL',
+        AgentTerminateMode.GOAL,
       );
       recordAgentRunMetricsModule(mockConfig, event);
 

--- a/packages/core/src/telemetry/metrics.test.ts
+++ b/packages/core/src/telemetry/metrics.test.ts
@@ -20,7 +20,7 @@ import {
   ApiRequestPhase,
 } from './metrics.js';
 import { makeFakeConfig } from '../test-utils/config.js';
-import { ModelRoutingEvent } from './types.js';
+import { ModelRoutingEvent, AgentFinishEvent } from './types.js';
 
 const mockCounterAddFn: Mock<
   (value: number, attributes?: Attributes, context?: Context) => void
@@ -89,6 +89,7 @@ describe('Telemetry Metrics', () => {
   let recordBaselineComparisonModule: typeof import('./metrics.js').recordBaselineComparison;
   let recordGenAiClientTokenUsageModule: typeof import('./metrics.js').recordGenAiClientTokenUsage;
   let recordGenAiClientOperationDurationModule: typeof import('./metrics.js').recordGenAiClientOperationDuration;
+  let recordAgentRunMetricsModule: typeof import('./metrics.js').recordAgentRunMetrics;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -121,6 +122,7 @@ describe('Telemetry Metrics', () => {
       metricsJsModule.recordGenAiClientTokenUsage;
     recordGenAiClientOperationDurationModule =
       metricsJsModule.recordGenAiClientOperationDuration;
+    recordAgentRunMetricsModule = metricsJsModule.recordAgentRunMetrics;
 
     const otelApiModule = await import('@opentelemetry/api');
 
@@ -435,6 +437,60 @@ describe('Telemetry Metrics', () => {
         'session.id': 'test-session-id',
         'routing.decision_source': 'classifier',
         'routing.error_message': 'test-error',
+      });
+    });
+  });
+
+  describe('recordAgentRunMetrics', () => {
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getTelemetryEnabled: () => true,
+    } as unknown as Config;
+
+    it('should not record metrics if not initialized', () => {
+      const event = new AgentFinishEvent(
+        'agent-123',
+        'TestAgent',
+        1000,
+        5,
+        'GOAL',
+      );
+      recordAgentRunMetricsModule(mockConfig, event);
+      expect(mockCounterAddFn).not.toHaveBeenCalled();
+      expect(mockHistogramRecordFn).not.toHaveBeenCalled();
+    });
+
+    it('should record agent run metrics', () => {
+      initializeMetricsModule(mockConfig);
+      mockCounterAddFn.mockClear();
+      mockHistogramRecordFn.mockClear();
+
+      const event = new AgentFinishEvent(
+        'agent-123',
+        'TestAgent',
+        1000,
+        5,
+        'GOAL',
+      );
+      recordAgentRunMetricsModule(mockConfig, event);
+
+      // Verify agent run counter
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
+        'session.id': 'test-session-id',
+        agent_name: 'TestAgent',
+        terminate_reason: 'GOAL',
+      });
+
+      // Verify agent duration histogram
+      expect(mockHistogramRecordFn).toHaveBeenCalledWith(1000, {
+        'session.id': 'test-session-id',
+        agent_name: 'TestAgent',
+      });
+
+      // Verify agent turns histogram
+      expect(mockHistogramRecordFn).toHaveBeenCalledWith(5, {
+        'session.id': 'test-session-id',
+        agent_name: 'TestAgent',
       });
     });
   });

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -8,7 +8,11 @@ import type { Attributes, Meter, Counter, Histogram } from '@opentelemetry/api';
 import { diag, metrics, ValueType } from '@opentelemetry/api';
 import { SERVICE_NAME, EVENT_CHAT_COMPRESSION } from './constants.js';
 import type { Config } from '../config/config.js';
-import type { ModelRoutingEvent, ModelSlashCommandEvent } from './types.js';
+import type {
+  ModelRoutingEvent,
+  ModelSlashCommandEvent,
+  AgentFinishEvent,
+} from './types.js';
 import { AuthType } from '../core/contentGenerator.js';
 
 const TOOL_CALL_COUNT = 'gemini_cli.tool.call.count';
@@ -26,6 +30,11 @@ const MODEL_ROUTING_LATENCY = 'gemini_cli.model_routing.latency';
 const MODEL_ROUTING_FAILURE_COUNT = 'gemini_cli.model_routing.failure.count';
 const MODEL_SLASH_COMMAND_CALL_COUNT =
   'gemini_cli.slash_command.model.call_count';
+
+// Agent Metrics
+const AGENT_RUN_COUNT = 'gemini_cli.agent.run.count';
+const AGENT_DURATION = 'gemini_cli.agent.duration';
+const AGENT_TURNS = 'gemini_cli.agent.turns';
 
 // OpenTelemetry GenAI Semantic Convention Metrics
 const GEN_AI_CLIENT_TOKEN_USAGE = 'gen_ai.client.token.usage';
@@ -144,6 +153,15 @@ const COUNTER_DEFINITIONS = {
       tokens_after: number;
     },
   },
+  [AGENT_RUN_COUNT]: {
+    description: 'Counts agent runs, tagged by name and termination reason.',
+    valueType: ValueType.INT,
+    assign: (c: Counter) => (agentRunCounter = c),
+    attributes: {} as {
+      agent_name: string;
+      terminate_reason: string;
+    },
+  },
 } as const;
 
 const HISTOGRAM_DEFINITIONS = {
@@ -173,6 +191,24 @@ const HISTOGRAM_DEFINITIONS = {
     attributes: {} as {
       'routing.decision_model': string;
       'routing.decision_source': string;
+    },
+  },
+  [AGENT_DURATION]: {
+    description: 'Duration of agent runs in milliseconds.',
+    unit: 'ms',
+    valueType: ValueType.INT,
+    assign: (h: Histogram) => (agentDurationHistogram = h),
+    attributes: {} as {
+      agent_name: string;
+    },
+  },
+  [AGENT_TURNS]: {
+    description: 'Number of turns taken by agents.',
+    unit: 'turns',
+    valueType: ValueType.INT,
+    assign: (h: Histogram) => (agentTurnsHistogram = h),
+    attributes: {} as {
+      agent_name: string;
     },
   },
   [GEN_AI_CLIENT_TOKEN_USAGE]: {
@@ -405,6 +441,9 @@ let contentRetryFailureCounter: Counter | undefined;
 let modelRoutingLatencyHistogram: Histogram | undefined;
 let modelRoutingFailureCounter: Counter | undefined;
 let modelSlashCommandCallCounter: Counter | undefined;
+let agentRunCounter: Counter | undefined;
+let agentDurationHistogram: Histogram | undefined;
+let agentTurnsHistogram: Histogram | undefined;
 
 // OpenTelemetry GenAI Semantic Convention Metrics
 let genAiClientTokenUsageHistogram: Histogram | undefined;
@@ -624,6 +663,37 @@ export function recordModelRoutingMetrics(
       'routing.error_message': event.error_message,
     });
   }
+}
+
+export function recordAgentRunMetrics(
+  config: Config,
+  event: AgentFinishEvent,
+): void {
+  if (
+    !agentRunCounter ||
+    !agentDurationHistogram ||
+    !agentTurnsHistogram ||
+    !isMetricsInitialized
+  )
+    return;
+
+  const commonAttributes = baseMetricDefinition.getCommonAttributes(config);
+
+  agentRunCounter.add(1, {
+    ...commonAttributes,
+    agent_name: event.agent_name,
+    terminate_reason: event.terminate_reason,
+  });
+
+  agentDurationHistogram.record(event.duration_ms, {
+    ...commonAttributes,
+    agent_name: event.agent_name,
+  });
+
+  agentTurnsHistogram.record(event.turn_count, {
+    ...commonAttributes,
+    agent_name: event.agent_name,
+  });
 }
 
 // OpenTelemetry GenAI Semantic Convention Recording Functions

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -33,7 +33,7 @@ const MODEL_SLASH_COMMAND_CALL_COUNT =
 
 // Agent Metrics
 const AGENT_RUN_COUNT = 'gemini_cli.agent.run.count';
-const AGENT_DURATION = 'gemini_cli.agent.duration';
+const AGENT_DURATION_MS = 'gemini_cli.agent.duration';
 const AGENT_TURNS = 'gemini_cli.agent.turns';
 
 // OpenTelemetry GenAI Semantic Convention Metrics
@@ -193,7 +193,7 @@ const HISTOGRAM_DEFINITIONS = {
       'routing.decision_source': string;
     },
   },
-  [AGENT_DURATION]: {
+  [AGENT_DURATION_MS]: {
     description: 'Duration of agent runs in milliseconds.',
     unit: 'ms',
     valueType: ValueType.INT,

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -752,7 +752,6 @@ export class AgentFinishEvent implements BaseTelemetryEvent {
   duration_ms: number;
   turn_count: number;
   terminate_reason: AgentTerminateMode;
-  error_message?: string;
 
   constructor(
     agent_id: string,
@@ -760,7 +759,6 @@ export class AgentFinishEvent implements BaseTelemetryEvent {
     duration_ms: number,
     turn_count: number,
     terminate_reason: AgentTerminateMode,
-    error_message?: string,
   ) {
     this['event.name'] = 'agent_finish';
     this['event.timestamp'] = new Date().toISOString();
@@ -769,6 +767,5 @@ export class AgentFinishEvent implements BaseTelemetryEvent {
     this.duration_ms = duration_ms;
     this.turn_count = turn_count;
     this.terminate_reason = terminate_reason;
-    this.error_message = error_message;
   }
 }

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -19,6 +19,7 @@ import type { FileOperation } from './metrics.js';
 export { ToolCallDecision };
 import type { ToolRegistry } from '../tools/tool-registry.js';
 import type { OutputFormat } from '../output/types.js';
+import type { AgentTerminateMode } from '../agents/types.js';
 
 export interface BaseTelemetryEvent {
   'event.name': string;
@@ -750,7 +751,7 @@ export class AgentFinishEvent implements BaseTelemetryEvent {
   agent_name: string;
   duration_ms: number;
   turn_count: number;
-  terminate_reason: string;
+  terminate_reason: AgentTerminateMode;
   error_message?: string;
 
   constructor(
@@ -758,7 +759,7 @@ export class AgentFinishEvent implements BaseTelemetryEvent {
     agent_name: string,
     duration_ms: number,
     turn_count: number,
-    terminate_reason: string,
+    terminate_reason: AgentTerminateMode,
     error_message?: string,
   ) {
     this['event.name'] = 'agent_finish';

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -687,7 +687,9 @@ export type TelemetryEvent =
   | ExtensionUninstallEvent
   | ModelRoutingEvent
   | ToolOutputTruncatedEvent
-  | ModelSlashCommandEvent;
+  | ModelSlashCommandEvent
+  | AgentStartEvent
+  | AgentFinishEvent;
 
 export class ExtensionDisableEvent implements BaseTelemetryEvent {
   'event.name': 'extension_disable';
@@ -724,5 +726,48 @@ export class SmartEditCorrectionEvent implements BaseTelemetryEvent {
     this['event.name'] = 'smart_edit_correction';
     this['event.timestamp'] = new Date().toISOString();
     this.correction = correction;
+  }
+}
+
+export class AgentStartEvent implements BaseTelemetryEvent {
+  'event.name': 'agent_start';
+  'event.timestamp': string;
+  agent_id: string;
+  agent_name: string;
+
+  constructor(agent_id: string, agent_name: string) {
+    this['event.name'] = 'agent_start';
+    this['event.timestamp'] = new Date().toISOString();
+    this.agent_id = agent_id;
+    this.agent_name = agent_name;
+  }
+}
+
+export class AgentFinishEvent implements BaseTelemetryEvent {
+  'event.name': 'agent_finish';
+  'event.timestamp': string;
+  agent_id: string;
+  agent_name: string;
+  duration_ms: number;
+  turn_count: number;
+  terminate_reason: string;
+  error_message?: string;
+
+  constructor(
+    agent_id: string,
+    agent_name: string,
+    duration_ms: number,
+    turn_count: number,
+    terminate_reason: string,
+    error_message?: string,
+  ) {
+    this['event.name'] = 'agent_finish';
+    this['event.timestamp'] = new Date().toISOString();
+    this.agent_id = agent_id;
+    this.agent_name = agent_name;
+    this.duration_ms = duration_ms;
+    this.turn_count = turn_count;
+    this.terminate_reason = terminate_reason;
+    this.error_message = error_message;
   }
 }


### PR DESCRIPTION
## TLDR

This PR adds telemetry for subagent execution in `AgentExecutor`. It introduces `AgentStartEvent` and `AgentFinishEvent` to track the start and completion of agent runs, including duration, turn count, and termination reason. It also updates `AgentExecutor` to use `promptIdContext` for proper prompt ID chaining in nested agent calls.

## Dive Deeper

*   **New Telemetry Events:**
    *   `AgentStartEvent`: Logged when an agent starts execution. Includes `agent_id` and `agent_name`.
    *   `AgentFinishEvent`: Logged when an agent finishes. Includes `agent_id`, `agent_name`, `duration_ms`, `turn_count`, `terminate_reason`, and `error_message` (if applicable).
*   **`AgentExecutor` Updates:**
    *   Logs `AgentStartEvent` at the beginning of `run()`.
    *   Logs `AgentFinishEvent` in the `finally` block of `run()`, capturing success or failure.
    *   Uses `promptIdContext` to inherit the parent's prompt ID and create a hierarchical `agentId`.
    *   Runs the model call within `promptIdContext.run()` to ensure tool calls made by the agent are correctly associated with the agent's prompt ID.
*   **Clearcut & OTEL Integration:**
    *   Updated `ClearcutLogger` to handle the new agent events and defined new `EventMetadataKey`s.
    *   Added `logAgentStart` and `logAgentFinish` to `loggers.ts` to send events to both Clearcut and OpenTelemetry logs.
    *   Added OpenTelemetry metrics (`agentRunCounter`, `agentDurationHistogram`, `agentTurnsHistogram`) in `metrics.ts` to track agent performance.
*   **Testing:**
    *   Updated `executor.test.ts` to verify telemetry logging and `promptIdContext` usage.
    *   Updated `clearcut-logger.test.ts`, `loggers.test.ts`, and `metrics.test.ts` to cover the new events, loggers, and metrics.

## Reviewer Test Plan

1.  **Unit Tests:** Run the updated unit tests to ensure they pass:
    ```bash
    npm run test -w @google/gemini-cli-core src/agents/executor.test.ts src/telemetry/clearcut-logger/clearcut-logger.test.ts src/telemetry/loggers.test.ts src/telemetry/metrics.test.ts
    ```
2.  **Integration/E2E (Optional but recommended):** If you have a setup to run an agent (e.g., via a subagent tool), run it and verify in the debug logs (or telemetry backend if configured) that `agent_start` and `agent_finish` events are logged with the correct metadata (ID, name, duration, turns, termination reason). Verify that nested agents have correctly chained prompt IDs.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |
