### PR TITLE
Improve rendering of ToDo lists.

### DIFF
--- a/packages/cli/src/ui/components/messages/TodoListDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/TodoListDisplay.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from 'ink-testing-library';
+import { describe, it, expect } from 'vitest';
+import { TodoListDisplay } from './TodoListDisplay.js';
+import type { TodoList, TodoStatus } from '@google/gemini-cli-core';
+
+describe('<TodoListDisplay />', () => {
+  const terminalWidth = 80;
+
+  it('renders an empty todo list correctly', () => {
+    const todos: TodoList = { todos: [] };
+    const { lastFrame } = render(
+      <TodoListDisplay todos={todos} terminalWidth={terminalWidth} />,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+  });
+
+  it('renders a todo list with various statuses correctly', () => {
+    const todos: TodoList = {
+      todos: [
+        { description: 'Task 1', status: 'pending' as TodoStatus },
+        { description: 'Task 2', status: 'in_progress' as TodoStatus },
+        { description: 'Task 3', status: 'completed' as TodoStatus },
+        { description: 'Task 4', status: 'cancelled' as TodoStatus },
+      ],
+    };
+    const { lastFrame } = render(
+      <TodoListDisplay todos={todos} terminalWidth={terminalWidth} />,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+  });
+
+  it('renders a todo list with long descriptions that wrap', () => {
+    const todos: TodoList = {
+      todos: [
+        {
+          description:
+            'This is a very long description for a pending task that should wrap around multiple lines when the terminal width is constrained.',
+          status: 'pending' as TodoStatus,
+        },
+        {
+          description:
+            'Another completed task with an equally verbose description to test wrapping behavior.',
+          status: 'completed' as TodoStatus,
+        },
+      ],
+    };
+    const { lastFrame } = render(
+      <TodoListDisplay todos={todos} terminalWidth={40} />,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+  });
+
+  it('renders a single todo item', () => {
+    const todos: TodoList = {
+      todos: [{ description: 'Single task', status: 'pending' as TodoStatus }],
+    };
+    const { lastFrame } = render(
+      <TodoListDisplay todos={todos} terminalWidth={terminalWidth} />,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+  });
+});

--- a/packages/cli/src/ui/components/messages/TodoListDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/TodoListDisplay.tsx
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import type { Todo, TodoList, TodoStatus } from '@google/gemini-cli-core';
+import { theme } from '../../semantic-colors.js';
+
+export interface TodoListDisplayProps {
+  todos: TodoList;
+  availableTerminalHeight?: number;
+  terminalWidth: number;
+}
+const TodoDisplay: React.FC<{ status: TodoStatus }> = ({ status }) => {
+  switch (status) {
+    case 'completed':
+      return <Text color={theme.status.success}>✓</Text>;
+    case 'in_progress':
+      return <Text color={theme.text.accent}>»</Text>;
+    case 'pending':
+      return <Text color={theme.text.primary}>☐</Text>;
+    case 'cancelled':
+      return <Text color={theme.status.error}>✗</Text>;
+    default:
+      return null;
+  }
+};
+
+export const TodoListDisplay: React.FC<TodoListDisplayProps> = ({
+  todos: data,
+  // availableTerminalHeight, // No longer needed without MaxSizedBox
+  terminalWidth,
+}) => (
+  <Box flexDirection="column" width={terminalWidth}>
+    {data.todos.map((todo: Todo, index: number) => (
+      <Box key={index} flexDirection="row" columnGap={3}>
+        <TodoDisplay status={todo.status} />
+        <Text wrap="wrap" color={theme.text.primary}>
+          {todo.description}
+        </Text>
+      </Box>
+    ))}
+  </Box>
+);

--- a/packages/cli/src/ui/components/messages/TodoListDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/TodoListDisplay.tsx
@@ -14,7 +14,7 @@ export interface TodoListDisplayProps {
   availableTerminalHeight?: number;
   terminalWidth: number;
 }
-const TodoDisplay: React.FC<{ status: TodoStatus }> = ({ status }) => {
+const TodoStatusDisplay: React.FC<{ status: TodoStatus }> = ({ status }) => {
   switch (status) {
     case 'completed':
       return <Text color={theme.status.success}>✓</Text>;
@@ -37,7 +37,7 @@ export const TodoListDisplay: React.FC<TodoListDisplayProps> = ({
   <Box flexDirection="column" width={terminalWidth}>
     {data.todos.map((todo: Todo, index: number) => (
       <Box key={index} flexDirection="row" columnGap={3}>
-        <TodoDisplay status={todo.status} />
+        <TodoStatusDisplay status={todo.status} />
         <Text wrap="wrap" color={theme.text.primary}>
           {todo.description}
         </Text>

--- a/packages/cli/src/ui/components/messages/TodoListDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/TodoListDisplay.tsx
@@ -11,7 +11,6 @@ import { theme } from '../../semantic-colors.js';
 
 export interface TodoListDisplayProps {
   todos: TodoList;
-  availableTerminalHeight?: number;
   terminalWidth: number;
 }
 const TodoStatusDisplay: React.FC<{ status: TodoStatus }> = ({ status }) => {
@@ -30,17 +29,18 @@ const TodoStatusDisplay: React.FC<{ status: TodoStatus }> = ({ status }) => {
 };
 
 export const TodoListDisplay: React.FC<TodoListDisplayProps> = ({
-  todos: data,
-  // availableTerminalHeight, // No longer needed without MaxSizedBox
+  todos,
   terminalWidth,
 }) => (
   <Box flexDirection="column" width={terminalWidth}>
-    {data.todos.map((todo: Todo, index: number) => (
-      <Box key={index} flexDirection="row" columnGap={3}>
-        <TodoStatusDisplay status={todo.status} />
-        <Text wrap="wrap" color={theme.text.primary}>
-          {todo.description}
-        </Text>
+    {todos.todos.map((todo: Todo, index: number) => (
+      <Box key={index} flexDirection="row">
+        <Box marginRight={1}>
+          <TodoStatusDisplay status={todo.status} />
+        </Box>
+        <Box flexShrink={1}>
+          <Text color={theme.text.primary}>{todo.description}</Text>
+        </Box>
       </Box>
     ))}
   </Box>

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -13,6 +13,7 @@ import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
 import { AnsiOutputText } from '../AnsiOutput.js';
 import { GeminiRespondingSpinner } from '../GeminiRespondingSpinner.js';
 import { MaxSizedBox } from '../shared/MaxSizedBox.js';
+import { TodoListDisplay } from './TodoListDisplay.js';
 import { ShellInputPrompt } from '../ShellInputPrompt.js';
 import {
   SHELL_COMMAND_NAME,
@@ -20,7 +21,7 @@ import {
   TOOL_STATUS,
 } from '../../constants.js';
 import { theme } from '../../semantic-colors.js';
-import type { AnsiOutput, Config } from '@google/gemini-cli-core';
+import type { AnsiOutput, Config, TodoList } from '@google/gemini-cli-core';
 import { useUIState } from '../../contexts/UIStateContext.js';
 
 const STATIC_HEIGHT = 1;
@@ -168,6 +169,13 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
                 diffContent={resultDisplay.fileDiff}
                 filename={resultDisplay.fileName}
                 availableTerminalHeight={availableHeight}
+                terminalWidth={childWidth}
+              />
+            ) : typeof resultDisplay === 'object' &&
+              'todos' in resultDisplay ? (
+              <TodoListDisplay
+                todos={resultDisplay as TodoList}
+                // availableTerminalHeight={availableHeight}
                 terminalWidth={childWidth}
               />
             ) : (

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -175,7 +175,6 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
               'todos' in resultDisplay ? (
               <TodoListDisplay
                 todos={resultDisplay as TodoList}
-                // availableTerminalHeight={availableHeight}
                 terminalWidth={childWidth}
               />
             ) : (

--- a/packages/cli/src/ui/components/messages/__snapshots__/TodoListDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/TodoListDisplay.test.tsx.snap
@@ -1,0 +1,22 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<TodoListDisplay /> > renders a single todo item 1`] = `"☐   Single task"`;
+
+exports[`<TodoListDisplay /> > renders a todo list with long descriptions that wrap 1`] = `
+"☐  This is a very long description for a
+    pending task that should wrap around
+    multiple lines when the terminal
+   width is constrained.
+✓  Another completed task with an
+   equally verbose description to test
+   wrapping behavior."
+`;
+
+exports[`<TodoListDisplay /> > renders a todo list with various statuses correctly 1`] = `
+"☐   Task 1
+»   Task 2
+✓   Task 3
+✗   Task 4"
+`;
+
+exports[`<TodoListDisplay /> > renders an empty todo list correctly 1`] = `""`;

--- a/packages/cli/src/ui/components/messages/__snapshots__/TodoListDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/TodoListDisplay.test.tsx.snap
@@ -1,22 +1,22 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`<TodoListDisplay /> > renders a single todo item 1`] = `"☐   Single task"`;
+exports[`<TodoListDisplay /> > renders a single todo item 1`] = `"☐ Single task"`;
 
 exports[`<TodoListDisplay /> > renders a todo list with long descriptions that wrap 1`] = `
-"☐  This is a very long description for a
-    pending task that should wrap around
-    multiple lines when the terminal
-   width is constrained.
-✓  Another completed task with an
-   equally verbose description to test
-   wrapping behavior."
+"☐ This is a very long description for a
+  pending task that should wrap around
+  multiple lines when the terminal width
+  is constrained.
+✓ Another completed task with an equally
+  verbose description to test wrapping
+  behavior."
 `;
 
 exports[`<TodoListDisplay /> > renders a todo list with various statuses correctly 1`] = `
-"☐   Task 1
-»   Task 2
-✓   Task 3
-✗   Task 4"
+"☐ Task 1
+» Task 2
+✓ Task 3
+✗ Task 4"
 `;
 
 exports[`<TodoListDisplay /> > renders an empty todo list correctly 1`] = `""`;

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -541,7 +541,18 @@ export function hasCycleInSchema(schema: object): boolean {
   return traverse(schema, new Set<string>(), new Set<string>());
 }
 
-export type ToolResultDisplay = string | FileDiff | AnsiOutput;
+export interface TodoList {
+  todos: Todo[];
+}
+
+export type ToolResultDisplay = string | FileDiff | AnsiOutput | TodoList;
+
+export type TodoStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled';
+
+export interface Todo {
+  description: string;
+  status: TodoStatus;
+}
 
 export interface FileDiff {
   fileDiff: string;

--- a/packages/core/src/tools/write-todos.test.ts
+++ b/packages/core/src/tools/write-todos.test.ts
@@ -86,7 +86,7 @@ describe('WriteTodosTool', () => {
       };
       const result = await tool.buildAndExecute(params, signal);
       expect(result.llmContent).toBe('Successfully cleared the todo list.');
-      expect(result.returnDisplay).toBe('Successfully cleared the todo list.');
+      expect(result.returnDisplay).toEqual({ todos: [] });
     });
 
     it('should return a formatted todo list on success', async () => {
@@ -103,7 +103,7 @@ describe('WriteTodosTool', () => {
 2. [in_progress] Second task
 3. [pending] Third task`;
       expect(result.llmContent).toBe(expectedOutput);
-      expect(result.returnDisplay).toBe(expectedOutput);
+      expect(result.returnDisplay).toEqual(params);
     });
   });
 });

--- a/packages/core/src/tools/write-todos.ts
+++ b/packages/core/src/tools/write-todos.ts
@@ -9,6 +9,7 @@ import {
   BaseDeclarativeTool,
   BaseToolInvocation,
   Kind,
+  type Todo,
   type ToolResult,
 } from './tools.js';
 import { WRITE_TODOS_TOOL_NAME } from './tool-names.js';
@@ -79,13 +80,6 @@ The agent did not use the todo list because this task could be completed by a ti
 </example>
 `;
 
-export type TodoStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled';
-
-export interface Todo {
-  description: string;
-  status: TodoStatus;
-}
-
 export interface WriteTodosToolParams {
   /**
    * The full list of todos. This will overwrite any existing list.
@@ -123,7 +117,7 @@ class WriteTodosToolInvocation extends BaseToolInvocation<
 
     return {
       llmContent,
-      returnDisplay: llmContent,
+      returnDisplay: { todos },
     };
   }
 }


### PR DESCRIPTION
## TLDR

Improve rendering of the ToDo list.

## Dive Deeper

This is the first step in the new ToDo list UX. The next step is to render this above the input box in expandable form.
<img width="854" height="182" alt="Screenshot 2025-10-16 at 1 32 04 PM" src="https://github.com/user-attachments/assets/efab8a5b-4d51-4fb6-b72d-66808f38f1d6" />

## Reviewer Test Plan

Add `"useWriteTodos": true,` to your `settings.json`.

Ask "Create a todo list with one item of each status. Make one of the items very long to test wrapping"

## Linked issues / bugs

For #10756