### PR TITLE
feat(config-xdg): enable XDG conventions

### DIFF
--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -6,7 +6,6 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { homedir } from 'node:os';
 import * as dotenv from 'dotenv';
 
 import type { TelemetryTarget } from '@google/gemini-cli-core';
@@ -17,9 +16,9 @@ import {
   FileDiscoveryService,
   ApprovalMode,
   loadServerHierarchicalMemory,
-  GEMINI_DIR,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_GEMINI_MODEL,
+  Storage,
   type ExtensionLoader,
 } from '@google/gemini-cli-core';
 
@@ -156,7 +155,7 @@ function findEnvFile(startDir: string): string | null {
   let currentDir = path.resolve(startDir);
   while (true) {
     // prefer gemini-specific .env under GEMINI_DIR
-    const geminiEnvPath = path.join(currentDir, GEMINI_DIR, '.env');
+    const geminiEnvPath = path.join(currentDir, '.env');
     if (fs.existsSync(geminiEnvPath)) {
       return geminiEnvPath;
     }
@@ -167,11 +166,11 @@ function findEnvFile(startDir: string): string | null {
     const parentDir = path.dirname(currentDir);
     if (parentDir === currentDir || !parentDir) {
       // check .env under home as fallback, again preferring gemini-specific .env
-      const homeGeminiEnvPath = path.join(process.cwd(), GEMINI_DIR, '.env');
+      const homeGeminiEnvPath = path.join(Storage.getConfigDir(), '.env');
       if (fs.existsSync(homeGeminiEnvPath)) {
         return homeGeminiEnvPath;
       }
-      const homeEnvPath = path.join(homedir(), '.env');
+      const homeEnvPath = path.join(Storage.getConfigDir(), '.env');
       if (fs.existsSync(homeEnvPath)) {
         return homeEnvPath;
       }

--- a/packages/a2a-server/src/config/extension.ts
+++ b/packages/a2a-server/src/config/extension.ts
@@ -7,17 +7,16 @@
 // Copied exactly from packages/cli/src/config/extension.ts, last PR #1026
 
 import {
-  GEMINI_DIR,
+  Storage,
   type MCPServerConfig,
   type ExtensionInstallMetadata,
   type GeminiCLIExtension,
 } from '@google/gemini-cli-core';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as os from 'node:os';
 import { logger } from '../utils/logger.js';
 
-export const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
+export const EXTENSIONS_DIRECTORY_NAME = 'extensions';
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
 export const INSTALL_METADATA_FILENAME = '.gemini-extension-install.json';
 
@@ -39,7 +38,7 @@ interface ExtensionConfig {
 export function loadExtensions(workspaceDir: string): GeminiCLIExtension[] {
   const allExtensions = [
     ...loadExtensionsFromDir(workspaceDir),
-    ...loadExtensionsFromDir(os.homedir()),
+    ...loadExtensionsFromDir(Storage.getConfigDir()),
   ];
 
   const uniqueExtensions: GeminiCLIExtension[] = [];

--- a/packages/cli/src/config/extensions/storage.ts
+++ b/packages/cli/src/config/extensions/storage.ts
@@ -36,7 +36,7 @@ export class ExtensionStorage {
   }
 
   static getUserExtensionsDir(): string {
-    return new Storage(os.homedir()).getExtensionsDir();
+    return path.join(Storage.getConfigDir(), 'extensions');
   }
 
   static async createTmpDir(): Promise<string> {

--- a/packages/cli/src/config/extensions/variables.ts
+++ b/packages/cli/src/config/extensions/variables.ts
@@ -4,11 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as path from 'node:path';
 import { type VariableSchema, VARIABLE_SCHEMA } from './variableSchema.js';
-import { GEMINI_DIR } from '@google/gemini-cli-core';
 
-export const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
+export const EXTENSIONS_DIRECTORY_NAME = 'extensions';
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
 export const INSTALL_METADATA_FILENAME = '.gemini-extension-install.json';
 export const EXTENSION_SETTINGS_FILENAME = '.env';

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -505,9 +505,9 @@ function findEnvFile(startDir: string): string | null {
     const parentDir = path.dirname(currentDir);
     if (parentDir === currentDir || !parentDir) {
       // check .env under home as fallback, again preferring gemini-specific .env
-      const homeGeminiEnvPath = path.join(homedir(), GEMINI_DIR, '.env');
-      if (fs.existsSync(homeGeminiEnvPath)) {
-        return homeGeminiEnvPath;
+      const userGeminiEnvPath = path.join(Storage.getConfigDir(), '.env');
+      if (fs.existsSync(userGeminiEnvPath)) {
+        return userGeminiEnvPath;
       }
       const homeEnvPath = path.join(homedir(), '.env');
       if (fs.existsSync(homeEnvPath)) {

--- a/packages/cli/src/config/trustedFolders.ts
+++ b/packages/cli/src/config/trustedFolders.ts
@@ -6,28 +6,23 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { homedir } from 'node:os';
 import {
   FatalConfigError,
   getErrorMessage,
   isWithinRoot,
   ideContextStore,
-  GEMINI_DIR,
+  Storage,
 } from '@google/gemini-cli-core';
 import type { Settings } from './settings.js';
 import stripJsonComments from 'strip-json-comments';
 
 export const TRUSTED_FOLDERS_FILENAME = 'trustedFolders.json';
 
-export function getUserSettingsDir(): string {
-  return path.join(homedir(), GEMINI_DIR);
-}
-
 export function getTrustedFoldersPath(): string {
   if (process.env['GEMINI_CLI_TRUSTED_FOLDERS_PATH']) {
     return process.env['GEMINI_CLI_TRUSTED_FOLDERS_PATH'];
   }
-  return path.join(getUserSettingsDir(), TRUSTED_FOLDERS_FILENAME);
+  return path.join(Storage.getConfigDir(), TRUSTED_FOLDERS_FILENAME);
 }
 
 export enum TrustLevel {

--- a/packages/cli/src/ui/components/Notifications.tsx
+++ b/packages/cli/src/ui/components/Notifications.tsx
@@ -12,13 +12,12 @@ import { theme } from '../semantic-colors.js';
 import { StreamingState } from '../types.js';
 import { UpdateNotification } from './UpdateNotification.js';
 
-import { GEMINI_DIR, Storage } from '@google/gemini-cli-core';
+import { Storage } from '@google/gemini-cli-core';
 
 import * as fs from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
 
-const settingsPath = path.join(os.homedir(), GEMINI_DIR, 'settings.json');
+const settingsPath = path.join(Storage.getConfigDir(), 'settings.json');
 
 const screenReaderNudgeFilePath = path.join(
   Storage.getGlobalTempDir(),

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.test.tsx
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.test.tsx
@@ -10,7 +10,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { createExtension } from '../../test-utils/createExtension.js';
 import { useExtensionUpdates } from './useExtensionUpdates.js';
-import { GEMINI_DIR } from '@google/gemini-cli-core';
+import { Storage } from '@google/gemini-cli-core';
 import { render } from '../../test-utils/render.js';
 import { waitFor } from '../../test-utils/async.js';
 import { MessageType } from '../types.js';
@@ -21,6 +21,17 @@ import {
 import { ExtensionUpdateState } from '../state/extensions.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { loadSettings } from '../../config/settings.js';
+
+beforeEach(() => {
+  vi.stubEnv('XDG_CONFIG_HOME', '');
+  vi.stubEnv('XDG_CACHE_HOME', '');
+  vi.stubEnv('XDG_DATA_HOME', '');
+  vi.stubEnv('XDG_STATE_HOME', '');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 vi.mock('os', async (importOriginal) => {
   const mockedOs = await importOriginal<typeof os>();
@@ -50,7 +61,7 @@ describe('useExtensionUpdates', () => {
       path.join(tempHomeDir, 'gemini-cli-test-workspace-'),
     );
     vi.spyOn(process, 'cwd').mockReturnValue(tempWorkspaceDir);
-    userExtensionsDir = path.join(tempHomeDir, GEMINI_DIR, 'extensions');
+    userExtensionsDir = path.join(Storage.getConfigDir(), 'extensions');
     fs.mkdirSync(userExtensionsDir, { recursive: true });
     vi.mocked(checkForAllExtensionUpdates).mockReset();
     vi.mocked(updateExtension).mockReset();

--- a/packages/cli/src/utils/persistentState.test.ts
+++ b/packages/cli/src/utils/persistentState.test.ts
@@ -13,7 +13,7 @@ import { PersistentState } from './persistentState.js';
 vi.mock('node:fs');
 vi.mock('@google/gemini-cli-core', () => ({
   Storage: {
-    getGlobalGeminiDir: vi.fn(),
+    getStateDir: vi.fn(),
   },
   debugLogger: {
     warn: vi.fn(),
@@ -27,7 +27,7 @@ describe('PersistentState', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.mocked(Storage.getGlobalGeminiDir).mockReturnValue(mockDir);
+    vi.mocked(Storage.getStateDir).mockReturnValue(mockDir);
     persistentState = new PersistentState();
   });
 

--- a/packages/cli/src/utils/persistentState.ts
+++ b/packages/cli/src/utils/persistentState.ts
@@ -21,7 +21,7 @@ export class PersistentState {
 
   private getPath(): string {
     if (!this.filePath) {
-      this.filePath = path.join(Storage.getGlobalGeminiDir(), STATE_FILENAME);
+      this.filePath = path.join(Storage.getStateDir(), STATE_FILENAME);
     }
     return this.filePath;
   }

--- a/packages/core/src/code_assist/oauth-credential-storage.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.ts
@@ -9,9 +9,8 @@ import { HybridTokenStorage } from '../mcp/token-storage/hybrid-token-storage.js
 import { OAUTH_FILE } from '../config/storage.js';
 import type { OAuthCredentials } from '../mcp/token-storage/types.js';
 import * as path from 'node:path';
-import * as os from 'node:os';
 import { promises as fs } from 'node:fs';
-import { GEMINI_DIR } from '../utils/paths.js';
+import { Storage } from '../config/storage.js';
 import { coreEvents } from '../utils/events.js';
 
 const KEYCHAIN_SERVICE_NAME = 'gemini-cli-oauth';
@@ -91,7 +90,7 @@ export class OAuthCredentialStorage {
       await this.storage.deleteCredentials(MAIN_ACCOUNT_KEY);
 
       // Also try to remove the old file if it exists
-      const oldFilePath = path.join(os.homedir(), GEMINI_DIR, OAUTH_FILE);
+      const oldFilePath = Storage.getOAuthCredsPath();
       await fs.rm(oldFilePath, { force: true }).catch(() => {});
     } catch (error: unknown) {
       coreEvents.emitFeedback(
@@ -107,7 +106,7 @@ export class OAuthCredentialStorage {
    * Migrate credentials from old file-based storage to keychain
    */
   private static async migrateFromFileStorage(): Promise<Credentials | null> {
-    const oldFilePath = path.join(os.homedir(), GEMINI_DIR, OAUTH_FILE);
+    const oldFilePath = path.join(Storage.getOAuthCredsPath(), OAUTH_FILE);
 
     let credsJson: string;
     try {

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -86,6 +86,7 @@ describe('oauth2', () => {
         path.join(os.tmpdir(), 'gemini-cli-test-home-'),
       );
       vi.mocked(os.homedir).mockReturnValue(tempHomeDir);
+      fs.mkdirSync(path.join(tempHomeDir, GEMINI_DIR), { recursive: true });
     });
     afterEach(() => {
       fs.rmSync(tempHomeDir, { recursive: true, force: true });

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -4,29 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import * as os from 'node:os';
+import { describe, it, expect } from 'vitest';
 import * as path from 'node:path';
 
-vi.mock('fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('fs')>();
-  return {
-    ...actual,
-    mkdirSync: vi.fn(),
-  };
-});
-
+import * as os from 'node:os';
 import { Storage } from './storage.js';
 import { GEMINI_DIR } from '../utils/paths.js';
 
-describe('Storage – getGlobalSettingsPath', () => {
-  it('returns path to ~/.gemini/settings.json', () => {
-    const expected = path.join(os.homedir(), GEMINI_DIR, 'settings.json');
+const homedir = os.homedir();
+const MOCK_GLOBAL_GEMINI_DIR = path.join(homedir, GEMINI_DIR);
+
+describe('Storage – getGlobalSettingsPath no XDG', () => {
+  it('returns path in homedir', () => {
+    const expected = MOCK_GLOBAL_GEMINI_DIR;
+    expect(Storage.getCacheDir()).toBe(expected);
+    expect(Storage.getConfigDir()).toBe(expected);
+    expect(Storage.getDataDir()).toBe(expected);
+    expect(Storage.getStateDir()).toBe(expected);
+  });
+
+  it('returns path to $HOME/gemini/settings.json', () => {
+    const expected = path.join(MOCK_GLOBAL_GEMINI_DIR, 'settings.json');
     expect(Storage.getGlobalSettingsPath()).toBe(expected);
   });
 });
 
-describe('Storage – additional helpers', () => {
+describe('Storage – additional helpers, no xdg env var', () => {
   const projectRoot = '/tmp/project';
   const storage = new Storage(projectRoot);
 
@@ -36,7 +39,7 @@ describe('Storage – additional helpers', () => {
   });
 
   it('getUserCommandsDir returns ~/.gemini/commands', () => {
-    const expected = path.join(os.homedir(), GEMINI_DIR, 'commands');
+    const expected = path.join(MOCK_GLOBAL_GEMINI_DIR, 'commands');
     expect(Storage.getUserCommandsDir()).toBe(expected);
   });
 
@@ -46,16 +49,12 @@ describe('Storage – additional helpers', () => {
   });
 
   it('getMcpOAuthTokensPath returns ~/.gemini/mcp-oauth-tokens.json', () => {
-    const expected = path.join(
-      os.homedir(),
-      GEMINI_DIR,
-      'mcp-oauth-tokens.json',
-    );
+    const expected = path.join(MOCK_GLOBAL_GEMINI_DIR, 'mcp-oauth-tokens.json');
     expect(Storage.getMcpOAuthTokensPath()).toBe(expected);
   });
 
-  it('getGlobalBinDir returns ~/.gemini/tmp/bin', () => {
-    const expected = path.join(os.homedir(), GEMINI_DIR, 'tmp', 'bin');
+  it('getGlobalBinDir returns ~/.gemini/bin', () => {
+    const expected = path.join(MOCK_GLOBAL_GEMINI_DIR, 'bin');
     expect(Storage.getGlobalBinDir()).toBe(expected);
   });
 });

--- a/packages/core/src/core/logger.test.ts
+++ b/packages/core/src/core/logger.test.ts
@@ -45,6 +45,17 @@ const TEST_CHECKPOINT_FILE_PATH = path.join(
   CHECKPOINT_FILE_NAME,
 );
 
+beforeEach(() => {
+  vi.stubEnv('XDG_CONFIG_HOME', '');
+  vi.stubEnv('XDG_CACHE_HOME', '');
+  vi.stubEnv('XDG_DATA_HOME', '');
+  vi.stubEnv('XDG_STATE_HOME', '');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 async function cleanupLogAndCheckpointFiles() {
   try {
     await fs.rm(TEST_GEMINI_DIR, { recursive: true, force: true });

--- a/packages/core/src/hooks/hookRegistry.test.ts
+++ b/packages/core/src/hooks/hookRegistry.test.ts
@@ -43,7 +43,7 @@ describe('HookRegistry', () => {
     vi.resetAllMocks();
 
     mockStorage = {
-      getGeminiDir: vi.fn().mockReturnValue('/project/.gemini'),
+      getWorkspaceGeminiDir: vi.fn().mockReturnValue('/project/.gemini'),
     } as unknown as Storage;
 
     mockConfig = {

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -35,8 +35,23 @@ vi.mock('node:child_process', async (importOriginal) => {
 vi.mock('../utils/textUtils.js', () => ({
   isBinary: mockIsBinary,
 }));
-vi.mock('os', () => ({
-  default: {
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return {
+    ...actual,
+    default: {
+      platform: mockPlatform,
+      homedir: () => '/home/user',
+      tmpdir: () => '/tmp',
+      constants: {
+        signals: {
+          SIGTERM: 15,
+          SIGKILL: 9,
+        },
+      },
+    },
+    homedir: () => '/home/user',
+    tmpdir: () => '/tmp',
     platform: mockPlatform,
     constants: {
       signals: {
@@ -44,15 +59,8 @@ vi.mock('os', () => ({
         SIGKILL: 9,
       },
     },
-  },
-  platform: mockPlatform,
-  constants: {
-    signals: {
-      SIGTERM: 15,
-      SIGKILL: 9,
-    },
-  },
-}));
+  };
+});
 vi.mock('../utils/getPty.js', () => ({
   getPty: mockGetPty,
 }));

--- a/packages/core/src/tools/__snapshots__/shell.test.ts.snap
+++ b/packages/core/src/tools/__snapshots__/shell.test.ts.snap
@@ -1,5 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ShellTool > getDescription > should return the linux description when on linux 1`] = `
+"This tool executes a given shell command as \`bash -c <command>\`. Command can start background processes using \`&\`. Command is executed as a subprocess that leads its own process group. Command process group can be terminated as \`kill -- -PGID\` or signaled as \`kill -s SIGNAL -- -PGID\`.
+
+      The following information is returned:
+
+      Command: Executed command.
+      Directory: Directory where command was executed, or \`(root)\`.
+      Stdout: Output on stdout stream. Can be \`(empty)\` or partial on error and for any unwaited background processes.
+      Stderr: Output on stderr stream. Can be \`(empty)\` or partial on error and for any unwaited background processes.
+      Error: Error or \`(none)\` if no error was reported for the subprocess.
+      Exit Code: Exit code or \`(none)\` if terminated by signal.
+      Signal: Signal number or \`(none)\` if no signal was received.
+      Background PIDs: List of background processes started or \`(none)\`.
+      Process Group PGID: Process group started or \`(none)\`"
+`;
+
 exports[`ShellTool > getDescription > should return the non-windows description when not on windows 1`] = `
 "This tool executes a given shell command as \`bash -c <command>\`. Command can start background processes using \`&\`. Command is executed as a subprocess that leads its own process group. Command process group can be terminated as \`kill -- -PGID\` or signaled as \`kill -s SIGNAL -- -PGID\`.
 

--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -99,7 +99,7 @@ interface SaveMemoryParams {
 }
 
 export function getGlobalMemoryFilePath(): string {
-  return path.join(Storage.getGlobalGeminiDir(), getCurrentGeminiMdFilename());
+  return path.join(Storage.getDataDir(), getCurrentGeminiMdFilename());
 }
 
 /**
@@ -237,7 +237,7 @@ class MemoryToolInvocation extends BaseToolInvocation<
     try {
       if (modified_by_user && modified_content !== undefined) {
         // User modified the content in external editor, write it directly
-        await fs.mkdir(path.dirname(getGlobalMemoryFilePath()), {
+        await fs.mkdir(path.dirname(Storage.getGlobalMemoryDir()), {
           recursive: true,
         });
         await fs.writeFile(

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -13,6 +13,7 @@ import { getAllGeminiMdFilenames } from '../tools/memoryTool.js';
 import type { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { processImports } from './memoryImportProcessor.js';
 import type { FileFilteringOptions } from '../config/constants.js';
+import { Storage } from '../config/storage.js';
 import { DEFAULT_MEMORY_FILE_FILTERING_OPTIONS } from '../config/constants.js';
 import { GEMINI_DIR } from './paths.js';
 import type { ExtensionLoader } from './extensionLoader.js';
@@ -380,7 +381,7 @@ async function findUpwardGeminiFiles(
   let currentDir = path.resolve(startDir);
   const resolvedStopDir = path.resolve(stopDir);
   const geminiMdFilenames = getAllGeminiMdFilenames();
-  const globalGeminiDir = path.join(homedir(), GEMINI_DIR);
+  const globalGeminiStateDir = path.join(Storage.getStateDir());
 
   if (debugMode) {
     logger.debug(
@@ -389,7 +390,7 @@ async function findUpwardGeminiFiles(
   }
 
   while (true) {
-    if (currentDir === globalGeminiDir) {
+    if (currentDir === globalGeminiStateDir) {
       break;
     }
 

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -8,7 +8,8 @@ import path from 'node:path';
 import os from 'node:os';
 import * as crypto from 'node:crypto';
 
-export const GEMINI_DIR = '.gemini';
+export const APP_NAME = 'gemini';
+export const GEMINI_DIR = `.${APP_NAME}`;
 export const GOOGLE_ACCOUNTS_FILENAME = 'google_accounts.json';
 
 /**

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -27,14 +27,17 @@ import type { Config } from '../config/config.js';
 import type { AnyToolInvocation } from '../index.js';
 
 const mockPlatform = vi.hoisted(() => vi.fn());
-const mockHomedir = vi.hoisted(() => vi.fn());
+const mockHomedir = vi.hoisted(() => vi.fn(() => '/home/user'));
+const mockTmpdir = vi.hoisted(() => vi.fn(() => '/tmp'));
 vi.mock('os', () => ({
   default: {
     platform: mockPlatform,
     homedir: mockHomedir,
+    tmpdir: mockTmpdir,
   },
   platform: mockPlatform,
   homedir: mockHomedir,
+  tmpdir: mockTmpdir,
 }));
 
 const mockQuote = vi.hoisted(() => vi.fn());

--- a/scripts/sandbox_command.js
+++ b/scripts/sandbox_command.js
@@ -25,7 +25,7 @@ import os from 'node:os';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import dotenv from 'dotenv';
-import { GEMINI_DIR } from '@google/gemini-cli-core';
+import { GEMINI_DIR, Storage } from '@google/gemini-cli-core';
 
 const argv = yargs(hideBin(process.argv)).option('q', {
   alias: 'quiet',
@@ -36,7 +36,7 @@ const argv = yargs(hideBin(process.argv)).option('q', {
 let geminiSandbox = process.env.GEMINI_SANDBOX;
 
 if (!geminiSandbox) {
-  const userSettingsFile = join(os.homedir(), GEMINI_DIR, 'settings.json');
+  const userSettingsFile = join(Storage.getConfigDir(), 'settings.json');
   if (existsSync(userSettingsFile)) {
     const settings = JSON.parse(
       stripJsonComments(readFileSync(userSettingsFile, 'utf-8')),

--- a/scripts/telemetry.js
+++ b/scripts/telemetry.js
@@ -9,15 +9,11 @@
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { existsSync, readFileSync } from 'node:fs';
-import { GEMINI_DIR } from '@google/gemini-cli-core';
+import { GEMINI_DIR, Storage } from '@google/gemini-cli-core';
 
 const projectRoot = join(import.meta.dirname, '..');
 
-const USER_SETTINGS_DIR = join(
-  process.env.HOME || process.env.USERPROFILE || process.env.HOMEPATH || '',
-  GEMINI_DIR,
-);
-const USER_SETTINGS_PATH = join(USER_SETTINGS_DIR, 'settings.json');
+const USER_SETTINGS_PATH = join(Storage.getConfigDir(), 'settings.json');
 const WORKSPACE_SETTINGS_PATH = join(projectRoot, GEMINI_DIR, 'settings.json');
 
 let settingsTarget = undefined;

--- a/scripts/telemetry_utils.js
+++ b/scripts/telemetry_utils.js
@@ -13,7 +13,7 @@ import os from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import crypto from 'node:crypto';
-import { GEMINI_DIR } from '@google/gemini-cli-core';
+import { GEMINI_DIR, Storage } from '@google/gemini-cli-core';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -25,12 +25,17 @@ const projectHash = crypto
   .digest('hex');
 
 // User-level .gemini directory in home
-const USER_GEMINI_DIR = path.join(os.homedir(), GEMINI_DIR);
+const USER_GEMINI_STATE_DIR = Storage.getStateDir();
 // Project-level .gemini directory in the workspace
 const WORKSPACE_GEMINI_DIR = path.join(projectRoot, GEMINI_DIR);
 
 // Telemetry artifacts are stored in a hashed directory under the user's ~/.gemini/tmp
-export const OTEL_DIR = path.join(USER_GEMINI_DIR, 'tmp', projectHash, 'otel');
+export const OTEL_DIR = path.join(
+  USER_GEMINI_STATE_DIR,
+  'tmp',
+  projectHash,
+  'otel',
+);
 export const BIN_DIR = path.join(OTEL_DIR, 'bin');
 
 // Workspace settings remain in the project's .gemini directory


### PR DESCRIPTION
XDG configurations bring flexibility to files previously written only to `~/.gemini directory`.

## Summary

Following XDG conventions for the path to gemini's configuration makes it easy to use Gemini as a developer tool while developing gemini and enables a clean home directory for users who like that.

## Details

Preserved the existing behaviour while enabling compatibility with environment variables (eg. $XDG_CONFIG_HOME) on all platforms and if neither `~/.gemini/` exists nor the environment variables are set, Gemini will use the platform-specific location for cache/config/data/state files.

## Related Issues

closes #1825

## How to Validate

for config:
if `~/.gemini/` exists and $XDG_CONFIG_HOME is not set then use `~/.gemini/`.
if `~/.gemini/` does not exist and $XDG_CONFIG_HOME is set then use `$XDG_CONFIG_HOME/config/`
if `~/.gemini/` does not exist and $XDG_CONFIG_HOME is not set then use platform-specific location.


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ X] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ X] MacOS
    - [ X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
