### PR TITLE
Enforce MCP OAuth resource validation

### DIFF
--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -253,6 +253,7 @@ describe('MCPOAuthProvider', () => {
       delete configWithoutAuth.tokenUrl;
 
       const mockResourceMetadata = {
+        resource: 'https://api.example.com',
         authorization_servers: ['https://discovered.auth.com'],
       };
 

--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -1210,6 +1210,7 @@ describe('MCPOAuthProvider', () => {
       delete configWithUserScopes.tokenUrl;
 
       const mockResourceMetadata = {
+        resource: 'https://api.example.com',
         authorization_servers: ['https://discovered.auth.com'],
       };
 
@@ -1298,6 +1299,7 @@ describe('MCPOAuthProvider', () => {
       delete configWithoutScopes.tokenUrl;
 
       const mockResourceMetadata = {
+        resource: 'https://api.example.com',
         authorization_servers: ['https://discovered.auth.com'],
       };
 

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -700,6 +700,7 @@ export class MCPOAuthProvider {
             const discoveredConfig =
               await OAuthUtils.discoverOAuthFromWWWAuthenticate(
                 wwwAuthenticate,
+                mcpServerUrl,
               );
             if (discoveredConfig) {
               // Merge discovered config with existing config, preserving clientId and clientSecret

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -611,8 +611,6 @@ describe('connectToMcpServer with OAuth', () => {
       'http://test-server.com/.well-known/oauth-protected-resource',
     );
 
-    vi.mocked(OAuthUtils.parseWWWAuthenticateHeader).mockReturnValue(null);
-
     const discoverArgs: unknown[][] = [];
     vi.mocked(OAuthUtils.discoverOAuthConfig).mockImplementation(
       async (...args: unknown[]) => {
@@ -646,7 +644,13 @@ describe('connectToMcpServer with OAuth', () => {
     expect(mockedClient.connect).toHaveBeenCalledTimes(2);
     expect(mockAuthProvider.authenticate).toHaveBeenCalledOnce();
     expect(discoverArgs.length).toBeGreaterThan(0);
-    expect(discoverArgs[0]?.[0]).toBe(serverUrl);
+    expect(discoverArgs[0]).toEqual([
+      serverUrl,
+      {
+        resourceMetadataUrl:
+          'http://test-server.com/.well-known/oauth-protected-resource',
+      },
+    ]);
 
     const authHeader =
       capturedTransport._requestInit?.headers?.['Authorization'];

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -342,7 +342,7 @@ async function handleAutomaticOAuth(
       OAuthUtils.parseWWWAuthenticateHeader(wwwAuthenticate);
     if (resourceMetadataUri && configuredServerUrl) {
       oauthConfig = await OAuthUtils.discoverOAuthConfig(configuredServerUrl, {
-        resourceMetadataUrl,
+        resourceMetadataUrl: resourceMetadataUri,
       });
     } else if (resourceMetadataUri && !configuredServerUrl) {
       debugLogger.warn(


### PR DESCRIPTION
## Summary
- validate protected resource metadata against the configured MCP server URL before using any authorization servers
- plumb the expected server URL through OAuth discovery flows, including WWW-Authenticate handling
- extend unit tests to cover matching and mismatching resource metadata scenarios

## Testing
- npx vitest run packages/core/src/mcp/oauth-utils.test.ts packages/core/src/tools/mcp-client.test.ts