### PR TITLE
fix(ci): ensure dry-run is false for scheduled nightly releases

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -57,7 +57,7 @@ jobs:
           echo "${{ toJSON(github.event.inputs) }}"
 
       - name: 'Run Tests'
-        if: "${{github.event.inputs.force_skip_tests == 'false'}}"
+        if: "${{ github.event_name == 'schedule' || github.event.inputs.force_skip_tests == 'false' }}"
         uses: './.github/actions/run-tests'
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
@@ -99,11 +99,11 @@ jobs:
           wombat-token-core: '${{ secrets.WOMBAT_TOKEN_CORE }}'
           wombat-token-cli: '${{ secrets.WOMBAT_TOKEN_CLI }}'
           github-token: '${{ secrets.GITHUB_TOKEN }}'
-          dry-run: '${{ github.event.inputs.dry_run }}'
+          dry-run: "${{ github.event_name != 'schedule' && github.event.inputs.dry_run == 'true' }}"
           previous-tag: '${{ steps.nightly_version.outputs.PREVIOUS_TAG }}'
           working-directory: './release'
           skip-branch-cleanup: true
-          force-skip-tests: '${{ github.event.inputs.force_skip_tests }}'
+          force-skip-tests: "${{ github.event_name != 'schedule' && github.event.inputs.force_skip_tests == 'true' }}"
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
 
       - name: 'Create and Merge Pull Request'
@@ -113,11 +113,11 @@ jobs:
           pr-title: 'chore/release: bump version to ${{ steps.nightly_version.outputs.RELEASE_VERSION }}'
           pr-body: 'Automated version bump for nightly release.'
           github-token: '${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}'
-          dry-run: '${{ github.event.inputs.dry_run }}'
+          dry-run: "${{ github.event_name != 'schedule' && github.event.inputs.dry_run == 'true' }}"
           working-directory: './release'
 
       - name: 'Create Issue on Failure'
-        if: "${{ failure() && github.event.inputs.dry_run != 'true' }}"
+        if: "${{ failure() && (github.event_name == 'schedule' || github.event.inputs.dry_run != 'true') }}"
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           RELEASE_TAG: '${{ steps.nightly_version.outputs.RELEASE_TAG }}'


### PR DESCRIPTION
## TLDR

This PR fixes the `release-nightly.yml` workflow to correctly disable `dry-run` and `force-skip-tests` when the workflow is triggered by a schedule. This ensures that nightly releases are actually published and tested.

## Dive Deeper

The previous configuration used `github.event.inputs.dry_run` which is only available for `workflow_dispatch` events. For `schedule` events, this input is not present, leading to an incorrect state where the release was not published. The workflow has been updated to explicitly check for `github.event_name == 'schedule'` to set these flags correctly.

## Reviewer Test Plan

Review the changes in `.github/workflows/release-nightly.yml`. The logic should now correctly handle both `schedule` and `workflow_dispatch` events.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes the issue where nightly releases were not being published.