### PR TITLE
fix(infra) - Add original PR number into hotfix branch

### DIFF
--- a/scripts/releasing/create-patch-pr.js
+++ b/scripts/releasing/create-patch-pr.js
@@ -53,7 +53,7 @@ async function main() {
   const nextVersion = releaseInfo.nextVersion;
 
   const releaseBranch = `release/${latestTag}-pr-${pullRequestNumber}`;
-  const hotfixBranch = `hotfix/${latestTag}/${nextVersion}/${channel}/cherry-pick-${commit.substring(0, 7)}`;
+  const hotfixBranch = `hotfix/${latestTag}/${nextVersion}/${channel}/cherry-pick-${commit.substring(0, 7)}/pr-${pullRequestNumber}`;
 
   // Create the release branch from the tag if it doesn't exist.
   if (!branchExists(releaseBranch)) {

--- a/scripts/releasing/patch-trigger.js
+++ b/scripts/releasing/patch-trigger.js
@@ -15,9 +15,9 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 /**
- * Extract base version and channel info from hotfix branch name. Branches can
- * be in multiple formats:
- *  - New NEW: hotfix/v0.5.3/v0.5.4/preview/cherry-pick-abc -> v0.5.4 and preview
+ * Extract base version, original pr, and originalPr info from hotfix branch name.
+ * Formats:
+ *  - New NEW: hotfix/v0.5.3/v0.5.4/preview/cherry-pick-abc/pr-1234 -> v0.5.4, preview, 1234
  *  - New format: hotfix/v0.5.3/preview/cherry-pick-abc -> v0.5.3 and preview
  *  - Old format: hotfix/v0.5.3/cherry-pick-abc -> v0.5.3 and stable (default)
  * We check the formats from newest to oldest. If the channel found is invalid,
@@ -26,9 +26,12 @@ import { hideBin } from 'yargs/helpers';
 function getBranchInfo({ branchName, context }) {
   const parts = branchName.split('/');
   const version = parts[1];
+  let prNum;
   let channel = 'stable'; // default for old format
-  if (parts.length >= 5 && (parts[3] === 'stable' || parts[3] === 'preview')) {
+  if (parts.length >= 6 && (parts[3] === 'stable' || parts[3] === 'preview')) {
     channel = parts[3];
+    const prMatch = parts[5].match(/pr-(\d+)/);
+    prNum = prMatch[1];
   } else if (
     parts.length >= 4 &&
     (parts[2] === 'stable' || parts[2] === 'preview')
@@ -47,7 +50,7 @@ function getBranchInfo({ branchName, context }) {
     );
   }
 
-  return { channel, version };
+  return { channel, prNum, version };
 }
 
 async function main() {
@@ -115,11 +118,14 @@ async function main() {
 
   console.log(`Processing patch trigger for branch: ${headRef}`);
 
-  const { version, channel } = getBranchInfo({ branchName: headRef, context });
+  const { prNum, version, channel } = getBranchInfo({
+    branchName: headRef,
+    context,
+  });
 
-  // Try to find the original PR that requested this patch
-  let originalPr = null;
-  if (!testMode) {
+  let originalPr = prNum;
+
+  if (!testMode && !originalPr) {
     try {
       console.log('Looking for original PR using search...');
       const { execFileSync } = await import('node:child_process');

--- a/scripts/releasing/patch-trigger.js
+++ b/scripts/releasing/patch-trigger.js
@@ -126,6 +126,7 @@ async function main() {
   let originalPr = prNum;
   console.log(`Found originalPr: ${prNum} from hotfix branch`);
 
+  // Fallback to using PR search (inconsistent) if no pr found in branch name.
   if (!testMode && !originalPr) {
     try {
       console.log('Looking for original PR using search...');

--- a/scripts/releasing/patch-trigger.js
+++ b/scripts/releasing/patch-trigger.js
@@ -167,7 +167,8 @@ async function main() {
     } catch (e) {
       console.log('Could not determine original PR:', e.message);
     }
-  } else {
+  }
+  if (!originalPr && testMode) {
     console.log('Skipping original PR lookup (test mode)');
     originalPr = 8655; // Mock for testing
   }

--- a/scripts/releasing/patch-trigger.js
+++ b/scripts/releasing/patch-trigger.js
@@ -124,6 +124,7 @@ async function main() {
   });
 
   let originalPr = prNum;
+  console.log(`Found originalPr: ${prNum} from hotfix branch`);
 
   if (!testMode && !originalPr) {
     try {


### PR DESCRIPTION
## TLDR

Instead of searching for originalPr number we will add the info into the hotfix branch

## Dive Deeper


## Reviewer Test Plan

`gh workflow run release-patch-1-create-pr.yml --ref ss/addPrHotfix -f ref=ss/addPrHotfix -f commit=0b979e5439fd153e9a7a8520bc466d1d7a3c7244 -f channel=preview -f dry_run=true -f original_pr=10484`

Dry run result: https://github.com/google-gemini/gemini-cli/actions/runs/18229753963/job/51909953796

`gh workflow run release-patch-2-trigger.yml --ref ss/addPrHotfix -f ref=hotfix/v0.8.0-preview.1/0.8.0-preview.2/preview/cherry-pick-0b979e5/pr-10484 -f workflow_ref=ss/addPrHotfix -f dry_run=true -f force_skip_tests=true`
Dry run result: https://github.com/google-gemini/gemini-cli/actions/runs/18229956817/job/51910678916
## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #10344
