### PR TITLE
feat(cli): always start in INSERT mode when vim mode is enabled

### DIFF
--- a/packages/cli/src/ui/contexts/VimModeContext.tsx
+++ b/packages/cli/src/ui/contexts/VimModeContext.tsx
@@ -34,18 +34,12 @@ export const VimModeProvider = ({
 }) => {
   const initialVimEnabled = settings.merged.general?.vimMode ?? false;
   const [vimEnabled, setVimEnabled] = useState(initialVimEnabled);
-  const [vimMode, setVimMode] = useState<VimMode>(
-    initialVimEnabled ? 'NORMAL' : 'INSERT',
-  );
+  const [vimMode, setVimMode] = useState<VimMode>('INSERT');
 
   useEffect(() => {
     // Initialize vimEnabled from settings on mount
     const enabled = settings.merged.general?.vimMode ?? false;
     setVimEnabled(enabled);
-    // When vim mode is enabled, always start in NORMAL mode
-    if (enabled) {
-      setVimMode('NORMAL');
-    }
   }, [settings.merged.general?.vimMode]);
 
   const toggleVimEnabled = useCallback(async () => {


### PR DESCRIPTION
## Summary

Always start in INSERT mode when vim mode is enabled.

## Details

The benefits of using Vim mode are limited to the input in the text buffer, and is typically empty when the CLI is first started anyway. Thus, there is no benefit in starting the CLI in NORMAL mode only because vim mode is enabled.
On the contrary, it introduces friction in using the CLI with vim-mode enabled, since users now need to explicitly enter INSERT mode first, before they can provide input into the text buffer.

So, always start in INSERT mode when vim mode is enabled. This is also consistent with how other similar interfaces that deal with vim-mode only in the context of a text buffer, implement vi/vim-mode.

## How to Validate

* Toggle vim-mode on with `/vim`
* Open a new instance of gemini-cli
* The text buffer should be in `INSERT` mode, not `NORMAL` mode

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [x] Podman
    - [x] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
