### PR TITLE
docs(models): Update Gemini model version references to 2.5

### DIFF
--- a/docs/get-started/configuration-v1.md
+++ b/docs/get-started/configuration-v1.md
@@ -658,7 +658,7 @@ for that specific session.
 
 - **`--model <model_name>`** (**`-m <model_name>`**):
   - Specifies the Gemini model to use for this session.
-  - Example: `npm start -- --model gemini-1.5-pro-latest`
+  - Example: `npm start -- --model gemini-2.5-pro`
 - **`--prompt <your_prompt>`** (**`-p <your_prompt>`**):
   - Used to pass a prompt directly to the command. This invokes Gemini CLI in a
     non-interactive mode.

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -562,7 +562,7 @@ of v0.3.0:
     "usageStatisticsEnabled": true
   },
   "model": {
-    "name": "gemini-1.5-pro-latest",
+    "name": "gemini-2.5-pro",
     "maxSessionTurns": 10,
     "summarizeToolOutput": {
       "run_shell_command": {
@@ -713,7 +713,7 @@ for that specific session.
 
 - **`--model <model_name>`** (**`-m <model_name>`**):
   - Specifies the Gemini model to use for this session.
-  - Example: `npm start -- --model gemini-1.5-pro-latest`
+  - Example: `npm start -- --model gemini-2.5-pro`
 - **`--prompt <your_prompt>`** (**`-p <your_prompt>`**):
   - Used to pass a prompt directly to the command. This invokes Gemini CLI in a
     non-interactive mode.


### PR DESCRIPTION
Fixes #10992

Outdated references to the Gemini 1.5 model family were present in the configuration documentation.

This commit updates these references from 'gemini-1.5-pro-latest' to the current 'gemini-2.5-pro' to ensure the examples are accurate and reflect the latest available models.