### PR TITLE
feat(ui): Add automatic theme matching based on terminal background

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -293,8 +293,52 @@ const SETTINGS_SCHEMA = {
         category: 'UI',
         requiresRestart: false,
         default: undefined as string | undefined,
-        description: 'The color theme for the UI.',
+        description:
+          'The color theme for the UI. Use "auto" to automatically match your terminal background (light/dark).',
         showInDialog: false,
+      },
+      autoThemePrompt: {
+        type: 'boolean',
+        label: 'Auto Theme Prompt',
+        category: 'UI',
+        requiresRestart: false,
+        default: true,
+        description:
+          'Show a one-time prompt to enable auto theme when terminal/theme mismatch is detected.',
+        showInDialog: false,
+      },
+      themePreferences: {
+        type: 'object',
+        label: 'Theme Preferences',
+        category: 'UI',
+        requiresRestart: false,
+        default: {
+          light: 'Default Light',
+          dark: 'Default',
+        } as { light: string; dark: string },
+        description:
+          'Preferred themes for auto mode. Specify which themes to use for light and dark terminal backgrounds.',
+        showInDialog: false,
+        properties: {
+          light: {
+            type: 'string',
+            label: 'Light Theme',
+            category: 'UI',
+            requiresRestart: false,
+            default: 'Default Light',
+            description: 'Theme to use when terminal has a light background.',
+            showInDialog: false,
+          },
+          dark: {
+            type: 'string',
+            label: 'Dark Theme',
+            category: 'UI',
+            requiresRestart: false,
+            default: 'Default',
+            description: 'Theme to use when terminal has a dark background.',
+            showInDialog: false,
+          },
+        },
       },
       customThemes: {
         type: 'object',

--- a/packages/cli/src/core/theme.ts
+++ b/packages/cli/src/core/theme.ts
@@ -6,6 +6,7 @@
 
 import { themeManager } from '../ui/themes/theme-manager.js';
 import { type LoadedSettings } from '../config/settings.js';
+import { AUTO_THEME } from '../ui/themes/theme.js';
 
 /**
  * Validates the configured theme.
@@ -14,6 +15,10 @@ import { type LoadedSettings } from '../config/settings.js';
  */
 export function validateTheme(settings: LoadedSettings): string | null {
   const effectiveTheme = settings.merged.ui?.theme;
+  // AUTO_THEME is a special theme value that gets resolved at runtime
+  if (effectiveTheme === AUTO_THEME) {
+    return null;
+  }
   if (effectiveTheme && !themeManager.findThemeByName(effectiveTheme)) {
     return `Theme "${effectiveTheme}" not found.`;
   }

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -444,6 +444,7 @@ describe('startInteractiveUI', () => {
       mockStartupWarnings,
       mockWorkspaceRoot,
       mockInitializationResult,
+      'unknown',
     );
 
     // Verify render was called with correct options
@@ -478,6 +479,7 @@ describe('startInteractiveUI', () => {
       mockStartupWarnings,
       mockWorkspaceRoot,
       mockInitializationResult,
+      'unknown',
     );
 
     // Verify all startup tasks were called

--- a/packages/cli/src/ui/components/ThemeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.test.tsx
@@ -10,6 +10,7 @@ import { ThemeDialog } from './ThemeDialog.js';
 import { LoadedSettings } from '../../config/settings.js';
 import { KeypressProvider } from '../contexts/KeypressContext.js';
 import { SettingsContext } from '../contexts/SettingsContext.js';
+import { ThemeContext } from '../contexts/ThemeContext.js';
 import { DEFAULT_THEME, themeManager } from '../themes/theme-manager.js';
 import { act } from 'react';
 
@@ -76,9 +77,11 @@ describe('ThemeDialog Snapshots', () => {
     const settings = createMockSettings();
     const { lastFrame } = render(
       <SettingsContext.Provider value={settings}>
-        <KeypressProvider kittyProtocolEnabled={false}>
-          <ThemeDialog {...baseProps} settings={settings} />
-        </KeypressProvider>
+        <ThemeContext.Provider value={{ terminalBackground: 'dark' }}>
+          <KeypressProvider kittyProtocolEnabled={false}>
+            <ThemeDialog {...baseProps} settings={settings} />
+          </KeypressProvider>
+        </ThemeContext.Provider>
       </SettingsContext.Provider>,
     );
 
@@ -89,9 +92,11 @@ describe('ThemeDialog Snapshots', () => {
     const settings = createMockSettings();
     const { lastFrame, stdin } = render(
       <SettingsContext.Provider value={settings}>
-        <KeypressProvider kittyProtocolEnabled={false}>
-          <ThemeDialog {...baseProps} settings={settings} />
-        </KeypressProvider>
+        <ThemeContext.Provider value={{ terminalBackground: 'dark' }}>
+          <KeypressProvider kittyProtocolEnabled={false}>
+            <ThemeDialog {...baseProps} settings={settings} />
+          </KeypressProvider>
+        </ThemeContext.Provider>
       </SettingsContext.Provider>,
     );
 

--- a/packages/cli/src/ui/components/__snapshots__/ThemeDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ThemeDialog.test.tsx.snap
@@ -18,18 +18,18 @@ exports[`ThemeDialog Snapshots > should render correctly in theme selection mode
 │                                                                                                  │
 │ > Select Theme                               Preview                                             │
 │ ▲                                            ┌─────────────────────────────────────────────────┐ │
-│    1. ANSI Dark                              │                                                 │ │
-│    2. Atom One Dark                          │ 1 # function                                    │ │
-│    3. Ayu Dark                               │ 2 def fibonacci(n):                             │ │
-│ ●  4. Default Dark                           │ 3     a, b = 0, 1                               │ │
-│    5. Dracula Dark                           │ 4     for _ in range(n):                        │ │
-│    6. GitHub Dark                            │ 5         a, b = b, a + b                       │ │
-│    7. Shades Of Purple Dark                  │ 6     return a                                  │ │
-│    8. ANSI Light Light                       │                                                 │ │
-│    9. Ayu Light Light                        │ 1 - print("Hello, " + name)                     │ │
-│   10. Default Light Light                    │ 1 + print(f"Hello, {name}!")                    │ │
-│   11. GitHub Light Light                     │                                                 │ │
-│   12. Google Code Light                      └─────────────────────────────────────────────────┘ │
+│    1. Auto Auto-detect                       │                                                 │ │
+│    2. ANSI Dark                              │ 1 # function                                    │ │
+│    3. Atom One Dark                          │ 2 def fibonacci(n):                             │ │
+│    4. Ayu Dark                               │ 3     a, b = 0, 1                               │ │
+│ ●  5. Default Dark                           │ 4     for _ in range(n):                        │ │
+│    6. Dracula Dark                           │ 5         a, b = b, a + b                       │ │
+│    7. GitHub Dark                            │ 6     return a                                  │ │
+│    8. Shades Of Purple Dark                  │                                                 │ │
+│    9. ANSI Light Light                       │ 1 - print("Hello, " + name)                     │ │
+│   10. Ayu Light Light                        │ 1 + print(f"Hello, {name}!")                    │ │
+│   11. Default Light Light                    │                                                 │ │
+│   12. GitHub Light Light                     └─────────────────────────────────────────────────┘ │
 │ ▼                                                                                                │
 │                                                                                                  │
 │ (Use Enter to select, Tab to configure scope)                                                    │

--- a/packages/cli/src/ui/contexts/ThemeContext.tsx
+++ b/packages/cli/src/ui/contexts/ThemeContext.tsx
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useContext } from 'react';
+
+export type TerminalBackground = 'light' | 'dark' | 'unknown';
+
+export interface ThemeContextValue {
+  terminalBackground: TerminalBackground;
+}
+
+export const ThemeContext = React.createContext<ThemeContextValue | undefined>(
+  undefined,
+);
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/packages/cli/src/ui/themes/theme-manager.test.ts
+++ b/packages/cli/src/ui/themes/theme-manager.test.ts
@@ -12,6 +12,7 @@ if (process.env['NO_COLOR'] !== undefined) {
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { themeManager, DEFAULT_THEME } from './theme-manager.js';
 import type { CustomTheme } from './theme.js';
+import { AUTO_THEME } from './theme.js';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import type * as osActual from 'node:os';
@@ -176,6 +177,319 @@ describe('ThemeManager', () => {
       );
 
       consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('Auto theme functionality', () => {
+    describe('setActiveTheme with AUTO_THEME', () => {
+      it('should set light theme when terminal is light', () => {
+        const result = themeManager.setActiveTheme(AUTO_THEME, 'light', {
+          light: 'Default Light',
+          dark: 'Default',
+        });
+
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('Default Light');
+        expect(themeManager.getActiveTheme().type).toBe('light');
+      });
+
+      it('should set dark theme when terminal is dark', () => {
+        const result = themeManager.setActiveTheme(AUTO_THEME, 'dark', {
+          light: 'Default Light',
+          dark: 'Default',
+        });
+
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('Default');
+        expect(themeManager.getActiveTheme().type).toBe('dark');
+      });
+
+      it('should fall back to dark theme when terminal is unknown', () => {
+        const result = themeManager.setActiveTheme(AUTO_THEME, 'unknown', {
+          light: 'Default Light',
+          dark: 'Default',
+        });
+
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('Default');
+      });
+
+      it('should use custom theme preferences for light terminal', () => {
+        const result = themeManager.setActiveTheme(AUTO_THEME, 'light', {
+          light: 'GitHub Light',
+          dark: 'Dracula',
+        });
+
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('GitHub Light');
+      });
+
+      it('should use custom theme preferences for dark terminal', () => {
+        const result = themeManager.setActiveTheme(AUTO_THEME, 'dark', {
+          light: 'GitHub Light',
+          dark: 'Dracula',
+        });
+
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('Dracula');
+      });
+
+      it('should use default preferences if not provided', () => {
+        const result = themeManager.setActiveTheme(AUTO_THEME, 'light');
+
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('Default Light');
+      });
+
+      it('should fall back to built-in theme if preferred theme not found', () => {
+        const result = themeManager.setActiveTheme(AUTO_THEME, 'light', {
+          light: 'NonExistentTheme',
+          dark: 'Default',
+        });
+
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('Default Light');
+      });
+
+      it('should return false if both preferred and fallback themes not found', () => {
+        // This is an edge case - should never happen in practice
+        const result = themeManager.setActiveTheme(AUTO_THEME, 'light', {
+          light: 'NonExistent1',
+          dark: 'NonExistent2',
+        });
+
+        // Should still succeed by falling back to built-in defaults
+        expect(result).toBe(true);
+      });
+
+      it('should handle missing terminalBackground parameter', () => {
+        const result = themeManager.setActiveTheme(AUTO_THEME);
+
+        expect(result).toBe(true);
+        // Should default to dark theme
+        expect(themeManager.getActiveTheme().name).toBe('Default');
+      });
+    });
+
+    describe('isAutoTheme', () => {
+      it('should return true for AUTO_THEME constant', () => {
+        expect(themeManager.isAutoTheme(AUTO_THEME)).toBe(true);
+      });
+
+      it('should return true for "auto" string', () => {
+        expect(themeManager.isAutoTheme('auto')).toBe(true);
+      });
+
+      it('should return false for other theme names', () => {
+        expect(themeManager.isAutoTheme('Default')).toBe(false);
+        expect(themeManager.isAutoTheme('Default Light')).toBe(false);
+        expect(themeManager.isAutoTheme('Dracula')).toBe(false);
+      });
+
+      it('should return false for undefined', () => {
+        expect(themeManager.isAutoTheme(undefined)).toBe(false);
+      });
+
+      it('should return false for empty string', () => {
+        expect(themeManager.isAutoTheme('')).toBe(false);
+      });
+
+      it('should be case-sensitive', () => {
+        expect(themeManager.isAutoTheme('Auto')).toBe(false);
+        expect(themeManager.isAutoTheme('AUTO')).toBe(false);
+      });
+    });
+
+    describe('resolveAutoThemeName', () => {
+      it('should resolve to light theme for light terminal', () => {
+        const resolved = themeManager.resolveAutoThemeName('light', {
+          light: 'GitHub Light',
+          dark: 'Dracula',
+        });
+
+        expect(resolved).toBe('GitHub Light');
+      });
+
+      it('should resolve to dark theme for dark terminal', () => {
+        const resolved = themeManager.resolveAutoThemeName('dark', {
+          light: 'GitHub Light',
+          dark: 'Dracula',
+        });
+
+        expect(resolved).toBe('Dracula');
+      });
+
+      it('should resolve to dark theme for unknown terminal', () => {
+        const resolved = themeManager.resolveAutoThemeName('unknown', {
+          light: 'GitHub Light',
+          dark: 'Dracula',
+        });
+
+        expect(resolved).toBe('Dracula');
+      });
+
+      it('should use default light theme if preferences not provided', () => {
+        const resolved = themeManager.resolveAutoThemeName('light');
+
+        expect(resolved).toBe('Default Light');
+      });
+
+      it('should use default dark theme if preferences not provided', () => {
+        const resolved = themeManager.resolveAutoThemeName('dark');
+
+        expect(resolved).toBe('Default');
+      });
+
+      it('should use default dark theme for unknown terminal without preferences', () => {
+        const resolved = themeManager.resolveAutoThemeName('unknown');
+
+        expect(resolved).toBe('Default');
+      });
+
+      it('should respect custom light theme preference', () => {
+        const resolved = themeManager.resolveAutoThemeName('light', {
+          light: 'Ayu Light',
+          dark: 'Ayu',
+        });
+
+        expect(resolved).toBe('Ayu Light');
+      });
+
+      it('should respect custom dark theme preference', () => {
+        const resolved = themeManager.resolveAutoThemeName('dark', {
+          light: 'Ayu Light',
+          dark: 'Ayu',
+        });
+
+        expect(resolved).toBe('Ayu');
+      });
+
+      it('should handle partial preferences (only light)', () => {
+        const resolved = themeManager.resolveAutoThemeName('dark', {
+          light: 'GitHub Light',
+          dark: undefined as unknown as string,
+        });
+
+        expect(resolved).toBe('Default');
+      });
+
+      it('should handle partial preferences (only dark)', () => {
+        const resolved = themeManager.resolveAutoThemeName('light', {
+          light: undefined as unknown as string,
+          dark: 'Dracula',
+        });
+
+        expect(resolved).toBe('Default Light');
+      });
+    });
+
+    describe('Auto theme with custom themes', () => {
+      beforeEach(() => {
+        const customLightTheme: CustomTheme = {
+          ...validCustomTheme,
+          name: 'My Light Theme',
+          type: 'custom',
+          Background: '#ffffff',
+          Foreground: '#000000',
+        };
+
+        const customDarkTheme: CustomTheme = {
+          ...validCustomTheme,
+          name: 'My Dark Theme',
+          type: 'custom',
+        };
+
+        themeManager.loadCustomThemes({
+          'My Light Theme': customLightTheme,
+          'My Dark Theme': customDarkTheme,
+        });
+      });
+
+      it('should work with custom light theme preference', () => {
+        const result = themeManager.setActiveTheme(AUTO_THEME, 'light', {
+          light: 'My Light Theme',
+          dark: 'My Dark Theme',
+        });
+
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('My Light Theme');
+      });
+
+      it('should work with custom dark theme preference', () => {
+        const result = themeManager.setActiveTheme(AUTO_THEME, 'dark', {
+          light: 'My Light Theme',
+          dark: 'My Dark Theme',
+        });
+
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('My Dark Theme');
+      });
+
+      it('should resolve custom theme names correctly', () => {
+        const resolved = themeManager.resolveAutoThemeName('light', {
+          light: 'My Light Theme',
+          dark: 'My Dark Theme',
+        });
+
+        expect(resolved).toBe('My Light Theme');
+      });
+    });
+
+    describe('AUTO_THEME constant', () => {
+      it('should be the string "auto"', () => {
+        expect(AUTO_THEME).toBe('auto');
+      });
+
+      it('should work with setActiveTheme', () => {
+        const result = themeManager.setActiveTheme(AUTO_THEME, 'dark');
+        expect(result).toBe(true);
+      });
+
+      it('should work with isAutoTheme', () => {
+        expect(themeManager.isAutoTheme(AUTO_THEME)).toBe(true);
+      });
+    });
+
+    describe('Edge cases', () => {
+      it('should handle empty theme preferences object', () => {
+        const result = themeManager.setActiveTheme(
+          AUTO_THEME,
+          'light',
+          {} as { light: string; dark: string },
+        );
+
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('Default Light');
+      });
+
+      it('should handle null theme preferences', () => {
+        const result = themeManager.setActiveTheme(
+          AUTO_THEME,
+          'light',
+          null as unknown as { light: string; dark: string },
+        );
+
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('Default Light');
+      });
+
+      it('should handle undefined theme preferences', () => {
+        const result = themeManager.setActiveTheme(
+          AUTO_THEME,
+          'light',
+          undefined,
+        );
+
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('Default Light');
+      });
+
+      it('should not confuse AUTO_THEME with a theme named "auto"', () => {
+        // Even if someone creates a theme named "auto", AUTO_THEME should trigger auto-detection
+        const result = themeManager.setActiveTheme(AUTO_THEME, 'dark');
+        expect(result).toBe(true);
+        expect(themeManager.getActiveTheme().name).toBe('Default');
+      });
     });
   });
 });

--- a/packages/cli/src/ui/themes/theme.ts
+++ b/packages/cli/src/ui/themes/theme.ts
@@ -10,6 +10,11 @@ import { resolveColor } from './color-utils.js';
 
 export type ThemeType = 'light' | 'dark' | 'ansi' | 'custom';
 
+/**
+ * Special theme value that automatically selects a theme based on terminal background.
+ */
+export const AUTO_THEME = 'auto' as const;
+
 export interface ColorsTheme {
   type: ThemeType;
   Background: string;

--- a/packages/cli/src/utils/autoThemePrompt.test.ts
+++ b/packages/cli/src/utils/autoThemePrompt.test.ts
@@ -1,0 +1,651 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { promptEnableAutoTheme } from './autoThemePrompt.js';
+import type { LoadedSettings } from '../config/settings.js';
+import { SettingScope } from '../config/settings.js';
+import { AUTO_THEME } from '../ui/themes/theme.js';
+import readline from 'node:readline';
+
+// Mock readline module
+vi.mock('node:readline', () => ({
+  default: {
+    createInterface: vi.fn(),
+  },
+}));
+
+describe('promptEnableAutoTheme', () => {
+  let mockSettings: LoadedSettings;
+  let mockReadlineInterface: {
+    question: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  };
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Create mock settings
+    mockSettings = {
+      merged: {
+        ui: {
+          autoThemePrompt: true,
+        },
+      },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    // Create mock readline interface
+    mockReadlineInterface = {
+      question: vi.fn(),
+      close: vi.fn(),
+    };
+
+    // Mock readline.createInterface
+    vi.mocked(readline.createInterface).mockReturnValue(
+      mockReadlineInterface as unknown as ReturnType<
+        typeof readline.createInterface
+      >,
+    );
+
+    // Spy on console.log
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy.mockRestore();
+  });
+
+  describe('Prompt suppression', () => {
+    it('should show notification but not prompt if autoThemePrompt is false', async () => {
+      mockSettings.merged.ui = { autoThemePrompt: false };
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(false);
+      // Should show the notification
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Terminal background is light'),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('using a dark theme'),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Use /theme to switch themes'),
+      );
+      // Should NOT create readline interface (no interactive prompt)
+      expect(readline.createInterface).not.toHaveBeenCalled();
+      expect(mockSettings.setValue).not.toHaveBeenCalled();
+    });
+
+    it('should show prompt if autoThemePrompt is undefined (defaults to showing)', async () => {
+      mockSettings.merged.ui = {};
+
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('n');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      // When undefined, it defaults to showing the prompt (not suppressing it)
+      expect(readline.createInterface).toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('should show prompt if autoThemePrompt is true', async () => {
+      mockSettings.merged.ui = { autoThemePrompt: true };
+
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('n');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(readline.createInterface).toHaveBeenCalled();
+    });
+
+    it('should show prompt if autoThemePrompt is not set (default behavior)', async () => {
+      mockSettings.merged.ui = undefined;
+
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('n');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(readline.createInterface).toHaveBeenCalled();
+    });
+  });
+
+  describe('Readline interface creation', () => {
+    it('should create readline interface with stdin and stdout', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('y');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(readline.createInterface).toHaveBeenCalledWith({
+        input: process.stdin,
+        output: process.stdout,
+      });
+    });
+
+    it('should close readline interface after answer', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('y');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(mockReadlineInterface.close).toHaveBeenCalled();
+    });
+  });
+
+  describe('Notification and prompt messages', () => {
+    it('should display notification for light terminal with dark theme', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('n');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      // Check notification message
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Terminal background is light'),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('using a dark theme'),
+      );
+    });
+
+    it('should display notification for dark terminal with light theme', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('n');
+      });
+
+      await promptEnableAutoTheme('dark', 'light', mockSettings);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Terminal background is dark'),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('using a light theme'),
+      );
+    });
+
+    it('should handle ANSI theme type in notification', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('n');
+      });
+
+      await promptEnableAutoTheme('light', 'ansi', mockSettings);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('using an ansi theme'),
+      );
+    });
+
+    it('should handle custom theme type in notification', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('n');
+      });
+
+      await promptEnableAutoTheme('dark', 'custom', mockSettings);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('using a custom theme'),
+      );
+    });
+
+    it('should display correct prompt message', async () => {
+      let questionMessage = '';
+      mockReadlineInterface.question.mockImplementation((msg, callback) => {
+        questionMessage = msg;
+        callback('n');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(questionMessage).toContain('enable auto theme');
+      expect(questionMessage).toContain('automatically match your terminal');
+    });
+  });
+
+  describe('User accepts prompt', () => {
+    it('should enable auto theme when user enters "y"', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('y');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(true);
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'ui.theme',
+        AUTO_THEME,
+      );
+    });
+
+    it('should enable auto theme when user enters "Y" (uppercase)', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('Y');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(true);
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'ui.theme',
+        AUTO_THEME,
+      );
+    });
+
+    it('should enable auto theme when user enters "yes"', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('yes');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(true);
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'ui.theme',
+        AUTO_THEME,
+      );
+    });
+
+    it('should enable auto theme when user enters "YES" (uppercase)', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('YES');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(true);
+    });
+
+    it('should enable auto theme when user presses Enter (empty input)', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(true);
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'ui.theme',
+        AUTO_THEME,
+      );
+    });
+
+    it('should trim whitespace from answer', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('  y  ');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(true);
+    });
+
+    it('should display success message when enabled', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('y');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Auto theme enabled'),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('match your terminal background'),
+      );
+    });
+
+    it('should display instructions about /theme command when enabled', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('y');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/theme'),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('gemini theme'),
+      );
+    });
+
+    it('should not disable autoThemePrompt when user accepts', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('y');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(mockSettings.setValue).not.toHaveBeenCalledWith(
+        SettingScope.User,
+        'ui.autoThemePrompt',
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('User declines prompt', () => {
+    it('should not enable auto theme when user enters "n"', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('n');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(false);
+      expect(mockSettings.setValue).not.toHaveBeenCalledWith(
+        SettingScope.User,
+        'ui.theme',
+        expect.anything(),
+      );
+    });
+
+    it('should not enable auto theme when user enters "N" (uppercase)', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('N');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(false);
+    });
+
+    it('should not enable auto theme when user enters "no"', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('no');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(false);
+    });
+
+    it('should not enable auto theme when user enters "NO" (uppercase)', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('NO');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(false);
+    });
+
+    it('should disable future prompts when user declines', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('n');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'ui.autoThemePrompt',
+        false,
+      );
+    });
+
+    it('should display message about disabling prompt when declined', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('n');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Auto theme prompt disabled'),
+      );
+    });
+
+    it('should display instructions about manual theme switching when declined', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('n');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/theme'),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('gemini theme'),
+      );
+    });
+
+    it('should treat any other input as declining', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('maybe');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(false);
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'ui.autoThemePrompt',
+        false,
+      );
+    });
+
+    it('should treat random input as declining', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('askjdhaksjdh');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('SettingScope usage', () => {
+    it('should save theme setting to User scope', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('y');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        expect.any(String),
+        expect.anything(),
+      );
+    });
+
+    it('should save autoThemePrompt to User scope when declining', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('n');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'ui.autoThemePrompt',
+        false,
+      );
+    });
+  });
+
+  describe('AUTO_THEME constant usage', () => {
+    it('should use AUTO_THEME constant instead of string literal', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('y');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'ui.theme',
+        AUTO_THEME,
+      );
+
+      // Verify it's not using the string 'auto'
+      const calls = vi.mocked(mockSettings.setValue).mock.calls;
+      const themeCall = calls.find((call) => call[1] === 'ui.theme');
+      expect(themeCall?.[2]).toBe(AUTO_THEME);
+      expect(AUTO_THEME).toBe('auto'); // Just to verify the constant value
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle settings without ui object', async () => {
+      // Create new settings object without ui property
+      const settingsWithoutUi = {
+        merged: {},
+        setValue: vi.fn(),
+      } as unknown as LoadedSettings;
+
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('y');
+      });
+
+      const result = await promptEnableAutoTheme(
+        'light',
+        'dark',
+        settingsWithoutUi,
+      );
+
+      expect(result).toBe(true);
+      expect(settingsWithoutUi.setValue).toHaveBeenCalled();
+    });
+
+    it('should handle all theme types correctly', async () => {
+      const themeTypes: Array<'light' | 'dark' | 'ansi' | 'custom'> = [
+        'light',
+        'dark',
+        'ansi',
+        'custom',
+      ];
+
+      for (const themeType of themeTypes) {
+        vi.clearAllMocks();
+
+        mockReadlineInterface.question.mockImplementation((_, callback) => {
+          callback('y');
+        });
+
+        const result = await promptEnableAutoTheme(
+          'light',
+          themeType,
+          mockSettings,
+        );
+
+        expect(result).toBe(true);
+        // Check that notification contains the theme type
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining(themeType),
+        );
+      }
+    });
+
+    it('should handle both terminal backgrounds correctly', async () => {
+      // Light terminal
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('y');
+      });
+
+      await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('light'),
+      );
+
+      vi.clearAllMocks();
+
+      // Dark terminal
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('y');
+      });
+
+      await promptEnableAutoTheme('dark', 'light', mockSettings);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('dark'),
+      );
+    });
+
+    it('should handle newline characters in input', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('y\n');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(true);
+    });
+
+    it('should handle tabs and spaces in input', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        callback('\t  y  \t');
+      });
+
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Promise resolution', () => {
+    it('should resolve promise after user answers', async () => {
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        // Simulate async user input
+        setTimeout(() => callback('y'), 10);
+      });
+
+      const start = Date.now();
+      const result = await promptEnableAutoTheme('light', 'dark', mockSettings);
+      const duration = Date.now() - start;
+
+      expect(result).toBe(true);
+      expect(duration).toBeGreaterThanOrEqual(10);
+    });
+
+    it('should not resolve until user provides input', async () => {
+      let resolveCallback: ((answer: string) => void) | undefined;
+
+      mockReadlineInterface.question.mockImplementation((_, callback) => {
+        resolveCallback = callback;
+      });
+
+      const promise = promptEnableAutoTheme('light', 'dark', mockSettings);
+
+      // Wait a bit
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Promise should still be pending
+      let resolved = false;
+      promise.then(() => {
+        resolved = true;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(resolved).toBe(false);
+
+      // Now resolve it
+      if (resolveCallback) {
+        resolveCallback('y');
+      }
+      await promise;
+      expect(resolved).toBe(true);
+    });
+  });
+});

--- a/packages/cli/src/utils/autoThemePrompt.ts
+++ b/packages/cli/src/utils/autoThemePrompt.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import readline from 'node:readline';
+import type { LoadedSettings } from '../config/settings.js';
+import { SettingScope } from '../config/settings.js';
+import type { ThemeType } from '../ui/themes/theme.js';
+import { AUTO_THEME } from '../ui/themes/theme.js';
+
+/**
+ * Prompts the user to enable auto theme when a theme/terminal mismatch is detected.
+ *
+ * This function displays an interactive prompt asking whether the user wants to enable
+ * automatic theme matching. It only shows if `ui.autoThemePrompt` is not explicitly
+ * disabled in settings.
+ *
+ * Behavior:
+ * - If user accepts (Y/y/yes/Enter): Sets `ui.theme` to AUTO_THEME and returns true
+ * - If user declines (n/no): Sets `ui.autoThemePrompt` to false to prevent future prompts
+ *
+ * The prompt uses readline for input and blocks until the user responds.
+ *
+ * @param terminalBackground The detected terminal background ('light' | 'dark').
+ * @param currentThemeType The current theme type ('light' | 'dark' | 'ansi' | 'custom').
+ * @param settings The loaded settings object.
+ * @returns Promise<boolean> - True if user wants to enable auto theme, false otherwise.
+ *
+ * @example
+ * ```typescript
+ * if (terminalBackground === 'light' && currentTheme.type === 'dark') {
+ *   const enabled = await promptEnableAutoTheme(terminalBackground, currentTheme.type, settings);
+ *   if (enabled) {
+ *     // Theme has been set to AUTO_THEME
+ *   }
+ * }
+ * ```
+ */
+/**
+ * Helper function to determine the correct article (a/an) for a word.
+ */
+function getArticle(word: string): string {
+  const firstLetter = word.charAt(0).toLowerCase();
+  return ['a', 'e', 'i', 'o', 'u'].includes(firstLetter) ? 'an' : 'a';
+}
+
+export async function promptEnableAutoTheme(
+  terminalBackground: 'light' | 'dark',
+  currentThemeType: ThemeType,
+  settings: LoadedSettings,
+): Promise<boolean> {
+  const article = getArticle(currentThemeType);
+
+  // Always show a notification about the mismatch
+  console.log(
+    `\n⚠️  Terminal background is ${terminalBackground}, but using ${article} ${currentThemeType} theme.`,
+  );
+
+  // Check if we should show the interactive prompt to enable auto-theme
+  if (settings.merged.ui?.autoThemePrompt === false) {
+    console.log(`    Use /theme to switch themes or enable auto-theme.\n`);
+    return false;
+  }
+
+  let rl: readline.Interface | undefined;
+  try {
+    // Ensure stdin is in the correct mode for readline
+    // detectTerminalBackground() may have left it paused
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false);
+      process.stdin.resume();
+    }
+
+    rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    const message = `Would you like to enable auto theme to automatically match your terminal? (Y/n): `;
+
+    const answer = await new Promise<string>((resolve) => {
+      rl!.question(message, resolve);
+    });
+
+    const normalizedAnswer = answer.trim().toLowerCase();
+    const shouldEnable =
+      normalizedAnswer === '' ||
+      normalizedAnswer === 'y' ||
+      normalizedAnswer === 'yes';
+
+    if (shouldEnable) {
+      // Enable auto theme
+      settings.setValue(SettingScope.User, 'ui.theme', AUTO_THEME);
+      console.log(
+        '\n✓ Auto theme enabled. Gemini will now match your terminal background.',
+      );
+      console.log(
+        '  You can change this anytime with /theme or: gemini theme <theme-name>\n',
+      );
+    } else {
+      // Disable the prompt for future sessions
+      settings.setValue(SettingScope.User, 'ui.autoThemePrompt', false);
+      console.log(
+        '\n  Auto theme prompt disabled. You can manually switch themes with /theme or: gemini theme <theme-name>',
+      );
+    }
+    return shouldEnable;
+  } catch (error) {
+    console.error(
+      '\nAn unexpected error occurred during the auto-theme prompt. Skipping.',
+      error,
+    );
+    return false; // Default to not enabling on error
+  } finally {
+    rl?.close();
+  }
+}

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -495,4 +495,21 @@ export function getEffectiveDisplayValue(
   return getSettingValue(key, settings, mergedSettings);
 }
 
+/**
+ * Gets theme preferences from settings with proper defaults.
+ * Used for auto-theme resolution across the application.
+ *
+ * @param settings The loaded settings object
+ * @returns Theme preferences with light and dark theme names
+ */
+export function getThemePreferences(settings: LoadedSettings): {
+  light: string;
+  dark: string;
+} {
+  return {
+    light: settings.merged.ui?.themePreferences?.light ?? 'Default Light',
+    dark: settings.merged.ui?.themePreferences?.dark ?? 'Default',
+  };
+}
+
 export const TEST_ONLY = { clearFlattenedSchema };

--- a/packages/cli/src/utils/terminalBackground.test.ts
+++ b/packages/cli/src/utils/terminalBackground.test.ts
@@ -1,0 +1,578 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { detectTerminalBackground } from './terminalBackground.js';
+import { EventEmitter } from 'node:events';
+
+describe('detectTerminalBackground', () => {
+  let mockStdin: EventEmitter & {
+    isTTY: boolean;
+    setRawMode: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
+    pause: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
+  };
+  let mockStdout: { isTTY: boolean; write: ReturnType<typeof vi.fn> };
+  let originalStdin: typeof process.stdin;
+  let originalStdout: typeof process.stdout;
+
+  beforeEach(() => {
+    // Save originals
+    originalStdin = process.stdin;
+    originalStdout = process.stdout;
+
+    // Create mock stdin
+    mockStdin = Object.assign(new EventEmitter(), {
+      isTTY: true,
+      setRawMode: vi.fn().mockReturnValue(mockStdin),
+      resume: vi.fn().mockReturnValue(mockStdin),
+      pause: vi.fn().mockReturnValue(mockStdin),
+      off: vi.fn(),
+    });
+
+    // Create mock stdout
+    mockStdout = {
+      isTTY: true,
+      write: vi.fn().mockReturnValue(true),
+    };
+
+    // Replace process streams
+    Object.defineProperty(process, 'stdin', {
+      value: mockStdin,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(process, 'stdout', {
+      value: mockStdout,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    mockStdin.removeAllListeners();
+
+    // Restore originals
+    Object.defineProperty(process, 'stdin', {
+      value: originalStdin,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(process, 'stdout', {
+      value: originalStdout,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  describe('TTY detection', () => {
+    it('should return "unknown" when stdin is not a TTY', async () => {
+      mockStdin.isTTY = false;
+
+      const result = await detectTerminalBackground();
+
+      expect(result).toBe('unknown');
+      expect(mockStdout.write).not.toHaveBeenCalled();
+    });
+
+    it('should return "unknown" when stdout is not a TTY', async () => {
+      mockStdout.isTTY = false;
+
+      const result = await detectTerminalBackground();
+
+      expect(result).toBe('unknown');
+      expect(mockStdout.write).not.toHaveBeenCalled();
+    });
+
+    it('should return "unknown" when both are not TTY', async () => {
+      mockStdin.isTTY = false;
+      mockStdout.isTTY = false;
+
+      const result = await detectTerminalBackground();
+
+      expect(result).toBe('unknown');
+    });
+  });
+
+  describe('OSC 11 query', () => {
+    it('should send OSC 11 query to terminal', async () => {
+      const promise = detectTerminalBackground();
+
+      // Emit response before timeout
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:ffff/ffff/ffff\x1b\\'));
+      }, 10);
+
+      await promise;
+
+      expect(mockStdout.write).toHaveBeenCalledWith('\x1b]11;?\x1b\\');
+      expect(mockStdin.setRawMode).toHaveBeenCalledWith(true);
+      expect(mockStdin.resume).toHaveBeenCalled();
+    });
+
+    it('should enable raw mode on stdin', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:0000/0000/0000\x1b\\'));
+      }, 10);
+
+      await promise;
+
+      expect(mockStdin.setRawMode).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('Light background detection', () => {
+    it('should detect white background (ffff/ffff/ffff) as light', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:ffff/ffff/ffff\x1b\\'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('light');
+    });
+
+    it('should detect light gray background (cccc/cccc/cccc) as light', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:cccc/cccc/cccc\x1b\\'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('light');
+    });
+
+    it('should detect medium gray background (8888/8888/8888) as light', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:8888/8888/8888\x1b\\'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('light');
+    });
+
+    it('should detect light blue background as light', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:aaaa/bbbb/ffff\x1b\\'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('light');
+    });
+  });
+
+  describe('Dark background detection', () => {
+    it('should detect black background (0000/0000/0000) as dark', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:0000/0000/0000\x1b\\'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('dark');
+    });
+
+    it('should detect dark gray background (3333/3333/3333) as dark', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:3333/3333/3333\x1b\\'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('dark');
+    });
+
+    it('should detect dark blue background as dark', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:1111/2222/3333\x1b\\'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('dark');
+    });
+  });
+
+  describe('OSC 11 response formats', () => {
+    it('should parse response with backslash terminator (ESC \\)', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:ffff/ffff/ffff\x1b\\'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('light');
+    });
+
+    it('should parse response with BEL terminator (\\x07)', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:0000/0000/0000\x07'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('dark');
+    });
+
+    it('should parse response with 2-digit hex values', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:ff/ff/ff\x1b\\'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('light');
+    });
+
+    it('should parse response with 4-digit hex values', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:ffff/ffff/ffff\x1b\\'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('light');
+    });
+
+    it('should parse response with mixed case hex values', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:FFFF/FFFF/FFFF\x1b\\'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('light');
+    });
+
+    it('should handle partial responses across multiple data events', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:'));
+        setTimeout(() => {
+          mockStdin.emit('data', Buffer.from('ffff/ffff/ffff\x1b\\'));
+        }, 5);
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('light');
+    });
+  });
+
+  describe('Timeout handling', () => {
+    it('should timeout after default 100ms and return "unknown"', async () => {
+      vi.useFakeTimers();
+
+      const promise = detectTerminalBackground();
+
+      // Advance time past the timeout
+      vi.advanceTimersByTime(100);
+
+      const result = await promise;
+      expect(result).toBe('unknown');
+    });
+
+    it('should timeout after custom timeout value', async () => {
+      vi.useFakeTimers();
+
+      const promise = detectTerminalBackground(200);
+
+      // Should not timeout at 100ms
+      vi.advanceTimersByTime(100);
+      await Promise.resolve(); // Let microtasks run
+
+      // Should timeout at 200ms
+      vi.advanceTimersByTime(100);
+
+      const result = await promise;
+      expect(result).toBe('unknown');
+    });
+
+    it('should not timeout if response arrives in time', async () => {
+      vi.useFakeTimers();
+
+      const promise = detectTerminalBackground(100);
+
+      // Send response before timeout
+      vi.advanceTimersByTime(50);
+      mockStdin.emit('data', Buffer.from('\x1b]11;rgb:ffff/ffff/ffff\x1b\\'));
+
+      const result = await promise;
+      expect(result).toBe('light');
+    });
+  });
+
+  describe('Cleanup behavior', () => {
+    it('should restore stdin to non-raw mode after success', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:ffff/ffff/ffff\x1b\\'));
+      }, 10);
+
+      await promise;
+
+      expect(mockStdin.setRawMode).toHaveBeenCalledWith(false);
+      expect(mockStdin.pause).toHaveBeenCalled();
+    });
+
+    it('should restore stdin to non-raw mode after timeout', async () => {
+      vi.useFakeTimers();
+
+      const promise = detectTerminalBackground();
+      vi.advanceTimersByTime(100);
+
+      await promise;
+
+      expect(mockStdin.setRawMode).toHaveBeenCalledWith(false);
+      expect(mockStdin.pause).toHaveBeenCalled();
+    });
+
+    it('should remove data event listener after success', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:ffff/ffff/ffff\x1b\\'));
+      }, 10);
+
+      await promise;
+
+      expect(mockStdin.off).toHaveBeenCalledWith('data', expect.any(Function));
+    });
+
+    it('should remove data event listener after timeout', async () => {
+      vi.useFakeTimers();
+
+      const promise = detectTerminalBackground();
+      vi.advanceTimersByTime(100);
+
+      await promise;
+
+      expect(mockStdin.off).toHaveBeenCalledWith('data', expect.any(Function));
+    });
+  });
+
+  describe('Race condition prevention', () => {
+    it('should only resolve once even if data arrives after timeout', async () => {
+      vi.useFakeTimers();
+
+      const promise = detectTerminalBackground(50);
+
+      // Timeout first
+      vi.advanceTimersByTime(50);
+      await Promise.resolve();
+
+      // Then emit data (should be ignored)
+      mockStdin.emit('data', Buffer.from('\x1b]11;rgb:ffff/ffff/ffff\x1b\\'));
+
+      const result = await promise;
+      expect(result).toBe('unknown'); // Should still be 'unknown' from timeout
+    });
+
+    it('should ignore data events after successful resolution', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        // First valid response
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:0000/0000/0000\x1b\\'));
+
+        // Second response (should be ignored due to resolved flag)
+        setTimeout(() => {
+          mockStdin.emit(
+            'data',
+            Buffer.from('\x1b]11;rgb:ffff/ffff/ffff\x1b\\'),
+          );
+        }, 5);
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('dark'); // First response wins
+    });
+
+    it('should clear timeout when data arrives before timeout', async () => {
+      vi.useFakeTimers();
+      const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+
+      const promise = detectTerminalBackground(100);
+
+      // Emit data before timeout
+      vi.advanceTimersByTime(50);
+      mockStdin.emit('data', Buffer.from('\x1b]11;rgb:ffff/ffff/ffff\x1b\\'));
+
+      await promise;
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should return "unknown" if setRawMode throws', async () => {
+      // Mock setRawMode to throw only on the first call (during setup)
+      // but succeed on the second call (during cleanup)
+      let callCount = 0;
+      mockStdin.setRawMode.mockImplementation((mode) => {
+        callCount++;
+        if (callCount === 1 && mode === true) {
+          throw new Error('setRawMode failed');
+        }
+        return mockStdin;
+      });
+
+      const result = await detectTerminalBackground();
+
+      expect(result).toBe('unknown');
+    });
+
+    it('should return "unknown" if write throws', async () => {
+      mockStdout.write.mockImplementation(() => {
+        throw new Error('write failed');
+      });
+
+      const result = await detectTerminalBackground();
+
+      expect(result).toBe('unknown');
+    });
+
+    it('should handle malformed responses gracefully', async () => {
+      vi.useFakeTimers();
+
+      const promise = detectTerminalBackground();
+
+      // Send malformed data
+      vi.advanceTimersByTime(10);
+      mockStdin.emit('data', Buffer.from('garbage data'));
+
+      // Should timeout since regex won't match
+      vi.advanceTimersByTime(90);
+
+      const result = await promise;
+      expect(result).toBe('unknown');
+    });
+
+    it('should handle incomplete OSC sequences', async () => {
+      vi.useFakeTimers();
+
+      const promise = detectTerminalBackground();
+
+      // Send incomplete sequence
+      vi.advanceTimersByTime(10);
+      mockStdin.emit('data', Buffer.from('\x1b]11;rgb:ff'));
+
+      // Should timeout
+      vi.advanceTimersByTime(90);
+
+      const result = await promise;
+      expect(result).toBe('unknown');
+    });
+  });
+
+  describe('WCAG luminance calculation', () => {
+    // NOTE: These tests verify WCAG luminance calculation formula
+    // Formula: (0.299*R + 0.587*G + 0.114*B) / 255
+    // Threshold: > 0.5 is light, <= 0.5 is dark
+
+    it('should correctly apply WCAG luminance formula', async () => {
+      vi.useRealTimers();
+      const promise = detectTerminalBackground();
+
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      // Medium gray: 0x80 = 128
+      // Luminance: (0.299*128 + 0.587*128 + 0.114*128) / 255 ≈ 0.502 (light)
+      mockStdin.emit('data', Buffer.from('\x1b]11;rgb:8080/8080/8080\x1b\\'));
+
+      const result = await promise;
+      // Verification: This is above the 0.5 threshold
+      expect(result).toBe('light');
+    });
+  });
+
+  describe('Edge cases', () => {
+    beforeEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should handle RGB values with leading zeros', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        mockStdin.emit('data', Buffer.from('\x1b]11;rgb:0001/0002/0003\x1b\\'));
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('dark');
+    });
+
+    it('should handle very long hex values (only use first 2 chars)', async () => {
+      const promise = detectTerminalBackground();
+
+      setTimeout(() => {
+        // Hex values where first 2 chars are low (dark)
+        // First 2 chars: 0x12 = 18, 0x23 = 35, 0x34 = 52
+        // Luminance: (0.299*18 + 0.587*35 + 0.114*52) / 255 ≈ 0.11 < 0.5 (dark)
+        mockStdin.emit(
+          'data',
+          Buffer.from('\x1b]11;rgb:1234ffff/2345ffff/3456ffff\x1b\\'),
+        );
+      }, 10);
+
+      const result = await promise;
+      expect(result).toBe('dark'); // First 2 chars determine darkness
+    });
+
+    it('should handle empty stdin data events', async () => {
+      vi.useFakeTimers();
+
+      const promise = detectTerminalBackground();
+
+      // Send empty buffer
+      vi.advanceTimersByTime(10);
+      mockStdin.emit('data', Buffer.from(''));
+
+      // Should timeout
+      vi.advanceTimersByTime(90);
+
+      const result = await promise;
+      expect(result).toBe('unknown');
+    });
+
+    it('should handle multiple incomplete chunks building up to valid response', async () => {
+      vi.useRealTimers();
+      const promise = detectTerminalBackground();
+
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      // Send in multiple chunks
+      mockStdin.emit('data', Buffer.from('\x1b'));
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      mockStdin.emit('data', Buffer.from(']11;'));
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      mockStdin.emit('data', Buffer.from('rgb:ff'));
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      mockStdin.emit('data', Buffer.from('ff/ffff/ffff\x1b\\'));
+
+      const result = await promise;
+      expect(result).toBe('light');
+    });
+  });
+});

--- a/packages/cli/src/utils/terminalBackground.ts
+++ b/packages/cli/src/utils/terminalBackground.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Detects whether the terminal background is light or dark using OSC 11 query.
+ *
+ * This function queries the terminal for its background color by sending an OSC 11
+ * escape sequence. The terminal responds with RGB values, which are used to calculate
+ * luminance via the WCAG formula. A threshold of 0.5 determines light vs dark.
+ *
+ * Falls back to 'unknown' if:
+ * - stdin/stdout is not a TTY
+ * - Terminal doesn't support OSC 11
+ * - Response times out
+ * - An error occurs during detection
+ *
+ * The function properly cleans up event listeners and restores stdin state to prevent
+ * race conditions and memory leaks.
+ *
+ * @param timeoutMs Timeout in milliseconds to wait for terminal response (default: 100ms)
+ * @returns Promise resolving to 'light', 'dark', or 'unknown'
+ *
+ * @example
+ * ```typescript
+ * const background = await detectTerminalBackground();
+ * if (background === 'light') {
+ *   // Use light theme
+ * }
+ * ```
+ */
+export async function detectTerminalBackground(
+  timeoutMs = 100,
+): Promise<'light' | 'dark' | 'unknown'> {
+  // Skip detection if stdin is not a TTY or in non-interactive mode
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    return 'unknown';
+  }
+
+  return new Promise((resolve) => {
+    let timeout: NodeJS.Timeout | null = null;
+    let dataHandler: ((data: Buffer) => void) | null = null;
+    let response = '';
+    let resolved = false;
+
+    const cleanup = () => {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      if (dataHandler) {
+        process.stdin.off('data', dataHandler);
+        dataHandler = null;
+      }
+      // Restore stdin state
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+      }
+    };
+
+    const safeResolve = (value: 'light' | 'dark' | 'unknown') => {
+      if (!resolved) {
+        resolved = true;
+        cleanup();
+        resolve(value);
+      }
+    };
+
+    // Set timeout for terminal response
+    timeout = setTimeout(() => {
+      safeResolve('unknown');
+    }, timeoutMs);
+
+    // Listen for terminal response
+    dataHandler = (data: Buffer) => {
+      // Ignore data if already resolved (safety check)
+      if (resolved) {
+        return;
+      }
+
+      response += data.toString();
+
+      // Parse OSC 11 response format: ESC]11;rgb:RRRR/GGGG/BBBBESC\ or ESC]11;rgb:RR/GG/BBBEL
+      const match = response.match(
+        // eslint-disable-next-line no-control-regex
+        /\x1b\]11;rgb:([0-9a-f]+)\/([0-9a-f]+)\/([0-9a-f]+)(?:\x1b\\|\x07)/i,
+      );
+
+      if (match) {
+        // Scale the hex value to an 8-bit integer (0-255) to handle different digit lengths (1-4).
+        const scale = (hex: string) =>
+          Math.round((parseInt(hex, 16) / (16 ** hex.length - 1)) * 255);
+        const r = scale(match[1]);
+        const g = scale(match[2]);
+        const b = scale(match[3]);
+
+        // Calculate relative luminance using WCAG formula
+        const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+
+        // Threshold of 0.5: above is light, below is dark
+        safeResolve(luminance > 0.5 ? 'light' : 'dark');
+      }
+    };
+
+    try {
+      // Set stdin to raw mode to receive terminal responses
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(true);
+        process.stdin.resume();
+      }
+
+      process.stdin.on('data', dataHandler);
+
+      // Send OSC 11 query to terminal
+      process.stdout.write('\x1b]11;?\x1b\\');
+    } catch (_error) {
+      safeResolve('unknown');
+    }
+  });
+}


### PR DESCRIPTION
## TLDR

Implements automatic terminal background detection and theme matching to fix readability issues for light mode users. When a theme/terminal mismatch is detected, users are notified and offered to enable auto-theme mode.

## Dive Deeper

This PR addresses the UX issue where users (especially light mode users) experience unreadable diffs and code because Gemini CLI doesn't match their terminal background.

**Key Features:**
- **Terminal Background Detection**: Uses OSC 11 escape sequence to detect light/dark terminal
- **Auto Theme Mode**: New `theme: "auto"` setting that automatically picks the right theme
- **Theme Preferences**: Configure which themes to use via `themePreferences.light`/`dark` settings
- **Mismatch Notifications**: Always shows warning on startup when theme doesn't match terminal
- **One-time Prompt**: Offers to enable auto-theme (controllable via `autoThemePrompt` setting)

**Implementation:**
- `packages/cli/src/utils/terminalBackground.ts`: OSC 11 terminal detection
- `packages/cli/src/utils/autoThemePrompt.ts`: Mismatch notifications and prompts
- `packages/cli/src/ui/themes/theme-manager.ts`: Auto theme resolution logic
- `packages/cli/src/config/settingsSchema.ts`: New settings schema
- Full test coverage 

## Reviewer Test Plan: Automatic Theme Matching

This test plan covers the new automatic theme matching feature.

## 1. `settings.json` Configuration

First, let's review the new settings in settings.json. You can open your user settings.json file to manually change these values during testing.

* "ui.theme": Can now be set to "auto".
* "ui.autoThemePrompt": A boolean (defaults to true) that controls whether to show the one-time prompt to enable auto theme.
* "ui.themePreferences": An object with light and dark properties to specify which themes to use for auto mode.
    * "light": Theme for light terminal background (defaults to "Default Light").
    * "dark": Theme for dark terminal background (defaults to "Default").

Example `settings.json`:

```json
{
  "ui": {
    "theme": "auto",
    "autoThemePrompt": true,
    "themePreferences": {
      "light": "GitHub Light",
      "dark": "Dracula"
    }
  }
}
```

---

## 2. Test Scenarios

Here are the scenarios to test, covering the core functionality and edge cases.

### Scenario A: First-time launch with theme mismatch

Goal: Verify the initial prompt to enable auto-theme works correctly.

1. Setup:
    * Ensure your settings.json does not have "ui.theme" or "ui.autoThemePrompt" set.
    * Use a terminal with a light background.
2. Execution:
    * Launch Gemini CLI.
3. Verification:
    * You should see a notification: ⚠️ Terminal background is light, but using a dark theme.
    * You should be prompted: Would you like to enable auto theme to automatically match your terminal? (Y/n):
    * Enter Y (or y, yes, or just press Enter).
    * The theme should switch to the default light theme ("Default Light").
    * Your user settings.json should now contain "ui.theme": "auto".
    * Restart the CLI. It should start with the light theme without any prompt.

### Scenario B: Declining the auto-theme prompt

Goal: Verify that declining the prompt disables it for future sessions.

1. Setup:
    * Reset your settings.json (remove "ui.theme" and "ui.autoThemePrompt").
    * Use a terminal with a light background.
2. Execution:
    * Launch Gemini CLI.
    * At the prompt, enter n (or no).
3. Verification:
    * The theme should remain the default dark theme.
    * You should see a message: Auto theme prompt disabled.
    * Your user settings.json should now contain "ui.autoThemePrompt": false.
    * Restart the CLI. You should see the mismatch notification (⚠️...) but no prompt.

### Scenario C: Manual "auto" mode

Goal: Verify setting the theme to "auto" manually works as expected.

1. Setup:
    * Manually set "ui.theme": "auto" in your settings.json.
2. Execution & Verification:
    * Light terminal:
        * Open the CLI in a light-background terminal.
        * Verify it uses the default light theme ("Default Light").
    * Dark terminal:
        * Switch your terminal to a dark background.
        * Restart the CLI.
        * Verify it uses the default dark theme ("Default").

### Scenario D: Custom theme preferences

Goal: Verify that themePreferences are respected in "auto" mode.

1. Setup:
    * In settings.json, set:

```json
"ui": {
  "theme": "auto",
  "themePreferences": {
    "light": "GitHub Light",
    "dark": "Dracula"
  }
}
```

2. Execution & Verification:
    * Light terminal:
        * Launch in a light-background terminal.
        * Verify the theme is "GitHub Light".
    * Dark terminal:
        * Launch in a dark-background terminal.
        * Verify the theme is "Dracula".

### Scenario E: `/theme` command

Goal: Verify the /theme command interaction with the new auto mode.

1. Execution:
    * Run the /theme command.
2. Verification:
    * The theme selection dialog should now have an "Auto (match terminal)" option at the top.
    * Select "Auto". The theme should change based on your current terminal background. Your settings.json should be updated.
    * Select a specific theme (e.g., "Dracula"). The theme should change, and your settings.json should be updated to "ui.theme": "Dracula".


## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #10710
Related to #10639