### PR TITLE
fix(cli): cancel ongoing request on `esc` iff in NORMAL with vim mode

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -68,6 +68,7 @@ import path from 'node:path';
 import { useSessionStats } from '../contexts/SessionContext.js';
 import { useKeypress } from './useKeypress.js';
 import type { LoadedSettings } from '../../config/settings.js';
+import { useVimMode } from '../contexts/VimModeContext.js';
 
 enum StreamProcessingStatus {
   Completed,
@@ -129,6 +130,7 @@ export const useGeminiStream = (
     }
     return new GitService(config.getProjectRoot(), storage);
   }, [config, storage]);
+  const { vimEnabled, vimMode } = useVimMode();
 
   const [
     toolCalls,
@@ -388,6 +390,10 @@ export const useGeminiStream = (
   useKeypress(
     (key) => {
       if (key.name === 'escape' && !isShellFocused) {
+        if (vimEnabled && vimMode !== 'NORMAL') {
+          return;
+        }
+
         cancelOngoingRequest();
       }
     },


### PR DESCRIPTION

## Summary

Allow users to switch to NORMAL mode when a request is currently ongoing, if vim mode is togged on.

## Details

When vim mode is toggled on, cancel ongoing requests if and only if the text buffer is in NORMAL mode; letting the vim context automatically switch to NORMAL mode otherwise.

This ensures that we can still interact with the text buffer in normal mode even when a request is ongoing.

## How to Validate

* Toggle vim mode on with `/vim`
* Go into `INSERT` mode
* Make a request
* Press `Esc`. Instead of cancelling the ongoing request, the text buffer will switch to "NORMAL" mode instead
* Pressing `Esc` as usual will cancel the request

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [x] Podman
    - [x] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
