### PR TITLE
fix: remove debug console in production builds

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -91,6 +91,7 @@ import { useSessionStats } from './contexts/SessionContext.js';
 import { useGitBranchName } from './hooks/useGitBranchName.js';
 import { useExtensionUpdates } from './hooks/useExtensionUpdates.js';
 import { ShellFocusContext } from './contexts/ShellFocusContext.js';
+import { isDevelopment } from '../utils/installationInfo.js';
 
 const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
 const QUEUE_ERROR_DISPLAY_DURATION_MS = 3000;
@@ -858,8 +859,10 @@ Logging in with Google... Please restart Gemini CLI to continue.
 
   useEffect(() => {
     const openDebugConsole = () => {
-      setShowErrorDetails(true);
-      setConstrainHeight(false);
+      if (isDevelopment) {
+        setShowErrorDetails(true);
+        setConstrainHeight(false);
+      }
     };
     appEvents.on(AppEvent.OpenDebugConsole, openDebugConsole);
 
@@ -968,7 +971,9 @@ Logging in with Google... Please restart Gemini CLI to continue.
       }
 
       if (keyMatchers[Command.SHOW_ERROR_DETAILS](key)) {
-        setShowErrorDetails((prev) => !prev);
+        if (isDevelopment) {
+          setShowErrorDetails((prev) => !prev);
+        }
       } else if (keyMatchers[Command.TOGGLE_MARKDOWN](key)) {
         setRenderMarkdown((prev) => {
           const newValue = !prev;

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -168,7 +168,7 @@ export const Footer: React.FC = () => {
                 </Text>
               </Box>
             )}
-            {!showErrorDetails && errorCount > 0 && (
+            {isDevelopment && !showErrorDetails && errorCount > 0 && (
               <Box paddingLeft={1} flexDirection="row">
                 <Text color={theme.ui.comment}>| </Text>
                 <ConsoleSummaryDisplay errorCount={errorCount} />


### PR DESCRIPTION
## TLDR

This PR disables the debug console and error summary in the footer for production builds. This ensures a cleaner user experience for end-users while retaining debugging capabilities for developers.

## Dive Deeper

The changes involve:
-   Wrapping the `ConsoleSummaryDisplay` in `Footer.tsx` with an `isDevelopment` check.
-   Preventing the debug console from opening via `Ctrl+O` or `AppEvent.OpenDebugConsole` in `AppContainer.tsx` when not in development mode.
-   Adding unit tests to `Footer.test.tsx` and `AppContainer.test.tsx` to verify this behavior.

## Reviewer Test Plan

1.  Modify `package.json` to set `"start": "node scripts/start.js"`.
2.  Run the application in development mode with a command that generates an error (e.g., using a non-existent model):
    ```bash
    NODE_ENV=development npm start -- --model non-existent-model
    ```
3.  Verify that the error count appears in the footer and that pressing `Ctrl+O` opens the debug console.
4.  Run the application in production mode with the same command:
    ```bash
    NODE_ENV=production npm start -- --model non-existent-model
    ```
5.  Verify that the error count does **not** appear in the footer and that pressing `Ctrl+O` does **not** open the debug console.
6.  Revert the changes to `package.json`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |

## Linked issues / bugs

- Closes #10761
