### PR TITLE
fix: Add folder names in permissions dialog similar to the launch dialog

### DIFF
--- a/packages/cli/src/ui/components/PermissionsModifyTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/PermissionsModifyTrustDialog.test.tsx
@@ -46,6 +46,7 @@ describe('PermissionsModifyTrustDialog', () => {
   let mockCommitTrustLevelChange: Mock;
 
   beforeEach(() => {
+    mockedCwd.mockReturnValue('/test/dir');
     mockUpdateTrustLevel = vi.fn();
     mockCommitTrustLevelChange = vi.fn();
     vi.mocked(usePermissionsModifyTrust).mockReturnValue({
@@ -117,6 +118,17 @@ describe('PermissionsModifyTrustDialog', () => {
       expect(lastFrame()).toContain(
         'Note: This folder behaves as a trusted folder because the connected IDE workspace is trusted.',
       );
+    });
+  });
+
+  it('should render the labels with folder names', async () => {
+    const { lastFrame } = renderWithProviders(
+      <PermissionsModifyTrustDialog onExit={vi.fn()} addItem={vi.fn()} />,
+    );
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('Trust this folder (dir)');
+      expect(lastFrame()).toContain('Trust parent folder (test)');
     });
   });
 

--- a/packages/cli/src/ui/components/PermissionsModifyTrustDialog.tsx
+++ b/packages/cli/src/ui/components/PermissionsModifyTrustDialog.tsx
@@ -6,6 +6,8 @@
 
 import { Box, Text } from 'ink';
 import type React from 'react';
+import * as process from 'node:process';
+import * as path from 'node:path';
 import { TrustLevel } from '../../config/trustedFolders.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { usePermissionsModifyTrust } from '../hooks/usePermissionsModifyTrust.js';
@@ -19,28 +21,31 @@ interface PermissionsModifyTrustDialogProps {
   addItem: UseHistoryManagerReturn['addItem'];
 }
 
-const TRUST_LEVEL_ITEMS = [
-  {
-    label: 'Trust this folder',
-    value: TrustLevel.TRUST_FOLDER,
-    key: TrustLevel.TRUST_FOLDER,
-  },
-  {
-    label: 'Trust parent folder',
-    value: TrustLevel.TRUST_PARENT,
-    key: TrustLevel.TRUST_PARENT,
-  },
-  {
-    label: "Don't trust",
-    value: TrustLevel.DO_NOT_TRUST,
-    key: TrustLevel.DO_NOT_TRUST,
-  },
-];
-
 export function PermissionsModifyTrustDialog({
   onExit,
   addItem,
 }: PermissionsModifyTrustDialogProps): React.JSX.Element {
+  const dirName = path.basename(process.cwd());
+  const parentFolder = path.basename(path.dirname(process.cwd()));
+
+  const TRUST_LEVEL_ITEMS = [
+    {
+      label: `Trust this folder (${dirName})`,
+      value: TrustLevel.TRUST_FOLDER,
+      key: TrustLevel.TRUST_FOLDER,
+    },
+    {
+      label: `Trust parent folder (${parentFolder})`,
+      value: TrustLevel.TRUST_PARENT,
+      key: TrustLevel.TRUST_PARENT,
+    },
+    {
+      label: "Don't trust",
+      value: TrustLevel.DO_NOT_TRUST,
+      key: TrustLevel.DO_NOT_TRUST,
+    },
+  ];
+
   const {
     cwd,
     currentTrustLevel,


### PR DESCRIPTION
## TLDR
**Before:**
<img width="688" height="359" alt="Screenshot 2025-10-16 at 3 14 37 PM" src="https://github.com/user-attachments/assets/a76dd637-3cfa-428b-9e58-9e0d861f0740" />

**After:**
<img width="550" height="325" alt="Screenshot 2025-10-16 at 3 13 59 PM" src="https://github.com/user-attachments/assets/9ae37721-ad63-4e65-a31c-f8a6550071ae" />

**Launch dialog for reference:**
<img width="1400" height="534" alt="Screenshot 2025-10-16 at 3 16 34 PM" src="https://github.com/user-attachments/assets/8ac40e3a-4d69-4cdb-91d5-45724eb1eb5c" />

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/845
