### PR TITLE
fix(infra) - Remove context input for setting status

### DIFF
--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -85,7 +85,7 @@ jobs:
           sha: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: 'pending'
-          context: 'Set e2e pending Status'
+          context: 'E2E'
 
   e2e_linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'
@@ -265,4 +265,4 @@ jobs:
           sha: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: '${{ job.status }}'
-          context: 'Set E2E Status'
+          context: 'E2E'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -85,7 +85,6 @@ jobs:
           sha: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: 'pending'
-          context: 'E2E'
 
   e2e_linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'
@@ -265,4 +264,3 @@ jobs:
           sha: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: '${{ job.status }}'
-          context: 'E2E'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -85,7 +85,6 @@ jobs:
           sha: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: 'pending'
-          context: 'Testing: E2E'
 
   e2e_linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'
@@ -265,4 +264,3 @@ jobs:
           sha: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: '${{ job.status }}'
-          context: 'Testing: E2E'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -85,6 +85,7 @@ jobs:
           sha: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: 'pending'
+          context: 'Testing: E2E / E2E'
 
   e2e_linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'
@@ -264,3 +265,4 @@ jobs:
           sha: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: '${{ job.status }}'
+          context: 'Testing: E2E / E2E'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -85,7 +85,6 @@ jobs:
           sha: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: 'pending'
-          context: 'Testing: E2E / E2E'
 
   e2e_linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'
@@ -265,4 +264,3 @@ jobs:
           sha: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: '${{ job.status }}'
-          context: 'Testing: E2E / E2E'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -85,6 +85,7 @@ jobs:
           sha: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: 'pending'
+          context: 'Testing: E2E'
 
   e2e_linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'
@@ -264,3 +265,4 @@ jobs:
           sha: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: '${{ job.status }}'
+          context: 'Testing: E2E'


### PR DESCRIPTION
## TLDR
Fix context for chained e2e to just default to workflow name

## Dive Deeper

## Reviewer Test Plan
```
gh workflow run test_chained_e2e.yml --ref ss/fixContext -f repo_name="google-gemini/gemini-cli" -f head_sha=52cc8a8f8426534312d638739e67b3da9eeb825c
```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Makes progress on #10008 
