### PR TITLE
feat(telemetry): Make surface a top-level event property

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -651,6 +651,7 @@ export async function loadCliConfig(
       settings.experimental?.codebaseInvestigatorSettings,
     retryFetchErrors: settings.general?.retryFetchErrors ?? false,
     ptyInfo: ptyInfo?.name,
+    ghaName: process.env['GHA_NAME'],
   });
 }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -285,6 +285,7 @@ export interface ConfigParameters {
   enableShellOutputEfficiency?: boolean;
   ptyInfo?: string;
   disableYoloMode?: boolean;
+  ghaName?: string;
 }
 
 export class Config {
@@ -382,6 +383,7 @@ export class Config {
   private readonly retryFetchErrors: boolean;
   private readonly enableShellOutputEfficiency: boolean;
   private readonly disableYoloMode: boolean;
+  private readonly ghaName: string | undefined;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -499,6 +501,7 @@ export class Config {
     };
     this.retryFetchErrors = params.retryFetchErrors ?? false;
     this.disableYoloMode = params.disableYoloMode ?? false;
+    this.ghaName = params.ghaName;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -874,6 +877,10 @@ export class Config {
 
   getUsageStatisticsEnabled(): boolean {
     return this.usageStatisticsEnabled;
+  }
+
+  getGhaName(): string | undefined {
+    return this.ghaName;
   }
 
   getExperimentalZedIntegration(): boolean {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -456,6 +456,12 @@ export class ClearcutLogger {
         value: event.extension_ids.toString(),
       },
     ];
+    if (event.gha_name) {
+      data.push({
+        gemini_cli_key: EventMetadataKey.GEMINI_CLI_GHA_NAME,
+        value: event.gha_name,
+      });
+    }
     this.sessionData = data;
 
     // Flush start event immediately

--- a/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
+++ b/packages/core/src/telemetry/clearcut-logger/event-metadata-key.ts
@@ -7,7 +7,7 @@
 // Defines valid event metadata keys for Clearcut logging.
 export enum EventMetadataKey {
   // Deleted enums: 24
-  // Next ID: 122
+  // Next ID: 123
 
   GEMINI_CLI_KEY_UNKNOWN = 0,
 
@@ -190,6 +190,9 @@ export enum EventMetadataKey {
 
   // Logs active user settings
   GEMINI_CLI_USER_SETTINGS = 84,
+
+  // Logs the name of the GitHub Action workflow that triggered the session.
+  GEMINI_CLI_GHA_NAME = 122,
 
   // ==========================================================================
   // Loop Detected Event Keys

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -56,6 +56,7 @@ export class StartSessionEvent implements BaseTelemetryEvent {
   output_format: OutputFormat;
   extensions_count: number;
   extension_ids: string;
+  gha_name?: string;
 
   constructor(config: Config, toolRegistry?: ToolRegistry) {
     const generatorConfig = config.getContentGeneratorConfig();
@@ -90,6 +91,7 @@ export class StartSessionEvent implements BaseTelemetryEvent {
     const extensions = config.getExtensions();
     this.extensions_count = extensions.length;
     this.extension_ids = extensions.map((e) => e.id).join(',');
+    this.gha_name = config.getGhaName();
     if (toolRegistry) {
       const mcpTools = toolRegistry
         .getAllTools()
@@ -123,6 +125,7 @@ export class StartSessionEvent implements BaseTelemetryEvent {
       output_format: this.output_format,
       extensions_count: this.extensions_count,
       extension_ids: this.extension_ids,
+      gha_name: this.gha_name,
     };
   }
 


### PR DESCRIPTION
Promotes the `surface` identifier to be a dedicated, top-level property on the Clearcut `LogEvent` object.

While this information was previously sent within the generic `event_metadata`, making it a first-class property improves data structure, ensures its presence via the type system, and simplifies backend querying and analysis.


