### PR TITLE
fix(editor): ensure preferred editor setting updates immediately

### DIFF
--- a/packages/cli/src/config/settingPaths.ts
+++ b/packages/cli/src/config/settingPaths.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const SettingPaths = {
+  General: {
+    PreferredEditor: 'general.preferredEditor',
+  },
+} as const;

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -33,6 +33,7 @@ import { resolveEnvVarsInObject } from '../utils/envVarResolver.js';
 import { customDeepMerge, type MergeableObject } from '../utils/deepMerge.js';
 import { updateSettingsFilePreservingFormat } from '../utils/commentJson.js';
 import type { ExtensionManager } from './extension-manager.js';
+import { SettingPaths } from './settingPaths.js';
 
 function getMergeStrategyForPath(path: string[]): MergeStrategy | undefined {
   let current: SettingDefinition | undefined = undefined;
@@ -108,7 +109,7 @@ const MIGRATION_MAP: Record<string, string> = {
   memoryImportFormat: 'context.importFormat',
   memoryDiscoveryMaxDirs: 'context.discoveryMaxDirs',
   model: 'model.name',
-  preferredEditor: 'general.preferredEditor',
+  preferredEditor: SettingPaths.General.PreferredEditor,
   retryFetchErrors: 'general.retryFetchErrors',
   sandbox: 'tools.sandbox',
   selectedAuthType: 'security.auth.selectedType',

--- a/packages/cli/src/ui/hooks/useEditorSettings.test.tsx
+++ b/packages/cli/src/ui/hooks/useEditorSettings.test.tsx
@@ -28,6 +28,8 @@ import {
   allowEditorTypeInSandbox,
 } from '@google/gemini-cli-core';
 
+import { SettingPaths } from '../../config/settingPaths.js';
+
 vi.mock('@google/gemini-cli-core', async () => {
   const actual = await vi.importActual('@google/gemini-cli-core');
   return {
@@ -114,7 +116,7 @@ describe('useEditorSettings', () => {
 
     expect(mockLoadedSettings.setValue).toHaveBeenCalledWith(
       scope,
-      'preferredEditor',
+      SettingPaths.General.PreferredEditor,
       editorType,
     );
 
@@ -142,7 +144,7 @@ describe('useEditorSettings', () => {
 
     expect(mockLoadedSettings.setValue).toHaveBeenCalledWith(
       scope,
-      'preferredEditor',
+      SettingPaths.General.PreferredEditor,
       undefined,
     );
 
@@ -171,7 +173,7 @@ describe('useEditorSettings', () => {
 
       expect(mockLoadedSettings.setValue).toHaveBeenCalledWith(
         scope,
-        'preferredEditor',
+        SettingPaths.General.PreferredEditor,
         editorType,
       );
 
@@ -201,7 +203,7 @@ describe('useEditorSettings', () => {
 
       expect(mockLoadedSettings.setValue).toHaveBeenCalledWith(
         scope,
-        'preferredEditor',
+        SettingPaths.General.PreferredEditor,
         editorType,
       );
 

--- a/packages/cli/src/ui/hooks/useEditorSettings.ts
+++ b/packages/cli/src/ui/hooks/useEditorSettings.ts
@@ -16,6 +16,8 @@ import {
   checkHasEditorType,
 } from '@google/gemini-cli-core';
 
+import { SettingPaths } from '../../config/settingPaths.js';
+
 interface UseEditorSettingsReturn {
   isEditorDialogOpen: boolean;
   openEditorDialog: () => void;
@@ -48,7 +50,11 @@ export const useEditorSettings = (
       }
 
       try {
-        loadedSettings.setValue(scope, 'preferredEditor', editorType);
+        loadedSettings.setValue(
+          scope,
+          SettingPaths.General.PreferredEditor,
+          editorType,
+        );
         addItem(
           {
             type: MessageType.INFO,


### PR DESCRIPTION
## Summary

Fixes a bug where changing the preferred editor required a session restart to take effect. This was caused by a mismatch between the setting key used for writing (`preferredEditor`) and reading (`general.preferredEditor`).

## Details

- Introduced `SettingPaths` constant to centralize setting keys and avoid magic strings.
- Updated `useEditorSettings` to use `SettingPaths.General.PreferredEditor`.
- Updated `MIGRATION_MAP` in `settings.ts` to use the same constant, ensuring consistency.
- This ensures that the setting is written directly to `general.preferredEditor`, which is where `AppContainer` reads it from, bypassing the need for a restart-triggered migration.

## Related Issues

Fixes the editor preference update delay.

Created #12982 to track a follow-up clean up task

## How to Validate

1. Open the CLI.
2. Run `/editor` and select an editor (e.g., `vim`).
3. Run a command that triggers an edit (e.g., modify a file). Verify it opens in `vim`.
4. Run `/editor` again and select a different editor (e.g., `nano` or `vscode`).
5. Run a command that triggers an edit.
6. **Expected Result**: After choosing modify with edition, the new editor should be used immediately without restarting the CLI.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
