### PR TITLE
feat(core) Bump get-ripgrep version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1781,9 +1781,10 @@
       }
     },
     "node_modules/@joshua.litt/get-ripgrep": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@joshua.litt/get-ripgrep/-/get-ripgrep-0.0.2.tgz",
-      "integrity": "sha512-cSHA+H+HEkOXeiCxrNvGj/pgv2Y0bfp4GbH3R87zr7Vob2pDUZV3BkUL9ucHMoDFID4GteSy5z5niN/lF9QeuQ==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@joshua.litt/get-ripgrep/-/get-ripgrep-0.0.3.tgz",
+      "integrity": "sha512-rycdieAKKqXi2bsM7G2ayDiNk5CAX8ZOzsTQsirfOqUKPef04Xw40BWGGyimaOOuvPgLWYt3tPnLLG3TvPXi5Q==",
+      "license": "MIT",
       "dependencies": {
         "@lvce-editor/verror": "^1.6.0",
         "execa": "^9.5.2",
@@ -18103,7 +18104,7 @@
         "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
         "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
         "@google/genai": "1.16.0",
-        "@joshua.litt/get-ripgrep": "^0.0.2",
+        "@joshua.litt/get-ripgrep": "^0.0.3",
         "@modelcontextprotocol/sdk": "^1.11.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.203.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
     "@google/genai": "1.16.0",
-    "@joshua.litt/get-ripgrep": "^0.0.2",
+    "@joshua.litt/get-ripgrep": "^0.0.3",
     "@modelcontextprotocol/sdk": "^1.11.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-logs-otlp-grpc": "^0.203.0",


### PR DESCRIPTION
Bumps get-ripgrep to include https://github.com/lvce-editor/ripgrep/commit/e6266d9fa2688517f07b72952542ccc11b59362a , which downloads ripgrep into a system temp directory.

Fixes https://github.com/google-gemini/gemini-cli/issues/11495 (The clean-up was already happening, but this PR will at least move the download directory to the system tmp dir, thus it should be less intrusive and will get cleaned up automatically)