### PR TITLE
feat: add dynamic run-names to patch release workflows

### DIFF
--- a/.github/workflows/release-patch-1-create-pr.yml
+++ b/.github/workflows/release-patch-1-create-pr.yml
@@ -1,5 +1,8 @@
 name: 'Release: Patch (1) Create PR'
 
+run-name: >-
+  Release Patch (1) Create PR | S:${{ inputs.channel }} | C:${{ inputs.commit }} ${{ inputs.original_pr && format('| PR:#{0}', inputs.original_pr) || '' }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-patch-2-trigger.yml
+++ b/.github/workflows/release-patch-2-trigger.yml
@@ -1,5 +1,10 @@
 name: 'Release: Patch (2) Trigger'
 
+run-name: >-
+  Release Patch (2) Trigger |
+  ${{ github.event.pull_request.number && format('PR #{0}', github.event.pull_request.number) || 'Manual' }} |
+  ${{ github.event.pull_request.head.ref || github.event.inputs.ref }}
+
 on:
   pull_request:
     types:

--- a/.github/workflows/release-patch-3-release.yml
+++ b/.github/workflows/release-patch-3-release.yml
@@ -1,5 +1,8 @@
 name: 'Release: Patch (3) Release'
 
+run-name: >-
+  Release Patch (3) Release | T:${{ inputs.type }} | R:${{ inputs.release_ref }} ${{ inputs.original_pr && format('| PR:#{0}', inputs.original_pr) || '' }}
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This PR adds dynamic run-names to the patch release workflows (release-patch-1-create-pr.yml, release-patch-2-trigger.yml, and release-patch-3-release.yml) to provide more descriptive titles for workflow runs. The run-names will include relevant information such as the release channel, commit SHA, and original PR number, depending on the workflow and its inputs.