### PR TITLE
Pin auth action in eval workflow

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: 'Authenticate to Google Cloud'
         id: 'auth'
-        uses: 'google-github-actions/auth@v2' # ratchet:exclude
+        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed' # ratchet:exclude pin@v2.1.7
         with:
           project_id: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
           workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'


### PR DESCRIPTION
## Summary
- change the eval workflow to use google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed
- keep the ratchet comment intact for future updates

## Testing
- docker run --rm -v "/usr/local/google/home/shikhman/gemini-cli":/src -v /tmp/semgrep-rules:/semgrep-rules -w /src returntocorp/semgrep:latest semgrep --config /semgrep-rules/yaml/github-actions/security --metrics=off .github/workflows --json

References [#891.](https://github.com/google-gemini/maintainers-gemini-cli/issues/891)