### PR TITLE
fix(core): remove duplicate session_id in GCP log exporter

### DIFF
--- a/packages/core/src/telemetry/gcp-exporters.test.ts
+++ b/packages/core/src/telemetry/gcp-exporters.test.ts
@@ -131,7 +131,7 @@ describe('GCP Exporters', () => {
           }),
           expect.objectContaining({
             message: 'Test log message',
-            session_id: 'test-session',
+            'session.id': 'test-session',
             'custom.attribute': 'value',
             'service.name': 'test-service',
           }),

--- a/packages/core/src/telemetry/gcp-exporters.ts
+++ b/packages/core/src/telemetry/gcp-exporters.ts
@@ -71,7 +71,6 @@ export class GcpLogExporter implements LogRecordExporter {
             },
           },
           {
-            session_id: log.attributes?.['session.id'],
             ...log.attributes,
             ...log.resource?.attributes,
             message: log.body,


### PR DESCRIPTION
## Summary

This PR fixes an issue where the `GcpLogExporter` was sending a redundant `session_id` in log entries. It removes the duplicate field to ensure a cleaner and more consistent log schema in Google Cloud Logging.

## Details

The session identifier was being included twice in the `jsonPayload`: once as a top-level `session_id` field and again as `session.id` within the attributes object. This change removes the redundant top-level `session_id` and relies solely on the `session.id` attribute.

The corresponding unit test (`gcp-exporters.test.ts`) has been updated to reflect this change and verify that only the correct field is present.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword (Related to #123). -->

Fixes #12369

## How to Validate

When running the CLI with telemetry enabled for GCP, inspect the logs in the Google Cloud Console. Verify that the  log entries no longer contains the top-level `session_id` field, they only have `session.id` field.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
```