### PR TITLE
feat(auth): Improve auth dialog error handling and messaging

### DIFF
--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -45,7 +45,9 @@ describe('validateAuthMethod', () => {
     it('should return an error message if GEMINI_API_KEY is not set', () => {
       vi.stubEnv('GEMINI_API_KEY', undefined);
       expect(validateAuthMethod(AuthType.USE_GEMINI)).toBe(
-        'GEMINI_API_KEY environment variable not found. Add that to your environment and try again (no reload needed if using .env)!',
+        'GEMINI_API_KEY not found. Find your existing key or generate a new one at: https://aistudio.google.com/apikey\n' +
+          '\n' +
+          'To continue, please set the GEMINI_API_KEY environment variable or add it to a .env file.',
       );
     });
   });

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -18,7 +18,11 @@ export function validateAuthMethod(authMethod: string): string | null {
 
   if (authMethod === AuthType.USE_GEMINI) {
     if (!process.env['GEMINI_API_KEY']) {
-      return 'GEMINI_API_KEY environment variable not found. Add that to your environment and try again (no reload needed if using .env)!';
+      return (
+        'GEMINI_API_KEY not found. Find your existing key or generate a new one at: https://aistudio.google.com/apikey\n' +
+        '\n' +
+        'To continue, please set the GEMINI_API_KEY environment variable or add it to a .env file.'
+      );
     }
     return null;
   }

--- a/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -73,7 +73,7 @@ describe('AuthDialog', () => {
     settings: LoadedSettings;
     setAuthState: (state: AuthState) => void;
     authError: string | null;
-    onAuthError: (error: string) => void;
+    onAuthError: (error: string | null) => void;
   };
   const originalEnv = { ...process.env };
 

--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -26,7 +26,7 @@ interface AuthDialogProps {
   settings: LoadedSettings;
   setAuthState: (state: AuthState) => void;
   authError: string | null;
-  onAuthError: (error: string) => void;
+  onAuthError: (error: string | null) => void;
 }
 
 export function AuthDialog({
@@ -174,6 +174,9 @@ Logging in with Google... Please restart Gemini CLI to continue.
           items={items}
           initialIndex={initialAuthIndex}
           onSelect={handleAuthSelect}
+          onHighlight={() => {
+            onAuthError(null);
+          }}
         />
       </Box>
       {authError && (

--- a/packages/cli/src/ui/auth/useAuth.ts
+++ b/packages/cli/src/ui/auth/useAuth.ts
@@ -33,9 +33,11 @@ export const useAuthCommand = (settings: LoadedSettings, config: Config) => {
   const [authError, setAuthError] = useState<string | null>(null);
 
   const onAuthError = useCallback(
-    (error: string) => {
+    (error: string | null) => {
       setAuthError(error);
-      setAuthState(AuthState.Updating);
+      if (error) {
+        setAuthState(AuthState.Updating);
+      }
     },
     [setAuthError, setAuthState],
   );

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -23,7 +23,7 @@ export interface UIActions {
     scope: SettingScope,
   ) => void;
   setAuthState: (state: AuthState) => void;
-  onAuthError: (error: string) => void;
+  onAuthError: (error: string | null) => void;
   handleEditorSelect: (
     editorType: EditorType | undefined,
     scope: SettingScope,


### PR DESCRIPTION
## TLDR

This PR introduces two key improvements to the authentication dialog UX:

1.  **Clearer API Key Error:** The error message for a missing `GEMINI_API_KEY` has been updated to be more instructive, providing a direct link for users to create a new key.
2.  **Disappearing Error Messages:** The auth dialog no longer shows a persistent error message. When a user encounters an auth error and then navigates to a different authentication option, the error message now correctly disappears.

These changes combine to create a less confusing and more user-friendly authentication experience.

## Dive Deeper

The primary UX issue addressed was that an error message (e.g., "GEMINI_API_KEY not found") would remain on-screen even after the user moved their selection to a different, valid auth method like "Login with Google".

To fix this, the `onAuthError` callback signature was updated throughout the auth-related components (`UIActionsContext`, `useAuth`, `AuthDialog`) to accept `string | null`. This allows us to explicitly clear the error state by passing `null`.

The `RadioButtonSelect` component already exposed an `onHighlight` prop, which is triggered whenever the user navigates the list with arrow keys. I hooked into this event in the `AuthDialog` to call `onAuthError(null)`, ensuring the error is cleared the moment the user explores other options.

Additionally, while in the code, the initial error message for the missing API key was improved to be more actionable, guiding the user directly to the solution.

## Reviewer Test Plan

To validate this change, a reviewer should manually test the authentication flow:

1.  Ensure no `GEMINI_API_KEY` is set in your environment (`unset GEMINI_API_KEY`).
2.  Run CLI.
3.  **Verify:** The Auth Dialog should appear with the new, more descriptive error message: "GEMINI_API_KEY not found. Find your existing key or generate a new one at: https://aistudio.google.com/apikey..."
4.  Press the up/down arrow keys to move the selection to "Login with Google" or another option.
5.  **Verify:** The error message immediately disappears as soon as you change the highlighted selection.
6.  Move the selection back and forth between options to ensure the error does not reappear and the UI feels responsive.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |

## Linked issues / bugs

- Closes #11311
