### PR TITLE
(fix): remove custom waitFor and use testing-library implementation

### DIFF
--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -28,6 +28,7 @@ import { LoadedSettings, SettingScope } from '../../config/settings.js';
 import { VimModeProvider } from '../contexts/VimModeContext.js';
 import { KeypressProvider } from '../contexts/KeypressContext.js';
 import { act } from 'react';
+import { waitFor } from '@testing-library/react';
 import { saveModifiedSettings, TEST_ONLY } from '../../utils/settingsUtils.js';
 import {
   getSettingsSchema,
@@ -247,29 +248,6 @@ const TOOLS_SHELL_FAKE_SCHEMA: SettingsSchemaType = {
 describe('SettingsDialog', () => {
   // Simple delay function for remaining tests that need gradual migration
   const wait = (ms = 50) => new Promise((resolve) => setTimeout(resolve, ms));
-
-  // Custom waitFor utility for ink testing environment (not compatible with @testing-library/react)
-  const waitFor = async (
-    predicate: () => void,
-    options: { timeout?: number; interval?: number } = {},
-  ) => {
-    const { timeout = 1000, interval = 10 } = options;
-    const start = Date.now();
-    let lastError: unknown;
-    while (Date.now() - start < timeout) {
-      try {
-        predicate();
-        return;
-      } catch (e) {
-        lastError = e;
-      }
-      await new Promise((resolve) => setTimeout(resolve, interval));
-    }
-    if (lastError) {
-      throw lastError;
-    }
-    throw new Error('waitFor timed out');
-  };
 
   beforeEach(() => {
     // Reset keypress mock state (variables are commented out)


### PR DESCRIPTION
custom `waitFor` implementation introduced in #8396
- we can definitely rely on `waitFor` from `@testing-library/react`
- although it relies on a DOM environment, our testing environment deliberately sets it up as so with `environment: 'jsdom' ` in our `vitest.config` 
- therefore the custom implementation is not needed
- 
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
