### PR TITLE
fix: Preserve symlink when saving settings.json

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -29,6 +29,7 @@ import {
 } from './settingsSchema.js';
 import { resolveEnvVarsInObject } from '../utils/envVarResolver.js';
 import { customDeepMerge, type MergeableObject } from '../utils/deepMerge.js';
+import { safeWriteFileSync } from '../utils/safeFs.js';
 import { updateSettingsFilePreservingFormat } from '../utils/commentJson.js';
 import { disableExtension } from './extension.js';
 
@@ -610,7 +611,7 @@ export function loadSettings(
             if (MIGRATE_V2_OVERWRITE) {
               try {
                 fs.renameSync(filePath, `${filePath}.orig`);
-                fs.writeFileSync(
+                safeWriteFileSync(
                   filePath,
                   JSON.stringify(migratedSettings, null, 2),
                   'utf-8',

--- a/packages/cli/src/utils/commentJson.ts
+++ b/packages/cli/src/utils/commentJson.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'node:fs';
 import { parse, stringify } from 'comment-json';
+import * as fs from 'node:fs';
+import { safeWriteFileSync } from './safeFs.js';
 
 /**
  * Type representing an object that may contain Symbol keys for comments.
@@ -20,7 +21,7 @@ export function updateSettingsFilePreservingFormat(
   updates: Record<string, unknown>,
 ): void {
   if (!fs.existsSync(filePath)) {
-    fs.writeFileSync(filePath, JSON.stringify(updates, null, 2), 'utf-8');
+    safeWriteFileSync(filePath, JSON.stringify(updates, null, 2), 'utf-8');
     return;
   }
 
@@ -40,7 +41,7 @@ export function updateSettingsFilePreservingFormat(
   const updatedStructure = applyUpdates(parsed, updates);
   const updatedContent = stringify(updatedStructure, null, 2);
 
-  fs.writeFileSync(filePath, updatedContent, 'utf-8');
+  safeWriteFileSync(filePath, updatedContent, 'utf-8');
 }
 
 /**

--- a/packages/cli/src/utils/safeFs.ts
+++ b/packages/cli/src/utils/safeFs.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+
+/**
+ * Safely writes data to a file. If the file is a symlink, it writes to the
+ * symlink's target.
+ *
+ * @param filePath The path to the file to write to.
+ * @param data The data to write to the file.
+ * @param options The options for writing the file.
+ */
+export function safeWriteFileSync(
+  filePath: string,
+  data: string,
+  options?: fs.WriteFileOptions,
+): void {
+  try {
+    const stat = fs.lstatSync(filePath);
+    if (stat.isSymbolicLink()) {
+      const targetPath = fs.readlinkSync(filePath);
+      fs.writeFileSync(targetPath, data, options);
+    } else {
+      fs.writeFileSync(filePath, data, options);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      // File doesn't exist, so just write it.
+      fs.writeFileSync(filePath, data, options);
+    } else {
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## TL;DR

Fixes #10960.

## Reviewer Test Plan

Make `~/.gemini/settings.json` a symlink instead of a regular file, and have Gemini CLI update it (e.g. by rewriting old to new config).

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #10960.