### PR TITLE
fix(cli): handle flash model errors gracefully

### DIFF
--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -125,6 +125,52 @@ describe('useQuotaAndFallback', () => {
       expect(mockHistoryManager.addItem).not.toHaveBeenCalled();
     });
 
+    describe('Flash Model Fallback', () => {
+      it('should show a terminal quota message and stop, without offering a fallback', async () => {
+        const handler = getRegisteredHandler();
+        // let result: FallbackIntent | null = null;
+        // await act(async () => {
+        //   result = await handler(
+        //     'gemini-2.5-flash',
+        //     'gemini-2.5-flash',
+        //     new TerminalQuotaError('flash quota', mockGoogleApiError),
+        //   );
+        // });
+        const result = await handler(
+          'gemini-2.5-flash',
+          'gemini-2.5-flash',
+          new TerminalQuotaError('flash quota', mockGoogleApiError),
+        );
+
+        expect(result).toBe('stop');
+        expect(mockHistoryManager.addItem).toHaveBeenCalledTimes(1);
+        const message = (mockHistoryManager.addItem as Mock).mock.calls[0][0]
+          .text;
+        expect(message).toContain(
+          'You have reached your daily gemini-2.5-flash',
+        );
+        expect(message).not.toContain('continue with the fallback model');
+      });
+
+      it('should show a capacity message and stop', async () => {
+        const handler = getRegisteredHandler();
+        // let result: FallbackIntent | null = null;
+        const result = await handler(
+          'gemini-2.5-flash',
+          'gemini-2.5-flash',
+          new Error('capacity'),
+        );
+
+        expect(result).toBe('stop');
+        expect(mockHistoryManager.addItem).toHaveBeenCalledTimes(1);
+        const message = (mockHistoryManager.addItem as Mock).mock.calls[0][0]
+          .text;
+        expect(message).toContain(
+          'Pardon Our Congestion! It looks like gemini-2.5-flash is very popular',
+        );
+      });
+    });
+
     describe('Interactive Fallback', () => {
       // Pro Quota Errors
       it('should set an interactive request and wait for user choice', async () => {

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -42,10 +42,6 @@ export function useQuotaAndFallback({
       fallbackModel,
       error,
     ): Promise<FallbackIntent | null> => {
-      if (config.isInFallbackMode()) {
-        return null;
-      }
-
       // Fallbacks are currently only handled for OAuth users.
       const contentGeneratorConfig = config.getContentGeneratorConfig();
       if (

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -11,6 +11,7 @@ import {
   type FallbackIntent,
   TerminalQuotaError,
   UserTierId,
+  DEFAULT_GEMINI_FLASH_MODEL,
 } from '@google/gemini-cli-core';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { type UseHistoryManagerReturn } from './useHistoryManager.js';
@@ -58,28 +59,35 @@ export function useQuotaAndFallback({
       const isPaidTier =
         userTier === UserTierId.LEGACY || userTier === UserTierId.STANDARD;
 
+      const isFallbackModel = failedModel === DEFAULT_GEMINI_FLASH_MODEL;
       let message: string;
 
       if (error instanceof TerminalQuotaError) {
-        // Pro Quota specific messages (Interactive)
+        // Common part of the message for both tiers
+        const messageLines = [
+          `⚡ You have reached your daily ${failedModel} quota limit.`,
+          `⚡ You can choose to authenticate with a paid API key${
+            isFallbackModel ? '.' : ' or continue with the fallback model.'
+          }`,
+        ];
+
+        // Tier-specific part
         if (isPaidTier) {
-          message = [
-            `⚡ You have reached your daily ${failedModel} quota limit.`,
-            `⚡ You can choose to authenticate with a paid API key or continue with the fallback model.`,
+          messageLines.push(
             `⚡ Increase your limits by using a Gemini API Key. See: https://goo.gle/gemini-cli-docs-auth#gemini-api-key`,
             `⚡ You can switch authentication methods by typing /auth`,
-          ].join('\n');
+          );
         } else {
-          message = [
-            `⚡ You have reached your daily ${failedModel} quota limit.`,
-            `⚡ You can choose to authenticate with a paid API key or continue with the fallback model.`,
+          messageLines.push(
             `⚡ Increase your limits by `,
             `⚡ - signing up for a plan with higher limits at https://goo.gle/set-up-gemini-code-assist`,
             `⚡ - or using a Gemini API Key. See: https://goo.gle/gemini-cli-docs-auth#gemini-api-key`,
             `⚡ You can switch authentication methods by typing /auth`,
-          ].join('\n');
+          );
         }
+        message = messageLines.join('\n');
       } else {
+        // Capacity error
         message = [
           `🚦Pardon Our Congestion! It looks like ${failedModel} is very popular at the moment.`,
           `Please retry again later.`,
@@ -94,6 +102,10 @@ export function useQuotaAndFallback({
         },
         Date.now(),
       );
+
+      if (isFallbackModel) {
+        return 'stop';
+      }
 
       setModelSwitchedFromQuotaError(true);
       config.setQuotaErrorOccurred(true);

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -73,14 +73,15 @@ describe('handleFallback', () => {
     expect(mockConfig.setFallbackMode).not.toHaveBeenCalled();
   });
 
-  it('should return null if the failed model is already the fallback model', async () => {
+  it('should still consult the handler if the failed model is the fallback model', async () => {
+    mockHandler.mockResolvedValue('stop');
     const result = await handleFallback(
       mockConfig,
       FALLBACK_MODEL, // Failed model is Flash
       AUTH_OAUTH,
     );
-    expect(result).toBeNull();
-    expect(mockHandler).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+    expect(mockHandler).toHaveBeenCalled();
   });
 
   it('should return null if no fallbackHandler is injected in config', async () => {

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -21,8 +21,6 @@ export async function handleFallback(
 
   const fallbackModel = DEFAULT_GEMINI_FLASH_MODEL;
 
-  if (failedModel === fallbackModel) return null;
-
   // Consult UI Handler for Intent
   const fallbackModelHandler = config.fallbackModelHandler;
   if (typeof fallbackModelHandler !== 'function') return null;


### PR DESCRIPTION
## Summary

This PR fixes a bug where users would see no feedback if the `flash` model failed due to a quota or capacity issue. Now, a clear, context-specific error message is displayed, and the fallback dialog is correctly suppressed.

## Details

Previously, the core fallback logic had a guard that would exit immediately if the failing model was already the designated fallback model. This prevented the UI layer from displaying anything other than the API Error received.

## Related Issues

Fixes: https://github.com/google-gemini/maintainers-gemini-cli/issues/1031
## How to Validate

Follows instructions at: [go/gca-qs-testing](http://goto.google.com/gca-qs-testing)

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
