### PR TITLE
feat(extensions): add optional author field to extension config

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -137,6 +137,7 @@ The file has the following structure:
 {
   "name": "my-extension",
   "version": "1.0.0",
+  "author": "Your Name or Organization",
   "mcpServers": {
     "my-server": {
       "command": "node my-server.js"
@@ -154,6 +155,10 @@ The file has the following structure:
   your extension in the CLI. Note that we expect this name to match the
   extension directory name.
 - `version`: The version of the extension.
+- `author` (optional): A string representing the author or organization that
+  created the extension. This can be a person's name (e.g., "Christine Betts"),
+  an organization (e.g., "Google"), or a website (e.g., "example.com"). This
+  field is displayed when listing extensions to help users identify the source.
 - `mcpServers`: A map of MCP servers to configure. The key is the name of the
   server, and the value is the server configuration. These servers will be
   loaded on startup just like MCP servers configured in a

--- a/packages/a2a-server/src/config/extension.ts
+++ b/packages/a2a-server/src/config/extension.ts
@@ -31,6 +31,7 @@ export const INSTALL_METADATA_FILENAME = '.gemini-extension-install.json';
 interface ExtensionConfig {
   name: string;
   version: string;
+  author?: string;
   mcpServers?: Record<string, MCPServerConfig>;
   contextFileName?: string | string[];
   excludeTools?: string[];
@@ -110,6 +111,7 @@ function loadExtension(extensionDir: string): GeminiCLIExtension | null {
     return {
       name: config.name,
       version: config.version,
+      author: config.author,
       path: extensionDir,
       contextFiles,
       installMetadata,

--- a/packages/cli/src/commands/extensions/examples/context/gemini-extension.json
+++ b/packages/cli/src/commands/extensions/examples/context/gemini-extension.json
@@ -1,4 +1,6 @@
 {
   "name": "context-example",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "author": "Google",
+  "contextFileName": "GEMINI.md"
 }

--- a/packages/cli/src/commands/extensions/examples/custom-commands/gemini-extension.json
+++ b/packages/cli/src/commands/extensions/examples/custom-commands/gemini-extension.json
@@ -1,4 +1,5 @@
 {
   "name": "custom-commands",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "author": "Google"
 }

--- a/packages/cli/src/commands/extensions/examples/exclude-tools/gemini-extension.json
+++ b/packages/cli/src/commands/extensions/examples/exclude-tools/gemini-extension.json
@@ -1,5 +1,6 @@
 {
   "name": "excludeTools",
   "version": "1.0.0",
+  "author": "Google",
   "excludeTools": ["run_shell_command(rm -rf)"]
 }

--- a/packages/cli/src/commands/extensions/examples/mcp-server/gemini-extension.json
+++ b/packages/cli/src/commands/extensions/examples/mcp-server/gemini-extension.json
@@ -1,6 +1,7 @@
 {
   "name": "mcp-server-example",
   "version": "1.0.0",
+  "author": "Google",
   "mcpServers": {
     "nodeServer": {
       "command": "node",

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -62,6 +62,7 @@ export const INSTALL_WARNING_MESSAGE =
 interface ExtensionConfig {
   name: string;
   version: string;
+  author?: string;
   mcpServers?: Record<string, MCPServerConfig>;
   contextFileName?: string | string[];
   excludeTools?: string[];
@@ -256,6 +257,7 @@ export function loadExtension(
     return {
       name: config.name,
       version: config.version,
+      author: config.author,
       path: effectiveExtensionPath,
       contextFiles,
       installMetadata,
@@ -624,6 +626,9 @@ function extensionConsentString(extensionConfig: ExtensionConfig): string {
   const output: string[] = [];
   const mcpServerEntries = Object.entries(sanitizedConfig.mcpServers || {});
   output.push(`Installing extension "${sanitizedConfig.name}".`);
+  if (sanitizedConfig.author) {
+    output.push(`Author: ${sanitizedConfig.author}`);
+  }
   output.push(INSTALL_WARNING_MESSAGE);
 
   if (mcpServerEntries.length) {
@@ -774,6 +779,9 @@ export function toOutputString(
 
   const status = workspaceEnabled ? chalk.green('✓') : chalk.red('✗');
   let output = `${status} ${extension.name} (${extension.version})`;
+  if (extension.author) {
+    output += `\n Author: ${extension.author}`;
+  }
   output += `\n Path: ${extension.path}`;
   if (extension.installMetadata) {
     output += `\n Source: ${extension.installMetadata.source} (Type: ${extension.installMetadata.type})`;

--- a/packages/cli/src/test-utils/createExtension.ts
+++ b/packages/cli/src/test-utils/createExtension.ts
@@ -19,6 +19,7 @@ export function createExtension({
   extensionsDir = 'extensions-dir',
   name = 'my-extension',
   version = '1.0.0',
+  author = undefined as string | undefined,
   addContextFile = false,
   contextFileName = undefined as string | undefined,
   mcpServers = {} as Record<string, MCPServerConfig>,
@@ -28,7 +29,7 @@ export function createExtension({
   fs.mkdirSync(extDir, { recursive: true });
   fs.writeFileSync(
     path.join(extDir, EXTENSIONS_CONFIG_FILENAME),
-    JSON.stringify({ name, version, contextFileName, mcpServers }),
+    JSON.stringify({ name, version, author, contextFileName, mcpServers }),
   );
 
   if (addContextFile) {

--- a/packages/cli/src/ui/components/views/ExtensionsList.test.tsx
+++ b/packages/cli/src/ui/components/views/ExtensionsList.test.tsx
@@ -21,6 +21,11 @@ const mockExtensions = [
   { name: 'ext-disabled', version: '3.0.0', isActive: false },
 ];
 
+const mockExtensionsWithAuthor = [
+  { name: 'ext-one', version: '1.0.0', author: 'Google', isActive: true },
+  { name: 'ext-two', version: '2.1.0', author: 'example.com', isActive: true },
+];
+
 describe('<ExtensionsList />', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -107,4 +112,19 @@ describe('<ExtensionsList />', () => {
       expect(lastFrame()).toContain(expectedText);
     });
   }
+
+  it('should display author when present', () => {
+    mockUIState(mockExtensionsWithAuthor, new Map());
+    const { lastFrame } = render(<ExtensionsList />);
+    const output = lastFrame();
+    expect(output).toContain('Author: Google');
+    expect(output).toContain('Author: example.com');
+  });
+
+  it('should not display author when not present', () => {
+    mockUIState([mockExtensions[0]], new Map());
+    const { lastFrame } = render(<ExtensionsList />);
+    const output = lastFrame();
+    expect(output).not.toContain('Author:');
+  });
 });

--- a/packages/cli/src/ui/components/views/ExtensionsList.tsx
+++ b/packages/cli/src/ui/components/views/ExtensionsList.tsx
@@ -52,12 +52,13 @@ export const ExtensionsList = () => {
           }
 
           return (
-            <Box key={ext.name}>
+            <Box key={ext.name} flexDirection="column">
               <Text>
                 <Text color="cyan">{`${ext.name} (v${ext.version})`}</Text>
                 {` - ${activeString}`}
                 {<Text color={stateColor}>{` (${stateText})`}</Text>}
               </Text>
+              {ext.author && <Text dimColor> Author: {ext.author}</Text>}
             </Box>
           );
         })}

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -135,6 +135,7 @@ export interface CodebaseInvestigatorSettings {
 export interface GeminiCLIExtension {
   name: string;
   version: string;
+  author?: string;
   isActive: boolean;
   path: string;
   installMetadata?: ExtensionInstallMetadata;


### PR DESCRIPTION
## TLDR

Adds an optional `author` field to extension configurations. The author is displayed in the extension list UI and during installation consent.

## Dive Deeper

This PR adds support for an optional `author` field in extension configurations, allowing extension creators to identify themselves. The field:

- Is read from the extension's `gemini-extension.json` config file
- Is stored in the `GeminiCLIExtension` interface
- Displays in the extension list UI on a separate dimmed line for better readability
- Shows during installation consent to inform users who created the extension
- Maintains full backward compatibility - extensions without an author field continue to work normally

Implementation spans three packages:
- **core**: `GeminiCLIExtension` interface includes the `author` field
- **cli**: Extension loading, consent display, and UI rendering
- **a2a-server**: Extension loading to match cli behavior

All example extensions have been updated to demonstrate the new field, and comprehensive tests ensure backward compatibility.

## Reviewer Test Plan

### Manual Testing
```bash
# Extension with author
mkdir -p ~/.gemini/extensions/test-with-author
cat > ~/.gemini/extensions/test-with-author/gemini-extension.json << 'EOF'
{
  "name": "test-with-author",
  "version": "1.0.0",
  "author": "Test Author"
}
EOF

# Extension without author (backward compatibility)
mkdir -p ~/.gemini/extensions/test-no-author
cat > ~/.gemini/extensions/test-no-author/gemini-extension.json << 'EOF'
{
  "name": "test-no-author",
  "version": "2.0.0"
}
EOF
```

### Verify
```bash
npm start
# In session: /extensions list
```

**Expected behavior:**
- Extension with author shows `Author: Test Author` on dimmed line
- Extension without author doesn't show author line
- Both extensions load and function normally

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #10588
