### PR TITLE
feat(core): retry once on InvalidStreamError with "Please continue."

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -724,6 +724,7 @@ export const useGeminiStream = (
             loopDetectedRef.current = true;
             break;
           case ServerGeminiEventType.Retry:
+          case ServerGeminiEventType.InvalidStream:
             // Will add the missing logic later
             break;
           default: {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -40,9 +40,11 @@ import { LoopDetectionService } from '../services/loopDetectionService.js';
 import { ideContextStore } from '../ide/ideContext.js';
 import {
   logChatCompression,
+  logContentRetryFailure,
   logNextSpeakerCheck,
 } from '../telemetry/loggers.js';
 import {
+  ContentRetryFailureEvent,
   makeChatCompressionEvent,
   NextSpeakerCheckEvent,
 } from '../telemetry/types.js';
@@ -544,6 +546,14 @@ export class GeminiClient {
       if (event.type === GeminiEventType.InvalidStream) {
         if (isInvalidStreamRetry) {
           // We already retried once, so stop here.
+          logContentRetryFailure(
+            this.config,
+            new ContentRetryFailureEvent(
+              4, // 2 initial + 2 after injections
+              'FAILED_AFTER_PROMPT_INJECTION',
+              modelToUse,
+            ),
+          );
           return turn;
         }
         const nextRequest = [{ text: 'Please continue.' }];

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -540,6 +540,16 @@ export class GeminiClient {
         return turn;
       }
       yield event;
+      if (event.type === GeminiEventType.InvalidStream) {
+        const nextRequest = [{ text: 'Please continue.' }];
+        yield* this.sendMessageStream(
+          nextRequest,
+          signal,
+          prompt_id,
+          boundedTurns - 1,
+        );
+        return turn;
+      }
       if (event.type === GeminiEventType.Error) {
         return turn;
       }

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -13,7 +13,7 @@ import { Turn, GeminiEventType } from './turn.js';
 import type { GenerateContentResponse, Part, Content } from '@google/genai';
 import { reportError } from '../utils/errorReporting.js';
 import type { GeminiChat } from './geminiChat.js';
-import { StreamEventType } from './geminiChat.js';
+import { InvalidStreamError, StreamEventType } from './geminiChat.js';
 
 const mockSendMessageStream = vi.fn();
 const mockGetHistory = vi.fn();
@@ -221,6 +221,28 @@ describe('Turn', () => {
         { type: GeminiEventType.UserCancelled },
       ]);
       expect(turn.getDebugResponses().length).toBe(1);
+    });
+
+    it('should yield InvalidStream event if sendMessageStream throws InvalidStreamError', async () => {
+      const error = new InvalidStreamError(
+        'Test invalid stream',
+        'NO_FINISH_REASON',
+      );
+      mockSendMessageStream.mockRejectedValue(error);
+      const reqParts: Part[] = [{ text: 'Trigger invalid stream' }];
+
+      const events = [];
+      for await (const event of turn.run(
+        'test-model',
+        reqParts,
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+
+      expect(events).toEqual([{ type: GeminiEventType.InvalidStream }]);
+      expect(turn.getDebugResponses().length).toBe(0);
+      expect(reportError).not.toHaveBeenCalled(); // Should not report as error
     });
 
     it('should yield Error event and report if sendMessageStream throws', async () => {


### PR DESCRIPTION
## TLDR

Implements an internal retry mechanism in `gemini-cli` core to handle `InvalidStreamError` from the Gemini API by sending "Please continue.". The retry is limited to a single attempt to prevent infinite loops.

## Dive Deeper

*   `packages/core/src/core/turn.ts`: Catches `InvalidStreamError` and yields a `GeminiEventType.InvalidStream` event.
*   `packages/core/src/core/client.ts`: Handles `GeminiEventType.InvalidStream` by retrying the request with "Please continue.". This retry is limited to a single attempt.
*   `packages/cli/src/ui/hooks/useGeminiStream.ts`: Ignores `GeminiEventType.InvalidStream` events, as they are handled internally by the core.

## Reviewer Test Plan

1.  Run the CLI and engage in a conversation that might trigger an `InvalidStreamError` (e.g., `Give me an overview of README.md`).
2.  Verify that the CLI automatically retries with "Please continue." and the conversation continues smoothly.
3.  Verify that if the retry also fails with an `InvalidStreamError`, the CLI stops and does not enter an infinite loop.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
