### PR TITLE
feat: Update client metadata for consistency

### DIFF
--- a/packages/core/src/code_assist/experiments/client_metadata.test.ts
+++ b/packages/core/src/code_assist/experiments/client_metadata.test.ts
@@ -103,10 +103,16 @@ describe('client_metadata', () => {
       expect(getReleaseChannel).toHaveBeenCalledTimes(1);
     });
 
-    it('should always return the IDE name as GEMINI_CLI', async () => {
+    it('should always return the IDE name as IDE_UNSPECIFIED', async () => {
       const { getClientMetadata } = await import('./client_metadata.js');
       const metadata = await getClientMetadata();
-      expect(metadata.ideName).toBe('GEMINI_CLI');
+      expect(metadata.ideName).toBe('IDE_UNSPECIFIED');
+    });
+
+    it('should always return the pluginType as GEMINI', async () => {
+      const { getClientMetadata } = await import('./client_metadata.js');
+      const metadata = await getClientMetadata();
+      expect(metadata.pluginType).toBe('GEMINI');
     });
   });
 });

--- a/packages/core/src/code_assist/experiments/client_metadata.ts
+++ b/packages/core/src/code_assist/experiments/client_metadata.ts
@@ -45,7 +45,8 @@ function getPlatform(): ClientMetadataPlatform {
 export async function getClientMetadata(): Promise<ClientMetadata> {
   if (!clientMetadataPromise) {
     clientMetadataPromise = (async () => ({
-      ideName: 'GEMINI_CLI',
+      ideName: 'IDE_UNSPECIFIED',
+      pluginType: 'GEMINI',
       ideVersion: process.env['CLI_VERSION'] || process.version,
       platform: getPlatform(),
       updateChannel: await getReleaseChannel(__dirname),


### PR DESCRIPTION
## TLDR
This pull request updates the client metadata to set `ideName` to `IDE_UNSPECIFIED` and  sets `pluginType` to `GEMINI`. This change ensures consistency with how client metadata is set for other CCPA requests from the CLI.