### PR TITLE
clean up extension tests

### DIFF
--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -20,7 +20,6 @@ import {
   loadExtensionConfig,
   loadExtensions,
   performWorkspaceExtensionMigration,
-  requestConsentNonInteractive,
   uninstallExtension,
 } from './extension.js';
 import {
@@ -99,15 +98,6 @@ vi.mock('child_process', async (importOriginal) => {
   };
 });
 
-const mockQuestion = vi.hoisted(() => vi.fn());
-const mockClose = vi.hoisted(() => vi.fn());
-vi.mock('node:readline', () => ({
-  createInterface: vi.fn(() => ({
-    question: mockQuestion,
-    close: mockClose,
-  })),
-}));
-
 const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
 
 describe('extension tests', () => {
@@ -128,7 +118,6 @@ describe('extension tests', () => {
     vi.mocked(os.homedir).mockReturnValue(tempHomeDir);
     vi.mocked(isWorkspaceTrusted).mockReturnValue(true);
     vi.spyOn(process, 'cwd').mockReturnValue(tempWorkspaceDir);
-    mockQuestion.mockImplementation((_query, callback) => callback('y'));
     vi.mocked(execSync).mockClear();
     Object.values(mockGit).forEach((fn) => fn.mockReset());
   });
@@ -137,8 +126,6 @@ describe('extension tests', () => {
     fs.rmSync(tempHomeDir, { recursive: true, force: true });
     fs.rmSync(tempWorkspaceDir, { recursive: true, force: true });
     vi.restoreAllMocks();
-    mockQuestion.mockClear();
-    mockClose.mockClear();
   });
 
   describe('loadExtensions', () => {
@@ -806,8 +793,8 @@ describe('extension tests', () => {
     });
 
     it('should install an extension from a git URL', async () => {
-      const gitUrl = 'https://github.com/google/gemini-extensions.git';
-      const extensionName = 'gemini-extensions';
+      const gitUrl = 'https://somehost.com/somerepo.git';
+      const extensionName = 'some-extension';
       const targetExtDir = path.join(userExtensionsDir, extensionName);
       const metadataPath = path.join(targetExtDir, INSTALL_METADATA_FILENAME);
 
@@ -834,7 +821,6 @@ describe('extension tests', () => {
         source: gitUrl,
         type: 'git',
       });
-      fs.rmSync(targetExtDir, { recursive: true, force: true });
     });
 
     it('should install a linked extension', async () => {
@@ -881,7 +867,6 @@ describe('extension tests', () => {
     });
 
     it('should show users information on their ansi escaped mcp servers when installing', async () => {
-      const consoleInfoSpy = vi.spyOn(console, 'info');
       const sourceExtDir = createExtension({
         extensionsDir: tempHomeDir,
         name: 'my-local-extension',
@@ -899,16 +884,17 @@ describe('extension tests', () => {
         },
       });
 
-      mockQuestion.mockImplementation((_query, callback) => callback('y'));
+      const mockRequestConsent = vi.fn();
+      mockRequestConsent.mockResolvedValue(true);
 
       await expect(
         installExtension(
           { source: sourceExtDir, type: 'local' },
-          requestConsentNonInteractive,
+          mockRequestConsent,
         ),
       ).resolves.toBe('my-local-extension');
 
-      expect(consoleInfoSpy).toHaveBeenCalledWith(
+      expect(mockRequestConsent).toHaveBeenCalledWith(
         `Installing extension "my-local-extension".
 **Extensions may introduce unexpected behavior. Ensure you have investigated the extension source and trust the author.**
 This extension will run the following MCP servers:
@@ -930,19 +916,12 @@ This extension will run the following MCP servers:
         },
       });
 
-      mockQuestion.mockImplementation((_query, callback) => callback('y'));
-
       await expect(
         installExtension(
           { source: sourceExtDir, type: 'local' },
-          requestConsentNonInteractive,
+          async () => true,
         ),
       ).resolves.toBe('my-local-extension');
-
-      expect(mockQuestion).toHaveBeenCalledWith(
-        expect.stringContaining('Do you want to continue? [Y/n]: '),
-        expect.any(Function),
-      );
     });
 
     it('should cancel installation if user declines prompt for local extension with mcp servers', async () => {
@@ -958,19 +937,12 @@ This extension will run the following MCP servers:
         },
       });
 
-      mockQuestion.mockImplementation((_query, callback) => callback('n'));
-
       await expect(
         installExtension(
           { source: sourceExtDir, type: 'local' },
-          requestConsentNonInteractive,
+          async () => false,
         ),
       ).rejects.toThrow('Installation cancelled for "my-local-extension".');
-
-      expect(mockQuestion).toHaveBeenCalledWith(
-        expect.stringContaining('Do you want to continue? [Y/n]: '),
-        expect.any(Function),
-      );
     });
 
     it('should save the autoUpdate flag to the install metadata', async () => {
@@ -1041,7 +1013,10 @@ This extension will run the following MCP servers:
       });
 
       await expect(
-        installExtension({ source: sourceExtDir, type: 'local' }),
+        installExtension(
+          { source: sourceExtDir, type: 'local' },
+          async () => true,
+        ),
       ).rejects.toThrow('Invalid extension name: "bad_name"');
     });
   });


### PR DESCRIPTION
## TLDR

- Removes mocks of `node:readline` which is really an implementation detail of `requestConsentNonInteractive` and instead passes a mock or custom function for requesting consent (this was already injectable).
- Updates the highly flaky install from git test so that it isn't a GitHub URL, which makes it not make http requests to github (this was causing it to hang, but only when ran with other tests, not sure why).

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #10739 - this test was already unskipped but I discovered the other flaky test when looking into it. I also don't believe the PR that unskipped it actually did anything to make it less flaky, but this should.