### PR TITLE
Fix links in Gemini 3 Pro documentation

### DIFF
--- a/docs/cli/model.md
+++ b/docs/cli/model.md
@@ -25,10 +25,10 @@ Running this command will open a dialog with your model options:
 
 Note: Gemini 3 is not currently available on all account types. To learn more
 about Gemini 3 access, refer to
-[Gemini 3 Pro on Gemini CLI](../get-started/gemini-3).
+[Gemini 3 Pro on Gemini CLI](../get-started/gemini-3.md).
 
 To enable Gemini 3 Pro (if available), enable
-[**Preview features** by using the `settings` command](../cli/settings). Once
+[**Preview features** by using the `settings` command](../cli/settings.md). Once
 enabled, Gemini CLI will attempt to use Gemini 3 Pro when you select **Auto** or
 **Pro**. Both **Auto** and **Pro** will try to use Gemini 3 Pro before falling
 back to Gemini 2.5 Pro.

--- a/docs/get-started/gemini-3.md
+++ b/docs/get-started/gemini-3.md
@@ -28,7 +28,7 @@ standard, and free tier users.
 
 Note: Whether you’re automatically granted access or accepted from the waitlist,
 you’ll still need to enable Gemini 3 Pro
-[using the `/settings` command](../cli/settings).
+[using the `/settings` command](../cli/settings.md).
 
 ## How to join the waitlist
 
@@ -56,7 +56,7 @@ access–you still need to enable Gemini 3 Pro within Gemini CLI.
 To enable Gemini 3 Pro, use the `/settings` command in Gemini CLI and set
 **Preview Features** to `true`.
 
-For more information, see [Gemini CLI Settings](../cli/settings).
+For more information, see [Gemini CLI Settings](../cli/settings.md).
 
 ### Usage limits and fallback
 


### PR DESCRIPTION
## Summary

I believe these links are broken (on the docs site, and on github). This fixes it on github, not sure how the docs site works (not a regular contributor here) but it aligns with the link below.

https://geminicli.com/docs/cli/model/
https://geminicli.com/docs/get-started/gemini-3/

## Details

N/A

## Related Issues

I did not make an issue, I ran into this on the docs site itself.

## How to Validate

Click on the link in preview mode. Not sure how you validate changes to the docs site.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
