### PR TITLE
(fix): appcontainer should not poll and footer should use currentModel from ui state

### DIFF
--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -23,6 +23,7 @@ const mockConfig = {
   getTargetDir: () =>
     '/Users/test/project/foo/bar/and/some/more/directories/to/make/it/long',
   getDebugMode: () => false,
+  isInFallbackMode: () => false,
 };
 
 const configProxy = new Proxy(mockConfig, {

--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -23,7 +23,6 @@ const mockConfig = {
   getTargetDir: () =>
     '/Users/test/project/foo/bar/and/some/more/directories/to/make/it/long',
   getDebugMode: () => false,
-  isInFallbackMode: () => false,
 };
 
 const configProxy = new Proxy(mockConfig, {
@@ -65,6 +64,7 @@ const baseMockUiState = {
   streamingState: StreamingState.Idle,
   mainAreaWidth: 100,
   terminalWidth: 120,
+  currentModel: 'gemini-pro',
 };
 
 export const renderWithProviders = (

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -261,20 +261,18 @@ export const AppContainer = (props: AppContainerProps) => {
     [historyManager.addItem],
   );
 
-  // Watch for model changes (e.g., from Flash fallback)
+  // Subscribe to fallback mode changes from core
   useEffect(() => {
-    const checkModelChange = () => {
+    const handleFallbackModeChanged = () => {
       const effectiveModel = getEffectiveModel();
-      if (effectiveModel !== currentModel) {
-        setCurrentModel(effectiveModel);
-      }
+      setCurrentModel(effectiveModel);
     };
 
-    checkModelChange();
-    const interval = setInterval(checkModelChange, 1000); // Check every second
-
-    return () => clearInterval(interval);
-  }, [config, currentModel, getEffectiveModel]);
+    coreEvents.on(CoreEvent.FallbackModeChanged, handleFallbackModeChanged);
+    return () => {
+      coreEvents.off(CoreEvent.FallbackModeChanged, handleFallbackModeChanged);
+    };
+  }, [getEffectiveModel]);
 
   const {
     consoleMessages,

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -9,12 +9,7 @@ import {
   createMockSettings,
 } from '../../test-utils/render.js';
 import { Footer } from './Footer.js';
-import type {
-  Config} from '@google/gemini-cli-core';
-import {
-  tildeifyPath,
-  ToolCallDecision
-} from '@google/gemini-cli-core';
+import { tildeifyPath, ToolCallDecision } from '@google/gemini-cli-core';
 import type { SessionStatsState } from '../contexts/SessionContext.js';
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
@@ -264,17 +259,12 @@ describe('<Footer />', () => {
 
 describe('fallback mode display', () => {
   it('should display Flash model when in fallback mode, not the configured Pro model', () => {
-    const fallbackConfig = {
-      getModel: () => 'gemini-2.5-pro', // Config still says Pro
-      getTargetDir: () => '/test/dir',
-      getDebugMode: () => false,
-      isInFallbackMode: () => true, // But we're in fallback mode
-    };
-
     const { lastFrame } = renderWithProviders(<Footer />, {
       width: 120,
-      config: fallbackConfig as unknown as Config,
-      uiState: { sessionStats: mockSessionStats },
+      uiState: {
+        sessionStats: mockSessionStats,
+        currentModel: 'gemini-2.5-flash', // Fallback active, showing Flash
+      },
     });
 
     // Footer should show the effective model (Flash), not the config model (Pro)
@@ -283,17 +273,12 @@ describe('fallback mode display', () => {
   });
 
   it('should display Pro model when NOT in fallback mode', () => {
-    const normalConfig = {
-      getModel: () => 'gemini-2.5-pro',
-      getTargetDir: () => '/test/dir',
-      getDebugMode: () => false,
-      isInFallbackMode: () => false,
-    };
-
     const { lastFrame } = renderWithProviders(<Footer />, {
       width: 120,
-      config: normalConfig as unknown as Config,
-      uiState: { sessionStats: mockSessionStats },
+      uiState: {
+        sessionStats: mockSessionStats,
+        currentModel: 'gemini-2.5-pro', // Normal mode, showing Pro
+      },
     });
 
     expect(lastFrame()).toContain('gemini-2.5-pro');

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -9,7 +9,12 @@ import {
   createMockSettings,
 } from '../../test-utils/render.js';
 import { Footer } from './Footer.js';
-import { tildeifyPath, ToolCallDecision } from '@google/gemini-cli-core';
+import type {
+  Config} from '@google/gemini-cli-core';
+import {
+  tildeifyPath,
+  ToolCallDecision
+} from '@google/gemini-cli-core';
 import type { SessionStatsState } from '../contexts/SessionContext.js';
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
@@ -254,5 +259,43 @@ describe('<Footer />', () => {
       });
       expect(lastFrame()).toMatchSnapshot('complete-footer-narrow');
     });
+  });
+});
+
+describe('fallback mode display', () => {
+  it('should display Flash model when in fallback mode, not the configured Pro model', () => {
+    const fallbackConfig = {
+      getModel: () => 'gemini-2.5-pro', // Config still says Pro
+      getTargetDir: () => '/test/dir',
+      getDebugMode: () => false,
+      isInFallbackMode: () => true, // But we're in fallback mode
+    };
+
+    const { lastFrame } = renderWithProviders(<Footer />, {
+      width: 120,
+      config: fallbackConfig as unknown as Config,
+      uiState: { sessionStats: mockSessionStats },
+    });
+
+    // Footer should show the effective model (Flash), not the config model (Pro)
+    expect(lastFrame()).toContain('gemini-2.5-flash');
+    expect(lastFrame()).not.toContain('gemini-2.5-pro');
+  });
+
+  it('should display Pro model when NOT in fallback mode', () => {
+    const normalConfig = {
+      getModel: () => 'gemini-2.5-pro',
+      getTargetDir: () => '/test/dir',
+      getDebugMode: () => false,
+      isInFallbackMode: () => false,
+    };
+
+    const { lastFrame } = renderWithProviders(<Footer />, {
+      width: 120,
+      config: normalConfig as unknown as Config,
+      uiState: { sessionStats: mockSessionStats },
+    });
+
+    expect(lastFrame()).toContain('gemini-2.5-pro');
   });
 });

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -7,7 +7,7 @@
 import type React from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
-import { shortenPath, tildeifyPath , getEffectiveModel } from '@google/gemini-cli-core';
+import { shortenPath, tildeifyPath } from '@google/gemini-cli-core';
 import { ConsoleSummaryDisplay } from './ConsoleSummaryDisplay.js';
 import process from 'node:process';
 import Gradient from 'ink-gradient';
@@ -40,7 +40,7 @@ export const Footer: React.FC = () => {
     isTrustedFolder,
     mainAreaWidth,
   } = {
-    model: getEffectiveModel(config.isInFallbackMode(), config.getModel()),
+    model: uiState.currentModel,
     targetDir: config.getTargetDir(),
     debugMode: config.getDebugMode(),
     branchName: uiState.branchName,

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -7,7 +7,7 @@
 import type React from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
-import { shortenPath, tildeifyPath } from '@google/gemini-cli-core';
+import { shortenPath, tildeifyPath , getEffectiveModel } from '@google/gemini-cli-core';
 import { ConsoleSummaryDisplay } from './ConsoleSummaryDisplay.js';
 import process from 'node:process';
 import Gradient from 'ink-gradient';
@@ -15,7 +15,6 @@ import { MemoryUsageDisplay } from './MemoryUsageDisplay.js';
 import { ContextUsageDisplay } from './ContextUsageDisplay.js';
 import { DebugProfiler } from './DebugProfiler.js';
 import { isDevelopment } from '../../utils/installationInfo.js';
-
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
@@ -41,7 +40,7 @@ export const Footer: React.FC = () => {
     isTrustedFolder,
     mainAreaWidth,
   } = {
-    model: config.getModel(),
+    model: getEffectiveModel(config.isInFallbackMode(), config.getModel()),
     targetDir: config.getTargetDir(),
     debugMode: config.getDebugMode(),
     branchName: uiState.branchName,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -49,6 +49,7 @@ import {
   DEFAULT_GEMINI_MODEL,
   DEFAULT_THINKING_MODE,
 } from './models.js';
+export * from './models.js';
 import { shouldAttemptBrowserLaunch } from '../utils/browser.js';
 import type { MCPOAuthConfig } from '../mcp/oauth-provider.js';
 import { ideContextStore } from '../ide/ideContext.js';

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -49,7 +49,6 @@ import {
   DEFAULT_GEMINI_MODEL,
   DEFAULT_THINKING_MODE,
 } from './models.js';
-export * from './models.js';
 import { shouldAttemptBrowserLaunch } from '../utils/browser.js';
 import type { MCPOAuthConfig } from '../mcp/oauth-provider.js';
 import { ideContextStore } from '../ide/ideContext.js';

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -8,6 +8,7 @@ import type { Config } from '../config/config.js';
 import { AuthType } from '../core/contentGenerator.js';
 import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
 import { logFlashFallback, FlashFallbackEvent } from '../telemetry/index.js';
+import { coreEvents } from '../utils/events.js';
 
 export async function handleFallback(
   config: Config,
@@ -62,6 +63,7 @@ export async function handleFallback(
 function activateFallbackMode(config: Config, authType: string | undefined) {
   if (!config.isInFallbackMode()) {
     config.setFallbackMode(true);
+    coreEvents.emitFallbackModeChanged(true);
     if (authType) {
       logFlashFallback(config, new FlashFallbackEvent(authType));
     }

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -33,8 +33,19 @@ export interface UserFeedbackPayload {
   error?: unknown;
 }
 
+/**
+ * Payload for the 'fallback-mode-changed' event.
+ */
+export interface FallbackModeChangedPayload {
+  /**
+   * Whether fallback mode is now active.
+   */
+  isInFallbackMode: boolean;
+}
+
 export enum CoreEvent {
   UserFeedback = 'user-feedback',
+  FallbackModeChanged = 'fallback-mode-changed',
 }
 
 export class CoreEventEmitter extends EventEmitter {
@@ -67,6 +78,15 @@ export class CoreEventEmitter extends EventEmitter {
   }
 
   /**
+   * Notifies subscribers that fallback mode has changed.
+   * This is synchronous and doesn't use backlog (UI should already be initialized).
+   */
+  emitFallbackModeChanged(isInFallbackMode: boolean): void {
+    const payload: FallbackModeChangedPayload = { isInFallbackMode };
+    this.emit(CoreEvent.FallbackModeChanged, payload);
+  }
+
+  /**
    * Flushes buffered messages. Call this immediately after primary UI listener
    * subscribes.
    */
@@ -83,6 +103,10 @@ export class CoreEventEmitter extends EventEmitter {
     listener: (payload: UserFeedbackPayload) => void,
   ): this;
   override on(
+    event: CoreEvent.FallbackModeChanged,
+    listener: (payload: FallbackModeChangedPayload) => void,
+  ): this;
+  override on(
     event: string | symbol,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     listener: (...args: any[]) => void,
@@ -95,6 +119,10 @@ export class CoreEventEmitter extends EventEmitter {
     listener: (payload: UserFeedbackPayload) => void,
   ): this;
   override off(
+    event: CoreEvent.FallbackModeChanged,
+    listener: (payload: FallbackModeChangedPayload) => void,
+  ): this;
+  override off(
     event: string | symbol,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     listener: (...args: any[]) => void,
@@ -105,6 +133,10 @@ export class CoreEventEmitter extends EventEmitter {
   override emit(
     event: CoreEvent.UserFeedback,
     payload: UserFeedbackPayload,
+  ): boolean;
+  override emit(
+    event: CoreEvent.FallbackModeChanged,
+    payload: FallbackModeChangedPayload,
   ): boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   override emit(event: string | symbol, ...args: any[]): boolean {


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

The model from config is not updated through the fallback logic. AppContainer polls and holds the right model in ui state but it's not used in Footer. Footer uses the model from config.

The way AppContainer polls for currentModel is not proper use of React

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
fixes #11957