### PR TITLE
docs: remove references to deprecated flags (--checkpointing, --sandbox-image)

### DIFF
--- a/docs/cli/checkpointing.md
+++ b/docs/cli/checkpointing.md
@@ -37,21 +37,7 @@ file in your project's temporary directory, typically located at
 
 ## Enabling the Feature
 
-The Checkpointing feature is disabled by default. To enable it, you can either
-use a command-line flag or edit your `settings.json` file.
-
-### Using the Command-Line Flag
-
-You can enable checkpointing for the current session by using the
-`--checkpointing` flag when starting the Gemini CLI:
-
-```bash
-gemini --checkpointing
-```
-
-### Using the `settings.json` File
-
-To enable checkpointing by default for all sessions, you need to edit your
+The Checkpointing feature is disabled by default. To enable it, you need to edit your
 `settings.json` file.
 
 Add the following key to your `settings.json`:

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -151,8 +151,7 @@ Slash commands provide meta-level control over the CLI itself.
     edits made by a tool. If run without a tool call ID, it will list available
     checkpoints to restore from.
   - **Usage:** `/restore [tool_call_id]`
-  - **Note:** Only available if the CLI is invoked with the `--checkpointing`
-    option or configured via [settings](../get-started/configuration.md). See
+  - **Note:** Only available if configured via [settings](../get-started/configuration.md). See
     [Checkpointing documentation](../cli/checkpointing.md) for more details.
 
 - **`/settings`**

--- a/docs/cli/enterprise.md
+++ b/docs/cli/enterprise.md
@@ -363,9 +363,8 @@ containerized environment.
 }
 ```
 
-You can also specify a custom, hardened Docker image for the sandbox using the
-`--sandbox-image` command-line argument or by building a custom
-`sandbox.Dockerfile` as described in the
+You can also specify a custom, hardened Docker image for the sandbox by 
+building a custom `sandbox.Dockerfile` as described in the
 [Sandboxing documentation](./sandbox.md).
 
 ## Controlling Network Access via Proxy


### PR DESCRIPTION
## Summary

Fixed #12201

Remove references to the `--checkpointing` and `--sandbox-image` command-line flags, which were deprecated in v0.11.0.

### Changes

- Removed `--checkpointing` from `docs/cli/checkpointing.md` and `docs/cli/commands.md`
- Removed `--sandbox-image` from `docs/cli/enterprise.md`.

### Notes

The `--checkpointing` flag is also referenced in `docs/cli/configuration.md` and `docs/cli/configuration-v1.md`. These instances were intentionally left untouched as they reside in legacy documentation files.