### PR TITLE
(fix): Enable Codebase Investigator for all modes 

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -46,6 +46,8 @@ import { StartSessionEvent } from '../telemetry/index.js';
 import {
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_THINKING_MODE,
 } from './models.js';
 import { shouldAttemptBrowserLaunch } from '../utils/browser.js';
 import type { MCPOAuthConfig } from '../mcp/oauth-provider.js';
@@ -371,7 +373,7 @@ export class Config {
   private readonly outputSettings: OutputSettings;
   private readonly useModelRouter: boolean;
   private readonly enableMessageBusIntegration: boolean;
-  private readonly codebaseInvestigatorSettings?: CodebaseInvestigatorSettings;
+  private readonly codebaseInvestigatorSettings: CodebaseInvestigatorSettings;
   private readonly continueOnFailedApiCall: boolean;
   private readonly retryFetchErrors: boolean;
   private readonly enableShellOutputEfficiency: boolean;
@@ -467,7 +469,15 @@ export class Config {
     this.useModelRouter = params.useModelRouter ?? false;
     this.enableMessageBusIntegration =
       params.enableMessageBusIntegration ?? false;
-    this.codebaseInvestigatorSettings = params.codebaseInvestigatorSettings;
+    this.codebaseInvestigatorSettings = {
+      enabled: params.codebaseInvestigatorSettings?.enabled ?? true,
+      maxNumTurns: params.codebaseInvestigatorSettings?.maxNumTurns ?? 15,
+      maxTimeMinutes: params.codebaseInvestigatorSettings?.maxTimeMinutes ?? 5,
+      thinkingBudget:
+        params.codebaseInvestigatorSettings?.thinkingBudget ??
+        DEFAULT_THINKING_MODE,
+      model: params.codebaseInvestigatorSettings?.model ?? DEFAULT_GEMINI_MODEL,
+    };
     this.continueOnFailedApiCall = params.continueOnFailedApiCall ?? true;
     this.enableShellOutputEfficiency =
       params.enableShellOutputEfficiency ?? true;
@@ -1062,7 +1072,7 @@ export class Config {
     return this.enableMessageBusIntegration;
   }
 
-  getCodebaseInvestigatorSettings(): CodebaseInvestigatorSettings | undefined {
+  getCodebaseInvestigatorSettings(): CodebaseInvestigatorSettings {
     return this.codebaseInvestigatorSettings;
   }
 
@@ -1158,7 +1168,7 @@ export class Config {
     }
 
     // Register Subagents as Tools
-    if (this.getCodebaseInvestigatorSettings()?.enabled) {
+    if (this.getCodebaseInvestigatorSettings().enabled) {
       const definition = this.agentRegistry.getDefinition(
         'codebase_investigator',
       );


### PR DESCRIPTION
## TLDR
----

This pull request ensures the Codebase Investigator is enabled by default across all modes, resolving an issue where it was not consistently active.

## Dive Deeper
-----------

This pull request addresses a critical issue that prevented the Codebase Investigator from being enabled in all operational modes. The fix ensures that the Codebase Investigator is always initialized with a default configuration, making it active by default. The type definitions have also been updated to reflect its mandatory presence, improving the reliability and availability of this feature.

## Reviewer Test Plan
------------------

1.  Verify that the Codebase Investigator is enabled by default in all modes.
2.  Confirm that the `codebaseInvestigatorSettings` property is no longer optional and is initialized with default values.
3.  Check that the new default values for `thinkingBudget` and `model` are correctly applied.

## Testing Matrix
--------------

| | 🍏 | 🪟 | 🐧 |
| --- | :-: | :-: | :-: |
| **npm run** | ✅ | ❓ | ❓ |
| **npx** | ✅ | ❓ | ❓ |
| **Docker** | ✅ | ❓ | ❓ |
| **Podman** | ✅ | - | - |
| **Seatbelt**| ✅ | - | - |

Linked issues / bugs
--------------------

