### PR TITLE
feat: Add experimental JIT context loading

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2442,3 +2442,32 @@ describe('Telemetry configuration via environment variables', () => {
     expect(config.getTelemetryLogPromptsEnabled()).toBe(false);
   });
 });
+
+describe('loadCliConfig experimentalJitContext', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    vi.stubEnv('GEMINI_API_KEY', 'test-api-key');
+    vi.spyOn(ExtensionManager.prototype, 'getExtensions').mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('should be false by default', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments({} as Settings);
+    const config = await loadCliConfig({}, 'test-session', argv);
+    expect(config.getExperimentalJitContext()).toBe(false);
+  });
+
+  it('should be true when set in settings', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings: Settings = { experimental: { jitContext: true } };
+    const argv = await parseArguments({} as Settings);
+    const config = await loadCliConfig(settings, 'test-session', argv);
+    expect(config.getExperimentalJitContext()).toBe(true);
+  });
+});

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -677,6 +677,7 @@ export async function loadCliConfig(
     model: resolvedModel,
     maxSessionTurns: settings.model?.maxSessionTurns ?? -1,
     experimentalZedIntegration: argv.experimentalAcp || false,
+    experimentalJitContext: settings.experimental?.jitContext ?? false,
     listExtensions: argv.listExtensions || false,
     enabledExtensions: argv.extensions,
     extensionLoader: extensionManager,

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -330,5 +330,20 @@ describe('SettingsSchema', () => {
         getSettingsSchema().experimental.properties.useModelRouter.default,
       ).toBe(true);
     });
+
+    it('should have jitContext setting in schema', () => {
+      expect(
+        getSettingsSchema().experimental.properties.jitContext,
+      ).toBeDefined();
+      expect(getSettingsSchema().experimental.properties.jitContext.type).toBe(
+        'boolean',
+      );
+      expect(
+        getSettingsSchema().experimental.properties.jitContext.category,
+      ).toBe('Experimental');
+      expect(
+        getSettingsSchema().experimental.properties.jitContext.default,
+      ).toBe(false);
+    });
   });
 });

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1145,6 +1145,15 @@ const SETTINGS_SCHEMA = {
           },
         },
       },
+      jitContext: {
+        type: 'boolean',
+        label: 'JIT Context Loading',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enable Just-In-Time loading of context files.',
+        showInDialog: false,
+      },
     },
   },
 

--- a/packages/core/src/services/contextManager.test.ts
+++ b/packages/core/src/services/contextManager.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import { ContextManager } from './contextManager.js';
+import { coreEvents } from '../utils/events.js';
+
+vi.mock('../tools/memoryTool.js', () => ({
+  getCurrentGeminiMdFilename: vi.fn(() => 'GEMINI.md'),
+}));
+
+vi.mock('../utils/memoryImportProcessor.js', () => ({
+  processImports: vi.fn(async (content) => ({
+    content,
+    importTree: { path: 'test' },
+  })),
+}));
+
+vi.mock('../utils/events.js', () => ({
+  coreEvents: {
+    emitFeedback: vi.fn(),
+  },
+}));
+
+describe('ContextManager', () => {
+  let testRootDir: string;
+  let projectRoot: string;
+  let contextManager: ContextManager;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    testRootDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'context-manager-test-'),
+    );
+    projectRoot = path.join(testRootDir, 'project');
+    await fs.mkdir(projectRoot, { recursive: true });
+
+    contextManager = new ContextManager(projectRoot);
+  });
+
+  afterEach(async () => {
+    await fs.rm(testRootDir, { recursive: true, force: true });
+  });
+
+  it('should manage loaded states correctly', () => {
+    const file = path.join(projectRoot, 'src/file.ts');
+    expect(contextManager.isLoaded(file)).toBe(false);
+
+    contextManager.markAsLoaded(file);
+    expect(contextManager.isLoaded(file)).toBe(true);
+
+    contextManager.unload(file);
+    expect(contextManager.isLoaded(file)).toBe(false);
+
+    contextManager.markAsLoaded(file);
+    contextManager.reset();
+    expect(contextManager.isLoaded(file)).toBe(false);
+  });
+
+  it('should discover context in the same directory', async () => {
+    const accessedPath = path.join(projectRoot, 'src');
+    await fs.mkdir(accessedPath, { recursive: true });
+    const contextFile = path.join(accessedPath, 'GEMINI.md');
+    await fs.writeFile(contextFile, 'Context content', 'utf8');
+
+    const result = await contextManager.discoverContext(accessedPath);
+
+    expect(result).toContain('Context content');
+    expect(result).toContain(path.join('src', 'GEMINI.md'));
+    expect(contextManager.isLoaded(contextFile)).toBe(true);
+  });
+
+  it('should start from parent directory if accessed path is a file', async () => {
+    const srcDir = path.join(projectRoot, 'src');
+    await fs.mkdir(srcDir, { recursive: true });
+    const accessedFile = path.join(srcDir, 'main.ts');
+    await fs.writeFile(accessedFile, '// some code', 'utf8');
+
+    const contextFile = path.join(srcDir, 'GEMINI.md');
+    await fs.writeFile(contextFile, 'Main context', 'utf8');
+
+    await contextManager.discoverContext(accessedFile);
+
+    expect(contextManager.isLoaded(contextFile)).toBe(true);
+  });
+
+  it('should traverse upwards to project root', async () => {
+    const authDir = path.join(projectRoot, 'src/features/auth');
+    await fs.mkdir(authDir, { recursive: true });
+
+    const authContext = path.join(authDir, 'GEMINI.md');
+    await fs.writeFile(authContext, 'Auth Context', 'utf8');
+
+    const srcContext = path.join(projectRoot, 'src/GEMINI.md');
+    await fs.writeFile(srcContext, 'Src Context', 'utf8');
+
+    const rootContext = path.join(projectRoot, 'GEMINI.md');
+    await fs.writeFile(rootContext, 'Root Context', 'utf8');
+
+    const result = await contextManager.discoverContext(authDir);
+
+    expect(result).toContain('Auth Context');
+    expect(result).toContain('Src Context');
+    expect(result).toContain('Root Context');
+    expect(contextManager.isLoaded(authContext)).toBe(true);
+    expect(contextManager.isLoaded(srcContext)).toBe(true);
+    expect(contextManager.isLoaded(rootContext)).toBe(true);
+  });
+
+  it('should stop traversal at project root', async () => {
+    const rootContext = path.join(projectRoot, 'GEMINI.md');
+    await fs.writeFile(rootContext, 'Root Context', 'utf8');
+
+    // Create a context file OUTSIDE the project root in the testRootDir
+    const outsideContext = path.join(testRootDir, 'GEMINI.md');
+    await fs.writeFile(outsideContext, 'Outside Context', 'utf8');
+
+    await contextManager.discoverContext(projectRoot);
+
+    expect(contextManager.isLoaded(rootContext)).toBe(true);
+    // Should NOT have loaded the one outside
+    expect(contextManager.isLoaded(outsideContext)).toBe(false);
+  });
+
+  it('should not re-load already loaded context', async () => {
+    const accessedPath = path.join(projectRoot, 'src');
+    await fs.mkdir(accessedPath, { recursive: true });
+    const contextFile = path.join(accessedPath, 'GEMINI.md');
+    await fs.writeFile(contextFile, 'Initial content', 'utf8');
+
+    // First load
+    const result1 = await contextManager.discoverContext(accessedPath);
+    expect(result1).toContain('Initial content');
+
+    // Modify file on disk
+    await fs.writeFile(contextFile, 'Modified content', 'utf8');
+
+    // Second load
+    const result2 = await contextManager.discoverContext(accessedPath);
+
+    // Should be empty because it's already loaded
+    expect(result2).toBe('');
+  });
+
+  it('should report read errors via coreEvents', async () => {
+    const accessedPath = path.join(projectRoot, 'src');
+    await fs.mkdir(accessedPath, { recursive: true });
+    const contextFile = path.join(accessedPath, 'GEMINI.md');
+
+    // Create a directory with the same name as the context file to cause a read error (EISDIR)
+    await fs.mkdir(contextFile);
+
+    await contextManager.discoverContext(accessedPath);
+
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'warning',
+      expect.stringContaining('Failed to read context file'),
+      expect.anything(),
+    );
+  });
+});

--- a/packages/core/src/services/contextManager.ts
+++ b/packages/core/src/services/contextManager.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as fsPromises from 'node:fs/promises';
+import { getCurrentGeminiMdFilename } from '../tools/memoryTool.js';
+import { processImports } from '../utils/memoryImportProcessor.js';
+import { coreEvents } from '../utils/events.js';
+
+export class ContextManager {
+  private loadedPaths: Set<string> = new Set();
+  private projectRoot: string;
+
+  constructor(projectRoot: string) {
+    this.projectRoot = path.resolve(projectRoot);
+  }
+
+  /**
+   * Marks a context file as loaded so it won't be re-loaded.
+   *
+   * @param filePath The absolute or relative path to the context file.
+   */
+  markAsLoaded(filePath: string) {
+    this.loadedPaths.add(path.resolve(filePath));
+  }
+
+  /**
+   * Marks a context file as unloaded. This is useful if the context was
+   * lost during chat compression and needs to be re-discoverable.
+   *
+   * @param filePath The absolute or relative path to the context file.
+   */
+  unload(filePath: string) {
+    this.loadedPaths.delete(path.resolve(filePath));
+  }
+
+  /**
+   * Checks if a context file has already been loaded.
+   *
+   * @param filePath The absolute or relative path to the context file.
+   * @returns True if the file has been loaded, false otherwise.
+   */
+  isLoaded(filePath: string): boolean {
+    return this.loadedPaths.has(path.resolve(filePath));
+  }
+
+  /**
+   * Resets the state of loaded context files.
+   */
+  reset() {
+    this.loadedPaths.clear();
+  }
+
+  /**
+   * Discovers and loads new context files by traversing upwards from the accessed path
+   * to the project root.
+   *
+   * @param accessedPath The path of the file or directory being accessed by a tool.
+   * @returns A formatted string containing newly discovered context, or an empty string if none found.
+   */
+  async discoverContext(accessedPath: string): Promise<string> {
+    const newContexts: string[] = [];
+    let currentDir = path.resolve(accessedPath);
+
+    // If accessedPath doesn't exist yet (e.g. writing a new file),
+    // we still want to check its intended parent directory.
+    // If it exists and is a file, start from its directory.
+    if (fs.existsSync(currentDir) && fs.statSync(currentDir).isFile()) {
+      currentDir = path.dirname(currentDir);
+    } else if (!fs.existsSync(currentDir) && path.extname(currentDir)) {
+      // Assume it's a file path if it has an extension, even if it doesn't exist yet
+      currentDir = path.dirname(currentDir);
+    }
+
+    const memoryFilename = getCurrentGeminiMdFilename();
+
+    // Traverse upwards until we reach the project root (inclusive)
+    while (true) {
+      // Safety check to prevent infinite loops if projectRoot is somehow bypassed
+      // or if we hit the file system root.
+      if (
+        !currentDir.startsWith(this.projectRoot) &&
+        currentDir !== this.projectRoot
+      ) {
+        // If we are outside the project root, we might still want to check if we are
+        // not at the system root yet, but generally we want to stop at project root.
+        if (currentDir === path.dirname(currentDir)) {
+          break; // Reached system root
+        }
+      }
+
+      const memoryFilePath = path.join(currentDir, memoryFilename);
+
+      if (fs.existsSync(memoryFilePath) && !this.isLoaded(memoryFilePath)) {
+        // Found a new context file
+        this.markAsLoaded(memoryFilePath);
+        try {
+          const content = await fsPromises.readFile(memoryFilePath, 'utf8');
+          // We don't have debugMode passed in here, defaulting to false
+          const processed = await processImports(
+            content,
+            path.dirname(memoryFilePath),
+            false,
+            undefined,
+            this.projectRoot,
+          );
+
+          if (processed.content) {
+            const relativePath = path.relative(
+              this.projectRoot,
+              memoryFilePath,
+            );
+            newContexts.push(
+              `--- Newly Discovered Context from: ${relativePath} ---\n${processed.content}\n--- End Context ---`,
+            );
+          }
+        } catch (error) {
+          coreEvents.emitFeedback(
+            'warning',
+            `Failed to read context file: ${memoryFilePath}`,
+            error,
+          );
+        }
+      }
+
+      if (currentDir === this.projectRoot) {
+        break;
+      }
+
+      const parentDir = path.dirname(currentDir);
+      if (parentDir === currentDir) {
+        break;
+      }
+      currentDir = parentDir;
+    }
+
+    return newContexts.join('\n\n');
+  }
+}


### PR DESCRIPTION
## Summary

Introduces an experimental `ContextManager` service to enable Just-In-Time (JIT) loading of `GEMINI.md` context files. This allows the agent to dynamically discover and load context relevant to the files it is currently accessing, rather than relying solely on pre-loaded global context.

> [!NOTE]
> This is the first step and does not actually wire up the loading of the memory files

## Details

This PR establishes the infrastructure for JIT context loading, gated behind a new experimental flag.

*   **New Service (`ContextManager`):**
    *   Traverses directory structures upwards from a given accessed path to the project root.
    *   Discovers `GEMINI.md` (or configured context filename) files along the path.
    *   Loads and processes these context files if they haven't been loaded previously during the session.
    *   Returns the newly discovered context for immediate use.
*   **Configuration:**
    *   Adds `experimental.jitContext` boolean setting (defaults to `false`).
    *   Updates `Config` to initialize the `ContextManager` only when this flag is enabled.
*   **Settings:**
    *   Adds the new setting to the CLI Settings Dialog under the Experimental property. **NOT** shown in `/settings`

## Related Issues

Closes #11978

## How to Validate

1. Run the debug mode and put a breakpoint at packages/core/src/config/config.ts.
2. When the experimental setting is set to false (or unset), the context manager should be undefined on the config.
3. Rerun the debugger, but this time add the "jitContext" property in settings.json and set it to true.
4. The context manager should be initialized now. 

## Pre-Merge Checklist

- [X] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [X] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [X] MacOS
    - [X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [X] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
