### PR TITLE
feat(extensions): add optional author field to ExtensionConfig

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -94,6 +94,7 @@ The `gemini-extension.json` file contains the configuration for the extension. T
 {
   "name": "my-extension",
   "version": "1.0.0",
+  "author": "Google",
   "mcpServers": {
     "my-server": {
       "command": "node my-server.js"
@@ -106,6 +107,7 @@ The `gemini-extension.json` file contains the configuration for the extension. T
 
 - `name`: The name of the extension. This is used to uniquely identify the extension and for conflict resolution when extension commands have the same name as user or project commands. The name should be lowercase or numbers and use dashes instead of underscores or spaces. This is how users will refer to your extension in the CLI. Note that we expect this name to match the extension directory name.
 - `version`: The version of the extension.
+- `author`: (Optional) A string representation of the author's name. This can be an individual name (e.g., "Christine Betts"), an organization (e.g., "Google"), or a domain (e.g., "example.com"). This information is displayed when listing extensions to help users identify the source.
 - `mcpServers`: A map of MCP servers to configure. The key is the name of the server, and the value is the server configuration. These servers will be loaded on startup just like MCP servers configured in a [`settings.json` file](../get-started/configuration.md). If both an extension and a `settings.json` file configure an MCP server with the same name, the server defined in the `settings.json` file takes precedence.
   - Note that all MCP server configuration options are supported except for `trust`.
 - `contextFileName`: The name of the file that contains the context for the extension. This will be used to load the context from the extension directory. If this property is not used but a `GEMINI.md` file is present in your extension directory, then that file will be loaded.

--- a/packages/a2a-server/src/config/extension.ts
+++ b/packages/a2a-server/src/config/extension.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Copied exactly from packages/cli/src/config/extension.ts, last PR #1026
+// Shared extension configuration now imported from core package
 
-import type { MCPServerConfig } from '@google/gemini-cli-core';
+import type { ExtensionConfig } from '@google/gemini-cli-core';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -16,16 +16,9 @@ export const EXTENSIONS_DIRECTORY_NAME = path.join('.gemini', 'extensions');
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
 
 export interface Extension {
+  path: string;
   config: ExtensionConfig;
   contextFiles: string[];
-}
-
-export interface ExtensionConfig {
-  name: string;
-  version: string;
-  author?: string;
-  mcpServers?: Record<string, MCPServerConfig>;
-  contextFileName?: string | string[];
 }
 
 export function loadExtensions(workspaceDir: string): Extension[] {
@@ -98,6 +91,7 @@ function loadExtension(extensionDir: string): Extension | null {
       .filter((contextFilePath) => fs.existsSync(contextFilePath));
 
     return {
+      path: extensionDir,
       config,
       contextFiles,
     };

--- a/packages/a2a-server/src/config/extension.ts
+++ b/packages/a2a-server/src/config/extension.ts
@@ -23,6 +23,7 @@ export interface Extension {
 export interface ExtensionConfig {
   name: string;
   version: string;
+  author?: string;
   mcpServers?: Record<string, MCPServerConfig>;
   contextFileName?: string | string[];
 }

--- a/packages/cli/src/commands/extensions/examples/context/gemini-extension.json
+++ b/packages/cli/src/commands/extensions/examples/context/gemini-extension.json
@@ -1,5 +1,6 @@
 {
   "name": "context-example",
   "version": "1.0.0",
+  "author": "Google",
   "contextFileName": "GEMINI.md"
 }

--- a/packages/cli/src/commands/extensions/examples/custom-commands/gemini-extension.json
+++ b/packages/cli/src/commands/extensions/examples/custom-commands/gemini-extension.json
@@ -1,4 +1,5 @@
 {
   "name": "custom-commands",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "author": "Google"
 }

--- a/packages/cli/src/commands/extensions/examples/exclude-tools/gemini-extension.json
+++ b/packages/cli/src/commands/extensions/examples/exclude-tools/gemini-extension.json
@@ -1,5 +1,6 @@
 {
   "name": "excludeTools",
   "version": "1.0.0",
+  "author": "Google",
   "excludeTools": ["run_shell_command(rm -rf)"]
 }

--- a/packages/cli/src/commands/extensions/examples/mcp-server/gemini-extension.json
+++ b/packages/cli/src/commands/extensions/examples/mcp-server/gemini-extension.json
@@ -1,6 +1,7 @@
 {
   "name": "mcp-server-example",
   "version": "1.0.0",
+  "author": "Google",
   "mcpServers": {
     "nodeServer": {
       "command": "node",

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -8,6 +8,7 @@ import type {
   MCPServerConfig,
   GeminiCLIExtension,
   ExtensionInstallMetadata,
+  ExtensionConfig,
 } from '@google/gemini-cli-core';
 import {
   GEMINI_DIR,
@@ -50,15 +51,6 @@ export interface Extension {
   config: ExtensionConfig;
   contextFiles: string[];
   installMetadata?: ExtensionInstallMetadata | undefined;
-}
-
-export interface ExtensionConfig {
-  name: string;
-  version: string;
-  author?: string;
-  mcpServers?: Record<string, MCPServerConfig>;
-  contextFileName?: string | string[];
-  excludeTools?: string[];
 }
 
 export interface ExtensionUpdateInfo {

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -55,6 +55,7 @@ export interface Extension {
 export interface ExtensionConfig {
   name: string;
   version: string;
+  author?: string;
   mcpServers?: Record<string, MCPServerConfig>;
   contextFileName?: string | string[];
   excludeTools?: string[];
@@ -328,6 +329,7 @@ export function annotateActiveExtensions(
   return extensions.map((extension) => ({
     name: extension.config.name,
     version: extension.config.version,
+    author: extension.config.author,
     isActive: manager.isEnabled(extension.config.name, workspaceDir),
     path: extension.path,
     installMetadata: extension.installMetadata,

--- a/packages/cli/src/ui/components/views/ExtensionsList.test.tsx
+++ b/packages/cli/src/ui/components/views/ExtensionsList.test.tsx
@@ -21,6 +21,16 @@ const mockExtensions = [
   { name: 'ext-disabled', version: '3.0.0', isActive: false },
 ];
 
+const mockExtensionsWithAuthor = [
+  {
+    name: 'ext-with-author',
+    version: '1.0.0',
+    author: 'Google',
+    isActive: true,
+  },
+  { name: 'ext-no-author', version: '2.0.0', isActive: true },
+];
+
 describe('<ExtensionsList />', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -70,6 +80,16 @@ describe('<ExtensionsList />', () => {
     mockUIState([mockExtensions[0]], new Map());
     const { lastFrame } = render(<ExtensionsList />);
     expect(lastFrame()).toContain('(unknown state)');
+  });
+
+  it('should display author information when available', () => {
+    mockUIState(mockExtensionsWithAuthor, new Map());
+    const { lastFrame } = render(<ExtensionsList />);
+    const output = lastFrame();
+    expect(output).toContain('ext-with-author (v1.0.0) by Google - active');
+    expect(output).toContain('ext-no-author (v2.0.0) - active');
+    // Should not contain "by" for extension without author
+    expect(output).not.toContain('ext-no-author (v2.0.0) by');
   });
 
   const stateTestCases = [

--- a/packages/cli/src/ui/components/views/ExtensionsList.tsx
+++ b/packages/cli/src/ui/components/views/ExtensionsList.tsx
@@ -55,6 +55,7 @@ export const ExtensionsList = () => {
             <Box key={ext.name}>
               <Text>
                 <Text color="cyan">{`${ext.name} (v${ext.version})`}</Text>
+                {ext.author && <Text color="gray">{` by ${ext.author}`}</Text>}
                 {` - ${activeString}`}
                 {<Text color={stateColor}>{` (${stateText})`}</Text>}
               </Text>

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -125,6 +125,15 @@ export interface GeminiCLIExtension {
   installMetadata?: ExtensionInstallMetadata;
 }
 
+export interface ExtensionConfig {
+  name: string;
+  version: string;
+  author?: string;
+  mcpServers?: Record<string, MCPServerConfig>;
+  contextFileName?: string | string[];
+  excludeTools?: string[];
+}
+
 export interface ExtensionInstallMetadata {
   source: string;
   type: 'git' | 'local' | 'link' | 'github-release';

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -119,6 +119,7 @@ export interface OutputSettings {
 export interface GeminiCLIExtension {
   name: string;
   version: string;
+  author?: string;
   isActive: boolean;
   path: string;
   installMetadata?: ExtensionInstallMetadata;


### PR DESCRIPTION
# feat(extensions): add optional author field to ExtensionConfig

- Add author?: string field to ExtensionConfig interfaces
- Update GeminiCLIExtension type to include author field
- Display author information in extensions list UI
- Update documentation with author field examples
- Add test coverage for author field display
- Update all example extensions to include author field

The author field allows extension creators to specify authorship information (e.g., 'Google', 'Christine Betts', 'example.com') which is displayed in the extensions list for better identification.

## TLDR

This PR adds an optional `author` field to the ExtensionConfig type that allows extension creators to specify authorship information. When present, the author name is displayed in the extensions list UI as "extension-name (v1.0.0) by Author Name - active". This helps users identify who created extensions and provides better transparency in the extension ecosystem.

## Dive Deeper

The implementation follows TypeScript best practices by:

1. **Type Safety**: Added `author?: string` to all relevant interfaces (ExtensionConfig, GeminiCLIExtension)
2. **Backward Compatibility**: The field is optional, so existing extensions continue to work unchanged
3. **UI Integration**: Enhanced the ExtensionsList component to conditionally display author information
4. **Documentation**: Updated the extensions documentation with clear examples and field descriptions
5. **Consistency**: Updated all example extensions to demonstrate the new field

The author field is deliberately flexible to accommodate different attribution patterns:
- Individual names: "Christine Betts"
- Organizations: "Google"
- Domains: "example.com"
- Any other string representation the author prefers

## Reviewer Test Plan

To validate this change:

1. **Install and test extension with author field**:
   ```bash
   # Create a test extension with author field
   mkdir test-extension && cd test-extension
   echo '{"name": "test-ext", "version": "1.0.0", "author": "Test Author"}' > gemini-extension.json
   
   # Install and list extensions
   gemini extensions install --path .
   gemini extensions list  # Should show "test-ext (v1.0.0) by Test Author - active"

2. **Create extension without author field
echo '{"name": "no-author-ext", "version": "1.0.0"}' > gemini-extension.json
gemini extensions install --path .
gemini extensions list  # Should show "no-author-ext (v1.0.0) - active" (no "by" text)

3. **Test UI rendering: Use /extensions list command in interactive mode to verify UI display

Verify examples work: Check that the updated example extensions can be created with gemini extensions new

| Platform | macOS | Windows | Linux |
|----------|-------|---------|-------|
| npm run  | ✅    | ❓      | ✅    |
| npx      | ✅    | ❓      | ❓    |
| Docker   | ❓    | ❓      | ❓    |
| Podman   | ❓    | -       | -     |
| Seatbelt | ❓    | -       | -     |

Tested on GitHub Codespaces (Linux) with Node.js v22.17.0

Linked issues / bugs
Resolves #10588