### PR TITLE
Fix detection of bun as package manager

### DIFF
--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -213,7 +213,7 @@ describe('getInstallationInfo', () => {
   });
 
   it('should detect global bun installation', () => {
-    const bunPath = `/Users/test/.bun/bin/gemini`;
+    const bunPath = `/Users/test/.bun/install/global/node_modules/@google/gemini-cli/dist/index.js`;
     process.argv[1] = bunPath;
     mockedRealPathSync.mockReturnValue(bunPath);
     mockedExecSync.mockImplementation(() => {

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -130,7 +130,7 @@ export function getInstallationInfo(
         updateMessage: 'Running via bunx, update not applicable.',
       };
     }
-    if (realPath.includes('/.bun/bin')) {
+    if (realPath.includes('/.bun/install/global')) {
       const updateCommand = 'bun add -g @google/gemini-cli@latest';
       return {
         packageManager: PackageManager.BUN,


### PR DESCRIPTION
## Summary

Bun was not properly being detected as the package manager due to the detection path being wrong. It was `.bun/bin` instead of `.bun/install/global`. This is because `bin/gemini` is actually a symlink to `install/global/...`. See https://bun.com/docs/guides/install/from-npm-install-to-bun-install#global-installs. 

Somehow even though an executable is located at `.bun/bin/gemini.exe` on Windows, not a symlink, the realpath also contains `.bun/install/global`. I'm not gonna question it.

Fixes #14298 

## How to Validate

- Install an old version with Bun: `bun install -g @google/gemini-cli@0.11.2`
- It tries to use npm to update.
- Install this version.
- It now detects bun as the package manager instead of npm.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
  - [x] Windows
  - [x] Linux
