### PR TITLE
Add extension alias for extensions command

### DIFF
--- a/packages/cli/src/commands/extensions.tsx
+++ b/packages/cli/src/commands/extensions.tsx
@@ -16,6 +16,7 @@ import { newCommand } from './extensions/new.js';
 
 export const extensionsCommand: CommandModule = {
   command: 'extensions <command>',
+  aliases: ['extension'],
   describe: 'Manage Gemini CLI extensions.',
   builder: (yargs) =>
     yargs


### PR DESCRIPTION
## TLDR

Add an "extensions" alias to the existing `extension` command. This means that `gemini extension install` and gemini extensions install` will both work.

## Dive Deeper

Previously using `gemini extension` would open the nonintereactive CLI. By adding an "extension" alias to the existing extensions command, now both "extension" and "extensions" will work as commands.

## Reviewer Test Plan

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #11114 
