### PR TITLE
Docs: Quick fix: Sidebar link.

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -161,7 +161,7 @@
       },
       {
         "label": "Get Started with Extensions",
-        "slug": "docs/extensions/getting-started-extensions.md"
+        "slug": "docs/extensions/getting-started-extensions"
       },
       {
         "label": "Extension Releasing",


### PR DESCRIPTION
## TLDR

Fixes sidebar link (for website table of contents).

A small change in the sidebar link for the **Extensions Section.**