### PR TITLE
Show model in history

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -225,6 +225,10 @@ their corresponding top-level category object in your `settings.json` file.
   - **Description:** Show citations for generated text in the chat.
   - **Default:** `false`
 
+- **`ui.showModelInfoInChat`** (boolean):
+  - **Description:** Show the model name in the chat for each model turn.
+  - **Default:** `false`
+
 - **`ui.useFullWidth`** (boolean):
   - **Description:** Use the entire width of the terminal for output.
   - **Default:** `true`

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -483,6 +483,15 @@ const SETTINGS_SCHEMA = {
         description: 'Show citations for generated text in the chat.',
         showInDialog: true,
       },
+      showModelInfoInChat: {
+        type: 'boolean',
+        label: 'Show Model Info In Chat',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description: 'Show the model name in the chat for each model turn.',
+        showInDialog: true,
+      },
       useFullWidth: {
         type: 'boolean',
         label: 'Use Full Width',

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -30,6 +30,7 @@ import { getMCPServerStatus } from '@google/gemini-cli-core';
 import { ToolsList } from './views/ToolsList.js';
 import { McpStatus } from './views/McpStatus.js';
 import { ChatList } from './views/ChatList.js';
+import { ModelMessage } from './messages/ModelMessage.js';
 
 interface HistoryItemDisplayProps {
   item: HistoryItem;
@@ -117,6 +118,9 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
       )}
       {itemForDisplay.type === 'model_stats' && <ModelStatsDisplay />}
       {itemForDisplay.type === 'tool_stats' && <ToolStatsDisplay />}
+      {itemForDisplay.type === 'model' && (
+        <ModelMessage model={itemForDisplay.model} />
+      )}
       {itemForDisplay.type === 'quit' && (
         <SessionSummaryDisplay duration={itemForDisplay.duration} />
       )}

--- a/packages/cli/src/ui/components/messages/ModelMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ModelMessage.tsx
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Text, Box } from 'ink';
+import { theme } from '../../semantic-colors.js';
+
+interface ModelMessageProps {
+  model: string;
+}
+
+export const ModelMessage: React.FC<ModelMessageProps> = ({ model }) => (
+  <Box marginLeft={3}>
+    <Text color={theme.ui.comment} italic>
+      responding with {model}
+    </Text>
+  </Box>
+);

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -151,6 +151,11 @@ export type HistoryItemToolStats = HistoryItemBase & {
   type: 'tool_stats';
 };
 
+export type HistoryItemModel = HistoryItemBase & {
+  type: 'model';
+  model: string;
+};
+
 export type HistoryItemQuit = HistoryItemBase & {
   type: 'quit';
   duration: string;
@@ -250,6 +255,7 @@ export type HistoryItemWithoutId =
   | HistoryItemStats
   | HistoryItemModelStats
   | HistoryItemToolStats
+  | HistoryItemModel
   | HistoryItemQuit
   | HistoryItemCompression
   | HistoryItemExtensionsList

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -521,6 +521,7 @@ export class GeminiClient {
       modelToUse = decision.model;
       // Lock the model for the rest of the sequence
       this.currentSequenceModel = modelToUse;
+      yield { type: GeminiEventType.ModelInfo, value: modelToUse };
     }
 
     const resultStream = turn.run(modelToUse, request, linkedSignal);

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -62,6 +62,7 @@ export enum GeminiEventType {
   Retry = 'retry',
   ContextWindowWillOverflow = 'context_window_will_overflow',
   InvalidStream = 'invalid_stream',
+  ModelInfo = 'model_info',
 }
 
 export type ServerGeminiRetryEvent = {
@@ -78,6 +79,11 @@ export type ServerGeminiContextWindowWillOverflowEvent = {
 
 export type ServerGeminiInvalidStreamEvent = {
   type: GeminiEventType.InvalidStream;
+};
+
+export type ServerGeminiModelInfoEvent = {
+  type: GeminiEventType.ModelInfo;
+  value: string;
 };
 
 export interface StructuredError {
@@ -212,7 +218,8 @@ export type ServerGeminiStreamEvent =
   | ServerGeminiUserCancelledEvent
   | ServerGeminiRetryEvent
   | ServerGeminiContextWindowWillOverflowEvent
-  | ServerGeminiInvalidStreamEvent;
+  | ServerGeminiInvalidStreamEvent
+  | ServerGeminiModelInfoEvent;
 
 // A turn manages the agentic loop turn within the server context.
 export class Turn {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -268,6 +268,13 @@
           "default": false,
           "type": "boolean"
         },
+        "showModelInfoInChat": {
+          "title": "Show Model Info In Chat",
+          "description": "Show the model name in the chat for each model turn.",
+          "markdownDescription": "Show the model name in the chat for each model turn.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
         "useFullWidth": {
           "title": "Use Full Width",
           "description": "Use the entire width of the terminal for output.",


### PR DESCRIPTION
## Summary

Add setting to show model in history (disabled by default).


## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1064

## How to Validate

toggle the option in /settings and see that it shows you the routed model with `auto` (and without)

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
