### PR TITLE
include extension name in `gemini mcp list` command

### DIFF
--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -4,7 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  type Mock,
+  type MockInstance,
+} from 'vitest';
 import { listMcpServers } from './list.js';
 import { loadSettings } from '../../config/settings.js';
 import { ExtensionStorage, loadExtensions } from '../../config/extension.js';
@@ -37,24 +46,25 @@ vi.mock('@google/gemini-cli-core', () => ({
 }));
 vi.mock('@modelcontextprotocol/sdk/client/index.js');
 
-const mockedExtensionStorage = ExtensionStorage as vi.Mock;
-const mockedLoadSettings = loadSettings as vi.Mock;
-const mockedLoadExtensions = loadExtensions as vi.Mock;
-const mockedCreateTransport = createTransport as vi.Mock;
-const MockedClient = Client as vi.Mock;
+const mockedGetUserExtensionsDir =
+  ExtensionStorage.getUserExtensionsDir as Mock;
+const mockedLoadSettings = loadSettings as Mock;
+const mockedLoadExtensions = loadExtensions as Mock;
+const mockedCreateTransport = createTransport as Mock;
+const MockedClient = Client as Mock;
 
 interface MockClient {
-  connect: vi.Mock;
-  ping: vi.Mock;
-  close: vi.Mock;
+  connect: Mock;
+  ping: Mock;
+  close: Mock;
 }
 
 interface MockTransport {
-  close: vi.Mock;
+  close: Mock;
 }
 
 describe('mcp list command', () => {
-  let consoleSpy: vi.SpyInstance;
+  let consoleSpy: MockInstance;
   let mockClient: MockClient;
   let mockTransport: MockTransport;
 
@@ -73,9 +83,7 @@ describe('mcp list command', () => {
     MockedClient.mockImplementation(() => mockClient);
     mockedCreateTransport.mockResolvedValue(mockTransport);
     mockedLoadExtensions.mockReturnValue([]);
-    mockedExtensionStorage.getUserExtensionsDir.mockReturnValue(
-      '/mocked/extensions/dir',
-    );
+    mockedGetUserExtensionsDir.mockReturnValue('/mocked/extensions/dir');
   });
 
   afterEach(() => {
@@ -170,7 +178,7 @@ describe('mcp list command', () => {
     );
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining(
-        'extension-server: /ext/server  (stdio) - Connected',
+        'extension-server (from test-extension): /ext/server  (stdio) - Connected',
       ),
     );
   });

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -115,7 +115,10 @@ export async function listMcpServers(): Promise<void> {
         break;
     }
 
-    let serverInfo = `${serverName}: `;
+    let serverInfo =
+      serverName +
+      (server.extensionName ? ` (from ${server.extensionName})` : '') +
+      ': ';
     if (server.httpUrl) {
       serverInfo += `${server.httpUrl} (http)`;
     } else if (server.url) {


### PR DESCRIPTION
## TLDR

Brings the `gemini mcp list` command more in line with the `/mcp list` CLI command.

<img width="472" height="17" alt="image" src="https://github.com/user-attachments/assets/7b113987-43ff-482a-853e-b5a58ddbe93e" />

And here is what it looks like from `/mcp list` for reference:

<img width="397" height="30" alt="image" src="https://github.com/user-attachments/assets/fe78f70a-7945-429a-9e97-68c1db790a97" />

These are still a little bit different, but now it includes the missing info.

## Dive Deeper

Also resolved several static errors in the test.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to https://github.com/google-gemini/gemini-cli/issues/11113
