### PR TITLE
feat(ui): shorten context overflow message when <75% of limit

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1861,16 +1861,16 @@ describe('useGeminiStream', () => {
         vi.mocked(tokenLimit).mockReturnValue(100);
       });
 
-      it('should add message without suggestion when remaining tokens are > 50% of limit', async () => {
+      it('should add message without suggestion when remaining tokens are > 75% of limit', async () => {
         // Setup mock to return a stream with ContextWindowWillOverflow event
-        // Limit is 100, remaining is 60 (> 50)
+        // Limit is 100, remaining is 80 (> 75)
         mockSendMessageStream.mockReturnValue(
           (async function* () {
             yield {
               type: ServerGeminiEventType.ContextWindowWillOverflow,
               value: {
-                estimatedRequestTokenCount: 40,
-                remainingTokenCount: 60,
+                estimatedRequestTokenCount: 20,
+                remainingTokenCount: 80,
               },
             };
           })(),
@@ -1909,23 +1909,23 @@ describe('useGeminiStream', () => {
           expect(mockAddItem).toHaveBeenCalledWith(
             {
               type: 'info',
-              text: `Sending this message (40 tokens) might exceed the remaining context window limit (60 tokens).`,
+              text: `Sending this message (20 tokens) might exceed the remaining context window limit (80 tokens).`,
             },
             expect.any(Number),
           );
         });
       });
 
-      it('should add message with suggestion when remaining tokens are < 50% of limit', async () => {
+      it('should add message with suggestion when remaining tokens are < 75% of limit', async () => {
         // Setup mock to return a stream with ContextWindowWillOverflow event
-        // Limit is 100, remaining is 40 (< 50)
+        // Limit is 100, remaining is 70 (< 75)
         mockSendMessageStream.mockReturnValue(
           (async function* () {
             yield {
               type: ServerGeminiEventType.ContextWindowWillOverflow,
               value: {
-                estimatedRequestTokenCount: 60,
-                remainingTokenCount: 40,
+                estimatedRequestTokenCount: 30,
+                remainingTokenCount: 70,
               },
             };
           })(),
@@ -1964,7 +1964,7 @@ describe('useGeminiStream', () => {
           expect(mockAddItem).toHaveBeenCalledWith(
             {
               type: 'info',
-              text: `Sending this message (60 tokens) might exceed the remaining context window limit (40 tokens). Please try reducing the size of your message or use the \`/compress\` command to compress the chat history.`,
+              text: `Sending this message (30 tokens) might exceed the remaining context window limit (70 tokens). Please try reducing the size of your message or use the \`/compress\` command to compress the chat history.`,
             },
             expect.any(Number),
           );

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -31,6 +31,7 @@ import {
   GeminiEventType as ServerGeminiEventType,
   ToolErrorType,
   ToolConfirmationOutcome,
+  tokenLimit,
 } from '@google/gemini-cli-core';
 import type { Part, PartListUnion } from '@google/genai';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
@@ -77,6 +78,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     GeminiClient: MockedGeminiClientClass,
     UserPromptEvent: MockedUserPromptEvent,
     parseAndFormatApiError: mockParseAndFormatApiError,
+    tokenLimit: vi.fn().mockReturnValue(100), // Mock tokenLimit
   };
 });
 
@@ -1854,57 +1856,119 @@ describe('useGeminiStream', () => {
       });
     });
 
-    it('should add info message for ContextWindowWillOverflow event', async () => {
-      // Setup mock to return a stream with ContextWindowWillOverflow event
-      mockSendMessageStream.mockReturnValue(
-        (async function* () {
-          yield {
-            type: ServerGeminiEventType.ContextWindowWillOverflow,
-            value: {
-              estimatedRequestTokenCount: 100,
-              remainingTokenCount: 50,
-            },
-          };
-        })(),
-      );
-
-      const { result } = renderHook(() =>
-        useGeminiStream(
-          new MockedGeminiClientClass(mockConfig),
-          [],
-          mockAddItem,
-          mockConfig,
-          mockLoadedSettings,
-          mockOnDebugMessage,
-          mockHandleSlashCommand,
-          false,
-          () => 'vscode' as EditorType,
-          () => {},
-          () => Promise.resolve(),
-          false,
-          () => {},
-          () => {},
-          () => {},
-          () => {},
-          80,
-          24,
-        ),
-      );
-
-      // Submit a query
-      await act(async () => {
-        await result.current.submitQuery('Test overflow');
+    describe('ContextWindowWillOverflow event', () => {
+      beforeEach(() => {
+        vi.mocked(tokenLimit).mockReturnValue(100);
       });
 
-      // Check that the info message was added
-      await waitFor(() => {
-        expect(mockAddItem).toHaveBeenCalledWith(
-          {
-            type: 'info',
-            text: `Sending this message (100 tokens) might exceed the remaining context window limit (50 tokens). Please try reducing the size of your message or use the \`/compress\` command to compress the chat history.`,
-          },
-          expect.any(Number),
+      it('should add message without suggestion when remaining tokens are > 50% of limit', async () => {
+        // Setup mock to return a stream with ContextWindowWillOverflow event
+        // Limit is 100, remaining is 60 (> 50)
+        mockSendMessageStream.mockReturnValue(
+          (async function* () {
+            yield {
+              type: ServerGeminiEventType.ContextWindowWillOverflow,
+              value: {
+                estimatedRequestTokenCount: 40,
+                remainingTokenCount: 60,
+              },
+            };
+          })(),
         );
+
+        const { result } = renderHook(() =>
+          useGeminiStream(
+            new MockedGeminiClientClass(mockConfig),
+            [],
+            mockAddItem,
+            mockConfig,
+            mockLoadedSettings,
+            mockOnDebugMessage,
+            mockHandleSlashCommand,
+            false,
+            () => 'vscode' as EditorType,
+            () => {},
+            () => Promise.resolve(),
+            false,
+            () => {},
+            () => {},
+            () => {},
+            () => {},
+            80,
+            24,
+          ),
+        );
+
+        // Submit a query
+        await act(async () => {
+          await result.current.submitQuery('Test overflow');
+        });
+
+        // Check that the message was added without suggestion
+        await waitFor(() => {
+          expect(mockAddItem).toHaveBeenCalledWith(
+            {
+              type: 'info',
+              text: `Sending this message (40 tokens) might exceed the remaining context window limit (60 tokens).`,
+            },
+            expect.any(Number),
+          );
+        });
+      });
+
+      it('should add message with suggestion when remaining tokens are < 50% of limit', async () => {
+        // Setup mock to return a stream with ContextWindowWillOverflow event
+        // Limit is 100, remaining is 40 (< 50)
+        mockSendMessageStream.mockReturnValue(
+          (async function* () {
+            yield {
+              type: ServerGeminiEventType.ContextWindowWillOverflow,
+              value: {
+                estimatedRequestTokenCount: 60,
+                remainingTokenCount: 40,
+              },
+            };
+          })(),
+        );
+
+        const { result } = renderHook(() =>
+          useGeminiStream(
+            new MockedGeminiClientClass(mockConfig),
+            [],
+            mockAddItem,
+            mockConfig,
+            mockLoadedSettings,
+            mockOnDebugMessage,
+            mockHandleSlashCommand,
+            false,
+            () => 'vscode' as EditorType,
+            () => {},
+            () => Promise.resolve(),
+            false,
+            () => {},
+            () => {},
+            () => {},
+            () => {},
+            80,
+            24,
+          ),
+        );
+
+        // Submit a query
+        await act(async () => {
+          await result.current.submitQuery('Test overflow');
+        });
+
+        // Check that the message was added with suggestion
+        await waitFor(() => {
+          expect(mockAddItem).toHaveBeenCalledWith(
+            {
+              type: 'info',
+              text: `Sending this message (60 tokens) might exceed the remaining context window limit (40 tokens). Please try reducing the size of your message or use the \`/compress\` command to compress the chat history.`,
+            },
+            expect.any(Number),
+          );
+        });
       });
     });
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -34,6 +34,7 @@ import {
   ToolConfirmationOutcome,
   promptIdContext,
   WRITE_FILE_TOOL_NAME,
+  tokenLimit,
 } from '@google/gemini-cli-core';
 import { type Part, type PartListUnion, FinishReason } from '@google/genai';
 import type {
@@ -642,15 +643,27 @@ export const useGeminiStream = (
     (estimatedRequestTokenCount: number, remainingTokenCount: number) => {
       onCancelSubmit();
 
+      const limit = tokenLimit(config.getModel());
+
+      const isLessThan50Percent =
+        limit > 0 && remainingTokenCount < limit * 0.5;
+
+      let text = `Sending this message (${estimatedRequestTokenCount} tokens) might exceed the remaining context window limit (${remainingTokenCount} tokens).`;
+
+      if (isLessThan50Percent) {
+        text +=
+          ' Please try reducing the size of your message or use the `/compress` command to compress the chat history.';
+      }
+
       addItem(
         {
           type: 'info',
-          text: `Sending this message (${estimatedRequestTokenCount} tokens) might exceed the remaining context window limit (${remainingTokenCount} tokens). Please try reducing the size of your message or use the \`/compress\` command to compress the chat history.`,
+          text,
         },
         Date.now(),
       );
     },
-    [addItem, onCancelSubmit],
+    [addItem, onCancelSubmit, config],
   );
 
   const handleLoopDetectionConfirmation = useCallback(

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -645,12 +645,12 @@ export const useGeminiStream = (
 
       const limit = tokenLimit(config.getModel());
 
-      const isLessThan50Percent =
-        limit > 0 && remainingTokenCount < limit * 0.5;
+      const isLessThan75Percent =
+        limit > 0 && remainingTokenCount < limit * 0.75;
 
       let text = `Sending this message (${estimatedRequestTokenCount} tokens) might exceed the remaining context window limit (${remainingTokenCount} tokens).`;
 
-      if (isLessThan50Percent) {
+      if (isLessThan75Percent) {
         text +=
           ' Please try reducing the size of your message or use the `/compress` command to compress the chat history.';
       }


### PR DESCRIPTION
## TLDR

This PR updates the message displayed when the context window is about to overflow. If the remaining token count is less than 50% of the model's limit, a suggestion to reduce the message size or use the `/compress` command is appended to the message.

## Dive Deeper

The `handleContextWindowWillOverflowEvent` in `useGeminiStream.ts` has been updated to check the remaining token count against the model's token limit. The `tokenLimit` function is imported from `@google/gemini-cli-core`.

## Reviewer Test Plan

1.  Run the CLI with a model that has a known token limit.
2.  Send a message that causes a `ContextWindowWillOverflow` event where the remaining tokens are > 50% of the limit. Verify the message does not include the suggestion.
3.  Send a message that causes a `ContextWindowWillOverflow` event where the remaining tokens are < 50% of the limit. Verify the message includes the suggestion to use `/compress`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
