### PR TITLE
fix: align shell allowlist handling (#11510)

### DIFF
--- a/integration-tests/run_shell_command.test.ts
+++ b/integration-tests/run_shell_command.test.ts
@@ -449,6 +449,7 @@ describe('run_shell_command', () => {
       .readToolLogs()
       .filter((log) => log.toolRequest.name === 'run_shell_command');
 
+    // Success is false because tool is in the scheduled state.
     for (const log of toolLogs) {
       expect(log.toolRequest.success).toBe(false);
       expect(log.toolRequest.args).toContain('&&');

--- a/integration-tests/run_shell_command.test.ts
+++ b/integration-tests/run_shell_command.test.ts
@@ -61,6 +61,28 @@ function getDisallowedFileReadCommand(testFile: string): {
   }
 }
 
+function getChainedEchoCommand(): { allowPattern: string; command: string } {
+  const secondCommand = getAllowedListCommand();
+  switch (shell) {
+    case 'powershell':
+      return {
+        allowPattern: 'Write-Output',
+        command: `Write-Output "foo" && ${secondCommand}`,
+      };
+    case 'cmd':
+      return {
+        allowPattern: 'echo',
+        command: `echo "foo" && ${secondCommand}`,
+      };
+    case 'bash':
+    default:
+      return {
+        allowPattern: 'echo',
+        command: `echo "foo" && ${secondCommand}`,
+      };
+  }
+}
+
 describe('run_shell_command', () => {
   it('should be able to run a shell command', async () => {
     const rig = new TestRig();
@@ -403,6 +425,30 @@ describe('run_shell_command', () => {
       'Expected failing run_shell_command invocation',
     ).toBeTruthy();
     expect(failureLog!.toolRequest.success).toBe(false);
+  });
+
+  it('should reject chained commands when only the first segment is allowlisted in non-interactive mode', async () => {
+    const rig = new TestRig();
+    await rig.setup(
+      'should reject chained commands when only the first segment is allowlisted',
+    );
+
+    const chained = getChainedEchoCommand();
+    const shellInjection = `!{${chained.command}}`;
+
+    await rig.run(
+      {
+        stdin: `${shellInjection}\n`,
+        yolo: false,
+      },
+      `--allowed-tools=ShellTool(${chained.allowPattern})`,
+    );
+
+    // CLI should refuse to execute the chained command without scheduling run_shell_command.
+    const toolLogs = rig
+      .readToolLogs()
+      .filter((log) => log.toolRequest.name === 'run_shell_command');
+    expect(toolLogs.length).toBe(0);
   });
 
   it('should allow all with "ShellTool" and other specific tools', async () => {

--- a/integration-tests/run_shell_command.test.ts
+++ b/integration-tests/run_shell_command.test.ts
@@ -448,7 +448,11 @@ describe('run_shell_command', () => {
     const toolLogs = rig
       .readToolLogs()
       .filter((log) => log.toolRequest.name === 'run_shell_command');
-    expect(toolLogs.length).toBe(0);
+
+    for (const log of toolLogs) {
+      expect(log.toolRequest.success).toBe(false);
+      expect(log.toolRequest.args).toContain('&&');
+    }
   });
 
   it('should allow all with "ShellTool" and other specific tools', async () => {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -480,6 +480,18 @@ describe('ShellTool', () => {
           invocation.shouldConfirmExecute(new AbortController().signal),
         ).rejects.toThrow('wc');
       });
+
+      it('should require all segments of a chained command to be allowlisted', async () => {
+        (mockConfig.getAllowedTools as Mock).mockReturnValue([
+          'ShellTool(echo)',
+        ]);
+        const invocation = shellTool.build({ command: 'echo "foo" && ls -l' });
+        await expect(
+          invocation.shouldConfirmExecute(new AbortController().signal),
+        ).rejects.toThrow(
+          'Command "echo "foo" && ls -l" is not in the list of allowed tools for non-interactive mode.',
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- ensure non-interactive shell confirmations reuse the segmented allowlist parser
- add targeted unit coverage for chained shell commands outside interactive mode
- expand integration tests to verify chained shell prompt injection is rejected when only the first segment is allowlisted

## Testing
- npx vitest run packages/core/src/tools/shell.test.ts
- GEMINI_API_KEY=<redacted> npx vitest run --root ./integration-tests run_shell_command.test.ts

Fixes https://github.com/google-gemini/gemini-cli/issues/11510 and https://github.com/google-gemini/gemini-cli/issues/11766