### PR TITLE
refactor: Migrate console.error to debugLogger.warn in atCommandProcessor.ts

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -281,7 +281,7 @@ export async function handleAtCommand({
                 );
               }
             } catch (globError) {
-              console.error(
+              debugLogger.warn(
                 `Error during glob search for ${pathName}: ${getErrorMessage(globError)}`,
               );
               onDebugMessage(
@@ -294,7 +294,7 @@ export async function handleAtCommand({
             );
           }
         } else {
-          console.error(
+          debugLogger.warn(
             `Error stating path ${pathName}: ${getErrorMessage(error)}`,
           );
           onDebugMessage(


### PR DESCRIPTION
## Summary

This PR migrates two `console.error` calls to `debugLogger.warn` in `atCommandProcessor.ts` as part of our logging standardization effort.

## Changes

- **Line 284**: Changed `console.error` to `debugLogger.warn` for glob search errors
- **Line 297**: Changed `console.error` to `debugLogger.warn` for file stat errors

## Context

Both `console.error` calls are in `catch` blocks that handle file system errors during @-command processing:
1. When glob search fails for a file path
2. When `fs.stat` operation fails on a path

In both cases, these are **non-critical, handled errors**. The code gracefully skips the problematic path and continues processing the user's query, making them appropriate for warning-level logging rather than error-level.

## Testing

- ✅ All tests pass (`npm run preflight`)
- ✅ No TypeScript errors
- ✅ Linting passes
- ✅ Existing test coverage validates the behavior

## Related Issues

Fixes #11903
Part of parent issue #10761
Reference PR #11803 for similar logging migrations