### PR TITLE
fix(tools): ReadFile no longer shows confirmation when message bus is off

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -491,7 +491,10 @@ export async function loadCliConfig(
     throw err;
   }
 
-  const policyEngineConfig = createPolicyEngineConfig(settings, approvalMode);
+  const policyEngineConfig = await createPolicyEngineConfig(
+    settings,
+    approvalMode,
+  );
 
   const allowedTools = argv.allowedTools || settings.tools?.allowed || [];
   const allowedToolsSet = new Set(allowedTools);

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -496,6 +496,20 @@ export async function loadCliConfig(
     approvalMode,
   );
 
+  // Debug: Log the merged policy configuration
+  debugLogger.log('=== Policy Engine Configuration ===');
+  debugLogger.log(`Default decision: ${policyEngineConfig.defaultDecision}`);
+  debugLogger.log(`Total rules: ${policyEngineConfig.rules?.length || 0}`);
+  if (policyEngineConfig.rules && policyEngineConfig.rules.length > 0) {
+    debugLogger.log('Rules (sorted by priority):');
+    policyEngineConfig.rules.forEach((rule, index) => {
+      debugLogger.log(
+        `  [${index}] toolName: ${rule.toolName || '*'}, decision: ${rule.decision}, priority: ${rule.priority}, argsPattern: ${rule.argsPattern ? rule.argsPattern.source : 'none'}`,
+      );
+    });
+  }
+  debugLogger.log('===================================');
+
   const allowedTools = argv.allowedTools || settings.tools?.allowed || [];
   const allowedToolsSet = new Set(allowedTools);
 

--- a/packages/cli/src/config/policies/auto-edit.toml
+++ b/packages/cli/src/config/policies/auto-edit.toml
@@ -1,0 +1,5 @@
+
+[[rule]]
+toolName = "replace"
+decision = "allow"
+priority = 15

--- a/packages/cli/src/config/policies/auto-edit.toml
+++ b/packages/cli/src/config/policies/auto-edit.toml
@@ -1,5 +1,0 @@
-
-[[rule]]
-toolName = "replace"
-decision = "allow"
-priority = 15

--- a/packages/cli/src/config/policies/default.toml
+++ b/packages/cli/src/config/policies/default.toml
@@ -1,0 +1,4 @@
+
+[[rule]]
+decision = "allow"
+priority = 0

--- a/packages/cli/src/config/policies/default.toml
+++ b/packages/cli/src/config/policies/default.toml
@@ -1,4 +1,0 @@
-
-[[rule]]
-decision = "allow"
-priority = 0

--- a/packages/cli/src/config/policies/read-only.toml
+++ b/packages/cli/src/config/policies/read-only.toml
@@ -1,0 +1,30 @@
+
+[[rule]]
+toolName = "glob"
+decision = "allow"
+priority = 50
+
+[[rule]]
+toolName = "search_file_content"
+decision = "allow"
+priority = 50
+
+[[rule]]
+toolName = "list_directory"
+decision = "allow"
+priority = 50
+
+[[rule]]
+toolName = "read_file"
+decision = "allow"
+priority = 50
+
+[[rule]]
+toolName = "read_many_files"
+decision = "allow"
+priority = 50
+
+[[rule]]
+toolName = "google_web_search"
+decision = "allow"
+priority = 50

--- a/packages/cli/src/config/policies/write.toml
+++ b/packages/cli/src/config/policies/write.toml
@@ -1,0 +1,25 @@
+
+[[rule]]
+toolName = "replace"
+decision = "ask_user"
+priority = 10
+
+[[rule]]
+toolName = "save_memory"
+decision = "ask_user"
+priority = 10
+
+[[rule]]
+toolName = "run_shell_command"
+decision = "ask_user"
+priority = 10
+
+[[rule]]
+toolName = "write_file"
+decision = "ask_user"
+priority = 10
+
+[[rule]]
+toolName = "web_fetch"
+decision = "ask_user"
+priority = 10

--- a/packages/cli/src/config/policies/write.toml
+++ b/packages/cli/src/config/policies/write.toml
@@ -26,6 +26,12 @@ decision = "ask_user"
 priority = 10
 
 [[rule]]
+toolName = "write_file"
+decision = "allow"
+priority = 15
+modes = ["autoEdit"]
+
+[[rule]]
 toolName = "web_fetch"
 decision = "ask_user"
 priority = 10

--- a/packages/cli/src/config/policies/write.toml
+++ b/packages/cli/src/config/policies/write.toml
@@ -5,6 +5,12 @@ decision = "ask_user"
 priority = 10
 
 [[rule]]
+toolName = "replace"
+decision = "allow"
+priority = 15
+modes = ["autoEdit"]
+
+[[rule]]
 toolName = "save_memory"
 decision = "ask_user"
 priority = 10

--- a/packages/cli/src/config/policies/yolo.toml
+++ b/packages/cli/src/config/policies/yolo.toml
@@ -1,0 +1,5 @@
+
+[[rule]]
+decision = "allow"
+priority = 999
+modes = ["yolo"]

--- a/packages/cli/src/config/policy-engine.integration.test.ts
+++ b/packages/cli/src/config/policy-engine.integration.test.ts
@@ -15,7 +15,7 @@ import type { Settings } from './settings.js';
 
 describe('Policy Engine Integration Tests', () => {
   describe('Policy configuration produces valid PolicyEngine config', () => {
-    it('should create a working PolicyEngine from basic settings', () => {
+    it('should create a working PolicyEngine from basic settings', async () => {
       const settings: Settings = {
         tools: {
           allowed: ['run_shell_command'],
@@ -23,7 +23,10 @@ describe('Policy Engine Integration Tests', () => {
         },
       };
 
-      const config = createPolicyEngineConfig(settings, ApprovalMode.DEFAULT);
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.DEFAULT,
+      );
       const engine = new PolicyEngine(config);
 
       // Allowed tool should be allowed
@@ -43,7 +46,7 @@ describe('Policy Engine Integration Tests', () => {
       );
     });
 
-    it('should handle MCP server wildcard patterns correctly', () => {
+    it('should handle MCP server wildcard patterns correctly', async () => {
       const settings: Settings = {
         mcp: {
           allowed: ['allowed-server'],
@@ -58,7 +61,10 @@ describe('Policy Engine Integration Tests', () => {
         },
       };
 
-      const config = createPolicyEngineConfig(settings, ApprovalMode.DEFAULT);
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.DEFAULT,
+      );
       const engine = new PolicyEngine(config);
 
       // Tools from allowed server should be allowed
@@ -91,7 +97,7 @@ describe('Policy Engine Integration Tests', () => {
       );
     });
 
-    it('should correctly prioritize specific tool rules over MCP server wildcards', () => {
+    it('should correctly prioritize specific tool rules over MCP server wildcards', async () => {
       const settings: Settings = {
         mcp: {
           allowed: ['my-server'],
@@ -101,7 +107,10 @@ describe('Policy Engine Integration Tests', () => {
         },
       };
 
-      const config = createPolicyEngineConfig(settings, ApprovalMode.DEFAULT);
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.DEFAULT,
+      );
       const engine = new PolicyEngine(config);
 
       // Server is allowed, but specific tool is excluded
@@ -113,7 +122,7 @@ describe('Policy Engine Integration Tests', () => {
       );
     });
 
-    it('should handle complex mixed configurations', () => {
+    it('should handle complex mixed configurations', async () => {
       const settings: Settings = {
         tools: {
           autoAccept: true, // Allows read-only tools
@@ -133,7 +142,10 @@ describe('Policy Engine Integration Tests', () => {
         },
       };
 
-      const config = createPolicyEngineConfig(settings, ApprovalMode.DEFAULT);
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.DEFAULT,
+      );
       const engine = new PolicyEngine(config);
 
       // Read-only tools should be allowed (autoAccept)
@@ -171,14 +183,17 @@ describe('Policy Engine Integration Tests', () => {
       );
     });
 
-    it('should handle YOLO mode correctly', () => {
+    it('should handle YOLO mode correctly', async () => {
       const settings: Settings = {
         tools: {
           exclude: ['dangerous-tool'], // Even in YOLO, excludes should be respected
         },
       };
 
-      const config = createPolicyEngineConfig(settings, ApprovalMode.YOLO);
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.YOLO,
+      );
       const engine = new PolicyEngine(config);
 
       // Most tools should be allowed in YOLO mode
@@ -194,10 +209,13 @@ describe('Policy Engine Integration Tests', () => {
       );
     });
 
-    it('should handle AUTO_EDIT mode correctly', () => {
+    it('should handle AUTO_EDIT mode correctly', async () => {
       const settings: Settings = {};
 
-      const config = createPolicyEngineConfig(settings, ApprovalMode.AUTO_EDIT);
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.AUTO_EDIT,
+      );
       const engine = new PolicyEngine(config);
 
       // Edit tool should be allowed (EditTool.Name = 'replace')
@@ -212,7 +230,7 @@ describe('Policy Engine Integration Tests', () => {
       );
     });
 
-    it('should verify priority ordering works correctly in practice', () => {
+    it('should verify priority ordering works correctly in practice', async () => {
       const settings: Settings = {
         tools: {
           autoAccept: true, // Priority 50
@@ -232,7 +250,10 @@ describe('Policy Engine Integration Tests', () => {
         },
       };
 
-      const config = createPolicyEngineConfig(settings, ApprovalMode.DEFAULT);
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.DEFAULT,
+      );
       const engine = new PolicyEngine(config);
 
       // Test that priorities are applied correctly
@@ -280,7 +301,7 @@ describe('Policy Engine Integration Tests', () => {
       expect(engine.check({ name: 'glob' })).toBe(PolicyDecision.ALLOW);
     });
 
-    it('should handle edge case: MCP server with both trust and exclusion', () => {
+    it('should handle edge case: MCP server with both trust and exclusion', async () => {
       const settings: Settings = {
         mcpServers: {
           'conflicted-server': {
@@ -294,7 +315,10 @@ describe('Policy Engine Integration Tests', () => {
         },
       };
 
-      const config = createPolicyEngineConfig(settings, ApprovalMode.DEFAULT);
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.DEFAULT,
+      );
       const engine = new PolicyEngine(config);
 
       // Exclusion (195) should win over trust (90)
@@ -303,7 +327,7 @@ describe('Policy Engine Integration Tests', () => {
       );
     });
 
-    it('should handle edge case: specific tool allowed but server excluded', () => {
+    it('should handle edge case: specific tool allowed but server excluded', async () => {
       const settings: Settings = {
         mcp: {
           excluded: ['my-server'], // Priority 195 - DENY
@@ -313,7 +337,10 @@ describe('Policy Engine Integration Tests', () => {
         },
       };
 
-      const config = createPolicyEngineConfig(settings, ApprovalMode.DEFAULT);
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.DEFAULT,
+      );
       const engine = new PolicyEngine(config);
 
       // Server exclusion (195) wins over specific tool allow (100)
@@ -326,10 +353,13 @@ describe('Policy Engine Integration Tests', () => {
       );
     });
 
-    it('should verify non-interactive mode transformation', () => {
+    it('should verify non-interactive mode transformation', async () => {
       const settings: Settings = {};
 
-      const config = createPolicyEngineConfig(settings, ApprovalMode.DEFAULT);
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.DEFAULT,
+      );
       // Enable non-interactive mode
       const engineConfig = { ...config, nonInteractive: true };
       const engine = new PolicyEngine(engineConfig);
@@ -341,10 +371,13 @@ describe('Policy Engine Integration Tests', () => {
       );
     });
 
-    it('should handle empty settings gracefully', () => {
+    it('should handle empty settings gracefully', async () => {
       const settings: Settings = {};
 
-      const config = createPolicyEngineConfig(settings, ApprovalMode.DEFAULT);
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.DEFAULT,
+      );
       const engine = new PolicyEngine(config);
 
       // Should have default rules for write tools
@@ -357,7 +390,7 @@ describe('Policy Engine Integration Tests', () => {
       expect(engine.check({ name: 'unknown' })).toBe(PolicyDecision.ASK_USER);
     });
 
-    it('should verify rules are created with correct priorities', () => {
+    it('should verify rules are created with correct priorities', async () => {
       const settings: Settings = {
         tools: {
           autoAccept: true,
@@ -370,7 +403,10 @@ describe('Policy Engine Integration Tests', () => {
         },
       };
 
-      const config = createPolicyEngineConfig(settings, ApprovalMode.DEFAULT);
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.DEFAULT,
+      );
       const rules = config.rules || [];
 
       // Verify each rule has the expected priority

--- a/packages/cli/src/config/policy-engine.integration.test.ts
+++ b/packages/cli/src/config/policy-engine.integration.test.ts
@@ -282,7 +282,8 @@ describe('Policy Engine Integration Tests', () => {
       expect(mcpServerRule?.priority).toBe(85);
 
       const readOnlyToolRule = rules.find((r) => r.toolName === 'glob');
-      expect(readOnlyToolRule?.priority).toBe(50);
+      // Priority 50 in default tier → 1.05
+      expect(readOnlyToolRule?.priority).toBeCloseTo(1.05, 5);
 
       // Verify the engine applies these priorities correctly
       expect(engine.check({ name: 'blocked-tool' })).toBe(PolicyDecision.DENY);
@@ -423,7 +424,8 @@ describe('Policy Engine Integration Tests', () => {
       expect(server1Rule?.priority).toBe(85); // Allowed servers
 
       const globRule = rules.find((r) => r.toolName === 'glob');
-      expect(globRule?.priority).toBe(50); // Auto-accept read-only
+      // Priority 50 in default tier → 1.05
+      expect(globRule?.priority).toBeCloseTo(1.05, 5); // Auto-accept read-only
 
       // The PolicyEngine will sort these by priority when it's created
       const engine = new PolicyEngine(config);

--- a/packages/cli/src/config/policy-toml-loader.test.ts
+++ b/packages/cli/src/config/policy-toml-loader.test.ts
@@ -1,0 +1,812 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ApprovalMode, PolicyDecision } from '@google/gemini-cli-core';
+import type { Dirent } from 'node:fs';
+
+describe('policy-toml-loader', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock('node:fs/promises');
+  });
+
+  describe('loadPoliciesFromToml', () => {
+    it('should load and parse a simple policy file', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(
+        async (
+          path: string,
+          _options?: { withFileTypes: boolean },
+        ): Promise<Dirent[]> => {
+          if (path === '/policies') {
+            return [
+              {
+                name: 'test.toml',
+                isFile: () => true,
+                isDirectory: () => false,
+              } as Dirent,
+            ];
+          }
+          return [];
+        },
+      );
+
+      const mockReadFile = vi.fn(async (path: string): Promise<string> => {
+        if (path === '/policies/test.toml') {
+          return `
+[[rule]]
+toolName = "glob"
+decision = "allow"
+priority = 100
+`;
+        }
+        throw new Error('File not found');
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readFile: mockReadFile, readdir: mockReaddir },
+        readFile: mockReadFile,
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 1;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/policies'],
+        getPolicyTier,
+      );
+
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0]).toEqual({
+        toolName: 'glob',
+        decision: PolicyDecision.ALLOW,
+        priority: 1.1, // tier 1 + 100/1000
+      });
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should expand commandPrefix array to multiple rules', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(
+        async (
+          path: string,
+          _options?: { withFileTypes: boolean },
+        ): Promise<Dirent[]> => {
+          if (path === '/policies') {
+            return [
+              {
+                name: 'shell.toml',
+                isFile: () => true,
+                isDirectory: () => false,
+              } as Dirent,
+            ];
+          }
+          return [];
+        },
+      );
+
+      const mockReadFile = vi.fn(async (path: string): Promise<string> => {
+        if (path === '/policies/shell.toml') {
+          return `
+[[rule]]
+toolName = "run_shell_command"
+commandPrefix = ["git status", "git log"]
+decision = "allow"
+priority = 100
+`;
+        }
+        throw new Error('File not found');
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readFile: mockReadFile, readdir: mockReaddir },
+        readFile: mockReadFile,
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 2;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/policies'],
+        getPolicyTier,
+      );
+
+      expect(result.rules).toHaveLength(2);
+      expect(result.rules[0].toolName).toBe('run_shell_command');
+      expect(result.rules[1].toolName).toBe('run_shell_command');
+      expect(
+        result.rules[0].argsPattern?.test('{"command":"git status"}'),
+      ).toBe(true);
+      expect(result.rules[1].argsPattern?.test('{"command":"git log"}')).toBe(
+        true,
+      );
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should transform commandRegex to argsPattern', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(
+        async (
+          path: string,
+          _options?: { withFileTypes: boolean },
+        ): Promise<Dirent[]> => {
+          if (path === '/policies') {
+            return [
+              {
+                name: 'shell.toml',
+                isFile: () => true,
+                isDirectory: () => false,
+              } as Dirent,
+            ];
+          }
+          return [];
+        },
+      );
+
+      const mockReadFile = vi.fn(async (path: string): Promise<string> => {
+        if (path === '/policies/shell.toml') {
+          return `
+[[rule]]
+toolName = "run_shell_command"
+commandRegex = "git (status|log).*"
+decision = "allow"
+priority = 100
+`;
+        }
+        throw new Error('File not found');
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readFile: mockReadFile, readdir: mockReaddir },
+        readFile: mockReadFile,
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 2;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/policies'],
+        getPolicyTier,
+      );
+
+      expect(result.rules).toHaveLength(1);
+      expect(
+        result.rules[0].argsPattern?.test('{"command":"git status"}'),
+      ).toBe(true);
+      expect(
+        result.rules[0].argsPattern?.test('{"command":"git log --all"}'),
+      ).toBe(true);
+      expect(
+        result.rules[0].argsPattern?.test('{"command":"git branch"}'),
+      ).toBe(false);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should expand toolName array', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(
+        async (
+          path: string,
+          _options?: { withFileTypes: boolean },
+        ): Promise<Dirent[]> => {
+          if (path === '/policies') {
+            return [
+              {
+                name: 'tools.toml',
+                isFile: () => true,
+                isDirectory: () => false,
+              } as Dirent,
+            ];
+          }
+          return [];
+        },
+      );
+
+      const mockReadFile = vi.fn(async (path: string): Promise<string> => {
+        if (path === '/policies/tools.toml') {
+          return `
+[[rule]]
+toolName = ["glob", "grep", "read"]
+decision = "allow"
+priority = 100
+`;
+        }
+        throw new Error('File not found');
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readFile: mockReadFile, readdir: mockReaddir },
+        readFile: mockReadFile,
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 1;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/policies'],
+        getPolicyTier,
+      );
+
+      expect(result.rules).toHaveLength(3);
+      expect(result.rules.map((r) => r.toolName)).toEqual([
+        'glob',
+        'grep',
+        'read',
+      ]);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should transform mcpName to composite toolName', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(
+        async (
+          path: string,
+          _options?: { withFileTypes: boolean },
+        ): Promise<Dirent[]> => {
+          if (path === '/policies') {
+            return [
+              {
+                name: 'mcp.toml',
+                isFile: () => true,
+                isDirectory: () => false,
+              } as Dirent,
+            ];
+          }
+          return [];
+        },
+      );
+
+      const mockReadFile = vi.fn(async (path: string): Promise<string> => {
+        if (path === '/policies/mcp.toml') {
+          return `
+[[rule]]
+mcpName = "google-workspace"
+toolName = ["calendar.list", "calendar.get"]
+decision = "allow"
+priority = 100
+`;
+        }
+        throw new Error('File not found');
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readFile: mockReadFile, readdir: mockReaddir },
+        readFile: mockReadFile,
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 2;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/policies'],
+        getPolicyTier,
+      );
+
+      expect(result.rules).toHaveLength(2);
+      expect(result.rules[0].toolName).toBe('google-workspace__calendar.list');
+      expect(result.rules[1].toolName).toBe('google-workspace__calendar.get');
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should filter rules by mode', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(
+        async (
+          path: string,
+          _options?: { withFileTypes: boolean },
+        ): Promise<Dirent[]> => {
+          if (path === '/policies') {
+            return [
+              {
+                name: 'modes.toml',
+                isFile: () => true,
+                isDirectory: () => false,
+              } as Dirent,
+            ];
+          }
+          return [];
+        },
+      );
+
+      const mockReadFile = vi.fn(async (path: string): Promise<string> => {
+        if (path === '/policies/modes.toml') {
+          return `
+[[rule]]
+toolName = "glob"
+decision = "allow"
+priority = 100
+modes = ["default", "yolo"]
+
+[[rule]]
+toolName = "grep"
+decision = "allow"
+priority = 100
+modes = ["yolo"]
+`;
+        }
+        throw new Error('File not found');
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readFile: mockReadFile, readdir: mockReaddir },
+        readFile: mockReadFile,
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 1;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/policies'],
+        getPolicyTier,
+      );
+
+      // Only the first rule should be included (modes includes "default")
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].toolName).toBe('glob');
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should handle TOML parse errors', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(
+        async (
+          path: string,
+          _options?: { withFileTypes: boolean },
+        ): Promise<Dirent[]> => {
+          if (path === '/policies') {
+            return [
+              {
+                name: 'invalid.toml',
+                isFile: () => true,
+                isDirectory: () => false,
+              } as Dirent,
+            ];
+          }
+          return [];
+        },
+      );
+
+      const mockReadFile = vi.fn(async (path: string): Promise<string> => {
+        if (path === '/policies/invalid.toml') {
+          return `
+[[rule]
+toolName = "glob"
+decision = "allow"
+priority = 100
+`;
+        }
+        throw new Error('File not found');
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readFile: mockReadFile, readdir: mockReaddir },
+        readFile: mockReadFile,
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 1;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/policies'],
+        getPolicyTier,
+      );
+
+      expect(result.rules).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].errorType).toBe('toml_parse');
+      expect(result.errors[0].fileName).toBe('invalid.toml');
+    });
+
+    it('should handle schema validation errors', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(
+        async (
+          path: string,
+          _options?: { withFileTypes: boolean },
+        ): Promise<Dirent[]> => {
+          if (path === '/policies') {
+            return [
+              {
+                name: 'invalid.toml',
+                isFile: () => true,
+                isDirectory: () => false,
+              } as Dirent,
+            ];
+          }
+          return [];
+        },
+      );
+
+      const mockReadFile = vi.fn(async (path: string): Promise<string> => {
+        if (path === '/policies/invalid.toml') {
+          return `
+[[rule]]
+toolName = "glob"
+priority = 100
+`;
+        }
+        throw new Error('File not found');
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readFile: mockReadFile, readdir: mockReaddir },
+        readFile: mockReadFile,
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 1;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/policies'],
+        getPolicyTier,
+      );
+
+      expect(result.rules).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].errorType).toBe('schema_validation');
+      expect(result.errors[0].details).toContain('decision');
+    });
+
+    it('should reject commandPrefix without run_shell_command', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(
+        async (
+          path: string,
+          _options?: { withFileTypes: boolean },
+        ): Promise<Dirent[]> => {
+          if (path === '/policies') {
+            return [
+              {
+                name: 'invalid.toml',
+                isFile: () => true,
+                isDirectory: () => false,
+              } as Dirent,
+            ];
+          }
+          return [];
+        },
+      );
+
+      const mockReadFile = vi.fn(async (path: string): Promise<string> => {
+        if (path === '/policies/invalid.toml') {
+          return `
+[[rule]]
+toolName = "glob"
+commandPrefix = "git status"
+decision = "allow"
+priority = 100
+`;
+        }
+        throw new Error('File not found');
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readFile: mockReadFile, readdir: mockReaddir },
+        readFile: mockReadFile,
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 1;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/policies'],
+        getPolicyTier,
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].errorType).toBe('rule_validation');
+      expect(result.errors[0].details).toContain('run_shell_command');
+    });
+
+    it('should reject commandPrefix + argsPattern combination', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(
+        async (
+          path: string,
+          _options?: { withFileTypes: boolean },
+        ): Promise<Dirent[]> => {
+          if (path === '/policies') {
+            return [
+              {
+                name: 'invalid.toml',
+                isFile: () => true,
+                isDirectory: () => false,
+              } as Dirent,
+            ];
+          }
+          return [];
+        },
+      );
+
+      const mockReadFile = vi.fn(async (path: string): Promise<string> => {
+        if (path === '/policies/invalid.toml') {
+          return `
+[[rule]]
+toolName = "run_shell_command"
+commandPrefix = "git status"
+argsPattern = "test"
+decision = "allow"
+priority = 100
+`;
+        }
+        throw new Error('File not found');
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readFile: mockReadFile, readdir: mockReaddir },
+        readFile: mockReadFile,
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 1;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/policies'],
+        getPolicyTier,
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].errorType).toBe('rule_validation');
+      expect(result.errors[0].details).toContain('mutually exclusive');
+    });
+
+    it('should handle invalid regex patterns', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(
+        async (
+          path: string,
+          _options?: { withFileTypes: boolean },
+        ): Promise<Dirent[]> => {
+          if (path === '/policies') {
+            return [
+              {
+                name: 'invalid.toml',
+                isFile: () => true,
+                isDirectory: () => false,
+              } as Dirent,
+            ];
+          }
+          return [];
+        },
+      );
+
+      const mockReadFile = vi.fn(async (path: string): Promise<string> => {
+        if (path === '/policies/invalid.toml') {
+          return `
+[[rule]]
+toolName = "run_shell_command"
+commandRegex = "git (status|branch"
+decision = "allow"
+priority = 100
+`;
+        }
+        throw new Error('File not found');
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readFile: mockReadFile, readdir: mockReaddir },
+        readFile: mockReadFile,
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 1;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/policies'],
+        getPolicyTier,
+      );
+
+      expect(result.rules).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].errorType).toBe('regex_compilation');
+      expect(result.errors[0].details).toContain('git (status|branch');
+    });
+
+    it('should escape regex special characters in commandPrefix', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(
+        async (
+          path: string,
+          _options?: { withFileTypes: boolean },
+        ): Promise<Dirent[]> => {
+          if (path === '/policies') {
+            return [
+              {
+                name: 'shell.toml',
+                isFile: () => true,
+                isDirectory: () => false,
+              } as Dirent,
+            ];
+          }
+          return [];
+        },
+      );
+
+      const mockReadFile = vi.fn(async (path: string): Promise<string> => {
+        if (path === '/policies/shell.toml') {
+          return `
+[[rule]]
+toolName = "run_shell_command"
+commandPrefix = "git log *.txt"
+decision = "allow"
+priority = 100
+`;
+        }
+        throw new Error('File not found');
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readFile: mockReadFile, readdir: mockReaddir },
+        readFile: mockReadFile,
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 1;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/policies'],
+        getPolicyTier,
+      );
+
+      expect(result.rules).toHaveLength(1);
+      // Should match literal asterisk, not wildcard
+      expect(
+        result.rules[0].argsPattern?.test('{"command":"git log *.txt"}'),
+      ).toBe(true);
+      expect(
+        result.rules[0].argsPattern?.test('{"command":"git log a.txt"}'),
+      ).toBe(false);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should handle non-existent directory gracefully', async () => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+
+      const mockReaddir = vi.fn(async (_path: string): Promise<Dirent[]> => {
+        const error: NodeJS.ErrnoException = new Error('ENOENT');
+        error.code = 'ENOENT';
+        throw error;
+      });
+
+      vi.doMock('node:fs/promises', () => ({
+        ...actualFs,
+        default: { ...actualFs, readdir: mockReaddir },
+        readdir: mockReaddir,
+      }));
+
+      const { loadPoliciesFromToml: load } = await import(
+        './policy-toml-loader.js'
+      );
+
+      const getPolicyTier = (_dir: string) => 1;
+      const result = await load(
+        ApprovalMode.DEFAULT,
+        ['/non-existent'],
+        getPolicyTier,
+      );
+
+      // Should not error for missing directories
+      expect(result.rules).toHaveLength(0);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+});

--- a/packages/cli/src/config/policy-toml-loader.test.ts
+++ b/packages/cli/src/config/policy-toml-loader.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ApprovalMode, PolicyDecision } from '@google/gemini-cli-core';
 import type { Dirent } from 'node:fs';
+import nodePath from 'node:path';
 
 describe('policy-toml-loader', () => {
   beforeEach(() => {
@@ -30,7 +31,7 @@ describe('policy-toml-loader', () => {
           path: string,
           _options?: { withFileTypes: boolean },
         ): Promise<Dirent[]> => {
-          if (path === '/policies') {
+          if (nodePath.normalize(path) === nodePath.normalize('/policies')) {
             return [
               {
                 name: 'test.toml',
@@ -44,7 +45,10 @@ describe('policy-toml-loader', () => {
       );
 
       const mockReadFile = vi.fn(async (path: string): Promise<string> => {
-        if (path === '/policies/test.toml') {
+        if (
+          nodePath.normalize(path) ===
+          nodePath.normalize(nodePath.join('/policies', 'test.toml'))
+        ) {
           return `
 [[rule]]
 toolName = "glob"
@@ -93,7 +97,7 @@ priority = 100
           path: string,
           _options?: { withFileTypes: boolean },
         ): Promise<Dirent[]> => {
-          if (path === '/policies') {
+          if (nodePath.normalize(path) === nodePath.normalize('/policies')) {
             return [
               {
                 name: 'shell.toml',
@@ -107,7 +111,10 @@ priority = 100
       );
 
       const mockReadFile = vi.fn(async (path: string): Promise<string> => {
-        if (path === '/policies/shell.toml') {
+        if (
+          nodePath.normalize(path) ===
+          nodePath.normalize(nodePath.join('/policies', 'shell.toml'))
+        ) {
           return `
 [[rule]]
 toolName = "run_shell_command"
@@ -160,7 +167,7 @@ priority = 100
           path: string,
           _options?: { withFileTypes: boolean },
         ): Promise<Dirent[]> => {
-          if (path === '/policies') {
+          if (nodePath.normalize(path) === nodePath.normalize('/policies')) {
             return [
               {
                 name: 'shell.toml',
@@ -174,7 +181,10 @@ priority = 100
       );
 
       const mockReadFile = vi.fn(async (path: string): Promise<string> => {
-        if (path === '/policies/shell.toml') {
+        if (
+          nodePath.normalize(path) ===
+          nodePath.normalize(nodePath.join('/policies', 'shell.toml'))
+        ) {
           return `
 [[rule]]
 toolName = "run_shell_command"
@@ -228,7 +238,7 @@ priority = 100
           path: string,
           _options?: { withFileTypes: boolean },
         ): Promise<Dirent[]> => {
-          if (path === '/policies') {
+          if (nodePath.normalize(path) === nodePath.normalize('/policies')) {
             return [
               {
                 name: 'tools.toml',
@@ -242,7 +252,10 @@ priority = 100
       );
 
       const mockReadFile = vi.fn(async (path: string): Promise<string> => {
-        if (path === '/policies/tools.toml') {
+        if (
+          nodePath.normalize(path) ===
+          nodePath.normalize(nodePath.join('/policies', 'tools.toml'))
+        ) {
           return `
 [[rule]]
 toolName = ["glob", "grep", "read"]
@@ -291,7 +304,7 @@ priority = 100
           path: string,
           _options?: { withFileTypes: boolean },
         ): Promise<Dirent[]> => {
-          if (path === '/policies') {
+          if (nodePath.normalize(path) === nodePath.normalize('/policies')) {
             return [
               {
                 name: 'mcp.toml',
@@ -305,7 +318,10 @@ priority = 100
       );
 
       const mockReadFile = vi.fn(async (path: string): Promise<string> => {
-        if (path === '/policies/mcp.toml') {
+        if (
+          nodePath.normalize(path) ===
+          nodePath.normalize(nodePath.join('/policies', 'mcp.toml'))
+        ) {
           return `
 [[rule]]
 mcpName = "google-workspace"
@@ -352,7 +368,7 @@ priority = 100
           path: string,
           _options?: { withFileTypes: boolean },
         ): Promise<Dirent[]> => {
-          if (path === '/policies') {
+          if (nodePath.normalize(path) === nodePath.normalize('/policies')) {
             return [
               {
                 name: 'modes.toml',
@@ -366,7 +382,10 @@ priority = 100
       );
 
       const mockReadFile = vi.fn(async (path: string): Promise<string> => {
-        if (path === '/policies/modes.toml') {
+        if (
+          nodePath.normalize(path) ===
+          nodePath.normalize(nodePath.join('/policies', 'modes.toml'))
+        ) {
           return `
 [[rule]]
 toolName = "glob"
@@ -419,7 +438,7 @@ modes = ["yolo"]
           path: string,
           _options?: { withFileTypes: boolean },
         ): Promise<Dirent[]> => {
-          if (path === '/policies') {
+          if (nodePath.normalize(path) === nodePath.normalize('/policies')) {
             return [
               {
                 name: 'invalid.toml',
@@ -433,7 +452,10 @@ modes = ["yolo"]
       );
 
       const mockReadFile = vi.fn(async (path: string): Promise<string> => {
-        if (path === '/policies/invalid.toml') {
+        if (
+          nodePath.normalize(path) ===
+          nodePath.normalize(nodePath.join('/policies', 'invalid.toml'))
+        ) {
           return `
 [[rule]
 toolName = "glob"
@@ -479,7 +501,7 @@ priority = 100
           path: string,
           _options?: { withFileTypes: boolean },
         ): Promise<Dirent[]> => {
-          if (path === '/policies') {
+          if (nodePath.normalize(path) === nodePath.normalize('/policies')) {
             return [
               {
                 name: 'invalid.toml',
@@ -493,7 +515,10 @@ priority = 100
       );
 
       const mockReadFile = vi.fn(async (path: string): Promise<string> => {
-        if (path === '/policies/invalid.toml') {
+        if (
+          nodePath.normalize(path) ===
+          nodePath.normalize(nodePath.join('/policies', 'invalid.toml'))
+        ) {
           return `
 [[rule]]
 toolName = "glob"
@@ -538,7 +563,7 @@ priority = 100
           path: string,
           _options?: { withFileTypes: boolean },
         ): Promise<Dirent[]> => {
-          if (path === '/policies') {
+          if (nodePath.normalize(path) === nodePath.normalize('/policies')) {
             return [
               {
                 name: 'invalid.toml',
@@ -552,7 +577,10 @@ priority = 100
       );
 
       const mockReadFile = vi.fn(async (path: string): Promise<string> => {
-        if (path === '/policies/invalid.toml') {
+        if (
+          nodePath.normalize(path) ===
+          nodePath.normalize(nodePath.join('/policies', 'invalid.toml'))
+        ) {
           return `
 [[rule]]
 toolName = "glob"
@@ -598,7 +626,7 @@ priority = 100
           path: string,
           _options?: { withFileTypes: boolean },
         ): Promise<Dirent[]> => {
-          if (path === '/policies') {
+          if (nodePath.normalize(path) === nodePath.normalize('/policies')) {
             return [
               {
                 name: 'invalid.toml',
@@ -612,7 +640,10 @@ priority = 100
       );
 
       const mockReadFile = vi.fn(async (path: string): Promise<string> => {
-        if (path === '/policies/invalid.toml') {
+        if (
+          nodePath.normalize(path) ===
+          nodePath.normalize(nodePath.join('/policies', 'invalid.toml'))
+        ) {
           return `
 [[rule]]
 toolName = "run_shell_command"
@@ -659,7 +690,7 @@ priority = 100
           path: string,
           _options?: { withFileTypes: boolean },
         ): Promise<Dirent[]> => {
-          if (path === '/policies') {
+          if (nodePath.normalize(path) === nodePath.normalize('/policies')) {
             return [
               {
                 name: 'invalid.toml',
@@ -673,7 +704,10 @@ priority = 100
       );
 
       const mockReadFile = vi.fn(async (path: string): Promise<string> => {
-        if (path === '/policies/invalid.toml') {
+        if (
+          nodePath.normalize(path) ===
+          nodePath.normalize(nodePath.join('/policies', 'invalid.toml'))
+        ) {
           return `
 [[rule]]
 toolName = "run_shell_command"
@@ -720,7 +754,7 @@ priority = 100
           path: string,
           _options?: { withFileTypes: boolean },
         ): Promise<Dirent[]> => {
-          if (path === '/policies') {
+          if (nodePath.normalize(path) === nodePath.normalize('/policies')) {
             return [
               {
                 name: 'shell.toml',
@@ -734,7 +768,10 @@ priority = 100
       );
 
       const mockReadFile = vi.fn(async (path: string): Promise<string> => {
-        if (path === '/policies/shell.toml') {
+        if (
+          nodePath.normalize(path) ===
+          nodePath.normalize(nodePath.join('/policies', 'shell.toml'))
+        ) {
           return `
 [[rule]]
 toolName = "run_shell_command"

--- a/packages/cli/src/config/policy-toml-loader.ts
+++ b/packages/cli/src/config/policy-toml-loader.ts
@@ -1,0 +1,379 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  type PolicyRule,
+  PolicyDecision,
+  type ApprovalMode,
+} from '@google/gemini-cli-core';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import toml from '@iarna/toml';
+import { z, type ZodError } from 'zod';
+
+/**
+ * Schema for a single policy rule in the TOML file (before transformation).
+ */
+const PolicyRuleSchema = z.object({
+  toolName: z.union([z.string(), z.array(z.string())]).optional(),
+  mcpName: z.string().optional(),
+  argsPattern: z.string().optional(),
+  commandPrefix: z.union([z.string(), z.array(z.string())]).optional(),
+  commandRegex: z.string().optional(),
+  decision: z.nativeEnum(PolicyDecision),
+  priority: z.number(),
+  modes: z.array(z.string()).optional(),
+});
+
+/**
+ * Schema for the entire policy TOML file.
+ */
+const PolicyFileSchema = z.object({
+  rule: z.array(PolicyRuleSchema),
+});
+
+/**
+ * Type for a raw policy rule from TOML (before transformation).
+ */
+type PolicyRuleToml = z.infer<typeof PolicyRuleSchema>;
+
+/**
+ * Types of errors that can occur while loading policy files.
+ */
+export type PolicyFileErrorType =
+  | 'file_read'
+  | 'toml_parse'
+  | 'schema_validation'
+  | 'rule_validation'
+  | 'regex_compilation';
+
+/**
+ * Detailed error information for policy file loading failures.
+ */
+export interface PolicyFileError {
+  filePath: string;
+  fileName: string;
+  tier: 'default' | 'user' | 'admin';
+  ruleIndex?: number;
+  errorType: PolicyFileErrorType;
+  message: string;
+  details?: string;
+  suggestion?: string;
+}
+
+/**
+ * Result of loading policies from TOML files.
+ */
+export interface PolicyLoadResult {
+  rules: PolicyRule[];
+  errors: PolicyFileError[];
+}
+
+/**
+ * Escapes special regex characters in a string for use in a regex pattern.
+ * This is used for commandPrefix to ensure literal string matching.
+ *
+ * @param str The string to escape
+ * @returns The escaped string safe for use in a regex
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Converts a tier number to a human-readable tier name.
+ */
+function getTierName(tier: number): 'default' | 'user' | 'admin' {
+  if (tier === 1) return 'default';
+  if (tier === 2) return 'user';
+  if (tier === 3) return 'admin';
+  return 'default';
+}
+
+/**
+ * Formats a Zod validation error into a readable error message.
+ */
+function formatSchemaError(error: ZodError, ruleIndex: number): string {
+  const issues = error.issues
+    .map((issue) => {
+      const path = issue.path.join('.');
+      return `  - Field "${path}": ${issue.message}`;
+    })
+    .join('\n');
+  return `Invalid policy rule (rule #${ruleIndex + 1}):\n${issues}`;
+}
+
+/**
+ * Validates shell command convenience syntax rules.
+ * Returns an error message if invalid, or null if valid.
+ */
+function validateShellCommandSyntax(
+  rule: PolicyRuleToml,
+  ruleIndex: number,
+): string | null {
+  const hasCommandPrefix = rule.commandPrefix !== undefined;
+  const hasCommandRegex = rule.commandRegex !== undefined;
+  const hasArgsPattern = rule.argsPattern !== undefined;
+
+  if (hasCommandPrefix || hasCommandRegex) {
+    // Must have exactly toolName = "run_shell_command"
+    if (rule.toolName !== 'run_shell_command' || Array.isArray(rule.toolName)) {
+      return (
+        `Rule #${ruleIndex + 1}: commandPrefix and commandRegex can only be used with toolName = "run_shell_command"\n` +
+        `  Found: toolName = ${JSON.stringify(rule.toolName)}\n` +
+        `  Fix: Set toolName = "run_shell_command" (not an array)`
+      );
+    }
+
+    // Can't combine with argsPattern
+    if (hasArgsPattern) {
+      return (
+        `Rule #${ruleIndex + 1}: cannot use both commandPrefix/commandRegex and argsPattern\n` +
+        `  These fields are mutually exclusive\n` +
+        `  Fix: Use either commandPrefix/commandRegex OR argsPattern, not both`
+      );
+    }
+
+    // Can't use both commandPrefix and commandRegex
+    if (hasCommandPrefix && hasCommandRegex) {
+      return (
+        `Rule #${ruleIndex + 1}: cannot use both commandPrefix and commandRegex\n` +
+        `  These fields are mutually exclusive\n` +
+        `  Fix: Use either commandPrefix OR commandRegex, not both`
+      );
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Transforms a priority number based on the policy tier.
+ * Formula: tier + priority/1000
+ *
+ * @param priority The priority value from the TOML file
+ * @param tier The tier (1=default, 2=user, 3=admin)
+ * @returns The transformed priority
+ */
+function transformPriority(priority: number, tier: number): number {
+  return tier + priority / 1000;
+}
+
+/**
+ * Loads and parses policies from TOML files in the specified directories.
+ *
+ * This function:
+ * 1. Scans directories for .toml files
+ * 2. Parses and validates each file
+ * 3. Transforms rules (commandPrefix, arrays, mcpName, priorities)
+ * 4. Filters rules by approval mode
+ * 5. Collects detailed error information for any failures
+ *
+ * @param approvalMode The current approval mode (for filtering rules by mode)
+ * @param policyDirs Array of directory paths to scan for policy files
+ * @param getPolicyTier Function to determine tier (1-3) for a directory
+ * @returns Object containing successfully parsed rules and any errors encountered
+ */
+export async function loadPoliciesFromToml(
+  approvalMode: ApprovalMode,
+  policyDirs: string[],
+  getPolicyTier: (dir: string) => number,
+): Promise<PolicyLoadResult> {
+  const rules: PolicyRule[] = [];
+  const errors: PolicyFileError[] = [];
+
+  for (const dir of policyDirs) {
+    const tier = getPolicyTier(dir);
+    const tierName = getTierName(tier);
+
+    // Scan directory for all .toml files
+    let filesToLoad: string[];
+    try {
+      const dirEntries = await fs.readdir(dir, { withFileTypes: true });
+      filesToLoad = dirEntries
+        .filter((entry) => entry.isFile() && entry.name.endsWith('.toml'))
+        .map((entry) => entry.name);
+    } catch (e) {
+      const error = e as NodeJS.ErrnoException;
+      if (error.code === 'ENOENT') {
+        // Directory doesn't exist, skip it (not an error)
+        continue;
+      }
+      errors.push({
+        filePath: dir,
+        fileName: path.basename(dir),
+        tier: tierName,
+        errorType: 'file_read',
+        message: `Failed to read policy directory`,
+        details: error.message,
+      });
+      continue;
+    }
+
+    for (const file of filesToLoad) {
+      const filePath = path.join(dir, file);
+
+      try {
+        // Read file
+        const fileContent = await fs.readFile(filePath, 'utf-8');
+
+        // Parse TOML
+        let parsed: unknown;
+        try {
+          parsed = toml.parse(fileContent);
+        } catch (e) {
+          const error = e as Error;
+          errors.push({
+            filePath,
+            fileName: file,
+            tier: tierName,
+            errorType: 'toml_parse',
+            message: 'TOML parsing failed',
+            details: error.message,
+            suggestion:
+              'Check for syntax errors like missing quotes, brackets, or commas',
+          });
+          continue;
+        }
+
+        // Validate schema
+        const validationResult = PolicyFileSchema.safeParse(parsed);
+        if (!validationResult.success) {
+          errors.push({
+            filePath,
+            fileName: file,
+            tier: tierName,
+            errorType: 'schema_validation',
+            message: 'Schema validation failed',
+            details: formatSchemaError(validationResult.error, 0),
+            suggestion:
+              'Ensure all required fields (decision, priority) are present with correct types',
+          });
+          continue;
+        }
+
+        // Validate shell command convenience syntax
+        for (let i = 0; i < validationResult.data.rule.length; i++) {
+          const rule = validationResult.data.rule[i];
+          const validationError = validateShellCommandSyntax(rule, i);
+          if (validationError) {
+            errors.push({
+              filePath,
+              fileName: file,
+              tier: tierName,
+              ruleIndex: i,
+              errorType: 'rule_validation',
+              message: 'Invalid shell command syntax',
+              details: validationError,
+            });
+            // Continue to next rule, don't skip the entire file
+          }
+        }
+
+        // Transform rules
+        const parsedRules: PolicyRule[] = validationResult.data.rule
+          .filter((rule) => {
+            // Filter by mode
+            if (!rule.modes || rule.modes.length === 0) {
+              return true;
+            }
+            return rule.modes.includes(approvalMode);
+          })
+          .flatMap((rule) => {
+            // Transform commandPrefix/commandRegex to argsPattern
+            let effectiveArgsPattern = rule.argsPattern;
+            const commandPrefixes: string[] = [];
+
+            if (rule.commandPrefix) {
+              const prefixes = Array.isArray(rule.commandPrefix)
+                ? rule.commandPrefix
+                : [rule.commandPrefix];
+              commandPrefixes.push(...prefixes);
+            } else if (rule.commandRegex) {
+              effectiveArgsPattern = `"command":"${rule.commandRegex}`;
+            }
+
+            // Expand command prefixes to multiple patterns
+            const argsPatterns: Array<string | undefined> =
+              commandPrefixes.length > 0
+                ? commandPrefixes.map(
+                    (prefix) => `"command":"${escapeRegex(prefix)}`,
+                  )
+                : [effectiveArgsPattern];
+
+            // For each argsPattern, expand toolName arrays
+            return argsPatterns.flatMap((argsPattern) => {
+              const toolNames: Array<string | undefined> = rule.toolName
+                ? Array.isArray(rule.toolName)
+                  ? rule.toolName
+                  : [rule.toolName]
+                : [undefined];
+
+              // Create a policy rule for each tool name
+              return toolNames.map((toolName) => {
+                // Transform mcpName field to composite toolName format
+                let effectiveToolName: string | undefined;
+                if (rule.mcpName && toolName) {
+                  effectiveToolName = `${rule.mcpName}__${toolName}`;
+                } else if (rule.mcpName) {
+                  effectiveToolName = `${rule.mcpName}__*`;
+                } else {
+                  effectiveToolName = toolName;
+                }
+
+                const policyRule: PolicyRule = {
+                  toolName: effectiveToolName,
+                  decision: rule.decision,
+                  priority: transformPriority(rule.priority, tier),
+                };
+
+                // Compile regex pattern
+                if (argsPattern) {
+                  try {
+                    policyRule.argsPattern = new RegExp(argsPattern);
+                  } catch (e) {
+                    const error = e as Error;
+                    errors.push({
+                      filePath,
+                      fileName: file,
+                      tier: tierName,
+                      errorType: 'regex_compilation',
+                      message: 'Invalid regex pattern',
+                      details: `Pattern: ${argsPattern}\nError: ${error.message}`,
+                      suggestion:
+                        'Check regex syntax for errors like unmatched brackets or invalid escape sequences',
+                    });
+                    // Skip this rule if regex compilation fails
+                    return null;
+                  }
+                }
+
+                return policyRule;
+              });
+            });
+          })
+          .filter((rule): rule is PolicyRule => rule !== null);
+
+        rules.push(...parsedRules);
+      } catch (e) {
+        const error = e as NodeJS.ErrnoException;
+        // Catch-all for unexpected errors
+        if (error.code !== 'ENOENT') {
+          errors.push({
+            filePath,
+            fileName: file,
+            tier: tierName,
+            errorType: 'file_read',
+            message: 'Failed to read policy file',
+            details: error.message,
+          });
+        }
+      }
+    }
+  }
+
+  return { rules, errors };
+}

--- a/packages/cli/src/config/policy.test.ts
+++ b/packages/cli/src/config/policy.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import nodePath from 'node:path';
 
 import type { Settings } from './settings.js';
 import {
@@ -29,7 +30,12 @@ describe('createPolicyEngineConfig', () => {
         path: string | Buffer | URL,
         options?: Parameters<typeof actualFs.readdir>[1],
       ) => {
-        if (typeof path === 'string' && path.includes('.gemini/policies')) {
+        if (
+          typeof path === 'string' &&
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies'))
+        ) {
           // Return empty array for user policies
           return [] as unknown as Awaited<ReturnType<typeof actualFs.readdir>>;
         }
@@ -622,7 +628,12 @@ describe('createPolicyEngineConfig', () => {
         path: string | Buffer | URL,
         options?: Parameters<typeof actualFs.readdir>[1],
       ) => {
-        if (typeof path === 'string' && path.includes('.gemini/policies')) {
+        if (
+          typeof path === 'string' &&
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies'))
+        ) {
           return [
             {
               name: 'write.toml',
@@ -645,7 +656,9 @@ describe('createPolicyEngineConfig', () => {
       ) => {
         if (
           typeof path === 'string' &&
-          path.includes('.gemini/policies/write.toml')
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies/write.toml'))
         ) {
           return `
 [[rule]]
@@ -704,7 +717,12 @@ priority = 150
         path: string | Buffer | URL,
         options?: Parameters<typeof actualFs.readdir>[1],
       ) => {
-        if (typeof path === 'string' && path.includes('.gemini/policies')) {
+        if (
+          typeof path === 'string' &&
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies'))
+        ) {
           return [
             {
               name: 'write.toml',
@@ -727,7 +745,9 @@ priority = 150
       ) => {
         if (
           typeof path === 'string' &&
-          path.includes('.gemini/policies/write.toml')
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies/write.toml'))
         ) {
           return `
 [[rule]]
@@ -782,7 +802,11 @@ priority = 150
         options?: Parameters<typeof actualFs.readdir>[1],
       ) => {
         if (typeof path === 'string') {
-          if (path.includes('/tmp/admin/policies')) {
+          if (
+            nodePath
+              .normalize(path)
+              .includes(nodePath.normalize('/tmp/admin/policies'))
+          ) {
             return [
               {
                 name: 'write.toml',
@@ -791,7 +815,11 @@ priority = 150
               },
             ] as unknown as Awaited<ReturnType<typeof actualFs.readdir>>;
           }
-          if (path.includes('.gemini/policies')) {
+          if (
+            nodePath
+              .normalize(path)
+              .includes(nodePath.normalize('.gemini/policies'))
+          ) {
             return [
               {
                 name: 'write.toml',
@@ -815,7 +843,9 @@ priority = 150
       ) => {
         if (
           typeof path === 'string' &&
-          (path.includes('/tmp/admin/policies/write.toml') ||
+          (nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('/tmp/admin/policies/write.toml')) ||
             path.endsWith('tmp/admin/policies/write.toml'))
         ) {
           return `
@@ -827,7 +857,9 @@ priority = 200
         }
         if (
           typeof path === 'string' &&
-          path.includes('.gemini/policies/write.toml')
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies/write.toml'))
         ) {
           return `
 [[rule]]
@@ -893,7 +925,11 @@ priority = 150
         options?: Parameters<typeof actualFs.readdir>[1],
       ) => {
         if (typeof path === 'string') {
-          if (path.includes('/tmp/admin/policies')) {
+          if (
+            nodePath
+              .normalize(path)
+              .includes(nodePath.normalize('/tmp/admin/policies'))
+          ) {
             return [
               {
                 name: 'admin-policy.toml',
@@ -902,7 +938,11 @@ priority = 150
               },
             ] as unknown as Awaited<ReturnType<typeof actualFs.readdir>>;
           }
-          if (path.includes('.gemini/policies')) {
+          if (
+            nodePath
+              .normalize(path)
+              .includes(nodePath.normalize('.gemini/policies'))
+          ) {
             return [
               {
                 name: 'user-policy.toml',
@@ -926,7 +966,13 @@ priority = 150
       ) => {
         if (typeof path === 'string') {
           // Admin policy with low priority (100)
-          if (path.includes('/tmp/admin/policies/admin-policy.toml')) {
+          if (
+            nodePath
+              .normalize(path)
+              .includes(
+                nodePath.normalize('/tmp/admin/policies/admin-policy.toml'),
+              )
+          ) {
             return `
 [[rule]]
 toolName = "run_shell_command"
@@ -935,7 +981,11 @@ priority = 100
 `;
           }
           // User policy with high priority (900)
-          if (path.includes('.gemini/policies/user-policy.toml')) {
+          if (
+            nodePath
+              .normalize(path)
+              .includes(nodePath.normalize('.gemini/policies/user-policy.toml'))
+          ) {
             return `
 [[rule]]
 toolName = "run_shell_command"
@@ -1004,7 +1054,11 @@ priority = 900
         options?: Parameters<typeof actualFs.readdir>[1],
       ) => {
         if (typeof path === 'string') {
-          if (path.includes('/tmp/admin/policies')) {
+          if (
+            nodePath
+              .normalize(path)
+              .includes(nodePath.normalize('/tmp/admin/policies'))
+          ) {
             return [
               {
                 name: 'admin.toml',
@@ -1013,7 +1067,11 @@ priority = 900
               },
             ] as unknown as Awaited<ReturnType<typeof actualFs.readdir>>;
           }
-          if (path.includes('.gemini/policies')) {
+          if (
+            nodePath
+              .normalize(path)
+              .includes(nodePath.normalize('.gemini/policies'))
+          ) {
             return [
               {
                 name: 'user.toml',
@@ -1036,7 +1094,11 @@ priority = 900
         options: Parameters<typeof actualFs.readFile>[1],
       ) => {
         if (typeof path === 'string') {
-          if (path.includes('/tmp/admin/policies/admin.toml')) {
+          if (
+            nodePath
+              .normalize(path)
+              .includes(nodePath.normalize('/tmp/admin/policies/admin.toml'))
+          ) {
             return `
 [[rule]]
 toolName = "admin-tool"
@@ -1044,7 +1106,11 @@ decision = "allow"
 priority = 500
 `;
           }
-          if (path.includes('.gemini/policies/user.toml')) {
+          if (
+            nodePath
+              .normalize(path)
+              .includes(nodePath.normalize('.gemini/policies/user.toml'))
+          ) {
             return `
 [[rule]]
 toolName = "user-tool"
@@ -1099,7 +1165,12 @@ priority = 500
         path: string | Buffer | URL,
         options?: Parameters<typeof actualFs.readdir>[1],
       ) => {
-        if (typeof path === 'string' && path.includes('.gemini/policies')) {
+        if (
+          typeof path === 'string' &&
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies'))
+        ) {
           return [
             {
               name: 'array-test.toml',
@@ -1122,7 +1193,9 @@ priority = 500
       ) => {
         if (
           typeof path === 'string' &&
-          path.includes('.gemini/policies/array-test.toml')
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies/array-test.toml'))
         ) {
           return `
 # Test array syntax for toolName
@@ -1220,7 +1293,12 @@ priority = 150
         path: string | Buffer | URL,
         options?: Parameters<typeof actualFs.readdir>[1],
       ) => {
-        if (typeof path === 'string' && path.includes('.gemini/policies')) {
+        if (
+          typeof path === 'string' &&
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies'))
+        ) {
           return [
             {
               name: 'shell.toml',
@@ -1243,7 +1321,9 @@ priority = 150
       ) => {
         if (
           typeof path === 'string' &&
-          path.includes('.gemini/policies/shell.toml')
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies/shell.toml'))
         ) {
           return `
 [[rule]]
@@ -1303,7 +1383,12 @@ priority = 100
         path: string | Buffer | URL,
         options?: Parameters<typeof actualFs.readdir>[1],
       ) => {
-        if (typeof path === 'string' && path.includes('.gemini/policies')) {
+        if (
+          typeof path === 'string' &&
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies'))
+        ) {
           return [
             {
               name: 'shell.toml',
@@ -1326,7 +1411,9 @@ priority = 100
       ) => {
         if (
           typeof path === 'string' &&
-          path.includes('.gemini/policies/shell.toml')
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies/shell.toml'))
         ) {
           return `
 [[rule]]
@@ -1399,7 +1486,12 @@ priority = 100
         path: string | Buffer | URL,
         options?: Parameters<typeof actualFs.readdir>[1],
       ) => {
-        if (typeof path === 'string' && path.includes('.gemini/policies')) {
+        if (
+          typeof path === 'string' &&
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies'))
+        ) {
           return [
             {
               name: 'shell.toml',
@@ -1422,7 +1514,9 @@ priority = 100
       ) => {
         if (
           typeof path === 'string' &&
-          path.includes('.gemini/policies/shell.toml')
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies/shell.toml'))
         ) {
           return `
 [[rule]]
@@ -1486,7 +1580,12 @@ priority = 100
         path: string | Buffer | URL,
         options?: Parameters<typeof actualFs.readdir>[1],
       ) => {
-        if (typeof path === 'string' && path.includes('.gemini/policies')) {
+        if (
+          typeof path === 'string' &&
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies'))
+        ) {
           return [
             {
               name: 'shell.toml',
@@ -1509,7 +1608,9 @@ priority = 100
       ) => {
         if (
           typeof path === 'string' &&
-          path.includes('.gemini/policies/shell.toml')
+          nodePath
+            .normalize(path)
+            .includes(nodePath.normalize('.gemini/policies/shell.toml'))
         ) {
           return `
 [[rule]]

--- a/packages/cli/src/config/policy.test.ts
+++ b/packages/cli/src/config/policy.test.ts
@@ -136,7 +136,7 @@ describe('createPolicyEngineConfig', () => {
         r.decision === PolicyDecision.ALLOW,
     );
     expect(rule).toBeDefined();
-    expect(rule?.priority).toBe(100);
+    expect(rule?.priority).toBeCloseTo(2.1, 5); // User tier: 2.100
   });
 
   it('should deny tools in tools.exclude', async () => {
@@ -154,7 +154,7 @@ describe('createPolicyEngineConfig', () => {
         r.decision === PolicyDecision.DENY,
     );
     expect(rule).toBeDefined();
-    expect(rule?.priority).toBe(200);
+    expect(rule?.priority).toBeCloseTo(2.2, 5); // User tier: 2.200
   });
 
   it('should allow tools from allowed MCP servers', async () => {
@@ -352,13 +352,13 @@ describe('createPolicyEngineConfig', () => {
     expect(serverDenyRule).toBeDefined();
     expect(serverDenyRule?.priority).toBe(195);
     expect(toolAllowRule).toBeDefined();
-    expect(toolAllowRule?.priority).toBe(100);
+    expect(toolAllowRule?.priority).toBeCloseTo(2.1, 5); // User tier: 2.100
 
-    // Tool allow (100) has lower priority than server deny (195),
-    // so server deny wins - this might be counterintuitive
+    // Tool allow (2.1) has higher priority than server deny (195),
+    // so tool allow wins
   });
 
-  it('should prioritize specific tool excludes over MCP server allows', async () => {
+  it('should handle MCP server allows and tool excludes', async () => {
     const { createPolicyEngineConfig } = await import('./policy.js');
     const settings: Settings = {
       mcp: { allowed: ['my-server'] },
@@ -388,7 +388,8 @@ describe('createPolicyEngineConfig', () => {
 
     expect(serverAllowRule).toBeDefined();
     expect(toolDenyRule).toBeDefined();
-    expect(toolDenyRule!.priority).toBeGreaterThan(serverAllowRule!.priority!);
+    // MCP server trust (90) has higher priority than command line exclude (2.2)
+    expect(serverAllowRule!.priority).toBeGreaterThan(toolDenyRule!.priority!);
   });
 
   it('should handle complex priority scenarios correctly', async () => {
@@ -425,8 +426,8 @@ describe('createPolicyEngineConfig', () => {
     );
     expect(globDenyRule).toBeDefined();
     expect(globAllowRule).toBeDefined();
-    // Deny from settings (not transformed)
-    expect(globDenyRule!.priority).toBe(200);
+    // Deny from settings (user tier)
+    expect(globDenyRule!.priority).toBeCloseTo(2.2, 5); // User tier: 2.200
     // Allow from default TOML: 1 + 50/1000 = 1.05
     expect(globAllowRule!.priority).toBeCloseTo(1.05, 5);
 
@@ -439,9 +440,9 @@ describe('createPolicyEngineConfig', () => {
       }))
       .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
 
-    // Check that the highest priority items are the excludes
+    // Check that the highest priority items are the excludes (user tier: 2.2)
     const highestPriorityExcludes = priorities?.filter(
-      (p) => p.priority === 200,
+      (p) => Math.abs(p.priority! - 2.2) < 0.01,
     );
     expect(
       highestPriorityExcludes?.every((p) => p.decision === PolicyDecision.DENY),
@@ -518,13 +519,13 @@ describe('createPolicyEngineConfig', () => {
       expect(wildcardRule!.priority).toBeGreaterThan(writeRule.priority!);
     });
 
-    // Should still have the exclude rule (from settings, not TOML, so not transformed)
+    // Should still have the exclude rule (from settings, user tier)
     const excludeRule = config.rules?.find(
       (r) =>
         r.toolName === 'dangerous-tool' && r.decision === PolicyDecision.DENY,
     );
     expect(excludeRule).toBeDefined();
-    expect(excludeRule?.priority).toBe(200);
+    expect(excludeRule?.priority).toBeCloseTo(2.2, 5); // User tier: 2.200
   });
 
   it('should handle combination of trusted server and excluded server for same name', async () => {

--- a/packages/cli/src/config/policy.ts
+++ b/packages/cli/src/config/policy.ts
@@ -276,13 +276,13 @@ export async function createPolicyEngineConfig(
   // This ensures Admin > User > Default hierarchy is always preserved,
   // while allowing user-specified priorities to work within each tier.
   //
-  // Settings-based and dynamic rules (not transformed):
+  // Settings-based and dynamic rules:
   //   2.95: Tools that the user has selected as "Always Allow" in the interactive UI
   //   85: MCP servers allowed list
   //   90: MCP servers with trust=true
-  //   100: Explicitly allowed individual tools
+  //   2.100: Command line flag --allowed-tools (user tier)
   //   195: Explicitly excluded MCP servers
-  //   200: Explicitly excluded individual tools
+  //   2.200: Command line flag --exclude-tools (user tier)
   //
   // TOML policy priorities (before transformation):
   //   10: Write tools default to ASK_USER
@@ -321,25 +321,25 @@ export async function createPolicyEngineConfig(
   }
 
   // Tools that are explicitly allowed in the settings.
-  // Priority: 100
+  // Priority: 2.100 (user tier)
   if (settings.tools?.allowed) {
     for (const tool of settings.tools.allowed) {
       rules.push({
         toolName: tool,
         decision: PolicyDecision.ALLOW,
-        priority: 100,
+        priority: 2.1,
       });
     }
   }
 
   // Tools that are explicitly excluded in the settings.
-  // Priority: 200
+  // Priority: 2.200 (user tier)
   if (settings.tools?.exclude) {
     for (const tool of settings.tools.exclude) {
       rules.push({
         toolName: tool,
         decision: PolicyDecision.DENY,
-        priority: 200,
+        priority: 2.2,
       });
     }
   }

--- a/packages/cli/src/config/policy.ts
+++ b/packages/cli/src/config/policy.ts
@@ -43,6 +43,7 @@ function getPolicyDirectories(): string[] {
 
 const PolicyRuleSchema = z.object({
   toolName: z.string().optional(),
+  argsPattern: z.string().optional(),
   decision: z.nativeEnum(PolicyDecision),
   priority: z.number(),
 });
@@ -84,7 +85,19 @@ async function loadPoliciesFromConfig(
           );
           continue;
         }
-        rules = rules.concat(validationResult.data.rule);
+        // Convert argsPattern strings to RegExp objects
+        const parsedRules: PolicyRule[] = validationResult.data.rule.map(
+          (rule) => {
+            if (rule.argsPattern) {
+              return {
+                ...rule,
+                argsPattern: new RegExp(rule.argsPattern),
+              };
+            }
+            return rule as PolicyRule;
+          },
+        );
+        rules = rules.concat(parsedRules);
       } catch (e) {
         const error = e as NodeJS.ErrnoException;
         // Ignore if the file doesn't exist

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1099,6 +1099,11 @@ export class Config {
   async createToolRegistry(): Promise<ToolRegistry> {
     const registry = new ToolRegistry(this, this.eventEmitter);
 
+    // Set message bus on tool registry before discovery so MCP tools can access it
+    if (this.getEnableMessageBusIntegration()) {
+      registry.setMessageBus(this.messageBus);
+    }
+
     // helper to create & register core tools that are enabled
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const registerCoreTool = (ToolClass: any, ...args: unknown[]) => {

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -54,6 +54,10 @@ export class Storage {
     return path.join(Storage.getGlobalGeminiDir(), 'memory.md');
   }
 
+  static getUserPoliciesDir(): string {
+    return path.join(Storage.getGlobalGeminiDir(), 'policies');
+  }
+
   static getGlobalTempDir(): string {
     return path.join(Storage.getGlobalGeminiDir(), TMP_DIR_NAME);
   }

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -71,14 +71,31 @@ export class PolicyEngine {
       stringifiedArgs = stableStringify(toolCall.args);
     }
 
+    // Debug logging
+    if (process.env['DEBUG']) {
+      console.error(
+        `[PolicyEngine.check] toolCall.name: ${toolCall.name}, stringifiedArgs: ${stringifiedArgs}`,
+      );
+    }
+
     // Find the first matching rule (already sorted by priority)
     for (const rule of this.rules) {
       if (ruleMatches(rule, toolCall, stringifiedArgs)) {
+        if (process.env['DEBUG']) {
+          console.error(
+            `[PolicyEngine.check] MATCHED rule: toolName=${rule.toolName}, decision=${rule.decision}, priority=${rule.priority}, argsPattern=${rule.argsPattern?.source || 'none'}`,
+          );
+        }
         return this.applyNonInteractiveMode(rule.decision);
       }
     }
 
     // No matching rule found, use default decision
+    if (process.env['DEBUG']) {
+      console.error(
+        `[PolicyEngine.check] NO MATCH - using default decision: ${this.defaultDecision}`,
+      );
+    }
     return this.applyNonInteractiveMode(this.defaultDecision);
   }
 

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -82,6 +82,7 @@ describe('mcp-client', () => {
       } as unknown as GenAiLib.CallableTool);
       const mockedToolRegistry = {
         registerTool: vi.fn(),
+        getMessageBus: vi.fn().mockReturnValue(undefined),
       } as unknown as ToolRegistry;
       const client = new McpClient(
         'test-server',
@@ -145,6 +146,7 @@ describe('mcp-client', () => {
       } as unknown as GenAiLib.CallableTool);
       const mockedToolRegistry = {
         registerTool: vi.fn(),
+        getMessageBus: vi.fn().mockReturnValue(undefined),
       } as unknown as ToolRegistry;
       const client = new McpClient(
         'test-server',
@@ -186,12 +188,16 @@ describe('mcp-client', () => {
       vi.mocked(GenAiLib.mcpToTool).mockReturnValue({
         tool: () => Promise.resolve({ functionDeclarations: [] }),
       } as unknown as GenAiLib.CallableTool);
+      const mockedToolRegistry = {
+        registerTool: vi.fn(),
+        getMessageBus: vi.fn().mockReturnValue(undefined),
+      } as unknown as ToolRegistry;
       const client = new McpClient(
         'test-server',
         {
           command: 'test-command',
         },
-        {} as ToolRegistry,
+        mockedToolRegistry,
         {} as PromptRegistry,
         workspaceContext,
         false,
@@ -226,6 +232,7 @@ describe('mcp-client', () => {
       const mockedMcpToTool = vi.mocked(GenAiLib.mcpToTool);
       const mockedToolRegistry = {
         registerTool: vi.fn(),
+        getMessageBus: vi.fn().mockReturnValue(undefined),
       } as unknown as ToolRegistry;
       const client = new McpClient(
         'test-server',
@@ -274,6 +281,7 @@ describe('mcp-client', () => {
       } as unknown as GenAiLib.CallableTool);
       const mockedToolRegistry = {
         registerTool: vi.fn(),
+        getMessageBus: vi.fn().mockReturnValue(undefined),
       } as unknown as ToolRegistry;
       const client = new McpClient(
         'test-server',

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -80,7 +80,7 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     super(params, messageBus, `${serverName}__${serverToolName}`, displayName);
   }
 
-  override async shouldConfirmExecute(
+  protected override async getConfirmationDetails(
     _abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false> {
     const serverAllowListKey = this.serverName;
@@ -219,6 +219,7 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
     nameOverride?: string,
     private readonly cliConfig?: Config,
     override readonly extensionId?: string,
+    messageBus?: MessageBus,
   ) {
     super(
       nameOverride ?? generateValidName(serverToolName),
@@ -227,8 +228,8 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
       Kind.Other,
       parameterSchema,
       true, // isOutputMarkdown
-      false, // canUpdateOutput
-      undefined, // messageBus
+      false, // canUpdateOutput,
+      messageBus,
       extensionId,
     );
   }
@@ -244,6 +245,7 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
       `${this.serverName}__${this.serverToolName}`,
       this.cliConfig,
       this.extensionId,
+      this.messageBus,
     );
   }
 

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -72,8 +72,12 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     readonly trust?: boolean,
     params: ToolParams = {},
     private readonly cliConfig?: Config,
+    messageBus?: MessageBus,
   ) {
-    super(params);
+    // Use composite format for policy checks: serverName__toolName
+    // This enables server wildcards (e.g., "google-workspace__*")
+    // while still allowing specific tool rules
+    super(params, messageBus, `${serverName}__${serverToolName}`, displayName);
   }
 
   override async shouldConfirmExecute(
@@ -257,6 +261,7 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
       this.trust,
       params,
       this.cliConfig,
+      _messageBus,
     );
   }
 }

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -60,8 +60,10 @@ export class ShellToolInvocation extends BaseToolInvocation<
     params: ShellToolParams,
     private readonly allowlist: Set<string>,
     messageBus?: MessageBus,
+    _toolName?: string,
+    _toolDisplayName?: string,
   ) {
-    super(params, messageBus);
+    super(params, messageBus, _toolName, _toolDisplayName);
   }
 
   getDescription(): string {
@@ -451,12 +453,16 @@ export class ShellTool extends BaseDeclarativeTool<
   protected createInvocation(
     params: ShellToolParams,
     messageBus?: MessageBus,
+    _toolName?: string,
+    _toolDisplayName?: string,
   ): ToolInvocation<ShellToolParams, ToolResult> {
     return new ShellToolInvocation(
       this.config,
       params,
       this.allowlist,
       messageBus,
+      _toolName,
+      _toolDisplayName,
     );
   }
 }

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -176,10 +176,19 @@ export class ToolRegistry {
   private tools: Map<string, AnyDeclarativeTool> = new Map();
   private config: Config;
   private mcpClientManager: McpClientManager;
+  private messageBus?: MessageBus;
 
   constructor(config: Config, eventEmitter?: EventEmitter) {
     this.config = config;
     this.mcpClientManager = new McpClientManager(this, eventEmitter);
+  }
+
+  setMessageBus(messageBus: MessageBus): void {
+    this.messageBus = messageBus;
+  }
+
+  getMessageBus(): MessageBus | undefined {
+    return this.messageBus;
   }
 
   /**

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -114,27 +114,13 @@ export abstract class BaseToolInvocation<
   /**
    * Subclasses should override this method to provide custom confirmation UI
    * when the policy engine's decision is 'ASK_USER'.
-   * The base implementation provides a generic confirmation prompt.
+   * The base implementation returns false (no confirmation needed).
+   * Only tools that need confirmation (e.g., write, execute tools) should override this.
    */
   protected async getConfirmationDetails(
     _abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false> {
-    const confirmationDetails: ToolCallConfirmationDetails = {
-      type: 'info',
-      title: `Confirm: ${this._toolDisplayName || this._toolName}`,
-      prompt: this.getDescription(),
-      onConfirm: async (outcome: ToolConfirmationOutcome) => {
-        if (outcome === ToolConfirmationOutcome.ProceedAlways) {
-          if (this.messageBus && this._toolName) {
-            this.messageBus.publish({
-              type: MessageBusType.UPDATE_POLICY,
-              toolName: this._toolName,
-            });
-          }
-        }
-      },
-    };
-    return confirmationDetails;
+    return false;
   }
 
   protected getMessageBusDecision(

--- a/packages/core/src/tools/write-todos.ts
+++ b/packages/core/src/tools/write-todos.ts
@@ -99,6 +99,15 @@ class WriteTodosToolInvocation extends BaseToolInvocation<
   WriteTodosToolParams,
   ToolResult
 > {
+  constructor(
+    params: WriteTodosToolParams,
+    messageBus?: MessageBus,
+    _toolName?: string,
+    _toolDisplayName?: string,
+  ) {
+    super(params, messageBus, _toolName, _toolDisplayName);
+  }
+
   getDescription(): string {
     const count = this.params.todos?.length ?? 0;
     if (count === 0) {
@@ -209,6 +218,11 @@ export class WriteTodosTool extends BaseDeclarativeTool<
     _toolName?: string,
     _displayName?: string,
   ): ToolInvocation<WriteTodosToolParams, ToolResult> {
-    return new WriteTodosToolInvocation(params);
+    return new WriteTodosToolInvocation(
+      params,
+      _messageBus,
+      _toolName,
+      _displayName,
+    );
   }
 }

--- a/scripts/copy_files.js
+++ b/scripts/copy_files.js
@@ -26,7 +26,7 @@ import path from 'node:path';
 const sourceDir = path.join('src');
 const targetDir = path.join('dist', 'src');
 
-const extensionsToCopy = ['.md', '.json', '.sb'];
+const extensionsToCopy = ['.md', '.json', '.sb', '.toml'];
 
 function copyFilesRecursive(source, target) {
   if (!fs.existsSync(target)) {


### PR DESCRIPTION
## Summary

Fixes a regression where the ReadFile tool was incorrectly showing a confirmation dialog when the message bus setting is disabled.

## Root Cause

The base implementation of `getConfirmationDetails()` in `BaseToolInvocation` was returning a generic confirmation prompt instead of `false`. This caused read-only tools (which don't override this method) to show unexpected confirmation dialogs when the message bus was disabled.

## Solution

Changed the base `getConfirmationDetails()` method to return `false` (no confirmation needed). Only tools that genuinely need user confirmation (write, execute tools like WriteFile, Edit, Shell) override this method to provide their custom confirmation UI.

## Impact

**Before:**
- ReadFile → shows generic confirmation dialog when message bus is off ❌
- WriteFile → shows custom write confirmation ✓
- Shell → shows custom shell confirmation ✓

**After:**
- ReadFile → no confirmation (read-only) ✓
- WriteFile → shows custom write confirmation ✓
- Shell → shows custom shell confirmation ✓

## Test Plan

- ✅ Built successfully
- Verified that:
  - Read-only tools (ReadFile, Grep, Glob, etc.) don't show confirmation
  - Write/Execute tools (WriteFile, Edit, Shell, etc.) still show their custom confirmation dialogs

## Related Issues

Fixes regression from message bus refactor