### PR TITLE
docs(cli): `user.email` attribute is only available for Google auth

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -225,8 +225,9 @@ For local development and debugging, you can capture telemetry data locally:
 The following section describes the structure of logs and metrics generated for
 Gemini CLI.
 
-The `session.id`, `installation.id`, and `user.email` are included as common
-attributes on all logs and metrics.
+The `session.id`, `installation.id`, and `user.email` (available only when
+authenticated with a Google account) are included as common attributes on all
+logs and metrics.
 
 ### Logs
 


### PR DESCRIPTION
## Summary

Clarifies that the `user-email` attribute is only available when authenticated with a Google account.

## Related Issues

Related to #9220

cc @blanca-delgado-parra 