### PR TITLE
fix(core): Preserve significant trailing spaces in gitignore patterns

### DIFF
--- a/packages/core/src/utils/gitIgnoreParser.test.ts
+++ b/packages/core/src/utils/gitIgnoreParser.test.ts
@@ -250,4 +250,24 @@ src/*.tmp
       expect(parser.isIgnored('bla/!bar')).toBe(true);
     });
   });
+
+  describe('Trailing Spaces', () => {
+    beforeEach(async () => {
+      await setupGitRepo();
+    });
+
+    it('should correctly handle significant trailing spaces', async () => {
+      await createTestFile('.gitignore', 'foo\\ \nbar ');
+      await createTestFile('foo ', 'content');
+      await createTestFile('bar', 'content');
+      await createTestFile('bar ', 'content');
+
+      // 'foo\ ' should match 'foo '
+      expect(parser.isIgnored('foo ')).toBe(true);
+
+      // 'bar ' should be trimmed to 'bar'
+      expect(parser.isIgnored('bar')).toBe(true);
+      expect(parser.isIgnored('bar ')).toBe(false);
+    });
+  });
 });

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -42,7 +42,7 @@ export class GitIgnoreParser implements GitIgnoreFilter {
 
     return content
       .split('\n')
-      .map((p) => p.trim())
+      .map((p) => p.trimStart())
       .filter((p) => p !== '' && !p.startsWith('#'))
       .map((p) => {
         const isNegative = p.startsWith('!');


### PR DESCRIPTION
## TLDR

Fixes a bug where the gitignore parser incorrectly stripped significant trailing spaces (escaped with `\ `) from patterns, causing them to fail. The parser now preserves these spaces.

## Dive Deeper

The `gitignore` specification dictates that trailing spaces are significant if they are escaped with a backslash (e.g., `foo\ `).

This change replaces `trim()` with `trimStart()`. This ensures that only leading whitespace is removed, preserving any backslash-escaped trailing spaces. The `node-ignore` library will take care of handling any trailing whitespace appropriately.

## Reviewer Test Plan

Reviewers can validate this change by running the unit tests. Specifically, the new 'Trailing Spaces' test suite in `packages/core/src/utils/gitIgnoreParser.test.ts` demonstrates the fn.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #11169
