### PR TITLE
test: add readWasmBinaryFromDisk unit test

### DIFF
--- a/packages/core/src/utils/__fixtures__/dummy.wasm
+++ b/packages/core/src/utils/__fixtures__/dummy.wasm
@@ -1,0 +1,1 @@
+This is a wasm fixture.

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -19,6 +19,7 @@ import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
+import { fileURLToPath } from 'node:url';
 // eslint-disable-next-line import/no-internal-modules
 import mime from 'mime/lite';
 
@@ -30,6 +31,7 @@ import {
   detectBOM,
   readFileWithEncoding,
   fileExists,
+  readWasmBinaryFromDisk,
 } from './fileUtils.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
 
@@ -75,6 +77,23 @@ describe('fileUtils', () => {
     }
     process.cwd = originalProcessCwd;
     vi.restoreAllMocks(); // Restore any spies
+  });
+
+  describe('readWasmBinaryFromDisk', () => {
+    it('loads a WASM binary from disk as a Uint8Array', async () => {
+      const wasmFixtureUrl = new URL(
+        './__fixtures__/dummy.wasm',
+        import.meta.url,
+      );
+      const wasmFixturePath = fileURLToPath(wasmFixtureUrl);
+      const result = await readWasmBinaryFromDisk(wasmFixturePath);
+      const expectedBytes = new Uint8Array(
+        await fsPromises.readFile(wasmFixturePath),
+      );
+
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result).toStrictEqual(expectedBytes);
+    });
   });
 
   describe('isWithinRoot', () => {


### PR DESCRIPTION
## Summary
- add fixture-backed unit test for readWasmBinaryFromDisk
- verify returned Uint8Array matches fixture bytes

## Testing
- npm run test --workspaces --if-present --parallel

Addresses a comment in https://github.com/google-gemini/gemini-cli/pull/11157.