### PR TITLE
add extension IDs

### DIFF
--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -1245,6 +1245,7 @@ This extension will run the following MCP servers:
           success: true,
           tagName: 'v1.0.0',
           type: 'github-release',
+          canonicalSourceUrl: gitUrl,
         });
 
         const tempDir = path.join(tempHomeDir, 'temp-ext');

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -512,7 +512,29 @@ describe('extension tests', () => {
     });
 
     describe('id generation', () => {
-      it('should generate id from source for git extension', () => {
+      it('should generate id from source for non-github git urls', () => {
+        const extensionDir = createExtension({
+          extensionsDir: userExtensionsDir,
+          name: 'my-ext',
+          version: '1.0.0',
+          installMetadata: {
+            type: 'git',
+            source: 'http://somehost.com/foo/bar',
+          },
+        });
+
+        const extension = loadExtension({
+          extensionDir,
+          workspaceDir: tempWorkspaceDir,
+        });
+
+        const expectedHash = createHash('sha256')
+          .update('http://somehost.com/foo/bar')
+          .digest('hex');
+        expect(extension?.id).toBe(expectedHash);
+      });
+
+      it('should generate id from owner/repo for github http urls', () => {
         const extensionDir = createExtension({
           extensionsDir: userExtensionsDir,
           name: 'my-ext',
@@ -529,7 +551,29 @@ describe('extension tests', () => {
         });
 
         const expectedHash = createHash('sha256')
-          .update('http://github.com/foo/bar')
+          .update('https://github.com/foo/bar')
+          .digest('hex');
+        expect(extension?.id).toBe(expectedHash);
+      });
+
+      it('should generate id from owner/repo for github ssh urls', () => {
+        const extensionDir = createExtension({
+          extensionsDir: userExtensionsDir,
+          name: 'my-ext',
+          version: '1.0.0',
+          installMetadata: {
+            type: 'git',
+            source: 'git@github.com:foo/bar',
+          },
+        });
+
+        const extension = loadExtension({
+          extensionDir,
+          workspaceDir: tempWorkspaceDir,
+        });
+
+        const expectedHash = createHash('sha256')
+          .update('https://github.com/foo/bar')
           .digest('hex');
         expect(extension?.id).toBe(expectedHash);
       });
@@ -1245,7 +1289,6 @@ This extension will run the following MCP servers:
           success: true,
           tagName: 'v1.0.0',
           type: 'github-release',
-          canonicalSourceUrl: gitUrl,
         });
 
         const tempDir = path.join(tempHomeDir, 'temp-ext');

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -556,7 +556,7 @@ describe('extension tests', () => {
         expect(extension?.id).toBe(expectedHash);
       });
 
-      it('should generate id from name for local extension', () => {
+      it('should generate id from the original source for local extension', () => {
         const extensionDir = createExtension({
           extensionsDir: userExtensionsDir,
           name: 'local-ext-name',
@@ -573,12 +573,12 @@ describe('extension tests', () => {
         });
 
         const expectedHash = createHash('sha256')
-          .update('local-ext-name')
+          .update('/some/path')
           .digest('hex');
         expect(extension?.id).toBe(expectedHash);
       });
 
-      it('should generate id from name for link extension', async () => {
+      it('should generate id from the original source for linked extensions', async () => {
         const extDevelopmentDir = path.join(tempHomeDir, 'local_extensions');
         const actualExtensionDir = createExtension({
           extensionsDir: extDevelopmentDir,
@@ -600,7 +600,7 @@ describe('extension tests', () => {
         });
 
         const expectedHash = createHash('sha256')
-          .update('link-ext-name')
+          .update(actualExtensionDir)
           .digest('hex');
         expect(extension?.id).toBe(expectedHash);
       });

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -253,22 +253,12 @@ export function loadExtension(
       )
       .filter((contextFilePath) => fs.existsSync(contextFilePath));
 
-    // IDs are created by hashing parts of the extension metadata in order to
-    // obfuscate any potentially sensitive information such as private
-    // git urls or project names.
+    // IDs are created by hashing the installation source of the extension or
+    // the extension name, in order to deduplicate extensions with conflicting
+    // names and also obfuscate any potentially sensitive information such as
+    // private git urls, system paths, or project names.
     const hash = createHash('sha256');
-    switch (installMetadata?.type) {
-      case 'git':
-      case 'github-release':
-        // For git and github-release installs, identify the extension based on the
-        // source it was installed from. This allows us to distinguish between
-        // extensions that happen to have the same name but are actually different.
-        hash.update(installMetadata.source);
-        break;
-      default:
-        // For all other install types, just use the name.
-        hash.update(config.name);
-    }
+    hash.update(installMetadata?.source ?? config.name);
     const id = hash.digest('hex');
 
     return {

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -494,12 +494,10 @@ export async function installOrUpdateExtension(
         await cloneFromGit(installMetadata, tempDir);
         installMetadata.type = 'git';
       } else {
-        const { owner, repo } = parsedGithubParts;
         const result = await downloadFromGitHubRelease(
           installMetadata,
           tempDir,
-          owner,
-          repo,
+          parsedGithubParts,
         );
         if (result.success) {
           installMetadata.type = result.type;

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -488,6 +488,7 @@ export async function installOrUpdateExtension(
       if (result.success) {
         installMetadata.type = result.type;
         installMetadata.releaseTag = result.tagName;
+        installMetadata.source = result.canonicalSourceUrl;
       } else if (
         // This repo has no github releases, and wasn't explicitly installed
         // from a github release, unconditionally just clone it.

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -11,7 +11,7 @@ import {
   extractFile,
   findReleaseAsset,
   fetchReleaseFromGithub,
-  parseGitHubRepoForReleases,
+  tryParseGithubUrl,
 } from './github.js';
 import { simpleGit, type SimpleGit } from 'simple-git';
 import { ExtensionUpdateState } from '../../ui/state/extensions.js';
@@ -348,61 +348,62 @@ describe('git extension helpers', () => {
   describe('parseGitHubRepoForReleases', () => {
     it('should parse owner and repo from a full GitHub URL', () => {
       const source = 'https://github.com/owner/repo.git';
-      const { owner, repo } = parseGitHubRepoForReleases(source)!;
+      const { owner, repo } = tryParseGithubUrl(source)!;
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
 
     it('should parse owner and repo from a full GitHub URL without .git', () => {
       const source = 'https://github.com/owner/repo';
-      const { owner, repo } = parseGitHubRepoForReleases(source)!;
+      const { owner, repo } = tryParseGithubUrl(source)!;
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
 
     it('should parse owner and repo from a full GitHub URL with a trailing slash', () => {
       const source = 'https://github.com/owner/repo/';
-      const { owner, repo } = parseGitHubRepoForReleases(source)!;
+      const { owner, repo } = tryParseGithubUrl(source)!;
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
 
-    it('should fail on a GitHub SSH URL', () => {
+    it('should parse owner and repo from a GitHub SSH URL', () => {
       const source = 'git@github.com:owner/repo.git';
-      expect(() => parseGitHubRepoForReleases(source)).toThrow(
-        'GitHub release-based extensions are not supported for SSH. You must use an HTTPS URI with a personal access token to download releases from private repositories. You can set your personal access token in the GITHUB_TOKEN environment variable and install the extension via SSH.',
-      );
+
+      const { owner, repo } = tryParseGithubUrl(source)!;
+      expect(owner).toBe('owner');
+      expect(repo).toBe('repo');
     });
 
     it('should return null on a non-GitHub URL', () => {
       const source = 'https://example.com/owner/repo.git';
-      expect(parseGitHubRepoForReleases(source)).toBe(null);
+      expect(tryParseGithubUrl(source)).toBe(null);
     });
 
     it('should parse owner and repo from a shorthand string', () => {
       const source = 'owner/repo';
-      const { owner, repo } = parseGitHubRepoForReleases(source)!;
+      const { owner, repo } = tryParseGithubUrl(source)!;
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
 
     it('should handle .git suffix in repo name', () => {
       const source = 'owner/repo.git';
-      const { owner, repo } = parseGitHubRepoForReleases(source)!;
+      const { owner, repo } = tryParseGithubUrl(source)!;
       expect(owner).toBe('owner');
       expect(repo).toBe('repo');
     });
 
     it('should throw error for invalid source format', () => {
       const source = 'invalid-format';
-      expect(() => parseGitHubRepoForReleases(source)).toThrow(
+      expect(() => tryParseGithubUrl(source)).toThrow(
         'Invalid GitHub repository source: invalid-format. Expected "owner/repo" or a github repo uri.',
       );
     });
 
     it('should throw error for source with too many parts', () => {
       const source = 'https://github.com/owner/repo/extra';
-      expect(() => parseGitHubRepoForReleases(source)).toThrow(
+      expect(() => tryParseGithubUrl(source)).toThrow(
         'Invalid GitHub repository source: https://github.com/owner/repo/extra. Expected "owner/repo" or a github repo uri.',
       );
     });

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -76,25 +76,30 @@ export async function cloneFromGit(
   }
 }
 
-export function parseGitHubRepoForReleases(source: string): {
+export interface GithubRepoInfo {
   owner: string;
   repo: string;
-  canonicalSourceUrl: string;
-} | null {
+}
+
+export function tryParseGithubUrl(source: string): GithubRepoInfo | null {
+  // First step in normalizing a github ssh URI to the https form.
+  if (source.startsWith('git@github.com:')) {
+    source = source.replace('git@github.com:', '');
+  }
   // Default to a github repo path, so `source` can be just an org/repo
   const parsedUrl = URL.parse(source, 'https://github.com');
   if (!parsedUrl) {
     throw new Error(`Invalid repo URL: ${source}`);
   }
-  // The pathname should be "/owner/repo".
-  const parts = parsedUrl?.pathname
-    .substring(1)
-    .split('/')
-    // Remove the empty segments, fixes trailing slashes
-    .filter((part) => part !== '');
   if (parsedUrl?.host !== 'github.com') {
     return null;
   }
+  // The pathname should be "/owner/repo".
+  const parts = parsedUrl?.pathname
+    .split('/')
+    // Remove the empty segments, fixes trailing and leading slashes
+    .filter((part) => part !== '');
+
   if (parts?.length !== 2) {
     throw new Error(
       `Invalid GitHub repository source: ${source}. Expected "owner/repo" or a github repo uri.`,
@@ -103,16 +108,9 @@ export function parseGitHubRepoForReleases(source: string): {
   const owner = parts[0];
   const repo = parts[1].replace('.git', '');
 
-  if (owner.startsWith('git@github.com')) {
-    throw new Error(
-      `GitHub release-based extensions are not supported for SSH. You must use an HTTPS URI with a personal access token to download releases from private repositories. You can set your personal access token in the GITHUB_TOKEN environment variable and install the extension via SSH.`,
-    );
-  }
-
   return {
     owner,
     repo,
-    canonicalSourceUrl: `https://github.com/${owner}/${repo}`,
   };
 }
 
@@ -222,7 +220,7 @@ export async function checkForExtensionUpdate(
         console.error(`No "source" provided for extension.`);
         return ExtensionUpdateState.ERROR;
       }
-      const repoInfo = parseGitHubRepoForReleases(source);
+      const repoInfo = tryParseGithubUrl(source);
       if (!repoInfo) {
         console.error(
           `Source is not a valid GitHub repository for release checks: ${source}`,
@@ -270,28 +268,18 @@ export type GitHubDownloadResult =
   | {
       tagName?: string;
       type: 'git' | 'github-release';
-      canonicalSourceUrl: string;
       success: true;
     };
 export async function downloadFromGitHubRelease(
   installMetadata: ExtensionInstallMetadata,
   destination: string,
+  githubRepoInfo: GithubRepoInfo,
 ): Promise<GitHubDownloadResult> {
-  const { source, ref, allowPreRelease: preRelease } = installMetadata;
+  const { ref, allowPreRelease: preRelease } = installMetadata;
+  const { owner, repo } = githubRepoInfo;
   let releaseData: GithubReleaseData | null = null;
 
   try {
-    const parts = parseGitHubRepoForReleases(source);
-    if (!parts) {
-      return {
-        failureReason: 'no release data',
-        success: false,
-        type: 'github-release',
-        errorMessage: `Not a github repo: ${source}`,
-      };
-    }
-    const { owner, repo, canonicalSourceUrl } = parts;
-
     try {
       releaseData = await fetchReleaseFromGithub(owner, repo, ref, preRelease);
       if (!releaseData) {
@@ -402,7 +390,6 @@ export async function downloadFromGitHubRelease(
       tagName: releaseData.tag_name,
       type: 'github-release',
       success: true,
-      canonicalSourceUrl,
     };
   } catch (error) {
     return {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -141,6 +141,7 @@ export interface GeminiCLIExtension {
   mcpServers?: Record<string, MCPServerConfig>;
   contextFiles: string[];
   excludeTools?: string[];
+  id?: string;
 }
 
 export interface ExtensionInstallMetadata {


### PR DESCRIPTION
## TLDR

Adds an `id` to extensions generated by hashing either the source or the name, depending on extension install type.

## Dive Deeper

This does mean that the same extension installed in different ways might have a different ID - but most of the time that is probably desirable. An extension using a local install dir or custom fork will have a different ID than the same extension installed from the official repo, which allows differentiating different forks of an extension even if they have the same name.

## Reviewer Test Plan

Run the tests, this ID isn't used yet.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅   |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

To be used by https://github.com/google-gemini/gemini-cli/pull/11261 for extension logging
