### PR TITLE
Create line change metrics

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -542,10 +542,6 @@ Measures tool usage and latency.
     - `decision` (string: "accept", "reject", "modify", or "auto_accept", if
       applicable)
     - `tool_type` (string: "mcp" or "native", if applicable)
-    - `model_added_lines` (Int, optional)
-    - `model_removed_lines` (Int, optional)
-    - `user_added_lines` (Int, optional)
-    - `user_removed_lines` (Int, optional)
 
 - `gemini_cli.tool.call.latency` (Histogram, ms): Measures tool call latency.
   - **Attributes**:
@@ -588,6 +584,12 @@ Counts file operations with basic context.
     - `mimetype` (string, optional)
     - `extension` (string, optional)
     - `programming_language` (string, optional)
+
+- `gemini_cli.lines.changed` (Counter, Int): Number of lines changed (from file
+  diffs).
+  - **Attributes**:
+    - `function_name`
+    - `type` ("added" or "removed")
 
 ##### Chat and Streaming
 

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -793,11 +793,15 @@ describe('loggers', () => {
 
     const mockMetrics = {
       recordToolCallMetrics: vi.fn(),
+      recordLinesChanged: vi.fn(),
     };
 
     beforeEach(() => {
       vi.spyOn(metrics, 'recordToolCallMetrics').mockImplementation(
         mockMetrics.recordToolCallMetrics,
+      );
+      vi.spyOn(metrics, 'recordLinesChanged').mockImplementation(
+        mockMetrics.recordLinesChanged,
       );
       mockLogger.emit.mockReset();
     });
@@ -895,10 +899,6 @@ describe('loggers', () => {
           success: true,
           decision: ToolCallDecision.ACCEPT,
           tool_type: 'native',
-          model_added_lines: 1,
-          model_removed_lines: 2,
-          user_added_lines: 5,
-          user_removed_lines: 6,
         },
       );
 
@@ -907,6 +907,19 @@ describe('loggers', () => {
         'event.name': EVENT_TOOL_CALL,
         'event.timestamp': '2025-01-01T00:00:00.000Z',
       });
+
+      expect(mockMetrics.recordLinesChanged).toHaveBeenCalledWith(
+        mockConfig,
+        1,
+        'added',
+        { function_name: 'test-function' },
+      );
+      expect(mockMetrics.recordLinesChanged).toHaveBeenCalledWith(
+        mockConfig,
+        2,
+        'removed',
+        { function_name: 'test-function' },
+      );
     });
     it('should log a tool call with a reject decision', () => {
       const call: ErroredToolCall = {


### PR DESCRIPTION
## Summary

This PR refactors the telemetry metrics for line changes by in a single `gemini_cli.lines.changed` metric.

## Details

The new `gemini_cli.lines.changed` metric uses a `type` attribute (`"added"` or `"removed"`) to differentiate the line changes. This change simplifies the telemetry for line changes.


## How to Validate

1.  Checkout branch and build Gemini CLI
2. Enabled telemetry to your preferred backend
3. Use Gemini CLI and send a prompt that would modify files
4. Confirm that the `git diff --stat`
    <img width="1280" height="74" alt="image" src="https://github.com/user-attachments/assets/9e33ce17-b69f-44ab-9b09-38d90b12c48f" />
6. Confirm that it's the same as metrics in your telemetry dashboard
    <img width="3034" height="350" alt="image" src="https://github.com/user-attachments/assets/e6870c3f-0267-499b-9f27-d68ad1e5157d" />

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
