### PR TITLE
Enable test-level parallelism for integration suite

### DIFF
--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -230,6 +230,7 @@ export class TestRig {
   testDir: string | null;
   testName?: string;
   _lastRunStdout?: string;
+  private static runCounter = 0;
 
   constructor() {
     this.bundlePath = join(__dirname, '..', 'bundle/gemini.js');
@@ -242,7 +243,9 @@ export class TestRig {
   ) {
     this.testName = testName;
     const sanitizedName = sanitizeTestName(testName);
-    this.testDir = join(env['INTEGRATION_TEST_FILE_DIR']!, sanitizedName);
+    const runId = (++TestRig.runCounter).toString(36).padStart(4, '0');
+    const uniqueName = `${sanitizedName}-${runId}`;
+    this.testDir = join(env['INTEGRATION_TEST_FILE_DIR']!, uniqueName);
     mkdirSync(this.testDir, { recursive: true });
 
     // Create a settings file to point the CLI to the local collector

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -16,6 +16,7 @@ import * as pty from '@lydell/node-pty';
 import stripAnsi from 'strip-ansi';
 import * as os from 'node:os';
 import { GEMINI_DIR } from '../packages/core/src/utils/paths.js';
+import crypto from 'node:crypto';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -230,7 +231,6 @@ export class TestRig {
   testDir: string | null;
   testName?: string;
   _lastRunStdout?: string;
-  private static runCounter = 0;
 
   constructor() {
     this.bundlePath = join(__dirname, '..', 'bundle/gemini.js');
@@ -243,8 +243,8 @@ export class TestRig {
   ) {
     this.testName = testName;
     const sanitizedName = sanitizeTestName(testName);
-    const runId = (++TestRig.runCounter).toString(36).padStart(4, '0');
-    const uniqueName = `${sanitizedName}-${runId}`;
+    const randomSuffix = crypto.randomBytes(2).toString('hex');
+    const uniqueName = `${sanitizedName}-${randomSuffix}`;
     this.testDir = join(env['INTEGRATION_TEST_FILE_DIR']!, uniqueName);
     mkdirSync(this.testDir, { recursive: true });
 

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -20,5 +20,8 @@ export default defineConfig({
         maxThreads: 16,
       },
     },
+    sequence: {
+      concurrent: true,
+    },
   },
 });


### PR DESCRIPTION
Enable Vitest sequence-level concurrency for integration tests so individual cases can run in parallel.

Adds a random suffix to the test directory to ensure that tests do not collide in output artifacts.

Speeds up E2E testing from ~180 seconds to ~20 seconds.