### PR TITLE
fix(core): use ripgrep --json output for robust cross-platform parsing

### DIFF
--- a/integration-tests/ripgrep-real.test.ts
+++ b/integration-tests/ripgrep-real.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import { RipGrepTool } from '../packages/core/src/tools/ripGrep.js';
+import { Config } from '../packages/core/src/config/config.js';
+import { WorkspaceContext } from '../packages/core/src/utils/workspaceContext.js';
+
+// Mock Config to provide necessary context
+class MockConfig {
+  constructor(private targetDir: string) {}
+
+  getTargetDir() {
+    return this.targetDir;
+  }
+
+  getWorkspaceContext() {
+    return new WorkspaceContext(this.targetDir, [this.targetDir]);
+  }
+
+  getDebugMode() {
+    return true;
+  }
+}
+
+describe('ripgrep-real-direct', () => {
+  let tempDir: string;
+  let tool: RipGrepTool;
+
+  beforeAll(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ripgrep-real-test-'));
+
+    // Create test files
+    await fs.writeFile(path.join(tempDir, 'file1.txt'), 'hello world\n');
+    await fs.mkdir(path.join(tempDir, 'subdir'));
+    await fs.writeFile(
+      path.join(tempDir, 'subdir', 'file2.txt'),
+      'hello universe\n',
+    );
+    await fs.writeFile(path.join(tempDir, 'file3.txt'), 'goodbye moon\n');
+
+    const config = new MockConfig(tempDir) as unknown as Config;
+    tool = new RipGrepTool(config);
+  });
+
+  afterAll(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should find matches using the real ripgrep binary', async () => {
+    const invocation = tool.build({ pattern: 'hello' });
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain('Found 2 matches');
+    expect(result.llmContent).toContain('file1.txt');
+    expect(result.llmContent).toContain('L1: hello world');
+    expect(result.llmContent).toContain('subdir'); // Should show path
+    expect(result.llmContent).toContain('file2.txt');
+    expect(result.llmContent).toContain('L1: hello universe');
+
+    expect(result.llmContent).not.toContain('goodbye moon');
+  });
+
+  it('should handle no matches correctly', async () => {
+    const invocation = tool.build({ pattern: 'nonexistent_pattern_123' });
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain('No matches found');
+  });
+
+  it('should respect include filters', async () => {
+    // Create a .js file
+    await fs.writeFile(
+      path.join(tempDir, 'script.js'),
+      'console.log("hello");\n',
+    );
+
+    const invocation = tool.build({ pattern: 'hello', include: '*.js' });
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain('Found 1 match');
+    expect(result.llmContent).toContain('script.js');
+    expect(result.llmContent).not.toContain('file1.txt');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a critical bug where `ripgrep` output parsing failed on Windows due to `os.EOL` mismatches and drive letter colons (e.g., `C:`) being misinterpreted as separators. This PR switches the `RipGrepTool` to use the `--json` flag, ensuring robust and consistent parsing across all platforms.

## Details

Previously, we were manually parsing `ripgrep` output by splitting on `os.EOL` and looking for the first colon to separate the file path. This failed on Windows because:
1.  `ripgrep` often outputs `\n` (Unix-style) even on Windows when piped, while `os.EOL` is `\r\n`, causing the split to fail.
2.  Absolute paths like `C:\Users\...` contain a colon at index 1, which our parser incorrectly identified as the separator, treating the drive letter as the filename.

This PR:
- Updates `RipGrepTool` to use `rg --json`.
- Implements a robust JSON parser for the output stream.
- Adds defensive checks for binary/invalid encoding.
- Updates unit tests to mock JSON output.
- Adds a new **direct integration test** (`integration-tests/ripgrep-real.test.ts`) that executes the real `rg` binary to verify the fix without the overhead/flakiness of a full LLM E2E test.

## Related Issues

N/A

## How to Validate

1.  **Run the new integration test:**
    ```bash
    npm run test:integration:sandbox:none -- integration-tests/ripgrep-real.test.ts
    ```
    This test runs the real `rg` binary against a temporary directory and verifies the output is parsed correctly.

2.  **Manual Verification (Windows):**
    - Run the CLI on Windows.
    - Guide model to use tool: `Where is the 'CommandContext' used`.
    - Verify that matches are found and displayed correctly (previously this would return "No matches found").

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

**Note on Testing:**
- The new integration test was run **30 times on Windows** to ensure it is not flaky.
- We opted for a direct integration test (invoking the tool class directly) rather than a full E2E test with an LLM call. This is faster, deterministic, and sufficient to prove that the binary execution and output parsing are working correctly across platforms.