### PR TITLE
fix: make keychain storage opt in

### DIFF
--- a/docs/get-started/authentication.md
+++ b/docs/get-started/authentication.md
@@ -10,6 +10,14 @@ CLI, configure **one** of the following authentication methods:
 - Headless (non-interactive) mode
 - Google Cloud Shell
 
+## Where credentials are stored
+
+By default the CLI uses encrypted file-based storage for tokens and other
+secrets, which works consistently in headless shells and CI. Keychain
+integration via Keytar is currently experimental; opt in by setting
+`GEMINI_ENABLE_KEYCHAIN_STORAGE=true` before launching the CLI. Use
+`GEMINI_FORCE_FILE_STORAGE=true` if you need to disable the experiment.
+
 ## Quick Check: Running in Google Cloud Shell?
 
 If you are running the Gemini CLI within a Google Cloud Shell environment,

--- a/packages/cli/src/config/extensions/extensionSettings.ts
+++ b/packages/cli/src/config/extensions/extensionSettings.ts
@@ -171,7 +171,7 @@ async function clearSettings(
   if (fsSync.existsSync(envFilePath)) {
     await fs.writeFile(envFilePath, '');
   }
-  if (!keychain.isAvailable()) {
+  if (!(await keychain.isAvailable())) {
     return;
   }
   const secrets = await keychain.listSecrets();

--- a/packages/core/src/mcp/token-storage/hybrid-token-storage.test.ts
+++ b/packages/core/src/mcp/token-storage/hybrid-token-storage.test.ts
@@ -88,7 +88,22 @@ describe('HybridTokenStorage', () => {
   });
 
   describe('storage selection', () => {
-    it('should use keychain when available', async () => {
+    it('should default to file storage when keychain not enabled', async () => {
+      mockFileStorage.getCredentials.mockResolvedValue(null);
+
+      await storage.getCredentials('test-server');
+
+      expect(mockKeychainStorage.isAvailable).not.toHaveBeenCalled();
+      expect(mockFileStorage.getCredentials).toHaveBeenCalledWith(
+        'test-server',
+      );
+      expect(await storage.getStorageType()).toBe(
+        TokenStorageType.ENCRYPTED_FILE,
+      );
+    });
+
+    it('should use keychain when explicitly enabled and available', async () => {
+      process.env['GEMINI_ENABLE_KEYCHAIN_STORAGE'] = 'true';
       mockKeychainStorage.isAvailable!.mockResolvedValue(true);
       mockKeychainStorage.getCredentials.mockResolvedValue(null);
 
@@ -103,6 +118,7 @@ describe('HybridTokenStorage', () => {
 
     it('should use file storage when GEMINI_FORCE_FILE_STORAGE is set', async () => {
       process.env['GEMINI_FORCE_FILE_STORAGE'] = 'true';
+      process.env['GEMINI_ENABLE_KEYCHAIN_STORAGE'] = 'true';
       mockFileStorage.getCredentials.mockResolvedValue(null);
 
       await storage.getCredentials('test-server');
@@ -117,6 +133,7 @@ describe('HybridTokenStorage', () => {
     });
 
     it('should fall back to file storage when keychain is unavailable', async () => {
+      process.env['GEMINI_ENABLE_KEYCHAIN_STORAGE'] = 'true';
       mockKeychainStorage.isAvailable!.mockResolvedValue(false);
       mockFileStorage.getCredentials.mockResolvedValue(null);
 
@@ -132,6 +149,7 @@ describe('HybridTokenStorage', () => {
     });
 
     it('should fall back to file storage when keychain throws error', async () => {
+      process.env['GEMINI_ENABLE_KEYCHAIN_STORAGE'] = 'true';
       mockKeychainStorage.isAvailable!.mockRejectedValue(
         new Error('Keychain error'),
       );
@@ -149,6 +167,7 @@ describe('HybridTokenStorage', () => {
     });
 
     it('should cache storage selection', async () => {
+      process.env['GEMINI_ENABLE_KEYCHAIN_STORAGE'] = 'true';
       mockKeychainStorage.isAvailable!.mockResolvedValue(true);
       mockKeychainStorage.getCredentials.mockResolvedValue(null);
 
@@ -161,6 +180,7 @@ describe('HybridTokenStorage', () => {
 
   describe('getCredentials', () => {
     it('should delegate to selected storage', async () => {
+      process.env['GEMINI_ENABLE_KEYCHAIN_STORAGE'] = 'true';
       const credentials: OAuthCredentials = {
         serverName: 'test-server',
         token: {
@@ -184,6 +204,7 @@ describe('HybridTokenStorage', () => {
 
   describe('setCredentials', () => {
     it('should delegate to selected storage', async () => {
+      process.env['GEMINI_ENABLE_KEYCHAIN_STORAGE'] = 'true';
       const credentials: OAuthCredentials = {
         serverName: 'test-server',
         token: {
@@ -206,6 +227,7 @@ describe('HybridTokenStorage', () => {
 
   describe('deleteCredentials', () => {
     it('should delegate to selected storage', async () => {
+      process.env['GEMINI_ENABLE_KEYCHAIN_STORAGE'] = 'true';
       mockKeychainStorage.isAvailable!.mockResolvedValue(true);
       mockKeychainStorage.deleteCredentials.mockResolvedValue(undefined);
 
@@ -219,6 +241,7 @@ describe('HybridTokenStorage', () => {
 
   describe('listServers', () => {
     it('should delegate to selected storage', async () => {
+      process.env['GEMINI_ENABLE_KEYCHAIN_STORAGE'] = 'true';
       const servers = ['server1', 'server2'];
       mockKeychainStorage.isAvailable!.mockResolvedValue(true);
       mockKeychainStorage.listServers.mockResolvedValue(servers);
@@ -232,6 +255,7 @@ describe('HybridTokenStorage', () => {
 
   describe('getAllCredentials', () => {
     it('should delegate to selected storage', async () => {
+      process.env['GEMINI_ENABLE_KEYCHAIN_STORAGE'] = 'true';
       const credentialsMap = new Map([
         [
           'server1',
@@ -263,6 +287,7 @@ describe('HybridTokenStorage', () => {
 
   describe('clearAll', () => {
     it('should delegate to selected storage', async () => {
+      process.env['GEMINI_ENABLE_KEYCHAIN_STORAGE'] = 'true';
       mockKeychainStorage.isAvailable!.mockResolvedValue(true);
       mockKeychainStorage.clearAll.mockResolvedValue(undefined);
 

--- a/packages/core/src/mcp/token-storage/hybrid-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/hybrid-token-storage.ts
@@ -10,6 +10,7 @@ import type { TokenStorage, OAuthCredentials } from './types.js';
 import { TokenStorageType } from './types.js';
 
 const FORCE_FILE_STORAGE_ENV_VAR = 'GEMINI_FORCE_FILE_STORAGE';
+const ENABLE_KEYCHAIN_STORAGE_ENV_VAR = 'GEMINI_ENABLE_KEYCHAIN_STORAGE';
 
 export class HybridTokenStorage extends BaseTokenStorage {
   private storage: TokenStorage | null = null;
@@ -22,8 +23,10 @@ export class HybridTokenStorage extends BaseTokenStorage {
 
   private async initializeStorage(): Promise<TokenStorage> {
     const forceFileStorage = process.env[FORCE_FILE_STORAGE_ENV_VAR] === 'true';
+    const enableKeychainStorage =
+      process.env[ENABLE_KEYCHAIN_STORAGE_ENV_VAR] === 'true';
 
-    if (!forceFileStorage) {
+    if (!forceFileStorage && enableKeychainStorage) {
       try {
         const { KeychainTokenStorage } = await import(
           './keychain-token-storage.js'


### PR DESCRIPTION
## Summary
- default hybrid token storage to encrypted files unless GEMINI_ENABLE_KEYCHAIN_STORAGE is set
- ensure extension settings cleanup awaits keychain availability
- document experimental status of keychain storage opt-in

## Testing
- npx vitest run packages/core/src/mcp/token-storage/hybrid-token-storage.test.ts
