### PR TITLE
Harden modifiable tool temp workspace

### DIFF
--- a/packages/core/src/tools/modifiable-tool.test.ts
+++ b/packages/core/src/tools/modifiable-tool.test.ts
@@ -89,7 +89,12 @@ describe('modifyWithEditor', () => {
 
   describe('successful modification', () => {
     const assertMode = (mode: number, expected: number): void => {
-      if (process.platform === 'win32') return;
+      if (process.platform === 'win32') {
+        // Windows reports POSIX modes as 0o666 regardless of requested bits.
+        // At minimum confirm the owner read/write bits are present.
+        expect(mode & 0o600).toBe(0o600);
+        return;
+      }
       expect(mode & 0o777).toBe(expected);
     };
 

--- a/packages/core/src/tools/modifiable-tool.test.ts
+++ b/packages/core/src/tools/modifiable-tool.test.ts
@@ -88,6 +88,11 @@ describe('modifyWithEditor', () => {
   });
 
   describe('successful modification', () => {
+    const assertMode = (mode: number, expected: number): void => {
+      if (process.platform === 'win32') return;
+      expect(mode & 0o777).toBe(expected);
+    };
+
     it('should successfully modify content with VSCode editor', async () => {
       const result = await modifyWithEditor(
         mockParams,
@@ -149,9 +154,9 @@ describe('modifyWithEditor', () => {
         const oldStats = await fsp.stat(oldPath);
         const newStats = await fsp.stat(newPath);
 
-        expect(dirStats.mode & 0o777).toBe(0o700);
-        expect(oldStats.mode & 0o777).toBe(0o600);
-        expect(newStats.mode & 0o777).toBe(0o600);
+        assertMode(dirStats.mode, 0o700);
+        assertMode(oldStats.mode, 0o600);
+        assertMode(newStats.mode, 0o600);
 
         await fsp.writeFile(newPath, modifiedContent, 'utf8');
       });

--- a/packages/core/src/tools/modifiable-tool.ts
+++ b/packages/core/src/tools/modifiable-tool.ts
@@ -59,12 +59,17 @@ function createTempFilesForModify(
   currentContent: string,
   proposedContent: string,
   file_path: string,
-): { oldPath: string; newPath: string } {
-  const tempDir = os.tmpdir();
-  const diffDir = path.join(tempDir, 'gemini-cli-tool-modify-diffs');
+): { oldPath: string; newPath: string; dirPath: string } {
+  const diffDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'gemini-cli-tool-modify-'),
+  );
 
-  if (!fs.existsSync(diffDir)) {
-    fs.mkdirSync(diffDir, { recursive: true });
+  try {
+    fs.chmodSync(diffDir, 0o700);
+  } catch {
+    debugLogger.error(
+      `Error setting permissions on temp diff directory: ${diffDir}`,
+    );
   }
 
   const ext = path.extname(file_path);
@@ -79,10 +84,16 @@ function createTempFilesForModify(
     `gemini-cli-modify-${fileName}-new-${timestamp}${ext}`,
   );
 
-  fs.writeFileSync(tempOldPath, currentContent, 'utf8');
-  fs.writeFileSync(tempNewPath, proposedContent, 'utf8');
+  fs.writeFileSync(tempOldPath, currentContent, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  fs.writeFileSync(tempNewPath, proposedContent, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
 
-  return { oldPath: tempOldPath, newPath: tempNewPath };
+  return { oldPath: tempOldPath, newPath: tempNewPath, dirPath: diffDir };
 }
 
 function getUpdatedParams<ToolParams>(
@@ -125,7 +136,11 @@ function getUpdatedParams<ToolParams>(
   return { updatedParams, updatedDiff };
 }
 
-function deleteTempFiles(oldPath: string, newPath: string): void {
+function deleteTempFiles(
+  oldPath: string,
+  newPath: string,
+  dirPath: string,
+): void {
   try {
     fs.unlinkSync(oldPath);
   } catch {
@@ -136,6 +151,12 @@ function deleteTempFiles(oldPath: string, newPath: string): void {
     fs.unlinkSync(newPath);
   } catch {
     debugLogger.error(`Error deleting temp diff file: ${newPath}`);
+  }
+
+  try {
+    fs.rmdirSync(dirPath);
+  } catch {
+    debugLogger.error(`Error deleting temp diff directory: ${dirPath}`);
   }
 }
 
@@ -154,7 +175,7 @@ export async function modifyWithEditor<ToolParams>(
   const proposedContent =
     await modifyContext.getProposedContent(originalParams);
 
-  const { oldPath, newPath } = createTempFilesForModify(
+  const { oldPath, newPath, dirPath } = createTempFilesForModify(
     currentContent,
     proposedContent,
     modifyContext.getFilePath(originalParams),
@@ -171,6 +192,6 @@ export async function modifyWithEditor<ToolParams>(
 
     return result;
   } finally {
-    deleteTempFiles(oldPath, newPath);
+    deleteTempFiles(oldPath, newPath, dirPath);
   }
 }

--- a/packages/core/src/tools/modifiable-tool.ts
+++ b/packages/core/src/tools/modifiable-tool.ts
@@ -66,10 +66,12 @@ function createTempFilesForModify(
 
   try {
     fs.chmodSync(diffDir, 0o700);
-  } catch {
+  } catch (e) {
     debugLogger.error(
       `Error setting permissions on temp diff directory: ${diffDir}`,
+      e,
     );
+    throw e;
   }
 
   const ext = path.extname(file_path);


### PR DESCRIPTION
## Summary
- Isolate each modify run in its own `mkdtemp` directory with restrictive permissions.
- Write diff files with `0o600` mode and remove the temp directory during cleanup.
- Add regression tests that assert the directory and files use the expected permissions.

## Details
The previous implementation reused a shared `/tmp/gemini-cli-tool-modify-diffs` directory and relied on the process umask for permissions. The new flow creates a per-run workspace under `os.tmpdir()`, locks down the directory/files explicitly, and removes the workspace in the finally block. The tests exercise the real filesystem paths to guard against future regressions.

## Related Issues
Fixes #12836

## How to Validate
1. `cd packages/core`
2. `npx vitest run src/tools/modifiable-tool.test.ts`

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [ ] npm run
    - [x] npx
    - [ ] Docker