### PR TITLE
Propagate traceID from CCPA to response

### DIFF
--- a/packages/a2a-server/src/http/app.test.ts
+++ b/packages/a2a-server/src/http/app.test.ts
@@ -624,4 +624,25 @@ describe('E2E Tests', () => {
     assertUniqueFinalEventIsLast(events);
     expect(events.length).toBe(10);
   });
+
+  it('should propagate traceId to the Gemini client', async () => {
+    sendMessageStreamSpy.mockImplementation(async function* () {
+      yield* [{ type: 'content', value: 'Hello how are you?' }];
+    });
+
+    const agent = request.agent(app);
+    await agent
+      .post('/')
+      .send(createStreamMessageRequest('hello', 'a2a-test-message'))
+      .set('Content-Type', 'application/json')
+      .set('X-Cloud-Trace-Context', 'a2a-test-trace-id/12345;o=1')
+      .expect(200);
+
+    expect(sendMessageStreamSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        traceId: 'a2a-test-trace-id',
+      }),
+    );
+  });
 });

--- a/packages/a2a-server/src/http/requestStorage.ts
+++ b/packages/a2a-server/src/http/requestStorage.ts
@@ -7,4 +7,7 @@
 import type express from 'express';
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-export const requestStorage = new AsyncLocalStorage<{ req: express.Request }>();
+export const requestStorage = new AsyncLocalStorage<{
+  req: express.Request;
+  traceId: string;
+}>();


### PR DESCRIPTION


## TLDR

Added traceID propagation support to Gemini CLI’s A2A server. Incoming requests now carry a traceID (from x-cloud-trace-context or a generated UUID), which is stored per-request and attached to the response headers.
This ensures end-to-end trace continuity between CCPA, Gemini CLI, and downstream A2A services.

## Dive Deeper

This change improves observability and debugging across distributed systems.
Previously, requests to Gemini CLI were not guaranteed to retain the trace context from upstream CCPA calls.
Now, every request has:

- A consistent traceID lifecycle (inbound → executor → outbound → response).
- AsyncLocalStorage isolation for concurrent request traces.
- E2E verification through the existing test:
“should propagate traceId to the Gemini client” in app.test.ts.

No functional behavior of task creation or agent execution was altered, only logging and header propagation were enhanced.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | 👍   | ?   | ?   |
| npx      | 👍   | ❓  | ❓  |
| Docker   | 👍   | ❓  | ❓  |
| Podman   | 👍   | -   | -   |
| Seatbelt | 👍   | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
