### PR TITLE
fix: set a2a-server publish to --no-tag

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -209,9 +209,9 @@ runs:
       # Tag staging for initial release
       run: |
         if [ "${{ inputs.dry-run }}" == "true" ]; then
-          npm publish --dry-run --workspace="@google/gemini-cli-a2a-server"
+          npm publish --dry-run --workspace="@google/gemini-cli-a2a-server" --no-tag
         else
-          npm publish --workspace="@google/gemini-cli-a2a-server" --access=public
+          npm publish --workspace="@google/gemini-cli-a2a-server" --no-tag
         fi
 
     - name: '🔬 Verify NPM release by version'

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -209,9 +209,9 @@ runs:
       # Tag staging for initial release
       run: |
         if [ "${{ inputs.dry-run }}" == "true" ]; then
-          npm publish --dry-run --workspace="@google/gemini-cli-a2a-server" --tag "staging"
+          npm publish --dry-run --workspace="@google/gemini-cli-a2a-server"
         else
-          npm publish --workspace="@google/gemini-cli-a2a-server" --tag "staging"
+          npm publish --workspace="@google/gemini-cli-a2a-server"
         fi
 
     - name: '🔬 Verify NPM release by version'

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -211,7 +211,7 @@ runs:
         if [ "${{ inputs.dry-run }}" == "true" ]; then
           npm publish --dry-run --workspace="@google/gemini-cli-a2a-server"
         else
-          npm publish --workspace="@google/gemini-cli-a2a-server"
+          npm publish --workspace="@google/gemini-cli-a2a-server" --access=public
         fi
 
     - name: '🔬 Verify NPM release by version'


### PR DESCRIPTION
## TLDR

Publishing npm packages for the first time required omitting `--no-tag` and explicitly setting `--access-public`. 
Now that https://www.npmjs.com/package/@google/gemini-cli-a2a-server is published we need to reset tagging to `--no-tag` so that the npm-tag-release flow works properly.

## Dive Deeper

Nightly Release [Green Run](https://github.com/google-gemini/gemini-cli/actions/runs/18507029036/job/52738370388)

## Linked issues / bugs
Fixes: https://github.com/google-gemini/gemini-cli/issues/9207