### PR TITLE
fix(core): ensure loop detection respects session disable flag

### DIFF
--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -143,6 +143,19 @@ describe('LoopDetectionService', () => {
       }
       expect(loggers.logLoopDetected).not.toHaveBeenCalled();
     });
+
+    it('should stop reporting a loop if disabled after detection', () => {
+      const event = createToolCallRequestEvent('testTool', { param: 'value' });
+      for (let i = 0; i < TOOL_CALL_LOOP_THRESHOLD; i++) {
+        service.addAndCheck(event);
+      }
+      expect(service.addAndCheck(event)).toBe(true);
+
+      service.disableForSession();
+
+      // Should now return false even though a loop was previously detected
+      expect(service.addAndCheck(event)).toBe(false);
+    });
   });
 
   describe('Content Loop Detection', () => {

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -123,7 +123,11 @@ export class LoopDetectionService {
    * @returns true if a loop is detected, false otherwise
    */
   addAndCheck(event: ServerGeminiStreamEvent): boolean {
-    if (this.loopDetected || this.disabledForSession) {
+    if (this.disabledForSession) {
+      return false;
+    }
+
+    if (this.loopDetected) {
       return this.loopDetected;
     }
 


### PR DESCRIPTION
## TLDR

Fixes an issue where loop detection would continue to report true even after being disabled for the session, if a loop had already been detected.

## Dive Deeper

The `addAndCheck` method in `LoopDetectionService` was checking `this.loopDetected || this.disabledForSession` and returning `this.loopDetected` if it was true, ignoring the `disabledForSession` flag. The fix reorders these checks to prioritize `disabledForSession`.

## Reviewer Test Plan

Run the newly added test case in `packages/core/src/services/loopDetectionService.test.ts` which specifically reproduces this scenario.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A
