### PR TITLE
Turns out the node console.clear() clears the buffer.

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -734,9 +734,16 @@ Logging in with Google... Please restart Gemini CLI to continue.
   const handleClearScreen = useCallback(() => {
     historyManager.clearItems();
     clearConsoleMessagesState();
-    console.clear();
+    if (!isAlternateBuffer) {
+      console.clear();
+    }
     refreshStatic();
-  }, [historyManager, clearConsoleMessagesState, refreshStatic]);
+  }, [
+    historyManager,
+    clearConsoleMessagesState,
+    refreshStatic,
+    isAlternateBuffer,
+  ]);
 
   const { handleInput: vimHandleInput } = useVim(buffer, handleFinalSubmit);
 


### PR DESCRIPTION
## Summary

We were still calling console.clear() in alternateBuffer mode. Turns out that method triggers writing ascii codes to clear the terminal which is particularly harmful when we are using incremental rendering in alternate buffer mode.
It is a bit questionable we are calling this method outside of alternate buffer mode but not the end of the world. Leaving that in to avoid regressing the legacy code.