### PR TITLE
I think the package lock was added in error to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 # Dependency directory
 node_modules
 bower_components
-package-lock.json
 
 # Editors
 .idea


### PR DESCRIPTION
## Summary

Believe we accidentally added package-lock.json to .gitignore as we check it it.

Hoping this explains some confusing behavior I'm seeing but it might be unrelated.
