### PR TITLE
fix(cli): Exit CLI when trust save unsuccessful during launch

### DIFF
--- a/packages/cli/src/config/trustedFolders.ts
+++ b/packages/cli/src/config/trustedFolders.ts
@@ -76,11 +76,17 @@ export class LoadedTrustedFolders {
    * @param location path
    * @returns
    */
-  isPathTrusted(location: string): boolean | undefined {
+  isPathTrusted(
+    location: string,
+    config?: Record<string, TrustLevel>,
+  ): boolean | undefined {
+    const configToUse = config ?? this.user.config;
     const trustedPaths: string[] = [];
     const untrustedPaths: string[] = [];
 
-    for (const rule of this.rules) {
+    for (const rule of Object.entries(configToUse).map(
+      ([path, trustLevel]) => ({ path, trustLevel }),
+    )) {
       switch (rule.trustLevel) {
         case TrustLevel.TRUST_FOLDER:
           trustedPaths.push(rule.path);
@@ -113,8 +119,19 @@ export class LoadedTrustedFolders {
   }
 
   setValue(path: string, trustLevel: TrustLevel): void {
+    const originalTrustLevel = this.user.config[path];
     this.user.config[path] = trustLevel;
-    saveTrustedFolders(this.user);
+    try {
+      saveTrustedFolders(this.user);
+    } catch (e) {
+      // Revert the in-memory change if the save failed.
+      if (originalTrustLevel === undefined) {
+        delete this.user.config[path];
+      } else {
+        this.user.config[path] = originalTrustLevel;
+      }
+      throw e;
+    }
   }
 }
 
@@ -174,21 +191,17 @@ export function loadTrustedFolders(): LoadedTrustedFolders {
 export function saveTrustedFolders(
   trustedFoldersFile: TrustedFoldersFile,
 ): void {
-  try {
-    // Ensure the directory exists
-    const dirPath = path.dirname(trustedFoldersFile.path);
-    if (!fs.existsSync(dirPath)) {
-      fs.mkdirSync(dirPath, { recursive: true });
-    }
-
-    fs.writeFileSync(
-      trustedFoldersFile.path,
-      JSON.stringify(trustedFoldersFile.config, null, 2),
-      { encoding: 'utf-8', mode: 0o600 },
-    );
-  } catch (error) {
-    console.error('Error saving trusted folders file:', error);
+  // Ensure the directory exists
+  const dirPath = path.dirname(trustedFoldersFile.path);
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
   }
+
+  fs.writeFileSync(
+    trustedFoldersFile.path,
+    JSON.stringify(trustedFoldersFile.config, null, 2),
+    { encoding: 'utf-8', mode: 0o600 },
+  );
 }
 
 /** Is folder trust feature enabled per the current applied settings */
@@ -201,10 +214,7 @@ function getWorkspaceTrustFromLocalConfig(
   trustConfig?: Record<string, TrustLevel>,
 ): TrustResult {
   const folders = loadTrustedFolders();
-
-  if (trustConfig) {
-    folders.user.config = trustConfig;
-  }
+  const configToUse = trustConfig ?? folders.user.config;
 
   if (folders.errors.length > 0) {
     const errorMessages = folders.errors.map(
@@ -215,7 +225,7 @@ function getWorkspaceTrustFromLocalConfig(
     );
   }
 
-  const isTrusted = folders.isPathTrusted(process.cwd());
+  const isTrusted = folders.isPathTrusted(process.cwd(), configToUse);
   return {
     isTrusted,
     source: isTrusted !== undefined ? 'file' : undefined,

--- a/packages/cli/src/ui/components/PermissionsModifyTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/PermissionsModifyTrustDialog.test.tsx
@@ -148,10 +148,11 @@ describe('PermissionsModifyTrustDialog', () => {
     });
   });
 
-  it('should commit, restart, and exit on `r` keypress', async () => {
+  it('should commit and restart `r` keypress', async () => {
     const mockRelaunchApp = vi
       .spyOn(processUtils, 'relaunchApp')
       .mockResolvedValue(undefined);
+    mockCommitTrustLevelChange.mockReturnValue(true);
     vi.mocked(usePermissionsModifyTrust).mockReturnValue({
       cwd: '/test/dir',
       currentTrustLevel: TrustLevel.DO_NOT_TRUST,
@@ -175,7 +176,6 @@ describe('PermissionsModifyTrustDialog', () => {
     await waitFor(() => {
       expect(mockCommitTrustLevelChange).toHaveBeenCalled();
       expect(mockRelaunchApp).toHaveBeenCalled();
-      expect(onExit).toHaveBeenCalled();
     });
 
     mockRelaunchApp.mockRestore();

--- a/packages/cli/src/ui/components/PermissionsModifyTrustDialog.tsx
+++ b/packages/cli/src/ui/components/PermissionsModifyTrustDialog.tsx
@@ -65,8 +65,9 @@ export function PermissionsModifyTrustDialog({
         const success = commitTrustLevelChange();
         if (success) {
           relaunchApp();
+        } else {
+          onExit();
         }
-        onExit();
       }
     },
     { isActive: true },

--- a/packages/cli/src/ui/components/PermissionsModifyTrustDialog.tsx
+++ b/packages/cli/src/ui/components/PermissionsModifyTrustDialog.tsx
@@ -62,8 +62,10 @@ export function PermissionsModifyTrustDialog({
         onExit();
       }
       if (needsRestart && key.name === 'r') {
-        commitTrustLevelChange();
-        relaunchApp();
+        const success = commitTrustLevelChange();
+        if (success) {
+          relaunchApp();
+        }
         onExit();
       }
     },

--- a/packages/cli/src/ui/hooks/useFolderTrust.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.ts
@@ -67,7 +67,22 @@ export const useFolderTrust = (
           return;
       }
 
-      trustedFolders.setValue(cwd, trustLevel);
+      try {
+        trustedFolders.setValue(cwd, trustLevel);
+      } catch (_e) {
+        addItem(
+          {
+            type: MessageType.WARNING,
+            text: 'Failed to save trust settings. Exiting Gemini CLI.',
+          },
+          Date.now(),
+        );
+        setTimeout(() => {
+          process.exit(1);
+        }, 100);
+        return;
+      }
+
       const currentIsTrusted =
         trustLevel === TrustLevel.TRUST_FOLDER ||
         trustLevel === TrustLevel.TRUST_PARENT;
@@ -82,7 +97,7 @@ export const useFolderTrust = (
         setIsFolderTrustDialogOpen(false);
       }
     },
-    [onTrustChange, isTrusted],
+    [onTrustChange, isTrusted, addItem],
   );
 
   return {

--- a/packages/cli/src/ui/hooks/useFolderTrust.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.ts
@@ -14,6 +14,7 @@ import {
 } from '../../config/trustedFolders.js';
 import * as process from 'node:process';
 import { type HistoryItemWithoutId, MessageType } from '../types.js';
+import { coreEvents } from '@google/gemini-cli-core';
 
 export const useFolderTrust = (
   settings: LoadedSettings,
@@ -70,12 +71,9 @@ export const useFolderTrust = (
       try {
         trustedFolders.setValue(cwd, trustLevel);
       } catch (_e) {
-        addItem(
-          {
-            type: MessageType.WARNING,
-            text: 'Failed to save trust settings. Exiting Gemini CLI.',
-          },
-          Date.now(),
+        coreEvents.emitFeedback(
+          'error',
+          'Failed to save trust settings. Exiting Gemini CLI.',
         );
         setTimeout(() => {
           process.exit(1);
@@ -97,7 +95,7 @@ export const useFolderTrust = (
         setIsFolderTrustDialogOpen(false);
       }
     },
-    [onTrustChange, isTrusted, addItem],
+    [onTrustChange, isTrusted],
   );
 
   return {

--- a/packages/cli/src/ui/hooks/usePermissionsModifyTrust.ts
+++ b/packages/cli/src/ui/hooks/usePermissionsModifyTrust.ts
@@ -101,7 +101,17 @@ export const usePermissionsModifyTrust = (
         setNeedsRestart(true);
       } else {
         const folders = loadTrustedFolders();
-        folders.setValue(cwd, trustLevel);
+        try {
+          folders.setValue(cwd, trustLevel);
+        } catch (_e) {
+          addItem(
+            {
+              type: MessageType.WARNING,
+              text: 'Failed to save trust settings. Your changes may not persist.',
+            },
+            Date.now(),
+          );
+        }
         onExit();
       }
     },
@@ -111,9 +121,24 @@ export const usePermissionsModifyTrust = (
   const commitTrustLevelChange = useCallback(() => {
     if (pendingTrustLevel) {
       const folders = loadTrustedFolders();
-      folders.setValue(cwd, pendingTrustLevel);
+      try {
+        folders.setValue(cwd, pendingTrustLevel);
+        return true;
+      } catch (_e) {
+        addItem(
+          {
+            type: MessageType.WARNING,
+            text: 'Failed to save trust settings. Your changes may not persist.',
+          },
+          Date.now(),
+        );
+        setNeedsRestart(false);
+        setPendingTrustLevel(undefined);
+        return false;
+      }
     }
-  }, [cwd, pendingTrustLevel]);
+    return true;
+  }, [cwd, pendingTrustLevel, addItem]);
 
   return {
     cwd,

--- a/packages/cli/src/ui/hooks/usePermissionsModifyTrust.ts
+++ b/packages/cli/src/ui/hooks/usePermissionsModifyTrust.ts
@@ -16,6 +16,7 @@ import { useSettings } from '../contexts/SettingsContext.js';
 import { MessageType } from '../types.js';
 import { type UseHistoryManagerReturn } from './useHistoryManager.js';
 import type { LoadedSettings } from '../../config/settings.js';
+import { coreEvents } from '@google/gemini-cli-core';
 
 interface TrustState {
   currentTrustLevel: TrustLevel | undefined;
@@ -104,12 +105,9 @@ export const usePermissionsModifyTrust = (
         try {
           folders.setValue(cwd, trustLevel);
         } catch (_e) {
-          addItem(
-            {
-              type: MessageType.WARNING,
-              text: 'Failed to save trust settings. Your changes may not persist.',
-            },
-            Date.now(),
+          coreEvents.emitFeedback(
+            'error',
+            'Failed to save trust settings. Your changes may not persist.',
           );
         }
         onExit();
@@ -125,12 +123,9 @@ export const usePermissionsModifyTrust = (
         folders.setValue(cwd, pendingTrustLevel);
         return true;
       } catch (_e) {
-        addItem(
-          {
-            type: MessageType.WARNING,
-            text: 'Failed to save trust settings. Your changes may not persist.',
-          },
-          Date.now(),
+        coreEvents.emitFeedback(
+          'error',
+          'Failed to save trust settings. Your changes may not persist.',
         );
         setNeedsRestart(false);
         setPendingTrustLevel(undefined);
@@ -138,7 +133,7 @@ export const usePermissionsModifyTrust = (
       }
     }
     return true;
-  }, [cwd, pendingTrustLevel, addItem]);
+  }, [cwd, pendingTrustLevel]);
 
   return {
     cwd,


### PR DESCRIPTION
## TLDR

Got rid of the console.error message as @abhipatel12 requested.
Also updated /permissions command to show a similar error message and avoid restarting in case of failures.

**Failure message during launch:**
<img width="1584" height="543" alt="Screenshot 2025-10-24 at 11 19 55 AM" src="https://github.com/user-attachments/assets/40e079f4-d83c-4272-8b15-1fb17decddaf" />

**Failure message from /permissions command:**
<img width="861" height="197" alt="Screenshot 2025-10-24 at 11 20 52 AM" src="https://github.com/user-attachments/assets/d0f294f3-0efc-4423-b334-3b842f43b222" />

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/919
