### PR TITLE
fix(infra) - Fix how we download and upload repo names

### DIFF
--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -75,8 +75,7 @@ jobs:
             const path = require('path');
             const temp = '${{ runner.temp }}/artifacts';
             const repo_name = Number(fs.readFileSync(path.join(temp, 'repo_name')));
-            core.setOutput('repo_name', repo_name);'
-          core: true
+            core.setOutput('repo_name', repo_name);
       - name: 'Output Input Repo Name'
         if: "${{ github.event_name != 'workflow_run' }}"
         id: 'output-input-repo-name'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -51,7 +51,7 @@ jobs:
       - name: 'Download the repo_name artifact'
         uses: 'actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0' # ratchet:actions/download-artifact@v5
         env:
-          RUN_ID: '${{ github.event_name == "workflow_run" && github.event.workflow_run.id || github.run_id  }}'
+          RUN_ID: "${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || github.run_id  }}"
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           name: 'repo_name'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -50,10 +50,12 @@ jobs:
           path: 'pr/'
       - name: 'Download the repo_name artifact'
         uses: 'actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0' # ratchet:actions/download-artifact@v5
+        env:
+          RUN_ID: '${{ github.event_name == "workflow_run" && github.event.workflow_run.id || github.run_id  }}'
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           name: 'repo_name'
-          run-id: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || '' }}
+          run-id: ${{ env.RUN_ID }}
           path: '${{ runner.temp }}/artifacts'
       - name: 'Unzip artifact'
         run: 'unzip "${{ runner.temp }}/artifacts/repo_name.zip" -d "${{ runner.temp }}/artifacts"'
@@ -68,12 +70,6 @@ jobs:
             const temp = '${{ runner.temp }}/artifacts';
             const repo_name = Number(fs.readFileSync(path.join(temp, 'repo_name')));
             core.setOutput('repo_name', repo_name);
-      - name: 'Output Input Repo Name'
-        if: "${{ github.event_name != 'workflow_run' }}"
-        id: 'output-input-repo-name'
-        run: |
-          echo "repo_name=${{ github.event.inputs.repo_name }}" >> "$GITHUB_OUTPUT"
-        shell: 'bash'
 
   e2e_linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -35,37 +35,28 @@ jobs:
     outputs:
       repo_name: '${{ steps.output-repo-name.outputs.repo_name }}'
     steps:
-      - name: 'Download artifact'
-        if: "${{ github.event_name == 'workflow_run' }}"
-        uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # ratchet:actions/github-script@v8
+      - name: 'Save Repo name'
+        if: "${{ github.event_name != 'workflow_run' }}"
+        env:
+          REPO_NAME: '${{ github.event.inputs.repo_name }}'
+        run: |
+          mkdir -p ./pr
+          echo '$REPO_NAME' > ./pr/repo_name
+      - uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "repo_name"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            const fs = require('fs');
-            const path = require('path');
-            const temp = '${{ runner.temp }}/artifacts';
-            if (!fs.existsSync(temp)){
-              fs.mkdirSync(temp);
-            }
-            fs.writeFileSync(path.join(temp, 'repo_name.zip'), Buffer.from(download.data));
+          name: 'repo_name'
+          path: 'pr/'
+      - name: 'Download the repo_name artifact'
+        uses: 'actions/download-artifact@v5'
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          name: 'repo_name'
+          run-id: ${{ github.event.workflow_run.id }}
+          path: '${{ runner.temp }}/artifacts'
       - name: 'Unzip artifact'
         if: "${{ github.event_name == 'workflow_run' }}"
         run: 'unzip "${{ runner.temp }}/artifacts/repo_name.zip" -d "${{ runner.temp }}/artifacts"'
       - name: 'Output Repo Name'
-        if: "${{ github.event_name == 'workflow_run' }}"
         id: 'output-repo-name'
         uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # ratchet:actions/github-script@v8
         with:
@@ -76,12 +67,6 @@ jobs:
             const temp = '${{ runner.temp }}/artifacts';
             const repo_name = Number(fs.readFileSync(path.join(temp, 'repo_name')));
             core.setOutput('repo_name', repo_name);
-      - name: 'Output Input Repo Name'
-        if: "${{ github.event_name != 'workflow_run' }}"
-        id: 'output-input-repo-name'
-        run: |
-          echo "repo_name=${{ github.event.inputs.repo_name }}" >> "$GITHUB_OUTPUT"
-        shell: 'bash'
 
   e2e_linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -47,7 +47,7 @@ jobs:
           name: 'repo_name'
           path: 'pr/'
       - name: 'Download the repo_name artifact'
-        uses: 'actions/download-artifact@v5'
+        uses: 'actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0' # ratchet:actions/download-artifact@v5
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           name: 'repo_name'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -67,7 +67,6 @@ jobs:
             const path = require('path');
             const temp = '${{ runner.temp }}/artifacts';
             const repo_name = String(fs.readFileSync(path.join(temp, 'repo_name')));
-            console.log('repo_name:', repo_name);
             core.setOutput('repo_name', repo_name);
 
   e2e_linux:

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -37,7 +37,7 @@ jobs:
     permissions:
       actions: read
     steps:
-      - name: 'Save Repo name'
+      - name: 'Mock Repo Artifact'
         if: "${{ github.event_name != 'workflow_run' }}"
         env:
           REPO_NAME: '${{ github.event.inputs.repo_name }}'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           name: 'repo_name'
-          run-id: ${{ env.RUN_ID }}
+          run-id: '${{ env.RUN_ID }}'
           path: '${{ runner.temp }}/artifacts'
       - name: 'Output Repo Name'
         id: 'output-repo-name'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -66,8 +66,7 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const temp = '${{ runner.temp }}/artifacts';
-            const repo_name = Number(fs.readFileSync(path.join(temp, 'repo_name')));
-            console.log('repo_name:', repo_name);
+            const repo_name = fs.readFileSync(path.join(temp, 'repo_name'));
             core.setOutput('repo_name', repo_name);
 
   e2e_linux:

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       repo_name: '${{ steps.output-repo-name.outputs.repo_name }}'
     permissions:
-      actions: read
+      actions: 'read'
     steps:
       - name: 'Mock Repo Artifact'
         if: "${{ github.event_name != 'workflow_run' }}"

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -51,10 +51,9 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           name: 'repo_name'
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id || '' }}
           path: '${{ runner.temp }}/artifacts'
       - name: 'Unzip artifact'
-        if: "${{ github.event_name == 'workflow_run' }}"
         run: 'unzip "${{ runner.temp }}/artifacts/repo_name.zip" -d "${{ runner.temp }}/artifacts"'
       - name: 'Output Repo Name'
         id: 'output-repo-name'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -66,7 +66,8 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const temp = '${{ runner.temp }}/artifacts';
-            const repo_name = fs.readFileSync(path.join(temp, 'repo_name'));
+            const repo_name = String(fs.readFileSync(path.join(temp, 'repo_name')));
+            console.log('repo_name:', repo_name);
             core.setOutput('repo_name', repo_name);
 
   e2e_linux:

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           name: 'repo_name'
-          run-id: ${{ github.event.workflow_run.id || '' }}
+          run-id: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || '' }}
           path: '${{ runner.temp }}/artifacts'
       - name: 'Unzip artifact'
         run: 'unzip "${{ runner.temp }}/artifacts/repo_name.zip" -d "${{ runner.temp }}/artifacts"'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -43,7 +43,7 @@ jobs:
           REPO_NAME: '${{ github.event.inputs.repo_name }}'
         run: |
           mkdir -p ./pr
-          echo '$REPO_NAME' > ./pr/repo_name
+          echo '${{ env.REPO_NAME }}' > ./pr/repo_name
       - uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'repo_name'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -57,8 +57,6 @@ jobs:
           name: 'repo_name'
           run-id: ${{ env.RUN_ID }}
           path: '${{ runner.temp }}/artifacts'
-      - name: 'Unzip artifact'
-        run: 'unzip "${{ runner.temp }}/artifacts/repo_name.zip" -d "${{ runner.temp }}/artifacts"'
       - name: 'Output Repo Name'
         id: 'output-repo-name'
         uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # ratchet:actions/github-script@v8

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -34,6 +34,8 @@ jobs:
     runs-on: 'gemini-cli-ubuntu-16-core'
     outputs:
       repo_name: '${{ steps.output-repo-name.outputs.repo_name }}'
+    permissions:
+      actions: read
     steps:
       - name: 'Save Repo name'
         if: "${{ github.event_name != 'workflow_run' }}"

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -34,8 +34,6 @@ jobs:
     runs-on: 'gemini-cli-ubuntu-16-core'
     outputs:
       repo_name: '${{ steps.output-repo-name.outputs.repo_name }}'
-    permissions:
-      actions: 'read'
     steps:
       - name: 'Mock Repo Artifact'
         if: "${{ github.event_name != 'workflow_run' }}"

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -67,6 +67,7 @@ jobs:
             const path = require('path');
             const temp = '${{ runner.temp }}/artifacts';
             const repo_name = Number(fs.readFileSync(path.join(temp, 'repo_name')));
+            console.log('repo_name:', repo_name);
             core.setOutput('repo_name', repo_name);
 
   e2e_linux:

--- a/.github/workflows/trigger_e2e.yml
+++ b/.github/workflows/trigger_e2e.yml
@@ -19,7 +19,7 @@ jobs:
           REPO_NAME: '${{ github.event.repository.name }}'
         run: |
           mkdir -p ./pr
-          echo '$REPO_NAME' > ./pr/repo_name
+          echo '${{ env.REPO_NAME }}' > ./pr/repo_name
       - uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'repo_name'


### PR DESCRIPTION
## TLDR

Fix repo name uploading

## Dive Deeper

Updated the chained e2e workflow file to mimick as close as possible what the trigger step does for better testing

## Reviewer Test Plan

```
gh workflow run test_chained_e2e.yml --ref ss/downloadFix -f head_sha=8d2033ff6556f2686071df9a25fbce3c895e2c83 -f repo_name="google-gemini/gemini-cli"
```
Sample run: https://github.com/google-gemini/gemini-cli/actions/runs/18696429924/job/53315028727

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Makes progress on #10008 