### PR TITLE
feat(core): Failed Response Retry via Extra Prompt

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -724,6 +724,7 @@ export const useGeminiStream = (
             loopDetectedRef.current = true;
             break;
           case ServerGeminiEventType.Retry:
+          case ServerGeminiEventType.InvalidStream:
             // Will add the missing logic later
             break;
           default: {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -619,6 +619,31 @@ describe('Server Config (config.ts)', () => {
     });
   });
 
+  describe('ContinueOnFailedApiCall Configuration', () => {
+    it('should default continueOnFailedApiCall to false when not provided', () => {
+      const config = new Config(baseParams);
+      expect(config.getContinueOnFailedApiCall()).toBe(false);
+    });
+
+    it('should set continueOnFailedApiCall to true when provided as true', () => {
+      const paramsWithContinueOnFailedApiCall: ConfigParameters = {
+        ...baseParams,
+        continueOnFailedApiCall: true,
+      };
+      const config = new Config(paramsWithContinueOnFailedApiCall);
+      expect(config.getContinueOnFailedApiCall()).toBe(true);
+    });
+
+    it('should set continueOnFailedApiCall to false when explicitly provided as false', () => {
+      const paramsWithContinueOnFailedApiCall: ConfigParameters = {
+        ...baseParams,
+        continueOnFailedApiCall: false,
+      };
+      const config = new Config(paramsWithContinueOnFailedApiCall);
+      expect(config.getContinueOnFailedApiCall()).toBe(false);
+    });
+  });
+
   describe('createToolRegistry', () => {
     it('should register a tool if coreTools contains an argument-specific pattern', async () => {
       const params: ConfigParameters = {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -622,7 +622,7 @@ describe('Server Config (config.ts)', () => {
   describe('ContinueOnFailedApiCall Configuration', () => {
     it('should default continueOnFailedApiCall to false when not provided', () => {
       const config = new Config(baseParams);
-      expect(config.getContinueOnFailedApiCall()).toBe(false);
+      expect(config.getContinueOnFailedApiCall()).toBe(true);
     });
 
     it('should set continueOnFailedApiCall to true when provided as true', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -455,7 +455,7 @@ export class Config {
     this.enableMessageBusIntegration =
       params.enableMessageBusIntegration ?? false;
     this.enableSubagents = params.enableSubagents ?? false;
-    this.continueOnFailedApiCall = params.continueOnFailedApiCall ?? false;
+    this.continueOnFailedApiCall = params.continueOnFailedApiCall ?? true;
     this.extensionManagement = params.extensionManagement ?? true;
     this.storage = new Storage(this.targetDir);
     this.enablePromptCompletion = params.enablePromptCompletion ?? false;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -260,6 +260,7 @@ export interface ConfigParameters {
   useModelRouter?: boolean;
   enableMessageBusIntegration?: boolean;
   enableSubagents?: boolean;
+  continueOnFailedApiCall?: boolean;
 }
 
 export class Config {
@@ -353,6 +354,7 @@ export class Config {
   private readonly useModelRouter: boolean;
   private readonly enableMessageBusIntegration: boolean;
   private readonly enableSubagents: boolean;
+  private readonly continueOnFailedApiCall: boolean;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -443,6 +445,7 @@ export class Config {
     this.enableMessageBusIntegration =
       params.enableMessageBusIntegration ?? false;
     this.enableSubagents = params.enableSubagents ?? false;
+    this.continueOnFailedApiCall = params.continueOnFailedApiCall ?? false;
     this.extensionManagement = params.extensionManagement ?? true;
     this.storage = new Storage(this.targetDir);
     this.enablePromptCompletion = params.enablePromptCompletion ?? false;
@@ -939,6 +942,10 @@ export class Config {
 
   getSkipNextSpeakerCheck(): boolean {
     return this.skipNextSpeakerCheck;
+  }
+
+  getContinueOnFailedApiCall(): boolean {
+    return this.continueOnFailedApiCall;
   }
 
   getShellExecutionConfig(): ShellExecutionConfig {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1839,7 +1839,7 @@ ${JSON.stringify(
       expect(mockTurnRunFn).toHaveBeenNthCalledWith(
         2,
         expect.any(String),
-        [{ text: 'Please continue.' }],
+        [{ text: 'System: Please continue.' }],
         expect.any(Object),
       );
     });

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -40,9 +40,11 @@ import { LoopDetectionService } from '../services/loopDetectionService.js';
 import { ideContextStore } from '../ide/ideContext.js';
 import {
   logChatCompression,
+  logContentRetryFailure,
   logNextSpeakerCheck,
 } from '../telemetry/loggers.js';
 import {
+  ContentRetryFailureEvent,
   makeChatCompressionEvent,
   NextSpeakerCheckEvent,
 } from '../telemetry/types.js';
@@ -544,6 +546,14 @@ export class GeminiClient {
       if (event.type === GeminiEventType.InvalidStream) {
         if (isInvalidStreamRetry) {
           // We already retried once, so stop here.
+          logContentRetryFailure(
+            this.config,
+            new ContentRetryFailureEvent(
+              4, // 2 initial + 2 after injections
+              'FAILED_AFTER_PROMPT_INJECTION',
+              modelToUse,
+            ),
+          );
           return turn;
         }
         const nextRequest = [{ text: 'Please continue.' }];

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -540,6 +540,16 @@ export class GeminiClient {
         return turn;
       }
       yield event;
+      if (event.type === GeminiEventType.InvalidStream) {
+        const nextRequest = [{ text: 'Please continue.' }];
+        yield* this.sendMessageStream(
+          nextRequest,
+          signal,
+          prompt_id,
+          boundedTurns - 1,
+        );
+        return turn;
+      }
       if (event.type === GeminiEventType.Error) {
         return turn;
       }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -643,18 +643,16 @@ My setup is complete. I will provide my first command in the next turn.
         ),
       );
       if (nextSpeakerCheck?.next_speaker === 'model') {
-        if (this.config.getContinueOnFailedApiCall()) {
-          const nextRequest = [{ text: 'Please continue.' }];
-          // This recursive call's events will be yielded out, but the final
-          // turn object will be from the top-level call.
-          yield* this.sendMessageStream(
-            nextRequest,
-            signal,
-            prompt_id,
-            boundedTurns - 1,
-            // isInvalidStreamRetry is false here, as this is a next speaker check
-          );
-        }
+        const nextRequest = [{ text: 'Please continue.' }];
+        // This recursive call's events will be yielded out, but the final
+        // turn object will be from the top-level call.
+        yield* this.sendMessageStream(
+          nextRequest,
+          signal,
+          prompt_id,
+          boundedTurns - 1,
+          // isInvalidStreamRetry is false here, as this is a next speaker check
+        );
       }
     }
     return turn;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -603,7 +603,7 @@ My setup is complete. I will provide my first command in the next turn.
             );
             return turn;
           }
-          const nextRequest = [{ text: 'Please continue.' }];
+          const nextRequest = [{ text: 'System: Please continue.' }];
           yield* this.sendMessageStream(
             nextRequest,
             signal,

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -13,7 +13,7 @@ import { Turn, GeminiEventType } from './turn.js';
 import type { GenerateContentResponse, Part, Content } from '@google/genai';
 import { reportError } from '../utils/errorReporting.js';
 import type { GeminiChat } from './geminiChat.js';
-import { StreamEventType } from './geminiChat.js';
+import { InvalidStreamError, StreamEventType } from './geminiChat.js';
 
 const mockSendMessageStream = vi.fn();
 const mockGetHistory = vi.fn();
@@ -221,6 +221,28 @@ describe('Turn', () => {
         { type: GeminiEventType.UserCancelled },
       ]);
       expect(turn.getDebugResponses().length).toBe(1);
+    });
+
+    it('should yield InvalidStream event if sendMessageStream throws InvalidStreamError', async () => {
+      const error = new InvalidStreamError(
+        'Test invalid stream',
+        'NO_FINISH_REASON',
+      );
+      mockSendMessageStream.mockRejectedValue(error);
+      const reqParts: Part[] = [{ text: 'Trigger invalid stream' }];
+
+      const events = [];
+      for await (const event of turn.run(
+        'test-model',
+        reqParts,
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+
+      expect(events).toEqual([{ type: GeminiEventType.InvalidStream }]);
+      expect(turn.getDebugResponses().length).toBe(0);
+      expect(reportError).not.toHaveBeenCalled(); // Should not report as error
     });
 
     it('should yield Error event and report if sendMessageStream throws', async () => {


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

This PR introduces a new feature to automatically "retry" a model call when the response stream terminates unexpectedly.

1. New Config Flag: A continueOnFailedApiCall flag (defaults to true) is added to control this behavior.
2. Retry Logic: If the flag is enabled and an InvalidStream event occurs, the client will automatically send the prompt "Please continue." to try and recover the rest of the model's response.
3. Safeguard: This retry mechanism will only execute once per user request.


## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
