### PR TITLE
fix: wrap OAuth login URL to prevent truncation in narrow terminals

### DIFF
--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -200,10 +200,11 @@ async function initOauthClient(
   } else {
     const webLogin = await authWithWeb(client);
 
+    const terminalWidth = process.stdout?.columns ?? 80;
     debugLogger.log(
       `\n\nCode Assist login required.\n` +
         `Attempting to open authentication page in your browser.\n` +
-        `Otherwise navigate to:\n\n${wrap(webLogin.authUrl, process.stdout?.columns ?? 80)}\n\n`,
+        `Otherwise navigate to:\n\n${wrap(webLogin.authUrl, terminalWidth)}\n\n`,
     );
     try {
       // Attempt to open the authentication URL in the default browser.

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -26,6 +26,7 @@ import readline from 'node:readline';
 import { Storage } from '../config/storage.js';
 import { OAuthCredentialStorage } from './oauth-credential-storage.js';
 import { FORCE_ENCRYPTED_FILE_ENV_VAR } from '../mcp/token-storage/index.js';
+import wrap from 'wrap-ansi';
 import { debugLogger } from '../utils/debugLogger.js';
 
 const userAccountManager = new UserAccountManager();
@@ -202,7 +203,7 @@ async function initOauthClient(
     debugLogger.log(
       `\n\nCode Assist login required.\n` +
         `Attempting to open authentication page in your browser.\n` +
-        `Otherwise navigate to:\n\n${webLogin.authUrl}\n\n`,
+        `Otherwise navigate to:\n\n${wrap(webLogin.authUrl, process.stdout?.columns ?? 80)}\n\n`,
     );
     try {
       // Attempt to open the authentication URL in the default browser.
@@ -278,7 +279,8 @@ async function authWithUserCode(client: OAuth2Client): Promise<boolean> {
     'Please visit the following URL to authorize the application:',
   );
   debugLogger.log('');
-  debugLogger.log(authUrl);
+  const terminalWidth = process.stdout?.columns ?? 80;
+  debugLogger.log(wrap(authUrl, terminalWidth));
   debugLogger.log('');
 
   const code = await new Promise<string>((resolve) => {


### PR DESCRIPTION
## Summary

The authorization URL displayed during OAuth login was truncating on narrow terminals that don't break long tokens.

## Details

This fix uses the existing wrap-ansi dependency to properly wrap the URL to the current terminal width, ensuring the full authorization link is displayed.

Both the NO_BROWSER user-code flow and the web login flow now display wrapped URLs that fit within the terminal width while maintaining readability.

## Related Issues

Issue: https://github.com/google-gemini/gemini-cli/issues/12137

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker
