### PR TITLE
Fix quoting when echoing workflow JSON

### DIFF
--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -32,7 +32,8 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: 'echo "${{ toJSON(inputs) }}"'
+      run: |
+        echo '${{ toJSON(inputs) }}'
     - name: 'Creates a Pull Request'
       if: "inputs.dry-run != 'true'"
       env:

--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -33,8 +33,8 @@ runs:
     - name: '📝 Print Inputs'
       shell: 'bash'
       env:
-        JSON_INPUTS: ${{ toJSON(inputs) }}
-      run: echo "$JSON_INPUTS"
+        JSON_INPUTS: '${{ toJSON(inputs) }}'
+      run: 'echo "$JSON_INPUTS"'
     - name: 'Creates a Pull Request'
       if: "inputs.dry-run != 'true'"
       env:

--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -32,8 +32,9 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: |
-        echo '${{ toJSON(inputs) }}'
+      env:
+        JSON_INPUTS: ${{ toJSON(inputs) }}
+      run: echo "$JSON_INPUTS"
     - name: 'Creates a Pull Request'
       if: "inputs.dry-run != 'true'"
       env:

--- a/.github/actions/post-coverage-comment/action.yml
+++ b/.github/actions/post-coverage-comment/action.yml
@@ -29,8 +29,9 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: |
-        echo '${{ toJSON(inputs) }}'
+      env:
+        JSON_INPUTS: ${{ toJSON(inputs) }}
+      run: echo "$JSON_INPUTS"
     - name: 'Prepare Coverage Comment'
       id: 'prep_coverage_comment'
       shell: 'bash'

--- a/.github/actions/post-coverage-comment/action.yml
+++ b/.github/actions/post-coverage-comment/action.yml
@@ -30,8 +30,8 @@ runs:
     - name: '📝 Print Inputs'
       shell: 'bash'
       env:
-        JSON_INPUTS: ${{ toJSON(inputs) }}
-      run: echo "$JSON_INPUTS"
+        JSON_INPUTS: '${{ toJSON(inputs) }}'
+      run: 'echo "$JSON_INPUTS"'
     - name: 'Prepare Coverage Comment'
       id: 'prep_coverage_comment'
       shell: 'bash'

--- a/.github/actions/post-coverage-comment/action.yml
+++ b/.github/actions/post-coverage-comment/action.yml
@@ -29,7 +29,8 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: 'echo "${{ toJSON(inputs) }}"'
+      run: |
+        echo '${{ toJSON(inputs) }}'
     - name: 'Prepare Coverage Comment'
       id: 'prep_coverage_comment'
       shell: 'bash'

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -57,8 +57,9 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: |
-        echo '${{ toJSON(inputs) }}'
+      env:
+        JSON_INPUTS: ${{ toJSON(inputs) }}
+      run: echo "$JSON_INPUTS"
 
     - name: '👤 Configure Git User'
       working-directory: '${{ inputs.working-directory }}'

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -58,8 +58,8 @@ runs:
     - name: '📝 Print Inputs'
       shell: 'bash'
       env:
-        JSON_INPUTS: ${{ toJSON(inputs) }}
-      run: echo "$JSON_INPUTS"
+        JSON_INPUTS: '${{ toJSON(inputs) }}'
+      run: 'echo "$JSON_INPUTS"'
 
     - name: '👤 Configure Git User'
       working-directory: '${{ inputs.working-directory }}'

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -57,7 +57,8 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: 'echo "${{ toJSON(inputs) }}"'
+      run: |
+        echo '${{ toJSON(inputs) }}'
 
     - name: '👤 Configure Git User'
       working-directory: '${{ inputs.working-directory }}'

--- a/.github/actions/push-docker/action.yml
+++ b/.github/actions/push-docker/action.yml
@@ -20,7 +20,8 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: 'echo "${{ toJSON(inputs) }}"'
+      run: |
+        echo '${{ toJSON(inputs) }}'
     - name: 'Checkout'
       uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v4
       with:

--- a/.github/actions/push-docker/action.yml
+++ b/.github/actions/push-docker/action.yml
@@ -20,8 +20,9 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: |
-        echo '${{ toJSON(inputs) }}'
+      env:
+        JSON_INPUTS: ${{ toJSON(inputs) }}
+      run: echo "$JSON_INPUTS"
     - name: 'Checkout'
       uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v4
       with:

--- a/.github/actions/push-docker/action.yml
+++ b/.github/actions/push-docker/action.yml
@@ -21,8 +21,8 @@ runs:
     - name: '📝 Print Inputs'
       shell: 'bash'
       env:
-        JSON_INPUTS: ${{ toJSON(inputs) }}
-      run: echo "$JSON_INPUTS"
+        JSON_INPUTS: '${{ toJSON(inputs) }}'
+      run: 'echo "$JSON_INPUTS"'
     - name: 'Checkout'
       uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v4
       with:

--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -30,7 +30,8 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: 'echo "${{ toJSON(inputs) }}"'
+      run: |
+        echo '${{ toJSON(inputs) }}'
     - name: 'Checkout'
       uses: 'actions/checkout@v4'
       with:

--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -31,8 +31,8 @@ runs:
     - name: '📝 Print Inputs'
       shell: 'bash'
       env:
-        JSON_INPUTS: ${{ toJSON(inputs) }}
-      run: echo "$JSON_INPUTS"
+        JSON_INPUTS: '${{ toJSON(inputs) }}'
+      run: 'echo "$JSON_INPUTS"'
     - name: 'Checkout'
       uses: 'actions/checkout@v4'
       with:

--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -30,8 +30,9 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: |
-        echo '${{ toJSON(inputs) }}'
+      env:
+        JSON_INPUTS: ${{ toJSON(inputs) }}
+      run: echo "$JSON_INPUTS"
     - name: 'Checkout'
       uses: 'actions/checkout@v4'
       with:

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -15,7 +15,8 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: 'echo "${{ toJSON(inputs) }}"'
+      run: |
+        echo '${{ toJSON(inputs) }}'
     - name: 'Run Tests'
       env:
         GEMINI_API_KEY: '${{ inputs.gemini_api_key }}'

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -16,8 +16,8 @@ runs:
     - name: '📝 Print Inputs'
       shell: 'bash'
       env:
-        JSON_INPUTS: ${{ toJSON(inputs) }}
-      run: echo "$JSON_INPUTS"
+        JSON_INPUTS: '${{ toJSON(inputs) }}'
+      run: 'echo "$JSON_INPUTS"'
     - name: 'Run Tests'
       env:
         GEMINI_API_KEY: '${{ inputs.gemini_api_key }}'

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -15,8 +15,9 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: |
-        echo '${{ toJSON(inputs) }}'
+      env:
+        JSON_INPUTS: ${{ toJSON(inputs) }}
+      run: echo "$JSON_INPUTS"
     - name: 'Run Tests'
       env:
         GEMINI_API_KEY: '${{ inputs.gemini_api_key }}'

--- a/.github/actions/tag-npm-release/action.yml
+++ b/.github/actions/tag-npm-release/action.yml
@@ -23,8 +23,8 @@ runs:
     - name: '📝 Print Inputs'
       shell: 'bash'
       env:
-        JSON_INPUTS: ${{ toJSON(inputs) }}
-      run: echo "$JSON_INPUTS"
+        JSON_INPUTS: '${{ toJSON(inputs) }}'
+      run: 'echo "$JSON_INPUTS"'
 
     - name: 'Setup Node.js'
       uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'

--- a/.github/actions/tag-npm-release/action.yml
+++ b/.github/actions/tag-npm-release/action.yml
@@ -22,7 +22,8 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: 'echo "${{ toJSON(inputs) }}"'
+      run: |
+        echo '${{ toJSON(inputs) }}'
 
     - name: 'Setup Node.js'
       uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'

--- a/.github/actions/tag-npm-release/action.yml
+++ b/.github/actions/tag-npm-release/action.yml
@@ -22,8 +22,9 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: |
-        echo '${{ toJSON(inputs) }}'
+      env:
+        JSON_INPUTS: ${{ toJSON(inputs) }}
+      run: echo "$JSON_INPUTS"
 
     - name: 'Setup Node.js'
       uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'

--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -23,7 +23,8 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: 'echo "${{ toJSON(inputs) }}"'
+      run: |
+        echo '${{ toJSON(inputs) }}'
 
     - name: 'Checkout'
       uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v4

--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -23,8 +23,9 @@ runs:
   steps:
     - name: '📝 Print Inputs'
       shell: 'bash'
-      run: |
-        echo '${{ toJSON(inputs) }}'
+      env:
+        JSON_INPUTS: ${{ toJSON(inputs) }}
+      run: echo "$JSON_INPUTS"
 
     - name: 'Checkout'
       uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v4

--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -24,8 +24,8 @@ runs:
     - name: '📝 Print Inputs'
       shell: 'bash'
       env:
-        JSON_INPUTS: ${{ toJSON(inputs) }}
-      run: echo "$JSON_INPUTS"
+        JSON_INPUTS: '${{ toJSON(inputs) }}'
+      run: 'echo "$JSON_INPUTS"'
 
     - name: 'Checkout'
       uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v4

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -66,7 +66,8 @@ jobs:
           fetch-depth: 0
 
       - name: 'Debug Inputs'
-        run: 'echo "${{ toJSON(inputs) }}"'
+        run: |
+          echo '${{ toJSON(inputs) }}'
 
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -68,8 +68,8 @@ jobs:
       - name: 'Debug Inputs'
         shell: 'bash'
         env:
-          JSON_INPUTS: ${{ toJSON(inputs) }}
-        run: echo "$JSON_INPUTS"
+          JSON_INPUTS: '${{ toJSON(inputs) }}'
+        run: 'echo "$JSON_INPUTS"'
 
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -66,8 +66,10 @@ jobs:
           fetch-depth: 0
 
       - name: 'Debug Inputs'
-        run: |
-          echo '${{ toJSON(inputs) }}'
+        shell: 'bash'
+        env:
+          JSON_INPUTS: ${{ toJSON(inputs) }}
+        run: echo "$JSON_INPUTS"
 
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: 'Print Inputs'
         run: |
-          echo "${{ toJSON(github.event.inputs) }}"
+          echo '${{ toJSON(github.event.inputs) }}'
 
       - name: 'Run Tests'
         if: "${{github.event.inputs.force_skip_tests == 'false'}}"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -53,8 +53,10 @@ jobs:
         run: 'npm ci'
 
       - name: 'Print Inputs'
-        run: |
-          echo '${{ toJSON(github.event.inputs) }}'
+        shell: 'bash'
+        env:
+          JSON_INPUTS: ${{ toJSON(github.event.inputs) }}
+        run: echo "$JSON_INPUTS"
 
       - name: 'Run Tests'
         if: "${{github.event.inputs.force_skip_tests == 'false'}}"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -55,8 +55,8 @@ jobs:
       - name: 'Print Inputs'
         shell: 'bash'
         env:
-          JSON_INPUTS: ${{ toJSON(github.event.inputs) }}
-        run: echo "$JSON_INPUTS"
+          JSON_INPUTS: '${{ toJSON(github.event.inputs) }}'
+        run: 'echo "$JSON_INPUTS"'
 
       - name: 'Run Tests'
         if: "${{github.event.inputs.force_skip_tests == 'false'}}"

--- a/.github/workflows/release-patch-3-release.yml
+++ b/.github/workflows/release-patch-3-release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: 'Print Inputs'
         shell: 'bash'
         run: |-
-          echo "${{ toJSON(inputs) }}"
+          echo '${{ toJSON(inputs) }}'
 
       - name: 'Get Patch Version'
         id: 'patch_version'

--- a/.github/workflows/release-patch-3-release.yml
+++ b/.github/workflows/release-patch-3-release.yml
@@ -64,8 +64,8 @@ jobs:
       - name: 'Print Inputs'
         shell: 'bash'
         env:
-          JSON_INPUTS: ${{ toJSON(inputs) }}
-        run: echo "$JSON_INPUTS"
+          JSON_INPUTS: '${{ toJSON(inputs) }}'
+        run: 'echo "$JSON_INPUTS"'
 
       - name: 'Get Patch Version'
         id: 'patch_version'

--- a/.github/workflows/release-patch-3-release.yml
+++ b/.github/workflows/release-patch-3-release.yml
@@ -63,8 +63,9 @@ jobs:
 
       - name: 'Print Inputs'
         shell: 'bash'
-        run: |-
-          echo '${{ toJSON(inputs) }}'
+        env:
+          JSON_INPUTS: ${{ toJSON(inputs) }}
+        run: echo "$JSON_INPUTS"
 
       - name: 'Get Patch Version'
         id: 'patch_version'

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -60,7 +60,7 @@ jobs:
       - name: 'Print Inputs'
         shell: 'bash'
         run: |-
-          echo "${{ toJSON(inputs) }}"
+          echo '${{ toJSON(inputs) }}'
 
       - name: 'Calculate Versions and SHAs'
         id: 'versions'

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -60,8 +60,8 @@ jobs:
       - name: 'Print Inputs'
         shell: 'bash'
         env:
-          JSON_INPUTS: ${{ toJSON(inputs) }}
-        run: echo "$JSON_INPUTS"
+          JSON_INPUTS: '${{ toJSON(inputs) }}'
+        run: 'echo "$JSON_INPUTS"'
 
       - name: 'Calculate Versions and SHAs'
         id: 'versions'

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -59,8 +59,9 @@ jobs:
 
       - name: 'Print Inputs'
         shell: 'bash'
-        run: |-
-          echo '${{ toJSON(inputs) }}'
+        env:
+          JSON_INPUTS: ${{ toJSON(inputs) }}
+        run: echo "$JSON_INPUTS"
 
       - name: 'Calculate Versions and SHAs'
         id: 'versions'


### PR DESCRIPTION
## TLDR
Load each toJSON(...) payload into an env var before echoing so the shell never reparses the JSON and handles any quotes safely.


## Dive Deeper

- Previously we did echo "${{ toJSON(...) }}", so once GitHub rendered the step the raw JSON (with double quotes, semicolons, etc.) hit bash unescaped and could break the script.
- Each step now exports the JSON via env: JSON_INPUTS: ${{ toJSON(...) }} and then runs echo "$JSON_INPUTS", which keeps the value intact regardless of single or double quotes.

Example:
- Passes with chore/release: bump version to 0.9.0-nightly.20251003.93c7378d at [nightly release](https://github.com/google-gemini/gemini-cli/actions/runs/18214566899/job/51861183438).
- Fails with "pr-title": "chore(release): bump version to 0.8.0-nightly.20251006.327d4711" at [nightly-release](https://github.com/google-gemini/gemini-cli/actions/runs/18284253526/job/52054841580)

## Reviewer Test Plan

Passing Nightly Release: https://github.com/google-gemini/gemini-cli/actions/runs/18287811721

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
