### PR TITLE
refactor: Remove deprecated --all-files flag

### DIFF
--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -233,12 +233,12 @@ gemini -p "List programming languages" | grep -i "python"
 
 Key command-line options for headless usage:
 
-| Option            | Description                        | Example                                  |
-| ----------------- | ---------------------------------- | ---------------------------------------- |
-| `--prompt`, `-p`  | Run in headless mode               | `gemini -p "query"`                      |
-| `--output-format` | Specify output format (text, json) | `gemini -p "query" --output-format json` |
-| `--model`, `-m`   | Specify the Gemini model           | `gemini -p "query" -m gemini-2.5-flash`  |
-| `--debug`, `-d`   | Enable debug mode                  | `gemini -p "query" --debug`              |
+| Option                  | Description                        | Example                                            |
+| ----------------------- | ---------------------------------- | -------------------------------------------------- |
+| `--prompt`, `-p`        | Run in headless mode               | `gemini -p "query"`                                |
+| `--output-format`       | Specify output format (text, json) | `gemini -p "query" --output-format json`           |
+| `--model`, `-m`         | Specify the Gemini model           | `gemini -p "query" -m gemini-2.5-flash`            |
+| `--debug`, `-d`         | Enable debug mode                  | `gemini -p "query" --debug`                        |
 | `--include-directories` | Include additional directories     | `gemini -p "query" --include-directories src,docs` |
 | `--yolo`, `-y`          | Auto-approve all actions           | `gemini -p "query" --yolo`                         |
 | `--approval-mode`       | Set approval mode                  | `gemini -p "query" --approval-mode auto_edit`      |

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -233,16 +233,17 @@ gemini -p "List programming languages" | grep -i "python"
 
 Key command-line options for headless usage:
 
-| Option                  | Description                        | Example                                            |
-| ----------------------- | ---------------------------------- | -------------------------------------------------- |
-| `--prompt`, `-p`        | Run in headless mode               | `gemini -p "query"`                                |
-| `--output-format`       | Specify output format (text, json) | `gemini -p "query" --output-format json`           |
-| `--model`, `-m`         | Specify the Gemini model           | `gemini -p "query" -m gemini-2.5-flash`            |
-| `--debug`, `-d`         | Enable debug mode                  | `gemini -p "query" --debug`                        |
-| `--all-files`, `-a`     | Include all files in context       | `gemini -p "query" --all-files`                    |
-| `--include-directories` | Include additional directories     | `gemini -p "query" --include-directories src,docs` |
-| `--yolo`, `-y`          | Auto-approve all actions           | `gemini -p "query" --yolo`                         |
-| `--approval-mode`       | Set approval mode                  | `gemini -p "query" --approval-mode auto_edit`      |
+| Option            | Description                        | Example                                  |
+| ----------------- | ---------------------------------- | ---------------------------------------- |
+| `--prompt`, `-p`  | Run in headless mode               | `gemini -p "query"`                      |
+| `--output-format` | Specify output format (text, json) | `gemini -p "query" --output-format json` |
+| `--model`, `-m`   | Specify the Gemini model           | `gemini -p "query" -m gemini-2.5-flash`  |
+| `--debug`, `-d`   | Enable debug mode                  | `gemini -p "query" --debug`              |
+
+| `--include-directories` | Include additional directories |
+`gemini -p "query" --include-directories src,docs` | | `--yolo`, `-y` |
+Auto-approve all actions | `gemini -p "query" --yolo` | | `--approval-mode` |
+Set approval mode | `gemini -p "query" --approval-mode auto_edit` |
 
 For complete details on all available configuration options, settings files, and
 environment variables, see the

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -239,11 +239,9 @@ Key command-line options for headless usage:
 | `--output-format` | Specify output format (text, json) | `gemini -p "query" --output-format json` |
 | `--model`, `-m`   | Specify the Gemini model           | `gemini -p "query" -m gemini-2.5-flash`  |
 | `--debug`, `-d`   | Enable debug mode                  | `gemini -p "query" --debug`              |
-
-| `--include-directories` | Include additional directories |
-`gemini -p "query" --include-directories src,docs` | | `--yolo`, `-y` |
-Auto-approve all actions | `gemini -p "query" --yolo` | | `--approval-mode` |
-Set approval mode | `gemini -p "query" --approval-mode auto_edit` |
+| `--include-directories` | Include additional directories     | `gemini -p "query" --include-directories src,docs` |
+| `--yolo`, `-y`          | Auto-approve all actions           | `gemini -p "query" --yolo`                         |
+| `--approval-mode`       | Set approval mode                  | `gemini -p "query" --approval-mode auto_edit`      |
 
 For complete details on all available configuration options, settings files, and
 environment variables, see the

--- a/docs/get-started/configuration-v1.md
+++ b/docs/get-started/configuration-v1.md
@@ -673,9 +673,7 @@ for that specific session.
   - Sets the sandbox image URI.
 - **`--debug`** (**`-d`**):
   - Enables debug mode for this session, providing more verbose output.
-- **`--all-files`** (**`-a`**):
-  - If set, recursively includes all files within the current directory as
-    context for the prompt.
+
 - **`--help`** (or **`-h`**):
   - Displays help information about command-line arguments.
 - **`--show-memory-usage`**:

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -726,9 +726,7 @@ for that specific session.
   - Sets the sandbox image URI.
 - **`--debug`** (**`-d`**):
   - Enables debug mode for this session, providing more verbose output.
-- **`--all-files`** (**`-a`**):
-  - If set, recursively includes all files within the current directory as
-    context for the prompt.
+
 - **`--help`** (or **`-h`**):
   - Displays help information about command-line arguments.
 - **`--show-memory-usage`**:

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -44,7 +44,7 @@ export async function loadConfig(
     targetDir: workspaceDir, // Or a specific directory the agent operates on
     debugMode: process.env['DEBUG'] === 'true' || false,
     question: '', // Not used in server mode directly like CLI
-    fullContext: false, // Server might have different context needs
+
     coreTools: settings.coreTools || undefined,
     excludeTools: settings.excludeTools || undefined,
     showMemoryUsage: settings.showMemoryUsage || false,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -66,7 +66,7 @@ export interface CliArgs {
   debug: boolean | undefined;
   prompt: string | undefined;
   promptInteractive: string | undefined;
-  allFiles: boolean | undefined;
+
   showMemoryUsage: boolean | undefined;
   yolo: boolean | undefined;
   approvalMode: string | undefined;
@@ -199,12 +199,7 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           type: 'string',
           description: 'Sandbox image URI.',
         })
-        .option('all-files', {
-          alias: ['a'],
-          type: 'boolean',
-          description: 'Include ALL files in context?',
-          default: false,
-        })
+
         .option('show-memory-usage', {
           type: 'boolean',
           description: 'Show memory usage in status bar',
@@ -300,10 +295,7 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           'checkpointing',
           'Use the "general.checkpointing.enabled" setting in settings.json instead. This flag will be removed in a future version.',
         )
-        .deprecateOption(
-          'all-files',
-          'Use @ includes in the application instead. This flag will be removed in a future version.',
-        )
+
         .deprecateOption(
           'prompt',
           'Use the positional prompt instead. This flag will be removed in a future version.',
@@ -694,7 +686,7 @@ export async function loadCliConfig(
       settings.context?.loadMemoryFromIncludeDirectories || false,
     debugMode,
     question,
-    fullContext: argv.allFiles || false,
+
     coreTools: settings.tools?.core || undefined,
     allowedTools: allowedTools.length > 0 ? allowedTools : undefined,
     policyEngineConfig,

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -320,7 +320,6 @@ describe('gemini.tsx main function kitty protocol', () => {
       prompt: undefined,
       promptInteractive: undefined,
       query: undefined,
-      allFiles: undefined,
       showMemoryUsage: undefined,
       yolo: undefined,
       approvalMode: undefined,

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -114,7 +114,7 @@ describe('runNonInteractive', () => {
         getProjectTempDir: vi.fn().mockReturnValue('/test/project/.gemini/tmp'),
       },
       getIdeMode: vi.fn().mockReturnValue(false),
-      getFullContext: vi.fn().mockReturnValue(false),
+
       getContentGeneratorConfig: vi.fn().mockReturnValue({}),
       getDebugMode: vi.fn().mockReturnValue(false),
       getOutputFormat: vi.fn().mockReturnValue('text'),

--- a/packages/cli/src/ui/hooks/useAutoAcceptIndicator.test.ts
+++ b/packages/cli/src/ui/hooks/useAutoAcceptIndicator.test.ts
@@ -46,7 +46,7 @@ interface MockConfigInstanceShape {
   getSandbox: Mock<() => boolean | string>;
   getDebugMode: Mock<() => boolean>;
   getQuestion: Mock<() => string | undefined>;
-  getFullContext: Mock<() => boolean>;
+
   getUserAgent: Mock<() => string>;
   getUserMemory: Mock<() => string>;
   getGeminiMdFileCount: Mock<() => number>;
@@ -93,7 +93,7 @@ describe('useAutoAcceptIndicator', () => {
         getQuestion: vi.fn().mockReturnValue(undefined) as Mock<
           () => string | undefined
         >,
-        getFullContext: vi.fn().mockReturnValue(false) as Mock<() => boolean>,
+
         getUserAgent: vi.fn().mockReturnValue('test-user-agent') as Mock<
           () => string
         >,

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -182,7 +182,7 @@ describe('useGeminiStream', () => {
       targetDir: '/test/dir',
       debugMode: false,
       question: undefined,
-      fullContext: false,
+
       coreTools: [],
       toolDiscoveryCommand: undefined,
       toolCallCommand: undefined,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -159,7 +159,6 @@ describe('Server Config (config.ts)', () => {
   const TARGET_DIR = '/path/to/target';
   const DEBUG_MODE = false;
   const QUESTION = 'test question';
-  const FULL_CONTEXT = false;
   const USER_MEMORY = 'Test User Memory';
   const TELEMETRY_SETTINGS = { enabled: false };
   const EMBEDDING_MODEL = 'gemini-embedding';
@@ -171,7 +170,6 @@ describe('Server Config (config.ts)', () => {
     targetDir: TARGET_DIR,
     debugMode: DEBUG_MODE,
     question: QUESTION,
-    fullContext: FULL_CONTEXT,
     userMemory: USER_MEMORY,
     telemetry: TELEMETRY_SETTINGS,
     sessionId: SESSION_ID,
@@ -1006,7 +1004,6 @@ describe('BaseLlmClient Lifecycle', () => {
   const TARGET_DIR = '/path/to/target';
   const DEBUG_MODE = false;
   const QUESTION = 'test question';
-  const FULL_CONTEXT = false;
   const USER_MEMORY = 'Test User Memory';
   const TELEMETRY_SETTINGS = { enabled: false };
   const EMBEDDING_MODEL = 'gemini-embedding';
@@ -1018,7 +1015,6 @@ describe('BaseLlmClient Lifecycle', () => {
     targetDir: TARGET_DIR,
     debugMode: DEBUG_MODE,
     question: QUESTION,
-    fullContext: FULL_CONTEXT,
     userMemory: USER_MEMORY,
     telemetry: TELEMETRY_SETTINGS,
     sessionId: SESSION_ID,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -216,7 +216,7 @@ export interface ConfigParameters {
   targetDir: string;
   debugMode: boolean;
   question?: string;
-  fullContext?: boolean;
+
   coreTools?: string[];
   allowedTools?: string[];
   excludeTools?: string[];
@@ -296,7 +296,7 @@ export class Config {
   private workspaceContext: WorkspaceContext;
   private readonly debugMode: boolean;
   private readonly question: string | undefined;
-  private readonly fullContext: boolean;
+
   private readonly coreTools: string[] | undefined;
   private readonly allowedTools: string[] | undefined;
   private readonly excludeTools: string[] | undefined;
@@ -389,7 +389,7 @@ export class Config {
     );
     this.debugMode = params.debugMode;
     this.question = params.question;
-    this.fullContext = params.fullContext ?? false;
+
     this.coreTools = params.coreTools;
     this.allowedTools = params.allowedTools;
     this.excludeTools = params.excludeTools;
@@ -680,10 +680,6 @@ export class Config {
   }
   getQuestion(): string | undefined {
     return this.question;
-  }
-
-  getFullContext(): boolean {
-    return this.fullContext;
   }
 
   getCoreTools(): string[] | undefined {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -289,7 +289,7 @@ describe('Gemini Client (client.ts)', () => {
       getVertexAI: vi.fn().mockReturnValue(false),
       getUserAgent: vi.fn().mockReturnValue('test-agent'),
       getUserMemory: vi.fn().mockReturnValue(''),
-      getFullContext: vi.fn().mockReturnValue(false),
+
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
       getProxy: vi.fn().mockReturnValue(undefined),
       getWorkingDir: vi.fn().mockReturnValue('/test/dir'),

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -592,7 +592,7 @@ describe('loggers', () => {
       }),
       getQuestion: () => 'test-question',
       getToolRegistry: () => new ToolRegistry(cfg1),
-      getFullContext: () => false,
+
       getUserMemory: () => 'user-memory',
     } as unknown as Config;
 

--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -91,7 +91,7 @@ describe('EditTool', () => {
       getSandbox: () => false,
       getDebugMode: () => false,
       getQuestion: () => undefined,
-      getFullContext: () => false,
+
       getToolDiscoveryCommand: () => undefined,
       getToolCallCommand: () => undefined,
       getMcpServerCommand: () => undefined,

--- a/packages/core/src/tools/smart-edit.test.ts
+++ b/packages/core/src/tools/smart-edit.test.ts
@@ -105,7 +105,7 @@ describe('SmartEditTool', () => {
       getSandbox: () => false,
       getDebugMode: () => false,
       getQuestion: () => undefined,
-      getFullContext: () => false,
+
       getToolDiscoveryCommand: () => undefined,
       getToolCallCommand: () => undefined,
       getMcpServerCommand: () => undefined,

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -81,7 +81,7 @@ const mockConfigInternal = {
   getSandbox: () => false,
   getDebugMode: () => false,
   getQuestion: () => undefined,
-  getFullContext: () => false,
+
   getToolDiscoveryCommand: () => undefined,
   getToolCallCommand: () => undefined,
   getMcpServerCommand: () => undefined,

--- a/packages/core/src/utils/editCorrector.test.ts
+++ b/packages/core/src/utils/editCorrector.test.ts
@@ -168,7 +168,7 @@ describe('editCorrector', () => {
         targetDir: '/test',
         debugMode: false,
         question: undefined as string | undefined,
-        fullContext: false,
+
         coreTools: undefined as string[] | undefined,
         toolDiscoveryCommand: undefined as string | undefined,
         toolCallCommand: undefined as string | undefined,
@@ -188,7 +188,7 @@ describe('editCorrector', () => {
         getToolRegistry: vi.fn(() => mockToolRegistry),
         getDebugMode: vi.fn(() => configParams.debugMode),
         getQuestion: vi.fn(() => configParams.question),
-        getFullContext: vi.fn(() => configParams.fullContext),
+
         getCoreTools: vi.fn(() => configParams.coreTools),
         getToolDiscoveryCommand: vi.fn(() => configParams.toolDiscoveryCommand),
         getToolCallCommand: vi.fn(() => configParams.toolCallCommand),

--- a/packages/core/src/utils/environmentContext.ts
+++ b/packages/core/src/utils/environmentContext.ts
@@ -68,42 +68,6 @@ ${directoryContext}
         `.trim();
 
   const initialParts: Part[] = [{ text: context }];
-  const toolRegistry = config.getToolRegistry();
-
-  // Add full file context if the flag is set
-  if (config.getFullContext()) {
-    try {
-      const readManyFilesTool = toolRegistry.getTool('read_many_files');
-      if (readManyFilesTool) {
-        const invocation = readManyFilesTool.build({
-          paths: ['**/*'], // Read everything recursively
-          useDefaultExcludes: true, // Use default excludes
-        });
-
-        // Read all files in the target directory
-        const result = await invocation.execute(AbortSignal.timeout(30000));
-        if (result.llmContent) {
-          initialParts.push({
-            text: `\n--- Full File Context ---\n${result.llmContent}`,
-          });
-        } else {
-          console.warn(
-            'Full context requested, but read_many_files returned no content.',
-          );
-        }
-      } else {
-        console.warn(
-          'Full context requested, but read_many_files tool not found.',
-        );
-      }
-    } catch (error) {
-      // Not using reportError here as it's a startup/config phase, not a chat/generation phase error.
-      console.error('Error reading full file context:', error);
-      initialParts.push({
-        text: '\n--- Error reading full file context ---',
-      });
-    }
-  }
 
   return initialParts;
 }


### PR DESCRIPTION
Removes the deprecated `--all-files` / `-a` command-line flag and its corresponding `fullContext` logic throughout the codebase.

This flag was previously used to include all files in the current directory as context. This functionality is now handled more explicitly by using `@` mentions (e.g., `@**/*`) within the prompt, providing users with more granular control.

This change removes the flag from:
- CLI argument parsing
- All related configuration interfaces and implementations
- Associated logic in the environment context builder
- All mentions in the documentation

Fixes #7361
