### PR TITLE
Use PascalCase for all tool display names

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1077,7 +1077,7 @@ const SETTINGS_SCHEMA = {
   },
   useWriteTodos: {
     type: 'boolean',
-    label: 'Use Write Todos',
+    label: 'Use WriteTodos',
     category: 'Advanced',
     requiresRestart: false,
     default: false,

--- a/packages/core/src/tools/memoryTool.test.ts
+++ b/packages/core/src/tools/memoryTool.test.ts
@@ -212,7 +212,7 @@ describe('MemoryTool', () => {
 
     it('should have correct name, displayName, description, and schema', () => {
       expect(memoryTool.name).toBe('save_memory');
-      expect(memoryTool.displayName).toBe('Save Memory');
+      expect(memoryTool.displayName).toBe('SaveMemory');
       expect(memoryTool.description).toContain(
         'Saves a specific piece of information',
       );

--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -303,7 +303,7 @@ export class MemoryTool
   constructor(messageBus?: MessageBus) {
     super(
       MemoryTool.Name,
-      'Save Memory',
+      'SaveMemory',
       memoryToolDescription,
       Kind.Think,
       memoryToolSchemaData.parametersJsonSchema as Record<string, unknown>,

--- a/packages/core/src/tools/write-todos.ts
+++ b/packages/core/src/tools/write-todos.ts
@@ -148,7 +148,7 @@ export class WriteTodosTool extends BaseDeclarativeTool<
   constructor() {
     super(
       WriteTodosTool.Name,
-      'Write Todos',
+      'WriteTodos',
       WRITE_TODOS_DESCRIPTION,
       Kind.Other,
       {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -977,7 +977,7 @@
       "type": "boolean"
     },
     "useWriteTodos": {
-      "title": "Use Write Todos",
+      "title": "Use WriteTodos",
       "description": "Enable the write_todos_list tool.",
       "markdownDescription": "Enable the write_todos_list tool.\n\n- Category: `Advanced`\n- Requires restart: `no`\n- Default: `false`",
       "default": false,


### PR DESCRIPTION
## Summary

`Write Todos` and `Save Memory` were the only tools not doing this so I fixed them.

## How to Validate

Ask to model to use the tools.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
