### PR TITLE
Fix atprocessor test on windows

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -183,7 +183,7 @@ describe('handleAtCommand', () => {
     const relativeDirPath = getRelativePath(dirPath);
     const relativeFilePath = getRelativePath(filePath);
     const query = `@${dirPath}`;
-    const resolvedGlob = `${relativeDirPath}/**`;
+    const resolvedGlob = path.join(relativeDirPath, '**');
 
     const result = await handleAtCommand({
       query,
@@ -1138,7 +1138,7 @@ describe('handleAtCommand', () => {
     it('should handle absolute directory paths correctly', async () => {
       const fileContent =
         'export default function test() { return "absolute dir test"; }';
-      const subDirPath = 'src/utils';
+      const subDirPath = path.join('src', 'utils');
       const fileName = 'helper.ts';
       await createTestFile(
         path.join(testRootDir, subDirPath, fileName),
@@ -1159,7 +1159,7 @@ describe('handleAtCommand', () => {
       expect(result.shouldProceed).toBe(true);
       expect(result.processedQuery).toEqual(
         expect.arrayContaining([
-          { text: `Check @${subDirPath}/** please.` },
+          { text: `Check @${path.join(subDirPath, '**')} please.` },
           expect.objectContaining({
             text: '\n--- Content from referenced files ---',
           }),
@@ -1167,7 +1167,7 @@ describe('handleAtCommand', () => {
       );
 
       expect(mockOnDebugMessage).toHaveBeenCalledWith(
-        expect.stringContaining(`using glob: ${subDirPath}/**`),
+        expect.stringContaining(`using glob: ${path.join(subDirPath, '**')}`),
       );
     });
 

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -243,8 +243,7 @@ export async function handleAtCommand({
           : pathName;
 
         if (stats.isDirectory()) {
-          currentPathSpec =
-            relativePath + (relativePath.endsWith(path.sep) ? `**` : `/**`);
+          currentPathSpec = path.join(relativePath, '**');
           onDebugMessage(
             `Path ${pathName} resolved to directory, using glob: ${currentPathSpec}`,
           );


### PR DESCRIPTION
## Summary

Fix atprocessor so it consistently uses the right path separator for the os

## Details

Fixes test broken in #9065.

Changes this message:
`Path C:\\foo\bar resolved to directory, using glob: C:\\foo\bar/**`
to
`Path C:\\foo\bar resolved to directory, using glob: C:\\foo\bar\**`

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

Follow up to #9016

## How to Validate

At include a directory on windows.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
