### PR TITLE
fix(compression): prevent unnecessary summarization when history is too short

### DIFF
--- a/packages/cli/src/ui/components/messages/CompressionMessage.tsx
+++ b/packages/cli/src/ui/components/messages/CompressionMessage.tsx
@@ -47,7 +47,7 @@ export function CompressionMessage({
       case CompressionStatus.COMPRESSION_FAILED_TOKEN_COUNT_ERROR:
         return 'Could not compress chat history due to a token counting error.';
       case CompressionStatus.NOOP:
-        return 'Chat history is already compressed.';
+        return 'Nothing to compress.';
       default:
         return '';
     }

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -590,16 +590,32 @@ describe('Gemini Client (client.ts)', () => {
       expect(newChat).toBe(initialChat);
     });
 
+    it('should return NOOP if history is too short to compress', async () => {
+      const { client } = setup({
+        chatHistory: [{ role: 'user', parts: [{ text: 'hi' }] }],
+      });
+
+      const result = await client.tryCompressChat('prompt-id-noop', false);
+
+      expect(result.compressionStatus).toBe(CompressionStatus.NOOP);
+      expect(mockGenerateContentFn).not.toHaveBeenCalled();
+    });
+
     it('logs a telemetry event when compressing', async () => {
       vi.spyOn(ClearcutLogger.prototype, 'logChatCompressionEvent');
-
       const MOCKED_TOKEN_LIMIT = 1000;
       const MOCKED_CONTEXT_PERCENTAGE_THRESHOLD = 0.5;
-      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
       vi.spyOn(client['config'], 'getChatCompression').mockReturnValue({
         contextPercentageThreshold: MOCKED_CONTEXT_PERCENTAGE_THRESHOLD,
       });
-      const history = [{ role: 'user', parts: [{ text: '...history...' }] }];
+      const history = [
+        { role: 'user', parts: [{ text: '...history...' }] },
+        { role: 'model', parts: [{ text: '...history...' }] },
+        { role: 'user', parts: [{ text: '...history...' }] },
+        { role: 'model', parts: [{ text: '...history...' }] },
+        { role: 'user', parts: [{ text: '...history...' }] },
+        { role: 'model', parts: [{ text: '...history...' }] },
+      ];
       mockGetHistory.mockReturnValue(history);
 
       const originalTokenCount =
@@ -674,7 +690,14 @@ describe('Gemini Client (client.ts)', () => {
       vi.spyOn(client['config'], 'getChatCompression').mockReturnValue({
         contextPercentageThreshold: MOCKED_CONTEXT_PERCENTAGE_THRESHOLD,
       });
-      const history = [{ role: 'user', parts: [{ text: '...history...' }] }];
+      const history = [
+        { role: 'user', parts: [{ text: '...history...' }] },
+        { role: 'model', parts: [{ text: '...history...' }] },
+        { role: 'user', parts: [{ text: '...history...' }] },
+        { role: 'model', parts: [{ text: '...history...' }] },
+        { role: 'user', parts: [{ text: '...history...' }] },
+        { role: 'model', parts: [{ text: '...history...' }] },
+      ];
       mockGetHistory.mockReturnValue(history);
 
       const originalTokenCount =
@@ -838,7 +861,14 @@ describe('Gemini Client (client.ts)', () => {
     });
 
     it('should always trigger summarization when force is true, regardless of token count', async () => {
-      const history = [{ role: 'user', parts: [{ text: '...history...' }] }];
+      const history = [
+        { role: 'user', parts: [{ text: '...history...' }] },
+        { role: 'model', parts: [{ text: '...history...' }] },
+        { role: 'user', parts: [{ text: '...history...' }] },
+        { role: 'model', parts: [{ text: '...history...' }] },
+        { role: 'user', parts: [{ text: '...history...' }] },
+        { role: 'model', parts: [{ text: '...history...' }] },
+      ];
       mockGetHistory.mockReturnValue(history);
 
       const originalTokenCount = 100; // Well below threshold, but > estimated new count

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -593,11 +593,16 @@ describe('Gemini Client (client.ts)', () => {
     it('should return NOOP if history is too short to compress', async () => {
       const { client } = setup({
         chatHistory: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        originalTokenCount: 50,
       });
 
       const result = await client.tryCompressChat('prompt-id-noop', false);
 
-      expect(result.compressionStatus).toBe(CompressionStatus.NOOP);
+      expect(result).toEqual({
+        compressionStatus: CompressionStatus.NOOP,
+        originalTokenCount: 50,
+        newTokenCount: 50,
+      });
       expect(mockGenerateContentFn).not.toHaveBeenCalled();
     });
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -777,6 +777,14 @@ My setup is complete. I will provide my first command in the next turn.
     const historyToCompress = curatedHistory.slice(0, splitPoint);
     const historyToKeep = curatedHistory.slice(splitPoint);
 
+    if (historyToCompress.length === 0) {
+      return {
+        originalTokenCount,
+        newTokenCount: originalTokenCount,
+        compressionStatus: CompressionStatus.NOOP,
+      };
+    }
+
     const summaryResponse = await this.config
       .getContentGenerator()
       .generateContent(


### PR DESCRIPTION
## TLDR

This PR fixes an issue where running `/compress` at the start of a session (or when history is very short) would trigger an unnecessary LLM call for summarization. It adds a check to early-exit with `CompressionStatus.NOOP` if there is no history to compress and updates the UI message accordingly.

## Dive Deeper

Previously, the compression logic could proceed to make a `generateContent` call for summarization even if the calculated `historyToCompress` was empty. This often happened if a user ran `/compress` immediately after startup, as the initial system/environment context messages were present in the history.

Changes included in this PR:

1.  **Logic (`packages/core/src/core/client.ts`)**: Added a check inside `tryCompressChat` to see if `historyToCompress.length === 0` after the history splitting logic. If so, it returns `CompressionStatus.NOOP` immediately, avoiding an LLM call.
2.  **UX (`packages/cli/src/ui/components/messages/CompressionMessage.tsx`)**: Updated the user-facing message for `CompressionStatus.NOOP` from "Chat history is already compressed." to "Nothing to compress." to better reflect the state at the start of a session.
3.  **Tests (`packages/core/src/core/client.test.ts`)**:
    *   Added a specific test case for the "too short to compress" scenario.
    *   Updated existing compression tests to use longer mock chat histories so they don't trigger the new `NOOP` condition prematurely.

## Reviewer Test Plan

To validate these changes:

1.  Start a new CLI session.
2.  Immediately run the `/compress` command.
3.  **Verify:** The output should say "Nothing to compress." and there should be no loading spinner indicating an LLM summarization call.
4.  Have a multi-turn conversation to build up chat history.
5.  Run `/compress` again.
6.  **Verify:** Compression proceeds normally (assuming history exceeds thresholds).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |

## Linked issues / bugs

Closes #11080
