### PR TITLE
Fix(cli): Use cross-platform path separators in extension tests

### DIFF
--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -293,8 +293,8 @@ describe('extension tests', () => {
         mcpServers: {
           'test-server': {
             command: 'node',
-            args: ['${extensionPath}/server/index.js'],
-            cwd: '${extensionPath}/server',
+            args: ['${extensionPath}${/}server${/}index.js'],
+            cwd: '${extensionPath}${/}server',
           },
         },
       });


### PR DESCRIPTION


## TLDR

A test needs to be updated to handle windows paths.

## Dive Deeper

Updates the test case to use `${/}` instead of hardcoded forward slashes. This ensures the test passes on Windows where  uses backslashes.

## Reviewer Test Plan

Run the extension tests on windows.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to #11867
