### PR TITLE
fix(web-fetch): respect Content-Type header in fallback mechanism

### DIFF
--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -133,14 +133,26 @@ class WebFetchToolInvocation extends BaseToolInvocation<
           `Request failed with status code ${response.status} ${response.statusText}`,
         );
       }
-      const html = await response.text();
-      const textContent = convert(html, {
-        wordwrap: false,
-        selectors: [
-          { selector: 'a', options: { ignoreHref: true } },
-          { selector: 'img', format: 'skip' },
-        ],
-      }).substring(0, MAX_CONTENT_LENGTH);
+
+      const rawContent = await response.text();
+      const contentType = response.headers.get('content-type') || '';
+      let textContent: string;
+
+      // Only use html-to-text if content type is HTML, or if no content type is provided (assume HTML)
+      if (contentType.includes('text/html') || contentType === '') {
+        textContent = convert(rawContent, {
+          wordwrap: false,
+          selectors: [
+            { selector: 'a', options: { ignoreHref: true } },
+            { selector: 'img', format: 'skip' },
+          ],
+        });
+      } else {
+        // For other content types (text/plain, application/json, etc.), use raw text
+        textContent = rawContent;
+      }
+
+      textContent = textContent.substring(0, MAX_CONTENT_LENGTH);
 
       const geminiClient = this.config.getGeminiClient();
       const fallbackPrompt = `The user requested the following: "${this.params.prompt}".

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -139,7 +139,10 @@ class WebFetchToolInvocation extends BaseToolInvocation<
       let textContent: string;
 
       // Only use html-to-text if content type is HTML, or if no content type is provided (assume HTML)
-      if (contentType.includes('text/html') || contentType === '') {
+      if (
+        contentType.toLowerCase().includes('text/html') ||
+        contentType === ''
+      ) {
         textContent = convert(rawContent, {
           wordwrap: false,
           selectors: [


### PR DESCRIPTION
## TLDR

Fixes #10728.

This PR modifies the fallback mechanism in `WebFetchTool` to respect the `Content-Type` HTTP header of the fetched resource. Previously, `html-to-text` conversion was applied unconditionally to all responses in the fallback path, which corrupted non-HTML data such as JSON APIs or raw source code files.

Now, `html-to-text` conversion is only applied if the `Content-Type` indicates HTML or is missing. For all other content types, the raw text content is returned.

## Dive Deeper

*   **Logic Change (`packages/core/src/tools/web-fetch.ts`)**:
    *   Updated `WebFetchToolInvocation.executeFallback` to retrieve the `content-type` header from the `fetchWithTimeout` response.
    *   Implemented logic to check if `contentType.includes('text/html')` or if it is empty string. Only in these cases is `html-to-text.convert()` called.
    *   Otherwise (e.g., `application/json`, `text/plain`), `response.text()` is used raw.
*   **Tests (`packages/core/src/tools/web-fetch.test.ts`)**:
    *   Added a new `describe('execute (fallback)', ...)` test block.
    *   Mocks the primary Gemini-based fetch to fail (returning empty candidates) to force execution into the `executeFallback` method.
    *   Adds specific test cases for:
        *   `text/html` (verified conversion happens).
        *   `application/json` (verified raw text is used).
        *   `text/plain` (verified raw text is used).
        *   Missing `Content-Type` header (verified conversion happens, preserving existing behavior).

## Reviewer Test Plan

Web fetch should still operate normally. Use natural language to guide the usage for the web fetch tool for various content type sites.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |

## Linked issues / bugs

- Closes #10728 
