### PR TITLE
Skip test that is failing on windows.

### DIFF
--- a/integration-tests/json-output.test.ts
+++ b/integration-tests/json-output.test.ts
@@ -35,7 +35,7 @@ describe('JSON output', () => {
     expect(typeof parsed.stats).toBe('object');
   });
 
-  it('should return a JSON error for sd auth mismatch before running', async () => {
+  it.skip('should return a JSON error for sd auth mismatch before running', async () => {
     process.env['GOOGLE_GENAI_USE_GCA'] = 'true';
     await rig.setup('json-output-auth-mismatch', {
       settings: {


### PR DESCRIPTION
The test consistently fails on windows. From running locally:

│     FAIL  json-output.test.ts > JSON output > should return a JSON
error for sd auth mismatch before running                      │
│
│
│     FAIL  json-output.test.ts > JSON output > should return a JSON
error for sd auth mismatch before running                      │
│
│
│     FAIL  json-output.test.ts > JSON output > should return a JSON
error for sd auth mismatch before running                      │
│
│
│    AssertionError: Expected to find a JSON object in the error output:
expected null to be truthy                                 │
│
│
│
│
│
│
│    - Expected:
│
│
│
│    true
│
│
│
│
│
│
│
│    + Received:
│
│
│
│    null
│
│
│
│
│
│
│
│     ❯ json-output.test.ts:67:7
│
│
│
│         65|       jsonMatch,
│
│
│
│         66|       'Expected to find a JSON object in the error
output',                                                           │
│
│
│         67|     ).toBeTruthy();
│
│
│
│           |       ^
│
│
│
│         68|
│
│
│
│         69|     let payload;
│
│

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
