### PR TITLE
Switch to alternate buffer mode before rendering Ink.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "ink": "npm:@jrichman/ink@^6.4.2",
+        "ink": "npm:@jrichman/ink@6.4.2",
         "latest-version": "^9.0.0",
         "simple-git": "^3.28.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "ink": "npm:@jrichman/ink@^6.4.2",
         "latest-version": "^9.0.0",
         "simple-git": "^3.28.0"
       },
@@ -9885,9 +9886,9 @@
     },
     "node_modules/ink": {
       "name": "@jrichman/ink",
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.1.tgz",
-      "integrity": "sha512-YeNdpjFjq7Qbu9FQDQiCNmw4QehoBWi9pMEr52ZM4xLwQkYNtzyi/J5169NPLQCX2kl1WepngoUrzWvuFmjeSA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.2.tgz",
+      "integrity": "sha512-jfne1I/8+kVhzY/aoIWUKS0adPNRUhnN/wEsdBtSheyAp0b3c94zVsWWyDxnfXKL3RqOd40/H1FFaPLTUwjLXQ==",
       "license": "MIT",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.1",
@@ -17265,7 +17266,7 @@
         "fzf": "^0.5.2",
         "glob": "^10.4.5",
         "highlight.js": "^11.11.1",
-        "ink": "npm:@jrichman/ink@6.4.1",
+        "ink": "npm:@jrichman/ink@6.4.2",
         "ink-gradient": "^3.0.0",
         "ink-spinner": "^5.0.0",
         "latest-version": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "ink": "npm:@jrichman/ink@^6.4.2",
+    "ink": "npm:@jrichman/ink@6.4.2",
     "latest-version": "^9.0.0",
     "simple-git": "^3.28.0"
   },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "pre-commit": "node scripts/pre-commit.js"
   },
   "overrides": {
-    "ink": "npm:@jrichman/ink@6.4.1",
+    "ink": "npm:@jrichman/ink@6.4.2",
     "wrap-ansi": "9.0.2",
     "cliui": {
       "wrap-ansi": "7.0.0"
@@ -118,6 +118,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
+    "ink": "npm:@jrichman/ink@^6.4.2",
     "latest-version": "^9.0.0",
     "simple-git": "^3.28.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
     "fzf": "^0.5.2",
     "glob": "^10.4.5",
     "highlight.js": "^11.11.1",
-    "ink": "npm:@jrichman/ink@6.4.1",
+    "ink": "npm:@jrichman/ink@6.4.2",
     "ink-gradient": "^3.0.0",
     "ink-spinner": "^5.0.0",
     "latest-version": "^9.0.0",

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -73,6 +73,7 @@ import { createPolicyUpdater } from './config/policy.js';
 import { requestConsentNonInteractive } from './config/extensions/consent.js';
 import { disableMouseEvents, enableMouseEvents } from './ui/utils/mouse.js';
 import { ScrollProvider } from './ui/contexts/ScrollProvider.js';
+import ansiEscapes from 'ansi-escapes';
 
 const SLOW_RENDER_MS = 200;
 
@@ -422,7 +423,7 @@ export async function main() {
       process.stdin.setRawMode(true);
 
       if (settings.merged.ui?.useAlternateBuffer) {
-        process.stdout.write('\x1b[?1049h');
+        process.stdout.write(ansiEscapes.enterAlternativeScreen);
 
         // Ink will cleanup so there is no need for us to manually cleanup.
       }

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -233,6 +233,7 @@ export async function startInteractiveUI(
         }
       },
       alternateBuffer: settings.merged.ui?.useAlternateBuffer,
+      alternateBufferAlreadyActive: settings.merged.ui?.useAlternateBuffer,
     },
   );
 
@@ -419,6 +420,12 @@ export async function main() {
       // Set this as early as possible to avoid spurious characters from
       // input showing up in the output.
       process.stdin.setRawMode(true);
+
+      if (settings.merged.ui?.useAlternateBuffer) {
+        process.stdout.write('\x1b[?1049h');
+
+        // Ink will cleanup so there is no need for us to manually cleanup.
+      }
 
       // This cleanup isn't strictly needed but may help in certain situations.
       process.on('SIGTERM', () => {


### PR DESCRIPTION
This ensures that when in alternate buffer mode we enter the kitty protocol only on the alternate buffer and not the main buffer.

This fixes an issue where terminals decided that the alternate buffer was not in kitty protocol mode.

Ink 6.4.2 adds the support to run Ink in alternate buffer mode but allow the application to control when alternate buffer mode is entered for easier lifecycle management.

## Related Issues

@scidomino reported this over the weekend. Mysteriously ctrl-O was getting the non-kitty sequence in alternate buffer mode.