### PR TITLE
Update nightly workflow to create issues for scheduled run failures

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -137,7 +137,7 @@ jobs:
           a2a-package-name: '${{ vars.A2A_PACKAGE_NAME }}'
 
       - name: 'Create and Merge Pull Request'
-        if: "github.event.inputs.environment == 'prod'"
+        if: "github.event.inputs.environment != 'dev'"
         uses: './.github/actions/create-pull-request'
         with:
           branch-name: 'release/${{ steps.nightly_version.outputs.RELEASE_TAG }}'
@@ -148,7 +148,7 @@ jobs:
           working-directory: './release'
 
       - name: 'Create Issue on Failure'
-        if: "${{ failure() && github.event.inputs.environment == 'prod' && (github.event_name == 'schedule' || github.event.inputs.dry_run != 'true') }}"
+        if: "${{ failure() && github.event.inputs.environment != 'dev' && (github.event_name == 'schedule' || github.event.inputs.dry_run != 'true') }}"
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           RELEASE_TAG: '${{ steps.nightly_version.outputs.RELEASE_TAG }}'


### PR DESCRIPTION
github.event.inputs.environment is empty for scheduled runs so we need to check != 'dev' instead so the issue gets created when github.event.inputs.environment == ''

## Fixes
#11530