### PR TITLE
feat: Expose `CODE_ASSIST_API_VERSION` similar to already exposed `CODE_ASSIST_ENDPOINT`

### DIFF
--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -229,7 +229,9 @@ export class CodeAssistServer implements ContentGenerator {
   getMethodUrl(method: string): string {
     const endpoint =
       process.env['CODE_ASSIST_ENDPOINT'] ?? CODE_ASSIST_ENDPOINT;
-    return `${endpoint}/${CODE_ASSIST_API_VERSION}:${method}`;
+    const apiVersion = 
+      process.env['CODE_ASSIST_API_VERSION'] ?? CODE_ASSIST_API_VERSION;
+    return `${endpoint}/${apiVersion}:${method}`;
   }
 }
 


### PR DESCRIPTION
## Summary

For testing purposes it is important to be able to override not only the already exposed `CODE_ASSIST_ENDPOINT` but also the `CODE_ASSIST_API_VERSION`. This PR exposes the `CODE_ASSIST_API_VERSION` similar to the already exposed `CODE_ASSIST_ENDPOINT`.

## Related Issues

closes #12160 

## How to Validate

- Set environment variable `CODE_ASSIST_API_VERSION` to a custom value (e.g. different from the default `v1internal`)
- Make a request with gemini-cli and check if the API version specified in `CODE_ASSIST_API_VERSION` was used

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
