### PR TITLE
chore(int): disable skip on "should trigger chat compression with /co…

### DIFF
--- a/integration-tests/context-compress-interactive.test.ts
+++ b/integration-tests/context-compress-interactive.test.ts
@@ -18,8 +18,7 @@ describe('Interactive Mode', () => {
     await rig.cleanup();
   });
 
-  //TODO - https://github.com/google-gemini/gemini-cli/issues/10770
-  it.skip('should trigger chat compression with /compress command', async () => {
+  it('should trigger chat compression with /compress command', async () => {
     await rig.setup('interactive-compress-test');
 
     const { ptyProcess } = rig.runInteractive();


### PR DESCRIPTION
## TLDR

Enables the integration test "should trigger chat compression with /compress command" in `integration-tests/context-compress-interactive.test.ts` by removing `.skip`.

## Dive Deeper

This test was previously skipped. Enabling it helps ensure the `/compress` command functionality is covered by integration tests.

## Reviewer Test Plan

Run the integration tests to ensure this specific test passes and doesn't introduce flakiness.

```bash
npm run test:e2e
```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #10770
