### PR TITLE
fix(tests): enable and update prompt for MCP add tool test

### DIFF
--- a/integration-tests/simple-mcp-server.test.ts
+++ b/integration-tests/simple-mcp-server.test.ts
@@ -210,11 +210,12 @@ describe('simple-mcp-server', () => {
     }
   });
 
-  //TODO -https://github.com/google-gemini/gemini-cli/issues/10738
-  it.skip('should add two numbers', async () => {
+  it('should add two numbers', async () => {
     // Test directory is already set up in before hook
     // Just run the command - MCP server config is in settings.json
-    const output = await rig.run('add 5 and 10');
+    const output = await rig.run(
+      'Use the `add` tool to calculate 5+10 and output only the resulting number.',
+    );
 
     const foundToolCall = await rig.waitForToolCall('add');
 


### PR DESCRIPTION
## TLDR

Enables the previously skipped `should add two numbers` test in `integration-tests/simple-mcp-server.test.ts` and updates the prompt to be more explicit for the model.

## Dive Deeper

The test was skipped with a TODO linking to an issue. By making the prompt more direct ("Use the `add` tool to calculate 5+10 and output only the resulting number."), the test becomes reliable enough to be enabled. I ran this test 100 times locally, and it passed every time.

## Reviewer Test Plan

Run the integration tests:
`npm run test:integration`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #10738