### PR TITLE
Tighten bash shell option handling

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -186,7 +186,10 @@ describe('ShellExecutionService', () => {
 
       expect(mockPtySpawn).toHaveBeenCalledWith(
         'bash',
-        ['-c', 'ls -l'],
+        [
+          '-c',
+          'shopt -u promptvars nullglob extglob nocaseglob dotglob; ls -l',
+        ],
         expect.any(Object),
       );
       expect(result.exitCode).toBe(0);
@@ -539,7 +542,10 @@ describe('ShellExecutionService', () => {
 
       expect(mockPtySpawn).toHaveBeenCalledWith(
         'bash',
-        ['-c', 'ls "foo bar"'],
+        [
+          '-c',
+          'shopt -u promptvars nullglob extglob nocaseglob dotglob; ls "foo bar"',
+        ],
         expect.any(Object),
       );
     });
@@ -691,7 +697,10 @@ describe('ShellExecutionService child_process fallback', () => {
 
       expect(mockCpSpawn).toHaveBeenCalledWith(
         'bash',
-        ['-c', 'ls -l'],
+        [
+          '-c',
+          'shopt -u promptvars nullglob extglob nocaseglob dotglob; ls -l',
+        ],
         expect.objectContaining({ shell: false, detached: true }),
       );
       expect(result.exitCode).toBe(0);
@@ -981,7 +990,10 @@ describe('ShellExecutionService child_process fallback', () => {
 
       expect(mockCpSpawn).toHaveBeenCalledWith(
         'bash',
-        ['-c', 'ls "foo bar"'],
+        [
+          '-c',
+          'shopt -u promptvars nullglob extglob nocaseglob dotglob; ls "foo bar"',
+        ],
         expect.objectContaining({
           shell: false,
           detached: true,

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -24,8 +24,9 @@ const { Terminal } = pkg;
 const SIGKILL_TIMEOUT_MS = 200;
 const MAX_CHILD_PROCESS_BUFFER_SIZE = 16 * 1024 * 1024; // 16MB
 
-const BASH_SHOPT_GUARD =
-  'shopt -u promptvars nullglob extglob nocaseglob dotglob;';
+const BASH_SHOPT_OPTIONS = 'promptvars nullglob extglob nocaseglob dotglob';
+const BASH_SHOPT_GUARD = `shopt -u ${BASH_SHOPT_OPTIONS};`;
+const BASH_SHOPT_GUARD_LONG_PREFIX = `shopt --unset ${BASH_SHOPT_OPTIONS}`;
 
 function ensurePromptvarsDisabled(command: string, shell: ShellType): string {
   if (shell !== 'bash') {
@@ -35,9 +36,7 @@ function ensurePromptvarsDisabled(command: string, shell: ShellType): string {
   const trimmed = command.trimStart();
   if (
     trimmed.startsWith(BASH_SHOPT_GUARD) ||
-    trimmed.startsWith(
-      'shopt --unset promptvars nullglob extglob nocaseglob dotglob',
-    )
+    trimmed.startsWith(BASH_SHOPT_GUARD_LONG_PREFIX)
   ) {
     return command;
   }

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -12,7 +12,7 @@ import { TextDecoder } from 'node:util';
 import os from 'node:os';
 import type { IPty } from '@lydell/node-pty';
 import { getCachedEncodingForBuffer } from '../utils/systemEncoding.js';
-import { getShellConfiguration } from '../utils/shell-utils.js';
+import { getShellConfiguration, type ShellType } from '../utils/shell-utils.js';
 import { isBinary } from '../utils/textUtils.js';
 import pkg from '@xterm/headless';
 import {
@@ -23,6 +23,27 @@ const { Terminal } = pkg;
 
 const SIGKILL_TIMEOUT_MS = 200;
 const MAX_CHILD_PROCESS_BUFFER_SIZE = 16 * 1024 * 1024; // 16MB
+
+const BASH_SHOPT_GUARD =
+  'shopt -u promptvars nullglob extglob nocaseglob dotglob;';
+
+function ensurePromptvarsDisabled(command: string, shell: ShellType): string {
+  if (shell !== 'bash') {
+    return command;
+  }
+
+  const trimmed = command.trimStart();
+  if (
+    trimmed.startsWith(BASH_SHOPT_GUARD) ||
+    trimmed.startsWith(
+      'shopt --unset promptvars nullglob extglob nocaseglob dotglob',
+    )
+  ) {
+    return command;
+  }
+
+  return `${BASH_SHOPT_GUARD} ${command}`;
+}
 
 /** A structured result from a shell command execution. */
 export interface ShellExecutionResult {
@@ -190,8 +211,9 @@ export class ShellExecutionService {
   ): ShellExecutionHandle {
     try {
       const isWindows = os.platform() === 'win32';
-      const { executable, argsPrefix } = getShellConfiguration();
-      const spawnArgs = [...argsPrefix, commandToExecute];
+      const { executable, argsPrefix, shell } = getShellConfiguration();
+      const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
+      const spawnArgs = [...argsPrefix, guardedCommand];
 
       const child = cpSpawn(executable, spawnArgs, {
         cwd,
@@ -403,8 +425,9 @@ export class ShellExecutionService {
     try {
       const cols = shellExecutionConfig.terminalWidth ?? 80;
       const rows = shellExecutionConfig.terminalHeight ?? 30;
-      const { executable, argsPrefix } = getShellConfiguration();
-      const args = [...argsPrefix, commandToExecute];
+      const { executable, argsPrefix, shell } = getShellConfiguration();
+      const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
+      const args = [...argsPrefix, guardedCommand];
 
       const ptyProcess = ptyInfo.module.spawn(executable, args, {
         cwd,

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -26,7 +26,6 @@ const MAX_CHILD_PROCESS_BUFFER_SIZE = 16 * 1024 * 1024; // 16MB
 
 const BASH_SHOPT_OPTIONS = 'promptvars nullglob extglob nocaseglob dotglob';
 const BASH_SHOPT_GUARD = `shopt -u ${BASH_SHOPT_OPTIONS};`;
-const BASH_SHOPT_GUARD_LONG_PREFIX = `shopt --unset ${BASH_SHOPT_OPTIONS}`;
 
 function ensurePromptvarsDisabled(command: string, shell: ShellType): string {
   if (shell !== 'bash') {
@@ -34,10 +33,7 @@ function ensurePromptvarsDisabled(command: string, shell: ShellType): string {
   }
 
   const trimmed = command.trimStart();
-  if (
-    trimmed.startsWith(BASH_SHOPT_GUARD) ||
-    trimmed.startsWith(BASH_SHOPT_GUARD_LONG_PREFIX)
-  ) {
+  if (trimmed.startsWith(BASH_SHOPT_GUARD)) {
     return command;
   }
 

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -282,6 +282,14 @@ EOF`,
     );
   });
 
+  it('should block simple prompt transformation expansions', () => {
+    const result = isCommandAllowed('echo ${foo@P}', config);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe(
+      'Command rejected because it could not be parsed safely',
+    );
+  });
+
   describe('command substitution', () => {
     it('should allow command substitution using `$(...)`', () => {
       const result = isCommandAllowed('echo $(goodCommand --safe)', config);
@@ -481,6 +489,11 @@ describe('getCommandRoots', () => {
     const roots = getCommandRoots(
       'echo "${var1=aa\\140 env| ls -l\\140}${var1@P}"',
     );
+    expect(roots).toEqual([]);
+  });
+
+  it('should not return roots for prompt transformation expansions', () => {
+    const roots = getCommandRoots('echo ${foo@P}');
     expect(roots).toEqual([]);
   });
 });

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -271,6 +271,17 @@ EOF`,
     );
   });
 
+  it('should block commands containing prompt transformations', () => {
+    const result = isCommandAllowed(
+      'echo "${var1=aa\\140 env| ls -l\\140}${var1@P}"',
+      config,
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe(
+      'Command rejected because it could not be parsed safely',
+    );
+  });
+
   describe('command substitution', () => {
     it('should allow command substitution using `$(...)`', () => {
       const result = isCommandAllowed('echo $(goodCommand --safe)', config);
@@ -464,6 +475,13 @@ describe('getCommandRoots', () => {
   it('should include backtick substitutions', () => {
     const result = getCommandRoots('echo `badCommand --danger`');
     expect(result).toEqual(['echo', 'badCommand']);
+  });
+
+  it('should treat parameter expansions with prompt transformations as unsafe', () => {
+    const roots = getCommandRoots(
+      'echo "${var1=aa\\140 env| ls -l\\140}${var1@P}"',
+    );
+    expect(roots).toEqual([]);
   });
 });
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -266,16 +266,9 @@ function hasPromptCommandTransform(root: Node): boolean {
     }
 
     if (current.type === 'expansion') {
-      for (let i = 0; i < current.namedChildCount; i += 1) {
-        const operatorNode = current.namedChild(i);
-        const transformNode = current.namedChild(i + 1);
-
-        if (
-          operatorNode?.text === '@' &&
-          transformNode?.text?.toLowerCase() === 'p'
-        ) {
-          return true;
-        }
+      const expansionText = current.text.toLowerCase();
+      if (expansionText.includes('@p')) {
+        return true;
       }
     }
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -266,14 +266,16 @@ function hasPromptCommandTransform(root: Node): boolean {
     }
 
     if (current.type === 'expansion') {
-      const operatorNode = current.child(2);
-      const transformNode = current.child(3);
+      for (let i = 0; i < current.namedChildCount; i += 1) {
+        const operatorNode = current.namedChild(i);
+        const transformNode = current.namedChild(i + 1);
 
-      if (
-        operatorNode?.text === '@' &&
-        transformNode?.text?.toLowerCase() === 'p'
-      ) {
-        return true;
+        if (
+          operatorNode?.text === '@' &&
+          transformNode?.text?.toLowerCase() === 'p'
+        ) {
+          return true;
+        }
       }
     }
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -266,9 +266,16 @@ function hasPromptCommandTransform(root: Node): boolean {
     }
 
     if (current.type === 'expansion') {
-      const expansionText = current.text.toLowerCase();
-      if (expansionText.includes('@p')) {
-        return true;
+      for (let i = 0; i < current.childCount - 1; i += 1) {
+        const operatorNode = current.child(i);
+        const transformNode = current.child(i + 1);
+
+        if (
+          operatorNode?.type === '@' &&
+          transformNode?.text?.toLowerCase() === 'p'
+        ) {
+          return true;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure bash commands start with a consistent shopt guard
- update shell command parsing tests around prompt transformations