### PR TITLE
feat: Prevent self-imports and fix build loop

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -162,6 +162,31 @@ export default tseslint.config(
     },
   },
   {
+    // Prevent self-imports in packages
+    files: ['packages/core/src/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          name: '@google/gemini-cli-core',
+          message: 'Please use relative imports within the @google/gemini-cli-core package.',
+        },
+      ],
+    },
+  },
+  {
+    files: ['packages/cli/src/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          name: '@google/gemini-cli',
+          message: 'Please use relative imports within the @google/gemini-cli package.',
+        },
+      ],
+    },
+  },
+  {
     files: ['packages/*/src/**/*.test.{ts,tsx}'],
     plugins: {
       vitest,

--- a/package.json
+++ b/package.json
@@ -127,7 +127,10 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "prettier --write",
-      "eslint --fix --max-warnings 0"
+      "eslint --fix --max-warnings 0 --no-warn-ignored"
+    ],
+    "eslint.config.js": [
+      "prettier --write"
     ],
     "*.{json,md}": [
       "prettier --write"

--- a/packages/core/src/code_assist/oauth-credential-storage.test.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.test.ts
@@ -31,7 +31,7 @@ vi.mock('node:fs', () => ({
 }));
 vi.mock('node:os');
 vi.mock('node:path');
-vi.mock('@google/gemini-cli-core', () => ({
+vi.mock('../utils/events.js', () => ({
   coreEvents: {
     emitFeedback: vi.fn(),
   },

--- a/packages/core/src/code_assist/oauth-credential-storage.test.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.test.ts
@@ -8,7 +8,7 @@ import { type Credentials } from 'google-auth-library';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { OAuthCredentialStorage } from './oauth-credential-storage.js';
 import type { OAuthCredentials } from '../mcp/token-storage/types.js';
-import { coreEvents } from '@google/gemini-cli-core';
+import { coreEvents } from '../utils/events.js';
 
 import * as path from 'node:path';
 import * as os from 'node:os';

--- a/packages/core/src/code_assist/oauth-credential-storage.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.ts
@@ -12,7 +12,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { promises as fs } from 'node:fs';
 import { GEMINI_DIR } from '../utils/paths.js';
-import { coreEvents } from '@google/gemini-cli-core';
+import { coreEvents } from '../utils/events.js';
 
 const KEYCHAIN_SERVICE_NAME = 'gemini-cli-oauth';
 const MAIN_ACCOUNT_KEY = 'main-account';

--- a/packages/core/src/mcp/oauth-token-storage.test.ts
+++ b/packages/core/src/mcp/oauth-token-storage.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { coreEvents } from '@google/gemini-cli-core';
+import { coreEvents } from '../utils/events.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';

--- a/packages/core/src/mcp/oauth-token-storage.test.ts
+++ b/packages/core/src/mcp/oauth-token-storage.test.ts
@@ -34,7 +34,7 @@ vi.mock('../config/storage.js', () => ({
   },
 }));
 
-vi.mock('@google/gemini-cli-core', () => ({
+vi.mock('../utils/events.js', () => ({
   coreEvents: {
     emitFeedback: vi.fn(),
   },

--- a/packages/core/src/mcp/oauth-token-storage.ts
+++ b/packages/core/src/mcp/oauth-token-storage.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { coreEvents } from '@google/gemini-cli-core';
+import { coreEvents } from '../utils/events.js';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { Storage } from '../config/storage.js';

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -92,7 +92,7 @@ import * as metrics from './metrics.js';
 import { FileOperation } from './metrics.js';
 import * as sdk from './sdk.js';
 import { vi, describe, beforeEach, it, expect, afterEach } from 'vitest';
-import { type GeminiCLIExtension } from '@google/gemini-cli-core';
+import { type GeminiCLIExtension } from '../config/config.js';
 import {
   FinishReason,
   type CallableTool,


### PR DESCRIPTION
This PR addresses a recurring build issue and improves repository health.

### The Problem
When running `npm run clean`, then `npm run build`, and then touching a file in `packages/core` and running `npm run build` again, a `tsc` failure would occur (`error TS5055: Cannot write file '...' because it would overwrite input file.`). This was caused by modules within `packages/core` using absolute imports (`@google/gemini-cli-core`) to refer to other modules within the same package, instead of using relative imports.

### The Fix
1.  **Resolved Self-Imports:** All instances of self-imports within the `packages/core` package have been updated to use relative paths. This resolves the `tsc` build loop.
2.  **Added ESLint Rule:** A new ESLint rule (`no-restricted-imports`) has been added to `eslint.config.js` to prevent future self-imports within both the `@google/gemini-cli-core` and `@google/gemini-cli` packages.
3.  **Pre-commit Hook Fix:** The pre-commit hook was failing when `eslint.config.js` was modified because ESLint would issue a warning that the file was ignoring itself. The `lint-staged` configuration has been updated to use the `--no-warn-ignored` flag to suppress this specific warning and prevent the commit from being blocked.

This change ensures a more stable build process and prevents this class of errors from being introduced in the future.

### Repo steps

Test 1: Edit a file and rebuild

   1. Clean: npm run clean
   2. Build: npm run build
   3. Edit file: replace tool was used to add a comment to packages/core/src/config/constants.ts.
   4. Build again: npm run build

  Test 2: Update package version and rebuild (simulating release process)

   1. Clean: npm run clean
   2. Build: npm run build
   3. Get next nightly version: node scripts/get-release-version.js --type=nightly
   4. Update package versions: npm version <new-version> --no-git-tag-version --allow-same-version (where <new-version> was 0.13.0-nightly.20251030.1e59a14a in our case)
   5. Build again: npm run build
