### PR TITLE
Don't always fall back on a git clone when installing extensions

### DIFF
--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -469,10 +469,10 @@ export async function installOrUpdateExtension(
         installMetadata.type = result.type;
         installMetadata.releaseTag = result.tagName;
       } else if (
-        // This repo has no github releases, and wasn't previously installed
+        // This repo has no github releases, and wasn't explicitly installed
         // from a github release, unconditionally just clone it.
         (result.failureReason === 'no release data' &&
-          installMetadata.type !== 'github-release') ||
+          installMetadata.type === 'git') ||
         // Otherwise ask the user if they would like to try a git clone.
         (await requestConsent(
           `Error downloading github release for ${installMetadata.source} with the following error: ${result.errorMessage}.\n\nWould you like to attempt to install via "git clone" instead?`,

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -464,16 +464,26 @@ export async function installOrUpdateExtension(
       installMetadata.type === 'github-release'
     ) {
       tempDir = await ExtensionStorage.createTmpDir();
-      try {
-        const result = await downloadFromGitHubRelease(
-          installMetadata,
-          tempDir,
-        );
+      const result = await downloadFromGitHubRelease(installMetadata, tempDir);
+      if (result.success) {
         installMetadata.type = result.type;
         installMetadata.releaseTag = result.tagName;
-      } catch (_error) {
+      } else if (
+        // This repo has no github releases, and wasn't previously installed
+        // from a github release, unconditionally just clone it.
+        (result.failureReason === 'no release data' &&
+          installMetadata.type !== 'github-release') ||
+        // Otherwise ask the user if they would like to try a git clone.
+        (await requestConsent(
+          `Error downloading github release for ${installMetadata.source} with the following error: ${result.errorMessage}.\n\nWould you like to attempt to install via "git clone" instead?`,
+        ))
+      ) {
         await cloneFromGit(installMetadata, tempDir);
         installMetadata.type = 'git';
+      } else {
+        throw new Error(
+          `Failed to install extension ${installMetadata.source}: ${result.errorMessage}`,
+        );
       }
       localSourcePath = tempDir;
     } else if (

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -348,21 +348,21 @@ describe('git extension helpers', () => {
   describe('parseGitHubRepoForReleases', () => {
     it('should parse owner and repo from a full GitHub URL', () => {
       const source = 'https://github.com/owner/repo.git';
-      const { owner, repo } = parseGitHubRepoForReleases(source);
+      const { owner, repo } = parseGitHubRepoForReleases(source)!;
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
 
     it('should parse owner and repo from a full GitHub URL without .git', () => {
       const source = 'https://github.com/owner/repo';
-      const { owner, repo } = parseGitHubRepoForReleases(source);
+      const { owner, repo } = parseGitHubRepoForReleases(source)!;
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
 
     it('should parse owner and repo from a full GitHub URL with a trailing slash', () => {
       const source = 'https://github.com/owner/repo/';
-      const { owner, repo } = parseGitHubRepoForReleases(source);
+      const { owner, repo } = parseGitHubRepoForReleases(source)!;
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
@@ -374,23 +374,21 @@ describe('git extension helpers', () => {
       );
     });
 
-    it('should fail on a non-GitHub URL', () => {
+    it('should return null on a non-GitHub URL', () => {
       const source = 'https://example.com/owner/repo.git';
-      expect(() => parseGitHubRepoForReleases(source)).toThrow(
-        'Invalid GitHub repository source: https://example.com/owner/repo.git. Expected "owner/repo" or a github repo uri.',
-      );
+      expect(parseGitHubRepoForReleases(source)).toBe(null);
     });
 
     it('should parse owner and repo from a shorthand string', () => {
       const source = 'owner/repo';
-      const { owner, repo } = parseGitHubRepoForReleases(source);
+      const { owner, repo } = parseGitHubRepoForReleases(source)!;
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
 
     it('should handle .git suffix in repo name', () => {
       const source = 'owner/repo.git';
-      const { owner, repo } = parseGitHubRepoForReleases(source);
+      const { owner, repo } = parseGitHubRepoForReleases(source)!;
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -79,16 +79,22 @@ export async function cloneFromGit(
 export function parseGitHubRepoForReleases(source: string): {
   owner: string;
   repo: string;
-} {
+} | null {
   // Default to a github repo path, so `source` can be just an org/repo
   const parsedUrl = URL.parse(source, 'https://github.com');
+  if (!parsedUrl) {
+    throw new Error(`Invalid repo URL: ${source}`);
+  }
   // The pathname should be "/owner/repo".
   const parts = parsedUrl?.pathname
     .substring(1)
     .split('/')
     // Remove the empty segments, fixes trailing slashes
     .filter((part) => part !== '');
-  if (parts?.length !== 2 || parsedUrl?.host !== 'github.com') {
+  if (parsedUrl?.host !== 'github.com') {
+    return null;
+  }
+  if (parts?.length !== 2) {
     throw new Error(
       `Invalid GitHub repository source: ${source}. Expected "owner/repo" or a github repo uri.`,
     );
@@ -110,7 +116,7 @@ export async function fetchReleaseFromGithub(
   repo: string,
   ref?: string,
   allowPreRelease?: boolean,
-): Promise<GithubReleaseData> {
+): Promise<GithubReleaseData | null> {
   if (ref) {
     return await fetchJson(
       `https://api.github.com/repos/${owner}/${repo}/releases/tags/${ref}`,
@@ -130,7 +136,7 @@ export async function fetchReleaseFromGithub(
     `https://api.github.com/repos/${owner}/${repo}/releases?per_page=1`,
   );
   if (releases.length === 0) {
-    throw new Error('No releases found');
+    return null;
   }
   return releases[0];
 }
@@ -206,7 +212,7 @@ export async function checkForExtensionUpdate(
         console.error(`No "source" provided for extension.`);
         return ExtensionUpdateState.ERROR;
       }
-      const { owner, repo } = parseGitHubRepoForReleases(source);
+      const { owner, repo } = parseGitHubRepoForReleases(source)!;
 
       const releaseData = await fetchReleaseFromGithub(
         owner,
@@ -214,6 +220,9 @@ export async function checkForExtensionUpdate(
         installMetadata.ref,
         installMetadata.allowPreRelease,
       );
+      if (!releaseData) {
+        return ExtensionUpdateState.ERROR;
+      }
       if (releaseData.tag_name !== releaseTag) {
         return ExtensionUpdateState.UPDATE_AVAILABLE;
       }
@@ -226,28 +235,57 @@ export async function checkForExtensionUpdate(
     return ExtensionUpdateState.ERROR;
   }
 }
+
 export interface GitHubDownloadResult {
-  tagName: string;
+  tagName?: string;
   type: 'git' | 'github-release';
+  success: boolean;
+  failureReason?:
+    | 'failed to fetch release data'
+    | 'no release data'
+    | 'no release asset found'
+    | 'failed to download asset'
+    | 'failed to extract asset'
+    | 'unknown';
+  errorMessage?: string;
 }
+
 export async function downloadFromGitHubRelease(
   installMetadata: ExtensionInstallMetadata,
   destination: string,
 ): Promise<GitHubDownloadResult> {
   const { source, ref, allowPreRelease: preRelease } = installMetadata;
-  const { owner, repo } = parseGitHubRepoForReleases(source);
+  let releaseData: GithubReleaseData | null = null;
 
   try {
-    const releaseData = await fetchReleaseFromGithub(
-      owner,
-      repo,
-      ref,
-      preRelease,
-    );
-    if (!releaseData) {
-      throw new Error(
-        `No release data found for ${owner}/${repo} at tag ${ref}`,
-      );
+    const parts = parseGitHubRepoForReleases(source);
+    if (!parts) {
+      return {
+        failureReason: 'no release data',
+        success: false,
+        type: 'github-release',
+        errorMessage: `Not a github repo: ${source}`,
+      };
+    }
+    const { owner, repo } = parts;
+
+    try {
+      releaseData = await fetchReleaseFromGithub(owner, repo, ref, preRelease);
+      if (!releaseData) {
+        return {
+          failureReason: 'no release data',
+          success: false,
+          type: 'github-release',
+          errorMessage: `No release data found for ${owner}/${repo} at tag ${ref}`,
+        };
+      }
+    } catch (error) {
+      return {
+        failureReason: 'failed to fetch release data',
+        success: false,
+        type: 'github-release',
+        errorMessage: `Failed to fetch release data for ${owner}/${repo} at tag ${ref}: ${getErrorMessage(error)}`,
+      };
     }
 
     const asset = findReleaseAsset(releaseData.assets);
@@ -266,9 +304,13 @@ export async function downloadFromGitHubRelease(
       }
     }
     if (!archiveUrl) {
-      throw new Error(
-        `No assets found for release with tag ${releaseData.tag_name}`,
-      );
+      return {
+        failureReason: 'no release asset found',
+        success: false,
+        type: 'github-release',
+        tagName: releaseData.tag_name,
+        errorMessage: `No assets found for release with tag ${releaseData.tag_name}`,
+      };
     }
     let downloadedAssetPath = path.join(
       destination,
@@ -280,9 +322,29 @@ export async function downloadFromGitHubRelease(
       downloadedAssetPath += '.zip';
     }
 
-    await downloadFile(archiveUrl, downloadedAssetPath);
+    try {
+      await downloadFile(archiveUrl, downloadedAssetPath);
+    } catch (error) {
+      return {
+        failureReason: 'failed to download asset',
+        success: false,
+        type: 'github-release',
+        tagName: releaseData.tag_name,
+        errorMessage: `Failed to download asset from ${archiveUrl}: ${getErrorMessage(error)}`,
+      };
+    }
 
-    await extractFile(downloadedAssetPath, destination);
+    try {
+      await extractFile(downloadedAssetPath, destination);
+    } catch (error) {
+      return {
+        failureReason: 'failed to extract asset',
+        success: false,
+        type: 'github-release',
+        tagName: releaseData.tag_name,
+        errorMessage: `Failed to extract asset from ${downloadedAssetPath}: ${getErrorMessage(error)}`,
+      };
+    }
 
     // For regular github releases, the repository is put inside of a top level
     // directory. In this case we should see exactly two file in the destination
@@ -316,11 +378,16 @@ export async function downloadFromGitHubRelease(
     return {
       tagName: releaseData.tag_name,
       type: 'github-release',
+      success: true,
     };
   } catch (error) {
-    throw new Error(
-      `Failed to download release from ${installMetadata.source}: ${getErrorMessage(error)}`,
-    );
+    return {
+      failureReason: 'unknown',
+      success: false,
+      type: 'github-release',
+      tagName: releaseData?.tag_name,
+      errorMessage: `Failed to download release from ${installMetadata.source}: ${getErrorMessage(error)}`,
+    };
   }
 }
 

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -126,9 +126,14 @@ export async function fetchReleaseFromGithub(
   if (!allowPreRelease) {
     // Grab the release that is tagged as the "latest", github does not allow
     // this to be a pre-release so we can blindly grab it.
-    return await fetchJson(
-      `https://api.github.com/repos/${owner}/${repo}/releases/latest`,
-    );
+    try {
+      await fetchJson(
+        `https://api.github.com/repos/${owner}/${repo}/releases/latest`,
+      );
+    } catch (_) {
+      // This can fail if there is no release marked latest. In that case
+      // we want to just try the pre-release logic below.
+    }
   }
 
   // If pre-releases are allowed, we just grab the most recent release.

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -127,7 +127,7 @@ export async function fetchReleaseFromGithub(
     // Grab the release that is tagged as the "latest", github does not allow
     // this to be a pre-release so we can blindly grab it.
     try {
-      await fetchJson(
+      return await fetchJson(
         `https://api.github.com/repos/${owner}/${repo}/releases/latest`,
       );
     } catch (_) {

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -217,7 +217,14 @@ export async function checkForExtensionUpdate(
         console.error(`No "source" provided for extension.`);
         return ExtensionUpdateState.ERROR;
       }
-      const { owner, repo } = parseGitHubRepoForReleases(source)!;
+      const repoInfo = parseGitHubRepoForReleases(source);
+      if (!repoInfo) {
+        console.error(
+          `Source is not a valid GitHub repository for release checks: ${source}`,
+        );
+        return ExtensionUpdateState.ERROR;
+      }
+      const { owner, repo } = repoInfo;
 
       const releaseData = await fetchReleaseFromGithub(
         owner,


### PR DESCRIPTION
## TLDR

Previously if we failed to install an extension from a GitHub release for any reason, we would just attempt a git clone. This would result in invalid installs of extensions that expect to be installed via GitHub releases.

Now, we return the reason for failure and handle those failures more appropriately.

I also added unit tests of the install from GitHub release flow, although they do currently mock out the entire `downloadFromGithubRelease` function, but this is in a separate library and should be separately unit tested.

## Dive Deeper

There are now only two situations in which we will git clone unconditionally:

- You are installing from a non-github URI
- We successfully list the releases but don't find any

Otherwise, we prompt the user whether or not they would like to try a git clone.

## Reviewer Test Plan

The easiest way to test this is to make up a GitHub URL to install, such as `gemini extensions install https://github.com/thisis/madeup`. You should see a message that we failed to list the GitHub releases, and then you can tell it to try and clone or just say no (the clone will also fail of course). 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✔️   | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #10358