### PR TITLE
feat(core): Add no-op finish tool.

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -83,6 +83,7 @@ const MIGRATION_MAP: Record<string, string> = {
   fileFiltering: 'context.fileFiltering',
   folderTrustFeature: 'security.folderTrust.featureEnabled',
   folderTrust: 'security.folderTrust.enabled',
+  enableFinishTool: 'experimental.enableFinishTool',
   hasSeenIdeIntegrationNudge: 'ide.hasSeenNudge',
   hideWindowTitle: 'ui.hideWindowTitle',
   showStatusInTitle: 'ui.showStatusInTitle',

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -330,5 +330,32 @@ describe('SettingsSchema', () => {
         getSettingsSchema().experimental.properties.useModelRouter.default,
       ).toBe(true);
     });
+
+    it('should have enableFinishTool setting in schema', () => {
+      expect(
+        getSettingsSchema().experimental.properties.enableFinishTool,
+      ).toBeDefined();
+      expect(
+        getSettingsSchema().experimental.properties.enableFinishTool.type,
+      ).toBe('boolean');
+      expect(
+        getSettingsSchema().experimental.properties.enableFinishTool.category,
+      ).toBe('Experimental');
+      expect(
+        getSettingsSchema().experimental.properties.enableFinishTool.default,
+      ).toBe(false);
+      expect(
+        getSettingsSchema().experimental.properties.enableFinishTool
+          .requiresRestart,
+      ).toBe(true);
+      expect(
+        getSettingsSchema().experimental.properties.enableFinishTool
+          .showInDialog,
+      ).toBe(false);
+      expect(
+        getSettingsSchema().experimental.properties.enableFinishTool
+          .description,
+      ).toBe('Enable the finish tool to explicitly end a turn.');
+    });
   });
 });

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1076,6 +1076,15 @@ const SETTINGS_SCHEMA = {
           'Enable model routing to route requests to the best model based on complexity.',
         showInDialog: true,
       },
+      enableFinishTool: {
+        type: 'boolean',
+        label: 'Enable Finish Tool',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enable the finish tool to explicitly end a turn.',
+        showInDialog: false,
+      },
       codebaseInvestigatorSettings: {
         type: 'object',
         label: 'Codebase Investigator Settings',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -78,6 +78,7 @@ import { ProxyAgent, setGlobalDispatcher } from 'undici';
 
 import { AgentRegistry } from '../agents/registry.js';
 import { SubagentToolWrapper } from '../agents/subagent-tool-wrapper.js';
+import { FinishTool } from '../tools/finish.js';
 
 export enum ApprovalMode {
   DEFAULT = 'default',
@@ -280,6 +281,7 @@ export interface ConfigParameters {
   continueOnFailedApiCall?: boolean;
   retryFetchErrors?: boolean;
   enableShellOutputEfficiency?: boolean;
+  enableFinishTool?: boolean;
 }
 
 export class Config {
@@ -375,6 +377,7 @@ export class Config {
   private readonly continueOnFailedApiCall: boolean;
   private readonly retryFetchErrors: boolean;
   private readonly enableShellOutputEfficiency: boolean;
+  private readonly enableFinishTool: boolean;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -471,6 +474,7 @@ export class Config {
     this.continueOnFailedApiCall = params.continueOnFailedApiCall ?? true;
     this.enableShellOutputEfficiency =
       params.enableShellOutputEfficiency ?? true;
+    this.enableFinishTool = params.enableFinishTool ?? false;
     this.extensionManagement = params.extensionManagement ?? true;
     this.storage = new Storage(this.targetDir);
     this.enablePromptCompletion = params.enablePromptCompletion ?? false;
@@ -981,6 +985,10 @@ export class Config {
     return this.enableShellOutputEfficiency;
   }
 
+  getEnableFinishTool(): boolean {
+    return this.enableFinishTool;
+  }
+
   getShellExecutionConfig(): ShellExecutionConfig {
     return this.shellExecutionConfig;
   }
@@ -1155,6 +1163,9 @@ export class Config {
     registerCoreTool(WebSearchTool, this);
     if (this.getUseWriteTodos()) {
       registerCoreTool(WriteTodosTool, this);
+    }
+    if (this.getEnableFinishTool()) {
+      registerCoreTool(FinishTool);
     }
 
     // Register Subagents as Tools

--- a/packages/core/src/tools/finish.test.ts
+++ b/packages/core/src/tools/finish.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FinishTool } from './finish.js';
+import { Kind } from './tools.js';
+
+describe('FinishTool', () => {
+  it('should have the correct properties', () => {
+    const tool = new FinishTool();
+    expect(tool.name).toBe('finish');
+    expect(tool.displayName).toBe('Finish');
+    expect(tool.description).toBe('Signals that the AI has finished its turn.');
+    expect(tool.kind).toBe(Kind.Other);
+    expect(
+      (tool.schema.parametersJsonSchema as { properties: unknown }).properties,
+    ).toHaveProperty('summary');
+  });
+
+  it('should create a valid invocation', () => {
+    const tool = new FinishTool();
+    const params = { summary: 'All tasks are complete.' };
+    const invocation = tool.build(params);
+    expect(invocation).toBeDefined();
+    expect(invocation.params).toEqual(params);
+  });
+
+  describe('FinishToolInvocation', () => {
+    it('should have a correct description', () => {
+      const tool = new FinishTool();
+      const params = { summary: 'The task is done.' };
+      const invocation = tool.build(params);
+      expect(invocation.getDescription()).toBe(
+        'Finishing turn with summary: The task is done.',
+      );
+    });
+
+    it('should execute and return the summary', async () => {
+      const tool = new FinishTool();
+      const params = { summary: 'Successfully refactored the component.' };
+      const invocation = tool.build(params);
+      const signal = new AbortController().signal;
+      const result = await invocation.execute(signal);
+      expect(result.llmContent).toBe(
+        'Finished: Successfully refactored the component.',
+      );
+      expect(result.returnDisplay).toBe(
+        'Finished: Successfully refactored the component.',
+      );
+    });
+  });
+});

--- a/packages/core/src/tools/finish.ts
+++ b/packages/core/src/tools/finish.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ToolInvocation, ToolResult } from './tools.js';
+import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+
+interface FinishToolParams {
+  summary: string;
+}
+
+export class FinishTool extends BaseDeclarativeTool<
+  FinishToolParams,
+  ToolResult
+> {
+  constructor() {
+    super(
+      'finish',
+      'Finish',
+      'Signals that the AI has finished its turn.',
+      Kind.Other,
+      {
+        type: 'object',
+        properties: {
+          summary: {
+            type: 'string',
+            description: 'A summary of what was finished.',
+          },
+        },
+        required: ['summary'],
+      },
+      false,
+      false,
+    );
+  }
+
+  protected createInvocation(
+    params: FinishToolParams,
+  ): ToolInvocation<FinishToolParams, ToolResult> {
+    return new FinishToolInvocation(params);
+  }
+}
+
+class FinishToolInvocation extends BaseToolInvocation<
+  FinishToolParams,
+  ToolResult
+> {
+  getDescription(): string {
+    return `Finishing turn with summary: ${this.params.summary}`;
+  }
+
+  async execute(): Promise<ToolResult> {
+    return {
+      llmContent: `Finished: ${this.params.summary}`,
+      returnDisplay: `Finished: ${this.params.summary}`,
+    };
+  }
+}


### PR DESCRIPTION
## TLDR

Adds a simple no-op finish tool behind an experimental setting.

## Reviewer Test Plan

Download patch and attempt tasks.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | :heavy_check_mark:   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

A first attempt to resolve https://github.com/google-gemini/gemini-cli/issues/10505
