### PR TITLE
Make PASTE_WORKAROUND the default.

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -752,7 +752,7 @@ describe('InputPrompt', () => {
     await wait();
 
     stdin.write('\x03'); // Ctrl+C character
-    await wait();
+    await wait(60);
 
     expect(props.buffer.setText).toHaveBeenCalledWith('');
     expect(mockCommandCompletion.resetCompletionState).toHaveBeenCalled();
@@ -766,7 +766,7 @@ describe('InputPrompt', () => {
     await wait();
 
     stdin.write('\x03'); // Ctrl+C character
-    await wait();
+    await wait(60);
 
     expect(props.buffer.setText).not.toHaveBeenCalled();
     unmount();
@@ -940,7 +940,7 @@ describe('InputPrompt', () => {
       await wait();
 
       stdin.write('\x1B[200~pasted text\x1B[201~');
-      await wait();
+      await wait(60);
 
       expect(mockBuffer.handleInput).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1331,7 +1331,7 @@ describe('InputPrompt', () => {
       await wait();
 
       stdin.write('\x1B');
-      await wait(100);
+      await wait(60);
 
       expect(props.buffer.setText).toHaveBeenCalledWith('');
       expect(mockCommandCompletion.resetCompletionState).toHaveBeenCalled();
@@ -1392,7 +1392,7 @@ describe('InputPrompt', () => {
       await wait();
 
       stdin.write('\x1B');
-      await wait(100);
+      await wait(60);
 
       expect(mockCommandCompletion.resetCompletionState).toHaveBeenCalled();
       unmount();

--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -1348,7 +1348,7 @@ describe('SettingsDialog', () => {
 
       // Press Escape to exit
       stdin.write('\u001B');
-      await wait(100);
+      await wait(60);
 
       expect(onSelect).toHaveBeenCalledWith(undefined, 'User');
 

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -481,19 +481,8 @@ export function useKeypressContext() {
   return context;
 }
 
-/**
- * Determines if the passthrough stream workaround should be used.
- * This is necessary for Node.js versions older than 20 or when the
- * PASTE_WORKAROUND environment variable is set, to correctly handle
- * paste events.
- */
 function shouldUsePassthrough(): boolean {
-  const nodeMajorVersion = parseInt(process.versions.node.split('.')[0], 10);
-  return (
-    nodeMajorVersion < 20 ||
-    process.env['PASTE_WORKAROUND'] === '1' ||
-    process.env['PASTE_WORKAROUND'] === 'true'
-  );
+  return process.env['PASTE_WORKAROUND'] !== 'false';
 }
 
 export function KeypressProvider({

--- a/packages/cli/src/ui/hooks/useKeypress.test.ts
+++ b/packages/cli/src/ui/hooks/useKeypress.test.ts
@@ -66,13 +66,6 @@ describe('useKeypress', () => {
     });
   });
 
-  const setNodeVersion = (version: string) => {
-    Object.defineProperty(process.versions, 'node', {
-      value: version,
-      configurable: true,
-    });
-  };
-
   it('should not listen if isActive is false', () => {
     renderHook(() => useKeypress(onKeypress, { isActive: false }), {
       wrapper,
@@ -124,19 +117,12 @@ describe('useKeypress', () => {
 
   describe.each([
     {
-      description: 'Modern Node (>= v20)',
-      setup: () => setNodeVersion('20.0.0'),
+      description: 'PASTE_WORKAROUND true',
+      setup: () => vi.stubEnv('PASTE_WORKAROUND', 'true'),
     },
     {
-      description: 'Legacy Node (< v20)',
-      setup: () => setNodeVersion('18.0.0'),
-    },
-    {
-      description: 'Workaround Env Var',
-      setup: () => {
-        setNodeVersion('20.0.0');
-        vi.stubEnv('PASTE_WORKAROUND', 'true');
-      },
+      description: 'PASTE_WORKAROUND false',
+      setup: () => vi.stubEnv('PASTE_WORKAROUND', 'false'),
     },
   ])('in $description', ({ setup }) => {
     beforeEach(() => {


### PR DESCRIPTION
## TLDR

This makes manual paste detection the default for all users unless they set `PASTE_WORKAROUND=false`.

## Dive Deeper

Once we are certain that this is stable and doesn't cause issues, we will remove the PASTE_WORKAROUND switch and just always use the manual paste detection for everyone.

## Reviewer Test Plan

Try pasting text in diff envs.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #7773