### PR TITLE
Fix shift+tab keybinding when not in kitty mode

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -166,7 +166,7 @@ function parseKittyPrefix(buffer: string): { key: Key; length: number } | null {
         shift: true,
         paste: false,
         sequence: buffer.slice(0, m[0].length),
-        kittyProtocol: true,
+        kittyProtocol: false,
       },
       length: m[0].length,
     };

--- a/packages/cli/src/ui/hooks/useKeypress.test.tsx
+++ b/packages/cli/src/ui/hooks/useKeypress.test.tsx
@@ -88,6 +88,7 @@ describe.each([true, false])(`useKeypress with useKitty=%s`, (useKitty) => {
     { key: { name: 'right', sequence: '\x1b[C' } },
     { key: { name: 'up', sequence: '\x1b[A' } },
     { key: { name: 'down', sequence: '\x1b[B' } },
+    { key: { name: 'tab', sequence: '\x1b[Z', shift: true } },
   ])('should listen for keypress when active for key $key.name', ({ key }) => {
     renderKeypressHook(true);
     act(() => stdin.write(key.sequence));


### PR DESCRIPTION
## Summary

This keypress was incorrectly being marked as a kitty protocol one when it's not.

## Related Issues

Fixes #12548

## How to Validate

run in mac terminal and press `shift+tab`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
