### PR TITLE
fix(core): retain user message in history on stream failure

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -899,9 +899,13 @@ describe('GeminiChat', () => {
       expect(mockLogContentRetry).toHaveBeenCalledTimes(1);
       expect(mockLogContentRetryFailure).toHaveBeenCalledTimes(1);
 
-      // History should be clean, as if the failed turn never happened.
+      // History should still contain the user message.
       const history = chat.getHistory();
-      expect(history.length).toBe(0);
+      expect(history.length).toBe(1);
+      expect(history[0]).toEqual({
+        role: 'user',
+        parts: [{ text: 'test' }],
+      });
     });
 
     describe('API error retry behavior', () => {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -326,10 +326,6 @@ export class GeminiChat {
               ),
             );
           }
-          // If the stream fails, remove the user message that was added.
-          if (self.history[self.history.length - 1] === userContent) {
-            self.history.pop();
-          }
           throw lastError;
         }
       } finally {


### PR DESCRIPTION
## TLDR

Previously, if a streaming response from the model failed definitively (after retries), the user's message was removed from the chat history. This change removes that logic, ensuring the user's message remains in history so they don't lose their input and can retry manually.

## Dive Deeper

Modified `packages/core/src/core/geminiChat.ts` to remove the `self.history.pop()` call in the `finally` block of the stream error handling. Updated `packages/core/src/core/geminiChat.test.ts` to assert that the user message is present after a persistent failure.

## Reviewer Test Plan

1. Start gemini with gemini-2.5-flash.
2. Send "Give me an overview of README.md"
3. After failure, save history and see the user message is there.


## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
