### PR TITLE
fix(ui): React reconciler crash when using /memory

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -24,6 +24,7 @@ import { theme } from '../../semantic-colors.js';
 import type { AnsiOutput, Config } from '@google/gemini-cli-core';
 import { useUIState } from '../../contexts/UIStateContext.js';
 import { useAlternateBuffer } from '../../hooks/useAlternateBuffer.js';
+import { useTimeout } from '../../hooks/useTimeout.js';
 
 const STATIC_HEIGHT = 1;
 const RESERVED_LINE_COUNT = 5; // for tool name, status, padding etc.
@@ -83,17 +84,14 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
     }
   }, [resultDisplay]);
 
-  React.useEffect(() => {
-    if (!lastUpdateTime) {
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      setShowFocusHint(true);
-    }, 5000);
-
-    return () => clearTimeout(timer);
-  }, [lastUpdateTime]);
+  useTimeout(
+    () => {
+      if (lastUpdateTime) {
+        setShowFocusHint(true);
+      }
+    },
+    lastUpdateTime ? 5000 : null,
+  );
 
   React.useEffect(() => {
     if (isThisShellFocused) {

--- a/packages/cli/src/ui/hooks/useTimeout.ts
+++ b/packages/cli/src/ui/hooks/useTimeout.ts
@@ -24,10 +24,9 @@ import { useEffect, useRef } from 'react';
 export function useTimeout(callback: () => void, delay: number | null): void {
   const savedCallback = useRef(callback);
 
-  // Update the saved callback if it changes
-  useEffect(() => {
-    savedCallback.current = callback;
-  }, [callback]);
+  // Always update the ref to the latest callback. It's safe to do this
+  // during render because it's not read until the effect runs.
+  savedCallback.current = callback;
 
   // Set up the timeout
   useEffect(() => {

--- a/packages/cli/src/ui/hooks/useTimeout.ts
+++ b/packages/cli/src/ui/hooks/useTimeout.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * A custom hook for handling timeouts in React components with proper lifecycle management.
+ *
+ * This hook encapsulates setTimeout and clearTimeout logic using useRef to store the callback.
+ * It ensures safe cleanup during component unmount and prevents race conditions that can occur
+ * with the standard setTimeout/clearTimeout pattern in useEffect.
+ *
+ * @param callback - The function to execute after the delay
+ * @param delay - The delay in milliseconds, or null to disable the timeout
+ *
+ * @example
+ * useTimeout(() => {
+ *   setShowFocusHint(true);
+ * }, 5000);
+ */
+export function useTimeout(callback: () => void, delay: number | null): void {
+  const savedCallback = useRef(callback);
+
+  // Update the saved callback if it changes
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the timeout
+  useEffect(() => {
+    if (delay === null) {
+      return;
+    }
+
+    const id = setTimeout(() => savedCallback.current(), delay);
+
+    return () => clearTimeout(id);
+  }, [delay]);
+}


### PR DESCRIPTION
## Summary

Fixes a React reconciler crash that occurs when using the `/memory` command to search past chats. The error shows as "Cannot read properties of null (reading 'removeListener')" during component unmount, causing the CLI to crash with a stack trace pointing to `commitPassiveUnmountOnFiber` and `recursivelyTraversePassiveUnmountEffects`.

## Details

The root cause was a problematic `useEffect` hook in `ToolMessage.tsx` that manages a focus hint timer. The issue is from how React's reconciler interacts with Node.js `setTimeout` return values during component unmount:

1. In Node.js, `setTimeout` returns a `Timeout` object (not a numeric ID like in browsers)
2. The `/memory` command triggers rapid `ToolMessage` mount/unmount cycles
3. When `ToolMessage` unmounts while the timer is active, React's reconciler encounters a race condition during cleanup
4. This causes the reconciler to attempt calling `.removeListener()` on a null reference

**Solution implemented:**
- Created a custom `useTimeout` hook that encapsulates `setTimeout`/`clearTimeout` logic with proper React lifecycle management
- Uses `useRef` to store the callback, ensuring safe cleanup during unmount and preventing race conditions
- Replaced the problematic `useEffect` in `ToolMessage.tsx` with a call to the new `useTimeout` hook
- The hook accepts `delay: number | null` to allow enabling/disabling the timeout, making it more robust

## Related Issues

Closes #13157 

## How to Validate

1. Run the CLI: `npm run build && npm start`
2. Execute different `/memory` commands multiple times in succession
3. Verify no React reconciler crashes or "Cannot read properties of null" errors occur
4. Verify focus hint functionality still works correctly after 5 seconds of tool output

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [x] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [x] Docker