### PR TITLE
fix(release): Update create-patch-pr.js to take a package name

### DIFF
--- a/scripts/releasing/create-patch-pr.js
+++ b/scripts/releasing/create-patch-pr.js
@@ -30,6 +30,12 @@ async function main() {
       choices: ['stable', 'preview'],
       demandOption: true,
     })
+    .option('cli-package-name', {
+      description:
+        'fully qualified package name with scope (e.g @google/gemini-cli)',
+      string: true,
+      default: '@google/gemini-cli',
+    })
     .option('dry-run', {
       description: 'Whether to run in dry-run mode.',
       type: 'boolean',
@@ -48,7 +54,7 @@ async function main() {
 
   run('git fetch --all --tags --prune', dryRun);
 
-  const releaseInfo = getLatestReleaseInfo(channel);
+  const releaseInfo = getLatestReleaseInfo({ argv, channel });
   const latestTag = releaseInfo.currentTag;
   const nextVersion = releaseInfo.nextVersion;
 
@@ -267,10 +273,10 @@ function branchExists(branchName) {
   }
 }
 
-function getLatestReleaseInfo(channel) {
+function getLatestReleaseInfo({ argv, channel } = {}) {
   console.log(`Fetching latest release info for channel: ${channel}...`);
   const patchFrom = channel; // 'stable' or 'preview'
-  const command = `node scripts/get-release-version.js --type=patch --patch-from=${patchFrom}`;
+  const command = `node scripts/get-release-version.js --cli-package-name="${argv['cli-package-name']}" --type=patch --patch-from=${patchFrom}`;
   try {
     const result = JSON.parse(execSync(command).toString().trim());
     console.log(`Current ${channel} tag: ${result.previousReleaseTag}`);


### PR DESCRIPTION
## TLDR

Update `create-patch-pr.js` to take a package name (default it to `@google/gemini-cli` for backwards compat)

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

```
➜  gemini-cli git:(rf/create-patch-pr) ✗ node scripts/releasing/create-patch-pr.js --dry-run --channel=stable --pullRequestNumber=11400 --commit=27ebe7b9da0d80a096b87cde0658448165244246 --cli-package-name=@google/gemini-cli 
Starting patch process for commit: 27ebe7b9da0d80a096b87cde0658448165244246
Targeting channel: stable
Running in dry-run mode.
> git fetch --all --tags --prune
Fetching latest release info for channel: stable...
Current stable tag: v0.9.0
Next stable version would be: 0.9.1
Release branch release/v0.9.0-pr-11400 does not exist. Creating it from tag v0.9.0...
> git checkout -b release/v0.9.0-pr-11400 v0.9.0
> git push origin release/v0.9.0-pr-11400
Creating hotfix branch hotfix/v0.9.0/0.9.1/stable/cherry-pick-27ebe7b/pr-11400 from release/v0.9.0-pr-11400...
> git checkout -b hotfix/v0.9.0/0.9.1/stable/cherry-pick-27ebe7b/pr-11400 origin/release/v0.9.0-pr-11400
Configuring git user for cherry-pick commits...
> git config user.name "gemini-cli-robot"
> git config user.email "gemini-cli-robot@google.com"
Cherry-picking commit 27ebe7b9da0d80a096b87cde0658448165244246 into hotfix/v0.9.0/0.9.1/stable/cherry-pick-27ebe7b/pr-11400...
[DRY RUN] Would cherry-pick 27ebe7b9da0d80a096b87cde0658448165244246
Pushing hotfix branch hotfix/v0.9.0/0.9.1/stable/cherry-pick-27ebe7b/pr-11400 to origin...
> git push --set-upstream origin hotfix/v0.9.0/0.9.1/stable/cherry-pick-27ebe7b/pr-11400
Creating pull request from hotfix/v0.9.0/0.9.1/stable/cherry-pick-27ebe7b/pr-11400 to release/v0.9.0-pr-11400...
> gh pr create --base release/v0.9.0-pr-11400 --head hotfix/v0.9.0/0.9.1/stable/cherry-pick-27ebe7b/pr-11400 --title "fix(patch): cherry-pick 27ebe7b to release/v0.9.0-pr-11400 to patch version v0.9.0 and create version 0.9.1" --body "This PR automatically cherry-picks commit 27ebe7b9da0d80a096b87cde0658448165244246 to patch v

**[DRY RUN]**"
✅ Patch process completed successfully!

--- Dry Run Summary ---
Release Branch: release/v0.9.0-pr-11400
Hotfix Branch: hotfix/v0.9.0/0.9.1/stable/cherry-pick-27ebe7b/pr-11400
Pull Request Command: gh pr create --base release/v0.9.0-pr-11400 --head hotfix/v0.9.0/0.9.1/stable/cherry-pick-27ebe7b/pr-11400 --title "fix(patch): cherry-pick 27ebe7b to release/v0.9.0-pr-11400 to patch version v0.9.0 and create version 0.9.1" --body "This PR automatically cherry-picks commit 27ebe7b9da0d80a096b87cde0658448

**[DRY RUN]**"
---------------------
```


```
➜  gemini-cli git:(rf/create-patch-pr) ✗ node scripts/releasing/create-patch-pr.js --dry-run --channel=stable --pullRequestNumber=11400 --commit=27ebe7b9da0d80a096b87cde0658448165244246 --cli-package-name=@google-gemini/gemini-cli
Starting patch process for commit: 27ebe7b9da0d80a096b87cde0658448165244246
Targeting channel: stable
Running in dry-run mode.
> git fetch --all --tags --prune
Fetching latest release info for channel: stable...
Rollback detected! NPM latest tag is 0.0.4, but using 0.0.777777777777 as baseline for next version calculation (highest existing version).
Current stable tag: v0.0.777777777777
Next stable version would be: 0.0.777777777778
Release branch release/v0.0.777777777777-pr-11400 does not exist. Creating it from tag v0.0.777777777777...
> git checkout -b release/v0.0.777777777777-pr-11400 v0.0.777777777777
> git push origin release/v0.0.777777777777-pr-11400
Creating hotfix branch hotfix/v0.0.777777777777/0.0.777777777778/stable/cherry-pick-27ebe7b/pr-11400 from release/v0.0.777777777777-pr-11400...
> git checkout -b hotfix/v0.0.777777777777/0.0.777777777778/stable/cherry-pick-27ebe7b/pr-11400 origin/release/v0.0.777777777777-pr-11400
Configuring git user for cherry-pick commits...
> git config user.name "gemini-cli-robot"
> git config user.email "gemini-cli-robot@google.com"
Cherry-picking commit 27ebe7b9da0d80a096b87cde0658448165244246 into hotfix/v0.0.777777777777/0.0.777777777778/stable/cherry-pick-27ebe7b/pr-11400...
[DRY RUN] Would cherry-pick 27ebe7b9da0d80a096b87cde0658448165244246
Pushing hotfix branch hotfix/v0.0.777777777777/0.0.777777777778/stable/cherry-pick-27ebe7b/pr-11400 to origin...
> git push --set-upstream origin hotfix/v0.0.777777777777/0.0.777777777778/stable/cherry-pick-27ebe7b/pr-11400
Creating pull request from hotfix/v0.0.777777777777/0.0.777777777778/stable/cherry-pick-27ebe7b/pr-11400 to release/v0.0.777777777777-pr-11400...
> gh pr create --base release/v0.0.777777777777-pr-11400 --head hotfix/v0.0.777777777777/0.0.777777777778/stable/cherry-pick-27ebe7b/pr-11400 --title "fix(patch): cherry-pick 27ebe7b to release/v0.0.777777777777-pr-11400 to patch version v0.0.777777777777 and create version 0.0.777777777778" --body "This PR automatically cherr

**[DRY RUN]**"
✅ Patch process completed successfully!

--- Dry Run Summary ---
Release Branch: release/v0.0.777777777777-pr-11400
Hotfix Branch: hotfix/v0.0.777777777777/0.0.777777777778/stable/cherry-pick-27ebe7b/pr-11400
Pull Request Command: gh pr create --base release/v0.0.777777777777-pr-11400 --head hotfix/v0.0.777777777777/0.0.777777777778/stable/cherry-pick-27ebe7b/pr-11400 --title "fix(patch): cherry-pick 27ebe7b to release/v0.0.777777777777-pr-11400 to patch version v0.0.777777777777 and create version 0.0.777777777778" --body "This PR

**[DRY RUN]**"
---------------------
```

## Testing Matrix

## Linked issues / bugs

[#11288](https://github.com/google-gemini/gemini-cli/issues/11288)