### PR TITLE
feat: Granular 'always allow' options for shell commands

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -640,6 +640,10 @@ export async function loadCliConfig(
     activeExtensions,
     extraExcludes.length > 0 ? extraExcludes : undefined,
   );
+  const shellCommandsWithSubcommands = mergeShellCommandsWithSubcommands(
+    settings,
+    activeExtensions,
+  );
   const blockedMcpServers: Array<{ name: string; extensionName: string }> = [];
 
   if (!argv.allowedMcpServerNames) {
@@ -699,6 +703,7 @@ export async function loadCliConfig(
     allowedTools: allowedTools.length > 0 ? allowedTools : undefined,
     policyEngineConfig,
     excludeTools,
+    shellCommandsWithSubcommands,
     toolDiscoveryCommand: settings.tools?.discoveryCommand,
     toolCallCommand: settings.tools?.callCommand,
     mcpServerCommand: settings.mcp?.serverCommand,
@@ -827,4 +832,19 @@ function mergeExcludeTools(
     }
   }
   return [...allExcludeTools];
+}
+
+function mergeShellCommandsWithSubcommands(
+  settings: Settings,
+  extensions: GeminiCLIExtension[],
+): string[] {
+  const allShellCommandsWithSubcommands = new Set([
+    ...(settings.tools?.shellCommandsWithSubcommands || []),
+  ]);
+  for (const extension of extensions) {
+    for (const command of extension.shellCommandsWithSubcommands || []) {
+      allShellCommandsWithSubcommands.add(command);
+    }
+  }
+  return [...allShellCommandsWithSubcommands];
 }

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -753,6 +753,17 @@ const SETTINGS_SCHEMA = {
           },
         },
       },
+      shellCommandsWithSubcommands: {
+        type: 'array',
+        label: 'Shell Commands with Subcommands',
+        category: 'Tools',
+        requiresRestart: true,
+        default: undefined as string[] | undefined,
+        description:
+          'A list of shell commands that have subcommands that can be used to create more specific command prefixes for approval.',
+        showInDialog: false,
+        mergeStrategy: MergeStrategy.UNION,
+      },
       autoAccept: {
         type: 'boolean',
         label: 'Auto Accept',

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -458,6 +458,7 @@ class Session {
             );
           case ToolConfirmationOutcome.ProceedOnce:
           case ToolConfirmationOutcome.ProceedAlways:
+          case ToolConfirmationOutcome.ProceedAlwaysExact:
           case ToolConfirmationOutcome.ProceedAlwaysServer:
           case ToolConfirmationOutcome.ProceedAlwaysTool:
           case ToolConfirmationOutcome.ModifyWithEditor:

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -46,3 +46,5 @@ export { ClearcutLogger } from './src/telemetry/clearcut-logger/clearcut-logger.
 export { logModelSlashCommand } from './src/telemetry/loggers.js';
 export * from './src/utils/googleQuotaErrors.js';
 export type { GoogleApiError } from './src/utils/googleErrors.js';
+export { getMcpServerForTool } from './src/utils/tool-utils.js';
+export { getCommandPrefix } from './src/utils/shell-utils.js';

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -131,6 +131,7 @@ export interface GeminiCLIExtension {
   mcpServers?: Record<string, MCPServerConfig>;
   contextFiles: string[];
   excludeTools?: string[];
+  shellCommandsWithSubcommands?: string[];
 }
 
 export interface ExtensionInstallMetadata {
@@ -211,6 +212,7 @@ export interface ConfigParameters {
   fullContext?: boolean;
   coreTools?: string[];
   allowedTools?: string[];
+  shellCommandsWithSubcommands?: string[];
   excludeTools?: string[];
   toolDiscoveryCommand?: string;
   toolCallCommand?: string;
@@ -289,6 +291,7 @@ export class Config {
   private readonly fullContext: boolean;
   private readonly coreTools: string[] | undefined;
   private readonly allowedTools: string[] | undefined;
+  private readonly shellCommandsWithSubcommands: string[];
   private readonly excludeTools: string[] | undefined;
   private readonly toolDiscoveryCommand: string | undefined;
   private readonly toolCallCommand: string | undefined;
@@ -380,6 +383,149 @@ export class Config {
     this.fullContext = params.fullContext ?? false;
     this.coreTools = params.coreTools;
     this.allowedTools = params.allowedTools;
+    this.shellCommandsWithSubcommands = params.shellCommandsWithSubcommands
+      ?.length
+      ? params.shellCommandsWithSubcommands
+      : [
+          'ansible',
+          'apt-get',
+          'aws',
+          'aws ec2',
+          'aws iam',
+          'aws s3',
+          'az',
+          'az group',
+          'az storage',
+          'az storage blob',
+          'az vm',
+          'brew',
+          'brew services',
+          'bun',
+          'bun pm',
+          'cargo',
+          'cargo component',
+          'choco',
+          'choco source',
+          'composer',
+          'conda',
+          'conda env',
+          'deno',
+          'deno jupyter',
+          'doctl',
+          'doctl compute',
+          'doctl compute droplet',
+          'docker',
+          'docker buildx',
+          'docker container',
+          'docker image',
+          'docker network',
+          'docker volume',
+          'dotnet',
+          'dotnet tool',
+          'drush',
+          'drush cache',
+          'drush config',
+          'firebase',
+          'flyctl',
+          'flyctl apps',
+          'flyctl machine',
+          'flux',
+          'flux create',
+          'flux create source',
+          'flux get',
+          'forge',
+          'gcloud',
+          'gcloud compute',
+          'gcloud compute instances',
+          'gcloud container',
+          'gcloud container clusters',
+          'gh',
+          'gh issue',
+          'gh pr',
+          'gh repo',
+          'gh run',
+          'gh workflow',
+          'git',
+          'git remote',
+          'git stash',
+          'git submodule',
+          'go',
+          'go mod',
+          'go tool',
+          'gradle',
+          'helm',
+          'helm repo',
+          'heroku',
+          'heroku apps',
+          'heroku domains',
+          'hg',
+          'istioctl',
+          'istioctl proxy-config',
+          'kubectl',
+          'kubectl config',
+          'linkerd',
+          'linkerd viz',
+          'minikube',
+          'minikube addons',
+          'minikube cache',
+          'mix',
+          'mix deps',
+          'mvn',
+          'npm',
+          'npm cache',
+          'npx',
+          'oc',
+          'oc config',
+          'openssl',
+          'pip',
+          'pip cache',
+          'pnpm',
+          'pnpm store',
+          'podman',
+          'podman container',
+          'podman image',
+          'poetry',
+          'poetry cache',
+          'poetry source',
+          'pulumi',
+          'pulumi config',
+          'pulumi stack',
+          'rails',
+          'rustup',
+          'rustup component',
+          'rustup toolchain',
+          'sam',
+          'sam remote',
+          'sbt',
+          'serverless',
+          'serverless plugin',
+          'supabase',
+          'supabase db',
+          'supabase functions',
+          'svn',
+          'systemctl',
+          'terraform',
+          'terraform state',
+          'terraform workspace',
+          'tkn',
+          'tkn pipeline',
+          'tkn taskrun',
+          'truffle',
+          'uv',
+          'uv pip',
+          'vagrant',
+          'vagrant box',
+          'vagrant plugin',
+          'vercel',
+          'vercel domains',
+          'wp-cli',
+          'wp post',
+          'wp plugin',
+          'wp user',
+          'yarn',
+          'yarn cache',
+          'yarn workspace',
+        ];
     this.excludeTools = params.excludeTools;
     this.toolDiscoveryCommand = params.toolDiscoveryCommand;
     this.toolCallCommand = params.toolCallCommand;
@@ -677,6 +823,10 @@ export class Config {
 
   getAllowedTools(): string[] | undefined {
     return this.allowedTools;
+  }
+
+  getShellCommandsWithSubcommands(): string[] {
+    return this.shellCommandsWithSubcommands;
   }
 
   getExcludeTools(): string[] | undefined {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -394,10 +394,10 @@ describe('ShellTool', () => {
       expect(confirmation).not.toBe(false);
       expect(confirmation && confirmation.type).toBe('exec');
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (confirmation as any).onConfirm(
-        ToolConfirmationOutcome.ProceedAlways,
-      );
+      // Simulate the user choosing "Always allow" for the "npm" prefix.
+      if (confirmation && confirmation.type === 'exec') {
+        await confirmation.onConfirm(ToolConfirmationOutcome.ProceedAlways);
+      }
 
       // Should now be allowlisted
       const secondInvocation = shellTool.build({ command: 'npm test' });

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -602,7 +602,9 @@ export interface ToolEditConfirmationDetails {
 export interface ToolConfirmationPayload {
   // used to override `modifiedProposedContent` for modifiable tools in the
   // inline modify flow
-  newContent: string;
+  newContent?: string;
+  // used to specify the exact command or prefix to allow for shell commands
+  commandToAllow?: string;
 }
 
 export interface ToolExecuteConfirmationDetails {
@@ -639,6 +641,7 @@ export type ToolCallConfirmationDetails =
 export enum ToolConfirmationOutcome {
   ProceedOnce = 'proceed_once',
   ProceedAlways = 'proceed_always',
+  ProceedAlwaysExact = 'proceed_always_exact',
   ProceedAlwaysServer = 'proceed_always_server',
   ProceedAlwaysTool = 'proceed_always_tool',
   ModifyWithEditor = 'modify_with_editor',

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -4,444 +4,55 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect, describe, it, beforeEach, vi, afterEach } from 'vitest';
-import {
-  checkCommandPermissions,
-  escapeShellArg,
-  getCommandRoots,
-  getShellConfiguration,
-  isCommandAllowed,
-  stripShellWrapper,
-} from './shell-utils.js';
-import type { Config } from '../config/config.js';
+import { describe, it, expect } from 'vitest';
+import { getCommandPrefix } from './shell-utils.js';
 
-const mockPlatform = vi.hoisted(() => vi.fn());
-const mockHomedir = vi.hoisted(() => vi.fn());
-vi.mock('os', () => ({
-  default: {
-    platform: mockPlatform,
-    homedir: mockHomedir,
-  },
-  platform: mockPlatform,
-  homedir: mockHomedir,
-}));
+describe('getCommandPrefix', () => {
+  const shellCommandsWithSubcommands = ['git', 'npm', 'npx', 'gh', 'gh run'];
 
-const mockQuote = vi.hoisted(() => vi.fn());
-vi.mock('shell-quote', () => ({
-  quote: mockQuote,
-}));
-
-let config: Config;
-
-beforeEach(() => {
-  mockPlatform.mockReturnValue('linux');
-  mockQuote.mockImplementation((args: string[]) =>
-    args.map((arg) => `'${arg}'`).join(' '),
-  );
-  config = {
-    getCoreTools: () => [],
-    getExcludeTools: () => [],
-    getAllowedTools: () => [],
-  } as unknown as Config;
-});
-
-afterEach(() => {
-  vi.clearAllMocks();
-});
-
-describe('isCommandAllowed', () => {
-  it('should allow a command if no restrictions are provided', () => {
-    const result = isCommandAllowed('ls -l', config);
-    expect(result.allowed).toBe(true);
+  it('should return only the root command for a simple command', () => {
+    const command = 'ls -l';
+    const prefix = getCommandPrefix(command, shellCommandsWithSubcommands);
+    expect(prefix).toEqual('ls');
   });
 
-  it('should allow a command if it is in the global allowlist', () => {
-    config.getCoreTools = () => ['ShellTool(ls)'];
-    const result = isCommandAllowed('ls -l', config);
-    expect(result.allowed).toBe(true);
+  it('should return the root and the subcommand for a stemmable command', () => {
+    const command = 'git status -v';
+    const prefix = getCommandPrefix(command, shellCommandsWithSubcommands);
+    expect(prefix).toEqual('git status');
   });
 
-  it('should block a command if it is not in a strict global allowlist', () => {
-    config.getCoreTools = () => ['ShellTool(ls -l)'];
-    const result = isCommandAllowed('rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      `Command(s) not in the allowed commands list. Disallowed commands: "rm -rf /"`,
+  it('should handle a complex stemmable command', () => {
+    const command = 'gh run view --web';
+    const prefix = getCommandPrefix(command, shellCommandsWithSubcommands);
+    expect(prefix).toEqual('gh run view');
+  });
+
+  it('should return only the root for a non-stemmable command with multiple parts', () => {
+    const command = 'echo "hello world"';
+    const prefix = getCommandPrefix(command, shellCommandsWithSubcommands);
+    expect(prefix).toEqual('echo');
+  });
+
+  it('should handle an empty command', () => {
+    const command = '';
+    const prefix = getCommandPrefix(command, shellCommandsWithSubcommands);
+    expect(prefix).toEqual('');
+  });
+
+  it('should handle a command with only whitespace', () => {
+    const command = '   ';
+    const prefix = getCommandPrefix(command, shellCommandsWithSubcommands);
+    expect(prefix).toEqual('');
+  });
+
+  it('should return the most specific prefix', () => {
+    const command = 'git checkout main';
+    const customShellCommandsWithSubcommands = ['git', 'git checkout'];
+    const prefix = getCommandPrefix(
+      command,
+      customShellCommandsWithSubcommands,
     );
-  });
-
-  it('should block a command if it is in the blocked list', () => {
-    config.getExcludeTools = () => ['ShellTool(rm -rf /)'];
-    const result = isCommandAllowed('rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      `Command 'rm -rf /' is blocked by configuration`,
-    );
-  });
-
-  it('should prioritize the blocklist over the allowlist', () => {
-    config.getCoreTools = () => ['ShellTool(rm -rf /)'];
-    config.getExcludeTools = () => ['ShellTool(rm -rf /)'];
-    const result = isCommandAllowed('rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      `Command 'rm -rf /' is blocked by configuration`,
-    );
-  });
-
-  it('should allow any command when a wildcard is in coreTools', () => {
-    config.getCoreTools = () => ['ShellTool'];
-    const result = isCommandAllowed('any random command', config);
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should block any command when a wildcard is in excludeTools', () => {
-    config.getExcludeTools = () => ['run_shell_command'];
-    const result = isCommandAllowed('any random command', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      'Shell tool is globally disabled in configuration',
-    );
-  });
-
-  it('should block a command on the blocklist even with a wildcard allow', () => {
-    config.getCoreTools = () => ['ShellTool'];
-    config.getExcludeTools = () => ['ShellTool(rm -rf /)'];
-    const result = isCommandAllowed('rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      `Command 'rm -rf /' is blocked by configuration`,
-    );
-  });
-
-  it('should allow a chained command if all parts are on the global allowlist', () => {
-    config.getCoreTools = () => [
-      'run_shell_command(echo)',
-      'run_shell_command(ls)',
-    ];
-    const result = isCommandAllowed('echo "hello" && ls -l', config);
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should block a chained command if any part is blocked', () => {
-    config.getExcludeTools = () => ['run_shell_command(rm)'];
-    const result = isCommandAllowed('echo "hello" && rm -rf /', config);
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toBe(
-      `Command 'rm -rf /' is blocked by configuration`,
-    );
-  });
-
-  describe('command substitution', () => {
-    it('should block command substitution using `$(...)`', () => {
-      const result = isCommandAllowed('echo $(rm -rf /)', config);
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toContain('Command substitution');
-    });
-
-    it('should block command substitution using `<(...)`', () => {
-      const result = isCommandAllowed('diff <(ls) <(ls -a)', config);
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toContain('Command substitution');
-    });
-
-    it('should block command substitution using `>(...)`', () => {
-      const result = isCommandAllowed(
-        'echo "Log message" > >(tee log.txt)',
-        config,
-      );
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toContain('Command substitution');
-    });
-
-    it('should block command substitution using backticks', () => {
-      const result = isCommandAllowed('echo `rm -rf /`', config);
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toContain('Command substitution');
-    });
-
-    it('should allow substitution-like patterns inside single quotes', () => {
-      config.getCoreTools = () => ['ShellTool(echo)'];
-      const result = isCommandAllowed("echo '$(pwd)'", config);
-      expect(result.allowed).toBe(true);
-    });
-  });
-});
-
-describe('checkCommandPermissions', () => {
-  describe('in "Default Allow" mode (no sessionAllowlist)', () => {
-    it('should return a detailed success object for an allowed command', () => {
-      const result = checkCommandPermissions('ls -l', config);
-      expect(result).toEqual({
-        allAllowed: true,
-        disallowedCommands: [],
-      });
-    });
-
-    it('should return a detailed failure object for a blocked command', () => {
-      config.getExcludeTools = () => ['ShellTool(rm)'];
-      const result = checkCommandPermissions('rm -rf /', config);
-      expect(result).toEqual({
-        allAllowed: false,
-        disallowedCommands: ['rm -rf /'],
-        blockReason: `Command 'rm -rf /' is blocked by configuration`,
-        isHardDenial: true,
-      });
-    });
-
-    it('should return a detailed failure object for a command not on a strict allowlist', () => {
-      config.getCoreTools = () => ['ShellTool(ls)'];
-      const result = checkCommandPermissions('git status && ls', config);
-      expect(result).toEqual({
-        allAllowed: false,
-        disallowedCommands: ['git status'],
-        blockReason: `Command(s) not in the allowed commands list. Disallowed commands: "git status"`,
-        isHardDenial: false,
-      });
-    });
-  });
-
-  describe('in "Default Deny" mode (with sessionAllowlist)', () => {
-    it('should allow a command on the sessionAllowlist', () => {
-      const result = checkCommandPermissions(
-        'ls -l',
-        config,
-        new Set(['ls -l']),
-      );
-      expect(result.allAllowed).toBe(true);
-    });
-
-    it('should block a command not on the sessionAllowlist or global allowlist', () => {
-      const result = checkCommandPermissions(
-        'rm -rf /',
-        config,
-        new Set(['ls -l']),
-      );
-      expect(result.allAllowed).toBe(false);
-      expect(result.blockReason).toContain(
-        'not on the global or session allowlist',
-      );
-      expect(result.disallowedCommands).toEqual(['rm -rf /']);
-    });
-
-    it('should allow a command on the global allowlist even if not on the session allowlist', () => {
-      config.getCoreTools = () => ['ShellTool(git status)'];
-      const result = checkCommandPermissions(
-        'git status',
-        config,
-        new Set(['ls -l']),
-      );
-      expect(result.allAllowed).toBe(true);
-    });
-
-    it('should allow a chained command if parts are on different allowlists', () => {
-      config.getCoreTools = () => ['ShellTool(git status)'];
-      const result = checkCommandPermissions(
-        'git status && git commit',
-        config,
-        new Set(['git commit']),
-      );
-      expect(result.allAllowed).toBe(true);
-    });
-
-    it('should block a command on the sessionAllowlist if it is also globally blocked', () => {
-      config.getExcludeTools = () => ['run_shell_command(rm)'];
-      const result = checkCommandPermissions(
-        'rm -rf /',
-        config,
-        new Set(['rm -rf /']),
-      );
-      expect(result.allAllowed).toBe(false);
-      expect(result.blockReason).toContain('is blocked by configuration');
-    });
-
-    it('should block a chained command if one part is not on any allowlist', () => {
-      config.getCoreTools = () => ['run_shell_command(echo)'];
-      const result = checkCommandPermissions(
-        'echo "hello" && rm -rf /',
-        config,
-        new Set(['echo']),
-      );
-      expect(result.allAllowed).toBe(false);
-      expect(result.disallowedCommands).toEqual(['rm -rf /']);
-    });
-  });
-});
-
-describe('getCommandRoots', () => {
-  it('should return a single command', () => {
-    expect(getCommandRoots('ls -l')).toEqual(['ls']);
-  });
-
-  it('should handle paths and return the binary name', () => {
-    expect(getCommandRoots('/usr/local/bin/node script.js')).toEqual(['node']);
-  });
-
-  it('should return an empty array for an empty string', () => {
-    expect(getCommandRoots('')).toEqual([]);
-  });
-
-  it('should handle a mix of operators', () => {
-    const result = getCommandRoots('a;b|c&&d||e&f');
-    expect(result).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
-  });
-
-  it('should correctly parse a chained command with quotes', () => {
-    const result = getCommandRoots('echo "hello" && git commit -m "feat"');
-    expect(result).toEqual(['echo', 'git']);
-  });
-});
-
-describe('stripShellWrapper', () => {
-  it('should strip sh -c with quotes', () => {
-    expect(stripShellWrapper('sh -c "ls -l"')).toEqual('ls -l');
-  });
-
-  it('should strip bash -c with extra whitespace', () => {
-    expect(stripShellWrapper('  bash  -c  "ls -l"  ')).toEqual('ls -l');
-  });
-
-  it('should strip zsh -c without quotes', () => {
-    expect(stripShellWrapper('zsh -c ls -l')).toEqual('ls -l');
-  });
-
-  it('should strip cmd.exe /c', () => {
-    expect(stripShellWrapper('cmd.exe /c "dir"')).toEqual('dir');
-  });
-
-  it('should not strip anything if no wrapper is present', () => {
-    expect(stripShellWrapper('ls -l')).toEqual('ls -l');
-  });
-});
-
-describe('escapeShellArg', () => {
-  describe('POSIX (bash)', () => {
-    it('should use shell-quote for escaping', () => {
-      mockQuote.mockReturnValueOnce("'escaped value'");
-      const result = escapeShellArg('raw value', 'bash');
-      expect(mockQuote).toHaveBeenCalledWith(['raw value']);
-      expect(result).toBe("'escaped value'");
-    });
-
-    it('should handle empty strings', () => {
-      const result = escapeShellArg('', 'bash');
-      expect(result).toBe('');
-      expect(mockQuote).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('Windows', () => {
-    describe('when shell is cmd.exe', () => {
-      it('should wrap simple arguments in double quotes', () => {
-        const result = escapeShellArg('search term', 'cmd');
-        expect(result).toBe('"search term"');
-      });
-
-      it('should escape internal double quotes by doubling them', () => {
-        const result = escapeShellArg('He said "Hello"', 'cmd');
-        expect(result).toBe('"He said ""Hello"""');
-      });
-
-      it('should handle empty strings', () => {
-        const result = escapeShellArg('', 'cmd');
-        expect(result).toBe('');
-      });
-    });
-
-    describe('when shell is PowerShell', () => {
-      it('should wrap simple arguments in single quotes', () => {
-        const result = escapeShellArg('search term', 'powershell');
-        expect(result).toBe("'search term'");
-      });
-
-      it('should escape internal single quotes by doubling them', () => {
-        const result = escapeShellArg("It's a test", 'powershell');
-        expect(result).toBe("'It''s a test'");
-      });
-
-      it('should handle double quotes without escaping them', () => {
-        const result = escapeShellArg('He said "Hello"', 'powershell');
-        expect(result).toBe('\'He said "Hello"\'');
-      });
-
-      it('should handle empty strings', () => {
-        const result = escapeShellArg('', 'powershell');
-        expect(result).toBe('');
-      });
-    });
-  });
-});
-
-describe('getShellConfiguration', () => {
-  const originalEnv = { ...process.env };
-
-  afterEach(() => {
-    process.env = originalEnv;
-  });
-
-  it('should return bash configuration on Linux', () => {
-    mockPlatform.mockReturnValue('linux');
-    const config = getShellConfiguration();
-    expect(config.executable).toBe('bash');
-    expect(config.argsPrefix).toEqual(['-c']);
-    expect(config.shell).toBe('bash');
-  });
-
-  it('should return bash configuration on macOS (darwin)', () => {
-    mockPlatform.mockReturnValue('darwin');
-    const config = getShellConfiguration();
-    expect(config.executable).toBe('bash');
-    expect(config.argsPrefix).toEqual(['-c']);
-    expect(config.shell).toBe('bash');
-  });
-
-  describe('on Windows', () => {
-    beforeEach(() => {
-      mockPlatform.mockReturnValue('win32');
-    });
-
-    it('should return cmd.exe configuration by default', () => {
-      delete process.env['ComSpec'];
-      const config = getShellConfiguration();
-      expect(config.executable).toBe('cmd.exe');
-      expect(config.argsPrefix).toEqual(['/d', '/s', '/c']);
-      expect(config.shell).toBe('cmd');
-    });
-
-    it('should respect ComSpec for cmd.exe', () => {
-      const cmdPath = 'C:\\WINDOWS\\system32\\cmd.exe';
-      process.env['ComSpec'] = cmdPath;
-      const config = getShellConfiguration();
-      expect(config.executable).toBe(cmdPath);
-      expect(config.argsPrefix).toEqual(['/d', '/s', '/c']);
-      expect(config.shell).toBe('cmd');
-    });
-
-    it('should return PowerShell configuration if ComSpec points to powershell.exe', () => {
-      const psPath =
-        'C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
-      process.env['ComSpec'] = psPath;
-      const config = getShellConfiguration();
-      expect(config.executable).toBe(psPath);
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
-      expect(config.shell).toBe('powershell');
-    });
-
-    it('should return PowerShell configuration if ComSpec points to pwsh.exe', () => {
-      const pwshPath = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe';
-      process.env['ComSpec'] = pwshPath;
-      const config = getShellConfiguration();
-      expect(config.executable).toBe(pwshPath);
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
-      expect(config.shell).toBe('powershell');
-    });
-
-    it('should be case-insensitive when checking ComSpec', () => {
-      process.env['ComSpec'] = 'C:\\Path\\To\\POWERSHELL.EXE';
-      const config = getShellConfiguration();
-      expect(config.executable).toBe('C:\\Path\\To\\POWERSHELL.EXE');
-      expect(config.argsPrefix).toEqual(['-NoProfile', '-Command']);
-      expect(config.shell).toBe('powershell');
-    });
+    expect(prefix).toEqual('git checkout main');
   });
 });

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -195,6 +195,39 @@ export function getCommandRoot(command: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Generates a command prefix to offer for approval.
+ *
+ * @param command The full command string.
+ * @param shellCommandsWithSubcommands A list of commands that can be "stemmed" to create
+ *   more specific prefixes (e.g., 'git', 'npm', 'gh run').
+ * @returns The most specific prefix to offer for approval.
+ */
+export function getCommandPrefix(
+  command: string,
+  shellCommandsWithSubcommands: string[],
+): string {
+  const parts = command.trim().split(/\s+/);
+  if (parts.length === 0 || parts[0] === '') {
+    return '';
+  }
+
+  // Find the longest matching stemmable prefix.
+  const longestMatch = shellCommandsWithSubcommands
+    .filter((prefix) => command.startsWith(prefix + ' '))
+    .sort((a, b) => b.length - a.length)[0];
+
+  if (longestMatch) {
+    const prefixParts = longestMatch.trim().split(/\s+/);
+    if (parts.length > prefixParts.length) {
+      // Add the next level of specificity.
+      return parts.slice(0, prefixParts.length + 1).join(' ');
+    }
+  }
+
+  return parts[0];
+}
+
 export function getCommandRoots(command: string): string[] {
   if (!command) {
     return [];

--- a/packages/core/src/utils/tool-utils.ts
+++ b/packages/core/src/utils/tool-utils.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AnyDeclarativeTool, AnyToolInvocation } from '../index.js';
+import type {
+  AnyDeclarativeTool,
+  AnyToolInvocation,
+  Config,
+} from '../index.js';
 import { isTool } from '../index.js';
 import { SHELL_TOOL_NAMES } from './shell-utils.js';
 
@@ -72,4 +76,23 @@ export function doesToolInvocationMatch(
   }
 
   return false;
+}
+
+export function getMcpServerForTool(
+  config: Config,
+  toolName: string,
+): string | undefined {
+  const mcpServers = config.getMcpServers();
+  if (!mcpServers) {
+    return undefined;
+  }
+
+  for (const serverName in mcpServers) {
+    const server = mcpServers[serverName];
+    if (server.includeTools?.includes(toolName)) {
+      return serverName;
+    }
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
## TLDR

When model calls `ShellTool(git diff HEAD)`, previously the options were "Allow once" and "Always allow `git`"

Now, you get "Allow once", "Always allow `git diff HEAD`", and "Always allow `git diff ...`"

## Dive Deeper

Previously, when running a command like 'git status --short', the user was only offered the option to trust all commands starting with the prefix 'git'.

With this update, the user is now presented with two distinct choices for "Always allow":
1.  **Exact Match:** Approve the precise command being executed (e.g., 'git status --short').
2.  **Prefix Match:** Approve commands starting with a logical subcommand prefix (e.g., 'git status').

The prefixes are determined by a configuration option `tools.shellCommandsWithSubcommands`. If `git` is in `tools.shellCommandsWithSubcommands`, then we ask the user to approve `git status` rather than `git` (i.e. one argv entry more than the entry in `shellCommandsWithSubcommands`.

## Reviewer Test Plan

`npm run start -- --prompt-interactive='Run git push'`

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | Yes  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
