### PR TITLE
Mark `model.compressionThreshold` as requiring a restart

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -590,7 +590,7 @@ const SETTINGS_SCHEMA = {
         type: 'number',
         label: 'Compression Threshold',
         category: 'Model',
-        requiresRestart: false,
+        requiresRestart: true,
         default: 0.2 as number,
         description:
           'The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3).',


### PR DESCRIPTION
## Summary

Mark `model.compressionThreshold` as requiring a restart

## Related Issues

For https://github.com/google-gemini/maintainers-gemini-cli/issues/973

## How to Validate

Change it with `/settings` and verify that it tells you to restart

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
