### PR TITLE
refactor: simplify daily quota error messages

### DIFF
--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -96,7 +96,7 @@ export function classifyGoogleError(error: unknown): unknown {
       const quotaId = violation.quotaId ?? '';
       if (quotaId.includes('PerDay') || quotaId.includes('Daily')) {
         return new TerminalQuotaError(
-          `${googleApiError.message}\nExpected quota reset within 24h.`,
+          `You have exhausted your daily quota on this model.`,
           googleApiError,
         );
       }
@@ -139,7 +139,7 @@ export function classifyGoogleError(error: unknown): unknown {
     const quotaLimit = errorInfo.metadata?.['quota_limit'] ?? '';
     if (quotaLimit.includes('PerDay') || quotaLimit.includes('Daily')) {
       return new TerminalQuotaError(
-        `${googleApiError.message}\nExpected quota reset within 24h.`,
+        `You have exhausted your daily quota on this model.`,
         googleApiError,
       );
     }


### PR DESCRIPTION
Simplifies the error message shown on the CLI, since the GCA service appends the quota project in the message which confuses users.

Before:
```
✕ [API Error: Quota exceeded for quota metric 'Gemini 2.5 Pro Requests' and limit 'Gemini 2.5 Pro Requests per
  day per user per tier' of service 'cloudcode-pa.googleapis.com' for consumer 'project_number:681255809395'.
  Expected quota reset within 24h.]
```

After:
```
✕ [You have exhausted your daily quota on this model.]
```
