### PR TITLE
Fix(security): Prioritize most specific trust rule

### DIFF
--- a/packages/cli/src/config/trustedFolders.test.ts
+++ b/packages/cli/src/config/trustedFolders.test.ts
@@ -307,12 +307,12 @@ describe('isWorkspaceTrusted', () => {
     expect(isWorkspaceTrusted(mockSettings).isTrusted).toBeUndefined();
   });
 
-  it('should prioritize trust over distrust', () => {
+  it('should prioritize the most specific rule (distrust over parent trust)', () => {
     mockCwd = '/home/user/projectA/untrusted';
     mockRules['/home/user/projectA'] = TrustLevel.TRUST_FOLDER;
     mockRules['/home/user/projectA/untrusted'] = TrustLevel.DO_NOT_TRUST;
     expect(isWorkspaceTrusted(mockSettings)).toEqual({
-      isTrusted: true,
+      isTrusted: false,
       source: 'file',
     });
   });


### PR DESCRIPTION
## Summary
This PR fixes a critical security vulnerability (Fixes #13125) where a general parent folder trust rule (`TRUST_FOLDER`) incorrectly overrode a specific `DO_NOT_TRUST` rule on a child folder.

The logic is updated to ensure the most specific rule always takes precedence. This prevents the CLI from running in a trusted state in a directory that the user has explicitly marked as untrusted.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
The fix is applied to the `isPathTrusted` function in `packages/cli/src/config/trustedFolders.ts`.

The original implementation checked for matching trust rules before checking for distrust rules. This meant that if a user was in `~/projects/malicious-repo` (marked `DO_NOT_TRUST`) but `~/projects` was marked `TRUST_FOLDER`, the CLI would incorrectly run as trusted.

The logic has been inverted to check for explicit `DO_NOT_TRUST` rules first. Only if no specific distrust rule matches does it proceed to check for trust rules. This adheres to the "secure by default" principle.

The corresponding unit test in `trustedFolders.test.ts` has been updated to assert this correct, secure behavior.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues
Fixes #13125
<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

1.  Create a folder structure (e.g., `~/test-project/untrusted-child`).
2.  In your global `trustedFolders.json`, add rules for both:
    ```json
    {
      "/path/to/test-project": "TRUST_FOLDER",
      "/path/to/test-project/untrusted-child": "DO_NOT_TRUST"
    }
    ```
    *(Use your actual full paths)*
3.  `cd` into the child directory: `cd ~/test-project/untrusted-child`
4.  Run `gemini`.
5.  **Verify:** The CLI should now operate in an **untrusted** state (e.g., it will prompt for trust, whereas before this fix it would have incorrectly run as trusted).
6.  Run the unit tests via `npm test` and confirm the test `it('should prioritize the most specific rule (distrust over parent trust)', ...)` in `trustedFolders.test.ts` now passes.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker