### PR TITLE
Add aria labels to Todo list display

### DIFF
--- a/packages/cli/src/ui/components/messages/Todo.tsx
+++ b/packages/cli/src/ui/components/messages/Todo.tsx
@@ -33,7 +33,7 @@ const TodoTitleDisplay: React.FC<{ todos: TodoList }> = ({ todos }) => {
 
   return (
     <Box flexDirection="row" columnGap={2} height={1}>
-      <Text color={theme.text.primary} bold>
+      <Text color={theme.text.primary} bold aria-label="Todo list">
         📝 Todo
       </Text>
       <Text color={theme.text.secondary}>{score} (ctrl+t to toggle)</Text>
@@ -44,22 +44,39 @@ const TodoTitleDisplay: React.FC<{ todos: TodoList }> = ({ todos }) => {
 const TodoStatusDisplay: React.FC<{ status: TodoStatus }> = ({ status }) => {
   switch (status) {
     case 'completed':
-      return <Text color={theme.status.success}>✓</Text>;
+      return (
+        <Text color={theme.status.success} aria-label="Completed">
+          ✓
+        </Text>
+      );
     case 'in_progress':
-      return <Text color={theme.text.accent}>»</Text>;
+      return (
+        <Text color={theme.text.accent} aria-label="In Progress">
+          »
+        </Text>
+      );
     case 'pending':
-      return <Text color={theme.text.primary}>☐</Text>;
+      return (
+        <Text color={theme.text.primary} aria-label="Pending">
+          ☐
+        </Text>
+      );
     case 'cancelled':
     default:
-      return <Text color={theme.status.error}>✗</Text>;
+      return (
+        <Text color={theme.status.error} aria-label="Cancelled">
+          ✗
+        </Text>
+      );
   }
 };
 
-const TodoItemDisplay: React.FC<{ todo: Todo; wrap?: 'truncate' }> = ({
-  todo,
-  wrap,
-}) => (
-  <Box flexDirection="row" columnGap={1}>
+const TodoItemDisplay: React.FC<{
+  todo: Todo;
+  wrap?: 'truncate';
+  role?: 'listitem';
+}> = ({ todo, wrap, role: ariaRole }) => (
+  <Box flexDirection="row" columnGap={1} aria-role={ariaRole}>
     <TodoStatusDisplay status={todo.status} />
     <Box flexShrink={1}>
       <Text color={theme.text.primary} wrap={wrap}>
@@ -140,9 +157,9 @@ interface TodoListDisplayProps {
 }
 
 const TodoListDisplay: React.FC<TodoListDisplayProps> = ({ todos }) => (
-  <Box flexDirection="column">
+  <Box flexDirection="column" aria-role="list">
     {todos.todos.map((todo: Todo, index: number) => (
-      <TodoItemDisplay todo={todo} key={index} />
+      <TodoItemDisplay todo={todo} key={index} role="listitem" />
     ))}
   </Box>
 );


### PR DESCRIPTION
## TLDR

Add aria labels to Todo list display for users using screenreaders

## Dive Deeper

Expanded:
```
~/src/gemini-cli (tomm_aria_todo*) no sandbox (see /docs) auto (98% context left)
Todo list 1/3 (ctrl+t to toggle)
list: listitem: Pending Pending item
listitem: In Progress In progress item
listitem: Completed Completed item
listitem: Cancelled Cancelled item
Using: 2 GEMINI.md files | 1 MCP server
>    Type your message or @path/to/file
```

Collapsed:
```
~/src/gemini-cli (tomm_aria_todo*) no sandbox (see /docs) auto (98% context left)
Todo list 1/3 (ctrl+t to toggle) In Progress In progress item
Using: 2 GEMINI.md files | 1 MCP server
>    Type your message or @path/to/file
```
## Reviewer Test Plan

Enable screenreader mode, Add `"useWriteTodos": true,` to `settings.json` and ask:

> Please create a todo list with one item of each status. Flash model has difficulty with this so use Pro, please.

(The second sentence avoids a bug in the new auto model picker)

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Follow up for #10756