### PR TITLE
Update extensions install warning

### DIFF
--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -19,7 +19,7 @@ interface InstallArgs {
   ref?: string;
   autoUpdate?: boolean;
   allowPreRelease?: boolean;
-  yes?: boolean;
+  consent?: boolean;
 }
 
 export async function handleInstall(args: InstallArgs) {
@@ -56,10 +56,10 @@ export async function handleInstall(args: InstallArgs) {
       }
     }
 
-    const requestConsent = args.yes
+    const requestConsent = args.consent
       ? () => Promise.resolve(true)
       : requestConsentNonInteractive;
-    if (args.yes) {
+    if (args.consent) {
       console.log('You have consented to the following:');
       console.log(INSTALL_WARNING_MESSAGE);
     }
@@ -96,12 +96,11 @@ export const installCommand: CommandModule = {
         describe: 'Enable pre-release versions for this extension.',
         type: 'boolean',
       })
-      .option('yes', {
+      .option('consent', {
         describe:
-          'Acknowledge the security risks of installing a third party extension and skip the confirmation prompt.',
+          'Acknowledge the security risks of installing an extension and skip the confirmation prompt.',
         type: 'boolean',
         default: false,
-        alias: 'y',
       })
       .check((argv) => {
         if (!argv.source) {
@@ -115,7 +114,7 @@ export const installCommand: CommandModule = {
       ref: argv['ref'] as string | undefined,
       autoUpdate: argv['auto-update'] as boolean | undefined,
       allowPreRelease: argv['pre-release'] as boolean | undefined,
-      yes: argv['yes'] as boolean | undefined,
+      consent: argv['consent'] as boolean | undefined,
     });
   },
 };

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -12,6 +12,7 @@ import {
   EXTENSIONS_CONFIG_FILENAME,
   ExtensionStorage,
   INSTALL_METADATA_FILENAME,
+  INSTALL_WARNING_MESSAGE,
   annotateActiveExtensions,
   disableExtension,
   enableExtension,
@@ -958,7 +959,7 @@ describe('extension tests', () => {
 
       expect(mockRequestConsent).toHaveBeenCalledWith(
         `Installing extension "my-local-extension".
-**Extensions may introduce unexpected behavior. Ensure you have investigated the extension source and trust the author.**
+${INSTALL_WARNING_MESSAGE}
 This extension will run the following MCP servers:
   * test-server (local): node dobadthing \\u001b[12D\\u001b[K server.js
   * test-server-2 (remote): https://google.com`,

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -50,7 +50,8 @@ export const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
 
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
 export const INSTALL_METADATA_FILENAME = '.gemini-extension-install.json';
-
+export const INSTALL_WARNING_MESSAGE =
+  '**The extension you are about to install may have been created by a third-party developer and sourced from a public repository. Google does not vet, endorse, or guarantee the functionality or security of extensions. Please carefully inspect any extension and its source code before installing to understand the permissions it requires and the actions it may perform. Do you wish to proceed with the installation?**';
 /**
  * Extension definition as written to disk in gemini-extension.json files.
  * This should *not* be referenced outside of the logic for reading files.
@@ -613,9 +614,7 @@ function extensionConsentString(extensionConfig: ExtensionConfig): string {
   const output: string[] = [];
   const mcpServerEntries = Object.entries(sanitizedConfig.mcpServers || {});
   output.push(`Installing extension "${sanitizedConfig.name}".`);
-  output.push(
-    '**Extensions may introduce unexpected behavior. Ensure you have investigated the extension source and trust the author.**',
-  );
+  output.push(INSTALL_WARNING_MESSAGE);
 
   if (mcpServerEntries.length) {
     output.push('This extension will run the following MCP servers:');

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -51,7 +51,7 @@ export const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
 export const INSTALL_METADATA_FILENAME = '.gemini-extension-install.json';
 export const INSTALL_WARNING_MESSAGE =
-  '**The extension you are about to install may have been created by a third-party developer and sourced from a public repository. Google does not vet, endorse, or guarantee the functionality or security of extensions. Please carefully inspect any extension and its source code before installing to understand the permissions it requires and the actions it may perform. Do you wish to proceed with the installation?**';
+  '**The extension you are about to install may have been created by a third-party developer and sourced from a public repository. Google does not vet, endorse, or guarantee the functionality or security of extensions. Please carefully inspect any extension and its source code before installing to understand the permissions it requires and the actions it may perform.**';
 /**
  * Extension definition as written to disk in gemini-extension.json files.
  * This should *not* be referenced outside of the logic for reading files.


### PR DESCRIPTION
## TLDR

Also added an option to auto-accept, but logging a warning of what was consented to (in case someone is sharing commands with -y attached).

## Dive Deeper

```
Installing extension "nanobanana".
**The extension you are about to install may have been created by a third-party developer and sourced from a public repository. Google does not vet, endorse, or guarantee the functionality or security of extensions. Please carefully inspect any extension and its source code before installing to understand the permissions it requires and the actions it may perform. Do you wish to proceed with the installation?**
This extension will run the following MCP servers:
  * nanobanana (local): node /Users/chrstn/.gemini/extensions/nanobanana/mcp-server/dist/index.js
This extension will append info to your gemini.md context using GEMINI.md
Do you want to continue? [Y/n]: n
Installation cancelled for "nanobanana".
````
## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #860