### PR TITLE
Docs: Add /model documentation

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -122,7 +122,7 @@ Slash commands provide meta-level control over the CLI itself.
         available tools.
 
 - [**`/model`**](./model.md)
-  - **Description:** Opens a dialog to configure the model.
+  - **Description:** Opens a dialog to choose your Gemini model.
 
 - **`/memory`**
   - **Description:** Manage the AI's instructional context (hierarchical memory

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -121,6 +121,9 @@ Slash commands provide meta-level control over the CLI itself.
       - **Description:** Restarts all MCP servers and re-discovers their
         available tools.
 
+- [**`/model`**](./model.md)
+  - **Description:** Opens a dialog to configure the model.
+
 - **`/memory`**
   - **Description:** Manage the AI's instructional context (hierarchical memory
     loaded from `GEMINI.md` files).

--- a/docs/cli/model.md
+++ b/docs/cli/model.md
@@ -1,9 +1,3 @@
----
-title: Select the /model you use with Gemini CLI
-description: Configure the model used by Gemini CLI.
-date: 2025-11-06
----
-
 # Gemini CLI Model Selection (`/model` Command)
 
 Select your Gemini CLI model. The `/model` command opens a dialog where you can

--- a/docs/cli/model.md
+++ b/docs/cli/model.md
@@ -1,0 +1,50 @@
+---
+title: Select the /model you use with Gemini CLI
+description: Configure the model used by Gemini CLI.
+date: 2025-11-06
+---
+
+# Gemini CLI Model Selection (`/model` Command)
+
+Select your Gemini CLI model. The `/model` command opens a dialog where you can
+configure the model used by Gemini CLI, giving you more control over your
+results.
+
+## How to use the `/model` command
+
+Use the following command in Gemini CLI:
+
+```
+/model
+```
+
+Running this command will open a dialog with your model options:
+
+- **Auto (recommended):** Let the system choose the best model for your task.
+  Typically, this is the best option.
+- **Pro:** For complex tasks that require deep reasoning and creativity. The Pro
+  model may take longer to return a response.
+- **Flash:** For tasks that need a balance of speed and reasoning. The Flash
+  model will usually return a faster response than Pro.
+- **Flash-Lite:** For simple tasks that need to be done quickly. The Flash-Lite
+  model is typically the fastest.
+
+Changes to these settings will be applied to all subsequent interactions with
+Gemini CLI.
+
+## Best practices for model selection
+
+- **Default to Auto (recommended).** For most users, the _Auto (recommended)_
+  model provides a balance between speed and performance, automatically
+  selecting the correct model based on the complexity of the task. Example:
+  Developing a web application could include a mix of complex tasks (building
+  architecture and scaffolding the project) and simple tasks (generating CSS).
+
+- **Switch to Pro if you aren't getting the results you want.** If you think you
+  need your model to be a little "smarter," use Pro. Pro will provide you with
+  the highest levels of reasoning and creativity. Example: A complex or
+  multi-stage debugging task.
+
+- **Switch to Flash or Flash-Lite if you need faster results.** If you need a
+  simple response quickly, Flash or Flash-Lite is the best option. Example:
+  Converting a JSON object to a YAML string.

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -73,6 +73,10 @@
         "slug": "docs/cli/keyboard-shortcuts"
       },
       {
+        "label": "Model Selection",
+        "slug": "docs/cli/model"
+      },
+      {
         "label": "Sandbox",
         "slug": "docs/cli/sandbox"
       },


### PR DESCRIPTION
## Summary

This PR adds documentation for the new /model command.

## Details

The new /model command lets users manually choose their Gemini CLI model. 

- This command is being introduced into docs/cli/commands.md.
- This command is being added as a feature in docs/cli/model.md.
- The sidebar of the website is being updated.

## Related Issues

Closes #12645

## How to Validate

Check for any unintentional changes or known inaccuracies.