### PR TITLE
fix(test): Add basic auth integ tests

### DIFF
--- a/integration-tests/authentication.test.ts
+++ b/integration-tests/authentication.test.ts
@@ -198,20 +198,15 @@ describe('authentication', () => {
 
     // We expect this to fail because it's a non-interactive environment
     // and it will try to launch a browser.
-    const { ptyProcess, promise } = rig.runInteractive('hello');
+    const interactiveRun = await rig.runInteractive(['hello'], {
+      waitForReady: false,
+    });
 
-    const foundPrompt = await rig.waitForText(
-      'Enter the authorization code:',
-      15000,
-    );
+    await interactiveRun.expectText('Enter the authorization code:', 15000);
 
     // Kill the process once we've seen the prompt.
-    ptyProcess.kill();
+    await interactiveRun.kill();
     // Wait for the process to fully exit.
-    await promise;
-
-    expect(foundPrompt, 'Expected to see the authorization code prompt').toBe(
-      true,
-    );
+    await interactiveRun.expectExit();
   });
 });

--- a/integration-tests/authentication.test.ts
+++ b/integration-tests/authentication.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestRig, validateModelOutput } from './test-helper.js';
+import { Storage } from '@google/gemini-cli-core';
+import * as fs from 'node:fs';
+
+describe('authentication', () => {
+  let rig: TestRig;
+  const originalEnv = { ...process.env };
+
+  beforeEach(async () => {
+    rig = new TestRig();
+  });
+
+  afterEach(async () => {
+    await rig.cleanup();
+    // Restore original environment variables after each test
+    for (const key in process.env) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    for (const key in originalEnv) {
+      process.env[key] = originalEnv[key];
+    }
+  });
+
+  it('should fail when no auth environment variables are set', async () => {
+    await rig.setup('auth-fail-test', {
+      settings: {
+        security: { auth: { enforcedType: '', selectedType: '' } },
+      },
+    });
+
+    // Unset all authentication-related environment variables
+    delete process.env['GEMINI_API_KEY'];
+    delete process.env['GOOGLE_API_KEY'];
+    delete process.env['GOOGLE_APPLICATION_CREDENTIALS'];
+    delete process.env['GOOGLE_CLOUD_PROJECT'];
+    delete process.env['GOOGLE_CLOUD_LOCATION'];
+    delete process.env['GOOGLE_GENAI_USE_GCA'];
+    delete process.env['GOOGLE_GENAI_USE_VERTEXAI'];
+
+    let thrown: Error | undefined;
+    try {
+      await rig.run('hello');
+      expect.fail('Expected process to exit with error');
+    } catch (e) {
+      thrown = e as Error;
+    }
+
+    expect(thrown).toBeDefined();
+    const message = (thrown as Error).message;
+
+    // Check for a message that indicates an authentication failure.
+    const isAuthError = message.includes('Please set an Auth method');
+
+    expect(
+      isAuthError,
+      `Expected an authentication error, but got: ${message}`,
+    ).toBe(true);
+  });
+
+  it('should succeed with GEMINI_API_KEY', async () => {
+    // This test relies on GEMINI_API_KEY being set in the testing environment (e.g., via GitHub secrets)
+    if (!process.env['GEMINI_API_KEY']) {
+      console.warn('Skipping GEMINI_API_KEY test: key is not set.');
+      return;
+    }
+
+    await rig.setup('auth-gemini-api-key-test', {
+      settings: {
+        security: {
+          auth: {
+            enforcedType: 'gemini-api-key',
+            selectedType: 'gemini-api-key',
+          },
+        },
+      },
+    });
+
+    // Unset other potentially conflicting auth variables
+    delete process.env['GOOGLE_API_KEY'];
+    delete process.env['GOOGLE_APPLICATION_CREDENTIALS'];
+    delete process.env['GOOGLE_CLOUD_PROJECT'];
+    delete process.env['GOOGLE_CLOUD_LOCATION'];
+    const result = await rig.run({
+      stdin: 'A one-word response: hi',
+    });
+
+    validateModelOutput(
+      result,
+      ['hi', 'hello', 'okay'],
+      'GEMINI_API_KEY auth test',
+    );
+  });
+
+  it('should succeed with Vertex AI authentication', async () => {
+    // This test relies on Vertex AI credentials being configured in the test environment
+    // and these two variables being set.
+    if (
+      !process.env['GOOGLE_CLOUD_PROJECT'] ||
+      !process.env['GOOGLE_CLOUD_LOCATION']
+    ) {
+      console.warn(
+        'Skipping Vertex AI test: GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_LOCATION is not set.',
+      );
+      return;
+    }
+
+    await rig.setup('auth-vertex-ai-test', {
+      settings: {
+        security: {
+          auth: { enforcedType: 'vertex-ai', selectedType: 'vertex-ai' },
+        },
+      },
+    });
+
+    // Unset other keys to ensure Vertex AI ADC is used
+    delete process.env['GEMINI_API_KEY'];
+    delete process.env['GOOGLE_API_KEY'];
+    delete process.env['GOOGLE_APPLICATION_CREDENTIALS'];
+    process.env['GOOGLE_GENAI_USE_VERTEXAI'] = 'true';
+
+    const result = await rig.run('A one-word response: hi');
+
+    validateModelOutput(result, ['hi', 'hello', 'okay'], 'Vertex AI auth test');
+  });
+
+  // TODO: Modify this test to check for cached keychain credentials once
+  // keychain storage is enabled by default.
+  it('should succeed with "Login with Google" (cached credentials)', async () => {
+    // This test relies on cached OAuth credentials being available.
+    if (!fs.existsSync(Storage.getOAuthCredsPath())) {
+      console.warn(
+        'Skipping "Login with Google" test: Cached credentials not found at ' +
+          Storage.getOAuthCredsPath(),
+      );
+      return;
+    }
+
+    await rig.setup('auth-login-with-google-test', {
+      settings: {
+        security: {
+          auth: {
+            enforcedType: 'oauth-personal',
+            selectedType: 'oauth-personal',
+          },
+        },
+      },
+    });
+
+    // Unset other auth methods
+    delete process.env['GEMINI_API_KEY'];
+    delete process.env['GOOGLE_API_KEY'];
+    delete process.env['GOOGLE_GENAI_USE_VERTEXAI'];
+    delete process.env['GOOGLE_CLOUD_LOCATION'];
+    process.env['GOOGLE_GENAI_USE_GCA'] = 'true';
+
+    const result = await rig.run({
+      stdin: 'A one-word response: hi',
+    });
+
+    validateModelOutput(
+      result,
+      ['hi', 'hello', 'okay'],
+      '"Login with Google" auth test',
+    );
+  });
+
+  it('should fail and prompt for browser login when no cached credentials exist', async () => {
+    await rig.setup('auth-oauth-no-cache-fail-test', {
+      settings: {
+        security: {
+          auth: {
+            enforcedType: 'oauth-personal',
+            selectedType: 'oauth-personal',
+          },
+        },
+      },
+    });
+    // Unset all other auth methods AND the cached credentials variable
+    delete process.env['GEMINI_API_KEY'];
+    delete process.env['GOOGLE_API_KEY'];
+    delete process.env['GOOGLE_GENAI_USE_VERTEXAI'];
+    delete process.env['GOOGLE_APPLICATION_CREDENTIALS'];
+    process.env['GOOGLE_GENAI_USE_GCA'] = 'true';
+    // Point to a non-existent credentials file to prevent CLI from finding global cache
+    process.env['FORCE_ENCRYPTED_FILE_ENV_VAR'] = 'false';
+    process.env['GEMINI_OAUTH_CREDS_PATH'] = 'mock-creds.json';
+    // Suppress the browser from opening in a non-interactive environment
+    process.env['NO_BROWSER'] = 'true';
+
+    // We expect this to fail because it's a non-interactive environment
+    // and it will try to launch a browser.
+    const { ptyProcess, promise } = rig.runInteractive('hello');
+
+    const foundPrompt = await rig.waitForText(
+      'Enter the authorization code:',
+      15000,
+    );
+
+    // Kill the process once we've seen the prompt.
+    ptyProcess.kill();
+    // Wait for the process to fully exit.
+    await promise;
+
+    expect(foundPrompt, 'Expected to see the authorization code prompt').toBe(
+      true,
+    );
+  });
+});

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -902,7 +902,7 @@ export class TestRig {
   }
 
   async runInteractive(
-    args: string[],
+    args: string[] = [],
     options: { waitForReady?: boolean } = {},
   ): Promise<InteractiveRun> {
     const { waitForReady = true } = options;

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -901,11 +901,15 @@ export class TestRig {
     return null;
   }
 
-  async runInteractive(...args: string[]): Promise<InteractiveRun> {
+  async runInteractive(
+    args: string[],
+    options: { waitForReady?: boolean } = {},
+  ): Promise<InteractiveRun> {
+    const { waitForReady = true } = options;
     const { command, initialArgs } = this._getCommandAndArgs(['--yolo']);
     const commandArgs = [...initialArgs, ...args];
 
-    const options: pty.IPtyForkOptions = {
+    const ptyOptions: pty.IPtyForkOptions = {
       name: 'xterm-color',
       cols: 80,
       rows: 24,
@@ -916,11 +920,13 @@ export class TestRig {
     };
 
     const executable = command === 'node' ? process.execPath : command;
-    const ptyProcess = pty.spawn(executable, commandArgs, options);
+    const ptyProcess = pty.spawn(executable, commandArgs, ptyOptions);
 
     const run = new InteractiveRun(ptyProcess);
-    // Wait for the app to be ready
-    await run.expectText('Type your message', 30000);
+    if (waitForReady) {
+      // Wait for the app to be ready
+      await run.expectText('Type your message', 30000);
+    }
     return run;
   }
 }

--- a/packages/core/src/code_assist/oauth-credential-storage.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.ts
@@ -6,13 +6,9 @@
 
 import { type Credentials } from 'google-auth-library';
 import { HybridTokenStorage } from '../mcp/token-storage/hybrid-token-storage.js';
-import { OAUTH_FILE } from '../config/storage.js';
+import { Storage } from '../config/storage.js';
 import type { OAuthCredentials } from '../mcp/token-storage/types.js';
-import * as path from 'node:path';
-import * as os from 'node:os';
 import { promises as fs } from 'node:fs';
-import { GEMINI_DIR } from '../utils/paths.js';
-
 const KEYCHAIN_SERVICE_NAME = 'gemini-cli-oauth';
 const MAIN_ACCOUNT_KEY = 'main-account';
 
@@ -86,7 +82,7 @@ export class OAuthCredentialStorage {
       await this.storage.deleteCredentials(MAIN_ACCOUNT_KEY);
 
       // Also try to remove the old file if it exists
-      const oldFilePath = path.join(os.homedir(), GEMINI_DIR, OAUTH_FILE);
+      const oldFilePath = Storage.getOAuthCredsPath();
       await fs.rm(oldFilePath, { force: true }).catch(() => {});
     } catch (error: unknown) {
       console.error(error);
@@ -98,7 +94,7 @@ export class OAuthCredentialStorage {
    * Migrate credentials from old file-based storage to keychain
    */
   private static async migrateFromFileStorage(): Promise<Credentials | null> {
-    const oldFilePath = path.join(os.homedir(), GEMINI_DIR, OAUTH_FILE);
+    const oldFilePath = Storage.getOAuthCredsPath();
 
     let credsJson: string;
     try {

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -77,6 +77,9 @@ export class Storage {
   }
 
   static getOAuthCredsPath(): string {
+    if (process.env['GEMINI_OAUTH_CREDS_PATH']) {
+      return process.env['GEMINI_OAUTH_CREDS_PATH'];
+    }
     return path.join(Storage.getGlobalGeminiDir(), OAUTH_FILE);
   }
 


### PR DESCRIPTION
## TLDR

Added tests for no auth method, Gemini API key, Vertex AI auth(non express mode), and for 'Login with Google' to test that it triggers browser request and that it uses cached creds if available.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to https://github.com/google-gemini/gemini-cli/issues/6787
