### PR TITLE
Show only the summary of the subagent to the user and save full result into file

### DIFF
--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -67,6 +67,7 @@ export const CodebaseInvestigatorAgent: AgentDefinition<
 
   // The 'output' parameter is now strongly typed as CodebaseInvestigationReportSchema
   processOutput: (output) => JSON.stringify(output, null, 2),
+  processOutputDisplay: (output) => output.SummaryOfFindings,
 
   modelConfig: {
     model: DEFAULT_GEMINI_MODEL,

--- a/packages/core/src/agents/invocation.test.ts
+++ b/packages/core/src/agents/invocation.test.ts
@@ -145,6 +145,7 @@ describe('SubagentInvocation', () => {
     it('should initialize and run the executor successfully', async () => {
       const mockOutput = {
         result: 'Analysis complete.',
+        displayResult: 'Analysis complete.',
         terminate_reason: AgentTerminateMode.GOAL,
       };
       mockExecutorInstance.run.mockResolvedValue(mockOutput);
@@ -163,11 +164,14 @@ describe('SubagentInvocation', () => {
       expect(result.llmContent).toEqual([
         {
           text: expect.stringContaining(
-            "Subagent 'MockAgent' finished.\nTermination Reason: GOAL\nResult:\nAnalysis complete.",
+            "Subagent 'MockAgent' finished.\nTermination Reason: GOAL\nResult:\nAnalysis complete.\nThe result has also been saved to a file:",
           ),
         },
       ]);
-      expect(result.returnDisplay).toContain('Result:\nAnalysis complete.');
+      expect(result.returnDisplay).toContain(
+        'Result summary: Analysis complete.',
+      );
+      expect(result.returnDisplay).toContain('Full result saved to');
       expect(result.returnDisplay).toContain('Termination Reason:\n GOAL');
     });
 
@@ -189,7 +193,11 @@ describe('SubagentInvocation', () => {
             data: { text: ' Still thinking.' },
           } as SubagentActivityEvent);
         }
-        return { result: 'Done', terminate_reason: AgentTerminateMode.GOAL };
+        return {
+          result: 'Done',
+          displayResult: 'Done',
+          terminate_reason: AgentTerminateMode.GOAL,
+        };
       });
 
       await invocation.execute(signal, updateOutput);
@@ -218,7 +226,11 @@ describe('SubagentInvocation', () => {
             data: { error: 'Failed' },
           } as SubagentActivityEvent);
         }
-        return { result: 'Done', terminate_reason: AgentTerminateMode.GOAL };
+        return {
+          result: 'Done',
+          displayResult: 'Done',
+          terminate_reason: AgentTerminateMode.GOAL,
+        };
       });
 
       await invocation.execute(signal, updateOutput);
@@ -240,13 +252,17 @@ describe('SubagentInvocation', () => {
             data: { text: 'Thinking silently.' },
           } as SubagentActivityEvent);
         }
-        return { result: 'Done', terminate_reason: AgentTerminateMode.GOAL };
+        return {
+          result: 'Done',
+          displayResult: 'Done',
+          terminate_reason: AgentTerminateMode.GOAL,
+        };
       });
 
       // Execute without the optional callback
       const result = await invocation.execute(signal);
       expect(result.error).toBeUndefined();
-      expect(result.returnDisplay).toContain('Result:\nDone');
+      expect(result.returnDisplay).toContain('Result summary: Done');
     });
 
     it('should handle executor run failure', async () => {

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -28,6 +28,7 @@ export enum AgentTerminateMode {
  */
 export interface OutputObject {
   result: string;
+  displayResult: string;
   terminate_reason: AgentTerminateMode;
 }
 
@@ -67,9 +68,18 @@ export interface AgentDefinition<TOutput extends z.ZodTypeAny = z.ZodUnknown> {
    * call into a string format.
    *
    * @param output The raw output value from the `complete_task` tool, now strongly typed with TOutput.
-   * @returns A string representation of the final output.
+   * @returns A string representation of the final output to be used as the LLM input.
    */
   processOutput?: (output: z.infer<TOutput>) => string;
+
+  /**
+   * An optional function to process the raw output from the agent's final tool
+   * call into a string format that will be displayed to the user.
+   *
+   * @param output The raw output value from the `complete_task` tool, now strongly typed with TOutput.
+   * @returns A string representation of the final output that will be displayed to the user
+   */
+  processOutputDisplay?: (output: z.infer<TOutput>) => string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Displaying the full result of a subagent when the result is along json object is not user friendly. 

To solve this, I added a new optional function to AgentDefinition allowing agents to define how their output should be summarized for display (processOutputDisplay).

The full output is now automatically saved to a temporary file, ensuring data integrity and traceability, while a customizable displayResult provides immediate, digestible feedback to the user. This change improves the clarity and usability of agent interactions by streamlining the information presented without losing any underlying detail.



## Details

Separate Display Output: Introduced a displayResult field in agent outputs, distinct from the full result, to provide a concise summary for users.

Customizable Display Logic: Added an optional processOutputDisplay function to AgentDefinition allowing agents to define how their output should be summarized for display.

Persistent Full Output: The complete agent output is now saved to a temporary file, with the display message indicating the file path for detailed review.

Agent Executor Updates: The AgentExecutor was modified to handle and propagate the new displayOutput throughout its execution flow.

Subagent Invocation Enhancements: SubagentInvocation now utilizes the displayResult for user-facing messages and manages the saving of full results to disk.
## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
