### PR TITLE
feat(cli): Enhance Subagent UX with custom formatting

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -27,7 +27,7 @@ const STATIC_HEIGHT = 1;
 const RESERVED_LINE_COUNT = 5; // for tool name, status, padding etc.
 const STATUS_INDICATOR_WIDTH = 3;
 const MIN_LINES_SHOWN = 2; // show at least this many lines
-const SUBAGENT_MAX_HEIGHT = 5;
+const SUBAGENT_MAX_HEIGHT = 4;
 
 // Large threshold to ensure we don't cause performance issues for very large
 // outputs that will get truncated further MaxSizedBox anyway.

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -217,6 +217,8 @@ export function mapToDisplay(
       let displayName: string;
       let description: string;
       let renderOutputAsMarkdown = false;
+      // Prefer the tool's name if available, otherwise fall back to the request name.
+      const internalName = trackedCall.tool?.name ?? trackedCall.request.name;
 
       if (trackedCall.status === 'error') {
         displayName =
@@ -236,6 +238,7 @@ export function mapToDisplay(
       > = {
         callId: trackedCall.request.callId,
         name: displayName,
+        internalName,
         description,
         renderOutputAsMarkdown,
       };

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -1062,4 +1062,31 @@ describe('mapToDisplay', () => {
     expect(display.tools[1].resultDisplay).toBe('markdown output');
     expect(display.tools[1].renderOutputAsMarkdown).toBe(true);
   });
+
+  it('should map internalName correctly', () => {
+    const toolCall: ToolCall = {
+      request: baseRequest,
+      status: 'success',
+      tool: baseTool,
+      invocation: baseTool.build(baseRequest.args),
+      response: baseResponse,
+    } as ToolCall;
+
+    const display = mapToDisplay(toolCall);
+    expect(display.tools[0].internalName).toBe(baseTool.name);
+  });
+
+  it('should fallback to request name for internalName if tool is undefined', () => {
+    const toolCall: ToolCall = {
+      request: baseRequest,
+      status: 'error',
+      response: {
+        ...baseResponse,
+        error: new Error('Tool not found'),
+      },
+    } as ToolCall;
+
+    const display = mapToDisplay(toolCall);
+    expect(display.tools[0].internalName).toBe(baseRequest.name);
+  });
 });

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -62,6 +62,7 @@ export interface ToolCallEvent {
 export interface IndividualToolCallDisplay {
   callId: string;
   name: string;
+  internalName?: string;
   description: string;
   resultDisplay: ToolResultDisplay | undefined;
   status: ToolCallStatus;

--- a/packages/core/src/agents/invocation.test.ts
+++ b/packages/core/src/agents/invocation.test.ts
@@ -195,8 +195,12 @@ describe('SubagentInvocation', () => {
       await invocation.execute(signal, updateOutput);
 
       expect(updateOutput).toHaveBeenCalledWith('Subagent starting...\n');
-      expect(updateOutput).toHaveBeenCalledWith('🤖💭 Analyzing...\n');
-      expect(updateOutput).toHaveBeenCalledWith('🤖💭  Still thinking.\n');
+      expect(updateOutput).toHaveBeenCalledWith(
+        '🤖💭 Analyzing...\n\nAgent working',
+      );
+      expect(updateOutput).toHaveBeenCalledWith(
+        '🤖💭  Still thinking.\n\nAgent working',
+      );
       expect(updateOutput).toHaveBeenCalledTimes(3); // Initial message + 2 thoughts
     });
 
@@ -225,7 +229,9 @@ describe('SubagentInvocation', () => {
 
       expect(updateOutput).toHaveBeenCalledWith('Subagent starting...\n');
       // Expect the tool call to be formatted and streamed
-      expect(updateOutput).toHaveBeenCalledWith('🔧 ls({"path":"."})');
+      expect(updateOutput).toHaveBeenCalledWith(
+        'Agent working\n\n🔧 ls({"path":"."})',
+      );
       expect(updateOutput).toHaveBeenCalledTimes(2);
     });
 
@@ -266,18 +272,24 @@ describe('SubagentInvocation', () => {
 
       expect(updateOutput).toHaveBeenCalledWith('Subagent starting...\n');
 
-      expect(updateOutput).toHaveBeenCalledWith('🤖💭 I need to list files.\n');
-
+      // 1. Thought
       expect(updateOutput).toHaveBeenCalledWith(
-        '🤖💭 I need to list files.\n\n🔧 ls({"path":"/src"})',
+        '🤖💭 I need to list files.\n\nAgent working',
       );
 
+      // 2. Tool Call (with previous thought)
       expect(updateOutput).toHaveBeenCalledWith(
-        '🤖💭 Now reading a file.\n\n🔧 ls({"path":"/src"})',
+        '🤖💭 I need to list files.\n\nAgent working\n\n🔧 ls({"path":"/src"})',
       );
 
+      // 3. New Thought (with previous tool call)
       expect(updateOutput).toHaveBeenCalledWith(
-        '🤖💭 Now reading a file.\n\n🔧 read_file({"path":"/src/index.ts"})\n   ls({"path":"/src"})',
+        '🤖💭 Now reading a file.\n\nAgent working\n\n🔧 ls({"path":"/src"})',
+      );
+
+      // 4. Another Tool Call (newest on top)
+      expect(updateOutput).toHaveBeenCalledWith(
+        '🤖💭 Now reading a file.\n\nAgent working\n\n🔧 read_file({"path":"/src/index.ts"})\n   ls({"path":"/src"})',
       );
 
       expect(updateOutput).toHaveBeenCalledTimes(5);

--- a/packages/core/src/agents/invocation.ts
+++ b/packages/core/src/agents/invocation.ts
@@ -96,6 +96,13 @@ export class SubagentInvocation<
           lines.push(`🤖💭 ${latestThought}`);
           lines.push(''); // Blank line separator
         }
+
+        lines.push('Agent working');
+
+        if (toolCalls.length > 0) {
+          lines.push(''); // Blank line separator
+        }
+
         toolCalls.forEach((tc, index) => {
           const prefix = index === 0 ? '🔧 ' : '   ';
           const callStr = `${tc.name}(${tc.args})`;


### PR DESCRIPTION
## TLDR

This PR implements a specialized user experience for subagents (specifically the `codebase_investigator`), improves the reliability of subagent detection in the UI. The goal is to provide a clearer, more stable view of the agent's thoughts and progress.

## Dive Deeper

### Custom Subagent UX
Now there is a specific UX for subagents to better handle their streaming output:
1.  **Formatted Output:** `SubagentInvocation` in `packages/core` has been updated to format the output stream. It now shows the agent's latest thought (`🤖💭 ...`), followed by a static "Agent working" message, and then a list of the tool calls the agent is making.
2.  **Height Constraint:** While the subagent is `Executing`, its output is constrained to a fixed height (`SUBAGENT_MAX_HEIGHT`). Once it finishes (`Success` or `Error`), the constraint is lifted so the full result can be viewed.
3.  **Overflow Behavior:** When constrained, the overflow direction is set to `'bottom'`. This ensures that as the agent makes more tool calls, the view automatically shows the most recent activity at the bottom of the constrained box.

## Reviewer Test Plan

To validate these changes, you need to trigger the `codebase_investigator` subagent.

**Prerequisites:**
Ensure subagents are enabled in your configuration. Your `~/.gemini/settings.json` should include:
```json
{
  "experimental": {
    "enableSubagents": true
  }
}
```

**Steps:**
1.  Start an interactive Gemini CLI session.
2.  Give a prompt that requires the codebase investigator, for example:
    > "Investigate how `MaxSizedBox` works in this project. Use the codebase investigator as a first step"
3.  **Observe the Running State:**
    *   You should see the agent's thought bubble (`🤖💭`).
    *   You should see the text "Agent working".
    *   The output box should be constrained to a few lines.
    *   As the agent makes tool calls (e.g., `search_file_content`, `read_file`), they should appear below "Agent working".
4.  **Test Expansion:**
    *   Press `Ctrl+S` to expand the tool output.
5.  **Observe Completion:**
    *   Wait for the agent to finish its task.
    *   Verify that the final output is displayed and is no longer artificially constrained by the subagent height limit.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅ | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅ | -   | -   |

## Linked issues / bugs

This PR makes progress on #6636
