### PR TITLE
fix: allow user to set pro model even in fallback

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1313,7 +1313,7 @@ describe('Config getHooks', () => {
   });
 
   describe('setModel', () => {
-    it('should allow setting a pro model and disable fallback mode', () => {
+    it('should allow setting a pro (any) model and disable fallback mode', () => {
       const config = new Config(baseParams);
       config.setFallbackMode(true);
       expect(config.isInFallbackMode()).toBe(true);
@@ -1324,21 +1324,6 @@ describe('Config getHooks', () => {
       expect(config.getModel()).toBe(proModel);
       expect(config.isInFallbackMode()).toBe(false);
       expect(mockCoreEvents.emitModelChanged).toHaveBeenCalledWith(proModel);
-    });
-
-    it('should not disable fallback mode when a non-pro model is set', () => {
-      const config = new Config(baseParams);
-      config.setFallbackMode(true);
-      expect(config.isInFallbackMode()).toBe(true);
-
-      const flashLiteModel = 'gemini-2.5-flash-lite';
-      config.setModel(flashLiteModel);
-
-      expect(config.getModel()).toBe(flashLiteModel);
-      expect(config.isInFallbackMode()).toBe(true);
-      expect(mockCoreEvents.emitModelChanged).toHaveBeenCalledWith(
-        flashLiteModel,
-      );
     });
   });
 });

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1311,4 +1311,34 @@ describe('Config getHooks', () => {
     expect(retrievedHooks).toEqual(allEventHooks);
     expect(Object.keys(retrievedHooks!)).toHaveLength(11); // All hook event types
   });
+
+  describe('setModel', () => {
+    it('should allow setting a pro model and disable fallback mode', () => {
+      const config = new Config(baseParams);
+      config.setFallbackMode(true);
+      expect(config.isInFallbackMode()).toBe(true);
+
+      const proModel = 'gemini-2.5-pro';
+      config.setModel(proModel);
+
+      expect(config.getModel()).toBe(proModel);
+      expect(config.isInFallbackMode()).toBe(false);
+      expect(mockCoreEvents.emitModelChanged).toHaveBeenCalledWith(proModel);
+    });
+
+    it('should not disable fallback mode when a non-pro model is set', () => {
+      const config = new Config(baseParams);
+      config.setFallbackMode(true);
+      expect(config.isInFallbackMode()).toBe(true);
+
+      const flashLiteModel = 'gemini-2.5-flash-lite';
+      config.setModel(flashLiteModel);
+
+      expect(config.getModel()).toBe(flashLiteModel);
+      expect(config.isInFallbackMode()).toBe(true);
+      expect(mockCoreEvents.emitModelChanged).toHaveBeenCalledWith(
+        flashLiteModel,
+      );
+    });
+  });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -670,10 +670,7 @@ export class Config {
   }
 
   setModel(newModel: string): void {
-    // Allow users to set any model, but if switching to a "pro" model, exit fallback mode
-    if (newModel.includes('pro')) {
-      this.setFallbackMode(false);
-    }
+    this.setFallbackMode(false);
 
     if (this.model !== newModel) {
       this.model = newModel;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -670,9 +670,9 @@ export class Config {
   }
 
   setModel(newModel: string): void {
-    // Do not allow Pro usage if the user is in fallback mode.
-    if (newModel.includes('pro') && this.isInFallbackMode()) {
-      return;
+    // Allow users to set any model, but if switching to a "pro" model, exit fallback mode
+    if (newModel.includes('pro')) {
+      this.setFallbackMode(false);
     }
 
     if (this.model !== newModel) {


### PR DESCRIPTION
## Summary

We should allow users to set any model of their choosing. Fallback mode can get trigger from transient capacity constraints so we should allow users to reset their model choice to pro in the same session.

## Related Issues

Fixes: https://github.com/google-gemini/maintainers-gemini-cli/issues/1028

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
