### PR TITLE
Docs: Add updates to changelog for v0.8.0

### DIFF
--- a/docs/changelogs/index.md
+++ b/docs/changelogs/index.md
@@ -2,6 +2,30 @@
 
 Wondering what's new in Gemini CLI? This document provides key highlights and notable changes to Gemini CLI.
 
+## v0.8.0 - Gemini CLI weekly update - 2025-09-29
+
+- 🎉 **Announcing Gemini CLI Extensions** 🎉
+  - Completely customize your Gemini CLI experience to fit your workflow.
+  - Build and share your own Gemini CLI extensions with the world.
+  - Launching with a growing catalog of community, partner, and Google-built extensions.
+    - Check extensions from [key launch partners](https://github.com/google-gemini/gemini-cli/discussions/10718).
+  - Easy install:
+    - `gemini extensions install <github url|folder path>`
+  - Easy management:
+    - `gemini extensions install|uninstall|link`
+    - `gemini extensions enable|disable`
+    - `gemini extensions list|update|new`
+  - Or use commands while running with `/extensions list|update`.
+  - Everything you need to know: [Now open for building: Introducing Gemini CLI extensions](https://blog.google/technology/developers/gemini-cli-extensions/).
+- 🎉 **Our New Home Page & Better Documentation** 🎉
+  - Check out our new home page for better getting started material, reference documentation, extensions and more!
+  - _Homepage:_ [https://geminicli.com](https://geminicli.com)
+  - ‼️*NEW documentation:* [https://geminicli.com/docs](https://geminicli.com/docs) (Have any [suggestions](https://github.com/google-gemini/gemini-cli/discussions/8722)?)
+  - _Extensions:_ [https://geminicli.com/extensions](https://geminicli.com/extensions)
+- **Non-Interactive Allowed Tools:** `--allowed-tools` will now also work in non-interactive mode. ([pr](https://github.com/google-gemini/gemini-cli/pull/9114) by [@mistergarrison](https://github.com/mistergarrison))
+- **Terminal Title Status:** See the CLI's real-time status and thoughts directly in the terminal window's title by setting `showStatusInTitle: true`. ([pr](https://github.com/google-gemini/gemini-cli/pull/4386) by [@Fridayxiao](https://github.com/Fridayxiao))
+- **Small features, polish, reliability & bug fixes:** A large amount of changes, smaller features, UI updates, reliability and bug fixes + general polish made it in this week!
+
 ## v0.7.0 - Gemini CLI weekly update - 2025-09-22
 
 - 🎉**Build your own Gemini CLI IDE plugin:** We've published a spec for creating IDE plugins to enable rich context-aware experiences and native in-editor diffing in your IDE of choice. ([pr](https://github.com/google-gemini/gemini-cli/pull/8479) by [@skeshive](https://github.com/skeshive))


### PR DESCRIPTION
## TLDR

Adds changelog for v0.8.0 - 2025-09-29!

## Dive Deeper

This PR updates /docs/changelogs/index.md to add the changelog for v0.8.0.

## Reviewer Test Plan

Check for any typos, mistakes, broken links, or unintended changes.