### PR TITLE
fix: Ignore correct errors thrown when resizing an exited pty

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -750,7 +750,11 @@ export class ShellExecutionService {
       } catch (e) {
         // Ignore errors if the pty has already exited, which can happen
         // due to a race condition between the exit event and this call.
-        if (e instanceof Error && 'code' in e && e.code === 'ESRCH') {
+        if (
+          e instanceof Error &&
+          (('code' in e && e.code === 'ESRCH') ||
+            e.message === 'Cannot resize a pty that has already exited')
+        ) {
           // ignore
         } else {
           throw e;


### PR DESCRIPTION
## TLDR

When a pty has already exited, operations like resize throws the following error: `throw new Error('Cannot resize a pty that has already exited')`. This change catches these specific errors and ignores them, preventing the gemini-cli crash. Currently, the errors catched are not being thrown.

## Reviewer Test Plan

On Windows, run any of the following terminal commands in the gemini-cli
`del <file_name>`
`git status`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | X  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Resolves #10258 
