### PR TITLE
Remove testing-library/react dep now that it is unused.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17751,7 +17751,6 @@
       "devDependencies": {
         "@babel/runtime": "^7.27.6",
         "@google/gemini-cli-test-utils": "file:../test-utils",
-        "@testing-library/react": "^16.3.0",
         "@types/archiver": "^6.0.3",
         "@types/command-exists": "^1.2.3",
         "@types/diff": "^7.0.2",
@@ -17773,34 +17772,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "packages/cli/node_modules/@testing-library/react": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
-      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": "^10.0.0",
-        "@types/react": "^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^18.0.0 || ^19.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
       }
     },
     "packages/cli/node_modules/emoji-regex": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,6 @@
   "devDependencies": {
     "@babel/runtime": "^7.27.6",
     "@google/gemini-cli-test-utils": "file:../test-utils",
-    "@testing-library/react": "^16.3.0",
     "@types/archiver": "^6.0.3",
     "@types/command-exists": "^1.2.3",
     "@types/diff": "^7.0.2",


### PR DESCRIPTION
## Summary

This dep is no longer used and needs to not be added back. It results in running tests in a jsdom env which doesn't make sense given we are an Ink app running in the terminal not the browser dom.
