### PR TITLE
docs: add Homebrew troubleshooting section for macOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,14 +376,39 @@ See the [Uninstall Guide](docs/cli/uninstall.md) for removal instructions.
 
 ## Troubleshooting Homebrew Installation (macOS)
 
-Some users may experience issues where `gemini` does not upgrade or install properly
-when using Homebrew. If you encounter problems such as:
+If you installed Gemini CLI with Homebrew on macOS and are facing issues, it's likely your shell is not configured correctly for Homebrew.
 
-- `brew upgrade gemini` does not update to the latest version  
-- `gemini` uses an outdated binary even after upgrading  
-- Homebrew works only inside `gemini shell` but not in normal Terminal  
+**Common Symptoms:**
 
-You can fix this by ensuring that Homebrew is initialized correctly in your shell:
+- `brew upgrade gemini` doesn't update to the latest version.
+- The `gemini` command uses an old binary even after upgrading.
+- The `gemini` command is not found in your terminal, or only works inside `gemini shell`.
 
-```bash
-eval "$(/opt/homebrew/bin/brew shellenv)"
+This happens when Homebrew's `bin` directory is not in your shell's `PATH`.
+
+### Permanent Fix
+
+To fix this permanently, you need to add Homebrew's initialization script to your shell's startup file.
+
+1.  **Add `brew shellenv` to your shell profile.**
+    The command depends on your Mac's architecture. The default shell on modern macOS is Zsh, which uses `~/.zshrc`.
+
+    - For **Apple Silicon** Macs (M1/M2/M3), run:
+      ```bash
+      echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zshrc
+      ```
+
+    - For **Intel** Macs, run:
+      ```bash
+      echo 'eval "$(/usr/local/bin/brew shellenv)"' >> ~/.zshrc
+      ```
+
+    > **Note:** If you use Bash, replace `~/.zshrc` with `~/.bash_profile`.
+
+2.  **Reload your shell** for the changes to take effect in your current session:
+    ```bash
+    source ~/.zshrc
+    ```
+    > Or `source ~/.bash_profile` if you use Bash.
+
+New terminal sessions will now have the correct `PATH` for Homebrew.

--- a/README.md
+++ b/README.md
@@ -372,3 +372,18 @@ See the [Uninstall Guide](docs/cli/uninstall.md) for removal instructions.
 <p align="center">
   Built with ❤️ by Google and the open source community
 </p>
+
+
+## Troubleshooting Homebrew Installation (macOS)
+
+Some users may experience issues where `gemini` does not upgrade or install properly
+when using Homebrew. If you encounter problems such as:
+
+- `brew upgrade gemini` does not update to the latest version  
+- `gemini` uses an outdated binary even after upgrading  
+- Homebrew works only inside `gemini shell` but not in normal Terminal  
+
+You can fix this by ensuring that Homebrew is initialized correctly in your shell:
+
+```bash
+eval "$(/opt/homebrew/bin/brew shellenv)"


### PR DESCRIPTION
This PR adds a Homebrew troubleshooting section to help macOS users resolve
PATH-related installation issues with Gemini CLI.

- Added `brew shellenv` instructions for zsh and bash
- Explained how to reload the shell configuration (`source ~/.zshrc`)
- Clarified PATH differences between Gemini shell and the normal Terminal

This will help macOS users who encounter inconsistent updates when upgrading via Homebrew.