### PR TITLE
fix: /init command respects context.fileName setting

### DIFF
--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -13,10 +13,11 @@ import type {
 } from './types.js';
 import { CommandKind } from './types.js';
 import { performInit } from '@google/gemini-cli-core';
+import { getCurrentGeminiMdFilename } from '@google/gemini-cli-core';
 
 export const initCommand: SlashCommand = {
   name: 'init',
-  description: 'Analyzes the project and creates a tailored GEMINI.md file',
+  description: 'Analyzes the project and creates a tailored context file',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
   action: async (
@@ -31,18 +32,19 @@ export const initCommand: SlashCommand = {
       };
     }
     const targetDir = context.services.config.getTargetDir();
-    const geminiMdPath = path.join(targetDir, 'GEMINI.md');
+    const contextFileName = getCurrentGeminiMdFilename();
+    const contextFilePath = path.resolve(targetDir, contextFileName);
 
-    const result = performInit(fs.existsSync(geminiMdPath));
+    const result = performInit(fs.existsSync(contextFilePath));
 
     if (result.type === 'submit_prompt') {
-      // Create an empty GEMINI.md file
+      // Create an empty GEMINI.md file or relevant context file
       fs.writeFileSync(geminiMdPath, '', 'utf8');
 
       context.ui.addItem(
         {
           type: 'info',
-          text: 'Empty GEMINI.md created. Now analyzing the project to populate it.',
+          text: `Empty ${contextFileName} created. Now analyzing the project to populate it.`,
         },
         Date.now(),
       );


### PR DESCRIPTION
## TLDR

The `/init` command was hardcoded to use GEMINI.md as the context file name. This change modifies the command to use the `context.fileName` setting from the user's configuration.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

Change your gemini-cli configuration to set `context.fileName` to anything other than "GEMINI.md", such as "AGENTS.md". In a directory that does not already have this file, run gemini-cli and issue the `/init` command. Validate that it did not create a GEMINI.md, but created the specified file name instead.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

