### PR TITLE
Polish sticky headers

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -243,6 +243,34 @@ describe('<ToolGroupMessage />', () => {
       expect(lastFrame()).toMatchSnapshot();
       unmount();
     });
+
+    it('renders two tool groups where only the last line of the previous group is visible', () => {
+      const toolCalls1 = [
+        createToolCall({
+          callId: '1',
+          name: 'tool-1',
+          description: 'Description 1',
+          resultDisplay: 'line1\nline2\nline3\nline4\nline5',
+        }),
+      ];
+      const toolCalls2 = [
+        createToolCall({
+          callId: '2',
+          name: 'tool-2',
+          description: 'Description 2',
+          resultDisplay: 'line1',
+        }),
+      ];
+
+      const { lastFrame, unmount } = renderWithProviders(
+        <Scrollable height={6} hasFocus={true} scrollToBottom={true}>
+          <ToolGroupMessage {...baseProps} toolCalls={toolCalls1} />
+          <ToolGroupMessage {...baseProps} toolCalls={toolCalls2} />
+        </Scrollable>,
+      );
+      expect(lastFrame()).toMatchSnapshot();
+      unmount();
+    });
   });
 
   describe('Border Color Logic', () => {

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -103,7 +103,6 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
       {toolCalls.map((tool, index) => {
         const isConfirming = toolAwaitingApproval?.callId === tool.callId;
         const isFirst = index === 0;
-        const isLast = index === toolCalls.length - 1;
         return (
           <Box
             key={tool.callId}
@@ -129,7 +128,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
               borderLeft={true}
               borderRight={true}
               borderTop={false}
-              borderBottom={isLast}
+              borderBottom={false}
               borderColor={borderColor}
               borderDimColor={borderDimColor}
               flexDirection="column"
@@ -161,6 +160,21 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
           </Box>
         );
       })}
+      {/*
+              We have to keep the bottom border separate so it doesn't get
+              drawn over by the sticky header directly inside it.
+             */}
+      <Box
+        height={0}
+        width={terminalWidth}
+        borderLeft={true}
+        borderRight={true}
+        borderTop={false}
+        borderBottom={true}
+        borderColor={borderColor}
+        borderDimColor={borderDimColor}
+        borderStyle="round"
+      />
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -160,21 +160,25 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
           </Box>
         );
       })}
-      {/*
+      {
+        /*
               We have to keep the bottom border separate so it doesn't get
               drawn over by the sticky header directly inside it.
-             */}
-      <Box
-        height={0}
-        width={terminalWidth}
-        borderLeft={true}
-        borderRight={true}
-        borderTop={false}
-        borderBottom={true}
-        borderColor={borderColor}
-        borderDimColor={borderDimColor}
-        borderStyle="round"
-      />
+             */
+        toolCalls.length > 0 && (
+          <Box
+            height={0}
+            width={terminalWidth}
+            borderLeft={true}
+            borderRight={true}
+            borderTop={false}
+            borderBottom={true}
+            borderColor={borderColor}
+            borderDimColor={borderDimColor}
+            borderStyle="round"
+          />
+        )
+      }
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
@@ -136,6 +136,15 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders tool call with output
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
 
+exports[`<ToolGroupMessage /> > Golden Snapshots > renders two tool groups where only the last line of the previous group is visible 1`] = `
+"╰──────────────────────────────────────────────────────────────────────────────╯
+╭──────────────────────────────────────────────────────────────────────────────╮
+│ ✓  tool-2 Description 2                                                      │
+│                                                                              │                                       ▄
+│ line1                                                                        │                                       █
+╰──────────────────────────────────────────────────────────────────────────────╯                                       █"
+`;
+
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders when not focused 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
 │ ✓  test-tool A tool for testing                                              │


### PR DESCRIPTION
## Summary

There was a bug where sticky headers were staying displayed 1 line longer than they should because the bottom of the box was part of the same parent Box as the header itself.

Fixed this and added a regression test

Behavior before:
<img width="2032" height="1136" alt="image" src="https://github.com/user-attachments/assets/762ab5c9-33f0-42a1-8bbd-4819d7fef647" />

Behavior after:
<img width="813" height="489" alt="image" src="https://github.com/user-attachments/assets/ce5bd954-c17b-445a-b156-f4ed938acbd3" />

## Details

Our sticky header support follows the same conventions as the web where sticky headers start scrolling out as their parent box starts scrolling out.

The snapshot in the test illustrates the case where the box of the parent is one frame from scrolling out so you should not see the sticky header any more. Before you would see the dark grey line for the sticky header here instead of the rounded box border.
