### PR TITLE
fix(core): use debugLogger.warn for loop detection errors

### DIFF
--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -432,7 +432,7 @@ export class LoopDetectionService {
       });
     } catch (e) {
       // Do nothing, treat it as a non-loop.
-      this.config.getDebugMode() ? console.error(e) : debugLogger.debug(e);
+      this.config.getDebugMode() ? debugLogger.warn(e) : debugLogger.debug(e);
       return false;
     }
 


### PR DESCRIPTION
## TLDR

Replaced `console.error` with `debugLogger.warn` in `LoopDetectionService` to standardize logging for non-critical LLM loop check failures.

## Dive Deeper

The `checkForLoopWithLLM` method catches errors when the LLM call fails. Previously it used `console.error` in debug mode. This change downgrades it to a warning using the standardized `debugLogger`, as recommended in issue #11886, since this is a background diagnostic failure and not a critical application error.

## Reviewer Test Plan

Verify the code change by inspection. The change is a straightforward replacement of the logging mechanism in the error handler.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #11886