### PR TITLE
 feat(telemetry): add TLS support for OTLP exporters 🔒

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -53,15 +53,16 @@ observability framework — Gemini CLI's observability system provides:
 All telemetry behavior is controlled through your `.gemini/settings.json` file.
 These settings can be overridden by environment variables or CLI flags.
 
-| Setting        | Environment Variable             | CLI Flag                                                 | Description                                       | Values            | Default                 |
-| -------------- | -------------------------------- | -------------------------------------------------------- | ------------------------------------------------- | ----------------- | ----------------------- |
-| `enabled`      | `GEMINI_TELEMETRY_ENABLED`       | `--telemetry` / `--no-telemetry`                         | Enable or disable telemetry                       | `true`/`false`    | `false`                 |
-| `target`       | `GEMINI_TELEMETRY_TARGET`        | `--telemetry-target <local\|gcp>`                        | Where to send telemetry data                      | `"gcp"`/`"local"` | `"local"`               |
-| `otlpEndpoint` | `GEMINI_TELEMETRY_OTLP_ENDPOINT` | `--telemetry-otlp-endpoint <URL>`                        | OTLP collector endpoint                           | URL string        | `http://localhost:4317` |
-| `otlpProtocol` | `GEMINI_TELEMETRY_OTLP_PROTOCOL` | `--telemetry-otlp-protocol <grpc\|http>`                 | OTLP transport protocol                           | `"grpc"`/`"http"` | `"grpc"`                |
-| `outfile`      | `GEMINI_TELEMETRY_OUTFILE`       | `--telemetry-outfile <path>`                             | Save telemetry to file (overrides `otlpEndpoint`) | file path         | -                       |
-| `logPrompts`   | `GEMINI_TELEMETRY_LOG_PROMPTS`   | `--telemetry-log-prompts` / `--no-telemetry-log-prompts` | Include prompts in telemetry logs                 | `true`/`false`    | `true`                  |
-| `useCollector` | `GEMINI_TELEMETRY_USE_COLLECTOR` | -                                                        | Use external OTLP collector (advanced)            | `true`/`false`    | `false`                 |
+| Setting        | Environment Variable              | CLI Flag                                                 | Description                                       | Values            | Default                 |
+| -------------- | --------------------------------- | -------------------------------------------------------- | ------------------------------------------------- | ----------------- | ----------------------- |
+| `enabled`      | `GEMINI_TELEMETRY_ENABLED`        | `--telemetry` / `--no-telemetry`                         | Enable or disable telemetry                       | `true`/`false`    | `false`                 |
+| `target`       | `GEMINI_TELEMETRY_TARGET`         | `--telemetry-target <local\|gcp>`                        | Where to send telemetry data                      | `"gcp"`/`"local"` | `"local"`               |
+| `otlpEndpoint` | `GEMINI_TELEMETRY_OTLP_ENDPOINT`  | `--telemetry-otlp-endpoint <URL>`                        | OTLP collector endpoint                           | URL string        | `http://localhost:4317` |
+| `otlpProtocol` | `GEMINI_TELEMETRY_OTLP_PROTOCOL`  | `--telemetry-otlp-protocol <grpc\|http>`                 | OTLP transport protocol                           | `"grpc"`/`"http"` | `"grpc"`                |
+| `outfile`      | `GEMINI_TELEMETRY_OUTFILE`        | `--telemetry-outfile <path>`                             | Save telemetry to file (overrides `otlpEndpoint`) | file path         | -                       |
+| `logPrompts`   | `GEMINI_TELEMETRY_LOG_PROMPTS`    | `--telemetry-log-prompts` / `--no-telemetry-log-prompts` | Include prompts in telemetry logs                 | `true`/`false`    | `true`                  |
+| `useCollector` | `GEMINI_TELEMETRY_USE_COLLECTOR`  | -                                                        | Use external OTLP collector (advanced)            | `true`/`false`    | `false`                 |
+| `rootCertPath` | `GEMINI_TELEMETRY_ROOT_CERT_PATH` | `--telemetry-root-cert-path <path>`                      | Path to a root CA certificate for TLS connections | file path         | -                       |
 
 **Note on boolean environment variables:** For the boolean settings (`enabled`,
 `logPrompts`, `useCollector`), setting the corresponding environment variable to
@@ -227,7 +228,7 @@ for Gemini CLI:
     - `file_filtering_respect_git_ignore` (boolean)
     - `debug_mode` (boolean)
     - `mcp_servers` (string)
-    - `output_format` (string: "text", "json", or "stream-json")
+    - `output_format` (string: "text" or "json")
 
 - `gemini_cli.user_prompt`: This event occurs when a user submits a prompt.
   - **Attributes**:

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -540,6 +540,25 @@ describe('Server Config (config.ts)', () => {
       const config = new Config(paramsWithoutTelemetry);
       expect(config.getTelemetryOtlpProtocol()).toBe('grpc');
     });
+
+    it('should return provided SSL root file path', () => {
+      const sslPath = '/path/to/cert.pem';
+      const params: ConfigParameters = {
+        ...baseParams,
+        telemetry: { enabled: true, rootCertPath: sslPath },
+      };
+      const config = new Config(params);
+      expect(config.getTelemetrySslRootFilePath()).toBe(sslPath);
+    });
+
+    it('should return undefined for SSL root file path if not provided', () => {
+      const params: ConfigParameters = {
+        ...baseParams,
+        telemetry: { enabled: true },
+      };
+      const config = new Config(params);
+      expect(config.getTelemetrySslRootFilePath()).toBeUndefined();
+    });
   });
 
   describe('UseRipgrep Configuration', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -46,6 +46,8 @@ import { StartSessionEvent } from '../telemetry/index.js';
 import {
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_THINKING_MODE,
 } from './models.js';
 import { shouldAttemptBrowserLaunch } from '../utils/browser.js';
 import type { MCPOAuthConfig } from '../mcp/oauth-provider.js';
@@ -372,7 +374,7 @@ export class Config {
   private readonly outputSettings: OutputSettings;
   private readonly useModelRouter: boolean;
   private readonly enableMessageBusIntegration: boolean;
-  private readonly codebaseInvestigatorSettings?: CodebaseInvestigatorSettings;
+  private readonly codebaseInvestigatorSettings: CodebaseInvestigatorSettings;
   private readonly continueOnFailedApiCall: boolean;
   private readonly retryFetchErrors: boolean;
   private readonly enableShellOutputEfficiency: boolean;
@@ -469,7 +471,15 @@ export class Config {
     this.useModelRouter = params.useModelRouter ?? false;
     this.enableMessageBusIntegration =
       params.enableMessageBusIntegration ?? false;
-    this.codebaseInvestigatorSettings = params.codebaseInvestigatorSettings;
+    this.codebaseInvestigatorSettings = {
+      enabled: params.codebaseInvestigatorSettings?.enabled ?? true,
+      maxNumTurns: params.codebaseInvestigatorSettings?.maxNumTurns ?? 15,
+      maxTimeMinutes: params.codebaseInvestigatorSettings?.maxTimeMinutes ?? 5,
+      thinkingBudget:
+        params.codebaseInvestigatorSettings?.thinkingBudget ??
+        DEFAULT_THINKING_MODE,
+      model: params.codebaseInvestigatorSettings?.model ?? DEFAULT_GEMINI_MODEL,
+    };
     this.continueOnFailedApiCall = params.continueOnFailedApiCall ?? true;
     this.enableShellOutputEfficiency =
       params.enableShellOutputEfficiency ?? true;
@@ -1068,7 +1078,7 @@ export class Config {
     return this.enableMessageBusIntegration;
   }
 
-  getCodebaseInvestigatorSettings(): CodebaseInvestigatorSettings | undefined {
+  getCodebaseInvestigatorSettings(): CodebaseInvestigatorSettings {
     return this.codebaseInvestigatorSettings;
   }
 
@@ -1164,7 +1174,7 @@ export class Config {
     }
 
     // Register Subagents as Tools
-    if (this.getCodebaseInvestigatorSettings()?.enabled) {
+    if (this.getCodebaseInvestigatorSettings().enabled) {
       const definition = this.agentRegistry.getDefinition(
         'codebase_investigator',
       );

--- a/packages/core/src/telemetry/config.test.ts
+++ b/packages/core/src/telemetry/config.test.ts
@@ -151,5 +151,32 @@ describe('telemetry/config helpers', () => {
         /Invalid telemetry target/i,
       );
     });
+
+    it('resolves rootCertPath from argv, env, and settings', async () => {
+      // Only settings
+      let resolved = await resolveTelemetrySettings({
+        settings: { rootCertPath: '/settings/cert.pem' },
+      });
+      expect(resolved.rootCertPath).toBe('/settings/cert.pem');
+
+      // Env overrides settings
+      resolved = await resolveTelemetrySettings({
+        settings: { rootCertPath: '/settings/cert.pem' },
+        env: { GEMINI_TELEMETRY_ROOT_CERT_PATH: '/env/cert.pem' },
+      });
+      expect(resolved.rootCertPath).toBe('/env/cert.pem');
+
+      // Argv overrides env and settings
+      resolved = await resolveTelemetrySettings({
+        argv: { telemetryRootCertPath: '/argv/cert.pem' },
+        settings: { rootCertPath: '/settings/cert.pem' },
+        env: { GEMINI_TELEMETRY_ROOT_CERT_PATH: '/env/cert.pem' },
+      });
+      expect(resolved.rootCertPath).toBe('/argv/cert.pem');
+
+      // Undefined when not present
+      resolved = await resolveTelemetrySettings({});
+      expect(resolved.rootCertPath).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/telemetry/config.ts
+++ b/packages/core/src/telemetry/config.ts
@@ -41,6 +41,7 @@ export interface TelemetryArgOverrides {
   telemetryOtlpProtocol?: string;
   telemetryLogPrompts?: boolean;
   telemetryOutfile?: string;
+  telemetryRootCertPath?: string;
 }
 
 /**
@@ -108,6 +109,11 @@ export async function resolveTelemetrySettings(options: {
     parseBooleanEnvFlag(env['GEMINI_TELEMETRY_USE_COLLECTOR']) ??
     settings.useCollector;
 
+  const rootCertPath =
+    argv.telemetryRootCertPath ??
+    env['GEMINI_TELEMETRY_ROOT_CERT_PATH'] ??
+    settings.rootCertPath;
+
   return {
     enabled,
     target,
@@ -116,5 +122,6 @@ export async function resolveTelemetrySettings(options: {
     logPrompts,
     outfile,
     useCollector,
+    rootCertPath,
   };
 }

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -294,7 +294,9 @@ describe('Telemetry SDK', () => {
     initializeTelemetry(mockConfig);
 
     expect(fs.readFileSync).toHaveBeenCalledWith(fakePath);
-    expect(credentials.createSsl).toHaveBeenCalledWith('fake-cert-content');
+    expect(credentials.createSsl).toHaveBeenCalledWith(
+      Buffer.from('fake-cert-content'),
+    );
     expect(OTLPTraceExporter).toHaveBeenCalledWith(
       expect.objectContaining({
         credentials: mockSslCreds,


### PR DESCRIPTION
## TLDR

This feature introduces support for using a root CA certificate for TLS connections to the OTLP collector in http and grpc mode.

A new `rootCertPath` setting is added to the telemetry configuration, which can be set via config file, environment variable, or CLI flag.     When provided, both gRPC and HTTP OTLP exporters will be configured to use the specified certificate for secure communication.

```json
"telemetry": {
    "enabled": true,
    "target": "gcp",
    "rootCertPath": "C:/Users/dasilvaf/.gemini/ca-cert.pem",
    "otlpEndpoint": "https://otl.gemini-cli.my-company.com",
    "logPrompts": true,
    "useCollector": true
  }
```

## Dive Deeper
When using Gemini CLI behind vpn and in a corporate company, the default implementation of the sdk telemetry doesn't manage ChannelCredentials with rootCerts which will avoid error of type "SELF_SIGNED_CERT_IN_CHAIN" when data are pushed to a remote and secured telemetry endpoint.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

None linked issue found so far
