### PR TITLE
chore: bump tar to 7.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15275,22 +15275,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tar": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-      "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -16982,7 +16966,7 @@
         "@google/gemini-cli-core": "file:../core",
         "express": "^5.1.0",
         "fs-extra": "^11.3.0",
-        "tar": "^7.4.3",
+        "tar": "^7.5.2",
         "uuid": "^11.1.0",
         "winston": "^3.17.0"
       },
@@ -17218,6 +17202,22 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "packages/a2a-server/node_modules/tar": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/a2a-server/node_modules/type-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17280,7 +17280,7 @@
         "string-width": "^8.1.0",
         "strip-ansi": "^7.1.0",
         "strip-json-comments": "^3.1.1",
-        "tar": "^7.5.1",
+        "tar": "^7.5.2",
         "tinygradient": "^1.1.5",
         "undici": "^7.10.0",
         "wrap-ansi": "9.0.2",
@@ -17329,6 +17329,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/tar": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/core": {

--- a/packages/a2a-server/package.json
+++ b/packages/a2a-server/package.json
@@ -30,7 +30,7 @@
     "@google/gemini-cli-core": "file:../core",
     "express": "^5.1.0",
     "fs-extra": "^11.3.0",
-    "tar": "^7.4.3",
+    "tar": "^7.5.2",
     "uuid": "^11.1.0",
     "winston": "^3.17.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
     "string-width": "^8.1.0",
     "strip-ansi": "^7.1.0",
     "strip-json-comments": "^3.1.1",
-    "tar": "^7.5.1",
+    "tar": "^7.5.2",
     "tinygradient": "^1.1.5",
     "undici": "^7.10.0",
     "wrap-ansi": "9.0.2",


### PR DESCRIPTION
## Summary
- bump tar to ^7.5.2 in CLI workspace and refresh lockfile
- bump tar to ^7.5.2 in A2A server workspace

addresses minor CVEs.