### PR TITLE
Give explicit instructions for failure text in json-output.test.ts

### DIFF
--- a/integration-tests/json-output.test.ts
+++ b/integration-tests/json-output.test.ts
@@ -87,7 +87,8 @@ describe('JSON output', () => {
 
   it('should not exit on tool errors and allow model to self-correct in JSON mode', async () => {
     const result = await rig.run(
-      'Read the contents of /path/to/nonexistent/file.txt and tell me what it says',
+      'Read the contents of /path/to/nonexistent/file.txt and tell me what it says. ' +
+        'On error, respond to the user with exactly the text "File not found".',
       '--output-format',
       'json',
     );
@@ -99,7 +100,10 @@ describe('JSON output', () => {
     expect(parsed).toHaveProperty('response');
     expect(typeof parsed.response).toBe('string');
 
-    // The model should acknowledge the error in its response
+    // The model should acknowledge the error in its response with exactly the
+    // text "File not found" based on the instruction above, but we also match
+    // some other forms. If you get flakes for this test please file an issue to
+    // come up with a more robust solution.
     expect(parsed.response.toLowerCase()).toMatch(
       /cannot|does not exist|doesn't exist|not found|unable to|error|couldn't/,
     );

--- a/integration-tests/json-output.test.ts
+++ b/integration-tests/json-output.test.ts
@@ -87,7 +87,7 @@ describe('JSON output', () => {
 
   it('should not exit on tool errors and allow model to self-correct in JSON mode', async () => {
     const result = await rig.run(
-      'Read the contents of /path/to/nonexistent/file.txt and tell me what it says. ' +
+      `Read the contents of ${rig.testDir}/path/to/nonexistent/file.txt and tell me what it says. ` +
         'On error, respond to the user with exactly the text "File not found".',
       '--output-format',
       'json',

--- a/integration-tests/json-output.test.ts
+++ b/integration-tests/json-output.test.ts
@@ -108,9 +108,14 @@ describe('JSON output', () => {
       /cannot|does not exist|doesn't exist|not found|unable to|error|couldn't/,
     );
 
-    // Stats should be present, indicating the session completed normally
+    // Stats should be present, indicating the session completed normally.
     expect(parsed).toHaveProperty('stats');
+
+    // Should see one failed tool call in the stats.
     expect(parsed.stats).toHaveProperty('tools');
+    expect(parsed.stats.tools.totalCalls).toBe(1);
+    expect(parsed.stats.tools.totalFail).toBe(1);
+    expect(parsed.stats.tools.totalSuccess).toBe(0);
 
     // Should NOT have an error field at the top level
     expect(parsed.error).toBeUndefined();


### PR DESCRIPTION
## TLDR

This test was flaky due to the model coming up with many ways of telling the user a file does not exist.

This attempts to fix that by adding some explicit instruction to the prompt.

## Dive Deeper

The file path given was also outside of the allowed paths, so sometimes Gemini would not invoke the tool at all and instead immediately return an LLM response saying it isn't allowed to read that file. I added some additional checks that there was actually a failed tool call.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to #8286