### PR TITLE
feat(core): Add support for listing experiments

### DIFF
--- a/packages/core/src/code_assist/experiments/client_metadata.ts
+++ b/packages/core/src/code_assist/experiments/client_metadata.ts
@@ -45,11 +45,11 @@ function getPlatform(): Platform {
 export async function getClientMetadata(): Promise<ClientMetadata> {
   if (!clientMetadataPromise) {
     clientMetadataPromise = (async () => ({
-        ide_type: 'GEMINI_CLI',
-        ide_version: process.env['CLI_VERSION'] || process.version,
-        platform: getPlatform(),
-        update_channel: await getReleaseChannel(__dirname),
-      }))();
+      ide_type: 'GEMINI_CLI',
+      ide_version: process.env['CLI_VERSION'] || process.version,
+      platform: getPlatform(),
+      update_channel: await getReleaseChannel(__dirname),
+    }))();
   }
   return await clientMetadataPromise;
 }

--- a/packages/core/src/code_assist/experiments/client_metadata.ts
+++ b/packages/core/src/code_assist/experiments/client_metadata.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isNightly, isPreview, ReleaseChannel } from '../../utils/channel.js';
+import { getReleaseChannel } from '../../utils/channel.js';
 import type { ClientMetadata, Platform } from './types.js';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -12,7 +12,7 @@ import path from 'node:path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Cache all metadata that is static for the session.
+// Cache all client metadata.
 let clientMetadata: ClientMetadata | undefined;
 
 function getPlatform(): Platform {
@@ -37,16 +37,6 @@ function getPlatform(): Platform {
   return 'PLATFORM_UNSPECIFIED';
 }
 
-async function getUpdateChannel(): Promise<ReleaseChannel> {
-  if (await isNightly(__dirname)) {
-    return ReleaseChannel.NIGHTLY;
-  }
-  if (await isPreview(__dirname)) {
-    return ReleaseChannel.PREVIEW;
-  }
-  return ReleaseChannel.STABLE;
-}
-
 /**
  * Returns the client metadata.
  *
@@ -58,7 +48,7 @@ export async function getClientMetadata(): Promise<ClientMetadata> {
       ide_type: 'GEMINI_CLI',
       ide_version: process.env['CLI_VERSION'] || process.version,
       platform: getPlatform(),
-      update_channel: await getUpdateChannel(),
+      update_channel: await getReleaseChannel(__dirname),
     };
   }
   return clientMetadata;

--- a/packages/core/src/code_assist/experiments/client_metadata.ts
+++ b/packages/core/src/code_assist/experiments/client_metadata.ts
@@ -13,7 +13,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Cache all client metadata.
-let clientMetadata: ClientMetadata | undefined;
+let clientMetadataPromise: Promise<ClientMetadata> | undefined;
 
 function getPlatform(): Platform {
   const platform = process.platform;
@@ -43,13 +43,13 @@ function getPlatform(): Platform {
  * The client metadata is cached so that it is only computed once per session.
  */
 export async function getClientMetadata(): Promise<ClientMetadata> {
-  if (!clientMetadata) {
-    clientMetadata = {
-      ide_type: 'GEMINI_CLI',
-      ide_version: process.env['CLI_VERSION'] || process.version,
-      platform: getPlatform(),
-      update_channel: await getReleaseChannel(__dirname),
-    };
+  if (!clientMetadataPromise) {
+    clientMetadataPromise = (async () => ({
+        ide_type: 'GEMINI_CLI',
+        ide_version: process.env['CLI_VERSION'] || process.version,
+        platform: getPlatform(),
+        update_channel: await getReleaseChannel(__dirname),
+      }))();
   }
-  return clientMetadata;
+  return await clientMetadataPromise;
 }

--- a/packages/core/src/code_assist/experiments/client_metadata.ts
+++ b/packages/core/src/code_assist/experiments/client_metadata.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isNightly, isPreview, ReleaseChannel } from '../../utils/channel.js';
+import type { ClientMetadata, Platform } from './types.js';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Cache all metadata that is static for the session.
+let clientMetadata: ClientMetadata | undefined;
+
+function getPlatform(): Platform {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  if (platform === 'darwin' && arch === 'x64') {
+    return 'DARWIN_AMD64';
+  }
+  if (platform === 'darwin' && arch === 'arm64') {
+    return 'DARWIN_ARM64';
+  }
+  if (platform === 'linux' && arch === 'x64') {
+    return 'LINUX_AMD64';
+  }
+  if (platform === 'linux' && arch === 'arm64') {
+    return 'LINUX_ARM64';
+  }
+  if (platform === 'win32' && arch === 'x64') {
+    return 'WINDOWS_AMD64';
+  }
+  return 'PLATFORM_UNSPECIFIED';
+}
+
+async function getUpdateChannel(): Promise<ReleaseChannel> {
+  if (await isNightly(__dirname)) {
+    return ReleaseChannel.NIGHTLY;
+  }
+  if (await isPreview(__dirname)) {
+    return ReleaseChannel.PREVIEW;
+  }
+  return ReleaseChannel.STABLE;
+}
+
+/**
+ * Returns the client metadata.
+ *
+ * The client metadata is cached so that it is only computed once per session.
+ */
+export async function getClientMetadata(): Promise<ClientMetadata> {
+  if (!clientMetadata) {
+    clientMetadata = {
+      ide_type: 'GEMINI_CLI',
+      ide_version: process.env['CLI_VERSION'] || process.version,
+      platform: getPlatform(),
+      update_channel: await getUpdateChannel(),
+    };
+  }
+  return clientMetadata;
+}

--- a/packages/core/src/code_assist/experiments/experiments.ts
+++ b/packages/core/src/code_assist/experiments/experiments.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CodeAssistServer } from '../server.js';
+import { getClientMetadata } from './client_metadata.js';
+import type { ListExperimentsResponse, Flag } from './types.js';
+
+export interface Experiments {
+  flags: Record<string, Flag>;
+  experimentIds: number[];
+}
+
+let experiments: Experiments | undefined;
+
+/**
+ * Gets the experiments from the server.
+ *
+ * The experiments are cached so that they are only fetched once.
+ */
+export async function getExperiments(
+  server: CodeAssistServer,
+): Promise<Experiments> {
+  if (experiments) {
+    return experiments;
+  }
+
+  const metadata = await getClientMetadata();
+  const response = await server.listExperiments(metadata);
+  experiments = parseExperiments(response);
+  return experiments;
+}
+
+function parseExperiments(response: ListExperimentsResponse): Experiments {
+  const flags: Record<string, Flag> = {};
+  for (const flag of response.flags ?? []) {
+    if (flag.name) {
+      flags[flag.name] = flag;
+    }
+  }
+  return {
+    flags,
+    experimentIds: response.experiment_ids ?? [],
+  };
+}

--- a/packages/core/src/code_assist/experiments/experiments.ts
+++ b/packages/core/src/code_assist/experiments/experiments.ts
@@ -13,7 +13,7 @@ export interface Experiments {
   experimentIds: number[];
 }
 
-let experiments: Experiments | undefined;
+let experimentsPromise: Promise<Experiments> | undefined;
 
 /**
  * Gets the experiments from the server.
@@ -23,14 +23,16 @@ let experiments: Experiments | undefined;
 export async function getExperiments(
   server: CodeAssistServer,
 ): Promise<Experiments> {
-  if (experiments) {
-    return experiments;
+  if (experimentsPromise) {
+    return await experimentsPromise;
   }
 
-  const metadata = await getClientMetadata();
-  const response = await server.listExperiments(metadata);
-  experiments = parseExperiments(response);
-  return experiments;
+  experimentsPromise = (async () => {
+    const metadata = await getClientMetadata();
+    const response = await server.listExperiments(metadata);
+    return parseExperiments(response);
+  })();
+  return await experimentsPromise;
 }
 
 function parseExperiments(response: ListExperimentsResponse): Experiments {

--- a/packages/core/src/code_assist/experiments/types.ts
+++ b/packages/core/src/code_assist/experiments/types.ts
@@ -44,6 +44,7 @@ export interface ClientMetadata {
   ide_version?: string;
   platform?: Platform;
   update_channel?: 'nightly' | 'preview' | 'stable';
+  duet_project?: string;
 }
 
 export type IdeType = 'GEMINI_CLI';

--- a/packages/core/src/code_assist/experiments/types.ts
+++ b/packages/core/src/code_assist/experiments/types.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface ListExperimentsRequest {
+  project: string;
+  metadata?: ClientMetadata;
+}
+
+export interface ListExperimentsResponse {
+  experiment_ids?: number[];
+  flags?: Flag[];
+  filtered_flags?: FilteredFlag[];
+  debug_string?: string;
+}
+
+export interface Flag {
+  name?: string;
+  bool_value?: boolean;
+  float_value?: number;
+  int_value?: string; // int64
+  string_value?: string;
+  int32_list_value?: Int32List;
+  string_list_value?: StringList;
+}
+
+export interface Int32List {
+  values?: number[];
+}
+
+export interface StringList {
+  values?: string[];
+}
+
+export interface FilteredFlag {
+  name?: string;
+  reason?: string;
+}
+
+export interface ClientMetadata {
+  ide_type?: IdeType;
+  ide_version?: string;
+  platform?: Platform;
+  update_channel?: 'nightly' | 'preview' | 'stable';
+}
+
+export type IdeType = 'GEMINI_CLI';
+
+export type Platform =
+  | 'PLATFORM_UNSPECIFIED'
+  | 'DARWIN_AMD64'
+  | 'DARWIN_ARM64'
+  | 'LINUX_AMD64'
+  | 'LINUX_ARM64'
+  | 'WINDOWS_AMD64';

--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -252,4 +252,30 @@ describe('CodeAssistServer', () => {
       currentTier: { id: UserTierId.STANDARD },
     });
   });
+
+  it('should call the listExperiments endpoint with metadata', async () => {
+    const client = new OAuth2Client();
+    const server = new CodeAssistServer(
+      client,
+      'test-project',
+      {},
+      'test-session',
+      UserTierId.FREE,
+    );
+    const mockResponse = {
+      experiments: [],
+    };
+    vi.spyOn(server, 'requestPost').mockResolvedValue(mockResponse);
+
+    const metadata = {
+      ide_version: 'v0.1.0',
+    };
+    const response = await server.listExperiments(metadata);
+
+    expect(server.requestPost).toHaveBeenCalledWith('listExperiments', {
+      project: 'test-project',
+      metadata: { ide_version: 'v0.1.0', duet_project: 'test-project' },
+    });
+    expect(response).toEqual(mockResponse);
+  });
 });

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -157,7 +157,10 @@ export class CodeAssistServer implements ContentGenerator {
   async listExperiments(
     metadata: ClientMetadata,
   ): Promise<ListExperimentsResponse> {
-    const projectId = this.projectId || '';
+    if (!this.projectId) {
+      throw new Error('projectId is not defined for CodeAssistServer.');
+    }
+    const projectId = this.projectId;
     const req: ListExperimentsRequest = {
       project: projectId,
       metadata: { ...metadata, duet_project: projectId },

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -155,11 +155,12 @@ export class CodeAssistServer implements ContentGenerator {
   }
 
   async listExperiments(
-    metadata?: ClientMetadata,
+    metadata: ClientMetadata,
   ): Promise<ListExperimentsResponse> {
+    const projectId = this.projectId || '';
     const req: ListExperimentsRequest = {
-      project: this.projectId || '',
-      metadata,
+      project: projectId,
+      metadata: { ...metadata, duet_project: projectId },
     };
     return await this.requestPost<ListExperimentsResponse>(
       'listExperiments',

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -15,6 +15,11 @@ import type {
   SetCodeAssistGlobalUserSettingRequest,
 } from './types.js';
 import type {
+  ListExperimentsRequest,
+  ListExperimentsResponse,
+  ClientMetadata,
+} from './experiments/types.js';
+import type {
   CountTokensParameters,
   CountTokensResponse,
   EmbedContentParameters,
@@ -147,6 +152,19 @@ export class CodeAssistServer implements ContentGenerator {
     _req: EmbedContentParameters,
   ): Promise<EmbedContentResponse> {
     throw Error();
+  }
+
+  async listExperiments(
+    metadata?: ClientMetadata,
+  ): Promise<ListExperimentsResponse> {
+    const req: ListExperimentsRequest = {
+      project: this.projectId || '',
+      metadata,
+    };
+    return await this.requestPost<ListExperimentsResponse>(
+      'listExperiments',
+      req,
+    );
   }
 
   async requestPost<T>(

--- a/packages/core/src/utils/channel.ts
+++ b/packages/core/src/utils/channel.ts
@@ -22,7 +22,7 @@ export function _clearCache() {
   cache.clear();
 }
 
-async function _getReleaseChannel(cwd: string): Promise<ReleaseChannel> {
+export async function getReleaseChannel(cwd: string): Promise<ReleaseChannel> {
   if (cache.has(cwd)) {
     return cache.get(cwd)!;
   }
@@ -43,13 +43,13 @@ async function _getReleaseChannel(cwd: string): Promise<ReleaseChannel> {
 }
 
 export async function isNightly(cwd: string): Promise<boolean> {
-  return (await _getReleaseChannel(cwd)) === ReleaseChannel.NIGHTLY;
+  return (await getReleaseChannel(cwd)) === ReleaseChannel.NIGHTLY;
 }
 
 export async function isPreview(cwd: string): Promise<boolean> {
-  return (await _getReleaseChannel(cwd)) === ReleaseChannel.PREVIEW;
+  return (await getReleaseChannel(cwd)) === ReleaseChannel.PREVIEW;
 }
 
 export async function isStable(cwd: string): Promise<boolean> {
-  return (await _getReleaseChannel(cwd)) === ReleaseChannel.STABLE;
+  return (await getReleaseChannel(cwd)) === ReleaseChannel.STABLE;
 }


### PR DESCRIPTION
feat(core): Add support for listing experiments

## TLDR

This pull request introduces the client-side infrastructure for fetching server-side experiments and feature flags. It adds a `listExperiments` method to the `CodeAssistServer` to communicate with the backend. This change allows for dynamic feature management based on client metadata.