### PR TITLE
fix test to use faketimer

### DIFF
--- a/packages/core/src/utils/llm-edit-fixer.test.ts
+++ b/packages/core/src/utils/llm-edit-fixer.test.ts
@@ -39,11 +39,22 @@ describe('FixLLMEditWithInstruction', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    // Mock AbortSignal.timeout to use setTimeout so it respects fake timers
+    vi.spyOn(AbortSignal, 'timeout').mockImplementation((ms) => {
+      const controller = new AbortController();
+      setTimeout(
+        () =>
+          controller.abort(new DOMException('TimeoutError', 'TimeoutError')),
+        ms,
+      );
+      return controller.signal;
+    });
     resetLlmEditFixerCaches_TEST_ONLY(); // Ensure cache is cleared before each test
   });
 
   afterEach(() => {
     vi.useRealTimers(); // Reset timers after each test
+    vi.restoreAllMocks();
   });
 
   const mockApiResponse: SearchReplaceEdit = {
@@ -329,45 +340,41 @@ describe('FixLLMEditWithInstruction', () => {
     });
   });
 
-  it(
-    'should return null if the LLM call times out',
-    { timeout: 60000 },
-    async () => {
-      mockGenerateJson.mockImplementation(
-        async ({ abortSignal }) =>
-          // Simulate a long-running operation that never resolves on its own.
-          // It will only reject when the abort signal is triggered by the timeout.
-          new Promise((_resolve, reject) => {
-            if (abortSignal?.aborted) {
-              return reject(new DOMException('Aborted', 'AbortError'));
-            }
-            abortSignal?.addEventListener('abort', () => {
-              reject(new DOMException('Aborted', 'AbortError'));
-            });
-          }),
-      );
+  it('should return null if the LLM call times out', async () => {
+    mockGenerateJson.mockImplementation(
+      async ({ abortSignal }) =>
+        // Simulate a long-running operation that never resolves on its own.
+        // It will only reject when the abort signal is triggered by the timeout.
+        new Promise((_resolve, reject) => {
+          if (abortSignal?.aborted) {
+            return reject(new DOMException('Aborted', 'AbortError'));
+          }
+          abortSignal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        }),
+    );
 
-      const testPromptId = 'test-prompt-id-timeout';
+    const testPromptId = 'test-prompt-id-timeout';
 
-      const fixPromise = promptIdContext.run(testPromptId, () =>
-        FixLLMEditWithInstruction(
-          instruction,
-          old_string,
-          new_string,
-          error,
-          current_content,
-          mockBaseLlmClient,
-          abortSignal,
-        ),
-      );
+    const fixPromise = promptIdContext.run(testPromptId, () =>
+      FixLLMEditWithInstruction(
+        instruction,
+        old_string,
+        new_string,
+        error,
+        current_content,
+        mockBaseLlmClient,
+        abortSignal,
+      ),
+    );
 
-      // Let the timers advance just past the 40000ms default timeout.
-      await vi.advanceTimersByTimeAsync(40001);
+    // Let the timers advance just past the 40000ms default timeout.
+    await vi.advanceTimersByTimeAsync(40001);
 
-      const result = await fixPromise;
+    const result = await fixPromise;
 
-      expect(result).toBeNull();
-      expect(mockGenerateJson).toHaveBeenCalledOnce();
-    },
-  );
+    expect(result).toBeNull();
+    expect(mockGenerateJson).toHaveBeenCalledOnce();
+  });
 });


### PR DESCRIPTION
## Summary

Fix test to use faketimer.

## Details

Previously, the abort context was not respecting the fake timer so the test took 40 actual seconds to run.
