### PR TITLE
Use Node.js built-ins in scripts/clean.js instead of glob.

### DIFF
--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -17,10 +17,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { rmSync, readFileSync } from 'node:fs';
+import { rmSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { globSync } from 'glob';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
@@ -39,10 +38,21 @@ const rootPackageJson = JSON.parse(
   readFileSync(join(root, 'package.json'), 'utf-8'),
 );
 for (const workspace of rootPackageJson.workspaces) {
-  const packages = globSync(join(workspace, 'package.json'), { cwd: root });
-  for (const pkgPath of packages) {
-    const pkgDir = dirname(join(root, pkgPath));
-    rmSync(join(pkgDir, 'dist'), RMRF_OPTIONS);
+  // Note: this is a simple glob implementation that only supports "packages/*".
+  const workspaceDir = join(root, dirname(workspace));
+  const packageDirs = readdirSync(workspaceDir);
+
+  for (const pkg of packageDirs) {
+    const pkgDir = join(workspaceDir, pkg);
+    try {
+      if (statSync(pkgDir).isDirectory()) {
+        rmSync(join(pkgDir, 'dist'), RMRF_OPTIONS);
+      }
+    } catch (e) {
+      if (e.code !== 'ENOENT') {
+        throw e;
+      }
+    }
   }
 }
 
@@ -51,9 +61,17 @@ rmSync(join(root, 'packages/vscode-ide-companion/node_modules'), {
   recursive: true,
   force: true,
 });
-const vsixFiles = globSync('packages/vscode-ide-companion/*.vsix', {
-  cwd: root,
-});
-for (const vsixFile of vsixFiles) {
-  rmSync(join(root, vsixFile), RMRF_OPTIONS);
+
+const vscodeCompanionDir = join(root, 'packages/vscode-ide-companion');
+try {
+  const files = readdirSync(vscodeCompanionDir);
+  for (const file of files) {
+    if (file.endsWith('.vsix')) {
+      rmSync(join(vscodeCompanionDir, file), RMRF_OPTIONS);
+    }
+  }
+} catch (e) {
+  if (e.code !== 'ENOENT') {
+    throw e;
+  }
 }


### PR DESCRIPTION
## TLDR

Use Node.js built-ins in scripts/clean.js instead of glob.

## Dive Deeper

The clean script was removing its own dependencies, causing it to fail on a
second run. This change replaces the glob dependency with Node.js's built-in
`fs` and `path` modules to handle file searching and deletion, which resolves
the issue.

## Reviewer Test Plan

Run, then re-run, `npm run clean` at least twice in succession.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #11273

