### PR TITLE
fix: only apply Alt key mapping on macOS to fix 'ç' on Linux

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -485,6 +485,10 @@ function shouldUsePassthrough(): boolean {
   return process.env['PASTE_WORKAROUND'] !== 'false';
 }
 
+function isMacOS(): boolean {
+  return process.platform === 'darwin';
+}
+
 export function KeypressProvider({
   children,
   kittyProtocolEnabled,
@@ -616,7 +620,7 @@ export function KeypressProvider({
       }
 
       const mappedLetter = ALT_KEY_CHARACTER_MAP[key.sequence];
-      if (mappedLetter && !key.meta && process.platform === 'darwin') {
+      if (mappedLetter && !key.meta && isMacOS()) {
         broadcast({
           name: mappedLetter,
           ctrl: false,

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -616,7 +616,7 @@ export function KeypressProvider({
       }
 
       const mappedLetter = ALT_KEY_CHARACTER_MAP[key.sequence];
-      if (mappedLetter && !key.meta) {
+      if (mappedLetter && !key.meta && process.platform === 'darwin') {
         broadcast({
           name: mappedLetter,
           ctrl: false,


### PR DESCRIPTION
Fixes #12021

## Description
This PR fixes the issue where the lowercase 'ç' character doesn't work on Linux keyboards.

## Changes
- Added platform detection (`process.platform === 'darwin'`) to only apply the Alt key mapping on macOS
- This preserves the macOS behavior where Alt+C produces 'ç'
- Allows Linux users to type 'ç' directly without it being interpreted as Alt+C

## Testing
- Tested on Linux with Portuguese (pt-PT) keyboard layout
- Character 'ç' now works correctly
- Build passes with no errors