### PR TITLE
Fix alt+left on ghostty

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -906,7 +906,6 @@ describe('Kitty Sequence Parsing', () => {
     // Should broadcast immediately as it's not a valid kitty pattern
     expect(keyHandler).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: '',
         sequence: '\x1b[m',
         paste: false,
       }),
@@ -1007,7 +1006,6 @@ describe('Kitty Sequence Parsing', () => {
     expect(keyHandler).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        name: '',
         sequence: '\x1b[!',
       }),
     );

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -686,12 +686,8 @@ export function KeypressProvider({
       }
 
       // Always check if this could start a sequence we need to buffer (Kitty or Mouse)
-      // We only want to intercept if it starts with ESC[ (CSI) or is EXACTLY ESC (waiting for more).
       // Other ESC sequences (like Alt+Key which is ESC+Key) should be let through if readline parsed them.
-      const isCSI = key.sequence.startsWith(`${ESC}[`);
-      const isExactEsc = key.sequence === ESC;
-      const shouldBuffer = isCSI || isExactEsc;
-
+      const shouldBuffer = couldBeKittySequence(key.sequence);
       const isExcluded = [
         PASTE_MODE_START,
         PASTE_MODE_END,

--- a/packages/cli/src/ui/hooks/useKeypress.test.tsx
+++ b/packages/cli/src/ui/hooks/useKeypress.test.tsx
@@ -38,7 +38,7 @@ class MockStdin extends EventEmitter {
   }
 }
 
-describe('useKeypress', () => {
+describe.each([true, false])(`useKeypress with useKitty=%s`, (useKitty) => {
   let stdin: MockStdin;
   const mockSetRawMode = vi.fn();
   const onKeypress = vi.fn();
@@ -50,7 +50,7 @@ describe('useKeypress', () => {
       return null;
     }
     return render(
-      <KeypressProvider kittyProtocolEnabled={false}>
+      <KeypressProvider kittyProtocolEnabled={useKitty}>
         <TestComponent />
       </KeypressProvider>,
     );
@@ -58,6 +58,7 @@ describe('useKeypress', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
     stdin = new MockStdin();
     (useStdin as Mock).mockReturnValue({
       stdin,
@@ -186,21 +187,28 @@ describe('useKeypress', () => {
       expect(onKeypress).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle paste false alarm', () => {
+    it('should handle paste false alarm', async () => {
       renderKeypressHook(true);
 
       act(() => {
         stdin.write(PASTE_START.slice(0, 5));
         stdin.write('do');
       });
-      expect(onKeypress).toHaveBeenCalledWith(
-        expect.objectContaining({ sequence: '\x1B[200d' }),
-      );
-      expect(onKeypress).toHaveBeenCalledWith(
-        expect.objectContaining({ sequence: 'o' }),
-      );
 
-      expect(onKeypress).toHaveBeenCalledTimes(2);
+      if (useKitty) {
+        vi.advanceTimersByTime(60); // wait for kitty timeout
+        expect(onKeypress).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({ sequence: '\x1B[200do' }),
+        );
+      } else {
+        expect(onKeypress).toHaveBeenCalledWith(
+          expect.objectContaining({ sequence: '\x1B[200d' }),
+        );
+        expect(onKeypress).toHaveBeenCalledWith(
+          expect.objectContaining({ sequence: 'o' }),
+        );
+        expect(onKeypress).toHaveBeenCalledTimes(2);
+      }
     });
 
     it('should handle back to back pastes', () => {
@@ -240,11 +248,11 @@ describe('useKeypress', () => {
       const pasteText = 'pasted';
       await act(async () => {
         stdin.write(PASTE_START.slice(0, 3));
-        await new Promise((r) => setTimeout(r, 50));
+        vi.advanceTimersByTime(50);
         stdin.write(PASTE_START.slice(3) + pasteText.slice(0, 3));
-        await new Promise((r) => setTimeout(r, 50));
+        vi.advanceTimersByTime(50);
         stdin.write(pasteText.slice(3) + PASTE_END.slice(0, 3));
-        await new Promise((r) => setTimeout(r, 50));
+        vi.advanceTimersByTime(50);
         stdin.write(PASTE_END.slice(3));
       });
       expect(onKeypress).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

Be smarter about which codes we attempt to parse as kitty codes.

## Details

Previously, we were trying to parse sequences that were not kitty codes at all and ended up breaking them.

## Related Issues

Fixes #12489

## How to Validate

Run in ghostty and verify that alt+left moves the cursor instead of printing "b".

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
