### PR TITLE
Simplify auth in interactive tests.

### DIFF
--- a/integration-tests/context-compress-interactive.test.ts
+++ b/integration-tests/context-compress-interactive.test.ts
@@ -21,8 +21,7 @@ describe('Interactive Mode', () => {
   it('should trigger chat compression with /compress command', async () => {
     await rig.setup('interactive-compress-test');
 
-    const { ptyProcess } = rig.runInteractive();
-    await rig.ensureReadyForInput(ptyProcess);
+    const ptyProcess = await rig.runInteractive();
 
     const longPrompt =
       'Dont do anything except returning a 1000 token long paragragh with the <name of the scientist who discovered theory of relativity> at the end to indicate end of response. This is a moderately long sentence.';
@@ -50,18 +49,12 @@ describe('Interactive Mode', () => {
   it.skip('should handle compression failure on token inflation', async () => {
     await rig.setup('interactive-compress-test');
 
-    const { ptyProcess } = rig.runInteractive();
-    await rig.ensureReadyForInput(ptyProcess);
+    const ptyProcess = await rig.runInteractive();
 
     await type(ptyProcess, '/compress');
     await new Promise((resolve) => setTimeout(resolve, 100));
     await type(ptyProcess, '\r');
 
-    const compressionFailed = await rig.waitForText(
-      'compression was not beneficial',
-      25000,
-    );
-
-    expect(compressionFailed).toBe(true);
+    await rig.waitForText('compression was not beneficial', 25000);
   });
 });

--- a/integration-tests/ctrl-c-exit.test.ts
+++ b/integration-tests/ctrl-c-exit.test.ts
@@ -7,33 +7,36 @@
 import { describe, it, expect } from 'vitest';
 import * as os from 'node:os';
 import { TestRig } from './test-helper.js';
+import * as pty from '@lydell/node-pty';
+
+function waitForExit(ptyProcess: pty.IPty): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () =>
+        reject(
+          new Error(`Test timed out: process did not exit within a minute.`),
+        ),
+      60000,
+    );
+    ptyProcess.onExit(({ exitCode }) => {
+      clearTimeout(timer);
+      resolve(exitCode);
+    });
+  });
+}
 
 describe('Ctrl+C exit', () => {
   it('should exit gracefully on second Ctrl+C', async () => {
     const rig = new TestRig();
     await rig.setup('should exit gracefully on second Ctrl+C');
 
-    const { ptyProcess, promise } = rig.runInteractive();
-
-    let output = '';
-    ptyProcess.onData((data) => {
-      output += data;
-    });
-
-    // Wait for the app to be ready by looking for the initial prompt indicator
-    await rig.poll(() => output.includes('▶'), 5000, 100);
+    const ptyProcess = await rig.runInteractive();
 
     // Send first Ctrl+C
     ptyProcess.write('\x03');
 
-    // Wait for the exit prompt
-    await rig.poll(
-      () => output.includes('Press Ctrl+C again to exit'),
-      1500,
-      50,
-    );
+    await rig.waitForText('Press Ctrl+C again to exit', 5000);
 
-    // Send second Ctrl+C
     if (os.platform() === 'win32') {
       // This is a workaround for node-pty/winpty on Windows.
       // Reliably sending a second Ctrl+C signal to a process that is already
@@ -44,50 +47,21 @@ describe('Ctrl+C exit', () => {
       // simulating a successful exit. We accept that we cannot test the
       // graceful shutdown message on Windows in this automated context.
       ptyProcess.kill();
-    } else {
-      // On Unix-like systems, send the second Ctrl+C to trigger the graceful exit.
-      ptyProcess.write('\x03');
-    }
 
-    const timeout = new Promise((_, reject) =>
-      setTimeout(
-        () =>
-          reject(
-            new Error(
-              `Test timed out: process did not exit within a minute. Output: ${output}`,
-            ),
-          ),
-        60000,
-      ),
-    );
-
-    const result = await Promise.race([promise, timeout]);
-
-    // On Windows, killing the process may result in a non-zero exit code. On
-    // other platforms, a graceful exit is code 0.
-    if (os.platform() === 'win32') {
+      const exitCode = await waitForExit(ptyProcess);
       // On Windows, the exit code after ptyProcess.kill() can be unpredictable
       // (often 1), so we accept any non-null exit code as a pass condition,
       // focusing on the fact that the process did terminate.
-      expect(
-        result.exitCode,
-        `Process exited with code ${result.exitCode}. Output: ${result.output}`,
-      ).not.toBeNull();
-    } else {
-      // Expect a graceful exit (code 0) on non-Windows platforms
-      expect(
-        result.exitCode,
-        `Process exited with code ${result.exitCode}. Output: ${result.output}`,
-      ).toBe(0);
-
-      // Only check for the quitting message on non-Windows platforms due to the
-      // forceful kill workaround.
-      const quittingMessage = 'Agent powering down. Goodbye!';
-      // The regex below is intentionally matching the ESC control character (\x1b)
-      // to strip ANSI color codes from the terminal output.
-      // eslint-disable-next-line no-control-regex
-      const cleanOutput = output.replace(/\x1b\[[0-9;]*m/g, '');
-      expect(cleanOutput).toContain(quittingMessage);
+      expect(exitCode, `Process exited with code ${exitCode}.`).not.toBeNull();
+      return;
     }
+
+    // Send second Ctrl+C
+    ptyProcess.write('\x03');
+
+    const exitCode = await waitForExit(ptyProcess);
+    expect(exitCode, `Process exited with code ${exitCode}.`).toBe(0);
+
+    await rig.waitForText('Agent powering down. Goodbye!', 5000);
   });
 });

--- a/integration-tests/file-system-interactive.test.ts
+++ b/integration-tests/file-system-interactive.test.ts
@@ -23,23 +23,7 @@ describe('Interactive file system', () => {
     rig.setup('interactive-read-then-write');
     rig.createFile(fileName, '1.0.0');
 
-    const { ptyProcess } = rig.runInteractive();
-
-    const authDialogAppeared = await rig.waitForText(
-      'How would you like to authenticate',
-      5000,
-    );
-
-    // select the second option if auth dialog come's up
-    if (authDialogAppeared) {
-      ptyProcess.write('2');
-    }
-
-    // Wait for the app to be ready
-    const isReady = await rig.waitForText('Type your message', 30000);
-    expect(isReady, 'CLI did not start up in interactive mode correctly').toBe(
-      true,
-    );
+    const ptyProcess = await rig.runInteractive();
 
     // Step 1: Read the file
     const readPrompt = `Read the version from ${fileName}`;
@@ -49,11 +33,7 @@ describe('Interactive file system', () => {
     const readCall = await rig.waitForToolCall('read_file', 30000);
     expect(readCall, 'Expected to find a read_file tool call').toBe(true);
 
-    const containsExpectedVersion = await rig.waitForText('1.0.0', 30000);
-    expect(
-      containsExpectedVersion,
-      'Expected to see version "1.0.0" in output',
-    ).toBe(true);
+    await rig.waitForText('1.0.0', 30000);
 
     // Step 2: Write the file
     const writePrompt = `now change the version to 1.0.1 in the file`;


### PR DESCRIPTION
## TLDR

Declare the auth type in the settings file instead of dealing with the auth dialog on startup. Also, simplify and centralize waiting for the prompt and change waitForText() to just throw an error if text isn't found.

## Reviewer Test Plan

See that the integration tests pass on this PR.

