### PR TITLE
refactor(actions): remove checkout from sub-actions

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -226,7 +226,7 @@ runs:
       with:
         npm-package: '${{ inputs.cli-package-name }}@${{ inputs.release-version }}'
         expected-version: '${{ inputs.release-version }}'
-        ref: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
+        working-directory: '${{ inputs.working-directory }}'
         gemini_api_key: '${{ inputs.gemini_api_key }}'
         github-token: '${{ inputs.github-token }}'
         npm-registry-url: '${{ inputs.npm-registry-url }}'
@@ -246,6 +246,7 @@ runs:
         cli-package-name: '${{ inputs.cli-package-name }}'
         core-package-name: '${{ inputs.core-package-name }}'
         a2a-package-name: '${{ inputs.a2a-package-name }}'
+        working-directory: '${{ inputs.working-directory }}'
 
     - name: '🎉 Create GitHub Release'
       working-directory: '${{ inputs.working-directory }}'

--- a/.github/actions/tag-npm-release/action.yml
+++ b/.github/actions/tag-npm-release/action.yml
@@ -32,11 +32,10 @@ inputs:
   a2a-package-name:
     description: 'The name of the a2a package.'
     required: true
-  ref:
-    description: 'The branch, tag, or SHA to release from.'
+  working-directory:
+    description: 'The working directory to run the commands in.'
     required: false
-    type: 'string'
-    default: 'main'
+    default: '.'
 
 runs:
   using: 'composite'
@@ -47,16 +46,10 @@ runs:
         JSON_INPUTS: '${{ toJSON(inputs) }}'
       run: 'echo "$JSON_INPUTS"'
 
-    - name: 'Checkout'
-      uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v4
-      with:
-        ref: '${{ github.event.inputs.ref }}'
-        fetch-depth: 0
-
     - name: 'Setup Node.js'
       uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
       with:
-        node-version-file: '.nvmrc'
+        node-version-file: '${{ inputs.working-directory }}/.nvmrc'
 
     - name: 'configure .npmrc'
       uses: './.github/actions/setup-npmrc'
@@ -79,6 +72,7 @@ runs:
       env:
         NODE_AUTH_TOKEN: '${{ steps.core-token.outputs.auth-token }}'
       shell: 'bash'
+      working-directory: '${{ inputs.working-directory }}'
       run: |
         npm dist-tag add ${{ inputs.core-package-name }}@${{ inputs.version }} ${{ inputs.channel }}
 
@@ -98,6 +92,7 @@ runs:
       env:
         NODE_AUTH_TOKEN: '${{ steps.cli-token.outputs.auth-token }}'
       shell: 'bash'
+      working-directory: '${{ inputs.working-directory }}'
       run: |
         npm dist-tag add ${{ inputs.cli-package-name }}@${{ inputs.version }} ${{ inputs.channel }}
 
@@ -107,6 +102,7 @@ runs:
       env:
         NODE_AUTH_TOKEN: '${{ inputs.wombat-token-a2a-server }}'
       shell: 'bash'
+      working-directory: '${{ inputs.working-directory }}'
       run: |
         npm dist-tag add @google/gemini-cli-a2a-server@${{ inputs.version }} ${{ inputs.channel }}
 
@@ -114,5 +110,6 @@ runs:
       if: |-
         ${{ inputs.dry-run == 'true' }}
       shell: 'bash'
+      working-directory: '${{ inputs.working-directory }}'
       run: |
         echo "Dry run: Would have added tag '${{ inputs.channel }}' to version '${{ inputs.version }}' for @google/gemini-cli and @google/gemini-cli-core."

--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -21,11 +21,10 @@ inputs:
   github-token:
     description: 'The GitHub token for running integration tests.'
     required: true
-  ref:
-    description: 'The branch, tag, or SHA to release from.'
+  working-directory:
+    description: 'The working directory to run the tests in.'
     required: false
-    type: 'string'
-    default: 'main'
+    default: '.'
 
 runs:
   using: 'composite'
@@ -35,13 +34,6 @@ runs:
       env:
         JSON_INPUTS: '${{ toJSON(inputs) }}'
       run: 'echo "$JSON_INPUTS"'
-
-    - name: 'Checkout'
-      uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v4
-      with:
-        path: 'verify'
-        ref: '${{ github.event.inputs.ref }}'
-        fetch-depth: 0
 
     - name: 'setup node'
       uses: 'actions/setup-node@v4'
@@ -64,12 +56,12 @@ runs:
         retry_wait_seconds: 30
         max_attempts: 10
         command: |-
-          cd ./verify
+          cd ${{ inputs.working-directory }}
           npm install --prefer-online --no-cache -g "${{ inputs.npm-package }}"
 
     - name: 'Smoke test - NPM Install'
       shell: 'bash'
-      working-directory: './verify'
+      working-directory: '${{ inputs.working-directory }}'
       run: |-
         gemini_version=$(gemini --version)
         if [ "$gemini_version" != "${{ inputs.expected-version }}" ]; then
@@ -83,7 +75,7 @@ runs:
 
     - name: 'Smoke test - NPX Run'
       shell: 'bash'
-      working-directory: './verify'
+      working-directory: '${{ inputs.working-directory }}'
       run: |-
         gemini_version=$(npx --prefer-online "${{ inputs.npm-package}}" --version)
         if [ "$gemini_version" != "${{ inputs.expected-version }}" ]; then
@@ -93,11 +85,11 @@ runs:
 
     - name: 'Install dependencies for integration tests'
       shell: 'bash'
-      working-directory: './verify'
+      working-directory: '${{ inputs.working-directory }}'
       run: 'npm ci'
 
     - name: '🔬 Run integration tests against NPM release'
-      working-directory: './verify'
+      working-directory: '${{ inputs.working-directory }}'
       env:
         GEMINI_API_KEY: '${{ inputs.gemini_api_key }}'
         INTEGRATION_TEST_USE_INSTALLED_GEMINI: 'true'

--- a/.github/workflows/release-change-tags.yml
+++ b/.github/workflows/release-change-tags.yml
@@ -62,4 +62,4 @@ jobs:
           cli-package-name: '${{ vars.CLI_PACKAGE_NAME }}'
           core-package-name: '${{ vars.CORE_PACKAGE_NAME }}'
           a2a-package-name: '${{ vars.A2A_PACKAGE_NAME }}'
-          ref: '${{ github.ref }}'
+          working-directory: '.'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -75,7 +75,7 @@ jobs:
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: './release/.nvmrc'
           cache: 'npm'
 
       - name: 'Install Dependencies'

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           npm-package: '${{vars.CLI_PACKAGE_NAME}}@${{github.event.inputs.npm-tag}}'
           expected-version: '${{github.event.inputs.version}}'
-          ref: '${{github.ref}}'
+          working-directory: '.'
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           npm-registry-url: '${{ vars.NPM_REGISTRY_URL }}'
           github-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Removes git checkout steps and `ref` inputs from `tag-npm-release` and `verify-release` actions. These actions now use a `working-directory` input, making them more modular and reusable.

Updates the calling workflows to pass the `working-directory` and removes the `ref` input where it is no longer needed. Also corrects an inconsistent path to the `.nvmrc` file in the `release-manual` workflow.

### Testing

- [release-change-tags.yml](https://github.com/google-gemini/gemini-cli/actions/runs/18538126995)
- [verify-release.yml](https://github.com/google-gemini/gemini-cli/actions/runs/18538248850)
- [release-manual.yml (dry run)](https://github.com/google-gemini/gemini-cli/actions/runs/18538599293)