### PR TITLE
feat(vscode-ide-companion): enforce auth token validation

### DIFF
--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -379,7 +379,7 @@ describe('IDEServer', () => {
       port = (ideServer as unknown as { port: number }).port;
     });
 
-    it('should allow request without auth token for backwards compatibility', async () => {
+    it('should reject request without auth token', async () => {
       const response = await fetch(`http://localhost:${port}/mcp`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -390,7 +390,7 @@ describe('IDEServer', () => {
           id: 1,
         }),
       });
-      expect(response.status).not.toBe(401);
+      expect(response.status).toBe(401);
     });
 
     it('should allow request with valid auth token', async () => {
@@ -550,6 +550,7 @@ describe('IDEServer HTTP endpoints', () => {
         headers: {
           Host: `localhost:${port}`,
           'Content-Type': 'application/json',
+          Authorization: 'Bearer test-auth-token',
         },
       },
       JSON.stringify({ jsonrpc: '2.0', method: 'initialize' }),

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -166,19 +166,22 @@ export class IDEServer {
 
       app.use((req, res, next) => {
         const authHeader = req.headers.authorization;
-        if (authHeader) {
-          const parts = authHeader.split(' ');
-          if (parts.length !== 2 || parts[0] !== 'Bearer') {
-            this.log('Malformed Authorization header. Rejecting request.');
-            res.status(401).send('Unauthorized');
-            return;
-          }
-          const token = parts[1];
-          if (token !== this.authToken) {
-            this.log('Invalid auth token provided. Rejecting request.');
-            res.status(401).send('Unauthorized');
-            return;
-          }
+        if (!authHeader) {
+          this.log('Missing Authorization header. Rejecting request.');
+          res.status(401).send('Unauthorized');
+          return;
+        }
+        const parts = authHeader.split(' ');
+        if (parts.length !== 2 || parts[0] !== 'Bearer') {
+          this.log('Malformed Authorization header. Rejecting request.');
+          res.status(401).send('Unauthorized');
+          return;
+        }
+        const token = parts[1];
+        if (token !== this.authToken) {
+          this.log('Invalid auth token provided. Rejecting request.');
+          res.status(401).send('Unauthorized');
+          return;
         }
         next();
       });


### PR DESCRIPTION
## TLDR

This pull request enforces mandatory authentication for all requests to the IDE server by requiring a valid `Authorization` header. Previously, requests without an auth token were allowed for backward compatibility; this is no longer the case.

## Testing
I confirmed the latest stable & preview versions are able to connect to the extension as expected an older versions (0.3.0) can no longer connect