### PR TITLE
fix(core): isSubpath failure on Unicode paths due to normalization mismatch

### DIFF
--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -193,6 +193,24 @@ describe('isSubpath', () => {
     expect(isSubpath('/a/b', '/a/b/c/')).toBe(true);
     expect(isSubpath('/a/b/', '/a/b/c/')).toBe(true);
   });
+
+  it('handles unicode normalization differences (NFC)',
+    () => {
+      const parent = '/Users/user/테스트';
+      const child = '/Users/user/테스트/gemini-cli';
+
+      const parentNFD = parent.normalize('NFD');
+      const childNFC = child.normalize('NFC');
+
+      expect(isSubpath(parentNFD, childNFC)).toBe(true);
+      expect(isSubpath(childNFC, parentNFD)).toBe(false);
+
+      const unrelated = '/Users/user/다른폴더';
+
+      const unrelatedNFC = unrelated.normalize('NFC');
+      expect(isSubpath(parentNFD, unrelatedNFC)).toBe(false);
+    },
+  );
 });
 
 describe('isSubpath on Windows', () => {

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -194,23 +194,21 @@ describe('isSubpath', () => {
     expect(isSubpath('/a/b/', '/a/b/c/')).toBe(true);
   });
 
-  it('handles unicode normalization differences (NFC)',
-    () => {
-      const parent = '/Users/user/테스트';
-      const child = '/Users/user/테스트/gemini-cli';
+  it('handles unicode normalization differences (NFC)', () => {
+    const parent = '/Users/user/테스트';
+    const child = '/Users/user/테스트/gemini-cli';
 
-      const parentNFD = parent.normalize('NFD');
-      const childNFC = child.normalize('NFC');
+    const parentNFD = parent.normalize('NFD');
+    const childNFC = child.normalize('NFC');
 
-      expect(isSubpath(parentNFD, childNFC)).toBe(true);
-      expect(isSubpath(childNFC, parentNFD)).toBe(false);
+    expect(isSubpath(parentNFD, childNFC)).toBe(true);
+    expect(isSubpath(childNFC, parentNFD)).toBe(false);
 
-      const unrelated = '/Users/user/다른폴더';
+    const unrelated = '/Users/user/다른폴더';
 
-      const unrelatedNFC = unrelated.normalize('NFC');
-      expect(isSubpath(parentNFD, unrelatedNFC)).toBe(false);
-    },
-  );
+    const unrelatedNFC = unrelated.normalize('NFC');
+    expect(isSubpath(parentNFD, unrelatedNFC)).toBe(false);
+  });
 });
 
 describe('isSubpath on Windows', () => {

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -312,8 +312,11 @@ export function isSubpath(parentPath: string, childPath: string): boolean {
   const isWindows = os.platform() === 'win32';
   const pathModule = isWindows ? path.win32 : path;
 
+  const normalizedParent = parentPath.normalize('NFC');
+  const normalizedChild = childPath.normalize('NFC');
+
   // On Windows, path.relative is case-insensitive. On POSIX, it's case-sensitive.
-  const relative = pathModule.relative(parentPath, childPath);
+  const relative = pathModule.relative(normalizedParent, normalizedChild);
 
   return (
     !relative.startsWith(`..${pathModule.sep}`) &&


### PR DESCRIPTION
## TLDR

This PR fixes a bug where `isSubpath` failed to compare paths with certain Unicode characters (e.g., Hangul, accented letters) on macOS. It resolves this by normalizing paths to the NFC standard before comparison, ensuring consistent and reliable behavior regardless of the underlying filesystem's normalization scheme.

## Dive Deeper

### The Problem

The root cause is a difference in Unicode normalization between systems. macOS filesystems (APFS, HFS+) typically store filenames using NFD (Normalization Form Decomposed), where a character like `é` is represented as a combination of `e` and `´`. In contrast, most web and JavaScript environments use NFC (Normalization Form Composed), where `é` is a single, pre-composed character.

This discrepancy causes `path.relative()`, which relies on string comparison, to see NFC and NFD paths as different. This leads to incorrect relative path calculations and causes `isSubpath` to fail for valid subpaths.

Example failure: `isSubpath('/Users/user/résumé', '/Users/user/résumé/details.txt')` could return `false`.

### The Solution: Normalize to NFC

The adopted solution is to use a single, consistent normalization form before any comparison. The `isSubpath` function now normalizes both the parent and child paths to NFC.

#### Why NFC was chosen:
- **Consistency & Web Standard**: NFC is the recommended standard for the web by the W3C and is the default in most JavaScript environments. This choice maintains consistency with the broader ecosystem.
- **Sufficiency**: The key to the fix is consistency. As long as both paths are in the same form (either NFC or NFD), the comparison will work correctly. Given that a choice had to be made, aligning with the more common standard was the most logical option.
- **Simplicity**: The fix uses the built-in `String.prototype.normalize()` method, requiring no external dependencies.

### Alternative Solutions and Why I Didn't Choose Them

- **Normalizing to NFD:** Technically, I could have solved the problem by normalizing all paths to NFD (Normalization Form Decomposed). However, this would only mirror the specific behavior of macOS filesystems and wouldn’t be consistent with the way paths are typically handled on the web or in most JavaScript environments. I wanted a solution that feels more universal and future-proof, so I decided against this approach.
- **Trying to Compare Without Normalization:** I also thought about comparing paths as-is and only normalizing if a mismatch in normalization forms was detected. But in practice, this adds a lot of unnecessary complexity and increases the risk of subtle bugs. I think that normalizing both paths up front is much simpler and ensures comparisons work reliably in all cases.

## Reviewer Test Plan

1.  Pull down this branch.
2.  Run the unit tests via `npm test`. The updated tests in `packages/core/src/utils/paths.test.ts` should pass, confirming the fix.
3.  (Manual Validation on macOS) To manually verify:
    *   Create a directory with a name containing Hangul or other non-ASCII characters (e.g., `mkdir ~/테스트` or `mkdir ~/résumé`).
    *   Create a file or directory inside it (e.g., `touch ~/테스트/file.txt`).
    *   Run the following Node.js script from your project root, which uses the compiled `isSubpath` function:
        ```javascript
        const { isSubpath } = require('./packages/core/dist/utils/paths.js');
        const parent = require('os').homedir() + '/테스트'; // or '/résumé'
        const child = require('os').homedir() + '/테스트/file.txt';
        console.log(`Is subpath? ${isSubpath(parent, child)}`); // Should print true
        ```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

- Fixes #12153
