### PR TITLE
chore(settings): Enable 'useSmartEdit' by default

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -899,7 +899,7 @@ const SETTINGS_SCHEMA = {
     label: 'Use Smart Edit',
     category: 'Advanced',
     requiresRestart: false,
-    default: false,
+    default: true,
     description: 'Enable the smart-edit tool instead of the replace tool.',
     showInDialog: false,
   },


### PR DESCRIPTION
## TLDR

This pull request changes the default value of the `useSmartEdit` setting in `packages/cli/src/config/settingsSchema.ts` from `false` to `true`. This should be a no-op change since the tool is already default true in config.ts

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |
