### PR TITLE
fix(ci): Default all GHA env variables to 'prod' set

### DIFF
--- a/.github/workflows/release-change-tags.yml
+++ b/.github/workflows/release-change-tags.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   change-tags:
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment }}'
+    environment: '${{ github.event.inputs.environment || "prod" }}'
     permissions:
       packages: 'write'
       issues: 'write'

--- a/.github/workflows/release-change-tags.yml
+++ b/.github/workflows/release-change-tags.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   change-tags:
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment || "prod" }}'
+    environment: "${{ github.event.inputs.environment || 'prod' }}"
     permissions:
       packages: 'write'
       issues: 'write'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   release:
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment || "prod" }}'
+    environment: "${{ github.event.inputs.environment || 'prod' }}"
     permissions:
       contents: 'write'
       packages: 'write'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   release:
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment }}'
+    environment: '${{ github.event.inputs.environment || "prod" }}'
     permissions:
       contents: 'write'
       packages: 'write'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   release:
-    environment: '${{ github.event.inputs.environment }}'
+    environment: '${{ github.event.inputs.environment || "prod" }}'
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'write'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   release:
-    environment: '${{ github.event.inputs.environment || "prod" }}'
+    environment: "${{ github.event.inputs.environment || 'prod' }}"
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'write'

--- a/.github/workflows/release-patch-1-create-pr.yml
+++ b/.github/workflows/release-patch-1-create-pr.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   create-patch:
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment || "prod" }}'
+    environment: "${{ github.event.inputs.environment || 'prod' }}"
     permissions:
       contents: 'write'
       pull-requests: 'write'

--- a/.github/workflows/release-patch-1-create-pr.yml
+++ b/.github/workflows/release-patch-1-create-pr.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   create-patch:
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment }}'
+    environment: '${{ github.event.inputs.environment || "prod" }}'
     permissions:
       contents: 'write'
       pull-requests: 'write'

--- a/.github/workflows/release-patch-2-trigger.yml
+++ b/.github/workflows/release-patch-2-trigger.yml
@@ -50,7 +50,7 @@ jobs:
   trigger-patch-release:
     if: "(github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'hotfix/')) || github.event_name == 'workflow_dispatch'"
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment || "prod" }}'
+    environment: "${{ github.event.inputs.environment || 'prod' }}"
     permissions:
       actions: 'write'
       contents: 'write'
@@ -83,6 +83,6 @@ jobs:
           GITHUB_EVENT_PAYLOAD: '${{ toJSON(github.event) }}'
           FORCE_SKIP_TESTS: '${{ github.event.inputs.force_skip_tests }}'
           TEST_MODE: '${{ github.event.inputs.test_mode }}'
-          ENVIRONMENT: '${{ github.event.inputs.environment || "prod" }}'
+          ENVIRONMENT: "${{ github.event.inputs.environment || 'prod' }}"
         run: |
           node scripts/releasing/patch-trigger.js --dry-run=${{ github.event.inputs.dry_run }}

--- a/.github/workflows/release-patch-2-trigger.yml
+++ b/.github/workflows/release-patch-2-trigger.yml
@@ -50,7 +50,7 @@ jobs:
   trigger-patch-release:
     if: "(github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'hotfix/')) || github.event_name == 'workflow_dispatch'"
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment }}'
+    environment: '${{ github.event.inputs.environment || "prod" }}'
     permissions:
       actions: 'write'
       contents: 'write'
@@ -83,6 +83,6 @@ jobs:
           GITHUB_EVENT_PAYLOAD: '${{ toJSON(github.event) }}'
           FORCE_SKIP_TESTS: '${{ github.event.inputs.force_skip_tests }}'
           TEST_MODE: '${{ github.event.inputs.test_mode }}'
-          ENVIRONMENT: '${{ github.event.inputs.environment }}'
+          ENVIRONMENT: '${{ github.event.inputs.environment || "prod" }}'
         run: |
           node scripts/releasing/patch-trigger.js --dry-run=${{ github.event.inputs.dry_run }}

--- a/.github/workflows/release-patch-3-release.yml
+++ b/.github/workflows/release-patch-3-release.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   release:
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment || "prod" }}'
+    environment: "${{ github.event.inputs.environment || 'prod' }}"
     permissions:
       contents: 'write'
       packages: 'write'

--- a/.github/workflows/release-patch-3-release.yml
+++ b/.github/workflows/release-patch-3-release.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   release:
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment }}'
+    environment: '${{ github.event.inputs.environment || "prod" }}'
     permissions:
       contents: 'write'
       packages: 'write'

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -39,7 +39,7 @@ jobs:
   calculate-versions:
     name: 'Calculate Versions and Plan'
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment }}'
+    environment: '${{ github.event.inputs.environment || "prod" }}'
 
     outputs:
       STABLE_VERSION: '${{ steps.versions.outputs.STABLE_VERSION }}'
@@ -179,7 +179,7 @@ jobs:
     name: 'Publish preview'
     needs: ['calculate-versions', 'test']
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment }}'
+    environment: '${{ github.event.inputs.environment || "prod" }}'
     permissions:
       contents: 'write'
       packages: 'write'
@@ -245,7 +245,7 @@ jobs:
     name: 'Publish stable'
     needs: ['calculate-versions', 'test', 'publish-preview']
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment }}'
+    environment: '${{ github.event.inputs.environment || "prod" }}'
     permissions:
       contents: 'write'
       packages: 'write'

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -39,7 +39,7 @@ jobs:
   calculate-versions:
     name: 'Calculate Versions and Plan'
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment || "prod" }}'
+    environment: "${{ github.event.inputs.environment || 'prod' }}"
 
     outputs:
       STABLE_VERSION: '${{ steps.versions.outputs.STABLE_VERSION }}'
@@ -179,7 +179,7 @@ jobs:
     name: 'Publish preview'
     needs: ['calculate-versions', 'test']
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment || "prod" }}'
+    environment: "${{ github.event.inputs.environment || 'prod' }}"
     permissions:
       contents: 'write'
       packages: 'write'
@@ -245,7 +245,7 @@ jobs:
     name: 'Publish stable'
     needs: ['calculate-versions', 'test', 'publish-preview']
     runs-on: 'ubuntu-latest'
-    environment: '${{ github.event.inputs.environment || "prod" }}'
+    environment: "${{ github.event.inputs.environment || 'prod' }}"
     permissions:
       contents: 'write'
       packages: 'write'

--- a/.github/workflows/release-rollback.yml
+++ b/.github/workflows/release-rollback.yml
@@ -42,7 +42,7 @@ on:
 
 jobs:
   change-tags:
-    environment: '${{ github.event.inputs.environment }}'
+    environment: '${{ github.event.inputs.environment || "prod" }}'
     runs-on: 'ubuntu-latest'
     permissions:
       packages: 'write'

--- a/.github/workflows/release-rollback.yml
+++ b/.github/workflows/release-rollback.yml
@@ -42,7 +42,7 @@ on:
 
 jobs:
   change-tags:
-    environment: '${{ github.event.inputs.environment || "prod" }}'
+    environment: "${{ github.event.inputs.environment || 'prod' }}"
     runs-on: 'ubuntu-latest'
     permissions:
       packages: 'write'

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   verify-release:
-    environment: '${{ github.event.inputs.environment || "prod" }}'
+    environment: "${{ github.event.inputs.environment || 'prod' }}"
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   verify-release:
-    environment: '${{ github.event.inputs.environment }}'
+    environment: '${{ github.event.inputs.environment || "prod" }}'
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'


### PR DESCRIPTION
## TLDR

For scheduled runs, `github.events.input....` is not set.

[#11288](https://github.com/google-gemini/gemini-cli/issues/11288), #11545