### PR TITLE
Protect stdout and stderr so JavaScript code can't accidentally write to stdout corrupting ink rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "ink": "npm:@jrichman/ink@6.4.3",
+        "ink": "npm:@jrichman/ink@6.4.5",
         "latest-version": "^9.0.0",
         "simple-git": "^3.28.0"
       },
@@ -2403,6 +2403,7 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -2583,6 +2584,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2616,6 +2618,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
       "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2984,6 +2987,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
       "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -3017,6 +3021,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz",
       "integrity": "sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1"
@@ -3069,6 +3074,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
       "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1",
@@ -4279,6 +4285,7 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4566,6 +4573,7 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -5489,6 +5497,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5924,8 +5933,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
@@ -7189,7 +7197,6 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -8205,6 +8212,7 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8794,7 +8802,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8804,7 +8811,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -8814,7 +8820,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9068,7 +9073,6 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
       "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
@@ -9087,7 +9091,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -9096,15 +9099,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/finalhandler/node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -10311,10 +10312,11 @@
     },
     "node_modules/ink": {
       "name": "@jrichman/ink",
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.3.tgz",
-      "integrity": "sha512-2qm05tjtdia+d1gD7LQjPJyCPJluKDuR5B+FI3ZZXshFoU1igZBFvXs2++x9OT6d9755q+gkRPOdtH8jzx5MiQ==",
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.5.tgz",
+      "integrity": "sha512-mIDkZqtJbedL9XDOoqoJt3S8aGQVqEJYnCnSeLlYzkpUWCsSWC0hW40yJ0DLH86lcl8k5R5lv/9C2i/3746nWw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.1",
         "ansi-escapes": "^7.0.0",
@@ -13422,8 +13424,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "3.0.0",
@@ -13958,6 +13959,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13968,6 +13970,7 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -16186,6 +16189,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16350,7 +16354,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -16358,6 +16363,7 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -16542,6 +16548,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16704,7 +16711,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -16760,6 +16766,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -16876,6 +16883,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16889,6 +16897,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -17595,6 +17604,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -17917,7 +17927,7 @@
         "fzf": "^0.5.2",
         "glob": "^12.0.0",
         "highlight.js": "^11.11.1",
-        "ink": "npm:@jrichman/ink@6.4.3",
+        "ink": "npm:@jrichman/ink@6.4.5",
         "ink-gradient": "^3.0.0",
         "ink-spinner": "^5.0.0",
         "latest-version": "^9.0.0",
@@ -18136,6 +18146,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pre-commit": "node scripts/pre-commit.js"
   },
   "overrides": {
-    "ink": "npm:@jrichman/ink@6.4.3",
+    "ink": "npm:@jrichman/ink@6.4.5",
     "wrap-ansi": "9.0.2",
     "cliui": {
       "wrap-ansi": "7.0.0"
@@ -119,7 +119,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "ink": "npm:@jrichman/ink@6.4.3",
+    "ink": "npm:@jrichman/ink@6.4.5",
     "latest-version": "^9.0.0",
     "simple-git": "^3.28.0"
   },

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -436,7 +436,6 @@ export class Task {
       onToolCallsUpdate: this._schedulerToolCallsUpdate.bind(this),
       getPreferredEditor: () => 'vscode',
       config: this.config,
-      onEditorClose: () => {},
     });
     return scheduler;
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
     "fzf": "^0.5.2",
     "glob": "^12.0.0",
     "highlight.js": "^11.11.1",
-    "ink": "npm:@jrichman/ink@6.4.3",
+    "ink": "npm:@jrichman/ink@6.4.5",
     "ink-gradient": "^3.0.0",
     "ink-spinner": "^5.0.0",
     "latest-version": "^9.0.0",

--- a/packages/cli/src/commands/mcp/add.test.ts
+++ b/packages/cli/src/commands/mcp/add.test.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, type Mock } from 'vitest';
+import { describe, it, expect, vi, type Mock, type MockInstance } from 'vitest';
 import yargs, { type Argv } from 'yargs';
 import { addCommand } from './add.js';
 import { loadSettings, SettingScope } from '../../config/settings.js';
+import { debugLogger } from '@google/gemini-cli-core';
 
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
@@ -38,6 +39,7 @@ describe('mcp add command', () => {
   let parser: Argv;
   let mockSetValue: Mock;
   let mockConsoleError: Mock;
+  let debugLoggerErrorSpy: MockInstance;
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -45,6 +47,9 @@ describe('mcp add command', () => {
     parser = yargsInstance;
     mockSetValue = vi.fn();
     mockConsoleError = vi.fn();
+    debugLoggerErrorSpy = vi
+      .spyOn(debugLogger, 'error')
+      .mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(mockConsoleError);
     mockedLoadSettings.mockReturnValue({
       forScope: () => ({ settings: {} }),
@@ -232,7 +237,7 @@ describe('mcp add command', () => {
           parser.parseAsync(`add ${serverName} ${command}`),
         ).rejects.toThrow('process.exit called');
 
-        expect(mockConsoleError).toHaveBeenCalledWith(
+        expect(debugLoggerErrorSpy).toHaveBeenCalledWith(
           'Error: Please use --scope user to edit settings in the home directory.',
         );
         expect(mockProcessExit).toHaveBeenCalledWith(1);
@@ -250,7 +255,7 @@ describe('mcp add command', () => {
           parser.parseAsync(`add --scope project ${serverName} ${command}`),
         ).rejects.toThrow('process.exit called');
 
-        expect(mockConsoleError).toHaveBeenCalledWith(
+        expect(debugLoggerErrorSpy).toHaveBeenCalledWith(
           'Error: Please use --scope user to edit settings in the home directory.',
         );
         expect(mockProcessExit).toHaveBeenCalledWith(1);
@@ -264,7 +269,7 @@ describe('mcp add command', () => {
           'mcpServers',
           expect.any(Object),
         );
-        expect(mockConsoleError).not.toHaveBeenCalled();
+        expect(debugLoggerErrorSpy).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -40,12 +40,6 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     GEMINI_DIR: '.gemini',
     getErrorMessage: (e: unknown) =>
       e instanceof Error ? e.message : String(e),
-    debugLogger: {
-      log: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    },
   };
 });
 vi.mock('@modelcontextprotocol/sdk/client/index.js');
@@ -78,6 +72,7 @@ describe('mcp list command', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.spyOn(debugLogger, 'log').mockImplementation(() => {});
 
     mockTransport = { close: vi.fn() };
     mockClient = {

--- a/packages/cli/src/commands/mcp/remove.test.ts
+++ b/packages/cli/src/commands/mcp/remove.test.ts
@@ -19,7 +19,7 @@ import { removeCommand } from './remove.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { GEMINI_DIR } from '@google/gemini-cli-core';
+import { GEMINI_DIR, debugLogger } from '@google/gemini-cli-core';
 
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
@@ -69,13 +69,16 @@ describe('mcp remove command', () => {
     });
 
     it('should show a message if server not found', async () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const debugLogSpy = vi
+        .spyOn(debugLogger, 'log')
+        .mockImplementation(() => {});
       await parser.parseAsync('remove non-existent-server');
 
       expect(mockSetValue).not.toHaveBeenCalled();
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(debugLogSpy).toHaveBeenCalledWith(
         'Server "non-existent-server" not found in project settings.',
       );
+      debugLogSpy.mockRestore();
     });
   });
 
@@ -123,18 +126,20 @@ describe('mcp remove command', () => {
       }`;
       fs.writeFileSync(settingsPath, originalContent, 'utf-8');
 
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const debugLogSpy = vi
+        .spyOn(debugLogger, 'log')
+        .mockImplementation(() => {});
       await parser.parseAsync('remove server-to-remove');
 
       const updatedContent = fs.readFileSync(settingsPath, 'utf-8');
       expect(updatedContent).toContain('"server-to-keep"');
       expect(updatedContent).not.toContain('"server-to-remove"');
 
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(debugLogSpy).toHaveBeenCalledWith(
         'Server "server-to-remove" removed from project settings.',
       );
 
-      consoleSpy.mockRestore();
+      debugLogSpy.mockRestore();
     });
 
     it('should preserve comments when removing a server', async () => {
@@ -154,7 +159,9 @@ describe('mcp remove command', () => {
       }`;
       fs.writeFileSync(settingsPath, originalContent, 'utf-8');
 
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const debugLogSpy = vi
+        .spyOn(debugLogger, 'log')
+        .mockImplementation(() => {});
       await parser.parseAsync('remove oldServer');
 
       const updatedContent = fs.readFileSync(settingsPath, 'utf-8');
@@ -163,7 +170,7 @@ describe('mcp remove command', () => {
       expect(updatedContent).not.toContain('"oldServer"');
       expect(updatedContent).toContain('// Server to remove');
 
-      consoleSpy.mockRestore();
+      debugLogSpy.mockRestore();
     });
 
     it('should handle removing the only server', async () => {
@@ -177,7 +184,9 @@ describe('mcp remove command', () => {
       }`;
       fs.writeFileSync(settingsPath, originalContent, 'utf-8');
 
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const debugLogSpy = vi
+        .spyOn(debugLogger, 'log')
+        .mockImplementation(() => {});
       await parser.parseAsync('remove only-server');
 
       const updatedContent = fs.readFileSync(settingsPath, 'utf-8');
@@ -185,7 +194,7 @@ describe('mcp remove command', () => {
       expect(updatedContent).not.toContain('"only-server"');
       expect(updatedContent).toMatch(/"mcpServers"\s*:\s*\{\s*\}/);
 
-      consoleSpy.mockRestore();
+      debugLogSpy.mockRestore();
     });
 
     it('should preserve other settings when removing a server', async () => {
@@ -211,7 +220,9 @@ describe('mcp remove command', () => {
       }`;
       fs.writeFileSync(settingsPath, originalContent, 'utf-8');
 
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const debugLogSpy = vi
+        .spyOn(debugLogger, 'log')
+        .mockImplementation(() => {});
       await parser.parseAsync('remove server1');
 
       const updatedContent = fs.readFileSync(settingsPath, 'utf-8');
@@ -222,7 +233,7 @@ describe('mcp remove command', () => {
       expect(updatedContent).toContain('"theme": "dark"');
       expect(updatedContent).not.toContain('"server1"');
 
-      consoleSpy.mockRestore();
+      debugLogSpy.mockRestore();
     });
   });
 });

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -16,6 +16,7 @@ import {
   WRITE_FILE_TOOL_NAME,
   EDIT_TOOL_NAME,
   type ExtensionLoader,
+  debugLogger,
 } from '@google/gemini-cli-core';
 import { loadCliConfig, parseArguments, type CliArgs } from './config.js';
 import type { Settings } from './settings.js';
@@ -165,19 +166,25 @@ describe('parseArguments', () => {
     const mockConsoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
+    const debugErrorSpy = vi
+      .spyOn(debugLogger, 'error')
+      .mockImplementation(() => {});
 
     await expect(parseArguments({} as Settings)).rejects.toThrow(
       'process.exit called',
     );
 
-    expect(mockConsoleError).toHaveBeenCalledWith(
+    expect(debugErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         'Cannot use both --prompt (-p) and --prompt-interactive (-i) together',
       ),
     );
+    // yargs.showHelp() calls console.error
+    expect(mockConsoleError).toHaveBeenCalled();
 
     mockExit.mockRestore();
     mockConsoleError.mockRestore();
+    debugErrorSpy.mockRestore();
   });
 
   it('should throw an error when using short flags -p and -i together', async () => {
@@ -197,19 +204,24 @@ describe('parseArguments', () => {
     const mockConsoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
+    const debugErrorSpy = vi
+      .spyOn(debugLogger, 'error')
+      .mockImplementation(() => {});
 
     await expect(parseArguments({} as Settings)).rejects.toThrow(
       'process.exit called',
     );
 
-    expect(mockConsoleError).toHaveBeenCalledWith(
+    expect(debugErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         'Cannot use both --prompt (-p) and --prompt-interactive (-i) together',
       ),
     );
+    expect(mockConsoleError).toHaveBeenCalled();
 
     mockExit.mockRestore();
     mockConsoleError.mockRestore();
+    debugErrorSpy.mockRestore();
   });
 
   it('should allow --prompt without --prompt-interactive', async () => {
@@ -376,19 +388,24 @@ describe('parseArguments', () => {
     const mockConsoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
+    const debugErrorSpy = vi
+      .spyOn(debugLogger, 'error')
+      .mockImplementation(() => {});
 
     await expect(parseArguments({} as Settings)).rejects.toThrow(
       'process.exit called',
     );
 
-    expect(mockConsoleError).toHaveBeenCalledWith(
+    expect(debugErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         'Cannot use both --yolo (-y) and --approval-mode together. Use --approval-mode=yolo instead.',
       ),
     );
+    expect(mockConsoleError).toHaveBeenCalled();
 
     mockExit.mockRestore();
     mockConsoleError.mockRestore();
+    debugErrorSpy.mockRestore();
   });
 
   it('should throw an error when using short flags -y and --approval-mode together', async () => {
@@ -401,19 +418,24 @@ describe('parseArguments', () => {
     const mockConsoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
+    const debugErrorSpy = vi
+      .spyOn(debugLogger, 'error')
+      .mockImplementation(() => {});
 
     await expect(parseArguments({} as Settings)).rejects.toThrow(
       'process.exit called',
     );
 
-    expect(mockConsoleError).toHaveBeenCalledWith(
+    expect(debugErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         'Cannot use both --yolo (-y) and --approval-mode together. Use --approval-mode=yolo instead.',
       ),
     );
+    expect(mockConsoleError).toHaveBeenCalled();
 
     mockExit.mockRestore();
     mockConsoleError.mockRestore();
+    debugErrorSpy.mockRestore();
   });
 
   it('should allow --approval-mode without --yolo', async () => {
@@ -440,17 +462,22 @@ describe('parseArguments', () => {
     const mockConsoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
+    const debugErrorSpy = vi
+      .spyOn(debugLogger, 'error')
+      .mockImplementation(() => {});
 
     await expect(parseArguments({} as Settings)).rejects.toThrow(
       'process.exit called',
     );
 
-    expect(mockConsoleError).toHaveBeenCalledWith(
+    expect(debugErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Invalid values:'),
     );
+    expect(mockConsoleError).toHaveBeenCalled();
 
     mockExit.mockRestore();
     mockConsoleError.mockRestore();
+    debugErrorSpy.mockRestore();
   });
 
   it('should throw an error when resuming a session without prompt in non-interactive mode', async () => {
@@ -465,20 +492,25 @@ describe('parseArguments', () => {
     const mockConsoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
+    const debugErrorSpy = vi
+      .spyOn(debugLogger, 'error')
+      .mockImplementation(() => {});
 
     try {
       await expect(parseArguments({} as Settings)).rejects.toThrow(
         'process.exit called',
       );
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
+      expect(debugErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining(
           'When resuming a session, you must provide a message via --prompt (-p) or stdin',
         ),
       );
+      expect(mockConsoleError).toHaveBeenCalled();
     } finally {
       mockExit.mockRestore();
       mockConsoleError.mockRestore();
+      debugErrorSpy.mockRestore();
       process.stdin.isTTY = originalIsTTY;
     }
   });
@@ -2233,21 +2265,30 @@ describe('Output format', () => {
   });
 
   it('should error on invalid --output-format argument', async () => {
-    process.argv = ['node', 'script.js', '--output-format', 'yaml'];
+    process.argv = ['node', 'script.js', '--output-format', 'invalid'];
+
     const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('process.exit called');
     });
+
     const mockConsoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
+    const debugErrorSpy = vi
+      .spyOn(debugLogger, 'error')
+      .mockImplementation(() => {});
+
     await expect(parseArguments({} as Settings)).rejects.toThrow(
       'process.exit called',
     );
-    expect(mockConsoleError).toHaveBeenCalledWith(
+    expect(debugErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Invalid values:'),
     );
+    expect(mockConsoleError).toHaveBeenCalled();
+
     mockExit.mockRestore();
     mockConsoleError.mockRestore();
+    debugErrorSpy.mockRestore();
   });
 });
 
@@ -2275,12 +2316,15 @@ describe('parseArguments with positional prompt', () => {
     const mockConsoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
+    const debugErrorSpy = vi
+      .spyOn(debugLogger, 'error')
+      .mockImplementation(() => {});
 
     await expect(parseArguments({} as Settings)).rejects.toThrow(
       'process.exit called',
     );
 
-    expect(mockConsoleError).toHaveBeenCalledWith(
+    expect(debugErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         'Cannot use both a positional prompt and the --prompt (-p) flag together',
       ),
@@ -2288,6 +2332,7 @@ describe('parseArguments with positional prompt', () => {
 
     mockExit.mockRestore();
     mockConsoleError.mockRestore();
+    debugErrorSpy.mockRestore();
   });
 
   it('should correctly parse a positional prompt to query field', async () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -263,19 +263,21 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
       if (argv['prompt'] && argv['promptInteractive']) {
         return 'Cannot use both --prompt (-p) and --prompt-interactive (-i) together';
       }
-      if (argv.resume && !argv.prompt && !process.stdin.isTTY) {
+      if (argv['resume'] && !argv['prompt'] && !process.stdin.isTTY) {
         throw new Error(
           'When resuming a session, you must provide a message via --prompt (-p) or stdin',
         );
       }
-      if (argv.yolo && argv['approvalMode']) {
+      if (argv['yolo'] && argv['approvalMode']) {
         return 'Cannot use both --yolo (-y) and --approval-mode together. Use --approval-mode=yolo instead.';
       }
       if (
-        argv.outputFormat &&
-        !['text', 'json', 'stream-json'].includes(argv.outputFormat as string)
+        argv['outputFormat'] &&
+        !['text', 'json', 'stream-json'].includes(
+          argv['outputFormat'] as string,
+        )
       ) {
-        return `Invalid values:\n  Argument: output-format, Given: "${argv.outputFormat}", Choices: "text", "json", "stream-json"`;
+        return `Invalid values:\n  Argument: output-format, Given: "${argv['outputFormat']}", Choices: "text", "json", "stream-json"`;
       }
       return true;
     });

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -46,6 +46,7 @@ import type { ExtensionEvents } from '@google/gemini-cli-core/src/utils/extensio
 import { requestConsentNonInteractive } from './extensions/consent.js';
 import { promptForSetting } from './extensions/extensionSettings.js';
 import type { EventEmitter } from 'node:stream';
+import { runExitCleanup } from '../utils/cleanup.js';
 
 export interface CliArgs {
   query: string | undefined;
@@ -239,40 +240,45 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
         .deprecateOption(
           'prompt',
           'Use the positional prompt instead. This flag will be removed in a future version.',
-        )
-        // Ensure validation flows through .fail() for clean UX
-        .fail((msg, err, yargs) => {
-          debugLogger.error(msg || err?.message || 'Unknown error');
-          yargs.showHelp();
-          process.exit(1);
-        })
-        .check((argv) => {
-          // The 'query' positional can be a string (for one arg) or string[] (for multiple).
-          // This guard safely checks if any positional argument was provided.
-          const query = argv['query'] as string | string[] | undefined;
-          const hasPositionalQuery = Array.isArray(query)
-            ? query.length > 0
-            : !!query;
-
-          if (argv['prompt'] && hasPositionalQuery) {
-            return 'Cannot use both a positional prompt and the --prompt (-p) flag together';
-          }
-          if (argv['prompt'] && argv['promptInteractive']) {
-            return 'Cannot use both --prompt (-p) and --prompt-interactive (-i) together';
-          }
-          if (argv.resume && !argv.prompt && !process.stdin.isTTY) {
-            throw new Error(
-              'When resuming a session, you must provide a message via --prompt (-p) or stdin',
-            );
-          }
-          if (argv.yolo && argv['approvalMode']) {
-            return 'Cannot use both --yolo (-y) and --approval-mode together. Use --approval-mode=yolo instead.';
-          }
-          return true;
-        }),
+        ),
     )
     // Register MCP subcommands
-    .command(mcpCommand);
+    .command(mcpCommand)
+    // Ensure validation flows through .fail() for clean UX
+    .fail((msg, err) => {
+      if (err) throw err;
+      throw new Error(msg);
+    })
+    .check((argv) => {
+      // The 'query' positional can be a string (for one arg) or string[] (for multiple).
+      // This guard safely checks if any positional argument was provided.
+      const query = argv['query'] as string | string[] | undefined;
+      const hasPositionalQuery = Array.isArray(query)
+        ? query.length > 0
+        : !!query;
+
+      if (argv['prompt'] && hasPositionalQuery) {
+        return 'Cannot use both a positional prompt and the --prompt (-p) flag together';
+      }
+      if (argv['prompt'] && argv['promptInteractive']) {
+        return 'Cannot use both --prompt (-p) and --prompt-interactive (-i) together';
+      }
+      if (argv.resume && !argv.prompt && !process.stdin.isTTY) {
+        throw new Error(
+          'When resuming a session, you must provide a message via --prompt (-p) or stdin',
+        );
+      }
+      if (argv.yolo && argv['approvalMode']) {
+        return 'Cannot use both --yolo (-y) and --approval-mode together. Use --approval-mode=yolo instead.';
+      }
+      if (
+        argv.outputFormat &&
+        !['text', 'json', 'stream-json'].includes(argv.outputFormat as string)
+      ) {
+        return `Invalid values:\n  Argument: output-format, Given: "${argv.outputFormat}", Choices: "text", "json", "stream-json"`;
+      }
+      return true;
+    });
 
   if (settings?.experimental?.extensionManagement ?? true) {
     yargsInstance.command(extensionsCommand);
@@ -284,10 +290,26 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
     .help()
     .alias('h', 'help')
     .strict()
-    .demandCommand(0, 0); // Allow base command to run with no subcommands
+    .demandCommand(0, 0) // Allow base command to run with no subcommands
+    .exitProcess(false);
 
   yargsInstance.wrap(yargsInstance.terminalWidth());
-  const result = await yargsInstance.parse();
+  let result;
+  try {
+    result = await yargsInstance.parse();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    debugLogger.error(msg);
+    yargsInstance.showHelp();
+    await runExitCleanup();
+    process.exit(1);
+  }
+
+  // Handle help and version flags manually since we disabled exitProcess
+  if (result['help'] || result['version']) {
+    await runExitCleanup();
+    process.exit(0);
+  }
 
   // If yargs handled --help/--version it will have exited; nothing to do here.
 
@@ -298,6 +320,7 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
     (result._[0] === 'mcp' || result._[0] === 'extensions')
   ) {
     // MCP commands handle their own execution and process exit
+    await runExitCleanup();
     process.exit(0);
   }
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -29,10 +29,16 @@ import { runNonInteractive } from './nonInteractiveCli.js';
 import {
   cleanupCheckpoints,
   registerCleanup,
+  registerSyncCleanup,
   runExitCleanup,
 } from './utils/cleanup.js';
 import { getCliVersion } from './utils/version.js';
-import type { Config, ResumedSessionData } from '@google/gemini-cli-core';
+import type {
+  Config,
+  ResumedSessionData,
+  OutputPayload,
+  ConsoleLogPayload,
+} from '@google/gemini-cli-core';
 import {
   sessionId,
   logUserPrompt,
@@ -41,6 +47,8 @@ import {
   UserPromptEvent,
   debugLogger,
   recordSlowRender,
+  coreEvents,
+  CoreEvent,
 } from '@google/gemini-cli-core';
 import {
   initializeApp,
@@ -77,6 +85,14 @@ import { disableMouseEvents, enableMouseEvents } from './ui/utils/mouse.js';
 import { ScrollProvider } from './ui/contexts/ScrollProvider.js';
 import ansiEscapes from 'ansi-escapes';
 import { isAlternateBufferEnabled } from './ui/hooks/useAlternateBuffer.js';
+import {
+  createInkStdio,
+  patchStdio,
+  writeToStderr,
+  writeToStdout,
+} from './utils/stdio.js';
+
+import { profiler } from './ui/components/DebugProfiler.js';
 
 const SLOW_RENDER_MS = 200;
 
@@ -142,7 +158,7 @@ Stack trace:
 ${reason.stack}`
         : ''
     }`;
-    appEvents.emit(AppEvent.LogError, errorMessage);
+    debugLogger.error(errorMessage);
     if (!unhandledRejectionOccurred) {
       unhandledRejectionOccurred = true;
       appEvents.emit(AppEvent.OpenDebugConsole);
@@ -174,6 +190,17 @@ export async function startInteractiveUI(
 
   const version = await getCliVersion();
   setWindowTitle(basename(workspaceRoot), settings);
+
+  const consolePatcher = new ConsolePatcher({
+    onNewMessage: (msg) => {
+      coreEvents.emitConsoleLog(msg.type, msg.content);
+    },
+    debugMode: config.getDebugMode(),
+  });
+  consolePatcher.patch();
+  registerCleanup(consolePatcher.cleanup);
+
+  const { stdout: inkStdout, stderr: inkStderr } = createInkStdio();
 
   // Create wrapper component to use hooks inside render
   const AppWrapper = () => {
@@ -218,13 +245,18 @@ export async function startInteractiveUI(
       <AppWrapper />
     ),
     {
+      stdout: inkStdout,
+      stderr: inkStderr,
+      stdin: process.stdin,
       exitOnCtrlC: false,
       isScreenReaderEnabled: config.getScreenReader(),
       onRender: ({ renderTime }: { renderTime: number }) => {
         if (renderTime > SLOW_RENDER_MS) {
           recordSlowRender(config, renderTime);
         }
+        profiler.reportFrameRendered();
       },
+      patchConsole: false,
       alternateBuffer: useAlternateBuffer,
       incrementalRendering:
         settings.merged.ui?.incrementalRendering !== false &&
@@ -247,6 +279,13 @@ export async function startInteractiveUI(
 }
 
 export async function main() {
+  const cleanupStdio = patchStdio();
+  registerSyncCleanup(() => {
+    // This is needed to ensure we don't lose any buffered output.
+    initializeOutputListenersAndFlush();
+    cleanupStdio();
+  });
+
   setupUnhandledRejectionHandler();
   const settings = loadSettings();
   migrateDeprecatedSettings(
@@ -266,9 +305,10 @@ export async function main() {
 
   // Check for invalid input combinations early to prevent crashes
   if (argv.promptInteractive && !process.stdin.isTTY) {
-    debugLogger.error(
-      'Error: The --prompt-interactive flag cannot be used when input is piped from stdin.',
+    writeToStderr(
+      'Error: The --prompt-interactive flag cannot be used when input is piped from stdin.\n',
     );
+    await runExitCleanup();
     process.exit(1);
   }
 
@@ -276,6 +316,9 @@ export async function main() {
   const consolePatcher = new ConsolePatcher({
     stderr: true,
     debugMode: isDebugMode,
+    onNewMessage: (msg) => {
+      coreEvents.emitConsoleLog(msg.type, msg.content);
+    },
   });
   consolePatcher.patch();
   registerCleanup(consolePatcher.cleanup);
@@ -351,6 +394,7 @@ export async function main() {
           );
         } catch (err) {
           debugLogger.error('Error authenticating:', err);
+          await runExitCleanup();
           process.exit(1);
         }
       }
@@ -387,6 +431,7 @@ export async function main() {
       await relaunchOnExitCode(() =>
         start_sandbox(sandboxConfig, memoryArgs, partialConfig, sandboxArgs),
       );
+      await runExitCleanup();
       process.exit(0);
     } else {
       // Relaunch app so we always have a child process that can be internally
@@ -413,12 +458,14 @@ export async function main() {
       for (const extension of config.getExtensions()) {
         debugLogger.log(`- ${extension.name}`);
       }
+      await runExitCleanup();
       process.exit(0);
     }
 
     // Handle --list-sessions flag
     if (config.getListSessions()) {
       await listSessions(config);
+      await runExitCleanup();
       process.exit(0);
     }
 
@@ -426,6 +473,7 @@ export async function main() {
     const sessionToDelete = config.getDeleteSession();
     if (sessionToDelete) {
       await deleteSession(config, sessionToDelete);
+      await runExitCleanup();
       process.exit(0);
     }
 
@@ -436,7 +484,7 @@ export async function main() {
       process.stdin.setRawMode(true);
 
       if (isAlternateBufferEnabled(settings)) {
-        process.stdout.write(ansiEscapes.enterAlternativeScreen);
+        writeToStdout(ansiEscapes.enterAlternativeScreen);
 
         // Ink will cleanup so there is no need for us to manually cleanup.
       }
@@ -491,6 +539,7 @@ export async function main() {
         console.error(
           `Error resuming session: ${error instanceof Error ? error.message : 'Unknown error'}`,
         );
+        await runExitCleanup();
         process.exit(1);
       }
     }
@@ -522,6 +571,7 @@ export async function main() {
       debugLogger.error(
         `No input provided via stdin. Input can be provided by piping data into gemini or using the --prompt option.`,
       );
+      await runExitCleanup();
       process.exit(1);
     }
 
@@ -550,6 +600,8 @@ export async function main() {
     const hasDeprecatedPromptArg = process.argv.some((arg) =>
       arg.startsWith('--prompt'),
     );
+    initializeOutputListenersAndFlush();
+
     await runNonInteractive({
       config: nonInteractiveConfig,
       settings,
@@ -567,10 +619,34 @@ export async function main() {
 function setWindowTitle(title: string, settings: LoadedSettings) {
   if (!settings.merged.ui?.hideWindowTitle) {
     const windowTitle = computeWindowTitle(title);
-    process.stdout.write(`\x1b]2;${windowTitle}\x07`);
+    writeToStdout(`\x1b]2;${windowTitle}\x07`);
 
     process.on('exit', () => {
-      process.stdout.write(`\x1b]2;\x07`);
+      writeToStdout(`\x1b]2;\x07`);
     });
   }
+}
+
+function initializeOutputListenersAndFlush() {
+  // If there are no listeners for output, make sure we flush so output is not
+  // lost.
+  if (coreEvents.listenerCount(CoreEvent.Output) === 0) {
+    // In non-interactive mode, ensure we drain any buffered output or logs to stderr
+    coreEvents.on(CoreEvent.Output, (payload: OutputPayload) => {
+      if (payload.isStderr) {
+        writeToStderr(payload.chunk, payload.encoding);
+      } else {
+        writeToStdout(payload.chunk, payload.encoding);
+      }
+    });
+
+    coreEvents.on(CoreEvent.ConsoleLog, (payload: ConsoleLogPayload) => {
+      if (payload.type === 'error' || payload.type === 'warn') {
+        writeToStderr(payload.content);
+      } else {
+        writeToStdout(payload.content);
+      }
+    });
+  }
+  coreEvents.drainBacklogs();
 }

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -43,7 +43,7 @@ vi.mock('./ui/hooks/atCommandProcessor.js');
 const mockCoreEvents = vi.hoisted(() => ({
   on: vi.fn(),
   off: vi.fn(),
-  drainFeedbackBacklog: vi.fn(),
+  drainBacklogs: vi.fn(),
   emit: vi.fn(),
 }));
 
@@ -1131,7 +1131,7 @@ describe('runNonInteractive', () => {
         CoreEvent.UserFeedback,
         expect.any(Function),
       );
-      expect(mockCoreEvents.drainFeedbackBacklog).toHaveBeenCalledTimes(1);
+      expect(mockCoreEvents.drainBacklogs).toHaveBeenCalledTimes(1);
     });
 
     it('unsubscribes from UserFeedback on finish', async () => {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -66,6 +66,9 @@ export async function runNonInteractive({
     const consolePatcher = new ConsolePatcher({
       stderr: true,
       debugMode: config.getDebugMode(),
+      onNewMessage: (msg) => {
+        coreEvents.emitConsoleLog(msg.type, msg.content);
+      },
     });
     const textOutput = new TextOutput();
 
@@ -177,7 +180,7 @@ export async function runNonInteractive({
       setupStdinCancellation();
 
       coreEvents.on(CoreEvent.UserFeedback, handleUserFeedback);
-      coreEvents.drainFeedbackBacklog();
+      coreEvents.drainBacklogs();
 
       // Handle EPIPE errors when the output is piped to a command that closes early.
       process.stdout.on('error', (err: NodeJS.ErrnoException) => {

--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -8,6 +8,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { CommandService } from './CommandService.js';
 import { type ICommandLoader } from './types.js';
 import { CommandKind, type SlashCommand } from '../ui/commands/types.js';
+import { debugLogger } from '@google/gemini-cli-core';
 
 const createMockCommand = (name: string, kind: CommandKind): SlashCommand => ({
   name,
@@ -35,7 +36,7 @@ class MockCommandLoader implements ICommandLoader {
 
 describe('CommandService', () => {
   beforeEach(() => {
-    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(debugLogger, 'debug').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -139,7 +140,7 @@ describe('CommandService', () => {
     const commands = service.getCommands();
     expect(commands).toHaveLength(1);
     expect(commands).toEqual([mockCommandA]);
-    expect(console.debug).toHaveBeenCalledWith(
+    expect(debugLogger.debug).toHaveBeenCalledWith(
       'A command loader failed:',
       error,
     );

--- a/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -15,7 +15,7 @@ import {
   type Mock,
 } from 'vitest';
 import { AuthDialog } from './AuthDialog.js';
-import { AuthType, type Config } from '@google/gemini-cli-core';
+import { AuthType, type Config, debugLogger } from '@google/gemini-cli-core';
 import type { LoadedSettings } from '../../config/settings.js';
 import { SettingScope } from '../../config/settings.js';
 import { AuthState } from '../types.js';
@@ -232,7 +232,7 @@ describe('AuthDialog', () => {
       const exitSpy = vi
         .spyOn(process, 'exit')
         .mockImplementation(() => undefined as never);
-      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const logSpy = vi.spyOn(debugLogger, 'log').mockImplementation(() => {});
       vi.mocked(props.config.isBrowserLaunchSuppressed).mockReturnValue(true);
       mockedValidateAuthMethod.mockReturnValue(null);
 

--- a/packages/cli/src/ui/commands/setupGithubCommand.test.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.test.ts
@@ -17,6 +17,7 @@ import {
 } from './setupGithubCommand.js';
 import type { CommandContext, ToolActionReturn } from './types.js';
 import * as commandUtils from '../utils/commandUtils.js';
+import { debugLogger } from '@google/gemini-cli-core';
 
 vi.mock('child_process');
 
@@ -219,7 +220,9 @@ describe('updateGitignore', () => {
   });
 
   it('handles permission errors gracefully', async () => {
-    const consoleSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const consoleSpy = vi
+      .spyOn(debugLogger, 'debug')
+      .mockImplementation(() => {});
 
     const fsModule = await import('node:fs');
     const writeFileSpy = vi

--- a/packages/cli/src/ui/components/DebugProfiler.test.tsx
+++ b/packages/cli/src/ui/components/DebugProfiler.test.tsx
@@ -17,6 +17,7 @@ import { debugState } from '../debug.js';
 describe('DebugProfiler', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    profiler.profilersActive = 1;
     profiler.numFrames = 0;
     profiler.totalIdleFrames = 0;
     profiler.lastFrameStartTime = 0;

--- a/packages/cli/src/ui/components/DebugProfiler.tsx
+++ b/packages/cli/src/ui/components/DebugProfiler.tsx
@@ -11,6 +11,7 @@ import { theme } from '../semantic-colors.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { debugState } from '../debug.js';
 import { appEvents, AppEvent } from '../../utils/events.js';
+import { debugLogger } from '@google/gemini-cli-core';
 
 // Frames that render at least this far before or after an action are considered
 // idle frames.
@@ -21,6 +22,7 @@ export const FRAME_TIMESTAMP_CAPACITY = 2048;
 
 // Exported for testing purposes.
 export const profiler = {
+  profilersActive: 0,
   numFrames: 0,
   totalIdleFrames: 0,
   totalFlickerFrames: 0,
@@ -47,25 +49,25 @@ export const profiler = {
   },
 
   reportFrameRendered() {
+    if (this.profilersActive === 0) {
+      return;
+    }
     const now = Date.now();
-    // Simple frame detection logic (a write after at least 16ms is a new frame)
-    if (now - this.lastFrameStartTime > 16) {
-      this.lastFrameStartTime = now;
-      this.numFrames++;
-      if (debugState.debugNumAnimatedComponents === 0) {
-        if (this.possiblyIdleFrameTimestamps.size >= FRAME_TIMESTAMP_CAPACITY) {
-          this.possiblyIdleFrameTimestamps.shift();
-        }
-        this.possiblyIdleFrameTimestamps.push(now);
-      } else {
-        // If a spinner is present, consider this an action that both prevents
-        // this frame from being idle and also should prevent a follow on frame
-        // from being considered idle.
-        if (this.actionTimestamps.size >= ACTION_TIMESTAMP_CAPACITY) {
-          this.actionTimestamps.shift();
-        }
-        this.actionTimestamps.push(now);
+    this.lastFrameStartTime = now;
+    this.numFrames++;
+    if (debugState.debugNumAnimatedComponents === 0) {
+      if (this.possiblyIdleFrameTimestamps.size >= FRAME_TIMESTAMP_CAPACITY) {
+        this.possiblyIdleFrameTimestamps.shift();
       }
+      this.possiblyIdleFrameTimestamps.push(now);
+    } else {
+      // If a spinner is present, consider this an action that both prevents
+      // this frame from being idle and also should prevent a follow on frame
+      // from being considered idle.
+      if (this.actionTimestamps.size >= ACTION_TIMESTAMP_CAPACITY) {
+        this.actionTimestamps.shift();
+      }
+      this.actionTimestamps.push(now);
     }
   },
 
@@ -108,8 +110,7 @@ export const profiler = {
         this.openedDebugConsole = true;
         appEvents.emit(AppEvent.OpenDebugConsole);
       }
-      appEvents.emit(
-        AppEvent.LogError,
+      debugLogger.error(
         `${idleInPastSecond} frames rendered while the app was ` +
           `idle in the past second. This likely indicates severe infinite loop ` +
           `React state management bugs.`,
@@ -130,8 +131,7 @@ export const profiler = {
 
       if (!this.hasLoggedFirstFlicker) {
         this.hasLoggedFirstFlicker = true;
-        appEvents.emit(
-          AppEvent.LogError,
+        debugLogger.error(
           'A flicker frame was detected. This will cause UI instability. Type `/profile` for more info.',
         );
       }
@@ -149,6 +149,7 @@ export const DebugProfiler = () => {
 
   // Effect for listening to stdin for keypresses and stdout for resize events.
   useEffect(() => {
+    profiler.profilersActive++;
     const stdin = process.stdin;
     const stdout = process.stdout;
 
@@ -162,31 +163,7 @@ export const DebugProfiler = () => {
     return () => {
       stdin.off('data', handler);
       stdout.off('resize', handler);
-    };
-  }, []);
-
-  // Effect for patching stdout to count frames and detect idle ones
-  useEffect(() => {
-    const originalWrite = process.stdout.write;
-    const boundOriginalWrite = originalWrite.bind(process.stdout);
-
-    process.stdout.write = (
-      chunk: Uint8Array | string,
-      encodingOrCb?:
-        | BufferEncoding
-        | ((err?: NodeJS.ErrnoException | null) => void),
-      cb?: (err?: NodeJS.ErrnoException | null) => void,
-    ) => {
-      profiler.reportFrameRendered();
-
-      if (typeof encodingOrCb === 'function') {
-        return boundOriginalWrite(chunk, encodingOrCb);
-      }
-      return boundOriginalWrite(chunk, encodingOrCb, cb);
-    };
-
-    return () => {
-      process.stdout.write = originalWrite;
+      profiler.profilersActive--;
     };
   }, []);
 

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import pathMod from 'node:path';
 import { useState, useCallback, useEffect, useMemo, useReducer } from 'react';
-import { unescapePath } from '@google/gemini-cli-core';
+import { unescapePath, coreEvents, CoreEvent } from '@google/gemini-cli-core';
 import {
   toCodePoints,
   cpLen,
@@ -1893,6 +1893,7 @@ export function useTextBuffer({
         console.error('[useTextBuffer] external editor error', err);
       } finally {
         enableSupportedProtocol();
+        coreEvents.emit(CoreEvent.ExternalEditorClosed);
         if (wasRaw) setRawMode?.(true);
         try {
           fs.unlinkSync(filePath);

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { debugLogger } from '@google/gemini-cli-core';
 import type React from 'react';
 import { act } from 'react';
 import { renderHook } from '../../test-utils/render.js';
@@ -322,17 +323,16 @@ describe('KeypressContext', () => {
   });
 
   describe('debug keystroke logging', () => {
-    let consoleLogSpy: ReturnType<typeof vi.spyOn>;
-    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+    let debugLoggerSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
-      consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-      consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      debugLoggerSpy = vi
+        .spyOn(debugLogger, 'log')
+        .mockImplementation(() => {});
     });
 
     afterEach(() => {
-      consoleLogSpy.mockRestore();
-      consoleWarnSpy.mockRestore();
+      debugLoggerSpy.mockRestore();
     });
 
     it('should not log keystrokes when debugKeystrokeLogging is false', async () => {
@@ -354,7 +354,7 @@ describe('KeypressContext', () => {
       });
 
       expect(keyHandler).toHaveBeenCalled();
-      expect(consoleLogSpy).not.toHaveBeenCalledWith(
+      expect(debugLoggerSpy).not.toHaveBeenCalledWith(
         expect.stringContaining('[DEBUG] Kitty'),
       );
     });
@@ -375,7 +375,7 @@ describe('KeypressContext', () => {
       // Send a complete kitty sequence for escape
       act(() => stdin.write('\x1b[27u'));
 
-      expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect(debugLoggerSpy).toHaveBeenCalledWith(
         `[DEBUG] Raw StdIn: ${JSON.stringify('\x1b[27u')}`,
       );
     });
@@ -397,7 +397,7 @@ describe('KeypressContext', () => {
       act(() => stdin.write(INCOMPLETE_KITTY_SEQUENCE));
 
       // Verify debug logging for accumulation
-      expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect(debugLoggerSpy).toHaveBeenCalledWith(
         `[DEBUG] Raw StdIn: ${JSON.stringify(INCOMPLETE_KITTY_SEQUENCE)}`,
       );
     });

--- a/packages/cli/src/ui/hooks/useBracketedPaste.ts
+++ b/packages/cli/src/ui/hooks/useBracketedPaste.ts
@@ -5,6 +5,7 @@
  */
 
 import { useEffect } from 'react';
+import { writeToStdout } from '../../utils/stdio.js';
 
 const ENABLE_BRACKETED_PASTE = '\x1b[?2004h';
 const DISABLE_BRACKETED_PASTE = '\x1b[?2004l';
@@ -17,11 +18,11 @@ const DISABLE_BRACKETED_PASTE = '\x1b[?2004l';
  */
 export const useBracketedPaste = () => {
   const cleanup = () => {
-    process.stdout.write(DISABLE_BRACKETED_PASTE);
+    writeToStdout(DISABLE_BRACKETED_PASTE);
   };
 
   useEffect(() => {
-    process.stdout.write(ENABLE_BRACKETED_PASTE);
+    writeToStdout(ENABLE_BRACKETED_PASTE);
 
     process.on('exit', cleanup);
     process.on('SIGINT', cleanup);

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -14,7 +14,7 @@ import {
   type Mock,
 } from 'vitest';
 import { act, useEffect } from 'react';
-import { render } from '../../test-utils/render.js';
+import { renderWithProviders } from '../../test-utils/render.js';
 import { waitFor } from '../../test-utils/async.js';
 import { useCommandCompletion } from './useCommandCompletion.js';
 import type { CommandContext } from '../commands/types.js';
@@ -132,7 +132,7 @@ describe('useCommandCompletion', () => {
       hookResult = { ...completion, textBuffer };
       return null;
     }
-    render(<TestComponent />);
+    renderWithProviders(<TestComponent />);
     return {
       result: {
         get current() {
@@ -516,7 +516,7 @@ describe('useCommandCompletion', () => {
         hookResult = { ...completion, textBuffer };
         return null;
       }
-      render(<TestComponent />);
+      renderWithProviders(<TestComponent />);
 
       // Should not trigger prompt completion for comments
       expect(hookResult!.suggestions.length).toBe(0);
@@ -549,7 +549,7 @@ describe('useCommandCompletion', () => {
         hookResult = { ...completion, textBuffer };
         return null;
       }
-      render(<TestComponent />);
+      renderWithProviders(<TestComponent />);
 
       // Should not trigger prompt completion for comments
       expect(hookResult!.suggestions.length).toBe(0);
@@ -582,7 +582,7 @@ describe('useCommandCompletion', () => {
         hookResult = { ...completion, textBuffer };
         return null;
       }
-      render(<TestComponent />);
+      renderWithProviders(<TestComponent />);
 
       // This test verifies that comments are filtered out while regular text is not
       expect(hookResult!.textBuffer.text).toBe(

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -347,7 +347,6 @@ describe('useGeminiStream', () => {
           () => {},
           () => {},
           () => {},
-          () => {},
           80,
           24,
         );
@@ -419,7 +418,6 @@ describe('useGeminiStream', () => {
       setShellInputFocused?: (focused: boolean) => void;
       performMemoryRefresh?: () => Promise<void>;
       onAuthError?: () => void;
-      onEditorClose?: () => void;
       setModelSwitched?: Mock;
       modelSwitched?: boolean;
     } = {},
@@ -430,7 +428,6 @@ describe('useGeminiStream', () => {
       setShellInputFocused = () => {},
       performMemoryRefresh = () => Promise.resolve(),
       onAuthError = () => {},
-      onEditorClose = () => {},
       setModelSwitched = vi.fn(),
       modelSwitched = false,
     } = options;
@@ -450,7 +447,6 @@ describe('useGeminiStream', () => {
         performMemoryRefresh,
         modelSwitched,
         setModelSwitched,
-        onEditorClose,
         onCancelSubmit,
         setShellInputFocused,
         80,
@@ -594,7 +590,6 @@ describe('useGeminiStream', () => {
         () => {},
         () => {},
         () => {},
-        () => {},
         80,
         24,
       ),
@@ -674,7 +669,6 @@ describe('useGeminiStream', () => {
         () => {},
         () => Promise.resolve(),
         false,
-        () => {},
         () => {},
         () => {},
         () => {},
@@ -789,7 +783,6 @@ describe('useGeminiStream', () => {
         () => {},
         () => {},
         () => {},
-        () => {},
         80,
         24,
       ),
@@ -900,7 +893,6 @@ describe('useGeminiStream', () => {
         () => {},
         () => Promise.resolve(),
         false,
-        () => {},
         () => {},
         () => {},
         () => {},
@@ -1035,7 +1027,6 @@ describe('useGeminiStream', () => {
           () => Promise.resolve(),
           false,
           () => {},
-          () => {},
           cancelSubmitSpy,
           () => {},
           80,
@@ -1075,7 +1066,6 @@ describe('useGeminiStream', () => {
           () => {},
           () => Promise.resolve(),
           false,
-          () => {},
           () => {},
           vi.fn(),
           setShellInputFocusedSpy, // Pass the spy here
@@ -1413,7 +1403,6 @@ describe('useGeminiStream', () => {
           () => {},
           () => {},
           () => {},
-          () => {},
           80,
           24,
         ),
@@ -1487,7 +1476,6 @@ describe('useGeminiStream', () => {
           () => {},
           () => {},
           () => {},
-          () => {},
           80,
           24,
         ),
@@ -1541,7 +1529,6 @@ describe('useGeminiStream', () => {
           () => {},
           () => Promise.resolve(),
           false,
-          () => {},
           () => {},
           () => {},
           () => {},
@@ -1846,7 +1833,6 @@ describe('useGeminiStream', () => {
           () => {},
           () => {},
           () => {},
-          () => {},
           80,
           24,
         ),
@@ -1952,7 +1938,6 @@ describe('useGeminiStream', () => {
           () => {},
           () => Promise.resolve(),
           false,
-          () => {},
           () => {},
           onCancelSubmitSpy,
           () => {},
@@ -2098,7 +2083,6 @@ describe('useGeminiStream', () => {
         vi.fn(), // performMemoryRefresh
         false, // modelSwitched
         vi.fn(), // setModelSwitched
-        vi.fn(), // onEditorClose
         vi.fn(), // onCancelSubmit
         vi.fn(), // setShellInputFocused
         80, // terminalWidth
@@ -2168,7 +2152,6 @@ describe('useGeminiStream', () => {
           () => {},
           () => Promise.resolve(),
           false,
-          () => {},
           () => {},
           () => {},
           () => {},
@@ -2252,7 +2235,6 @@ describe('useGeminiStream', () => {
           () => {},
           () => {},
           () => {},
-          () => {},
           80,
           24,
         ),
@@ -2322,7 +2304,6 @@ describe('useGeminiStream', () => {
           () => {},
           () => {},
           () => {},
-          () => {},
           80,
           24,
         ),
@@ -2377,7 +2358,6 @@ describe('useGeminiStream', () => {
           () => {},
           () => Promise.resolve(),
           false,
-          () => {},
           () => {},
           () => {},
           () => {},

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -105,7 +105,6 @@ export const useGeminiStream = (
   performMemoryRefresh: () => Promise<void>,
   modelSwitchedFromQuotaError: boolean,
   setModelSwitchedFromQuotaError: React.Dispatch<React.SetStateAction<boolean>>,
-  onEditorClose: () => void,
   onCancelSubmit: (shouldRestorePrompt?: boolean) => void,
   setShellInputFocused: (value: boolean) => void,
   terminalWidth: number,
@@ -178,7 +177,6 @@ export const useGeminiStream = (
     },
     config,
     getPreferredEditor,
-    onEditorClose,
   );
 
   const pendingToolCallGroupDisplay = useMemo(

--- a/packages/cli/src/ui/hooks/useInputHistoryStore.test.ts
+++ b/packages/cli/src/ui/hooks/useInputHistoryStore.test.ts
@@ -8,6 +8,7 @@ import { act } from 'react';
 import { renderHook } from '../../test-utils/render.js';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { useInputHistoryStore } from './useInputHistoryStore.js';
+import { debugLogger } from '@google/gemini-cli-core';
 
 describe('useInputHistoryStore', () => {
   beforeEach(() => {
@@ -108,7 +109,9 @@ describe('useInputHistoryStore', () => {
         .mockRejectedValue(new Error('Logger error')),
     };
 
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const consoleSpy = vi
+      .spyOn(debugLogger, 'warn')
+      .mockImplementation(() => {});
 
     const { result } = renderHook(() => useInputHistoryStore());
 

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.test.ts
@@ -29,7 +29,6 @@ describe('useReactToolScheduler', () => {
   it('only creates one instance of CoreToolScheduler even if props change', () => {
     const onComplete = vi.fn();
     const getPreferredEditor = vi.fn();
-    const onEditorClose = vi.fn();
     const config = {} as Config;
 
     const { rerender } = renderHook(
@@ -38,14 +37,12 @@ describe('useReactToolScheduler', () => {
           props.onComplete,
           props.config,
           props.getPreferredEditor,
-          props.onEditorClose,
         ),
       {
         initialProps: {
           onComplete,
           config,
           getPreferredEditor,
-          onEditorClose,
         },
       },
     );
@@ -58,7 +55,6 @@ describe('useReactToolScheduler', () => {
       onComplete: newOnComplete,
       config,
       getPreferredEditor,
-      onEditorClose,
     });
     expect(mockCoreToolScheduler).toHaveBeenCalledTimes(1);
 
@@ -68,17 +64,13 @@ describe('useReactToolScheduler', () => {
       onComplete: newOnComplete,
       config,
       getPreferredEditor: newGetPreferredEditor,
-      onEditorClose,
     });
     expect(mockCoreToolScheduler).toHaveBeenCalledTimes(1);
 
-    // Rerender with a new onEditorClose function
-    const newOnEditorClose = vi.fn();
     rerender({
       onComplete: newOnComplete,
       config,
       getPreferredEditor: newGetPreferredEditor,
-      onEditorClose: newOnEditorClose,
     });
     expect(mockCoreToolScheduler).toHaveBeenCalledTimes(1);
   });

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -68,7 +68,6 @@ export function useReactToolScheduler(
   onComplete: (tools: CompletedToolCall[]) => Promise<void>,
   config: Config,
   getPreferredEditor: () => EditorType | undefined,
-  onEditorClose: () => void,
 ): [
   TrackedToolCall[],
   ScheduleFn,
@@ -83,7 +82,6 @@ export function useReactToolScheduler(
   // Store callbacks in refs to keep them up-to-date without causing re-renders.
   const onCompleteRef = useRef(onComplete);
   const getPreferredEditorRef = useRef(getPreferredEditor);
-  const onEditorCloseRef = useRef(onEditorClose);
 
   useEffect(() => {
     onCompleteRef.current = onComplete;
@@ -92,10 +90,6 @@ export function useReactToolScheduler(
   useEffect(() => {
     getPreferredEditorRef.current = getPreferredEditor;
   }, [getPreferredEditor]);
-
-  useEffect(() => {
-    onEditorCloseRef.current = onEditorClose;
-  }, [onEditorClose]);
 
   const outputUpdateHandler: OutputUpdateHandler = useCallback(
     (toolCallId, outputChunk) => {
@@ -158,7 +152,6 @@ export function useReactToolScheduler(
     () => getPreferredEditorRef.current(),
     [],
   );
-  const stableOnEditorClose = useCallback(() => onEditorCloseRef.current(), []);
 
   const scheduler = useMemo(
     () =>
@@ -168,7 +161,6 @@ export function useReactToolScheduler(
         onToolCallsUpdate: toolCallsUpdateHandler,
         getPreferredEditor: stableGetPreferredEditor,
         config,
-        onEditorClose: stableOnEditorClose,
       }),
     [
       config,
@@ -176,7 +168,6 @@ export function useReactToolScheduler(
       allToolCallsCompleteHandler,
       toolCallsUpdateHandler,
       stableGetPreferredEditor,
-      stableOnEditorClose,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/useReverseSearchCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useReverseSearchCompletion.test.tsx
@@ -4,13 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act } from 'react';
-import { renderHook } from '../../test-utils/render.js';
+import { renderHookWithProviders } from '../../test-utils/render.js';
 import { useReverseSearchCompletion } from './useReverseSearchCompletion.js';
 import { useTextBuffer } from '../components/shared/text-buffer.js';
 
 describe('useReverseSearchCompletion', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   function useTextBufferForTest(text: string) {
     return useTextBuffer({
       initialText: text,
@@ -26,7 +34,7 @@ describe('useReverseSearchCompletion', () => {
       it('should initialize with default state', () => {
         const mockShellHistory = ['echo hello'];
 
-        const { result } = renderHook(() =>
+        const { result } = renderHookWithProviders(() =>
           useReverseSearchCompletion(
             useTextBufferForTest(''),
             mockShellHistory,
@@ -43,7 +51,7 @@ describe('useReverseSearchCompletion', () => {
 
       it('should reset state when reverseSearchActive becomes false', () => {
         const mockShellHistory = ['echo hello'];
-        const { result, rerender } = renderHook(
+        const { result, rerender } = renderHookWithProviders(
           ({ text, active }) => {
             const textBuffer = useTextBufferForTest(text);
             return useReverseSearchCompletion(
@@ -68,7 +76,7 @@ describe('useReverseSearchCompletion', () => {
         it('should handle navigateUp with no suggestions', () => {
           const mockShellHistory = ['echo hello'];
 
-          const { result } = renderHook(() =>
+          const { result } = renderHookWithProviders(() =>
             useReverseSearchCompletion(
               useTextBufferForTest('grep'),
               mockShellHistory,
@@ -85,7 +93,7 @@ describe('useReverseSearchCompletion', () => {
 
         it('should handle navigateDown with no suggestions', () => {
           const mockShellHistory = ['echo hello'];
-          const { result } = renderHook(() =>
+          const { result } = renderHookWithProviders(() =>
             useReverseSearchCompletion(
               useTextBufferForTest('grep'),
               mockShellHistory,
@@ -110,7 +118,7 @@ describe('useReverseSearchCompletion', () => {
             'echo Hi',
           ];
 
-          const { result } = renderHook(() =>
+          const { result } = renderHookWithProviders(() =>
             useReverseSearchCompletion(
               useTextBufferForTest('echo'),
               mockShellHistory,
@@ -137,7 +145,7 @@ describe('useReverseSearchCompletion', () => {
             'echo "Hello, World!"',
             'echo Hi',
           ];
-          const { result } = renderHook(() =>
+          const { result } = renderHookWithProviders(() =>
             useReverseSearchCompletion(
               useTextBufferForTest('ls'),
               mockShellHistory,
@@ -165,7 +173,7 @@ describe('useReverseSearchCompletion', () => {
             'echo "Hi all"',
           ];
 
-          const { result } = renderHook(() =>
+          const { result } = renderHookWithProviders(() =>
             useReverseSearchCompletion(
               useTextBufferForTest('l'),
               mockShellHistory,
@@ -208,7 +216,7 @@ describe('useReverseSearchCompletion', () => {
             (_, i) => `echo ${i}`,
           );
 
-          const { result } = renderHook(() =>
+          const { result } = renderHookWithProviders(() =>
             useReverseSearchCompletion(
               useTextBufferForTest('echo'),
               largeMockCommands,
@@ -234,7 +242,7 @@ describe('useReverseSearchCompletion', () => {
   describe('Filtering', () => {
     it('filters history by buffer.text and sets showSuggestions', () => {
       const history = ['foo', 'barfoo', 'baz'];
-      const { result } = renderHook(() =>
+      const { result } = renderHookWithProviders(() =>
         useReverseSearchCompletion(useTextBufferForTest('foo'), history, true),
       );
 
@@ -248,7 +256,7 @@ describe('useReverseSearchCompletion', () => {
 
     it('hides suggestions when there are no matches', () => {
       const history = ['alpha', 'beta'];
-      const { result } = renderHook(() =>
+      const { result } = renderHookWithProviders(() =>
         useReverseSearchCompletion(useTextBufferForTest('γ'), history, true),
       );
 

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -135,7 +135,6 @@ describe('useReactToolScheduler in YOLO Mode', () => {
         onComplete,
         mockConfig as unknown as Config,
         () => undefined,
-        () => {},
       ),
     );
 
@@ -264,7 +263,6 @@ describe('useReactToolScheduler', () => {
         onComplete,
         mockConfig as unknown as Config,
         () => undefined,
-        () => {},
       ),
     );
 

--- a/packages/cli/src/ui/themes/theme-manager.test.ts
+++ b/packages/cli/src/ui/themes/theme-manager.test.ts
@@ -15,6 +15,7 @@ import type { CustomTheme } from './theme.js';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import type * as osActual from 'node:os';
+import { debugLogger } from '@google/gemini-cli-core';
 
 vi.mock('node:fs');
 vi.mock('node:os', async (importOriginal) => {
@@ -164,7 +165,7 @@ describe('ThemeManager', () => {
       vi.spyOn(fs, 'existsSync').mockReturnValue(true);
       vi.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(mockTheme));
       const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
+        .spyOn(debugLogger, 'warn')
         .mockImplementation(() => {});
 
       const result = themeManager.setActiveTheme('/untrusted/my-theme.json');

--- a/packages/cli/src/ui/utils/ConsolePatcher.ts
+++ b/packages/cli/src/ui/utils/ConsolePatcher.ts
@@ -27,11 +27,11 @@ export class ConsolePatcher {
   }
 
   patch() {
-    console.log = this.patchConsoleMethod('log', this.originalConsoleLog);
-    console.warn = this.patchConsoleMethod('warn', this.originalConsoleWarn);
-    console.error = this.patchConsoleMethod('error', this.originalConsoleError);
-    console.debug = this.patchConsoleMethod('debug', this.originalConsoleDebug);
-    console.info = this.patchConsoleMethod('info', this.originalConsoleInfo);
+    console.log = this.patchConsoleMethod('log');
+    console.warn = this.patchConsoleMethod('warn');
+    console.error = this.patchConsoleMethod('error');
+    console.debug = this.patchConsoleMethod('debug');
+    console.info = this.patchConsoleMethod('info');
   }
 
   cleanup = () => {
@@ -45,20 +45,13 @@ export class ConsolePatcher {
   private formatArgs = (args: unknown[]): string => util.format(...args);
 
   private patchConsoleMethod =
-    (
-      type: 'log' | 'warn' | 'error' | 'debug' | 'info',
-      originalMethod: (...args: unknown[]) => void,
-    ) =>
+    (type: 'log' | 'warn' | 'error' | 'debug' | 'info') =>
     (...args: unknown[]) => {
       if (this.params.stderr) {
         if (type !== 'debug' || this.params.debugMode) {
           this.originalConsoleError(this.formatArgs(args));
         }
       } else {
-        if (this.params.debugMode) {
-          originalMethod.apply(console, args);
-        }
-
         if (type !== 'debug' || this.params.debugMode) {
           this.params.onNewMessage?.({
             type,

--- a/packages/cli/src/ui/utils/mouse.ts
+++ b/packages/cli/src/ui/utils/mouse.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import process from 'node:process';
+import { writeToStdout } from '../../utils/stdio.js';
 import {
   SGR_MOUSE_REGEX,
   X11_MOUSE_REGEX,
@@ -234,10 +234,10 @@ export function enableMouseEvents() {
   // Enable mouse tracking with SGR format
   // ?1002h = button event tracking (clicks + drags + scroll wheel)
   // ?1006h = SGR extended mouse mode (better coordinate handling)
-  process.stdout.write('\u001b[?1002h\u001b[?1006h');
+  writeToStdout('\u001b[?1002h\u001b[?1006h');
 }
 
 export function disableMouseEvents() {
   // Disable mouse tracking with SGR format
-  process.stdout.write('\u001b[?1006l\u001b[?1002l');
+  writeToStdout('\u001b[?1006l\u001b[?1002l');
 }

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -17,6 +17,7 @@ import {
   FatalToolExecutionError,
   isFatalToolError,
 } from '@google/gemini-cli-core';
+import { runSyncCleanup } from './cleanup.js';
 
 export function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -90,6 +91,7 @@ export function handleError(
       stats: streamFormatter.convertToStreamStats(metrics, 0),
     });
 
+    runSyncCleanup();
     process.exit(getNumericExitCode(errorCode));
   } else if (config.getOutputFormat() === OutputFormat.JSON) {
     const formatter = new JsonFormatter();
@@ -101,6 +103,7 @@ export function handleError(
     );
 
     console.error(formattedError);
+    runSyncCleanup();
     process.exit(getNumericExitCode(errorCode));
   } else {
     console.error(errorMessage);
@@ -154,6 +157,7 @@ export function handleToolError(
     } else {
       console.error(errorMessage);
     }
+    runSyncCleanup();
     process.exit(toolExecutionError.exitCode);
   }
 
@@ -180,6 +184,7 @@ export function handleCancellationError(config: Config): never {
       },
       stats: streamFormatter.convertToStreamStats(metrics, 0),
     });
+    runSyncCleanup();
     process.exit(cancellationError.exitCode);
   } else if (config.getOutputFormat() === OutputFormat.JSON) {
     const formatter = new JsonFormatter();
@@ -189,9 +194,11 @@ export function handleCancellationError(config: Config): never {
     );
 
     console.error(formattedError);
+    runSyncCleanup();
     process.exit(cancellationError.exitCode);
   } else {
     console.error(cancellationError.message);
+    runSyncCleanup();
     process.exit(cancellationError.exitCode);
   }
 }
@@ -217,6 +224,7 @@ export function handleMaxTurnsExceededError(config: Config): never {
       },
       stats: streamFormatter.convertToStreamStats(metrics, 0),
     });
+    runSyncCleanup();
     process.exit(maxTurnsError.exitCode);
   } else if (config.getOutputFormat() === OutputFormat.JSON) {
     const formatter = new JsonFormatter();
@@ -226,9 +234,11 @@ export function handleMaxTurnsExceededError(config: Config): never {
     );
 
     console.error(formattedError);
+    runSyncCleanup();
     process.exit(maxTurnsError.exitCode);
   } else {
     console.error(maxTurnsError.message);
+    runSyncCleanup();
     process.exit(maxTurnsError.exitCode);
   }
 }

--- a/packages/cli/src/utils/events.ts
+++ b/packages/cli/src/utils/events.ts
@@ -9,7 +9,6 @@ import { EventEmitter } from 'node:events';
 
 export enum AppEvent {
   OpenDebugConsole = 'open-debug-console',
-  LogError = 'log-error',
   OauthDisplayMessage = 'oauth-display-message',
   Flicker = 'flicker',
   McpClientUpdate = 'mcp-client-update',
@@ -19,7 +18,6 @@ export enum AppEvent {
 
 export interface AppEvents extends ExtensionEvents {
   [AppEvent.OpenDebugConsole]: never[];
-  [AppEvent.LogError]: string[];
   [AppEvent.OauthDisplayMessage]: string[];
   [AppEvent.Flicker]: never[];
   [AppEvent.McpClientUpdate]: Array<Map<string, McpClient> | never>;

--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -11,15 +11,14 @@ import * as path from 'node:path';
 import * as childProcess from 'node:child_process';
 import { isGitRepository, debugLogger } from '@google/gemini-cli-core';
 
-vi.mock('@google/gemini-cli-core', () => ({
-  isGitRepository: vi.fn(),
-  debugLogger: {
-    log: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  },
-}));
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    isGitRepository: vi.fn(),
+  };
+});
 
 vi.mock('fs', async (importOriginal) => {
   const actualFs = await importOriginal<typeof fs>();
@@ -52,6 +51,7 @@ describe('getInstallationInfo', () => {
     originalArgv = [...process.argv];
     // Mock process.cwd() for isGitRepository
     vi.spyOn(process, 'cwd').mockReturnValue(projectRoot);
+    vi.spyOn(debugLogger, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {

--- a/packages/cli/src/utils/sessionCleanup.test.ts
+++ b/packages/cli/src/utils/sessionCleanup.test.ts
@@ -7,7 +7,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { SESSION_FILE_PREFIX, type Config } from '@google/gemini-cli-core';
+import {
+  SESSION_FILE_PREFIX,
+  type Config,
+  debugLogger,
+} from '@google/gemini-cli-core';
 import type { Settings } from '../config/settings.js';
 import { cleanupExpiredSessions } from './sessionCleanup.js';
 import { type SessionInfo, getAllSessionFiles } from './sessionUtils.js';
@@ -389,7 +393,9 @@ describe('Session Cleanup', () => {
       );
       mockFs.unlink.mockResolvedValue(undefined);
 
-      const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+      const debugSpy = vi
+        .spyOn(debugLogger, 'debug')
+        .mockImplementation(() => {});
 
       await cleanupExpiredSessions(config, settings);
 

--- a/packages/cli/src/utils/stdio.test.ts
+++ b/packages/cli/src/utils/stdio.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { patchStdio, createInkStdio } from './stdio.js';
+import { coreEvents } from '@google/gemini-cli-core';
+
+vi.mock('@google/gemini-cli-core', () => ({
+  coreEvents: {
+    emitOutput: vi.fn(),
+  },
+}));
+
+describe('stdio utils', () => {
+  let originalStdoutWrite: typeof process.stdout.write;
+  let originalStderrWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    originalStdoutWrite = process.stdout.write;
+    originalStderrWrite = process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    vi.restoreAllMocks();
+  });
+
+  it('patchStdio redirects stdout and stderr to coreEvents', () => {
+    const cleanup = patchStdio();
+
+    process.stdout.write('test stdout');
+    expect(coreEvents.emitOutput).toHaveBeenCalledWith(
+      false,
+      'test stdout',
+      undefined,
+    );
+
+    process.stderr.write('test stderr');
+    expect(coreEvents.emitOutput).toHaveBeenCalledWith(
+      true,
+      'test stderr',
+      undefined,
+    );
+
+    cleanup();
+
+    // Verify cleanup
+    expect(process.stdout.write).toBe(originalStdoutWrite);
+    expect(process.stderr.write).toBe(originalStderrWrite);
+  });
+
+  it('createInkStdio writes to real stdout/stderr bypassing patch', () => {
+    const cleanup = patchStdio();
+    const { stdout: inkStdout, stderr: inkStderr } = createInkStdio();
+
+    inkStdout.write('ink stdout');
+    expect(coreEvents.emitOutput).not.toHaveBeenCalled();
+
+    inkStderr.write('ink stderr');
+    expect(coreEvents.emitOutput).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+});

--- a/packages/cli/src/utils/stdio.ts
+++ b/packages/cli/src/utils/stdio.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { coreEvents } from '@google/gemini-cli-core';
+
+// Capture the original stdout and stderr write methods before any monkey patching occurs.
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+/**
+ * Writes to the real stdout, bypassing any monkey patching on process.stdout.write.
+ */
+export function writeToStdout(
+  ...args: Parameters<typeof process.stdout.write>
+): boolean {
+  return originalStdoutWrite(...args);
+}
+
+/**
+ * Writes to the real stderr, bypassing any monkey patching on process.stderr.write.
+ */
+export function writeToStderr(
+  ...args: Parameters<typeof process.stderr.write>
+): boolean {
+  return originalStderrWrite(...args);
+}
+
+/**
+ * Monkey patches process.stdout.write and process.stderr.write to redirect output to the provided logger.
+ * This prevents stray output from libraries (or the app itself) from corrupting the UI.
+ * Returns a cleanup function that restores the original write methods.
+ */
+export function patchStdio(): () => void {
+  const previousStdoutWrite = process.stdout.write;
+  const previousStderrWrite = process.stderr.write;
+
+  process.stdout.write = (
+    chunk: Uint8Array | string,
+    encodingOrCb?:
+      | BufferEncoding
+      | ((err?: NodeJS.ErrnoException | null) => void),
+    cb?: (err?: NodeJS.ErrnoException | null) => void,
+  ) => {
+    const encoding =
+      typeof encodingOrCb === 'string' ? encodingOrCb : undefined;
+    coreEvents.emitOutput(false, chunk, encoding);
+    const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb;
+    if (callback) {
+      callback();
+    }
+    return true;
+  };
+
+  process.stderr.write = (
+    chunk: Uint8Array | string,
+    encodingOrCb?:
+      | BufferEncoding
+      | ((err?: NodeJS.ErrnoException | null) => void),
+    cb?: (err?: NodeJS.ErrnoException | null) => void,
+  ) => {
+    const encoding =
+      typeof encodingOrCb === 'string' ? encodingOrCb : undefined;
+    coreEvents.emitOutput(true, chunk, encoding);
+    const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb;
+    if (callback) {
+      callback();
+    }
+    return true;
+  };
+
+  return () => {
+    process.stdout.write = previousStdoutWrite;
+    process.stderr.write = previousStderrWrite;
+  };
+}
+
+/**
+ * Creates proxies for process.stdout and process.stderr that use the real write methods
+ * (writeToStdout and writeToStderr) bypassing any monkey patching.
+ * This is used by Ink to render to the real output.
+ */
+export function createInkStdio() {
+  const inkStdout = new Proxy(process.stdout, {
+    get(target, prop, receiver) {
+      if (prop === 'write') {
+        return writeToStdout;
+      }
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value === 'function') {
+        return value.bind(target);
+      }
+      return value;
+    },
+  });
+
+  const inkStderr = new Proxy(process.stderr, {
+    get(target, prop, receiver) {
+      if (prop === 'write') {
+        return writeToStderr;
+      }
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value === 'function') {
+        return value.bind(target);
+      }
+      return value;
+    },
+  });
+
+  return { stdout: inkStdout, stderr: inkStderr };
+}

--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -19,6 +19,7 @@ import {
   AuthType,
   OutputFormat,
   makeFakeConfig,
+  debugLogger,
 } from '@google/gemini-cli-core';
 import type { Config } from '@google/gemini-cli-core';
 import * as auth from './config/auth.js';
@@ -35,6 +36,7 @@ describe('validateNonInterActiveAuth', () => {
   let originalEnvVertexAi: string | undefined;
   let originalEnvGcp: string | undefined;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let debugLoggerErrorSpy: ReturnType<typeof vi.spyOn>;
   let processExitSpy: MockInstance;
   let refreshAuthMock: Mock;
   let mockSettings: LoadedSettings;
@@ -47,6 +49,9 @@ describe('validateNonInterActiveAuth', () => {
     delete process.env['GOOGLE_GENAI_USE_VERTEXAI'];
     delete process.env['GOOGLE_GENAI_USE_GCA'];
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    debugLoggerErrorSpy = vi
+      .spyOn(debugLogger, 'error')
+      .mockImplementation(() => {});
     processExitSpy = vi
       .spyOn(process, 'exit')
       .mockImplementation((code?: string | number | null | undefined) => {
@@ -113,7 +118,7 @@ describe('validateNonInterActiveAuth', () => {
     } catch (e) {
       expect((e as Error).message).toContain('process.exit(1) called');
     }
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
+    expect(debugLoggerErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Please set an Auth method'),
     );
     expect(processExitSpy).toHaveBeenCalledWith(1);
@@ -265,7 +270,7 @@ describe('validateNonInterActiveAuth', () => {
     } catch (e) {
       expect((e as Error).message).toContain('process.exit(1) called');
     }
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Auth error!');
+    expect(debugLoggerErrorSpy).toHaveBeenCalledWith('Auth error!');
     expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 
@@ -287,7 +292,7 @@ describe('validateNonInterActiveAuth', () => {
     );
 
     expect(validateAuthMethodSpy).not.toHaveBeenCalled();
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(debugLoggerErrorSpy).not.toHaveBeenCalled();
     expect(processExitSpy).not.toHaveBeenCalled();
     // We still expect refreshAuth to be called with the (invalid) type
     expect(refreshAuthMock).toHaveBeenCalledWith('invalid-auth-type');
@@ -326,7 +331,7 @@ describe('validateNonInterActiveAuth', () => {
     } catch (e) {
       expect((e as Error).message).toContain('process.exit(1) called');
     }
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
+    expect(debugLoggerErrorSpy).toHaveBeenCalledWith(
       "The enforced authentication type is 'oauth-personal', but the current type is 'gemini-api-key'. Please re-authenticate with the correct type.",
     );
     expect(processExitSpy).toHaveBeenCalledWith(1);
@@ -351,7 +356,7 @@ describe('validateNonInterActiveAuth', () => {
     } catch (e) {
       expect((e as Error).message).toContain('process.exit(1) called');
     }
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
+    expect(debugLoggerErrorSpy).toHaveBeenCalledWith(
       "The enforced authentication type is 'oauth-personal', but the current type is 'gemini-api-key'. Please re-authenticate with the correct type.",
     );
     expect(processExitSpy).toHaveBeenCalledWith(1);

--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -10,6 +10,7 @@ import { USER_SETTINGS_PATH } from './config/settings.js';
 import { validateAuthMethod } from './config/auth.js';
 import { type LoadedSettings } from './config/settings.js';
 import { handleError } from './utils/errors.js';
+import { runExitCleanup } from './utils/cleanup.js';
 
 function getAuthTypeFromEnv(): AuthType | undefined {
   if (process.env['GOOGLE_GENAI_USE_GCA'] === 'true') {
@@ -66,6 +67,7 @@ export async function validateNonInteractiveAuth(
       );
     } else {
       debugLogger.error(error instanceof Error ? error.message : String(error));
+      await runExitCleanup();
       process.exit(1);
     }
   }

--- a/packages/core/src/agents/executor.test.ts
+++ b/packages/core/src/agents/executor.test.ts
@@ -13,6 +13,7 @@ import {
   afterEach,
   type Mock,
 } from 'vitest';
+import { debugLogger } from '../utils/debugLogger.js';
 import { AgentExecutor, type ActivityCallback } from './executor.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import { ToolRegistry } from '../tools/tool-registry.js';
@@ -927,7 +928,7 @@ describe('AgentExecutor', () => {
       ]);
 
       const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
+        .spyOn(debugLogger, 'warn')
         .mockImplementation(() => {});
 
       await executor.run({ goal: 'Sec test' }, signal);

--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -9,6 +9,7 @@ import { AgentRegistry, getModelConfigAlias } from './registry.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import type { AgentDefinition } from './types.js';
 import type { Config } from '../config/config.js';
+import { debugLogger } from '../utils/debugLogger.js';
 
 // A test-only subclass to expose the protected `registerAgent` method.
 class TestableAgentRegistry extends AgentRegistry {
@@ -60,14 +61,14 @@ describe('AgentRegistry', () => {
     it('should log the count of loaded agents in debug mode', async () => {
       const debugConfig = makeFakeConfig({ debugMode: true });
       const debugRegistry = new TestableAgentRegistry(debugConfig);
-      const consoleLogSpy = vi
-        .spyOn(console, 'log')
+      const debugLogSpy = vi
+        .spyOn(debugLogger, 'log')
         .mockImplementation(() => {});
 
       await debugRegistry.initialize();
 
       const agentCount = debugRegistry.getAllDefinitions().length;
-      expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect(debugLogSpy).toHaveBeenCalledWith(
         `[AgentRegistry] Initialized with ${agentCount} agents.`,
       );
     });
@@ -107,28 +108,28 @@ describe('AgentRegistry', () => {
 
     it('should reject an agent definition missing a name', () => {
       const invalidAgent = { ...MOCK_AGENT_V1, name: '' };
-      const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
+      const debugWarnSpy = vi
+        .spyOn(debugLogger, 'warn')
         .mockImplementation(() => {});
 
       registry.testRegisterAgent(invalidAgent);
 
       expect(registry.getDefinition('MockAgent')).toBeUndefined();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect(debugWarnSpy).toHaveBeenCalledWith(
         '[AgentRegistry] Skipping invalid agent definition. Missing name or description.',
       );
     });
 
     it('should reject an agent definition missing a description', () => {
       const invalidAgent = { ...MOCK_AGENT_V1, description: '' };
-      const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
+      const debugWarnSpy = vi
+        .spyOn(debugLogger, 'warn')
         .mockImplementation(() => {});
 
       registry.testRegisterAgent(invalidAgent as AgentDefinition);
 
       expect(registry.getDefinition('MockAgent')).toBeUndefined();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect(debugWarnSpy).toHaveBeenCalledWith(
         '[AgentRegistry] Skipping invalid agent definition. Missing name or description.',
       );
     });
@@ -149,27 +150,27 @@ describe('AgentRegistry', () => {
     it('should log overwrites when in debug mode', () => {
       const debugConfig = makeFakeConfig({ debugMode: true });
       const debugRegistry = new TestableAgentRegistry(debugConfig);
-      const consoleLogSpy = vi
-        .spyOn(console, 'log')
+      const debugLogSpy = vi
+        .spyOn(debugLogger, 'log')
         .mockImplementation(() => {});
 
       debugRegistry.testRegisterAgent(MOCK_AGENT_V1);
       debugRegistry.testRegisterAgent(MOCK_AGENT_V2);
 
-      expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect(debugLogSpy).toHaveBeenCalledWith(
         `[AgentRegistry] Overriding agent 'MockAgent'`,
       );
     });
 
     it('should not log overwrites when not in debug mode', () => {
-      const consoleLogSpy = vi
-        .spyOn(console, 'log')
+      const debugLogSpy = vi
+        .spyOn(debugLogger, 'log')
         .mockImplementation(() => {});
 
       registry.testRegisterAgent(MOCK_AGENT_V1);
       registry.testRegisterAgent(MOCK_AGENT_V2);
 
-      expect(consoleLogSpy).not.toHaveBeenCalledWith(
+      expect(debugLogSpy).not.toHaveBeenCalledWith(
         `[AgentRegistry] Overriding agent 'MockAgent'`,
       );
     });

--- a/packages/core/src/code_assist/oauth-credential-storage.test.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.test.ts
@@ -34,6 +34,7 @@ vi.mock('node:path');
 vi.mock('../utils/events.js', () => ({
   coreEvents: {
     emitFeedback: vi.fn(),
+    emitConsoleLog: vi.fn(),
   },
 }));
 

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -26,6 +26,7 @@ import type { Config } from '../config/config.js';
 import readline from 'node:readline';
 import { FORCE_ENCRYPTED_FILE_ENV_VAR } from '../mcp/token-storage/index.js';
 import { GEMINI_DIR } from '../utils/paths.js';
+import { debugLogger } from '../utils/debugLogger.js';
 
 vi.mock('os', async (importOriginal) => {
   const os = await importOriginal<typeof import('os')>();
@@ -241,7 +242,7 @@ describe('oauth2', () => {
       (readline.createInterface as Mock).mockReturnValue(mockReadline);
 
       const consoleLogSpy = vi
-        .spyOn(console, 'log')
+        .spyOn(debugLogger, 'log')
         .mockImplementation(() => {});
 
       const client = await getOauthClient(
@@ -855,7 +856,7 @@ describe('oauth2', () => {
         } as unknown as Response);
 
         const consoleLogSpy = vi
-          .spyOn(console, 'log')
+          .spyOn(debugLogger, 'log')
           .mockImplementation(() => {});
 
         let requestCallback!: http.RequestListener;
@@ -935,10 +936,10 @@ describe('oauth2', () => {
         (readline.createInterface as Mock).mockReturnValue(mockReadline);
 
         const consoleLogSpy = vi
-          .spyOn(console, 'log')
+          .spyOn(debugLogger, 'log')
           .mockImplementation(() => {});
         const consoleErrorSpy = vi
-          .spyOn(console, 'error')
+          .spyOn(debugLogger, 'error')
           .mockImplementation(() => {});
 
         await expect(

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -145,6 +145,7 @@ vi.mock('../agents/subagent-tool-wrapper.js', () => ({
 const mockCoreEvents = vi.hoisted(() => ({
   emitFeedback: vi.fn(),
   emitModelChanged: vi.fn(),
+  emitConsoleLog: vi.fn(),
 }));
 
 const mockSetGlobalProxy = vi.hoisted(() => vi.fn());

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -292,7 +292,6 @@ describe('CoreToolScheduler', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -358,7 +357,6 @@ describe('CoreToolScheduler', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -460,7 +458,6 @@ describe('CoreToolScheduler', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -557,7 +554,6 @@ describe('CoreToolScheduler', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const request = {
@@ -595,7 +591,6 @@ describe('CoreToolScheduler', () => {
       const scheduler = new CoreToolScheduler({
         config: mockConfig,
         getPreferredEditor: () => 'vscode',
-        onEditorClose: vi.fn(),
       });
 
       // Test that the right tool is selected, with only 1 result, for typos
@@ -650,7 +645,6 @@ describe('CoreToolScheduler with payload', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -952,7 +946,6 @@ describe('CoreToolScheduler edit cancellation', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -1038,7 +1031,6 @@ describe('CoreToolScheduler YOLO mode', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -1125,7 +1117,6 @@ describe('CoreToolScheduler request queueing', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -1239,7 +1230,6 @@ describe('CoreToolScheduler request queueing', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -1347,7 +1337,6 @@ describe('CoreToolScheduler request queueing', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -1404,7 +1393,6 @@ describe('CoreToolScheduler request queueing', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -1508,7 +1496,6 @@ describe('CoreToolScheduler request queueing', () => {
         });
       },
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -1632,7 +1619,6 @@ describe('CoreToolScheduler Sequential Execution', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -1732,7 +1718,6 @@ describe('CoreToolScheduler Sequential Execution', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const requests = [
@@ -1831,7 +1816,6 @@ describe('CoreToolScheduler Sequential Execution', () => {
       onAllToolCallsComplete,
       onToolCallsUpdate,
       getPreferredEditor: () => 'vscode',
-      onEditorClose: vi.fn(),
     });
 
     const abortController = new AbortController();
@@ -1865,7 +1849,7 @@ describe('CoreToolScheduler Sequential Execution', () => {
     const overrides =
       modifyWithEditorSpy.mock.calls[
         modifyWithEditorSpy.mock.calls.length - 1
-      ][5];
+      ][4];
     expect(overrides).toEqual({
       currentContent: 'originalContent',
       proposedContent: 'newContent',

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -329,7 +329,6 @@ interface CoreToolSchedulerOptions {
   onAllToolCallsComplete?: AllToolCallsCompleteHandler;
   onToolCallsUpdate?: ToolCallsUpdateHandler;
   getPreferredEditor: () => EditorType | undefined;
-  onEditorClose: () => void;
 }
 
 export class CoreToolScheduler {
@@ -346,7 +345,6 @@ export class CoreToolScheduler {
   private onToolCallsUpdate?: ToolCallsUpdateHandler;
   private getPreferredEditor: () => EditorType | undefined;
   private config: Config;
-  private onEditorClose: () => void;
   private isFinalizingToolCalls = false;
   private isScheduling = false;
   private isCancelling = false;
@@ -365,7 +363,6 @@ export class CoreToolScheduler {
     this.onAllToolCallsComplete = options.onAllToolCallsComplete;
     this.onToolCallsUpdate = options.onToolCallsUpdate;
     this.getPreferredEditor = options.getPreferredEditor;
-    this.onEditorClose = options.onEditorClose;
 
     // Subscribe to message bus for ASK_USER policy decisions
     // Use a static WeakMap to ensure we only subscribe ONCE per MessageBus instance
@@ -995,7 +992,6 @@ export class CoreToolScheduler {
           modifyContext as ModifyContext<typeof waitingToolCall.request.args>,
           editorType,
           signal,
-          this.onEditorClose,
           contentOverrides,
         );
         this.setArgsInternal(callId, updatedParams);

--- a/packages/core/src/core/logger.test.ts
+++ b/packages/core/src/core/logger.test.ts
@@ -29,6 +29,7 @@ import type { Content } from '@google/genai';
 import crypto from 'node:crypto';
 import os from 'node:os';
 import { GEMINI_DIR } from '../utils/paths.js';
+import { debugLogger } from '../utils/debugLogger.js';
 
 const TMP_DIR_NAME = 'tmp';
 const LOG_FILE_NAME = 'logs.json';
@@ -193,7 +194,7 @@ describe('Logger', () => {
     it('should handle invalid JSON in log file by backing it up and starting fresh', async () => {
       await fs.writeFile(TEST_LOG_FILE_PATH, 'invalid json');
       const consoleDebugSpy = vi
-        .spyOn(console, 'debug')
+        .spyOn(debugLogger, 'debug')
         .mockImplementation(() => {});
 
       const newLogger = new Logger(testSessionId, new Storage(process.cwd()));
@@ -221,7 +222,7 @@ describe('Logger', () => {
         JSON.stringify({ not: 'an array' }),
       );
       const consoleDebugSpy = vi
-        .spyOn(console, 'debug')
+        .spyOn(debugLogger, 'debug')
         .mockImplementation(() => {});
 
       const newLogger = new Logger(testSessionId, new Storage(process.cwd()));
@@ -280,7 +281,7 @@ describe('Logger', () => {
       );
       uninitializedLogger.close(); // Ensure it's treated as uninitialized
       const consoleDebugSpy = vi
-        .spyOn(console, 'debug')
+        .spyOn(debugLogger, 'debug')
         .mockImplementation(() => {});
       await uninitializedLogger.logMessage(MessageSenderType.USER, 'test');
       expect(consoleDebugSpy).toHaveBeenCalledWith(
@@ -336,7 +337,7 @@ describe('Logger', () => {
     it('should not throw, not increment messageId, and log error if writing to file fails', async () => {
       vi.spyOn(fs, 'writeFile').mockRejectedValueOnce(new Error('Disk full'));
       const consoleDebugSpy = vi
-        .spyOn(console, 'debug')
+        .spyOn(debugLogger, 'debug')
         .mockImplementation(() => {});
       const initialMessageId = logger['messageId'];
       const initialLogCount = logger['logs'].length;
@@ -455,7 +456,7 @@ describe('Logger', () => {
       );
       uninitializedLogger.close();
       const consoleErrorSpy = vi
-        .spyOn(console, 'error')
+        .spyOn(debugLogger, 'error')
         .mockImplementation(() => {});
 
       await expect(
@@ -554,7 +555,7 @@ describe('Logger', () => {
       );
       await fs.writeFile(taggedFilePath, 'invalid json');
       const consoleErrorSpy = vi
-        .spyOn(console, 'error')
+        .spyOn(debugLogger, 'error')
         .mockImplementation(() => {});
       const loadedCheckpoint = await logger.loadCheckpoint(tag);
       expect(loadedCheckpoint).toEqual({ history: [] });
@@ -571,7 +572,7 @@ describe('Logger', () => {
       );
       uninitializedLogger.close();
       const consoleErrorSpy = vi
-        .spyOn(console, 'error')
+        .spyOn(debugLogger, 'error')
         .mockImplementation(() => {});
       const loadedCheckpoint = await uninitializedLogger.loadCheckpoint('tag');
       expect(loadedCheckpoint).toEqual({ history: [] });
@@ -643,7 +644,7 @@ describe('Logger', () => {
         }),
       );
       const consoleErrorSpy = vi
-        .spyOn(console, 'error')
+        .spyOn(debugLogger, 'error')
         .mockImplementation(() => {});
 
       await expect(logger.deleteCheckpoint(tag)).rejects.toThrow(
@@ -662,7 +663,7 @@ describe('Logger', () => {
       );
       uninitializedLogger.close();
       const consoleErrorSpy = vi
-        .spyOn(console, 'error')
+        .spyOn(debugLogger, 'error')
         .mockImplementation(() => {});
 
       const result = await uninitializedLogger.deleteCheckpoint(tag);
@@ -715,7 +716,7 @@ describe('Logger', () => {
         }),
       );
       const consoleErrorSpy = vi
-        .spyOn(console, 'error')
+        .spyOn(debugLogger, 'error')
         .mockImplementation(() => {});
 
       await expect(logger.checkpointExists(tag)).rejects.toThrow(
@@ -758,7 +759,7 @@ describe('Logger', () => {
       await logger.logMessage(MessageSenderType.USER, 'A message');
       logger.close();
       const consoleDebugSpy = vi
-        .spyOn(console, 'debug')
+        .spyOn(debugLogger, 'debug')
         .mockImplementation(() => {});
       await logger.logMessage(MessageSenderType.USER, 'Another message');
       expect(consoleDebugSpy).toHaveBeenCalledWith(

--- a/packages/core/src/core/nonInteractiveToolExecutor.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.ts
@@ -22,10 +22,6 @@ export async function executeToolCall(
     const scheduler = new CoreToolScheduler({
       config,
       getPreferredEditor: () => undefined,
-      onEditorClose: () => {},
-      onAllToolCallsComplete: async (completedToolCalls) => {
-        resolve(completedToolCalls[0]);
-      },
     });
 
     scheduler.schedule(toolCallRequest, abortSignal).catch((error) => {

--- a/packages/core/src/core/nonInteractiveToolExecutor.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.ts
@@ -22,6 +22,13 @@ export async function executeToolCall(
     const scheduler = new CoreToolScheduler({
       config,
       getPreferredEditor: () => undefined,
+      onAllToolCallsComplete: async (completedToolCalls) => {
+        if (completedToolCalls.length > 0) {
+          resolve(completedToolCalls[0]);
+        } else {
+          reject(new Error('No completed tool calls returned.'));
+        }
+      },
     });
 
     scheduler.schedule(toolCallRequest, abortSignal).catch((error) => {

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -13,6 +13,7 @@ import path from 'node:path';
 import type { Config } from '../config/config.js';
 import { CodebaseInvestigatorAgent } from '../agents/codebase-investigator.js';
 import { GEMINI_DIR } from '../utils/paths.js';
+import { debugLogger } from '../utils/debugLogger.js';
 
 // Mock tool names if they are dynamically generated or complex
 vi.mock('../tools/ls', () => ({ LSTool: { Name: 'list_directory' } }));
@@ -346,7 +347,9 @@ describe('resolvePathFromEnv helper function', () => {
       vi.spyOn(os, 'homedir').mockImplementation(() => {
         throw new Error('Cannot resolve home directory');
       });
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const consoleSpy = vi
+        .spyOn(debugLogger, 'warn')
+        .mockImplementation(() => {});
 
       const result = resolvePathFromEnv('~/documents/file.txt');
       expect(result).toEqual({

--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -30,6 +30,7 @@ vi.mock('./oauth-token-storage.js', () => {
 vi.mock('../utils/events.js', () => ({
   coreEvents: {
     emitFeedback: vi.fn(),
+    emitConsoleLog: vi.fn(),
   },
 }));
 

--- a/packages/core/src/routing/strategies/classifierStrategy.test.ts
+++ b/packages/core/src/routing/strategies/classifierStrategy.test.ts
@@ -20,6 +20,7 @@ import {
 import { promptIdContext } from '../../utils/promptIdContext.js';
 import type { Content } from '@google/genai';
 import type { ResolvedModelConfig } from '../../services/modelConfigService.js';
+import { debugLogger } from '../../utils/debugLogger.js';
 
 vi.mock('../../core/baseLlmClient.js');
 vi.mock('../../utils/promptIdContext.js');
@@ -132,7 +133,7 @@ describe('ClassifierStrategy', () => {
 
   it('should return null if the classifier API call fails', async () => {
     const consoleWarnSpy = vi
-      .spyOn(console, 'warn')
+      .spyOn(debugLogger, 'warn')
       .mockImplementation(() => {});
     const testError = new Error('API Failure');
     vi.mocked(mockBaseLlmClient.generateJson).mockRejectedValue(testError);
@@ -150,7 +151,7 @@ describe('ClassifierStrategy', () => {
 
   it('should return null if the classifier returns a malformed JSON object', async () => {
     const consoleWarnSpy = vi
-      .spyOn(console, 'warn')
+      .spyOn(debugLogger, 'warn')
       .mockImplementation(() => {});
     const malformedApiResponse = {
       reasoning: 'This is a simple task.',
@@ -252,7 +253,7 @@ describe('ClassifierStrategy', () => {
 
   it('should use a fallback promptId if not found in context', async () => {
     const consoleWarnSpy = vi
-      .spyOn(console, 'warn')
+      .spyOn(debugLogger, 'warn')
       .mockImplementation(() => {});
     vi.mocked(promptIdContext.getStore).mockReturnValue(undefined);
     const mockApiResponse = {

--- a/packages/core/src/telemetry/activity-monitor.test.ts
+++ b/packages/core/src/telemetry/activity-monitor.test.ts
@@ -17,6 +17,7 @@ import {
 import { ActivityType } from './activity-types.js';
 import type { ActivityEvent } from './activity-monitor.js';
 import type { Config } from '../config/config.js';
+import { debugLogger } from '../utils/debugLogger.js';
 
 // Mock the dependencies
 vi.mock('./metrics.js', () => ({
@@ -191,7 +192,9 @@ describe('ActivityMonitor', () => {
       };
 
       // Spy on console.debug to check error handling
-      const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+      const debugSpy = vi
+        .spyOn(debugLogger, 'debug')
+        .mockImplementation(() => {});
 
       activityMonitor.addListener(faultyListener);
       activityMonitor.addListener(goodListener);

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -40,6 +40,7 @@ vi.mock('../mcp/oauth-utils.js');
 vi.mock('../utils/events.js', () => ({
   coreEvents: {
     emitFeedback: vi.fn(),
+    emitConsoleLog: vi.fn(),
   },
 }));
 

--- a/packages/core/src/tools/modifiable-tool.test.ts
+++ b/packages/core/src/tools/modifiable-tool.test.ts
@@ -18,6 +18,7 @@ import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import * as path from 'node:path';
+import { debugLogger } from '../utils/debugLogger.js';
 
 // Mock dependencies
 const mockOpenDiff = vi.hoisted(() => vi.fn());
@@ -104,7 +105,6 @@ describe('modifyWithEditor', () => {
         mockModifyContext,
         'vscode' as EditorType,
         abortSignal,
-        vi.fn(),
       );
 
       expect(mockModifyContext.getCurrentContent).toHaveBeenCalledWith(
@@ -171,7 +171,6 @@ describe('modifyWithEditor', () => {
         mockModifyContext,
         'vscode' as EditorType,
         abortSignal,
-        vi.fn(),
       );
     });
   });
@@ -187,7 +186,6 @@ describe('modifyWithEditor', () => {
       mockModifyContext,
       'vscode' as EditorType,
       abortSignal,
-      vi.fn(),
     );
 
     expect(mockCreatePatch).toHaveBeenCalledWith(
@@ -216,7 +214,6 @@ describe('modifyWithEditor', () => {
       mockModifyContext,
       'vscode' as EditorType,
       abortSignal,
-      vi.fn(),
     );
 
     expect(mockCreatePatch).toHaveBeenCalledWith(
@@ -246,7 +243,6 @@ describe('modifyWithEditor', () => {
       mockModifyContext,
       'vscode' as EditorType,
       abortSignal,
-      vi.fn(),
       {
         currentContent: overrideCurrent,
         proposedContent: overrideProposed,
@@ -274,7 +270,6 @@ describe('modifyWithEditor', () => {
       mockModifyContext,
       'vscode' as EditorType,
       abortSignal,
-      vi.fn(),
       {
         currentContent: null,
         proposedContent: 'override proposed content',
@@ -305,7 +300,6 @@ describe('modifyWithEditor', () => {
         mockModifyContext,
         'vscode' as EditorType,
         abortSignal,
-        vi.fn(),
       ),
     ).rejects.toThrow('Editor failed to open');
 
@@ -321,7 +315,7 @@ describe('modifyWithEditor', () => {
 
   it('should handle temp file cleanup errors gracefully', async () => {
     const consoleErrorSpy = vi
-      .spyOn(console, 'error')
+      .spyOn(debugLogger, 'error')
       .mockImplementation(() => {});
     vi.spyOn(fs, 'unlinkSync').mockImplementation(() => {
       throw new Error('Failed to delete file');
@@ -335,7 +329,6 @@ describe('modifyWithEditor', () => {
       mockModifyContext,
       'vscode' as EditorType,
       abortSignal,
-      vi.fn(),
     );
 
     expect(consoleErrorSpy).toHaveBeenCalledTimes(3);
@@ -362,7 +355,6 @@ describe('modifyWithEditor', () => {
       mockModifyContext,
       'vscode' as EditorType,
       abortSignal,
-      vi.fn(),
     );
 
     expect(mockOpenDiff).toHaveBeenCalledOnce();
@@ -384,7 +376,6 @@ describe('modifyWithEditor', () => {
       mockModifyContext,
       'vscode' as EditorType,
       abortSignal,
-      vi.fn(),
     );
 
     expect(mockOpenDiff).toHaveBeenCalledOnce();

--- a/packages/core/src/tools/modifiable-tool.ts
+++ b/packages/core/src/tools/modifiable-tool.ts
@@ -176,7 +176,6 @@ export async function modifyWithEditor<ToolParams>(
   modifyContext: ModifyContext<ToolParams>,
   editorType: EditorType,
   _abortSignal: AbortSignal,
-  onEditorClose: () => void,
   overrides?: ModifyContentOverrides,
 ): Promise<ModifyResult<ToolParams>> {
   const hasCurrentOverride =
@@ -199,7 +198,7 @@ export async function modifyWithEditor<ToolParams>(
   );
 
   try {
-    await openDiff(oldPath, newPath, editorType, onEditorClose);
+    await openDiff(oldPath, newPath, editorType);
     const result = getUpdatedParams(
       oldPath,
       newPath,

--- a/packages/core/src/utils/debugLogger.test.ts
+++ b/packages/core/src/utils/debugLogger.test.ts
@@ -4,76 +4,79 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { debugLogger } from './debugLogger.js';
 
 describe('DebugLogger', () => {
-  // Spy on all console methods before each test
-  beforeEach(() => {
-    vi.spyOn(console, 'log').mockImplementation(() => {});
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-    vi.spyOn(console, 'debug').mockImplementation(() => {});
-  });
-
-  // Restore original console methods after each test
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it('should call console.log with the correct arguments', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const message = 'This is a log message';
     const data = { key: 'value' };
     debugLogger.log(message, data);
-    expect(console.log).toHaveBeenCalledWith(message, data);
-    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(message, data);
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('should call console.warn with the correct arguments', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const message = 'This is a warning message';
     const data = [1, 2, 3];
     debugLogger.warn(message, data);
-    expect(console.warn).toHaveBeenCalledWith(message, data);
-    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(message, data);
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('should call console.error with the correct arguments', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const message = 'This is an error message';
     const error = new Error('Something went wrong');
     debugLogger.error(message, error);
-    expect(console.error).toHaveBeenCalledWith(message, error);
-    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(message, error);
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('should call console.debug with the correct arguments', () => {
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
     const message = 'This is a debug message';
     const obj = { a: { b: 'c' } };
     debugLogger.debug(message, obj);
-    expect(console.debug).toHaveBeenCalledWith(message, obj);
-    expect(console.debug).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(message, obj);
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('should handle multiple arguments correctly for all methods', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
     debugLogger.log('one', 2, true);
-    expect(console.log).toHaveBeenCalledWith('one', 2, true);
+    expect(logSpy).toHaveBeenCalledWith('one', 2, true);
 
     debugLogger.warn('one', 2, false);
-    expect(console.warn).toHaveBeenCalledWith('one', 2, false);
+    expect(warnSpy).toHaveBeenCalledWith('one', 2, false);
 
     debugLogger.error('one', 2, null);
-    expect(console.error).toHaveBeenCalledWith('one', 2, null);
+    expect(errorSpy).toHaveBeenCalledWith('one', 2, null);
 
     debugLogger.debug('one', 2, undefined);
-    expect(console.debug).toHaveBeenCalledWith('one', 2, undefined);
+    expect(debugSpy).toHaveBeenCalledWith('one', 2, undefined);
   });
 
   it('should handle calls with no arguments', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
     debugLogger.log();
-    expect(console.log).toHaveBeenCalledWith();
-    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith();
+    expect(logSpy).toHaveBeenCalledTimes(1);
 
     debugLogger.warn();
-    expect(console.warn).toHaveBeenCalledWith();
-    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -6,6 +6,7 @@
 
 import { execSync, spawn, spawnSync } from 'node:child_process';
 import { debugLogger } from './debugLogger.js';
+import { coreEvents, CoreEvent } from './events.js';
 
 export type EditorType =
   | 'vscode'
@@ -189,7 +190,6 @@ export async function openDiff(
   oldPath: string,
   newPath: string,
   editor: EditorType,
-  onEditorClose: () => void,
 ): Promise<void> {
   const diffCommand = getDiffCommand(oldPath, newPath, editor);
   if (!diffCommand) {
@@ -211,7 +211,7 @@ export async function openDiff(
         throw new Error(`${editor} exited with code ${result.status}`);
       }
     } finally {
-      onEditorClose();
+      coreEvents.emit(CoreEvent.ExternalEditorClosed);
     }
     return;
   }

--- a/packages/core/src/utils/installationManager.test.ts
+++ b/packages/core/src/utils/installationManager.test.ts
@@ -12,6 +12,7 @@ import * as os from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { GEMINI_DIR } from './paths.js';
+import { debugLogger } from './debugLogger.js';
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
@@ -92,7 +93,7 @@ describe('InstallationManager', () => {
         throw new Error('Read error');
       });
       const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
+        .spyOn(debugLogger, 'warn')
         .mockImplementation(() => {});
 
       const id = installationManager.getInstallationId();

--- a/packages/core/src/utils/llm-edit-fixer.test.ts
+++ b/packages/core/src/utils/llm-edit-fixer.test.ts
@@ -12,6 +12,7 @@ import {
 } from './llm-edit-fixer.js';
 import { promptIdContext } from './promptIdContext.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
+import { debugLogger } from './debugLogger.js';
 
 // Mock the BaseLlmClient
 const mockGenerateJson = vi.fn();
@@ -92,7 +93,7 @@ describe('FixLLMEditWithInstruction', () => {
   it('should generate and use a fallback promptId when context is not available', async () => {
     mockGenerateJson.mockResolvedValue(mockApiResponse);
     const consoleWarnSpy = vi
-      .spyOn(console, 'warn')
+      .spyOn(debugLogger, 'warn')
       .mockImplementation(() => {});
 
     // Run the function outside of any context

--- a/packages/core/src/utils/memoryDiscovery.test.ts
+++ b/packages/core/src/utils/memoryDiscovery.test.ts
@@ -25,6 +25,7 @@ import { Config, type GeminiCLIExtension } from '../config/config.js';
 import { Storage } from '../config/storage.js';
 import { SimpleExtensionLoader } from './extensionLoader.js';
 import { CoreEvent, coreEvents } from './events.js';
+import { debugLogger } from './debugLogger.js';
 
 vi.mock('os', async (importOriginal) => {
   const actualOs = await importOriginal<typeof os>();
@@ -439,7 +440,7 @@ My code memory
 
   it('should respect the maxDirs parameter during downward scan', async () => {
     const consoleDebugSpy = vi
-      .spyOn(console, 'debug')
+      .spyOn(debugLogger, 'debug')
       .mockImplementation(() => {});
 
     // Create directories in parallel for better performance
@@ -469,7 +470,7 @@ My code memory
       expect.stringContaining('Scanning [1/1]:'),
     );
 
-    vi.mocked(console.debug).mockRestore();
+    consoleDebugSpy.mockRestore();
 
     const result = await loadServerHierarchicalMemory(
       cwd,

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -20,7 +20,7 @@ const logger = {
     debugLogger.warn('[WARN] [ImportProcessor]', ...args),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: (...args: any[]) =>
-    console.error('[ERROR] [ImportProcessor]', ...args),
+    debugLogger.error('[ERROR] [ImportProcessor]', ...args),
 };
 
 /**

--- a/packages/core/src/utils/systemEncoding.test.ts
+++ b/packages/core/src/utils/systemEncoding.test.ts
@@ -8,6 +8,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'node:child_process';
 import * as os from 'node:os';
 import { detect as chardetDetect } from 'chardet';
+import { debugLogger } from './debugLogger.js';
 
 // Mock dependencies
 vi.mock('child_process');
@@ -30,7 +31,7 @@ describe('Shell Command Processor - Encoding Functions', () => {
   let mockedChardetDetect: ReturnType<typeof vi.mocked<typeof chardetDetect>>;
 
   beforeEach(() => {
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(debugLogger, 'warn').mockImplementation(() => {});
     mockedExecSync = vi.mocked(execSync);
     mockedOsPlatform = vi.mocked(os.platform);
     mockedChardetDetect = vi.mocked(chardetDetect);

--- a/packages/core/src/utils/userAccountManager.test.ts
+++ b/packages/core/src/utils/userAccountManager.test.ts
@@ -11,6 +11,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import path from 'node:path';
 import { GEMINI_DIR } from './paths.js';
+import { debugLogger } from './debugLogger.js';
 
 vi.mock('os', async (importOriginal) => {
   const os = await importOriginal<typeof import('os')>();
@@ -102,7 +103,7 @@ describe('UserAccountManager', () => {
       fs.mkdirSync(path.dirname(accountsFile()), { recursive: true });
       fs.writeFileSync(accountsFile(), 'not valid json');
       const consoleLogSpy = vi
-        .spyOn(console, 'log')
+        .spyOn(debugLogger, 'log')
         .mockImplementation(() => {});
 
       await userAccountManager.cacheGoogleAccount('test1@google.com');
@@ -121,7 +122,7 @@ describe('UserAccountManager', () => {
         JSON.stringify({ active: 'test1@google.com', old: 'not-an-array' }),
       );
       const consoleLogSpy = vi
-        .spyOn(console, 'log')
+        .spyOn(debugLogger, 'log')
         .mockImplementation(() => {});
 
       await userAccountManager.cacheGoogleAccount('test2@google.com');
@@ -161,7 +162,7 @@ describe('UserAccountManager', () => {
       fs.mkdirSync(path.dirname(accountsFile()), { recursive: true });
       fs.writeFileSync(accountsFile(), '{ "active": "test@google.com"'); // Invalid JSON
       const consoleLogSpy = vi
-        .spyOn(console, 'log')
+        .spyOn(debugLogger, 'log')
         .mockImplementation(() => {});
 
       const account = userAccountManager.getCachedGoogleAccount();
@@ -210,7 +211,7 @@ describe('UserAccountManager', () => {
       fs.mkdirSync(path.dirname(accountsFile()), { recursive: true });
       fs.writeFileSync(accountsFile(), 'not valid json');
       const consoleLogSpy = vi
-        .spyOn(console, 'log')
+        .spyOn(debugLogger, 'log')
         .mockImplementation(() => {});
 
       await userAccountManager.clearCachedGoogleAccount();
@@ -272,7 +273,7 @@ describe('UserAccountManager', () => {
       fs.mkdirSync(path.dirname(accountsFile()), { recursive: true });
       fs.writeFileSync(accountsFile(), 'invalid json');
       const consoleDebugSpy = vi
-        .spyOn(console, 'log')
+        .spyOn(debugLogger, 'log')
         .mockImplementation(() => {});
 
       expect(userAccountManager.getLifetimeGoogleAccounts()).toBe(0);
@@ -319,7 +320,7 @@ describe('UserAccountManager', () => {
         JSON.stringify({ active: null, old: 1 }),
       );
       const consoleLogSpy = vi
-        .spyOn(console, 'log')
+        .spyOn(debugLogger, 'log')
         .mockImplementation(() => {});
 
       expect(userAccountManager.getLifetimeGoogleAccounts()).toBe(0);

--- a/packages/core/src/utils/workspaceContext.test.ts
+++ b/packages/core/src/utils/workspaceContext.test.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { WorkspaceContext } from './workspaceContext.js';
+import { debugLogger } from './debugLogger.js';
 
 describe('WorkspaceContext with real filesystem', () => {
   let tempDir: string;
@@ -395,7 +396,7 @@ describe('WorkspaceContext with optional directories', () => {
     fs.mkdirSync(existingDir1, { recursive: true });
     fs.mkdirSync(existingDir2, { recursive: true });
 
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(debugLogger, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -410,8 +411,8 @@ describe('WorkspaceContext with optional directories', () => {
     ]);
     const directories = workspaceContext.getDirectories();
     expect(directories).toEqual([cwd, existingDir1]);
-    expect(console.warn).toHaveBeenCalledTimes(1);
-    expect(console.warn).toHaveBeenCalledWith(
+    expect(debugLogger.warn).toHaveBeenCalledTimes(1);
+    expect(debugLogger.warn).toHaveBeenCalledWith(
       `[WARN] Skipping unreadable directory: ${nonExistentDir} (Directory does not exist: ${nonExistentDir})`,
     );
   });
@@ -420,6 +421,6 @@ describe('WorkspaceContext with optional directories', () => {
     const workspaceContext = new WorkspaceContext(cwd, [existingDir1]);
     const directories = workspaceContext.getDirectories();
     expect(directories).toEqual([cwd, existingDir1]);
-    expect(console.warn).not.toHaveBeenCalled();
+    expect(debugLogger.warn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

This avoids rendering artifacts particularly problematic in alternate buffer mode.

Also fix issue where running vim to edit a prompt or confirm a diff was corrupting the alternate buffer. Note that there was a bug and we were cleaning up when vim was used to confirm an edit.

## Details
This pr is big but most changes are just fixing tests to expect the more modern libraries rather than watching for stdout.
Test changes can almost all be lightly skimmed as they are purely mechanical with no interesting deltas.

Similarly to how we monkey patched console.log we now monkey patch stdout and stderr. We get clever about ensuring we still write them out to the output when we know we are in non interactive mode and we write them to the debug console if the interactive mode was set.

Simplified console.log monkey patching as the code initially had multiple infinite loop bugs due to complexity of how we were doing this.

Things to test.
non-interactive mode still works with proper stdout even though we are trapping stdout at the beginning. Verify that output still streams fine.
<img width="1297" height="330" alt="Screenshot 2025-11-20 at 1 26 52 AM" src="https://github.com/user-attachments/assets/c4fa4154-50e1-4ca6-b029-6851b6519092" />

Example show that debug output now gets through to the debug console in gemini cli even if it was rendered before entering the alternate buffer:

<img width="1434" height="1287" alt="Screenshot 2025-11-20 at 1 46 35 AM" src="https://github.com/user-attachments/assets/5a46072e-1123-43dc-bd24-aa1f97eb55c9" />


