### PR TITLE
Rename /chat resume to /chat load

### DIFF
--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -35,7 +35,7 @@ describe('chatCommand', () => {
   let mockGetHistory: ReturnType<typeof vi.fn>;
 
   const getSubCommand = (
-    name: 'list' | 'save' | 'resume' | 'delete' | 'share',
+    name: 'list' | 'save' | 'load' | 'delete' | 'share',
   ): SlashCommand => {
     const subCommand = chatCommand.subCommands?.find(
       (cmd) => cmd.name === name,
@@ -224,29 +224,33 @@ describe('chatCommand', () => {
     });
   });
 
-  describe('resume subcommand', () => {
+  describe('load subcommand', () => {
     const goodTag = 'good-tag';
     const badTag = 'bad-tag';
 
-    let resumeCommand: SlashCommand;
+    let loadCommand: SlashCommand;
     beforeEach(() => {
-      resumeCommand = getSubCommand('resume');
+      loadCommand = getSubCommand('load');
+    });
+
+    it('should have "resume" as an alias', () => {
+      expect(loadCommand.altNames).toContain('resume');
     });
 
     it('should return an error if tag is missing', async () => {
-      const result = await resumeCommand?.action?.(mockContext, '');
+      const result = await loadCommand?.action?.(mockContext, '');
 
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: 'Missing tag. Usage: /chat resume <tag>',
+        content: 'Missing tag. Usage: /chat load <tag>',
       });
     });
 
     it('should inform if checkpoint is not found', async () => {
       mockLoadCheckpoint.mockResolvedValue([]);
 
-      const result = await resumeCommand?.action?.(mockContext, badTag);
+      const result = await loadCommand?.action?.(mockContext, badTag);
 
       expect(result).toEqual({
         type: 'message',
@@ -255,14 +259,14 @@ describe('chatCommand', () => {
       });
     });
 
-    it('should resume a conversation', async () => {
+    it('should load a conversation', async () => {
       const conversation: Content[] = [
         { role: 'user', parts: [{ text: 'hello gemini' }] },
         { role: 'model', parts: [{ text: 'hello world' }] },
       ];
       mockLoadCheckpoint.mockResolvedValue(conversation);
 
-      const result = await resumeCommand?.action?.(mockContext, goodTag);
+      const result = await loadCommand?.action?.(mockContext, goodTag);
 
       expect(result).toEqual({
         type: 'load_history',
@@ -289,7 +293,7 @@ describe('chatCommand', () => {
             }) as Stats) as unknown as typeof fsPromises.stat,
         );
 
-        const result = await resumeCommand?.completion?.(mockContext, 'a');
+        const result = await loadCommand?.completion?.(mockContext, 'a');
 
         expect(result).toEqual(['alpha']);
       });
@@ -310,7 +314,7 @@ describe('chatCommand', () => {
           return { mtime: new Date(date.getTime() + 1000) } as Stats;
         }) as unknown as typeof fsPromises.stat);
 
-        const result = await resumeCommand?.completion?.(mockContext, '');
+        const result = await loadCommand?.completion?.(mockContext, '');
         // Sort items by last modified time (newest first)
         expect(result).toEqual(['test2', 'test1']);
       });

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -144,11 +144,10 @@ const saveCommand: SlashCommand = {
   },
 };
 
-const resumeCommand: SlashCommand = {
-  name: 'resume',
-  altNames: ['load'],
-  description:
-    'Resume a conversation from a checkpoint. Usage: /chat resume <tag>',
+const loadCommand: SlashCommand = {
+  name: 'load',
+  altNames: ['resume'],
+  description: 'Load a conversation from a checkpoint. Usage: /chat load <tag>',
   kind: CommandKind.BUILT_IN,
   action: async (context, args) => {
     const tag = args.trim();
@@ -156,7 +155,7 @@ const resumeCommand: SlashCommand = {
       return {
         type: 'message',
         messageType: 'error',
-        content: 'Missing tag. Usage: /chat resume <tag>',
+        content: 'Missing tag. Usage: /chat load <tag>',
       };
     }
 
@@ -362,7 +361,7 @@ export const chatCommand: SlashCommand = {
   subCommands: [
     listCommand,
     saveCommand,
-    resumeCommand,
+    loadCommand,
     deleteCommand,
     shareCommand,
   ],

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -206,7 +206,7 @@ export interface SlashCommand {
     | SlashCommandActionReturn
     | Promise<void | SlashCommandActionReturn>;
 
-  // Provides argument completion (e.g., completing a tag for `/chat resume <tag>`).
+  // Provides argument completion (e.g., completing a tag for `/chat load <tag>`).
   completion?: (
     context: CommandContext,
     partialArg: string,

--- a/packages/cli/src/ui/hooks/usePhraseCycler.ts
+++ b/packages/cli/src/ui/hooks/usePhraseCycler.ts
@@ -241,7 +241,7 @@ export const INFORMATIVE_TIPS = [
   'File a bug report directly with /bug...',
   'List your saved chat checkpoints with /chat list...',
   'Save your current conversation with /chat save <tag>...',
-  'Resume a saved conversation with /chat resume <tag>...',
+  'Load a saved conversation with /chat load <tag>...',
   'Delete a conversation checkpoint with /chat delete <tag>...',
   'Share your conversation to a file with /chat share <file>...',
   'Clear the screen and history with /clear...',

--- a/packages/cli/src/ui/hooks/useSlashCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.test.ts
@@ -651,8 +651,8 @@ describe('useSlashCompletion', () => {
           description: 'Manage chat history',
           subCommands: [
             createTestCommand({
-              name: 'resume',
-              description: 'Resume a saved chat',
+              name: 'load',
+              description: 'Load a saved chat',
               completion: mockCompletionFn,
             }),
           ],
@@ -662,7 +662,7 @@ describe('useSlashCompletion', () => {
       const { result, unmount } = renderHook(() =>
         useTestHarnessForSlashCompletion(
           true,
-          '/chat resume my-ch',
+          '/chat load my-ch',
           slashCommands,
           mockCommandContext,
         ),
@@ -673,8 +673,8 @@ describe('useSlashCompletion', () => {
           expect(mockCompletionFn).toHaveBeenCalledWith(
             expect.objectContaining({
               invocation: {
-                raw: '/chat resume my-ch',
-                name: 'resume',
+                raw: '/chat load my-ch',
+                name: 'load',
                 args: 'my-ch',
               },
             }),
@@ -689,7 +689,7 @@ describe('useSlashCompletion', () => {
             { label: 'my-chat-tag-1', value: 'my-chat-tag-1' },
             { label: 'my-chat-tag-2', value: 'my-chat-tag-2' },
           ]);
-          expect(result.current.completionStart).toBe(13);
+          expect(result.current.completionStart).toBe(11);
           expect(result.current.isLoadingSuggestions).toBe(false);
         });
       });
@@ -707,8 +707,8 @@ describe('useSlashCompletion', () => {
           description: 'Manage chat history',
           subCommands: [
             createTestCommand({
-              name: 'resume',
-              description: 'Resume a saved chat',
+              name: 'load',
+              description: 'Load a saved chat',
               completion: mockCompletionFn,
             }),
           ],
@@ -718,7 +718,7 @@ describe('useSlashCompletion', () => {
       const { result, unmount } = renderHook(() =>
         useTestHarnessForSlashCompletion(
           true,
-          '/chat resume ',
+          '/chat load ',
           slashCommands,
           mockCommandContext,
         ),
@@ -729,8 +729,8 @@ describe('useSlashCompletion', () => {
           expect(mockCompletionFn).toHaveBeenCalledWith(
             expect.objectContaining({
               invocation: {
-                raw: '/chat resume ',
-                name: 'resume',
+                raw: '/chat load ',
+                name: 'load',
                 args: '',
               },
             }),
@@ -742,7 +742,7 @@ describe('useSlashCompletion', () => {
       await act(async () => {
         await waitFor(() => {
           expect(result.current.suggestions).toHaveLength(3);
-          expect(result.current.completionStart).toBe(13);
+          expect(result.current.completionStart).toBe(11);
         });
       });
       unmount();


### PR DESCRIPTION
## Summary

Rename /chat resume to /chat load, keeping resume as alias

## How to Validate

Load a chat

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
