### PR TITLE
feat: enhance RipGrep tool with advanced search options and improved defaults

### DIFF
--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -19,6 +19,10 @@ import { fileExists } from '../utils/fileUtils.js';
 import { Storage } from '../config/storage.js';
 import { GREP_TOOL_NAME } from './tool-names.js';
 import { debugLogger } from '../utils/debugLogger.js';
+import {
+  FileExclusions,
+  COMMON_DIRECTORY_EXCLUDES,
+} from '../utils/ignorePatterns.js';
 
 const DEFAULT_TOTAL_MAX_MATCHES = 20000;
 
@@ -76,6 +80,51 @@ export async function ensureRgPath(): Promise<string> {
 }
 
 /**
+ * Checks if a path is within the root directory and resolves it.
+ * @param config The configuration object.
+ * @param relativePath Path relative to the root directory (or undefined for root).
+ * @returns The absolute path if valid and exists, or null if no path specified.
+ * @throws {Error} If path is outside root, doesn't exist, or isn't a directory/file.
+ */
+function resolveAndValidatePath(
+  config: Config,
+  relativePath?: string,
+): string | null {
+  if (!relativePath) {
+    return null;
+  }
+
+  const targetDir = config.getTargetDir();
+  const targetPath = path.resolve(targetDir, relativePath);
+
+  // Ensure the resolved path is within workspace boundaries
+  const workspaceContext = config.getWorkspaceContext();
+  if (!workspaceContext.isPathWithinWorkspace(targetPath)) {
+    const directories = workspaceContext.getDirectories();
+    throw new Error(
+      `Path validation failed: Attempted path "${relativePath}" resolves outside the allowed workspace directories: ${directories.join(', ')}`,
+    );
+  }
+
+  // Check existence and type after resolving
+  try {
+    const stats = fs.statSync(targetPath);
+    if (!stats.isDirectory() && !stats.isFile()) {
+      throw new Error(
+        `Path is not a valid directory or file: ${targetPath} (CWD: ${targetDir})`,
+      );
+    }
+  } catch (error: unknown) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      throw new Error(`Path does not exist: ${targetPath} (CWD: ${targetDir})`);
+    }
+    throw new Error(`Failed to access path stats for ${targetPath}: ${error}`);
+  }
+
+  return targetPath;
+}
+
+/**
  * Parameters for the GrepTool
  */
 export interface RipGrepToolParams {
@@ -93,6 +142,36 @@ export interface RipGrepToolParams {
    * File pattern to include in the search (e.g. "*.js", "*.{ts,tsx}")
    */
   include?: string;
+
+  /**
+   * If true, searches case-sensitively. Defaults to false.
+   */
+  case_sensitive?: boolean;
+
+  /**
+   * If true, treats pattern as a literal string. Defaults to false.
+   */
+  fixed_strings?: boolean;
+
+  /**
+   * Show num lines of context around each match.
+   */
+  context?: number;
+
+  /**
+   * Show num lines after each match.
+   */
+  after?: number;
+
+  /**
+   * Show num lines before each match.
+   */
+  before?: number;
+
+  /**
+   * If true, does not respect .gitignore or default ignores (like build/dist).
+   */
+  no_ignore?: boolean;
 }
 
 /**
@@ -118,60 +197,22 @@ class GrepToolInvocation extends BaseToolInvocation<
     super(params, messageBus, _toolName, _toolDisplayName);
   }
 
-  /**
-   * Checks if a path is within the root directory and resolves it.
-   * @param relativePath Path relative to the root directory (or undefined for root).
-   * @returns The absolute path if valid and exists, or null if no path specified (to search all directories).
-   * @throws {Error} If path is outside root, doesn't exist, or isn't a directory.
-   */
-  private resolveAndValidatePath(relativePath?: string): string | null {
-    // If no path specified, return null to indicate searching all workspace directories
-    if (!relativePath) {
-      return null;
-    }
-
-    const targetPath = path.resolve(this.config.getTargetDir(), relativePath);
-
-    // Security Check: Ensure the resolved path is within workspace boundaries
-    const workspaceContext = this.config.getWorkspaceContext();
-    if (!workspaceContext.isPathWithinWorkspace(targetPath)) {
-      const directories = workspaceContext.getDirectories();
-      throw new Error(
-        `Path validation failed: Attempted path "${relativePath}" resolves outside the allowed workspace directories: ${directories.join(', ')}`,
-      );
-    }
-
-    // Check existence and type after resolving
-    try {
-      const stats = fs.statSync(targetPath);
-      if (!stats.isDirectory()) {
-        throw new Error(`Path is not a directory: ${targetPath}`);
-      }
-    } catch (error: unknown) {
-      if (isNodeError(error) && error.code !== 'ENOENT') {
-        throw new Error(`Path does not exist: ${targetPath}`);
-      }
-      throw new Error(
-        `Failed to access path stats for ${targetPath}: ${error}`,
-      );
-    }
-
-    return targetPath;
-  }
-
   async execute(signal: AbortSignal): Promise<ToolResult> {
     try {
       const workspaceContext = this.config.getWorkspaceContext();
-      const searchDirAbs = this.resolveAndValidatePath(this.params.dir_path);
-      const searchDirDisplay = this.params.dir_path || '.';
+      // Default to '.' if path is explicitly undefined/null.
+      // This forces CWD search instead of 'all workspaces' search by default.
+      const pathParam = this.params.dir_path || '.';
+
+      const searchDirAbs = resolveAndValidatePath(this.config, pathParam);
+      const searchDirDisplay = pathParam;
 
       // Determine which directories to search
       let searchDirectories: readonly string[];
       if (searchDirAbs === null) {
-        // No path specified - search all workspace directories
+        // Fallback only if something went wrong with '.' resolution, though it should be caught by validation
         searchDirectories = workspaceContext.getDirectories();
       } else {
-        // Specific path provided - search only that directory
         searchDirectories = [searchDirAbs];
       }
 
@@ -187,6 +228,12 @@ class GrepToolInvocation extends BaseToolInvocation<
           pattern: this.params.pattern,
           path: searchDir,
           include: this.params.include,
+          case_sensitive: this.params.case_sensitive,
+          fixed_strings: this.params.fixed_strings,
+          context: this.params.context,
+          after: this.params.after,
+          before: this.params.before,
+          no_ignore: this.params.no_ignore,
           signal,
         });
 
@@ -314,29 +361,66 @@ class GrepToolInvocation extends BaseToolInvocation<
     pattern: string;
     path: string;
     include?: string;
+    case_sensitive?: boolean;
+    fixed_strings?: boolean;
+    context?: number;
+    after?: number;
+    before?: number;
+    no_ignore?: boolean;
     signal: AbortSignal;
   }): Promise<GrepMatch[]> {
-    const { pattern, path: absolutePath, include } = options;
+    const {
+      pattern,
+      path: absolutePath,
+      include,
+      case_sensitive,
+      fixed_strings,
+      context,
+      after,
+      before,
+      no_ignore,
+    } = options;
 
-    const rgArgs = ['--json', '--ignore-case', '--regexp', pattern];
+    const rgArgs = ['--json'];
+
+    if (!case_sensitive) {
+      rgArgs.push('--ignore-case');
+    }
+
+    if (fixed_strings) {
+      rgArgs.push('--fixed-strings');
+    }
+
+    if (context) {
+      rgArgs.push('--context', context.toString());
+    }
+    if (after) {
+      rgArgs.push('--after-context', after.toString());
+    }
+    if (before) {
+      rgArgs.push('--before-context', before.toString());
+    }
+    if (no_ignore) {
+      rgArgs.push('--no-ignore');
+    }
+
+    rgArgs.push('--regexp', pattern);
 
     if (include) {
       rgArgs.push('--glob', include);
     }
 
-    const excludes = [
-      '.git',
-      'node_modules',
-      'bower_components',
-      '*.log',
-      '*.tmp',
-      'build',
-      'dist',
-      'coverage',
-    ];
-    excludes.forEach((exclude) => {
-      rgArgs.push('--glob', `!${exclude}`);
-    });
+    if (!no_ignore) {
+      const fileExclusions = new FileExclusions(this.config);
+      const excludes = fileExclusions.getGlobExcludes([
+        ...COMMON_DIRECTORY_EXCLUDES,
+        '*.log',
+        '*.tmp',
+      ]);
+      excludes.forEach((exclude) => {
+        rgArgs.push('--glob', `!${exclude}`);
+      });
+    }
 
     rgArgs.push('--threads', '4');
     rgArgs.push(absolutePath);
@@ -405,30 +489,16 @@ class GrepToolInvocation extends BaseToolInvocation<
     if (this.params.include) {
       description += ` in ${this.params.include}`;
     }
-    if (this.params.dir_path) {
-      const resolvedPath = path.resolve(
-        this.config.getTargetDir(),
-        this.params.dir_path,
-      );
-      if (
-        resolvedPath === this.config.getTargetDir() ||
-        this.params.dir_path === '.'
-      ) {
-        description += ` within ./`;
-      } else {
-        const relativePath = makeRelative(
-          resolvedPath,
-          this.config.getTargetDir(),
-        );
-        description += ` within ${shortenPath(relativePath)}`;
-      }
+    const pathParam = this.params.dir_path || '.';
+    const resolvedPath = path.resolve(this.config.getTargetDir(), pathParam);
+    if (resolvedPath === this.config.getTargetDir() || pathParam === '.') {
+      description += ` within ./`;
     } else {
-      // When no path is specified, indicate searching all workspace directories
-      const workspaceContext = this.config.getWorkspaceContext();
-      const directories = workspaceContext.getDirectories();
-      if (directories.length > 1) {
-        description += ` across all workspace directories`;
-      }
+      const relativePath = makeRelative(
+        resolvedPath,
+        this.config.getTargetDir(),
+      );
+      description += ` within ${shortenPath(relativePath)}`;
     }
     return description;
   }
@@ -450,24 +520,54 @@ export class RipGrepTool extends BaseDeclarativeTool<
     super(
       RipGrepTool.Name,
       'SearchText',
-      'Searches for a regular expression pattern within the content of files in a specified directory (or current working directory). Can filter files by a glob pattern. Returns the lines containing matches, along with their file paths and line numbers. Total results limited to 20,000 matches like VSCode.',
+      'FAST, optimized search powered by `ripgrep`. PREFERRED over standard `run_shell_command("grep ...")` due to better performance and automatic output limiting (max 20k matches).',
       Kind.Search,
       {
         properties: {
           pattern: {
             description:
-              "The regular expression (regex) pattern to search for within file contents (e.g., 'function\\s+myFunction', 'import\\s+\\{.*\\}\\s+from\\s+.*').",
+              "The pattern to search for. By default, treated as a Rust-flavored regular expression. Use '\\b' for precise symbol matching (e.g., '\\bMatchMe\\b').",
             type: 'string',
           },
           dir_path: {
             description:
-              'Optional: The absolute path to the directory to search within. If omitted, searches the current working directory.',
+              "Directory or file to search. Directories are searched recursively. Relative paths are resolved against current working directory. Defaults to current working directory ('.') if omitted.",
             type: 'string',
           },
           include: {
             description:
-              "Optional: A glob pattern to filter which files are searched (e.g., '*.js', '*.{ts,tsx}', 'src/**'). If omitted, searches all files (respecting potential global ignores).",
+              "Glob pattern to filter files (e.g., '*.ts', 'src/**'). Recommended for large repositories to reduce noise. Defaults to all files if omitted.",
             type: 'string',
+          },
+          case_sensitive: {
+            description:
+              'If true, search is case-sensitive. Defaults to false (ignore case) if omitted.',
+            type: 'boolean',
+          },
+          fixed_strings: {
+            description:
+              'If true, treats the `pattern` as a literal string instead of a regular expression. Defaults to false (basic regex) if omitted.',
+            type: 'boolean',
+          },
+          context: {
+            description:
+              'Show this many lines of context around each match (equivalent to grep -C). Defaults to 0 if omitted.',
+            type: 'integer',
+          },
+          after: {
+            description:
+              'Show this many lines after each match (equivalent to grep -A). Defaults to 0 if omitted.',
+            type: 'integer',
+          },
+          before: {
+            description:
+              'Show this many lines before each match (equivalent to grep -B). Defaults to 0 if omitted.',
+            type: 'integer',
+          },
+          no_ignore: {
+            description:
+              'If true, searches all files including those usually ignored (like in .gitignore, build/, dist/, etc). Defaults to false if omitted.',
+            type: 'boolean',
           },
         },
         required: ['pattern'],
@@ -477,47 +577,6 @@ export class RipGrepTool extends BaseDeclarativeTool<
       false, // canUpdateOutput
       messageBus,
     );
-  }
-
-  /**
-   * Checks if a path is within the root directory and resolves it.
-   * @param relativePath Path relative to the root directory (or undefined for root).
-   * @returns The absolute path if valid and exists, or null if no path specified (to search all directories).
-   * @throws {Error} If path is outside root, doesn't exist, or isn't a directory.
-   */
-  private resolveAndValidatePath(relativePath?: string): string | null {
-    // If no path specified, return null to indicate searching all workspace directories
-    if (!relativePath) {
-      return null;
-    }
-
-    const targetPath = path.resolve(this.config.getTargetDir(), relativePath);
-
-    // Security Check: Ensure the resolved path is within workspace boundaries
-    const workspaceContext = this.config.getWorkspaceContext();
-    if (!workspaceContext.isPathWithinWorkspace(targetPath)) {
-      const directories = workspaceContext.getDirectories();
-      throw new Error(
-        `Path validation failed: Attempted path "${relativePath}" resolves outside the allowed workspace directories: ${directories.join(', ')}`,
-      );
-    }
-
-    // Check existence and type after resolving
-    try {
-      const stats = fs.statSync(targetPath);
-      if (!stats.isDirectory()) {
-        throw new Error(`Path is not a directory: ${targetPath}`);
-      }
-    } catch (error: unknown) {
-      if (isNodeError(error) && error.code !== 'ENOENT') {
-        throw new Error(`Path does not exist: ${targetPath}`);
-      }
-      throw new Error(
-        `Failed to access path stats for ${targetPath}: ${error}`,
-      );
-    }
-
-    return targetPath;
   }
 
   /**
@@ -537,7 +596,7 @@ export class RipGrepTool extends BaseDeclarativeTool<
     // Only validate path if one is provided
     if (params.dir_path) {
       try {
-        this.resolveAndValidatePath(params.dir_path);
+        resolveAndValidatePath(this.config, params.dir_path);
       } catch (error) {
         return getErrorMessage(error);
       }


### PR DESCRIPTION
## Summary

This PR enhances the `RipGrepTool` by adding support for advanced search options, improving default behaviors, and clarifying parameter names.

## Details

- **New Parameters**: Added support for `case_sensitive`, `fixed_strings`, `no_ignore`, `context`, `after`, and `before` to expose more of ripgrep's powerful features.
- **Improved Defaults**:
  - Renamed `path` parameter to `dir_path` for clarity.
  - Defaults to searching the current working directory (`.`) when `dir_path` is not provided, offering a more predictable and scoped search compared to the previous "all workspace directories" default.
- **File Support**: `dir_path` can now be a path to a single file, allowing for targeted searches within specific files.
- **Testing**: Comprehensive updates to `ripGrep.test.ts` cover all new parameters and verify the updated default behaviors. Snapshots in `prompts.test.ts` were updated to reflect the tool name change.

## Related Issues

N/A

## How to Validate

1. Run unit tests for RipGrep:
   ```bash
   npm run test packages/core/src/tools/ripGrep.test.ts
   ```
   Verify all 50 tests pass.
2. Run full preflight check:
   ```bash
   npm run preflight
   ```
   Verify all checks pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
