### PR TITLE
fix(ci): Make the release-rollback action properly support non-prod envs

### DIFF
--- a/.github/workflows/release-rollback.yml
+++ b/.github/workflows/release-rollback.yml
@@ -105,7 +105,7 @@ jobs:
           wombat-token-a2a-server: '${{ secrets.WOMBAT_TOKEN_A2A_SERVER }}'
 
       - name: 'Deprecate Cli Npm Package'
-        if: "${{ github.event.inputs.dry-run == 'false' }}"
+        if: "${{ github.event.inputs.dry-run == 'false' && github.event.inputs.environment == 'prod' }}"
         env:
           NODE_AUTH_TOKEN: '${{ steps.cli-token.outputs.auth-token }}'
         shell: 'bash'
@@ -123,7 +123,7 @@ jobs:
           wombat-token-a2a-server: '${{ secrets.WOMBAT_TOKEN_A2A_SERVER }}'
 
       - name: 'Deprecate Core Npm Package'
-        if: "${{ github.event.inputs.dry-run == 'false' }}"
+        if: "${{ github.event.inputs.dry-run == 'false' && github.event.inputs.environment == 'prod' }}"
         env:
           NODE_AUTH_TOKEN: '${{ steps.core-token.outputs.auth-token }}'
         shell: 'bash'
@@ -141,7 +141,7 @@ jobs:
           wombat-token-a2a-server: '${{ secrets.WOMBAT_TOKEN_A2A_SERVER }}'
 
       - name: 'Deprecate A2A Server Npm Package'
-        if: "${{ github.event.inputs.dry-run == 'false' }}"
+        if: "${{ github.event.inputs.dry-run == 'false' && github.event.inputs.environment == 'prod'  }}"
         env:
           NODE_AUTH_TOKEN: '${{ steps.a2a-token.outputs.auth-token }}'
         shell: 'bash'
@@ -149,7 +149,7 @@ jobs:
           npm deprecate ${{ vars.A2A_PACKAGE_NAME }}@${{ github.event.inputs.rollback_origin }} "This version has been rolled back."
 
       - name: 'Delete Github Release'
-        if: "${{ github.event.inputs.dry-run == 'false' && inputs.environment == 'prod'}}"
+        if: "${{ github.event.inputs.dry-run == 'false' && github.event.inputs.environment == 'prod'}}"
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         shell: 'bash'

--- a/.github/workflows/release-rollback.yml
+++ b/.github/workflows/release-rollback.yml
@@ -31,10 +31,18 @@ on:
         required: false
         type: 'boolean'
         default: true
+      environment:
+        description: 'Environment'
+        required: false
+        type: 'choice'
+        options:
+          - 'prod'
+          - 'dev'
+        default: 'prod'
 
 jobs:
   change-tags:
-    environment: 'prod' ## TODO(richieforeman) Support Dev mode
+    environment: '${{ github.event.inputs.environment }}'
     runs-on: 'ubuntu-latest'
     permissions:
       packages: 'write'
@@ -50,8 +58,11 @@ jobs:
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
         with:
           node-version-file: '.nvmrc'
-          registry-url: 'https://wombat-dressing-room.appspot.com'
-          scope: '@google'
+
+      - name: 'configure .npmrc'
+        uses: './.github/actions/setup-npmrc'
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: 'Get Origin Version Tag'
         id: 'origin_tag'
@@ -83,32 +94,62 @@ jobs:
           core-package-name: '${{ vars.CORE_PACKAGE_NAME }}'
           a2a-package-name: '${{ vars.A2A_PACKAGE_NAME }}'
 
+      - name: 'Get cli Token'
+        uses: './.github/actions/npm-auth-token'
+        id: 'cli-token'
+        with:
+          package-name: '${{ vars.CLI_PACKAGE_NAME }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          wombat-token-core: '${{ secrets.WOMBAT_TOKEN_CORE }}'
+          wombat-token-cli: '${{ secrets.WOMBAT_TOKEN_CLI }}'
+          wombat-token-a2a-server: '${{ secrets.WOMBAT_TOKEN_A2A_SERVER }}'
+
       - name: 'Deprecate Cli Npm Package'
         if: "${{ github.event.inputs.dry-run == 'false' }}"
         env:
-          NODE_AUTH_TOKEN: '${{ secrets.WOMBAT_TOKEN_CLI }}'
+          NODE_AUTH_TOKEN: '${{ steps.cli-token.outputs.auth-token }}'
         shell: 'bash'
         run: |
-          npm deprecate @google/gemini-cli@${{ github.event.inputs.rollback_origin }} "This version has been rolled back."
+          npm deprecate ${{ vars.CLI_PACKAGE_NAME }}@${{ github.event.inputs.rollback_origin }} "This version has been rolled back."
+
+      - name: 'Get core Token'
+        uses: './.github/actions/npm-auth-token'
+        id: 'core-token'
+        with:
+          package-name: '${{ vars.CLI_PACKAGE_NAME }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          wombat-token-core: '${{ secrets.WOMBAT_TOKEN_CORE }}'
+          wombat-token-cli: '${{ secrets.WOMBAT_TOKEN_CLI }}'
+          wombat-token-a2a-server: '${{ secrets.WOMBAT_TOKEN_A2A_SERVER }}'
 
       - name: 'Deprecate Core Npm Package'
         if: "${{ github.event.inputs.dry-run == 'false' }}"
         env:
-          NODE_AUTH_TOKEN: '${{ secrets.WOMBAT_TOKEN_CORE }}'
+          NODE_AUTH_TOKEN: '${{ steps.core-token.outputs.auth-token }}'
         shell: 'bash'
         run: |
-          npm deprecate @google/gemini-core@${{ github.event.inputs.rollback_origin }} "This version has been rolled back."
+          npm deprecate ${{ vars.CORE_PACKAGE_NAME }}@${{ github.event.inputs.rollback_origin }} "This version has been rolled back."
+
+      - name: 'Get a2a Token'
+        uses: './.github/actions/npm-auth-token'
+        id: 'a2a-token'
+        with:
+          package-name: '${{ vars.A2A_PACKAGE_NAME }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          wombat-token-core: '${{ secrets.WOMBAT_TOKEN_CORE }}'
+          wombat-token-cli: '${{ secrets.WOMBAT_TOKEN_CLI }}'
+          wombat-token-a2a-server: '${{ secrets.WOMBAT_TOKEN_A2A_SERVER }}'
 
       - name: 'Deprecate A2A Server Npm Package'
         if: "${{ github.event.inputs.dry-run == 'false' }}"
         env:
-          NODE_AUTH_TOKEN: '${{ secrets.WOMBAT_TOKEN_A2A_SERVER }}'
+          NODE_AUTH_TOKEN: '${{ steps.a2a-token.outputs.auth-token }}'
         shell: 'bash'
         run: |
-          npm deprecate @google/gemini-cli-a2a-server@${{ github.event.inputs.rollback_origin }} "This version has been rolled back."
+          npm deprecate ${{ vars.A2A_PACKAGE_NAME }}@${{ github.event.inputs.rollback_origin }} "This version has been rolled back."
 
       - name: 'Delete Github Release'
-        if: "${{ github.event.inputs.dry-run == 'false' }}"
+        if: "${{ github.event.inputs.dry-run == 'false' && inputs.environment == 'prod'}}"
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         shell: 'bash'
@@ -172,7 +213,7 @@ jobs:
           - ORIGIN_HASH: '${{ steps.origin_hash.outputs.ORIGIN_HASH }}'
           - ROLLBACK_TAG: '${{ steps.rollback_tag.outputs.ROLLBACK_TAG }}'
 
-          Would have npm deprecate @google/gemini-cli@${{ github.event.inputs.rollback_origin }} and @google/gemini-core@${{ github.event.inputs.rollback_origin }}
+          Would have npm deprecate ${{vars.CLI_PACKAGE_NAME}}@${{ github.event.inputs.rollback_origin }}, ${{vars.CORE_PACKAGE_NAME}}@${{ github.event.inputs.rollback_origin }}, and ${{ vars.A2A_PACKAGE_NAME }}@${{ github.event.inputs.rollback_origin }}
           Would have deleted the github release with tag ${{ steps.origin_tag.outputs.ORIGIN_TAG }}
           Would have added tag ${{ steps.origin_tag.outputs.ORIGIN_TAG }}-rollback to ${{ steps.origin_hash.outputs.ORIGIN_HASH }}
           "


### PR DESCRIPTION
## TLDR

Make release-rollback work with the new non-prod env.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

NOTE: It is not possible to deprecate a github-npm-published package due to the lack of the `_id` field being set by the publishing repository (e.g. github, not us).  For this reason (and expected), the deprecate commands are if'd out on non-prod envs.

```
➜  gemini-cli git:(rf/rollback) npm view @google-gemini/gemini-cli --json | grep _id
  "_id": "",
```

dry @ https://github.com/google-gemini/gemini-cli/actions/runs/18547644914/job/52868664915
wet @ https://github.com/google-gemini/gemini-cli/actions/runs/18548011452/job/52869676716 (note, I ran out of versions to rollback, but the change tag succeeded okay).

before
```
➜  gemini-cli git:(rf/rollback) npm dist-tags @google-gemini/gemini-cli
dev: 0.0.33333
false: 0.0.4
latest: 0.0.55555
nightly: 0.0.6
```

after 
```
➜  gemini-cli git:(rf/rollback) npm dist-tags @google-gemini/gemini-cli           
dev: 0.0.33333
false: 0.0.4
latest: 0.0.4
nightly: 0.0.6
```

Resolves #10452 11244
