### PR TITLE
fix(infra) - Fix merge queue skipper issues for chain e2e

### DIFF
--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -120,7 +120,7 @@ jobs:
       - 'parse_run_context'
     runs-on: 'gemini-cli-ubuntu-16-core'
     if: |
-      always() && (needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
+      always() && (needs.merge_queue_skipper.result.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
     strategy:
       fail-fast: false
       matrix:
@@ -172,7 +172,7 @@ jobs:
       - 'parse_run_context'
     runs-on: 'macos-latest'
     if: |
-      always() && (needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
+      always() && (needs.merge_queue_skipper.result.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
@@ -210,7 +210,7 @@ jobs:
       - 'merge_queue_skipper'
       - 'parse_run_context'
     if: |
-      always() && (needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
+      always() && (needs.merge_queue_skipper.result.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
     runs-on: 'gemini-cli-windows-16-core'
     continue-on-error: true
 
@@ -268,7 +268,7 @@ jobs:
   e2e:
     name: 'E2E'
     if: |
-      always() && (needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
+      always() && (needs.merge_queue_skipper.result.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
     needs:
       - 'e2e_linux'
       - 'e2e_mac'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   merge_queue_skipper:
     name: 'Merge Queue Skipper'
+    permissions: 'read-all'
     runs-on: 'gemini-cli-ubuntu-16-core'
     outputs:
       skip: '${{ steps.merge-queue-e2e-skipper.outputs.skip-check }}'
@@ -37,6 +38,7 @@ jobs:
         uses: 'cariad-tech/merge-queue-ci-skipper@1032489e59437862c90a08a2c92809c903883772' # ratchet:cariad-tech/merge-queue-ci-skipper@main
         with:
           secret: '${{ secrets.GITHUB_TOKEN }}'
+    continue-on-error: true
 
   download_repo_name:
     runs-on: 'gemini-cli-ubuntu-16-core'
@@ -113,8 +115,12 @@ jobs:
 
   e2e_linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'
-    needs: 'parse_run_context'
+    needs: 
+      - 'merge_queue_skipper'
+      - parse_run_context'
     runs-on: 'gemini-cli-ubuntu-16-core'
+    if: |
+      needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false'
     strategy:
       fail-fast: false
       matrix:
@@ -161,8 +167,12 @@ jobs:
 
   e2e_mac:
     name: 'E2E Test (macOS)'
-    needs: 'parse_run_context'
+    needs:
+      - 'merge_queue_skipper'
+      - parse_run_context'
     runs-on: 'macos-latest'
+    if: |
+      needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
@@ -200,7 +210,7 @@ jobs:
       - 'merge_queue_skipper'
       - 'parse_run_context'
     if: |
-      needs.merge_queue_skipper.outputs.skip == 'false'
+      needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false'
     runs-on: 'gemini-cli-windows-16-core'
     continue-on-error: true
 
@@ -258,7 +268,7 @@ jobs:
   e2e:
     name: 'E2E'
     if: |
-      always() && needs.merge_queue_skipper.outputs.skip == 'false'
+      always() && (needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
     needs:
       - 'e2e_linux'
       - 'e2e_mac'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -120,7 +120,7 @@ jobs:
       - 'parse_run_context'
     runs-on: 'gemini-cli-ubuntu-16-core'
     if: |
-      needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false'
+      always() && (needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
     strategy:
       fail-fast: false
       matrix:
@@ -172,7 +172,7 @@ jobs:
       - 'parse_run_context'
     runs-on: 'macos-latest'
     if: |
-      needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false'
+      always() && (needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
@@ -210,7 +210,7 @@ jobs:
       - 'merge_queue_skipper'
       - 'parse_run_context'
     if: |
-      needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false'
+      always() && (needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
     runs-on: 'gemini-cli-windows-16-core'
     continue-on-error: true
 

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -117,7 +117,7 @@ jobs:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'
     needs: 
       - 'merge_queue_skipper'
-      - parse_run_context'
+      - 'parse_run_context'
     runs-on: 'gemini-cli-ubuntu-16-core'
     if: |
       needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false'
@@ -169,7 +169,7 @@ jobs:
     name: 'E2E Test (macOS)'
     needs:
       - 'merge_queue_skipper'
-      - parse_run_context'
+      - 'parse_run_context'
     runs-on: 'macos-latest'
     if: |
       needs.merge-queue-e2e-skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -120,7 +120,7 @@ jobs:
       - 'parse_run_context'
     runs-on: 'gemini-cli-ubuntu-16-core'
     if: |
-      always() && (needs.merge_queue_skipper.result.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
+      always() && (needs.merge_queue_skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
     strategy:
       fail-fast: false
       matrix:
@@ -172,7 +172,7 @@ jobs:
       - 'parse_run_context'
     runs-on: 'macos-latest'
     if: |
-      always() && (needs.merge_queue_skipper.result.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
+      always() && (needs.merge_queue_skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
@@ -210,7 +210,7 @@ jobs:
       - 'merge_queue_skipper'
       - 'parse_run_context'
     if: |
-      always() && (needs.merge_queue_skipper.result.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
+      always() && (needs.merge_queue_skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
     runs-on: 'gemini-cli-windows-16-core'
     continue-on-error: true
 
@@ -268,7 +268,7 @@ jobs:
   e2e:
     name: 'E2E'
     if: |
-      always() && (needs.merge_queue_skipper.result.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
+      always() && (needs.merge_queue_skipper.result !='success' || needs.merge_queue_skipper.outputs.skip == 'false')
     needs:
       - 'e2e_linux'
       - 'e2e_mac'

--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -115,7 +115,7 @@ jobs:
 
   e2e_linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'
-    needs: 
+    needs:
       - 'merge_queue_skipper'
       - 'parse_run_context'
     runs-on: 'gemini-cli-ubuntu-16-core'


### PR DESCRIPTION
## TLDR

Previous failing jobs can cause subsequent jobs to be skipped so we make merge queue skipper continue on failure and add always to e2e jobs

## Dive Deeper

Merge queue failure example: https://github.com/google-gemini/gemini-cli/actions/runs/18756375031
Push skips example: https://github.com/google-gemini/gemini-cli/actions/runs/18756417417

## Reviewer Test Plan

```
gh workflow run test_chained_e2e.yml --ref ss/chainCheck -f repo_name="google-gemini/gemini-cli" -f head_sha=b06dbc69c06a90faa0982de8ab777efe45823a25
```

Sample run: https://github.com/google-gemini/gemini-cli/actions/runs/18757516420
## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Makes progress on #10008 
