### PR TITLE
fix(mcp): Include path in oauth resource parameter

### DIFF
--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -297,14 +297,32 @@ describe('OAuthUtils', () => {
       const result = OAuthUtils.buildResourceParameter(
         'https://example.com/oauth/token',
       );
-      expect(result).toBe('https://example.com');
+      expect(result).toBe('https://example.com/oauth/token');
     });
 
     it('should handle URLs with ports', () => {
       const result = OAuthUtils.buildResourceParameter(
         'https://example.com:8080/oauth/token',
       );
-      expect(result).toBe('https://example.com:8080');
+      expect(result).toBe('https://example.com:8080/oauth/token');
+    });
+
+    it('should strip query parameters from the URL', () => {
+      const result = OAuthUtils.buildResourceParameter(
+        'https://example.com/api/v1/data?user=123&scope=read',
+      );
+      expect(result).toBe('https://example.com/api/v1/data');
+    });
+
+    it('should strip URL fragments from the URL', () => {
+      const result = OAuthUtils.buildResourceParameter(
+        'https://example.com/api/v1/data#section-one',
+      );
+      expect(result).toBe('https://example.com/api/v1/data');
+    });
+
+    it('should throw an error for invalid URLs', () => {
+      expect(() => OAuthUtils.buildResourceParameter('not-a-url')).toThrow();
     });
   });
 });

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -360,6 +360,6 @@ export class OAuthUtils {
    */
   static buildResourceParameter(endpointUrl: string): string {
     const url = new URL(endpointUrl);
-    return `${url.protocol}//${url.host}`;
+    return `${url.protocol}//${url.host}${url.pathname}`;
   }
 }


### PR DESCRIPTION
## TLDR
The `buildResourceParameter` function was previously only returning the origin of the provided URL. This change updates the function to include the pathname in the returned resource parameter.

This is necessary for OAuth providers that require the full path of the token endpoint in the resource parameter.

The tests have been updated to reflect this change, and new tests have been added to handle query parameters, fragments, and invalid URLs.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

Validated that the fix is working and resolves the bug. To test locally, follow the following steps:
1. Add a mcp server which requires oauth in the settings.json, e.g.
```
"supabase": {
    "type": "http",
    "url": "https://mcp.supabase.com/mcp"
}
```
2. Run `gemini` and perform auth using `/mcp auth <mcp_server_name>`
3. Follow the auth url, it should redirect to the auth page and not give ```400 - {"message":"resource: Invalid input"}```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #10994 