### PR TITLE
Style slash command descriptions consistently

### DIFF
--- a/packages/cli/src/ui/commands/aboutCommand.test.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.test.ts
@@ -77,7 +77,7 @@ describe('aboutCommand', () => {
 
   it('should have the correct name and description', () => {
     expect(aboutCommand.name).toBe('about');
-    expect(aboutCommand.description).toBe('show version info');
+    expect(aboutCommand.description).toBe('Show version info');
   });
 
   it('should call addItem with all version info', async () => {

--- a/packages/cli/src/ui/commands/aboutCommand.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.ts
@@ -13,7 +13,7 @@ import { IdeClient } from '@google/gemini-cli-core';
 
 export const aboutCommand: SlashCommand = {
   name: 'about',
-  description: 'show version info',
+  description: 'Show version info',
   kind: CommandKind.BUILT_IN,
   action: async (context) => {
     const osVersion = process.platform;

--- a/packages/cli/src/ui/commands/authCommand.test.ts
+++ b/packages/cli/src/ui/commands/authCommand.test.ts
@@ -31,6 +31,6 @@ describe('authCommand', () => {
 
   it('should have the correct name and description', () => {
     expect(authCommand.name).toBe('auth');
-    expect(authCommand.description).toBe('change the auth method');
+    expect(authCommand.description).toBe('Change the auth method');
   });
 });

--- a/packages/cli/src/ui/commands/authCommand.ts
+++ b/packages/cli/src/ui/commands/authCommand.ts
@@ -9,7 +9,7 @@ import { CommandKind } from './types.js';
 
 export const authCommand: SlashCommand = {
   name: 'auth',
-  description: 'change the auth method',
+  description: 'Change the auth method',
   kind: CommandKind.BUILT_IN,
   action: (_context, _args): OpenDialogActionReturn => ({
     type: 'dialog',

--- a/packages/cli/src/ui/commands/bugCommand.ts
+++ b/packages/cli/src/ui/commands/bugCommand.ts
@@ -19,7 +19,7 @@ import { IdeClient, sessionId } from '@google/gemini-cli-core';
 
 export const bugCommand: SlashCommand = {
   name: 'bug',
-  description: 'submit a bug report',
+  description: 'Submit a bug report',
   kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext, args?: string): Promise<void> => {
     const bugDescription = (args || '').trim();

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -83,7 +83,7 @@ describe('chatCommand', () => {
 
   it('should have the correct main command definition', () => {
     expect(chatCommand.name).toBe('chat');
-    expect(chatCommand.description).toBe('Manage conversation history.');
+    expect(chatCommand.description).toBe('Manage conversation history');
     expect(chatCommand.subCommands).toHaveLength(5);
   });
 

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -357,7 +357,7 @@ const shareCommand: SlashCommand = {
 
 export const chatCommand: SlashCommand = {
   name: 'chat',
-  description: 'Manage conversation history.',
+  description: 'Manage conversation history',
   kind: CommandKind.BUILT_IN,
   subCommands: [
     listCommand,

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -10,7 +10,7 @@ import { CommandKind } from './types.js';
 
 export const clearCommand: SlashCommand = {
   name: 'clear',
-  description: 'clear the screen and conversation history',
+  description: 'Clear the screen and conversation history',
   kind: CommandKind.BUILT_IN,
   action: async (context, _args) => {
     const geminiClient = context.services.config?.getGeminiClient();

--- a/packages/cli/src/ui/commands/compressCommand.ts
+++ b/packages/cli/src/ui/commands/compressCommand.ts
@@ -12,7 +12,7 @@ import { CommandKind } from './types.js';
 export const compressCommand: SlashCommand = {
   name: 'compress',
   altNames: ['summarize'],
-  description: 'Compresses the context by replacing it with a summary.',
+  description: 'Compresses the context by replacing it with a summary',
   kind: CommandKind.BUILT_IN,
   action: async (context) => {
     const { ui } = context;

--- a/packages/cli/src/ui/commands/corgiCommand.test.ts
+++ b/packages/cli/src/ui/commands/corgiCommand.test.ts
@@ -29,6 +29,6 @@ describe('corgiCommand', () => {
 
   it('should have the correct name and description', () => {
     expect(corgiCommand.name).toBe('corgi');
-    expect(corgiCommand.description).toBe('Toggles corgi mode.');
+    expect(corgiCommand.description).toBe('Toggles corgi mode');
   });
 });

--- a/packages/cli/src/ui/commands/corgiCommand.ts
+++ b/packages/cli/src/ui/commands/corgiCommand.ts
@@ -8,7 +8,7 @@ import { CommandKind, type SlashCommand } from './types.js';
 
 export const corgiCommand: SlashCommand = {
   name: 'corgi',
-  description: 'Toggles corgi mode.',
+  description: 'Toggles corgi mode',
   hidden: true,
   kind: CommandKind.BUILT_IN,
   action: (context, _args) => {

--- a/packages/cli/src/ui/commands/docsCommand.ts
+++ b/packages/cli/src/ui/commands/docsCommand.ts
@@ -15,7 +15,7 @@ import { MessageType } from '../types.js';
 
 export const docsCommand: SlashCommand = {
   name: 'docs',
-  description: 'open full Gemini CLI documentation in your browser',
+  description: 'Open full Gemini CLI documentation in your browser',
   kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext): Promise<void> => {
     const docsUrl = 'https://goo.gle/gemini-cli-docs';

--- a/packages/cli/src/ui/commands/editorCommand.test.ts
+++ b/packages/cli/src/ui/commands/editorCommand.test.ts
@@ -25,6 +25,6 @@ describe('editorCommand', () => {
 
   it('should have the correct name and description', () => {
     expect(editorCommand.name).toBe('editor');
-    expect(editorCommand.description).toBe('set external editor preference');
+    expect(editorCommand.description).toBe('Set external editor preference');
   });
 });

--- a/packages/cli/src/ui/commands/editorCommand.ts
+++ b/packages/cli/src/ui/commands/editorCommand.ts
@@ -12,7 +12,7 @@ import {
 
 export const editorCommand: SlashCommand = {
   name: 'editor',
-  description: 'set external editor preference',
+  description: 'Set external editor preference',
   kind: CommandKind.BUILT_IN,
   action: (): OpenDialogActionReturn => ({
     type: 'dialog',

--- a/packages/cli/src/ui/commands/helpCommand.test.ts
+++ b/packages/cli/src/ui/commands/helpCommand.test.ts
@@ -47,6 +47,6 @@ describe('helpCommand', () => {
   it('should have the correct command properties', () => {
     expect(helpCommand.name).toBe('help');
     expect(helpCommand.kind).toBe(CommandKind.BUILT_IN);
-    expect(helpCommand.description).toBe('for help on gemini-cli');
+    expect(helpCommand.description).toBe('For help on gemini-cli');
   });
 });

--- a/packages/cli/src/ui/commands/helpCommand.ts
+++ b/packages/cli/src/ui/commands/helpCommand.ts
@@ -12,7 +12,7 @@ export const helpCommand: SlashCommand = {
   name: 'help',
   altNames: ['?'],
   kind: CommandKind.BUILT_IN,
-  description: 'for help on gemini-cli',
+  description: 'For help on gemini-cli',
   action: async (context) => {
     const helpItem: Omit<HistoryItemHelp, 'id'> = {
       type: MessageType.HELP,

--- a/packages/cli/src/ui/commands/ideCommand.ts
+++ b/packages/cli/src/ui/commands/ideCommand.ts
@@ -138,7 +138,7 @@ export const ideCommand = async (): Promise<SlashCommand> => {
   if (!currentIDE) {
     return {
       name: 'ide',
-      description: 'manage IDE integration',
+      description: 'Manage IDE integration',
       kind: CommandKind.BUILT_IN,
       action: (): SlashCommandActionReturn =>
         ({
@@ -151,14 +151,14 @@ export const ideCommand = async (): Promise<SlashCommand> => {
 
   const ideSlashCommand: SlashCommand = {
     name: 'ide',
-    description: 'manage IDE integration',
+    description: 'Manage IDE integration',
     kind: CommandKind.BUILT_IN,
     subCommands: [],
   };
 
   const statusCommand: SlashCommand = {
     name: 'status',
-    description: 'check status of IDE integration',
+    description: 'Check status of IDE integration',
     kind: CommandKind.BUILT_IN,
     action: async (): Promise<SlashCommandActionReturn> => {
       const { messageType, content } =
@@ -173,7 +173,7 @@ export const ideCommand = async (): Promise<SlashCommand> => {
 
   const installCommand: SlashCommand = {
     name: 'install',
-    description: `install required IDE companion for ${ideClient.getDetectedIdeDisplayName()}`,
+    description: `Install required IDE companion for ${ideClient.getDetectedIdeDisplayName()}`,
     kind: CommandKind.BUILT_IN,
     action: async (context) => {
       const installer = getIdeInstaller(currentIDE);
@@ -246,7 +246,7 @@ export const ideCommand = async (): Promise<SlashCommand> => {
 
   const enableCommand: SlashCommand = {
     name: 'enable',
-    description: 'enable IDE integration',
+    description: 'Enable IDE integration',
     kind: CommandKind.BUILT_IN,
     action: async (context: CommandContext) => {
       context.services.settings.setValue(
@@ -268,7 +268,7 @@ export const ideCommand = async (): Promise<SlashCommand> => {
 
   const disableCommand: SlashCommand = {
     name: 'disable',
-    description: 'disable IDE integration',
+    description: 'Disable IDE integration',
     kind: CommandKind.BUILT_IN,
     action: async (context: CommandContext) => {
       context.services.settings.setValue(

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -15,7 +15,7 @@ import { CommandKind } from './types.js';
 
 export const initCommand: SlashCommand = {
   name: 'init',
-  description: 'Analyzes the project and creates a tailored GEMINI.md file.',
+  description: 'Analyzes the project and creates a tailored GEMINI.md file',
   kind: CommandKind.BUILT_IN,
   action: async (
     context: CommandContext,

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -285,7 +285,7 @@ const schemaCommand: SlashCommand = {
 
 const refreshCommand: SlashCommand = {
   name: 'refresh',
-  description: 'Restarts MCP servers.',
+  description: 'Restarts MCP servers',
   kind: CommandKind.BUILT_IN,
   action: async (
     context: CommandContext,

--- a/packages/cli/src/ui/commands/memoryCommand.ts
+++ b/packages/cli/src/ui/commands/memoryCommand.ts
@@ -12,12 +12,12 @@ import { CommandKind } from './types.js';
 
 export const memoryCommand: SlashCommand = {
   name: 'memory',
-  description: 'Commands for interacting with memory.',
+  description: 'Commands for interacting with memory',
   kind: CommandKind.BUILT_IN,
   subCommands: [
     {
       name: 'show',
-      description: 'Show the current memory contents.',
+      description: 'Show the current memory contents',
       kind: CommandKind.BUILT_IN,
       action: async (context) => {
         const memoryContent = context.services.config?.getUserMemory() || '';
@@ -39,7 +39,7 @@ export const memoryCommand: SlashCommand = {
     },
     {
       name: 'add',
-      description: 'Add content to the memory.',
+      description: 'Add content to the memory',
       kind: CommandKind.BUILT_IN,
       action: (context, args): SlashCommandActionReturn | void => {
         if (!args || args.trim() === '') {
@@ -67,7 +67,7 @@ export const memoryCommand: SlashCommand = {
     },
     {
       name: 'refresh',
-      description: 'Refresh the memory from the source.',
+      description: 'Refresh the memory from the source',
       kind: CommandKind.BUILT_IN,
       action: async (context) => {
         context.ui.addItem(
@@ -128,7 +128,7 @@ export const memoryCommand: SlashCommand = {
     },
     {
       name: 'list',
-      description: 'Lists the paths of the GEMINI.md files in use.',
+      description: 'Lists the paths of the GEMINI.md files in use',
       kind: CommandKind.BUILT_IN,
       action: async (context) => {
         const filePaths = context.services.config?.getGeminiMdFilePaths() || [];

--- a/packages/cli/src/ui/commands/privacyCommand.test.ts
+++ b/packages/cli/src/ui/commands/privacyCommand.test.ts
@@ -33,6 +33,6 @@ describe('privacyCommand', () => {
 
   it('should have the correct name and description', () => {
     expect(privacyCommand.name).toBe('privacy');
-    expect(privacyCommand.description).toBe('display the privacy notice');
+    expect(privacyCommand.description).toBe('Display the privacy notice');
   });
 });

--- a/packages/cli/src/ui/commands/privacyCommand.ts
+++ b/packages/cli/src/ui/commands/privacyCommand.ts
@@ -9,7 +9,7 @@ import { CommandKind } from './types.js';
 
 export const privacyCommand: SlashCommand = {
   name: 'privacy',
-  description: 'display the privacy notice',
+  description: 'Display the privacy notice',
   kind: CommandKind.BUILT_IN,
   action: (): OpenDialogActionReturn => ({
     type: 'dialog',

--- a/packages/cli/src/ui/commands/quitCommand.ts
+++ b/packages/cli/src/ui/commands/quitCommand.ts
@@ -10,7 +10,7 @@ import { CommandKind, type SlashCommand } from './types.js';
 export const quitCommand: SlashCommand = {
   name: 'quit',
   altNames: ['exit'],
-  description: 'exit the cli',
+  description: 'Exit the cli',
   kind: CommandKind.BUILT_IN,
   action: (context) => {
     const now = Date.now();

--- a/packages/cli/src/ui/commands/statsCommand.ts
+++ b/packages/cli/src/ui/commands/statsCommand.ts
@@ -16,7 +16,7 @@ import {
 export const statsCommand: SlashCommand = {
   name: 'stats',
   altNames: ['usage'],
-  description: 'check session stats. Usage: /stats [model|tools]',
+  description: 'Check session stats. Usage: /stats [model|tools]',
   kind: CommandKind.BUILT_IN,
   action: (context: CommandContext) => {
     const now = new Date();
@@ -43,7 +43,7 @@ export const statsCommand: SlashCommand = {
   subCommands: [
     {
       name: 'model',
-      description: 'Show model-specific usage statistics.',
+      description: 'Show model-specific usage statistics',
       kind: CommandKind.BUILT_IN,
       action: (context: CommandContext) => {
         context.ui.addItem(
@@ -56,7 +56,7 @@ export const statsCommand: SlashCommand = {
     },
     {
       name: 'tools',
-      description: 'Show tool-specific usage statistics.',
+      description: 'Show tool-specific usage statistics',
       kind: CommandKind.BUILT_IN,
       action: (context: CommandContext) => {
         context.ui.addItem(

--- a/packages/cli/src/ui/commands/themeCommand.test.ts
+++ b/packages/cli/src/ui/commands/themeCommand.test.ts
@@ -33,6 +33,6 @@ describe('themeCommand', () => {
 
   it('should have the correct name and description', () => {
     expect(themeCommand.name).toBe('theme');
-    expect(themeCommand.description).toBe('change the theme');
+    expect(themeCommand.description).toBe('Change the theme');
   });
 });

--- a/packages/cli/src/ui/commands/themeCommand.ts
+++ b/packages/cli/src/ui/commands/themeCommand.ts
@@ -9,7 +9,7 @@ import { CommandKind } from './types.js';
 
 export const themeCommand: SlashCommand = {
   name: 'theme',
-  description: 'change the theme',
+  description: 'Change the theme',
   kind: CommandKind.BUILT_IN,
   action: (_context, _args): OpenDialogActionReturn => ({
     type: 'dialog',

--- a/packages/cli/src/ui/commands/toolsCommand.ts
+++ b/packages/cli/src/ui/commands/toolsCommand.ts
@@ -13,7 +13,7 @@ import { MessageType, type HistoryItemToolsList } from '../types.js';
 
 export const toolsCommand: SlashCommand = {
   name: 'tools',
-  description: 'list available Gemini CLI tools. Usage: /tools [desc]',
+  description: 'List available Gemini CLI tools. Usage: /tools [desc]',
   kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext, args?: string): Promise<void> => {
     const subCommand = args?.trim();

--- a/packages/cli/src/ui/commands/vimCommand.ts
+++ b/packages/cli/src/ui/commands/vimCommand.ts
@@ -9,7 +9,7 @@ import { CommandKind } from './types.js';
 
 export const vimCommand: SlashCommand = {
   name: 'vim',
-  description: 'toggle vim mode on/off',
+  description: 'Toggle vim mode on/off',
   kind: CommandKind.BUILT_IN,
   action: async (context, _args) => {
     const newVimState = await context.ui.toggleVimEnabled();


### PR DESCRIPTION
## TLDR

Make all slash command descriptions start with a capital letter and not end with a period.

## Reviewer Test Plan

Look at the slash command autocomplete.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #11383