### PR TITLE
feat(docs): Symlink CONTRIBUTING.md in the docs folder so that the site can pick it up.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,7 +243,7 @@ npm run test:e2e
 ```
 
 For more detailed information on the integration testing framework, please see
-the [Integration Tests documentation](./docs/integration-tests.md).
+the [Integration Tests documentation](/docs/integration-tests.md).
 
 ### Linting and preflight checks
 
@@ -472,7 +472,7 @@ code.
 
 ### Documentation structure
 
-Our documentation is organized using [sidebar.json](docs/sidebar.json) as the
+Our documentation is organized using [sidebar.json](/docs/sidebar.json) as the
 table of contents. When adding new documentation:
 
 1. Create your markdown file **in the appropriate directory** under `/docs`.
@@ -524,7 +524,7 @@ Before submitting your documentation pull request, please:
 
 If you have questions about contributing documentation:
 
-- Check our [FAQ](docs/faq.md).
+- Check our [FAQ](/docs/faq.md).
 - Review existing documentation for examples.
 - Open [an issue](https://github.com/google-gemini/gemini-cli/issues) to discuss
   your proposed changes.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -9,6 +9,10 @@
       {
         "label": "Architecture Overview",
         "slug": "docs/architecture"
+      },
+      {
+        "label": "Contribution Guide",
+        "slug": "docs/contributing"
       }
     ]
   },


### PR DESCRIPTION
## Summary

Adds a symlink for `~/docs/CONTRIBUTING.md` to `~/CONTRIBUTING.md`

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

https://github.com/google-gemini/geminicli-site/issues/81

## How to Validate

N/A

## Pre-Merge Checklist

N/A
