### PR TITLE
Skip failing test.

### DIFF
--- a/integration-tests/run_shell_command.test.ts
+++ b/integration-tests/run_shell_command.test.ts
@@ -338,7 +338,7 @@ describe('run_shell_command', () => {
     }
   });
 
-  it('should reject commands not on the allowlist', async () => {
+  it.skip('should reject commands not on the allowlist', async () => {
     const rig = new TestRig();
     await rig.setup('should reject commands not on the allowlist');
 


### PR DESCRIPTION
## TLDR

Skip failing test.
Filed https://github.com/google-gemini/gemini-cli/issues/11336 to track re-enabling it.
