### PR TITLE
Fix Windows ripgrep detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ packages/cli/src/generated/
 packages/core/src/generated/
 .integration-tests/
 packages/vscode-ide-companion/*.vsix
+packages/cli/download-ripgrep*/
 
 # GHA credentials
 gha-creds-*.json

--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -107,7 +107,9 @@ describe('canUseRipgrep', () => {
     const expectedPath = path.join(binDir, candidateNames[0]);
     const existenceMap = new Map<string, boolean>();
 
-    (fileExists as Mock).mockImplementation(async (filePath: string) => existenceMap.get(filePath) ?? false);
+    (fileExists as Mock).mockImplementation(
+      async (filePath: string) => existenceMap.get(filePath) ?? false,
+    );
 
     const downloadMock = downloadRipGrep as Mock;
     downloadMock.mockImplementation(

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -36,13 +36,24 @@ async function resolveExistingRgPath(): Promise<string | null> {
   return null;
 }
 
+let ripgrepAcquisitionPromise: Promise<string | null> | null = null;
+
 async function ensureRipgrepAvailable(): Promise<string | null> {
   const existingPath = await resolveExistingRgPath();
   if (existingPath) {
     return existingPath;
   }
-  await downloadRipGrep(Storage.getGlobalBinDir());
-  return resolveExistingRgPath();
+  if (!ripgrepAcquisitionPromise) {
+    ripgrepAcquisitionPromise = (async () => {
+      try {
+        await downloadRipGrep(Storage.getGlobalBinDir());
+        return await resolveExistingRgPath();
+      } finally {
+        ripgrepAcquisitionPromise = null;
+      }
+    })();
+  }
+  return ripgrepAcquisitionPromise;
 }
 
 /**

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -36,28 +36,27 @@ async function resolveExistingRgPath(): Promise<string | null> {
   return null;
 }
 
+async function ensureRipgrepAvailable(): Promise<string | null> {
+  const existingPath = await resolveExistingRgPath();
+  if (existingPath) {
+    return existingPath;
+  }
+  await downloadRipGrep(Storage.getGlobalBinDir());
+  return resolveExistingRgPath();
+}
+
 /**
  * Checks if `rg` exists, if not then attempt to download it.
  */
 export async function canUseRipgrep(): Promise<boolean> {
-  if (await resolveExistingRgPath()) {
-    return true;
-  }
-
-  await downloadRipGrep(Storage.getGlobalBinDir());
-  return (await resolveExistingRgPath()) !== null;
+  return (await ensureRipgrepAvailable()) !== null;
 }
 
 /**
  * Ensures `rg` is downloaded, or throws.
  */
 export async function ensureRgPath(): Promise<string> {
-  const existingPath = await resolveExistingRgPath();
-  if (existingPath) {
-    return existingPath;
-  }
-  await downloadRipGrep(Storage.getGlobalBinDir());
-  const downloadedPath = await resolveExistingRgPath();
+  const downloadedPath = await ensureRipgrepAvailable();
   if (downloadedPath) {
     return downloadedPath;
   }

--- a/third_party/get-ripgrep/src/downloadRipGrep.js
+++ b/third_party/get-ripgrep/src/downloadRipGrep.js
@@ -104,7 +104,7 @@ const untarGz = async (inFile, outDir) => {
   }
 }
 
-export const downloadRipGrep = async () => {
+export const downloadRipGrep = async (binPath = BIN_PATH) => {
   const target = getTarget()
   const url = `https://github.com/${REPOSITORY}/releases/download/${VERSION}/ripgrep-${VERSION}-${target}`
   const downloadPath = `${xdgCache}/vscode-ripgrep/ripgrep-${VERSION}-${target}`
@@ -114,9 +114,9 @@ export const downloadRipGrep = async () => {
     console.info(`File ${downloadPath} has been cached`)
   }
   if (downloadPath.endsWith('.tar.gz')) {
-    await untarGz(downloadPath, BIN_PATH)
+    await untarGz(downloadPath, binPath)
   } else if (downloadPath.endsWith('.zip')) {
-    await unzip(downloadPath, BIN_PATH)
+    await unzip(downloadPath, binPath)
   } else {
     throw new VError(`Invalid downloadPath ${downloadPath}`)
   }


### PR DESCRIPTION
  - detect both `rg` and `rg.exe`, returning whichever exists and downloading only once even with
  concurrent callers
  - refactor ripgrep availability logic into a shared helper and reuse it from `canUseRipgrep`/
  `ensureRgPath`
  - expand the test suite with Windows-specific and concurrency regressions, and ignore temporary
  `download-ripgrep*` artifacts

  Related to #11438