### PR TITLE
feat(cli): Include upgrade command in extension update notification

### DIFF
--- a/packages/cli/src/ui/hooks/useExtensionUpdates.test.tsx
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.test.tsx
@@ -107,7 +107,7 @@ describe('useExtensionUpdates', () => {
       expect(addItem).toHaveBeenCalledWith(
         {
           type: MessageType.INFO,
-          text: 'You have 1 extension with an update available, run "/extensions list" for more information.',
+          text: 'You have 1 extension with an update available.\nRun "gemini extensions update test-extension" to upgrade, or "/extensions list" for details.',
         },
         expect.any(Number),
       );

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -194,7 +194,7 @@ export const useExtensionUpdates = (
       addItem(
         {
           type: MessageType.INFO,
-          text: `You have ${extensionsWithUpdatesCount} extension${s} with an update available, run "/extensions list" for more information.`,
+          text: `You have ${extensionsWithUpdatesCount} extension${s} with an update available. Run "gemini extensions update <extension-name>" to upgrade, or "/extensions list" for details.`,
         },
         Date.now(),
       );

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -190,11 +190,20 @@ export const useExtensionUpdates = (
       }
     }
     if (shouldNotifyOfUpdates) {
-      const s = extensionsWithUpdatesCount > 1 ? 's' : '';
+      const updatableExtensions = extensions.filter(
+        (ext) => extensionsUpdateState.extensionStatuses.get(ext.name)?.status === ExtensionUpdateState.UPDATE_AVAILABLE
+      );
+
+      const commandHint =
+        updatableExtensions.length > 1
+          ? '--all'
+          : updatableExtensions[0]?.name || '<extension-name>';
       addItem(
         {
           type: MessageType.INFO,
-          text: `You have ${extensionsWithUpdatesCount} extension${s} with an update available. Run "gemini extensions update <extension-name>" to upgrade, or "/extensions list" for details.`,
+          text: `You have ${updatableExtensions.length} extension${
+            updatableExtensions.length > 1 ? 's' : ''
+          } with an update available.\nRun "gemini extensions update ${commandHint}" to upgrade, or "/extensions list" for details.`,
         },
         Date.now(),
       );


### PR DESCRIPTION
## Summary

Improves the user experience (UX) for extension update notifications by directly including the upgrade command. This resolves issue #10906 and eliminates the need for users to search for the upgrade command when they see an update available notification.

## Details

This change updates the user-facing message displayed when an extension update is available. The previous message only directed users to the /extensions list command; this update adds the actual command needed to perform the upgrade, improving the user experience.

## Related Issues

Fixes #10906

## How to Validate

1. Ensure you have an extension installed that has a newer version available, but is not set for autoUpdate.
2. Run the CLI.
3. Expected result: The INFO message displayed should now include the upgrade command:

`ℹ You have 1 extension with an update available. Run "gemini extensions update <extension-name>" to upgrade, or "/extensions list" for details.`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
