### PR TITLE
feat: Integrate A2A Server into Gemini CLI for External Control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17154,6 +17154,7 @@
       "name": "@google/gemini-cli",
       "version": "0.9.0-nightly.20251001.163dba7e",
       "dependencies": {
+        "@a2a-js/sdk": "^0.3.4",
         "@google/gemini-cli-core": "file:../core",
         "@google/genai": "1.16.0",
         "@iarna/toml": "^2.2.5",
@@ -17212,6 +17213,25 @@
         "node": ">=20"
       }
     },
+    "packages/cli/node_modules/@a2a-js/sdk": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.4.tgz",
+      "integrity": "sha512-WXMk/UspvQFxesvb8hXyfPE8d3ibpiRie24Yw/5ruMqNJcdwxjfZ1G0gj6vYE/I9RAZD145CNzedpZA2cLV2JQ==",
+      "dependencies": {
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
     "packages/cli/node_modules/@testing-library/react": {
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
@@ -17255,6 +17275,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/core": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "start": "cross-env node scripts/start.js",
-    "start:a2a-server": "CODER_AGENT_PORT=41242 npm run start --workspace @google/gemini-cli-a2a-server",
+    "start:a2a-server": "CODER_AGENT_PORT=41243 npm run start --workspace @google/gemini-cli-a2a-server",
     "debug": "cross-env DEBUG=1 node --inspect-brk scripts/start.js",
     "auth:npm": "npx google-artifactregistry-auth",
     "auth:docker": "gcloud auth configure-docker us-west1-docker.pkg.dev",

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -19,6 +19,7 @@ import type {
 } from '@google/gemini-cli-core';
 import { GeminiEventType } from '@google/gemini-cli-core';
 import { v4 as uuidv4 } from 'uuid';
+import type { EventEmitter } from 'node:events';
 
 import { logger } from '../utils/logger.js';
 import type {
@@ -86,7 +87,11 @@ export class CoderAgentExecutor implements AgentExecutor {
   // Track tasks with an active execution loop.
   private executingTasks = new Set<string>();
 
-  constructor(private taskStore?: TaskStore) {}
+  constructor(
+    private taskStore?: TaskStore,
+    private cliConfig?: Config,
+    private cliAppEvents?: EventEmitter,
+  ) {}
 
   private async getConfig(
     agentSettings: AgentSettings,

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -97,6 +97,7 @@ export class CoderAgentExecutor implements AgentExecutor {
     agentSettings: AgentSettings,
     taskId: string,
   ): Promise<Config> {
+    // TODO(b/369671111): Use cliConfig if available
     const workspaceRoot = setTargetDir(agentSettings);
     loadEnvironment(); // Will override any global env with workspace envs
     const settings = loadSettings(workspaceRoot);
@@ -129,6 +130,7 @@ export class CoderAgentExecutor implements AgentExecutor {
       contextId,
       config,
       eventBus,
+      this.cliAppEvents,
     );
     runtimeTask.taskState = persistedState._taskState;
     await runtimeTask.geminiClient.initialize();
@@ -147,7 +149,13 @@ export class CoderAgentExecutor implements AgentExecutor {
   ): Promise<TaskWrapper> {
     const agentSettings = agentSettingsInput || ({} as AgentSettings);
     const config = await this.getConfig(agentSettings, taskId);
-    const runtimeTask = await Task.create(taskId, contextId, config, eventBus);
+    const runtimeTask = await Task.create(
+      taskId,
+      contextId,
+      config,
+      eventBus,
+      this.cliAppEvents,
+    );
     await runtimeTask.geminiClient.initialize();
 
     const wrapper = new TaskWrapper(runtimeTask, agentSettings);

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -920,7 +920,21 @@ export class Task {
       yield* (async function* () {})(); // Yield nothing
     }
   }
-
+  async *processUserInput(
+    inputText: string,
+    abortSignal: AbortSignal,
+    promptId: string,
+  ): AsyncGenerator<ServerGeminiStreamEvent> {
+    const stream = this.geminiClient.sendMessageStream(
+      inputText,
+      abortSignal,
+      promptId,
+    );
+    for await (const event of stream) {
+      await this.acceptAgentMessage(event);
+      yield event;
+    }
+  }
   _sendTextContent(content: string): void {
     if (content === '') {
       return;

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -138,13 +138,21 @@ export function mergeMcpServers(settings: Settings, extensions: Extension[]) {
 
 export function setTargetDir(agentSettings: AgentSettings | undefined): string {
   const originalCWD = process.cwd();
+  logger.info(`[setTargetDir] Original CWD: ${originalCWD}`);
+  logger.info(`[setTargetDir] AgentSettings: ${JSON.stringify(agentSettings)}`);
+
   const targetDir =
     process.env['CODER_AGENT_WORKSPACE_PATH'] ??
     (agentSettings?.kind === CoderAgentEvent.StateAgentSettingsEvent
       ? agentSettings.workspacePath
       : undefined);
 
+  logger.info(`[setTargetDir] Target directory: ${targetDir}`);
+
   if (!targetDir) {
+    logger.info(
+      '[setTargetDir] No targetDir specified, returning original CWD.',
+    );
     return originalCWD;
   }
 
@@ -154,11 +162,13 @@ export function setTargetDir(agentSettings: AgentSettings | undefined): string {
 
   try {
     const resolvedPath = path.resolve(targetDir);
+    logger.info(`[setTargetDir] Resolved path: ${resolvedPath}`);
     process.chdir(resolvedPath);
+    logger.info(`[setTargetDir] New CWD: ${process.cwd()}`);
     return resolvedPath;
   } catch (e) {
     logger.error(
-      `[CoderAgentExecutor] Error resolving workspace path: ${e}, returning original os.cwd()`,
+      `[CoderAgentExecutor] Error resolving or changing workspace path: ${e}, returning original os.cwd()`,
     );
     return originalCWD;
   }

--- a/packages/a2a-server/src/http/app.test.ts
+++ b/packages/a2a-server/src/http/app.test.ts
@@ -100,7 +100,8 @@ describe('E2E Tests', () => {
   let server: Server;
 
   beforeAll(async () => {
-    app = await createApp();
+    const { expressApp } = await createApp();
+    app = expressApp;
     server = app.listen(0); // Listen on a random available port
   });
 

--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -8,7 +8,11 @@ import express from 'express';
 
 import type { AgentCard } from '@a2a-js/sdk';
 import type { TaskStore } from '@a2a-js/sdk/server';
-import { DefaultRequestHandler, InMemoryTaskStore } from '@a2a-js/sdk/server';
+import {
+  DefaultRequestHandler,
+  InMemoryTaskStore,
+  DefaultExecutionEventBusManager,
+} from '@a2a-js/sdk/server';
 import { A2AExpressApp } from '@a2a-js/sdk/server/express'; // Import server components
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../utils/logger.js';
@@ -93,10 +97,13 @@ export async function createApp(
       cliAppEvents,
     );
 
+    const eventBusManager = new DefaultExecutionEventBusManager();
+
     const requestHandler = new DefaultRequestHandler(
       coderAgentCard,
       taskStoreForHandler,
       agentExecutor,
+      eventBusManager,
     );
 
     let expressApp = express();
@@ -182,7 +189,7 @@ export async function createApp(
       }
       res.json({ metadata: await wrapper.task.getMetadata() });
     });
-    return { expressApp, agentExecutor };
+    return { expressApp, agentExecutor, eventBusManager };
   } catch (error) {
     logger.error('[CoreAgent] Error during startup:', error);
     process.exit(1);

--- a/packages/a2a-server/src/http/endpoints.test.ts
+++ b/packages/a2a-server/src/http/endpoints.test.ts
@@ -91,7 +91,8 @@ describe('Agent Server Endpoints', () => {
     testWorkspace = fs.mkdtempSync(
       path.join(os.tmpdir(), 'gemini-agent-test-'),
     );
-    app = await createApp();
+    const { expressApp } = await createApp();
+    app = expressApp;
     await new Promise<void>((resolve) => {
       server = app.listen(0, () => {
         const port = (server.address() as AddressInfo).port;

--- a/packages/a2a-server/src/http/server.ts
+++ b/packages/a2a-server/src/http/server.ts
@@ -7,7 +7,7 @@
 import * as url from 'node:url';
 import * as path from 'node:path';
 
-import { logger } from '../utils/logger.js';
+import { logger, initializeLogger } from '../utils/logger.js';
 import { main } from './app.js';
 
 // Check if the module is the main script being run. path.resolve() creates a
@@ -26,6 +26,7 @@ if (
   isMainModule &&
   process.env['NODE_ENV'] !== 'test'
 ) {
+  initializeLogger(); // Enable console logging for standalone server
   main().catch((error) => {
     logger.error('[CoreAgent] Unhandled error in main:', error);
     process.exit(1);

--- a/packages/a2a-server/src/types.ts
+++ b/packages/a2a-server/src/types.ts
@@ -37,6 +37,10 @@ export enum CoderAgentEvent {
    * An event that contains a thought from the agent.
    */
   ThoughtEvent = 'thought',
+  /**
+   * An event representing the initial user message from an external source.
+   */
+  ExternalUserMessageEvent = 'external-user-message',
 }
 
 export interface AgentSettings {
@@ -64,6 +68,10 @@ export interface Thought {
   kind: CoderAgentEvent.ThoughtEvent;
 }
 
+export interface ExternalUserMessage {
+  kind: CoderAgentEvent.ExternalUserMessageEvent;
+}
+
 export type ThoughtSummary = {
   subject: string;
   description: string;
@@ -80,7 +88,8 @@ export type CoderAgentMessage =
   | ToolCallUpdate
   | TextContent
   | StateChange
-  | Thought;
+  | Thought
+  | ExternalUserMessage;
 
 export interface TaskMetadata {
   id: string;

--- a/packages/a2a-server/src/types.ts
+++ b/packages/a2a-server/src/types.ts
@@ -40,7 +40,7 @@ export enum CoderAgentEvent {
 }
 
 export interface AgentSettings {
-  kind: CoderAgentEvent.StateAgentSettingsEvent;
+  kind: 'agent-settings';
   workspacePath: string;
 }
 

--- a/packages/a2a-server/src/utils/logger.ts
+++ b/packages/a2a-server/src/utils/logger.ts
@@ -22,7 +22,13 @@ const logger = winston.createLogger({
       ); // Only print ...rest if present
     }),
   ),
-  transports: [new winston.transports.Console()],
+  transports: [], // Console transport added by initializeLogger
 });
+
+export function initializeLogger(): void {
+  if (!logger.transports.some((t) => t instanceof winston.transports.Console)) {
+    logger.add(new winston.transports.Console());
+  }
+}
 
 export { logger };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
     "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.9.0-nightly.20251001.163dba7e"
   },
   "dependencies": {
+    "@a2a-js/sdk": "^0.3.4",
     "@google/gemini-cli-core": "file:../core",
     "@google/genai": "1.16.0",
     "@iarna/toml": "^2.2.5",

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -87,6 +87,7 @@ export interface CliArgs {
   useSmartEdit: boolean | undefined;
   useWriteTodos: boolean | undefined;
   outputFormat: string | undefined;
+  a2aPort: number | undefined;
 }
 
 export async function parseArguments(settings: Settings): Promise<CliArgs> {
@@ -167,6 +168,10 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
       'proxy',
       'Use the "proxy" setting in settings.json instead. This flag will be removed in a future version.',
     )
+    .option('a2a-port', {
+      type: 'number',
+      description: 'Port number for the A2A server.',
+    })
     .command('$0 [query..]', 'Launch Gemini CLI', (yargsInstance) =>
       yargsInstance
         .positional('query', {

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -330,6 +330,7 @@ describe('gemini.tsx main function kitty protocol', () => {
       useSmartEdit: undefined,
       useWriteTodos: undefined,
       outputFormat: undefined,
+      a2aPort: undefined,
     });
 
     await main();

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -370,8 +370,16 @@ export async function main() {
         appEvents,
       );
       agentExecutor = exec;
-      expressApp.listen(argv.a2aPort, () => {
+      const server = expressApp.listen(argv.a2aPort, () => {
         console.log(`A2A server listening on port ${argv.a2aPort}`);
+      });
+      server.on('error', (err) => {
+        console.error(
+          `Failed to start A2A server on port ${argv.a2aPort}:`,
+          err,
+        );
+        // Optionally exit or prevent agentExecutor from being used
+        agentExecutor = undefined;
       });
     }
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -61,7 +61,6 @@ import { useTerminalSize } from './hooks/useTerminalSize.js';
 import { calculatePromptWidths } from './components/InputPrompt.js';
 import { useStdin, useStdout } from 'ink';
 import ansiEscapes from 'ansi-escapes';
-import * as fs from 'node:fs';
 import { basename } from 'node:path';
 import { computeWindowTitle } from '../utils/windowTitle.js';
 import { useTextBuffer } from './components/shared/text-buffer.js';
@@ -91,6 +90,7 @@ import { useGitBranchName } from './hooks/useGitBranchName.js';
 import { useExtensionUpdates } from './hooks/useExtensionUpdates.js';
 import { ShellFocusContext } from './contexts/ShellFocusContext.js';
 import type { CoderAgentExecutor } from '@google/gemini-cli-a2a-server/src/agent/executor.js';
+import type { ExecutionEventBus } from '@a2a-js/sdk/server';
 
 const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
 
@@ -112,6 +112,7 @@ interface AppContainerProps {
   version: string;
   initializationResult: InitializationResult;
   agentExecutor?: CoderAgentExecutor;
+  a2aEventBus?: ExecutionEventBus;
 }
 
 /**
@@ -567,6 +568,13 @@ Logging in with Google... Please restart Gemini CLI to continue.
 
   const cancelHandlerRef = useRef<() => void>(() => {});
 
+  const logDebugMessage = useCallback(
+    (message: string) => {
+      setDebugMessage(message);
+    },
+    [setDebugMessage],
+  );
+
   const {
     streamingState,
     submitQuery,
@@ -583,7 +591,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     historyManager.addItem,
     config,
     settings,
-    setDebugMessage,
+    logDebugMessage,
     handleSlashCommand,
     shellModeActive,
     () => settings.merged.general?.preferredEditor as EditorType,
@@ -598,6 +606,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     terminalHeight,
     embeddedShellFocused,
     props.agentExecutor,
+    props.a2aEventBus,
   );
 
   // Auto-accept indicator

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -90,6 +90,7 @@ import { useSessionStats } from './contexts/SessionContext.js';
 import { useGitBranchName } from './hooks/useGitBranchName.js';
 import { useExtensionUpdates } from './hooks/useExtensionUpdates.js';
 import { ShellFocusContext } from './contexts/ShellFocusContext.js';
+import type { CoderAgentExecutor } from '@google/gemini-cli-a2a-server/src/agent/executor.js';
 
 const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
 
@@ -110,6 +111,7 @@ interface AppContainerProps {
   startupWarnings?: string[];
   version: string;
   initializationResult: InitializationResult;
+  agentExecutor?: CoderAgentExecutor;
 }
 
 /**

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -61,6 +61,7 @@ import { useTerminalSize } from './hooks/useTerminalSize.js';
 import { calculatePromptWidths } from './components/InputPrompt.js';
 import { useStdin, useStdout } from 'ink';
 import ansiEscapes from 'ansi-escapes';
+import * as fs from 'node:fs';
 import { basename } from 'node:path';
 import { computeWindowTitle } from '../utils/windowTitle.js';
 import { useTextBuffer } from './components/shared/text-buffer.js';

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -597,6 +597,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     terminalWidth,
     terminalHeight,
     embeddedShellFocused,
+    props.agentExecutor,
   );
 
   // Auto-accept indicator

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -156,7 +156,7 @@ export function useReactToolScheduler(
       request: ToolCallRequestInfo | ToolCallRequestInfo[],
       signal: AbortSignal,
     ) => {
-      void scheduler.schedule(request, signal);
+      void scheduler.schedule(request, signal, 'cli');
     },
     [scheduler],
   );

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -84,5 +84,5 @@
     "src/services/prompt-processors/shellProcessor.test.ts",
     "src/commands/extensions/examples/**"
   ],
-  "references": [{ "path": "../core" }]
+  "references": [{ "path": "../core" }, { "path": "../a2a-server" }]
 }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import type {
   GenerateContentConfig,
   PartListUnion,
@@ -150,7 +156,9 @@ export class GeminiClient {
   }
 
   async initialize() {
-    this.chat = await this.startChat();
+    if (!this.chat) {
+      this.chat = await this.startChat();
+    }
   }
 
   private getContentGeneratorOrFail(): ContentGenerator {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -275,7 +275,7 @@ describe('CoreToolScheduler', () => {
     };
 
     abortController.abort();
-    await scheduler.schedule([request], abortController.signal);
+    await scheduler.schedule([request], abortController.signal, 'cli');
 
     expect(onAllToolCallsComplete).toHaveBeenCalled();
     const completedCalls = onAllToolCallsComplete.mock
@@ -350,7 +350,7 @@ describe('CoreToolScheduler', () => {
       prompt_id: 'prompt-id-abort',
     };
 
-    await scheduler.schedule([request], abortController.signal);
+    await scheduler.schedule([request], abortController.signal, 'cli');
 
     expect(onAllToolCallsComplete).toHaveBeenCalled();
     const completedCalls = onAllToolCallsComplete.mock
@@ -467,7 +467,7 @@ describe('CoreToolScheduler with payload', () => {
       prompt_id: 'prompt-id-2',
     };
 
-    await scheduler.schedule([request], abortController.signal);
+    await scheduler.schedule([request], abortController.signal, 'cli');
 
     const awaitingCall = (await waitForStatus(
       onToolCallsUpdate,
@@ -787,7 +787,7 @@ describe('CoreToolScheduler edit cancellation', () => {
       prompt_id: 'prompt-id-1',
     };
 
-    await scheduler.schedule([request], abortController.signal);
+    await scheduler.schedule([request], abortController.signal, 'cli');
 
     const awaitingCall = (await waitForStatus(
       onToolCallsUpdate,
@@ -894,7 +894,7 @@ describe('CoreToolScheduler YOLO mode', () => {
     };
 
     // Act
-    await scheduler.schedule([request], abortController.signal);
+    await scheduler.schedule([request], abortController.signal, 'cli');
 
     // Wait for the tool execution to complete
     await vi.waitFor(() => {
@@ -1008,7 +1008,7 @@ describe('CoreToolScheduler request queueing', () => {
     };
 
     // Schedule the first call, which will pause execution.
-    scheduler.schedule([request1], abortController.signal);
+    scheduler.schedule([request1], abortController.signal, 'cli');
 
     // Wait for the first call to be in the 'executing' state.
     await waitForStatus(onToolCallsUpdate, 'executing');
@@ -1017,6 +1017,7 @@ describe('CoreToolScheduler request queueing', () => {
     const schedulePromise2 = scheduler.schedule(
       [request2],
       abortController.signal,
+      'cli',
     );
 
     // Ensure the second tool call hasn't been executed yet.
@@ -1133,7 +1134,7 @@ describe('CoreToolScheduler request queueing', () => {
     };
 
     // Act
-    await scheduler.schedule([request], abortController.signal);
+    await scheduler.schedule([request], abortController.signal, 'cli');
 
     // Wait for the tool execution to complete
     await vi.waitFor(() => {
@@ -1245,10 +1246,12 @@ describe('CoreToolScheduler request queueing', () => {
     const schedulePromise1 = scheduler.schedule(
       [request1],
       abortController.signal,
+      'cli',
     );
     const schedulePromise2 = scheduler.schedule(
       [request2],
       abortController.signal,
+      'cli',
     );
 
     // Wait for both promises to resolve.
@@ -1372,7 +1375,7 @@ describe('CoreToolScheduler request queueing', () => {
       },
     ];
 
-    await scheduler.schedule(requests, abortController.signal);
+    await scheduler.schedule(requests, abortController.signal, 'cli');
 
     // Wait for all tools to be awaiting approval
     await vi.waitFor(() => {

--- a/packages/core/src/core/nonInteractiveToolExecutor.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.ts
@@ -28,7 +28,7 @@ export async function executeToolCall(
         resolve(completedToolCalls[0].response);
       },
     })
-      .schedule(toolCallRequest, abortSignal)
+      .schedule(toolCallRequest, abortSignal, 'cli')
       .catch(reject);
   });
 }


### PR DESCRIPTION
Issue link: https://github.com/google-gemini/gemini-cli/issues/10482

This pull request integrates the `@google/gemini-cli-a2a-server` directly within the Gemini CLI application. This allows the CLI to start an A2A server on a specified port, enabling external control and interaction with the active Gemini session.

**Key Changes & Features:**

1.  **Embedded A2A Server:**
    *   The CLI can now optionally start the A2A server on launch via the `--a2a-port` flag.
    *   The server uses the CLI's existing `Config` object and `EventEmitter`, ensuring a shared context.
    *   An `InMemoryTaskStore` is used when running in this embedded mode.

2.  **External Message Injection:**
    *   External clients can send messages to the A2A server's endpoints.
    *   These messages are treated as user input within the CLI session, appearing in the UI prefixed with "ext - ".
    *   The `CoderAgentExecutor` now publishes an `ExternalUserMessageEvent` to the event bus for the CLI to display these incoming messages.

3.  **Event Streaming & UI Updates:**
    *   The `useGeminiStream` hook now subscribes to events from the A2A server's event bus when the server is active.
    *   It handles events like `TextContentEvent`, `ThoughtEvent`, and `StateChangeEvent` originating from external A2A interactions, updating the CLI UI accordingly (e.g., displaying agent responses, thoughts, and state changes).
    *   Tool call events from external requests are also handled, leveraging the existing `useReactToolScheduler` integration.

4.  **Bidirectional Communication:**
    *   Messages and tool calls initiated from the CLI UI are processed by the shared `CoderAgentExecutor`.
    *   Responses and updates from the agent, whether triggered by the CLI or external requests, are reflected in the CLI UI.

5.  **Context & State Sharing:**
    *   The same `GeminiClient` and `CoreToolScheduler` instances are used for both CLI and external interactions, maintaining a consistent session state.
    *   A `source` property (`'cli'` | `'external'`) has been added to various event handlers and scheduler methods to distinguish the origin of requests and events.

6.  **Configuration & Initialization:**
    *   `createApp` in the A2A server can now accept a `cliConfig` and `cliAppEvents` to initialize in embedded mode.
    *   Logger initialization is adjusted to only add a console transport when the A2A server is run standalone.

**Purpose:**

This integration enables powerful new use cases, such as:

*   Programmatic control of the Gemini CLI from other applications or scripts.
*   Building custom interfaces or workflows that leverage the CLI's agentic capabilities.
*   Facilitating more complex interactions where input comes from multiple sources.

**Testing:**

To test this integration, start Gemini CLI with the A2A server enabled:

```bash
gemini --a2a-port 41243
```

You can then interact with the A2A server using HTTP requests. Here are some examples using `fetch` in Node.js:

**1. Sending a User Message:**

This will inject a message into the CLI as if the user typed it.

```javascript
const A2A_SERVER_URL = 'http://localhost:41243/';
const TASK_ID = 'cli-session-task';
const CONTEXT_ID = 'cli-session-context';

async function sendMessage(messageText) {
  const response = await fetch(A2A_SERVER_URL, {
    method: 'POST',
    headers: { 'Content-Type': 'application/json' },
    body: JSON.stringify({
      jsonrpc: '2.0',
      id: '123',
      method: 'message/stream',
      params: {
        message: {
          kind: 'message',
          role: 'user',
          parts: [{ kind: 'text', text: messageText }],
          taskId: TASK_ID,
          contextId: CONTEXT_ID,
        },
      },
    }),
  });
  console.log('Message sent, status:', response.status);
  // Note: The response body is a stream of events, not handled in this snippet
}

// Example:
// sendMessage("What is the capital of France?");
```

**2. Listening for Events:**

This connects to the event stream for the CLI session.

```javascript
const A2A_SERVER_URL = 'http://localhost:41243/';
const TASK_ID = 'cli-session-task';
const CONTEXT_ID = 'cli-session-context';

async function listenForEvents() {
  const response = await fetch(A2A_SERVER_URL, {
    method: 'POST',
    headers: {
      'Content-Type': 'application/json',
      'Accept': 'text/event-stream',
    },
    body: JSON.stringify({
      jsonrpc: '2.0',
      id: '456',
      method: 'message/stream',
      params: {
        message: {
          kind: 'message',
          role: 'user',
          parts: [{ kind: 'text', text: '' }], // Empty message to initiate
          taskId: TASK_ID,
          contextId: CONTEXT_ID,
        },
      },
    }),
  });

  if (response.body) {
    const reader = response.body.getReader();
    const decoder = new TextDecoder();
    console.log('--- Listening for events ---');
    while (true) {
      const { done, value } = await reader.read();
      if (done) break;
      const chunk = decoder.decode(value, { stream: true });
      const eventLines = chunk.split('\\n');
      for (const line of eventLines) {
        if (line.startsWith('data: ')) {
          try {
            const data = JSON.parse(line.substring(6));
            console.log('EVENT:', JSON.stringify(data, null, 2));
          } catch (e) {
            console.error('Parse error:', e);
          }
        }
      }
    }
  }
}

// Example:
// listenForEvents();
```

**3. Getting Task Metadata:**

This fetches information about the active tasks, including the CLI session.

```javascript
const A2A_SERVER_URL = 'http://localhost:41243/';

async function getTasks() {
  const response = await fetch(`${A2A_SERVER_URL}tasks/metadata`);
  if (response.ok && response.status !== 204) {
    const tasks = await response.json();
    console.log('TASKS:', JSON.stringify(tasks, null, 2));
  } else {
    console.log('No tasks or error:', response.status);
  }
}

// Example:
// getTasks();
```

**4. Sending Tool Confirmation:**

If the agent requests tool confirmation, you can respond like this:

```javascript
const A2A_SERVER_URL = 'http://localhost:41243/';
const TASK_ID = 'cli-session-task';
const CONTEXT_ID = 'cli-session-context';

async function sendToolConfirmation(toolCallId, outcome) { // outcome: 'proceed_once' | 'cancel'
  const response = await fetch(A2A_SERVER_URL, {
    method: 'POST',
    headers: { 'Content-Type': 'application/json' },
    body: JSON.stringify({
      jsonrpc: '2.0',
      id: '789',
      method: 'message/stream',
      params: {
        message: {
          kind: 'message',
          role: 'user',
          parts: [{
            kind: 'data',
            data: { callId: toolCallId, outcome: outcome },
          }],
          taskId: TASK_ID,
          contextId: CONTEXT_ID,
        },
      },
    }),
  });
  console.log('Tool confirmation sent, status:', response.status);
}

// Example (get toolCallId from an event):
// sendToolConfirmation('tool_call_id_123', 'proceed_once');
```
