### PR TITLE
Fix tool output fragmentation by encapsulating content in functionResponse

### DIFF
--- a/packages/a2a-server/src/utils/testing_utils.ts
+++ b/packages/a2a-server/src/utils/testing_utils.ts
@@ -11,6 +11,7 @@ import type {
 } from '@a2a-js/sdk';
 import {
   ApprovalMode,
+  DEFAULT_GEMINI_MODEL,
   DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
   DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
   GeminiClient,
@@ -46,6 +47,7 @@ export function createMockConfig(
     getTruncateToolOutputThreshold: () =>
       DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
     getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+    getActiveModel: vi.fn().mockReturnValue(DEFAULT_GEMINI_MODEL),
     getDebugMode: vi.fn().mockReturnValue(false),
     getContentGeneratorConfig: vi.fn().mockReturnValue({ model: 'gemini-pro' }),
     getModel: vi.fn().mockReturnValue('gemini-pro'),

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -33,6 +33,7 @@ import {
   ApprovalMode,
   MockTool,
   HookSystem,
+  PREVIEW_GEMINI_MODEL,
 } from '@google/gemini-cli-core';
 import { createMockMessageBus } from '@google/gemini-cli-core/src/test-utils/mock-message-bus.js';
 import { ToolCallStatus } from '../types.js';
@@ -71,6 +72,7 @@ const mockConfig = {
   getTruncateToolOutputThreshold: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
   getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
   getAllowedTools: vi.fn(() => []),
+  getActiveModel: () => PREVIEW_GEMINI_MODEL,
   getContentGeneratorConfig: () => ({
     model: 'test-model',
     authType: 'oauth-personal',

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -497,7 +497,12 @@ export class Session {
         ),
       );
 
-      return convertToFunctionResponse(fc.name, callId, toolResult.llmContent);
+      return convertToFunctionResponse(
+        fc.name,
+        callId,
+        toolResult.llmContent,
+        this.config.getActiveModel(),
+      );
     } catch (e) {
       const error = e instanceof Error ? e : new Error(String(e));
 

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -14,7 +14,24 @@ import {
   GEMINI_MODEL_ALIAS_PRO,
   GEMINI_MODEL_ALIAS_FLASH,
   GEMINI_MODEL_ALIAS_FLASH_LITE,
+  supportsMultimodalFunctionResponse,
 } from './models.js';
+
+describe('supportsMultimodalFunctionResponse', () => {
+  it('should return true for gemini-3 model', () => {
+    expect(supportsMultimodalFunctionResponse('gemini-3-pro')).toBe(true);
+  });
+
+  it('should return false for gemini-2 models', () => {
+    expect(supportsMultimodalFunctionResponse('gemini-2.5-pro')).toBe(false);
+    expect(supportsMultimodalFunctionResponse('gemini-2.5-flash')).toBe(false);
+  });
+
+  it('should return false for other models', () => {
+    expect(supportsMultimodalFunctionResponse('some-other-model')).toBe(false);
+    expect(supportsMultimodalFunctionResponse('')).toBe(false);
+  });
+});
 
 describe('getEffectiveModel', () => {
   describe('When NOT in fallback mode', () => {

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -99,8 +99,19 @@ export function getEffectiveModel(
  * Checks if the model is a Gemini 2.x model.
  *
  * @param model The model name to check.
- * @returns True if the model is a Gemini 2.x model.
+ * @returns True if the model is a Gemini-2.x model.
  */
 export function isGemini2Model(model: string): boolean {
   return /^gemini-2(\.|$)/.test(model);
+}
+
+/**
+ * Checks if the model supports multimodal function responses (multimodal data nested within function response).
+ * This is supported in Gemini 3.
+ *
+ * @param model The model name to check.
+ * @returns True if the model supports multimodal function responses.
+ */
+export function supportsMultimodalFunctionResponse(model: string): boolean {
+  return model.startsWith('gemini-3-');
 }

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -787,7 +787,7 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { content: [llmContent] },
+          response: { output: 'Text from Part object' },
         },
       },
     ]);
@@ -801,7 +801,7 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { content: llmContent },
+          response: { output: 'Text from array' },
         },
       },
     ]);
@@ -814,7 +814,7 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { content: llmContent },
+          response: { output: 'part1\npart2' },
         },
       },
     ]);
@@ -830,20 +830,26 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { content: [llmContent] },
+          response: {},
+          parts: [llmContent],
         },
       },
     ]);
   });
 
-  it('should preserve inner functionResponse id and name when flattening', () => {
+  it('should preserve existing functionResponse metadata', () => {
     const innerId = 'inner-call-id';
     const innerName = 'inner-tool-name';
+    const responseMetadata = {
+      flags: ['flag1'],
+      isError: false,
+      customData: { key: 'value' },
+    };
     const input: Part = {
       functionResponse: {
         id: innerId,
         name: innerName,
-        response: { content: [{ text: 'inner content' }] },
+        response: responseMetadata,
       },
     };
 
@@ -851,9 +857,9 @@ describe('convertToFunctionResponse', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].functionResponse).toEqual({
-      id: innerId,
-      name: innerName,
-      response: { output: 'inner content' },
+      id: callId,
+      name: toolName,
+      response: responseMetadata,
     });
   });
 
@@ -869,7 +875,12 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { content: llmContent },
+          response: {
+            output: 'Some textual description\nAnother text part',
+          },
+          parts: [
+            { inlineData: { mimeType: 'image/jpeg', data: 'base64data...' } },
+          ],
         },
       },
     ]);
@@ -885,7 +896,8 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { content: llmContent },
+          response: {},
+          parts: llmContent,
         },
       },
     ]);
@@ -899,7 +911,7 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { content: [llmContent] },
+          response: {},
         },
       },
     ]);
@@ -927,7 +939,7 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { content: [] },
+          response: {},
         },
       },
     ]);
@@ -941,7 +953,7 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { content: [llmContent] },
+          response: {},
         },
       },
     ]);

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -820,22 +820,6 @@ describe('convertToFunctionResponse', () => {
     ]);
   });
 
-  it('should handle llmContent with inlineData', () => {
-    const llmContent: Part = {
-      inlineData: { mimeType: 'image/png', data: 'base64...' },
-    };
-    const result = convertToFunctionResponse(toolName, callId, llmContent);
-    expect(result).toEqual([
-      {
-        functionResponse: {
-          name: toolName,
-          id: callId,
-          response: { content: [llmContent] },
-        },
-      },
-    ]);
-  });
-
   it('should handle llmContent with fileData', () => {
     const llmContent: Part = {
       fileData: { mimeType: 'application/pdf', fileUri: 'gs://...' },
@@ -850,6 +834,27 @@ describe('convertToFunctionResponse', () => {
         },
       },
     ]);
+  });
+
+  it('should preserve inner functionResponse id and name when flattening', () => {
+    const innerId = 'inner-call-id';
+    const innerName = 'inner-tool-name';
+    const input: Part = {
+      functionResponse: {
+        id: innerId,
+        name: innerName,
+        response: { content: [{ text: 'inner content' }] },
+      },
+    };
+
+    const result = convertToFunctionResponse(toolName, callId, input);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].functionResponse).toEqual({
+      id: innerId,
+      name: innerName,
+      response: { output: 'inner content' },
+    });
   });
 
   it('should handle llmContent as an array of multiple Parts (text and inlineData)', () => {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -787,7 +787,7 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { output: 'Text from Part object' },
+          response: { content: [llmContent] },
         },
       },
     ]);
@@ -801,7 +801,20 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { output: 'Text from array' },
+          response: { content: llmContent },
+        },
+      },
+    ]);
+  });
+  it('should handle llmContent as a PartListUnion array with multiple Parts', () => {
+    const llmContent: PartListUnion = [{ text: 'part1' }, { text: 'part2' }];
+    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    expect(result).toEqual([
+      {
+        functionResponse: {
+          name: toolName,
+          id: callId,
+          response: { content: llmContent },
         },
       },
     ]);
@@ -817,12 +830,9 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: {
-            output: 'Binary content of type image/png was processed.',
-          },
+          response: { content: [llmContent] },
         },
       },
-      llmContent,
     ]);
   });
 
@@ -836,12 +846,9 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: {
-            output: 'Binary content of type application/pdf was processed.',
-          },
+          response: { content: [llmContent] },
         },
       },
-      llmContent,
     ]);
   });
 
@@ -857,10 +864,9 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { output: 'Tool execution succeeded.' },
+          response: { content: llmContent },
         },
       },
-      ...llmContent,
     ]);
   });
 
@@ -874,12 +880,9 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: {
-            output: 'Binary content of type image/gif was processed.',
-          },
+          response: { content: llmContent },
         },
       },
-      ...llmContent,
     ]);
   });
 
@@ -891,7 +894,7 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { output: 'Tool execution succeeded.' },
+          response: { content: [llmContent] },
         },
       },
     ]);
@@ -919,7 +922,7 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { output: 'Tool execution succeeded.' },
+          response: { content: [] },
         },
       },
     ]);
@@ -933,7 +936,7 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { output: 'Tool execution succeeded.' },
+          response: { content: [llmContent] },
         },
       },
     ]);

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -46,6 +46,10 @@ import * as modifiableToolModule from '../tools/modifiable-tool.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { isShellInvocationAllowlisted } from '../utils/shell-permissions.js';
+import {
+  DEFAULT_GEMINI_MODEL,
+  PREVIEW_GEMINI_MODEL,
+} from '../config/models.js';
 
 vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),
@@ -255,6 +259,7 @@ function createMockConfig(overrides: Partial<Config> = {}): Config {
       DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
     getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
     getToolRegistry: () => defaultToolRegistry,
+    getActiveModel: () => DEFAULT_GEMINI_MODEL,
     getUseSmartEdit: () => false,
     getGeminiClient: () => null,
     getEnableMessageBusIntegration: () => false,
@@ -767,7 +772,12 @@ describe('convertToFunctionResponse', () => {
 
   it('should handle simple string llmContent', () => {
     const llmContent = 'Simple text output';
-    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      DEFAULT_GEMINI_MODEL,
+    );
     expect(result).toEqual([
       {
         functionResponse: {
@@ -781,7 +791,12 @@ describe('convertToFunctionResponse', () => {
 
   it('should handle llmContent as a single Part with text', () => {
     const llmContent: Part = { text: 'Text from Part object' };
-    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      DEFAULT_GEMINI_MODEL,
+    );
     expect(result).toEqual([
       {
         functionResponse: {
@@ -795,7 +810,12 @@ describe('convertToFunctionResponse', () => {
 
   it('should handle llmContent as a PartListUnion array with a single text Part', () => {
     const llmContent: PartListUnion = [{ text: 'Text from array' }];
-    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      DEFAULT_GEMINI_MODEL,
+    );
     expect(result).toEqual([
       {
         functionResponse: {
@@ -806,9 +826,15 @@ describe('convertToFunctionResponse', () => {
       },
     ]);
   });
+
   it('should handle llmContent as a PartListUnion array with multiple Parts', () => {
     const llmContent: PartListUnion = [{ text: 'part1' }, { text: 'part2' }];
-    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      DEFAULT_GEMINI_MODEL,
+    );
     expect(result).toEqual([
       {
         functionResponse: {
@@ -820,20 +846,69 @@ describe('convertToFunctionResponse', () => {
     ]);
   });
 
-  it('should handle llmContent with fileData', () => {
+  it('should handle llmContent with fileData for Gemini 3 model (should be siblings)', () => {
     const llmContent: Part = {
       fileData: { mimeType: 'application/pdf', fileUri: 'gs://...' },
     };
-    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      PREVIEW_GEMINI_MODEL,
+    );
     expect(result).toEqual([
       {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: {},
+          response: { output: 'Binary content provided (1 item(s)).' },
+        },
+      },
+      llmContent,
+    ]);
+  });
+
+  it('should handle llmContent with inlineData for Gemini 3 model (should be nested)', () => {
+    const llmContent: Part = {
+      inlineData: { mimeType: 'image/png', data: 'base64...' },
+    };
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      PREVIEW_GEMINI_MODEL,
+    );
+    expect(result).toEqual([
+      {
+        functionResponse: {
+          name: toolName,
+          id: callId,
+          response: { output: 'Binary content provided (1 item(s)).' },
           parts: [llmContent],
         },
       },
+    ]);
+  });
+
+  it('should handle llmContent with fileData for non-Gemini 3 models', () => {
+    const llmContent: Part = {
+      fileData: { mimeType: 'application/pdf', fileUri: 'gs://...' },
+    };
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      DEFAULT_GEMINI_MODEL,
+    );
+    expect(result).toEqual([
+      {
+        functionResponse: {
+          name: toolName,
+          id: callId,
+          response: { output: 'Binary content provided (1 item(s)).' },
+        },
+      },
+      llmContent,
     ]);
   });
 
@@ -853,7 +928,12 @@ describe('convertToFunctionResponse', () => {
       },
     };
 
-    const result = convertToFunctionResponse(toolName, callId, input);
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      input,
+      DEFAULT_GEMINI_MODEL,
+    );
 
     expect(result).toHaveLength(1);
     expect(result[0].functionResponse).toEqual({
@@ -869,7 +949,12 @@ describe('convertToFunctionResponse', () => {
       { inlineData: { mimeType: 'image/jpeg', data: 'base64data...' } },
       { text: 'Another text part' },
     ];
-    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      PREVIEW_GEMINI_MODEL,
+    );
     expect(result).toEqual([
       {
         functionResponse: {
@@ -890,13 +975,18 @@ describe('convertToFunctionResponse', () => {
     const llmContent: PartListUnion = [
       { inlineData: { mimeType: 'image/gif', data: 'gifdata...' } },
     ];
-    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      PREVIEW_GEMINI_MODEL,
+    );
     expect(result).toEqual([
       {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: {},
+          response: { output: 'Binary content provided (1 item(s)).' },
           parts: llmContent,
         },
       },
@@ -905,7 +995,12 @@ describe('convertToFunctionResponse', () => {
 
   it('should handle llmContent as a generic Part (not text, inlineData, or fileData)', () => {
     const llmContent: Part = { functionCall: { name: 'test', args: {} } };
-    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      PREVIEW_GEMINI_MODEL,
+    );
     expect(result).toEqual([
       {
         functionResponse: {
@@ -919,7 +1014,12 @@ describe('convertToFunctionResponse', () => {
 
   it('should handle empty string llmContent', () => {
     const llmContent = '';
-    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      PREVIEW_GEMINI_MODEL,
+    );
     expect(result).toEqual([
       {
         functionResponse: {
@@ -933,7 +1033,12 @@ describe('convertToFunctionResponse', () => {
 
   it('should handle llmContent as an empty array', () => {
     const llmContent: PartListUnion = [];
-    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      PREVIEW_GEMINI_MODEL,
+    );
     expect(result).toEqual([
       {
         functionResponse: {
@@ -947,7 +1052,12 @@ describe('convertToFunctionResponse', () => {
 
   it('should handle llmContent as a Part with undefined inlineData/fileData/text', () => {
     const llmContent: Part = {}; // An empty part object
-    const result = convertToFunctionResponse(toolName, callId, llmContent);
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      PREVIEW_GEMINI_MODEL,
+    );
     expect(result).toEqual([
       {
         functionResponse: {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -181,50 +181,32 @@ export function convertToFunctionResponse(
     return [createFunctionResponsePart(callId, toolName, contentToProcess)];
   }
 
-  if (Array.isArray(contentToProcess)) {
-    const functionResponse = createFunctionResponsePart(
-      callId,
-      toolName,
-      'Tool execution succeeded.',
-    );
-    return [functionResponse, ...toParts(contentToProcess)];
-  }
+  // contentToProcess is either a single Part or an array of Parts, so we wrap
+  // everything into a single functionResponse with a 'content' field.
+  const parts = toParts(contentToProcess);
 
-  // After this point, contentToProcess is a single Part object.
-  if (contentToProcess.functionResponse) {
-    if (contentToProcess.functionResponse.response?.['content']) {
+  if (parts.length === 1 && parts[0].functionResponse) {
+    const singlePart = parts[0];
+    if (singlePart.functionResponse?.response?.['content']) {
       const stringifiedOutput =
         getResponseTextFromParts(
-          contentToProcess.functionResponse.response['content'] as Part[],
+          singlePart.functionResponse.response['content'] as Part[],
         ) || '';
       return [createFunctionResponsePart(callId, toolName, stringifiedOutput)];
     }
-    // It's a functionResponse that we should pass through as is.
-    return [contentToProcess];
+    return [singlePart];
   }
 
-  if (contentToProcess.inlineData || contentToProcess.fileData) {
-    const mimeType =
-      contentToProcess.inlineData?.mimeType ||
-      contentToProcess.fileData?.mimeType ||
-      'unknown';
-    const functionResponse = createFunctionResponsePart(
-      callId,
-      toolName,
-      `Binary content of type ${mimeType} was processed.`,
-    );
-    return [functionResponse, contentToProcess];
-  }
-
-  if (contentToProcess.text !== undefined) {
-    return [
-      createFunctionResponsePart(callId, toolName, contentToProcess.text),
-    ];
-  }
-
-  // Default case for other kinds of parts.
   return [
-    createFunctionResponsePart(callId, toolName, 'Tool execution succeeded.'),
+    {
+      functionResponse: {
+        id: callId,
+        name: toolName,
+        response: {
+          content: parts,
+        },
+      },
+    },
   ];
 }
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -192,7 +192,13 @@ export function convertToFunctionResponse(
         getResponseTextFromParts(
           singlePart.functionResponse.response['content'] as Part[],
         ) || '';
-      return [createFunctionResponsePart(callId, toolName, stringifiedOutput)];
+      return [
+        createFunctionResponsePart(
+          singlePart.functionResponse.id ?? callId,
+          singlePart.functionResponse.name ?? toolName,
+          stringifiedOutput,
+        ),
+      ];
     }
     return [singlePart];
   }

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -49,6 +49,7 @@ import {
   fireToolNotificationHook,
   executeToolWithHooks,
 } from './coreToolHookTriggers.js';
+import { debugLogger } from '../utils/debugLogger.js';
 
 export type ValidatingToolCall = {
   status: 'validating';
@@ -187,6 +188,11 @@ export function convertToFunctionResponse(
     } else if (part.inlineData || part.fileData) {
       binaryParts.push(part);
     } else if (part.functionResponse) {
+      if (parts.length > 1) {
+        debugLogger.warn(
+          'convertToFunctionResponse received multiple parts with a functionResponse. Only the functionResponse will be used, other parts will be ignored',
+        );
+      }
       // Handle passthrough case
       return [
         {

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -321,9 +321,8 @@ describe('executeToolCall', () => {
           functionResponse: {
             name: 'testTool',
             id: 'call6',
-            response: {
-              content: [imageDataPart],
-            },
+            response: {},
+            parts: [imageDataPart],
           },
         },
       ],

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -322,11 +322,10 @@ describe('executeToolCall', () => {
             name: 'testTool',
             id: 'call6',
             response: {
-              output: 'Binary content of type image/png was processed.',
+              content: [imageDataPart],
             },
           },
         },
-        imageDataPart,
       ],
     });
   });

--- a/packages/core/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.test.ts
@@ -19,6 +19,7 @@ import {
   ToolErrorType,
   ApprovalMode,
   HookSystem,
+  PREVIEW_GEMINI_MODEL,
 } from '../index.js';
 import type { Part } from '@google/genai';
 import { MockTool } from '../test-utils/mock-tool.js';
@@ -61,6 +62,7 @@ describe('executeToolCall', () => {
       getTruncateToolOutputThreshold: () =>
         DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
       getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+      getActiveModel: () => PREVIEW_GEMINI_MODEL,
       getUseSmartEdit: () => false,
       getGeminiClient: () => null, // No client needed for these tests
       getEnableMessageBusIntegration: () => false,
@@ -321,7 +323,7 @@ describe('executeToolCall', () => {
           functionResponse: {
             name: 'testTool',
             id: 'call6',
-            response: {},
+            response: { output: 'Binary content provided (1 item(s)).' },
             parts: [imageDataPart],
           },
         },


### PR DESCRIPTION
## Summary

Refactors `convertToFunctionResponse` to ensure all tool outputs—specifically arrays and binary data—are consistently wrapped within the `content` field of a single `functionResponse` part. This fixes an issue where certain tools (like `ReadManyFilesTool` and `DiscoveredMCPTool`) returned fragmented responses across multiple parts.

## Details

- **Encapsulation:** Modified `convertToFunctionResponse` in `packages/core/src/core/coreToolScheduler.ts` to wrap `Part[]` and `PartListUnion` outputs into `response: { content: [...] }`.
- **Backward Compatibility:** Simple string outputs continue to use the legacy `response: { output: ... }` format to minimize disruption for simple tools.
- **Test Updates:** Updated `coreToolScheduler.test.ts` and `nonInteractiveToolExecutor.test.ts` to match the new output structure, ensuring binary data and mixed content are correctly asserted as being inside `functionResponse`.

## How to Validate

1.  **Run Core Scheduler Tests:**

    ```bash
    npm test src/core/coreToolScheduler.test.ts
    ```

    Verify that all tests pass, especially the new cases for "PartListUnion array" and "inlineData".

2.  **Run Executor Tests:**

    ```bash
    npm test src/core/nonInteractiveToolExecutor.test.ts
    ```

    Confirm that `should correctly format llmContent with inlineData` passes with the new expectation.

3.  **Manual Verification (Optional):**
    - Use `ReadFileTool` to read an image or PDF (ask the model to do this)
    - Inspect the tool output to ensure it is a single `functionResponse` part containing the binary data within `content`, rather than a `functionResponse` followed by a separate `inlineData` part (via `/chat share foo.json`)

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
