### PR TITLE
Fixes #12841: Plumb headers through google_credentials transport crea…

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -501,6 +501,9 @@ describe('mcp-client', () => {
             oauth: {
               scopes: ['scope1'],
             },
+            headers: {
+              'X-Goog-User-Project': 'myproject',
+            },
           },
           false,
         );
@@ -509,6 +512,9 @@ describe('mcp-client', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const authProvider = (transport as any)._authProvider;
         expect(authProvider).toBeInstanceOf(GoogleCredentialProvider);
+        const googUserProject =
+          transport._requestInit?.headers?.['X-Goog-User-Project'];
+        expect(googUserProject).toBe('myproject');
       });
 
       it('should use GoogleCredentialProvider with SSE transport', async () => {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -1185,7 +1185,6 @@ export async function createTransport(
       requestInit: createTransportRequestInit(mcpServerConfig, {}),
       authProvider: provider,
     };
-    console.log('Headers are ' + mcpServerConfig.headers);
 
     if (mcpServerConfig.httpUrl) {
       return new StreamableHTTPClientTransport(

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -395,6 +395,24 @@ async function handleAutomaticOAuth(
 }
 
 /**
+ * Create RequestInit for TransportOptions.
+ *
+ * @param mcpServerConfig The MCP server configuration
+ * @param headers Additional headers
+ */
+function createTransportRequestInit(
+  mcpServerConfig: MCPServerConfig,
+  headers: Record<string, string>,
+): RequestInit {
+  return {
+    headers: {
+      ...mcpServerConfig.headers,
+      ...headers,
+    },
+  };
+}
+
+/**
  * Create a transport with OAuth token for the given server configuration.
  *
  * @param mcpServerName The name of the MCP server
@@ -411,12 +429,9 @@ async function createTransportWithOAuth(
     if (mcpServerConfig.httpUrl) {
       // Create HTTP transport with OAuth token
       const oauthTransportOptions: StreamableHTTPClientTransportOptions = {
-        requestInit: {
-          headers: {
-            ...mcpServerConfig.headers,
-            Authorization: `Bearer ${accessToken}`,
-          },
-        },
+        requestInit: createTransportRequestInit(mcpServerConfig, {
+          Authorization: `Bearer ${accessToken}`,
+        }),
       };
 
       return new StreamableHTTPClientTransport(
@@ -426,12 +441,9 @@ async function createTransportWithOAuth(
     } else if (mcpServerConfig.url) {
       // Create SSE transport with OAuth token in Authorization header
       return new SSEClientTransport(new URL(mcpServerConfig.url), {
-        requestInit: {
-          headers: {
-            ...mcpServerConfig.headers,
-            Authorization: `Bearer ${accessToken}`,
-          },
-        },
+        requestInit: createTransportRequestInit(mcpServerConfig, {
+          Authorization: `Bearer ${accessToken}`,
+        }),
       });
     }
 
@@ -1170,8 +1182,10 @@ export async function createTransport(
     const transportOptions:
       | StreamableHTTPClientTransportOptions
       | SSEClientTransportOptions = {
+      requestInit: createTransportRequestInit(mcpServerConfig, {}),
       authProvider: provider,
     };
+    console.log('Headers are ' + mcpServerConfig.headers);
 
     if (mcpServerConfig.httpUrl) {
       return new StreamableHTTPClientTransport(
@@ -1197,6 +1211,7 @@ export async function createTransport(
     const transportOptions:
       | StreamableHTTPClientTransportOptions
       | SSEClientTransportOptions = {
+      requestInit: createTransportRequestInit(mcpServerConfig, {}),
       authProvider: provider,
     };
     if (mcpServerConfig.httpUrl) {


### PR DESCRIPTION
## Summary

Plumb headers through google_credentials authProvider config during transport creation.

## Details

Plumb headers through google_credentials authProvider config during transport creation.

Run gcloud to get xapi.zoo scope

~/google-cloud-sdk/bin/gcloud  auth application-default login --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/xapi.zoo

Make MCP call to google API:

    "echo": {
      "httpUrl": "https://test-echo-pa.sandbox.googleapis.com/mcp",
      "timeout": 10000,
      "authProviderType": "google_credentials",
      "oauth": {
        "scopes": [
          "https://www.googleapis.com/auth/xapi.zoo"
        ]
      },
      "headers": {
         "X-Goog-User-Project": "myproject", // Causes GCP to check activation, quota on myproject
      }
    }
  },

Then ask gemini-cli to "Call echo"


## Related Issues

Fixes #12841 

## How to Validate

Use google_credentials auth_provider and a header.  

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ X] npm run
    - [ ] npx
    - [ ] Docker
