### PR TITLE
refactor(test): replace custom wait with waitFor in InputPrompt tests

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -233,29 +233,25 @@ describe('InputPrompt', () => {
     };
   });
 
-  const wait = (ms = 50) => new Promise((resolve) => setTimeout(resolve, ms));
-
   it('should call shellHistory.getPreviousCommand on up arrow in shell mode', async () => {
     props.shellModeActive = true;
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\u001B[A');
-    await wait();
-
-    expect(mockShellHistory.getPreviousCommand).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockShellHistory.getPreviousCommand).toHaveBeenCalled();
+    });
     unmount();
   });
 
   it('should call shellHistory.getNextCommand on down arrow in shell mode', async () => {
     props.shellModeActive = true;
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\u001B[B');
-    await wait();
-
-    expect(mockShellHistory.getNextCommand).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockShellHistory.getNextCommand).toHaveBeenCalled();
+    });
     unmount();
   });
 
@@ -265,13 +261,12 @@ describe('InputPrompt', () => {
       'previous command',
     );
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\u001B[A');
-    await wait();
-
-    expect(mockShellHistory.getPreviousCommand).toHaveBeenCalled();
-    expect(props.buffer.setText).toHaveBeenCalledWith('previous command');
+    await waitFor(() => {
+      expect(mockShellHistory.getPreviousCommand).toHaveBeenCalled();
+      expect(props.buffer.setText).toHaveBeenCalledWith('previous command');
+    });
     unmount();
   });
 
@@ -279,35 +274,33 @@ describe('InputPrompt', () => {
     props.shellModeActive = true;
     props.buffer.setText('ls -l');
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\r');
-    await wait();
-
-    expect(mockShellHistory.addCommandToHistory).toHaveBeenCalledWith('ls -l');
-    expect(props.onSubmit).toHaveBeenCalledWith('ls -l');
+    await waitFor(() => {
+      expect(mockShellHistory.addCommandToHistory).toHaveBeenCalledWith(
+        'ls -l',
+      );
+      expect(props.onSubmit).toHaveBeenCalledWith('ls -l');
+    });
     unmount();
   });
 
   it('should NOT call shell history methods when not in shell mode', async () => {
     props.buffer.setText('some text');
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\u001B[A'); // Up arrow
-    await wait();
     stdin.write('\u001B[B'); // Down arrow
-    await wait();
     stdin.write('\r'); // Enter
-    await wait();
+    await waitFor(() => {
+      expect(mockShellHistory.getPreviousCommand).not.toHaveBeenCalled();
+      expect(mockShellHistory.getNextCommand).not.toHaveBeenCalled();
+      expect(mockShellHistory.addCommandToHistory).not.toHaveBeenCalled();
 
-    expect(mockShellHistory.getPreviousCommand).not.toHaveBeenCalled();
-    expect(mockShellHistory.getNextCommand).not.toHaveBeenCalled();
-    expect(mockShellHistory.addCommandToHistory).not.toHaveBeenCalled();
-
-    expect(mockInputHistory.navigateUp).toHaveBeenCalled();
-    expect(mockInputHistory.navigateDown).toHaveBeenCalled();
-    expect(props.onSubmit).toHaveBeenCalledWith('some text');
+      expect(mockInputHistory.navigateUp).toHaveBeenCalled();
+      expect(mockInputHistory.navigateDown).toHaveBeenCalled();
+      expect(props.onSubmit).toHaveBeenCalledWith('some text');
+    });
     unmount();
   });
 
@@ -324,16 +317,15 @@ describe('InputPrompt', () => {
     props.buffer.setText('/mem');
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     // Test up arrow
     stdin.write('\u001B[A'); // Up arrow
-    await wait();
 
     stdin.write('\u0010'); // Ctrl+P
-    await wait();
-    expect(mockCommandCompletion.navigateUp).toHaveBeenCalledTimes(2);
-    expect(mockCommandCompletion.navigateDown).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockCommandCompletion.navigateUp).toHaveBeenCalledTimes(2);
+      expect(mockCommandCompletion.navigateDown).not.toHaveBeenCalled();
+    });
 
     unmount();
   });
@@ -350,16 +342,15 @@ describe('InputPrompt', () => {
     props.buffer.setText('/mem');
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     // Test down arrow
     stdin.write('\u001B[B'); // Down arrow
-    await wait();
 
     stdin.write('\u000E'); // Ctrl+N
-    await wait();
-    expect(mockCommandCompletion.navigateDown).toHaveBeenCalledTimes(2);
-    expect(mockCommandCompletion.navigateUp).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockCommandCompletion.navigateDown).toHaveBeenCalledTimes(2);
+      expect(mockCommandCompletion.navigateUp).not.toHaveBeenCalled();
+    });
 
     unmount();
   });
@@ -372,19 +363,15 @@ describe('InputPrompt', () => {
     props.buffer.setText('some text');
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\u001B[A'); // Up arrow
-    await wait();
     stdin.write('\u001B[B'); // Down arrow
-    await wait();
     stdin.write('\u0010'); // Ctrl+P
-    await wait();
     stdin.write('\u000E'); // Ctrl+N
-    await wait();
-
-    expect(mockCommandCompletion.navigateUp).not.toHaveBeenCalled();
-    expect(mockCommandCompletion.navigateDown).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockCommandCompletion.navigateUp).not.toHaveBeenCalled();
+      expect(mockCommandCompletion.navigateDown).not.toHaveBeenCalled();
+    });
     unmount();
   });
 
@@ -406,20 +393,19 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       // Send Ctrl+V
       stdin.write('\x16'); // Ctrl+V
-      await wait();
-
-      expect(clipboardUtils.clipboardHasImage).toHaveBeenCalled();
-      expect(clipboardUtils.saveClipboardImage).toHaveBeenCalledWith(
-        props.config.getTargetDir(),
-      );
-      expect(clipboardUtils.cleanupOldClipboardImages).toHaveBeenCalledWith(
-        props.config.getTargetDir(),
-      );
-      expect(mockBuffer.replaceRangeByOffset).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(clipboardUtils.clipboardHasImage).toHaveBeenCalled();
+        expect(clipboardUtils.saveClipboardImage).toHaveBeenCalledWith(
+          props.config.getTargetDir(),
+        );
+        expect(clipboardUtils.cleanupOldClipboardImages).toHaveBeenCalledWith(
+          props.config.getTargetDir(),
+        );
+        expect(mockBuffer.replaceRangeByOffset).toHaveBeenCalled();
+      });
       unmount();
     });
 
@@ -429,14 +415,13 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\x16'); // Ctrl+V
-      await wait();
-
-      expect(clipboardUtils.clipboardHasImage).toHaveBeenCalled();
-      expect(clipboardUtils.saveClipboardImage).not.toHaveBeenCalled();
-      expect(mockBuffer.setText).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(clipboardUtils.clipboardHasImage).toHaveBeenCalled();
+        expect(clipboardUtils.saveClipboardImage).not.toHaveBeenCalled();
+        expect(mockBuffer.setText).not.toHaveBeenCalled();
+      });
       unmount();
     });
 
@@ -447,13 +432,12 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\x16'); // Ctrl+V
-      await wait();
-
-      expect(clipboardUtils.saveClipboardImage).toHaveBeenCalled();
-      expect(mockBuffer.setText).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(clipboardUtils.saveClipboardImage).toHaveBeenCalled();
+        expect(mockBuffer.setText).not.toHaveBeenCalled();
+      });
       unmount();
     });
 
@@ -475,13 +459,12 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\x16'); // Ctrl+V
-      await wait();
-
-      // Should insert at cursor position with spaces
-      expect(mockBuffer.replaceRangeByOffset).toHaveBeenCalled();
+      await waitFor(() => {
+        // Should insert at cursor position with spaces
+        expect(mockBuffer.replaceRangeByOffset).toHaveBeenCalled();
+      });
 
       // Get the actual call to see what path was used
       const actualCall = vi.mocked(mockBuffer.replaceRangeByOffset).mock
@@ -505,16 +488,15 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\x16'); // Ctrl+V
-      await wait();
-
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Error handling clipboard image:',
-        expect.any(Error),
-      );
-      expect(mockBuffer.setText).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Error handling clipboard image:',
+          expect.any(Error),
+        );
+        expect(mockBuffer.setText).not.toHaveBeenCalled();
+      });
 
       consoleErrorSpy.mockRestore();
       unmount();
@@ -532,12 +514,11 @@ describe('InputPrompt', () => {
     props.buffer.setText('/mem');
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\t'); // Press Tab
-    await wait();
-
-    expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
+    await waitFor(() => {
+      expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
+    });
     unmount();
   });
 
@@ -555,12 +536,11 @@ describe('InputPrompt', () => {
     props.buffer.setText('/memory ');
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\t'); // Press Tab
-    await wait();
-
-    expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(1);
+    await waitFor(() => {
+      expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(1);
+    });
     unmount();
   });
 
@@ -579,13 +559,12 @@ describe('InputPrompt', () => {
     props.buffer.setText('/memory');
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\t'); // Press Tab
-    await wait();
-
-    // It should NOT become '/show'. It should correctly become '/memory show'.
-    expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
+    await waitFor(() => {
+      // It should NOT become '/show'. It should correctly become '/memory show'.
+      expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
+    });
     unmount();
   });
 
@@ -600,12 +579,11 @@ describe('InputPrompt', () => {
     props.buffer.setText('/chat resume fi-');
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\t'); // Press Tab
-    await wait();
-
-    expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
+    await waitFor(() => {
+      expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
+    });
     unmount();
   });
 
@@ -619,15 +597,14 @@ describe('InputPrompt', () => {
     props.buffer.setText('/mem');
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\r');
-    await wait();
+    await waitFor(() => {
+      // The app should autocomplete the text, NOT submit.
+      expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
 
-    // The app should autocomplete the text, NOT submit.
-    expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
-
-    expect(props.onSubmit).not.toHaveBeenCalled();
+      expect(props.onSubmit).not.toHaveBeenCalled();
+    });
     unmount();
   });
 
@@ -650,12 +627,11 @@ describe('InputPrompt', () => {
     props.buffer.setText('/?');
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\t'); // Press Tab for autocomplete
-    await wait();
-
-    expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
+    await waitFor(() => {
+      expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
+    });
     unmount();
   });
 
@@ -663,12 +639,11 @@ describe('InputPrompt', () => {
     props.buffer.setText('   '); // Set buffer to whitespace
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\r'); // Press Enter
-    await wait();
-
-    expect(props.onSubmit).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(props.onSubmit).not.toHaveBeenCalled();
+    });
     unmount();
   });
 
@@ -681,12 +656,11 @@ describe('InputPrompt', () => {
     props.buffer.setText('/clear');
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\r');
-    await wait();
-
-    expect(props.onSubmit).toHaveBeenCalledWith('/clear');
+    await waitFor(() => {
+      expect(props.onSubmit).toHaveBeenCalledWith('/clear');
+    });
     unmount();
   });
 
@@ -699,12 +673,11 @@ describe('InputPrompt', () => {
     props.buffer.setText('/clear');
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\r');
-    await wait();
-
-    expect(props.onSubmit).toHaveBeenCalledWith('/clear');
+    await waitFor(() => {
+      expect(props.onSubmit).toHaveBeenCalledWith('/clear');
+    });
     unmount();
   });
 
@@ -718,13 +691,12 @@ describe('InputPrompt', () => {
     props.buffer.setText('@src/components/');
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\r');
-    await wait();
-
-    expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
-    expect(props.onSubmit).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
+      expect(props.onSubmit).not.toHaveBeenCalled();
+    });
     unmount();
   });
 
@@ -735,40 +707,37 @@ describe('InputPrompt', () => {
     mockBuffer.lines = ['first line\\'];
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\r');
-    await wait();
-
-    expect(props.onSubmit).not.toHaveBeenCalled();
-    expect(props.buffer.backspace).toHaveBeenCalled();
-    expect(props.buffer.newline).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(props.onSubmit).not.toHaveBeenCalled();
+      expect(props.buffer.backspace).toHaveBeenCalled();
+      expect(props.buffer.newline).toHaveBeenCalled();
+    });
     unmount();
   });
 
   it('should clear the buffer on Ctrl+C if it has text', async () => {
     props.buffer.setText('some text to clear');
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\x03'); // Ctrl+C character
-    await wait();
-
-    expect(props.buffer.setText).toHaveBeenCalledWith('');
-    expect(mockCommandCompletion.resetCompletionState).toHaveBeenCalled();
-    expect(props.onSubmit).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(props.buffer.setText).toHaveBeenCalledWith('');
+      expect(mockCommandCompletion.resetCompletionState).toHaveBeenCalled();
+      expect(props.onSubmit).not.toHaveBeenCalled();
+    });
     unmount();
   });
 
   it('should NOT clear the buffer on Ctrl+C if it is empty', async () => {
     props.buffer.text = '';
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
 
     stdin.write('\x03'); // Ctrl+C character
-    await wait();
-
-    expect(props.buffer.setText).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(props.buffer.setText).not.toHaveBeenCalled();
+    });
     unmount();
   });
 
@@ -786,19 +755,19 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      // Verify useCompletion was called with correct signature
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        // Verify useCompletion was called with correct signature
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -815,18 +784,18 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -843,18 +812,18 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -871,18 +840,18 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -899,18 +868,18 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -927,19 +896,19 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      // Verify useCompletion was called with the buffer
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        // Verify useCompletion was called with the buffer
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -956,18 +925,18 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -985,18 +954,18 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -1014,18 +983,18 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -1043,18 +1012,18 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -1072,18 +1041,18 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -1103,18 +1072,18 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -1132,18 +1101,18 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -1163,18 +1132,18 @@ describe('InputPrompt', () => {
       });
 
       const { unmount } = renderWithProviders(<InputPrompt {...props} />);
-      await wait();
-
-      expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
-        mockBuffer,
-        ['/test/project/src'],
-        path.join('test', 'project', 'src'),
-        mockSlashCommands,
-        mockCommandContext,
-        false,
-        false,
-        expect.any(Object),
-      );
+      await waitFor(() => {
+        expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
+          mockBuffer,
+          ['/test/project/src'],
+          path.join('test', 'project', 'src'),
+          mockSlashCommands,
+          mockCommandContext,
+          false,
+          false,
+          expect.any(Object),
+        );
+      });
 
       unmount();
     });
@@ -1186,13 +1155,12 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('i');
-      await wait();
-
-      expect(props.vimHandleInput).toHaveBeenCalled();
-      expect(mockBuffer.handleInput).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(props.vimHandleInput).toHaveBeenCalled();
+        expect(mockBuffer.handleInput).not.toHaveBeenCalled();
+      });
       unmount();
     });
 
@@ -1201,13 +1169,12 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('i');
-      await wait();
-
-      expect(props.vimHandleInput).toHaveBeenCalled();
-      expect(mockBuffer.handleInput).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(props.vimHandleInput).toHaveBeenCalled();
+        expect(mockBuffer.handleInput).toHaveBeenCalled();
+      });
       unmount();
     });
 
@@ -1217,13 +1184,12 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('i');
-      await wait();
-
-      expect(props.vimHandleInput).toHaveBeenCalled();
-      expect(mockBuffer.handleInput).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(props.vimHandleInput).toHaveBeenCalled();
+        expect(mockBuffer.handleInput).toHaveBeenCalled();
+      });
       unmount();
     });
   });
@@ -1234,17 +1200,16 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\x1B[200~pasted text\x1B[201~');
-      await wait();
-
-      expect(mockBuffer.handleInput).toHaveBeenCalledWith(
-        expect.objectContaining({
-          paste: true,
-          sequence: 'pasted text',
-        }),
-      );
+      await waitFor(() => {
+        expect(mockBuffer.handleInput).toHaveBeenCalledWith(
+          expect.objectContaining({
+            paste: true,
+            sequence: 'pasted text',
+          }),
+        );
+      });
       unmount();
     });
 
@@ -1253,12 +1218,11 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('a');
-      await wait();
-
-      expect(mockBuffer.handleInput).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockBuffer.handleInput).not.toHaveBeenCalled();
+      });
       unmount();
     });
   });
@@ -1273,11 +1237,11 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      // The component will render the text with the character at the cursor inverted.
-      expect(frame).toContain(`hel${chalk.inverse('l')}o world`);
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        // The component will render the text with the character at the cursor inverted.
+        expect(frame).toContain(`hel${chalk.inverse('l')}o world`);
+      });
       unmount();
     });
 
@@ -1290,10 +1254,10 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      expect(frame).toContain(`${chalk.inverse('h')}ello`);
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        expect(frame).toContain(`${chalk.inverse('h')}ello`);
+      });
       unmount();
     });
 
@@ -1306,10 +1270,10 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      expect(frame).toContain(`hello${chalk.inverse(' ')}`);
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        expect(frame).toContain(`hello${chalk.inverse(' ')}`);
+      });
       unmount();
     });
 
@@ -1322,11 +1286,11 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      // The token '@path/to/file' is colored, and the cursor highlights one char inside it.
-      expect(frame).toContain(`@path/${chalk.inverse('t')}o/file`);
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        // The token '@path/to/file' is colored, and the cursor highlights one char inside it.
+        expect(frame).toContain(`@path/${chalk.inverse('t')}o/file`);
+      });
       unmount();
     });
 
@@ -1340,10 +1304,10 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      expect(frame).toContain(`hello ${chalk.inverse('👍')} world`);
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        expect(frame).toContain(`hello ${chalk.inverse('👍')} world`);
+      });
       unmount();
     });
 
@@ -1357,10 +1321,10 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      expect(frame).toContain(`hello 👍${chalk.inverse(' ')}`);
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        expect(frame).toContain(`hello 👍${chalk.inverse(' ')}`);
+      });
       unmount();
     });
 
@@ -1373,10 +1337,10 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      expect(frame).toContain(chalk.inverse(' '));
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        expect(frame).toContain(chalk.inverse(' '));
+      });
       unmount();
     });
 
@@ -1389,10 +1353,10 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      expect(frame).toContain(`hello${chalk.inverse(' ')}world`);
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        expect(frame).toContain(`hello${chalk.inverse(' ')}world`);
+      });
       unmount();
     });
 
@@ -1411,10 +1375,10 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      expect(frame).toContain(`sec${chalk.inverse('o')}nd line`);
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        expect(frame).toContain(`sec${chalk.inverse('o')}nd line`);
+      });
       unmount();
     });
 
@@ -1432,10 +1396,10 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      expect(frame).toContain(`${chalk.inverse('s')}econd line`);
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        expect(frame).toContain(`${chalk.inverse('s')}econd line`);
+      });
       unmount();
     });
 
@@ -1453,10 +1417,10 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      expect(frame).toContain(`first line${chalk.inverse(' ')}`);
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        expect(frame).toContain(`first line${chalk.inverse(' ')}`);
+      });
       unmount();
     });
 
@@ -1475,14 +1439,14 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      const lines = frame!.split('\n');
-      // The line with the cursor should just be an inverted space inside the box border
-      expect(
-        lines.find((l) => l.includes(chalk.inverse(' '))),
-      ).not.toBeUndefined();
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        const lines = frame!.split('\n');
+        // The line with the cursor should just be an inverted space inside the box border
+        expect(
+          lines.find((l) => l.includes(chalk.inverse(' '))),
+        ).not.toBeUndefined();
+      });
       unmount();
     });
   });
@@ -1505,13 +1469,13 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-
-      const frame = stdout.lastFrame();
-      // Check that all lines, including the empty one, are rendered.
-      // This implicitly tests that the Box wrapper provides height for the empty line.
-      expect(frame).toContain('hello');
-      expect(frame).toContain(`world${chalk.inverse(' ')}`);
+      await waitFor(() => {
+        const frame = stdout.lastFrame();
+        // Check that all lines, including the empty one, are rendered.
+        // This implicitly tests that the Box wrapper provides height for the empty line.
+        expect(frame).toContain('hello');
+        expect(frame).toContain(`world${chalk.inverse(' ')}`);
+      });
 
       const outputLines = frame!.split('\n');
       // The number of lines should be 2 for the border plus 3 for the content.
@@ -1538,20 +1502,19 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       // Simulate a bracketed paste event from the terminal
       stdin.write(`\x1b[200~${pastedText}\x1b[201~`);
-      await wait();
-
-      // Verify that the buffer's handleInput was called once with the full text
-      expect(props.buffer.handleInput).toHaveBeenCalledTimes(1);
-      expect(props.buffer.handleInput).toHaveBeenCalledWith(
-        expect.objectContaining({
-          paste: true,
-          sequence: pastedText,
-        }),
-      );
+      await waitFor(() => {
+        // Verify that the buffer's handleInput was called once with the full text
+        expect(props.buffer.handleInput).toHaveBeenCalledTimes(1);
+        expect(props.buffer.handleInput).toHaveBeenCalledWith(
+          expect.objectContaining({
+            paste: true,
+            sequence: pastedText,
+          }),
+        );
+      });
 
       unmount();
     });
@@ -1692,16 +1655,14 @@ describe('InputPrompt', () => {
         <InputPrompt {...props} />,
         { kittyProtocolEnabled: false },
       );
-      await wait();
 
       stdin.write('\x1B');
-      await wait();
 
       stdin.write('\x1B');
-      await wait();
-
-      expect(props.buffer.setText).toHaveBeenCalledWith('');
-      expect(mockCommandCompletion.resetCompletionState).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(props.buffer.setText).toHaveBeenCalledWith('');
+        expect(mockCommandCompletion.resetCompletionState).toHaveBeenCalled();
+      });
       unmount();
     });
 
@@ -1736,12 +1697,11 @@ describe('InputPrompt', () => {
         <InputPrompt {...props} />,
         { kittyProtocolEnabled: false },
       );
-      await wait();
 
       stdin.write('\x1B');
-      await wait();
-
-      expect(props.setShellModeActive).toHaveBeenCalledWith(false);
+      await waitFor(() => {
+        expect(props.setShellModeActive).toHaveBeenCalledWith(false);
+      });
       unmount();
     });
 
@@ -1756,12 +1716,11 @@ describe('InputPrompt', () => {
         <InputPrompt {...props} />,
         { kittyProtocolEnabled: false },
       );
-      await wait();
 
       stdin.write('\x1B');
-      await wait();
-
-      expect(mockCommandCompletion.resetCompletionState).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockCommandCompletion.resetCompletionState).toHaveBeenCalled();
+      });
       unmount();
     });
 
@@ -1788,17 +1747,16 @@ describe('InputPrompt', () => {
         <InputPrompt {...props} />,
         { kittyProtocolEnabled: false },
       );
-      await wait();
 
       stdin.write('\x0C');
-      await wait();
-
-      expect(props.onClearScreen).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(props.onClearScreen).toHaveBeenCalled();
+      });
 
       stdin.write('\x01');
-      await wait();
-
-      expect(props.buffer.move).toHaveBeenCalledWith('home');
+      await waitFor(() => {
+        expect(props.buffer.move).toHaveBeenCalledWith('home');
+      });
       unmount();
     });
   });
@@ -1832,7 +1790,6 @@ describe('InputPrompt', () => {
       const { stdin, stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       // Trigger reverse search with Ctrl+R
       act(() => {
@@ -1854,10 +1811,8 @@ describe('InputPrompt', () => {
       const { stdin, stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\x12');
-      await wait();
       stdin.write('\x1B');
       stdin.write('\u001b[27u'); // Press kitty escape key
 
@@ -1910,10 +1865,10 @@ describe('InputPrompt', () => {
       act(() => {
         stdin.write('\t');
       });
-      await wait();
-
-      expect(mockHandleAutocomplete).toHaveBeenCalledWith(0);
-      expect(props.buffer.setText).toHaveBeenCalledWith('echo hello');
+      await waitFor(() => {
+        expect(mockHandleAutocomplete).toHaveBeenCalledWith(0);
+        expect(props.buffer.setText).toHaveBeenCalledWith('echo hello');
+      });
       unmount();
     }, 15000);
 
@@ -1975,7 +1930,6 @@ describe('InputPrompt', () => {
       const { stdin, stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       // reverse search with Ctrl+R
       act(() => {
@@ -2010,13 +1964,12 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\x05'); // Ctrl+E
-      await wait();
-
-      expect(props.buffer.move).toHaveBeenCalledWith('end');
-      expect(props.buffer.moveToOffset).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(props.buffer.move).toHaveBeenCalledWith('end');
+        expect(props.buffer.moveToOffset).not.toHaveBeenCalled();
+      });
       unmount();
     });
 
@@ -2028,13 +1981,12 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\x05'); // Ctrl+E
-      await wait();
-
-      expect(props.buffer.move).toHaveBeenCalledWith('end');
-      expect(props.buffer.moveToOffset).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(props.buffer.move).toHaveBeenCalledWith('end');
+        expect(props.buffer.moveToOffset).not.toHaveBeenCalled();
+      });
       unmount();
     });
   });
@@ -2060,17 +2012,16 @@ describe('InputPrompt', () => {
       const { stdin, stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       act(() => {
         stdin.write('\x12'); // Ctrl+R
       });
-      await wait();
-
-      const frame = stdout.lastFrame() ?? '';
-      expect(frame).toContain('(r:)');
-      expect(frame).toContain('git commit');
-      expect(frame).toContain('git push');
+      await waitFor(() => {
+        const frame = stdout.lastFrame() ?? '';
+        expect(frame).toContain('(r:)');
+        expect(frame).toContain('git commit');
+        expect(frame).toContain('git push');
+      });
       unmount();
     });
 
@@ -2090,26 +2041,26 @@ describe('InputPrompt', () => {
       const { stdin, stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\x12');
-      await wait();
-
-      expect(clean(stdout.lastFrame())).toContain('→');
+      await waitFor(() => {
+        expect(clean(stdout.lastFrame())).toContain('→');
+      });
 
       stdin.write('\u001B[C');
-      await wait(200);
+      await new Promise((resolve) => setTimeout(resolve, 200));
       expect(clean(stdout.lastFrame())).toContain('←');
       expect(stdout.lastFrame()).toMatchSnapshot(
         'command-search-expanded-match',
       );
 
       stdin.write('\u001B[D');
-      await wait();
-      expect(clean(stdout.lastFrame())).toContain('→');
-      expect(stdout.lastFrame()).toMatchSnapshot(
-        'command-search-collapsed-match',
-      );
+      await waitFor(() => {
+        expect(clean(stdout.lastFrame())).toContain('→');
+        expect(stdout.lastFrame()).toMatchSnapshot(
+          'command-search-collapsed-match',
+        );
+      });
       unmount();
     });
 
@@ -2132,19 +2083,20 @@ describe('InputPrompt', () => {
       const { stdin, stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\x12');
-      await wait();
-      expect(stdout.lastFrame()).toMatchSnapshot(
-        'command-search-collapsed-match',
-      );
+      await waitFor(() => {
+        expect(stdout.lastFrame()).toMatchSnapshot(
+          'command-search-collapsed-match',
+        );
+      });
 
       stdin.write('\u001B[C');
-      await wait();
-      expect(stdout.lastFrame()).toMatchSnapshot(
-        'command-search-expanded-match',
-      );
+      await waitFor(() => {
+        expect(stdout.lastFrame()).toMatchSnapshot(
+          'command-search-expanded-match',
+        );
+      });
 
       unmount();
     });
@@ -2165,14 +2117,13 @@ describe('InputPrompt', () => {
       const { stdin, stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\x12');
-      await wait();
-
-      const frame = clean(stdout.lastFrame());
-      expect(frame).not.toContain('→');
-      expect(frame).not.toContain('←');
+      await waitFor(() => {
+        const frame = clean(stdout.lastFrame());
+        expect(frame).not.toContain('→');
+        expect(frame).not.toContain('←');
+      });
       unmount();
     });
   });
@@ -2186,12 +2137,11 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\u001B[A');
-      await wait();
-
-      expect(mockPopAllMessages).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockPopAllMessages).toHaveBeenCalled();
+      });
       const callback = mockPopAllMessages.mock.calls[0][0];
 
       act(() => {
@@ -2211,12 +2161,12 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\u001B[A');
-      await wait();
-      expect(mockPopAllMessages).not.toHaveBeenCalled();
-      expect(mockInputHistory.navigateUp).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockPopAllMessages).not.toHaveBeenCalled();
+        expect(mockInputHistory.navigateUp).toHaveBeenCalled();
+      });
       unmount();
     });
 
@@ -2228,12 +2178,11 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\u001B[A');
-      await wait();
-
-      expect(mockPopAllMessages).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockPopAllMessages).toHaveBeenCalled();
+      });
       const callback = mockPopAllMessages.mock.calls[0][0];
       act(() => {
         callback(undefined);
@@ -2255,11 +2204,11 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\u001B[A');
-      await wait();
-      expect(mockPopAllMessages).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockPopAllMessages).toHaveBeenCalled();
+      });
       unmount();
     });
 
@@ -2271,10 +2220,8 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\u001B[A');
-      await wait();
 
       const callback = mockPopAllMessages.mock.calls[0][0];
       act(() => {
@@ -2293,12 +2240,11 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\u001B[A');
-      await wait();
-
-      expect(mockPopAllMessages).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockPopAllMessages).toHaveBeenCalled();
+      });
       unmount();
     });
 
@@ -2309,12 +2255,11 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\u001B[A');
-      await wait();
-
-      expect(mockInputHistory.navigateUp).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockInputHistory.navigateUp).toHaveBeenCalled();
+      });
       unmount();
     });
 
@@ -2326,12 +2271,11 @@ describe('InputPrompt', () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
 
       stdin.write('\u001B[A');
-      await wait();
-
-      expect(mockPopAllMessages).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockPopAllMessages).toHaveBeenCalled();
+      });
 
       const callback = mockPopAllMessages.mock.calls[0][0];
       act(() => {
@@ -2351,8 +2295,9 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-      expect(stdout.lastFrame()).toMatchSnapshot();
+      await waitFor(() => {
+        expect(stdout.lastFrame()).toMatchSnapshot();
+      });
       unmount();
     });
 
@@ -2361,8 +2306,9 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-      expect(stdout.lastFrame()).toMatchSnapshot();
+      await waitFor(() => {
+        expect(stdout.lastFrame()).toMatchSnapshot();
+      });
       unmount();
     });
 
@@ -2371,8 +2317,9 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-      expect(stdout.lastFrame()).toMatchSnapshot();
+      await waitFor(() => {
+        expect(stdout.lastFrame()).toMatchSnapshot();
+      });
       unmount();
     });
 
@@ -2382,8 +2329,9 @@ describe('InputPrompt', () => {
       const { stdout, unmount } = renderWithProviders(
         <InputPrompt {...props} />,
       );
-      await wait();
-      expect(stdout.lastFrame()).not.toContain(`{chalk.inverse(' ')}`);
+      await waitFor(() => {
+        expect(stdout.lastFrame()).not.toContain(`{chalk.inverse(' ')}`);
+      });
       // This snapshot is good to make sure there was an input prompt but does
       // not show the inverted cursor because snapshots do not show colors.
       expect(stdout.lastFrame()).toMatchSnapshot();
@@ -2395,12 +2343,11 @@ describe('InputPrompt', () => {
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
       shellFocus: false,
     });
-    await wait();
 
     stdin.write('a');
-    await wait();
-
-    expect(mockBuffer.handleInput).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockBuffer.handleInput).toHaveBeenCalled();
+    });
     unmount();
   });
   it('should prevent slash commands from being queued while streaming', async () => {
@@ -2409,15 +2356,14 @@ describe('InputPrompt', () => {
     props.setQueueErrorMessage = vi.fn();
     props.streamingState = StreamingState.Responding;
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
     stdin.write('/help');
     stdin.write('\r');
-    await wait();
-
-    expect(props.onSubmit).not.toHaveBeenCalled();
-    expect(props.setQueueErrorMessage).toHaveBeenCalledWith(
-      'Slash commands cannot be queued',
-    );
+    await waitFor(() => {
+      expect(props.onSubmit).not.toHaveBeenCalled();
+      expect(props.setQueueErrorMessage).toHaveBeenCalledWith(
+        'Slash commands cannot be queued',
+      );
+    });
     unmount();
   });
   it('should prevent shell commands from being queued while streaming', async () => {
@@ -2427,15 +2373,14 @@ describe('InputPrompt', () => {
     props.streamingState = StreamingState.Responding;
     props.shellModeActive = true;
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
     stdin.write('ls');
     stdin.write('\r');
-    await wait();
-
-    expect(props.onSubmit).not.toHaveBeenCalled();
-    expect(props.setQueueErrorMessage).toHaveBeenCalledWith(
-      'Shell commands cannot be queued',
-    );
+    await waitFor(() => {
+      expect(props.onSubmit).not.toHaveBeenCalled();
+      expect(props.setQueueErrorMessage).toHaveBeenCalledWith(
+        'Shell commands cannot be queued',
+      );
+    });
     unmount();
   });
   it('should allow regular messages to be queued while streaming', async () => {
@@ -2444,13 +2389,12 @@ describe('InputPrompt', () => {
     props.setQueueErrorMessage = vi.fn();
     props.streamingState = StreamingState.Responding;
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
     stdin.write('regular message');
     stdin.write('\r');
-    await wait();
-
-    expect(props.onSubmit).toHaveBeenCalledWith('regular message');
-    expect(props.setQueueErrorMessage).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(props.onSubmit).toHaveBeenCalledWith('regular message');
+      expect(props.setQueueErrorMessage).not.toHaveBeenCalled();
+    });
     unmount();
   });
 });

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -2048,8 +2048,9 @@ describe('InputPrompt', () => {
       });
 
       stdin.write('\u001B[C');
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      expect(clean(stdout.lastFrame())).toContain('←');
+      await waitFor(() => {
+        expect(clean(stdout.lastFrame())).toContain('←');
+      });
       expect(stdout.lastFrame()).toMatchSnapshot(
         'command-search-expanded-match',
       );
@@ -2057,10 +2058,10 @@ describe('InputPrompt', () => {
       stdin.write('\u001B[D');
       await waitFor(() => {
         expect(clean(stdout.lastFrame())).toContain('→');
-        expect(stdout.lastFrame()).toMatchSnapshot(
-          'command-search-collapsed-match',
-        );
       });
+      expect(stdout.lastFrame()).toMatchSnapshot(
+        'command-search-collapsed-match',
+      );
       unmount();
     });
 
@@ -2086,17 +2087,19 @@ describe('InputPrompt', () => {
 
       stdin.write('\x12');
       await waitFor(() => {
-        expect(stdout.lastFrame()).toMatchSnapshot(
-          'command-search-collapsed-match',
-        );
+        expect(stdout.lastFrame()).toContain('(r:)');
       });
+      expect(stdout.lastFrame()).toMatchSnapshot(
+        'command-search-collapsed-match',
+      );
 
       stdin.write('\u001B[C');
       await waitFor(() => {
-        expect(stdout.lastFrame()).toMatchSnapshot(
-          'command-search-expanded-match',
-        );
+        expect(stdout.lastFrame()).toContain('git commit');
       });
+      expect(stdout.lastFrame()).toMatchSnapshot(
+        'command-search-expanded-match',
+      );
 
       unmount();
     });
@@ -2296,8 +2299,9 @@ describe('InputPrompt', () => {
         <InputPrompt {...props} />,
       );
       await waitFor(() => {
-        expect(stdout.lastFrame()).toMatchSnapshot();
+        expect(stdout.lastFrame()).toContain('>');
       });
+      expect(stdout.lastFrame()).toMatchSnapshot();
       unmount();
     });
 
@@ -2307,8 +2311,9 @@ describe('InputPrompt', () => {
         <InputPrompt {...props} />,
       );
       await waitFor(() => {
-        expect(stdout.lastFrame()).toMatchSnapshot();
+        expect(stdout.lastFrame()).toContain('>');
       });
+      expect(stdout.lastFrame()).toMatchSnapshot();
       unmount();
     });
 
@@ -2318,8 +2323,9 @@ describe('InputPrompt', () => {
         <InputPrompt {...props} />,
       );
       await waitFor(() => {
-        expect(stdout.lastFrame()).toMatchSnapshot();
+        expect(stdout.lastFrame()).toContain('>');
       });
+      expect(stdout.lastFrame()).toMatchSnapshot();
       unmount();
     });
 


### PR DESCRIPTION
## TLDR

Replaced flaky custom `wait()` helper with standard `waitFor` from `@testing-library/react` in `InputPrompt.test.tsx`.

## Dive Deeper

The custom `wait(ms)` function relies on arbitrary timeouts which can lead to flaky tests on slower CI environments. `waitFor` polls until the expectation passes or times out, which is more robust and standard practice in this codebase.

## Reviewer Test Plan

Run the tests for this component:
`npm run test packages/cli/src/ui/components/InputPrompt.test.tsx`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A