### PR TITLE
feat(ide): add dialog to open default IDE in unsupported environments

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -43,6 +43,7 @@ import {
   clearCachedCredentialFile,
   ShellExecutionService,
 } from '@google/gemini-cli-core';
+import { openDefaultIde } from '../utils/openDefaultIde.js';
 import { validateAuthMethod } from '../config/auth.js';
 import { loadHierarchicalGeminiMemory } from '../config/config.js';
 import process from 'node:process';
@@ -166,6 +167,8 @@ export const AppContainer = (props: AppContainerProps) => {
   );
 
   const [isPermissionsDialogOpen, setPermissionsDialogOpen] = useState(false);
+  const [isOpenDefaultIdeDialogOpen, setOpenDefaultIdeDialogOpen] =
+    useState(false);
   const openPermissionsDialog = useCallback(
     () => setPermissionsDialogOpen(true),
     [],
@@ -173,6 +176,43 @@ export const AppContainer = (props: AppContainerProps) => {
   const closePermissionsDialog = useCallback(
     () => setPermissionsDialogOpen(false),
     [],
+  );
+
+  const openDefaultIdeDialog = useCallback(
+    () => setOpenDefaultIdeDialogOpen(true),
+    [],
+  );
+
+  const closeDefaultIdeDialog = useCallback(
+    () => setOpenDefaultIdeDialogOpen(false),
+    [],
+  );
+
+  const handleOpenDefaultIde = useCallback(
+    async (choice: 'yes' | 'no') => {
+      closeDefaultIdeDialog();
+      if (choice === 'yes') {
+        try {
+          await openDefaultIde();
+          historyManager.addItem(
+            {
+              type: 'info',
+              text: 'Gemini CLI has attempted to open your default IDE. In your IDE, open the terminal, and run `gemini` to continue.',
+            },
+            Date.now(),
+          );
+        } catch (error) {
+          historyManager.addItem(
+            {
+              type: 'error',
+              text: `Failed to open default IDE: ${getErrorMessage(error)}`,
+            },
+            Date.now(),
+          );
+        }
+      }
+    },
+    [closeDefaultIdeDialog, historyManager],
   );
 
   // Helper to determine the effective model, considering the fallback state.
@@ -451,6 +491,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       openSettingsDialog,
       openModelDialog,
       openPermissionsDialog,
+      openDefaultIdeDialog,
       quit: (messages: HistoryItem[]) => {
         setQuittingMessages(messages);
         setTimeout(async () => {
@@ -475,6 +516,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       setCorgiMode,
       dispatchExtensionStateUpdate,
       openPermissionsDialog,
+      openDefaultIdeDialog,
       addConfirmUpdateExtensionRequest,
     ],
   );
@@ -736,6 +778,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       !isAuthDialogOpen &&
       !isThemeDialogOpen &&
       !isEditorDialogOpen &&
+      !isOpenDefaultIdeDialogOpen &&
       !showPrivacyNotice &&
       geminiClient?.isInitialized?.()
     ) {
@@ -750,6 +793,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     isAuthDialogOpen,
     isThemeDialogOpen,
     isEditorDialogOpen,
+    isOpenDefaultIdeDialogOpen,
     showPrivacyNotice,
     geminiClient,
   ]);
@@ -1053,6 +1097,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     isSettingsDialogOpen ||
     isModelDialogOpen ||
     isPermissionsDialogOpen ||
+    isOpenDefaultIdeDialogOpen ||
     isAuthenticating ||
     isAuthDialogOpen ||
     isEditorDialogOpen ||
@@ -1084,6 +1129,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       isSettingsDialogOpen,
       isModelDialogOpen,
       isPermissionsDialogOpen,
+      isOpenDefaultIdeDialogOpen,
       slashCommands,
       pendingSlashCommandHistoryItems,
       commandContext,
@@ -1163,6 +1209,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       isSettingsDialogOpen,
       isModelDialogOpen,
       isPermissionsDialogOpen,
+      isOpenDefaultIdeDialogOpen,
       slashCommands,
       pendingSlashCommandHistoryItems,
       commandContext,
@@ -1242,6 +1289,9 @@ Logging in with Google... Please restart Gemini CLI to continue.
       closeSettingsDialog,
       closeModelDialog,
       closePermissionsDialog,
+      openDefaultIdeDialog,
+      closeDefaultIdeDialog,
+      handleOpenDefaultIde,
       setShellModeActive,
       vimHandleInput,
       handleIdePromptComplete,
@@ -1266,6 +1316,9 @@ Logging in with Google... Please restart Gemini CLI to continue.
       closeSettingsDialog,
       closeModelDialog,
       closePermissionsDialog,
+      openDefaultIdeDialog,
+      closeDefaultIdeDialog,
+      handleOpenDefaultIde,
       setShellModeActive,
       vimHandleInput,
       handleIdePromptComplete,

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -140,12 +140,15 @@ export const ideCommand = async (): Promise<SlashCommand> => {
       name: 'ide',
       description: 'manage IDE integration',
       kind: CommandKind.BUILT_IN,
-      action: (): SlashCommandActionReturn =>
-        ({
+      action: (context: CommandContext): SlashCommandActionReturn => {
+        // Show dialog to ask if user wants to open default IDE
+        context.ui.openDefaultIdeDialog();
+        return {
           type: 'message',
-          messageType: 'error',
+          messageType: 'info',
           content: `IDE integration is not supported in your current environment. To use this feature, run Gemini CLI in one of these supported IDEs: VS Code or VS Code forks.`,
-        }) as const,
+        } as const;
+      },
     };
   }
 

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -72,6 +72,7 @@ export interface CommandContext {
     extensionsUpdateState: Map<string, ExtensionUpdateStatus>;
     dispatchExtensionStateUpdate: (action: ExtensionUpdateAction) => void;
     addConfirmUpdateExtensionRequest: (value: ConfirmationRequest) => void;
+    openDefaultIdeDialog: () => void;
   };
   // Session-specific data
   session: {

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -28,6 +28,7 @@ import { useSettings } from '../contexts/SettingsContext.js';
 import process from 'node:process';
 import { type UseHistoryManagerReturn } from '../hooks/useHistoryManager.js';
 import { IdeTrustChangeDialog } from './IdeTrustChangeDialog.js';
+import { OpenDefaultIdeDialog } from './OpenDefaultIdeDialog.js';
 
 interface DialogManagerProps {
   addItem: UseHistoryManagerReturn['addItem'];
@@ -49,6 +50,9 @@ export const DialogManager = ({
 
   if (uiState.showIdeRestartPrompt) {
     return <IdeTrustChangeDialog reason={uiState.ideTrustRestartReason} />;
+  }
+  if (uiState.isOpenDefaultIdeDialogOpen) {
+    return <OpenDefaultIdeDialog onChoice={uiActions.handleOpenDefaultIde} />;
   }
   if (uiState.showWorkspaceMigrationDialog) {
     return (

--- a/packages/cli/src/ui/components/OpenDefaultIdeDialog.test.tsx
+++ b/packages/cli/src/ui/components/OpenDefaultIdeDialog.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { act } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/render.js';
+import { OpenDefaultIdeDialog } from './OpenDefaultIdeDialog.js';
+
+describe('OpenDefaultIdeDialog', () => {
+  it('should render dialog with title and options', () => {
+    const onChoice = vi.fn();
+    const { lastFrame } = renderWithProviders(
+      <OpenDefaultIdeDialog onChoice={onChoice} />,
+    );
+
+    expect(lastFrame()).toContain('Do you want to open your default IDE?');
+    expect(lastFrame()).toContain('Yes');
+    expect(lastFrame()).toContain('No (esc)');
+  });
+
+  it('should call onChoice with "yes" when Yes is selected', async () => {
+    const onChoice = vi.fn();
+    const { stdin } = renderWithProviders(
+      <OpenDefaultIdeDialog onChoice={onChoice} />,
+    );
+
+    // Simulate pressing Enter (should select the first option by default)
+    act(() => {
+      stdin.write('\r');
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(onChoice).toHaveBeenCalledWith('yes');
+  });
+
+  it('should call onChoice with "no" when escape is pressed', async () => {
+    const onChoice = vi.fn();
+    const { stdin } = renderWithProviders(
+      <OpenDefaultIdeDialog onChoice={onChoice} />,
+    );
+
+    // Simulate pressing Escape
+    act(() => {
+      stdin.write('\x1b');
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(onChoice).toHaveBeenCalledWith('no');
+  });
+});

--- a/packages/cli/src/ui/components/OpenDefaultIdeDialog.tsx
+++ b/packages/cli/src/ui/components/OpenDefaultIdeDialog.tsx
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Text } from 'ink';
+import type React from 'react';
+import { theme } from '../semantic-colors.js';
+import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
+import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+
+export interface OpenDefaultIdeDialogProps {
+  onChoice: (choice: 'yes' | 'no') => void;
+}
+
+export const OpenDefaultIdeDialog: React.FC<OpenDefaultIdeDialogProps> = ({
+  onChoice,
+}) => {
+  useKeypress(
+    (key) => {
+      if (key.name === 'escape') {
+        onChoice('no');
+      }
+    },
+    { isActive: true },
+  );
+
+  const options: Array<RadioSelectItem<'yes' | 'no'>> = [
+    {
+      label: 'Yes',
+      value: 'yes',
+      key: 'Yes',
+    },
+    {
+      label: 'No (esc)',
+      value: 'no',
+      key: 'No (esc)',
+    },
+  ];
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.status.warning}
+      padding={1}
+      width="100%"
+      marginLeft={1}
+    >
+      <Box flexDirection="column" marginBottom={1}>
+        <Text bold color={theme.text.primary}>
+          Do you want to open your default IDE?
+        </Text>
+        <Text color={theme.text.secondary}>
+          IDE integration is not supported in your current environment. This
+          will open your system&apos;s default IDE for code editing.
+        </Text>
+      </Box>
+
+      <RadioButtonSelect items={options} onSelect={onChoice} isFocused />
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -45,6 +45,9 @@ export interface UIActions {
   onWorkspaceMigrationDialogOpen: () => void;
   onWorkspaceMigrationDialogClose: () => void;
   handleProQuotaChoice: (choice: 'auth' | 'continue') => void;
+  openDefaultIdeDialog: () => void;
+  closeDefaultIdeDialog: () => void;
+  handleOpenDefaultIde: (choice: 'yes' | 'no') => void;
 }
 
 export const UIActionsContext = createContext<UIActions | null>(null);

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -118,6 +118,7 @@ export interface UIState {
   isRestarting: boolean;
   extensionsUpdateState: Map<string, ExtensionUpdateState>;
   activePtyId: number | undefined;
+  isOpenDefaultIdeDialogOpen: boolean;
   embeddedShellFocused: boolean;
 }
 

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -48,6 +48,7 @@ interface SlashCommandProcessorActions {
   openSettingsDialog: () => void;
   openModelDialog: () => void;
   openPermissionsDialog: () => void;
+  openDefaultIdeDialog: () => void;
   quit: (messages: HistoryItem[]) => void;
   setDebugMessage: (message: string) => void;
   toggleCorgiMode: () => void;
@@ -204,6 +205,7 @@ export const useSlashCommandProcessor = (
         dispatchExtensionStateUpdate: actions.dispatchExtensionStateUpdate,
         addConfirmUpdateExtensionRequest:
           actions.addConfirmUpdateExtensionRequest,
+        openDefaultIdeDialog: actions.openDefaultIdeDialog,
       },
       session: {
         stats: session.stats,

--- a/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
+++ b/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
@@ -27,5 +27,6 @@ export function createNonInteractiveUI(): CommandContext['ui'] {
     extensionsUpdateState: new Map(),
     dispatchExtensionStateUpdate: (_action: ExtensionUpdateAction) => {},
     addConfirmUpdateExtensionRequest: (_request) => {},
+    openDefaultIdeDialog: () => {},
   };
 }

--- a/packages/cli/src/utils/openDefaultIde.ts
+++ b/packages/cli/src/utils/openDefaultIde.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import open from 'open';
+import { getErrorMessage } from '@google/gemini-cli-core';
+import { spawn } from 'node:child_process';
+import { platform } from 'node:os';
+
+/**
+ * Common code editors to try, in order of preference
+ */
+const CODE_EDITORS = [
+  // VS Code and its forks
+  'code', // Visual Studio Code
+  'code-insiders', // Visual Studio Code Insiders
+  'codium', // VSCodium (open source fork of VS Code)
+  'cursor', // Cursor (VS Code fork)
+  'theia', // Theia (framework for VS Code alternatives)
+];
+
+/**
+ * Checks if a command is available in the system PATH
+ */
+async function isCommandAvailable(command: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn(platform() === 'win32' ? 'where' : 'which', [command], {
+      stdio: 'ignore',
+    });
+
+    child.on('exit', (code) => {
+      resolve(code === 0);
+    });
+
+    child.on('error', () => {
+      resolve(false);
+    });
+  });
+}
+
+/**
+ * Opens the default IDE/editor for the current working directory.
+ * This will attempt to open the directory in a code editor, trying
+ * common editors in order of preference before falling back to the
+ * system's default application for directories.
+ */
+export async function openDefaultIde(directory = process.cwd()): Promise<void> {
+  try {
+    // First, try to find and open with a code editor
+    for (const editor of CODE_EDITORS) {
+      if (await isCommandAvailable(editor)) {
+        try {
+          const childProcess = spawn(editor, [directory], {
+            detached: true,
+            stdio: 'ignore',
+          });
+
+          // Unref so the parent process can exit
+          childProcess.unref();
+
+          return; // Successfully opened with a code editor
+        } catch (error) {
+          // Continue to next editor if this one fails
+          console.debug(
+            `Failed to open with ${editor}:`,
+            getErrorMessage(error),
+          );
+        }
+      }
+    }
+
+    // Fallback: open with system default application
+    console.log(
+      'No code editor found, opening with system default application...',
+    );
+    const childProcess = await open(directory);
+
+    // Attach an error handler to prevent unhandled errors
+    childProcess.on('error', (error) => {
+      console.error(
+        'Failed to open default application.',
+        getErrorMessage(error),
+      );
+    });
+  } catch (error) {
+    console.error('Failed to open default IDE:', getErrorMessage(error));
+    throw error;
+  }
+}


### PR DESCRIPTION
## TLDR

This PR improves the `/ide` command behavior in unsupported environments.  
Previously, users only saw a static warning message. Now, they are presented with an **interactive dialog** that asks if they’d like to open their default IDE.

- If the user chooses **Yes**, Gemini CLI will attempt to open their system’s default IDE.  
- If the user chooses **No**, they can continue in their current environment as before.  

This provides a smoother fallback and improves usability.  

## Dive Deeper

- **Old behavior:** Only a warning message was shown:  

  <img width="1743" height="165" alt="Screenshot from 2025-10-03 17-36-17" src="https://github.com/user-attachments/assets/db09f145-357b-4133-bb80-bc7be7d76a4f" />

- **New behavior:** An interactive prompt is displayed.  

  <img width="1725" height="253" alt="Screenshot from 2025-10-03 17-36-49" src="https://github.com/user-attachments/assets/cb7b416e-fc0a-4f29-b304-2fceffd6d4d5" />

  - Users can press **Yes** → CLI opens their system’s default IDE.  
  - Users can press **No** → CLI falls back to the terminal environment and continues working.  

This gives users more control and reduces confusion, especially for those not running in VS Code or supported forks.  

## Reviewer Test Plan

1. Run Gemini CLI in an unsupported environment (e.g., plain terminal without VS Code).  
2. Trigger the `/ide` command.  
3. Confirm that:  
   - The interactive dialog appears instead of just the warning.  
   - Choosing **Yes** opens the system’s default IDE.  
   - Choosing **No** lets the user continue in their current shell.  
4. Validate that behavior in supported IDEs (VS Code, VS Code forks) is unchanged.  

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❌  | ❌  | ✅  |
| npx      | ❌  | ❌  | ❌  |
| Docker   | ❌  | ❌  | ❌  |
| Podman   | ❌  | -   | -   |
| Seatbelt | ❌  | -   | -   |

## Linked issues / bugs

Resolves #10479
