### PR TITLE
fix: integrate DiscoveredTool with Policy Engine

### DIFF
--- a/packages/core/src/policy/policies/discovered.toml
+++ b/packages/core/src/policy/policies/discovered.toml
@@ -1,0 +1,8 @@
+# Default policy for tools discovered via toolDiscoveryCommand.
+# These tools are potentially dangerous as they are arbitrary scripts.
+# We default them to ASK_USER for safety.
+
+[[rule]]
+toolName = "discovered_tool_*"
+decision = "ask_user"
+priority = 10

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -11,7 +11,11 @@ import type { ConfigParameters } from '../config/config.js';
 import { Config } from '../config/config.js';
 import { ApprovalMode } from '../policy/types.js';
 
-import { ToolRegistry, DiscoveredTool } from './tool-registry.js';
+import {
+  ToolRegistry,
+  DiscoveredTool,
+  DISCOVERED_TOOL_PREFIX,
+} from './tool-registry.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import type { FunctionDeclaration, CallableTool } from '@google/genai';
 import { mcpToTool } from '@google/genai';
@@ -258,6 +262,7 @@ describe('ToolRegistry', () => {
       const discovered1 = new DiscoveredTool(
         config,
         'discovered-1',
+        DISCOVERED_TOOL_PREFIX + 'discovered-1',
         'desc',
         {},
       );
@@ -289,7 +294,7 @@ describe('ToolRegistry', () => {
       expect(toolRegistry.getAllToolNames()).toEqual([
         'builtin-1',
         'builtin-2',
-        'discovered-1',
+        DISCOVERED_TOOL_PREFIX + 'discovered-1',
         'mcp-apple',
         'mcp-zebra',
       ]);
@@ -347,7 +352,9 @@ describe('ToolRegistry', () => {
 
       await toolRegistry.discoverAllTools();
 
-      const discoveredTool = toolRegistry.getTool('tool-with-bad-format');
+      const discoveredTool = toolRegistry.getTool(
+        DISCOVERED_TOOL_PREFIX + 'tool-with-bad-format',
+      );
       expect(discoveredTool).toBeDefined();
 
       const registeredParams = (discoveredTool as DiscoveredTool).schema
@@ -402,7 +409,9 @@ describe('ToolRegistry', () => {
       });
 
       await toolRegistry.discoverAllTools();
-      const discoveredTool = toolRegistry.getTool('failing-tool');
+      const discoveredTool = toolRegistry.getTool(
+        DISCOVERED_TOOL_PREFIX + 'failing-tool',
+      );
       expect(discoveredTool).toBeDefined();
 
       // --- Execution Mock ---
@@ -481,7 +490,9 @@ describe('ToolRegistry', () => {
       });
 
       await toolRegistry.discoverAllTools();
-      const tool = toolRegistry.getTool('policy-test-tool');
+      const tool = toolRegistry.getTool(
+        DISCOVERED_TOOL_PREFIX + 'policy-test-tool',
+      );
       expect(tool).toBeDefined();
 
       // Verify DiscoveredTool has the message bus
@@ -496,7 +507,13 @@ describe('ToolRegistry', () => {
 
   describe('DiscoveredToolInvocation', () => {
     it('should return the stringified params from getDescription', () => {
-      const tool = new DiscoveredTool(config, 'test-tool', 'A test tool', {});
+      const tool = new DiscoveredTool(
+        config,
+        'test-tool',
+        DISCOVERED_TOOL_PREFIX + 'test-tool',
+        'A test tool',
+        {},
+      );
       const params = { param: 'testValue' };
       const invocation = tool.build(params);
       const description = invocation.getDescription();

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -22,6 +22,8 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { coreEvents } from '../utils/events.js';
 
+export const DISCOVERED_TOOL_PREFIX = 'discovered_tool_';
+
 type ToolParams = Record<string, unknown>;
 
 class DiscoveredToolInvocation extends BaseToolInvocation<
@@ -30,11 +32,12 @@ class DiscoveredToolInvocation extends BaseToolInvocation<
 > {
   constructor(
     private readonly config: Config,
-    private readonly toolName: string,
+    private readonly originalToolName: string,
+    prefixedToolName: string,
     params: ToolParams,
     messageBus?: MessageBus,
   ) {
-    super(params, messageBus, toolName);
+    super(params, messageBus, prefixedToolName);
   }
 
   getDescription(): string {
@@ -46,7 +49,7 @@ class DiscoveredToolInvocation extends BaseToolInvocation<
     _updateOutput?: (output: string) => void,
   ): Promise<ToolResult> {
     const callCommand = this.config.getToolCallCommand()!;
-    const child = spawn(callCommand, [this.toolName]);
+    const child = spawn(callCommand, [this.originalToolName]);
     child.stdin.write(JSON.stringify(this.params));
     child.stdin.end();
 
@@ -125,19 +128,24 @@ export class DiscoveredTool extends BaseDeclarativeTool<
   ToolParams,
   ToolResult
 > {
+  private readonly originalName: string;
+
   constructor(
     private readonly config: Config,
-    name: string,
-    override readonly description: string,
+    originalName: string,
+    prefixedName: string,
+    description: string,
     override readonly parameterSchema: Record<string, unknown>,
     messageBus?: MessageBus,
   ) {
     const discoveryCmd = config.getToolDiscoveryCommand()!;
     const callCommand = config.getToolCallCommand()!;
-    description += `
+    const fullDescription =
+      description +
+      `
 
 This tool was discovered from the project by executing the command \`${discoveryCmd}\` on project root.
-When called, this tool will execute the command \`${callCommand} ${name}\` on project root.
+When called, this tool will execute the command \`${callCommand} ${originalName}\` on project root.
 Tool discovery and call commands can be configured in project or user settings.
 
 When called, the tool call command is executed as a subprocess.
@@ -151,15 +159,16 @@ Exit Code: Exit code or \`(none)\` if terminated by signal.
 Signal: Signal number or \`(none)\` if no signal was received.
 `;
     super(
-      name,
-      name,
-      description,
+      prefixedName,
+      prefixedName,
+      fullDescription,
       Kind.Other,
       parameterSchema,
       false, // isOutputMarkdown
       false, // canUpdateOutput
       messageBus,
     );
+    this.originalName = originalName;
   }
 
   protected createInvocation(
@@ -170,6 +179,7 @@ Signal: Signal number or \`(none)\` if no signal was received.
   ): ToolInvocation<ToolParams, ToolResult> {
     return new DiscoveredToolInvocation(
       this.config,
+      this.originalName,
       this.name,
       params,
       _messageBus,
@@ -393,6 +403,7 @@ export class ToolRegistry {
           new DiscoveredTool(
             this.config,
             func.name,
+            DISCOVERED_TOOL_PREFIX + func.name,
             func.description ?? '',
             parameters as Record<string, unknown>,
             this.messageBus,

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -32,8 +32,9 @@ class DiscoveredToolInvocation extends BaseToolInvocation<
     private readonly config: Config,
     private readonly toolName: string,
     params: ToolParams,
+    messageBus?: MessageBus,
   ) {
-    super(params);
+    super(params, messageBus, toolName);
   }
 
   getDescription(): string {
@@ -129,6 +130,7 @@ export class DiscoveredTool extends BaseDeclarativeTool<
     name: string,
     override readonly description: string,
     override readonly parameterSchema: Record<string, unknown>,
+    messageBus?: MessageBus,
   ) {
     const discoveryCmd = config.getToolDiscoveryCommand()!;
     const callCommand = config.getToolCallCommand()!;
@@ -156,6 +158,7 @@ Signal: Signal number or \`(none)\` if no signal was received.
       parameterSchema,
       false, // isOutputMarkdown
       false, // canUpdateOutput
+      messageBus,
     );
   }
 
@@ -165,7 +168,12 @@ Signal: Signal number or \`(none)\` if no signal was received.
     _toolName?: string,
     _displayName?: string,
   ): ToolInvocation<ToolParams, ToolResult> {
-    return new DiscoveredToolInvocation(this.config, this.name, params);
+    return new DiscoveredToolInvocation(
+      this.config,
+      this.name,
+      params,
+      _messageBus,
+    );
   }
 }
 
@@ -387,6 +395,7 @@ export class ToolRegistry {
             func.name,
             func.description ?? '',
             parameters as Record<string, unknown>,
+            this.messageBus,
           ),
         );
       }


### PR DESCRIPTION
Fixes a security vulnerability where tools discovered via toolDiscoveryCommand bypassed the Policy Engine. This change ensures that DiscoveredTool and DiscoveredToolInvocation correctly utilize the MessageBus to trigger policy checks before execution.