### PR TITLE
WIP fix(tests): fix interleaved output in integration tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,8 +90,6 @@ jobs:
       - name: 'Run E2E tests'
         env:
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
-          KEEP_OUTPUT: 'true'
-          VERBOSE: 'true'
         shell: 'bash'
         run: |
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
@@ -144,9 +142,7 @@ jobs:
         if: "runner.os != 'Windows'"
         env:
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
-          KEEP_OUTPUT: 'true'
           SANDBOX: 'sandbox:none'
-          VERBOSE: 'true'
         run: 'npm run test:integration:sandbox:none'
 
   e2e_windows:
@@ -211,9 +207,7 @@ jobs:
       - name: 'Run E2E tests'
         env:
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
-          KEEP_OUTPUT: 'true'
           SANDBOX: 'sandbox:none'
-          VERBOSE: 'true'
           NODE_OPTIONS: '--max-old-space-size=32768 --max-semi-space-size=256'
           UV_THREADPOOL_SIZE: '32'
           NODE_ENV: 'test'

--- a/integration-tests/context-compress-interactive.test.ts
+++ b/integration-tests/context-compress-interactive.test.ts
@@ -14,8 +14,8 @@ describe('Interactive Mode', () => {
     rig = new TestRig();
   });
 
-  afterEach(async () => {
-    await rig.cleanup();
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
   });
 
   // TODO(#11062): Make this test reliable by not using the actual Gemini model

--- a/integration-tests/ctrl-c-exit.test.ts
+++ b/integration-tests/ctrl-c-exit.test.ts
@@ -4,13 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as os from 'node:os';
 import { TestRig } from './test-helper.js';
 
 describe.skip('Ctrl+C exit', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it('should exit gracefully on second Ctrl+C', async () => {
-    const rig = new TestRig();
     await rig.setup('should exit gracefully on second Ctrl+C');
 
     const run = await rig.runInteractive();

--- a/integration-tests/extensions-install.test.ts
+++ b/integration-tests/extensions-install.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect, test } from 'vitest';
+import { expect, test, beforeEach, afterEach } from 'vitest';
 import { TestRig } from './test-helper.js';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -19,8 +19,17 @@ const extensionUpdate = `{
   "version": "0.0.2"
 }`;
 
+let rig: TestRig;
+
+beforeEach(() => {
+  rig = new TestRig();
+});
+
+afterEach(async (ctx) => {
+  await rig.cleanup(ctx);
+});
+
 test('installs a local extension, verifies a command, and updates it', async () => {
-  const rig = new TestRig();
   rig.setup('extension install test');
   const testServerPath = join(rig.testDir!, 'gemini-extension.json');
   writeFileSync(testServerPath, extension);
@@ -47,6 +56,4 @@ test('installs a local extension, verifies a command, and updates it', async () 
   expect(updateResult).toContain('0.0.2');
 
   await rig.runCommand(['extensions', 'uninstall', 'test-extension']);
-
-  await rig.cleanup();
 });

--- a/integration-tests/file-system-interactive.test.ts
+++ b/integration-tests/file-system-interactive.test.ts
@@ -14,8 +14,8 @@ describe.skip('Interactive file system', () => {
     rig = new TestRig();
   });
 
-  afterEach(async () => {
-    await rig.cleanup();
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
   });
 
   it('should perform a read-then-write sequence', async () => {

--- a/integration-tests/file-system.test.ts
+++ b/integration-tests/file-system.test.ts
@@ -4,14 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 import { TestRig, printDebugInfo, validateModelOutput } from './test-helper.js';
 
 describe('file-system', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it('should be able to read a file', async () => {
-    const rig = new TestRig();
     await rig.setup('should be able to read a file');
     rig.createFile('test.txt', 'hello world');
 
@@ -39,7 +48,6 @@ describe('file-system', () => {
   });
 
   it('should be able to write a file', async () => {
-    const rig = new TestRig();
     await rig.setup('should be able to write a file');
     rig.createFile('test.txt', '');
 
@@ -94,7 +102,6 @@ describe('file-system', () => {
   });
 
   it('should correctly handle file paths with spaces', async () => {
-    const rig = new TestRig();
     await rig.setup('should correctly handle file paths with spaces');
     const fileName = 'my test file.txt';
 
@@ -114,7 +121,6 @@ describe('file-system', () => {
   });
 
   it('should perform a read-then-write sequence', async () => {
-    const rig = new TestRig();
     await rig.setup('should perform a read-then-write sequence');
     const fileName = 'version.txt';
     rig.createFile(fileName, '1.0.0');
@@ -149,7 +155,6 @@ describe('file-system', () => {
   });
 
   it.skip('should replace multiple instances of a string', async () => {
-    const rig = new TestRig();
     await rig.setup('should replace multiple instances of a string');
     const fileName = 'ambiguous.txt';
     const fileContent = 'Hey there, \ntest line\ntest line';
@@ -192,7 +197,6 @@ describe('file-system', () => {
   });
 
   it('should fail safely when trying to edit a non-existent file', async () => {
-    const rig = new TestRig();
     await rig.setup(
       'should fail safely when trying to edit a non-existent file',
     );

--- a/integration-tests/flicker.test.ts
+++ b/integration-tests/flicker.test.ts
@@ -4,12 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig } from './test-helper.js';
 
 describe('Flicker Detector', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it('should not detect a flicker under the max height budget', async () => {
-    const rig = new TestRig();
     await rig.setup('flicker-detector-test');
 
     const run = await rig.runInteractive();

--- a/integration-tests/google_web_search.test.ts
+++ b/integration-tests/google_web_search.test.ts
@@ -5,12 +5,21 @@
  */
 
 import { WEB_SEARCH_TOOL_NAME } from '../packages/core/src/tools/tool-names.js';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig, printDebugInfo, validateModelOutput } from './test-helper.js';
 
 describe(WEB_SEARCH_TOOL_NAME, () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it('should be able to search the web', async () => {
-    const rig = new TestRig();
     await rig.setup('should be able to search the web');
 
     let result;

--- a/integration-tests/json-output.test.ts
+++ b/integration-tests/json-output.test.ts
@@ -15,8 +15,8 @@ describe('JSON output', () => {
     await rig.setup('json-output-test');
   });
 
-  afterEach(async () => {
-    await rig.cleanup();
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
   });
 
   it('should return a valid JSON with response and stats', async () => {

--- a/integration-tests/list_directory.test.ts
+++ b/integration-tests/list_directory.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   TestRig,
   poll,
@@ -15,8 +15,17 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 describe('list_directory', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it('should be able to list a directory', async () => {
-    const rig = new TestRig();
     await rig.setup('should be able to list a directory');
     rig.createFile('file1.txt', 'file 1 content');
     rig.mkdir('subdir');

--- a/integration-tests/mcp_server_cyclic_schema.test.ts
+++ b/integration-tests/mcp_server_cyclic_schema.test.ts
@@ -23,7 +23,7 @@
 
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { beforeAll, describe, it } from 'vitest';
+import { beforeEach, afterEach, describe, it } from 'vitest';
 import { TestRig } from './test-helper.js';
 
 // Create a minimal MCP server that doesn't require external dependencies
@@ -166,9 +166,10 @@ rpc.send({
 `;
 
 describe('mcp server with cyclic tool schema is detected', () => {
-  const rig = new TestRig();
+  let rig: TestRig;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
+    rig = new TestRig();
     // Setup test directory with MCP server configuration
     await rig.setup('cyclic-schema-mcp-server', {
       settings: {
@@ -190,6 +191,10 @@ describe('mcp server with cyclic tool schema is detected', () => {
       const { chmodSync } = await import('node:fs');
       chmodSync(testServerPath, 0o755);
     }
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
   });
 
   it('mcp tool list should include tool with cyclic tool schema', async () => {

--- a/integration-tests/mixed-input-crash.test.ts
+++ b/integration-tests/mixed-input-crash.test.ts
@@ -4,12 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig } from './test-helper.js';
 
 describe('mixed input crash prevention', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it('should not crash when using mixed prompt inputs', async () => {
-    const rig = new TestRig();
     rig.setup('should not crash when using mixed prompt inputs');
 
     // Test: echo "say '1'." | gemini --prompt-interactive="say '2'." say '3'.
@@ -40,7 +49,6 @@ describe('mixed input crash prevention', () => {
   });
 
   it('should provide clear error message for mixed input', async () => {
-    const rig = new TestRig();
     rig.setup('should provide clear error message for mixed input');
 
     try {

--- a/integration-tests/read_many_files.test.ts
+++ b/integration-tests/read_many_files.test.ts
@@ -4,12 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig, printDebugInfo, validateModelOutput } from './test-helper.js';
 
 describe('read_many_files', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it.skip('should be able to read multiple files', async () => {
-    const rig = new TestRig();
     await rig.setup('should be able to read multiple files');
     rig.createFile('file1.txt', 'file 1 content');
     rig.createFile('file2.txt', 'file 2 content');

--- a/integration-tests/replace.test.ts
+++ b/integration-tests/replace.test.ts
@@ -4,12 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig } from './test-helper.js';
 
 describe('replace', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it('should be able to replace content in a file', async () => {
-    const rig = new TestRig();
     await rig.setup('should be able to replace content in a file');
 
     const fileName = 'file_to_replace.txt';
@@ -27,7 +36,6 @@ describe('replace', () => {
   });
 
   it('should handle $ literally when replacing text ending with $', async () => {
-    const rig = new TestRig();
     await rig.setup(
       'should handle $ literally when replacing text ending with $',
     );
@@ -49,7 +57,6 @@ describe('replace', () => {
   });
 
   it('should insert a multi-line block of text', async () => {
-    const rig = new TestRig();
     await rig.setup('should insert a multi-line block of text');
     const fileName = 'insert_block.txt';
     const originalContent = 'Line A\n<INSERT_TEXT_HERE>\nLine C';
@@ -68,7 +75,6 @@ describe('replace', () => {
   });
 
   it('should delete a block of text', async () => {
-    const rig = new TestRig();
     await rig.setup('should delete a block of text');
     const fileName = 'delete_block.txt';
     const blockToDelete =

--- a/integration-tests/run_shell_command.test.ts
+++ b/integration-tests/run_shell_command.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig, printDebugInfo, validateModelOutput } from './test-helper.js';
 import { getShellConfiguration } from '../packages/core/src/utils/shell-utils.js';
 
@@ -22,8 +22,17 @@ function getLineCountCommand(): { command: string; tool: string } {
 }
 
 describe('run_shell_command', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it('should be able to run a shell command', async () => {
-    const rig = new TestRig();
     await rig.setup('should be able to run a shell command');
 
     const prompt = `Please run the command "echo hello-world" and show me the output`;
@@ -55,7 +64,6 @@ describe('run_shell_command', () => {
   });
 
   it('should be able to run a shell command via stdin', async () => {
-    const rig = new TestRig();
     await rig.setup('should be able to run a shell command via stdin');
 
     const prompt = `Please run the command "echo test-stdin" and show me what it outputs`;
@@ -83,7 +91,6 @@ describe('run_shell_command', () => {
   });
 
   it('should run allowed sub-command in non-interactive mode', async () => {
-    const rig = new TestRig();
     await rig.setup('should run allowed sub-command in non-interactive mode');
 
     const testFile = rig.createFile('test.txt', 'Lorem\nIpsum\nDolor\n');
@@ -121,7 +128,6 @@ describe('run_shell_command', () => {
   });
 
   it('should succeed with no parens in non-interactive mode', async () => {
-    const rig = new TestRig();
     await rig.setup('should succeed with no parens in non-interactive mode');
 
     const testFile = rig.createFile('test.txt', 'Lorem\nIpsum\nDolor\n');
@@ -158,7 +164,6 @@ describe('run_shell_command', () => {
   });
 
   it('should succeed with --yolo mode', async () => {
-    const rig = new TestRig();
     await rig.setup('should succeed with --yolo mode');
 
     const testFile = rig.createFile('test.txt', 'Lorem\nIpsum\nDolor\n');
@@ -192,7 +197,6 @@ describe('run_shell_command', () => {
   });
 
   it('should work with ShellTool alias', async () => {
-    const rig = new TestRig();
     await rig.setup('should work with ShellTool alias');
 
     const testFile = rig.createFile('test.txt', 'Lorem\nIpsum\nDolor\n');
@@ -231,7 +235,6 @@ describe('run_shell_command', () => {
   // TODO(#11062): Un-skip this once we can make it reliable by using hard coded
   // model responses.
   it.skip('should combine multiple --allowed-tools flags', async () => {
-    const rig = new TestRig();
     await rig.setup('should combine multiple --allowed-tools flags');
 
     const { tool, command } = getLineCountCommand();
@@ -281,7 +284,6 @@ describe('run_shell_command', () => {
   });
 
   it('should allow all with "ShellTool" and other specific tools', async () => {
-    const rig = new TestRig();
     await rig.setup(
       'should allow all with "ShellTool" and other specific tools',
     );
@@ -328,7 +330,6 @@ describe('run_shell_command', () => {
   });
 
   it('should propagate environment variables to the child process', async () => {
-    const rig = new TestRig();
     await rig.setup('should propagate environment variables');
 
     const varName = 'GEMINI_CLI_TEST_VAR';
@@ -360,7 +361,6 @@ describe('run_shell_command', () => {
   });
 
   it('should run a platform-specific file listing command', async () => {
-    const rig = new TestRig();
     await rig.setup('should run platform-specific file listing');
     const fileName = `test-file-${Math.random().toString(36).substring(7)}.txt`;
     rig.createFile(fileName, 'test content');

--- a/integration-tests/save_memory.test.ts
+++ b/integration-tests/save_memory.test.ts
@@ -4,12 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig, printDebugInfo, validateModelOutput } from './test-helper.js';
 
 describe('save_memory', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it('should be able to save to memory', async () => {
-    const rig = new TestRig();
     await rig.setup('should be able to save to memory');
 
     const prompt = `remember that my favorite color is  blue.

--- a/integration-tests/simple-mcp-server.test.ts
+++ b/integration-tests/simple-mcp-server.test.ts
@@ -10,7 +10,7 @@
  * external dependencies, making it compatible with Docker sandbox mode.
  */
 
-import { describe, it, beforeAll, expect } from 'vitest';
+import { describe, it, beforeEach, afterEach, expect } from 'vitest';
 import { TestRig, poll, validateModelOutput } from './test-helper.js';
 import { join } from 'node:path';
 import { writeFileSync } from 'node:fs';
@@ -165,9 +165,10 @@ rpc.send({
 `;
 
 describe('simple-mcp-server', () => {
-  const rig = new TestRig();
+  let rig: TestRig;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
+    rig = new TestRig();
     // Setup test directory with MCP server configuration
     await rig.setup('simple-mcp-server', {
       settings: {
@@ -208,6 +209,10 @@ describe('simple-mcp-server', () => {
     if (!isReady) {
       throw new Error('MCP server script was not ready in time.');
     }
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
   });
 
   it('should add two numbers', async () => {

--- a/integration-tests/stdin-context.test.ts
+++ b/integration-tests/stdin-context.test.ts
@@ -4,12 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig, printDebugInfo, validateModelOutput } from './test-helper.js';
 
 describe.skip('stdin context', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it('should be able to use stdin as context for a prompt', async () => {
-    const rig = new TestRig();
     await rig.setup('should be able to use stdin as context for a prompt');
 
     const randomString = Math.random().toString(36).substring(7);
@@ -75,7 +84,6 @@ describe.skip('stdin context', () => {
       even though gemini is intended to run interactively.
     */
 
-    const rig = new TestRig();
     await rig.setup('should exit quickly if stdin stream does not end');
 
     try {

--- a/integration-tests/telemetry.test.ts
+++ b/integration-tests/telemetry.test.ts
@@ -4,12 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig } from './test-helper.js';
 
 describe('telemetry', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it('should emit a metric and a log event', async () => {
-    const rig = new TestRig();
     rig.setup('should emit a metric and a log event');
 
     // Run a simple command that should trigger telemetry

--- a/integration-tests/utf-bom-encoding.test.ts
+++ b/integration-tests/utf-bom-encoding.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { writeFileSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { TestRig } from './test-helper.js';
@@ -50,18 +50,18 @@ const utf32BE = (s: string) => {
   return Buffer.concat([bom, payload]);
 };
 
-let rig: TestRig;
-let dir: string;
-
 d('BOM end-to-end integration', () => {
-  beforeAll(async () => {
+  let rig: TestRig;
+  let dir: string;
+
+  beforeEach(async () => {
     rig = new TestRig();
     await rig.setup('bom-integration');
     dir = rig.testDir!;
   });
 
-  afterAll(async () => {
-    await rig.cleanup();
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
   });
 
   async function runAndAssert(

--- a/integration-tests/write_file.test.ts
+++ b/integration-tests/write_file.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   TestRig,
   createToolCallErrorMessage,
@@ -13,8 +13,17 @@ import {
 } from './test-helper.js';
 
 describe('write_file', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async (ctx) => {
+    await rig.cleanup(ctx);
+  });
+
   it('should be able to write a file', async () => {
-    const rig = new TestRig();
     await rig.setup('should be able to write a file');
     const prompt = `show me an example of using the write tool. put a dad joke in dad.txt`;
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "npm run test --workspaces --if-present --parallel",
     "test:ci": "npm run test:ci --workspaces --if-present --parallel && npm run test:scripts",
     "test:scripts": "vitest run --config ./scripts/tests/vitest.config.ts",
-    "test:e2e": "cross-env VERBOSE=true KEEP_OUTPUT=true npm run test:integration:sandbox:none",
+    "test:e2e": "npm run test:integration:sandbox:none",
     "test:integration:all": "npm run test:integration:sandbox:none && npm run test:integration:sandbox:docker && npm run test:integration:sandbox:podman",
     "test:integration:sandbox:none": "cross-env GEMINI_SANDBOX=false vitest run --root ./integration-tests",
     "test:integration:sandbox:docker": "cross-env GEMINI_SANDBOX=docker npm run build:sandbox && cross-env GEMINI_SANDBOX=docker vitest run --root ./integration-tests",

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -742,8 +742,9 @@ export async function start_sandbox(
       const originalCommand = finalEntrypoint[2];
       const escapedOriginalCommand = originalCommand.replace(/'/g, "'\\''");
 
-      // Use `su -p` to preserve the environment.
-      const suCommand = `su -p ${username} -c '${escapedOriginalCommand}'`;
+      // Use `su -p` to preserve the environment, but explicitly set HOME
+      // to ensure it's correct for the new user in the container context.
+      const suCommand = `su -p ${username} -c 'HOME="${homeDir}" ${escapedOriginalCommand}'`;
 
       // The entrypoint is always `['bash', '-c', '<command>']`, so we modify the command part.
       finalEntrypoint[2] = `${setupUserCommands} && ${suCommand}`;


### PR DESCRIPTION
## TLDR

Fixes the issue of interleaved CLI output in CI integration test logs when running tests in parallel.

## Dive Deeper

Previously, integration tests printed CLI output directly to `stdout`/`stderr` immediately. When running in parallel (default Vitest behavior), this caused output from different tests to mix, making logs unreadable.

This PR:
1. Modifies `TestRig` in `integration-tests/test-helper.ts` to capture CLI output in memory.
2. Updates `TestRig.cleanup(ctx)` to print the captured output *only* if the test failed (using Vitest context).
3. Refactors all integration tests to use `beforeEach` for setup and `afterEach` for cleanup, passing the test context.
4. Removes `VERBOSE=true` and `KEEP_OUTPUT=true` from CI workflows and `package.json` scripts, relying on the new capture-on-failure mechanism.

## Reviewer Test Plan

Run integration tests locally:
`npm run test:integration:sandbox:none`

Verify that output is clean and not verbose unless a test fails. Introduce a deliberate failure in a test to verify output is printed for failed tests.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A