### PR TITLE
Standardize error logging with coreEvents.emitFeedback

### DIFF
--- a/packages/cli/src/utils/commentJson.ts
+++ b/packages/cli/src/utils/commentJson.ts
@@ -6,6 +6,7 @@
 
 import * as fs from 'node:fs';
 import { parse, stringify } from 'comment-json';
+import { coreEvents } from '@google/gemini-cli-core';
 
 /**
  * Type representing an object that may contain Symbol keys for comments.
@@ -30,9 +31,10 @@ export function updateSettingsFilePreservingFormat(
   try {
     parsed = parse(originalContent) as Record<string, unknown>;
   } catch (error) {
-    console.error('Error parsing settings file:', error);
-    console.error(
-      'Settings file may be corrupted. Please check the JSON syntax.',
+    coreEvents.emitFeedback(
+      'error',
+      'Error parsing settings file. Please check the JSON syntax.',
+      error,
     );
     return;
   }

--- a/packages/cli/src/zed-integration/acp.ts
+++ b/packages/cli/src/zed-integration/acp.ts
@@ -11,6 +11,7 @@ import * as schema from './schema.js';
 export * from './schema.js';
 
 import type { WritableStream, ReadableStream } from 'node:stream/web';
+import { coreEvents } from '@google/gemini-cli-core';
 
 export class AgentSideConnection implements Client {
   #connection: Connection;
@@ -281,7 +282,7 @@ class Connection {
       })
       .catch((error) => {
         // Continue processing writes on error
-        console.error('ACP write error:', error);
+        coreEvents.emitFeedback('error', 'ACP write error.', error);
       });
     return this.#writeQueue;
   }


### PR DESCRIPTION
## Summary
Standardize error logging with coreEvents.emitFeedback for acp and commentJson files.

Migrate console.error calls to use coreEvents.emitFeedback for improved standardization and user-facing feedback.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Related Issues
Fixes #11913 
Fixes #11911 

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
