### PR TITLE
fix: F1 key input issue in non-kitty mode

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -224,7 +224,7 @@ function parseKittyPrefix(buffer: string): { key: Key; length: number } | null {
         shift,
         paste: false,
         sequence: buffer.slice(0, m[0].length),
-        kittyProtocol: true,
+        kittyProtocol: false,
       },
       length: m[0].length,
     };


### PR DESCRIPTION
### Details

fix: #12614

### summary
- Fix F1 key input issue in non-kitty mode where function keys produced unwanted characters.

### Details

- Parameterized functional key sequences were incorrectly marked as kittyProtocol: true, causing them to be ignored when kitty protocol is disabled. Changed to kittyProtocol: false to ensure F1-F4 keys work in both kitty and non-kitty modes.

