### PR TITLE
fix(ui): ensure model changes update the UI immediately

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -1506,7 +1506,7 @@ describe('AppContainer State Management', () => {
       // Arrange: Mock initial model
       vi.spyOn(mockConfig, 'getModel').mockReturnValue('initial-model');
 
-      const { rerender: actualRerender, unmount: actualUnmount } = render(
+      const { unmount } = render(
         <AppContainer
           config={mockConfig}
           settings={mockSettings}
@@ -1514,9 +1514,6 @@ describe('AppContainer State Management', () => {
           initializationResult={mockInitResult}
         />,
       );
-
-      const rerender = actualRerender;
-      const unmount = actualUnmount;
 
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
@@ -1535,16 +1532,6 @@ describe('AppContainer State Management', () => {
       act(() => {
         handler({ model: 'new-model' });
       });
-
-      // Rerender to reflect state change
-      rerender(
-        <AppContainer
-          config={mockConfig}
-          settings={mockSettings}
-          version="1.0.0"
-          initializationResult={mockInitResult}
-        />,
-      );
 
       // Assert: Verify model is updated
       expect(capturedUIState.currentModel).toBe('new-model');

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -1515,12 +1515,12 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
       // Verify initial model
-      expect(capturedUIState.currentModel).toBe('initial-model');
+      await act(async () => {
+        await vi.waitFor(() => {
+          expect(capturedUIState?.currentModel).toBe('initial-model');
+        });
+      });
 
       // Get the registered handler for ModelChanged
       const handler = mockCoreEvents.on.mock.calls.find(

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -1501,5 +1501,54 @@ describe('AppContainer State Management', () => {
       );
       unmount();
     });
+
+    it('updates currentModel when ModelChanged event is received', async () => {
+      // Arrange: Mock initial model
+      vi.spyOn(mockConfig, 'getModel').mockReturnValue('initial-model');
+
+      const { rerender: actualRerender, unmount: actualUnmount } = render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      const rerender = actualRerender;
+      const unmount = actualUnmount;
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Verify initial model
+      expect(capturedUIState.currentModel).toBe('initial-model');
+
+      // Get the registered handler for ModelChanged
+      const handler = mockCoreEvents.on.mock.calls.find(
+        (call: unknown[]) => call[0] === CoreEvent.ModelChanged,
+      )?.[1];
+      expect(handler).toBeDefined();
+
+      // Act: Simulate ModelChanged event
+      act(() => {
+        handler({ model: 'new-model' });
+      });
+
+      // Rerender to reflect state change
+      rerender(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      // Assert: Verify model is updated
+      expect(capturedUIState.currentModel).toBe('new-model');
+      unmount();
+    });
   });
 });

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -48,6 +48,7 @@ import {
   debugLogger,
   coreEvents,
   CoreEvent,
+  type ModelChangedPayload,
 } from '@google/gemini-cli-core';
 import { validateAuthMethod } from '../config/auth.js';
 import { loadHierarchicalGeminiMemory } from '../config/config.js';
@@ -258,16 +259,22 @@ export const AppContainer = (props: AppContainerProps) => {
     [historyManager.addItem],
   );
 
-  // Subscribe to fallback mode changes from core
+  // Subscribe to fallback mode and model changes from core
   useEffect(() => {
     const handleFallbackModeChanged = () => {
       const effectiveModel = getEffectiveModel();
       setCurrentModel(effectiveModel);
     };
 
+    const handleModelChanged = (payload: ModelChangedPayload) => {
+      setCurrentModel(payload.model);
+    };
+
     coreEvents.on(CoreEvent.FallbackModeChanged, handleFallbackModeChanged);
+    coreEvents.on(CoreEvent.ModelChanged, handleModelChanged);
     return () => {
       coreEvents.off(CoreEvent.FallbackModeChanged, handleFallbackModeChanged);
+      coreEvents.off(CoreEvent.ModelChanged, handleModelChanged);
     };
   }, [getEffectiveModel]);
 

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -147,6 +147,7 @@ vi.mock('../agents/subagent-tool-wrapper.js', () => ({
 
 const mockCoreEvents = vi.hoisted(() => ({
   emitFeedback: vi.fn(),
+  emitModelChanged: vi.fn(),
 }));
 
 const mockSetGlobalProxy = vi.hoisted(() => vi.fn());

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -41,6 +41,7 @@ import {
   DEFAULT_OTLP_ENDPOINT,
   uiTelemetryService,
 } from '../telemetry/index.js';
+import { coreEvents } from '../utils/events.js';
 import { tokenLimit } from '../core/tokenLimits.js';
 import {
   DEFAULT_GEMINI_EMBEDDING_MODEL,
@@ -711,7 +712,10 @@ export class Config {
       return;
     }
 
-    this.model = newModel;
+    if (this.model !== newModel) {
+      this.model = newModel;
+      coreEvents.emitModelChanged(newModel);
+    }
   }
 
   isInFallbackMode(): boolean {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -77,7 +77,6 @@ import type { UserTierId } from '../code_assist/types.js';
 import { AgentRegistry } from '../agents/registry.js';
 import { setGlobalProxy } from '../utils/fetch.js';
 import { SubagentToolWrapper } from '../agents/subagent-tool-wrapper.js';
-import { coreEvents } from '../utils/events.js';
 
 export enum ApprovalMode {
   DEFAULT = 'default',

--- a/packages/core/src/utils/events.test.ts
+++ b/packages/core/src/utils/events.test.ts
@@ -156,4 +156,17 @@ describe('CoreEventEmitter', () => {
     });
     expect(listener.mock.calls[2][0]).toMatchObject({ message: 'Buffered 2' });
   });
+
+  describe('ModelChanged Event', () => {
+    it('should emit ModelChanged event with correct payload', () => {
+      const listener = vi.fn();
+      events.on(CoreEvent.ModelChanged, listener);
+
+      const newModel = 'gemini-2.5-pro';
+      events.emitModelChanged(newModel);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith({ model: newModel });
+    });
+  });
 });

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -43,9 +43,20 @@ export interface FallbackModeChangedPayload {
   isInFallbackMode: boolean;
 }
 
+/**
+ * Payload for the 'model-changed' event.
+ */
+export interface ModelChangedPayload {
+  /**
+   * The new model that was set.
+   */
+  model: string;
+}
+
 export enum CoreEvent {
   UserFeedback = 'user-feedback',
   FallbackModeChanged = 'fallback-mode-changed',
+  ModelChanged = 'model-changed',
 }
 
 export class CoreEventEmitter extends EventEmitter {
@@ -87,6 +98,14 @@ export class CoreEventEmitter extends EventEmitter {
   }
 
   /**
+   * Notifies subscribers that the model has changed.
+   */
+  emitModelChanged(model: string): void {
+    const payload: ModelChangedPayload = { model };
+    this.emit(CoreEvent.ModelChanged, payload);
+  }
+
+  /**
    * Flushes buffered messages. Call this immediately after primary UI listener
    * subscribes.
    */
@@ -107,6 +126,10 @@ export class CoreEventEmitter extends EventEmitter {
     listener: (payload: FallbackModeChangedPayload) => void,
   ): this;
   override on(
+    event: CoreEvent.ModelChanged,
+    listener: (payload: ModelChangedPayload) => void,
+  ): this;
+  override on(
     event: string | symbol,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     listener: (...args: any[]) => void,
@@ -123,6 +146,10 @@ export class CoreEventEmitter extends EventEmitter {
     listener: (payload: FallbackModeChangedPayload) => void,
   ): this;
   override off(
+    event: CoreEvent.ModelChanged,
+    listener: (payload: ModelChangedPayload) => void,
+  ): this;
+  override off(
     event: string | symbol,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     listener: (...args: any[]) => void,
@@ -137,6 +164,10 @@ export class CoreEventEmitter extends EventEmitter {
   override emit(
     event: CoreEvent.FallbackModeChanged,
     payload: FallbackModeChangedPayload,
+  ): boolean;
+  override emit(
+    event: CoreEvent.ModelChanged,
+    payload: ModelChangedPayload,
   ): boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   override emit(event: string | symbol, ...args: any[]): boolean {


### PR DESCRIPTION
## Summary

This PR fixes a bug where changing the model via the `/model` slash command did not immediately update the UI (specifically the footer status bar).

## Details

The `Config` object is a plain TypeScript class and its state changes are not automatically reactive in the React UI. Previously, the UI only updated when other actions triggered a re-render.

Changes included in this PR:
- Introduced a new `CoreEvent.ModelChanged` event in `CoreEventEmitter`.
- Updated `Config.setModel()` to emit this event whenever the model actually changes.
- Updated `AppContainer` to subscribe to this event and sync the `currentModel` React state, ensuring immediate UI updates.
- Added unit tests for the new event and integration tests for the `AppContainer` subscription.

## How to Validate

1. Start the CLI: `npm run start`
2. Observe the current model displayed in the footer (bottom right).
3. Run the `/model` command and select a different model.
4. Verify that the footer immediately updates to reflect the newly selected model.

## Pre-Merge Checklist

- [X] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [X] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [X] MacOS
    - [X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [X] Seatbelt
