### PR TITLE
Fix test to not leave terminal in mouse mode

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -124,6 +124,13 @@ vi.mock('./config/sandboxConfig.js', () => ({
   loadSandboxConfig: vi.fn(),
 }));
 
+vi.mock('./ui/utils/mouse.js', () => ({
+  enableMouseEvents: vi.fn(),
+  disableMouseEvents: vi.fn(),
+  parseMouseEvent: vi.fn(),
+  isIncompleteMouseSequence: vi.fn(),
+}));
+
 describe('gemini.tsx main function', () => {
   let originalEnvGeminiSandbox: string | undefined;
   let originalEnvSandbox: string | undefined;


### PR DESCRIPTION
## Summary

Fix test to not leave the terminal in mouse mode.

## Details

Previously, running this test would break mouse scrolling in the terminal.

## How to Validate

Run the test and verify that the mouse still works.
