### PR TITLE
Remove tool.display_name in favor of just name

### DIFF
--- a/docs/core/tools-api.md
+++ b/docs/core/tools-api.md
@@ -10,7 +10,6 @@ content, and perform various actions beyond simple text generation.
 - **Tool (`tools.ts`):** An interface and base class (`BaseTool`) that defines
   the contract for all tools. Each tool must have:
   - `name`: A unique internal name (used in API calls to Gemini).
-  - `displayName`: A user-friendly name.
   - `description`: A clear explanation of what the tool does, which is provided
     to the Gemini model.
   - `parameterSchema`: A JSON schema defining the parameters that the tool

--- a/docs/tools/file-system.md
+++ b/docs/tools/file-system.md
@@ -10,14 +10,13 @@ current working directory where you launched the CLI) for security. Paths that
 you provide to these tools are generally expected to be absolute or are resolved
 relative to this root directory.
 
-## 1. `list_directory` (ReadFolder)
+## 1. `list_directory`
 
 `list_directory` lists the names of files and subdirectories directly within a
 specified directory path. It can optionally ignore entries matching provided
 glob patterns.
 
 - **Tool name:** `list_directory`
-- **Display name:** ReadFolder
 - **File:** `ls.ts`
 - **Parameters:**
   - `path` (string, required): The absolute path to the directory to list.
@@ -33,14 +32,13 @@ glob patterns.
   `Directory listing for /path/to/your/folder:\n[DIR] subfolder1\nfile1.txt\nfile2.png`
 - **Confirmation:** No.
 
-## 2. `read_file` (ReadFile)
+## 2. `read_file`
 
 `read_file` reads and returns the content of a specified file. This tool handles
 text, images (PNG, JPG, GIF, WEBP, SVG, BMP), and PDF files. For text files, it
 can read specific line ranges. Other binary file types are generally skipped.
 
 - **Tool name:** `read_file`
-- **Display name:** ReadFile
 - **File:** `read-file.ts`
 - **Parameters:**
   - `path` (string, required): The absolute path to the file to read.
@@ -68,14 +66,13 @@ can read specific line ranges. Other binary file types are generally skipped.
     `Cannot display content of binary file: /path/to/data.bin`.
 - **Confirmation:** No.
 
-## 3. `write_file` (WriteFile)
+## 3. `write_file`
 
 `write_file` writes content to a specified file. If the file exists, it will be
 overwritten. If the file doesn't exist, it (and any necessary parent
 directories) will be created.
 
 - **Tool name:** `write_file`
-- **Display name:** WriteFile
 - **File:** `write-file.ts`
 - **Parameters:**
   - `file_path` (string, required): The absolute path to the file to write to.
@@ -89,13 +86,12 @@ directories) will be created.
 - **Confirmation:** Yes. Shows a diff of changes and asks for user approval
   before writing.
 
-## 4. `glob` (FindFiles)
+## 4. `glob`
 
 `glob` finds files matching specific glob patterns (e.g., `src/**/*.ts`,
 `*.md`), returning absolute paths sorted by modification time (newest first).
 
 - **Tool name:** `glob`
-- **Display name:** FindFiles
 - **File:** `glob.ts`
 - **Parameters:**
   - `pattern` (string, required): The glob pattern to match against (e.g.,
@@ -116,7 +112,7 @@ directories) will be created.
   `Found 5 file(s) matching "*.ts" within src, sorted by modification time (newest first):\nsrc/file1.ts\nsrc/subdir/file2.ts...`
 - **Confirmation:** No.
 
-## 5. `search_file_content` (SearchText)
+## 5. `search_file_content`
 
 `search_file_content` searches for a regular expression pattern within the
 content of files in a specified directory. Can filter files by a glob pattern.
@@ -124,7 +120,6 @@ Returns the lines containing matches, along with their file paths and line
 numbers.
 
 - **Tool name:** `search_file_content`
-- **Display name:** SearchText
 - **File:** `grep.ts`
 - **Parameters:**
   - `pattern` (string, required): The regular expression (regex) to search for
@@ -153,7 +148,7 @@ numbers.
   ```
 - **Confirmation:** No.
 
-## 6. `replace` (Edit)
+## 6. `replace`
 
 `replace` replaces text within a file. By default, replaces a single occurrence,
 but can replace multiple occurrences when `expected_replacements` is specified.
@@ -161,7 +156,6 @@ This tool is designed for precise, targeted changes and requires significant
 context around the `old_string` to ensure it modifies the correct location.
 
 - **Tool name:** `replace`
-- **Display name:** Edit
 - **File:** `edit.ts`
 - **Parameters:**
   - `file_path` (string, required): The absolute path to the file to modify.

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -476,7 +476,6 @@ export class Task {
       serializableToolCall.tool = this._pickFields(
         tc.tool,
         'name',
-        'displayName',
         'description',
         'kind',
         'isOutputMarkdown',

--- a/packages/cli/src/ui/commands/toolsCommand.test.ts
+++ b/packages/cli/src/ui/commands/toolsCommand.test.ts
@@ -15,13 +15,11 @@ import type { ToolBuilder, ToolResult } from '@google/gemini-cli-core';
 const mockTools = [
   {
     name: 'file-reader',
-    displayName: 'File Reader',
     description: 'Reads files from the local system.',
     schema: {},
   },
   {
     name: 'code-editor',
-    displayName: 'Code Editor',
     description: 'Edits code files.',
     schema: {},
   },
@@ -90,8 +88,8 @@ describe('toolsCommand', () => {
     expect(message.type).toBe(MessageType.TOOLS_LIST);
     expect(message.showDescriptions).toBe(false);
     expect(message.tools).toHaveLength(2);
-    expect(message.tools[0].displayName).toBe('File Reader');
-    expect(message.tools[1].displayName).toBe('Code Editor');
+    expect(message.tools[0].name).toBe('file-reader');
+    expect(message.tools[1].name).toBe('code-editor');
   });
 
   it('should list tools with descriptions when "desc" arg is passed', async () => {

--- a/packages/cli/src/ui/commands/toolsCommand.ts
+++ b/packages/cli/src/ui/commands/toolsCommand.ts
@@ -10,7 +10,6 @@ import {
   CommandKind,
 } from './types.js';
 import { MessageType, type HistoryItemToolsList } from '../types.js';
-import { READ_MANY_FILES_TOOL_NAME } from '@google/gemini-cli-core';
 
 export const toolsCommand: SlashCommand = {
   name: 'tools',
@@ -45,10 +44,6 @@ export const toolsCommand: SlashCommand = {
       type: MessageType.TOOLS_LIST,
       tools: geminiTools.map((tool) => ({
         name: tool.name,
-        displayName:
-          tool.name === READ_MANY_FILES_TOOL_NAME
-            ? `${tool.displayName} (Deprecated)`
-            : tool.displayName,
         description: tool.description,
       })),
       showDescriptions: useShowDescriptions,

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
@@ -99,7 +99,6 @@ describe('ToolConfirmationMessage', () => {
       title: 'Confirm MCP Tool',
       serverName: 'test-server',
       toolName: 'test-tool',
-      toolDisplayName: 'Test Tool',
       onConfirm: vi.fn(),
     };
 

--- a/packages/cli/src/ui/components/views/ToolsList.test.tsx
+++ b/packages/cli/src/ui/components/views/ToolsList.test.tsx
@@ -12,12 +12,10 @@ import { renderWithProviders } from '../../../test-utils/render.js';
 const mockTools: ToolDefinition[] = [
   {
     name: 'test-tool-one',
-    displayName: 'Test Tool One',
     description: 'This is the first test tool.',
   },
   {
     name: 'test-tool-two',
-    displayName: 'Test Tool Two',
     description: `This is the second test tool.
   1. Tool descriptions support markdown formatting.
   2. **note** use this tool wisely and be sure to consider how this tool interacts with word wrap.
@@ -25,7 +23,6 @@ const mockTools: ToolDefinition[] = [
   },
   {
     name: 'test-tool-three',
-    displayName: 'Test Tool Three',
     description: 'This is the third test tool.',
   },
 ];

--- a/packages/cli/src/ui/components/views/ToolsList.tsx
+++ b/packages/cli/src/ui/components/views/ToolsList.tsx
@@ -32,8 +32,7 @@ export const ToolsList: React.FC<ToolsListProps> = ({
           <Text color={theme.text.primary}>{'  '}- </Text>
           <Box flexDirection="column">
             <Text bold color={theme.text.accent}>
-              {tool.displayName}
-              {showDescriptions ? ` (${tool.name})` : ''}
+              {tool.name}
             </Text>
             {showDescriptions && tool.description && (
               <MarkdownDisplay

--- a/packages/cli/src/ui/components/views/__snapshots__/ToolsList.test.tsx.snap
+++ b/packages/cli/src/ui/components/views/__snapshots__/ToolsList.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`<ToolsList /> > renders correctly with descriptions 1`] = `
 "Available Gemini CLI tools:
 
-  - Test Tool One (test-tool-one)
+  - test-tool-one
     This is the first test tool.
-  - Test Tool Two (test-tool-two)
+  - test-tool-two
     This is the second test tool.
        1. Tool descriptions support markdown formatting.
        2. note use this tool wisely and be sure to consider how this tool interacts with word wrap.
        3. important this tool is awesome.
-  - Test Tool Three (test-tool-three)
+  - test-tool-three
     This is the third test tool.
 "
 `;
@@ -25,8 +25,8 @@ exports[`<ToolsList /> > renders correctly with no tools 1`] = `
 exports[`<ToolsList /> > renders correctly without descriptions 1`] = `
 "Available Gemini CLI tools:
 
-  - Test Tool One
-  - Test Tool Two
-  - Test Tool Three
+  - test-tool-one
+  - test-tool-two
+  - test-tool-three
 "
 `;

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -430,7 +430,7 @@ export async function handleAtCommand({
     const result = await invocation.execute(signal);
     toolCallDisplay = {
       callId: `client-read-${userMessageTimestamp}`,
-      name: readManyFilesTool.displayName,
+      name: readManyFilesTool.name,
       description: invocation.getDescription(),
       status: ToolCallStatus.Success,
       resultDisplay:
@@ -496,7 +496,7 @@ export async function handleAtCommand({
   } catch (error: unknown) {
     toolCallDisplay = {
       callId: `client-read-${userMessageTimestamp}`,
-      name: readManyFilesTool.displayName,
+      name: readManyFilesTool.name,
       description:
         invocation?.getDescription() ??
         'Error attempting to execute tool to read files',

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -402,7 +402,6 @@ describe('useGeminiStream', () => {
           },
     tool: {
       name: toolName,
-      displayName: toolName,
       description: `${toolName} description`,
       build: vi.fn(),
     } as any,
@@ -480,7 +479,6 @@ describe('useGeminiStream', () => {
         },
         tool: {
           name: 'tool1',
-          displayName: 'tool1',
           description: 'desc1',
           build: vi.fn(),
         } as any,
@@ -501,7 +499,6 @@ describe('useGeminiStream', () => {
         responseSubmittedToGemini: false,
         tool: {
           name: 'tool2',
-          displayName: 'tool2',
           description: 'desc2',
           build: vi.fn(),
         } as any,
@@ -543,7 +540,7 @@ describe('useGeminiStream', () => {
           errorType: undefined, // FIX: Added missing property
         },
         tool: {
-          displayName: 'MockTool',
+          name: 'MockTool',
         },
         invocation: {
           getDescription: () => `Mock description`,
@@ -641,7 +638,7 @@ describe('useGeminiStream', () => {
         },
         responseSubmittedToGemini: false,
         tool: {
-          displayName: 'mock tool',
+          name: 'mock tool',
         },
         invocation: {
           getDescription: () => `Mock description`,
@@ -712,7 +709,6 @@ describe('useGeminiStream', () => {
       },
       tool: {
         name: 'toolA',
-        displayName: 'toolA',
         description: 'descA',
         build: vi.fn(),
       } as any,
@@ -741,7 +737,6 @@ describe('useGeminiStream', () => {
       },
       tool: {
         name: 'toolB',
-        displayName: 'toolB',
         description: 'descB',
         build: vi.fn(),
       } as any,
@@ -844,7 +839,6 @@ describe('useGeminiStream', () => {
         responseSubmittedToGemini: false,
         tool: {
           name: 'tool1',
-          displayName: 'tool1',
           description: 'desc',
           build: vi.fn(),
         } as any,

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -265,10 +265,10 @@ export function mapToDisplay(
         displayName =
           trackedCall.tool === undefined
             ? trackedCall.request.name
-            : trackedCall.tool.displayName;
+            : trackedCall.tool.name;
         description = JSON.stringify(trackedCall.request.args);
       } else {
-        displayName = trackedCall.tool.displayName;
+        displayName = trackedCall.tool.name;
         description = trackedCall.invocation.getDescription();
         renderOutputAsMarkdown = trackedCall.tool.isOutputMarkdown;
       }

--- a/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
@@ -101,7 +101,6 @@ describe('convertSessionToHistoryFormats', () => {
           {
             id: 'tool-1',
             name: 'bash',
-            displayName: 'Execute Command',
             description: 'Run bash command',
             args: { command: 'ls -la' },
             status: 'success',
@@ -112,7 +111,6 @@ describe('convertSessionToHistoryFormats', () => {
           {
             id: 'tool-2',
             name: 'read',
-            displayName: 'Read File',
             description: 'Read file contents',
             args: { path: '/etc/hosts' },
             status: 'error',
@@ -138,7 +136,7 @@ describe('convertSessionToHistoryFormats', () => {
       expect(result.uiHistory[1].tools).toHaveLength(2);
       expect(result.uiHistory[1].tools[0]).toEqual({
         callId: 'tool-1',
-        name: 'Execute Command',
+        name: 'bash',
         description: 'Run bash command',
         renderOutputAsMarkdown: false,
         status: ToolCallStatus.Success,
@@ -147,7 +145,7 @@ describe('convertSessionToHistoryFormats', () => {
       });
       expect(result.uiHistory[1].tools[1]).toEqual({
         callId: 'tool-2',
-        name: 'Read File',
+        name: 'read',
         description: 'Read file contents',
         renderOutputAsMarkdown: true, // default value
         status: ToolCallStatus.Error,

--- a/packages/cli/src/ui/hooks/useSessionBrowser.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.ts
@@ -51,7 +51,7 @@ export function convertSessionToHistoryFormats(
         type: 'tool_group',
         tools: msg.toolCalls.map((tool) => ({
           callId: tool.id,
-          name: tool.displayName || tool.name,
+          name: tool.name,
           description: tool.description || '',
           renderOutputAsMarkdown: tool.renderOutputAsMarkdown ?? true,
           status:

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -85,13 +85,11 @@ const mockConfig = {
 
 const mockTool = new MockTool({
   name: 'mockTool',
-  displayName: 'Mock Tool',
   execute: vi.fn(),
   shouldConfirmExecute: vi.fn(),
 });
 const mockToolWithLiveOutput = new MockTool({
   name: 'mockToolWithLiveOutput',
-  displayName: 'Mock Tool With Live Output',
   description: 'A mock tool for testing',
   params: {},
   isOutputMarkdown: true,
@@ -102,7 +100,6 @@ const mockToolWithLiveOutput = new MockTool({
 let mockOnUserConfirmForToolConfirmation: Mock;
 const mockToolRequiresConfirmation = new MockTool({
   name: 'mockToolRequiresConfirmation',
-  displayName: 'Mock Tool Requires Confirmation',
   execute: vi.fn(),
   shouldConfirmExecute: vi.fn(),
 });
@@ -652,7 +649,6 @@ describe('useReactToolScheduler', () => {
   it('should schedule and execute multiple tool calls', async () => {
     const tool1 = new MockTool({
       name: 'tool1',
-      displayName: 'Tool 1',
       execute: vi.fn().mockResolvedValue({
         llmContent: 'Output 1',
         returnDisplay: 'Display 1',
@@ -661,7 +657,6 @@ describe('useReactToolScheduler', () => {
 
     const tool2 = new MockTool({
       name: 'tool2',
-      displayName: 'Tool 2',
       execute: vi.fn().mockResolvedValue({
         llmContent: 'Output 2',
         returnDisplay: 'Display 2',
@@ -826,7 +821,6 @@ describe('mapToDisplay', () => {
 
   const baseTool = new MockTool({
     name: 'testTool',
-    displayName: 'Test Tool Display',
     execute: vi.fn(),
     shouldConfirmExecute: vi.fn(),
   });
@@ -889,7 +883,7 @@ describe('mapToDisplay', () => {
       status: 'validating',
       extraProps: { tool: baseTool, invocation: baseInvocation },
       expectedStatus: ToolCallStatus.Executing,
-      expectedName: baseTool.displayName,
+      expectedName: baseTool.name,
       expectedDescription: baseInvocation.getDescription(),
     },
     {
@@ -904,7 +898,6 @@ describe('mapToDisplay', () => {
           title: 'Test Tool Display',
           serverName: 'testTool',
           toolName: 'testTool',
-          toolDisplayName: 'Test Tool Display',
           filePath: 'mock',
           fileName: 'test.ts',
           fileDiff: 'Test diff',
@@ -913,7 +906,7 @@ describe('mapToDisplay', () => {
         } as ToolCallConfirmationDetails,
       },
       expectedStatus: ToolCallStatus.Confirming,
-      expectedName: baseTool.displayName,
+      expectedName: baseTool.name,
       expectedDescription: baseInvocation.getDescription(),
     },
     {
@@ -921,7 +914,7 @@ describe('mapToDisplay', () => {
       status: 'scheduled',
       extraProps: { tool: baseTool, invocation: baseInvocation },
       expectedStatus: ToolCallStatus.Pending,
-      expectedName: baseTool.displayName,
+      expectedName: baseTool.name,
       expectedDescription: baseInvocation.getDescription(),
     },
     {
@@ -929,7 +922,7 @@ describe('mapToDisplay', () => {
       status: 'executing',
       extraProps: { tool: baseTool, invocation: baseInvocation },
       expectedStatus: ToolCallStatus.Executing,
-      expectedName: baseTool.displayName,
+      expectedName: baseTool.name,
       expectedDescription: baseInvocation.getDescription(),
     },
     {
@@ -942,7 +935,7 @@ describe('mapToDisplay', () => {
       },
       expectedStatus: ToolCallStatus.Executing,
       expectedResultDisplay: 'Live test output',
-      expectedName: baseTool.displayName,
+      expectedName: baseTool.name,
       expectedDescription: baseInvocation.getDescription(),
     },
     {
@@ -955,7 +948,7 @@ describe('mapToDisplay', () => {
       },
       expectedStatus: ToolCallStatus.Success,
       expectedResultDisplay: baseResponse.resultDisplay as any,
-      expectedName: baseTool.displayName,
+      expectedName: baseTool.name,
       expectedDescription: baseInvocation.getDescription(),
     },
     {
@@ -986,7 +979,7 @@ describe('mapToDisplay', () => {
       },
       expectedStatus: ToolCallStatus.Error,
       expectedResultDisplay: 'Execution failed display',
-      expectedName: baseTool.displayName, // Changed from baseTool.name
+      expectedName: baseTool.name, // Changed from baseTool.name
       expectedDescription: JSON.stringify(baseRequest.args),
     },
     {
@@ -1002,7 +995,7 @@ describe('mapToDisplay', () => {
       },
       expectedStatus: ToolCallStatus.Canceled,
       expectedResultDisplay: 'Cancelled display',
-      expectedName: baseTool.displayName,
+      expectedName: baseTool.name,
       expectedDescription: baseInvocation.getDescription(),
     },
   ];
@@ -1060,7 +1053,6 @@ describe('mapToDisplay', () => {
     } as ToolCall;
     const toolForCall2 = new MockTool({
       name: baseTool.name,
-      displayName: baseTool.displayName,
       isOutputMarkdown: true,
       execute: vi.fn(),
       shouldConfirmExecute: vi.fn(),

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -188,7 +188,6 @@ export type HistoryItemChatList = HistoryItemBase & {
 
 export interface ToolDefinition {
   name: string;
-  displayName: string;
   description?: string;
 }
 

--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -91,7 +91,6 @@ describe('textUtils', () => {
             title: '\u001b[34mCloud Run\u001b[0m',
             serverName: '\u001b[31mmy-server\u001b[0m',
             toolName: '\u001b[32mdeploy\u001b[0m',
-            toolDisplayName: '\u001b[33mDeploy Service\u001b[0m',
             onConfirm: async () => {},
           };
 
@@ -101,9 +100,6 @@ describe('textUtils', () => {
             expect(sanitized.title).toBe('\\u001b[34mCloud Run\\u001b[0m');
             expect(sanitized.serverName).toBe('\\u001b[31mmy-server\\u001b[0m');
             expect(sanitized.toolName).toBe('\\u001b[32mdeploy\\u001b[0m');
-            expect(sanitized.toolDisplayName).toBe(
-              '\\u001b[33mDeploy Service\\u001b[0m',
-            );
           }
         });
 

--- a/packages/core/src/agents/subagent-tool-wrapper.test.ts
+++ b/packages/core/src/agents/subagent-tool-wrapper.test.ts
@@ -76,23 +76,10 @@ describe('SubagentToolWrapper', () => {
       const wrapper = new SubagentToolWrapper(mockDefinition, mockConfig);
 
       expect(wrapper.name).toBe(mockDefinition.name);
-      expect(wrapper.displayName).toBe(mockDefinition.displayName);
       expect(wrapper.description).toBe(mockDefinition.description);
       expect(wrapper.kind).toBe(Kind.Think);
       expect(wrapper.isOutputMarkdown).toBe(true);
       expect(wrapper.canUpdateOutput).toBe(true);
-    });
-
-    it('should fall back to the agent name for displayName if it is not provided', () => {
-      const definitionWithoutDisplayName = {
-        ...mockDefinition,
-        displayName: undefined,
-      };
-      const wrapper = new SubagentToolWrapper(
-        definitionWithoutDisplayName,
-        mockConfig,
-      );
-      expect(wrapper.displayName).toBe(definitionWithoutDisplayName.name);
     });
 
     it('should generate a valid tool schema using the definition and converted schema', () => {

--- a/packages/core/src/agents/subagent-tool-wrapper.ts
+++ b/packages/core/src/agents/subagent-tool-wrapper.ts
@@ -46,7 +46,6 @@ export class SubagentToolWrapper extends BaseDeclarativeTool<
 
     super(
       definition.name,
-      definition.displayName ?? definition.name,
       definition.description,
       Kind.Think,
       parameterSchema,

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -51,7 +51,6 @@ class TestApprovalTool extends BaseDeclarativeTool<{ id: string }, ToolResult> {
   constructor(private config: Config) {
     super(
       TestApprovalTool.Name,
-      'TestApprovalTool',
       'A tool for testing approval logic',
       Kind.Edit,
       {
@@ -154,7 +153,6 @@ class AbortDuringConfirmationTool extends BaseDeclarativeTool<
   ) {
     super(
       'abortDuringConfirmationTool',
-      'Abort During Confirmation Tool',
       'A tool that aborts while confirming execution.',
       Kind.Other,
       {
@@ -912,7 +910,7 @@ class MockEditTool extends BaseDeclarativeTool<
   ToolResult
 > {
   constructor() {
-    super('mockEditTool', 'mockEditTool', 'A mock edit tool', Kind.Edit, {});
+    super('mockEditTool', 'A mock edit tool', Kind.Edit, {});
   }
 
   protected createInvocation(

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -482,7 +482,7 @@ export class GeminiChat {
             hasCycleInSchema(tool.schema.parametersJsonSchema)) ||
           (tool.schema.parameters && hasCycleInSchema(tool.schema.parameters))
         ) {
-          cyclicSchemaTools.push(tool.displayName);
+          cyclicSchemaTools.push(tool.name);
         }
       }
       if (cyclicSchemaTools.length > 0) {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -328,7 +328,6 @@ describe('ChatRecordingService', () => {
         toolCalls: [
           {
             ...toolCall,
-            displayName: 'Test Tool',
             description: 'A test tool',
             renderOutputAsMarkdown: false,
           },
@@ -381,7 +380,6 @@ describe('ChatRecordingService', () => {
         toolCalls: [
           {
             ...toolCall,
-            displayName: 'Test Tool',
             description: 'A test tool',
             renderOutputAsMarkdown: false,
           },

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -51,7 +51,6 @@ export interface ToolCallRecord {
   status: Status;
   timestamp: string;
   // UI-specific fields for display purposes
-  displayName?: string;
   description?: string;
   resultDisplay?: string;
   renderOutputAsMarkdown?: boolean;
@@ -295,7 +294,6 @@ export class ChatRecordingService {
       const toolInstance = toolRegistry.getTool(toolCall.name);
       return {
         ...toolCall,
-        displayName: toolInstance?.displayName || toolCall.name,
         description: toolInstance?.description || '',
         renderOutputAsMarkdown: toolInstance?.isOutputMarkdown || false,
       };

--- a/packages/core/src/test-utils/mock-tool.ts
+++ b/packages/core/src/test-utils/mock-tool.ts
@@ -90,7 +90,6 @@ export class MockTool extends BaseDeclarativeTool<
   constructor(options: MockToolOptions) {
     super(
       options.name,
-      options.displayName ?? options.name,
       options.description ?? options.name,
       Kind.Other,
       options.params,
@@ -189,7 +188,7 @@ export class MockModifiableTool
   shouldConfirm = true;
 
   constructor(name = 'mockModifiableTool') {
-    super(name, name, 'A mock modifiable tool for testing.', Kind.Other, {
+    super(name, 'A mock modifiable tool for testing.', Kind.Other, {
       type: 'object',
       properties: { param: { type: 'string' } },
     });

--- a/packages/core/src/tools/base-tool-invocation.test.ts
+++ b/packages/core/src/tools/base-tool-invocation.test.ts
@@ -42,7 +42,6 @@ describe('BaseToolInvocation', () => {
       {},
       messageBus,
       'test-tool',
-      'Test Tool',
       serverName,
     );
 
@@ -97,7 +96,6 @@ describe('BaseToolInvocation', () => {
       {},
       messageBus,
       'test-tool',
-      'Test Tool',
       // no serverName
     );
 

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -120,9 +120,8 @@ class EditToolInvocation
     params: EditToolParams,
     messageBus?: MessageBus,
     toolName?: string,
-    displayName?: string,
   ) {
-    super(params, messageBus, toolName, displayName);
+    super(params, messageBus, toolName);
     this.resolvedPath = path.resolve(
       this.config.getTargetDir(),
       this.params.file_path,
@@ -492,7 +491,6 @@ export class EditTool
   ) {
     super(
       EditTool.Name,
-      'Edit',
       `Replaces text within a file. By default, replaces a single occurrence, but can replace multiple occurrences when \`expected_replacements\` is specified. This tool requires providing significant context around the change to ensure precise targeting. Always use the ${READ_FILE_TOOL_NAME} tool to examine the file's current content before attempting a text replacement.
 
       The user has the ability to modify the \`new_string\` content. If modified, this will be stated in the response.
@@ -566,14 +564,12 @@ Expectation for required parameters:
     params: EditToolParams,
     messageBus?: MessageBus,
     toolName?: string,
-    displayName?: string,
   ): ToolInvocation<EditToolParams, ToolResult> {
     return new EditToolInvocation(
       this.config,
       params,
       messageBus ?? this.messageBus,
       toolName ?? this.name,
-      displayName ?? this.displayName,
     );
   }
 

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -93,9 +93,8 @@ class GlobToolInvocation extends BaseToolInvocation<
     params: GlobToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ) {
-    super(params, messageBus, _toolName, _toolDisplayName);
+    super(params, messageBus, _toolName);
   }
 
   getDescription(): string {
@@ -266,7 +265,6 @@ export class GlobTool extends BaseDeclarativeTool<GlobToolParams, ToolResult> {
   ) {
     super(
       GlobTool.Name,
-      'FindFiles',
       'Efficiently finds files matching specific glob patterns (e.g., `src/**/*.ts`, `**/*.md`), returning absolute paths sorted by modification time (newest first). Ideal for quickly locating files based on their name or path structure, especially in large codebases.',
       Kind.Search,
       {
@@ -350,14 +348,7 @@ export class GlobTool extends BaseDeclarativeTool<GlobToolParams, ToolResult> {
     params: GlobToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ): ToolInvocation<GlobToolParams, ToolResult> {
-    return new GlobToolInvocation(
-      this.config,
-      params,
-      messageBus,
-      _toolName,
-      _toolDisplayName,
-    );
+    return new GlobToolInvocation(this.config, params, messageBus, _toolName);
   }
 }

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -64,9 +64,8 @@ class GrepToolInvocation extends BaseToolInvocation<
     params: GrepToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ) {
-    super(params, messageBus, _toolName, _toolDisplayName);
+    super(params, messageBus, _toolName);
     this.fileExclusions = config.getFileExclusions();
   }
 
@@ -575,7 +574,6 @@ export class GrepTool extends BaseDeclarativeTool<GrepToolParams, ToolResult> {
   ) {
     super(
       GrepTool.Name,
-      'SearchText',
       'Searches for a regular expression pattern within the content of files in a specified directory (or current working directory). Can filter files by a glob pattern. Returns the lines containing matches, along with their file paths and line numbers.',
       Kind.Search,
       {
@@ -676,14 +674,7 @@ export class GrepTool extends BaseDeclarativeTool<GrepToolParams, ToolResult> {
     params: GrepToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ): ToolInvocation<GrepToolParams, ToolResult> {
-    return new GrepToolInvocation(
-      this.config,
-      params,
-      messageBus,
-      _toolName,
-      _toolDisplayName,
-    );
+    return new GrepToolInvocation(this.config, params, messageBus, _toolName);
   }
 }

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -75,9 +75,8 @@ class LSToolInvocation extends BaseToolInvocation<LSToolParams, ToolResult> {
     params: LSToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ) {
-    super(params, messageBus, _toolName, _toolDisplayName);
+    super(params, messageBus, _toolName);
   }
 
   /**
@@ -263,7 +262,6 @@ export class LSTool extends BaseDeclarativeTool<LSToolParams, ToolResult> {
   ) {
     super(
       LSTool.Name,
-      'ReadFolder',
       'Lists the names of files and subdirectories directly within a specified directory path. Can optionally ignore entries matching provided glob patterns.',
       Kind.Search,
       {
@@ -332,14 +330,7 @@ export class LSTool extends BaseDeclarativeTool<LSToolParams, ToolResult> {
     params: LSToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ): ToolInvocation<LSToolParams, ToolResult> {
-    return new LSToolInvocation(
-      this.config,
-      params,
-      messageBus,
-      _toolName,
-      _toolDisplayName,
-    );
+    return new LSToolInvocation(this.config, params, messageBus, _toolName);
   }
 }

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -68,7 +68,6 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     private readonly mcpTool: CallableTool,
     readonly serverName: string,
     readonly serverToolName: string,
-    readonly displayName: string,
     readonly trust?: boolean,
     params: ToolParams = {},
     private readonly cliConfig?: Config,
@@ -78,13 +77,7 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     // This enables server wildcards (e.g., "google-workspace__*")
     // while still allowing specific tool rules
 
-    super(
-      params,
-      messageBus,
-      `${serverName}__${serverToolName}`,
-      displayName,
-      serverName,
-    );
+    super(params, messageBus, `${serverName}__${serverToolName}`, serverName);
   }
 
   protected override async getConfirmationDetails(
@@ -108,8 +101,7 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
       type: 'mcp',
       title: 'Confirm MCP Tool Execution',
       serverName: this.serverName,
-      toolName: this.serverToolName, // Display original tool name in confirmation
-      toolDisplayName: this.displayName, // Display global registry name exposed to model and user
+      toolName: this.serverToolName,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlwaysServer) {
           DiscoveredMCPToolInvocation.allowlist.add(serverAllowListKey);
@@ -231,7 +223,6 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
   ) {
     super(
       nameOverride ?? generateValidName(serverToolName),
-      `${serverToolName} (${serverName} MCP Server)`,
       description,
       Kind.Other,
       parameterSchema,
@@ -267,13 +258,11 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
     params: ToolParams,
     _messageBus?: MessageBus,
     _toolName?: string,
-    _displayName?: string,
   ): ToolInvocation<ToolParams, ToolResult> {
     return new DiscoveredMCPToolInvocation(
       this.mcpTool,
       this.serverName,
       this.serverToolName,
-      this.displayName,
       this.trust,
       params,
       this.cliConfig,

--- a/packages/core/src/tools/memoryTool.test.ts
+++ b/packages/core/src/tools/memoryTool.test.ts
@@ -210,9 +210,8 @@ describe('MemoryTool', () => {
       // Cast needed as spyOn returns MockInstance
     });
 
-    it('should have correct name, displayName, description, and schema', () => {
+    it('should have correct name, description, and schema', () => {
       expect(memoryTool.name).toBe('save_memory');
-      expect(memoryTool.displayName).toBe('Save Memory');
       expect(memoryTool.description).toContain(
         'Saves a specific piece of information',
       );

--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -181,9 +181,8 @@ class MemoryToolInvocation extends BaseToolInvocation<
     params: SaveMemoryParams,
     messageBus?: MessageBus,
     toolName?: string,
-    displayName?: string,
   ) {
-    super(params, messageBus, toolName, displayName);
+    super(params, messageBus, toolName);
   }
 
   getDescription(): string {
@@ -303,7 +302,6 @@ export class MemoryTool
   constructor(messageBus?: MessageBus) {
     super(
       MemoryTool.Name,
-      'Save Memory',
       memoryToolDescription,
       Kind.Think,
       memoryToolSchemaData.parametersJsonSchema as Record<string, unknown>,
@@ -327,13 +325,11 @@ export class MemoryTool
     params: SaveMemoryParams,
     messageBus?: MessageBus,
     toolName?: string,
-    displayName?: string,
   ) {
     return new MemoryToolInvocation(
       params,
       messageBus ?? this.messageBus,
       toolName ?? this.name,
-      displayName ?? this.displayName,
     );
   }
 

--- a/packages/core/src/tools/message-bus-integration.test.ts
+++ b/packages/core/src/tools/message-bus-integration.test.ts
@@ -74,7 +74,6 @@ class TestTool extends BaseDeclarativeTool<TestParams, TestResult> {
   constructor(messageBus?: MessageBus) {
     super(
       'test-tool',
-      'Test Tool',
       'A test tool for message bus integration',
       Kind.Other,
       {

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -52,9 +52,8 @@ class ReadFileToolInvocation extends BaseToolInvocation<
     params: ReadFileToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ) {
-    super(params, messageBus, _toolName, _toolDisplayName);
+    super(params, messageBus, _toolName);
     this.resolvedPath = path.resolve(
       this.config.getTargetDir(),
       this.params.file_path,
@@ -153,7 +152,6 @@ export class ReadFileTool extends BaseDeclarativeTool<
   ) {
     super(
       ReadFileTool.Name,
-      'ReadFile',
       `Reads and returns the content of a specified file. If the file is large, the content will be truncated. The tool's response will clearly indicate if truncation has occurred and will provide details on how to read more of the file using the 'offset' and 'limit' parameters. Handles text, images (PNG, JPG, GIF, WEBP, SVG, BMP), and PDF files. For text files, it can read specific line ranges.`,
       Kind.Read,
       {
@@ -227,14 +225,12 @@ export class ReadFileTool extends BaseDeclarativeTool<
     params: ReadFileToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ): ToolInvocation<ReadFileToolParams, ToolResult> {
     return new ReadFileToolInvocation(
       this.config,
       params,
       messageBus,
       _toolName,
-      _toolDisplayName,
     );
   }
 }

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -109,9 +109,8 @@ class ReadManyFilesToolInvocation extends BaseToolInvocation<
     params: ReadManyFilesParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ) {
-    super(params, messageBus, _toolName, _toolDisplayName);
+    super(params, messageBus, _toolName);
   }
 
   getDescription(): string {
@@ -375,7 +374,7 @@ ${finalExclusionPatternsForDescription
       }
     }
 
-    let displayMessage = `### ReadManyFiles Result (Target Dir: \`${this.config.getTargetDir()}\`)\n\n`;
+    let displayMessage = `### read_many_files Result (Target Dir: \`${this.config.getTargetDir()}\`)\n\n`;
     if (processedFilesRelativePaths.length > 0) {
       displayMessage += `Successfully read and concatenated content from **${processedFilesRelativePaths.length} file(s)**.\n`;
       if (processedFilesRelativePaths.length <= 10) {
@@ -503,7 +502,6 @@ export class ReadManyFilesTool extends BaseDeclarativeTool<
 
     super(
       ReadManyFilesTool.Name,
-      'ReadManyFiles',
       `Reads content from multiple files specified by glob patterns within a configured target directory. For text files, it concatenates their content into a single string. It is primarily designed for text-based files. However, it can also process image (e.g., .png, .jpg) and PDF (.pdf) files if their file names or extensions are explicitly included in the 'include' argument. For these explicitly requested non-text files, their data is read and included in a format suitable for model consumption (e.g., base64 encoded).
 
 This tool is useful when you need to understand or analyze a collection of files, such as:
@@ -526,14 +524,12 @@ Use this tool when the user's query implies needing the content of several files
     params: ReadManyFilesParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ): ToolInvocation<ReadManyFilesParams, ToolResult> {
     return new ReadManyFilesToolInvocation(
       this.config,
       params,
       messageBus,
       _toolName,
-      _toolDisplayName,
     );
   }
 }

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -113,9 +113,8 @@ class GrepToolInvocation extends BaseToolInvocation<
     params: RipGrepToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ) {
-    super(params, messageBus, _toolName, _toolDisplayName);
+    super(params, messageBus, _toolName);
   }
 
   /**
@@ -449,7 +448,6 @@ export class RipGrepTool extends BaseDeclarativeTool<
   ) {
     super(
       RipGrepTool.Name,
-      'SearchText',
       'Searches for a regular expression pattern within the content of files in a specified directory (or current working directory). Can filter files by a glob pattern. Returns the lines containing matches, along with their file paths and line numbers. Total results limited to 20,000 matches like VSCode.',
       Kind.Search,
       {
@@ -550,14 +548,7 @@ export class RipGrepTool extends BaseDeclarativeTool<
     params: RipGrepToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ): ToolInvocation<RipGrepToolParams, ToolResult> {
-    return new GrepToolInvocation(
-      this.config,
-      params,
-      messageBus,
-      _toolName,
-      _toolDisplayName,
-    );
+    return new GrepToolInvocation(this.config, params, messageBus, _toolName);
   }
 }

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -62,9 +62,8 @@ export class ShellToolInvocation extends BaseToolInvocation<
     private readonly allowlist: Set<string>,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ) {
-    super(params, messageBus, _toolName, _toolDisplayName);
+    super(params, messageBus, _toolName);
   }
 
   getDescription(): string {
@@ -391,7 +390,6 @@ export class ShellTool extends BaseDeclarativeTool<
     });
     super(
       ShellTool.Name,
-      'Shell',
       getShellToolDescription(),
       Kind.Execute,
       {
@@ -457,7 +455,6 @@ export class ShellTool extends BaseDeclarativeTool<
     params: ShellToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ): ToolInvocation<ShellToolParams, ToolResult> {
     return new ShellToolInvocation(
       this.config,
@@ -465,7 +462,6 @@ export class ShellTool extends BaseDeclarativeTool<
       this.allowlist,
       messageBus,
       _toolName,
-      _toolDisplayName,
     );
   }
 }

--- a/packages/core/src/tools/smart-edit.ts
+++ b/packages/core/src/tools/smart-edit.ts
@@ -388,9 +388,8 @@ class EditToolInvocation
     params: EditToolParams,
     messageBus?: MessageBus,
     toolName?: string,
-    displayName?: string,
   ) {
-    super(params, messageBus, toolName, displayName);
+    super(params, messageBus, toolName);
   }
 
   override toolLocations(): ToolLocation[] {
@@ -845,15 +844,12 @@ export class SmartEditTool
   extends BaseDeclarativeTool<EditToolParams, ToolResult>
   implements ModifiableDeclarativeTool<EditToolParams>
 {
-  static readonly Name = EDIT_TOOL_NAME;
-
   constructor(
     private readonly config: Config,
     messageBus?: MessageBus,
   ) {
     super(
-      SmartEditTool.Name,
-      'Edit',
+      EDIT_TOOL_NAME,
       `Replaces text within a file. By default, replaces a single occurrence, but can replace multiple occurrences when \`expected_replacements\` is specified. This tool requires providing significant context around the change to ensure precise targeting. Always use the ${READ_FILE_TOOL_NAME} tool to examine the file's current content before attempting a text replacement.
       
       The user has the ability to modify the \`new_string\` content. If modified, this will be stated in the response.
@@ -957,7 +953,6 @@ A good instruction should concisely answer:
       params,
       this.messageBus,
       this.name,
-      this.displayName,
     );
   }
 

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -159,11 +159,9 @@ describe('ToolRegistry', () => {
   describe('excluded tools', () => {
     const simpleTool = new MockTool({
       name: 'tool-a',
-      displayName: 'Tool a',
     });
     const excludedTool = new ExcludedMockTool({
       name: 'excluded-tool-class',
-      displayName: 'Excluded Tool Class',
     });
     const mockCallable = {} as CallableTool;
     const mcpTool = new DiscoveredMCPTool(
@@ -175,7 +173,6 @@ describe('ToolRegistry', () => {
     );
     const allowedTool = new MockTool({
       name: 'allowed-tool',
-      displayName: 'Allowed Tool',
     });
 
     it.each([
@@ -226,30 +223,30 @@ describe('ToolRegistry', () => {
   });
 
   describe('getAllTools', () => {
-    it('should return all registered tools sorted alphabetically by displayName', () => {
-      // Register tools with displayNames in non-alphabetical order
-      const toolC = new MockTool({ name: 'c-tool', displayName: 'Tool C' });
-      const toolA = new MockTool({ name: 'a-tool', displayName: 'Tool A' });
-      const toolB = new MockTool({ name: 'b-tool', displayName: 'Tool B' });
+    it('should return all registered tools sorted alphabetically by name', () => {
+      // Register tools with names in non-alphabetical order
+      const toolC = new MockTool({ name: 'c-tool' });
+      const toolA = new MockTool({ name: 'a-tool' });
+      const toolB = new MockTool({ name: 'b-tool' });
 
       toolRegistry.registerTool(toolC);
       toolRegistry.registerTool(toolA);
       toolRegistry.registerTool(toolB);
 
       const allTools = toolRegistry.getAllTools();
-      const displayNames = allTools.map((t) => t.displayName);
+      const toolNames = allTools.map((t) => t.name);
 
-      // Assert that the returned array is sorted by displayName
-      expect(displayNames).toEqual(['Tool A', 'Tool B', 'Tool C']);
+      // Assert that the returned array is sorted by name
+      expect(toolNames).toEqual(['a-tool', 'b-tool', 'c-tool']);
     });
   });
 
   describe('getAllToolNames', () => {
     it('should return all registered tool names', () => {
-      // Register tools with displayNames in non-alphabetical order
-      const toolC = new MockTool({ name: 'c-tool', displayName: 'Tool C' });
-      const toolA = new MockTool({ name: 'a-tool', displayName: 'Tool A' });
-      const toolB = new MockTool({ name: 'b-tool', displayName: 'Tool B' });
+      // Register tools with names in non-alphabetical order
+      const toolC = new MockTool({ name: 'c-tool' });
+      const toolA = new MockTool({ name: 'a-tool' });
+      const toolB = new MockTool({ name: 'b-tool' });
 
       toolRegistry.registerTool(toolC);
       toolRegistry.registerTool(toolA);

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -160,7 +160,6 @@ Signal: Signal number or \`(none)\` if no signal was received.
 `;
     super(
       prefixedName,
-      prefixedName,
       fullDescription,
       Kind.Other,
       parameterSchema,
@@ -175,7 +174,6 @@ Signal: Signal number or \`(none)\` if no signal was received.
     params: ToolParams,
     _messageBus?: MessageBus,
     _toolName?: string,
-    _displayName?: string,
   ): ToolInvocation<ToolParams, ToolResult> {
     return new DiscoveredToolInvocation(
       this.config,
@@ -503,9 +501,7 @@ export class ToolRegistry {
    * Returns an array of all registered and discovered tool instances.
    */
   getAllTools(): AnyDeclarativeTool[] {
-    return this.getActiveTools().sort((a, b) =>
-      a.displayName.localeCompare(b.displayName),
-    );
+    return this.getActiveTools().sort((a, b) => a.name.localeCompare(b.name));
   }
 
   /**

--- a/packages/core/src/tools/tools.test.ts
+++ b/packages/core/src/tools/tools.test.ts
@@ -36,7 +36,7 @@ class TestTool extends DeclarativeTool<object, ToolResult> {
   private readonly buildFn: (params: object) => TestToolInvocation;
 
   constructor(buildFn: (params: object) => TestToolInvocation) {
-    super('test-tool', 'Test Tool', 'A tool for testing', Kind.Other, {});
+    super('test-tool', 'A tool for testing', Kind.Other, {});
     this.buildFn = buildFn;
   }
 

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -77,7 +77,6 @@ export abstract class BaseToolInvocation<
     readonly params: TParams,
     protected readonly messageBus?: MessageBus,
     readonly _toolName?: string,
-    readonly _toolDisplayName?: string,
     readonly _serverName?: string,
   ) {}
 
@@ -98,9 +97,7 @@ export abstract class BaseToolInvocation<
 
       if (decision === 'DENY') {
         throw new Error(
-          `Tool execution for "${
-            this._toolDisplayName || this._toolName
-          }" denied by policy.`,
+          `Tool execution for "${this._toolName}" denied by policy.`,
         );
       }
 
@@ -126,7 +123,7 @@ export abstract class BaseToolInvocation<
 
     const confirmationDetails: ToolCallConfirmationDetails = {
       type: 'info',
-      title: `Confirm: ${this._toolDisplayName || this._toolName}`,
+      title: `Confirm: ${this._toolName}`,
       prompt: this.getDescription(),
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
@@ -253,11 +250,6 @@ export interface ToolBuilder<
   name: string;
 
   /**
-   * The user-friendly display name of the tool.
-   */
-  displayName: string;
-
-  /**
    * Description of what the tool does.
    */
   description: string;
@@ -301,7 +293,6 @@ export abstract class DeclarativeTool<
 {
   constructor(
     readonly name: string,
-    readonly displayName: string,
     readonly description: string,
     readonly kind: Kind,
     readonly parameterSchema: unknown,
@@ -433,12 +424,7 @@ export abstract class BaseDeclarativeTool<
     if (validationError) {
       throw new Error(validationError);
     }
-    return this.createInvocation(
-      params,
-      this.messageBus,
-      this.name,
-      this.displayName,
-    );
+    return this.createInvocation(params, this.messageBus, this.name);
   }
 
   override validateToolParams(params: TParams): string | null {
@@ -462,7 +448,6 @@ export abstract class BaseDeclarativeTool<
     params: TParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ): ToolInvocation<TParams, TResult>;
 }
 
@@ -663,7 +648,6 @@ export interface ToolMcpConfirmationDetails {
   title: string;
   serverName: string;
   toolName: string;
-  toolDisplayName: string;
   onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
 }
 

--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -528,7 +528,7 @@ describe('WebFetchTool', () => {
 
       // Should reject with error when denied
       await expect(confirmationPromise).rejects.toThrow(
-        'Tool execution for "WebFetch" denied by policy.',
+        'Tool execution for "web_fetch" denied by policy.',
       );
     });
 
@@ -566,7 +566,7 @@ describe('WebFetchTool', () => {
       abortController.abort();
 
       await expect(confirmationPromise).rejects.toThrow(
-        'Tool execution for "WebFetch" denied by policy.',
+        'Tool execution for "web_fetch" denied by policy.',
       );
     });
 

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -111,9 +111,8 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     params: WebFetchToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ) {
-    super(params, messageBus, _toolName, _toolDisplayName);
+    super(params, messageBus, _toolName);
   }
 
   private async executeFallback(signal: AbortSignal): Promise<ToolResult> {
@@ -391,7 +390,6 @@ export class WebFetchTool extends BaseDeclarativeTool<
   ) {
     super(
       WebFetchTool.Name,
-      'WebFetch',
       "Processes content from URL(s), including local and private network addresses (e.g., localhost), embedded in a prompt. Include up to 20 URLs and instructions (e.g., summarize, extract specific data) directly in the 'prompt' parameter.",
       Kind.Fetch,
       {
@@ -435,14 +433,12 @@ export class WebFetchTool extends BaseDeclarativeTool<
     params: WebFetchToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ): ToolInvocation<WebFetchToolParams, ToolResult> {
     return new WebFetchToolInvocation(
       this.config,
       params,
       messageBus,
       _toolName,
-      _toolDisplayName,
     );
   }
 }

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -66,9 +66,8 @@ class WebSearchToolInvocation extends BaseToolInvocation<
     params: WebSearchToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ) {
-    super(params, messageBus, _toolName, _toolDisplayName);
+    super(params, messageBus, _toolName);
   }
 
   override getDescription(): string {
@@ -195,7 +194,6 @@ export class WebSearchTool extends BaseDeclarativeTool<
   ) {
     super(
       WebSearchTool.Name,
-      'GoogleSearch',
       'Performs a web search using Google Search (via the Gemini API) and returns the results. This tool is useful for finding information on the internet based on a query.',
       Kind.Search,
       {
@@ -232,14 +230,12 @@ export class WebSearchTool extends BaseDeclarativeTool<
     params: WebSearchToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ): ToolInvocation<WebSearchToolParams, WebSearchToolResult> {
     return new WebSearchToolInvocation(
       this.config,
       params,
       messageBus,
       _toolName,
-      _toolDisplayName,
     );
   }
 }

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -150,9 +150,8 @@ class WriteFileToolInvocation extends BaseToolInvocation<
     params: WriteFileToolParams,
     messageBus?: MessageBus,
     toolName?: string,
-    displayName?: string,
   ) {
-    super(params, messageBus, toolName, displayName);
+    super(params, messageBus, toolName);
     this.resolvedPath = path.resolve(
       this.config.getTargetDir(),
       this.params.file_path,
@@ -408,7 +407,6 @@ export class WriteFileTool
   ) {
     super(
       WriteFileTool.Name,
-      'WriteFile',
       `Writes content to a specified file in the local filesystem.
 
       The user has the ability to modify \`content\`. If modified, this will be stated in the response.`,
@@ -476,7 +474,6 @@ export class WriteFileTool
       params,
       this.messageBus,
       this.name,
-      this.displayName,
     );
   }
 

--- a/packages/core/src/tools/write-todos.ts
+++ b/packages/core/src/tools/write-todos.ts
@@ -103,9 +103,8 @@ class WriteTodosToolInvocation extends BaseToolInvocation<
     params: WriteTodosToolParams,
     messageBus?: MessageBus,
     _toolName?: string,
-    _toolDisplayName?: string,
   ) {
-    super(params, messageBus, _toolName, _toolDisplayName);
+    super(params, messageBus, _toolName);
   }
 
   getDescription(): string {
@@ -146,39 +145,33 @@ export class WriteTodosTool extends BaseDeclarativeTool<
   static readonly Name = WRITE_TODOS_TOOL_NAME;
 
   constructor() {
-    super(
-      WriteTodosTool.Name,
-      'Write Todos',
-      WRITE_TODOS_DESCRIPTION,
-      Kind.Other,
-      {
-        type: 'object',
-        properties: {
-          todos: {
-            type: 'array',
-            description:
-              'The complete list of todo items. This will replace the existing list.',
-            items: {
-              type: 'object',
-              description: 'A single todo item.',
-              properties: {
-                description: {
-                  type: 'string',
-                  description: 'The description of the task.',
-                },
-                status: {
-                  type: 'string',
-                  description: 'The current status of the task.',
-                  enum: TODO_STATUSES,
-                },
+    super(WriteTodosTool.Name, WRITE_TODOS_DESCRIPTION, Kind.Other, {
+      type: 'object',
+      properties: {
+        todos: {
+          type: 'array',
+          description:
+            'The complete list of todo items. This will replace the existing list.',
+          items: {
+            type: 'object',
+            description: 'A single todo item.',
+            properties: {
+              description: {
+                type: 'string',
+                description: 'The description of the task.',
               },
-              required: ['description', 'status'],
+              status: {
+                type: 'string',
+                description: 'The current status of the task.',
+                enum: TODO_STATUSES,
+              },
             },
+            required: ['description', 'status'],
           },
         },
-        required: ['todos'],
       },
-    );
+      required: ['todos'],
+    });
   }
 
   protected override validateToolParamValues(
@@ -216,13 +209,7 @@ export class WriteTodosTool extends BaseDeclarativeTool<
     params: WriteTodosToolParams,
     _messageBus?: MessageBus,
     _toolName?: string,
-    _displayName?: string,
   ): ToolInvocation<WriteTodosToolParams, ToolResult> {
-    return new WriteTodosToolInvocation(
-      params,
-      _messageBus,
-      _toolName,
-      _displayName,
-    );
+    return new WriteTodosToolInvocation(params, _messageBus, _toolName);
   }
 }


### PR DESCRIPTION
## Summary

Remove tool display name in favor of just name.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/12909

## How to Validate

do various tool operations. call /tools. do a tool confirmation. list mcp tools. etc.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
