### PR TITLE
fix(cli): re-throw errors in non-interactive mode

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -213,6 +213,8 @@ export async function runNonInteractive(
                 message: 'Maximum session turns exceeded',
               });
             }
+          } else if (event.type === GeminiEventType.Error) {
+            throw event.value.error;
           }
         }
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -71,6 +71,7 @@ export async function runNonInteractive(
         ? new StreamJsonFormatter()
         : null;
 
+    let errorToHandle: unknown | undefined;
     try {
       consolePatcher.patch();
       coreEvents.on(CoreEvent.UserFeedback, handleUserFeedback);
@@ -304,13 +305,17 @@ export async function runNonInteractive(
         }
       }
     } catch (error) {
-      handleError(error, config);
+      errorToHandle = error;
     } finally {
       consolePatcher.cleanup();
       coreEvents.off(CoreEvent.UserFeedback, handleUserFeedback);
       if (isTelemetrySdkInitialized()) {
         await shutdownTelemetry(config);
       }
+    }
+
+    if (errorToHandle) {
+      handleError(errorToHandle, config);
     }
   });
 }


### PR DESCRIPTION
## TLDR

Fixes an issue where errors were swallowed in non-interactive mode by re-throwing them when `GeminiEventType.Error` is encountered. Additionally ensures that critical cleanup (like telemetry shutdown) occurs before the process exits due to these errors.

## Dive Deeper

Two main changes:
1.  The non-interactive event loop was missing a handler for `GeminiEventType.Error`. This could cause the CLI to hang or exit silently instead of failing loudly.
2.  Refactored `runNonInteractive` to capture errors and handle them *after* the `finally` block. Previously, calling `handleError` directly inside the `catch` block could trigger `process.exit()`, bypassing the `finally` block and skipping telemetry shutdown.

## Reviewer Test Plan

Run a non-interactive command that is expected to fail (e.g., trigger a network error).
1.  Verify the CLI exits with a non-zero exit code and prints the error.
2.  (Optional but recommended) Verify telemetry is correctly sent even when a crash occurs.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
