### PR TITLE
fix(cli): fix race condition and unskip tests in useGitBranchName

### DIFF
--- a/packages/cli/src/ui/hooks/useGitBranchName.test.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.test.ts
@@ -9,7 +9,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useGitBranchName } from './useGitBranchName.js';
-import { fs, vol } from 'memfs'; // For mocking fs
+import { fs, vol } from 'memfs';
+import * as fsPromises from 'node:fs/promises'; // For mocking fs
 import { spawnAsync as mockSpawnAsync } from '@google/gemini-cli-core';
 
 // Mock @google/gemini-cli-core
@@ -34,7 +35,7 @@ vi.mock('node:fs', async () => {
 
 vi.mock('node:fs/promises', async () => {
   const memfs = await vi.importActual<typeof import('memfs')>('memfs');
-  return memfs.fs.promises;
+  return { ...memfs.fs.promises, default: memfs.fs.promises };
 });
 
 const CWD = '/test/project';
@@ -46,12 +47,10 @@ describe('useGitBranchName', () => {
     vol.fromJSON({
       [GIT_LOGS_HEAD_PATH]: 'ref: refs/heads/main',
     });
-    vi.useFakeTimers(); // Use fake timers for async operations
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.clearAllTimers();
   });
 
   it('should return branch name', async () => {
@@ -63,7 +62,6 @@ describe('useGitBranchName', () => {
     const { result, rerender } = renderHook(() => useGitBranchName(CWD));
 
     await act(async () => {
-      vi.runAllTimers(); // Advance timers to trigger useEffect and exec callback
       rerender(); // Rerender to get the updated state
     });
 
@@ -79,7 +77,6 @@ describe('useGitBranchName', () => {
     expect(result.current).toBeUndefined();
 
     await act(async () => {
-      vi.runAllTimers();
       rerender();
     });
     expect(result.current).toBeUndefined();
@@ -99,7 +96,6 @@ describe('useGitBranchName', () => {
 
     const { result, rerender } = renderHook(() => useGitBranchName(CWD));
     await act(async () => {
-      vi.runAllTimers();
       rerender();
     });
     expect(result.current).toBe('a1b2c3d');
@@ -119,20 +115,21 @@ describe('useGitBranchName', () => {
 
     const { result, rerender } = renderHook(() => useGitBranchName(CWD));
     await act(async () => {
-      vi.runAllTimers();
       rerender();
     });
     expect(result.current).toBeUndefined();
   });
 
-  it('should update branch name when .git/HEAD changes', async ({ skip }) => {
-    skip(); // TODO: fix
+  it('should update branch name when .git/HEAD changes', async () => {
+    vi.spyOn(fsPromises, 'access').mockResolvedValue(undefined);
+    const watchSpy = vi.spyOn(fs, 'watch');
+
     (mockSpawnAsync as MockedFunction<typeof mockSpawnAsync>)
       .mockResolvedValueOnce({ stdout: 'main\n' } as {
         stdout: string;
         stderr: string;
       })
-      .mockResolvedValueOnce({ stdout: 'develop\n' } as {
+      .mockResolvedValue({ stdout: 'develop\n' } as {
         stdout: string;
         stderr: string;
       });
@@ -140,16 +137,18 @@ describe('useGitBranchName', () => {
     const { result, rerender } = renderHook(() => useGitBranchName(CWD));
 
     await act(async () => {
-      vi.runAllTimers();
       rerender();
     });
     expect(result.current).toBe('main');
 
+    // Wait for watcher to be set up
+    await waitFor(() => {
+      expect(watchSpy).toHaveBeenCalled();
+    });
+
     // Simulate file change event
-    // Ensure the watcher is set up before triggering the change
     await act(async () => {
       fs.writeFileSync(GIT_LOGS_HEAD_PATH, 'ref: refs/heads/develop'); // Trigger watcher
-      vi.runAllTimers(); // Process timers for watcher and exec
       rerender();
     });
 
@@ -171,7 +170,6 @@ describe('useGitBranchName', () => {
     const { result, rerender } = renderHook(() => useGitBranchName(CWD));
 
     await act(async () => {
-      vi.runAllTimers();
       rerender();
     });
 
@@ -192,7 +190,6 @@ describe('useGitBranchName', () => {
 
     await act(async () => {
       fs.writeFileSync(GIT_LOGS_HEAD_PATH, 'ref: refs/heads/develop');
-      vi.runAllTimers();
       rerender();
     });
 
@@ -200,8 +197,8 @@ describe('useGitBranchName', () => {
     expect(result.current).toBe('main');
   });
 
-  it('should cleanup watcher on unmount', async ({ skip }) => {
-    skip(); // TODO: fix
+  it('should cleanup watcher on unmount', async () => {
+    vi.spyOn(fsPromises, 'access').mockResolvedValue(undefined);
     const closeMock = vi.fn();
     const watchMock = vi.spyOn(fs, 'watch').mockReturnValue({
       close: closeMock,
@@ -216,15 +213,18 @@ describe('useGitBranchName', () => {
     const { unmount, rerender } = renderHook(() => useGitBranchName(CWD));
 
     await act(async () => {
-      vi.runAllTimers();
       rerender();
     });
 
+    // Wait for watcher to be set up BEFORE unmounting
+    await waitFor(() => {
+      expect(watchMock).toHaveBeenCalledWith(
+        GIT_LOGS_HEAD_PATH,
+        expect.any(Function),
+      );
+    });
+
     unmount();
-    expect(watchMock).toHaveBeenCalledWith(
-      GIT_LOGS_HEAD_PATH,
-      expect.any(Function),
-    );
     expect(closeMock).toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/ui/hooks/useGitBranchName.test.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.test.ts
@@ -10,7 +10,8 @@ import { act } from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useGitBranchName } from './useGitBranchName.js';
 import { fs, vol } from 'memfs';
-import * as fsPromises from 'node:fs/promises'; // For mocking fs
+import * as fsPromises from 'node:fs/promises';
+import path from 'node:path'; // For mocking fs
 import { spawnAsync as mockSpawnAsync } from '@google/gemini-cli-core';
 
 // Mock @google/gemini-cli-core
@@ -39,7 +40,7 @@ vi.mock('node:fs/promises', async () => {
 });
 
 const CWD = '/test/project';
-const GIT_LOGS_HEAD_PATH = `${CWD}/.git/logs/HEAD`;
+const GIT_LOGS_HEAD_PATH = path.join(CWD, '.git', 'logs', 'HEAD');
 
 describe('useGitBranchName', () => {
   beforeEach(() => {

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -41,11 +41,13 @@ export function useGitBranchName(cwd: string): string | undefined {
 
     const gitLogsHeadPath = path.join(cwd, '.git', 'logs', 'HEAD');
     let watcher: fs.FSWatcher | undefined;
+    let cancelled = false;
 
     const setupWatcher = async () => {
       try {
         // Check if .git/logs/HEAD exists, as it might not in a new repo or orphaned head
         await fsPromises.access(gitLogsHeadPath, fs.constants.F_OK);
+        if (cancelled) return;
         watcher = fs.watch(gitLogsHeadPath, (eventType: string) => {
           // Changes to .git/logs/HEAD (appends) indicate HEAD has likely changed
           if (eventType === 'change' || eventType === 'rename') {
@@ -63,6 +65,7 @@ export function useGitBranchName(cwd: string): string | undefined {
     setupWatcher();
 
     return () => {
+      cancelled = true;
       watcher?.close();
     };
   }, [cwd, fetchBranchName]);


### PR DESCRIPTION
## TLDR

Unskipped and fixed tests in `useGitBranchName.test.ts`. Fixed a race condition in `useGitBranchName.ts` where the watcher might try to update state after the component unmounted.

## Dive Deeper

The tests were failing due to missing mocks for `node:fs/promises` and issues with fake timers not playing well with the `fs.watch` mock. Switched to real timers and `waitFor` for more reliable async testing. Added a `cancelled` check in the `useEffect` cleanup of `useGitBranchName` to prevent state updates after unmount.

## Reviewer Test Plan

Run `npm run test packages/cli/src/ui/hooks/useGitBranchName.test.ts` and verify all tests pass.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A
