### PR TITLE
Change default compress threshold to 0.7 for api key users

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -300,7 +300,7 @@ their corresponding top-level category object in your `settings.json` file.
 - **`model.compressionThreshold`** (number):
   - **Description:** The fraction of context usage at which to trigger context
     compression (e.g. 0.2, 0.3).
-  - **Default:** `0.2`
+  - **Default:** `0.7`
   - **Requires restart:** Yes
 
 - **`model.skipNextSpeakerCheck`** (boolean):

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -683,7 +683,7 @@ const SETTINGS_SCHEMA = {
         label: 'Compression Threshold',
         category: 'Model',
         requiresRestart: true,
-        default: 0.2 as number,
+        default: 0.7 as number,
         description:
           'The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3).',
         showInDialog: true,

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -19,7 +19,7 @@ import { getInitialChatHistory } from '../utils/environmentContext.js';
  * Default threshold for compression token count as a fraction of the model's
  * token limit. If the chat history exceeds this threshold, it will be compressed.
  */
-export const DEFAULT_COMPRESSION_TOKEN_THRESHOLD = 0.2;
+export const DEFAULT_COMPRESSION_TOKEN_THRESHOLD = 0.7;
 
 /**
  * The fraction of the latest chat history to keep. A value of 0.3

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -412,8 +412,8 @@
         "compressionThreshold": {
           "title": "Compression Threshold",
           "description": "The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3).",
-          "markdownDescription": "The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3).\n\n- Category: `Model`\n- Requires restart: `yes`\n- Default: `0.2`",
-          "default": 0.2,
+          "markdownDescription": "The fraction of context usage at which to trigger context compression (e.g. 0.2, 0.3).\n\n- Category: `Model`\n- Requires restart: `yes`\n- Default: `0.7`",
+          "default": 0.7,
           "type": "number"
         },
         "skipNextSpeakerCheck": {


### PR DESCRIPTION
## Summary

Changes the default compress threshold to 0.7 from 0.2.

## Details

We already set the default for oauth users to 0.7 using the remote configuration system. This changes the same threshold for api key users who don't use that system.

## How to Validate

Start up and check the default in the settings screen.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
