### PR TITLE
feat: Improve build process with dependency-ordered builds and tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ package-lock.json
 .DS_Store
 Thumbs.db
 
+.cache/
+
 # TypeScript build info files
 *.tsbuildinfo
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "build-and-start": "npm run build && npm run start",
     "build:vscode": "node scripts/build_vscode_companion.js",
     "build:all": "npm run build && npm run build:sandbox && npm run build:vscode",
-    "build:packages": "npm run build --workspaces",
     "build:sandbox": "node scripts/build_sandbox.js",
     "bundle": "npm run generate && node esbuild.config.js && node scripts/copy_bundle_assets.js",
     "test": "npm run test --workspaces --if-present",

--- a/packages/a2a-server/tsconfig.json
+++ b/packages/a2a-server/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "composite": true,
+    "tsBuildInfoFile": "../../.cache/a2a-server.tsbuildinfo",
     "types": ["node", "vitest/globals"]
   },
   "include": ["index.ts", "src/**/*.ts", "src/**/*.json"],

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ES2023"],
-    "types": ["node", "vitest/globals"]
+    "types": ["node", "vitest/globals"],
+    "tsBuildInfoFile": "../../.cache/cli.tsbuildinfo"
   },
   "include": [
     "index.ts",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "composite": true,
+    "tsBuildInfoFile": "../../.cache/core.tsbuildinfo",
     "types": ["node", "vitest/globals"]
   },
   "include": ["index.ts", "src/**/*.ts", "src/**/*.json"],

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "lib": ["DOM", "DOM.Iterable", "ES2021"],
     "composite": true,
+    "tsBuildInfoFile": "../../.cache/test-utils.tsbuildinfo",
     "types": ["node"]
   },
   "include": ["index.ts", "src/**/*.ts", "src/**/*.json"],

--- a/packages/vscode-ide-companion/tsconfig.json
+++ b/packages/vscode-ide-companion/tsconfig.json
@@ -13,7 +13,8 @@
      */
     "skipLibCheck": true,
     "rootDir": "src",
-    "strict": true /* enable all strict type-checking options */
+    "strict": true /* enable all strict type-checking options */,
+    "tsBuildInfoFile": "../../.cache/vscode-ide-companion.tsbuildinfo"
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -30,9 +30,27 @@ if (!existsSync(join(root, 'node_modules'))) {
   execSync('npm install', { stdio: 'inherit', cwd: root });
 }
 
+const workspaces = [
+  '@google/gemini-cli-test-utils',
+  '@google/gemini-cli-core',
+  '@google/gemini-cli-a2a-server',
+  '@google/gemini-cli',
+  'gemini-cli-vscode-ide-companion',
+];
+
+function buildWorkspace(workspace) {
+  console.log(`Building ${workspace}...`);
+  execSync(`npm run build --workspace ${workspace}`, {
+    stdio: 'inherit',
+    cwd: root,
+  });
+}
+
 // build all workspaces/packages
 execSync('npm run generate', { stdio: 'inherit', cwd: root });
-execSync('npm run build --workspaces', { stdio: 'inherit', cwd: root });
+for (const workspace of workspaces) {
+  buildWorkspace(workspace);
+}
 
 // also build container image if sandboxing is enabled
 // skip (-s) npm install + build since we did that above


### PR DESCRIPTION
- Updated `scripts/build.js` to build workspaces in their dependency order, ensuring that dependent packages are built before their consumers.
- Configured each workspace's `tsconfig.json` to use a dedicated `tsbuildinfo` file in a shared `.cache` directory, improving incremental build performance.
- Added `.cache/` to `.gitignore` to prevent build artifacts from being committed.
- Removed the redundant `build:packages` script from `package.json`.
