### PR TITLE
Remove context percentage in footer by default

### DIFF
--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -159,6 +159,10 @@ describe('SettingsSchema', () => {
       expect(
         getSettingsSchema().ui.properties.showMemoryUsage.showInDialog,
       ).toBe(true);
+      expect(
+        getSettingsSchema().ui.properties.footer.properties
+          .hideContextPercentage.showInDialog,
+      ).toBe(true);
       expect(getSettingsSchema().general.properties.vimMode.showInDialog).toBe(
         true,
       );

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -389,6 +389,15 @@ const SETTINGS_SCHEMA = {
             description: 'Hide the model name and context usage in the footer.',
             showInDialog: true,
           },
+          hideContextPercentage: {
+            type: 'boolean',
+            label: 'Hide Context Window Percentage',
+            category: 'UI',
+            requiresRestart: false,
+            default: true,
+            description: 'Hides the context window remaining percentage.',
+            showInDialog: true,
+          },
         },
       },
       hideFooter: {

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { describe, it, expect, vi } from 'vitest';
 import {
   renderWithProviders,
   createMockSettings,
@@ -120,6 +121,13 @@ describe('<Footer />', () => {
     const { lastFrame } = renderWithProviders(<Footer />, {
       width: 120,
       uiState: { sessionStats: mockSessionStats },
+      settings: createMockSettings({
+        ui: {
+          footer: {
+            hideContextPercentage: false,
+          },
+        },
+      }),
     });
     expect(lastFrame()).toContain(defaultProps.model);
     expect(lastFrame()).toMatch(/\(\d+% context left\)/);
@@ -129,6 +137,13 @@ describe('<Footer />', () => {
     const { lastFrame } = renderWithProviders(<Footer />, {
       width: 99,
       uiState: { sessionStats: mockSessionStats },
+      settings: createMockSettings({
+        ui: {
+          footer: {
+            hideContextPercentage: false,
+          },
+        },
+      }),
     });
     expect(lastFrame()).toContain(defaultProps.model);
     expect(lastFrame()).toMatch(/\(\d+%\)/);
@@ -192,6 +207,13 @@ describe('<Footer />', () => {
       const { lastFrame } = renderWithProviders(<Footer />, {
         width: 120,
         uiState: { sessionStats: mockSessionStats },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              hideContextPercentage: false,
+            },
+          },
+        }),
       });
       expect(lastFrame()).toMatchSnapshot('complete-footer-wide');
     });
@@ -247,10 +269,49 @@ describe('<Footer />', () => {
       expect(lastFrame()).toMatchSnapshot('footer-only-sandbox');
     });
 
+    it('hides the context percentage when hideContextPercentage is true', () => {
+      const { lastFrame } = renderWithProviders(<Footer />, {
+        width: 120,
+        uiState: { sessionStats: mockSessionStats },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              hideContextPercentage: true,
+            },
+          },
+        }),
+      });
+      expect(lastFrame()).toContain(defaultProps.model);
+      expect(lastFrame()).not.toMatch(/\(\d+% context left\)/);
+    });
+
+    it('shows the context percentage when hideContextPercentage is false', () => {
+      const { lastFrame } = renderWithProviders(<Footer />, {
+        width: 120,
+        uiState: { sessionStats: mockSessionStats },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              hideContextPercentage: false,
+            },
+          },
+        }),
+      });
+      expect(lastFrame()).toContain(defaultProps.model);
+      expect(lastFrame()).toMatch(/\(\d+% context left\)/);
+    });
+
     it('renders complete footer in narrow terminal (baseline narrow)', () => {
       const { lastFrame } = renderWithProviders(<Footer />, {
         width: 79,
         uiState: { sessionStats: mockSessionStats },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              hideContextPercentage: false,
+            },
+          },
+        }),
       });
       expect(lastFrame()).toMatchSnapshot('complete-footer-narrow');
     });

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -60,6 +60,8 @@ export const Footer: React.FC = () => {
   const hideSandboxStatus =
     settings.merged.ui?.footer?.hideSandboxStatus || false;
   const hideModelInfo = settings.merged.ui?.footer?.hideModelInfo || false;
+  const hideContextPercentage =
+    settings.merged.ui?.footer?.hideContextPercentage ?? true;
 
   const pathLength = Math.max(20, Math.floor(mainAreaWidth * 0.25));
   const displayPath = shortenPath(tildeifyPath(targetDir), pathLength);
@@ -145,12 +147,17 @@ export const Footer: React.FC = () => {
         <Box alignItems="center" justifyContent="flex-end">
           <Box alignItems="center">
             <Text color={theme.text.accent}>
-              {model}{' '}
-              <ContextUsageDisplay
-                promptTokenCount={promptTokenCount}
-                model={model}
-                terminalWidth={mainAreaWidth}
-              />
+              {model}
+              {!hideContextPercentage && (
+                <>
+                  {' '}
+                  <ContextUsageDisplay
+                    promptTokenCount={promptTokenCount}
+                    model={model}
+                    terminalWidth={mainAreaWidth}
+                  />
+                </>
+              )}
             </Text>
             {showMemoryUsage && <MemoryUsageDisplay />}
           </Box>


### PR DESCRIPTION
## Summary

This PR updates the default behavior of the footer to hide the context window percentage. It also introduces a new setting, `ui.footer.hideContextPercentage`, allowing users to toggle this display.

This was done to reduce confusion over what the percentage represents and our current compression strategy for quality

## Related Issues

For https://github.com/google-gemini/maintainers-gemini-cli/issues/973

## How to Validate

1.  Run the CLI without any custom settings.
2.  Observe that the context percentage is NOT displayed in the footer.
3.  Update your settings to make the value false.
4.  Observe that the context percentage IS displayed in the footer.

## Pre-Merge Checklist

- [X] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [X] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [X] MacOS
    - [X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [X] Seatbelt
