### PR TITLE
Fix link to Gemini 3 Pro documentation

### DIFF
--- a/docs/cli/model.md
+++ b/docs/cli/model.md
@@ -25,7 +25,7 @@ Running this command will open a dialog with your model options:
 
 Note: Gemini 3 is not currently available on all account types. To learn more
 about Gemini 3 access, refer to
-[Gemini 3 Pro on Gemini CLI](../get-started/gemini-3).
+[Gemini 3 Pro on Gemini CLI](../get-started/gemini-3.md).
 
 To enable Gemini 3 Pro (if available), enable
 [**Preview features** by using the `settings` command](../cli/settings). Once


### PR DESCRIPTION
## Summary

Very simple, pointing to a markdown so this markdown file is not pointing to broken links.

## Details

No details beyond the summary.

## Related Issues

No issues seem to be open for this and only noticed this as I was reading the documentation myself in github.

## How to Validate

Pretty boring, but click https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/model.md and try to access the first link and you'll discover a 404.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [x] Podman
    - [x] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [x] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [x] Docker
