### PR TITLE
skip flaky test

### DIFF
--- a/integration-tests/ctrl-c-exit.test.ts
+++ b/integration-tests/ctrl-c-exit.test.ts
@@ -9,7 +9,7 @@ import * as os from 'node:os';
 import { TestRig } from './test-helper.js';
 
 describe('Ctrl+C exit', () => {
-  it('should exit gracefully on second Ctrl+C', async () => {
+  it.skip('should exit gracefully on second Ctrl+C', async () => {
     const rig = new TestRig();
     await rig.setup('should exit gracefully on second Ctrl+C');
 


### PR DESCRIPTION
I'm seeing the following error in the nightly release:

```
  [Error: EACCES: permission denied, scandir '/home/runner/work/gemini-cli/gemini-cli/release/.integration-tests/1760984998995/should-exit-gracefully-on-second-ctrl-c/download-ripgrepcNyCIL'] {
    errno: -13,
    code: 'EACCES',
    syscall: 'scandir',
    path: '/home/runner/work/gemini-cli/gemini-cli/release/.integration-tests/1760984998995/should-exit-gracefully-on-second-ctrl-c/download-ripgrepcNyCIL'
  }
```

However, I don't see the same error when attempting a dev release from main so likely this test is still flaky (we re-enabled it recently)