### PR TITLE
Always show the tool internal name in /tools

### DIFF
--- a/packages/cli/src/ui/components/views/ToolsList.tsx
+++ b/packages/cli/src/ui/components/views/ToolsList.tsx
@@ -32,8 +32,7 @@ export const ToolsList: React.FC<ToolsListProps> = ({
           <Text color={theme.text.primary}>{'  '}- </Text>
           <Box flexDirection="column">
             <Text bold color={theme.text.accent}>
-              {tool.displayName}
-              {showDescriptions ? ` (${tool.name})` : ''}
+              {tool.displayName} ({tool.name})
             </Text>
             {showDescriptions && tool.description && (
               <MarkdownDisplay

--- a/packages/cli/src/ui/components/views/__snapshots__/ToolsList.test.tsx.snap
+++ b/packages/cli/src/ui/components/views/__snapshots__/ToolsList.test.tsx.snap
@@ -25,8 +25,8 @@ exports[`<ToolsList /> > renders correctly with no tools 1`] = `
 exports[`<ToolsList /> > renders correctly without descriptions 1`] = `
 "Available Gemini CLI tools:
 
-  - Test Tool One
-  - Test Tool Two
-  - Test Tool Three
+  - Test Tool One (test-tool-one)
+  - Test Tool Two (test-tool-two)
+  - Test Tool Three (test-tool-three)
 "
 `;


### PR DESCRIPTION
## Summary

Always show the tool internal name in `/tools`.

## Details

Previously we only showed the tool internal name when running `/tool desc`.

## How to Validate

Execute `/tools`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
