### PR TITLE
Fix(cli): Use the correct extensionPath

### DIFF
--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -474,11 +474,10 @@ export class ExtensionManager {
           `Invalid configuration in ${configFilePath}: missing ${!rawConfig.name ? '"name"' : '"version"'}`,
         );
       }
-      const installDir = new ExtensionStorage(rawConfig.name).getExtensionDir();
       const config = recursivelyHydrateStrings(
         rawConfig as unknown as JsonObject,
         {
-          extensionPath: installDir,
+          extensionPath: extensionDir,
           workspacePath: this.workspaceDir,
           '/': path.sep,
           pathSeparator: path.sep,

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -285,6 +285,32 @@ describe('extension tests', () => {
       ]);
     });
 
+    it('should hydrate ${extensionPath} correctly for linked extensions', async () => {
+      const sourceExtDir = createExtension({
+        extensionsDir: tempWorkspaceDir,
+        name: 'my-linked-extension-with-path',
+        version: '1.0.0',
+        mcpServers: {
+          'test-server': {
+            command: 'node',
+            args: ['${extensionPath}/server/index.js'],
+            cwd: '${extensionPath}/server',
+          },
+        },
+      });
+
+      await extensionManager.installOrUpdateExtension({
+        source: sourceExtDir,
+        type: 'link',
+      });
+
+      const extensions = extensionManager.loadExtensions();
+      expect(extensions).toHaveLength(1);
+      expect(extensions[0].mcpServers?.['test-server'].cwd).toBe(
+        path.join(sourceExtDir, 'server'),
+      );
+    });
+
     it('should resolve environment variables in extension configuration', () => {
       process.env['TEST_API_KEY'] = 'test-api-key-123';
       process.env['TEST_DB_URL'] = 'postgresql://localhost:5432/testdb';


### PR DESCRIPTION
When hydrating the extension config the `extensionPath` was using the incorrect path. This led to extensions registered with `extension link` using the `~/.gemini/extensions` path rather than the linked path.

## TLDR

For extensions registered with `link` `extensionPath` was using the incorrect path.

## Dive Deeper

When hydrating the extension config the `extensionPath` was using the incorrect path. This led to extensions registered with `extension link` using the `~/.gemini/extensions` path rather than the linked path.

## Reviewer Test Plan

A test has been added to `packages/cli/src/config/extension.test.ts`.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #11867.
