### PR TITLE
fix(cli): Use correct defaults for file filtering

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+  DEFAULT_FILE_FILTERING_OPTIONS,
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_MODEL_AUTO,
   OutputFormat,
@@ -582,6 +583,19 @@ describe('loadCliConfig', () => {
         expect(config.getProxy()).toBe(expected);
       });
     });
+  });
+
+  it('should use default fileFilter options when unconfigured', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments({} as Settings);
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, [], 'test-session', argv);
+    expect(config.getFileFilteringRespectGitIgnore()).toBe(
+      DEFAULT_FILE_FILTERING_OPTIONS.respectGitIgnore,
+    );
+    expect(config.getFileFilteringRespectGeminiIgnore()).toBe(
+      DEFAULT_FILE_FILTERING_OPTIONS.respectGeminiIgnore,
+    );
   });
 });
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_MODEL_AUTO,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
+  DEFAULT_FILE_FILTERING_OPTIONS,
   DEFAULT_MEMORY_FILE_FILTERING_OPTIONS,
   FileDiscoveryService,
   WRITE_FILE_TOOL_NAME,
@@ -394,8 +395,13 @@ export async function loadCliConfig(
 
   const fileService = new FileDiscoveryService(cwd);
 
-  const fileFiltering = {
+  const memoryFileFiltering = {
     ...DEFAULT_MEMORY_FILE_FILTERING_OPTIONS,
+    ...settings.context?.fileFiltering,
+  };
+
+  const fileFiltering = {
+    ...DEFAULT_FILE_FILTERING_OPTIONS,
     ...settings.context?.fileFiltering,
   };
 
@@ -416,7 +422,7 @@ export async function loadCliConfig(
       allExtensions,
       trustedFolder,
       memoryImportFormat,
-      fileFiltering,
+      memoryFileFiltering,
     );
 
   let mcpServers = mergeMcpServers(settings, allExtensions);


### PR DESCRIPTION
## TLDR

This PR fixes a bug where the `ReadManyFiles` tool was not respecting `.gitignore` patterns by default. It ensures that file filtering options use the correct defaults, preventing ignored files from being included in the tool's output.

## Dive Deeper

File filtering options should use the defaults when they are not
overridden in settings files. This fixes a bug where the defaults for
memory files were used instead which led to `.gitignore` filtering being
disabled unless explicitly overridden.

A test is added to reproduce the issue and prevent further regressions.

## Reviewer Test Plan

1. Add a new entry to `.gitignore`: `erahm.test`, this should ignore all files named `erahm.test`
2. Add 3 files called `erahm.test` in nested directories:
3. Ask `gemini-cli` to tell me which tests in the erahm test framework failed

### Example setup
```
echo "erahm.test" >> .gitignore
echo "Test passed" >> packages/core/erahm.test
echo "Test passed" >> packages/core/src/tools/erahm.test
echo "Test failed" >> packages/core/src/utils/erahm.test
# confirm gitignore
git status
# run gemini with query
node packages/cli -i "Can you tell me which tests failed from the erahm framework? The status is in the erahm.test files."
```

After this change, the tool should not find any `erahm.test` files.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #11399