### PR TITLE
fix(integration-tests): Set correct permissions for test directories

### DIFF
--- a/integration-tests/globalSetup.ts
+++ b/integration-tests/globalSetup.ts
@@ -20,7 +20,7 @@ let runDir = ''; // Make runDir accessible in teardown
 
 export async function setup() {
   runDir = join(integrationTestsDir, `${Date.now()}`);
-  await mkdir(runDir, { recursive: true });
+  await mkdir(runDir, { recursive: true, mode: 0o777 });
 
   // Set the home directory to the test run directory to avoid conflicts
   // with the user's local config.


### PR DESCRIPTION
## TLDR
This PR fixes an `EACCES: permission denied` error that can occur during integration tests, especially in CI environments. It ensures that the test run directories are created with appropriate write permissions.