### PR TITLE
fix(ci): Move from self-hosted -> ubuntu-latest

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -47,7 +47,7 @@ on:
 
 jobs:
   release:
-    runs-on: 'self-hosted'
+    runs-on: 'ubuntu-latest'
     environment: '${{ github.event.inputs.environment }}'
     permissions:
       contents: 'write'


### PR DESCRIPTION
I think this got gobbled in a merge conflict, however, self-hosted runners are broken and we should be using `ubuntu-latest`