### PR TITLE
fix(cli): Enable typechecking for more test files

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -23,7 +23,7 @@ import {
 } from '@google/gemini-cli-core';
 import type { Part } from '@google/genai';
 import { runNonInteractive } from './nonInteractiveCli.js';
-import { vi } from 'vitest';
+import { vi, type Mock, type MockInstance } from 'vitest';
 import type { LoadedSettings } from './config/settings.js';
 
 // Mock core modules
@@ -63,13 +63,13 @@ describe('runNonInteractive', () => {
   let mockConfig: Config;
   let mockSettings: LoadedSettings;
   let mockToolRegistry: ToolRegistry;
-  let mockCoreExecuteToolCall: vi.Mock;
-  let mockShutdownTelemetry: vi.Mock;
-  let consoleErrorSpy: vi.SpyInstance;
-  let processStdoutSpy: vi.SpyInstance;
+  let mockCoreExecuteToolCall: Mock;
+  let mockShutdownTelemetry: Mock;
+  let consoleErrorSpy: MockInstance;
+  let processStdoutSpy: MockInstance;
   let mockGeminiClient: {
-    sendMessageStream: vi.Mock;
-    getChatRecordingService: vi.Mock;
+    sendMessageStream: Mock;
+    getChatRecordingService: Mock;
   };
 
   beforeEach(async () => {

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -7,7 +7,7 @@
 import { describe, it, expect, vi, type Mock } from 'vitest';
 import { render } from 'ink-testing-library';
 import { Text, useIsScreenReaderEnabled } from 'ink';
-import { type Config } from '@google/gemini-cli-core';
+import { makeFakeConfig } from '@google/gemini-cli-core';
 import { App } from './App.js';
 import { UIStateContext, type UIState } from './contexts/UIStateContext.js';
 import { StreamingState } from './types.js';
@@ -61,7 +61,7 @@ describe('App', () => {
     },
   };
 
-  const mockConfig = {} as unknown as Config;
+  const mockConfig = makeFakeConfig();
 
   const renderWithProviders = (ui: React.ReactElement, state: UIState) =>
     render(

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -4,17 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, type Mock } from 'vitest';
 import { render } from 'ink-testing-library';
 import { Text, useIsScreenReaderEnabled } from 'ink';
+import { type Config } from '@google/gemini-cli-core';
 import { App } from './App.js';
 import { UIStateContext, type UIState } from './contexts/UIStateContext.js';
 import { StreamingState } from './types.js';
-import {
-  ConfigContext,
-  type Config,
-  type Telemetry,
-} from './contexts/ConfigContext.js';
+import { ConfigContext } from './contexts/ConfigContext.js';
 
 vi.mock('ink', async (importOriginal) => {
   const original = await importOriginal<typeof import('ink')>();
@@ -64,9 +61,7 @@ describe('App', () => {
     },
   };
 
-  const mockConfig = {
-    telemetry: {} as Telemetry,
-  } as Config;
+  const mockConfig = {} as unknown as Config;
 
   const renderWithProviders = (ui: React.ReactElement, state: UIState) =>
     render(
@@ -132,7 +127,7 @@ describe('App', () => {
   });
 
   it('should render ScreenReaderAppLayout when screen reader is enabled', () => {
-    (useIsScreenReaderEnabled as vi.Mock).mockReturnValue(true);
+    (useIsScreenReaderEnabled as Mock).mockReturnValue(true);
 
     const { lastFrame } = renderWithProviders(<App />, mockUIState as UIState);
 
@@ -142,7 +137,7 @@ describe('App', () => {
   });
 
   it('should render DefaultAppLayout when screen reader is not enabled', () => {
-    (useIsScreenReaderEnabled as vi.Mock).mockReturnValue(false);
+    (useIsScreenReaderEnabled as Mock).mockReturnValue(false);
 
     const { lastFrame } = renderWithProviders(<App />, mockUIState as UIState);
 

--- a/packages/cli/src/ui/contexts/SessionContext.test.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.test.tsx
@@ -84,6 +84,7 @@ describe('SessionStatsContext', () => {
           accept: 1,
           reject: 0,
           modify: 0,
+          auto_accept: 0,
         },
         byName: {
           'test-tool': {
@@ -95,9 +96,14 @@ describe('SessionStatsContext', () => {
               accept: 1,
               reject: 0,
               modify: 0,
+              auto_accept: 0,
             },
           },
         },
+      },
+      files: {
+        totalLinesAdded: 0,
+        totalLinesRemoved: 0,
       },
     };
 
@@ -152,8 +158,12 @@ describe('SessionStatsContext', () => {
         totalSuccess: 0,
         totalFail: 0,
         totalDurationMs: 0,
-        totalDecisions: { accept: 0, reject: 0, modify: 0 },
+        totalDecisions: { accept: 0, reject: 0, modify: 0, auto_accept: 0 },
         byName: {},
+      },
+      files: {
+        totalLinesAdded: 0,
+        totalLinesRemoved: 0,
       },
     };
 

--- a/packages/cli/src/ui/themes/theme.test.ts
+++ b/packages/cli/src/ui/themes/theme.test.ts
@@ -86,7 +86,9 @@ describe('themeManager.loadCustomThemes', () => {
     delete legacyTheme.DiffAdded;
     delete legacyTheme.DiffRemoved;
 
-    themeManager.loadCustomThemes({ 'Legacy Custom Theme': legacyTheme });
+    themeManager.loadCustomThemes({
+      'Legacy Custom Theme': legacyTheme as CustomTheme,
+    });
     const result = themeManager.getTheme('Legacy Custom Theme')!;
 
     expect(result.colors.DiffAdded).toBe(darkTheme.DiffAdded);

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -17,14 +17,9 @@
     "node_modules",
     "dist",
     // TODO(5691): Fix type errors and remove excludes.
-    "src/nonInteractiveCli.test.ts",
-    "src/services/FileCommandLoader.test.ts",
-    "src/services/prompt-processors/argumentProcessor.test.ts",
     "src/utils/cleanup.test.ts",
     "src/utils/handleAutoUpdate.test.ts",
     "src/utils/startupWarnings.test.ts",
-    "src/ui/App.test.tsx",
-    "src/ui/contexts/SessionContext.test.tsx",
     "src/ui/hooks/slashCommandProcessor.test.ts",
     "src/ui/hooks/useAtCompletion.test.ts",
     "src/ui/hooks/useConsoleMessages.test.ts",
@@ -36,9 +31,6 @@
     "src/ui/hooks/usePhraseCycler.test.ts",
     "src/ui/hooks/vim.test.ts",
     "src/ui/utils/computeStats.test.ts",
-    "src/ui/themes/theme.test.ts",
-    "src/validateNonInterActiveAuth.test.ts",
-    "src/services/prompt-processors/shellProcessor.test.ts",
     "src/commands/extensions/examples/**"
   ],
   "references": [{ "path": "../core" }]

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -30,8 +30,7 @@
     "src/ui/hooks/useKeypress.test.ts",
     "src/ui/hooks/usePhraseCycler.test.ts",
     "src/ui/hooks/vim.test.ts",
-    "src/ui/utils/computeStats.test.ts",
-    "src/commands/extensions/examples/**"
+    "src/ui/utils/computeStats.test.ts"
   ],
   "references": [{ "path": "../core" }]
 }


### PR DESCRIPTION
## TLDR

Removed several test files from the `exclude` list in `packages/cli/tsconfig.json` and fixed the resulting type errors.

## Dive Deeper

Addressed part of `TODO(5691)` by enabling typechecking for the following files and fixing identified issues:
- `src/nonInteractiveCli.test.ts`
- `src/ui/App.test.tsx`
- `src/ui/contexts/SessionContext.test.tsx`
- `src/ui/themes/theme.test.ts`
- `src/validateNonInterActiveAuth.test.ts`

Other files were also enabled but required no changes.

## Reviewer Test Plan

Run typechecking for the CLI package:
```bash
npm run typecheck
```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

#9403
