### PR TITLE
fix(ui): Clear input prompt on Escape key press

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -1814,4 +1814,61 @@ describe('AppContainer State Management', () => {
       });
     });
   });
+
+  describe('onCancelSubmit Behavior', () => {
+    let mockSetText: Mock;
+
+    beforeEach(() => {
+      mockSetText = vi.fn();
+      mockedUseTextBuffer.mockReturnValue({
+        text: '',
+        setText: mockSetText,
+      });
+      mockedUseLogger.mockReturnValue({
+        getPreviousUserMessages: vi.fn().mockResolvedValue([]),
+      });
+    });
+
+    it('clears the prompt when onCancelSubmit is called with shouldRestorePrompt=false', async () => {
+      const { unmount } = renderAppContainer();
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      const onCancelSubmit = mockedUseGeminiStream.mock.lastCall![14];
+
+      expect(typeof onCancelSubmit).toBe('function');
+
+      act(() => {
+        onCancelSubmit(false);
+      });
+
+      expect(mockSetText).toHaveBeenCalledWith('');
+
+      unmount();
+    });
+
+    it('restores the prompt when onCancelSubmit is called with shouldRestorePrompt=true (or undefined)', async () => {
+      mockedUseLogger.mockReturnValue({
+        getPreviousUserMessages: vi
+          .fn()
+          .mockResolvedValue(['previous message']),
+      });
+
+      const { unmount } = renderAppContainer();
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      const onCancelSubmit = mockedUseGeminiStream.mock.lastCall![14];
+
+      await act(async () => {
+        onCancelSubmit(true);
+      });
+
+      expect(mockSetText).toHaveBeenCalledWith('previous message');
+
+      unmount();
+    });
+  });
 });

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -37,12 +37,18 @@ const mockCoreEvents = vi.hoisted(() => ({
   emit: vi.fn(),
 }));
 
+// Mock IdeClient
+const mockIdeClient = vi.hoisted(() => ({
+  getInstance: vi.fn().mockReturnValue(new Promise(() => {})),
+}));
+
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@google/gemini-cli-core')>();
   return {
     ...actual,
     coreEvents: mockCoreEvents,
+    IdeClient: mockIdeClient,
   };
 });
 import type { LoadedSettings } from '../config/settings.js';
@@ -313,7 +319,7 @@ describe('AppContainer State Management', () => {
       // Add other properties if AppContainer uses them
     });
     mockedUseLogger.mockReturnValue({
-      getPreviousUserMessages: vi.fn().mockResolvedValue([]),
+      getPreviousUserMessages: vi.fn().mockReturnValue(new Promise(() => {})),
     });
     mockedUseLoadingIndicator.mockReturnValue({
       elapsedTime: '0.0s',
@@ -1775,9 +1781,6 @@ describe('AppContainer State Management', () => {
         text: '',
         setText: mockSetText,
       });
-      mockedUseLogger.mockReturnValue({
-        getPreviousUserMessages: vi.fn().mockResolvedValue([]),
-      });
     });
 
     it('clears the prompt when onCancelSubmit is called with shouldRestorePrompt=false', async () => {
@@ -1787,8 +1790,6 @@ describe('AppContainer State Management', () => {
       const { onCancelSubmit } = extractUseGeminiStreamArgs(
         mockedUseGeminiStream.mock.lastCall!,
       );
-
-      expect(typeof onCancelSubmit).toBe('function');
 
       act(() => {
         onCancelSubmit(false);

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -15,6 +15,7 @@ import {
   type MockedObject,
 } from 'vitest';
 import { render } from '../test-utils/render.js';
+import { waitFor } from '../test-utils/async.js';
 import { cleanup } from 'ink-testing-library';
 import { act, useContext } from 'react';
 import { AppContainer } from './AppContainer.js';
@@ -367,9 +368,7 @@ describe('AppContainer State Management', () => {
   describe('Basic Rendering', () => {
     it('renders without crashing with minimal props', async () => {
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
       unmount();
     });
 
@@ -377,9 +376,7 @@ describe('AppContainer State Management', () => {
       const startupWarnings = ['Warning 1', 'Warning 2'];
 
       const { unmount } = renderAppContainer({ startupWarnings });
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
       unmount();
     });
   });
@@ -394,9 +391,7 @@ describe('AppContainer State Management', () => {
       const { unmount } = renderAppContainer({
         initResult: initResultWithError,
       });
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
       unmount();
     });
 
@@ -413,9 +408,7 @@ describe('AppContainer State Management', () => {
   describe('Context Providers', () => {
     it('provides AppContext with correct values', async () => {
       const { unmount } = renderAppContainer({ version: '2.0.0' });
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
 
       // Should render and unmount cleanly
       expect(() => unmount()).not.toThrow();
@@ -423,25 +416,19 @@ describe('AppContainer State Management', () => {
 
     it('provides UIStateContext with state management', async () => {
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
       unmount();
     });
 
     it('provides UIActionsContext with action handlers', async () => {
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
       unmount();
     });
 
     it('provides ConfigContext with config object', async () => {
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
       unmount();
     });
   });
@@ -458,9 +445,7 @@ describe('AppContainer State Management', () => {
       } as unknown as LoadedSettings;
 
       const { unmount } = renderAppContainer({ settings: settingsAllHidden });
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
       unmount();
     });
 
@@ -475,9 +460,7 @@ describe('AppContainer State Management', () => {
       } as unknown as LoadedSettings;
 
       const { unmount } = renderAppContainer({ settings: settingsWithMemory });
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
       unmount();
     });
   });
@@ -487,9 +470,7 @@ describe('AppContainer State Management', () => {
       'handles version format: %s',
       async (version) => {
         const { unmount } = renderAppContainer({ version });
-        await act(async () => {
-          await new Promise((resolve) => setTimeout(resolve, 0));
-        });
+        await waitFor(() => expect(capturedUIState).toBeTruthy());
         unmount();
       },
     );
@@ -504,9 +485,6 @@ describe('AppContainer State Management', () => {
 
       // Should still render without crashing - errors should be handled internally
       const { unmount } = renderAppContainer({ config: errorConfig });
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
       unmount();
     });
 
@@ -516,9 +494,7 @@ describe('AppContainer State Management', () => {
       } as LoadedSettings;
 
       const { unmount } = renderAppContainer({ settings: undefinedSettings });
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
       unmount();
     });
   });
@@ -849,12 +825,10 @@ describe('AppContainer State Management', () => {
     it('passes a null proQuotaRequest to UIStateContext by default', async () => {
       // The default mock from beforeEach already sets proQuotaRequest to null
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
+      await waitFor(() => {
+        // Assert that the context value is as expected
+        expect(capturedUIState.proQuotaRequest).toBeNull();
       });
-
-      // Assert that the context value is as expected
-      expect(capturedUIState.proQuotaRequest).toBeNull();
       unmount();
     });
 
@@ -872,12 +846,10 @@ describe('AppContainer State Management', () => {
 
       // Act: Render the container
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
+      await waitFor(() => {
+        // Assert: The mock request is correctly passed through the context
+        expect(capturedUIState.proQuotaRequest).toEqual(mockRequest);
       });
-
-      // Assert: The mock request is correctly passed through the context
-      expect(capturedUIState.proQuotaRequest).toEqual(mockRequest);
       unmount();
     });
 
@@ -891,12 +863,10 @@ describe('AppContainer State Management', () => {
 
       // Act: Render the container
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
+      await waitFor(() => {
+        // Assert: The action in the context is the mock handler we provided
+        expect(capturedUIActions.handleProQuotaChoice).toBe(mockHandler);
       });
-
-      // Assert: The action in the context is the mock handler we provided
-      expect(capturedUIActions.handleProQuotaChoice).toBe(mockHandler);
 
       // You can even verify that the plumbed function is callable
       act(() => {
@@ -1308,13 +1278,7 @@ describe('AppContainer State Management', () => {
       });
 
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      // Assert: The shell should be resized to a minimum height of 1, not a negative number.
-      // The old code would have tried to set a negative height.
-      expect(resizePtySpy).toHaveBeenCalled();
+      await waitFor(() => expect(resizePtySpy).toHaveBeenCalled());
       const lastCall =
         resizePtySpy.mock.calls[resizePtySpy.mock.calls.length - 1];
       // Check the height argument specifically
@@ -1649,9 +1613,7 @@ describe('AppContainer State Management', () => {
       });
 
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
 
       expect(capturedUIState.isModelDialogOpen).toBe(true);
       unmount();
@@ -1667,9 +1629,7 @@ describe('AppContainer State Management', () => {
       });
 
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
 
       // Verify that the actions are correctly passed through context
       act(() => {
@@ -1683,9 +1643,7 @@ describe('AppContainer State Management', () => {
   describe('CoreEvents Integration', () => {
     it('subscribes to UserFeedback and drains backlog on mount', async () => {
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
 
       expect(mockCoreEvents.on).toHaveBeenCalledWith(
         CoreEvent.UserFeedback,
@@ -1697,9 +1655,7 @@ describe('AppContainer State Management', () => {
 
     it('unsubscribes from UserFeedback on unmount', async () => {
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
 
       unmount();
 
@@ -1711,9 +1667,7 @@ describe('AppContainer State Management', () => {
 
     it('adds history item when UserFeedback event is received', async () => {
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
 
       // Get the registered handler
       const handler = mockCoreEvents.on.mock.calls.find(
@@ -1745,10 +1699,8 @@ describe('AppContainer State Management', () => {
       vi.spyOn(mockConfig, 'getModel').mockReturnValue('initial-model');
 
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await vi.waitFor(() => {
-          expect(capturedUIState?.currentModel).toBe('initial-model');
-        });
+      await waitFor(() => {
+        expect(capturedUIState?.currentModel).toBe('initial-model');
       });
 
       // Get the registered handler for ModelChanged
@@ -1789,11 +1741,7 @@ describe('AppContainer State Management', () => {
       // The main assertion is that the render does not throw.
       const { unmount } = renderAppContainer();
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      expect(resizePtySpy).toHaveBeenCalled();
+      await waitFor(() => expect(resizePtySpy).toHaveBeenCalled());
       unmount();
     });
   });
@@ -1805,10 +1753,7 @@ describe('AppContainer State Management', () => {
         apiKey: 'fake-key',
       });
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-      await vi.waitFor(() => {
+      await waitFor(() => {
         expect(capturedUIState.bannerData.defaultText).toBeDefined();
         unmount();
       });
@@ -1817,6 +1762,12 @@ describe('AppContainer State Management', () => {
 
   describe('onCancelSubmit Behavior', () => {
     let mockSetText: Mock;
+
+    // Helper to extract arguments from the useGeminiStream hook call
+    // This isolates the positional argument dependency to a single location
+    const extractUseGeminiStreamArgs = (args: unknown[]) => ({
+      onCancelSubmit: args[14] as (shouldRestorePrompt?: boolean) => void,
+    });
 
     beforeEach(() => {
       mockSetText = vi.fn();
@@ -1831,11 +1782,11 @@ describe('AppContainer State Management', () => {
 
     it('clears the prompt when onCancelSubmit is called with shouldRestorePrompt=false', async () => {
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
 
-      const onCancelSubmit = mockedUseGeminiStream.mock.lastCall![14];
+      const { onCancelSubmit } = extractUseGeminiStreamArgs(
+        mockedUseGeminiStream.mock.lastCall!,
+      );
 
       expect(typeof onCancelSubmit).toBe('function');
 
@@ -1856,11 +1807,13 @@ describe('AppContainer State Management', () => {
       });
 
       const { unmount } = renderAppContainer();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitFor(() =>
+        expect(capturedUIState.userMessages).toContain('previous message'),
+      );
 
-      const onCancelSubmit = mockedUseGeminiStream.mock.lastCall![14];
+      const { onCancelSubmit } = extractUseGeminiStreamArgs(
+        mockedUseGeminiStream.mock.lastCall!,
+      );
 
       await act(async () => {
         onCancelSubmit(true);

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1050,7 +1050,7 @@ describe('useGeminiStream', () => {
 
       simulateEscapeKeyPress();
 
-      expect(cancelSubmitSpy).toHaveBeenCalled();
+      expect(cancelSubmitSpy).toHaveBeenCalledWith(false);
     });
 
     it('should call setShellInputFocused(false) when escape is pressed', async () => {
@@ -1968,7 +1968,7 @@ describe('useGeminiStream', () => {
 
       // Check that onCancelSubmit was called
       await waitFor(() => {
-        expect(onCancelSubmitSpy).toHaveBeenCalled();
+        expect(onCancelSubmitSpy).toHaveBeenCalledWith(true);
       });
     });
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -105,7 +105,7 @@ export const useGeminiStream = (
   modelSwitchedFromQuotaError: boolean,
   setModelSwitchedFromQuotaError: React.Dispatch<React.SetStateAction<boolean>>,
   onEditorClose: () => void,
-  onCancelSubmit: () => void,
+  onCancelSubmit: (shouldRestorePrompt?: boolean) => void,
   setShellInputFocused: (value: boolean) => void,
   terminalWidth: number,
   terminalHeight: number,
@@ -324,7 +324,7 @@ export const useGeminiStream = (
       setIsResponding(false);
     }
 
-    onCancelSubmit();
+    onCancelSubmit(false);
     setShellInputFocused(false);
   }, [
     streamingState,
@@ -690,7 +690,7 @@ export const useGeminiStream = (
 
   const handleContextWindowWillOverflowEvent = useCallback(
     (estimatedRequestTokenCount: number, remainingTokenCount: number) => {
-      onCancelSubmit();
+      onCancelSubmit(true);
 
       const limit = tokenLimit(config.getModel());
 


### PR DESCRIPTION
## TLDR

This PR fixes a UX regression where pressing the Escape key to cancel a request would inadvertently restore the previous user prompt to the input buffer. This change ensures that pressing Escape clears the input field, while retaining the behavior of restoring the prompt for system-initiated cancellations like context window overflows.

## Dive Deeper

The regression was introduced in **[#10719](https://github.com/google-gemini/gemini-cli/pull/10719)** ("feat(sessions): add resuming to geminiChat").

That PR updated the `cancelHandlerRef` in `AppContainer.tsx` to automatically populate the input buffer with the last user message whenever a request was cancelled. The intention was to help users recover their prompt if a request failed or was cancelled due to system limits (like context overflow). However, this logic was applied unconditionally to *all* cancellation events, including when the user explicitly pressed the **Escape** key, leading to the frustrating experience of having to clear the prompt manually.

This PR refactors the `onCancelSubmit` handler to accept a `shouldRestorePrompt` flag:
- **Escape Key:** Calls `onCancelSubmit(false)`, ensuring the input is cleared.
- **System Cancellations:** Calls `onCancelSubmit(true)` (or defaults to true), preserving the user's prompt for editing.

## Reviewer Test Plan

1. **Escape Key:**
   - Send a long prompt to the CLI.
   - While it is streaming the response, press `Escape`.
   - **Expected:** The request cancels, and the input field is **empty**.

2. **Context Overflow:**
   - Trigger a context window overflow event (if feasible).
   - **Expected:** The request cancels, and the input field **contains the previous prompt**.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #13306