### PR TITLE
Preserve tabs on paste

### DIFF
--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -9,9 +9,15 @@ import type {
   ToolCallConfirmationDetails,
   ToolEditConfirmationDetails,
 } from '@google/gemini-cli-core';
-import { escapeAnsiCtrlCodes } from './textUtils.js';
+import { escapeAnsiCtrlCodes, stripUnsafeCharacters } from './textUtils.js';
 
 describe('textUtils', () => {
+  describe('stripUnsafeCharacters', () => {
+    it('should not strip tab characters', () => {
+      const input = 'hello	world';
+      expect(stripUnsafeCharacters(input)).toBe('hello	world');
+    });
+  });
   describe('escapeAnsiCtrlCodes', () => {
     describe('escapeAnsiCtrlCodes string case study', () => {
       it('should replace ANSI escape codes with a visible representation', () => {

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -89,6 +89,7 @@ export function cpSlice(str: string, start: number, end?: number): string {
  * - All printable Unicode including emojis
  * - DEL (0x7F) - handled functionally by applyOperations, not a display issue
  * - CR/LF (0x0D/0x0A) - needed for line breaks
+ * - TAB (0x09) - preserve tabs
  */
 export function stripUnsafeCharacters(str: string): string {
   const strippedAnsi = stripAnsi(str);
@@ -99,8 +100,8 @@ export function stripUnsafeCharacters(str: string): string {
       const code = char.codePointAt(0);
       if (code === undefined) return false;
 
-      // Preserve CR/LF for line handling
-      if (code === 0x0a || code === 0x0d) return true;
+      // Preserve CR/LF/TAB for line handling
+      if (code === 0x0a || code === 0x0d || code === 0x09) return true;
 
       // Remove C0 control chars (except CR/LF) that can break display
       // Examples: BELL(0x07) makes noise, BS(0x08) moves cursor, VT(0x0B), FF(0x0C)


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
User reported tabs are not preserved when pasting text in the input prompt

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #10546 

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

Paste a string in the input prompt with a bunch of tabs. Here's a screenshot with how a random text with tabs looks like in the input prompt.

```
Column 1	Column 2	Column 3	Column 4
	This line starts with one tab.
		This line starts with two tabs.
			This line starts with three tabs.
				This line starts with four tabs.
Apple		Banana		Cherry		Date
```

<img width="1068" height="199" alt="image" src="https://github.com/user-attachments/assets/2700907a-012b-4c35-aae1-4c71828ecef4" />



## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [X] npm run
    - [ ] npx
    - [ ] Docker
