### PR TITLE
refactor: move `web_fetch` tool name to `tool-names.ts`

### DIFF
--- a/packages/cli/src/config/policy.test.ts
+++ b/packages/cli/src/config/policy.test.ts
@@ -7,7 +7,11 @@
 import { describe, it, expect } from 'vitest';
 import { createPolicyEngineConfig } from './policy.js';
 import type { Settings } from './settings.js';
-import { ApprovalMode, PolicyDecision } from '@google/gemini-cli-core';
+import {
+  ApprovalMode,
+  PolicyDecision,
+  WEB_FETCH_TOOL_NAME,
+} from '@google/gemini-cli-core';
 
 describe('createPolicyEngineConfig', () => {
   it('should return ASK_USER for all tools by default', () => {
@@ -19,7 +23,7 @@ describe('createPolicyEngineConfig', () => {
       { toolName: 'save_memory', decision: 'ask_user', priority: 10 },
       { toolName: 'run_shell_command', decision: 'ask_user', priority: 10 },
       { toolName: 'write_file', decision: 'ask_user', priority: 10 },
-      { toolName: 'web_fetch', decision: 'ask_user', priority: 10 },
+      { toolName: WEB_FETCH_TOOL_NAME, decision: 'ask_user', priority: 10 },
     ]);
   });
 
@@ -366,7 +370,7 @@ describe('createPolicyEngineConfig', () => {
           'save_memory',
           'run_shell_command',
           'write_file',
-          'web_fetch',
+          WEB_FETCH_TOOL_NAME,
         ].includes(r.toolName || '') && r.decision === PolicyDecision.ASK_USER,
     );
     expect(writeToolRules).toHaveLength(0);

--- a/packages/cli/src/config/policy.ts
+++ b/packages/cli/src/config/policy.ts
@@ -21,7 +21,7 @@ import {
   MemoryTool,
   ShellTool,
   WRITE_FILE_TOOL_NAME,
-  WebFetchTool,
+  WEB_FETCH_TOOL_NAME,
   WebSearchTool,
 } from '@google/gemini-cli-core';
 import type { Settings } from './settings.js';
@@ -49,7 +49,7 @@ const WRITE_TOOLS = new Set([
   MemoryTool.Name,
   ShellTool.Name,
   WRITE_FILE_TOOL_NAME,
-  WebFetchTool.Name,
+  WEB_FETCH_TOOL_NAME,
 ]);
 
 export function createPolicyEngineConfig(

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -12,6 +12,7 @@ export const GLOB_TOOL_NAME = 'glob';
 export const WRITE_TODOS_TOOL_NAME = 'write_todos';
 export const WRITE_FILE_TOOL_NAME = 'write_file';
 export const WEB_SEARCH_TOOL_NAME = 'google_web_search';
+export const WEB_FETCH_TOOL_NAME = 'web_fetch';
 
 // TODO: Migrate other tool names here to follow this pattern and prevent future circular dependencies.
 // Candidates for migration:

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -27,6 +27,7 @@ import {
   logWebFetchFallbackAttempt,
   WebFetchFallbackAttemptEvent,
 } from '../telemetry/index.js';
+import { WEB_FETCH_TOOL_NAME } from './tool-names.js';
 
 const URL_FETCH_TIMEOUT_MS = 10000;
 const MAX_CONTENT_LENGTH = 100000;
@@ -364,7 +365,7 @@ export class WebFetchTool extends BaseDeclarativeTool<
   WebFetchToolParams,
   ToolResult
 > {
-  static readonly Name: string = 'web_fetch';
+  static readonly Name: string = WEB_FETCH_TOOL_NAME;
 
   constructor(private readonly config: Config) {
     super(


### PR DESCRIPTION
## TLDR

This PR moves the hardcoded `'web_fetch'` string used for the Web Fetch tool name into the centralized `packages/core/src/tools/tool-names.ts` file as `WEB_FETCH_TOOL_NAME`. It updates the tool implementation, policy configuration, and tests to use this exported constant.

This should be a no-op

## Reviewer Test Plan

This is a refactor with no functional changes. Verification relies on the build and test suite.

1. Checkout this branch.
2. Run `npm run build` to verify there are no TypeScript errors related to imports or variable usage.
3. Run `npm run test` to ensure all tests pass, specifically `packages/cli/src/config/policy.test.ts` which was modified.
4. (Optional) Run `npm run preflight` for a comprehensive check.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |
