### PR TITLE
feat(ID token support): Add ID token support for authenticating to MC…

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -150,6 +150,12 @@ Each server configuration supports the following properties:
   server. Tools listed here will not be available to the model, even if they are
   exposed by the server. **Note:** `excludeTools` takes precedence over
   `includeTools` - if a tool is in both lists, it will be excluded.
+- **`allow_scoped_id_tokens_cloud_run`** (boolean): When `true` and the MCP
+  server host is a Cloud Run service (`*.run.app`), the CLI will use Google
+  Application Default Credentials (ADC) to generate an ID token and send it as
+  `Authorization: Bearer <token>`. The ID token audience is automatically
+  derived from the server URL (e.g., `https://my-service.run.app`). When using
+  this flag, do not set OAuth scopes; they are not needed.
 - **`targetAudience`** (string): The OAuth Client ID allowlisted on the
   IAP-protected application you are trying to access. Used with
   `authProviderType: 'service_account_impersonation'`.
@@ -280,6 +286,26 @@ property:
   }
 }
 ```
+
+#### Google Credential with Cloud Run ID tokens
+
+When connecting to a Cloud Run service endpoint (`*.run.app`), you can opt into
+ID token based authentication using ADC. The audience is derived from the MCP
+server URL automatically, and no scopes are required.
+
+```json
+{
+  "mcpServers": {
+    "googleCloudServer": {
+      "url": "https://my-gcp-service.run.app/sse",
+      "authProviderType": "google_credentials",
+      "allow_scoped_id_tokens_cloud_run": true
+    }
+  }
+}
+```
+
+Note: Only `*.run.app` hosts are supported for this flag.
 
 #### Service Account Impersonation
 

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -150,12 +150,11 @@ Each server configuration supports the following properties:
   server. Tools listed here will not be available to the model, even if they are
   exposed by the server. **Note:** `excludeTools` takes precedence over
   `includeTools` - if a tool is in both lists, it will be excluded.
-- **`allow_scoped_id_tokens_cloud_run`** (boolean): When `true` and the MCP
+- **`allow_unscoped_id_tokens_cloud_run`** (boolean): When `true` and the MCP
   server host is a Cloud Run service (`*.run.app`), the CLI will use Google
-  Application Default Credentials (ADC) to generate an ID token and send it as
-  `Authorization: Bearer <token>`. The ID token audience is automatically
-  derived from the server URL (e.g., `https://my-service.run.app`). When using
-  this flag, do not set OAuth scopes; they are not needed.
+  Application Default Credentials (ADC) to generate an unscoped ID token and
+  send it as `Authorization: Bearer <token>`. When using this flag, do not set
+  OAuth scopes; they are not needed.
 - **`targetAudience`** (string): The OAuth Client ID allowlisted on the
   IAP-protected application you are trying to access. Used with
   `authProviderType: 'service_account_impersonation'`.
@@ -289,9 +288,9 @@ property:
 
 #### Google Credential with Cloud Run ID tokens
 
-When connecting to a Cloud Run service endpoint (`*.run.app`), you can opt into
-ID token based authentication using ADC. The audience is derived from the MCP
-server URL automatically, and no scopes are required.
+When connecting to a Cloud Run service endpoint (`*.run.app`), you must opt into
+ID token based authentication using ADC. Note that the generated ID token is
+unscoped.
 
 ```json
 {
@@ -299,7 +298,7 @@ server URL automatically, and no scopes are required.
     "googleCloudServer": {
       "url": "https://my-gcp-service.run.app/sse",
       "authProviderType": "google_credentials",
-      "allow_scoped_id_tokens_cloud_run": true
+      "allow_unscoped_id_tokens_cloud_run": true
     }
   }
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -193,6 +193,8 @@ export class MCPServerConfig {
     // OAuth configuration
     readonly oauth?: MCPOAuthConfig,
     readonly authProviderType?: AuthProviderType,
+    // When true, use Google ADC to fetch ID tokens for Cloud Run
+    readonly allow_scoped_id_tokens_cloud_run?: boolean,
     // Service Account Configuration
     /* targetAudience format: CLIENT_ID.apps.googleusercontent.com */
     readonly targetAudience?: string,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -194,7 +194,7 @@ export class MCPServerConfig {
     readonly oauth?: MCPOAuthConfig,
     readonly authProviderType?: AuthProviderType,
     // When true, use Google ADC to fetch ID tokens for Cloud Run
-    readonly allow_scoped_id_tokens_cloud_run?: boolean,
+    readonly allow_unscoped_id_tokens_cloud_run?: boolean,
     // Service Account Configuration
     /* targetAudience format: CLIENT_ID.apps.googleusercontent.com */
     readonly targetAudience?: string,

--- a/packages/core/src/mcp/google-auth-provider.test.ts
+++ b/packages/core/src/mcp/google-auth-provider.test.ts
@@ -29,13 +29,12 @@ describe('GoogleCredentialProvider', () => {
       url: 'https://test.googleapis.com',
     } as MCPServerConfig;
     expect(() => new GoogleCredentialProvider(config)).toThrow(
-      'Scopes must be provided in the oauth config for Google Credentials provider (or enable allow_unscoped_id_tokens_cloud_run. to use ID tokens)',
+      'Scopes must be provided in the oauth config for Google Credentials provider (or enable allow_unscoped_id_tokens_for_cloud_run to use ID tokens)',
     );
   });
 
   it('should use scopes from the config if provided', () => {
-    const provider = new GoogleCredentialProvider(validConfig);
-    expect(provider.clientInformation()).toBeUndefined();
+    new GoogleCredentialProvider(validConfig);
     expect(GoogleAuth).toHaveBeenCalledWith({
       scopes: ['scope1', 'scope2'],
     });
@@ -60,8 +59,7 @@ describe('GoogleCredentialProvider', () => {
         scopes: ['scope1', 'scope2'],
       },
     } as MCPServerConfig;
-    const provider = new GoogleCredentialProvider(config);
-    expect(provider.clientInformation()).toBeUndefined();
+    new GoogleCredentialProvider(config);
   });
 
   it('should allow sub.luci.app', () => {

--- a/packages/core/src/mcp/google-auth-provider.test.ts
+++ b/packages/core/src/mcp/google-auth-provider.test.ts
@@ -29,7 +29,7 @@ describe('GoogleCredentialProvider', () => {
       url: 'https://test.googleapis.com',
     } as MCPServerConfig;
     expect(() => new GoogleCredentialProvider(config)).toThrow(
-      'Scopes must be provided in the oauth config for Google Credentials provider (or enable allow_unscoped_id_tokens_for_cloud_run to use ID tokens)',
+      'Scopes must be provided in the oauth config for Google Credentials provider (or enable allow_unscoped_id_tokens_for_cloud_run to use ID tokens for Cloud Run endpoints)',
     );
   });
 

--- a/packages/core/src/mcp/google-auth-provider.ts
+++ b/packages/core/src/mcp/google-auth-provider.ts
@@ -70,7 +70,7 @@ export class GoogleCredentialProvider implements OAuthClientProvider {
     // If we are using the access token flow, we MUST have scopes.
     if (!this.useIdToken && !this.config?.oauth?.scopes) {
       throw new Error(
-        'Scopes must be provided in the oauth config for Google Credentials provider (or enable allow_unscoped_id_tokens_for_cloud_run to use ID tokens)',
+        'Scopes must be provided in the oauth config for Google Credentials provider (or enable allow_unscoped_id_tokens_for_cloud_run to use ID tokens for Cloud Run endpoints)',
       );
     }
 


### PR DESCRIPTION
## TLDR
This pull request adds ID token support for authenticating to MCP servers hosted on Cloud Run since Cloud Run does not currently accept access tokens. Related to go/gemini-cli-cloud-run-iap-issue

## Dive Deeper

This change allows the GeminiCLI client to correctly fetch and use an **audience-scoped** ID token when communicating with a restricted MCP server on Cloud Run. It introduces a new Boolean field called `allow_scoped_id_tokens_cloud_run` which when set to true in `settings.json` and when MCP server URL is `run.app` URL then it tells the GeminiCLI client to use ID tokens for connecting to MCP servers hosted on Cloud Run. Otherwise GeminiCLI defaults to using access tokens. This ID token support works with the Cloud Run inbuilt IAM check and not IAP (Identity Aware Proxy). The token generated is scoped to specific audience (run.app URL) which is automatically generated from the MCP server URL provided.

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

1. Create and deploy an MCP server on Cloud Run. 
2. Enable Require Authentication and then select Identity and Access Management (IAM) in the Security tab. Do not enable IAP.
3. Provide the user principal `run.invoker` permission on the MCP server deployed. 
4. Update your `settings.json` with the MCP server details and the required fields as below: 

```
"mcpServers": {
    "my-mcp-server": {
      "httpUrl": "https://my-server-12345678.europe-west1.run.app/mcp",
      "authProviderType": "google_credentials",
      "allow_scoped_id_tokens_cloud_run": "true"
    }
}
```
5. Run the CLI and ensure that it can connect to the MCP server and that the tools are discovered.
6. Run the unit tests to ensure that all tests pass via `npm test`.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | x  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

#12030 
<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
