### PR TITLE
Update shell tool call colors for confirmed actions

### DIFF
--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -170,7 +170,7 @@ export const Footer: React.FC = () => {
             )}
             {!showErrorDetails && errorCount > 0 && (
               <Box paddingLeft={1} flexDirection="row">
-                <Text color={theme.ui.symbol}>| </Text>
+                <Text color={theme.ui.comment}>| </Text>
                 <ConsoleSummaryDisplay errorCount={errorCount} />
               </Box>
             )}

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -51,7 +51,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     (t) => t.name === SHELL_COMMAND_NAME || t.name === SHELL_NAME,
   );
   const borderColor =
-    isShellCommand || isEmbeddedShellFocused
+    (isShellCommand && hasPending) || isEmbeddedShellFocused
       ? theme.ui.symbol
       : hasPending
         ? theme.status.warning

--- a/packages/cli/src/ui/components/messages/UserShellMessage.tsx
+++ b/packages/cli/src/ui/components/messages/UserShellMessage.tsx
@@ -18,7 +18,7 @@ export const UserShellMessage: React.FC<UserShellMessageProps> = ({ text }) => {
 
   return (
     <Box>
-      <Text color={theme.text.link}>$ </Text>
+      <Text color={theme.ui.symbol}>$ </Text>
       <Text color={theme.text.primary}>{commandToDisplay}</Text>
     </Box>
   );


### PR DESCRIPTION
## TLDR

This makes a slight fix for shell tool calls to not use the bright blue border for confirmed calls to reduce visual noise. Also cleaned up some minor uses of `theme.ui.symbol`

## Dive Deeper

### Before
<img width="600" alt="CleanShot 2025-10-14 at 11 10 45@2x" src="https://github.com/user-attachments/assets/b2f10481-027b-444c-81c0-e88a9507dc82" />

### After
<img width="600" alt="CleanShot 2025-10-14 at 11 11 38@2x" src="https://github.com/user-attachments/assets/29e77d47-deae-49cb-9d5a-8118f9b3ed54" />

You'll only see the blue border when needing to confirm changes:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/f81cb1cf-8e2e-47fd-a24c-e9c9ec0941ca" />


## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
