### PR TITLE
Set process title and add POSIX integration test

### DIFF
--- a/integration-tests/process-title.test.ts
+++ b/integration-tests/process-title.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TestRig, poll } from './test-helper.js';
+import { execFileSync } from 'node:child_process';
+import * as os from 'node:os';
+
+const EXPECTED_TITLE = 'gemini-cli';
+
+const isWindows = os.platform() === 'win32';
+
+// Windows Task Manager ignores process.title overrides for node.exe, so we skip there.
+(isWindows ? describe.skip : describe)('process title', () => {
+  it('exposes gemini-cli process name in system process list', async () => {
+    const rig = new TestRig();
+    await rig.setup('process title integration test', {
+      settings: { tools: { useRipgrep: false } },
+    });
+
+    const run = await rig.runInteractive();
+    const pid = run.ptyProcess.pid;
+
+    const foundTitle = await poll(
+      () => {
+        try {
+          const output = execFileSync(
+            'ps',
+            ['-p', String(pid), '-o', 'comm='],
+            { encoding: 'utf-8' },
+          );
+          const name = output.trim();
+          return name === EXPECTED_TITLE;
+        } catch {
+          return false;
+        }
+      },
+      10000,
+      200,
+    );
+
+    expect(
+      foundTitle,
+      `Expected process ${pid} to appear as ${EXPECTED_TITLE}`,
+    ).toBe(true);
+
+    run.sendKeys('\x03');
+    await run.expectText('Press Ctrl+C again to exit', 5000);
+    run.sendKeys('\x03');
+    const exitCode = await run.expectExit();
+    expect(exitCode).toBe(0);
+  });
+});

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+process.title = 'gemini-cli';
+
 import './src/gemini.js';
 import { main } from './src/gemini.js';
 import { debugLogger, FatalError } from '@google/gemini-cli-core';


### PR DESCRIPTION
## TLDR

Set the CLI process title to `gemini-cli` so the process name appears consistently in POSIX listings, and add test coverage.

## Dive Deeper

- Set `process.title` to `gemini-cli`.
- Add an integration test that polls `ps` on POSIX systems and skips on Windows where titles are ignored.

## Reviewer Test Plan

- npm run test:integration:sandbox:none -- --run integration-tests/process-title.test.ts

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❌  | ❌  | ❌  |
| npx      | ❌  | ❌  | ❌  |
| Docker   | ❌  | ❌  | ❌  |
| Podman   | ❌  | -   | -   |
| Seatbelt | ❌  | -   | -   |

## Linked issues / bugs

Fixes #11626
