### PR TITLE
chore: disable flaky test

### DIFF
--- a/integration-tests/file-system.test.ts
+++ b/integration-tests/file-system.test.ts
@@ -148,7 +148,7 @@ describe('file-system', () => {
     expect(newFileContent).toBe('1.0.1');
   });
 
-  it('should replace multiple instances of a string', async () => {
+  it.skip('should replace multiple instances of a string', async () => {
     const rig = new TestRig();
     rig.setup('should replace multiple instances of a string');
     const fileName = 'ambiguous.txt';


### PR DESCRIPTION
## Summary

It disables the flaky test from the `file-system.test.ts` file that asserts that multiple instances of a word should be replaced.

## Related Issues

It reverts the change made in this PR: 