### PR TITLE
fix: google auth provider reads headers from settings and quota from ADC

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,3 +18,4 @@ eslint.config.js
 gha-creds-*.json
 junit.xml
 Thumbs.db
+.pytest_cache

--- a/packages/core/src/mcp/google-auth-provider.test.ts
+++ b/packages/core/src/mcp/google-auth-provider.test.ts
@@ -86,6 +86,7 @@ describe('GoogleCredentialProvider', () => {
     let mockClient: {
       getAccessToken: Mock;
       credentials?: { expiry_date: number | null };
+      quotaProjectId?: string;
     };
 
     beforeEach(() => {
@@ -152,6 +153,12 @@ describe('GoogleCredentialProvider', () => {
       expect(mockGetAccessToken).toHaveBeenCalledTimes(2); // new fetch
 
       vi.useRealTimers();
+    });
+
+    it('should return the quota project ID', async () => {
+      mockClient.quotaProjectId = 'test-quota-project';
+      const quotaProjectId = await provider.getQuotaProjectId();
+      expect(quotaProjectId).toBe('test-quota-project');
     });
   });
 });

--- a/packages/core/src/mcp/google-auth-provider.ts
+++ b/packages/core/src/mcp/google-auth-provider.ts
@@ -123,4 +123,24 @@ export class GoogleCredentialProvider implements OAuthClientProvider {
     // No-op
     return '';
   }
+
+  /**
+   * Returns the project ID used for quota.
+   */
+  async getQuotaProjectId(): Promise<string | undefined> {
+    const client = await this.auth.getClient();
+    return client.quotaProjectId;
+  }
+
+  /**
+   * Returns custom headers to be added to the request.
+   */
+  async getRequestHeaders(): Promise<Record<string, string>> {
+    const quotaProjectId = await this.getQuotaProjectId();
+    const headers: Record<string, string> = {};
+    if (quotaProjectId) {
+      headers['X-Goog-User-Project'] = quotaProjectId;
+    }
+    return headers;
+  }
 }

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -37,6 +37,19 @@ vi.mock('../mcp/oauth-provider.js');
 vi.mock('../mcp/oauth-token-storage.js');
 vi.mock('../mcp/oauth-utils.js');
 
+vi.mock('../mcp/google-auth-provider.js', () => {
+  const mockGetRequestHeaders = vi.fn().mockResolvedValue({});
+  const mockTokens = vi.fn().mockResolvedValue({ access_token: 'test-token' });
+
+  const MockGoogleCredentialProvider = vi.fn().mockImplementation(() => ({
+    getRequestHeaders: mockGetRequestHeaders,
+    tokens: mockTokens,
+  }));
+
+  return {
+    GoogleCredentialProvider: MockGoogleCredentialProvider,
+  };
+});
 vi.mock('../utils/events.js', () => ({
   coreEvents: {
     emitFeedback: vi.fn(),

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -400,12 +400,12 @@ async function handleAutomaticOAuth(
  */
 function createTransportRequestInit(
   mcpServerConfig: MCPServerConfig,
-  headers: Record<string, string>,
+  defaultHeaders: Record<string, string>,
 ): RequestInit {
   return {
     headers: {
+      ...defaultHeaders,
       ...mcpServerConfig.headers,
-      ...headers,
     },
   };
 }
@@ -1263,10 +1263,11 @@ export async function createTransport(
     mcpServerConfig.authProviderType === AuthProviderType.GOOGLE_CREDENTIALS
   ) {
     const provider = new GoogleCredentialProvider(mcpServerConfig);
+    const customHeaders = await provider.getRequestHeaders();
     const transportOptions:
       | StreamableHTTPClientTransportOptions
       | SSEClientTransportOptions = {
-      requestInit: createTransportRequestInit(mcpServerConfig, {}),
+      requestInit: createTransportRequestInit(mcpServerConfig, customHeaders),
       authProvider: provider,
     };
     if (mcpServerConfig.httpUrl) {


### PR DESCRIPTION
## Summary

For `google_credentials` auth provider type, auth library is used to perform ADC and obtains access token, but quota project is not obtained from the ADC file currently.
Introducing a way to read quota project from ADC and use it in the `x-goog-user-project` header if the header is already not set through `settings.json`.

## Details

For `google_credentials` auth provider type, auth library is used to perform ADC and obtains access token, but quota project is not obtained from the ADC file currently.
Introducing a way to read quota project from ADC and use it in the `x-goog-user-project` header if the header is already not set through `settings.json`.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

Run gcloud to get xapi.zoo scope

```
gcloud auth application-default login --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/xapi.zoo
```

Setup an MCP server that uses ADC auth:

```
"echo": {
"httpUrl": "https://test-echo-pa.sandbox.googleapis.com/mcp",
"timeout": 10000,
"authProviderType": "google_credentials",
"oauth": {
"scopes": [
"https://www.googleapis.com/auth/xapi.zoo"
]
},
"headers": {
"X-Goog-User-Project": "myproject", // Causes GCP to check activation, quota on myproject
}
}
},
```

Then ask gemini-cli to "Call echo"

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
