### PR TITLE
Fix extensions disable/enable commands not awaiting handler

### DIFF
--- a/packages/cli/src/commands/extensions/disable.ts
+++ b/packages/cli/src/commands/extensions/disable.ts
@@ -76,8 +76,8 @@ export const disableCommand: CommandModule = {
         }
         return true;
       }),
-  handler: (argv) => {
-    handleDisable({
+  handler: async (argv) => {
+    await handleDisable({
       name: argv['name'] as string,
       scope: argv['scope'] as string,
     });

--- a/packages/cli/src/commands/extensions/enable.ts
+++ b/packages/cli/src/commands/extensions/enable.ts
@@ -32,9 +32,9 @@ export async function handleEnable(args: EnableArgs) {
 
   try {
     if (args.scope?.toLowerCase() === 'workspace') {
-      extensionManager.enableExtension(args.name, SettingScope.Workspace);
+      await extensionManager.enableExtension(args.name, SettingScope.Workspace);
     } else {
-      extensionManager.enableExtension(args.name, SettingScope.User);
+      await extensionManager.enableExtension(args.name, SettingScope.User);
     }
     if (args.scope) {
       debugLogger.log(

--- a/packages/cli/src/commands/extensions/enable.ts
+++ b/packages/cli/src/commands/extensions/enable.ts
@@ -81,8 +81,8 @@ export const enableCommand: CommandModule = {
         }
         return true;
       }),
-  handler: (argv) => {
-    handleEnable({
+  handler: async (argv) => {
+    await handleEnable({
       name: argv['name'] as string,
       scope: argv['scope'] as string,
     });


### PR DESCRIPTION
Fixes https://github.com/google-gemini/gemini-cli/issues/12914

The issue was a race condition caused by how the CLI handles command execution and process termination. `handleDisable` and `handleEnable` are async functions performing file I/O. The original yargs handlers were synchronous, firing off these promises without waiting for them.

In `packages/cli/src/config/config.ts`, the code explicitly exits the process (`process.exit(0)`) after parsing arguments for extension commands. Because the handler returned immediately, the process was killed while the file write operation was still pending, preventing the changes from being persisted.

This PR makes the handlers async and awaits the underlying functions.