### PR TITLE
Allow for gemini extension installation bypass

### DIFF
--- a/packages/cli/src/commands/extensions/install.test.ts
+++ b/packages/cli/src/commands/extensions/install.test.ts
@@ -12,9 +12,9 @@ const { mockRequestFn } = vi.hoisted(() => ({
   mockRequestFn: vi.fn(),
 }));
 const mockInstallExtension = vi.hoisted(() =>
-  vi.fn(() =>
+  vi.fn((_: unknown, requestConsent: (consent: string) => void) =>
     // Simulate mockRequestFn being called by installExtension
-    mockRequestFn(),
+    requestConsent('Consent'),
   ),
 );
 
@@ -115,7 +115,7 @@ describe.only('handleInstall', () => {
       source: 'https://google.com',
       yolo: true,
     });
-    expect(mockRequestFn).toHaveBeenCalled();
+    expect(mockRequestFn).not.toHaveBeenCalled();
   });
 
   it('should install an extension from a git source', async () => {

--- a/packages/cli/src/commands/extensions/install.test.ts
+++ b/packages/cli/src/commands/extensions/install.test.ts
@@ -58,7 +58,7 @@ describe('extensions install command', () => {
   });
 });
 
-describe.only('handleInstall', () => {
+describe('handleInstall', () => {
   let consoleLogSpy: MockInstance;
   let consoleErrorSpy: MockInstance;
   let processSpy: MockInstance;

--- a/packages/cli/src/commands/extensions/install.test.ts
+++ b/packages/cli/src/commands/extensions/install.test.ts
@@ -9,12 +9,14 @@ import { handleInstall, installCommand } from './install.js';
 import yargs from 'yargs';
 
 const { mockRequestFn } = vi.hoisted(() => ({
-    mockRequestFn: vi.fn(),
-  }));
-const mockInstallExtension = vi.hoisted(() => vi.fn(() => 
+  mockRequestFn: vi.fn(),
+}));
+const mockInstallExtension = vi.hoisted(() =>
+  vi.fn(() =>
     // Simulate mockRequestFn being called by installExtension
-     mockRequestFn()
-  ));
+    mockRequestFn(),
+  ),
+);
 
 vi.mock('../../config/extension.js', () => ({
   installExtension: mockInstallExtension,

--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -90,7 +90,7 @@ export const installCommand: CommandModule = {
       })
       .option('yolo', {
         alias: 'y',
-        describe: 'Enable yolo mode',
+        describe: 'Enable yolo mode, and bypass the consent prompt.',
         type: 'boolean',
       })
       .conflicts('source', 'path')

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -496,7 +496,6 @@ export async function installExtension(
           `Extension "${newExtensionName}" is already installed. Please uninstall it first.`,
         );
       }
-      // TODO: only request consent if -y isn't passed in
       await maybeRequestConsentOrFail(
         newExtensionConfig,
         requestConsent,

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -496,6 +496,7 @@ export async function installExtension(
           `Extension "${newExtensionName}" is already installed. Please uninstall it first.`,
         );
       }
+      // TODO: only request consent if -y isn't passed in
       await maybeRequestConsentOrFail(
         newExtensionConfig,
         requestConsent,

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -123,23 +123,22 @@ describe('handleAutoUpdate', () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it.each([
-    PackageManager.NPX,
-    PackageManager.PNPX,
-    PackageManager.BUNX,
-  ])('should suppress update notifications when running via %s', (packageManager) => {
-    mockGetInstallationInfo.mockReturnValue({
-      updateCommand: undefined,
-      updateMessage: `Running via ${packageManager}, update not applicable.`,
-      isGlobal: false,
-      packageManager,
-    });
+  it.each([PackageManager.NPX, PackageManager.PNPX, PackageManager.BUNX])(
+    'should suppress update notifications when running via %s',
+    (packageManager) => {
+      mockGetInstallationInfo.mockReturnValue({
+        updateCommand: undefined,
+        updateMessage: `Running via ${packageManager}, update not applicable.`,
+        isGlobal: false,
+        packageManager,
+      });
 
-    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+      handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
 
-    expect(mockUpdateEventEmitter.emit).not.toHaveBeenCalled();
-    expect(mockSpawn).not.toHaveBeenCalled();
-  });
+      expect(mockUpdateEventEmitter.emit).not.toHaveBeenCalled();
+      expect(mockSpawn).not.toHaveBeenCalled();
+    },
+  );
 
   it('should emit "update-received" but not update if no update command is found', () => {
     mockGetInstallationInfo.mockReturnValue({

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -33,11 +33,9 @@ export function handleAutoUpdate(
   );
 
   if (
-    [
-      PackageManager.NPX,
-      PackageManager.PNPX,
-      PackageManager.BUNX
-    ].includes(installationInfo.packageManager)
+    [PackageManager.NPX, PackageManager.PNPX, PackageManager.BUNX].includes(
+      installationInfo.packageManager,
+    )
   ) {
     return;
   }


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->
Currently, if the gemini CLI attempts to install gemini extensions, it fails due to the consent requirement. This PR allows users and gemini CLI to skip that step.

This is similar to the gemini CLI's root `-y` command.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->
* Wrote additional tests
* Ran manually with a local build with a GEMINI.md file with `-y` flag

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
