### PR TITLE
chore: set explicit tag for first publish of a2a-server

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -210,7 +210,7 @@ runs:
         if [ "${{ inputs.dry-run }}" == "true" ]; then
           npm publish --dry-run --workspace="@google/gemini-cli-a2a-server" --no-tag
         else
-          npm publish --workspace="@google/gemini-cli-a2a-server" --no-tag
+          npm publish --workspace="@google/gemini-cli-a2a-server" --tag "${{ inputs.npm-tag }}"
         fi
 
     - name: '🔬 Verify NPM release by version'


### PR DESCRIPTION
## TLDR

Recommended fix from previous Nighty run is to explicitly set tag for first publish.

https://github.com/google-gemini/gemini-cli/actions/runs/18468202923/job/52627225824
Error from previous Nightly:
```
npm notice Publishing to https://wombat-dressing-room.appspot.com/ with tag false and default access
npm error code E500
npm error 500 Internal Server Error - PUT https://wombat-dressing-room.appspot.com/@google%2fgemini-cli-a2a-server - 
npm error   ===============================
npm error   Publish service error
npm error   -------------------------------
npm error   not supported yet. package is rather strange. its not new and has no latest version
npm error   ===============================
npm error   
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-10-13T16_27_17_508Z-debug-0.log
```