### PR TITLE
Switch back to truncating headers. Unfortunately we have too many headers that are 10+ lines for no good reason so we need to add back this truncation until we fix them.

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -202,17 +202,20 @@ describe('<ToolGroupMessage />', () => {
       unmount();
     });
 
-    it('renders sticky header when scrolled', () => {
+    it('renders header when scrolled', () => {
       const toolCalls = [
         createToolCall({
           callId: '1',
           name: 'tool-1',
-          description: 'Description 1\n'.repeat(5),
+          description:
+            'Description 1. This is a long description that will need to be truncated if the terminal width is small.',
+          resultDisplay: 'line1\nline2\nline3\nline4\nline5',
         }),
         createToolCall({
           callId: '2',
           name: 'tool-2',
-          description: 'Description 2\n'.repeat(5),
+          description: 'Description 2',
+          resultDisplay: 'line1\nline2',
         }),
       ];
       const { lastFrame, unmount } = renderWithProviders(

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -322,8 +322,8 @@ const ToolInfo: React.FC<ToolInfo> = ({
     }
   }, [emphasis]);
   return (
-    <Box>
-      <Text strikethrough={status === ToolCallStatus.Canceled}>
+    <Box overflow="hidden" height={1} flexGrow={1} flexShrink={1}>
+      <Text strikethrough={status === ToolCallStatus.Canceled} wrap="truncate">
         <Text color={nameColor} bold>
           {name}
         </Text>{' '}

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`<ToolGroupMessage /> > Border Color Logic > uses yellow border when too
 
 exports[`<ToolGroupMessage /> > Confirmation Handling > shows confirmation dialog for first confirming tool only 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
-│ ?  first-confirm A tool for testing ←                                        │
+│ ?  first-confirm A tool for testing                                        ← │
 │                                                                              │
 │ Test result                                                                  │
 │ Confirm first tool                                                           │
@@ -49,6 +49,19 @@ exports[`<ToolGroupMessage /> > Confirmation Handling > shows confirmation dialo
 `;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders empty tool calls array 1`] = `""`;
+
+exports[`<ToolGroupMessage /> > Golden Snapshots > renders header when scrolled 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ ✓  tool-1 Description 1. This is a long description that will need to be tr… │
+│──────────────────────────────────────────────────────────────────────────────│
+│ line5                                                                        │                                       █
+│                                                                              │                                       █
+│ ✓  tool-2 Description 2                                                      │                                       █
+│                                                                              │                                       █
+│ line1                                                                        │                                       █
+│ line2                                                                        │                                       █
+╰──────────────────────────────────────────────────────────────────────────────╯                                       █"
+`;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders mixed tool calls including shell command 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
@@ -98,22 +111,9 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders single successful too
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
 
-exports[`<ToolGroupMessage /> > Golden Snapshots > renders sticky header when scrolled 1`] = `
-"│                                                                              │
-│ ✓  tool-2 Description 2                                                      │
-│    Description 2                                                             │
-│    Description 2                                                             │
-│    Description 2                                                             │                                       ▄
-│    Description 2                                                             │                                       █
-│                                                                              │                                       █
-│                                                                              │                                       █
-│ Test result                                                                  │                                       █
-╰──────────────────────────────────────────────────────────────────────────────╯                                       █"
-`;
-
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders tool call awaiting confirmation 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
-│ ?  confirmation-tool This tool needs confirmation ←                          │
+│ ?  confirmation-tool This tool needs confirmation                          ← │
 │                                                                              │
 │ Test result                                                                  │
 │ Are you sure you want to proceed?                                            │
@@ -158,10 +158,7 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders with limited terminal
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders with narrow terminal width 1`] = `
 "╭──────────────────────────────────────╮
-│ ✓  very-long-tool-name-that-might-wr │
-│    ap This is a very long            │
-│    description that might cause      │
-│    wrapping issues                   │
+│ ✓  very-long-tool-name-that-might-w… │
 │                                      │
 │ Test result                          │
 ╰──────────────────────────────────────╯"


### PR DESCRIPTION
## Summary

We used to truncate headers so we missed that many of our headers are silly with huge blocks of JSON. Before we can remove truncation we need to fix the descriptions shown in the headers and likely add a nice truncated header class that truncates to 2 or 3 lines. Sticky headers that are more than about 3 lines are a horrible user experience.

<img width="777" height="368" alt="image" src="https://github.com/user-attachments/assets/7770eaa3-9176-409d-80c7-b5bd2214c236" />


