### PR TITLE
Remove obsolete reference to "help wanted" label in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,10 +70,6 @@ augment their manual review process.
 
 ### Self assigning issues
 
-If you're looking for an issue to work on, check out our list of issues that are
-labeled
-["help wanted"](https://github.com/google-gemini/gemini-cli/issues?q=is%3Aissue+state%3Aopen+label%3A%22help+wanted%22).
-
 To assign an issue to yourself, simply add a comment with the text `/assign`.
 The comment must contain only that text and nothing else. This command will
 assign the issue to you, provided it is not already assigned.


### PR DESCRIPTION
## Summary

Updating CONTRIBUTING.md to remove obsolete reference to "help wanted" label