### PR TITLE
Only check for updates if disableUpdateNag is false

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -206,7 +206,7 @@ export async function startInteractiveUI(
     },
   );
 
-  checkForUpdates()
+  checkForUpdates(settings)
     .then((info) => {
       handleAutoUpdate(info, settings, config.getProjectRoot());
     })

--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -8,6 +8,7 @@ import type { UpdateInfo } from 'update-notifier';
 import updateNotifier from 'update-notifier';
 import semver from 'semver';
 import { getPackageJson } from '../../utils/package.js';
+import type { LoadedSettings } from '../../config/settings.js';
 
 export const FETCH_TIMEOUT_MS = 2000;
 
@@ -39,8 +40,13 @@ function getBestAvailableUpdate(
   return semver.gt(stableVer, nightlyVer) ? stable : nightly;
 }
 
-export async function checkForUpdates(): Promise<UpdateObject | null> {
+export async function checkForUpdates(
+  settings: LoadedSettings,
+): Promise<UpdateObject | null> {
   try {
+    if (settings.merged.general?.disableUpdateNag) {
+      return null;
+    }
     // Skip update check when running from source (development mode)
     if (process.env['DEV'] === 'true') {
       return null;


### PR DESCRIPTION
## TLDR

Today even if the auto update nag is off, the app still seems to check for new versions with npm. This fix proposes checking with the setting before checking for updates.

## Reviewer Test Plan

Please help make sure auto updates still work. :)

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #11403