### PR TITLE
Enforce timeout for subagents 

### DIFF
--- a/packages/core/src/agents/executor.ts
+++ b/packages/core/src/agents/executor.ts
@@ -246,6 +246,14 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
         currentMessage = nextMessage;
       }
 
+      if (terminateReason === AgentTerminateMode.TIMEOUT) {
+        finalResult = `Agent timed out after ${this.definition.runConfig.max_time_minutes} minutes.`;
+        this.emitActivity('ERROR', {
+          error: finalResult,
+          context: 'timeout',
+        });
+      }
+
       if (terminateReason === AgentTerminateMode.GOAL) {
         return {
           result: finalResult || 'Task completed.',


### PR DESCRIPTION
## Summary


We noticed that the agent was running over the time limit imposed by its configurations. 
Our main hypothesis is that the model call is taking too long (including the retries) and since the timeouts are only checked after each turn, they were not being enforced. 



This pull request refactors the agent execution timeout logic to use a more modern and efficient `AbortController`-based approach. This change ensures that subagents adhere strictly to their configured `max_time_minutes` by actively aborting their operations when the time limit is reached, while also maintaining the ability to respond to external abort signals. The update improves the reliability and clarity of agent termination events by providing distinct reasons for termination.

### Highlights

* **New Timeout Mechanism**: Implemented a new timeout mechanism using `AbortController` and `AbortSignal.any()` to enforce `max_time_minutes` for agent execution, providing a more robust and immediate termination.
* **Combined Abort Signals**: The agent now listens to both an external abort signal and an internal time-based timeout signal, allowing for graceful termination based on whichever event occurs first.
* **Differentiated Termination Reasons**: The system can now accurately distinguish between an agent being explicitly aborted by an external signal and an agent timing out due to exceeding its allocated time, setting the `terminateReason` accordingly.
* **Removed Legacy Timeout Check**: The previous polling-based timeout check, which relied on calculating `elapsedMinutes`, has been removed in favor of the new `AbortController`-based approach, streamlining the agent's execution loop.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
