### PR TITLE
Fix shift+return in vscode.

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -105,6 +105,21 @@ describe('KeypressContext', () => {
       );
     });
 
+    it('should handle backslash return', async () => {
+      const { keyHandler } = setupKeypressTest();
+
+      act(() => stdin.write('\\\r'));
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'return',
+          ctrl: false,
+          meta: false,
+          shift: true,
+        }),
+      );
+    });
+
     it.each([
       {
         modifier: 'Shift',

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -68,7 +68,7 @@ function bufferBackslashEnter(
 
       if (key == null) {
         continue;
-      } else if (key.name !== '\\') {
+      } else if (key.sequence !== '\\') {
         keypressHandler(key);
         continue;
       }
@@ -84,7 +84,7 @@ function bufferBackslashEnter(
         keypressHandler(key);
       } else if (nextKey.name === 'return') {
         keypressHandler({
-          ...key,
+          ...nextKey,
           shift: true,
           sequence: '\r', // Corrected escaping for newline
         });


### PR DESCRIPTION
## Summary

This was accidentally broken in #12746.

## Details

We were looking at the name instead of the sequence.

## How to Validate

try shift+return in vscode.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
