### PR TITLE
Adds executeCommand endpoint with support for /extensions list

### DIFF
--- a/packages/a2a-server/src/commands/command-registry.test.ts
+++ b/packages/a2a-server/src/commands/command-registry.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('CommandRegistry', () => {
+  const mockListExtensionsCommandInstance = {
+    names: ['extensions', 'extensions list'],
+    execute: vi.fn(),
+  };
+  const mockListExtensionsCommand = vi.fn(
+    () => mockListExtensionsCommandInstance,
+  );
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.doMock('./list-extensions', () => ({
+      ListExtensionsCommand: mockListExtensionsCommand,
+    }));
+  });
+
+  it('should register ListExtensionsCommand on initialization', async () => {
+    const { commandRegistry } = await import('./command-registry.js');
+    expect(mockListExtensionsCommand).toHaveBeenCalled();
+    const command = commandRegistry.get('extensions');
+    expect(command).toBe(mockListExtensionsCommandInstance);
+  });
+
+  it('get() should return undefined for a non-existent command', async () => {
+    const { commandRegistry } = await import('./command-registry.js');
+    const command = commandRegistry.get('non-existent');
+    expect(command).toBeUndefined();
+  });
+
+  it('register() should register a new command', async () => {
+    const { commandRegistry } = await import('./command-registry.js');
+    const mockCommand = {
+      names: ['test-command'],
+      execute: vi.fn(),
+    };
+    commandRegistry.register(mockCommand);
+    const command = commandRegistry.get('test-command');
+    expect(command).toBe(mockCommand);
+  });
+});

--- a/packages/a2a-server/src/commands/command-registry.ts
+++ b/packages/a2a-server/src/commands/command-registry.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ListExtensionsCommand } from './list-extensions.js';
+import type { Config } from '@google/gemini-cli-core';
+
+export interface Command {
+  readonly names: string[];
+  execute(config: Config, args: string[]): Promise<unknown>;
+}
+
+class CommandRegistry {
+  private readonly commands = new Map<string, Command>();
+
+  constructor() {
+    this.register(new ListExtensionsCommand());
+  }
+
+  register(command: Command) {
+    for (const name of command.names) {
+      this.commands.set(name, command);
+    }
+  }
+
+  get(commandName: string): Command | undefined {
+    return this.commands.get(commandName);
+  }
+}
+
+export const commandRegistry = new CommandRegistry();

--- a/packages/a2a-server/src/commands/list-extensions.test.ts
+++ b/packages/a2a-server/src/commands/list-extensions.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ListExtensionsCommand } from './list-extensions.js';
+import type { Config } from '@google/gemini-cli-core';
+
+const mockListExtensions = vi.hoisted(() => vi.fn());
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+
+  return {
+    ...original,
+    listExtensions: mockListExtensions,
+  };
+});
+
+describe('ListExtensionsCommand', () => {
+  it('should have the correct names', () => {
+    const command = new ListExtensionsCommand();
+    expect(command.names).toEqual(['extensions', 'extensions list']);
+  });
+
+  it('should call listExtensions with the provided config', async () => {
+    const command = new ListExtensionsCommand();
+    const mockConfig = {} as Config;
+    const mockExtensions = [{ name: 'ext1' }];
+    mockListExtensions.mockReturnValue(mockExtensions);
+
+    const result = await command.execute(mockConfig, []);
+
+    expect(result).toEqual(mockExtensions);
+    expect(mockListExtensions).toHaveBeenCalledWith(mockConfig);
+  });
+});

--- a/packages/a2a-server/src/commands/list-extensions.ts
+++ b/packages/a2a-server/src/commands/list-extensions.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { listExtensions, type Config } from '@google/gemini-cli-core';
+import type { Command } from './command-registry.js';
+
+export class ListExtensionsCommand implements Command {
+  readonly names = ['extensions', 'extensions list'];
+
+  async execute(config: Config, _: string[]): Promise<unknown> {
+    return listExtensions(config);
+  }
+}

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -71,6 +71,7 @@ export async function loadConfig(
     },
     ideMode: false,
     folderTrust: settings.folderTrust === true,
+    extensions,
   };
 
   const fileService = new FileDiscoveryService(workspaceDir);

--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -16,6 +16,10 @@ import type { AgentSettings } from '../types.js';
 import { GCSTaskStore, NoOpTaskStore } from '../persistence/gcs.js';
 import { CoderAgentExecutor } from '../agent/executor.js';
 import { requestStorage } from './requestStorage.js';
+import { loadConfig, loadEnvironment, setTargetDir } from '../config/config.js';
+import { loadSettings } from '../config/settings.js';
+import { loadExtensions } from '../config/extension.js';
+import { commandRegistry } from '../commands/command-registry.js';
 
 const coderAgentCard: AgentCard = {
   name: 'Gemini SDLC Agent',
@@ -61,6 +65,13 @@ export function updateCoderAgentCardUrl(port: number) {
 
 export async function createApp() {
   try {
+    // Load the server configuration once on startup.
+    const workspaceRoot = setTargetDir(undefined);
+    loadEnvironment();
+    const settings = loadSettings(workspaceRoot);
+    const extensions = loadExtensions(workspaceRoot);
+    const config = await loadConfig(settings, extensions, 'a2a-server');
+
     // loadEnvironment() is called within getConfig now
     const bucketName = process.env['GCS_BUCKET_NAME'];
     let taskStoreForExecutor: TaskStore;
@@ -116,6 +127,36 @@ export async function createApp() {
             ? error.message
             : 'Unknown error creating task';
         res.status(500).send({ error: errorMessage });
+      }
+    });
+
+    expressApp.post('/executeCommand', async (req, res) => {
+      try {
+        const { command, args } = req.body;
+
+        if (typeof command !== 'string') {
+          return res.status(400).json({ error: 'Invalid "command" field.' });
+        }
+
+        if (args && !Array.isArray(args)) {
+          return res
+            .status(400)
+            .json({ error: '"args" field must be an array.' });
+        }
+
+        const commandToExecute = commandRegistry.get(command);
+
+        if (!commandToExecute) {
+          return res
+            .status(404)
+            .json({ error: `Command not found: ${command}` });
+        }
+
+        const result = await commandToExecute.execute(config, args ?? []);
+        return res.status(200).json(result);
+      } catch (e) {
+        logger.error('Error executing /executeCommand:', e);
+        return res.status(500).json({ error: (e as Error).message });
       }
     });
 

--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -156,7 +156,9 @@ export async function createApp() {
         return res.status(200).json(result);
       } catch (e) {
         logger.error('Error executing /executeCommand:', e);
-        return res.status(500).json({ error: (e as Error).message });
+        const errorMessage =
+          e instanceof Error ? e.message : 'Unknown error executing command';
+        return res.status(500).json({ error: errorMessage });
       }
     });
 

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -25,6 +25,7 @@ describe('extensionsCommand', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    mockGetExtensions.mockReturnValue([]);
     mockContext = createMockCommandContext({
       services: {
         config: {

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -46,6 +46,7 @@ describe('extensionsCommand', () => {
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
           type: MessageType.EXTENSIONS_LIST,
+          extensions: expect.any(Array),
         },
         expect.any(Number),
       );
@@ -113,11 +114,13 @@ describe('extensionsCommand', () => {
       await updateAction(mockContext, '--all');
       expect(mockContext.ui.setPendingItem).toHaveBeenCalledWith({
         type: MessageType.EXTENSIONS_LIST,
+        extensions: expect.any(Array),
       });
       expect(mockContext.ui.setPendingItem).toHaveBeenCalledWith(null);
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
           type: MessageType.EXTENSIONS_LIST,
+          extensions: expect.any(Array),
         },
         expect.any(Number),
       );
@@ -130,11 +133,13 @@ describe('extensionsCommand', () => {
       await updateAction(mockContext, '--all');
       expect(mockContext.ui.setPendingItem).toHaveBeenCalledWith({
         type: MessageType.EXTENSIONS_LIST,
+        extensions: expect.any(Array),
       });
       expect(mockContext.ui.setPendingItem).toHaveBeenCalledWith(null);
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
           type: MessageType.EXTENSIONS_LIST,
+          extensions: expect.any(Array),
         },
         expect.any(Number),
       );
@@ -202,11 +207,13 @@ describe('extensionsCommand', () => {
       });
       expect(mockContext.ui.setPendingItem).toHaveBeenCalledWith({
         type: MessageType.EXTENSIONS_LIST,
+        extensions: expect.any(Array),
       });
       expect(mockContext.ui.setPendingItem).toHaveBeenCalledWith(null);
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         {
           type: MessageType.EXTENSIONS_LIST,
+          extensions: expect.any(Array),
         },
         expect.any(Number),
       );

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -130,7 +130,9 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
       {itemForDisplay.type === 'compression' && (
         <CompressionMessage compression={itemForDisplay.compression} />
       )}
-      {itemForDisplay.type === 'extensions_list' && <ExtensionsList />}
+      {itemForDisplay.type === 'extensions_list' && (
+        <ExtensionsList extensions={itemForDisplay.extensions} />
+      )}
       {itemForDisplay.type === 'tools_list' && (
         <ToolsList
           terminalWidth={terminalWidth}

--- a/packages/cli/src/ui/components/views/ExtensionsList.test.tsx
+++ b/packages/cli/src/ui/components/views/ExtensionsList.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { render } from 'ink-testing-library';
-import { vi } from 'vitest';
+import { vi, describe, beforeEach, it, expect } from 'vitest';
 import { useUIState } from '../../contexts/UIStateContext.js';
 import { ExtensionUpdateState } from '../../state/extensions.js';
 import { ExtensionsList } from './ExtensionsList.js';
@@ -16,9 +16,27 @@ vi.mock('../../contexts/UIStateContext.js');
 const mockUseUIState = vi.mocked(useUIState);
 
 const mockExtensions = [
-  { name: 'ext-one', version: '1.0.0', isActive: true },
-  { name: 'ext-two', version: '2.1.0', isActive: true },
-  { name: 'ext-disabled', version: '3.0.0', isActive: false },
+  {
+    name: 'ext-one',
+    version: '1.0.0',
+    isActive: true,
+    path: '/path/to/ext-one',
+    contextFiles: [],
+  },
+  {
+    name: 'ext-two',
+    version: '2.1.0',
+    isActive: true,
+    path: '/path/to/ext-two',
+    contextFiles: [],
+  },
+  {
+    name: 'ext-disabled',
+    version: '3.0.0',
+    isActive: false,
+    path: '/path/to/ext-disabled',
+    contextFiles: [],
+  },
 ];
 
 describe('<ExtensionsList />', () => {
@@ -27,31 +45,25 @@ describe('<ExtensionsList />', () => {
   });
 
   const mockUIState = (
-    extensions: unknown[],
     extensionsUpdateState: Map<string, ExtensionUpdateState>,
   ) => {
     mockUseUIState.mockReturnValue({
-      commandContext: createMockCommandContext({
-        services: {
-          config: {
-            getExtensions: () => extensions,
-          },
-        },
-      }),
       extensionsUpdateState,
       // Add other required properties from UIState if needed by the component
     } as never);
   };
 
   it('should render "No extensions installed." if there are no extensions', () => {
-    mockUIState([], new Map());
-    const { lastFrame } = render(<ExtensionsList />);
+    mockUIState(new Map());
+    const { lastFrame } = render(<ExtensionsList extensions={[]} />);
     expect(lastFrame()).toContain('No extensions installed.');
   });
 
   it('should render a list of extensions with their version and status', () => {
-    mockUIState(mockExtensions, new Map());
-    const { lastFrame } = render(<ExtensionsList />);
+    mockUIState(new Map());
+    const { lastFrame } = render(
+      <ExtensionsList extensions={mockExtensions} />,
+    );
     const output = lastFrame();
     expect(output).toContain('ext-one (v1.0.0) - active');
     expect(output).toContain('ext-two (v2.1.0) - active');
@@ -59,8 +71,10 @@ describe('<ExtensionsList />', () => {
   });
 
   it('should display "unknown state" if an extension has no update state', () => {
-    mockUIState([mockExtensions[0]], new Map());
-    const { lastFrame } = render(<ExtensionsList />);
+    mockUIState(new Map());
+    const { lastFrame } = render(
+      <ExtensionsList extensions={[mockExtensions[0]]} />,
+    );
     expect(lastFrame()).toContain('(unknown state)');
   });
 
@@ -94,8 +108,10 @@ describe('<ExtensionsList />', () => {
   for (const { state, expectedText } of stateTestCases) {
     it(`should correctly display the state: ${state}`, () => {
       const updateState = new Map([[mockExtensions[0].name, state]]);
-      mockUIState([mockExtensions[0]], updateState);
-      const { lastFrame } = render(<ExtensionsList />);
+      mockUIState(updateState);
+      const { lastFrame } = render(
+        <ExtensionsList extensions={[mockExtensions[0]]} />,
+      );
       expect(lastFrame()).toContain(expectedText);
     });
   }

--- a/packages/cli/src/ui/components/views/ExtensionsList.test.tsx
+++ b/packages/cli/src/ui/components/views/ExtensionsList.test.tsx
@@ -9,7 +9,6 @@ import { vi, describe, beforeEach, it, expect } from 'vitest';
 import { useUIState } from '../../contexts/UIStateContext.js';
 import { ExtensionUpdateState } from '../../state/extensions.js';
 import { ExtensionsList } from './ExtensionsList.js';
-import { createMockCommandContext } from '../../../test-utils/mockCommandContext.js';
 
 vi.mock('../../contexts/UIStateContext.js');
 
@@ -22,6 +21,7 @@ const mockExtensions = [
     isActive: true,
     path: '/path/to/ext-one',
     contextFiles: [],
+    id: '',
   },
   {
     name: 'ext-two',
@@ -29,6 +29,7 @@ const mockExtensions = [
     isActive: true,
     path: '/path/to/ext-two',
     contextFiles: [],
+    id: '',
   },
   {
     name: 'ext-disabled',
@@ -36,6 +37,7 @@ const mockExtensions = [
     isActive: false,
     path: '/path/to/ext-disabled',
     contextFiles: [],
+    id: '',
   },
 ];
 

--- a/packages/cli/src/ui/components/views/ExtensionsList.tsx
+++ b/packages/cli/src/ui/components/views/ExtensionsList.tsx
@@ -4,15 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type React from 'react';
 import { Box, Text } from 'ink';
 import { useUIState } from '../../contexts/UIStateContext.js';
 import { ExtensionUpdateState } from '../../state/extensions.js';
+import type { GeminiCLIExtension } from '@google/gemini-cli-core';
 
-export const ExtensionsList = () => {
-  const { commandContext, extensionsUpdateState } = useUIState();
-  const allExtensions = commandContext.services.config!.getExtensions();
+interface ExtensionsList {
+  extensions: readonly GeminiCLIExtension[];
+}
 
-  if (allExtensions.length === 0) {
+export const ExtensionsList: React.FC<ExtensionsList> = ({ extensions }) => {
+  const { extensionsUpdateState } = useUIState();
+
+  if (extensions.length === 0) {
     return <Text>No extensions installed.</Text>;
   }
 
@@ -20,7 +25,7 @@ export const ExtensionsList = () => {
     <Box flexDirection="column" marginTop={1} marginBottom={1}>
       <Text>Installed extensions:</Text>
       <Box flexDirection="column" paddingLeft={2}>
-        {allExtensions.map((ext) => {
+        {extensions.map((ext) => {
           const state = extensionsUpdateState.get(ext.name);
           const isActive = ext.isActive;
           const activeString = isActive ? 'active' : 'disabled';

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -6,6 +6,7 @@
 
 import type {
   CompressionStatus,
+  GeminiCLIExtension,
   MCPServerConfig,
   ThoughtSummary,
   ToolCallConfirmationDetails,
@@ -163,6 +164,7 @@ export type HistoryItemCompression = HistoryItemBase & {
 
 export type HistoryItemExtensionsList = HistoryItemBase & {
   type: 'extensions_list';
+  extensions: GeminiCLIExtension[];
 };
 
 export interface ChatDetail {

--- a/packages/core/src/commands/extensions.test.ts
+++ b/packages/core/src/commands/extensions.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { listExtensions } from './extensions.js';
+import type { Config } from '../config/config.js';
+
+describe('listExtensions', () => {
+  it('should call config.getExtensions and return the result', () => {
+    const mockExtensions = [{ name: 'ext1' }, { name: 'ext2' }];
+    const mockConfig = {
+      getExtensions: vi.fn().mockReturnValue(mockExtensions),
+    } as unknown as Config;
+
+    const result = listExtensions(mockConfig);
+
+    expect(mockConfig.getExtensions).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(mockExtensions);
+  });
+});

--- a/packages/core/src/commands/extensions.ts
+++ b/packages/core/src/commands/extensions.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../config/config.js';
+
+export function listExtensions(config: Config) {
+  return config.getExtensions();
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,9 @@ export * from './policy/policy-engine.js';
 export * from './confirmation-bus/types.js';
 export * from './confirmation-bus/message-bus.js';
 
+// Export Commands logic
+export * from './commands/extensions.js';
+
 // Export Core Logic
 export * from './core/client.js';
 export * from './core/contentGenerator.js';


### PR DESCRIPTION
## TLDR

executeCommand endpoint in a2a server. Also registers /extensions list as the first exposed command

## Dive Deeper

Deeper discussion at: [go/gc-a2a-server-slash-commands](http://goto.google.com/gc-a2a-server-slash-commands)

## Reviewer Test Plan

Run A2A Server locally and call "/executeCommand"

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅ |

## Linked issues / bugs

- Closes #11513 
- Closes #11514 