### PR TITLE
Enforce PowerShell constrained language mode

### DIFF
--- a/packages/core/src/utils/secure-browser-launcher.test.ts
+++ b/packages/core/src/utils/secure-browser-launcher.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { openBrowserSecurely } from './secure-browser-launcher.js';
+import { POWERSHELL_CONSTRAINED_LANGUAGE_ENV } from './shell-utils.js';
 
 // Create mock function using vi.hoisted
 const mockExecFile = vi.hoisted(() => vi.fn());
@@ -23,6 +24,7 @@ describe('secure-browser-launcher', () => {
     vi.clearAllMocks();
     mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
     originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    delete process.env[POWERSHELL_CONSTRAINED_LANGUAGE_ENV];
   });
 
   afterEach(() => {
@@ -112,7 +114,11 @@ describe('secure-browser-launcher', () => {
           '-Command',
           `Start-Process '${maliciousUrl.replace(/'/g, "''")}'`,
         ],
-        expect.any(Object),
+        expect.objectContaining({
+          env: expect.objectContaining({
+            __PSLockdownPolicy: '4',
+          }),
+        }),
       );
     });
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -39,6 +39,23 @@ export interface ShellConfiguration {
   shell: ShellType;
 }
 
+export const POWERSHELL_CONSTRAINED_LANGUAGE_ENV = '__PSLockdownPolicy';
+export const POWERSHELL_CONSTRAINED_LANGUAGE_VALUE = '4';
+
+/**
+ * Ensures any PowerShell process spawned with this env runs in Constrained Language Mode
+ * by forcing the lockdown policy value prior to launch.
+ */
+export function ensureConstrainedLanguageEnv(
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    [POWERSHELL_CONSTRAINED_LANGUAGE_ENV]:
+      POWERSHELL_CONSTRAINED_LANGUAGE_VALUE,
+  };
+}
+
 let bashLanguage: Language | null = null;
 let treeSitterInitialization: Promise<void> | null = null;
 let treeSitterInitializationError: Error | null = null;


### PR DESCRIPTION
## Summary
- force __PSLockdownPolicy=4 for every CLI powerShell invocation via a shared helper
- apply the constrained env to both shell execution paths and the secure browser launcher
- expand tests to cover the new env behavior and keep builds green

## Testing
- npm run build
- npx vitest run packages/core/src/services/shellExecutionService.test.ts packages/core/src/utils/secure-browser-launcher.test.ts