### PR TITLE
Remove MCP Tips and reorganize MCP slash commands

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -100,16 +100,26 @@ Slash commands provide meta-level control over the CLI itself.
     available commands and their usage.
 
 - **`/mcp`**
-  - **Description:** List configured Model Context Protocol (MCP) servers, their
-    connection status, server details, and available tools.
+  - **Description:** Manage configured Model Context Protocol (MCP) servers.
   - **Sub-commands:**
-    - **`desc`** or **`descriptions`**:
-      - **Description:** Show detailed descriptions for MCP servers and tools.
-    - **`nodesc`** or **`nodescriptions`**:
-      - **Description:** Hide tool descriptions, showing only the tool names.
+    - **`list`** or **`ls`**:
+      - **Description:** List configured MCP servers and tools. This is the
+        default action if no subcommand is specified.
+    - **`desc`**
+      - **Description:** List configured MCP servers and tools with
+        descriptions.
     - **`schema`**:
-      - **Description:** Show the full JSON schema for the tool's configured
-        parameters.
+      - **Description:** List configured MCP servers and tools with descriptions
+        and schemas.
+    - **`auth`**:
+      - **Description:** Authenticate with an OAuth-enabled MCP server.
+      - **Usage:** `/mcp auth <server-name>`
+      - **Details:** If `<server-name>` is provided, it initiates the OAuth flow
+        for that server. If no server name is provided, it lists all configured
+        servers that support OAuth authentication.
+    - **`refresh`**:
+      - **Description:** Restarts all MCP servers and re-discovers their
+        available tools.
 
 - **`/memory`**
   - **Description:** Manage the AI's instructional context (hierarchical memory

--- a/packages/cli/src/ui/commands/mcpCommand.test.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.test.ts
@@ -175,33 +175,36 @@ describe('mcpCommand', () => {
             description: tool.description,
             schema: tool.schema,
           })),
-          showTips: true,
         }),
         expect.any(Number),
       );
     });
 
     it('should display tool descriptions when desc argument is used', async () => {
-      await mcpCommand.action!(mockContext, 'desc');
+      const descSubCommand = mcpCommand.subCommands!.find(
+        (c) => c.name === 'desc',
+      );
+      await descSubCommand!.action!(mockContext, '');
 
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.MCP_STATUS,
           showDescriptions: true,
-          showTips: false,
         }),
         expect.any(Number),
       );
     });
 
     it('should not display descriptions when nodesc argument is used', async () => {
-      await mcpCommand.action!(mockContext, 'nodesc');
+      const listSubCommand = mcpCommand.subCommands!.find(
+        (c) => c.name === 'list',
+      );
+      await listSubCommand!.action!(mockContext, '');
 
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.MCP_STATUS,
           showDescriptions: false,
-          showTips: false,
         }),
         expect.any(Number),
       );

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -1923,7 +1923,7 @@ describe('InputPrompt', () => {
       unmount();
     });
 
-    it('text and cursor position should be restored after reverse search', async () => {
+    it.skip('text and cursor position should be restored after reverse search', async () => {
       props.buffer.setText('initial text');
       props.buffer.cursor = [0, 3];
       const { stdin, stdout, unmount } = renderWithProviders(

--- a/packages/cli/src/ui/components/views/McpStatus.test.tsx
+++ b/packages/cli/src/ui/components/views/McpStatus.test.tsx
@@ -43,7 +43,6 @@ describe('McpStatus', () => {
     connectingServers: [],
     showDescriptions: true,
     showSchema: false,
-    showTips: false,
   };
 
   it('renders correctly with a connected server', () => {
@@ -120,11 +119,6 @@ describe('McpStatus', () => {
         showSchema={true}
       />,
     );
-    expect(lastFrame()).toMatchSnapshot();
-  });
-
-  it('renders correctly with tips enabled', () => {
-    const { lastFrame } = render(<McpStatus {...baseProps} showTips={true} />);
     expect(lastFrame()).toMatchSnapshot();
   });
 

--- a/packages/cli/src/ui/components/views/McpStatus.tsx
+++ b/packages/cli/src/ui/components/views/McpStatus.tsx
@@ -26,7 +26,6 @@ interface McpStatusProps {
   connectingServers: string[];
   showDescriptions: boolean;
   showSchema: boolean;
-  showTips: boolean;
 }
 
 export const McpStatus: React.FC<McpStatusProps> = ({
@@ -40,7 +39,6 @@ export const McpStatus: React.FC<McpStatusProps> = ({
   connectingServers,
   showDescriptions,
   showSchema,
-  showTips,
 }) => {
   const serverNames = Object.keys(servers);
 
@@ -249,29 +247,6 @@ export const McpStatus: React.FC<McpStatusProps> = ({
           <Text> - Blocked</Text>
         </Box>
       ))}
-
-      {showTips && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color={theme.text.accent}>💡 Tips:</Text>
-          <Text>
-            {'  '}- Use <Text color={theme.text.accent}>/mcp desc</Text> to show
-            server and tool descriptions
-          </Text>
-          <Text>
-            {'  '}- Use <Text color={theme.text.accent}>/mcp schema</Text> to
-            show tool parameter schemas
-          </Text>
-          <Text>
-            {'  '}- Use <Text color={theme.text.accent}>/mcp nodesc</Text> to
-            hide descriptions
-          </Text>
-          <Text>
-            {'  '}- Use{' '}
-            <Text color={theme.text.accent}>/mcp auth &lt;server-name&gt;</Text>{' '}
-            to authenticate with OAuth-enabled servers
-          </Text>
-        </Box>
-      )}
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/views/__snapshots__/McpStatus.test.tsx.snap
+++ b/packages/cli/src/ui/components/views/__snapshots__/McpStatus.test.tsx.snap
@@ -136,23 +136,6 @@ A test server
 "
 `;
 
-exports[`McpStatus > renders correctly with tips enabled 1`] = `
-"Configured MCP servers:
-
-🟢 server-1 - Ready (1 tool)
-A test server
-  Tools:
-  - tool-1
-    A test tool
-
-
-💡 Tips:
-  - Use /mcp desc to show server and tool descriptions
-  - Use /mcp schema to show tool parameter schemas
-  - Use /mcp nodesc to hide descriptions
-  - Use /mcp auth <server-name> to authenticate with OAuth-enabled servers"
-`;
-
 exports[`McpStatus > renders correctly with unauthenticated OAuth status 1`] = `
 "Configured MCP servers:
 

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -219,7 +219,6 @@ export type HistoryItemMcpStatus = HistoryItemBase & {
   connectingServers: string[];
   showDescriptions: boolean;
   showSchema: boolean;
-  showTips: boolean;
 };
 
 // Using Omit<HistoryItem, 'id'> seems to have some issues with typescript's


### PR DESCRIPTION
## TLDR

Simplify `/mcp` commands so that autocomplete actually shows you all the options. Remove the MCP Tips since autocomplete now tells you what you need to know.

Also skip flakey test #11390

## Dive Deeper

The tips were introduced before we had good slash command autocomplete so they are redundant now.

## Reviewer Test Plan

Try all the `/mcp` commands and verify that the auto complete works as expected.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

For #10756