### PR TITLE
fix: Exit app on pressing esc on trust dialog at launch

### DIFF
--- a/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
@@ -53,7 +53,7 @@ describe('FolderTrustDialog', () => {
     stdin.write('\x1b'); // escape key
 
     await waitFor(() => {
-      expect(mockedExit).toHaveBeenCalledWith(0);
+      expect(mockedExit).toHaveBeenCalledWith(1);
     });
   });
 

--- a/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
@@ -7,7 +7,7 @@
 import { renderWithProviders } from '../../test-utils/render.js';
 import { waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
-import { FolderTrustDialog, FolderTrustChoice } from './FolderTrustDialog.js';
+import { FolderTrustDialog } from './FolderTrustDialog.js';
 import * as processUtils from '../../utils/processUtils.js';
 
 vi.mock('../../utils/processUtils.js', () => ({
@@ -44,7 +44,7 @@ describe('FolderTrustDialog', () => {
     );
   });
 
-  it('should call onSelect with DO_NOT_TRUST when escape is pressed and not restarting', async () => {
+  it('should call process.exit when escape is pressed and not restarting', async () => {
     const onSelect = vi.fn();
     const { stdin } = renderWithProviders(
       <FolderTrustDialog onSelect={onSelect} isRestarting={false} />,
@@ -53,7 +53,7 @@ describe('FolderTrustDialog', () => {
     stdin.write('\x1b'); // escape key
 
     await waitFor(() => {
-      expect(onSelect).toHaveBeenCalledWith(FolderTrustChoice.DO_NOT_TRUST);
+      expect(mockedExit).toHaveBeenCalledWith(0);
     });
   });
 

--- a/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.test.tsx
@@ -44,30 +44,23 @@ describe('FolderTrustDialog', () => {
     );
   });
 
-  it('should call process.exit when escape is pressed and not restarting', async () => {
+  it('should display exit message and call process.exit and not call onSelect when escape is pressed', async () => {
     const onSelect = vi.fn();
-    const { stdin } = renderWithProviders(
+    const { lastFrame, stdin } = renderWithProviders(
       <FolderTrustDialog onSelect={onSelect} isRestarting={false} />,
     );
 
     stdin.write('\x1b'); // escape key
 
     await waitFor(() => {
+      expect(lastFrame()).toContain(
+        'A folder trust level must be selected to continue. Exiting since escape was pressed.',
+      );
+    });
+    await waitFor(() => {
       expect(mockedExit).toHaveBeenCalledWith(1);
     });
-  });
-
-  it('should not call onSelect when escape is pressed and is restarting', async () => {
-    const onSelect = vi.fn();
-    const { stdin } = renderWithProviders(
-      <FolderTrustDialog onSelect={onSelect} isRestarting={true} />,
-    );
-
-    stdin.write('\x1b'); // escape key
-
-    await waitFor(() => {
-      expect(onSelect).not.toHaveBeenCalled();
-    });
+    expect(onSelect).not.toHaveBeenCalled();
   });
 
   it('should display restart message when isRestarting is true', () => {
@@ -84,7 +77,7 @@ describe('FolderTrustDialog', () => {
     renderWithProviders(
       <FolderTrustDialog onSelect={vi.fn()} isRestarting={true} />,
     );
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(250);
     expect(relaunchApp).toHaveBeenCalled();
     vi.useRealTimers();
   });

--- a/packages/cli/src/ui/components/FolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.tsx
@@ -44,7 +44,7 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
   useKeypress(
     (key) => {
       if (key.name === 'escape') {
-        process.exit(0);
+        process.exit(1);
       }
     },
     { isActive: !isRestarting },

--- a/packages/cli/src/ui/components/FolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.tsx
@@ -6,7 +6,7 @@
 
 import { Box, Text } from 'ink';
 import type React from 'react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { theme } from '../semantic-colors.js';
 import type { RadioSelectItem } from './shared/RadioButtonSelect.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
@@ -30,6 +30,7 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
   onSelect,
   isRestarting,
 }) => {
+  const [exiting, setExiting] = useState(false);
   useEffect(() => {
     const doRelaunch = async () => {
       if (isRestarting) {
@@ -44,7 +45,10 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
   useKeypress(
     (key) => {
       if (key.name === 'escape') {
-        process.exit(1);
+        setExiting(true);
+        setTimeout(() => {
+          process.exit(1);
+        }, 100);
       }
     },
     { isActive: !isRestarting },
@@ -102,6 +106,14 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
         <Box marginLeft={1} marginTop={1}>
           <Text color={theme.status.warning}>
             Gemini CLI is restarting to apply the trust changes...
+          </Text>
+        </Box>
+      )}
+      {exiting && (
+        <Box marginLeft={1} marginTop={1}>
+          <Text color={theme.status.warning}>
+            A folder trust level must be selected to continue. Exiting since
+            escape was pressed.
           </Text>
         </Box>
       )}

--- a/packages/cli/src/ui/components/FolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.tsx
@@ -44,7 +44,7 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
   useKeypress(
     (key) => {
       if (key.name === 'escape') {
-        onSelect(FolderTrustChoice.DO_NOT_TRUST);
+        process.exit(0);
       }
     },
     { isActive: !isRestarting },
@@ -65,9 +65,9 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
       key: `Trust parent folder (${parentFolder})`,
     },
     {
-      label: "Don't trust (esc)",
+      label: "Don't trust",
       value: FolderTrustChoice.DO_NOT_TRUST,
-      key: "Don't trust (esc)",
+      key: "Don't trust",
     },
   ];
 


### PR DESCRIPTION
## TLDR

Message shown before exiting:
<img width="904" height="525" alt="Screenshot 2025-10-09 at 10 58 22 AM" src="https://github.com/user-attachments/assets/e10ff749-feb4-4fe3-8ec3-57d047f2c5e4" />


## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/842
