### PR TITLE
Use env variables in workflows

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -70,8 +70,10 @@ jobs:
       - name: 'Check for triage label on manual trigger'
         if: |-
           github.event_name == 'workflow_dispatch' && !contains(steps.get_issue_data.outputs.labels, 'status/need-triage')
+        env:
+          ISSUE_NUMBER_INPUT: '${{ github.event.inputs.issue_number }}'
         run: |
-          echo "Issue #${{ github.event.inputs.issue_number }} does not have the 'status/need-triage' label. Stopping workflow."
+          echo "Issue #${ISSUE_NUMBER_INPUT} does not have the 'status/need-triage' label. Stopping workflow."
           exit 1
 
       - name: 'Checkout'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -85,8 +85,10 @@ jobs:
       - name: 'Prepare Release Info'
         id: 'release_info'
         working-directory: './release'
+        env:
+          INPUT_VERSION: '${{ github.event.inputs.version }}'
         run: |
-          RELEASE_VERSION="${{ github.event.inputs.version }}"
+          RELEASE_VERSION="${INPUT_VERSION}"
           echo "RELEASE_VERSION=${RELEASE_VERSION#v}" >> "${GITHUB_OUTPUT}"
           echo "PREVIOUS_TAG=$(git describe --tags --abbrev=0)" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/release-patch-1-create-pr.yml
+++ b/.github/workflows/release-patch-1-create-pr.yml
@@ -67,22 +67,35 @@ jobs:
         run: 'npm install yargs --no-package-lock'
 
       - name: 'Configure Git User'
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          REPOSITORY: '${{ github.repository }}'
         run: |-
           git config user.name "gemini-cli-robot"
           git config user.email "gemini-cli-robot@google.com"
           # Configure git to use GITHUB_TOKEN for remote operations (has actions:write for workflow files)
-          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git"
 
       - name: 'Create Patch'
         id: 'create_patch'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           GH_TOKEN: '${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}'
+          CLI_PACKAGE_NAME: '${{ vars.CLI_PACKAGE_NAME }}'
+          PATCH_COMMIT: '${{ github.event.inputs.commit }}'
+          PATCH_CHANNEL: '${{ github.event.inputs.channel }}'
+          ORIGINAL_PR: '${{ github.event.inputs.original_pr }}'
+          DRY_RUN: '${{ github.event.inputs.dry_run }}'
         continue-on-error: true
         run: |
           # Capture output and display it in logs using tee
           {
-            node scripts/releasing/create-patch-pr.js --cli-package-name="${{ vars.CLI_PACKAGE_NAME }}" --commit=${{ github.event.inputs.commit }} --channel=${{ github.event.inputs.channel }} --pullRequestNumber=${{ github.event.inputs.original_pr }} --dry-run=${{ github.event.inputs.dry_run }}
+            node scripts/releasing/create-patch-pr.js \
+              --cli-package-name="${CLI_PACKAGE_NAME}" \
+              --commit="${PATCH_COMMIT}" \
+              --channel="${PATCH_CHANNEL}" \
+              --pullRequestNumber="${ORIGINAL_PR}" \
+              --dry-run="${DRY_RUN}"
             echo "EXIT_CODE=$?" >> "$GITHUB_OUTPUT"
           } 2>&1 | tee >(
             echo "LOG_CONTENT<<EOF" >> "$GITHUB_ENV"
@@ -101,14 +114,17 @@ jobs:
           REPOSITORY: '${{ github.repository }}'
           GITHUB_RUN_ID: '${{ github.run_id }}'
           LOG_CONTENT: '${{ env.LOG_CONTENT }}'
+          TARGET_REF: '${{ github.event.inputs.ref }}'
         continue-on-error: true
         run: |
-          git checkout '${{ github.event.inputs.ref }}'
+          git checkout "${TARGET_REF}"
           node scripts/releasing/patch-create-comment.js
 
       - name: 'Fail Workflow if Main Task Failed'
         if: 'always() && steps.create_patch.outputs.EXIT_CODE != 0'
+        env:
+          EXIT_CODE: '${{ steps.create_patch.outputs.EXIT_CODE }}'
         run: |
-          echo "Patch creation failed with exit code: ${{ steps.create_patch.outputs.EXIT_CODE }}"
+          echo "Patch creation failed with exit code: ${EXIT_CODE}"
           echo "Check the logs above and the comment posted to the original PR for details."
           exit 1

--- a/.github/workflows/release-patch-2-trigger.yml
+++ b/.github/workflows/release-patch-2-trigger.yml
@@ -84,5 +84,6 @@ jobs:
           FORCE_SKIP_TESTS: '${{ github.event.inputs.force_skip_tests }}'
           TEST_MODE: '${{ github.event.inputs.test_mode }}'
           ENVIRONMENT: '${{ github.event.inputs.environment }}'
+          DRY_RUN: '${{ github.event.inputs.dry_run }}'
         run: |
-          node scripts/releasing/patch-trigger.js --dry-run=${{ github.event.inputs.dry_run }}
+          node scripts/releasing/patch-trigger.js --dry-run="${DRY_RUN}"

--- a/.github/workflows/release-patch-3-release.yml
+++ b/.github/workflows/release-patch-3-release.yml
@@ -80,10 +80,11 @@ jobs:
         id: 'patch_version'
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          PATCH_FROM: '${{ github.event.inputs.type }}'
         run: |
           # Use the existing get-release-version.js script to calculate patch version
           # Run from main checkout which has full git history and access to npm
-          PATCH_JSON=$(node scripts/get-release-version.js --type=patch --patch-from=${{ github.event.inputs.type }})
+          PATCH_JSON=$(node scripts/get-release-version.js --type=patch --patch-from="${PATCH_FROM}")
           echo "Patch version calculation result: ${PATCH_JSON}"
 
           RELEASE_VERSION=$(echo "${PATCH_JSON}" | jq -r .releaseVersion)
@@ -100,14 +101,13 @@ jobs:
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           CHANNEL: '${{ github.event.inputs.type }}'
+          ORIGINAL_RELEASE_VERSION: '${{ steps.patch_version.outputs.RELEASE_VERSION }}'
+          ORIGINAL_RELEASE_TAG: '${{ steps.patch_version.outputs.RELEASE_TAG }}'
+          ORIGINAL_PREVIOUS_TAG: '${{ steps.patch_version.outputs.PREVIOUS_TAG }}'
         run: |
           echo "🔍 Verifying no concurrent patch releases have occurred..."
 
           # Store original calculation for comparison
-          ORIGINAL_RELEASE_VERSION="${{ steps.patch_version.outputs.RELEASE_VERSION }}"
-          ORIGINAL_RELEASE_TAG="${{ steps.patch_version.outputs.RELEASE_TAG }}"
-          ORIGINAL_PREVIOUS_TAG="${{ steps.patch_version.outputs.PREVIOUS_TAG }}"
-
           echo "Original calculation:"
           echo "  Release version: ${ORIGINAL_RELEASE_VERSION}"
           echo "  Release tag: ${ORIGINAL_RELEASE_TAG}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -77,10 +77,19 @@ jobs:
         id: 'versions'
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          STABLE_OVERRIDE: '${{ github.event.inputs.stable_version_override }}'
+          PREVIEW_OVERRIDE: '${{ github.event.inputs.preview_version_override }}'
+          REF_INPUT: '${{ github.event.inputs.ref }}'
         run: |
           set -e
-          STABLE_COMMAND="node scripts/get-release-version.js --type=stable ${{ github.event.inputs.stable_version_override && format('--stable_version_override={0}', github.event.inputs.stable_version_override) || '' }}"
-          PREVIEW_COMMAND="node scripts/get-release-version.js --type=preview ${{ github.event.inputs.preview_version_override && format('--preview_version_override={0}', github.event.inputs.preview_version_override) || '' }}"
+          STABLE_COMMAND="node scripts/get-release-version.js --type=stable"
+          if [[ -n "${STABLE_OVERRIDE}" ]]; then
+            STABLE_COMMAND+=" --stable_version_override=${STABLE_OVERRIDE}"
+          fi
+          PREVIEW_COMMAND="node scripts/get-release-version.js --type=preview"
+          if [[ -n "${PREVIEW_OVERRIDE}" ]]; then
+            PREVIEW_COMMAND+=" --preview_version_override=${PREVIEW_OVERRIDE}"
+          fi
           NIGHTLY_COMMAND="node scripts/get-release-version.js --type=promote-nightly"
           STABLE_JSON=$(${STABLE_COMMAND})
           PREVIEW_JSON=$(${PREVIEW_COMMAND})
@@ -97,7 +106,7 @@ jobs:
           echo "PREVIOUS_STABLE_TAG=$(echo "${STABLE_JSON}" | jq -r .previousReleaseTag)" >> "${GITHUB_OUTPUT}"
           echo "PREVIEW_VERSION=$(echo "${PREVIEW_JSON}" | jq -r .releaseVersion)" >> "${GITHUB_OUTPUT}"
           # shellcheck disable=SC1083
-          REF="${{ github.event.inputs.ref }}"
+          REF="${REF_INPUT}"
           SHA=$(git ls-remote origin "$REF" | awk '{print $1}')
           if [ -z "$SHA" ]; then
             if [[ "$REF" =~ ^[0-9a-f]{7,40}$ ]]; then
@@ -116,20 +125,30 @@ jobs:
           echo "NEXT_SHA=$SHA" >> "${GITHUB_OUTPUT}"
 
       - name: 'Display Pending Updates'
+        env:
+          STABLE_VERSION: '${{ steps.versions.outputs.STABLE_VERSION }}'
+          STABLE_SHA: '${{ steps.versions.outputs.STABLE_SHA }}'
+          PREVIOUS_STABLE_TAG: '${{ steps.versions.outputs.PREVIOUS_STABLE_TAG }}'
+          PREVIEW_VERSION: '${{ steps.versions.outputs.PREVIEW_VERSION }}'
+          PREVIEW_SHA: '${{ steps.versions.outputs.PREVIEW_SHA }}'
+          PREVIOUS_PREVIEW_TAG: '${{ steps.versions.outputs.PREVIOUS_PREVIEW_TAG }}'
+          NEXT_NIGHTLY_VERSION: '${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}'
+          PREVIOUS_NIGHTLY_TAG: '${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}'
+          INPUT_REF: '${{ github.event.inputs.ref }}'
         run: |
           echo "Release Plan:"
           echo "-----------"
-          echo "Stable Release: ${{ steps.versions.outputs.STABLE_VERSION }}"
-          echo "  - Commit: ${{ steps.versions.outputs.STABLE_SHA }}"
-          echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_STABLE_TAG }}"
+          echo "Stable Release: ${STABLE_VERSION}"
+          echo "  - Commit: ${STABLE_SHA}"
+          echo "  - Previous Tag: ${PREVIOUS_STABLE_TAG}"
           echo ""
-          echo "Preview Release: ${{ steps.versions.outputs.PREVIEW_VERSION }}"
-          echo "  - Commit: ${{ steps.versions.outputs.PREVIEW_SHA }} (${{ github.event.inputs.ref }})"
-          echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_PREVIEW_TAG }}"
+          echo "Preview Release: ${PREVIEW_VERSION}"
+          echo "  - Commit: ${PREVIEW_SHA} (${INPUT_REF})"
+          echo "  - Previous Tag: ${PREVIOUS_PREVIEW_TAG}"
           echo ""
-          echo "Preparing Next Nightly Release: ${{ steps.versions.outputs.NEXT_NIGHTLY_VERSION }}"
-          echo "  - Merging Version Update PR to Branch: ${{ github.event.inputs.ref }}"
-          echo "  - Previous Tag: ${{ steps.versions.outputs.PREVIOUS_NIGHTLY_TAG }}"
+          echo "Preparing Next Nightly Release: ${NEXT_NIGHTLY_VERSION}"
+          echo "  - Merging Version Update PR to Branch: ${INPUT_REF}"
+          echo "  - Previous Tag: ${PREVIOUS_NIGHTLY_TAG}"
 
   test:
     name: 'Test ${{ matrix.channel }}'

--- a/.github/workflows/release-rollback.yml
+++ b/.github/workflows/release-rollback.yml
@@ -67,17 +67,20 @@ jobs:
       - name: 'Get Origin Version Tag'
         id: 'origin_tag'
         shell: 'bash'
+        env:
+          ROLLBACK_ORIGIN: '${{ github.event.inputs.rollback_origin }}'
         run: |
-          TAG_VALUE="v${{ github.event.inputs.rollback_origin }}"
+          TAG_VALUE="v${ROLLBACK_ORIGIN}"
           echo "ORIGIN_TAG=$TAG_VALUE" >> "$GITHUB_OUTPUT"
 
       - name: 'Get Origin Commit Hash'
         id: 'origin_hash'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          ORIGIN_TAG: '${{ steps.origin_tag.outputs.ORIGIN_TAG }}'
         shell: 'bash'
         run: |
-          echo "ORIGIN_HASH=$(git rev-parse ${{ steps.origin_tag.outputs.ORIGIN_TAG }})" >> "$GITHUB_OUTPUT"
+          echo "ORIGIN_HASH=$(git rev-parse "${ORIGIN_TAG}")" >> "$GITHUB_OUTPUT"
 
       - name: 'Change tag'
         if: "${{ github.event.inputs.rollback_destination != '' }}"
@@ -108,9 +111,11 @@ jobs:
         if: "${{ github.event.inputs.dry-run == 'false' && github.event.inputs.environment == 'prod' }}"
         env:
           NODE_AUTH_TOKEN: '${{ steps.cli-token.outputs.auth-token }}'
+          PACKAGE_NAME: '${{ vars.CLI_PACKAGE_NAME }}'
+          ROLLBACK_ORIGIN: '${{ github.event.inputs.rollback_origin }}'
         shell: 'bash'
         run: |
-          npm deprecate ${{ vars.CLI_PACKAGE_NAME }}@${{ github.event.inputs.rollback_origin }} "This version has been rolled back."
+          npm deprecate "${PACKAGE_NAME}@${ROLLBACK_ORIGIN}" "This version has been rolled back."
 
       - name: 'Get core Token'
         uses: './.github/actions/npm-auth-token'
@@ -126,9 +131,11 @@ jobs:
         if: "${{ github.event.inputs.dry-run == 'false' && github.event.inputs.environment == 'prod' }}"
         env:
           NODE_AUTH_TOKEN: '${{ steps.core-token.outputs.auth-token }}'
+          PACKAGE_NAME: '${{ vars.CORE_PACKAGE_NAME }}'
+          ROLLBACK_ORIGIN: '${{ github.event.inputs.rollback_origin }}'
         shell: 'bash'
         run: |
-          npm deprecate ${{ vars.CORE_PACKAGE_NAME }}@${{ github.event.inputs.rollback_origin }} "This version has been rolled back."
+          npm deprecate "${PACKAGE_NAME}@${ROLLBACK_ORIGIN}" "This version has been rolled back."
 
       - name: 'Get a2a Token'
         uses: './.github/actions/npm-auth-token'
@@ -144,28 +151,31 @@ jobs:
         if: "${{ github.event.inputs.dry-run == 'false' && github.event.inputs.environment == 'prod'  }}"
         env:
           NODE_AUTH_TOKEN: '${{ steps.a2a-token.outputs.auth-token }}'
+          PACKAGE_NAME: '${{ vars.A2A_PACKAGE_NAME }}'
+          ROLLBACK_ORIGIN: '${{ github.event.inputs.rollback_origin }}'
         shell: 'bash'
         run: |
-          npm deprecate ${{ vars.A2A_PACKAGE_NAME }}@${{ github.event.inputs.rollback_origin }} "This version has been rolled back."
+          npm deprecate "${PACKAGE_NAME}@${ROLLBACK_ORIGIN}" "This version has been rolled back."
 
       - name: 'Delete Github Release'
         if: "${{ github.event.inputs.dry-run == 'false' && github.event.inputs.environment == 'prod'}}"
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          ORIGIN_TAG: '${{ steps.origin_tag.outputs.ORIGIN_TAG }}'
         shell: 'bash'
         run: |
-          gh release delete '${{ steps.origin_tag.outputs.ORIGIN_TAG }}' --yes
+          gh release delete "${ORIGIN_TAG}" --yes
 
       - name: 'Verify Origin Release Deletion'
         if: "${{ github.event.inputs.dry-run == 'false' }}"
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          TARGET_TAG: '${{ steps.origin_tag.outputs.ORIGIN_TAG }}'
         shell: 'bash'
         run: |
-          TARGET_TAG="${{ steps.origin_tag.outputs.ORIGIN_TAG }}"
           RELEASE_TAG=$(gh release view "$TARGET_TAG" --json tagName --jq .tagName)
           if [ "$RELEASE_TAG" = "$TARGET_TAG" ]; then
-            echo '❌ Failed to delete release with tag ${{ steps.origin_tag.outputs.ORIGIN_TAG }}'
+            echo "❌ Failed to delete release with tag ${TARGET_TAG}"
             echo '❌ This means the release was not deleted, and the workflow should fail.'
             exit 1
           fi
@@ -175,21 +185,22 @@ jobs:
         if: "${{ github.event.inputs.dry-run == 'false' }}"
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          ROLLBACK_TAG_NAME: '${{ steps.origin_tag.outputs.ORIGIN_TAG }}-rollback'
+          ORIGIN_HASH: '${{ steps.origin_hash.outputs.ORIGIN_HASH }}'
         shell: 'bash'
         run: |
-          ROLLBACK_TAG_NAME="${{ steps.origin_tag.outputs.ORIGIN_TAG }}-rollback"
           echo "ROLLBACK_TAG=$ROLLBACK_TAG_NAME" >> "$GITHUB_OUTPUT"
-          git tag "$ROLLBACK_TAG_NAME" "${{ steps.origin_hash.outputs.ORIGIN_HASH }}"
+          git tag "$ROLLBACK_TAG_NAME" "${ORIGIN_HASH}"
           git push origin --tags
 
       - name: 'Verify Rollback Tag Added'
         if: "${{ github.event.inputs.dry-run == 'false' }}"
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          TARGET_TAG: '${{ steps.rollback_tag.outputs.ROLLBACK_TAG }}'
+          TARGET_HASH: '${{ steps.origin_hash.outputs.ORIGIN_HASH }}'
         shell: 'bash'
         run: |
-          TARGET_TAG="${{ steps.rollback_tag.outputs.ROLLBACK_TAG }}"
-          TARGET_HASH="${{ steps.origin_hash.outputs.ORIGIN_HASH }}"
           ROLLBACK_COMMIT=$(git rev-parse -q --verify "$TARGET_TAG")
           if [ "$ROLLBACK_COMMIT" != "$TARGET_HASH" ]; then
             echo '❌ Failed to add tag $TARGET_TAG to commit $TARGET_HASH'
@@ -199,21 +210,32 @@ jobs:
 
       - name: 'Log Dry run'
         if: "${{ github.event.inputs.dry-run == 'true' }}"
+        env:
+          ROLLBACK_ORIGIN: '${{ github.event.inputs.rollback_origin }}'
+          ROLLBACK_DESTINATION: '${{ github.event.inputs.rollback_destination }}'
+          CHANNEL: '${{ github.event.inputs.channel }}'
+          REF_INPUT: '${{ github.event.inputs.ref }}'
+          ORIGIN_TAG: '${{ steps.origin_tag.outputs.ORIGIN_TAG }}'
+          ORIGIN_HASH: '${{ steps.origin_hash.outputs.ORIGIN_HASH }}'
+          ROLLBACK_TAG: '${{ steps.rollback_tag.outputs.ROLLBACK_TAG }}'
+          CLI_PACKAGE_NAME: '${{ vars.CLI_PACKAGE_NAME }}'
+          CORE_PACKAGE_NAME: '${{ vars.CORE_PACKAGE_NAME }}'
+          A2A_PACKAGE_NAME: '${{ vars.A2A_PACKAGE_NAME }}'
         shell: 'bash'
         run: |
           echo "
           Inputs:
-          - rollback_origin: '${{ github.event.inputs.rollback_origin }}'
-          - rollback_destination: '${{ github.event.inputs.rollback_destination }}'
-          - channel: '${{ github.event.inputs.channel }}'
-          - ref: '${{ github.event.inputs.ref }}'
+          - rollback_origin: '${ROLLBACK_ORIGIN}'
+          - rollback_destination: '${ROLLBACK_DESTINATION}'
+          - channel: '${CHANNEL}'
+          - ref: '${REF_INPUT}'
 
           Outputs:
-          - ORIGIN_TAG: '${{ steps.origin_tag.outputs.ORIGIN_TAG }}'
-          - ORIGIN_HASH: '${{ steps.origin_hash.outputs.ORIGIN_HASH }}'
-          - ROLLBACK_TAG: '${{ steps.rollback_tag.outputs.ROLLBACK_TAG }}'
+          - ORIGIN_TAG: '${ORIGIN_TAG}'
+          - ORIGIN_HASH: '${ORIGIN_HASH}'
+          - ROLLBACK_TAG: '${ROLLBACK_TAG}'
 
-          Would have npm deprecate ${{vars.CLI_PACKAGE_NAME}}@${{ github.event.inputs.rollback_origin }}, ${{vars.CORE_PACKAGE_NAME}}@${{ github.event.inputs.rollback_origin }}, and ${{ vars.A2A_PACKAGE_NAME }}@${{ github.event.inputs.rollback_origin }}
-          Would have deleted the github release with tag ${{ steps.origin_tag.outputs.ORIGIN_TAG }}
-          Would have added tag ${{ steps.origin_tag.outputs.ORIGIN_TAG }}-rollback to ${{ steps.origin_hash.outputs.ORIGIN_HASH }}
+          Would have npm deprecate ${CLI_PACKAGE_NAME}@${ROLLBACK_ORIGIN}, ${CORE_PACKAGE_NAME}@${ROLLBACK_ORIGIN}, and ${A2A_PACKAGE_NAME}@${ROLLBACK_ORIGIN}
+          Would have deleted the github release with tag ${ORIGIN_TAG}
+          Would have added tag ${ORIGIN_TAG}-rollback to ${ORIGIN_HASH}
           "


### PR DESCRIPTION
## Summary
- move workflow shell scripts to consume GitHub context via env vars
- align release automations with the Semgrep guidance so commands no longer interpolate expressions directly
- verified no additional workflow regressions while keeping existing outputs intact

## Testing
- docker run --rm -v "/usr/local/google/home/shikhman/gemini-cli":/src -v /tmp/semgrep-rules:/semgrep-rules -w /src returntocorp/semgrep:latest semgrep --config /semgrep-rules/yaml/github-actions/security --metrics=off .github/workflows --json

References google-gemini/maintainers-gemini-cli#892
References google-gemini/maintainers-gemini-cli#893
References google-gemini/maintainers-gemini-cli#894
References google-gemini/maintainers-gemini-cli#895
References google-gemini/maintainers-gemini-cli#896
References google-gemini/maintainers-gemini-cli#897
References google-gemini/maintainers-gemini-cli#898
References google-gemini/maintainers-gemini-cli#899
References google-gemini/maintainers-gemini-cli#900
References google-gemini/maintainers-gemini-cli#901
References google-gemini/maintainers-gemini-cli#902
References google-gemini/maintainers-gemini-cli#903
References google-gemini/maintainers-gemini-cli#904