### PR TITLE
fix(ci): use standard integration test command on windows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -218,7 +218,7 @@ jobs:
           UV_THREADPOOL_SIZE: '32'
           NODE_ENV: 'test'
         shell: 'pwsh'
-        run: 'npm run deflake:test:integration:sandbox:none'
+        run: 'npm run test:integration:sandbox:none'
 
   e2e:
     name: 'E2E'


### PR DESCRIPTION
## TLDR

Switches the Windows integration test command from the deflake wrapper to the standard `npm run test:integration:sandbox:none` in `.github/workflows/e2e.yml`.

## Dive Deeper

Adjusting the CI command for Windows environment to use the direct test command.

## Reviewer Test Plan

Verify that the CI workflows pass with this change.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
