### PR TITLE
fix(test): Enable Ctrl+C exit test

### DIFF
--- a/integration-tests/ctrl-c-exit.test.ts
+++ b/integration-tests/ctrl-c-exit.test.ts
@@ -9,9 +9,11 @@ import * as os from 'node:os';
 import { TestRig } from './test-helper.js';
 
 describe('Ctrl+C exit', () => {
-  it.skip('should exit gracefully on second Ctrl+C', async () => {
+  it('should exit gracefully on second Ctrl+C', async () => {
     const rig = new TestRig();
-    await rig.setup('should exit gracefully on second Ctrl+C');
+    await rig.setup('should exit gracefully on second Ctrl+C', {
+      settings: { tools: { useRipgrep: false } },
+    });
 
     const run = await rig.runInteractive();
 


### PR DESCRIPTION
## TLDR

Un-skips the Ctrl+C exit integration test and disables ripgrep for this specific test to ensure stability.

## Dive Deeper

The `Ctrl+C exit` test was previously skipped. This PR enables it and explicitly disables `ripgrep` in the test rig settings, which appears to be necessary for this test to pass reliably in the integration test environment.

## Reviewer Test Plan

Run the specific integration test:
`npm run test:integration integration-tests/ctrl-c-exit.test.ts`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Fixes #11127