### PR TITLE
Remove separate --path argument for extensions install command

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -14,7 +14,7 @@ Note that all of these commands will only be reflected in active CLI sessions on
 
 ### Installing an extension
 
-You can install an extension using `gemini extensions install` with either a GitHub URL source or `--path=some/local/path`.
+You can install an extension using `gemini extensions install` with either a GitHub URL or a local path`.
 
 Note that we create a copy of the installed extension, so you will need to run `gemini extensions update` to pull in changes from both locally-defined extensions and those on GitHub.
 

--- a/integration-tests/extensions-install.test.ts
+++ b/integration-tests/extensions-install.test.ts
@@ -31,7 +31,7 @@ test('installs a local extension, verifies a command, and updates it', async () 
   }
 
   const result = await rig.runCommand(
-    ['extensions', 'install', `--path=${rig.testDir!}`],
+    ['extensions', 'install', `${rig.testDir!}`],
     { stdin: 'y\n' },
   );
   expect(result).toContain('test-extension');

--- a/packages/cli/src/commands/extensions/install.test.ts
+++ b/packages/cli/src/commands/extensions/install.test.ts
@@ -10,6 +10,7 @@ import yargs from 'yargs';
 
 const mockInstallExtension = vi.hoisted(() => vi.fn());
 const mockRequestConsentNonInteractive = vi.hoisted(() => vi.fn());
+const mockStat = vi.hoisted(() => vi.fn());
 
 vi.mock('../../config/extension.js', () => ({
   installExtension: mockInstallExtension,
@@ -20,34 +21,19 @@ vi.mock('../../utils/errors.js', () => ({
   getErrorMessage: vi.fn((error: Error) => error.message),
 }));
 
+vi.mock('node:fs/promises', () => ({
+  stat: mockStat,
+  default: {
+    stat: mockStat,
+  },
+}));
+
 describe('extensions install command', () => {
   it('should fail if no source is provided', () => {
     const validationParser = yargs([]).command(installCommand).fail(false);
     expect(() => validationParser.parse('install')).toThrow(
-      'Either source or --path must be provided.',
+      'Not enough non-option arguments: got 0, need at least 1',
     );
-  });
-
-  it('should fail if both git source and local path are provided', () => {
-    const validationParser = yargs([])
-      .command(installCommand)
-      .fail(false)
-      .locale('en');
-    expect(() =>
-      validationParser.parse('install some-url --path /some/path'),
-    ).toThrow('Arguments source and path are mutually exclusive');
-  });
-
-  it('should fail if both auto update and local path are provided', () => {
-    const validationParser = yargs([])
-      .command(installCommand)
-      .fail(false)
-      .locale('en');
-    expect(() =>
-      validationParser.parse(
-        'install some-url --path /some/path --auto-update',
-      ),
-    ).toThrow('Arguments path and auto-update are mutually exclusive');
   });
 });
 
@@ -67,6 +53,7 @@ describe('handleInstall', () => {
   afterEach(() => {
     mockInstallExtension.mockClear();
     mockRequestConsentNonInteractive.mockClear();
+    mockStat.mockClear();
     vi.resetAllMocks();
   });
 
@@ -107,13 +94,12 @@ describe('handleInstall', () => {
   });
 
   it('throws an error from an unknown source', async () => {
+    mockStat.mockRejectedValue({});
     await handleInstall({
       source: 'test://google.com',
     });
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'The source "test://google.com" is not a valid URL format.',
-    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Install source not found.');
     expect(processSpy).toHaveBeenCalledWith(1);
   });
 
@@ -131,23 +117,14 @@ describe('handleInstall', () => {
 
   it('should install an extension from a local path', async () => {
     mockInstallExtension.mockResolvedValue('local-extension');
-
+    mockStat.mockResolvedValue({});
     await handleInstall({
-      path: '/some/path',
+      source: '/some/path',
     });
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
       'Extension "local-extension" installed successfully and enabled.',
     );
-  });
-
-  it('should throw an error if no source or path is provided', async () => {
-    await handleInstall({});
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Either --source or --path must be provided.',
-    );
-    expect(processSpy).toHaveBeenCalledWith(1);
   });
 
   it('should throw an error if install extension fails', async () => {

--- a/packages/cli/src/commands/extensions/install.test.ts
+++ b/packages/cli/src/commands/extensions/install.test.ts
@@ -94,7 +94,7 @@ describe('handleInstall', () => {
   });
 
   it('throws an error from an unknown source', async () => {
-    mockStat.mockRejectedValue({});
+    mockStat.mockRejectedValue(new Error('ENOENT: no such file or directory'));
     await handleInstall({
       source: 'test://google.com',
     });

--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -10,12 +10,11 @@ import {
   requestConsentNonInteractive,
 } from '../../config/extension.js';
 import type { ExtensionInstallMetadata } from '@google/gemini-cli-core';
-
 import { getErrorMessage } from '../../utils/errors.js';
+import { stat } from 'node:fs/promises';
 
 interface InstallArgs {
-  source?: string;
-  path?: string;
+  source: string;
   ref?: string;
   autoUpdate?: boolean;
 }
@@ -23,32 +22,34 @@ interface InstallArgs {
 export async function handleInstall(args: InstallArgs) {
   try {
     let installMetadata: ExtensionInstallMetadata;
-    if (args.source) {
-      const { source } = args;
-      if (
-        source.startsWith('http://') ||
-        source.startsWith('https://') ||
-        source.startsWith('git@') ||
-        source.startsWith('sso://')
-      ) {
-        installMetadata = {
-          source,
-          type: 'git',
-          ref: args.ref,
-          autoUpdate: args.autoUpdate,
-        };
-      } else {
-        throw new Error(`The source "${source}" is not a valid URL format.`);
-      }
-    } else if (args.path) {
+    const { source } = args;
+    if (
+      source.startsWith('http://') ||
+      source.startsWith('https://') ||
+      source.startsWith('git@') ||
+      source.startsWith('sso://')
+    ) {
       installMetadata = {
-        source: args.path,
-        type: 'local',
+        source,
+        type: 'git',
+        ref: args.ref,
         autoUpdate: args.autoUpdate,
       };
     } else {
-      // This should not be reached due to the yargs check.
-      throw new Error('Either --source or --path must be provided.');
+      if (args.ref || args.autoUpdate) {
+        throw new Error(
+          '--ref and --auto-update are not applicable for local extensions.',
+        );
+      }
+      try {
+        await stat(source);
+        installMetadata = {
+          source,
+          type: 'local',
+        };
+      } catch {
+        throw new Error('Install source not found.');
+      }
     }
 
     const name = await installExtension(
@@ -63,17 +64,14 @@ export async function handleInstall(args: InstallArgs) {
 }
 
 export const installCommand: CommandModule = {
-  command: 'install [<source>] [--path] [--ref] [--auto-update]',
+  command: 'install <source>',
   describe: 'Installs an extension from a git repository URL or a local path.',
   builder: (yargs) =>
     yargs
       .positional('source', {
-        describe: 'The github URL of the extension to install.',
+        describe: 'The github URL or local path of the extension to install.',
         type: 'string',
-      })
-      .option('path', {
-        describe: 'Path to a local extension directory.',
-        type: 'string',
+        demandOption: true,
       })
       .option('ref', {
         describe: 'The git ref to install from.',
@@ -83,19 +81,15 @@ export const installCommand: CommandModule = {
         describe: 'Enable auto-update for this extension.',
         type: 'boolean',
       })
-      .conflicts('source', 'path')
-      .conflicts('path', 'ref')
-      .conflicts('path', 'auto-update')
       .check((argv) => {
-        if (!argv.source && !argv.path) {
-          throw new Error('Either source or --path must be provided.');
+        if (!argv.source) {
+          throw new Error('The source argument must be provided.');
         }
         return true;
       }),
   handler: async (argv) => {
     await handleInstall({
-      source: argv['source'] as string | undefined,
-      path: argv['path'] as string | undefined,
+      source: argv['source'] as string,
       ref: argv['ref'] as string | undefined,
       autoUpdate: argv['auto-update'] as boolean | undefined,
     });


### PR DESCRIPTION
## TLDR

Use the positional argument instead

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
