### PR TITLE
feat(ui): Fix Todo item text color not propagating for custom themes

### DIFF
--- a/packages/cli/src/ui/components/messages/Todo.tsx
+++ b/packages/cli/src/ui/components/messages/Todo.tsx
@@ -76,12 +76,17 @@ const TodoItemDisplay: React.FC<{
   wrap?: 'truncate';
   role?: 'listitem';
 }> = ({ todo, wrap, role: ariaRole }) => {
-  const statusTextColor: Partial<Record<TodoStatus, string>> = {
-    in_progress: theme.text.accent,
-    completed: theme.text.secondary,
-    cancelled: theme.text.secondary,
-  };
-  const textColor = statusTextColor[todo.status] ?? theme.text.primary;
+  const textColor = (() => {
+    switch (todo.status) {
+      case 'in_progress':
+        return theme.text.accent;
+      case 'completed':
+      case 'cancelled':
+        return theme.text.secondary;
+      default:
+        return theme.text.primary;
+    }
+  })();
   const strikethrough = todo.status === 'cancelled';
 
   return (

--- a/packages/cli/src/ui/components/messages/Todo.tsx
+++ b/packages/cli/src/ui/components/messages/Todo.tsx
@@ -71,17 +71,16 @@ const TodoStatusDisplay: React.FC<{ status: TodoStatus }> = ({ status }) => {
   }
 };
 
-const statusTextColor: Partial<Record<TodoStatus, string>> = {
-  in_progress: theme.text.accent,
-  completed: theme.text.secondary,
-  cancelled: theme.text.secondary,
-};
-
 const TodoItemDisplay: React.FC<{
   todo: Todo;
   wrap?: 'truncate';
   role?: 'listitem';
 }> = ({ todo, wrap, role: ariaRole }) => {
+  const statusTextColor: Partial<Record<TodoStatus, string>> = {
+    in_progress: theme.text.accent,
+    completed: theme.text.secondary,
+    cancelled: theme.text.secondary,
+  };
   const textColor = statusTextColor[todo.status] ?? theme.text.primary;
   const strikethrough = todo.status === 'cancelled';
 


### PR DESCRIPTION
## Summary

There was a minor bug where a custom theme wasn't theming the active todo properly.

## Details

## Before
<img width="800" height="454" alt="CleanShot 2025-10-29 at 14 04 55@2x" src="https://github.com/user-attachments/assets/1b270146-dd12-4c23-a3eb-4c6e4f0c4d94" />


## After
<img width="800" alt="CleanShot 2025-10-29 at 16 05 02@2x" src="https://github.com/user-attachments/assets/a6782063-f769-433a-b14e-a1ae74719474" />


## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
