### PR TITLE
fix(tools): restore static tool names to fix configuration exclusions

### DIFF
--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -464,9 +464,11 @@ export class EditTool
   extends BaseDeclarativeTool<EditToolParams, ToolResult>
   implements ModifiableDeclarativeTool<EditToolParams>
 {
+  static readonly Name = EDIT_TOOL_NAME;
+
   constructor(private readonly config: Config) {
     super(
-      EDIT_TOOL_NAME,
+      EditTool.Name,
       'Edit',
       `Replaces text within a file. By default, replaces a single occurrence, but can replace multiple occurrences when \`expected_replacements\` is specified. This tool requires providing significant context around the change to ensure precise targeting. Always use the ${READ_FILE_TOOL_NAME} tool to examine the file's current content before attempting a text replacement.
 

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -260,9 +260,11 @@ class GlobToolInvocation extends BaseToolInvocation<
  * Implementation of the Glob tool logic
  */
 export class GlobTool extends BaseDeclarativeTool<GlobToolParams, ToolResult> {
+  static readonly Name = GLOB_TOOL_NAME;
+
   constructor(private config: Config) {
     super(
-      GLOB_TOOL_NAME,
+      GlobTool.Name,
       'FindFiles',
       'Efficiently finds files matching specific glob patterns (e.g., `src/**/*.ts`, `**/*.md`), returning absolute paths sorted by modification time (newest first). Ideal for quickly locating files based on their name or path structure, especially in large codebases.',
       Kind.Search,

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -564,9 +564,11 @@ class GrepToolInvocation extends BaseToolInvocation<
  * Implementation of the Grep tool logic (moved from CLI)
  */
 export class GrepTool extends BaseDeclarativeTool<GrepToolParams, ToolResult> {
+  static readonly Name = GREP_TOOL_NAME;
+
   constructor(private readonly config: Config) {
     super(
-      GREP_TOOL_NAME,
+      GrepTool.Name,
       'SearchText',
       'Searches for a regular expression pattern within the content of files in a specified directory (or current working directory). Can filter files by a glob pattern. Returns the lines containing matches, along with their file paths and line numbers.',
       Kind.Search,

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -253,9 +253,11 @@ class LSToolInvocation extends BaseToolInvocation<LSToolParams, ToolResult> {
  * Implementation of the LS tool logic
  */
 export class LSTool extends BaseDeclarativeTool<LSToolParams, ToolResult> {
+  static readonly Name = LS_TOOL_NAME;
+
   constructor(private config: Config) {
     super(
-      LS_TOOL_NAME,
+      LSTool.Name,
       'ReadFolder',
       'Lists the names of files and subdirectories directly within a specified directory path. Can optionally ignore entries matching provided glob patterns.',
       Kind.Search,

--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -289,9 +289,11 @@ export class MemoryTool
   extends BaseDeclarativeTool<SaveMemoryParams, ToolResult>
   implements ModifiableDeclarativeTool<SaveMemoryParams>
 {
+  static readonly Name = MEMORY_TOOL_NAME;
+
   constructor() {
     super(
-      MEMORY_TOOL_NAME,
+      MemoryTool.Name,
       'Save Memory',
       memoryToolDescription,
       Kind.Think,

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -136,9 +136,11 @@ export class ReadFileTool extends BaseDeclarativeTool<
   ReadFileToolParams,
   ToolResult
 > {
+  static readonly Name = READ_FILE_TOOL_NAME;
+
   constructor(private config: Config) {
     super(
-      READ_FILE_TOOL_NAME,
+      ReadFileTool.Name,
       'ReadFile',
       `Reads and returns the content of a specified file. If the file is large, the content will be truncated. The tool's response will clearly indicate if truncation has occurred and will provide details on how to read more of the file using the 'offset' and 'limit' parameters. Handles text, images (PNG, JPG, GIF, WEBP, SVG, BMP), and PDF files. For text files, it can read specific line ranges.`,
       Kind.Read,

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -475,6 +475,8 @@ export class ReadManyFilesTool extends BaseDeclarativeTool<
   ReadManyFilesParams,
   ToolResult
 > {
+  static readonly Name = READ_MANY_FILES_TOOL_NAME;
+
   constructor(private config: Config) {
     const parameterSchema = {
       type: 'object',
@@ -543,7 +545,7 @@ export class ReadManyFilesTool extends BaseDeclarativeTool<
     };
 
     super(
-      READ_MANY_FILES_TOOL_NAME,
+      ReadManyFilesTool.Name,
       'ReadManyFiles',
       `Reads content from multiple files specified by paths or glob patterns within a configured target directory. For text files, it concatenates their content into a single string. It is primarily designed for text-based files. However, it can also process image (e.g., .png, .jpg) and PDF (.pdf) files if their file names or extensions are explicitly included in the 'paths' argument. For these explicitly requested non-text files, their data is read and included in a format suitable for model consumption (e.g., base64 encoded).
 

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -447,9 +447,11 @@ export class RipGrepTool extends BaseDeclarativeTool<
   RipGrepToolParams,
   ToolResult
 > {
+  static readonly Name = GREP_TOOL_NAME;
+
   constructor(private readonly config: Config) {
     super(
-      GREP_TOOL_NAME,
+      RipGrepTool.Name,
       'SearchText',
       'Searches for a regular expression pattern within the content of files in a specified directory (or current working directory). Can filter files by a glob pattern. Returns the lines containing matches, along with their file paths and line numbers. Total results limited to 20,000 matches like VSCode.',
       Kind.Search,

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -360,6 +360,8 @@ export class ShellTool extends BaseDeclarativeTool<
   ShellToolParams,
   ToolResult
 > {
+  static readonly Name = SHELL_TOOL_NAME;
+
   private allowlist: Set<string> = new Set();
 
   constructor(private readonly config: Config) {
@@ -367,7 +369,7 @@ export class ShellTool extends BaseDeclarativeTool<
       // Errors are surfaced when parsing commands.
     });
     super(
-      SHELL_TOOL_NAME,
+      ShellTool.Name,
       'Shell',
       getShellToolDescription(),
       Kind.Execute,

--- a/packages/core/src/tools/smart-edit.ts
+++ b/packages/core/src/tools/smart-edit.ts
@@ -815,9 +815,11 @@ export class SmartEditTool
   extends BaseDeclarativeTool<EditToolParams, ToolResult>
   implements ModifiableDeclarativeTool<EditToolParams>
 {
+  static readonly Name = EDIT_TOOL_NAME;
+
   constructor(private readonly config: Config) {
     super(
-      EDIT_TOOL_NAME,
+      SmartEditTool.Name,
       'Edit',
       `Replaces text within a file. Replaces a single occurrence. This tool requires providing significant context around the change to ensure precise targeting. Always use the ${READ_FILE_TOOL_NAME} tool to examine the file's current content before attempting a text replacement.
       

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -395,12 +395,14 @@ export class WebFetchTool extends BaseDeclarativeTool<
   WebFetchToolParams,
   ToolResult
 > {
+  static readonly Name = WEB_FETCH_TOOL_NAME;
+
   constructor(
     private readonly config: Config,
     messageBus?: MessageBus,
   ) {
     super(
-      WEB_FETCH_TOOL_NAME,
+      WebFetchTool.Name,
       'WebFetch',
       "Processes content from URL(s), including local and private network addresses (e.g., localhost), embedded in a prompt. Include up to 20 URLs and instructions (e.g., summarize, extract specific data) directly in the 'prompt' parameter.",
       Kind.Fetch,

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -185,9 +185,11 @@ export class WebSearchTool extends BaseDeclarativeTool<
   WebSearchToolParams,
   WebSearchToolResult
 > {
+  static readonly Name = WEB_SEARCH_TOOL_NAME;
+
   constructor(private readonly config: Config) {
     super(
-      WEB_SEARCH_TOOL_NAME,
+      WebSearchTool.Name,
       'GoogleSearch',
       'Performs a web search using Google Search (via the Gemini API) and returns the results. This tool is useful for finding information on the internet based on a query.',
       Kind.Search,

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -390,9 +390,11 @@ export class WriteFileTool
   extends BaseDeclarativeTool<WriteFileToolParams, ToolResult>
   implements ModifiableDeclarativeTool<WriteFileToolParams>
 {
+  static readonly Name = WRITE_FILE_TOOL_NAME;
+
   constructor(private readonly config: Config) {
     super(
-      WRITE_FILE_TOOL_NAME,
+      WriteFileTool.Name,
       'WriteFile',
       `Writes content to a specified file in the local filesystem.
 

--- a/packages/core/src/tools/write-todos.ts
+++ b/packages/core/src/tools/write-todos.ts
@@ -126,9 +126,11 @@ export class WriteTodosTool extends BaseDeclarativeTool<
   WriteTodosToolParams,
   ToolResult
 > {
+  static readonly Name = WRITE_TODOS_TOOL_NAME;
+
   constructor() {
     super(
-      WRITE_TODOS_TOOL_NAME,
+      WriteTodosTool.Name,
       'Write Todos',
       WRITE_TODOS_DESCRIPTION,
       Kind.Other,


### PR DESCRIPTION
## TLDR

Restores the `static readonly Name` property to all core tool classes. This fixes a regression introduced in PR #11493 where tool exclusions defined in `settings.json` were being ignored because tools were registering under their JavaScript class names (e.g., `WebSearchTool`) instead of their standardized external names (e.g., `google_web_search`).

## Dive Deeper

The tool registration logic in `packages/core/src/config/config.ts` determines the tool name using:
```typescript
const toolName = ToolClass.Name || className;
```

When the `static readonly Name` properties were removed in the previous PR, registration fell back to `className`. Since `settings.json` uses the standardized snake_case names for exclusions, these settings no longer matched the registered tool names, causing exclusions to fail.

This PR restores `static readonly Name = [TOOL_CONSTANT_NAME];` to all core tools and updates their constructors to use this static property for consistency, ensuring they register with the correct identifiers.

## Reviewer Test Plan

1. Open your `settings.json` (usually `~/.gemini/etc/settings.json` or via standard configuration paths).
2. Add an exclusion for a specific tool, for example, Web Search:
   ```json
   {
     "tools": {
       "exclude": ["google_web_search"]
     }
   }
   ```
3. Start the Gemini CLI.
4. Ask a question that requires searching, e.g., "What is the current stock price of Google?".
5. **Verify:** The model should NOT be able to use the `google_web_search` tool and should likely state it cannot access real-time information (or try to use another tool if available). You can use `/tools`
6. Without this fix, the model would still be able to use the search tool despite the exclusion.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅ | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅ | -   | -   |
