### PR TITLE
fix(ci): pre-download ripgrep in global setup to prevent race conditions

### DIFF
--- a/integration-tests/globalSetup.ts
+++ b/integration-tests/globalSetup.ts
@@ -34,12 +34,10 @@ export async function setup() {
   process.env['GEMINI_CONFIG_DIR'] = join(runDir, '.gemini');
 
   // Download ripgrep to avoid race conditions in parallel tests
-  console.log('Ensuring ripgrep binary is available for tests...');
   const available = await canUseRipgrep();
   if (!available) {
     throw new Error('Failed to download ripgrep binary');
   }
-  console.log('Ripgrep is ready to use!');
 
   // Clean up old test runs, but keep the latest few for debugging
   try {

--- a/integration-tests/globalSetup.ts
+++ b/integration-tests/globalSetup.ts
@@ -34,7 +34,7 @@ export async function setup() {
   process.env['GEMINI_CONFIG_DIR'] = join(runDir, '.gemini');
 
   // Download ripgrep to avoid race conditions in parallel tests
-  console.log('Downloading ripgrep binary for tests...');
+  console.log('Ensuring ripgrep binary is available for tests...');
   const available = await canUseRipgrep();
   if (!available) {
     throw new Error('Failed to download ripgrep binary');

--- a/integration-tests/globalSetup.ts
+++ b/integration-tests/globalSetup.ts
@@ -12,6 +12,7 @@ if (process.env['NO_COLOR'] !== undefined) {
 import { mkdir, readdir, rm } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { canUseRipgrep } from '../packages/core/src/tools/ripGrep.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
@@ -31,6 +32,14 @@ export async function setup() {
   // We also need to set the config dir explicitly, since the code might
   // construct the path before the HOME env var is set.
   process.env['GEMINI_CONFIG_DIR'] = join(runDir, '.gemini');
+
+  // Download ripgrep to avoid race conditions in parallel tests
+  console.log('Downloading ripgrep binary for tests...');
+  const available = await canUseRipgrep();
+  if (!available) {
+    throw new Error('Failed to download ripgrep binary');
+  }
+  console.log('Ripgrep is ready to use!');
 
   // Clean up old test runs, but keep the latest few for debugging
   try {


### PR DESCRIPTION
## Summary

Fixes a critical race condition in the Windows E2E CI environment where parallel test execution caused file locking errors (`EBUSY`, `dest already exists`) during the lazy download of the `ripgrep` binary.

## Details

The `RipGrepTool` was designed to download the `ripgrep` binary on first use. In the CI environment, which starts fresh for every run, multiple parallel Vitest workers would trigger this download simultaneously, leading to resource contention and test failures on Windows.

This PR modifies `integration-tests/globalSetup.ts` to explicitly check for and download the `ripgrep` binary _once_ during the global setup phase, before any  individual tests are executed. This ensures that all worker threads access a pre-existing binary, eliminating the race condition.

## Related Issues

Fixes Windows E2E CI failures.

## How to Validate

1.  **Local Validation:**
    - Clear any existing cached binary (optional).
    - Run `npm run test:integration:sandbox:none`.
    - Observe the log line `Downloading ripgrep binary for tests...` (or `Ripgrep is ready to use` if already present) in the output.
    - Ensure all tests pass.

2.  **CI Validation:**
    - Monitor the `e2e_windows` job in the GitHub Actions workflow for this PR. It should now pass without `EBUSY` errors.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (Modified test setup logic)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
