### PR TITLE
feat(routing): make model router configurable

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -113,11 +113,16 @@ they appear in the UI.
 
 ### Experimental
 
-| UI Label         | Setting                      | Description                                                                         | Default |
-| ---------------- | ---------------------------- | ----------------------------------------------------------------------------------- | ------- |
-| Agent Skills     | `experimental.skills`        | Enable Agent Skills (experimental).                                                 | `false` |
-| Use OSC 52 Paste | `experimental.useOSC52Paste` | Use OSC 52 sequence for pasting instead of clipboardy (useful for remote sessions). | `false` |
-| Plan             | `experimental.plan`          | Enable planning features (Plan Mode and tools).                                     | `false` |
+| UI Label                            | Setting                                                 | Description                                                                                    | Default              |
+| ----------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------------------- |
+| Agent Skills                        | `experimental.skills`                                   | Enable Agent Skills (experimental).                                                            | `false`              |
+| Enable Codebase Investigator        | `experimental.codebaseInvestigatorSettings.enabled`     | Enable the Codebase Investigator agent.                                                        | `true`               |
+| Codebase Investigator Max Num Turns | `experimental.codebaseInvestigatorSettings.maxNumTurns` | Maximum number of turns for the Codebase Investigator agent.                                   | `10`                 |
+| Enable Model Router                 | `experimental.modelRouter.enabled`                      | Enable model routing to route requests to the best model based on complexity.                  | `true`               |
+| Simple Task Model                   | `experimental.modelRouter.simpleTaskModel`              | The model to use for simple, well-defined tasks when the model router is enabled.              | `"gemini-2.5-flash"` |
+| Complex Task Model                  | `experimental.modelRouter.complexTaskModel`             | The model to use for complex, multi-step, or ambiguous tasks when the model router is enabled. | `"gemini-2.5-pro"`   |
+| Use OSC 52 Paste                    | `experimental.useOSC52Paste`                            | Use OSC 52 sequence for pasting instead of clipboardy (useful for remote sessions).            | `false`              |
+| Plan                                | `experimental.plan`                                     | Enable planning features (Plan Mode and tools).                                     | `false`              |
 
 ### HooksConfig
 

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -855,6 +855,60 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `false`
   - **Requires restart:** Yes
 
+- **`experimental.codebaseInvestigatorSettings.enabled`** (boolean):
+  - **Description:** Enable the Codebase Investigator agent.
+  - **Default:** `true`
+  - **Requires restart:** Yes
+
+- **`experimental.codebaseInvestigatorSettings.maxNumTurns`** (number):
+  - **Description:** Maximum number of turns for the Codebase Investigator
+    agent.
+  - **Default:** `10`
+  - **Requires restart:** Yes
+
+- **`experimental.codebaseInvestigatorSettings.maxTimeMinutes`** (number):
+  - **Description:** Maximum time for the Codebase Investigator agent (in
+    minutes).
+  - **Default:** `3`
+  - **Requires restart:** Yes
+
+- **`experimental.codebaseInvestigatorSettings.thinkingBudget`** (number):
+  - **Description:** The thinking budget for the Codebase Investigator agent.
+  - **Default:** `8192`
+  - **Requires restart:** Yes
+
+- **`experimental.codebaseInvestigatorSettings.model`** (string):
+  - **Description:** The model to use for the Codebase Investigator agent.
+  - **Default:** `"auto"`
+  - **Requires restart:** Yes
+
+- **`experimental.modelRouter.enabled`** (boolean):
+  - **Description:** Enable model routing to route requests to the best model
+    based on complexity.
+  - **Default:** `true`
+  - **Requires restart:** Yes
+
+- **`experimental.modelRouter.simpleTaskModel`** (string):
+  - **Description:** The model to use for simple, well-defined tasks when the
+    model router is enabled.
+  - **Default:** `"gemini-2.5-flash"`
+  - **Requires restart:** Yes
+
+- **`experimental.modelRouter.complexTaskModel`** (string):
+  - **Description:** The model to use for complex, multi-step, or ambiguous
+    tasks when the model router is enabled.
+  - **Default:** `"gemini-2.5-pro"`
+  - **Requires restart:** Yes
+
+- **`experimental.useOSC52Paste`** (boolean):
+  - **Description:** Use OSC 52 sequence for pasting instead of clipboardy
+    (useful for remote sessions).
+  - **Default:** `false`
+
+- **`experimental.plan`** (boolean):
+  - **Description:** Enable planning features (Plan Mode and tools).
+  - **Default:** `false`
+  - **Requires restart:** Yes
 - **`experimental.useOSC52Paste`** (boolean):
   - **Description:** Use OSC 52 sequence for pasting instead of clipboardy
     (useful for remote sessions).

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -784,6 +784,9 @@ export async function loadCliConfig(
     disableLLMCorrection: settings.tools?.disableLLMCorrection,
     rawOutput: argv.rawOutput,
     acceptRawOutputRisk: argv.acceptRawOutputRisk,
+    useModelRouter: settings.experimental?.modelRouter?.enabled,
+    simpleTaskModel: settings.experimental?.modelRouter?.simpleTaskModel,
+    complexTaskModel: settings.experimental?.modelRouter?.complexTaskModel,
     modelConfigServiceConfig: settings.modelConfigs,
     // TODO: loading of hooks based on workspace trust
     enableHooks:

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -20,6 +20,9 @@ import {
   DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
   DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
   DEFAULT_MODEL_CONFIGS,
+  DEFAULT_GEMINI_FLASH_MODEL,
+  DEFAULT_GEMINI_MODEL,
+  GEMINI_MODEL_ALIAS_AUTO,
 } from '@google/gemini-cli-core';
 import type { CustomTheme } from '../ui/themes/theme.js';
 import type { SessionRetentionSettings } from './settings.js';
@@ -1459,6 +1462,107 @@ const SETTINGS_SCHEMA = {
         default: false,
         description: 'Enable Agent Skills (experimental).',
         showInDialog: true,
+      },
+      codebaseInvestigatorSettings: {
+        type: 'object',
+        label: 'Codebase Investigator Settings',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: {},
+        description: 'Configuration for Codebase Investigator.',
+        showInDialog: false,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Enable Codebase Investigator',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: true,
+            description: 'Enable the Codebase Investigator agent.',
+            showInDialog: true,
+          },
+          maxNumTurns: {
+            type: 'number',
+            label: 'Codebase Investigator Max Num Turns',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: 10,
+            description:
+              'Maximum number of turns for the Codebase Investigator agent.',
+            showInDialog: true,
+          },
+          maxTimeMinutes: {
+            type: 'number',
+            label: 'Max Time (Minutes)',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: 3,
+            description:
+              'Maximum time for the Codebase Investigator agent (in minutes).',
+            showInDialog: false,
+          },
+          thinkingBudget: {
+            type: 'number',
+            label: 'Thinking Budget',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: 8192,
+            description:
+              'The thinking budget for the Codebase Investigator agent.',
+            showInDialog: false,
+          },
+          model: {
+            type: 'string',
+            label: 'Model',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: GEMINI_MODEL_ALIAS_AUTO,
+            description:
+              'The model to use for the Codebase Investigator agent.',
+            showInDialog: false,
+          },
+        },
+      },
+      modelRouter: {
+        type: 'object',
+        label: 'Model Router',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: {},
+        description: 'Settings for configuring the model router.',
+        showInDialog: false,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Enable Model Router',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: true,
+            description:
+              'Enable model routing to route requests to the best model based on complexity.',
+            showInDialog: true,
+          },
+          simpleTaskModel: {
+            type: 'string',
+            label: 'Simple Task Model',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: DEFAULT_GEMINI_FLASH_MODEL,
+            description:
+              'The model to use for simple, well-defined tasks when the model router is enabled.',
+            showInDialog: true,
+          },
+          complexTaskModel: {
+            type: 'string',
+            label: 'Complex Task Model',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: DEFAULT_GEMINI_MODEL,
+            description:
+              'The model to use for complex, multi-step, or ambiguous tasks when the model router is enabled.',
+            showInDialog: true,
+          },
+        },
       },
       useOSC52Paste: {
         type: 'boolean',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -48,6 +48,7 @@ import { tokenLimit } from '../core/tokenLimits.js';
 import {
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
+  DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_MODEL_AUTO,
   isPreviewModel,
   PREVIEW_GEMINI_MODEL,
@@ -394,6 +395,9 @@ export interface ConfigParameters {
   experimentalJitContext?: boolean;
   disableLLMCorrection?: boolean;
   plan?: boolean;
+  useModelRouter?: boolean;
+  simpleTaskModel?: string;
+  complexTaskModel?: string;
   onModelChange?: (model: string) => void;
   mcpEnabled?: boolean;
   extensionsEnabled?: boolean;
@@ -551,6 +555,9 @@ export class Config {
   private readonly experimentalJitContext: boolean;
   private readonly disableLLMCorrection: boolean;
   private readonly planEnabled: boolean;
+  private readonly useModelRouter: boolean;
+  private readonly simpleTaskModel: string;
+  private readonly complexTaskModel: string;
   private contextManager?: ContextManager;
   private terminalBackground: string | undefined = undefined;
   private remoteAdminSettings: FetchAdminControlsResponse | undefined;
@@ -635,6 +642,9 @@ export class Config {
     this.disableLLMCorrection = params.disableLLMCorrection ?? true;
     this.planEnabled = params.plan ?? false;
     this.enableEventDrivenScheduler = params.enableEventDrivenScheduler ?? true;
+    this.useModelRouter = params.useModelRouter ?? true;
+    this.simpleTaskModel = params.simpleTaskModel ?? DEFAULT_GEMINI_FLASH_MODEL;
+    this.complexTaskModel = params.complexTaskModel ?? DEFAULT_GEMINI_MODEL;
     this.skillsSupport = params.skillsSupport ?? false;
     this.disabledSkills = params.disabledSkills ?? [];
     this.adminSkillsEnabled = params.adminSkillsEnabled ?? true;
@@ -1584,6 +1594,18 @@ export class Config {
 
   isPlanEnabled(): boolean {
     return this.planEnabled;
+  }
+
+  isModelRouterEnabled(): boolean {
+    return this.useModelRouter;
+  }
+
+  getSimpleTaskModel(): string {
+    return this.simpleTaskModel;
+  }
+
+  getComplexTaskModel(): string {
+    return this.complexTaskModel;
   }
 
   isAgentsEnabled(): boolean {

--- a/packages/core/src/routing/strategies/classifierStrategy.ts
+++ b/packages/core/src/routing/strategies/classifierStrategy.ts
@@ -12,7 +12,6 @@ import type {
   RoutingDecision,
   RoutingStrategy,
 } from '../routingStrategy.js';
-import { resolveClassifierModel } from '../../config/models.js';
 import { createUserContent, Type } from '@google/genai';
 import type { Config } from '../../config/config.js';
 import {
@@ -29,16 +28,20 @@ const FLASH_MODEL = 'flash';
 const PRO_MODEL = 'pro';
 
 const CLASSIFIER_SYSTEM_PROMPT = `
-You are a specialized Task Routing AI. Your sole function is to analyze the user's request and classify its complexity. Choose between \`${FLASH_MODEL}\` (SIMPLE) or \`${PRO_MODEL}\` (COMPLEX).
-1.  \`${FLASH_MODEL}\`: A fast, efficient model for simple, well-defined tasks.
-2.  \`${PRO_MODEL}\`: A powerful, advanced model for complex, open-ended, or multi-step tasks.
+You are a specialized Task Routing AI. Your sole function is to analyze the user's request and classify its complexity. Choose between 
+${FLASH_MODEL}
+ (SIMPLE) or 
+${PRO_MODEL}
+ (COMPLEX).
+1.  \n${FLASH_MODEL}\n: A fast, efficient model for simple, well-defined tasks.
+2.  \n${PRO_MODEL}\n: A powerful, advanced model for complex, open-ended, or multi-step tasks.
 <complexity_rubric>
-A task is COMPLEX (Choose \`${PRO_MODEL}\`) if it meets ONE OR MORE of the following criteria:
+A task is COMPLEX (Choose \n${PRO_MODEL}\n) if it meets ONE OR MORE of the following criteria:
 1.  **High Operational Complexity (Est. 4+ Steps/Tool Calls):** Requires dependent actions, significant planning, or multiple coordinated changes.
 2.  **Strategic Planning & Conceptual Design:** Asking "how" or "why." Requires advice, architecture, or high-level strategy.
 3.  **High Ambiguity or Large Scope (Extensive Investigation):** Broadly defined requests requiring extensive investigation.
 4.  **Deep Debugging & Root Cause Analysis:** Diagnosing unknown or complex problems from symptoms.
-A task is SIMPLE (Choose \`${FLASH_MODEL}\`) if it is highly specific, bounded, and has Low Operational Complexity (Est. 1-3 tool calls). Operational simplicity overrides strategic phrasing.
+A task is SIMPLE (Choose \n${FLASH_MODEL}\n) if it is highly specific, bounded, and has Low Operational Complexity (Est. 1-3 tool calls). Operational simplicity overrides strategic phrasing.
 </complexity_rubric>
 **Output Format:**
 Respond *only* in JSON format according to the following schema. Do not include any text outside the JSON structure.
@@ -131,6 +134,9 @@ export class ClassifierStrategy implements RoutingStrategy {
     config: Config,
     baseLlmClient: BaseLlmClient,
   ): Promise<RoutingDecision | null> {
+    if (!config.isModelRouterEnabled()) {
+      return null;
+    }
     const startTime = Date.now();
     try {
       if (await config.getNumericalRoutingEnabled()) {
@@ -163,20 +169,26 @@ export class ClassifierStrategy implements RoutingStrategy {
 
       const reasoning = routerResponse.reasoning;
       const latencyMs = Date.now() - startTime;
-      const selectedModel = resolveClassifierModel(
-        context.requestedModel ?? config.getModel(),
-        routerResponse.model_choice,
-        config.getPreviewFeatures(),
-      );
 
-      return {
-        model: selectedModel,
-        metadata: {
-          source: 'Classifier',
-          latencyMs,
-          reasoning,
-        },
-      };
+      if (routerResponse.model_choice === FLASH_MODEL) {
+        return {
+          model: config.getSimpleTaskModel(),
+          metadata: {
+            source: 'Classifier',
+            latencyMs,
+            reasoning,
+          },
+        };
+      } else {
+        return {
+          model: config.getComplexTaskModel(),
+          metadata: {
+            source: 'Classifier',
+            reasoning,
+            latencyMs,
+          },
+        };
+      }
     } catch (error) {
       // If the classifier fails for any reason (API error, parsing error, etc.),
       // we log it and return null to allow the composite strategy to proceed.

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1428,6 +1428,82 @@
           "default": false,
           "type": "boolean"
         },
+        "codebaseInvestigatorSettings": {
+          "title": "Codebase Investigator Settings",
+          "description": "Configuration for Codebase Investigator.",
+          "markdownDescription": "Configuration for Codebase Investigator.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `{}`",
+          "default": {},
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable Codebase Investigator",
+              "description": "Enable the Codebase Investigator agent.",
+              "markdownDescription": "Enable the Codebase Investigator agent.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `true`",
+              "default": true,
+              "type": "boolean"
+            },
+            "maxNumTurns": {
+              "title": "Codebase Investigator Max Num Turns",
+              "description": "Maximum number of turns for the Codebase Investigator agent.",
+              "markdownDescription": "Maximum number of turns for the Codebase Investigator agent.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `10`",
+              "default": 10,
+              "type": "number"
+            },
+            "maxTimeMinutes": {
+              "title": "Max Time (Minutes)",
+              "description": "Maximum time for the Codebase Investigator agent (in minutes).",
+              "markdownDescription": "Maximum time for the Codebase Investigator agent (in minutes).\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `3`",
+              "default": 3,
+              "type": "number"
+            },
+            "thinkingBudget": {
+              "title": "Thinking Budget",
+              "description": "The thinking budget for the Codebase Investigator agent.",
+              "markdownDescription": "The thinking budget for the Codebase Investigator agent.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `8192`",
+              "default": 8192,
+              "type": "number"
+            },
+            "model": {
+              "title": "Model",
+              "description": "The model to use for the Codebase Investigator agent.",
+              "markdownDescription": "The model to use for the Codebase Investigator agent.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `auto`",
+              "default": "auto",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "modelRouter": {
+          "title": "Model Router",
+          "description": "Settings for configuring the model router.",
+          "markdownDescription": "Settings for configuring the model router.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `{}`",
+          "default": {},
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable Model Router",
+              "description": "Enable model routing to route requests to the best model based on complexity.",
+              "markdownDescription": "Enable model routing to route requests to the best model based on complexity.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `true`",
+              "default": true,
+              "type": "boolean"
+            },
+            "simpleTaskModel": {
+              "title": "Simple Task Model",
+              "description": "The model to use for simple, well-defined tasks when the model router is enabled.",
+              "markdownDescription": "The model to use for simple, well-defined tasks when the model router is enabled.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `gemini-2.5-flash`",
+              "default": "gemini-2.5-flash",
+              "type": "string"
+            },
+            "complexTaskModel": {
+              "title": "Complex Task Model",
+              "description": "The model to use for complex, multi-step, or ambiguous tasks when the model router is enabled.",
+              "markdownDescription": "The model to use for complex, multi-step, or ambiguous tasks when the model router is enabled.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `gemini-2.5-pro`",
+              "default": "gemini-2.5-pro",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "useOSC52Paste": {
           "title": "Use OSC 52 Paste",
           "description": "Use OSC 52 sequence for pasting instead of clipboardy (useful for remote sessions).",


### PR DESCRIPTION
This change introduces the ability to configure the models used by the model router through the settings.json file.

Users can now specify `simpleTaskModel` and `complexTaskModel` within the `experimental.router` object in their settings to override the default models used for simple and complex tasks.

This enhances the flexibility of the model router, allowing for the use of fine-tuned or company-specific models.

## TLDR

This pull request introduces the ability to configure the models used by the experimental model router. Users can now specify a `simpleTaskModel` and a `complexTaskModel` in their `settings.json` file, allowing for greater flexibility and the use of fine-tuned or company-specific models.

## Dive Deeper

The primary goal of this change is to decouple the model router's logic from hardcoded model names. Previously, the `ClassifierStrategy` would always choose between `gemini-2.5-pro` and `gemini-2.5-flash`. This PR modifies the configuration schema and the core `Config` object to read custom model names from the `experimental.router` section of a user's settings.

The changes include:
-   **`settingsSchema.ts`**: Updated to define the new `experimental.router` object with `simpleTaskModel` and `complexTaskModel` properties, including default values for backward compatibility.
-   **`config.ts` (core)**: The `Config` class now stores these model names and provides `getSimpleTaskModel()` and `getComplexTaskModel()` getters.
-   **`config.ts` (cli)**: The `loadCliConfig` function now reads the new settings and passes them to the `Config` object.
-   **`classifierStrategy.ts`**: The strategy now uses the new getters on the `Config` object to determine which model to use, instead of relying on hardcoded constants.
-   **Tests**: Added and updated tests for the settings schema, `Config` object, and `ClassifierStrategy` to ensure the new functionality is working as expected and to prevent regressions.

## Reviewer Test Plan

To validate these changes, you can perform the following steps:

1.  **Create a `settings.json` file** in the root of the project with the following content:

    ```json
    {
      "experimental": {
        "useModelRouter": true,
        "router": {
          "simpleTaskModel": "my-custom-flash",
          "complexTaskModel": "my-custom-pro"
        }
      }
    }
    ```

2.  **Run the CLI with debug mode enabled** to see the internal logging from the model router.

    For a simple task:
    ```bash
    DEBUG_MODE=true npm start -- "list the files in the current directory"
    ```
    Look for a debug log indicating that `my-custom-flash` was selected.

    For a complex task:
    ```bash
    DEBUG_MODE=true npm start -- "how would I add a new command to this CLI?"
    ```
    Look for a debug log indicating that `my-custom-pro` was selected.

3.  **Verify Default Behavior**: Remove the `settings.json` file and run the same commands. The router should fall back to the default models (`gemini-2.5-flash` and `gemini-2.5-pro`).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes: #16501
