### PR TITLE
WIP chore(ci): Stress test InputPrompt.test.tsx in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
       - name: 'Run tests and generate reports'
         env:
           NO_COLOR: true
-        run: 'npm run test:ci'
+        run: 'npx vitest run packages/cli/src/ui/components/InputPrompt.test.tsx --repeats 100'
 
       - name: 'Bundle'
         run: 'npm run bundle'
@@ -197,7 +197,7 @@ jobs:
       - name: 'Run tests and generate reports'
         env:
           NO_COLOR: true
-        run: 'npm run test:ci -- --coverage.enabled=false'
+        run: 'npx vitest run packages/cli/src/ui/components/InputPrompt.test.tsx --repeats 100'
 
       - name: 'Bundle'
         run: 'npm run bundle'
@@ -338,7 +338,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=32768 --max-semi-space-size=256'
           UV_THREADPOOL_SIZE: '32'
           NODE_ENV: 'test'
-        run: 'npm run test:ci -- --coverage.enabled=false'
+        run: 'npx vitest run packages/cli/src/ui/components/InputPrompt.test.tsx --repeats 100'
         shell: 'pwsh'
 
       - name: 'Bundle'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,11 @@ jobs:
       - name: 'Run tests and generate reports'
         env:
           NO_COLOR: true
-        run: 'npx vitest run packages/cli/src/ui/components/InputPrompt.test.tsx --repeats 100'
+        run: |
+          for i in {1..100}; do
+            echo "Run #$i"
+            npm run test -w @google/gemini-cli -- src/ui/components/InputPrompt.test.tsx || exit 1
+          done
 
       - name: 'Bundle'
         run: 'npm run bundle'
@@ -197,7 +201,11 @@ jobs:
       - name: 'Run tests and generate reports'
         env:
           NO_COLOR: true
-        run: 'npx vitest run packages/cli/src/ui/components/InputPrompt.test.tsx --repeats 100'
+        run: |
+          for i in {1..100}; do
+            echo "Run #$i"
+            npm run test -w @google/gemini-cli -- src/ui/components/InputPrompt.test.tsx || exit 1
+          done
 
       - name: 'Bundle'
         run: 'npm run bundle'
@@ -338,7 +346,8 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=32768 --max-semi-space-size=256'
           UV_THREADPOOL_SIZE: '32'
           NODE_ENV: 'test'
-        run: 'npx vitest run packages/cli/src/ui/components/InputPrompt.test.tsx --repeats 100'
+        run: |
+          for ($i=1; $i -le 100; $i++) { Write-Host "Run #$i"; npm run test -w @google/gemini-cli -- src/ui/components/shared/BaseSelectionList.test.tsx; if ($LASTEXITCODE -ne 0) { exit 1 } }
         shell: 'pwsh'
 
       - name: 'Bundle'

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -1581,8 +1581,9 @@ describe('InputPrompt', () => {
       await vi.runAllTimersAsync();
 
       // Simulate a paste operation (this should set the paste protection)
-      stdin.write(`\x1b[200~pasted content\x1b[201~`);
-      await vi.runAllTimersAsync();
+      act(() => {
+        stdin.write(`\x1b[200~pasted content\x1b[201~`);
+      });
 
       // Simulate an Enter key press immediately after paste
       stdin.write('\r');

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -2073,7 +2073,7 @@ describe('InputPrompt', () => {
       unmount();
     });
 
-    it.skip('expands and collapses long suggestion via Right/Left arrows', async () => {
+    it('expands and collapses long suggestion via Right/Left arrows', async () => {
       props.shellModeActive = false;
       const longValue = 'l'.repeat(200);
 


### PR DESCRIPTION
## TLDR

Unskips 'expands and collapses long suggestion via Right/Left arrows' in `InputPrompt.test.tsx` and modifies CI to run this test 100 times on all platforms to check for flakiness.

## Dive Deeper

This is a temporary change to stress test a specific test case that might be flaky. The CI workflow has been modified to replace the standard `npm run test:ci` with `npx vitest run packages/cli/src/ui/components/InputPrompt.test.tsx --repeats 100`.

## Reviewer Test Plan

Trigger the CI workflow and observe the results of the 'Test (Linux)', 'Test (Mac)', and 'Slow Test - Win' jobs.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

