### PR TITLE
fix(settings): persist restart-required changes when exiting with ESC

### DIFF
--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -730,6 +730,29 @@ export function SettingsDialog({
         if (editingKey) {
           commitEdit(editingKey);
         } else {
+          // Save any restart-required settings before closing
+          const restartRequiredSettings =
+            getRestartRequiredFromModified(modifiedSettings);
+          const restartRequiredSet = new Set(restartRequiredSettings);
+
+          if (restartRequiredSet.size > 0) {
+            saveModifiedSettings(
+              restartRequiredSet,
+              pendingSettings,
+              settings,
+              selectedScope,
+            );
+
+            setGlobalPendingChanges((prev) => {
+              if (prev.size === 0) return prev;
+              const next = new Map(prev);
+              for (const key of restartRequiredSet) {
+                next.delete(key);
+              }
+              return next;
+            });
+          }
+
           onSelect(undefined, selectedScope);
         }
       }

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -453,6 +453,31 @@ export function SettingsDialog({
   const showScrollUp = items.length > effectiveMaxItemsToShow;
   const showScrollDown = items.length > effectiveMaxItemsToShow;
 
+  const saveRestartRequiredSettings = () => {
+    const restartRequiredSettings =
+      getRestartRequiredFromModified(modifiedSettings);
+    const restartRequiredSet = new Set(restartRequiredSettings);
+
+    if (restartRequiredSet.size > 0) {
+      saveModifiedSettings(
+        restartRequiredSet,
+        pendingSettings,
+        settings,
+        selectedScope,
+      );
+
+      // Remove saved keys from global pending changes
+      setGlobalPendingChanges((prev) => {
+        if (prev.size === 0) return prev;
+        const next = new Map(prev);
+        for (const key of restartRequiredSet) {
+          next.delete(key);
+        }
+        return next;
+      });
+    }
+  };
+
   useKeypress(
     (key) => {
       const { name, ctrl } = key;
@@ -699,28 +724,7 @@ export function SettingsDialog({
       }
       if (showRestartPrompt && name === 'r') {
         // Only save settings that require restart (non-restart settings were already saved immediately)
-        const restartRequiredSettings =
-          getRestartRequiredFromModified(modifiedSettings);
-        const restartRequiredSet = new Set(restartRequiredSettings);
-
-        if (restartRequiredSet.size > 0) {
-          saveModifiedSettings(
-            restartRequiredSet,
-            pendingSettings,
-            settings,
-            selectedScope,
-          );
-
-          // Remove saved keys from global pending changes
-          setGlobalPendingChanges((prev) => {
-            if (prev.size === 0) return prev;
-            const next = new Map(prev);
-            for (const key of restartRequiredSet) {
-              next.delete(key);
-            }
-            return next;
-          });
-        }
+        saveRestartRequiredSettings();
 
         setShowRestartPrompt(false);
         setRestartRequiredSettings(new Set()); // Clear restart-required settings
@@ -731,28 +735,7 @@ export function SettingsDialog({
           commitEdit(editingKey);
         } else {
           // Save any restart-required settings before closing
-          const restartRequiredSettings =
-            getRestartRequiredFromModified(modifiedSettings);
-          const restartRequiredSet = new Set(restartRequiredSettings);
-
-          if (restartRequiredSet.size > 0) {
-            saveModifiedSettings(
-              restartRequiredSet,
-              pendingSettings,
-              settings,
-              selectedScope,
-            );
-
-            setGlobalPendingChanges((prev) => {
-              if (prev.size === 0) return prev;
-              const next = new Map(prev);
-              for (const key of restartRequiredSet) {
-                next.delete(key);
-              }
-              return next;
-            });
-          }
-
+          saveRestartRequiredSettings();
           onSelect(undefined, selectedScope);
         }
       }


### PR DESCRIPTION
## Summary

Fixes ESC key not persisting restart-required settings changes in `/settings` dialog.

## Details

Previously, pressing ESC after modifying settings would discard changes, while pressing 'r' would save them. The ESC handler now saves restart-required settings before closing, matching the 'r' key behavior.

## Related Issues

Fixes #12410 

## How to Validate

- Run `npm run build && npm run start`
- Go to `/settings` and change `Compress Threshold`
- When prompted for restarting by hitting 'r', press ESC. Close the cli and reopen.
- Go back to `/settings`, your changes should be saved.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [x] Docker
- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
