### PR TITLE
Always emit keypress events to stdin.

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -817,20 +817,17 @@ export function KeypressProvider({
       }
     };
 
-    let rl: readline.Interface;
+    let input: NodeJS.ReadableStream;
     if (keypressStream !== null) {
-      rl = readline.createInterface({
-        input: keypressStream,
-        escapeCodeTimeout: 0,
-      });
-      readline.emitKeypressEvents(keypressStream, rl);
-      keypressStream.on('keypress', handleKeypress);
+      // handleRawKeypress sends data to keypressStream
       stdin.on('data', handleRawKeypress);
+      input = keypressStream;
     } else {
-      rl = readline.createInterface({ input: stdin, escapeCodeTimeout: 0 });
-      readline.emitKeypressEvents(stdin, rl);
-      stdin.on('keypress', handleKeypress);
+      input = stdin;
     }
+    const rl = readline.createInterface({ input, escapeCodeTimeout: 0 });
+    readline.emitKeypressEvents(stdin, rl);
+    stdin.on('keypress', handleKeypress);
 
     return () => {
       if (keypressStream !== null) {


### PR DESCRIPTION
## TLDR

Instead of emitting keypress events to keypressStream and then listening to it, emit them to stdin and listen to that consistently in both the passthrough and no-passthrough case.

## Dive Deeper

Originally I intended to convert all the tests to use kitty sequences instead of keyPress events but there were weird timing issues with that which made the tests flakey.

Logically, this change should affect anything, but I wanted to give it it's own PR just to make sure I didn't miss anything.

## Reviewer Test Plan

Try various key combinations and make sure they work.

* Drag and drop a file
* \\+enter
* copy paste a chunk

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

For #7773