### PR TITLE
Harden hook runner command execution

### DIFF
--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -46,11 +46,12 @@ describe('HookRunner', () => {
     timestamp: '2025-01-01T00:00:00.000Z',
   };
 
-  const createInput = <T extends HookInput>(overrides: Partial<T> = {}): T => ({
+  const createInput = <T extends HookInput>(overrides: Partial<T> = {}): T =>
+    ({
       ...baseInput,
       cwd: overrides.cwd ?? projectDir,
       ...overrides,
-    } as T);
+    }) as T;
 
   const writeHookScript = (
     relativePath: string,
@@ -65,7 +66,8 @@ describe('HookRunner', () => {
     return `./${rel}`;
   };
 
-  const readProjectFile = (relativePath: string, dir: string = projectDir) => readFileSync(path.join(dir, relativePath), 'utf8');
+  const readProjectFile = (relativePath: string, dir: string = projectDir) =>
+    readFileSync(path.join(dir, relativePath), 'utf8');
 
   beforeEach(() => {
     hookRunner = new HookRunner();
@@ -394,7 +396,12 @@ async function readStdin() {
         ...createInput({ hook_event_name: HookEventName.BeforeModel }),
         llm_request: {
           model: 'gemini-1.5-pro',
-          contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
+          messages: [
+            {
+              role: 'user',
+              content: 'Hello',
+            },
+          ],
         },
       };
 

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -168,7 +168,7 @@ setInterval(() => {}, 1000);
 
       expect(result.success).toBe(false);
       expect(result.error?.message).toContain('timed out');
-    });
+    }, 15000);
 
     it('converts plain text stdout to HookOutput when JSON parsing fails', async () => {
       const plainText = 'Add this context';

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -64,7 +64,12 @@ describe('HookRunner', () => {
     writeFileSync(filePath, `#!/usr/bin/env node\n${body}`);
     chmodSync(filePath, 0o755);
     const rel = path.relative(dir, filePath).replace(/\\/g, '/');
-    return `./${rel}`;
+    const commandPath = `./${rel}`;
+    if (process.platform === 'win32') {
+      // PowerShell does not honor POSIX shebangs; invoke node explicitly.
+      return `node ${JSON.stringify(commandPath)}`;
+    }
+    return commandPath;
   };
 
   const readProjectFile = (relativePath: string, dir: string = projectDir) =>

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -14,6 +14,7 @@ import {
   chmodSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
 } from 'node:fs';
 import { HookRunner } from './hookRunner.js';
 import {
@@ -265,9 +266,11 @@ console.log(JSON.stringify({ decision: 'allow' }));
 
       expect(result.success).toBe(true);
       const envData = JSON.parse(readProjectFile(envCaptureFile));
-      expect(envData.gemini).toBe(projectDir);
-      expect(envData.claude).toBe(projectDir);
-      expect(envData.cwd).toBe(projectDir);
+      const normalize = (value: string): string => realpathSync(value);
+      const projectDirReal = realpathSync(projectDir);
+      expect(normalize(envData.gemini)).toBe(projectDirReal);
+      expect(normalize(envData.claude)).toBe(projectDirReal);
+      expect(normalize(envData.cwd)).toBe(projectDirReal);
     });
 
     it('escapes cwd when expanding commands on POSIX platforms', () => {

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -272,7 +272,7 @@ console.log(JSON.stringify({ decision: 'allow' }));
 
     it('escapes cwd when expanding commands on POSIX platforms', () => {
       const cwdWithQuotes = "/tmp/project with 'quotes' && rm -rf /";
-      const runner = new HookRunner({ platform: 'linux' });
+      const runner = new HookRunner({ platformOverride: 'linux' });
       const expanded = (
         runner as unknown as {
           expandCommand(command: string, input: HookInput): string;
@@ -290,7 +290,7 @@ console.log(JSON.stringify({ decision: 'allow' }));
     it('escapes cwd when expanding commands on Windows', () => {
       const cwdWithQuotes =
         'C\\\\project with "quotes" && del C\\\\windows\\system32';
-      const runner = new HookRunner({ platform: 'win32' });
+      const runner = new HookRunner({ platformOverride: 'win32' });
       const expanded = (
         runner as unknown as {
           expandCommand(command: string, input: HookInput): string;
@@ -301,13 +301,10 @@ console.log(JSON.stringify({ decision: 'allow' }));
       });
 
       expect(expanded).toBe(
-        '"C\\\\project with ""quotes"" && del C\\\\windows\\system32"/cleanup.cmd',
+        '\'C\\\\project with "quotes" && del C\\\\windows\\system32\'/cleanup.cmd',
       );
 
-      const psRunner = new HookRunner({
-        platform: 'win32',
-        shell: 'powershell.exe',
-      });
+      const psRunner = new HookRunner({ platformOverride: 'win32' });
 
       const cwdWithSingleQuotes =
         "C\\\\project with 'quotes' && del C\\\\windows\\system32";

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -318,9 +318,6 @@ console.log(JSON.stringify({ decision: 'allow' }));
         cwd: cwdWithSingleQuotes,
       });
 
-      expect((psRunner as Record<string, unknown>)['shellFlavor']).toBe(
-        'powershell',
-      );
       expect(psExpanded).toBe(
         "'C\\\\project with ''quotes'' && del C\\\\windows\\system32'/cleanup.cmd",
       );

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -272,7 +272,7 @@ console.log(JSON.stringify({ decision: 'allow' }));
 
     it('escapes cwd when expanding commands on POSIX platforms', () => {
       const cwdWithQuotes = "/tmp/project with 'quotes' && rm -rf /";
-      const runner = new HookRunner('linux');
+      const runner = new HookRunner({ platform: 'linux' });
       const expanded = (
         runner as unknown as {
           expandCommand(command: string, input: HookInput): string;
@@ -290,7 +290,7 @@ console.log(JSON.stringify({ decision: 'allow' }));
     it('escapes cwd when expanding commands on Windows', () => {
       const cwdWithQuotes =
         'C\\\\project with "quotes" && del C\\\\windows\\system32';
-      const runner = new HookRunner('win32');
+      const runner = new HookRunner({ platform: 'win32' });
       const expanded = (
         runner as unknown as {
           expandCommand(command: string, input: HookInput): string;
@@ -302,6 +302,30 @@ console.log(JSON.stringify({ decision: 'allow' }));
 
       expect(expanded).toBe(
         '"C\\\\project with ""quotes"" && del C\\\\windows\\system32"/cleanup.cmd',
+      );
+
+      const psRunner = new HookRunner({
+        platform: 'win32',
+        shell: 'powershell.exe',
+      });
+
+      const cwdWithSingleQuotes =
+        "C\\\\project with 'quotes' && del C\\\\windows\\system32";
+
+      const psExpanded = (
+        psRunner as unknown as {
+          expandCommand(command: string, input: HookInput): string;
+        }
+      ).expandCommand('$GEMINI_PROJECT_DIR/cleanup.cmd', {
+        ...baseInput,
+        cwd: cwdWithSingleQuotes,
+      });
+
+      expect((psRunner as Record<string, unknown>)['shellFlavor']).toBe(
+        'powershell',
+      );
+      expect(psExpanded).toBe(
+        "'C\\\\project with ''quotes'' && del C\\\\windows\\system32'/cleanup.cmd",
       );
     });
   });

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -4,31 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+} from 'node:fs';
 import { HookRunner } from './hookRunner.js';
-import { HookEventName, HookType } from './types.js';
-import type { HookConfig } from './types.js';
-import type { HookInput } from './types.js';
-import type { Readable, Writable } from 'node:stream';
+import {
+  HookEventName,
+  HookType,
+  type HookConfig,
+  type HookInput,
+  type BeforeAgentInput,
+  type BeforeModelInput,
+} from './types.js';
 
-// Mock type for the child_process spawn
-type MockChildProcessWithoutNullStreams = ChildProcessWithoutNullStreams & {
-  mockStdoutOn: ReturnType<typeof vi.fn>;
-  mockStderrOn: ReturnType<typeof vi.fn>;
-  mockProcessOn: ReturnType<typeof vi.fn>;
-};
-
-// Mock child_process with importOriginal for partial mocking
-vi.mock('node:child_process', async (importOriginal) => {
-  const actual = (await importOriginal()) as object;
-  return {
-    ...actual,
-    spawn: vi.fn(),
-  };
-});
-
-// Mock console methods
 const mockConsole = {
   log: vi.fn(),
   warn: vi.fn(),
@@ -40,251 +36,257 @@ vi.stubGlobal('console', mockConsole);
 
 describe('HookRunner', () => {
   let hookRunner: HookRunner;
-  let mockSpawn: MockChildProcessWithoutNullStreams;
+  let projectDir: string;
 
-  const mockInput: HookInput = {
+  const baseInput: HookInput = {
     session_id: 'test-session',
     transcript_path: '/path/to/transcript',
-    cwd: '/test/project',
-    hook_event_name: 'BeforeTool',
+    cwd: '',
+    hook_event_name: HookEventName.BeforeTool,
     timestamp: '2025-01-01T00:00:00.000Z',
   };
 
+  const createInput = <T extends HookInput>(overrides: Partial<T> = {}): T => ({
+      ...baseInput,
+      cwd: overrides.cwd ?? projectDir,
+      ...overrides,
+    } as T);
+
+  const writeHookScript = (
+    relativePath: string,
+    body: string,
+    dir: string = projectDir,
+  ): string => {
+    const filePath = path.join(dir, relativePath);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, `#!/usr/bin/env node\n${body}`);
+    chmodSync(filePath, 0o755);
+    const rel = path.relative(dir, filePath).replace(/\\/g, '/');
+    return `./${rel}`;
+  };
+
+  const readProjectFile = (relativePath: string, dir: string = projectDir) => readFileSync(path.join(dir, relativePath), 'utf8');
+
   beforeEach(() => {
-    vi.resetAllMocks();
-
     hookRunner = new HookRunner();
-
-    // Mock spawn with accessible mock functions
-    const mockStdoutOn = vi.fn();
-    const mockStderrOn = vi.fn();
-    const mockProcessOn = vi.fn();
-
-    mockSpawn = {
-      stdin: {
-        write: vi.fn(),
-        end: vi.fn(),
-      } as unknown as Writable,
-      stdout: {
-        on: mockStdoutOn,
-      } as unknown as Readable,
-      stderr: {
-        on: mockStderrOn,
-      } as unknown as Readable,
-      on: mockProcessOn,
-      kill: vi.fn(),
-      killed: false,
-      mockStdoutOn,
-      mockStderrOn,
-      mockProcessOn,
-    } as unknown as MockChildProcessWithoutNullStreams;
-
-    vi.mocked(spawn).mockReturnValue(mockSpawn);
+    projectDir = mkdtempSync(path.join(tmpdir(), 'hook-runner-test-'));
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    rmSync(projectDir, { recursive: true, force: true });
+    vi.clearAllMocks();
   });
 
   describe('executeHook', () => {
-    describe('command hooks', () => {
-      const commandConfig: HookConfig = {
+    it('executes a command hook successfully with JSON output', async () => {
+      const expectedOutput = { decision: 'allow', reason: 'All good' };
+      const command = writeHookScript(
+        'hooks/success.cjs',
+        `
+const payload = ${JSON.stringify(expectedOutput)};
+console.log(JSON.stringify(payload));
+`,
+      );
+
+      const config: HookConfig = { type: HookType.Command, command };
+      const result = await hookRunner.executeHook(
+        config,
+        HookEventName.BeforeTool,
+        createInput(),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.output).toEqual(expectedOutput);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('captures stderr and non-zero exits', async () => {
+      const errorMessage = 'Command failed';
+      const command = writeHookScript(
+        'hooks/fail.cjs',
+        `
+console.error(${JSON.stringify(errorMessage)});
+process.exit(1);
+`,
+      );
+
+      const config: HookConfig = { type: HookType.Command, command };
+      const result = await hookRunner.executeHook(
+        config,
+        HookEventName.BeforeTool,
+        createInput(),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr?.trim()).toBe(errorMessage);
+      expect(result.output).toEqual({
+        decision: 'allow',
+        systemMessage: `Warning: ${errorMessage}`,
+      });
+    });
+
+    it('times out long-running hooks', async () => {
+      const command = writeHookScript(
+        'hooks/hang.cjs',
+        `
+setInterval(() => {}, 1000);
+`,
+      );
+
+      const config: HookConfig = {
         type: HookType.Command,
-        command: './hooks/test.sh',
-        timeout: 5000,
+        command,
+        timeout: 50,
       };
 
-      it('should execute command hook successfully', async () => {
-        const mockOutput = { decision: 'allow', reason: 'All good' };
+      const result = await hookRunner.executeHook(
+        config,
+        HookEventName.BeforeTool,
+        createInput(),
+      );
 
-        // Mock successful execution
-        mockSpawn.mockStdoutOn.mockImplementation(
-          (event: string, callback: (data: Buffer) => void) => {
-            if (event === 'data') {
-              setTimeout(
-                () => callback(Buffer.from(JSON.stringify(mockOutput))),
-                10,
-              );
-            }
-          },
-        );
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('timed out');
+    });
 
-        mockSpawn.mockProcessOn.mockImplementation(
-          (event: string, callback: (code: number) => void) => {
-            if (event === 'close') {
-              setTimeout(() => callback(0), 20);
-            }
-          },
-        );
+    it('converts plain text stdout to HookOutput when JSON parsing fails', async () => {
+      const plainText = 'Add this context';
+      const command = writeHookScript(
+        'hooks/plain.cjs',
+        `
+console.log(${JSON.stringify(plainText)});
+`,
+      );
 
-        const result = await hookRunner.executeHook(
-          commandConfig,
-          HookEventName.BeforeTool,
-          mockInput,
-        );
+      const result = await hookRunner.executeHook(
+        { type: HookType.Command, command },
+        HookEventName.BeforeTool,
+        createInput(),
+      );
 
-        expect(result.success).toBe(true);
-        expect(result.output).toEqual(mockOutput);
-        expect(result.exitCode).toBe(0);
-        expect(mockSpawn.stdin.write).toHaveBeenCalledWith(
-          JSON.stringify(mockInput),
-        );
+      expect(result.success).toBe(true);
+      expect(result.output).toEqual({
+        decision: 'allow',
+        systemMessage: plainText,
+      });
+    });
+
+    it('treats exit code 2 stderr as blocking error output', async () => {
+      const errorMessage = 'Blocking error';
+      const command = writeHookScript(
+        'hooks/blocking.cjs',
+        `
+console.error(${JSON.stringify(errorMessage)});
+process.exit(2);
+`,
+      );
+
+      const result = await hookRunner.executeHook(
+        { type: HookType.Command, command },
+        HookEventName.BeforeTool,
+        createInput(),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(2);
+      expect(result.output).toEqual({
+        decision: 'deny',
+        reason: errorMessage,
+      });
+    });
+
+    it('handles double-encoded JSON hook output', async () => {
+      const payload = { decision: 'allow', reason: 'Nested' };
+      const command = writeHookScript(
+        'hooks/double.cjs',
+        `
+const payload = ${JSON.stringify(payload)};
+console.log(JSON.stringify(JSON.stringify(payload)));
+`,
+      );
+
+      const result = await hookRunner.executeHook(
+        { type: HookType.Command, command },
+        HookEventName.BeforeTool,
+        createInput(),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.output).toEqual(payload);
+    });
+
+    it('expands project directory placeholders and preserves env vars', async () => {
+      const envCaptureFile = 'env-capture.json';
+      const commandPath = 'hooks/env-check.cjs';
+      writeHookScript(
+        commandPath,
+        `
+const fs = require('node:fs');
+const payload = {
+  gemini: process.env.GEMINI_PROJECT_DIR,
+  claude: process.env.CLAUDE_PROJECT_DIR,
+  cwd: process.cwd(),
+};
+fs.writeFileSync(${JSON.stringify(envCaptureFile)}, JSON.stringify(payload));
+console.log(JSON.stringify({ decision: 'allow' }));
+`,
+      );
+
+      const config: HookConfig = {
+        type: HookType.Command,
+        command: `$GEMINI_PROJECT_DIR/${commandPath}`,
+      };
+
+      const result = await hookRunner.executeHook(
+        config,
+        HookEventName.BeforeTool,
+        createInput(),
+      );
+
+      expect(result.success).toBe(true);
+      const envData = JSON.parse(readProjectFile(envCaptureFile));
+      expect(envData.gemini).toBe(projectDir);
+      expect(envData.claude).toBe(projectDir);
+      expect(envData.cwd).toBe(projectDir);
+    });
+
+    it('escapes cwd when expanding commands', () => {
+      const cwdWithQuotes = "/tmp/project with 'quotes' && rm -rf /";
+      const runner = new HookRunner();
+      const expanded = (
+        runner as unknown as {
+          expandCommand(command: string, input: HookInput): string;
+        }
+      ).expandCommand('$GEMINI_PROJECT_DIR/run.sh', {
+        ...baseInput,
+        cwd: cwdWithQuotes,
       });
 
-      it('should handle command hook failure', async () => {
-        const errorMessage = 'Command failed';
-
-        mockSpawn.mockStderrOn.mockImplementation(
-          (event: string, callback: (data: Buffer) => void) => {
-            if (event === 'data') {
-              setTimeout(() => callback(Buffer.from(errorMessage)), 10);
-            }
-          },
-        );
-
-        mockSpawn.mockProcessOn.mockImplementation(
-          (event: string, callback: (code: number) => void) => {
-            if (event === 'close') {
-              setTimeout(() => callback(1), 20);
-            }
-          },
-        );
-
-        const result = await hookRunner.executeHook(
-          commandConfig,
-          HookEventName.BeforeTool,
-          mockInput,
-        );
-
-        expect(result.success).toBe(false);
-        expect(result.exitCode).toBe(1);
-        expect(result.stderr).toBe(errorMessage);
-      });
-
-      it('should handle command hook timeout', async () => {
-        const shortTimeoutConfig: HookConfig = {
-          type: HookType.Command,
-          command: './hooks/slow.sh',
-          timeout: 50, // Very short timeout for testing
-        };
-
-        let closeCallback: ((code: number) => void) | undefined;
-        let killWasCalled = false;
-
-        // Mock a hanging process that registers the close handler but doesn't call it initially
-        mockSpawn.mockProcessOn.mockImplementation(
-          (event: string, callback: (code: number) => void) => {
-            if (event === 'close') {
-              closeCallback = callback; // Store the callback but don't call it yet
-            }
-          },
-        );
-
-        // Mock the kill method to simulate the process being killed
-        mockSpawn.kill = vi.fn().mockImplementation((_signal: string) => {
-          killWasCalled = true;
-          // Simulate that killing the process triggers the close event
-          if (closeCallback) {
-            setTimeout(() => {
-              closeCallback!(128); // Exit code 128 indicates process was killed by signal
-            }, 5);
-          }
-          return true;
-        });
-
-        const result = await hookRunner.executeHook(
-          shortTimeoutConfig,
-          HookEventName.BeforeTool,
-          mockInput,
-        );
-
-        expect(result.success).toBe(false);
-        expect(killWasCalled).toBe(true);
-        expect(result.error?.message).toContain('timed out');
-        expect(mockSpawn.kill).toHaveBeenCalledWith('SIGTERM');
-      });
-
-      it('should expand environment variables in commands', async () => {
-        const configWithEnvVar: HookConfig = {
-          type: HookType.Command,
-          command: '$GEMINI_PROJECT_DIR/hooks/test.sh',
-        };
-
-        mockSpawn.mockProcessOn.mockImplementation(
-          (event: string, callback: (code: number) => void) => {
-            if (event === 'close') {
-              setTimeout(() => callback(0), 10);
-            }
-          },
-        );
-
-        await hookRunner.executeHook(
-          configWithEnvVar,
-          HookEventName.BeforeTool,
-          mockInput,
-        );
-
-        expect(spawn).toHaveBeenCalledWith(
-          '/test/project/hooks/test.sh',
-          expect.objectContaining({
-            shell: true,
-            env: expect.objectContaining({
-              GEMINI_PROJECT_DIR: '/test/project',
-              CLAUDE_PROJECT_DIR: '/test/project',
-            }),
-          }),
-        );
-      });
+      expect(expanded).toBe(
+        "'/tmp/project with '\\''quotes'\\'' && rm -rf /'/run.sh",
+      );
     });
   });
 
   describe('executeHooksParallel', () => {
-    it('should execute multiple hooks in parallel', async () => {
-      const configs: HookConfig[] = [
-        { type: HookType.Command, command: './hook1.sh' },
-        { type: HookType.Command, command: './hook2.sh' },
-      ];
-
-      // Mock both commands to succeed
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            setTimeout(() => callback(0), 10);
-          }
-        },
+    it('runs hooks in parallel and collects results', async () => {
+      const successScript = writeHookScript(
+        'hooks/parallel-success.cjs',
+        `console.log(JSON.stringify({ decision: 'allow' }));`,
+      );
+      const warnScript = writeHookScript(
+        'hooks/parallel-warn.cjs',
+        `console.error('warn'); process.exit(1);`,
       );
 
       const results = await hookRunner.executeHooksParallel(
-        configs,
+        [
+          { type: HookType.Command, command: successScript },
+          { type: HookType.Command, command: warnScript },
+        ],
         HookEventName.BeforeTool,
-        mockInput,
-      );
-
-      expect(results).toHaveLength(2);
-      expect(results.every((r) => r.success)).toBe(true);
-      expect(spawn).toHaveBeenCalledTimes(2);
-    });
-
-    it('should handle mixed success and failure', async () => {
-      const configs: HookConfig[] = [
-        { type: HookType.Command, command: './hook1.sh' },
-        { type: HookType.Command, command: './hook2.sh' },
-      ];
-
-      let callCount = 0;
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            const exitCode = callCount++ === 0 ? 0 : 1; // First succeeds, second fails
-            setTimeout(() => callback(exitCode), 10);
-          }
-        },
-      );
-
-      const results = await hookRunner.executeHooksParallel(
-        configs,
-        HookEventName.BeforeTool,
-        mockInput,
+        createInput(),
       );
 
       expect(results).toHaveLength(2);
@@ -294,436 +296,191 @@ describe('HookRunner', () => {
   });
 
   describe('executeHooksSequential', () => {
-    it('should execute multiple hooks in sequence', async () => {
+    it('propagates additional context between BeforeAgent hooks', async () => {
+      const contextHook = writeHookScript(
+        'hooks/context.cjs',
+        `
+const payload = {
+  decision: 'allow',
+  hookSpecificOutput: { additionalContext: 'Context from hook 1' },
+};
+console.log(JSON.stringify(payload));
+`,
+      );
+
+      const recorder = writeHookScript(
+        'hooks/record.cjs',
+        `
+const fs = require('node:fs');
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString();
+}
+(async () => {
+  const input = await readStdin();
+  fs.writeFileSync('second-hook-input.json', input);
+  console.log(JSON.stringify({ decision: 'allow' }));
+})();
+`,
+      );
+
       const configs: HookConfig[] = [
-        { type: HookType.Command, command: './hook1.sh' },
-        { type: HookType.Command, command: './hook2.sh' },
+        { type: HookType.Command, command: contextHook },
+        { type: HookType.Command, command: recorder },
       ];
 
-      const executionOrder: string[] = [];
-
-      // Mock both commands to succeed
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            const command =
-              vi.mocked(spawn).mock.calls[executionOrder.length][0];
-            executionOrder.push(command);
-            setTimeout(() => callback(0), 10);
-          }
-        },
-      );
-
-      const results = await hookRunner.executeHooksSequential(
-        configs,
-        HookEventName.BeforeTool,
-        mockInput,
-      );
-
-      expect(results).toHaveLength(2);
-      expect(results.every((r) => r.success)).toBe(true);
-      expect(spawn).toHaveBeenCalledTimes(2);
-      // Verify they were called sequentially
-      expect(executionOrder).toEqual(['./hook1.sh', './hook2.sh']);
-    });
-
-    it('should continue execution even if a hook fails', async () => {
-      const configs: HookConfig[] = [
-        { type: HookType.Command, command: './hook1.sh' },
-        { type: HookType.Command, command: './hook2.sh' },
-        { type: HookType.Command, command: './hook3.sh' },
-      ];
-
-      let callCount = 0;
-      mockSpawn.mockStderrOn.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === 'data' && callCount === 1) {
-            // Second hook fails
-            setTimeout(() => callback(Buffer.from('Hook 2 failed')), 10);
-          }
-        },
-      );
-
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            const exitCode = callCount++ === 1 ? 1 : 0; // Second fails, others succeed
-            setTimeout(() => callback(exitCode), 20);
-          }
-        },
-      );
-
-      const results = await hookRunner.executeHooksSequential(
-        configs,
-        HookEventName.BeforeTool,
-        mockInput,
-      );
-
-      expect(results).toHaveLength(3);
-      expect(results[0].success).toBe(true);
-      expect(results[1].success).toBe(false);
-      expect(results[2].success).toBe(true);
-      expect(spawn).toHaveBeenCalledTimes(3);
-    });
-
-    it('should pass modified input from one hook to the next for BeforeAgent', async () => {
-      const configs: HookConfig[] = [
-        { type: HookType.Command, command: './hook1.sh' },
-        { type: HookType.Command, command: './hook2.sh' },
-      ];
-
-      const mockBeforeAgentInput = {
-        ...mockInput,
+      const beforeAgentInput: BeforeAgentInput = {
+        ...createInput({ hook_event_name: HookEventName.BeforeAgent }),
         prompt: 'Original prompt',
       };
-
-      const mockOutput1 = {
-        decision: 'allow' as const,
-        hookSpecificOutput: {
-          additionalContext: 'Context from hook 1',
-        },
-      };
-
-      let hookCallCount = 0;
-      mockSpawn.mockStdoutOn.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === 'data') {
-            if (hookCallCount === 0) {
-              setTimeout(
-                () => callback(Buffer.from(JSON.stringify(mockOutput1))),
-                10,
-              );
-            }
-          }
-        },
-      );
-
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            hookCallCount++;
-            setTimeout(() => callback(0), 20);
-          }
-        },
-      );
 
       const results = await hookRunner.executeHooksSequential(
         configs,
         HookEventName.BeforeAgent,
-        mockBeforeAgentInput,
+        beforeAgentInput,
       );
 
       expect(results).toHaveLength(2);
       expect(results[0].success).toBe(true);
-      expect(results[0].output).toEqual(mockOutput1);
-
-      // Verify that the second hook received modified input
-      const secondHookInput = JSON.parse(
-        vi.mocked(mockSpawn.stdin.write).mock.calls[1][0],
+      const recordedInput = JSON.parse(
+        readProjectFile('second-hook-input.json'),
       );
-      expect(secondHookInput.prompt).toContain('Original prompt');
-      expect(secondHookInput.prompt).toContain('Context from hook 1');
+      expect(recordedInput.prompt).toContain('Original prompt');
+      expect(recordedInput.prompt).toContain('Context from hook 1');
     });
 
-    it('should pass modified LLM request from one hook to the next for BeforeModel', async () => {
+    it('merges LLM request fields for BeforeModel hooks', async () => {
+      const llmModifier = writeHookScript(
+        'hooks/llmModifier.cjs',
+        `
+const payload = {
+  decision: 'allow',
+  hookSpecificOutput: {
+    llm_request: { temperature: 0.5 },
+  },
+};
+console.log(JSON.stringify(payload));
+`,
+      );
+
+      const recorder = writeHookScript(
+        'hooks/model-record.cjs',
+        `
+const fs = require('node:fs');
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString();
+}
+(async () => {
+  const input = await readStdin();
+  fs.writeFileSync('second-model-input.json', input);
+  console.log(JSON.stringify({ decision: 'allow' }));
+})();
+`,
+      );
+
       const configs: HookConfig[] = [
-        { type: HookType.Command, command: './hook1.sh' },
-        { type: HookType.Command, command: './hook2.sh' },
+        { type: HookType.Command, command: llmModifier },
+        { type: HookType.Command, command: recorder },
       ];
 
-      const mockBeforeModelInput = {
-        ...mockInput,
+      const beforeModelInput: BeforeModelInput = {
+        ...createInput({ hook_event_name: HookEventName.BeforeModel }),
         llm_request: {
           model: 'gemini-1.5-pro',
-          messages: [{ role: 'user', content: 'Hello' }],
+          contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
         },
       };
 
-      const mockOutput1 = {
-        decision: 'allow' as const,
-        hookSpecificOutput: {
-          llm_request: {
-            temperature: 0.7,
-          },
-        },
-      };
-
-      let hookCallCount = 0;
-      mockSpawn.mockStdoutOn.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === 'data') {
-            if (hookCallCount === 0) {
-              setTimeout(
-                () => callback(Buffer.from(JSON.stringify(mockOutput1))),
-                10,
-              );
-            }
-          }
-        },
-      );
-
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            hookCallCount++;
-            setTimeout(() => callback(0), 20);
-          }
-        },
-      );
-
-      const results = await hookRunner.executeHooksSequential(
+      await hookRunner.executeHooksSequential(
         configs,
         HookEventName.BeforeModel,
-        mockBeforeModelInput,
+        beforeModelInput,
       );
 
-      expect(results).toHaveLength(2);
-      expect(results[0].success).toBe(true);
-
-      // Verify that the second hook received modified input
-      const secondHookInput = JSON.parse(
-        vi.mocked(mockSpawn.stdin.write).mock.calls[1][0],
+      const recordedInput = JSON.parse(
+        readProjectFile('second-model-input.json'),
       );
-      expect(secondHookInput.llm_request.model).toBe('gemini-1.5-pro');
-      expect(secondHookInput.llm_request.temperature).toBe(0.7);
+      expect(recordedInput.llm_request.model).toBe('gemini-1.5-pro');
+      expect(recordedInput.llm_request.temperature).toBe(0.5);
     });
 
-    it('should not modify input if hook fails', async () => {
+    it('does not propagate modifications when a hook fails', async () => {
+      const failingHook = writeHookScript(
+        'hooks/fail-first.cjs',
+        `console.error('fail'); process.exit(1);`,
+      );
+
+      const recorder = writeHookScript(
+        'hooks/record-original.cjs',
+        `
+const fs = require('node:fs');
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString();
+}
+(async () => {
+  const input = await readStdin();
+  fs.writeFileSync('unchanged-input.json', input);
+  console.log(JSON.stringify({ decision: 'allow' }));
+})();
+`,
+      );
+
       const configs: HookConfig[] = [
-        { type: HookType.Command, command: './hook1.sh' },
-        { type: HookType.Command, command: './hook2.sh' },
+        { type: HookType.Command, command: failingHook },
+        { type: HookType.Command, command: recorder },
       ];
 
-      mockSpawn.mockStderrOn.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === 'data') {
-            setTimeout(() => callback(Buffer.from('Hook failed')), 10);
-          }
-        },
-      );
-
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            setTimeout(() => callback(1), 20); // All hooks fail
-          }
-        },
-      );
+      const beforeAgentInput: BeforeAgentInput = {
+        ...createInput({ hook_event_name: HookEventName.BeforeAgent }),
+        prompt: 'Base prompt',
+      };
 
       const results = await hookRunner.executeHooksSequential(
         configs,
-        HookEventName.BeforeTool,
-        mockInput,
+        HookEventName.BeforeAgent,
+        beforeAgentInput,
       );
 
-      expect(results).toHaveLength(2);
-      expect(results.every((r) => !r.success)).toBe(true);
-
-      // Verify that both hooks received the same original input
-      const firstHookInput = JSON.parse(
-        vi.mocked(mockSpawn.stdin.write).mock.calls[0][0],
-      );
-      const secondHookInput = JSON.parse(
-        vi.mocked(mockSpawn.stdin.write).mock.calls[1][0],
-      );
-      expect(firstHookInput).toEqual(secondHookInput);
+      expect(results[0].success).toBe(false);
+      const recordedInput = JSON.parse(readProjectFile('unchanged-input.json'));
+      expect(recordedInput.prompt).toBe('Base prompt');
     });
   });
 
-  describe('invalid JSON handling', () => {
-    const commandConfig: HookConfig = {
-      type: HookType.Command,
-      command: './hooks/test.sh',
-    };
-
-    it('should handle invalid JSON output gracefully', async () => {
-      const invalidJson = '{ "decision": "allow", incomplete';
-
-      mockSpawn.mockStdoutOn.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === 'data') {
-            setTimeout(() => callback(Buffer.from(invalidJson)), 10);
-          }
-        },
+  describe('cwd escaping integration', () => {
+    it('runs hooks from directories containing quotes', async () => {
+      const quotedDir = path.join(projectDir, "proj with 'quotes'");
+      mkdirSync(quotedDir, { recursive: true });
+      const scriptRelativePath = 'hooks/quoted.cjs';
+      writeHookScript(
+        scriptRelativePath,
+        `console.log(JSON.stringify({ decision: 'allow' }));`,
+        quotedDir,
       );
 
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            setTimeout(() => callback(0), 20);
-          }
-        },
-      );
+      const config: HookConfig = {
+        type: HookType.Command,
+        command: `$GEMINI_PROJECT_DIR/${scriptRelativePath}`,
+      };
 
       const result = await hookRunner.executeHook(
-        commandConfig,
+        config,
         HookEventName.BeforeTool,
-        mockInput,
+        createInput({ cwd: quotedDir }),
       );
 
       expect(result.success).toBe(true);
-      expect(result.exitCode).toBe(0);
-      // Should convert plain text to structured output
-      expect(result.output).toEqual({
-        decision: 'allow',
-        systemMessage: invalidJson,
-      });
-    });
-
-    it('should handle malformed JSON with exit code 0', async () => {
-      const malformedJson = 'not json at all';
-
-      mockSpawn.mockStdoutOn.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === 'data') {
-            setTimeout(() => callback(Buffer.from(malformedJson)), 10);
-          }
-        },
-      );
-
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            setTimeout(() => callback(0), 20);
-          }
-        },
-      );
-
-      const result = await hookRunner.executeHook(
-        commandConfig,
-        HookEventName.BeforeTool,
-        mockInput,
-      );
-
-      expect(result.success).toBe(true);
-      expect(result.output).toEqual({
-        decision: 'allow',
-        systemMessage: malformedJson,
-      });
-    });
-
-    it('should handle invalid JSON with exit code 1 (non-blocking error)', async () => {
-      const invalidJson = '{ broken json';
-
-      mockSpawn.mockStderrOn.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === 'data') {
-            setTimeout(() => callback(Buffer.from(invalidJson)), 10);
-          }
-        },
-      );
-
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            setTimeout(() => callback(1), 20);
-          }
-        },
-      );
-
-      const result = await hookRunner.executeHook(
-        commandConfig,
-        HookEventName.BeforeTool,
-        mockInput,
-      );
-
-      expect(result.success).toBe(false);
-      expect(result.exitCode).toBe(1);
-      expect(result.output).toEqual({
-        decision: 'allow',
-        systemMessage: `Warning: ${invalidJson}`,
-      });
-    });
-
-    it('should handle invalid JSON with exit code 2 (blocking error)', async () => {
-      const invalidJson = '{ "error": incomplete';
-
-      mockSpawn.mockStderrOn.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === 'data') {
-            setTimeout(() => callback(Buffer.from(invalidJson)), 10);
-          }
-        },
-      );
-
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            setTimeout(() => callback(2), 20);
-          }
-        },
-      );
-
-      const result = await hookRunner.executeHook(
-        commandConfig,
-        HookEventName.BeforeTool,
-        mockInput,
-      );
-
-      expect(result.success).toBe(false);
-      expect(result.exitCode).toBe(2);
-      expect(result.output).toEqual({
-        decision: 'deny',
-        reason: invalidJson,
-      });
-    });
-
-    it('should handle empty JSON output', async () => {
-      mockSpawn.mockStdoutOn.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === 'data') {
-            setTimeout(() => callback(Buffer.from('')), 10);
-          }
-        },
-      );
-
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            setTimeout(() => callback(0), 20);
-          }
-        },
-      );
-
-      const result = await hookRunner.executeHook(
-        commandConfig,
-        HookEventName.BeforeTool,
-        mockInput,
-      );
-
-      expect(result.success).toBe(true);
-      expect(result.exitCode).toBe(0);
-      expect(result.output).toBeUndefined();
-    });
-
-    it('should handle double-encoded JSON string', async () => {
-      const mockOutput = { decision: 'allow', reason: 'All good' };
-      const doubleEncodedJson = JSON.stringify(JSON.stringify(mockOutput));
-
-      mockSpawn.mockStdoutOn.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === 'data') {
-            setTimeout(() => callback(Buffer.from(doubleEncodedJson)), 10);
-          }
-        },
-      );
-
-      mockSpawn.mockProcessOn.mockImplementation(
-        (event: string, callback: (code: number) => void) => {
-          if (event === 'close') {
-            setTimeout(() => callback(0), 20);
-          }
-        },
-      );
-
-      const result = await hookRunner.executeHook(
-        commandConfig,
-        HookEventName.BeforeTool,
-        mockInput,
-      );
-
-      expect(result.success).toBe(true);
-      expect(result.output).toEqual(mockOutput);
     });
   });
 });

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -309,7 +309,7 @@ console.log(JSON.stringify({ decision: 'allow' }));
       });
 
       expect(expanded).toBe(
-        '\'C\\\\project with "quotes" && del C\\\\windows\\system32\'/cleanup.cmd',
+        '& \'C\\project with "quotes" && del C\\windows\\system32\\cleanup.cmd\'',
       );
 
       const psRunner = new HookRunner({ platformOverride: 'win32' });
@@ -327,7 +327,7 @@ console.log(JSON.stringify({ decision: 'allow' }));
       });
 
       expect(psExpanded).toBe(
-        "'C\\\\project with ''quotes'' && del C\\\\windows\\system32'/cleanup.cmd",
+        "& 'C\\project with ''quotes'' && del C\\windows\\system32\\cleanup.cmd'",
       );
     });
   });

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -128,6 +128,23 @@ process.exit(1);
       });
     });
 
+    it('reports errors when the hook command is missing', async () => {
+      const config: HookConfig = {
+        type: HookType.Command,
+        command: './hooks/does-not-exist.cjs',
+      };
+
+      const result = await hookRunner.executeHook(
+        config,
+        HookEventName.BeforeTool,
+        createInput(),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toMatch(/No such file/);
+    });
+
     it('times out long-running hooks', async () => {
       const command = writeHookScript(
         'hooks/hang.cjs',

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -323,9 +323,21 @@ export class HookRunner {
    * Expand command with environment variables and input context
    */
   private expandCommand(command: string, input: HookInput): string {
+    const escapedCwd = this.escapeShellArg(input.cwd);
+
     return command
-      .replace(/\$GEMINI_PROJECT_DIR/g, input.cwd)
-      .replace(/\$CLAUDE_PROJECT_DIR/g, input.cwd); // For compatibility
+      .replace(/\$GEMINI_PROJECT_DIR/g, escapedCwd)
+      .replace(/\$CLAUDE_PROJECT_DIR/g, escapedCwd); // For compatibility
+  }
+
+  /**
+   * Wrap a value so the shell treats it as a literal argument.
+   */
+  private escapeShellArg(value: string): string {
+    // Single quotes prevent the shell from interpreting metacharacters.
+    // Any embedded single quote is escaped by closing, inserting '\'',
+    // then reopening the quote (POSIX-compliant technique).
+    return `'${value.replace(/'/g, "'\\''")}'`;
   }
 
   /**

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -34,7 +34,7 @@ const EXIT_CODE_NON_BLOCKING_ERROR = 1;
  * Hook runner that executes command hooks
  */
 export class HookRunner {
-  constructor() {}
+  constructor(private readonly platform: NodeJS.Platform = process.platform) {}
 
   /**
    * Execute a single hook
@@ -334,10 +334,23 @@ export class HookRunner {
    * Wrap a value so the shell treats it as a literal argument.
    */
   private escapeShellArg(value: string): string {
+    if (this.platform === 'win32') {
+      return this.escapeWindowsShellArg(value);
+    }
+    return this.escapePosixShellArg(value);
+  }
+
+  private escapePosixShellArg(value: string): string {
     // Single quotes prevent the shell from interpreting metacharacters.
     // Any embedded single quote is escaped by closing, inserting '\'',
     // then reopening the quote (POSIX-compliant technique).
     return `'${value.replace(/'/g, "'\\''")}'`;
+  }
+
+  private escapeWindowsShellArg(value: string): string {
+    // Double quotes protect spaces and metacharacters in cmd.exe.
+    // Double any embedded double quotes so they are interpreted literally.
+    return `"${value.replace(/"/g, '""')}"`;
   }
 
   /**

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -5,6 +5,7 @@
  */
 
 import { spawn } from 'node:child_process';
+import path from 'node:path';
 import type { HookConfig } from './types.js';
 import { HookEventName } from './types.js';
 import type {
@@ -33,8 +34,28 @@ const EXIT_CODE_NON_BLOCKING_ERROR = 1;
 /**
  * Hook runner that executes command hooks
  */
+type ShellFlavor = 'posix' | 'cmd' | 'powershell';
+
+export interface HookRunnerOptions {
+  platform?: NodeJS.Platform;
+  shell?: string;
+  shellFlavor?: ShellFlavor;
+}
+
 export class HookRunner {
-  constructor(private readonly platform: NodeJS.Platform = process.platform) {}
+  private readonly platform: NodeJS.Platform;
+  private readonly shellCommand?: string;
+  private readonly shellFlavor: ShellFlavor;
+
+  constructor(options: HookRunnerOptions = {}) {
+    this.platform = options.platform ?? process.platform;
+    const envShell =
+      process.env.GEMINI_HOOK_SHELL ?? process.env.CLAUDE_HOOK_SHELL;
+    this.shellCommand = this.normalizeShellCommand(options.shell ?? envShell);
+    this.shellFlavor =
+      options.shellFlavor ??
+      this.detectShellFlavor(this.shellCommand, this.platform);
+  }
 
   /**
    * Execute a single hook
@@ -214,7 +235,7 @@ export class HookRunner {
         env,
         cwd: input.cwd,
         stdio: ['pipe', 'pipe', 'pipe'],
-        shell: true,
+        shell: this.shellCommand ?? true,
       });
 
       // Set up timeout
@@ -334,10 +355,14 @@ export class HookRunner {
    * Wrap a value so the shell treats it as a literal argument.
    */
   private escapeShellArg(value: string): string {
-    if (this.platform === 'win32') {
-      return this.escapeWindowsShellArg(value);
+    switch (this.shellFlavor) {
+      case 'cmd':
+        return this.escapeCmdShellArg(value);
+      case 'powershell':
+        return this.escapePowerShellArg(value);
+      default:
+        return this.escapePosixShellArg(value);
     }
-    return this.escapePosixShellArg(value);
   }
 
   private escapePosixShellArg(value: string): string {
@@ -347,10 +372,50 @@ export class HookRunner {
     return `'${value.replace(/'/g, "'\\''")}'`;
   }
 
-  private escapeWindowsShellArg(value: string): string {
+  private escapeCmdShellArg(value: string): string {
     // Double quotes protect spaces and metacharacters in cmd.exe.
     // Double any embedded double quotes so they are interpreted literally.
     return `"${value.replace(/"/g, '""')}"`;
+  }
+
+  private escapePowerShellArg(value: string): string {
+    // Single quotes in PowerShell behave like literal strings.
+    // Escape embedded single quotes by doubling them up.
+    return `'${value.replace(/'/g, "''")}'`;
+  }
+
+  private normalizeShellCommand(shellValue?: string): string | undefined {
+    if (!shellValue) {
+      return undefined;
+    }
+    const trimmed = shellValue.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    if (/^powershell$/i.test(trimmed)) {
+      return this.platform === 'win32' ? 'powershell.exe' : 'pwsh';
+    }
+    if (/^pwsh$/i.test(trimmed)) {
+      return 'pwsh';
+    }
+    return trimmed;
+  }
+
+  private detectShellFlavor(
+    shellCommand: string | undefined,
+    platform: NodeJS.Platform,
+  ): ShellFlavor {
+    if (shellCommand) {
+      const shellName = path.basename(shellCommand).toLowerCase();
+      if (shellName.includes('powershell') || shellName === 'pwsh') {
+        return 'powershell';
+      }
+      if (platform === 'win32') {
+        return 'cmd';
+      }
+      return 'posix';
+    }
+    return platform === 'win32' ? 'cmd' : 'posix';
   }
 
   /**


### PR DESCRIPTION
## Summary
- escape `$GEMINI_PROJECT_DIR`/`$CLAUDE_PROJECT_DIR` substitutions so hook commands can't inject shell syntax
- rebuild `HookRunner` tests to execute real hook scripts (no mocked spawn) and cover cwd quoting behavior
- fix the BeforeModel test input to match the stable `LLMRequest` shape

## Details
- hook runner now routes cwd through a POSIX single-quote helper before command expansion, keeping existing `shell: true` semantics but removing command-injection risk
- the test suite now creates temporary hook projects, writes executable scripts, and exercises real child-process execution, improving confidence in timeout/output parsing/propagation behavior
- added focused tests for cwd quoting (including quoted directories) and ensured sequential BeforeAgent/BeforeModel scenarios still work with the new harness

## Related Issues
- n/a

## How to Validate
1. `npx vitest run packages/core/src/hooks/hookRunner.test.ts`
   - All 13 tests should pass.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
