### PR TITLE
Add --output option to deflake script for JSON result saving

### DIFF
--- a/scripts/deflake.js
+++ b/scripts/deflake.js
@@ -7,12 +7,14 @@
 import { spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 // Script to deflake tests
 // Ex. npm run deflake -- --command="npm run test:e2e -- --test-name-pattern 'extension'" --runs=3
+// Ex. npm run deflake -- --command="npm run test:e2e" --runs=5 --output=deflake-results.json
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
@@ -23,14 +25,17 @@ const DOCKERIGNORE_CONTENT = `.integration-tests`.trim();
 /**
  * Runs a command and streams its output to the console.
  * @param {string} command The command string to execute (e.g., 'npm run test:e2e -- --watch').
- * @returns {Promise<number>} A Promise that resolves with the exit code of the process.
+ * @returns {Promise<{exitCode: number, startTime: Date, endTime: Date}>} A Promise that resolves with run details.
  */
 function runCommand(cmd, args = []) {
   if (!cmd) {
-    return Promise.resolve(1);
+    const now = new Date();
+    return Promise.resolve({ exitCode: 1, startTime: now, endTime: now });
   }
 
   return new Promise((resolve, reject) => {
+    const startTime = new Date();
+    
     const child = spawn(cmd, args, {
       shell: true,
       stdio: 'inherit',
@@ -38,16 +43,46 @@ function runCommand(cmd, args = []) {
     });
 
     child.on('close', (code) => {
-      resolve(code ?? 1); // code can be null if the process was killed
+      const endTime = new Date();
+      resolve({ exitCode: code ?? 1, startTime, endTime }); // code can be null if the process was killed
     });
 
     child.on('error', (err) => {
       // An error occurred in spawning the process (e.g., command not found).
       console.error(`Failed to start command: ${err.message}`);
-      reject(err);
+      const endTime = new Date();
+      reject({ error: err, startTime, endTime });
     });
   });
 }
+
+/**
+ * Gets system environment information for the JSON output
+ */
+function getEnvironmentInfo() {
+  return {
+    nodeVersion: process.version,
+    npmVersion: process.env.npm_version || 'unknown',
+    platform: process.platform,
+    arch: process.arch,
+    cwd: process.cwd(),
+    cpuCores: os.cpus().length,
+    memoryMB: Math.round(os.totalmem() / 1024 / 1024)
+  };
+}
+
+/**
+ * Saves deflake results to a JSON file
+ */
+async function saveResults(outputPath, results) {
+  try {
+    await fs.writeFile(outputPath, JSON.stringify(results, null, 2));
+    console.log(`\n📁 Results saved to: ${outputPath}`);
+  } catch (error) {
+    console.error(`❌ Failed to save results to ${outputPath}:`, error.message);
+  }
+}
+
 // -------------------------------------------------------------------
 
 async function main() {
@@ -61,17 +96,30 @@ async function main() {
       type: 'number',
       default: 5,
       description: 'The number of runs to perform',
-    }).argv;
+    })
+    .option('output', {
+      type: 'string',
+      description: 'Path to save JSON results (optional)',
+    })
+    .help()
+    .argv;
 
   const NUM_RUNS = argv.runs;
   const COMMAND = argv.command;
   const ARGS = argv._;
+  const OUTPUT_PATH = argv.output;
+  
   let failures = 0;
+  const runDetails = [];
+  const overallStartTime = new Date();
 
   const backupDockerIgnorePath = dockerIgnorePath + '.bak';
   let originalDockerIgnoreRenamed = false;
 
   console.log(`--- Starting Deflake Run (${NUM_RUNS} iterations) ---`);
+  if (OUTPUT_PATH) {
+    console.log(`📝 Results will be saved to: ${OUTPUT_PATH}`);
+  }
 
   try {
     try {
@@ -90,7 +138,19 @@ async function main() {
       console.log(`\n[RUN ${i}/${NUM_RUNS}]`);
 
       try {
-        const exitCode = await runCommand(COMMAND, ARGS);
+        const { exitCode, startTime, endTime } = await runCommand(COMMAND, ARGS);
+        const durationSeconds = (endTime.getTime() - startTime.getTime()) / 1000;
+        
+        const runDetail = {
+          run: i,
+          status: exitCode === 0 ? 'PASS' : 'FAIL',
+          exitCode,
+          startTime: startTime.toISOString(),
+          endTime: endTime.toISOString(),
+          durationSeconds: Number(durationSeconds.toFixed(3))
+        };
+        
+        runDetails.push(runDetail);
 
         if (exitCode === 0) {
           console.log('✅ Run PASS');
@@ -100,6 +160,18 @@ async function main() {
         }
       } catch (error) {
         console.error('❌ Run FAIL (Execution Error)', error);
+        
+        const runDetail = {
+          run: i,
+          status: 'FAIL',
+          exitCode: 1,
+          startTime: error.startTime?.toISOString() || new Date().toISOString(),
+          endTime: error.endTime?.toISOString() || new Date().toISOString(),
+          durationSeconds: 0,
+          error: error.error?.message || 'Unknown execution error'
+        };
+        
+        runDetails.push(runDetail);
         failures++;
       }
     }
@@ -121,9 +193,46 @@ async function main() {
     }
   }
 
+  const overallEndTime = new Date();
+  const passRuns = runDetails.filter(r => r.status === 'PASS').map(r => r.run);
+  const failRuns = runDetails.filter(r => r.status === 'FAIL').map(r => r.run);
+  const durations = runDetails.map(r => r.durationSeconds);
+  const fastestRun = Math.min(...durations);
+  const slowestRun = Math.max(...durations);
+  const averageRun = (durations.reduce((a, b) => a + b, 0) / durations.length);
+  
   console.log('\n--- FINAL DEFLAKE SUMMARY ---');
   console.log(`Total Runs: ${NUM_RUNS}`);
   console.log(`Total Failures: ${failures}`);
+  console.log(`Pass Rate: ${((NUM_RUNS - failures) / NUM_RUNS * 100).toFixed(2)}%`);
+  
+  if (durations.length > 0) {
+    console.log(`Fastest Run: ${fastestRun.toFixed(3)}s`);
+    console.log(`Slowest Run: ${slowestRun.toFixed(3)}s`);
+    console.log(`Average Run: ${averageRun.toFixed(2)}s`);
+  }
+
+  // Save JSON results if output path is specified
+  if (OUTPUT_PATH) {
+    const results = {
+      timestamp: overallStartTime.toISOString(),
+      command: COMMAND,
+      runs: NUM_RUNS,
+      failures,
+      passRate: `${((NUM_RUNS - failures) / NUM_RUNS * 100).toFixed(2)}%`,
+      runDetails,
+      summary: {
+        fastestRunSeconds: durations.length > 0 ? fastestRun : 0,
+        slowestRunSeconds: durations.length > 0 ? slowestRun : 0,
+        averageRunSeconds: durations.length > 0 ? averageRun.toFixed(2) : '0.00',
+        passRuns,
+        failRuns
+      },
+      env: getEnvironmentInfo()
+    };
+    
+    await saveResults(OUTPUT_PATH, results);
+  }
 
   process.exit(failures > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Overview

This pull request implements the enhancement requested in issue #11470 by adding a `--output` option to the `deflake.js` script that allows saving test results as JSON files.

## 🚀 Changes

### New Features
- **`--output` flag**: Optional parameter to specify JSON output file path
- **Comprehensive JSON structure**: Includes all data specified in the original issue
- **Detailed run tracking**: Records timestamps, durations, and exit codes for each test run
- **Environment metadata**: Captures system information for debugging and analysis
- **Backward compatibility**: Existing functionality remains unchanged when `--output` is not specified

### Usage Examples

```bash
# Save results to default filename
npm run deflake -- --command="npm run test:e2e" --runs=5 --output=deflake-results.json

# Continue using without output (existing behavior)
npm run deflake -- --command="npm run test:e2e" --runs=5

# Custom output filename
npm run deflake -- --command="npm run test:unit" --runs=10 --output=./reports/unit-test-flake-analysis.json
```

### JSON Output Structure

The generated JSON includes all fields requested in the original issue:

```json
{
  "timestamp": "2025-10-19T17:38:50.000Z",
  "command": "npm run test:e2e", 
  "runs": 5,
  "failures": 1,
  "passRate": "80.00%",
  "runDetails": [
    {
      "run": 1,
      "status": "PASS",
      "exitCode": 0,
      "startTime": "2025-10-19T17:38:51.000Z",
      "endTime": "2025-10-19T17:39:15.000Z", 
      "durationSeconds": 24.123
    }
    // ... more runs
  ],
  "summary": {
    "fastestRunSeconds": 22.1,
    "slowestRunSeconds": 28.5,
    "averageRunSeconds": "24.85",
    "passRuns": [1, 2, 4, 5],
    "failRuns": [3]
  },
  "env": {
    "nodeVersion": "v22.20.0",
    "npmVersion": "10.9.2", 
    "platform": "darwin",
    "arch": "arm64",
    "cwd": "/path/to/project",
    "cpuCores": 8,
    "memoryMB": 16384
  }
}
```

## 📝 Benefits

1. **CI/CD Integration**: Machine-readable JSON enables automated analysis in build pipelines
2. **Historical Tracking**: Results can be stored and compared across multiple deflake sessions
3. **Dashboard Integration**: JSON output can feed into monitoring and reporting dashboards
4. **Performance Analysis**: Detailed timing data helps identify performance patterns
5. **Environment Correlation**: System metadata helps correlate flakiness with environmental factors

## ✅ Validation

- **Backward Compatibility**: All existing deflake functionality preserved
- **Optional Feature**: No impact when `--output` flag is not used
- **Error Handling**: Graceful handling of file write errors
- **Comprehensive Data**: Matches the JSON structure specification from issue #11470
- **User-Friendly**: Clear console output indicates when and where results are saved

## 🔗 Fixes

Fixes #11470 

---

**Note**: This implementation is fully backward-compatible and enhances the deflake tool's utility for CI/CD pipelines and automated testing workflows without affecting existing usage patterns.