### PR TITLE
fix(security): block shell redirections to files outside workspace

### DIFF
--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -406,9 +406,11 @@ export class ShellTool extends BaseDeclarativeTool<
 
     // Check for unsafe file redirections outside workspace
     const workspaceDirs = this.config.getWorkspaceContext().getDirectories();
+    const cwd = params.directory || this.config.getTargetDir();
     const redirectionCheck = checkForUnsafeRedirections(
       params.command,
       workspaceDirs,
+      cwd,
     );
 
     if (redirectionCheck.isOutsideWorkspace) {

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -24,6 +24,7 @@ import {
   stripShellWrapper,
 } from './shell-utils.js';
 import type { Config } from '../config/config.js';
+import type { WorkspaceContext } from './workspaceContext.js';
 
 const mockPlatform = vi.hoisted(() => vi.fn());
 const mockHomedir = vi.hoisted(() => vi.fn());
@@ -200,9 +201,10 @@ describe('isCommandAllowed', () => {
 
   describe('with unsafe redirections', () => {
     beforeEach(() => {
-      config.getWorkspaceContext = () => ({
-        getDirectories: () => ['/workspace'],
-      });
+      config.getWorkspaceContext = () =>
+        ({
+          getDirectories: () => ['/workspace'],
+        }) as Partial<WorkspaceContext> as WorkspaceContext;
     });
 
     it('should block output redirection to home directory', () => {
@@ -234,9 +236,10 @@ describe('isCommandAllowed', () => {
     });
 
     it('should block path traversal attempts', () => {
-      config.getWorkspaceContext = () => ({
-        getDirectories: () => ['/workspace/project/subdir'],
-      });
+      config.getWorkspaceContext = () =>
+        ({
+          getDirectories: () => ['/workspace/project/subdir'],
+        }) as Partial<WorkspaceContext> as WorkspaceContext;
       const result = isCommandAllowed(
         'cat secret > ../../../etc/passwd',
         config,

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -769,4 +769,24 @@ describe('checkForUnsafeRedirections', () => {
     expect(result.isOutsideWorkspace).toBe(true);
     expect(result.unsafeTargets).toContain('/tmp/file.txt');
   });
+
+  it('should block redirection to a dynamic path with variable expansion', () => {
+    const result = checkForUnsafeRedirections(
+      'echo test > $DANGEROUS_PATH',
+      ['/workspace'],
+      '/workspace',
+    );
+    expect(result.isOutsideWorkspace).toBe(true);
+    expect(result.unsafeTargets).toContain('$DANGEROUS_PATH');
+  });
+
+  it('should block redirection to a dynamic path with command substitution', () => {
+    const result = checkForUnsafeRedirections(
+      'echo test > /tmp/$(whoami).txt',
+      ['/workspace'],
+      '/workspace',
+    );
+    expect(result.isOutsideWorkspace).toBe(true);
+    expect(result.unsafeTargets).toContain('/tmp/$(whoami).txt');
+  });
 });

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -299,7 +299,11 @@ function collectRedirections(root: Node, source: string): RedirectionDetail[] {
             (child) =>
               child?.type === '>' ||
               child?.type === '>>' ||
-              child?.type === '<',
+              child?.type === '<' ||
+              child?.type === '&>' ||
+              child?.type === '&>>' ||
+              child?.type === '<>' ||
+              child?.type === '>|',
           );
           const operator = operatorNode
             ? source.slice(operatorNode.startIndex, operatorNode.endIndex)
@@ -646,7 +650,10 @@ function isPathOutsideWorkspace(
       // If it's a relative path with .., it might escape
       // We'll resolve it against a workspace dir to check
       if (workspaceDirs.length === 0) {
-        return false; // No workspace restriction
+        // If there are no workspace directories, we cannot safely resolve
+        // a relative path. Treat it as unsafe, consistent with how
+        // absolute paths are handled in this scenario.
+        return true;
       }
       expandedPath = path.resolve(workspaceDirs[0], expandedPath);
     }

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -298,7 +298,10 @@ function collectRedirections(root: Node, source: string): RedirectionDetail[] {
           // A redirection target is dynamic if it contains any shell expansions.
           // We cannot safely validate dynamic paths, so they must be blocked.
           const isDynamic =
+            destination.type === 'process_substitution' ||
+            destination.descendantsOfType('process_substitution').length > 0 ||
             destination.descendantsOfType('expansion').length > 0 ||
+            destination.descendantsOfType('simple_expansion').length > 0 ||
             destination.descendantsOfType('command_substitution').length > 0;
 
           // Determine redirect type by looking at the operator

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -5,7 +5,7 @@
  */
 
 import type { AnyToolInvocation } from '../index.js';
-import type { Config } from '../config.js';
+import type { Config } from '../config/config.js';
 import os from 'node:os';
 import path from 'node:path';
 import { quote } from 'shell-quote';
@@ -297,7 +297,9 @@ function collectRedirections(root: Node, source: string): RedirectionDetail[] {
           // Determine redirect type by looking at the operator
           const operatorNode = current.children.find(
             (child) =>
-              child.type === '>' || child.type === '>>' || child.type === '<',
+              child?.type === '>' ||
+              child?.type === '>>' ||
+              child?.type === '<',
           );
           const operator = operatorNode
             ? source.slice(operatorNode.startIndex, operatorNode.endIndex)
@@ -632,7 +634,7 @@ function unquotePath(filePath: string): string {
  */
 function isPathOutsideWorkspace(
   targetPath: string,
-  workspaceDirs: string[],
+  workspaceDirs: readonly string[],
 ): boolean {
   try {
     // Expand tilde and remove quotes
@@ -678,7 +680,7 @@ function isPathOutsideWorkspace(
  */
 export function checkForUnsafeRedirections(
   command: string,
-  workspaceDirs: string[],
+  workspaceDirs: readonly string[],
 ): RedirectionCheckResult {
   const tree = parseCommandTree(command);
   if (!tree) {
@@ -867,7 +869,7 @@ export function checkCommandPermissions(
   } else {
     // "DEFAULT ALLOW" MODE: No session allowlist.
     const hasSpecificAllowedCommands =
-      coreTools.filter((tool) =>
+      coreTools.filter((tool: string) =>
         SHELL_TOOL_NAMES.some((name) => tool.startsWith(`${name}(`)),
       ).length > 0;
 


### PR DESCRIPTION
# Security Fix: Block File Redirections Outside Workspace

## TLDR

This PR fixes a  security vulnerability where shell commands could use file redirections (`>`, `>>`, `<`) to read from or write to arbitrary files outside the workspace directory. The fix adds AST-based parsing to detect redirections and validates that all redirection targets are within workspace boundaries.

## Dive Deeper

### Security Issue

Previously, when a user allowed a command like `wc`, the CLI would silently permit `wc README.md > ~/wc_output`, enabling writes to the home directory, system files, or any location on the filesystem. This bypassed the workspace directory restrictions that other tools enforce.

### Implementation

- Uses tree-sitter bash parser to extract file redirection nodes from the AST
- Detects output (`>`), append (`>>`), input (`<`), and heredoc (`<<`) redirections
- Validates redirection target paths against workspace directories
- Handles edge cases: tilde expansion, quoted paths, relative paths with `../`
- Blocks absolute paths outside workspace while allowing workspace-internal redirections

### Design Decisions

- AST parsing ensures accurate detection even with complex command structures
- Validation happens at two layers: `checkCommandPermissions()` and `validateToolParamValues()`
- When no workspace directories are configured, absolute paths are considered unsafe
- Pipes (`|`) are detected but not blocked (they connect commands, not files)

## Reviewer Test Plan

To validate the fix:

### 1. Test blocked redirections

```bash
# Should be blocked with clear error message
wc README.md > ~/output.txt
echo secret > /tmp/data.txt
cat file > ../../escape.txt
```

### 2. Test allowed redirections

```bash
# Should work normally
echo "test" > output.txt
npm test > logs/results.txt
cat data.csv | grep error > errors.txt
```

### 3. Run test suite

```bash
cd packages/core
npm test -- src/utils/shell-utils.test.ts
npm test -- src/tools/shell.test.ts
```

### Expected behavior

- Blocked commands show error: "Command uses file redirection to paths outside the workspace: "
- Allowed commands execute normally


## Testing Matrix

|          | 🍏 macOS | 🪟 Windows | 🐧 Linux |
|----------|----------|------------|----------|
| npm run  | ❓        | ❓          | ✅        |
| npx      | ❓        | ❓          | ❓        |
| Docker   | ❓        | ❓          | ❓        |
| Podman   | ❓        | -          | -        |
| Seatbelt | ❓        | -          | -        |

Tested on Linux. The implementation uses cross-platform path resolution and should work on all platforms, but additional testing on macOS and Windows would be valuable.

## Linked Issues / Bugs

Fixes #11047