### PR TITLE
Add OTLP headers for telemetry

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -80,6 +80,7 @@ These settings can be overridden by environment variables or CLI flags.
 | `target`       | `GEMINI_TELEMETRY_TARGET`        | `--telemetry-target <local\|gcp>`                        | Where to send telemetry data                      | `"gcp"`/`"local"` | `"local"`               |
 | `otlpEndpoint` | `GEMINI_TELEMETRY_OTLP_ENDPOINT` | `--telemetry-otlp-endpoint <URL>`                        | OTLP collector endpoint                           | URL string        | `http://localhost:4317` |
 | `otlpProtocol` | `GEMINI_TELEMETRY_OTLP_PROTOCOL` | `--telemetry-otlp-protocol <grpc\|http>`                 | OTLP transport protocol                           | `"grpc"`/`"http"` | `"grpc"`                |
+| `otlpHeaders`  | `GEMINI_TELEMETRY_OTLP_HEADERS`  | `--telemetry-otlp-headers <headers>`                     | OTLP transport headers                            | headers string    | -                       |
 | `outfile`      | `GEMINI_TELEMETRY_OUTFILE`       | `--telemetry-outfile <path>`                             | Save telemetry to file (overrides `otlpEndpoint`) | file path         | -                       |
 | `logPrompts`   | `GEMINI_TELEMETRY_LOG_PROMPTS`   | `--telemetry-log-prompts` / `--no-telemetry-log-prompts` | Include prompts in telemetry logs                 | `true`/`false`    | `true`                  |
 | `useCollector` | `GEMINI_TELEMETRY_USE_COLLECTOR` | -                                                        | Use external OTLP collector (advanced)            | `true`/`false`    | `false`                 |

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -511,9 +511,12 @@ see [Telemetry](../cli/telemetry.md).
     values are `local` and `gcp`.
   - **`otlpEndpoint`** (string): The endpoint for the OTLP Exporter.
   - **`otlpProtocol`** (string): The protocol for the OTLP Exporter (`grpc` or
-    `http`).
-  - **`logPrompts`** (boolean): Whether or not to include the content of user
-    prompts in the logs.
+    `http`). Defaults to `grpc`.
+  - **`otlpHeaders`** (object): Custom headers to send with OTLP telemetry
+    requests. Useful for authentication (e.g., API keys, bearer tokens). Values
+    can reference environment variables using `$VAR_NAME` or `${VAR_NAME}`
+    syntax. - **`logPrompts`** (boolean): Whether or not to include the content
+    of user prompts in the logs.
   - **`outfile`** (string): The file to write telemetry to when `target` is
     `local`.
   - **`useCollector`** (boolean): Whether to use an external OTLP collector.
@@ -557,6 +560,11 @@ of v0.3.0:
     "enabled": true,
     "target": "local",
     "otlpEndpoint": "http://localhost:4317",
+    "otlpProtocol": "http",
+    "otlpHeaders": {
+      "Authorization": "Bearer ${MY_TOKEN}",
+      "x-api-key": "abc123"
+    },
     "logPrompts": true
   },
   "privacy": {
@@ -664,6 +672,15 @@ the `advanced.excludedEnvVars` setting in your `settings.json` file.
 - **`GEMINI_TELEMETRY_OTLP_PROTOCOL`**:
   - Sets the OTLP protocol (`grpc` or `http`).
   - Overrides the `telemetry.otlpProtocol` setting.
+- **`GEMINI_TELEMETRY_OTLP_HEADERS`**:
+  - Custom headers to send with OTLP telemetry requests. Can be specified in
+    JSON format or as comma/semicolon-delimited `key=value` pairs.
+  - Useful for authentication with secured OTLP collectors (e.g., API keys,
+    bearer tokens).
+  - JSON format example:
+    `export GEMINI_TELEMETRY_OTLP_HEADERS='{"Authorization":"Bearer token","x-api-key":"abc123"}'`
+  - Delimiter format example:
+    `export GEMINI_TELEMETRY_OTLP_HEADERS='Authorization=Bearer token,x-api-key=abc123'`
 - **`GEMINI_TELEMETRY_LOG_PROMPTS`**:
   - Set to `true` or `1` to enable or disable logging of user prompts. Any other
     value is treated as disabling it.
@@ -771,6 +788,12 @@ for that specific session.
 - **`--telemetry-otlp-protocol`**:
   - Sets the OTLP protocol for telemetry (`grpc` or `http`). Defaults to `grpc`.
     See [telemetry](../cli/telemetry.md) for more information.
+- **`--telemetry-otlp-header <key=value>`**:
+  - Adds a custom OTLP header in `key=value` format. Can be specified multiple
+    times to add multiple headers. Useful for authentication (e.g.,
+    `--telemetry-otlp-header "Authorization=Bearer token"`).
+  - Example:
+    `gemini --telemetry --telemetry-otlp-header "Authorization=Bearer xyz" --telemetry-otlp-header "x-api-key=abc123"`
 - **`--telemetry-log-prompts`**:
   - Enables logging of prompts for telemetry. See
     [telemetry](../cli/telemetry.md) for more information.

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -520,6 +520,34 @@ describe('Server Config (config.ts)', () => {
       const config = new Config(paramsWithoutTelemetry);
       expect(config.getTelemetryOtlpProtocol()).toBe('grpc');
     });
+    it('should return provided OTLP headers', () => {
+      const headers = {
+        Authorization: 'Bearer token',
+        'x-api-key': 'abc123',
+      };
+      const params: ConfigParameters = {
+        ...baseParams,
+        telemetry: { enabled: true, otlpHeaders: headers },
+      };
+      const config = new Config(params);
+      expect(config.getTelemetryOtlpHeaders()).toEqual(headers);
+    });
+
+    it('should return empty object for OTLP headers if not provided', () => {
+      const params: ConfigParameters = {
+        ...baseParams,
+        telemetry: { enabled: true },
+      };
+      const config = new Config(params);
+      expect(config.getTelemetryOtlpHeaders()).toEqual({});
+    });
+
+    it('should return empty object for OTLP headers if telemetry object is not provided', () => {
+      const paramsWithoutTelemetry: ConfigParameters = { ...baseParams };
+      delete paramsWithoutTelemetry.telemetry;
+      const config = new Config(paramsWithoutTelemetry);
+      expect(config.getTelemetryOtlpHeaders()).toEqual({});
+    });
   });
 
   describe('UseRipgrep Configuration', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -101,6 +101,7 @@ export interface TelemetrySettings {
   target?: TelemetryTarget;
   otlpEndpoint?: string;
   otlpProtocol?: 'grpc' | 'http';
+  otlpHeaders?: Record<string, string>;
   logPrompts?: boolean;
   outfile?: string;
   useCollector?: boolean;
@@ -421,6 +422,7 @@ export class Config {
       target: params.telemetry?.target ?? DEFAULT_TELEMETRY_TARGET,
       otlpEndpoint: params.telemetry?.otlpEndpoint ?? DEFAULT_OTLP_ENDPOINT,
       otlpProtocol: params.telemetry?.otlpProtocol,
+      otlpHeaders: params.telemetry?.otlpHeaders,
       logPrompts: params.telemetry?.logPrompts ?? true,
       outfile: params.telemetry?.outfile,
       useCollector: params.telemetry?.useCollector,
@@ -825,6 +827,10 @@ export class Config {
 
   getTelemetryUseCollector(): boolean {
     return this.telemetrySettings.useCollector ?? false;
+  }
+
+  getTelemetryOtlpHeaders(): Record<string, string> {
+    return this.telemetrySettings.otlpHeaders ?? {};
   }
 
   getGeminiClient(): GeminiClient {

--- a/packages/core/src/telemetry/config.ts
+++ b/packages/core/src/telemetry/config.ts
@@ -34,11 +34,76 @@ export function parseTelemetryTargetValue(
   return undefined;
 }
 
+/**
+ * Parse OTLP headers from a string value.
+ * Supports JSON format or key=value pairs separated by comma or semicolon.
+ * Returns Record<string, string> or undefined if parsing fails.
+ */
+export function parseOtlpHeaders(
+  value: string | undefined,
+): Record<string, string> | undefined {
+  if (value === undefined || value.trim() === '') {
+    return undefined;
+  }
+
+  const trimmedValue = value.trim();
+
+  // Try JSON format first
+  if (trimmedValue.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmedValue);
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        !Array.isArray(parsed)
+      ) {
+        const result: Record<string, string> = {};
+        for (const [key, val] of Object.entries(parsed)) {
+          if (key && val !== undefined && val !== null) {
+            result[key] = String(val);
+          }
+        }
+        return Object.keys(result).length > 0 ? result : undefined;
+      }
+    } catch {
+      // It looked like JSON but failed to parse, so we assume it's invalid.
+      return undefined;
+    }
+  }
+  // Try delimiter parsing (comma or semicolon)
+  if (trimmedValue.includes('=')) {
+    const result: Record<string, string> = {};
+    // Split by comma first, then handle semicolons
+    const pairs = trimmedValue.split(/[,;]/);
+
+    for (const pair of pairs) {
+      const trimmedPair = pair.trim();
+      if (!trimmedPair) continue;
+
+      const equalsIndex = trimmedPair.indexOf('=');
+      if (equalsIndex === -1) continue;
+
+      const key = trimmedPair.substring(0, equalsIndex).trim();
+      const val = trimmedPair.substring(equalsIndex + 1).trim();
+
+      if (key && val) {
+        result[key] = val;
+      }
+    }
+
+    if (Object.keys(result).length > 0) {
+      return result;
+    }
+  }
+
+  return undefined;
+}
 export interface TelemetryArgOverrides {
   telemetry?: boolean;
   telemetryTarget?: string | TelemetryTarget;
   telemetryOtlpEndpoint?: string;
   telemetryOtlpProtocol?: string;
+  telemetryOtlpHeader?: string[];
   telemetryLogPrompts?: boolean;
   telemetryOutfile?: string;
 }
@@ -108,11 +173,36 @@ export async function resolveTelemetrySettings(options: {
     parseBooleanEnvFlag(env['GEMINI_TELEMETRY_USE_COLLECTOR']) ??
     settings.useCollector;
 
+  // Merge OTLP headers from settings, env, and argv (in that order, later overwrites earlier)
+  const otlpHeaders: Record<string, string> = {};
+
+  // Start with settings
+  if (settings.otlpHeaders) {
+    Object.assign(otlpHeaders, settings.otlpHeaders);
+  }
+
+  // Merge environment variable headers
+  const envHeaders = parseOtlpHeaders(env['GEMINI_TELEMETRY_OTLP_HEADERS']);
+  if (envHeaders) {
+    Object.assign(otlpHeaders, envHeaders);
+  }
+
+  // Merge CLI argument headers (highest precedence)
+  if (argv.telemetryOtlpHeader && Array.isArray(argv.telemetryOtlpHeader)) {
+    for (const headerArg of argv.telemetryOtlpHeader) {
+      const parsed = parseOtlpHeaders(headerArg);
+      if (parsed) {
+        Object.assign(otlpHeaders, parsed);
+      }
+    }
+  }
+
   return {
     enabled,
     target,
     otlpEndpoint,
     otlpProtocol,
+    otlpHeaders: Object.keys(otlpHeaders).length > 0 ? otlpHeaders : undefined,
     logPrompts,
     outfile,
     useCollector,

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -42,6 +42,7 @@ describe('Telemetry SDK', () => {
       getTelemetryEnabled: () => true,
       getTelemetryOtlpEndpoint: () => 'http://localhost:4317',
       getTelemetryOtlpProtocol: () => 'grpc',
+      getTelemetryOtlpHeaders: () => ({}),
       getTelemetryTarget: () => 'local',
       getTelemetryUseCollector: () => false,
       getTelemetryOutfile: () => undefined,
@@ -235,5 +236,108 @@ describe('Telemetry SDK', () => {
     expect(OTLPLogExporterHttp).not.toHaveBeenCalled();
     expect(OTLPMetricExporterHttp).not.toHaveBeenCalled();
     expect(NodeSDK.prototype.start).toHaveBeenCalled();
+  });
+  it('should pass headers to HTTP exporters', () => {
+    const headers = {
+      Authorization: 'Bearer token123',
+      'x-api-key': 'abc456',
+    };
+    vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
+    vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
+      'http://localhost:4318',
+    );
+    vi.spyOn(mockConfig, 'getTelemetryOtlpHeaders').mockReturnValue(headers);
+
+    initializeTelemetry(mockConfig);
+
+    expect(OTLPTraceExporterHttp).toHaveBeenCalledWith({
+      url: 'http://localhost:4318/',
+      headers,
+    });
+    expect(OTLPLogExporterHttp).toHaveBeenCalledWith({
+      url: 'http://localhost:4318/',
+      headers,
+    });
+    expect(OTLPMetricExporterHttp).toHaveBeenCalledWith({
+      url: 'http://localhost:4318/',
+      headers,
+    });
+  });
+
+  it('should pass metadata to gRPC exporters', () => {
+    const headers = {
+      Authorization: 'Bearer token123',
+      'x-api-key': 'abc456',
+    };
+    vi.spyOn(mockConfig, 'getTelemetryOtlpHeaders').mockReturnValue(headers);
+
+    initializeTelemetry(mockConfig);
+
+    expect(OTLPTraceExporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'http://localhost:4317',
+        compression: 'gzip',
+        metadata: expect.any(Object),
+      }),
+    );
+    expect(OTLPLogExporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'http://localhost:4317',
+        compression: 'gzip',
+        metadata: expect.any(Object),
+      }),
+    );
+    expect(OTLPMetricExporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'http://localhost:4317',
+        compression: 'gzip',
+        metadata: expect.any(Object),
+      }),
+    );
+  });
+
+  it('should not pass headers when none are configured', () => {
+    vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
+    vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
+      'http://localhost:4318',
+    );
+    vi.spyOn(mockConfig, 'getTelemetryOtlpHeaders').mockReturnValue({});
+
+    initializeTelemetry(mockConfig);
+
+    expect(OTLPTraceExporterHttp).toHaveBeenCalledWith({
+      url: 'http://localhost:4318/',
+      headers: undefined,
+    });
+    expect(OTLPLogExporterHttp).toHaveBeenCalledWith({
+      url: 'http://localhost:4318/',
+      headers: undefined,
+    });
+    expect(OTLPMetricExporterHttp).toHaveBeenCalledWith({
+      url: 'http://localhost:4318/',
+      headers: undefined,
+    });
+  });
+
+  it('should not pass metadata to gRPC exporters when no headers configured', () => {
+    vi.spyOn(mockConfig, 'getTelemetryOtlpHeaders').mockReturnValue({});
+
+    initializeTelemetry(mockConfig);
+
+    expect(OTLPTraceExporter).toHaveBeenCalledWith({
+      url: 'http://localhost:4317',
+      compression: 'gzip',
+      metadata: undefined,
+    });
+    expect(OTLPLogExporter).toHaveBeenCalledWith({
+      url: 'http://localhost:4317',
+      compression: 'gzip',
+      metadata: undefined,
+    });
+    expect(OTLPMetricExporter).toHaveBeenCalledWith({
+      url: 'http://localhost:4317',
+      compression: 'gzip',
+      metadata: undefined,
+    });
   });
 });

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -34,6 +34,7 @@ describe('telemetry', () => {
     vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
       'http://localhost:4317',
     );
+    vi.spyOn(mockConfig, 'getTelemetryOtlpHeaders').mockReturnValue({});
     vi.spyOn(mockConfig, 'getSessionId').mockReturnValue('test-session-id');
     mockNodeSdk = {
       start: vi.fn(),


### PR DESCRIPTION
## TLDR
Reopened version of https://github.com/google-gemini/gemini-cli/pull/11754 by @brandonin

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->
In most cases we will need to add authentication headers to send to our Otel Collector. This pull request adds support for custom OTLP headers in telemetry configuration for the Gemini CLI, allowing users to specify authentication and other headers for telemetry requests via settings files, environment variables, and CLI arguments.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->
 It introduces a parsing and merging strategy for these headers, updates documentation, and ensures correct propagation of headers to both HTTP and gRPC exporters.

**Telemetry configuration and parsing enhancements:**

* Added support for specifying custom OTLP headers (`otlpHeaders`) in configuration files, environment variables (`GEMINI_TELEMETRY_OTLP_HEADERS`), and CLI arguments (`--telemetry-otlp-header`). Headers can be provided in JSON or key=value formats, and are merged with correct precedence (CLI > env > settings). 
* Implemented the `parseOtlpHeaders` function to handle various input formats, and updated `resolveTelemetrySettings` to merge headers from all sources.

**Documentation updates:**

* Updated `docs/get-started/configuration.md` to document the new `otlpHeaders` option, environment variable, and CLI flag, including usage examples for authentication scenarios.

**Telemetry SDK integration:**

* Modified telemetry SDK initialization to pass custom headers to HTTP exporters and as gRPC metadata, ensuring correct transmission of authentication information.

This update makes it much easier to securely configure telemetry authentication for remote environments.
