### PR TITLE
feat(ux): Surface internal errors via unified event system

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -15,6 +15,7 @@ import {
   GEMINI_DIR,
   getErrorMessage,
   Storage,
+  coreEvents,
 } from '@google/gemini-cli-core';
 import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
@@ -799,6 +800,10 @@ export function saveSettings(settingsFile: SettingsFile): void {
       settingsToSave as Record<string, unknown>,
     );
   } catch (error) {
-    console.error('Error saving user settings file:', error);
+    coreEvents.emitFeedback(
+      'error',
+      'There was an error saving your latest settings changes.',
+      error,
+    );
   }
 }

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -11,6 +11,7 @@ import type {
   SessionMetrics,
   AnyDeclarativeTool,
   AnyToolInvocation,
+  UserFeedbackPayload,
 } from '@google/gemini-cli-core';
 import {
   executeToolCall,
@@ -20,14 +21,32 @@ import {
   OutputFormat,
   uiTelemetryService,
   FatalInputError,
+  CoreEvent,
 } from '@google/gemini-cli-core';
 import type { Part } from '@google/genai';
 import { runNonInteractive } from './nonInteractiveCli.js';
-import { vi, type Mock, type MockInstance } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type Mock,
+  type MockInstance,
+} from 'vitest';
 import type { LoadedSettings } from './config/settings.js';
 
 // Mock core modules
 vi.mock('./ui/hooks/atCommandProcessor.js');
+
+const mockCoreEvents = vi.hoisted(() => ({
+  on: vi.fn(),
+  off: vi.fn(),
+  drainFeedbackBacklog: vi.fn(),
+  emit: vi.fn(),
+}));
+
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const original =
     await importOriginal<typeof import('@google/gemini-cli-core')>();
@@ -48,6 +67,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     uiTelemetryService: {
       getMetrics: vi.fn(),
     },
+    coreEvents: mockCoreEvents,
   };
 });
 
@@ -1050,5 +1070,132 @@ describe('runNonInteractive', () => {
       expect.any(AbortSignal),
     );
     expect(processStdoutSpy).toHaveBeenCalledWith('file.txt');
+  });
+
+  describe('CoreEvents Integration', () => {
+    it('subscribes to UserFeedback and drains backlog on start', async () => {
+      const events: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 0 } },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(events),
+      );
+
+      await runNonInteractive(
+        mockConfig,
+        mockSettings,
+        'test',
+        'prompt-id-events',
+      );
+
+      expect(mockCoreEvents.on).toHaveBeenCalledWith(
+        CoreEvent.UserFeedback,
+        expect.any(Function),
+      );
+      expect(mockCoreEvents.drainFeedbackBacklog).toHaveBeenCalledTimes(1);
+    });
+
+    it('unsubscribes from UserFeedback on finish', async () => {
+      const events: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 0 } },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(events),
+      );
+
+      await runNonInteractive(
+        mockConfig,
+        mockSettings,
+        'test',
+        'prompt-id-events',
+      );
+
+      expect(mockCoreEvents.off).toHaveBeenCalledWith(
+        CoreEvent.UserFeedback,
+        expect.any(Function),
+      );
+    });
+
+    it('logs to console.error when UserFeedback event is received', async () => {
+      const events: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 0 } },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(events),
+      );
+
+      await runNonInteractive(
+        mockConfig,
+        mockSettings,
+        'test',
+        'prompt-id-events',
+      );
+
+      // Get the registered handler
+      const handler = mockCoreEvents.on.mock.calls.find(
+        (call: unknown[]) => call[0] === CoreEvent.UserFeedback,
+      )?.[1];
+      expect(handler).toBeDefined();
+
+      // Simulate an event
+      const payload: UserFeedbackPayload = {
+        severity: 'error',
+        message: 'Test error message',
+      };
+      handler(payload);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[ERROR] Test error message',
+      );
+    });
+
+    it('logs optional error object to console.error in debug mode', async () => {
+      vi.mocked(mockConfig.getDebugMode).mockReturnValue(true);
+      const events: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 0 } },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(events),
+      );
+
+      await runNonInteractive(
+        mockConfig,
+        mockSettings,
+        'test',
+        'prompt-id-events',
+      );
+
+      // Get the registered handler
+      const handler = mockCoreEvents.on.mock.calls.find(
+        (call: unknown[]) => call[0] === CoreEvent.UserFeedback,
+      )?.[1];
+      expect(handler).toBeDefined();
+
+      // Simulate an event with error object
+      const errorObj = new Error('Original error');
+      const payload: UserFeedbackPayload = {
+        severity: 'warning',
+        message: 'Test warning message',
+        error: errorObj,
+      };
+      handler(payload);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[WARNING] Test warning message',
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(errorObj);
+    });
   });
 });

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -8,6 +8,7 @@ import type {
   Config,
   ToolCallRequestInfo,
   CompletedToolCall,
+  UserFeedbackPayload,
 } from '@google/gemini-cli-core';
 import { isSlashCommand } from './ui/utils/commandUtils.js';
 import type { LoadedSettings } from './config/settings.js';
@@ -24,6 +25,8 @@ import {
   JsonStreamEventType,
   uiTelemetryService,
   debugLogger,
+  coreEvents,
+  CoreEvent,
 } from '@google/gemini-cli-core';
 
 import type { Content, Part } from '@google/genai';
@@ -50,6 +53,14 @@ export async function runNonInteractive(
       debugMode: config.getDebugMode(),
     });
 
+    const handleUserFeedback = (payload: UserFeedbackPayload) => {
+      const prefix = payload.severity.toUpperCase();
+      console.error(`[${prefix}] ${payload.message}`);
+      if (payload.error && config.getDebugMode()) {
+        console.error(payload.error);
+      }
+    };
+
     const startTime = Date.now();
     const streamFormatter =
       config.getOutputFormat() === OutputFormat.STREAM_JSON
@@ -58,6 +69,9 @@ export async function runNonInteractive(
 
     try {
       consolePatcher.patch();
+      coreEvents.on(CoreEvent.UserFeedback, handleUserFeedback);
+      coreEvents.drainFeedbackBacklog();
+
       // Handle EPIPE errors when the output is piped to a command that closes early.
       process.stdout.on('error', (err: NodeJS.ErrnoException) => {
         if (err.code === 'EPIPE') {
@@ -287,6 +301,7 @@ export async function runNonInteractive(
       handleError(error, config);
     } finally {
       consolePatcher.cleanup();
+      coreEvents.off(CoreEvent.UserFeedback, handleUserFeedback);
       if (isTelemetrySdkInitialized()) {
         await shutdownTelemetry(config);
       }

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -55,9 +55,13 @@ export async function runNonInteractive(
 
     const handleUserFeedback = (payload: UserFeedbackPayload) => {
       const prefix = payload.severity.toUpperCase();
-      console.error(`[${prefix}] ${payload.message}`);
+      process.stderr.write(`[${prefix}] ${payload.message}\n`);
       if (payload.error && config.getDebugMode()) {
-        console.error(payload.error);
+        const errorToLog =
+          payload.error instanceof Error
+            ? payload.error.stack || payload.error.message
+            : String(payload.error);
+        process.stderr.write(`${errorToLog}\n`);
       }
     };
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1080,9 +1080,12 @@ Logging in with Google... Please restart Gemini CLI to continue.
           type = MessageType.WARNING;
           break;
         case 'info':
-        default:
           type = MessageType.INFO;
           break;
+        default:
+          throw new Error(
+            `Unexpected severity for user feedback: ${payload.severity}`,
+          );
       }
 
       historyManager.addItem(

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -34,6 +34,7 @@ import {
   type IdeInfo,
   type IdeContext,
   type UserTierId,
+  type UserFeedbackPayload,
   DEFAULT_GEMINI_FLASH_MODEL,
   IdeClient,
   ideContextStore,
@@ -44,6 +45,8 @@ import {
   recordExitFail,
   ShellExecutionService,
   debugLogger,
+  coreEvents,
+  CoreEvent,
 } from '@google/gemini-cli-core';
 import { validateAuthMethod } from '../config/auth.js';
 import { loadHierarchicalGeminiMemory } from '../config/config.js';
@@ -1065,6 +1068,50 @@ Logging in with Google... Please restart Gemini CLI to continue.
     settings.merged.ui?.hideWindowTitle,
     stdout,
   ]);
+
+  useEffect(() => {
+    const handleUserFeedback = (payload: UserFeedbackPayload) => {
+      let type: MessageType;
+      switch (payload.severity) {
+        case 'error':
+          type = MessageType.ERROR;
+          break;
+        case 'warning':
+          type = MessageType.WARNING;
+          break;
+        case 'info':
+        default:
+          type = MessageType.INFO;
+          break;
+      }
+
+      historyManager.addItem(
+        {
+          type,
+          text: payload.message,
+        },
+        Date.now(),
+      );
+
+      // If there is an attached error object, log it to the debug drawer.
+      if (payload.error) {
+        debugLogger.warn(
+          `[Feedback Details for "${payload.message}"]`,
+          payload.error,
+        );
+      }
+    };
+
+    coreEvents.on(CoreEvent.UserFeedback, handleUserFeedback);
+
+    // Flush any messages that happened during startup before this component
+    // mounted.
+    coreEvents.drainFeedbackBacklog();
+
+    return () => {
+      coreEvents.off(CoreEvent.UserFeedback, handleUserFeedback);
+    };
+  }, [historyManager]);
 
   const filteredConsoleMessages = useMemo(() => {
     if (config.getDebugMode()) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,7 @@ export * from './utils/partUtils.js';
 export * from './utils/promptIdContext.js';
 export * from './utils/thoughtUtils.js';
 export * from './utils/debugLogger.js';
+export * from './utils/events.js';
 
 // Export services
 export * from './services/fileDiscoveryService.js';

--- a/packages/core/src/utils/events.test.ts
+++ b/packages/core/src/utils/events.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CoreEventEmitter, CoreEvent } from './events.js';
+
+describe('CoreEventEmitter', () => {
+  let events: CoreEventEmitter;
+
+  beforeEach(() => {
+    events = new CoreEventEmitter();
+  });
+
+  it('should emit feedback immediately when a listener is present', () => {
+    const listener = vi.fn();
+    events.on(CoreEvent.UserFeedback, listener);
+
+    const payload = {
+      severity: 'info' as const,
+      message: 'Test message',
+    };
+
+    events.emitFeedback(payload.severity, payload.message);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining(payload));
+  });
+
+  it('should buffer feedback when no listener is present', () => {
+    const listener = vi.fn();
+    const payload = {
+      severity: 'warning' as const,
+      message: 'Buffered message',
+    };
+
+    // Emit while no listeners attached
+    events.emitFeedback(payload.severity, payload.message);
+    expect(listener).not.toHaveBeenCalled();
+
+    // Attach listener and drain
+    events.on(CoreEvent.UserFeedback, listener);
+    events.drainFeedbackBacklog();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining(payload));
+  });
+
+  it('should respect the backlog size limit and maintain FIFO order', () => {
+    const listener = vi.fn();
+    const MAX_BACKLOG_SIZE = 100;
+
+    for (let i = 0; i < MAX_BACKLOG_SIZE + 10; i++) {
+      events.emitFeedback('info', `Message ${i}`);
+    }
+
+    events.on(CoreEvent.UserFeedback, listener);
+    events.drainFeedbackBacklog();
+
+    expect(listener).toHaveBeenCalledTimes(MAX_BACKLOG_SIZE);
+    // Verify strictly that the FIRST call was Message 10 (0-9 dropped)
+    expect(listener.mock.calls[0][0]).toMatchObject({ message: 'Message 10' });
+    // Verify strictly that the LAST call was Message 109
+    expect(listener.mock.lastCall?.[0]).toMatchObject({
+      message: `Message ${MAX_BACKLOG_SIZE + 9}`,
+    });
+  });
+
+  it('should clear the backlog after draining', () => {
+    const listener = vi.fn();
+    events.emitFeedback('error', 'Test error');
+
+    events.on(CoreEvent.UserFeedback, listener);
+    events.drainFeedbackBacklog();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    listener.mockClear();
+    events.drainFeedbackBacklog();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('should include optional error object in payload', () => {
+    const listener = vi.fn();
+    events.on(CoreEvent.UserFeedback, listener);
+
+    const error = new Error('Original error');
+    events.emitFeedback('error', 'Something went wrong', error);
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'error',
+        message: 'Something went wrong',
+        error,
+      }),
+    );
+  });
+
+  it('should handle multiple listeners correctly', () => {
+    const listenerA = vi.fn();
+    const listenerB = vi.fn();
+
+    events.on(CoreEvent.UserFeedback, listenerA);
+    events.on(CoreEvent.UserFeedback, listenerB);
+
+    events.emitFeedback('info', 'Broadcast message');
+
+    expect(listenerA).toHaveBeenCalledTimes(1);
+    expect(listenerB).toHaveBeenCalledTimes(1);
+  });
+
+  it('should stop receiving events after off() is called', () => {
+    const listener = vi.fn();
+    events.on(CoreEvent.UserFeedback, listener);
+
+    events.emitFeedback('info', 'First message');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    events.off(CoreEvent.UserFeedback, listener);
+    events.emitFeedback('info', 'Second message');
+    expect(listener).toHaveBeenCalledTimes(1); // Still 1
+  });
+});

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -39,11 +39,10 @@ export enum CoreEvent {
 
 export class CoreEventEmitter extends EventEmitter {
   private _feedbackBacklog: UserFeedbackPayload[] = [];
-  private static readonly MAX_BACKLOG_SIZE = 100;
+  private static readonly MAX_BACKLOG_SIZE = 10000;
 
   constructor() {
     super();
-    this.setMaxListeners(20);
   }
 
   /**
@@ -72,14 +71,13 @@ export class CoreEventEmitter extends EventEmitter {
    * subscribes.
    */
   drainFeedbackBacklog(): void {
-    let item = this._feedbackBacklog.shift();
-    while (item) {
-      this.emit(CoreEvent.UserFeedback, item);
-      item = this._feedbackBacklog.shift();
+    const backlog = [...this._feedbackBacklog];
+    this._feedbackBacklog.length = 0; // Clear in-place
+    for (const payload of backlog) {
+      this.emit(CoreEvent.UserFeedback, payload);
     }
   }
 
-  // --- Minimal Type Overrides ---
   override on(
     event: CoreEvent.UserFeedback,
     listener: (payload: UserFeedbackPayload) => void,

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EventEmitter } from 'node:events';
+
+/**
+ * Defines the severity level for user-facing feedback.
+ * This maps loosely to UI `MessageType`
+ */
+export type FeedbackSeverity = 'info' | 'warning' | 'error';
+
+/**
+ * Payload for the 'user-feedback' event.
+ */
+export interface UserFeedbackPayload {
+  /**
+   * The severity level determines how the message is rendered in the UI
+   * (e.g. colored text, specific icon).
+   */
+  severity: FeedbackSeverity;
+  /**
+   * The main message to display to the user in the chat history or stdout.
+   */
+  message: string;
+  /**
+   * The original error object, if applicable.
+   * Listeners can use this to extract stack traces for debug logging
+   * or verbose output, while keeping the 'message' field clean for end users.
+   */
+  error?: unknown;
+}
+
+export enum CoreEvent {
+  UserFeedback = 'user-feedback',
+}
+
+export class CoreEventEmitter extends EventEmitter {
+  private _feedbackBacklog: UserFeedbackPayload[] = [];
+  private static readonly MAX_BACKLOG_SIZE = 100;
+
+  constructor() {
+    super();
+    this.setMaxListeners(20);
+  }
+
+  /**
+   * Sends actionable feedback to the user.
+   * Buffers automatically if the UI hasn't subscribed yet.
+   */
+  emitFeedback(
+    severity: FeedbackSeverity,
+    message: string,
+    error?: unknown,
+  ): void {
+    const payload: UserFeedbackPayload = { severity, message, error };
+
+    if (this.listenerCount(CoreEvent.UserFeedback) === 0) {
+      if (this._feedbackBacklog.length >= CoreEventEmitter.MAX_BACKLOG_SIZE) {
+        this._feedbackBacklog.shift();
+      }
+      this._feedbackBacklog.push(payload);
+    } else {
+      this.emit(CoreEvent.UserFeedback, payload);
+    }
+  }
+
+  /**
+   * Flushes buffered messages. Call this immediately after primary UI listener
+   * subscribes.
+   */
+  drainFeedbackBacklog(): void {
+    let item = this._feedbackBacklog.shift();
+    while (item) {
+      this.emit(CoreEvent.UserFeedback, item);
+      item = this._feedbackBacklog.shift();
+    }
+  }
+
+  // --- Minimal Type Overrides ---
+  override on(
+    event: CoreEvent.UserFeedback,
+    listener: (payload: UserFeedbackPayload) => void,
+  ): this;
+  override on(
+    event: string | symbol,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    listener: (...args: any[]) => void,
+  ): this {
+    return super.on(event, listener);
+  }
+
+  override off(
+    event: CoreEvent.UserFeedback,
+    listener: (payload: UserFeedbackPayload) => void,
+  ): this;
+  override off(
+    event: string | symbol,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    listener: (...args: any[]) => void,
+  ): this {
+    return super.off(event, listener);
+  }
+
+  override emit(
+    event: CoreEvent.UserFeedback,
+    payload: UserFeedbackPayload,
+  ): boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  override emit(event: string | symbol, ...args: any[]): boolean {
+    return super.emit(event, ...args);
+  }
+}
+
+export const coreEvents = new CoreEventEmitter();


### PR DESCRIPTION
## TLDR

This PR introduces a unified, decoupled mechanism for low-level services to report non-fatal errors, warnings, and info messages to the user, regardless of the active UI mode (interactive TUI or non-interactive CLI).

It replaces direct `console.error` calls—which can be swallowed, missed, or corrupt the TUI—with a new `coreEvents` emitter that safely routes these messages to the appropriate presentation layer.

## Dive Deeper

Previously, deep services like `FileCommandLoader` or `Settings` had no clean way to inform the user of non-fatal issues (like a malformed TOML file that is skipped, or a failure to save settings). They relied on `console.error`, which is problematic:
- In **Interactive Mode**, `console.error` might be patched, hidden, or corrupt the Ink rendering output.
- In **Non-Interactive Mode**, it might be missed if standard error isn't monitored closely, or it might pollute structured output if not handled correctly.

### Key Changes
1.  **`CoreEventEmitter`**: Added to `@google/gemini-cli-core`. It's a typed `EventEmitter` specifically for `UserFeedback` events. Crucially, it includes a **backlog** to buffer messages emitted before the UI layer has fully initialized and subscribed.
2.  **Interactive UI Integration**: `AppContainer` now subscribes to these events and renders them directly into the chat history as `INFO`, `WARNING`, or `ERROR` messages. This ensures users see startup warnings immediately upon entering the app.
3.  **Non-Interactive CLI Integration**: `runNonInteractive` subscribes and routes these events safely to `stderr`, ensuring they don't interfere with piped `stdout` (especially important for JSON output modes).
4.  **Settings Adoption**: Migrated `saveSettings` error handling to use this new system as a first consumer.

This infrastructure lays the groundwork for migrating other silent or messy `console.error` calls (like those in `FileCommandLoader`) to this new system in subsequent PRs.

## Reviewer Test Plan

### Manual Verification

To manually verify the end-to-end flow before more services adopt it, you can temporarily inject a test event:

1.  **Interactive Mode**:
    Add this to `packages/cli/src/gemini.tsx` before `startInteractiveUI` is called:
    ```typescript
    coreEvents.emitFeedback('warning', 'This is a test warning from the core event system!');
    ```
    Run `npm start`. You should see the warning appear in the chat history immediately after startup.

2.  **Non-Interactive Mode**:
    Add the same line before `runNonInteractive` in `packages/cli/src/gemini.tsx`.
    Run `npm start -- "hello"`. You should see the warning printed to stderr.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  |✅| ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt |✅| -   | -   |

## Linked issues / bugs

Related to #10761 
