### PR TITLE
feat(telemetry): add diff stats to tool call metrics

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -345,6 +345,14 @@ Metrics are numerical measurements of behavior over time.
     - `success` (boolean)
     - `decision` (string: "accept", "reject", or "modify", if applicable)
     - `tool_type` (string: "mcp", or "native", if applicable)
+    - `model_added_lines` (Int, optional): Lines added by model in the proposed
+      changes, if applicable
+    - `model_removed_lines` (Int, optional): Lines removed by model in the
+      proposed changes, if applicable
+    - `user_added_lines` (Int, optional): Lines added by user edits after model
+      proposal, if applicable
+    - `user_removed_lines` (Int, optional): Lines removed by user edits after
+      model proposal, if applicable
 
 - `gemini_cli.tool.call.latency` (Histogram, ms): Measures tool call latency.
   - **Attributes**:
@@ -379,14 +387,6 @@ Metrics are numerical measurements of behavior over time.
     - `lines` (Int, if applicable): Number of lines in the file.
     - `mimetype` (string, if applicable): Mimetype of the file.
     - `extension` (string, if applicable): File extension of the file.
-    - `model_added_lines` (Int, if applicable): Number of lines added/changed by
-      the model.
-    - `model_removed_lines` (Int, if applicable): Number of lines
-      removed/changed by the model.
-    - `user_added_lines` (Int, if applicable): Number of lines added/changed by
-      user in AI proposed changes.
-    - `user_removed_lines` (Int, if applicable): Number of lines removed/changed
-      by user in AI proposed changes.
     - `programming_language` (string, if applicable): The programming language
       of the file.
 

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -694,6 +694,10 @@ describe('loggers', () => {
           success: true,
           decision: ToolCallDecision.ACCEPT,
           tool_type: 'native',
+          model_added_lines: 1,
+          model_removed_lines: 2,
+          user_added_lines: 5,
+          user_removed_lines: 6,
         },
       );
 

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -209,6 +209,14 @@ export function logToolCall(config: Config, event: ToolCallEvent): void {
     success: event.success,
     decision: event.decision,
     tool_type: event.tool_type,
+    ...(event.metadata
+      ? {
+          model_added_lines: event.metadata['model_added_lines'],
+          model_removed_lines: event.metadata['model_removed_lines'],
+          user_added_lines: event.metadata['user_added_lines'],
+          user_removed_lines: event.metadata['user_removed_lines'],
+        }
+      : {}),
   });
 }
 

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -70,6 +70,11 @@ const COUNTER_DEFINITIONS = {
       success: boolean;
       decision?: 'accept' | 'reject' | 'modify' | 'auto_accept';
       tool_type?: 'native' | 'mcp';
+      // Optional diff statistics for file-modifying tools
+      model_added_lines?: number;
+      model_removed_lines?: number;
+      user_added_lines?: number;
+      user_removed_lines?: number;
     },
   },
   [API_REQUEST_COUNT]: {


### PR DESCRIPTION
## TLDR

This pull request adds optional diff statistics to the `gemini_cli.tool.call.count` metric. This will allow us to track the number of lines added, modified, or removed by both the model and the user during file-based operations.

## Dive Deeper

To better understand how file-modifying tools are used and how users interact with the suggested changes, we need more granular data. This change introduces four new optional attributes to the tool call metric:

- `model_added_lines`
- `model_removed_lines`
- `user_added_lines`
- `user_removed_lines`

These attributes will be populated for tools that involve file patching, providing insight into the extent of changes proposed by the model and the adjustments made by the user.

The changes include:
- Updating the metric definition in `packages/core/src/telemetry/metrics.ts`.
- Modifying the `logToolCall` function in `packages/core/src/telemetry/loggers.ts` to pass the new metadata.
- Updating the corresponding test in `packages/core/src/telemetry/loggers.test.ts`.
- Documenting the new attributes in `docs/cli/telemetry.md`.

## Reviewer Test Plan

1.  Review the code changes to ensure they correctly implement the new metric attributes.
2.  Check the updated documentation in `docs/cli/telemetry.md` for accuracy and clarity.
3.  To manually test, you would need to trigger a tool call that results in a file modification and inspect the logged telemetry event to ensure the new diff-related attributes are present and correct.

cc @bobcatfish @blanca-delgado-parra 