### PR TITLE
Docs: Fix broken links in architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,11 +9,11 @@ The Gemini CLI is primarily composed of two main packages, along with a suite of
 1.  **CLI package (`packages/cli`):**
     - **Purpose:** This contains the user-facing portion of the Gemini CLI, such as handling the initial user input, presenting the final output, and managing the overall user experience.
     - **Key functions contained in the package:**
-      - [Input processing](../cli/commands.md)
+      - [Input processing](/docs/cli/commands.md)
       - History management
       - Display rendering
-      - [Theme and UI customization](../cli/themes.md)
-      - [CLI configuration settings](../get-started/configuration.md)
+      - [Theme and UI customization](/docs/cli/themes.md)
+      - [CLI configuration settings](/docs/get-started/configuration.md)
 
 2.  **Core package (`packages/core`):**
     - **Purpose:** This acts as the backend for the Gemini CLI. It receives requests sent from `packages/cli`, orchestrates interactions with the Gemini API, and manages the execution of available tools.


### PR DESCRIPTION
## TLDR

Fix two broken links in architecture.md

## Dive Deeper

Two links were broken in architecture.md as a result of page restructuring. This PR updates architecture.md with the correct relative links.

## Reviewer Test Plan

Check for any unintended changes.