### PR TITLE
fix(tests): log actual output in validateModelOutput on failure

### DIFF
--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -104,6 +104,7 @@ export function validateModelOutput(
       console.warn(
         'The tool was called successfully, which is the main requirement.',
       );
+      console.warn('Actual output:', result);
       return false;
     } else if (process.env.VERBOSE === 'true') {
       console.log(`${testName}: Model output validated successfully.`);

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -104,6 +104,7 @@ export function validateModelOutput(
       console.warn(
         'The tool was called successfully, which is the main requirement.',
       );
+      console.warn('Expected content:', expectedContent);
       console.warn('Actual output:', result);
       return false;
     } else if (process.env.VERBOSE === 'true') {


### PR DESCRIPTION
## TLDR

Add `console.warn` to `validateModelOutput` in `integration-tests/test-helper.ts` to log the actual LLM output when expected content is missing. This improves debugging for integration test failures.

## Dive Deeper

Currently, when `validateModelOutput` warns about missing content, it only logs what was expected. By logging the actual output, we can quickly see why the validation failed (e.g., slightly different wording, completely wrong output, etc.) without having to run with verbose logging enabled globally.

## Reviewer Test Plan

Run an integration test that triggers the warning in `validateModelOutput` (or temporarily modify a test to expect something not in the output) and observe that the actual output is logged to the console.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A