### PR TITLE
refactor(core): migrate web search tool to tool-names

### DIFF
--- a/integration-tests/google_web_search.test.ts
+++ b/integration-tests/google_web_search.test.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { WEB_SEARCH_TOOL_NAME } from '../packages/core/src/tools/tool-names.js';
 import { describe, it, expect } from 'vitest';
 import { TestRig, printDebugInfo, validateModelOutput } from './test-helper.js';
 
-describe('google_web_search', () => {
+describe(WEB_SEARCH_TOOL_NAME, () => {
   it('should be able to search the web', async () => {
     const rig = new TestRig();
     await rig.setup('should be able to search the web');
@@ -30,7 +31,7 @@ describe('google_web_search', () => {
       throw error; // Re-throw if not a network error
     }
 
-    const foundToolCall = await rig.waitForToolCall('google_web_search');
+    const foundToolCall = await rig.waitForToolCall(WEB_SEARCH_TOOL_NAME);
 
     // Add debugging information
     if (!foundToolCall) {
@@ -39,11 +40,11 @@ describe('google_web_search', () => {
       // Check if the tool call failed due to network issues
       const failedSearchCalls = allTools.filter(
         (t) =>
-          t.toolRequest.name === 'google_web_search' && !t.toolRequest.success,
+          t.toolRequest.name === WEB_SEARCH_TOOL_NAME && !t.toolRequest.success,
       );
       if (failedSearchCalls.length > 0) {
         console.warn(
-          'google_web_search tool was called but failed, possibly due to network issues',
+          `${WEB_SEARCH_TOOL_NAME} tool was called but failed, possibly due to network issues`,
         );
         console.warn(
           'Failed calls:',
@@ -55,7 +56,7 @@ describe('google_web_search', () => {
 
     expect(
       foundToolCall,
-      'Expected to find a call to google_web_search',
+      `Expected to find a call to ${WEB_SEARCH_TOOL_NAME}`,
     ).toBeTruthy();
 
     // Validate model output - will throw if no output, warn if missing expected content
@@ -69,7 +70,7 @@ describe('google_web_search', () => {
     if (!hasExpectedContent) {
       const searchCalls = rig
         .readToolLogs()
-        .filter((t) => t.toolRequest.name === 'google_web_search');
+        .filter((t) => t.toolRequest.name === WEB_SEARCH_TOOL_NAME);
       if (searchCalls.length > 0) {
         console.warn(
           'Search queries used:',

--- a/packages/core/src/agents/executor.ts
+++ b/packages/core/src/agents/executor.ts
@@ -20,14 +20,13 @@ import { executeToolCall } from '../core/nonInteractiveToolExecutor.js';
 import { ToolRegistry } from '../tools/tool-registry.js';
 import type { ToolCallRequestInfo } from '../core/turn.js';
 import { getDirectoryContextString } from '../utils/environmentContext.js';
-import { GlobTool } from '../tools/glob.js';
 import { GrepTool } from '../tools/grep.js';
 import { RipGrepTool } from '../tools/ripGrep.js';
 import { LSTool } from '../tools/ls.js';
 import { MemoryTool } from '../tools/memoryTool.js';
 import { ReadFileTool } from '../tools/read-file.js';
 import { ReadManyFilesTool } from '../tools/read-many-files.js';
-import { WebSearchTool } from '../tools/web-search.js';
+import { GLOB_TOOL_NAME, WEB_SEARCH_TOOL_NAME } from '../tools/tool-names.js';
 import { promptIdContext } from '../utils/promptIdContext.js';
 import { logAgentStart, logAgentFinish } from '../telemetry/loggers.js';
 import { AgentStartEvent, AgentFinishEvent } from '../telemetry/types.js';
@@ -713,10 +712,10 @@ Important Rules:
       ReadFileTool.Name,
       GrepTool.Name,
       RipGrepTool.Name,
-      GlobTool.Name,
+      GLOB_TOOL_NAME,
       ReadManyFilesTool.Name,
       MemoryTool.Name,
-      WebSearchTool.Name,
+      WEB_SEARCH_TOOL_NAME,
     ]);
     for (const tool of toolRegistry.getAllTools()) {
       if (!allowlist.has(tool.name)) {

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -11,6 +11,7 @@
 export const GLOB_TOOL_NAME = 'glob';
 export const WRITE_TODOS_TOOL_NAME = 'write_todos';
 export const WRITE_FILE_TOOL_NAME = 'write_file';
+export const WEB_SEARCH_TOOL_NAME = 'google_web_search';
 
 // TODO: Migrate other tool names here to follow this pattern and prevent future circular dependencies.
 // Candidates for migration:

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { WEB_SEARCH_TOOL_NAME } from './tool-names.js';
 import type { GroundingMetadata } from '@google/genai';
 import type { ToolInvocation, ToolResult } from './tools.js';
 import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
@@ -184,7 +185,7 @@ export class WebSearchTool extends BaseDeclarativeTool<
   WebSearchToolParams,
   WebSearchToolResult
 > {
-  static readonly Name: string = 'google_web_search';
+  static readonly Name: string = WEB_SEARCH_TOOL_NAME;
 
   constructor(private readonly config: Config) {
     super(


### PR DESCRIPTION
## TLDR

This PR refactors the `google_web_search` tool to use a centralized constant from `tool-names.ts` instead of a hardcoded string. This improves maintainability and helps prevent potential circular dependencies.

## Dive Deeper

As part of a broader effort to make our tool registration more robust, this change migrates the `WebSearchTool` to use a centralized naming constant.

Previously, the tool's name, `'google_web_search'`, was defined as a static property directly within the `web-search.ts` file. This pattern can lead to issues, especially circular dependencies, when other parts of the system (like agents or registries) need to reference a tool's name without importing its full implementation.

This PR introduces a `WEB_SEARCH_TOOL_NAME` constant in `packages/core/src/tools/tool-names.ts` and updates the following files to use it:
- `packages/core/src/tools/web-search.ts`: The tool's primary definition.
- `packages/core/src/agents/executor.ts`: The agent's tool allowlist.
- `integration-tests/google_web_search.test.ts`: The corresponding integration test.

This change makes the codebase cleaner and sets a clear pattern for migrating other tools in the future.

## Reviewer Test Plan

This should be a no-op change. The reviewer should pull down the branch and ensure the tool works as expected.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |
