### PR TITLE
Improve MALFORMED_FUNCTION_CALL handling

### DIFF
--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -442,7 +442,7 @@ export function logContentRetry(
     attributes: event.toOpenTelemetryAttributes(config),
   };
   logger.emit(logRecord);
-  recordContentRetry(config);
+  recordContentRetry(config, event.error_type);
 }
 
 export function logContentRetryFailure(
@@ -458,7 +458,7 @@ export function logContentRetryFailure(
     attributes: event.toOpenTelemetryAttributes(config),
   };
   logger.emit(logRecord);
-  recordContentRetryFailure(config);
+  recordContentRetryFailure(config, event.final_error_type);
 }
 
 export function logModelRouting(

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -136,13 +136,17 @@ const COUNTER_DEFINITIONS = {
     description: 'Counts retries due to content errors (e.g., empty stream).',
     valueType: ValueType.INT,
     assign: (c: Counter) => (contentRetryCounter = c),
-    attributes: {} as Record<string, never>,
+    attributes: {} as {
+      error_type: string;
+    },
   },
   [CONTENT_RETRY_FAILURE_COUNT]: {
     description: 'Counts occurrences of all content retries failing.',
     valueType: ValueType.INT,
     assign: (c: Counter) => (contentRetryFailureCounter = c),
-    attributes: {} as Record<string, never>,
+    attributes: {} as {
+      error_type: string;
+    },
   },
   [MODEL_ROUTING_FAILURE_COUNT]: {
     description: 'Counts model routing failures.',
@@ -715,20 +719,26 @@ export function recordInvalidChunk(config: Config): void {
 /**
  * Records a metric for when a retry is triggered due to a content error.
  */
-export function recordContentRetry(config: Config): void {
+export function recordContentRetry(config: Config, errorType: string): void {
   if (!contentRetryCounter || !isMetricsInitialized) return;
-  contentRetryCounter.add(1, baseMetricDefinition.getCommonAttributes(config));
+  contentRetryCounter.add(1, {
+    ...baseMetricDefinition.getCommonAttributes(config),
+    error_type: errorType,
+  });
 }
 
 /**
  * Records a metric for when all content error retries have failed for a request.
  */
-export function recordContentRetryFailure(config: Config): void {
+export function recordContentRetryFailure(
+  config: Config,
+  errorType: string,
+): void {
   if (!contentRetryFailureCounter || !isMetricsInitialized) return;
-  contentRetryFailureCounter.add(
-    1,
-    baseMetricDefinition.getCommonAttributes(config),
-  );
+  contentRetryFailureCounter.add(1, {
+    ...baseMetricDefinition.getCommonAttributes(config),
+    error_type: errorType,
+  });
 }
 
 export function recordModelSlashCommand(


### PR DESCRIPTION
## Summary

Retry on MALFORMED_FUNCTION_CALL and properly log it.

## Related Issues

Fixes #12674

## How to Validate

I removed the schema override on the `write_todos` to trigger this issue and test it that way.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
