### PR TITLE
feat(auth): Add option for metadata server application default credentials without project override

### DIFF
--- a/docs/get-started/authentication.md
+++ b/docs/get-started/authentication.md
@@ -8,12 +8,22 @@ CLI, configure **one** of the following authentication methods:
   - Use Gemini API key
   - Use Vertex AI
 - Headless (non-interactive) mode
-- Google Cloud Shell
+- Google Cloud Environments (Cloud Shell, Compute Engine, etc.)
 
 ## Quick Check: Running in Google Cloud Shell?
 
 If you are running the Gemini CLI within a Google Cloud Shell environment,
 authentication is typically automatic using your Cloud Shell credentials.
+
+### Other Google Cloud Environments (e.g., Compute Engine)
+
+Some other Google Cloud environments, such as Compute Engine VMs, might also
+support automatic authentication. In these environments, Gemini CLI can
+automatically use Application Default Credentials (ADC) sourced from the
+environment's metadata server.
+
+If automatic authentication does not occur in your environment, you will need to
+use one of the interactive methods described below.
 
 ## Authenticate in Interactive mode
 

--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -32,8 +32,8 @@ describe('validateAuthMethod', () => {
     expect(validateAuthMethod(AuthType.LOGIN_WITH_GOOGLE)).toBeNull();
   });
 
-  it('should return null for CLOUD_SHELL', () => {
-    expect(validateAuthMethod(AuthType.CLOUD_SHELL)).toBeNull();
+  it('should return null for COMPUTE_ADC', () => {
+    expect(validateAuthMethod(AuthType.COMPUTE_ADC)).toBeNull();
   });
 
   describe('USE_GEMINI', () => {

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -11,7 +11,7 @@ export function validateAuthMethod(authMethod: string): string | null {
   loadEnvironment(loadSettings().merged);
   if (
     authMethod === AuthType.LOGIN_WITH_GOOGLE ||
-    authMethod === AuthType.CLOUD_SHELL
+    authMethod === AuthType.COMPUTE_ADC
   ) {
     return null;
   }

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -284,13 +284,19 @@ export async function main() {
     validateDnsResolutionOrder(settings.merged.advanced?.dnsResolutionOrder),
   );
 
-  // Set a default auth type if one isn't set.
-  if (!settings.merged.security?.auth?.selectedType) {
-    if (process.env['CLOUD_SHELL'] === 'true') {
+  // Set a default auth type if one isn't set or is set to a legacy type
+  if (
+    !settings.merged.security?.auth?.selectedType ||
+    settings.merged.security?.auth?.selectedType === AuthType.LEGACY_CLOUD_SHELL
+  ) {
+    if (
+      process.env['CLOUD_SHELL'] === 'true' ||
+      process.env['GEMINI_CLI_USE_COMPUTE_ADC'] === 'true'
+    ) {
       settings.setValue(
         SettingScope.User,
         'selectedAuthType',
-        AuthType.CLOUD_SHELL,
+        AuthType.COMPUTE_ADC,
       );
     }
   }

--- a/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -109,8 +109,41 @@ describe('AuthDialog', () => {
     const items = mockedRadioButtonSelect.mock.calls[0][0].items;
     expect(items).toContainEqual({
       label: 'Use Cloud Shell user credentials',
-      value: AuthType.CLOUD_SHELL,
-      key: AuthType.CLOUD_SHELL,
+      value: AuthType.COMPUTE_ADC,
+      key: AuthType.COMPUTE_ADC,
+    });
+  });
+
+  it('does not show application default credentials option in Cloud Shell environment', () => {
+    process.env['CLOUD_SHELL'] = 'true';
+    renderWithProviders(<AuthDialog {...props} />);
+    const items = mockedRadioButtonSelect.mock.calls[0][0].items;
+    expect(items).not.toContainEqual({
+      label: 'Use application default credentials',
+      value: AuthType.COMPUTE_ADC,
+      key: AuthType.COMPUTE_ADC,
+    });
+  });
+
+  it('shows application default credentials option when GEMINI_CLI_USE_COMPUTE_ADC env var is true', () => {
+    process.env['GEMINI_CLI_USE_COMPUTE_ADC'] = 'true';
+    renderWithProviders(<AuthDialog {...props} />);
+    const items = mockedRadioButtonSelect.mock.calls[0][0].items;
+    expect(items).toContainEqual({
+      label: 'Use application default credentials',
+      value: AuthType.COMPUTE_ADC,
+      key: AuthType.COMPUTE_ADC,
+    });
+  });
+
+  it('does not show Cloud Shell option when when GEMINI_CLI_USE_COMPUTE_ADC env var is true', () => {
+    process.env['GEMINI_CLI_USE_COMPUTE_ADC'] = 'true';
+    renderWithProviders(<AuthDialog {...props} />);
+    const items = mockedRadioButtonSelect.mock.calls[0][0].items;
+    expect(items).not.toContainEqual({
+      label: 'Use Cloud Shell user credentials',
+      value: AuthType.COMPUTE_ADC,
+      key: AuthType.COMPUTE_ADC,
     });
   });
 

--- a/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -114,23 +114,23 @@ describe('AuthDialog', () => {
     });
   });
 
-  it('does not show application default credentials option in Cloud Shell environment', () => {
+  it('does not show metadata server application default credentials option in Cloud Shell environment', () => {
     process.env['CLOUD_SHELL'] = 'true';
     renderWithProviders(<AuthDialog {...props} />);
     const items = mockedRadioButtonSelect.mock.calls[0][0].items;
     expect(items).not.toContainEqual({
-      label: 'Use application default credentials',
+      label: 'Use metadata server application default credentials',
       value: AuthType.COMPUTE_ADC,
       key: AuthType.COMPUTE_ADC,
     });
   });
 
-  it('shows application default credentials option when GEMINI_CLI_USE_COMPUTE_ADC env var is true', () => {
+  it('shows metadata server application default credentials option when GEMINI_CLI_USE_COMPUTE_ADC env var is true', () => {
     process.env['GEMINI_CLI_USE_COMPUTE_ADC'] = 'true';
     renderWithProviders(<AuthDialog {...props} />);
     const items = mockedRadioButtonSelect.mock.calls[0][0].items;
     expect(items).toContainEqual({
-      label: 'Use application default credentials',
+      label: 'Use metadata server application default credentials',
       value: AuthType.COMPUTE_ADC,
       key: AuthType.COMPUTE_ADC,
     });

--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -50,11 +50,19 @@ export function AuthDialog({
       ? [
           {
             label: 'Use Cloud Shell user credentials',
-            value: AuthType.CLOUD_SHELL,
-            key: AuthType.CLOUD_SHELL,
+            value: AuthType.COMPUTE_ADC,
+            key: AuthType.COMPUTE_ADC,
           },
         ]
-      : []),
+      : process.env['GEMINI_CLI_USE_COMPUTE_ADC'] === 'true'
+        ? [
+            {
+              label: 'Use application default credentials',
+              value: AuthType.COMPUTE_ADC,
+              key: AuthType.COMPUTE_ADC,
+            },
+          ]
+        : []),
     {
       label: 'Use Gemini API Key',
       value: AuthType.USE_GEMINI,

--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -57,7 +57,7 @@ export function AuthDialog({
       : process.env['GEMINI_CLI_USE_COMPUTE_ADC'] === 'true'
         ? [
             {
-              label: 'Use application default credentials',
+              label: 'Use metadata server application default credentials',
               value: AuthType.COMPUTE_ADC,
               key: AuthType.COMPUTE_ADC,
             },

--- a/packages/core/src/code_assist/codeAssist.test.ts
+++ b/packages/core/src/code_assist/codeAssist.test.ts
@@ -68,18 +68,18 @@ describe('codeAssist', () => {
       expect(generator).toBeInstanceOf(MockedCodeAssistServer);
     });
 
-    it('should create a server for CLOUD_SHELL', async () => {
+    it('should create a server for COMPUTE_ADC', async () => {
       mockedGetOauthClient.mockResolvedValue(mockAuthClient as never);
       mockedSetupUser.mockResolvedValue(mockUserData);
 
       const generator = await createCodeAssistContentGenerator(
         httpOptions,
-        AuthType.CLOUD_SHELL,
+        AuthType.COMPUTE_ADC,
         mockConfig,
       );
 
       expect(getOauthClient).toHaveBeenCalledWith(
-        AuthType.CLOUD_SHELL,
+        AuthType.COMPUTE_ADC,
         mockConfig,
       );
       expect(setupUser).toHaveBeenCalledWith(mockAuthClient);

--- a/packages/core/src/code_assist/codeAssist.ts
+++ b/packages/core/src/code_assist/codeAssist.ts
@@ -21,7 +21,7 @@ export async function createCodeAssistContentGenerator(
 ): Promise<ContentGenerator> {
   if (
     authType === AuthType.LOGIN_WITH_GOOGLE ||
-    authType === AuthType.CLOUD_SHELL
+    authType === AuthType.COMPUTE_ADC
   ) {
     const authClient = await getOauthClient(authType, config);
     const userData = await setupUser(authClient);

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -318,7 +318,7 @@ describe('oauth2', () => {
       });
 
       it('should use Compute to get a client if no cached credentials exist', async () => {
-        await getOauthClient(AuthType.CLOUD_SHELL, mockConfig);
+        await getOauthClient(AuthType.COMPUTE_ADC, mockConfig);
 
         expect(Compute).toHaveBeenCalledWith({});
         expect(mockGetAccessToken).toHaveBeenCalled();
@@ -329,7 +329,7 @@ describe('oauth2', () => {
         mockComputeClient.credentials = newCredentials;
         mockGetAccessToken.mockResolvedValue({ token: 'new-adc-token' });
 
-        await getOauthClient(AuthType.CLOUD_SHELL, mockConfig);
+        await getOauthClient(AuthType.COMPUTE_ADC, mockConfig);
 
         const credsPath = path.join(
           tempHomeDir,
@@ -340,7 +340,7 @@ describe('oauth2', () => {
       });
 
       it('should return the Compute client on successful ADC authentication', async () => {
-        const client = await getOauthClient(AuthType.CLOUD_SHELL, mockConfig);
+        const client = await getOauthClient(AuthType.COMPUTE_ADC, mockConfig);
         expect(client).toBe(mockComputeClient);
       });
 
@@ -349,9 +349,9 @@ describe('oauth2', () => {
         mockGetAccessToken.mockRejectedValue(testError);
 
         await expect(
-          getOauthClient(AuthType.CLOUD_SHELL, mockConfig),
+          getOauthClient(AuthType.COMPUTE_ADC, mockConfig),
         ).rejects.toThrow(
-          'Could not authenticate using Cloud Shell credentials. Please select a different authentication method or ensure you are in a properly configured environment. Error: ADC Failed',
+          'Could not authenticate using application default credentials. Please select a different authentication method or ensure you are in a properly configured environment. Error: ADC Failed',
         );
       });
     });

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -351,7 +351,7 @@ describe('oauth2', () => {
         await expect(
           getOauthClient(AuthType.COMPUTE_ADC, mockConfig),
         ).rejects.toThrow(
-          'Could not authenticate using application default credentials. Please select a different authentication method or ensure you are in a properly configured environment. Error: ADC Failed',
+          'Could not authenticate using metadata server application default credentials. Please select a different authentication method or ensure you are in a properly configured environment. Error: ADC Failed',
         );
       });
     });

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -161,7 +161,7 @@ async function initOauthClient(
   if (authType === AuthType.COMPUTE_ADC) {
     try {
       debugLogger.log(
-        'Attempting to authenticate via application default credentials.',
+        'Attempting to authenticate via metadata server application default credentials.',
       );
 
       const computeClient = new Compute({
@@ -175,7 +175,7 @@ async function initOauthClient(
       return computeClient;
     } catch (e) {
       throw new Error(
-        `Could not authenticate using application default credentials. Please select a different authentication method or ensure you are in a properly configured environment. Error: ${getErrorMessage(
+        `Could not authenticate using metadata server application default credentials. Please select a different authentication method or ensure you are in a properly configured environment. Error: ${getErrorMessage(
           e,
         )}`,
       );

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -155,12 +155,15 @@ async function initOauthClient(
     }
   }
 
-  // In Google Cloud Shell, we can use Application Default Credentials (ADC)
-  // provided via its metadata server to authenticate non-interactively using
-  // the identity of the user logged into Cloud Shell.
-  if (authType === AuthType.CLOUD_SHELL) {
+  // In Google Compute Engine based environments (including Cloud Shell), we can
+  // use Application Default Credentials (ADC) provided via its metadata server
+  // to authenticate non-interactively using the identity of the logged-in user.
+  if (authType === AuthType.COMPUTE_ADC) {
     try {
-      debugLogger.log("Attempting to authenticate via Cloud Shell VM's ADC.");
+      debugLogger.log(
+        'Attempting to authenticate via application default credentials.',
+      );
+
       const computeClient = new Compute({
         // We can leave this empty, since the metadata server will provide
         // the service account email.
@@ -172,7 +175,7 @@ async function initOauthClient(
       return computeClient;
     } catch (e) {
       throw new Error(
-        `Could not authenticate using Cloud Shell credentials. Please select a different authentication method or ensure you are in a properly configured environment. Error: ${getErrorMessage(
+        `Could not authenticate using application default credentials. Please select a different authentication method or ensure you are in a properly configured environment. Error: ${getErrorMessage(
           e,
         )}`,
       );

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -67,7 +67,7 @@ describe('createContentGenerator', () => {
     expect(generator).toBeInstanceOf(RecordingContentGenerator);
   });
 
-  it('should create a CodeAssistContentGenerator', async () => {
+  it('should create a CodeAssistContentGenerator when AuthType is LOGIN_WITH_GOOGLE', async () => {
     const mockGenerator = {} as unknown as ContentGenerator;
     vi.mocked(createCodeAssistContentGenerator).mockResolvedValue(
       mockGenerator as never,
@@ -75,6 +75,23 @@ describe('createContentGenerator', () => {
     const generator = await createContentGenerator(
       {
         authType: AuthType.LOGIN_WITH_GOOGLE,
+      },
+      mockConfig,
+    );
+    expect(createCodeAssistContentGenerator).toHaveBeenCalled();
+    expect(generator).toEqual(
+      new LoggingContentGenerator(mockGenerator, mockConfig),
+    );
+  });
+
+  it('should create a CodeAssistContentGenerator when AuthType is COMPUTE_ADC', async () => {
+    const mockGenerator = {} as unknown as ContentGenerator;
+    vi.mocked(createCodeAssistContentGenerator).mockResolvedValue(
+      mockGenerator as never,
+    );
+    const generator = await createContentGenerator(
+      {
+        authType: AuthType.COMPUTE_ADC,
       },
       mockConfig,
     );

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -48,7 +48,8 @@ export enum AuthType {
   LOGIN_WITH_GOOGLE = 'oauth-personal',
   USE_GEMINI = 'gemini-api-key',
   USE_VERTEX_AI = 'vertex-ai',
-  CLOUD_SHELL = 'cloud-shell',
+  LEGACY_CLOUD_SHELL = 'cloud-shell',
+  COMPUTE_ADC = 'compute-default-credentials',
 }
 
 export type ContentGeneratorConfig = {
@@ -79,7 +80,7 @@ export async function createContentGeneratorConfig(
   // If we are using Google auth or we are in Cloud Shell, there is nothing else to validate for now
   if (
     authType === AuthType.LOGIN_WITH_GOOGLE ||
-    authType === AuthType.CLOUD_SHELL
+    authType === AuthType.COMPUTE_ADC
   ) {
     return contentGeneratorConfig;
   }
@@ -120,7 +121,7 @@ export async function createContentGenerator(
     };
     if (
       config.authType === AuthType.LOGIN_WITH_GOOGLE ||
-      config.authType === AuthType.CLOUD_SHELL
+      config.authType === AuthType.COMPUTE_ADC
     ) {
       const httpOptions = { headers: baseHeaders };
       return new LoggingContentGenerator(

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -298,7 +298,7 @@ describe('loggers', () => {
       const event = new UserPromptEvent(
         11,
         'prompt-id-9',
-        AuthType.CLOUD_SHELL,
+        AuthType.COMPUTE_ADC,
         'test-prompt',
       );
 
@@ -315,7 +315,7 @@ describe('loggers', () => {
           interactive: false,
           prompt_length: 11,
           prompt_id: 'prompt-id-9',
-          auth_type: 'cloud-shell',
+          auth_type: 'compute-default-credentials',
         },
       });
     });

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -886,7 +886,7 @@ export function getConventionAttributes(event: {
 function getGenAiProvider(authType?: string): GenAiProviderName {
   switch (authType) {
     case AuthType.USE_VERTEX_AI:
-    case AuthType.CLOUD_SHELL:
+    case AuthType.COMPUTE_ADC:
     case AuthType.LOGIN_WITH_GOOGLE:
       return GenAiProviderName.GCP_VERTEX_AI;
     case AuthType.USE_GEMINI:


### PR DESCRIPTION
## Summary

This PR introduces a more flexible way to authenticate with Gemini CLI using Application Default Credentials (ADC) from a metadata server, such as in Compute Engine VMs. It adds support for a new environment variable `GEMINI_CLI_USE_COMPUTE_ADC` that enables this method without altering the user's `GOOGLE_CLOUD_PROJECT` setting. This decouples the automatic ADC flow from the project override behavior currently tied to the `CLOUD_SHELL` environment variable. Backward compatibility for existing settings is maintained.

## Details

The core change is the introduction of the `GEMINI_CLI_USE_COMPUTE_ADC` environment variable. When set to `true`, Gemini CLI will attempt to source credentials from the metadata server.

- **New Behavior:** `GEMINI_CLI_USE_COMPUTE_ADC=true` enables metadata server ADC *without* overriding `GOOGLE_CLOUD_PROJECT`.
- **Existing Behavior:** `CLOUD_SHELL=true` remains unchanged. It still enables metadata server ADC but also *does* override `GOOGLE_CLOUD_PROJECT` to the Cloud Shell default.
- **Internal Refactor:** The internal authentication type `AuthType.CLOUD_SHELL` has been renamed to `AuthType.COMPUTE_ADC`. This type now conditionally handles the project override logic based on whether `CLOUD_SHELL` or `GEMINI_CLI_USE_COMPUTE_ADC` is the active environment variable.
- **Backward Compatibility:** To prevent errors for users with existing settings files that reference the old auth type, the CLI will recognize the `selectedType": "cloud-shell"` setting. When this legacy configuration is detected in the settings file, it will be internally mapped to the new `COMPUTE_ADC` type, preserving the original Cloud Shell behavior (including the project override, assuming the `CLOUD_SHELL` environment variable is still set). This ensures a smooth transition for existing users.

This change allows users in non-Cloud Shell Google Cloud environments to benefit from seamless metadata server authentication while maintaining explicit control over their target Google Cloud project.

## Related Issues

Fixes #12671

## How to Validate

1.  **Test Case 1: New Variable - Explicit Project, No Override**
    *   Unset `CLOUD_SHELL` in your environment.
    *   Set `export GEMINI_CLI_USE_COMPUTE_ADC=true`
    *   Set `export GOOGLE_CLOUD_PROJECT="your-test-project"`
    *   Run `npm run start`: Expect successful authentication using ADC from the metadata server.
    *   Verify that the CLI uses `"your-test-project"` and does not default to the Cloud Shell project.

2.  **Test Case 2: New Variable - No Project Set (Free Tier)**
    *   Unset `CLOUD_SHELL` and `GOOGLE_CLOUD_PROJECT` in your environment.
    *   Set `export GEMINI_CLI_USE_COMPUTE_ADC=true`
    *   Run `npm run start` (as a user eligible for a free tier managed project): Expect successful authentication using ADC from the metadata server.
    *   Verify that the CLI provisions or uses a Gemini CLI managed project for the user.

3.  **Test Case 3: Cloud Shell Variable - Project Override Still Occurs**
    *   Unset `GEMINI_CLI_USE_COMPUTE_ADC` and `GOOGLE_CLOUD_PROJECT` in your environment.
    *   Set `export CLOUD_SHELL=true`
    *   Run `npm run start`: Expect successful authentication using ADC.
    *   Verify that the CLI defaults to the Cloud Shell project (this requires running within a Cloud Shell environment or mocking it).

4.  **Test Case 4: Neither Variable Set**
    *   Unset `CLOUD_SHELL` and `GEMINI_CLI_USE_COMPUTE_ADC` in your environment.
    *   Run `npm run start`: Expect the standard interactive authentication prompts (Login with Google, API Key, etc.).

5.  **Test Case 5: Project set in .env with CLOUD_SHELL=true**
    *   Set `export CLOUD_SHELL=true` in the environment.
    *   Create a `.env` file (e.g., in home directory) with `GOOGLE_CLOUD_PROJECT="dotenv-project"`.
    *   Run `npm run start`: Expect successful authentication, using the project `"dotenv-project"` (as .env takes precedence).

6.  **Test Case 6: Backward Compatibility with Legacy Settings**
    *   Create or modify a settings file (e.g., `~/.gemini/settings.json`) to explicitly use the old auth type:
        ```json
        {
          "security": {
            "auth": {
              "selectedType": "cloud-shell"
            }
          }
        }
        ```
    *   Unset `GEMINI_CLI_USE_COMPUTE_ADC` and `GOOGLE_CLOUD_PROJECT`, in your environment.
    *   Set `export CLOUD_SHELL=true`
    *   Run `npm run start`: Expect successful authentication, and crucially, verify that the `GOOGLE_CLOUD_PROJECT` is overridden, just like the standard `CLOUD_SHELL=true` behavior. The CLI should not throw an error about an invalid auth type.

## Pre-Merge Checklist

- [X ] Updated relevant documentation and README (if needed)
- [X ] Added/updated tests (if needed)
- [ N/A] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ X] npm run
    - [ ] npx
    - [ ] Docker
