### PR TITLE
docs: add known issue for Docker sandbox image accessss

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,23 @@
+## Docker Sandbox Image Access Issue
+
+Some users may experience errors when trying to pull the Gemini sandbox image
+from: `us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.10.0`
+
+### ��� Error Example
+
+Error response from daemon: Get "https://us-docker.pkg.dev/v2/ ": context
+deadline exceeded
+
+### ��� Why It Happens
+
+This occurs because the registry is internal to Google and not publicly
+accessible.
+
+### ��� Suggested Workaround
+
+- Build the sandbox image locally using:
+  ```bash
+  npm run build:all
+  Or request that the image be published publicly on Docker Hub.
+  Contributor: @Nimraakram12
+  ```

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -18,6 +18,3 @@ accessible.
 - Build the sandbox image locally using:
   ```bash
   npm run build:all
-  Or request that the image be published publicly on Docker Hub.
-  Contributor: @Nimraakram12
-  ```


### PR DESCRIPTION
## TLDR

Documented a known issue with pulling the `sandbox:0.10.0` image from `us-docker.pkg.dev` and added a suggested workaround.

## Dive Deeper

This PR documents a known issue where the Gemini CLI sandbox image
cannot be pulled from `us-docker.pkg.dev`.  
It adds an explanation and a workaround for affected users.

Fixes #11685

## Reviewer Test Plan

- Open `docs/known-issues.md`
- Verify that the new section clearly describes the sandbox image error
- Ensure formatting follows markdown style used elsewhere

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ✅  | ✅  |
| npx      | ✅  | ✅  | ✅  |
| Docker   | ✅  | ✅  | ✅  |
| Podman   | ❌  | -   | -   |
| Seatbelt | ❌  | -   | -   |

## Linked issues / bugs

Fixes #11685
