### PR TITLE
fix(#11707): should replace multiple instances of a string test

### DIFF
--- a/integration-tests/file-system.test.ts
+++ b/integration-tests/file-system.test.ts
@@ -148,46 +148,53 @@ describe('file-system', () => {
     expect(newFileContent).toBe('1.0.1');
   });
 
-  it.skip('should replace multiple instances of a string', async () => {
+  it('should replace multiple instances of a string', async () => {
     const rig = new TestRig();
-    await rig.setup('should replace multiple instances of a string');
+    rig.setup('should replace multiple instances of a string');
     const fileName = 'ambiguous.txt';
     const fileContent = 'Hey there, \ntest line\ntest line';
     const expectedContent = 'Hey there, \nnew line\nnew line';
     rig.createFile(fileName, fileContent);
 
     const result = await rig.run(
-      `replace "test line" with "new line" in ${fileName}`,
+      `rewrite the file ${fileName} to replace all instances of "test line" with "new line"`,
     );
 
-    const foundToolCall = await rig.waitForAnyToolCall([
-      'replace',
-      'write_file',
-    ]);
+    const foundToolCall = await rig.waitForToolCall('write_file');
     if (!foundToolCall) {
-      printDebugInfo(rig, result);
+      printDebugInfo(rig, result, {
+        'Tool call found': foundToolCall,
+        'Tool logs': rig.readToolLogs(),
+      });
     }
     expect(
       foundToolCall,
-      'Expected to find a replace or write_file tool call',
+      'Expected to find a write_file tool call',
     ).toBeTruthy();
 
     const toolLogs = rig.readToolLogs();
     const successfulEdit = toolLogs.some(
-      (log) =>
-        (log.toolRequest.name === 'replace' ||
-          log.toolRequest.name === 'write_file') &&
-        log.toolRequest.success,
+      (log) => log.toolRequest.name === 'write_file' && log.toolRequest.success,
     );
     if (!successfulEdit) {
       console.error(
-        'Expected a successful edit tool call, but none was found.',
+        'Expected a successful write_file tool call, but none was found.',
       );
       printDebugInfo(rig, result);
     }
-    expect(successfulEdit, 'Expected a successful edit tool call').toBeTruthy();
+    expect(
+      successfulEdit,
+      'Expected a successful write_file tool call',
+    ).toBeTruthy();
 
     const newFileContent = rig.readFile(fileName);
+    if (newFileContent !== expectedContent) {
+      printDebugInfo(rig, result, {
+        'Final file content': newFileContent,
+        'Expected file content': expectedContent,
+        'Tool logs': rig.readToolLogs(),
+      });
+    }
     expect(newFileContent).toBe(expectedContent);
   });
 

--- a/integration-tests/file-system.test.ts
+++ b/integration-tests/file-system.test.ts
@@ -160,7 +160,8 @@ describe('file-system', () => {
       `rewrite the file ${fileName} to replace all instances of "test line" with "new line"`,
     );
 
-    const foundToolCall = await rig.waitForToolCall('write_file');
+    const validTools = ['write_file', 'edit'];
+    const foundToolCall = await rig.waitForAnyToolCall(validTools);
     if (!foundToolCall) {
       printDebugInfo(rig, result, {
         'Tool call found': foundToolCall,
@@ -169,22 +170,23 @@ describe('file-system', () => {
     }
     expect(
       foundToolCall,
-      'Expected to find a write_file tool call',
+      `Expected to find one of ${validTools.join(', ')} tool calls`,
     ).toBeTruthy();
 
     const toolLogs = rig.readToolLogs();
     const successfulEdit = toolLogs.some(
-      (log) => log.toolRequest.name === 'write_file' && log.toolRequest.success,
+      (log) =>
+        validTools.includes(log.toolRequest.name) && log.toolRequest.success,
     );
     if (!successfulEdit) {
       console.error(
-        'Expected a successful write_file tool call, but none was found.',
+        `Expected a successful edit tool call (${validTools.join(', ')}), but none was found.`,
       );
       printDebugInfo(rig, result);
     }
     expect(
       successfulEdit,
-      'Expected a successful write_file tool call',
+      `Expected a successful edit tool call (${validTools.join(', ')})`,
     ).toBeTruthy();
 
     const newFileContent = rig.readFile(fileName);


### PR DESCRIPTION
## Summary

This is about fixing the test in `file-system.test.ts` that asserts that multiple instances of a string should be replaced.

## Details

Before, the `replace` tool was being used, or it was expected to have been used. However, its description clearly states that `replace` only replaces a _single_ occurrance. Thus the error.

## Related Issues

Fixes: https://github.com/google-gemini/gemini-cli/issues/11707

## How to Validate

If you only want to run the tests from the `file-system.test.ts` file where this test lives, please run:

```
npm run test:integration:sandbox:none -- file-system.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
