### PR TITLE
fix: make local telemetry export JSONL compatible

### DIFF
--- a/packages/core/src/telemetry/file-exporters.ts
+++ b/packages/core/src/telemetry/file-exporters.ts
@@ -26,7 +26,7 @@ class FileExporter {
   }
 
   protected serialize(data: unknown): string {
-    return JSON.stringify(data, null, 2) + '\n';
+    return JSON.stringify(data) + '\n';
   }
 
   shutdown(): Promise<void> {


### PR DESCRIPTION
## TLDR

Currently, local telemetry export outputs indented JSON separated by newlines which is hard for humans to read because it's dense and verbose and also hard for machines to read. This one-line change alters the export format to unindented JSON so that the telemetry log can reasonably parsed as a JSONL file.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
