### PR TITLE
Improve keyboard code parsing

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -406,6 +406,7 @@ describe('KeypressContext', () => {
   describe('Parameterized functional keys', () => {
     it.each([
       // Parameterized
+      { sequence: `\x1b[1;129A`, expected: { name: 'up' } },
       { sequence: `\x1b[1;2H`, expected: { name: 'home', shift: true } },
       { sequence: `\x1b[1;5F`, expected: { name: 'end', ctrl: true } },
       { sequence: `\x1b[1;1P`, expected: { name: 'f1' } },
@@ -448,6 +449,10 @@ describe('KeypressContext', () => {
       {
         sequence: `\x1b[F`,
         expected: { name: 'end', ctrl: false, meta: false, shift: false },
+      },
+      {
+        sequence: `\x1b[5H`,
+        expected: { name: 'home', ctrl: true, meta: false, shift: false },
       },
     ])(
       'should recognize sequence "$sequence" as $expected.name',

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -405,9 +405,9 @@ function* emitKeys(
           code += match[1] + match[3];
           // Defaults to '1' if no modifier exists, resulting in a 0 modifier value
           modifier = parseInt(match[2] ?? '1', 10) - 1;
-        } else if ((match = /^((\d;)?(\d))?([A-Za-z])$/.exec(cmd))) {
-          code += match[4];
-          modifier = parseInt(match[3] ?? '1', 10) - 1;
+        } else if ((match = /^(\d+)?(?:;(\d+))?([A-Za-z])$/.exec(cmd))) {
+          code += match[3];
+          modifier = parseInt(match[2] ?? match[1] ?? '1', 10) - 1;
         } else {
           code += cmd;
         }


### PR DESCRIPTION
## Summary
Improve keyboard code parsing.

## Details

Our regex was previously rejecting cases that it should accept (where there was more than one digit in the modifier). This was causing it to reject keys when numlock is on (since it's code is the three digit 128).

## How to Validate

Use up arrow with numlock.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
