### PR TITLE
Include cached and thoughts token counts in `stream-json` output

### DIFF
--- a/packages/core/src/output/stream-json-formatter.test.ts
+++ b/packages/core/src/output/stream-json-formatter.test.ts
@@ -150,6 +150,8 @@ describe('StreamJsonFormatter', () => {
           total_tokens: 100,
           input_tokens: 50,
           output_tokens: 50,
+          cached_tokens: 0,
+          thoughts_tokens: 0,
           duration_ms: 1200,
           tool_calls: 2,
         },
@@ -174,6 +176,8 @@ describe('StreamJsonFormatter', () => {
           total_tokens: 100,
           input_tokens: 50,
           output_tokens: 50,
+          cached_tokens: 0,
+          thoughts_tokens: 0,
           duration_ms: 1200,
           tool_calls: 0,
         },
@@ -260,8 +264,8 @@ describe('StreamJsonFormatter', () => {
               prompt: 50,
               candidates: 30,
               total: 80,
-              cached: 0,
-              thoughts: 0,
+              cached: 10,
+              thoughts: 5,
               tool: 0,
             },
           },
@@ -291,6 +295,8 @@ describe('StreamJsonFormatter', () => {
         total_tokens: 80,
         input_tokens: 50,
         output_tokens: 30,
+        cached_tokens: 10,
+        thoughts_tokens: 5,
         duration_ms: 1200,
         tool_calls: 2,
       });
@@ -309,8 +315,8 @@ describe('StreamJsonFormatter', () => {
               prompt: 50,
               candidates: 30,
               total: 80,
-              cached: 0,
-              thoughts: 0,
+              cached: 10,
+              thoughts: 5,
               tool: 0,
             },
           },
@@ -324,8 +330,8 @@ describe('StreamJsonFormatter', () => {
               prompt: 100,
               candidates: 70,
               total: 170,
-              cached: 0,
-              thoughts: 0,
+              cached: 20,
+              thoughts: 10,
               tool: 0,
             },
           },
@@ -355,6 +361,8 @@ describe('StreamJsonFormatter', () => {
         total_tokens: 250, // 80 + 170
         input_tokens: 150, // 50 + 100
         output_tokens: 100, // 30 + 70
+        cached_tokens: 30, // 10 + 20
+        thoughts_tokens: 15, // 5 + 10
         duration_ms: 3000,
         tool_calls: 5,
       });
@@ -388,6 +396,8 @@ describe('StreamJsonFormatter', () => {
         total_tokens: 0,
         input_tokens: 0,
         output_tokens: 0,
+        cached_tokens: 0,
+        thoughts_tokens: 0,
         duration_ms: 100,
         tool_calls: 0,
       });
@@ -515,6 +525,8 @@ describe('StreamJsonFormatter', () => {
             total_tokens: 0,
             input_tokens: 0,
             output_tokens: 0,
+            cached_tokens: 0,
+            thoughts_tokens: 0,
             duration_ms: 0,
             tool_calls: 0,
           },
@@ -536,6 +548,8 @@ describe('StreamJsonFormatter', () => {
           total_tokens: 100,
           input_tokens: 50,
           output_tokens: 50,
+          cached_tokens: 10,
+          thoughts_tokens: 5,
           duration_ms: 1200,
           tool_calls: 2,
         },
@@ -547,6 +561,8 @@ describe('StreamJsonFormatter', () => {
       expect(typeof parsed.stats.total_tokens).toBe('number');
       expect(typeof parsed.stats.input_tokens).toBe('number');
       expect(typeof parsed.stats.output_tokens).toBe('number');
+      expect(typeof parsed.stats.cached_tokens).toBe('number');
+      expect(typeof parsed.stats.thoughts_tokens).toBe('number');
       expect(typeof parsed.stats.duration_ms).toBe('number');
       expect(typeof parsed.stats.tool_calls).toBe('number');
     });

--- a/packages/core/src/output/stream-json-formatter.ts
+++ b/packages/core/src/output/stream-json-formatter.ts
@@ -43,18 +43,24 @@ export class StreamJsonFormatter {
     let totalTokens = 0;
     let inputTokens = 0;
     let outputTokens = 0;
+    let cachedTokens = 0;
+    let thoughtsTokens = 0;
 
     // Aggregate token counts across all models
     for (const modelMetrics of Object.values(metrics.models)) {
       totalTokens += modelMetrics.tokens.total;
       inputTokens += modelMetrics.tokens.prompt;
       outputTokens += modelMetrics.tokens.candidates;
+      cachedTokens += modelMetrics.tokens.cached;
+      thoughtsTokens += modelMetrics.tokens.thoughts;
     }
 
     return {
       total_tokens: totalTokens,
       input_tokens: inputTokens,
       output_tokens: outputTokens,
+      cached_tokens: cachedTokens,
+      thoughts_tokens: thoughtsTokens,
       duration_ms: durationMs,
       tool_calls: metrics.tools.totalCalls,
     };

--- a/packages/core/src/output/types.ts
+++ b/packages/core/src/output/types.ts
@@ -80,6 +80,8 @@ export interface StreamStats {
   total_tokens: number;
   input_tokens: number;
   output_tokens: number;
+  cached_tokens: number;
+  thoughts_tokens: number;
   duration_ms: number;
   tool_calls: number;
 }


### PR DESCRIPTION
## Summary

Currently, `stream-json` output does not include the cached input token count even though it is shown in the interactive UI by running `/stats model`.

## Details

This PR adds two new fields in the `stream-json` output to align it with what is shown in TUI.

## How to Validate

Run a simple non-interactive session and check the final output.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
