### PR TITLE
Gemini CLI should use OAuth scopes as specified in the mcpServers entry

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -233,7 +233,9 @@ Use the `/mcp auth` command to manage OAuth authentication:
 - **`authorizationUrl`** (string): OAuth authorization endpoint (auto-discovered
   if omitted)
 - **`tokenUrl`** (string): OAuth token endpoint (auto-discovered if omitted)
-- **`scopes`** (string[]): Required OAuth scopes
+- **`scopes`** (string[]): OAuth scopes to request. Use an empty array to
+  affirmatively request no scopes. Omit this to tell Gemini CLI to request all
+  the scopes supported by the resource.
 - **`redirectUri`** (string): Custom redirect URI (defaults to
   `http://localhost:7777/oauth/callback`)
 - **`tokenParamName`** (string): Query parameter name for tokens in SSE URLs

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -627,7 +627,7 @@ export class MCPOAuthProvider {
                 ...config,
                 authorizationUrl: discoveredConfig.authorizationUrl,
                 tokenUrl: discoveredConfig.tokenUrl,
-                scopes: discoveredConfig.scopes || config.scopes || [],
+                scopes: config.scopes ?? discoveredConfig.scopes ?? [],
                 // Preserve existing client credentials
                 clientId: config.clientId,
                 clientSecret: config.clientSecret,
@@ -651,7 +651,7 @@ export class MCPOAuthProvider {
             ...config,
             authorizationUrl: discoveredConfig.authorizationUrl,
             tokenUrl: discoveredConfig.tokenUrl,
-            scopes: discoveredConfig.scopes || config.scopes || [],
+            scopes: config.scopes ?? discoveredConfig.scopes ?? [],
             registrationUrl: discoveredConfig.registrationUrl,
             // Preserve existing client credentials
             clientId: config.clientId,

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -364,8 +364,7 @@ async function handleAutomaticOAuth(
       authorizationUrl: resourceOauthConfig.authorizationUrl,
       tokenUrl: resourceOauthConfig.tokenUrl,
       // mcpServer scopes is possibly an empty array
-      scopes:
-        mcpServerScopes == null ? resourceOauthConfig.scopes : mcpServerScopes,
+      scopes: mcpServerScopes ?? resourceOauthConfig.scopes ?? [],
     };
 
     // Perform OAuth authentication
@@ -1062,10 +1061,7 @@ export async function connectToMcpServer(
                 enabled: true,
                 authorizationUrl: oauthConfig.authorizationUrl,
                 tokenUrl: oauthConfig.tokenUrl,
-                scopes:
-                  mcpServerScopes == null
-                    ? oauthConfig.scopes
-                    : mcpServerScopes,
+                scopes: mcpServerScopes ?? oauthConfig.scopes ?? [],
               };
 
               // Perform OAuth authentication

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -351,8 +351,12 @@ async function handleAutomaticOAuth(
     // OAuth configuration discovered - proceed with authentication
 
     // Create OAuth configuration for authentication
-    const mcpServerScopes = mcpServerConfig?.oauth?.scopes || null;
-    if (mcpServerScopes && !Array.isArray(mcpServerScopes)) {
+    const mcpServerScopes = mcpServerConfig?.oauth?.scopes;
+    if (
+      mcpServerScopes !== undefined &&
+      mcpServerScopes !== null &&
+      !Array.isArray(mcpServerScopes)
+    ) {
       console.error(
         `❌ Could not configure OAuth for '${mcpServerName}' - scopes value when present should be a string array`,
       );
@@ -1048,12 +1052,9 @@ export async function connectToMcpServer(
 
               const mcpServerScopes = mcpServerConfig?.oauth?.scopes || null;
               if (mcpServerScopes && !Array.isArray(mcpServerScopes)) {
-                console.error(
-                  `invalid OAuth config for '${mcpServerName}' - scopes value when present should be a string array`,
-                );
-                throw new Error(
-                  `invalid OAuth config for '${mcpServerName}' - scopes value when present should be a string array`,
-                );
+                const errorMessage = `invalid OAuth config for '${mcpServerName}' - scopes value when present must be a string array`;
+                console.error(errorMessage);
+                throw new Error(errorMessage);
               }
 
               // Create OAuth configuration for authentication


### PR DESCRIPTION
## TLDR

This changes Gemini CLI mcp-client and oauth-provider to use the `scopes` array specified in the mcpServers entry, and fallback to the discovered scopes supported on the protected resource, only if the `scopes` value in the mcpServers entry is missing.

## Dive Deeper

About authorization servers metadata, [IETF RFC8414 (section 2) ](https://datatracker.ietf.org/doc/html/rfc8414#section-2) states that `scopes_supported` is recommended but optional and also not authoritative even if specified.
```
scopes_supported
      RECOMMENDED.  JSON array containing a list of the OAuth 2.0
      RFC6749  "scope" values that this authorization server supports.
      Servers MAY choose not to advertise some supported scope values
      even when this parameter is used.
```
[IETF RFC 9728 (Section 2)](https://datatracker.ietf.org/doc/html/rfc9728#section-2) makes a similar statement about oauth-protected-resource metadata:
```
scopes_supported
      RECOMMENDED. JSON array containing a list of scope values, as defined in RFC6749
      that are used in authorization requests to request access to this protected resource. 
      Protected resources MAY choose not to advertise some scope values supported 
      even when this parameter is used.
```

The upshot is, the `scopes_supported` field in the discovery metadata for either the oauth-protected-resource or the oauth-authorization-server... _is an optional hint_.  And in the case of the Google IDP which has metadata at this endpoint: `https://accounts.google.com/.well-known/oauth-authorization-server` , there is no `supported_scopes` value. Google opted out of providing the `supported_scopes` hint. 

In contrast, in an entry in the `mcpServers` array in settings.json, the `scopes` array is imperative.

Therefore it makes sense for Gemini CLI to prefer the value in the entry in the `mcpServers` array, and fallback to the discovered scopes if and only if the value in the mcpServers entry is not present. 

The logic is:
- use the scopes in the entry in the `mcpServers` array if it is present, even if it is an empty array
- otherwise use the discovered scopes, or, an empty array if there is no `supported_scopes` value asserted in the metadata. 

In JS: 
**NEW**
```
  mcpServerConfig?.oauth?.scopes ?? discoveredConfig.scopes ?? []
```

**Changed from**
```
  discoveredConfig.scopes || mcpServerConfig?.oauth?.scopes || []
```

## Reviewer Test Plan

1. configure an MCP server to respond to `/.well-known/oauth-protected-resource/mcp/my-server` with a JSON payload pointing to Google as the IDP: 
   ```
   {
     "resource": "https://33.44.55.66.nip.io/mcp/my-server",
     "resource_name": "my nifty server",
     "authorization_servers": [ "https://accounts.google.com" ],
     "scopes_supported":
         ["https://www.googleapis.com/auth/userinfo.email","https://www.googleapis.com/auth/userinfo.profile"],
     "bearer_methods_supported": [ "header" ]
   }
   ```   
2. in [Google cloud console](https://console.cloud.google.com/apis/credentials), configure an OAuth client (type: Desktop app) with client credentials (ID + Secret) . Copy the ID and Secret. (You may also have to configure specific emails that can login with this OAuth app). 
3. In the `~/.gemini/settings.json` file, configure an mcpServers entry with the OAuth credentials created above:
   ```
    "my-server": {
      "httpUrl": "https://33.44.55.66.nip.io/mcp/my-server",
      "oauth": {
        "enabled": true,
        "clientId": "your-credentials.apps.googleusercontent.com",
        "clientSecret": "GOCXYZ-ABCDEFGH999",
        "scopes": [
          "https://www.googleapis.com/auth/userinfo.email",
          "https://www.googleapis.com/auth/userinfo.profile"
        ]
      }
    }
   ```
4. Start Gemini CLI
5. Do the `/mcp auth my-server` thing 
6. Observe that the `/authorize` URL now contains scopes  `https://www.googleapis.com/auth/userinfo.email` and `https://www.googleapis.com/auth/userinfo.profile`
7. Proceed, and see that the login and consent works. 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #10937 
