### PR TITLE
chore(release): bump version to 0.11.0-nightly.20251015.203bad7c

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.10.0-nightly.20251007.c195a9aa",
+  "version": "0.11.0-nightly.20251015.203bad7c",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@google/gemini-cli",
-      "version": "0.10.0-nightly.20251007.c195a9aa",
+      "version": "0.11.0-nightly.20251015.203bad7c",
       "workspaces": [
         "packages/*"
       ],
@@ -17601,7 +17601,7 @@
     },
     "packages/a2a-server": {
       "name": "@google/gemini-cli-a2a-server",
-      "version": "0.10.0-nightly.20251007.c195a9aa",
+      "version": "0.11.0-nightly.20251015.203bad7c",
       "dependencies": {
         "@a2a-js/sdk": "^0.3.2",
         "@google-cloud/storage": "^7.16.0",
@@ -17875,7 +17875,7 @@
     },
     "packages/cli": {
       "name": "@google/gemini-cli",
-      "version": "0.10.0-nightly.20251007.c195a9aa",
+      "version": "0.11.0-nightly.20251015.203bad7c",
       "dependencies": {
         "@google/gemini-cli-core": "file:../core",
         "@google/genai": "1.16.0",
@@ -17988,7 +17988,7 @@
     },
     "packages/core": {
       "name": "@google/gemini-cli-core",
-      "version": "0.10.0-nightly.20251007.c195a9aa",
+      "version": "0.11.0-nightly.20251015.203bad7c",
       "dependencies": {
         "@google-cloud/logging": "^11.2.1",
         "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
@@ -18127,7 +18127,7 @@
     },
     "packages/test-utils": {
       "name": "@google/gemini-cli-test-utils",
-      "version": "0.10.0-nightly.20251007.c195a9aa",
+      "version": "0.11.0-nightly.20251015.203bad7c",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -18138,7 +18138,7 @@
     },
     "packages/vscode-ide-companion": {
       "name": "gemini-cli-vscode-ide-companion",
-      "version": "0.10.0-nightly.20251007.c195a9aa",
+      "version": "0.11.0-nightly.20251015.203bad7c",
       "license": "LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.10.0-nightly.20251007.c195a9aa",
+  "version": "0.11.0-nightly.20251015.203bad7c",
   "engines": {
     "node": ">=20.0.0"
   },
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/google-gemini/gemini-cli.git"
   },
   "config": {
-    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.10.0-nightly.20251007.c195a9aa"
+    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.11.0-nightly.20251015.203bad7c"
   },
   "scripts": {
     "start": "cross-env NODE_ENV=development node scripts/start.js",

--- a/packages/a2a-server/package.json
+++ b/packages/a2a-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli-a2a-server",
-  "version": "0.10.0-nightly.20251007.c195a9aa",
+  "version": "0.11.0-nightly.20251015.203bad7c",
   "description": "Gemini CLI A2A Server",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.10.0-nightly.20251007.c195a9aa",
+  "version": "0.11.0-nightly.20251015.203bad7c",
   "description": "Gemini CLI",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.10.0-nightly.20251007.c195a9aa"
+    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.11.0-nightly.20251015.203bad7c"
   },
   "dependencies": {
     "@google/gemini-cli-core": "file:../core",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli-core",
-  "version": "0.10.0-nightly.20251007.c195a9aa",
+  "version": "0.11.0-nightly.20251015.203bad7c",
   "description": "Gemini CLI Core",
   "repository": {
     "type": "git",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli-test-utils",
-  "version": "0.10.0-nightly.20251007.c195a9aa",
+  "version": "0.11.0-nightly.20251015.203bad7c",
   "private": true,
   "main": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -2,7 +2,7 @@
   "name": "gemini-cli-vscode-ide-companion",
   "displayName": "Gemini CLI Companion",
   "description": "Enable Gemini CLI with direct access to your IDE workspace.",
-  "version": "0.10.0-nightly.20251007.c195a9aa",
+  "version": "0.11.0-nightly.20251015.203bad7c",
   "publisher": "google",
   "icon": "assets/icon.png",
   "repository": {


### PR DESCRIPTION
Version bump to prepare for the next nightly release.