### PR TITLE
fix(scripts): Update get-release-version to use yargs parsing, handle a dynamically set package name

### DIFF
--- a/scripts/get-release-version.js
+++ b/scripts/get-release-version.js
@@ -43,7 +43,6 @@ function getArgs() {
       string: true,
       default: '@google/gemini-cli',
     })
-    .option('')
     .option('preview_version_override', {
       description: 'Override the calculated preview version.',
       string: true,

--- a/scripts/get-release-version.js
+++ b/scripts/get-release-version.js
@@ -10,20 +10,47 @@ import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
 import semver from 'semver';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+const TAG_LATEST = 'latest';
+const TAG_NIGHTLY = 'nightly';
+const TAG_PREVIEW = 'preview';
 
 function readJson(filePath) {
   return JSON.parse(readFileSync(filePath, 'utf-8'));
 }
 
 function getArgs() {
-  const args = {};
-  process.argv.slice(2).forEach((arg) => {
-    if (arg.startsWith('--')) {
-      const [key, value] = arg.substring(2).split('=');
-      args[key] = value === undefined ? true : value;
-    }
-  });
-  return args;
+  return yargs(hideBin(process.argv))
+    .option('type', {
+      description: 'The type of release to generate a version for.',
+      choices: [TAG_NIGHTLY, 'promote-nightly', 'stable', TAG_PREVIEW, 'patch'],
+      default: TAG_NIGHTLY,
+    })
+    .option('patch-from', {
+      description: 'When type is "patch", specifies the source branch.',
+      choices: ['stable', TAG_PREVIEW],
+      string: true,
+    })
+    .option('stable_version_override', {
+      description: 'Override the calculated stable version.',
+      string: true,
+    })
+    .option('cli-package-name', {
+      description:
+        'fully qualified package name with scope (e.g @google/gemini-cli)',
+      string: true,
+      default: '@google/gemini-cli',
+    })
+    .option('')
+    .option('preview_version_override', {
+      description: 'Override the calculated preview version.',
+      string: true,
+    })
+    .help(false)
+    .version(false)
+    .parse();
 }
 
 function getLatestTag(pattern) {
@@ -54,20 +81,20 @@ function getLatestTag(pattern) {
   }
 }
 
-function getVersionFromNPM(distTag) {
-  const command = `npm view @google/gemini-cli version --tag=${distTag}`;
+function getVersionFromNPM({ args, npmDistTag } = {}) {
+  const command = `npm view ${args['cli-package-name']} version --tag=${npmDistTag}`;
   try {
     return execSync(command).toString().trim();
   } catch (error) {
     console.error(
-      `Failed to get NPM version for dist-tag "${distTag}": ${error.message}`,
+      `Failed to get NPM version for dist-tag "${npmDistTag}": ${error.message}`,
     );
     return '';
   }
 }
 
-function getAllVersionsFromNPM() {
-  const command = `npm view @google/gemini-cli versions --json`;
+function getAllVersionsFromNPM({ args } = {}) {
+  const command = `npm view ${args['cli-package-name']} versions --json`;
   try {
     const versionsJson = execSync(command).toString().trim();
     return JSON.parse(versionsJson);
@@ -77,8 +104,8 @@ function getAllVersionsFromNPM() {
   }
 }
 
-function isVersionDeprecated(version) {
-  const command = `npm view @google/gemini-cli@${version} deprecated`;
+function isVersionDeprecated({ args, version } = {}) {
+  const command = `npm view ${args['cli-package-name']}@${version} deprecated`;
   try {
     const output = execSync(command).toString().trim();
     return output.length > 0;
@@ -91,29 +118,29 @@ function isVersionDeprecated(version) {
   }
 }
 
-function detectRollbackAndGetBaseline(npmDistTag) {
+function detectRollbackAndGetBaseline({ args, npmDistTag } = {}) {
   // Get the current dist-tag version
-  const distTagVersion = getVersionFromNPM(npmDistTag);
+  const distTagVersion = getVersionFromNPM({ args, npmDistTag });
   if (!distTagVersion) return { baseline: '', isRollback: false };
 
   // Get all published versions
-  const allVersions = getAllVersionsFromNPM();
+  const allVersions = getAllVersionsFromNPM({ args });
   if (allVersions.length === 0)
     return { baseline: distTagVersion, isRollback: false };
 
   // Filter versions by type to match the dist-tag
   let matchingVersions;
-  if (npmDistTag === 'latest') {
+  if (npmDistTag === TAG_LATEST) {
     // Stable versions: no prerelease identifiers
     matchingVersions = allVersions.filter(
       (v) => semver.valid(v) && !semver.prerelease(v),
     );
-  } else if (npmDistTag === 'preview') {
+  } else if (npmDistTag === TAG_PREVIEW) {
     // Preview versions: contain -preview
     matchingVersions = allVersions.filter(
       (v) => semver.valid(v) && v.includes('-preview'),
     );
-  } else if (npmDistTag === 'nightly') {
+  } else if (npmDistTag === TAG_NIGHTLY) {
     // Nightly versions: contain -nightly
     matchingVersions = allVersions.filter(
       (v) => semver.valid(v) && v.includes('-nightly'),
@@ -132,7 +159,7 @@ function detectRollbackAndGetBaseline(npmDistTag) {
   // Find the highest non-deprecated version
   let highestExistingVersion = '';
   for (const version of matchingVersions) {
-    if (!isVersionDeprecated(version)) {
+    if (!isVersionDeprecated({ version, args })) {
       highestExistingVersion = version;
       break; // Found the one we want
     } else {
@@ -156,10 +183,10 @@ function detectRollbackAndGetBaseline(npmDistTag) {
   };
 }
 
-function doesVersionExist(version) {
+function doesVersionExist({ args, version } = {}) {
   // Check NPM
   try {
-    const command = `npm view @google/gemini-cli@${version} version 2>/dev/null`;
+    const command = `npm view ${args['cli-package-name']}@${version} version 2>/dev/null`;
     const output = execSync(command).toString().trim();
     if (output === version) {
       console.error(`Version ${version} already exists on NPM.`);
@@ -205,9 +232,9 @@ function doesVersionExist(version) {
   return false;
 }
 
-function getAndVerifyTags(npmDistTag, _gitTagPattern) {
+function getAndVerifyTags({ npmDistTag, args } = {}) {
   // Detect rollback scenarios and get the correct baseline
-  const rollbackInfo = detectRollbackAndGetBaseline(npmDistTag);
+  const rollbackInfo = detectRollbackAndGetBaseline({ args, npmDistTag });
   const baselineVersion = rollbackInfo.baseline;
 
   if (!baselineVersion) {
@@ -229,11 +256,11 @@ function getAndVerifyTags(npmDistTag, _gitTagPattern) {
   };
 }
 
-function promoteNightlyVersion() {
-  const { latestVersion, latestTag } = getAndVerifyTags(
-    'nightly',
-    'v*-nightly*',
-  );
+function promoteNightlyVersion({ args } = {}) {
+  const { latestVersion, latestTag } = getAndVerifyTags({
+    npmDistTag: TAG_NIGHTLY,
+    args,
+  });
   const baseVersion = latestVersion.split('-')[0];
   const versionParts = baseVersion.split('.');
   const major = versionParts[0];
@@ -243,7 +270,7 @@ function promoteNightlyVersion() {
   const gitShortHash = execSync('git rev-parse --short HEAD').toString().trim();
   return {
     releaseVersion: `${major}.${nextMinor}.0-nightly.${date}.${gitShortHash}`,
-    npmTag: 'nightly',
+    npmTag: TAG_NIGHTLY,
     previousReleaseTag: latestTag,
   };
 }
@@ -258,7 +285,7 @@ function getNightlyVersion() {
 
   return {
     releaseVersion,
-    npmTag: 'nightly',
+    npmTag: TAG_NIGHTLY,
     previousReleaseTag,
   };
 }
@@ -277,10 +304,10 @@ function validateVersion(version, format, name) {
 }
 
 function getStableVersion(args) {
-  const { latestVersion: latestPreviewVersion } = getAndVerifyTags(
-    'preview',
-    'v*-preview*',
-  );
+  const { latestVersion: latestPreviewVersion } = getAndVerifyTags({
+    npmDistTag: TAG_PREVIEW,
+    args,
+  });
   let releaseVersion;
   if (args.stable_version_override) {
     const overrideVersion = args.stable_version_override.replace(/^v/, '');
@@ -290,23 +317,23 @@ function getStableVersion(args) {
     releaseVersion = latestPreviewVersion.replace(/-preview.*/, '');
   }
 
-  const { latestTag: previousStableTag } = getAndVerifyTags(
-    'latest',
-    'v[0-9].[0-9].[0-9]',
-  );
+  const { latestTag: previousStableTag } = getAndVerifyTags({
+    npmDistTag: TAG_LATEST,
+    args,
+  });
 
   return {
     releaseVersion,
-    npmTag: 'latest',
+    npmTag: TAG_LATEST,
     previousReleaseTag: previousStableTag,
   };
 }
 
 function getPreviewVersion(args) {
-  const { latestVersion: latestNightlyVersion } = getAndVerifyTags(
-    'nightly',
-    'v*-nightly*',
-  );
+  const { latestVersion: latestNightlyVersion } = getAndVerifyTags({
+    npmDistTag: TAG_NIGHTLY,
+    args,
+  });
   let releaseVersion;
   if (args.preview_version_override) {
     const overrideVersion = args.preview_version_override.replace(/^v/, '');
@@ -321,27 +348,28 @@ function getPreviewVersion(args) {
       latestNightlyVersion.replace(/-nightly.*/, '') + '-preview.0';
   }
 
-  const { latestTag: previousPreviewTag } = getAndVerifyTags(
-    'preview',
-    'v*-preview*',
-  );
+  const { latestTag: previousPreviewTag } = getAndVerifyTags({
+    npmDistTag: TAG_PREVIEW,
+    args,
+  });
 
   return {
     releaseVersion,
-    npmTag: 'preview',
+    npmTag: TAG_PREVIEW,
     previousReleaseTag: previousPreviewTag,
   };
 }
 
 function getPatchVersion(patchFrom) {
-  if (!patchFrom || (patchFrom !== 'stable' && patchFrom !== 'preview')) {
+  if (!patchFrom || (patchFrom !== 'stable' && patchFrom !== TAG_PREVIEW)) {
     throw new Error(
       'Patch type must be specified with --patch-from=stable or --patch-from=preview',
     );
   }
-  const distTag = patchFrom === 'stable' ? 'latest' : 'preview';
-  const pattern = distTag === 'latest' ? 'v[0-9].[0-9].[0-9]' : 'v*-preview*';
-  const { latestVersion, latestTag } = getAndVerifyTags(distTag, pattern);
+  const distTag = patchFrom === 'stable' ? TAG_LATEST : TAG_PREVIEW;
+  const { latestVersion, latestTag } = getAndVerifyTags({
+    npmDistTag: distTag,
+  });
 
   if (patchFrom === 'stable') {
     // For stable versions, increment the patch number: 0.5.4 -> 0.5.5
@@ -380,11 +408,11 @@ function getPatchVersion(patchFrom) {
 
 export function getVersion(options = {}) {
   const args = { ...getArgs(), ...options };
-  const type = args.type || 'nightly';
+  const type = args.type || TAG_NIGHTLY;
 
   let versionData;
   switch (type) {
-    case 'nightly':
+    case TAG_NIGHTLY:
       versionData = getNightlyVersion();
       // Nightly versions include a git hash, so conflicts are highly unlikely
       // and indicate a problem. We'll still validate but not auto-increment.
@@ -400,7 +428,7 @@ export function getVersion(options = {}) {
     case 'stable':
       versionData = getStableVersion(args);
       break;
-    case 'preview':
+    case TAG_PREVIEW:
       versionData = getPreviewVersion(args);
       break;
     case 'patch':
@@ -411,7 +439,7 @@ export function getVersion(options = {}) {
   }
 
   // For patchable versions, check for existence and increment if needed.
-  if (type === 'stable' || type === 'preview' || type === 'patch') {
+  if (type === 'stable' || type === TAG_PREVIEW || type === 'patch') {
     let releaseVersion = versionData.releaseVersion;
     while (doesVersionExist(releaseVersion)) {
       console.error(`Version ${releaseVersion} exists, incrementing.`);

--- a/scripts/get-release-version.js
+++ b/scripts/get-release-version.js
@@ -309,8 +309,8 @@ function getStableVersion(args) {
     args,
   });
   let releaseVersion;
-  if (args.stable_version_override) {
-    const overrideVersion = args.stable_version_override.replace(/^v/, '');
+  if (args['stable_version_override']) {
+    const overrideVersion = args['stable_version_override'].replace(/^v/, '');
     validateVersion(overrideVersion, 'X.Y.Z', 'stable_version_override');
     releaseVersion = overrideVersion;
   } else {
@@ -335,8 +335,8 @@ function getPreviewVersion(args) {
     args,
   });
   let releaseVersion;
-  if (args.preview_version_override) {
-    const overrideVersion = args.preview_version_override.replace(/^v/, '');
+  if (args['preview_version_override']) {
+    const overrideVersion = args['preview_version_override'].replace(/^v/, '');
     validateVersion(
       overrideVersion,
       'X.Y.Z-preview.N',
@@ -408,7 +408,7 @@ function getPatchVersion(patchFrom) {
 
 export function getVersion(options = {}) {
   const args = { ...getArgs(), ...options };
-  const type = args.type || TAG_NIGHTLY;
+  const type = args['type']; // Nightly is the default.
 
   let versionData;
   switch (type) {

--- a/scripts/get-release-version.js
+++ b/scripts/get-release-version.js
@@ -433,7 +433,6 @@ export function getVersion(options = {}) {
       versionData = getPreviewVersion(args);
       break;
     case 'patch':
-      console.log(args);
       versionData = getPatchVersion(args);
       break;
     default:


### PR DESCRIPTION

## TLDR

We need to be able to support dynamic package names for dev vs prod.  It made sense to update this to use yargs.

## Reviewer Test Plan

```
➜  gemini-cli git:(rf/yargs-release) node scripts/get-release-version.js --type=preview
{
  "releaseTag": "v0.10.0-preview.0",
  "releaseVersion": "0.10.0-preview.0",
  "npmTag": "preview",
  "previousReleaseTag": "v0.10.0-preview.1"
}
```
```
➜  gemini-cli git:(rf/yargs-release) node scripts/get-release-version.js --type=stable 
{
  "releaseTag": "v0.10.0",
  "releaseVersion": "0.10.0",
  "npmTag": "latest",
  "previousReleaseTag": "v0.9.0"
}
```

```
➜  gemini-cli git:(rf/yargs-release) node scripts/get-release-version.js --type=nightly
{
  "releaseTag": "v0.11.0-nightly.20251017.834a940b5",
  "releaseVersion": "0.11.0-nightly.20251017.834a940b5",
  "npmTag": "nightly",
  "previousReleaseTag": "v0.10.0-nightly.20251015.996c9f59"
}
```

### dev

```
➜  gemini-cli git:(rf/yargs-release) node scripts/get-release-version.js --type=stable --cli-package-name=@google-gemini/gemini-cli
Rollback detected! NPM latest tag is 0.0.4, but using 0.0.777777777777 as baseline for next version calculation (highest existing version).
{
  "releaseTag": "v0.0.33333",
  "releaseVersion": "0.0.33333",
  "npmTag": "latest",
  "previousReleaseTag": "v0.0.777777777777"
}
```

```
➜  gemini-cli git:(rf/yargs-release) node scripts/get-release-version.js --type=preview --cli-package-name=@google-gemini/gemini-cli
{
  "releaseTag": "v0.0.33333-preview.0",
  "releaseVersion": "0.0.33333-preview.0",
  "npmTag": "preview",
  "previousReleaseTag": "v0.0.33333"
}
```

```
  gemini-cli git:(rf/yargs-release) node scripts/get-release-version.js --type=nightly --cli-package-name=@google-gemini/gemini-cli
{
  "releaseTag": "v0.11.0-nightly.20251017.834a940b5",
  "releaseVersion": "0.11.0-nightly.20251017.834a940b5",
  "npmTag": "nightly",
  "previousReleaseTag": "v0.10.0-nightly.20251015.996c9f59"
}
```


## Linked issues / bugs

Part of [#11288](https://github.com/google-gemini/gemini-cli/issues/11288)
