### PR TITLE
feat: Allow expanding MCP call arguments

### DIFF
--- a/docs/cli/keyboard-shortcuts.md
+++ b/docs/cli/keyboard-shortcuts.md
@@ -62,6 +62,12 @@ This document lists the available keyboard shortcuts in the Gemini CLI.
 | `1-9`              | Select an item by its number.                                                                                 |
 | (multi-digit)      | For items with numbers greater than 9, press the digits in quick succession to select the corresponding item. |
 
+## Tool Use
+
+| Shortcut | Description                                                                                          |
+| -------- | ---------------------------------------------------------------------------------------------------- |
+| `Ctrl+S` | When confirming an MCP tool call, toggle display of the input arguments to the MCP server (as JSON). |
+
 ## IDE Integration
 
 | Shortcut | Description                       |

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -52,6 +52,9 @@ export enum Command {
   EXIT = 'exit',
   SHOW_MORE_LINES = 'showMoreLines',
 
+  // Tool calling
+  TOGGLE_TOOL_CALL_ARGUMENTS_EXPANSION = 'toggleToolCallArgumentsExpansion',
+
   // Shell commands
   REVERSE_SEARCH = 'reverseSearch',
   SUBMIT_REVERSE_SEARCH = 'submitReverseSearch',
@@ -161,6 +164,9 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.QUIT]: [{ key: 'c', ctrl: true }],
   [Command.EXIT]: [{ key: 'd', ctrl: true }],
   [Command.SHOW_MORE_LINES]: [{ key: 's', ctrl: true }],
+
+  // Tool calling
+  [Command.TOGGLE_TOOL_CALL_ARGUMENTS_EXPANSION]: [{ key: 's', ctrl: true }],
 
   // Shell commands
   [Command.REVERSE_SEARCH]: [{ key: 'r', ctrl: true }],

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -963,7 +963,8 @@ Logging in with Google... Please restart Gemini CLI to continue.
       ) {
         handleSlashCommand('/ide status');
       } else if (
-        keyMatchers[Command.SHOW_MORE_LINES](key) &&
+        (keyMatchers[Command.SHOW_MORE_LINES](key) ||
+          keyMatchers[Command.TOGGLE_TOOL_CALL_ARGUMENTS_EXPANSION](key)) &&
         !enteringConstrainHeightMode
       ) {
         setConstrainHeight(false);

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -963,8 +963,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       ) {
         handleSlashCommand('/ide status');
       } else if (
-        (keyMatchers[Command.SHOW_MORE_LINES](key) ||
-          keyMatchers[Command.TOGGLE_TOOL_CALL_ARGUMENTS_EXPANSION](key)) &&
+        keyMatchers[Command.SHOW_MORE_LINES](key) &&
         !enteringConstrainHeightMode
       ) {
         setConstrainHeight(false);

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
@@ -100,6 +100,7 @@ describe('ToolConfirmationMessage', () => {
       serverName: 'test-server',
       toolName: 'test-tool',
       toolDisplayName: 'Test Tool',
+      args: {},
       onConfirm: vi.fn(),
     };
 

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -44,6 +44,7 @@ export const ToolConfirmationMessage: React.FC<
 
   const [ideClient, setIdeClient] = useState<IdeClient | null>(null);
   const [isDiffingEnabled, setIsDiffingEnabled] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -83,6 +84,8 @@ export const ToolConfirmationMessage: React.FC<
       if (!isFocused) return;
       if (key.name === 'escape' || (key.ctrl && key.name === 'c')) {
         handleConfirm(ToolConfirmationOutcome.Cancel);
+      } else if (key.ctrl && key.name === 's') {
+        setIsExpanded((prev) => !prev);
       }
     },
     { isActive: isFocused },
@@ -273,6 +276,14 @@ export const ToolConfirmationMessage: React.FC<
       <Box flexDirection="column" paddingX={1} marginLeft={1}>
         <Text color={theme.text.link}>MCP Server: {mcpProps.serverName}</Text>
         <Text color={theme.text.link}>Tool: {mcpProps.toolName}</Text>
+        {isExpanded && (
+          <Text color={theme.text.link}>
+            Arguments: {JSON.stringify(mcpProps.args, null, 2)}
+          </Text>
+        )}
+        <Text color={theme.text.secondary}>
+          (Press CTRL+s to {isExpanded ? 'collapse' : 'expand'} arguments)
+        </Text>
       </Box>
     );
 

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -58,6 +58,8 @@ describe('keyMatchers', () => {
     [Command.QUIT]: (key: Key) => key.ctrl && key.name === 'c',
     [Command.EXIT]: (key: Key) => key.ctrl && key.name === 'd',
     [Command.SHOW_MORE_LINES]: (key: Key) => key.ctrl && key.name === 's',
+    [Command.TOGGLE_TOOL_CALL_ARGUMENTS_EXPANSION]: (key: Key) =>
+      key.ctrl && key.name === 's',
     [Command.REVERSE_SEARCH]: (key: Key) => key.ctrl && key.name === 'r',
     [Command.SUBMIT_REVERSE_SEARCH]: (key: Key) =>
       key.name === 'return' && !key.ctrl,
@@ -237,6 +239,13 @@ describe('keyMatchers', () => {
     },
     {
       command: Command.SHOW_MORE_LINES,
+      positive: [createKey('s', { ctrl: true })],
+      negative: [createKey('s'), createKey('l', { ctrl: true })],
+    },
+
+    // Tool calling
+    {
+      command: Command.TOGGLE_TOOL_CALL_ARGUMENTS_EXPANSION,
       positive: [createKey('s', { ctrl: true })],
       negative: [createKey('s'), createKey('l', { ctrl: true })],
     },

--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -86,6 +86,7 @@ describe('textUtils', () => {
             serverName: '\u001b[31mmy-server\u001b[0m',
             toolName: '\u001b[32mdeploy\u001b[0m',
             toolDisplayName: '\u001b[33mDeploy Service\u001b[0m',
+            args: { a: '\u001b[35mvalue\u001b[0m' },
             onConfirm: async () => {},
           };
 
@@ -97,6 +98,9 @@ describe('textUtils', () => {
             expect(sanitized.toolName).toBe('\\u001b[32mdeploy\\u001b[0m');
             expect(sanitized.toolDisplayName).toBe(
               '\\u001b[33mDeploy Service\\u001b[0m',
+            );
+            expect((sanitized.args as { a: string }).a).toBe(
+              '\\u001b[35mvalue\\u001b[0m',
             );
           }
         });

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -98,6 +98,7 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
       serverName: this.serverName,
       toolName: this.serverToolName, // Display original tool name in confirmation
       toolDisplayName: this.displayName, // Display global registry name exposed to model and user
+      args: this.params,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlwaysServer) {
           DiscoveredMCPToolInvocation.allowlist.add(serverAllowListKey);

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -619,6 +619,7 @@ export interface ToolMcpConfirmationDetails {
   serverName: string;
   toolName: string;
   toolDisplayName: string;
+  args: Record<string, unknown>;
   onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
 }
 


### PR DESCRIPTION
## TLDR

During confirmation, the arguments to the MCP call can now be expanded using CTRL+s. I'm a bit worried about the interplay with the `Command.SHOW_MORE_LINES` (in `keyBindings.ts`), which shares the same keybinding, but was unable to produce a test case.

## Reviewer Test Plan

Ask the model to execute any of your configured MCP servers that takes arguments; then press CTRL+s to toggle display of the arguments.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Closes #11031.
