### PR TITLE
fix: Address silent failure in release-patch-1-create-pr workflow

### DIFF
--- a/.github/workflows/release-patch-1-create-pr.yml
+++ b/.github/workflows/release-patch-1-create-pr.yml
@@ -99,12 +99,12 @@ jobs:
               --channel="${PATCH_CHANNEL}" \
               --pullRequestNumber="${ORIGINAL_PR}" \
               --dry-run="${DRY_RUN}"
-            echo "EXIT_CODE=$?" >> "$GITHUB_OUTPUT"
           } 2>&1 | tee >(
             echo "LOG_CONTENT<<EOF" >> "$GITHUB_ENV"
             cat >> "$GITHUB_ENV"
             echo "EOF" >> "$GITHUB_ENV"
           )
+          echo "EXIT_CODE=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: 'Comment on Original PR'
         if: 'always() && inputs.original_pr'

--- a/scripts/releasing/create-patch-pr.js
+++ b/scripts/releasing/create-patch-pr.js
@@ -174,7 +174,7 @@ async function main() {
             `📝 Creating commit with conflict markers for manual resolution...`,
           );
           execSync('git add .');
-          execSync(`git commit --no-edit`);
+          execSync(`git commit --no-edit --no-verify`);
           console.log(`✅ Committed cherry-pick with conflict markers`);
         } else {
           // Re-throw if it's not a conflict error


### PR DESCRIPTION
This commit fixes two issues in the `release-patch-1-create-1-create-pr.yml` workflow:

1.  **Incorrect EXIT_CODE capture:** The `EXIT_CODE` from the `create-patch-pr.js` script was not being correctly captured due to the `tee` command. This has been corrected by using `${PIPESTATUS[0]}` to get the exit code of the pipelines first command.
2.  **Pre-commit hook failure during cherry-pick:** When a cherry-pick resulted in conflicts, the subsequent commit (intended to include conflict markers) failed due to pre-commit hooks (`prettier`) encountering syntax errors. This prevented the PR from being created and the workflow from properly reporting the failure. The `git commit` command in `scripts/releasing/create-patch-pr.js` now includes `--no-verify` to skip pre-commit hooks, allowing the commit with conflict markers to succeed.

These changes ensure that the workflow correctly reports patch creation failures and creates pull requests even when merge conflicts occur, allowing for manual resolution.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
