### PR TITLE
Fix rough edges around extension updates

### DIFF
--- a/packages/cli/src/commands/extensions/install.test.ts
+++ b/packages/cli/src/commands/extensions/install.test.ts
@@ -8,12 +8,12 @@ import { describe, it, expect, vi, type MockInstance } from 'vitest';
 import { handleInstall, installCommand } from './install.js';
 import yargs from 'yargs';
 
-const mockInstallExtension = vi.hoisted(() => vi.fn());
+const mockInstallOrUpdateExtension = vi.hoisted(() => vi.fn());
 const mockRequestConsentNonInteractive = vi.hoisted(() => vi.fn());
 const mockStat = vi.hoisted(() => vi.fn());
 
 vi.mock('../../config/extension.js', () => ({
-  installExtension: mockInstallExtension,
+  installOrUpdateExtension: mockInstallOrUpdateExtension,
   requestConsentNonInteractive: mockRequestConsentNonInteractive,
 }));
 
@@ -51,14 +51,14 @@ describe('handleInstall', () => {
   });
 
   afterEach(() => {
-    mockInstallExtension.mockClear();
+    mockInstallOrUpdateExtension.mockClear();
     mockRequestConsentNonInteractive.mockClear();
     mockStat.mockClear();
     vi.resetAllMocks();
   });
 
   it('should install an extension from a http source', async () => {
-    mockInstallExtension.mockResolvedValue('http-extension');
+    mockInstallOrUpdateExtension.mockResolvedValue('http-extension');
 
     await handleInstall({
       source: 'http://google.com',
@@ -70,7 +70,7 @@ describe('handleInstall', () => {
   });
 
   it('should install an extension from a https source', async () => {
-    mockInstallExtension.mockResolvedValue('https-extension');
+    mockInstallOrUpdateExtension.mockResolvedValue('https-extension');
 
     await handleInstall({
       source: 'https://google.com',
@@ -82,7 +82,7 @@ describe('handleInstall', () => {
   });
 
   it('should install an extension from a git source', async () => {
-    mockInstallExtension.mockResolvedValue('git-extension');
+    mockInstallOrUpdateExtension.mockResolvedValue('git-extension');
 
     await handleInstall({
       source: 'git@some-url',
@@ -104,7 +104,7 @@ describe('handleInstall', () => {
   });
 
   it('should install an extension from a sso source', async () => {
-    mockInstallExtension.mockResolvedValue('sso-extension');
+    mockInstallOrUpdateExtension.mockResolvedValue('sso-extension');
 
     await handleInstall({
       source: 'sso://google.com',
@@ -116,7 +116,7 @@ describe('handleInstall', () => {
   });
 
   it('should install an extension from a local path', async () => {
-    mockInstallExtension.mockResolvedValue('local-extension');
+    mockInstallOrUpdateExtension.mockResolvedValue('local-extension');
     mockStat.mockResolvedValue({});
     await handleInstall({
       source: '/some/path',
@@ -128,7 +128,7 @@ describe('handleInstall', () => {
   });
 
   it('should throw an error if install extension fails', async () => {
-    mockInstallExtension.mockRejectedValue(
+    mockInstallOrUpdateExtension.mockRejectedValue(
       new Error('Install extension failed'),
     );
 

--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -6,7 +6,7 @@
 
 import type { CommandModule } from 'yargs';
 import {
-  installExtension,
+  installOrUpdateExtension,
   requestConsentNonInteractive,
 } from '../../config/extension.js';
 import type { ExtensionInstallMetadata } from '@google/gemini-cli-core';
@@ -54,7 +54,7 @@ export async function handleInstall(args: InstallArgs) {
       }
     }
 
-    const name = await installExtension(
+    const name = await installOrUpdateExtension(
       installMetadata,
       requestConsentNonInteractive,
     );

--- a/packages/cli/src/commands/extensions/link.ts
+++ b/packages/cli/src/commands/extensions/link.ts
@@ -6,7 +6,7 @@
 
 import type { CommandModule } from 'yargs';
 import {
-  installExtension,
+  installOrUpdateExtension,
   requestConsentNonInteractive,
 } from '../../config/extension.js';
 import type { ExtensionInstallMetadata } from '@google/gemini-cli-core';
@@ -23,7 +23,7 @@ export async function handleLink(args: InstallArgs) {
       source: args.path,
       type: 'link',
     };
-    const extensionName = await installExtension(
+    const extensionName = await installOrUpdateExtension(
       installMetadata,
       requestConsentNonInteractive,
     );

--- a/packages/cli/src/commands/extensions/uninstall.ts
+++ b/packages/cli/src/commands/extensions/uninstall.ts
@@ -14,7 +14,7 @@ interface UninstallArgs {
 
 export async function handleUninstall(args: UninstallArgs) {
   try {
-    await uninstallExtension(args.name);
+    await uninstallExtension(args.name, false);
     console.log(`Extension "${args.name}" successfully uninstalled.`);
   } catch (error) {
     console.error(getErrorMessage(error));

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -15,7 +15,7 @@ import {
   annotateActiveExtensions,
   disableExtension,
   enableExtension,
-  installExtension,
+  installOrUpdateExtension,
   loadExtension,
   loadExtensionConfig,
   loadExtensions,
@@ -257,7 +257,7 @@ describe('extension tests', () => {
       });
       fs.writeFileSync(path.join(sourceExtDir, 'context.md'), 'linked context');
 
-      const extensionName = await installExtension(
+      const extensionName = await installOrUpdateExtension(
         {
           source: sourceExtDir,
           type: 'link',
@@ -700,7 +700,7 @@ describe('extension tests', () => {
       const targetExtDir = path.join(userExtensionsDir, 'my-local-extension');
       const metadataPath = path.join(targetExtDir, INSTALL_METADATA_FILENAME);
 
-      await installExtension(
+      await installOrUpdateExtension(
         { source: sourceExtDir, type: 'local' },
         async (_) => true,
       );
@@ -721,12 +721,12 @@ describe('extension tests', () => {
         name: 'my-local-extension',
         version: '1.0.0',
       });
-      await installExtension(
+      await installOrUpdateExtension(
         { source: sourceExtDir, type: 'local' },
         async (_) => true,
       );
       await expect(
-        installExtension(
+        installOrUpdateExtension(
           { source: sourceExtDir, type: 'local' },
           async (_) => true,
         ),
@@ -741,7 +741,7 @@ describe('extension tests', () => {
       const configPath = path.join(sourceExtDir, EXTENSIONS_CONFIG_FILENAME);
 
       await expect(
-        installExtension(
+        installOrUpdateExtension(
           { source: sourceExtDir, type: 'local' },
           async (_) => true,
         ),
@@ -758,7 +758,7 @@ describe('extension tests', () => {
       fs.writeFileSync(configPath, '{ "name": "bad-json", "version": "1.0.0"'); // Malformed JSON
 
       await expect(
-        installExtension(
+        installOrUpdateExtension(
           { source: sourceExtDir, type: 'local' },
           async (_) => true,
         ),
@@ -783,7 +783,7 @@ describe('extension tests', () => {
       fs.writeFileSync(configPath, JSON.stringify({ version: '1.0.0' }));
 
       await expect(
-        installExtension(
+        installOrUpdateExtension(
           { source: sourceExtDir, type: 'local' },
           async (_) => true,
         ),
@@ -809,7 +809,7 @@ describe('extension tests', () => {
       });
       mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
 
-      await installExtension(
+      await installOrUpdateExtension(
         { source: gitUrl, type: 'git' },
         async (_) => true,
       );
@@ -833,7 +833,7 @@ describe('extension tests', () => {
       const metadataPath = path.join(targetExtDir, INSTALL_METADATA_FILENAME);
       const configPath = path.join(targetExtDir, EXTENSIONS_CONFIG_FILENAME);
 
-      await installExtension(
+      await installOrUpdateExtension(
         { source: sourceExtDir, type: 'link' },
         async (_) => true,
       );
@@ -858,7 +858,7 @@ describe('extension tests', () => {
         version: '1.0.0',
       });
 
-      await installExtension(
+      await installOrUpdateExtension(
         { source: sourceExtDir, type: 'local' },
         async (_) => true,
       );
@@ -888,7 +888,7 @@ describe('extension tests', () => {
       mockRequestConsent.mockResolvedValue(true);
 
       await expect(
-        installExtension(
+        installOrUpdateExtension(
           { source: sourceExtDir, type: 'local' },
           mockRequestConsent,
         ),
@@ -917,7 +917,7 @@ This extension will run the following MCP servers:
       });
 
       await expect(
-        installExtension(
+        installOrUpdateExtension(
           { source: sourceExtDir, type: 'local' },
           async () => true,
         ),
@@ -938,7 +938,7 @@ This extension will run the following MCP servers:
       });
 
       await expect(
-        installExtension(
+        installOrUpdateExtension(
           { source: sourceExtDir, type: 'local' },
           async () => false,
         ),
@@ -954,7 +954,7 @@ This extension will run the following MCP servers:
       const targetExtDir = path.join(userExtensionsDir, 'my-local-extension');
       const metadataPath = path.join(targetExtDir, INSTALL_METADATA_FILENAME);
 
-      await installExtension(
+      await installOrUpdateExtension(
         {
           source: sourceExtDir,
           type: 'local',
@@ -990,7 +990,7 @@ This extension will run the following MCP servers:
       const mockRequestConsent = vi.fn();
 
       await expect(
-        installExtension(
+        installOrUpdateExtension(
           { source: sourceExtDir, type: 'local' },
           mockRequestConsent,
           process.cwd(),
@@ -1013,7 +1013,7 @@ This extension will run the following MCP servers:
       });
 
       await expect(
-        installExtension(
+        installOrUpdateExtension(
           { source: sourceExtDir, type: 'local' },
           async () => true,
         ),

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -870,6 +870,8 @@ describe('extension tests', () => {
               async (_) => true,
             );
           }
+          // Clears out any calls to mocks from the above function calls.
+          vi.clearAllMocks();
         });
 
         it(`should log an ${isUpdate ? 'update' : 'install'} event to clearcut on success`, async () => {
@@ -887,8 +889,10 @@ describe('extension tests', () => {
 
           if (isUpdate) {
             expect(mockLogExtensionUpdateEvent).toHaveBeenCalled();
+            expect(mockLogExtensionInstallEvent).not.toHaveBeenCalled();
           } else {
             expect(mockLogExtensionInstallEvent).toHaveBeenCalled();
+            expect(mockLogExtensionUpdateEvent).not.toHaveBeenCalled();
           }
         });
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -40,6 +40,8 @@ import { ExtensionEnablementManager } from './extensions/extensionEnablement.js'
 import chalk from 'chalk';
 import type { ConfirmationRequest } from '../ui/types.js';
 import { escapeAnsiCtrlCodes } from '../ui/utils/textUtils.js';
+import { logExtensionUpdateEvent } from '@google/gemini-cli-core/src/telemetry/loggers.js';
+import { ExtensionUpdateEvent } from '@google/gemini-cli-core/src/telemetry/types.js';
 
 export const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
 
@@ -126,7 +128,7 @@ export async function performWorkspaceExtensionMigration(
         source: extension.path,
         type: 'local',
       };
-      await installExtension(installMetadata, requestConsent);
+      await installOrUpdateExtension(installMetadata, requestConsent);
     } catch (_) {
       failedInstallNames.push(extension.name);
     }
@@ -423,12 +425,13 @@ async function promptForConsentInteractive(
   });
 }
 
-export async function installExtension(
+export async function installOrUpdateExtension(
   installMetadata: ExtensionInstallMetadata,
   requestConsent: (consent: string) => Promise<boolean>,
   cwd: string = process.cwd(),
   previousExtensionConfig?: ExtensionConfig,
 ): Promise<string> {
+  const isUpdate = !!previousExtensionConfig;
   const telemetryConfig = getTelemetryConfig(cwd);
   let newExtensionConfig: ExtensionConfig | null = null;
   let localSourcePath: string | undefined;
@@ -486,24 +489,32 @@ export async function installExtension(
       });
 
       const newExtensionName = newExtensionConfig.name;
-      const extensionStorage = new ExtensionStorage(newExtensionName);
-      const destinationPath = extensionStorage.getExtensionDir();
-
-      const installedExtensions = loadUserExtensions();
-      if (
-        installedExtensions.some(
-          (installed) => installed.name === newExtensionName,
-        )
-      ) {
-        throw new Error(
-          `Extension "${newExtensionName}" is already installed. Please uninstall it first.`,
-        );
+      if (!isUpdate) {
+        const installedExtensions = loadUserExtensions();
+        if (
+          installedExtensions.some(
+            (installed) => installed.name === newExtensionName,
+          )
+        ) {
+          throw new Error(
+            `Extension "${newExtensionName}" is already installed. Please uninstall it first.`,
+          );
+        }
       }
+
       await maybeRequestConsentOrFail(
         newExtensionConfig,
         requestConsent,
         previousExtensionConfig,
       );
+
+      const extensionStorage = new ExtensionStorage(newExtensionName);
+      const destinationPath = extensionStorage.getExtensionDir();
+
+      if (isUpdate) {
+        await uninstallExtension(newExtensionName, isUpdate, cwd);
+      }
+
       await fs.promises.mkdir(destinationPath, { recursive: true });
 
       if (
@@ -526,40 +537,66 @@ export async function installExtension(
       }
     }
 
-    logExtensionInstallEvent(
-      telemetryConfig,
-      new ExtensionInstallEvent(
-        newExtensionConfig!.name,
-        newExtensionConfig!.version,
-        installMetadata.source,
-        'success',
-      ),
-    );
+    if (isUpdate) {
+      logExtensionUpdateEvent(
+        telemetryConfig,
+        new ExtensionUpdateEvent(
+          newExtensionConfig.name,
+          newExtensionConfig.version,
+          previousExtensionConfig.version,
+          installMetadata.source,
+          'success',
+        ),
+      );
+    } else {
+      logExtensionInstallEvent(
+        telemetryConfig,
+        new ExtensionInstallEvent(
+          newExtensionConfig.name,
+          newExtensionConfig.version,
+          installMetadata.source,
+          'success',
+        ),
+      );
+      enableExtension(newExtensionConfig.name, SettingScope.User);
+    }
 
-    enableExtension(newExtensionConfig!.name, SettingScope.User);
     return newExtensionConfig!.name;
   } catch (error) {
-    // Attempt to load config from the source path even if installation fails
-    // to get the name and version for logging.
-    if (!newExtensionConfig && localSourcePath) {
-      try {
-        newExtensionConfig = loadExtensionConfig({
-          extensionDir: localSourcePath,
-          workspaceDir: cwd,
-        });
-      } catch {
-        // Ignore error, this is just for logging.
+    if (isUpdate) {
+      logExtensionUpdateEvent(
+        telemetryConfig,
+        new ExtensionUpdateEvent(
+          newExtensionConfig?.name ?? previousExtensionConfig.name,
+          newExtensionConfig?.version ?? '',
+          previousExtensionConfig.version,
+          installMetadata.source,
+          'error',
+        ),
+      );
+    } else {
+      // Attempt to load config from the source path even if installation fails
+      // to get the name and version for logging.
+      if (!newExtensionConfig && localSourcePath) {
+        try {
+          newExtensionConfig = loadExtensionConfig({
+            extensionDir: localSourcePath,
+            workspaceDir: cwd,
+          });
+        } catch {
+          // Ignore error, this is just for logging.
+        }
       }
+      logExtensionInstallEvent(
+        telemetryConfig,
+        new ExtensionInstallEvent(
+          newExtensionConfig?.name ?? '',
+          newExtensionConfig?.version ?? '',
+          installMetadata.source,
+          'error',
+        ),
+      );
     }
-    logExtensionInstallEvent(
-      telemetryConfig,
-      new ExtensionInstallEvent(
-        newExtensionConfig?.name ?? '',
-        newExtensionConfig?.version ?? '',
-        installMetadata.source,
-        'error',
-      ),
-    );
     throw error;
   }
 }
@@ -670,9 +707,9 @@ export function loadExtensionConfig(
 
 export async function uninstallExtension(
   extensionIdentifier: string,
+  isUpdate: boolean,
   cwd: string = process.cwd(),
 ): Promise<void> {
-  const telemetryConfig = getTelemetryConfig(cwd);
   const installedExtensions = loadUserExtensions();
   const extensionName = installedExtensions.find(
     (installed) =>
@@ -683,17 +720,24 @@ export async function uninstallExtension(
   if (!extensionName) {
     throw new Error(`Extension not found.`);
   }
-  const manager = new ExtensionEnablementManager(
-    ExtensionStorage.getUserExtensionsDir(),
-    [extensionName],
-  );
-  manager.remove(extensionName);
   const storage = new ExtensionStorage(extensionName);
 
   await fs.promises.rm(storage.getExtensionDir(), {
     recursive: true,
     force: true,
   });
+
+  // The rest of the cleanup below here is only for true uninstalls, not
+  // uninstalls related to updates.
+  if (isUpdate) return;
+
+  const manager = new ExtensionEnablementManager(
+    ExtensionStorage.getUserExtensionsDir(),
+    [extensionName],
+  );
+  manager.remove(extensionName);
+
+  const telemetryConfig = getTelemetryConfig(cwd);
   logExtensionUninstall(
     telemetryConfig,
     new ExtensionUninstallEvent(extensionName, 'success'),

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -15,6 +15,7 @@ import {
   Config,
   ExtensionInstallEvent,
   ExtensionUninstallEvent,
+  ExtensionUpdateEvent,
   ExtensionDisableEvent,
   ExtensionEnableEvent,
   logExtensionEnable,
@@ -41,7 +42,6 @@ import { ExtensionEnablementManager } from './extensions/extensionEnablement.js'
 import chalk from 'chalk';
 import type { ConfirmationRequest } from '../ui/types.js';
 import { escapeAnsiCtrlCodes } from '../ui/utils/textUtils.js';
-import { ExtensionUpdateEvent } from '@google/gemini-cli-core/src/telemetry/types.js';
 
 export const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -563,6 +563,18 @@ export async function installOrUpdateExtension(
 
     return newExtensionConfig!.name;
   } catch (error) {
+    // Attempt to load config from the source path even if installation fails
+    // to get the name and version for logging.
+    if (!newExtensionConfig && localSourcePath) {
+      try {
+        newExtensionConfig = loadExtensionConfig({
+          extensionDir: localSourcePath,
+          workspaceDir: cwd,
+        });
+      } catch {
+        // Ignore error, this is just for logging.
+      }
+    }
     if (isUpdate) {
       logExtensionUpdateEvent(
         telemetryConfig,
@@ -575,18 +587,6 @@ export async function installOrUpdateExtension(
         ),
       );
     } else {
-      // Attempt to load config from the source path even if installation fails
-      // to get the name and version for logging.
-      if (!newExtensionConfig && localSourcePath) {
-        try {
-          newExtensionConfig = loadExtensionConfig({
-            extensionDir: localSourcePath,
-            workspaceDir: cwd,
-          });
-        } catch {
-          // Ignore error, this is just for logging.
-        }
-      }
       logExtensionInstallEvent(
         telemetryConfig,
         new ExtensionInstallEvent(

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -20,6 +20,7 @@ import {
   logExtensionEnable,
   logExtensionInstallEvent,
   logExtensionUninstall,
+  logExtensionUpdateEvent,
   logExtensionDisable,
 } from '@google/gemini-cli-core';
 import * as fs from 'node:fs';
@@ -40,7 +41,6 @@ import { ExtensionEnablementManager } from './extensions/extensionEnablement.js'
 import chalk from 'chalk';
 import type { ConfirmationRequest } from '../ui/types.js';
 import { escapeAnsiCtrlCodes } from '../ui/utils/textUtils.js';
-import { logExtensionUpdateEvent } from '@google/gemini-cli-core/src/telemetry/loggers.js';
 import { ExtensionUpdateEvent } from '@google/gemini-cli-core/src/telemetry/types.js';
 
 export const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');

--- a/packages/cli/src/config/extensions/update.ts
+++ b/packages/cli/src/config/extensions/update.ts
@@ -11,8 +11,7 @@ import {
 } from '../../ui/state/extensions.js';
 import {
   copyExtension,
-  installExtension,
-  uninstallExtension,
+  installOrUpdateExtension,
   loadExtension,
   loadInstallMetadata,
   ExtensionStorage,
@@ -65,13 +64,11 @@ export async function updateExtension(
 
   const tempDir = await ExtensionStorage.createTmpDir();
   try {
-    await copyExtension(extension.path, tempDir);
     const previousExtensionConfig = await loadExtensionConfig({
       extensionDir: extension.path,
       workspaceDir: cwd,
     });
-    await uninstallExtension(extension.name, cwd);
-    await installExtension(
+    await installOrUpdateExtension(
       installMetadata,
       requestConsent,
       cwd,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -37,6 +37,7 @@ export {
   ExtensionDisableEvent,
   ExtensionEnableEvent,
   ExtensionUninstallEvent,
+  ExtensionUpdateEvent,
   ModelSlashCommandEvent,
 } from './src/telemetry/types.js';
 export { makeFakeConfig } from './src/test-utils/config.js';

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -36,6 +36,7 @@ import type {
   AgentStartEvent,
   AgentFinishEvent,
   WebFetchFallbackAttemptEvent,
+  ExtensionUpdateEvent,
 } from '../types.js';
 import { EventMetadataKey } from './event-metadata-key.js';
 import type { Config } from '../../config/config.js';
@@ -77,6 +78,7 @@ export enum EventNames {
   EXTENSION_DISABLE = 'extension_disable',
   EXTENSION_INSTALL = 'extension_install',
   EXTENSION_UNINSTALL = 'extension_uninstall',
+  EXTENSION_UPDATE = 'extension_update',
   TOOL_OUTPUT_TRUNCATED = 'tool_output_truncated',
   MODEL_ROUTING = 'model_routing',
   MODEL_SLASH_COMMAND = 'model_slash_command',
@@ -923,6 +925,38 @@ export class ClearcutLogger {
 
     this.enqueueLogEvent(
       this.createLogEvent(EventNames.EXTENSION_UNINSTALL, data),
+    );
+    this.flushToClearcut().catch((error) => {
+      console.debug('Error flushing to Clearcut:', error);
+    });
+  }
+
+  logExtensionUpdateEvent(event: ExtensionUpdateEvent): void {
+    const data: EventValue[] = [
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_EXTENSION_NAME,
+        value: event.extension_name,
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_EXTENSION_VERSION,
+        value: event.extension_version,
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_EXTENSION_PREVIOUS_VERSION,
+        value: event.extension_previous_version,
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_EXTENSION_SOURCE,
+        value: event.extension_source,
+      },
+      {
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_EXTENSION_UPDATE_STATUS,
+        value: event.status,
+      },
+    ];
+
+    this.enqueueLogEvent(
+      this.createLogEvent(EventNames.EXTENSION_UPDATE, data),
     );
     this.flushToClearcut().catch((error) => {
       console.debug('Error flushing to Clearcut:', error);

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -367,7 +367,7 @@ export enum EventMetadataKey {
   GEMINI_CLI_NODE_VERSION = 83,
 
   // ==========================================================================
-  // Extension Install Event Keys
+  // Extension Event Keys
   // ===========================================================================
 
   // Logs the name of the extension.
@@ -375,6 +375,9 @@ export enum EventMetadataKey {
 
   // Logs the version of the extension.
   GEMINI_CLI_EXTENSION_VERSION = 86,
+
+  // Logs the previous version of the extension.
+  GEMINI_CLI_EXTENSION_PREVIOUS_VERSION = 117,
 
   // Logs the source of the extension.
   GEMINI_CLI_EXTENSION_SOURCE = 87,
@@ -384,6 +387,9 @@ export enum EventMetadataKey {
 
   // Logs the status of the extension uninstall
   GEMINI_CLI_EXTENSION_UNINSTALL_STATUS = 96,
+
+  // Logs the status of the extension uninstall
+  GEMINI_CLI_EXTENSION_UPDATE_STATUS = 118,
 
   // Logs the setting scope for an extension enablement.
   GEMINI_CLI_EXTENSION_ENABLE_SETTING_SCOPE = 102,

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -44,6 +44,7 @@ export {
   logExtensionEnable,
   logExtensionInstallEvent,
   logExtensionUninstall,
+  logExtensionUpdateEvent,
   logWebFetchFallbackAttempt,
 } from './loggers.js';
 export type { SlashCommandEvent, ChatCompressionEvent } from './types.js';

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -42,6 +42,7 @@ import {
   logAgentStart,
   logAgentFinish,
   logWebFetchFallbackAttempt,
+  logExtensionUpdateEvent,
 } from './loggers.js';
 import { ToolCallDecision } from './tool-call-decision.js';
 import {
@@ -82,6 +83,8 @@ import {
   AgentStartEvent,
   AgentFinishEvent,
   WebFetchFallbackAttemptEvent,
+  ExtensionUpdateEvent,
+  EVENT_EXTENSION_UPDATE,
 } from './types.js';
 import * as metrics from './metrics.js';
 import {
@@ -1292,6 +1295,9 @@ describe('loggers', () => {
     const mockConfig = {
       getSessionId: () => 'test-session-id',
       getUsageStatisticsEnabled: () => true,
+      getContentGeneratorConfig: () => null,
+      getUseSmartEdit: () => null,
+      getUseModelRouter: () => null,
     } as unknown as Config;
 
     beforeEach(() => {
@@ -1333,10 +1339,63 @@ describe('loggers', () => {
     });
   });
 
+  describe('logExtensionUpdate', () => {
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+      getContentGeneratorConfig: () => null,
+      getUseSmartEdit: () => null,
+      getUseModelRouter: () => null,
+    } as unknown as Config;
+
+    beforeEach(() => {
+      vi.spyOn(ClearcutLogger.prototype, 'logExtensionUpdateEvent');
+    });
+
+    afterEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it('should log extension update event', () => {
+      const event = new ExtensionUpdateEvent(
+        'vscode',
+        '0.1.0',
+        '0.1.1',
+        'git',
+        'success',
+      );
+
+      logExtensionUpdateEvent(mockConfig, event);
+
+      expect(
+        ClearcutLogger.prototype.logExtensionUpdateEvent,
+      ).toHaveBeenCalledWith(event);
+
+      expect(mockLogger.emit).toHaveBeenCalledWith({
+        body: 'Updated extension vscode',
+        attributes: {
+          'session.id': 'test-session-id',
+          'user.email': 'test-user@example.com',
+          'installation.id': 'test-installation-id',
+          'event.name': EVENT_EXTENSION_UPDATE,
+          'event.timestamp': '2025-01-01T00:00:00.000Z',
+          extension_name: 'vscode',
+          extension_version: '0.1.0',
+          extension_previous_version: '0.1.1',
+          extension_source: 'git',
+          status: 'success',
+        },
+      });
+    });
+  });
+
   describe('logExtensionUninstall', () => {
     const mockConfig = {
       getSessionId: () => 'test-session-id',
       getUsageStatisticsEnabled: () => true,
+      getContentGeneratorConfig: () => null,
+      getUseSmartEdit: () => null,
+      getUseModelRouter: () => null,
     } as unknown as Config;
 
     beforeEach(() => {

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -47,6 +47,7 @@ import type {
   AgentStartEvent,
   AgentFinishEvent,
   WebFetchFallbackAttemptEvent,
+  ExtensionUpdateEvent,
 } from './types.js';
 import {
   recordApiErrorMetrics,
@@ -521,6 +522,21 @@ export function logExtensionUninstall(
   event: ExtensionUninstallEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logExtensionUninstallEvent(event);
+  if (!isTelemetrySdkInitialized()) return;
+
+  const logger = logs.getLogger(SERVICE_NAME);
+  const logRecord: LogRecord = {
+    body: event.toLogBody(),
+    attributes: event.toOpenTelemetryAttributes(config),
+  };
+  logger.emit(logRecord);
+}
+
+export function logExtensionUpdateEvent(
+  config: Config,
+  event: ExtensionUpdateEvent,
+): void {
+  ClearcutLogger.getInstance(config)?.logExtensionUpdateEvent(event);
   if (!isTelemetrySdkInitialized()) return;
 
   const logger = logs.getLogger(SERVICE_NAME);

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1156,6 +1156,50 @@ export class ExtensionUninstallEvent implements BaseTelemetryEvent {
   }
 }
 
+export const EVENT_EXTENSION_UPDATE = 'gemini_cli.extension_update';
+export class ExtensionUpdateEvent implements BaseTelemetryEvent {
+  'event.name': 'extension_update';
+  'event.timestamp': string;
+  extension_name: string;
+  extension_previous_version: string;
+  extension_version: string;
+  extension_source: string;
+  status: 'success' | 'error';
+
+  constructor(
+    extension_name: string,
+    extension_version: string,
+    extension_previous_version: string,
+    extension_source: string,
+    status: 'success' | 'error',
+  ) {
+    this['event.name'] = 'extension_update';
+    this['event.timestamp'] = new Date().toISOString();
+    this.extension_name = extension_name;
+    this.extension_version = extension_version;
+    this.extension_previous_version = extension_previous_version;
+    this.extension_source = extension_source;
+    this.status = status;
+  }
+
+  toOpenTelemetryAttributes(config: Config): LogAttributes {
+    return {
+      ...getCommonAttributes(config),
+      'event.name': EVENT_EXTENSION_UPDATE,
+      'event.timestamp': this['event.timestamp'],
+      extension_name: this.extension_name,
+      extension_version: this.extension_version,
+      extension_previous_version: this.extension_previous_version,
+      extension_source: this.extension_source,
+      status: this.status,
+    };
+  }
+
+  toLogBody(): string {
+    return `Updated extension ${this.extension_name}`;
+  }
+}
+
 export const EVENT_EXTENSION_ENABLE = 'gemini_cli.extension_enable';
 export class ExtensionEnableEvent implements BaseTelemetryEvent {
   'event.name': 'extension_enable';


### PR DESCRIPTION
## TLDR

- Fixes a case where exiting Gemini CLI during extension consent would leave the extension uninstalled
- Fixes a case where all extension enablement configuration was lost on update
- Adds an "update" event for extensions and logs that instead of an uninstall followed by an install.

## Dive Deeper

Previously, we would do a very raw uninstall followed by a fresh install in order to do updates. This moves the update logic inside `installExtension`, renaming it `installOrUpdateExtension`, so that we can wait to uninstall the old extension until after the consent has been received.  This significantly lowers the chance of leaving extensions in an uninstalled state (although it is still possible for the program to be killed in the middle, the chance is much lower).

This also allows us to not unconditionally enable/disable the extension - we only do that on a true uninstall or fresh install (unrelated to an update). We also fire a single update event now and skip the other events, in the update case.

Added some tests around extension enablement and disablement and logging.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓ | ❓  | ✅   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/gemini-cli/issues/10899
Fixes https://github.com/google-gemini/gemini-cli/issues/10908