### PR TITLE
refactor(core): improve error handling for setGlobalProxy

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -958,7 +958,7 @@ describe('Server Config (config.ts)', () => {
 
       expect(mockCoreEvents.emitFeedback).toHaveBeenCalledWith(
         'error',
-        'Failed to set invalid proxy from configuration.',
+        'Invalid proxy configuration detected. Check debug drawer for more details (F12)',
         proxyError,
       );
     });

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -139,6 +139,20 @@ vi.mock('../agents/subagent-tool-wrapper.js', () => ({
   SubagentToolWrapper: vi.fn(),
 }));
 
+const mockCoreEvents = vi.hoisted(() => ({
+  emitFeedback: vi.fn(),
+}));
+
+const mockSetGlobalProxy = vi.hoisted(() => vi.fn());
+
+vi.mock('../utils/events.js', () => ({
+  coreEvents: mockCoreEvents,
+}));
+
+vi.mock('../utils/fetch.js', () => ({
+  setGlobalProxy: mockSetGlobalProxy,
+}));
+
 import { BaseLlmClient } from '../core/baseLlmClient.js';
 import { tokenLimit } from '../core/tokenLimits.js';
 import { uiTelemetryService } from '../telemetry/index.js';
@@ -904,6 +918,63 @@ describe('Server Config (config.ts)', () => {
       // 4 * (32000 - 1000) = 124000
       // custom threshold is 50000
       expect(config.getTruncateToolOutputThreshold()).toBe(50000);
+    });
+  });
+
+  describe('Proxy Configuration Error Handling', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should call setGlobalProxy when proxy is configured', () => {
+      const paramsWithProxy: ConfigParameters = {
+        ...baseParams,
+        proxy: 'http://proxy.example.com:8080',
+      };
+      new Config(paramsWithProxy);
+
+      expect(mockSetGlobalProxy).toHaveBeenCalledWith(
+        'http://proxy.example.com:8080',
+      );
+    });
+
+    it('should not call setGlobalProxy when proxy is not configured', () => {
+      new Config(baseParams);
+
+      expect(mockSetGlobalProxy).not.toHaveBeenCalled();
+    });
+
+    it('should emit error feedback when setGlobalProxy throws an error', () => {
+      const proxyError = new Error('Invalid proxy URL');
+      mockSetGlobalProxy.mockImplementation(() => {
+        throw proxyError;
+      });
+
+      const paramsWithProxy: ConfigParameters = {
+        ...baseParams,
+        proxy: 'invalid-proxy',
+      };
+      new Config(paramsWithProxy);
+
+      expect(mockCoreEvents.emitFeedback).toHaveBeenCalledWith(
+        'error',
+        'Failed to set invalid proxy from configuration.',
+        proxyError,
+      );
+    });
+
+    it('should not emit error feedback when setGlobalProxy succeeds', () => {
+      mockSetGlobalProxy.mockImplementation(() => {
+        // Success - no error thrown
+      });
+
+      const paramsWithProxy: ConfigParameters = {
+        ...baseParams,
+        proxy: 'http://proxy.example.com:8080',
+      };
+      new Config(paramsWithProxy);
+
+      expect(mockCoreEvents.emitFeedback).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -521,13 +521,14 @@ export class Config {
       initializeTelemetry(this);
     }
 
-    if (this.getProxy()) {
+    const proxy = this.getProxy();
+    if (proxy) {
       try {
-        setGlobalProxy(this.getProxy() as string);
+        setGlobalProxy(proxy);
       } catch (error) {
         coreEvents.emitFeedback(
           'error',
-          'Failed to set invalid proxy from configuration.',
+          'Invalid proxy configuration detected. Check debug drawer for more details (F12)',
           error,
         );
       }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -76,6 +76,7 @@ import type { UserTierId } from '../code_assist/types.js';
 import { AgentRegistry } from '../agents/registry.js';
 import { setGlobalProxy } from '../utils/fetch.js';
 import { SubagentToolWrapper } from '../agents/subagent-tool-wrapper.js';
+import { coreEvents } from '../utils/events.js';
 
 export enum ApprovalMode {
   DEFAULT = 'default',
@@ -521,7 +522,15 @@ export class Config {
     }
 
     if (this.getProxy()) {
-      setGlobalProxy(this.getProxy() as string);
+      try {
+        setGlobalProxy(this.getProxy() as string);
+      } catch (error) {
+        coreEvents.emitFeedback(
+          'error',
+          'Failed to set invalid proxy from configuration.',
+          error,
+        );
+      }
     }
     this.geminiClient = new GeminiClient(this);
     this.modelRouterService = new ModelRouterService(this);

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -21,11 +21,7 @@ import { getErrorMessage } from '../utils/errors.js';
 import type { Config } from '../config/config.js';
 import { ApprovalMode, DEFAULT_GEMINI_FLASH_MODEL } from '../config/config.js';
 import { getResponseText } from '../utils/partUtils.js';
-import {
-  fetchWithTimeout,
-  isPrivateIp,
-  setGlobalProxy,
-} from '../utils/fetch.js';
+import { fetchWithTimeout, isPrivateIp } from '../utils/fetch.js';
 import { convert } from 'html-to-text';
 import {
   logWebFetchFallbackAttempt,
@@ -415,10 +411,6 @@ export class WebFetchTool extends BaseDeclarativeTool<
       false, // canUpdateOutput
       messageBus,
     );
-    const proxy = config.getProxy();
-    if (proxy) {
-      setGlobalProxy(proxy);
-    }
   }
 
   protected override validateToolParamValues(

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -58,9 +58,5 @@ export async function fetchWithTimeout(
 }
 
 export function setGlobalProxy(proxy: string) {
-  try {
-    setGlobalDispatcher(new ProxyAgent(proxy));
-  } catch (e) {
-    console.error(`Failed to set proxy: ${getErrorMessage(e)}`);
-  }
+  setGlobalDispatcher(new ProxyAgent(proxy));
 }


### PR DESCRIPTION
## Summary

Refactored proxy configuration error handling to be context-aware, ensuring errors are properly surfaced to users and eliminating redundant code.

Fixes #11878

## Changes

### 1. `packages/core/src/utils/fetch.ts`
**Before:**
```typescript
export function setGlobalProxy(proxy: string) {
  try {
    setGlobalDispatcher(new ProxyAgent(proxy));
  } catch (e) {
    console.error(`Failed to set proxy: ${getErrorMessage(e)}`);
  }
}
```

**After:**
```typescript
export function setGlobalProxy(proxy: string) {
  setGlobalDispatcher(new ProxyAgent(proxy));
}
```

- Removed try-catch block
- Function now throws errors instead of catching and logging to console.error
- Allows calling contexts to handle errors appropriately

### 2. `packages/core/src/config/config.ts`
- Added try-catch wrapper around `setGlobalProxy` call in constructor
- Implemented `coreEvents.emitFeedback('error', ...)` for startup error reporting
- Provides user-friendly error message: "Failed to set invalid proxy from configuration."
- Errors now surface correctly to users in both interactive and non-interactive modes

### 3. `packages/core/src/tools/web-fetch.ts`
- Removed duplicate `setGlobalProxy` call from constructor
- Removed `setGlobalProxy` from imports
- Proxy is now only set once in Config constructor (eliminates redundancy)

### 4. `packages/core/src/config/config.test.ts`
- Added comprehensive test suite "Proxy Configuration Error Handling"
- Added mocks for `coreEvents` and `setGlobalProxy`
- 4 new test cases covering:
  - Calling setGlobalProxy when proxy is configured
  - Not calling setGlobalProxy when proxy is not configured
  - Emitting error feedback when setGlobalProxy throws
  - Not emitting error feedback when setGlobalProxy succeeds

## Problem Statement

Previously, `setGlobalProxy` silently logged errors to `console.error`, which meant:
- ❌ Users were not informed when their configured proxy failed
- ❌ Errors bypassed the standardized error reporting system
- ❌ The function was called redundantly in multiple locations (config.ts and web-fetch.ts)
- ❌ No way for calling code to know if proxy setup succeeded

## Solution

This refactor implements the recommendation from issue #11878:

1. **Let errors propagate**: `setGlobalProxy` now throws errors instead of catching them
2. **Context-aware handling**: Config constructor (startup context) catches and reports via `coreEvents.emitFeedback`
3. **Eliminate redundancy**: Removed duplicate call from web-fetch.ts
4. **User-friendly**: Errors surface with clear messages in the chat/terminal

## Error Flow

### When proxy configuration fails:
1. User configures invalid proxy in settings
2. Config constructor calls `setGlobalProxy(proxy)`
3. ProxyAgent throws error (invalid URL, etc.)
4. Config's try-catch catches it
5. `coreEvents.emitFeedback('error', ...)` emits feedback
6. User sees error message in UI/terminal: "Failed to set invalid proxy from configuration."
7. Application continues (non-fatal error)

## Testing

### All tests passing ✅
- **config.test.ts**: 77 tests (including 4 new proxy tests)
- **web-fetch.test.ts**: 32 tests
- **All core tests**: 2,814+ tests passing

### Preflight checks ✅
- ✅ ESLint
- ✅ Prettier
- ✅ TypeScript
- ✅ Build
- ✅ All tests

## Related Issues

- Fixes #11878
- Related to #10761 (parent issue for error handling standardization)
- Follows pattern from #11803 (reference PR for `coreEvents.emitFeedback` usage)

## Checklist

- [x] Code follows existing patterns and conventions
- [x] Comprehensive tests added
- [x] All existing tests pass
- [x] Preflight checks pass
- [x] Error messages are user-friendly
- [x] No breaking changes
- [x] Documentation updated (inline code comments)