### PR TITLE
Enhance debug profiler to track tree framerate and dispatch errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17694,6 +17694,7 @@
         "ink-gradient": "^3.0.0",
         "ink-spinner": "^5.0.0",
         "lowlight": "^3.3.0",
+        "mnemonist": "^0.40.3",
         "open": "^10.1.2",
         "react": "^19.1.0",
         "read-package-up": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.9.0-nightly.20251001.163dba7e"
   },
   "scripts": {
-    "start": "cross-env node scripts/start.js",
+    "start": "cross-env NODE_ENV=development node scripts/start.js",
     "start:a2a-server": "CODER_AGENT_PORT=41242 npm run start --workspace @google/gemini-cli-a2a-server",
     "debug": "cross-env DEBUG=1 node --inspect-brk scripts/start.js",
     "auth:npm": "npx google-artifactregistry-auth",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,6 +45,7 @@
     "ink-gradient": "^3.0.0",
     "ink-spinner": "^5.0.0",
     "lowlight": "^3.3.0",
+    "mnemonist": "^0.40.3",
     "open": "^10.1.2",
     "react": "^19.1.0",
     "read-package-up": "^11.0.0",

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -115,7 +115,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.CLEAR_SCREEN]: [{ key: 'l', ctrl: true }],
 
   // History navigation
-  [Command.HISTORY_UP]: [{ key: 'p', ctrl: true }],
+  [Command.HISTORY_UP]: [{ key: 'p', ctrl: true, shift: false }],
   [Command.HISTORY_DOWN]: [{ key: 'n', ctrl: true }],
   [Command.NAVIGATION_UP]: [{ key: 'up' }],
   [Command.NAVIGATION_DOWN]: [{ key: 'down' }],

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { isDevelopment } from '../utils/installationInfo.js';
 import type { ICommandLoader } from './types.js';
 import type { SlashCommand } from '../ui/commands/types.js';
 import type { Config } from '@google/gemini-cli-core';
@@ -27,6 +28,7 @@ import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { modelCommand } from '../ui/commands/modelCommand.js';
 import { permissionsCommand } from '../ui/commands/permissionsCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
+import { profileCommand } from '../ui/commands/profileCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
@@ -73,6 +75,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       ...(this.config?.getUseModelRouter() ? [modelCommand] : []),
       ...(this.config?.getFolderTrust() ? [permissionsCommand] : []),
       privacyCommand,
+      ...(isDevelopment ? [profileCommand] : []),
       quitCommand,
       restoreCommand(this.config),
       statsCommand,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -139,6 +139,7 @@ export const AppContainer = (props: AppContainerProps) => {
   );
   const [isProcessing, setIsProcessing] = useState<boolean>(false);
   const [embeddedShellFocused, setEmbeddedShellFocused] = useState(false);
+  const [showDebugProfiler, setShowDebugProfiler] = useState(false);
 
   const [geminiMdFileCount, setGeminiMdFileCount] = useState<number>(
     initializationResult.geminiMdFileCount,
@@ -172,6 +173,11 @@ export const AppContainer = (props: AppContainerProps) => {
   );
   const closePermissionsDialog = useCallback(
     () => setPermissionsDialogOpen(false),
+    [],
+  );
+
+  const toggleDebugProfiler = useCallback(
+    () => setShowDebugProfiler((prev) => !prev),
     [],
   );
 
@@ -460,6 +466,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       },
       setDebugMessage,
       toggleCorgiMode: () => setCorgiMode((prev) => !prev),
+      toggleDebugProfiler,
       dispatchExtensionStateUpdate,
       addConfirmUpdateExtensionRequest,
     }),
@@ -476,6 +483,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       dispatchExtensionStateUpdate,
       openPermissionsDialog,
       addConfirmUpdateExtensionRequest,
+      toggleDebugProfiler,
     ],
   );
 
@@ -1146,6 +1154,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       extensionsUpdateState,
       activePtyId,
       embeddedShellFocused,
+      showDebugProfiler,
     }),
     [
       isThemeDialogOpen,
@@ -1226,6 +1235,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       activePtyId,
       historyManager,
       embeddedShellFocused,
+      showDebugProfiler,
     ],
   );
 

--- a/packages/cli/src/ui/auth/AuthInProgress.tsx
+++ b/packages/cli/src/ui/auth/AuthInProgress.tsx
@@ -7,7 +7,7 @@
 import type React from 'react';
 import { useState, useEffect } from 'react';
 import { Box, Text } from 'ink';
-import Spinner from 'ink-spinner';
+import { CliSpinner } from '../components/CliSpinner.js';
 import { theme } from '../semantic-colors.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 
@@ -53,8 +53,8 @@ export function AuthInProgress({
       ) : (
         <Box>
           <Text>
-            <Spinner type="dots" /> Waiting for auth... (Press ESC or CTRL+C to
-            cancel)
+            <CliSpinner type="dots" /> Waiting for auth... (Press ESC or CTRL+C
+            to cancel)
           </Text>
         </Box>
       )}

--- a/packages/cli/src/ui/commands/profileCommand.ts
+++ b/packages/cli/src/ui/commands/profileCommand.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isDevelopment } from '../../utils/installationInfo.js';
+import { CommandKind, type SlashCommand } from './types.js';
+
+export const profileCommand: SlashCommand | null = isDevelopment
+  ? {
+      name: 'profile',
+      kind: CommandKind.BUILT_IN,
+      description: 'Toggle the debug profile display',
+      action: async (context) => {
+        context.ui.toggleDebugProfiler();
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: 'Toggled profile display.',
+        };
+      },
+    }
+  : null;

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -66,6 +66,7 @@ export interface CommandContext {
     loadHistory: UseHistoryManagerReturn['loadHistory'];
     /** Toggles a special display mode. */
     toggleCorgiMode: () => void;
+    toggleDebugProfiler: () => void;
     toggleVimEnabled: () => Promise<boolean>;
     setGeminiMdFileCount: (count: number) => void;
     reloadCommands: () => void;

--- a/packages/cli/src/ui/components/CliSpinner.tsx
+++ b/packages/cli/src/ui/components/CliSpinner.tsx
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Spinner from 'ink-spinner';
+import { type ComponentProps, useEffect } from 'react';
+
+// A top-level field to track the total number of active spinners.
+export let debugNumSpinners = 0;
+
+export type SpinnerProps = ComponentProps<typeof Spinner>;
+
+export const CliSpinner = (props: SpinnerProps) => {
+  useEffect(() => {
+    debugNumSpinners++;
+    return () => {
+      debugNumSpinners--;
+    };
+  }, []);
+
+  return <Spinner {...props} />;
+};

--- a/packages/cli/src/ui/components/DebugProfiler.test.tsx
+++ b/packages/cli/src/ui/components/DebugProfiler.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  profiler,
+  ACTION_TIMESTAMP_CAPACITY,
+  FRAME_TIMESTAMP_CAPACITY,
+} from './DebugProfiler.js';
+import { FixedDeque } from 'mnemonist';
+
+describe('DebugProfiler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    profiler.numFrames = 0;
+    profiler.totalIdleFrames = 0;
+    profiler.lastFrameStartTime = 0;
+    profiler.openedDebugConsole = false;
+    profiler.lastActionTimestamp = 0;
+    profiler.possiblyIdleFrameTimestamps = new FixedDeque<number>(
+      Array,
+      FRAME_TIMESTAMP_CAPACITY,
+    );
+    profiler.actionTimestamps = new FixedDeque<number>(
+      Array,
+      ACTION_TIMESTAMP_CAPACITY,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    profiler.actionTimestamps.clear();
+    profiler.possiblyIdleFrameTimestamps.clear();
+  });
+
+  it('should not exceed action timestamp capacity', () => {
+    for (let i = 0; i < ACTION_TIMESTAMP_CAPACITY + 10; i++) {
+      profiler.reportAction();
+      // To ensure we don't trigger the debounce
+      profiler.lastActionTimestamp = 0;
+    }
+    expect(profiler.actionTimestamps.size).toBe(ACTION_TIMESTAMP_CAPACITY);
+  });
+
+  it('should not exceed frame timestamp capacity', () => {
+    for (let i = 0; i < FRAME_TIMESTAMP_CAPACITY + 10; i++) {
+      profiler.reportFrameRendered();
+      // To ensure we don't trigger the debounce
+      profiler.lastFrameStartTime = 0;
+    }
+    expect(profiler.possiblyIdleFrameTimestamps.size).toBe(
+      FRAME_TIMESTAMP_CAPACITY,
+    );
+  });
+
+  it('should drop oldest action timestamps when capacity is reached', () => {
+    for (let i = 0; i < ACTION_TIMESTAMP_CAPACITY; i++) {
+      profiler.actionTimestamps.push(i);
+    }
+    profiler.lastActionTimestamp = 0;
+    profiler.reportAction();
+
+    expect(profiler.actionTimestamps.size).toBe(ACTION_TIMESTAMP_CAPACITY);
+    expect(profiler.actionTimestamps.peekFirst()).toBe(1);
+  });
+
+  it('should drop oldest frame timestamps when capacity is reached', () => {
+    for (let i = 0; i < FRAME_TIMESTAMP_CAPACITY; i++) {
+      profiler.possiblyIdleFrameTimestamps.push(i);
+    }
+    profiler.lastFrameStartTime = 0;
+    profiler.reportFrameRendered();
+
+    expect(profiler.possiblyIdleFrameTimestamps.size).toBe(
+      FRAME_TIMESTAMP_CAPACITY,
+    );
+    expect(profiler.possiblyIdleFrameTimestamps.peekFirst()).toBe(1);
+  });
+
+  it('should not report frames as idle if an action happens shortly after', async () => {
+    const startTime = Date.now();
+    vi.setSystemTime(startTime);
+
+    for (let i = 0; i < 5; i++) {
+      profiler.reportFrameRendered();
+      vi.advanceTimersByTime(20);
+    }
+
+    vi.setSystemTime(startTime + 400);
+    profiler.reportAction();
+
+    vi.advanceTimersByTime(600);
+    profiler.checkForIdleFrames();
+
+    expect(profiler.totalIdleFrames).toBe(0);
+  });
+
+  it('should report frames as idle if no action happens nearby', async () => {
+    const startTime = Date.now();
+    vi.setSystemTime(startTime);
+
+    for (let i = 0; i < 5; i++) {
+      profiler.reportFrameRendered();
+      vi.advanceTimersByTime(20);
+    }
+
+    vi.advanceTimersByTime(1000);
+    profiler.checkForIdleFrames();
+
+    expect(profiler.totalIdleFrames).toBe(5);
+  });
+
+  it('should not report frames as idle if an action happens shortly before', async () => {
+    const startTime = Date.now();
+    vi.setSystemTime(startTime);
+
+    profiler.reportAction();
+
+    vi.advanceTimersByTime(400);
+
+    for (let i = 0; i < 5; i++) {
+      profiler.reportFrameRendered();
+      vi.advanceTimersByTime(20);
+    }
+
+    vi.advanceTimersByTime(600);
+    profiler.checkForIdleFrames();
+
+    expect(profiler.totalIdleFrames).toBe(0);
+  });
+
+  it('should correctly identify mixed idle and non-idle frames', async () => {
+    const startTime = Date.now();
+    vi.setSystemTime(startTime);
+
+    for (let i = 0; i < 3; i++) {
+      profiler.reportFrameRendered();
+      vi.advanceTimersByTime(20);
+    }
+
+    vi.advanceTimersByTime(1000);
+
+    profiler.reportAction();
+    vi.advanceTimersByTime(100);
+
+    for (let i = 0; i < 3; i++) {
+      profiler.reportFrameRendered();
+      vi.advanceTimersByTime(20);
+    }
+
+    vi.advanceTimersByTime(600);
+    profiler.checkForIdleFrames();
+
+    expect(profiler.totalIdleFrames).toBe(3);
+  });
+
+  it('should not report idle frames when actions are interleaved', async () => {
+    const startTime = Date.now();
+    vi.setSystemTime(startTime);
+
+    profiler.reportFrameRendered();
+    vi.advanceTimersByTime(20);
+
+    profiler.reportFrameRendered();
+    vi.advanceTimersByTime(200);
+
+    profiler.reportAction();
+    vi.advanceTimersByTime(200);
+
+    profiler.reportFrameRendered();
+    vi.advanceTimersByTime(20);
+
+    profiler.reportFrameRendered();
+
+    vi.advanceTimersByTime(600);
+    profiler.checkForIdleFrames();
+
+    expect(profiler.totalIdleFrames).toBe(0);
+  });
+});

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -18,6 +18,7 @@ import { DebugProfiler } from './DebugProfiler.js';
 
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import { isNarrowWidth } from '../utils/isNarrowWidth.js';
+import { isDevelopment } from '../../utils/installationInfo.js';
 
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
@@ -76,6 +77,8 @@ export const Footer: React.FC = () => {
   const justifyContent = hideCWD && hideModelInfo ? 'center' : 'space-between';
   const displayVimMode = vimEnabled ? vimMode : undefined;
 
+  const showDebugProfiler = debugMode || isDevelopment;
+
   return (
     <Box
       justifyContent={justifyContent}
@@ -83,9 +86,9 @@ export const Footer: React.FC = () => {
       flexDirection={isNarrow ? 'column' : 'row'}
       alignItems={isNarrow ? 'flex-start' : 'center'}
     >
-      {(debugMode || displayVimMode || !hideCWD) && (
+      {(showDebugProfiler || displayVimMode || !hideCWD) && (
         <Box>
-          {debugMode && <DebugProfiler />}
+          {showDebugProfiler && <DebugProfiler />}
           {displayVimMode && (
             <Text color={theme.text.secondary}>[{displayVimMode}] </Text>
           )}

--- a/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
+++ b/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
@@ -6,7 +6,7 @@
 
 import type React from 'react';
 import { Text, useIsScreenReaderEnabled } from 'ink';
-import Spinner from 'ink-spinner';
+import { CliSpinner } from './CliSpinner.js';
 import type { SpinnerName } from 'cli-spinners';
 import { useStreamingContext } from '../contexts/StreamingContext.js';
 import { StreamingState } from '../types.js';
@@ -61,7 +61,7 @@ export const GeminiSpinner: React.FC<GeminiSpinnerProps> = ({
     <Text>{altText}</Text>
   ) : (
     <Text color={theme.text.primary}>
-      <Spinner type={spinnerType} />
+      <CliSpinner type={spinnerType} />
     </Text>
   );
 };

--- a/packages/cli/src/ui/components/messages/CompressionMessage.tsx
+++ b/packages/cli/src/ui/components/messages/CompressionMessage.tsx
@@ -6,7 +6,7 @@
 
 import { Box, Text } from 'ink';
 import type { CompressionProps } from '../../types.js';
-import Spinner from 'ink-spinner';
+import { CliSpinner } from '../CliSpinner.js';
 import { theme } from '../../semantic-colors.js';
 import { SCREEN_READER_MODEL_PREFIX } from '../../textConstants.js';
 import { CompressionStatus } from '@google/gemini-cli-core';
@@ -59,7 +59,7 @@ export function CompressionMessage({
     <Box flexDirection="row">
       <Box marginRight={1}>
         {isPending ? (
-          <Spinner type="dots" />
+          <CliSpinner type="dots" />
         ) : (
           <Text color={theme.text.accent}>✦</Text>
         )}

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -119,6 +119,7 @@ export interface UIState {
   extensionsUpdateState: Map<string, ExtensionUpdateState>;
   activePtyId: number | undefined;
   embeddedShellFocused: boolean;
+  showDebugProfiler: boolean;
 }
 
 export const UIStateContext = createContext<UIState | null>(null);

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -51,6 +51,7 @@ interface SlashCommandProcessorActions {
   quit: (messages: HistoryItem[]) => void;
   setDebugMessage: (message: string) => void;
   toggleCorgiMode: () => void;
+  toggleDebugProfiler: () => void;
   dispatchExtensionStateUpdate: (action: ExtensionUpdateAction) => void;
   addConfirmUpdateExtensionRequest: (request: ConfirmationRequest) => void;
 }
@@ -197,6 +198,7 @@ export const useSlashCommandProcessor = (
         pendingItem,
         setPendingItem,
         toggleCorgiMode: actions.toggleCorgiMode,
+        toggleDebugProfiler: actions.toggleDebugProfiler,
         toggleVimEnabled,
         setGeminiMdFileCount,
         reloadCommands,

--- a/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
+++ b/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
@@ -21,6 +21,7 @@ export function createNonInteractiveUI(): CommandContext['ui'] {
     pendingItem: null,
     setPendingItem: (_item) => {},
     toggleCorgiMode: () => {},
+    toggleDebugProfiler: () => {},
     toggleVimEnabled: async () => false,
     setGeminiMdFileCount: (_count) => {},
     reloadCommands: () => {},

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -8,6 +8,9 @@ import { isGitRepository } from '@google/gemini-cli-core';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as childProcess from 'node:child_process';
+import process from 'node:process';
+
+export const isDevelopment = process.env['NODE_ENV'] === 'development';
 
 export enum PackageManager {
   NPM = 'npm',


### PR DESCRIPTION
## TLDR

Detect when we render frames and surface warnings if we are continously rendering frames when the app should be idle.

Only enabled when using `npm run start` so no production impact.
In those development builds the `/profile` tool is available and toggles this mode.

## Dive Deeper

We had a fairly accurate DebugProfiler that could be enabled with `ctrl-b` if you ran with DEBUG=1 but few developers did resulting in multiple bugs it could have caught making it to production.

We improve the robustness of frame detection by watching stdout to detect when Ink really is rendering frames rather than relying on a particular component being recomputed to indicate that a frame was rendered. Without this check we would miss frames due to proper use of React memoization. For example, renders of the input prompt were not captured as renders by the previous profiler.

Video of the alerts in action on an intentionally broken build:
[Demo of debug tracking.webm](https://github.com/user-attachments/assets/f66121e3-bf9b-45c0-915f-d950d4a1f1b7)
<img width="927" height="342" alt="Screenshot 2025-10-03 at 11 52 51 AM" src="https://github.com/user-attachments/assets/de144d31-3b92-4792-864b-7a237ce5fc09" />

UI when running a dev build after pressing ctrl+shift+P

**Open concern** resizing the app heavily appears to be trigger a flurry of frames not-associated with keyboard input. May need to tweak the thresholds a bit to reduce false positives.

## Reviewer Test Plan

Run Gemini CLI with npm run start. Verify that the profiler is available (ctrl+shift+p) 
Intentionally introduce a bug in Gemini CLI that renders constantly
Verify that the debug console gets opened and shows errors about the frames.

Verify that ctrl+shift+p is not available when running Gemini CLI via a mechanism other than npm run start.

## Linked issues / bugs

Resolves: #10257