### PR TITLE
Adding Parameterised tests

### DIFF
--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -181,6 +181,13 @@ describe('Core System Prompt (prompts.ts)', () => {
       expect(prompt).not.toContain('custom system prompt');
     });
 
+    it('should use default prompt when GEMINI_SYSTEM_MD is "0"', () => {
+      vi.stubEnv('GEMINI_SYSTEM_MD', '0');
+      const prompt = getCoreSystemPrompt(mockConfig);
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+      expect(prompt).not.toContain('custom system prompt');
+    });
+
     it('should throw error if GEMINI_SYSTEM_MD points to a non-existent file', () => {
       const customPath = '/non/existent/path/system.md';
       vi.stubEnv('GEMINI_SYSTEM_MD', customPath);
@@ -193,6 +200,17 @@ describe('Core System Prompt (prompts.ts)', () => {
     it('should read from default path when GEMINI_SYSTEM_MD is "true"', () => {
       const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
       vi.stubEnv('GEMINI_SYSTEM_MD', 'true');
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('custom system prompt');
+
+      const prompt = getCoreSystemPrompt(mockConfig);
+      expect(fs.readFileSync).toHaveBeenCalledWith(defaultPath, 'utf8');
+      expect(prompt).toBe('custom system prompt');
+    });
+
+    it('should read from default path when GEMINI_SYSTEM_MD is "1"', () => {
+      const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
+      vi.stubEnv('GEMINI_SYSTEM_MD', '1');
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue('custom system prompt');
 
@@ -237,9 +255,25 @@ describe('Core System Prompt (prompts.ts)', () => {
       expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
 
+    it('should not write to file when GEMINI_WRITE_SYSTEM_MD is "0"', () => {
+      vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', '0');
+      getCoreSystemPrompt(mockConfig);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
     it('should write to default path when GEMINI_WRITE_SYSTEM_MD is "true"', () => {
       const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
       vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', 'true');
+      getCoreSystemPrompt(mockConfig);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        defaultPath,
+        expect.any(String),
+      );
+    });
+
+    it('should write to default path when GEMINI_WRITE_SYSTEM_MD is "1"', () => {
+      const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
+      vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', '1');
       getCoreSystemPrompt(mockConfig);
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         defaultPath,

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -174,15 +174,12 @@ describe('Core System Prompt (prompts.ts)', () => {
   });
 
   describe('GEMINI_SYSTEM_MD environment variable', () => {
-    it.each(['false', '0'])(
-      'should use default prompt when GEMINI_SYSTEM_MD is "%s"',
-      (value) => {
-        vi.stubEnv('GEMINI_SYSTEM_MD', value);
-        const prompt = getCoreSystemPrompt(mockConfig);
-        expect(fs.readFileSync).not.toHaveBeenCalled();
-        expect(prompt).not.toContain('custom system prompt');
-      },
-    );
+    it('should use default prompt when GEMINI_SYSTEM_MD is "false"', () => {
+      vi.stubEnv('GEMINI_SYSTEM_MD', 'false');
+      const prompt = getCoreSystemPrompt(mockConfig);
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+      expect(prompt).not.toContain('custom system prompt');
+    });
 
     it('should throw error if GEMINI_SYSTEM_MD points to a non-existent file', () => {
       const customPath = '/non/existent/path/system.md';
@@ -193,19 +190,16 @@ describe('Core System Prompt (prompts.ts)', () => {
       );
     });
 
-    it.each(['true', '1'])(
-      'should read from default path when GEMINI_SYSTEM_MD is "%s"',
-      (value) => {
-        const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
-        vi.stubEnv('GEMINI_SYSTEM_MD', value);
-        vi.mocked(fs.existsSync).mockReturnValue(true);
-        vi.mocked(fs.readFileSync).mockReturnValue('custom system prompt');
+    it('should read from default path when GEMINI_SYSTEM_MD is "true"', () => {
+      const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
+      vi.stubEnv('GEMINI_SYSTEM_MD', 'true');
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('custom system prompt');
 
-        const prompt = getCoreSystemPrompt(mockConfig);
-        expect(fs.readFileSync).toHaveBeenCalledWith(defaultPath, 'utf8');
-        expect(prompt).toBe('custom system prompt');
-      },
-    );
+      const prompt = getCoreSystemPrompt(mockConfig);
+      expect(fs.readFileSync).toHaveBeenCalledWith(defaultPath, 'utf8');
+      expect(prompt).toBe('custom system prompt');
+    });
 
     it('should read from custom path when GEMINI_SYSTEM_MD provides one, preserving case', () => {
       const customPath = path.resolve('/custom/path/SyStEm.Md');
@@ -237,27 +231,21 @@ describe('Core System Prompt (prompts.ts)', () => {
   });
 
   describe('GEMINI_WRITE_SYSTEM_MD environment variable', () => {
-    it.each(['false', '0'])(
-      'should not write to file when GEMINI_WRITE_SYSTEM_MD is "%s"',
-      (value) => {
-        vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', value);
-        getCoreSystemPrompt(mockConfig);
-        expect(fs.writeFileSync).not.toHaveBeenCalled();
-      },
-    );
+    it('should not write to file when GEMINI_WRITE_SYSTEM_MD is "false"', () => {
+      vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', 'false');
+      getCoreSystemPrompt(mockConfig);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
 
-    it.each(['true', '1'])(
-      'should write to default path when GEMINI_WRITE_SYSTEM_MD is "%s"',
-      (value) => {
-        const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
-        vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', value);
-        getCoreSystemPrompt(mockConfig);
-        expect(fs.writeFileSync).toHaveBeenCalledWith(
-          defaultPath,
-          expect.any(String),
-        );
-      },
-    );
+    it('should write to default path when GEMINI_WRITE_SYSTEM_MD is "true"', () => {
+      const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
+      vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', 'true');
+      getCoreSystemPrompt(mockConfig);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        defaultPath,
+        expect.any(String),
+      );
+    });
 
     it('should write to custom path when GEMINI_WRITE_SYSTEM_MD provides one', () => {
       const customPath = path.resolve('/custom/path/system.md');

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -174,19 +174,15 @@ describe('Core System Prompt (prompts.ts)', () => {
   });
 
   describe('GEMINI_SYSTEM_MD environment variable', () => {
-    it('should use default prompt when GEMINI_SYSTEM_MD is "false"', () => {
-      vi.stubEnv('GEMINI_SYSTEM_MD', 'false');
-      const prompt = getCoreSystemPrompt(mockConfig);
-      expect(fs.readFileSync).not.toHaveBeenCalled();
-      expect(prompt).not.toContain('custom system prompt');
-    });
-
-    it('should use default prompt when GEMINI_SYSTEM_MD is "0"', () => {
-      vi.stubEnv('GEMINI_SYSTEM_MD', '0');
-      const prompt = getCoreSystemPrompt(mockConfig);
-      expect(fs.readFileSync).not.toHaveBeenCalled();
-      expect(prompt).not.toContain('custom system prompt');
-    });
+    it.each(['false', '0'])(
+      'should use default prompt when GEMINI_SYSTEM_MD is "%s"',
+      (value) => {
+        vi.stubEnv('GEMINI_SYSTEM_MD', value);
+        const prompt = getCoreSystemPrompt(mockConfig);
+        expect(fs.readFileSync).not.toHaveBeenCalled();
+        expect(prompt).not.toContain('custom system prompt');
+      },
+    );
 
     it('should throw error if GEMINI_SYSTEM_MD points to a non-existent file', () => {
       const customPath = '/non/existent/path/system.md';
@@ -197,27 +193,19 @@ describe('Core System Prompt (prompts.ts)', () => {
       );
     });
 
-    it('should read from default path when GEMINI_SYSTEM_MD is "true"', () => {
-      const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
-      vi.stubEnv('GEMINI_SYSTEM_MD', 'true');
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue('custom system prompt');
+    it.each(['true', '1'])(
+      'should read from default path when GEMINI_SYSTEM_MD is "%s"',
+      (value) => {
+        const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
+        vi.stubEnv('GEMINI_SYSTEM_MD', value);
+        vi.mocked(fs.existsSync).mockReturnValue(true);
+        vi.mocked(fs.readFileSync).mockReturnValue('custom system prompt');
 
-      const prompt = getCoreSystemPrompt(mockConfig);
-      expect(fs.readFileSync).toHaveBeenCalledWith(defaultPath, 'utf8');
-      expect(prompt).toBe('custom system prompt');
-    });
-
-    it('should read from default path when GEMINI_SYSTEM_MD is "1"', () => {
-      const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
-      vi.stubEnv('GEMINI_SYSTEM_MD', '1');
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue('custom system prompt');
-
-      const prompt = getCoreSystemPrompt(mockConfig);
-      expect(fs.readFileSync).toHaveBeenCalledWith(defaultPath, 'utf8');
-      expect(prompt).toBe('custom system prompt');
-    });
+        const prompt = getCoreSystemPrompt(mockConfig);
+        expect(fs.readFileSync).toHaveBeenCalledWith(defaultPath, 'utf8');
+        expect(prompt).toBe('custom system prompt');
+      },
+    );
 
     it('should read from custom path when GEMINI_SYSTEM_MD provides one, preserving case', () => {
       const customPath = path.resolve('/custom/path/SyStEm.Md');
@@ -249,37 +237,27 @@ describe('Core System Prompt (prompts.ts)', () => {
   });
 
   describe('GEMINI_WRITE_SYSTEM_MD environment variable', () => {
-    it('should not write to file when GEMINI_WRITE_SYSTEM_MD is "false"', () => {
-      vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', 'false');
-      getCoreSystemPrompt(mockConfig);
-      expect(fs.writeFileSync).not.toHaveBeenCalled();
-    });
+    it.each(['false', '0'])(
+      'should not write to file when GEMINI_WRITE_SYSTEM_MD is "%s"',
+      (value) => {
+        vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', value);
+        getCoreSystemPrompt(mockConfig);
+        expect(fs.writeFileSync).not.toHaveBeenCalled();
+      },
+    );
 
-    it('should not write to file when GEMINI_WRITE_SYSTEM_MD is "0"', () => {
-      vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', '0');
-      getCoreSystemPrompt(mockConfig);
-      expect(fs.writeFileSync).not.toHaveBeenCalled();
-    });
-
-    it('should write to default path when GEMINI_WRITE_SYSTEM_MD is "true"', () => {
-      const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
-      vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', 'true');
-      getCoreSystemPrompt(mockConfig);
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        defaultPath,
-        expect.any(String),
-      );
-    });
-
-    it('should write to default path when GEMINI_WRITE_SYSTEM_MD is "1"', () => {
-      const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
-      vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', '1');
-      getCoreSystemPrompt(mockConfig);
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        defaultPath,
-        expect.any(String),
-      );
-    });
+    it.each(['true', '1'])(
+      'should write to default path when GEMINI_WRITE_SYSTEM_MD is "%s"',
+      (value) => {
+        const defaultPath = path.resolve(path.join(GEMINI_DIR, 'system.md'));
+        vi.stubEnv('GEMINI_WRITE_SYSTEM_MD', value);
+        getCoreSystemPrompt(mockConfig);
+        expect(fs.writeFileSync).toHaveBeenCalledWith(
+          defaultPath,
+          expect.any(String),
+        );
+      },
+    );
 
     it('should write to custom path when GEMINI_WRITE_SYSTEM_MD provides one', () => {
       const customPath = path.resolve('/custom/path/system.md');

--- a/packages/core/src/utils/ignorePatterns.test.ts
+++ b/packages/core/src/utils/ignorePatterns.test.ts
@@ -201,23 +201,14 @@ describe('FileExclusions', () => {
 });
 
 describe('BINARY_EXTENSIONS', () => {
-  it('should include common binary file extensions', () => {
-    expect(BINARY_EXTENSIONS).toContain('.exe');
-    expect(BINARY_EXTENSIONS).toContain('.dll');
-    expect(BINARY_EXTENSIONS).toContain('.jar');
-    expect(BINARY_EXTENSIONS).toContain('.zip');
-  });
-
-  it('should include additional binary extensions', () => {
-    expect(BINARY_EXTENSIONS).toContain('.dat');
-    expect(BINARY_EXTENSIONS).toContain('.obj');
-    expect(BINARY_EXTENSIONS).toContain('.wasm');
-  });
-
-  it('should include media file extensions', () => {
-    expect(BINARY_EXTENSIONS).toContain('.pdf');
-    expect(BINARY_EXTENSIONS).toContain('.png');
-    expect(BINARY_EXTENSIONS).toContain('.jpg');
+  it.each([
+    ['common binary file extensions', ['.exe', '.dll', '.jar', '.zip']],
+    ['additional binary extensions', ['.dat', '.obj', '.wasm']],
+    ['media file extensions', ['.pdf', '.png', '.jpg']],
+  ])('should include %s', (_, extensions) => {
+    extensions.forEach((ext) => {
+      expect(BINARY_EXTENSIONS).toContain(ext);
+    });
   });
 
   it('should be sorted', () => {
@@ -235,11 +226,25 @@ describe('BINARY_EXTENSIONS', () => {
 });
 
 describe('extractExtensionsFromPatterns', () => {
-  it('should extract simple extensions', () => {
-    const patterns = ['**/*.exe', '**/*.jar', '**/*.zip'];
+  it.each([
+    [
+      'simple extensions',
+      ['**/*.exe', '**/*.jar', '**/*.zip'],
+      ['.exe', '.jar', '.zip'],
+    ],
+    [
+      'compound extensions',
+      ['**/*.tar.gz', '**/*.min.js', '**/*.d.ts'],
+      ['.gz', '.js', '.ts'],
+    ],
+    [
+      'dotfiles',
+      ['**/*.gitignore', '**/*.profile', '**/*.bashrc'],
+      ['.bashrc', '.gitignore', '.profile'],
+    ],
+  ])('should extract %s', (_, patterns, expected) => {
     const result = extractExtensionsFromPatterns(patterns);
-
-    expect(result).toEqual(['.exe', '.jar', '.zip']);
+    expect(result).toEqual(expected);
   });
 
   it('should handle brace expansion patterns', () => {
@@ -291,22 +296,6 @@ describe('extractExtensionsFromPatterns', () => {
     const result = extractExtensionsFromPatterns(patterns);
 
     expect(result).toEqual(['.css', '.html', '.js', '.jsx', '.ts', '.tsx']);
-  });
-
-  it('should handle compound extensions correctly using path.extname', () => {
-    const patterns = ['**/*.tar.gz', '**/*.min.js', '**/*.d.ts'];
-    const result = extractExtensionsFromPatterns(patterns);
-
-    // Should extract the final extension part only
-    expect(result).toEqual(['.gz', '.js', '.ts']);
-  });
-
-  it('should handle dotfiles correctly', () => {
-    const patterns = ['**/*.gitignore', '**/*.profile', '**/*.bashrc'];
-    const result = extractExtensionsFromPatterns(patterns);
-
-    // Dotfiles should be extracted properly
-    expect(result).toEqual(['.bashrc', '.gitignore', '.profile']);
   });
 
   it('should handle edge cases with path.extname', () => {

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -8,76 +8,31 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { escapePath, unescapePath, isSubpath } from './paths.js';
 
 describe('escapePath', () => {
-  it('should escape spaces', () => {
-    expect(escapePath('my file.txt')).toBe('my\\ file.txt');
-  });
-
-  it('should escape tabs', () => {
-    expect(escapePath('file\twith\ttabs.txt')).toBe('file\\\twith\\\ttabs.txt');
-  });
-
-  it('should escape parentheses', () => {
-    expect(escapePath('file(1).txt')).toBe('file\\(1\\).txt');
-  });
-
-  it('should escape square brackets', () => {
-    expect(escapePath('file[backup].txt')).toBe('file\\[backup\\].txt');
-  });
-
-  it('should escape curly braces', () => {
-    expect(escapePath('file{temp}.txt')).toBe('file\\{temp\\}.txt');
-  });
-
-  it('should escape semicolons', () => {
-    expect(escapePath('file;name.txt')).toBe('file\\;name.txt');
-  });
-
-  it('should escape ampersands', () => {
-    expect(escapePath('file&name.txt')).toBe('file\\&name.txt');
-  });
-
-  it('should escape pipes', () => {
-    expect(escapePath('file|name.txt')).toBe('file\\|name.txt');
-  });
-
-  it('should escape asterisks', () => {
-    expect(escapePath('file*.txt')).toBe('file\\*.txt');
-  });
-
-  it('should escape question marks', () => {
-    expect(escapePath('file?.txt')).toBe('file\\?.txt');
-  });
-
-  it('should escape dollar signs', () => {
-    expect(escapePath('file$name.txt')).toBe('file\\$name.txt');
-  });
-
-  it('should escape backticks', () => {
-    expect(escapePath('file`name.txt')).toBe('file\\`name.txt');
-  });
-
-  it('should escape single quotes', () => {
-    expect(escapePath("file'name.txt")).toBe("file\\'name.txt");
-  });
-
-  it('should escape double quotes', () => {
-    expect(escapePath('file"name.txt')).toBe('file\\"name.txt');
-  });
-
-  it('should escape hash symbols', () => {
-    expect(escapePath('file#name.txt')).toBe('file\\#name.txt');
-  });
-
-  it('should escape exclamation marks', () => {
-    expect(escapePath('file!name.txt')).toBe('file\\!name.txt');
-  });
-
-  it('should escape tildes', () => {
-    expect(escapePath('file~name.txt')).toBe('file\\~name.txt');
-  });
-
-  it('should escape less than and greater than signs', () => {
-    expect(escapePath('file<name>.txt')).toBe('file\\<name\\>.txt');
+  it.each([
+    ['spaces', 'my file.txt', 'my\\ file.txt'],
+    ['tabs', 'file\twith\ttabs.txt', 'file\\\twith\\\ttabs.txt'],
+    ['parentheses', 'file(1).txt', 'file\\(1\\).txt'],
+    ['square brackets', 'file[backup].txt', 'file\\[backup\\].txt'],
+    ['curly braces', 'file{temp}.txt', 'file\\{temp\\}.txt'],
+    ['semicolons', 'file;name.txt', 'file\\;name.txt'],
+    ['ampersands', 'file&name.txt', 'file\\&name.txt'],
+    ['pipes', 'file|name.txt', 'file\\|name.txt'],
+    ['asterisks', 'file*.txt', 'file\\*.txt'],
+    ['question marks', 'file?.txt', 'file\\?.txt'],
+    ['dollar signs', 'file$name.txt', 'file\\$name.txt'],
+    ['backticks', 'file`name.txt', 'file\\`name.txt'],
+    ['single quotes', "file'name.txt", "file\\'name.txt"],
+    ['double quotes', 'file"name.txt', 'file\\"name.txt'],
+    ['hash symbols', 'file#name.txt', 'file\\#name.txt'],
+    ['exclamation marks', 'file!name.txt', 'file\\!name.txt'],
+    ['tildes', 'file~name.txt', 'file\\~name.txt'],
+    [
+      'less than and greater than signs',
+      'file<name>.txt',
+      'file\\<name\\>.txt',
+    ],
+  ])('should escape %s', (_, input, expected) => {
+    expect(escapePath(input)).toBe(expected);
   });
 
   it('should handle multiple special characters', () => {
@@ -135,26 +90,14 @@ describe('escapePath', () => {
 });
 
 describe('unescapePath', () => {
-  it('should unescape spaces', () => {
-    expect(unescapePath('my\\ file.txt')).toBe('my file.txt');
-  });
-
-  it('should unescape tabs', () => {
-    expect(unescapePath('file\\\twith\\\ttabs.txt')).toBe(
-      'file\twith\ttabs.txt',
-    );
-  });
-
-  it('should unescape parentheses', () => {
-    expect(unescapePath('file\\(1\\).txt')).toBe('file(1).txt');
-  });
-
-  it('should unescape square brackets', () => {
-    expect(unescapePath('file\\[backup\\].txt')).toBe('file[backup].txt');
-  });
-
-  it('should unescape curly braces', () => {
-    expect(unescapePath('file\\{temp\\}.txt')).toBe('file{temp}.txt');
+  it.each([
+    ['spaces', 'my\\ file.txt', 'my file.txt'],
+    ['tabs', 'file\\\twith\\\ttabs.txt', 'file\twith\ttabs.txt'],
+    ['parentheses', 'file\\(1\\).txt', 'file(1).txt'],
+    ['square brackets', 'file\\[backup\\].txt', 'file[backup].txt'],
+    ['curly braces', 'file\\{temp\\}.txt', 'file{temp}.txt'],
+  ])('should unescape %s', (_, input, expected) => {
+    expect(unescapePath(input)).toBe(expected);
   });
 
   it('should unescape multiple special characters', () => {


### PR DESCRIPTION
 ## TLDR
  Refactored test files to use parameterized tests with Vitest's `it.each`, reducing code duplication and
  improving maintainability while preserving all test coverage.

  ## Changes

  ### Files Modified
  - `packages/core/src/utils/paths.test.ts`
  - `packages/core/src/utils/ignorePatterns.test.ts`

  ### Metrics
   | File | Before | After | Lines Saved | Reduction |
   |---|---|---|---|---|
   | `paths.test.ts` | 316 lines | 259 lines | 57 lines | 18.0% |
   | `ignorePatterns.test.ts` | 319 lines | 308 lines | 11 lines | 3.4% |
   | **Total** | **635 lines** | **567 lines** | **68 lines** | **10.7%** |

  ## Details

  ### `paths.test.ts`
  - **Group 1**: Consolidated 18 individual character escaping tests into a single parameterized test
    - Covers: spaces, tabs, parentheses, square brackets, curly braces, semicolons, ampersands, pipes,
  asterisks, question marks, dollar signs, backticks, quotes, hash symbols, exclamation marks, tildes, and
  angle brackets
  - **Group 2**: Consolidated 5 character unescaping tests

  ### `ignorePatterns.test.ts`
  - **BINARY_EXTENSIONS tests**: Consolidated 3 tests checking different extension categories into a single 
  parameterized test
    - Common binary extensions (`.exe`, `.dll`, `.jar`, `.zip`)
    - Additional binary extensions (`.dat`, `.obj`, `.wasm`)
    - Media file extensions (`.pdf`, `.png`, `.jpg`)
  - **extractExtensionsFromPatterns tests**: Consolidated 3 extension extraction tests
    - Simple extensions
    - Compound extensions (`.tar.gz`, `.min.js`, `.d.ts`)
    - Dotfiles (`.gitignore`, `.profile`, `.bashrc`)

  ## Testing
  ```bash
  npx vitest run src/core/prompts.test.ts
  npx vitest run src/utils/paths.test.ts
  npx vitest run src/utils/ignorePatterns.test.ts

  All test suites pass with 100% of original test coverage maintained.
  ```
