### PR TITLE
Change debug drawer keybinding to F12

### DIFF
--- a/docs/cli/keyboard-shortcuts.md
+++ b/docs/cli/keyboard-shortcuts.md
@@ -10,10 +10,10 @@ This document lists the available keyboard shortcuts in the Gemini CLI.
 | `Ctrl+C` | Cancel the ongoing request and clear the input. Press twice to exit the application.                                  |
 | `Ctrl+D` | Exit the application if the input is empty. Press twice to confirm.                                                   |
 | `Ctrl+L` | Clear the screen.                                                                                                     |
-| `Ctrl+O` | Toggle the display of the debug console.                                                                              |
 | `Ctrl+S` | Allows long responses to print fully, disabling truncation. Use your terminal's scrollback to view the entire output. |
 | `Ctrl+T` | Toggle the display of the todo list.                                                                                  |
 | `Ctrl+Y` | Toggle auto-approval (YOLO mode) for all tool calls.                                                                  |
+| `F12`    | Toggle the display of the debug console.                                                                              |
 
 ## Input Prompt
 

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -156,7 +156,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.PASTE_CLIPBOARD_IMAGE]: [{ key: 'v', ctrl: true }],
 
   // App level bindings
-  [Command.SHOW_ERROR_DETAILS]: [{ key: 'o', ctrl: true }],
+  [Command.SHOW_ERROR_DETAILS]: [{ key: 'f12' }],
   [Command.SHOW_FULL_TODOS]: [{ key: 't', ctrl: true }],
   [Command.TOGGLE_IDE_CONTEXT_DETAIL]: [{ key: 'g', ctrl: true }],
   [Command.TOGGLE_MARKDOWN]: [{ key: 'm', command: true }],

--- a/packages/cli/src/ui/components/ConsoleSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ConsoleSummaryDisplay.tsx
@@ -27,7 +27,7 @@ export const ConsoleSummaryDisplay: React.FC<ConsoleSummaryDisplayProps> = ({
       {errorCount > 0 && (
         <Text color={theme.status.error}>
           {errorIcon} {errorCount} error{errorCount > 1 ? 's' : ''}{' '}
-          <Text color={theme.text.secondary}>(ctrl+o for details)</Text>
+          <Text color={theme.text.secondary}>(F12 for details)</Text>
         </Text>
       )}
     </Box>

--- a/packages/cli/src/ui/components/DetailedMessagesDisplay.tsx
+++ b/packages/cli/src/ui/components/DetailedMessagesDisplay.tsx
@@ -37,8 +37,7 @@ export const DetailedMessagesDisplay: React.FC<
     >
       <Box marginBottom={1}>
         <Text bold color={theme.text.primary}>
-          Debug Console{' '}
-          <Text color={theme.text.secondary}>(ctrl+o to close)</Text>
+          Debug Console <Text color={theme.text.secondary}>(F12 to close)</Text>
         </Text>
       </Box>
       <MaxSizedBox maxHeight={maxHeight} maxWidth={width - borderAndPadding}>

--- a/packages/cli/src/ui/hooks/usePhraseCycler.ts
+++ b/packages/cli/src/ui/hooks/usePhraseCycler.ts
@@ -209,7 +209,7 @@ export const INFORMATIVE_TIPS = [
   'Cancel a request with Ctrl+C, or press twice to exit...',
   'Exit the app with Ctrl+D on an empty line...',
   'Clear your screen at any time with Ctrl+L...',
-  'Toggle the debug console display with Ctrl+O...',
+  'Toggle the debug console display with F12...',
   'See full, untruncated responses with Ctrl+S...',
   'Toggle auto-approval (YOLO mode) for all tools with Ctrl+Y...',
   'Toggle shell mode by typing ! in an empty prompt...',

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -50,7 +50,7 @@ describe('keyMatchers', () => {
     [Command.OPEN_EXTERNAL_EDITOR]: (key: Key) =>
       key.ctrl && (key.name === 'x' || key.sequence === '\x18'),
     [Command.PASTE_CLIPBOARD_IMAGE]: (key: Key) => key.ctrl && key.name === 'v',
-    [Command.SHOW_ERROR_DETAILS]: (key: Key) => key.ctrl && key.name === 'o',
+    [Command.SHOW_ERROR_DETAILS]: (key: Key) => key.name === 'f12',
     [Command.SHOW_FULL_TODOS]: (key: Key) => key.ctrl && key.name === 't',
     [Command.TOGGLE_IDE_CONTEXT_DETAIL]: (key: Key) =>
       key.ctrl && key.name === 'g',
@@ -212,8 +212,8 @@ describe('keyMatchers', () => {
     // App level bindings
     {
       command: Command.SHOW_ERROR_DETAILS,
-      positive: [createKey('o', { ctrl: true })],
-      negative: [createKey('o'), createKey('e', { ctrl: true })],
+      positive: [createKey('f12')],
+      negative: [createKey('o', { ctrl: true }), createKey('f11')],
     },
     {
       command: Command.SHOW_FULL_TODOS,


### PR DESCRIPTION
## Summary

Change debug drawer keybinding to F12

After researching various unused `ctrl+` it became clear that none of them would work for our purposes without clashing with existing systems:

   * Ctrl+B: tmux control character
   * Ctrl+H: Backspace (risky)
   * Ctrl+I: Tab (risky)
   * Ctrl+Q: Flow control (often freezes terminal)
   * Ctrl+W: Delete word backward (standard unix)
   * Ctrl+Y: Yank/Paste (emacs/readline standard)
   * Ctrl+Z: Suspend process (standard unix)

`F12` is often used for developer tools so I'm going with that.

## Related Issues

Fixes #11915

## How to Validate

Open the debug drawer by hitting `F12`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
