### PR TITLE
fix(scripts): dynamically locate python user base for linters

### DIFF
--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -108,10 +108,18 @@ function runCommand(command, stdio = 'inherit') {
     const env = { ...process.env };
     const nodeBin = join(process.cwd(), 'node_modules', '.bin');
     env.PATH = `${nodeBin}:${TEMP_DIR}/actionlint:${TEMP_DIR}/shellcheck:${env.PATH}`;
-    if (process.platform === 'darwin') {
-      env.PATH = `${env.PATH}:${process.env.HOME}/Library/Python/3.12/bin`;
-    } else if (process.platform === 'linux') {
-      env.PATH = `${env.PATH}:${process.env.HOME}/.local/bin`;
+    try {
+      const pythonUserBase = execSync('python3 -m site --user-base', {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      if (pythonUserBase) {
+        env.PATH = `${env.PATH}:${pythonUserBase}/bin`;
+      }
+    } catch (_e) {
+      if (process.platform === 'linux') {
+        env.PATH = `${env.PATH}:${process.env.HOME}/.local/bin`;
+      }
     }
     execSync(command, { stdio, env });
     return true;

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -119,6 +119,8 @@ function runCommand(command, stdio = 'inherit') {
     } catch (_e) {
       if (process.platform === 'linux') {
         env.PATH = `${env.PATH}:${process.env.HOME}/.local/bin`;
+      } else if (process.platform === 'darwin') {
+        env.PATH = `${env.PATH}:${process.env.HOME}/Library/Python/3.12/bin`;
       }
     }
     execSync(command, { stdio, env });


### PR DESCRIPTION
## TLDR

Updates `scripts/lint.js` to dynamically determine the Python user base directory instead of relying on hardcoded paths.

## Dive Deeper

Previously, `scripts/lint.js` hardcoded the path to `Library/Python/3.12/bin` on macOS to find user-installed pip packages like `yamllint`. This caused failures for users with different Python versions (e.g., 3.13). This change uses `python3 -m site --user-base` to accurately locate the user base directory regardless of the Python version or platform, improving the robustness of the linting script.

## Reviewer Test Plan

Run `npm run lint:all` on a system where `yamllint` is installed via `pip3 install --user` and ensure it executes correctly without manual PATH adjustments.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A