### PR TITLE
fix(core): Add rootDir to tsconfig.json to resolve TS5055 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "typecheck": "npm run typecheck --workspaces --if-present",
     "preflight": "npm run clean && npm ci && npm run format && npm run lint:ci && npm run build && npm run typecheck && npm run test:ci",
     "postinstall": "husky",
+    "prepare": "npm run bundle",
     "prepare:package": "node scripts/prepare-package.js",
     "release:version": "node scripts/version.js",
     "telemetry": "node scripts/telemetry.js",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "format": "prettier --experimental-cli --write .",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "preflight": "npm run clean && npm ci && npm run format && npm run lint:ci && npm run build && npm run typecheck && npm run test:ci",
-    "prepare": "husky && npm run bundle",
+    "postinstall": "husky",
     "prepare:package": "node scripts/prepare-package.js",
     "release:version": "node scripts/version.js",
     "telemetry": "node scripts/telemetry.js",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,6 +7,6 @@
     "rootDir": ".",
     "types": ["node", "vitest/globals"]
   },
-  "include": ["index.ts", "src/**/*.ts", "src/**/*.json"],
+  "include": ["index.ts", "src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -8,5 +8,5 @@
     "types": ["node", "vitest/globals"]
   },
   "include": ["index.ts", "src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.snap", "**/*.wasm"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "composite": true,
+    "rootDir": ".",
     "types": ["node", "vitest/globals"]
   },
   "include": ["index.ts", "src/**/*.ts", "src/**/*.json"],


### PR DESCRIPTION
This change fixes a build failure that was occurring in the release CI pipeline.

The build was failing with the error: `TS5055: Cannot write file ... because it would overwrite input file.`

This error was caused by an ambiguity in the TypeScript configuration for the `@google/gemini-cli-core` package. The `index.ts` file at the package root re-exports symbols from `src/index.ts`, which confuses the TypeScript compiler when it tries to determine the project's file structure for generating declaration files.

This change resolves the issue by adding `\rootDir\: \.\` to the `compilerOptions` in `packages/core/tsconfig.json`. This explicitly tells the compiler to treat the entire package directory as the source root, removing the ambiguity and allowing the build to complete successfully. It also changes the globbing includes to limit it expliclity to the SRC dir. This was the actual fix.

## Pre change repo steps
1. npm run clean
2. npm ci
3. npm run build
4. touch a random file in core e.g. add a zero in constants.ts
6. npm run build again. this time the build will fail

## After fix
Repeat above steps with no errors.