### PR TITLE
chore: make clear that `--model` is for choosing model on startup

### DIFF
--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -40,7 +40,7 @@ const renderComponent = (
 
   const mockConfig = contextValue
     ? ({
-        // --- Functions used by ModelDialog ---
+        // --- Functions d by ModelDialog ---
         getModel: vi.fn(() => DEFAULT_GEMINI_MODEL_AUTO),
         setModel: vi.fn(),
 
@@ -85,7 +85,7 @@ describe('<ModelDialog />', () => {
     expect(lastFrame()).toContain('Select Model');
     expect(lastFrame()).toContain('(Press Esc to close)');
     expect(lastFrame()).toContain(
-      '> To use a specific Gemini model, use the --model flag.',
+      '> To use a specific Gemini model on startup, use the --model flag.',
     );
     unmount();
   });

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -40,7 +40,7 @@ const renderComponent = (
 
   const mockConfig = contextValue
     ? ({
-        // --- Functions d by ModelDialog ---
+        // --- Functions used by ModelDialog ---
         getModel: vi.fn(() => DEFAULT_GEMINI_MODEL_AUTO),
         setModel: vi.fn(),
 

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -104,7 +104,7 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
       </Box>
       <Box flexDirection="column">
         <Text color={theme.text.secondary}>
-          {'> To use a specific Gemini model, use the --model flag.'}
+          {'> To use a specific Gemini model on startup, use the --model flag.'}
         </Text>
       </Box>
       <Box marginTop={1} flexDirection="column">


### PR DESCRIPTION
## Summary

The `/model` output is somewhat confusing as it does not clearly state that `--model` is for on startup.

Changing message to:

```bash
To use a specific Gemini model on startup, use the --model flag
```

<img width="1593" height="552" alt="image" src="https://github.com/user-attachments/assets/a8d4dd8a-cdd7-4366-8e77-4d54aaddb149" />
