### PR TITLE
Reenable NPM integration tests

### DIFF
--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -70,5 +70,18 @@ runs:
           exit 1
         fi
 
-# TODO: Add back integration tests once we resolve
-# https://github.com/google-gemini/gemini-cli/issues/10517
+    - name: 'Install dependencies for integration tests'
+      shell: 'bash'
+      working-directory: './verify'
+      run: 'npm ci'
+
+    - name: '🔬 Run integration tests against NPM release'
+      working-directory: './verify'
+      env:
+        GEMINI_API_KEY: '${{ inputs.gemini_api_key }}'
+        INTEGRATION_TEST_USE_INSTALLED_GEMINI: 'true'
+        # We must diable CI mode here because it interferes with interactive tests.
+        # See https://github.com/google-gemini/gemini-cli/issues/10517
+        CI: 'false'
+      shell: 'bash'
+      run: 'npm run test:integration:sandbox:none'


### PR DESCRIPTION
## TLDR

Reverts #10520 along with a one line fix that makes interactive integration tests work.

## Dive Deeper

Github sets a `CI=true` environment variable. For reasons I still don't understand, this breaks the interactive tests when `INTEGRATION_TEST_USE_INSTALLED_GEMINI` is true.

## Reviewer Test Plan

I ran: 

```
gh workflow run verify-release.yml --ref tomm_npm_verify -f ref=tomm_npm_verify -f version='0.8.2' -f npm-package='@google/gemini-cli@latest'
```

Which ran successfully: https://github.com/google-gemini/gemini-cli/actions/runs/18412811531

## Linked issues / bugs

Fixes #10517