### PR TITLE
fix(test): deflake flicker integration test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,9 +95,9 @@ jobs:
         shell: 'bash'
         run: |
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
-            npm run test:integration:sandbox:docker
+            npm run deflake:test:integration:sandbox:docker
           else
-            npm run test:integration:sandbox:none
+            npm run deflake:test:integration:sandbox:none
           fi
 
   e2e_mac:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,9 +95,9 @@ jobs:
         shell: 'bash'
         run: |
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
-            npm run deflake:test:integration:sandbox:docker
+            npm run test:integration:sandbox:docker
           else
-            npm run deflake:test:integration:sandbox:none
+            npm run test:integration:sandbox:none
           fi
 
   e2e_mac:

--- a/integration-tests/flicker.test.ts
+++ b/integration-tests/flicker.test.ts
@@ -20,8 +20,8 @@ describe('Flicker Detector', () => {
     const hasUserPromptEvent = await rig.waitForTelemetryEvent('user_prompt');
     expect(hasUserPromptEvent).toBe(true);
 
-    const sessionCountMetric = rig.readMetric('session.count');
-    expect(sessionCountMetric).not.toBeNull();
+    const hasSessionCountMetric = await rig.waitForMetric('session.count');
+    expect(hasSessionCountMetric).toBe(true);
 
     // We expect NO flicker event to be found.
     const flickerMetric = rig.readMetric('ui.flicker.count');

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -910,6 +910,22 @@ export class TestRig {
     return apiRequests.pop() || null;
   }
 
+  async waitForMetric(metricName: string, timeout?: number) {
+    if (!timeout) {
+      timeout = getDefaultTimeout();
+    }
+
+    await this.waitForTelemetryReady();
+
+    return poll(
+      () => {
+        return this.readMetric(metricName) !== null;
+      },
+      timeout,
+      100,
+    );
+  }
+
   readMetric(metricName: string): Record<string, unknown> | null {
     const logs = this._readAndParseTelemetryLog();
     for (const logData of logs) {


### PR DESCRIPTION
## TLDR

Fixes a flaky test in `integration-tests/flicker.test.ts` caused by a race condition where telemetry metrics were not fully flushed before assertion.

## Dive Deeper

The test was failing because `rig.readMetric('session.count')` was called before the metric was written to the telemetry log. To fix this, I added a `waitForMetric` helper method to the `TestRig` class in `integration-tests/test-helper.ts`, which polls for the existence of a specific metric. Updated `flicker.test.ts` to use `await rig.waitForMetric('session.count')`.

## Reviewer Test Plan

Run the deflake script on the specific test:
`node scripts/deflake.js --command="npx vitest run integration-tests/flicker.test.ts" --runs=10`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
