### PR TITLE
Adding the Policy Engine docs to indexes.

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -11,6 +11,8 @@ requests sent from `packages/cli`. For a general overview of Gemini CLI, see the
   registered, and used by the core.
 - **[Memory Import Processor](./memport.md):** Documentation for the modular
   GEMINI.md import feature using @file.md syntax.
+- **[Policy Engine](./policy-engine.md):** Use the Policy Engine for
+  fine-grained control over tool execution.
 
 ## Role of the core
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,8 @@ This documentation is organized into the following sections:
 - **[Memport](./core/memport.md):** Using the Memory Import Processor.
 - **[Tools API](./core/tools-api.md):** Information on how the core manages and
   exposes tools.
+- **[Policy Engine](./core/policy-engine.md):** Use the Policy Engine for
+  fine-grained control over tool execution.
 
 ### Tools
 


### PR DESCRIPTION
## Summary

A quick fast-follow to add the core/policy-engine.md doc into the indexes.

## Details

This PR adds /core/policy-engine.md into the /core/index.md and /index.md files. 

## Related Issues

This is a fast-follow to this PR: #12240.

## How to Validate

Text-only update. Check for any unintended changes.

## Pre-Merge Checklist

- [X] Updated relevant documentation and README (if needed)