### PR TITLE
feat(cli): Support wl-clipboard for wayland

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -68,8 +68,9 @@ Slash commands provide meta-level control over the CLI itself.
     clipboard, for easy sharing or reuse.
   - **Note:** This command requires platform-specific clipboard tools to be
     installed.
-    - On Linux, it requires `xclip` or `xsel`. You can typically install them
-      using your system's package manager.
+    - On Linux, it requires `xclip` or `xsel` for X11 and `wl-clipboard` for
+      wayland. You can typically install them using your system's package
+      manager.
     - On macOS, it requires `pbcopy`, and on Windows, it requires `clip`. These
       tools are typically pre-installed on their respective systems.
 


### PR DESCRIPTION
## TLDR

As documented, `/copy` uses `xsel` or `xclip` under the hood. They only works on X11. 
This PR uses wl-copy for wayland session.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->
1. Run Linux with wayland compositor. 
2. install wl-clipboard
3. try `/copy`

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✔  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #11505 
