### PR TITLE
Deprecate read_many_files tool

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -82,8 +82,8 @@ Gemini CLI's built-in tools can be broadly categorized as follows:
   from URLs.
 - **[Web Search Tool](./web-search.md) (`google_web_search`):** For searching
   the web.
-- **[Multi-File Read Tool](./multi-file.md) (`read_many_files`):** A specialized
-  tool for reading content from multiple files or directories.
+- **[Multi-File Read Tool](./multi-file.md) (`read_many_files`):** (Deprecated)
+  A specialized tool for reading content from multiple files or directories.
 - **[Memory Tool](./memory.md) (`save_memory`):** For saving and recalling
   information across sessions.
 - **[Todo Tool](./todos.md) (`write_todos`):** For managing subtasks of complex

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -82,8 +82,9 @@ Gemini CLI's built-in tools can be broadly categorized as follows:
   from URLs.
 - **[Web Search Tool](./web-search.md) (`google_web_search`):** For searching
   the web.
-- **[Multi-File Read Tool](./multi-file.md) (`read_many_files`):** (Deprecated)
-  A specialized tool for reading content from multiple files or directories.
+- **[Multi-File Read Tool](./multi-file.md) (`read_many_files`):** (Deprecated,
+  will be removed in v0.14.0) A specialized tool for reading content from
+  multiple files or directories.
 - **[Memory Tool](./memory.md) (`save_memory`):** For saving and recalling
   information across sessions.
 - **[Todo Tool](./todos.md) (`write_todos`):** For managing subtasks of complex

--- a/docs/tools/multi-file.md
+++ b/docs/tools/multi-file.md
@@ -1,5 +1,9 @@
 # Multi File Read Tool (`read_many_files`)
 
+> **Deprecated:** This tool is deprecated and will be removed in a future
+> release. Please use `read_file` instead. If you need to read multiple files,
+> you can make multiple parallel calls to `read_file`.
+
 This document describes the `read_many_files` tool for the Gemini CLI.
 
 ## Description

--- a/docs/tools/multi-file.md
+++ b/docs/tools/multi-file.md
@@ -1,8 +1,8 @@
 # Multi File Read Tool (`read_many_files`)
 
-> **Deprecated:** This tool is deprecated and will be removed in a future
-> release. Please use `read_file` instead. If you need to read multiple files,
-> you can make multiple parallel calls to `read_file`.
+> **Deprecated:** This tool is deprecated and will be removed in v0.14.0. Please
+> use `read_file` instead. If you need to read multiple files, you can make
+> multiple parallel calls to `read_file`.
 
 This document describes the `read_many_files` tool for the Gemini CLI.
 

--- a/packages/cli/src/ui/commands/toolsCommand.ts
+++ b/packages/cli/src/ui/commands/toolsCommand.ts
@@ -10,6 +10,7 @@ import {
   CommandKind,
 } from './types.js';
 import { MessageType, type HistoryItemToolsList } from '../types.js';
+import { READ_MANY_FILES_TOOL_NAME } from '@google/gemini-cli-core';
 
 export const toolsCommand: SlashCommand = {
   name: 'tools',
@@ -44,7 +45,10 @@ export const toolsCommand: SlashCommand = {
       type: MessageType.TOOLS_LIST,
       tools: geminiTools.map((tool) => ({
         name: tool.name,
-        displayName: tool.displayName,
+        displayName:
+          tool.name === READ_MANY_FILES_TOOL_NAME
+            ? `${tool.displayName} (Deprecated)`
+            : tool.displayName,
         description: tool.description,
       })),
       showDescriptions: useShowDescriptions,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -34,6 +34,7 @@ import { logRipgrepFallback } from '../telemetry/loggers.js';
 import { RipgrepFallbackEvent } from '../telemetry/types.js';
 import { ToolRegistry } from '../tools/tool-registry.js';
 import { DEFAULT_MODEL_CONFIGS } from './defaultModelConfigs.js';
+import { READ_MANY_FILES_TOOL_NAME } from '../tools/tool-names.js';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
@@ -1038,6 +1039,40 @@ describe('Server Config (config.ts)', () => {
       new Config(paramsWithProxy);
 
       expect(mockCoreEvents.emitFeedback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkDeprecatedTools', () => {
+    it('should emit a warning when a deprecated tool is in coreTools', async () => {
+      const params: ConfigParameters = {
+        ...baseParams,
+        coreTools: [READ_MANY_FILES_TOOL_NAME],
+      };
+      const config = new Config(params);
+      await config.initialize();
+
+      expect(mockCoreEvents.emitFeedback).toHaveBeenCalledWith(
+        'warning',
+        expect.stringContaining(
+          `The tool '${READ_MANY_FILES_TOOL_NAME}' (or 'ReadManyFilesTool') specified in 'tools.core' is deprecated`,
+        ),
+      );
+    });
+
+    it('should emit a warning when a deprecated tool is in allowedTools', async () => {
+      const params: ConfigParameters = {
+        ...baseParams,
+        allowedTools: ['ReadManyFilesTool'],
+      };
+      const config = new Config(params);
+      await config.initialize();
+
+      expect(mockCoreEvents.emitFeedback).toHaveBeenCalledWith(
+        'warning',
+        expect.stringContaining(
+          `The tool '${READ_MANY_FILES_TOOL_NAME}' (or 'ReadManyFilesTool') specified in 'tools.allowed' is deprecated`,
+        ),
+      );
     });
   });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -164,6 +164,7 @@ import {
   SimpleExtensionLoader,
 } from '../utils/extensionLoader.js';
 import { McpClientManager } from '../tools/mcp-client-manager.js';
+import { READ_MANY_FILES_TOOL_NAME } from '../tools/tool-names.js';
 
 export type { FileFilteringOptions };
 export {
@@ -631,6 +632,37 @@ export class Config {
     ]);
 
     await this.geminiClient.initialize();
+
+    this.checkDeprecatedTools();
+  }
+
+  private checkDeprecatedTools(): void {
+    const deprecatedTools = [
+      {
+        name: READ_MANY_FILES_TOOL_NAME,
+        alternateName: 'ReadManyFilesTool',
+      },
+    ];
+
+    const checkList = (list: string[] | undefined, listName: string) => {
+      if (!list) return;
+      for (const tool of deprecatedTools) {
+        if (list.includes(tool.name) || list.includes(tool.alternateName)) {
+          coreEvents.emitFeedback(
+            'warning',
+            `The tool '${tool.name}' (or '${tool.alternateName}') specified in '${listName}' is deprecated and will be removed in a future release.`,
+          );
+        }
+      }
+    };
+
+    console.log(
+      `the coretools are: ${this.coreTools}\nthe allowed tools are ${this.allowedTools}\nthe excluded tools are ${this.excludeTools}`,
+    );
+
+    checkList(this.coreTools, 'tools.core');
+    checkList(this.allowedTools, 'tools.allowed');
+    checkList(this.excludeTools, 'tools.exclude');
   }
 
   getContentGenerator(): ContentGenerator {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -656,13 +656,8 @@ export class Config {
       }
     };
 
-    console.log(
-      `the coretools are: ${this.coreTools}\nthe allowed tools are ${this.allowedTools}\nthe excluded tools are ${this.excludeTools}`,
-    );
-
     checkList(this.coreTools, 'tools.core');
     checkList(this.allowedTools, 'tools.allowed');
-    checkList(this.excludeTools, 'tools.exclude');
   }
 
   getContentGenerator(): ContentGenerator {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -650,7 +650,7 @@ export class Config {
         if (list.includes(tool.name) || list.includes(tool.alternateName)) {
           coreEvents.emitFeedback(
             'warning',
-            `The tool '${tool.name}' (or '${tool.alternateName}') specified in '${listName}' is deprecated and will be removed in a future release.`,
+            `The tool '${tool.name}' (or '${tool.alternateName}') specified in '${listName}' is deprecated and will be removed in v0.14.0.`,
           );
         }
       }

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -20,7 +20,7 @@ exports[`Core System Prompt (prompts.ts) > should append userMemory with separat
 ## Software Engineering Tasks
 When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
 1. **Understand:** Think about the user's request and the relevant codebase context. Use 'search_file_content' and 'glob' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. 
-Use 'read_file' and 'read_many_files' to understand context and validate any assumptions you may have.
+Use 'read_file' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to 'read_file'.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.
 3. **Implement:** Use the available tools (e.g., 'replace', 'write_file' 'run_shell_command' ...) to act on the plan, strictly adhering to the project's established conventions (detailed under 'Core 
 Mandates').
@@ -94,7 +94,7 @@ You are running outside of a sandbox container, directly on the user's system. F
 
 
 # Final Reminder
-Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' or 'read_many_files' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved.
+Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved.
 
 ---
 
@@ -122,7 +122,7 @@ exports[`Core System Prompt (prompts.ts) > should include git instructions when 
 ## Software Engineering Tasks
 When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
 1. **Understand:** Think about the user's request and the relevant codebase context. Use 'search_file_content' and 'glob' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. 
-Use 'read_file' and 'read_many_files' to understand context and validate any assumptions you may have.
+Use 'read_file' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to 'read_file'.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.
 3. **Implement:** Use the available tools (e.g., 'replace', 'write_file' 'run_shell_command' ...) to act on the plan, strictly adhering to the project's established conventions (detailed under 'Core 
 Mandates').
@@ -211,7 +211,7 @@ You are running outside of a sandbox container, directly on the user's system. F
 
 
 # Final Reminder
-Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' or 'read_many_files' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
+Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
 `;
 
 exports[`Core System Prompt (prompts.ts) > should include non-sandbox instructions when SANDBOX env var is not set 1`] = `
@@ -234,7 +234,7 @@ exports[`Core System Prompt (prompts.ts) > should include non-sandbox instructio
 ## Software Engineering Tasks
 When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
 1. **Understand:** Think about the user's request and the relevant codebase context. Use 'search_file_content' and 'glob' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. 
-Use 'read_file' and 'read_many_files' to understand context and validate any assumptions you may have.
+Use 'read_file' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to 'read_file'.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.
 3. **Implement:** Use the available tools (e.g., 'replace', 'write_file' 'run_shell_command' ...) to act on the plan, strictly adhering to the project's established conventions (detailed under 'Core 
 Mandates').
@@ -308,7 +308,7 @@ You are running outside of a sandbox container, directly on the user's system. F
 
 
 # Final Reminder
-Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' or 'read_many_files' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
+Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
 `;
 
 exports[`Core System Prompt (prompts.ts) > should include sandbox-specific instructions when SANDBOX env var is set 1`] = `
@@ -331,7 +331,7 @@ exports[`Core System Prompt (prompts.ts) > should include sandbox-specific instr
 ## Software Engineering Tasks
 When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
 1. **Understand:** Think about the user's request and the relevant codebase context. Use 'search_file_content' and 'glob' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. 
-Use 'read_file' and 'read_many_files' to understand context and validate any assumptions you may have.
+Use 'read_file' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to 'read_file'.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.
 3. **Implement:** Use the available tools (e.g., 'replace', 'write_file' 'run_shell_command' ...) to act on the plan, strictly adhering to the project's established conventions (detailed under 'Core 
 Mandates').
@@ -405,7 +405,7 @@ You are running in a sandbox container with limited access to files outside the 
 
 
 # Final Reminder
-Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' or 'read_many_files' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
+Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
 `;
 
 exports[`Core System Prompt (prompts.ts) > should include seatbelt-specific instructions when SANDBOX env var is "sandbox-exec" 1`] = `
@@ -428,7 +428,7 @@ exports[`Core System Prompt (prompts.ts) > should include seatbelt-specific inst
 ## Software Engineering Tasks
 When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
 1. **Understand:** Think about the user's request and the relevant codebase context. Use 'search_file_content' and 'glob' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. 
-Use 'read_file' and 'read_many_files' to understand context and validate any assumptions you may have.
+Use 'read_file' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to 'read_file'.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.
 3. **Implement:** Use the available tools (e.g., 'replace', 'write_file' 'run_shell_command' ...) to act on the plan, strictly adhering to the project's established conventions (detailed under 'Core 
 Mandates').
@@ -502,7 +502,7 @@ You are running under macos seatbelt with limited access to files outside the pr
 
 
 # Final Reminder
-Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' or 'read_many_files' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
+Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
 `;
 
 exports[`Core System Prompt (prompts.ts) > should not include git instructions when not in a git repo 1`] = `
@@ -525,7 +525,7 @@ exports[`Core System Prompt (prompts.ts) > should not include git instructions w
 ## Software Engineering Tasks
 When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
 1. **Understand:** Think about the user's request and the relevant codebase context. Use 'search_file_content' and 'glob' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. 
-Use 'read_file' and 'read_many_files' to understand context and validate any assumptions you may have.
+Use 'read_file' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to 'read_file'.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.
 3. **Implement:** Use the available tools (e.g., 'replace', 'write_file' 'run_shell_command' ...) to act on the plan, strictly adhering to the project's established conventions (detailed under 'Core 
 Mandates').
@@ -599,7 +599,7 @@ You are running outside of a sandbox container, directly on the user's system. F
 
 
 # Final Reminder
-Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' or 'read_many_files' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
+Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
 `;
 
 exports[`Core System Prompt (prompts.ts) > should return the base prompt when userMemory is empty string 1`] = `
@@ -622,7 +622,7 @@ exports[`Core System Prompt (prompts.ts) > should return the base prompt when us
 ## Software Engineering Tasks
 When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
 1. **Understand:** Think about the user's request and the relevant codebase context. Use 'search_file_content' and 'glob' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. 
-Use 'read_file' and 'read_many_files' to understand context and validate any assumptions you may have.
+Use 'read_file' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to 'read_file'.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.
 3. **Implement:** Use the available tools (e.g., 'replace', 'write_file' 'run_shell_command' ...) to act on the plan, strictly adhering to the project's established conventions (detailed under 'Core 
 Mandates').
@@ -696,7 +696,7 @@ You are running outside of a sandbox container, directly on the user's system. F
 
 
 # Final Reminder
-Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' or 'read_many_files' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
+Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
 `;
 
 exports[`Core System Prompt (prompts.ts) > should return the base prompt when userMemory is whitespace only 1`] = `
@@ -719,7 +719,7 @@ exports[`Core System Prompt (prompts.ts) > should return the base prompt when us
 ## Software Engineering Tasks
 When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
 1. **Understand:** Think about the user's request and the relevant codebase context. Use 'search_file_content' and 'glob' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. 
-Use 'read_file' and 'read_many_files' to understand context and validate any assumptions you may have.
+Use 'read_file' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to 'read_file'.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.
 3. **Implement:** Use the available tools (e.g., 'replace', 'write_file' 'run_shell_command' ...) to act on the plan, strictly adhering to the project's established conventions (detailed under 'Core 
 Mandates').
@@ -793,7 +793,7 @@ You are running outside of a sandbox container, directly on the user's system. F
 
 
 # Final Reminder
-Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' or 'read_many_files' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
+Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
 `;
 
 exports[`Core System Prompt (prompts.ts) > should return the interactive avoidance prompt when in non-interactive mode 1`] = `
@@ -816,7 +816,7 @@ exports[`Core System Prompt (prompts.ts) > should return the interactive avoidan
 ## Software Engineering Tasks
 When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
 1. **Understand:** Think about the user's request and the relevant codebase context. Use 'search_file_content' and 'glob' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. 
-Use 'read_file' and 'read_many_files' to understand context and validate any assumptions you may have.
+Use 'read_file' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to 'read_file'.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.
 3. **Implement:** Use the available tools (e.g., 'replace', 'write_file' 'run_shell_command' ...) to act on the plan, strictly adhering to the project's established conventions (detailed under 'Core 
 Mandates').
@@ -890,5 +890,5 @@ You are running outside of a sandbox container, directly on the user's system. F
 
 
 # Final Reminder
-Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' or 'read_many_files' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
+Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved."
 `;

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -13,7 +13,6 @@ import {
   GREP_TOOL_NAME,
   MEMORY_TOOL_NAME,
   READ_FILE_TOOL_NAME,
-  READ_MANY_FILES_TOOL_NAME,
   SHELL_TOOL_NAME,
   WRITE_FILE_TOOL_NAME,
   WRITE_TODOS_TOOL_NAME,
@@ -138,7 +137,7 @@ export function getCoreSystemPrompt(
 ## Software Engineering Tasks
 When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
 1. **Understand:** Think about the user's request and the relevant codebase context. Use '${GREP_TOOL_NAME}' and '${GLOB_TOOL_NAME}' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. 
-Use '${READ_FILE_TOOL_NAME}' and '${READ_MANY_FILES_TOOL_NAME}' to understand context and validate any assumptions you may have.
+Use '${READ_FILE_TOOL_NAME}' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to '${READ_FILE_TOOL_NAME}'.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.`,
 
       primaryWorkflows_prefix_ci: `
@@ -162,7 +161,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 
 ## Software Engineering Tasks
 When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
-1. **Understand:** Think about the user's request and the relevant codebase context. Use '${GREP_TOOL_NAME}' and '${GLOB_TOOL_NAME}' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. Use '${READ_FILE_TOOL_NAME}' and '${READ_MANY_FILES_TOOL_NAME}' to understand context and validate any assumptions you may have.
+1. **Understand:** Think about the user's request and the relevant codebase context. Use '${GREP_TOOL_NAME}' and '${GLOB_TOOL_NAME}' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. Use '${READ_FILE_TOOL_NAME}' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to '${READ_FILE_TOOL_NAME}'.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. For complex tasks, break them down into smaller, manageable subtasks and use the \`${WRITE_TODOS_TOOL_NAME}\` tool to track your progress. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.`,
       primaryWorkflows_suffix: `3. **Implement:** Use the available tools (e.g., '${EDIT_TOOL_NAME}', '${WRITE_FILE_TOOL_NAME}' '${SHELL_TOOL_NAME}' ...) to act on the plan, strictly adhering to the project's established conventions (detailed under 'Core 
 Mandates').
@@ -296,7 +295,7 @@ ${(function () {
 })()}`,
       finalReminder: `
 # Final Reminder
-Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use '${READ_FILE_TOOL_NAME}' or '${READ_MANY_FILES_TOOL_NAME}' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved.`,
+Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use '${READ_FILE_TOOL_NAME}' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved.`,
     };
 
     const orderedPrompts: Array<keyof typeof promptConfig> = [


### PR DESCRIPTION
## Summary

Deprecates the `read_many_files` tool in favor of parallel `read_file` calls. This simplifies the toolset and encourages more efficient patterns.

## Details

- **Documentation**: Updated `docs/tools/index.md` and `docs/tools/multi-file.md` to mark the tool as deprecated.
- **CLI UI**: Updated `toolsCommand.ts` to display `(Deprecated)` next to the tool name in the `/tools` list.
- **Configuration**: Added a check in `Config.ts` to emit a warning if `read_many_files` is present in `coreTools` or `allowedTools`.
- **Prompts**: Updated system prompts to instruct the model to use `read_file` (in parallel) instead of `read_many_files`.
- **Tests**: Added unit tests in `config.test.ts` to verify the deprecation warning.

## Related Issues

N/A

## How to Validate

1. **Unit Tests**: Run `npm run test packages/core/src/config/config.test.ts` and ensure all tests pass.
2. **CLI UI**: Start the CLI (`npm start`) and run `/tools`. Verify `read_many_files` is listed as `(Deprecated)`.
3. **Config Warning**:
   - Add `read_many_files` to your `coreTools` or `allowedTools` in your config.
   - Start the CLI.
   - Verify a warning message appears regarding the deprecation.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
