### PR TITLE
fix(core): Prepend user message to loop detection history if it starts with a function call

### DIFF
--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Content } from '@google/genai';
 import type { Config } from '../config/config.js';
 import type { GeminiClient } from '../core/client.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
@@ -753,5 +754,34 @@ describe('LoopDetectionService LLM Checks', () => {
     const result = await service.turnStarted(abortController.signal);
     expect(result).toBe(false);
     expect(mockBaseLlmClient.generateJson).not.toHaveBeenCalled();
+  });
+  it('should prepend user message if history starts with a function call', async () => {
+    const functionCallHistory: Content[] = [
+      {
+        role: 'model',
+        parts: [{ functionCall: { name: 'someTool', args: {} } }],
+      },
+      {
+        role: 'model',
+        parts: [{ text: 'Some follow up text' }],
+      },
+    ];
+    vi.mocked(mockGeminiClient.getHistory).mockReturnValue(functionCallHistory);
+
+    mockBaseLlmClient.generateJson = vi
+      .fn()
+      .mockResolvedValue({ confidence: 0.1 });
+
+    await advanceTurns(30);
+
+    expect(mockBaseLlmClient.generateJson).toHaveBeenCalledTimes(1);
+    const calledArg = vi.mocked(mockBaseLlmClient.generateJson).mock
+      .calls[0][0];
+    expect(calledArg.contents[0]).toEqual({
+      role: 'user',
+      parts: [{ text: 'Recent conversation history:' }],
+    });
+    // Verify the original history follows
+    expect(calledArg.contents[1]).toEqual(functionCallHistory[0]);
   });
 });

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -755,6 +755,7 @@ describe('LoopDetectionService LLM Checks', () => {
     expect(result).toBe(false);
     expect(mockBaseLlmClient.generateJson).not.toHaveBeenCalled();
   });
+
   it('should prepend user message if history starts with a function call', async () => {
     const functionCallHistory: Content[] = [
       {

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -404,6 +404,12 @@ export class LoopDetectionService {
       ...trimmedHistory,
       { role: 'user', parts: [{ text: taskPrompt }] },
     ];
+    if (contents.length > 0 && isFunctionCall(contents[0])) {
+      contents.unshift({
+        role: 'user',
+        parts: [{ text: 'Recent conversation history:' }],
+      });
+    }
     const schema: Record<string, unknown> = {
       type: 'object',
       properties: {


### PR DESCRIPTION
## TLDR

Prepends a user message to the conversation history sent to the LLM for loop detection if the history starts with a function call. This ensures the conversation history always starts with a user message, preventing potential errors when the history is truncated.

## Dive Deeper

The `LoopDetectionService` truncates history to a fixed number of turns. If this truncation happens to start with a `functionCall` (model role), it can violate the expected turn structure. By prepending a generic user message ("Recent conversation history:"), we ensure a valid turn structure for the loop detection analysis prompt.

## Reviewer Test Plan

Rely on the newly added unit test `should prepend user message if history starts with a function call` in `packages/core/src/services/loopDetectionService.test.ts`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

#11814 