### PR TITLE
fix(cli): enable and fix types for MCP command tests

### DIFF
--- a/packages/cli/src/commands/mcp/add.test.ts
+++ b/packages/cli/src/commands/mcp/add.test.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import yargs from 'yargs';
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import yargs, { type Argv } from 'yargs';
 import { addCommand } from './add.js';
 import { loadSettings, SettingScope } from '../../config/settings.js';
 
@@ -31,12 +32,12 @@ vi.mock('../../config/settings.js', async () => {
   };
 });
 
-const mockedLoadSettings = loadSettings as vi.Mock;
+const mockedLoadSettings = loadSettings as Mock;
 
 describe('mcp add command', () => {
-  let parser: yargs.Argv;
-  let mockSetValue: vi.Mock;
-  let mockConsoleError: vi.Mock;
+  let parser: Argv;
+  let mockSetValue: Mock;
+  let mockConsoleError: Mock;
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -207,7 +208,7 @@ describe('mcp add command', () => {
           .spyOn(process, 'exit')
           .mockImplementation((() => {
             throw new Error('process.exit called');
-          }) as (code?: number) => never);
+          }) as (code?: number | string | null) => never);
 
         await expect(
           parser.parseAsync(`add ${serverName} ${command}`),
@@ -225,7 +226,7 @@ describe('mcp add command', () => {
           .spyOn(process, 'exit')
           .mockImplementation((() => {
             throw new Error('process.exit called');
-          }) as (code?: number) => never);
+          }) as (code?: number | string | null) => never);
 
         await expect(
           parser.parseAsync(`add --scope project ${serverName} ${command}`),

--- a/packages/cli/src/commands/mcp/remove.test.ts
+++ b/packages/cli/src/commands/mcp/remove.test.ts
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import yargs from 'yargs';
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import yargs, { type Argv } from 'yargs';
 import { SettingScope, type LoadedSettings } from '../../config/settings.js';
 import { removeCommand } from './remove.js';
 import * as fs from 'node:fs';
@@ -20,8 +28,8 @@ vi.mock('fs/promises', () => ({
 
 describe('mcp remove command', () => {
   describe('unit tests with mocks', () => {
-    let parser: yargs.Argv;
-    let mockSetValue: vi.Mock;
+    let parser: Argv;
+    let mockSetValue: Mock;
     let mockSettings: Record<string, unknown>;
 
     beforeEach(async () => {
@@ -42,7 +50,9 @@ describe('mcp remove command', () => {
       ).mockReturnValue({
         forScope: () => ({ settings: mockSettings }),
         setValue: mockSetValue,
-      } as Partial<LoadedSettings> as LoadedSettings);
+        workspace: { path: '/path/to/project' },
+        user: { path: '/home/user' },
+      } as unknown as LoadedSettings);
 
       const yargsInstance = yargs([]).command(removeCommand);
       parser = yargsInstance;
@@ -73,7 +83,7 @@ describe('mcp remove command', () => {
     let tempDir: string;
     let settingsDir: string;
     let settingsPath: string;
-    let parser: yargs.Argv;
+    let parser: Argv;
     let cwdSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -17,10 +17,6 @@
     "node_modules",
     "dist",
     // TODO(5691): Fix type errors and remove excludes.
-    "src/commands/mcp.test.ts",
-    "src/commands/mcp/add.test.ts",
-    "src/commands/mcp/list.test.ts",
-    "src/commands/mcp/remove.test.ts",
     "src/config/config.integration.test.ts",
     "src/config/config.test.ts",
     "src/config/extension.test.ts",


### PR DESCRIPTION
## TLDR

Enables type checking for MCP command tests in `packages/cli/tsconfig.json` and fixes resulting TypeScript errors in `mcp.test.ts`, `mcp/add.test.ts`, and `mcp/remove.test.ts`.

## Dive Deeper

*   Removed `src/commands/mcp.test.ts`, `src/commands/mcp/add.test.ts`, `src/commands/mcp/list.test.ts`, and `src/commands/mcp/remove.test.ts` from the `exclude` list in `packages/cli/tsconfig.json`.
*   Fixed `yargs` type assertions in `src/commands/mcp.test.ts`.
*   Refactored a test in `src/commands/mcp.test.ts` to verify help output via console mocks instead of inspecting internal `yargs` state.
*   Fixed import types (`Mock`, `Argv`) and mock implementations (specifically `loadSettings` and `process.exit`) in `src/commands/mcp/add.test.ts` and `src/commands/mcp/remove.test.ts` to satisfy the type checker.

## Reviewer Test Plan

Run `npm run typecheck` in `packages/cli` to verify no type errors. Run `npm run test packages/cli/src/commands/mcp*` to verify tests pass.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #5691