### PR TITLE
Don't clear buffers on cleanup.

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -593,16 +593,8 @@ export function KeypressProvider({
     }
 
     stdin.on('data', dataListener);
-
     return () => {
-      // flush buffers by sending null key
-      backslashBufferer(null);
-      pasteBufferer(null);
-      // flush by sending empty string to the data listener
-      dataListener('');
       stdin.removeListener('data', dataListener);
-
-      // Restore the terminal to its original state.
       if (wasRaw === false) {
         setRawMode(false);
       }

--- a/packages/cli/src/ui/hooks/useKeypress.test.tsx
+++ b/packages/cli/src/ui/hooks/useKeypress.test.tsx
@@ -262,29 +262,5 @@ describe(`useKeypress`, () => {
 
       expect(onKeypress).toHaveBeenCalledTimes(3);
     });
-
-    it('should emit partial paste content if unmounted mid-paste', () => {
-      const { unmount } = renderKeypressHook(true);
-      const pasteText = 'incomplete paste';
-
-      act(() => stdin.write(PASTE_START + pasteText));
-
-      // No event should be fired yet.
-      expect(onKeypress).not.toHaveBeenCalled();
-
-      // Unmounting should trigger the flush.
-      unmount();
-
-      expect(onKeypress).toHaveBeenCalledTimes(1);
-      expect(onKeypress).toHaveBeenCalledWith({
-        name: '',
-        ctrl: false,
-        meta: false,
-        shift: false,
-        paste: true,
-        insertable: true,
-        sequence: pasteText,
-      });
-    });
   });
 });


### PR DESCRIPTION
## Summary

Don't clear keypress buffers on cleanup. We believe this is causing stray control characters to be output to the screen on exit.

## How to Validate

Exit with `Ctrl+C` and verify that it works ok.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
