### PR TITLE
feat: add missing visual cue for closing dialogs with Esc key

### DIFF
--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -185,7 +185,9 @@ Logging in with Google... Please restart Gemini CLI to continue.
         </Box>
       )}
       <Box marginTop={1}>
-        <Text color={theme.text.secondary}>(Use Enter to select)</Text>
+        <Text color={theme.text.secondary}>
+          (Use Enter to select, Esc to close)
+        </Text>
       </Box>
       <Box marginTop={1}>
         <Text color={theme.text.primary}>

--- a/packages/cli/src/ui/components/EditorSettingsDialog.tsx
+++ b/packages/cli/src/ui/components/EditorSettingsDialog.tsx
@@ -157,7 +157,7 @@ export function EditorSettingsDialog({
 
         <Box marginTop={1}>
           <Text color={theme.text.secondary}>
-            (Use Enter to select, Tab to change focus)
+            (Use Enter to select, Tab to change focus, Esc to close)
           </Text>
         </Box>
       </Box>

--- a/packages/cli/src/ui/components/PermissionsModifyTrustDialog.tsx
+++ b/packages/cli/src/ui/components/PermissionsModifyTrustDialog.tsx
@@ -114,7 +114,9 @@ export function PermissionsModifyTrustDialog({
           initialIndex={initialIndex}
         />
         <Box marginTop={1}>
-          <Text color={theme.text.secondary}>(Use Enter to select)</Text>
+          <Text color={theme.text.secondary}>
+            (Use Enter to select, Esc to close)
+          </Text>
         </Box>
       </Box>
       {needsRestart && (

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -275,7 +275,7 @@ def fibonacci(n):
       <Box marginTop={1}>
         <Text color={theme.text.secondary} wrap="truncate">
           (Use Enter to {mode === 'theme' ? 'select' : 'apply scope'}, Tab to{' '}
-          {mode === 'theme' ? 'configure scope' : 'select theme'})
+          {mode === 'theme' ? 'configure scope' : 'select theme'}, Esc to close)
         </Text>
       </Box>
     </Box>

--- a/packages/cli/src/ui/components/__snapshots__/ThemeDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ThemeDialog.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ThemeDialog Snapshots > should render correctly in scope selector mode 
 │   2. Workspace Settings                                                                          │
 │   3. System Settings                                                                             │
 │                                                                                                  │
-│ (Use Enter to apply scope, Tab to select theme)                                                  │
+│ (Use Enter to apply scope, Tab to select theme, Esc to close)                                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;
@@ -32,7 +32,7 @@ exports[`ThemeDialog Snapshots > should render correctly in theme selection mode
 │   12. Google Code Light                      └─────────────────────────────────────────────────┘ │
 │ ▼                                                                                                │
 │                                                                                                  │
-│ (Use Enter to select, Tab to configure scope)                                                    │
+│ (Use Enter to select, Tab to configure scope, Esc to close)                                      │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;


### PR DESCRIPTION
<h2>TLDR</h2>
<p>Added a missing visual cue for dialogs that support closing with the <code>Esc</code> key but did not previously display any hint about it.</p>
<h2>Testing Matrix</h2>

  | 🍏 | 🪟 | 🐧
-- | -- | -- | --
npm run | ❓ | ❓ | ❓
npx | ❓ | ❓ | ❓
Docker | ❓ | ❓ | ❓
Podman | ❓ | - | -
Seatbelt | ❓ | - | -
