### PR TITLE
fix(remove private) from gemini-cli-a2a-server

### DIFF
--- a/packages/a2a-server/package.json
+++ b/packages/a2a-server/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@google/gemini-cli-a2a-server",
   "version": "0.10.0-nightly.20251007.c195a9aa",
-  "private": true,
   "description": "Gemini CLI A2A Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## TLDR

Remove private:true from a2a-server package.json
