### PR TITLE
fix: Enable tool output truncation for all tools, not just shell #12172

### DIFF
--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1176,7 +1176,7 @@ export class CoreToolScheduler {
       // After completion, process the next item in the queue.
       if (this.requestQueue.length > 0) {
         const next = this.requestQueue.shift()!;
-        _schedule(next.request, next.signal)
+        this._schedule(next.request, next.signal)
           .then(next.resolve)
           .catch(next.reject);
       }

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1067,7 +1067,6 @@ export class CoreToolScheduler {
               typeof content === 'string' ? content.length : undefined;
             if (
               typeof content === 'string' &&
-              toolName === SHELL_TOOL_NAME &&
               this.config.getEnableToolOutputTruncation() &&
               this.config.getTruncateToolOutputThreshold() > 0 &&
               this.config.getTruncateToolOutputLines() > 0
@@ -1177,7 +1176,7 @@ export class CoreToolScheduler {
       // After completion, process the next item in the queue.
       if (this.requestQueue.length > 0) {
         const next = this.requestQueue.shift()!;
-        this._schedule(next.request, next.signal)
+        _schedule(next.request, next.signal)
           .then(next.resolve)
           .catch(next.reject);
       }


### PR DESCRIPTION
## Summary

Fixed tool output truncation feature to work with all tools, not just shell commands. MCP Server tools like `list_instances` are now properly truncated when `enableToolOutputTruncation` setting is enabled.

## Details

The tool output truncation settings (`enableToolOutputTruncation`, `truncateToolOutputLines`, `truncateToolOutputThreshold`) were only being applied to shell tool outputs. MCP Server tools were excluded due to a tool name check that specifically looked for `SHELL_TOOL_NAME`. This meant users couldn't truncate large outputs from MCP tools even when the feature was enabled.

The fix removes the shell-only restriction from the truncation logic, allowing all tools that produce string output to be truncated when the setting is enabled.

## Related Issues

Closes #12172

## How to Validate

1. **Build the project:**
```bash
   npm install
   npm run build
```

2. **Update settings.json with truncation enabled:**
```json
   {
     "tools": {
       "enableToolOutputTruncation": true,
       "truncateToolOutputLines": 5,
       "truncateToolOutputThreshold": 10
     }
   }
```

3. **Test with MCP tool:**
```bash
   gemini > list_instances
```
   
4. **Expected result:** Output should be truncated to 5 lines with "... (output truncated - X more lines)" message

5. **Test with shell command:**
```bash
   gemini > ls -la /large/directory
```
   
6. **Expected result:** Shell tool output should still be truncated as before

## Pre-Merge Checklist

- [x] Updated relevant documentation (if needed)
- [x] Added/updated tests (if needed) 
- [x] No breaking changes to existing functionality
- [x] All existing features still work (shell tool truncation unchanged)
- [x] Code follows project conventions
- [x] Solution is minimal and focused on the issue