### PR TITLE
Extension pre-releases

### DIFF
--- a/docs/extensions/extension-releasing.md
+++ b/docs/extensions/extension-releasing.md
@@ -35,7 +35,9 @@ Gemini CLI extensions can be distributed through [GitHub Releases](https://docs.
 
 Each release includes at least one archive file, which contains the full contents of the repo at the tag that it was linked to. Releases may also include [pre-built archives](#custom-pre-built-archives) if your extension requires some build step or has platform specific binaries attached to it.
 
-When checking for updates, gemini will just look for the latest release on github (you must mark it as such when creating the release), unless the user installed a specific release by passing `--ref=<some-release-tag>`. We do not at this time support opting in to pre-release releases or semver.
+When checking for updates, gemini will just look for the "latest" release on github (you must mark it as such when creating the release), unless the user installed a specific release by passing `--ref=<some-release-tag>`.
+
+You may also install extensions with the `--pre-release` flag in order to get the latest release regardless of whether it has been marked as "latest". This allows you to test that your release works before actually pushing it to all users.
 
 ### Custom pre-built archives
 

--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -17,6 +17,7 @@ interface InstallArgs {
   source: string;
   ref?: string;
   autoUpdate?: boolean;
+  allowPreRelease?: boolean;
 }
 
 export async function handleInstall(args: InstallArgs) {
@@ -34,6 +35,7 @@ export async function handleInstall(args: InstallArgs) {
         type: 'git',
         ref: args.ref,
         autoUpdate: args.autoUpdate,
+        allowPreRelease: args.allowPreRelease,
       };
     } else {
       if (args.ref || args.autoUpdate) {
@@ -81,6 +83,10 @@ export const installCommand: CommandModule = {
         describe: 'Enable auto-update for this extension.',
         type: 'boolean',
       })
+      .option('pre-release', {
+        describe: 'Enable pre-release versions for this extension.',
+        type: 'boolean',
+      })
       .check((argv) => {
         if (!argv.source) {
           throw new Error('The source argument must be provided.');
@@ -92,6 +98,7 @@ export const installCommand: CommandModule = {
       source: argv['source'] as string,
       ref: argv['ref'] as string | undefined,
       autoUpdate: argv['auto-update'] as boolean | undefined,
+      allowPreRelease: argv['pre-release'] as boolean | undefined,
     });
   },
 };

--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -66,7 +66,7 @@ export async function handleInstall(args: InstallArgs) {
 }
 
 export const installCommand: CommandModule = {
-  command: 'install <source>',
+  command: 'install <source> [--auto-update] [--pre-release]',
   describe: 'Installs an extension from a git repository URL or a local path.',
   builder: (yargs) =>
     yargs

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -38,7 +38,7 @@ vi.mock('simple-git');
 
 const fetchJsonMock = vi.hoisted(() => vi.fn());
 vi.mock('./github_fetch.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof os>();
+  const actual = await importOriginal<typeof import('./github_fetch.js')>();
   return {
     ...actual,
     fetchJson: fetchJsonMock,

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -234,11 +234,8 @@ describe('git extension helpers', () => {
   });
 
   describe('fetchReleaseFromGithub', () => {
-    it('should fetch the latest pre-release if allowPreRelease is true', async () => {
-      const releases = [
-        { tag_name: 'v1.0.0-alpha', prerelease: true },
-        { tag_name: 'v0.9.0', prerelease: false },
-      ];
+    it('should fetch the latest release if allowPreRelease is true', async () => {
+      const releases = [{ tag_name: 'v1.0.0-alpha' }, { tag_name: 'v0.9.0' }];
       fetchJsonMock.mockResolvedValueOnce(releases);
 
       const result = await fetchReleaseFromGithub(
@@ -249,17 +246,14 @@ describe('git extension helpers', () => {
       );
 
       expect(fetchJsonMock).toHaveBeenCalledWith(
-        'https://api.github.com/repos/owner/repo/releases?page=1',
+        'https://api.github.com/repos/owner/repo/releases?per_page=1',
       );
       expect(result).toEqual(releases[0]);
     });
 
-    it('should fetch the latest stable release if allowPreRelease is false', async () => {
-      const releases = [
-        { tag_name: 'v1.0.0-alpha', prerelease: true },
-        { tag_name: 'v0.9.0', prerelease: false },
-      ];
-      fetchJsonMock.mockResolvedValueOnce(releases);
+    it('should fetch the latest release if allowPreRelease is false', async () => {
+      const release = { tag_name: 'v0.9.0' };
+      fetchJsonMock.mockResolvedValueOnce(release);
 
       const result = await fetchReleaseFromGithub(
         'owner',
@@ -269,13 +263,13 @@ describe('git extension helpers', () => {
       );
 
       expect(fetchJsonMock).toHaveBeenCalledWith(
-        'https://api.github.com/repos/owner/repo/releases?page=1',
+        'https://api.github.com/repos/owner/repo/releases/latest',
       );
-      expect(result).toEqual(releases[1]);
+      expect(result).toEqual(release);
     });
 
     it('should fetch a release by tag if ref is provided', async () => {
-      const release = { tag_name: 'v0.9.0', prerelease: false };
+      const release = { tag_name: 'v0.9.0' };
       fetchJsonMock.mockResolvedValueOnce(release);
 
       const result = await fetchReleaseFromGithub('owner', 'repo', 'v0.9.0');
@@ -287,47 +281,15 @@ describe('git extension helpers', () => {
     });
 
     it('should fetch latest stable release if allowPreRelease is undefined', async () => {
-      const releases = [
-        { tag_name: 'v1.0.0-alpha', prerelease: true },
-        { tag_name: 'v0.9.0', prerelease: false },
-      ];
-      fetchJsonMock.mockResolvedValueOnce(releases);
+      const release = { tag_name: 'v0.9.0' };
+      fetchJsonMock.mockResolvedValueOnce(release);
 
       const result = await fetchReleaseFromGithub('owner', 'repo');
 
       expect(fetchJsonMock).toHaveBeenCalledWith(
-        'https://api.github.com/repos/owner/repo/releases?page=1',
+        'https://api.github.com/repos/owner/repo/releases/latest',
       );
-      expect(result).toEqual(releases[1]);
-    });
-
-    it('should paginate to find a stable release', async () => {
-      const page1Releases = [
-        { tag_name: 'v1.0.0-alpha', prerelease: true },
-        { tag_name: 'v0.9.9-beta', prerelease: true },
-      ];
-      const page2Releases = [
-        { tag_name: 'v0.9.1-beta', prerelease: true },
-        { tag_name: 'v0.8.0', prerelease: false },
-      ];
-      fetchJsonMock
-        .mockResolvedValueOnce(page1Releases)
-        .mockResolvedValueOnce(page2Releases);
-
-      const result = await fetchReleaseFromGithub(
-        'owner',
-        'repo',
-        undefined,
-        false,
-      );
-
-      expect(fetchJsonMock).toHaveBeenCalledWith(
-        'https://api.github.com/repos/owner/repo/releases?page=1',
-      );
-      expect(fetchJsonMock).toHaveBeenCalledWith(
-        'https://api.github.com/repos/owner/repo/releases?page=2',
-      );
-      expect(result).toEqual(page2Releases[1]);
+      expect(result).toEqual(release);
     });
   });
 

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -18,11 +18,7 @@ import * as path from 'node:path';
 import { EXTENSIONS_CONFIG_FILENAME, loadExtension } from '../extension.js';
 import * as tar from 'tar';
 import extract from 'extract-zip';
-import { fetchJson } from './github_fetch.js';
-
-export function getGitHubToken(): string | undefined {
-  return process.env['GITHUB_TOKEN'];
-}
+import { fetchJson, getGitHubToken } from './github_fetch.js';
 
 /**
  * Clones a Git repository to a specified local path.

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -18,8 +18,9 @@ import * as path from 'node:path';
 import { EXTENSIONS_CONFIG_FILENAME, loadExtension } from '../extension.js';
 import * as tar from 'tar';
 import extract from 'extract-zip';
+import { fetchJson } from './github_fetch.js';
 
-function getGitHubToken(): string | undefined {
+export function getGitHubToken(): string | undefined {
   return process.env['GITHUB_TOKEN'];
 }
 
@@ -108,7 +109,7 @@ export function parseGitHubRepoForReleases(source: string): {
   return { owner, repo };
 }
 
-async function fetchReleaseFromGithub(
+export async function fetchReleaseFromGithub(
   owner: string,
   repo: string,
   ref?: string,
@@ -378,33 +379,6 @@ export function findReleaseAsset(assets: Asset[]): Asset | undefined {
   }
 
   return undefined;
-}
-
-async function fetchJson<T>(url: string): Promise<T> {
-  const headers: { 'User-Agent': string; Authorization?: string } = {
-    'User-Agent': 'gemini-cli',
-  };
-  const token = getGitHubToken();
-  if (token) {
-    headers.Authorization = `token ${token}`;
-  }
-  return new Promise((resolve, reject) => {
-    https
-      .get(url, { headers }, (res) => {
-        if (res.statusCode !== 200) {
-          return reject(
-            new Error(`Request failed with status code ${res.statusCode}`),
-          );
-        }
-        const chunks: Buffer[] = [];
-        res.on('data', (chunk) => chunks.push(chunk));
-        res.on('end', () => {
-          const data = Buffer.concat(chunks).toString();
-          resolve(JSON.parse(data) as T);
-        });
-      })
-      .on('error', reject);
-  });
 }
 
 async function downloadFile(url: string, dest: string): Promise<void> {

--- a/packages/cli/src/config/extensions/github_fetch.ts
+++ b/packages/cli/src/config/extensions/github_fetch.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getGitHubToken } from './github.js';
+import * as https from 'node:https';
+
+export async function fetchJson<T>(url: string): Promise<T> {
+  const headers: { 'User-Agent': string; Authorization?: string } = {
+    'User-Agent': 'gemini-cli',
+  };
+  const token = getGitHubToken();
+  if (token) {
+    headers.Authorization = `token ${token}`;
+  }
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, { headers }, (res) => {
+        if (res.statusCode !== 200) {
+          return reject(
+            new Error(`Request failed with status code ${res.statusCode}`),
+          );
+        }
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          const data = Buffer.concat(chunks).toString();
+          resolve(JSON.parse(data) as T);
+        });
+      })
+      .on('error', reject);
+  });
+}

--- a/packages/cli/src/config/extensions/github_fetch.ts
+++ b/packages/cli/src/config/extensions/github_fetch.ts
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getGitHubToken } from './github.js';
 import * as https from 'node:https';
+
+export function getGitHubToken(): string | undefined {
+  return process.env['GITHUB_TOKEN'];
+}
 
 export async function fetchJson<T>(url: string): Promise<T> {
   const headers: { 'User-Agent': string; Authorization?: string } = {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -139,6 +139,7 @@ export interface ExtensionInstallMetadata {
   releaseTag?: string; // Only present for github-release installs.
   ref?: string;
   autoUpdate?: boolean;
+  allowPreRelease?: boolean;
 }
 
 import type { FileFilteringOptions } from './constants.js';


### PR DESCRIPTION
## TLDR

Adds a `--pre-release` flag to `gemini extensions install`.

When enabled, we will always install the most recent GitHub release instead of the one tagged as the "latest". 

## Dive Deeper

This allows extension authors to test their releases prior to pushing them to all their users - they can create a release without marking it as "latest" (and optionally mark it as a pre-release).

Then, they install using this `--pre-release` flag, and they will get that release, but none of their users (that didn't also opt in) will get that release. Then, when they are ready to release it to all users they can just go into the GitHub UI and mark the release as "latest".

## Reviewer Test Plan

Install an extension with `--pre-release`, and then create a release for that extension but don't mark it as the latest release. On install, you should get that release.

If you then uninstall the extension and re-install without that flag, you should not get that release (but instead the one marked as "latest").

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #8654