### PR TITLE
fix(scripts): add tsconfig linter to prevent adding files to the exclude list

### DIFF
--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -263,18 +263,15 @@ export function runTSConfigLinter() {
 
   let files = [];
   try {
-    // Find all tsconfig.json files under packages/
-    files = execSync("git ls-files | grep 'packages/.*/tsconfig.json$'")
+    // Find all tsconfig.json files under packages/ using a git pathspec
+    files = execSync("git ls-files 'packages/**/tsconfig.json'")
       .toString()
       .trim()
       .split('\n')
       .filter(Boolean);
   } catch (e) {
-    // If grep finds nothing, it might exit with 1.
-    if (e.status !== 1) {
-      console.error('Error finding tsconfig.json files:', e.message);
-      process.exit(1);
-    }
+    console.error('Error finding tsconfig.json files:', e.message);
+    process.exit(1);
   }
 
   let hasError = false;

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -251,6 +251,82 @@ export function runSensitiveKeywordLinter() {
   }
 }
 
+function stripJSONComments(json) {
+  return json.replace(
+    /\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g,
+    (m, g) => (g ? '' : m),
+  );
+}
+
+export function runTSConfigLinter() {
+  console.log('\nRunning tsconfig linter...');
+
+  let files = [];
+  try {
+    // Find all tsconfig.json files under packages/
+    files = execSync("git ls-files | grep 'packages/.*/tsconfig.json$'")
+      .toString()
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+  } catch (e) {
+    // If grep finds nothing, it might exit with 1.
+    if (e.status !== 1) {
+      console.error('Error finding tsconfig.json files:', e.message);
+      process.exit(1);
+    }
+  }
+
+  let hasError = false;
+
+  for (const file of files) {
+    const tsconfigPath = join(process.cwd(), file);
+    if (!existsSync(tsconfigPath)) {
+      console.error(`Error: ${tsconfigPath} does not exist.`);
+      hasError = true;
+      continue;
+    }
+
+    try {
+      const content = readFileSync(tsconfigPath, 'utf-8');
+      const config = JSON.parse(stripJSONComments(content));
+
+      // Check if exclude exists and matches exactly
+      if (config.exclude) {
+        if (!Array.isArray(config.exclude)) {
+          console.error(
+            `Error: ${file} "exclude" must be an array. Found: ${JSON.stringify(
+              config.exclude,
+            )}`,
+          );
+          hasError = true;
+        } else {
+          const allowedExclude = new Set(['node_modules', 'dist']);
+          const invalidExcludes = config.exclude.filter(
+            (item) => !allowedExclude.has(item),
+          );
+
+          if (invalidExcludes.length > 0) {
+            console.error(
+              `Error: ${file} "exclude" contains invalid items: ${JSON.stringify(
+                invalidExcludes,
+              )}. Only "node_modules" and "dist" are allowed.`,
+            );
+            hasError = true;
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Error parsing ${tsconfigPath}: ${error.message}`);
+      hasError = true;
+    }
+  }
+
+  if (hasError) {
+    process.exit(1);
+  }
+}
+
 function main() {
   const args = process.argv.slice(2);
 
@@ -275,6 +351,9 @@ function main() {
   if (args.includes('--sensitive-keywords')) {
     runSensitiveKeywordLinter();
   }
+  if (args.includes('--tsconfig')) {
+    runTSConfigLinter();
+  }
 
   if (args.length === 0) {
     setupLinters();
@@ -284,6 +363,7 @@ function main() {
     runYamllint();
     runPrettier();
     runSensitiveKeywordLinter();
+    runTSConfigLinter();
     console.log('\nAll linting checks passed!');
   }
 }


### PR DESCRIPTION
## TLDR
Adds a new linter to `scripts/lint.js` that validates `tsconfig.json` files in `packages/` to ensure they only exclude "node_modules" and "dist".

## Dive Deeper
This prevents accidental exclusion of files that should be part of the package, ensuring consistent build configurations across packages. It uses `git ls-files` to find relevant tsconfigs and strips comments before parsing to handle standard `tsconfig.json` formats.

## Reviewer Test Plan
Run `node scripts/lint.js --tsconfig` to verify it passes on the current codebase.
Try adding an invalid exclusion (e.g., `"temp-exclude"`) to `packages/cli/tsconfig.json` and verify the linter fails.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Fixes #9403