### PR TITLE
[feat]: Add `/extensions restart` command

### DIFF
--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -630,7 +630,7 @@ describe('extensionsCommand', () => {
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.INFO,
-          text: 'All extensions restarted successfully.',
+          text: '2 extensions restarted successfully.',
         }),
         expect.any(Number),
       );
@@ -703,7 +703,7 @@ describe('extensionsCommand', () => {
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.ERROR,
-          text: 'Failed to restart some extensions: Failed to restart',
+          text: 'Failed to restart some extensions:\n  ext1: Failed to restart',
         }),
         expect.any(Number),
       );

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { GeminiCLIExtension } from '@google/gemini-cli-core';
+import type {
+  ExtensionLoader,
+  GeminiCLIExtension,
+} from '@google/gemini-cli-core';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { MessageType } from '../types.js';
 import {
@@ -13,12 +16,21 @@ import {
   extensionsCommand,
 } from './extensionsCommand.js';
 import { type CommandContext, type SlashCommand } from './types.js';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockedFunction,
+} from 'vitest';
 import { type ExtensionUpdateAction } from '../state/extensions.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { SettingScope } from '../../config/settings.js';
 
 import open from 'open';
+
 vi.mock('open', () => ({
   default: vi.fn(),
 }));
@@ -570,6 +582,143 @@ describe('extensionsCommand', () => {
         'another-active-ext',
         SettingScope.Session,
       );
+    });
+  });
+
+  describe('restart', () => {
+    let restartAction: SlashCommand['action'];
+    let mockRestartExtension: MockedFunction<
+      typeof ExtensionLoader.prototype.restartExtension
+    >;
+
+    beforeEach(() => {
+      restartAction = extensionsCommand().subCommands?.find(
+        (c) => c.name === 'restart',
+      )?.action;
+      expect(restartAction).not.toBeNull();
+
+      mockRestartExtension = vi.fn();
+      mockContext.services.config!.getExtensionLoader = vi
+        .fn()
+        .mockImplementation(() => ({
+          getExtensions: mockGetExtensions,
+          restartExtension: mockRestartExtension,
+        }));
+      mockContext.invocation!.name = 'restart';
+    });
+
+    it('restarts all active extensions when --all is provided', async () => {
+      const mockExtensions = [
+        { name: 'ext1', isActive: true },
+        { name: 'ext2', isActive: true },
+        { name: 'ext3', isActive: false },
+      ] as GeminiCLIExtension[];
+      mockGetExtensions.mockReturnValue(mockExtensions);
+
+      await restartAction!(mockContext, '--all');
+
+      expect(mockRestartExtension).toHaveBeenCalledTimes(2);
+      expect(mockRestartExtension).toHaveBeenCalledWith(mockExtensions[0]);
+      expect(mockRestartExtension).toHaveBeenCalledWith(mockExtensions[1]);
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: 'Restarting 2 extensions...',
+        }),
+        expect.any(Number),
+      );
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: 'All extensions restarted successfully.',
+        }),
+        expect.any(Number),
+      );
+      expect(mockContext.ui.dispatchExtensionStateUpdate).toHaveBeenCalledWith({
+        type: 'RESTARTED',
+        payload: { name: 'ext1' },
+      });
+      expect(mockContext.ui.dispatchExtensionStateUpdate).toHaveBeenCalledWith({
+        type: 'RESTARTED',
+        payload: { name: 'ext2' },
+      });
+    });
+
+    it('restarts only specified active extensions', async () => {
+      const mockExtensions = [
+        { name: 'ext1', isActive: false },
+        { name: 'ext2', isActive: true },
+        { name: 'ext3', isActive: true },
+      ] as GeminiCLIExtension[];
+      mockGetExtensions.mockReturnValue(mockExtensions);
+
+      await restartAction!(mockContext, 'ext1 ext3');
+
+      expect(mockRestartExtension).toHaveBeenCalledTimes(1);
+      expect(mockRestartExtension).toHaveBeenCalledWith(mockExtensions[2]);
+      expect(mockContext.ui.dispatchExtensionStateUpdate).toHaveBeenCalledWith({
+        type: 'RESTARTED',
+        payload: { name: 'ext3' },
+      });
+    });
+
+    it('shows an error if no extension loader is available', async () => {
+      mockContext.services.config!.getExtensionLoader = vi.fn();
+
+      await restartAction!(mockContext, '--all');
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          text: "Extensions are not yet loaded, can't restart yet",
+        }),
+        expect.any(Number),
+      );
+      expect(mockRestartExtension).not.toHaveBeenCalled();
+    });
+
+    it('shows usage error for no arguments', async () => {
+      await restartAction!(mockContext, '');
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          text: 'Usage: /extensions restart <extension-names>|--all',
+        }),
+        expect.any(Number),
+      );
+      expect(mockRestartExtension).not.toHaveBeenCalled();
+    });
+
+    it('handles errors during extension restart', async () => {
+      const mockExtensions = [
+        { name: 'ext1', isActive: true },
+      ] as GeminiCLIExtension[];
+      mockGetExtensions.mockReturnValue(mockExtensions);
+      mockRestartExtension.mockRejectedValue(new Error('Failed to restart'));
+
+      await restartAction!(mockContext, '--all');
+
+      expect(mockRestartExtension).toHaveBeenCalledWith(mockExtensions[0]);
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          text: 'Failed to restart some extensions: Failed to restart',
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should suggest only enabled extension names for the restart command', async () => {
+      mockContext.invocation!.name = 'restart';
+      const mockExtensions = [
+        { name: 'ext1', isActive: true },
+        { name: 'ext2', isActive: false },
+      ] as GeminiCLIExtension[];
+      mockGetExtensions.mockReturnValue(mockExtensions);
+
+      const suggestions = completeExtensions(mockContext, 'ext');
+      expect(suggestions).toEqual(['ext1']);
     });
   });
 });

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -709,6 +709,43 @@ describe('extensionsCommand', () => {
       );
     });
 
+    it('shows a warning if an extension is not found', async () => {
+      const mockExtensions = [
+        { name: 'ext1', isActive: true },
+      ] as GeminiCLIExtension[];
+      mockGetExtensions.mockReturnValue(mockExtensions);
+
+      await restartAction!(mockContext, 'ext1 ext2');
+
+      expect(mockRestartExtension).toHaveBeenCalledTimes(1);
+      expect(mockRestartExtension).toHaveBeenCalledWith(mockExtensions[0]);
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.WARNING,
+          text: 'Extension(s) not found or not active: ext2',
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('does not restart any extensions if none are found', async () => {
+      const mockExtensions = [
+        { name: 'ext1', isActive: true },
+      ] as GeminiCLIExtension[];
+      mockGetExtensions.mockReturnValue(mockExtensions);
+
+      await restartAction!(mockContext, 'ext2 ext3');
+
+      expect(mockRestartExtension).not.toHaveBeenCalled();
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.WARNING,
+          text: 'Extension(s) not found or not active: ext2, ext3',
+        }),
+        expect.any(Number),
+      );
+    });
+
     it('should suggest only enabled extension names for the restart command', async () => {
       mockContext.invocation!.name = 'restart';
       const mockExtensions = [

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -7,7 +7,11 @@
 import { debugLogger, listExtensions } from '@google/gemini-cli-core';
 import type { ExtensionUpdateInfo } from '../../config/extension.js';
 import { getErrorMessage } from '../../utils/errors.js';
-import { MessageType, type HistoryItemExtensionsList } from '../types.js';
+import {
+  MessageType,
+  type HistoryItemExtensionsList,
+  type HistoryItemInfo,
+} from '../types.js';
 import {
   type CommandContext,
   type SlashCommand,
@@ -17,6 +21,7 @@ import open from 'open';
 import process from 'node:process';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { SettingScope } from '../../config/settings.js';
+import { theme } from '../semantic-colors.js';
 
 async function listAction(context: CommandContext) {
   const historyItem: HistoryItemExtensionsList = {
@@ -178,13 +183,12 @@ async function restartAction(
 
   const s = extensionsToRestart.length > 1 ? 's' : '';
 
-  context.ui.addItem(
-    {
-      type: MessageType.INFO,
-      text: `Restarting ${extensionsToRestart.length} extension${s}...`,
-    },
-    Date.now(),
-  );
+  const restartingMessage = {
+    type: MessageType.INFO,
+    text: `Restarting ${extensionsToRestart.length} extension${s}...`,
+    color: theme.text.primary,
+  };
+  context.ui.addItem(restartingMessage, Date.now());
 
   const results = await Promise.allSettled(
     extensionsToRestart.map(async (extension) => {
@@ -219,13 +223,13 @@ async function restartAction(
       Date.now(),
     );
   } else {
-    context.ui.addItem(
-      {
-        type: MessageType.INFO,
-        text: `${extensionsToRestart.length} extension${s} restarted successfully.`,
-      },
-      Date.now(),
-    );
+    const infoItem: HistoryItemInfo = {
+      type: MessageType.INFO,
+      text: `${extensionsToRestart.length} extension${s} restarted successfully.`,
+      icon: '  ',
+      color: theme.text.primary,
+    };
+    context.ui.addItem(infoItem, Date.now());
   }
 }
 

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -153,6 +153,27 @@ async function restartAction(
     extensionsToRestart = extensionsToRestart.filter((extension) =>
       names.includes(extension.name),
     );
+    if (names.length !== extensionsToRestart.length) {
+      const notFound = names.filter(
+        (name) =>
+          !extensionsToRestart.some((extension) => extension.name === name),
+      );
+      if (notFound.length > 0) {
+        context.ui.addItem(
+          {
+            type: MessageType.WARNING,
+            text: `Extension(s) not found or not active: ${notFound.join(
+              ', ',
+            )}`,
+          },
+          Date.now(),
+        );
+      }
+    }
+  }
+  if (extensionsToRestart.length === 0) {
+    // We will have logged a different message above already.
+    return;
   }
 
   const s = extensionsToRestart.length > 1 ? 's' : '';

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -86,7 +86,11 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
         />
       )}
       {itemForDisplay.type === 'info' && (
-        <InfoMessage text={itemForDisplay.text} />
+        <InfoMessage
+          text={itemForDisplay.text}
+          icon={itemForDisplay.icon}
+          color={itemForDisplay.color}
+        />
       )}
       {itemForDisplay.type === 'warning' && (
         <WarningMessage text={itemForDisplay.text} />

--- a/packages/cli/src/ui/components/messages/InfoMessage.tsx
+++ b/packages/cli/src/ui/components/messages/InfoMessage.tsx
@@ -11,21 +11,28 @@ import { RenderInline } from '../../utils/InlineMarkdownRenderer.js';
 
 interface InfoMessageProps {
   text: string;
+  icon?: string;
+  color?: string;
 }
 
-export const InfoMessage: React.FC<InfoMessageProps> = ({ text }) => {
-  const prefix = 'ℹ ';
+export const InfoMessage: React.FC<InfoMessageProps> = ({
+  text,
+  icon,
+  color,
+}) => {
+  color ??= theme.status.warning;
+  const prefix = icon ?? 'ℹ ';
   const prefixWidth = prefix.length;
 
   return (
     <Box flexDirection="row" marginTop={1}>
       <Box width={prefixWidth}>
-        <Text color={theme.status.warning}>{prefix}</Text>
+        <Text color={color}>{prefix}</Text>
       </Box>
       <Box flexGrow={1} flexDirection="column">
         {text.split('\n').map((line, index) => (
           <Text wrap="wrap" key={index}>
-            <RenderInline text={line} defaultColor={theme.status.warning} />
+            <RenderInline text={line} defaultColor={color} />
           </Text>
         ))}
       </Box>

--- a/packages/cli/src/ui/state/extensions.test.ts
+++ b/packages/cli/src/ui/state/extensions.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  extensionUpdatesReducer,
+  type ExtensionUpdatesState,
+  ExtensionUpdateState,
+} from './extensions.js';
+
+describe('extensionUpdatesReducer', () => {
+  it('should handle RESTARTED action', () => {
+    const initialState: ExtensionUpdatesState = {
+      extensionStatuses: new Map([
+        [
+          'ext1',
+          {
+            status: ExtensionUpdateState.UPDATED_NEEDS_RESTART,
+            lastUpdateTime: 0,
+            lastUpdateCheck: 0,
+            notified: true,
+          },
+        ],
+      ]),
+      batchChecksInProgress: 0,
+      scheduledUpdate: null,
+    };
+
+    const action = {
+      type: 'RESTARTED' as const,
+      payload: { name: 'ext1' },
+    };
+
+    const newState = extensionUpdatesReducer(initialState, action);
+
+    const expectedStatus = {
+      status: ExtensionUpdateState.UPDATED,
+      lastUpdateTime: 0,
+      lastUpdateCheck: 0,
+      notified: true,
+    };
+
+    expect(newState.extensionStatuses.get('ext1')).toEqual(expectedStatus);
+  });
+
+  it('should not change state for RESTARTED action if status is not UPDATED_NEEDS_RESTART', () => {
+    const initialState: ExtensionUpdatesState = {
+      extensionStatuses: new Map([
+        [
+          'ext1',
+          {
+            status: ExtensionUpdateState.UPDATED,
+            lastUpdateTime: 0,
+            lastUpdateCheck: 0,
+            notified: true,
+          },
+        ],
+      ]),
+      batchChecksInProgress: 0,
+      scheduledUpdate: null,
+    };
+
+    const action = {
+      type: 'RESTARTED' as const,
+      payload: { name: 'ext1' },
+    };
+
+    const newState = extensionUpdatesReducer(initialState, action);
+
+    expect(newState).toEqual(initialState);
+  });
+});

--- a/packages/cli/src/ui/state/extensions.ts
+++ b/packages/cli/src/ui/state/extensions.ts
@@ -63,7 +63,8 @@ export type ExtensionUpdateAction =
   | { type: 'BATCH_CHECK_START' }
   | { type: 'BATCH_CHECK_END' }
   | { type: 'SCHEDULE_UPDATE'; payload: ScheduleUpdateArgs }
-  | { type: 'CLEAR_SCHEDULED_UPDATE' };
+  | { type: 'CLEAR_SCHEDULED_UPDATE' }
+  | { type: 'RESTARTED'; payload: { name: string } };
 
 export function extensionUpdatesReducer(
   state: ExtensionUpdatesState,
@@ -125,6 +126,20 @@ export function extensionUpdatesReducer(
         ...state,
         scheduledUpdate: null,
       };
+    case 'RESTARTED': {
+      const existing = state.extensionStatuses.get(action.payload.name);
+      if (existing?.status !== ExtensionUpdateState.UPDATED_NEEDS_RESTART) {
+        return state;
+      }
+
+      const newStatuses = new Map(state.extensionStatuses);
+      newStatuses.set(action.payload.name, {
+        ...existing,
+        status: ExtensionUpdateState.UPDATED,
+      });
+
+      return { ...state, extensionStatuses: newStatuses };
+    }
     default:
       checkExhaustive(action);
   }

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -103,6 +103,8 @@ export type HistoryItemGeminiContent = HistoryItemBase & {
 export type HistoryItemInfo = HistoryItemBase & {
   type: 'info';
   text: string;
+  icon?: string;
+  color?: string;
 };
 
 export type HistoryItemError = HistoryItemBase & {

--- a/packages/core/src/utils/extensionLoader.test.ts
+++ b/packages/core/src/utils/extensionLoader.test.ts
@@ -169,4 +169,27 @@ describe('SimpleExtensionLoader', () => {
       },
     );
   });
+
+  describe('restartExtension', () => {
+    it('should stop and then start the extension', async () => {
+      const loader = new TestingSimpleExtensionLoader([activeExtension]);
+      vi.spyOn(loader, 'stopExtension');
+      vi.spyOn(loader, 'startExtension');
+      await loader.start(mockConfig);
+      await loader.restartExtension(activeExtension);
+      expect(loader.stopExtension).toHaveBeenCalledWith(activeExtension);
+      expect(loader.startExtension).toHaveBeenCalledWith(activeExtension);
+    });
+  });
 });
+
+// Adding these overrides allows us to access the protected members.
+class TestingSimpleExtensionLoader extends SimpleExtensionLoader {
+  override async startExtension(extension: GeminiCLIExtension): Promise<void> {
+    await super.startExtension(extension);
+  }
+
+  override async stopExtension(extension: GeminiCLIExtension): Promise<void> {
+    await super.stopExtension(extension);
+  }
+}

--- a/packages/core/src/utils/extensionLoader.ts
+++ b/packages/core/src/utils/extensionLoader.ts
@@ -200,6 +200,11 @@ export abstract class ExtensionLoader {
     }
     return;
   }
+
+  async restartExtension(extension: GeminiCLIExtension): Promise<void> {
+    await this.stopExtension(extension);
+    await this.startExtension(extension);
+  }
 }
 
 export interface ExtensionEvents {


### PR DESCRIPTION
## Summary

Now that we have all extension reloading features working, this adds an `/extensions restart` command to explicitly restart extensions.

This command exists currently without opting into the extension reloading experiment - so that experiment just makes it _automatic_, but there is a way to restart extensions generally without opting in to anything.

## Details

Also adds an event for the extensions update state reducer to update the "(updated, needs restart)" message for extensions after they have been updated.

## Related Issues

Related to https://github.com/google-gemini/gemini-cli/issues/11108

## How to Validate

Update an extension and then restart it - you should see all the new features and also if you do `/extensions list` you should see its updated state is now green.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
