### PR TITLE
feat: add click-to-focus support for interactive shell

### DIFF
--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -76,7 +76,7 @@ export const simulateClick = async (
   row: number,
   button: 0 | 1 | 2 = 0, // 0 for left, 1 for middle, 2 for right
 ) => {
-  // Ink mouse events are 1-based, so convert if necessary.
+  // Terminal mouse events are 1-based, so convert if necessary.
   const mouseEventString = `\x1b[<${button};${col};${row}M`;
   await act(async () => {
     stdin.write(mouseEventString);

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1565,6 +1565,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       handleApiKeySubmit,
       handleApiKeyCancel,
       setBannerVisible,
+      setEmbeddedShellFocused,
     }),
     [
       handleThemeSelect,
@@ -1595,6 +1596,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
       handleApiKeySubmit,
       handleApiKeyCancel,
       setBannerVisible,
+      setEmbeddedShellFocused,
     ],
   );
 

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -104,6 +104,10 @@ describe('InputPrompt', () => {
     useReverseSearchCompletion,
   );
   const mockedUseKittyKeyboardProtocol = vi.mocked(useKittyKeyboardProtocol);
+  const mockSetEmbeddedShellFocused = vi.fn();
+  const uiActions = {
+    setEmbeddedShellFocused: mockSetEmbeddedShellFocused,
+  };
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -241,7 +245,9 @@ describe('InputPrompt', () => {
 
   it('should call shellHistory.getPreviousCommand on up arrow in shell mode', async () => {
     props.shellModeActive = true;
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\u001B[A');
@@ -254,7 +260,9 @@ describe('InputPrompt', () => {
 
   it('should call shellHistory.getNextCommand on down arrow in shell mode', async () => {
     props.shellModeActive = true;
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\u001B[B');
@@ -270,7 +278,9 @@ describe('InputPrompt', () => {
     vi.mocked(mockShellHistory.getPreviousCommand).mockReturnValue(
       'previous command',
     );
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\u001B[A');
@@ -285,7 +295,9 @@ describe('InputPrompt', () => {
   it('should call shellHistory.addCommandToHistory on submit in shell mode', async () => {
     props.shellModeActive = true;
     props.buffer.setText('ls -l');
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\r');
@@ -301,7 +313,9 @@ describe('InputPrompt', () => {
 
   it('should NOT call shell history methods when not in shell mode', async () => {
     props.buffer.setText('some text');
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\u001B[A'); // Up arrow
@@ -340,7 +354,9 @@ describe('InputPrompt', () => {
 
     props.buffer.setText('/mem');
 
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     // Test up arrow
     await act(async () => {
@@ -372,7 +388,9 @@ describe('InputPrompt', () => {
     });
     props.buffer.setText('/mem');
 
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     // Test down arrow
     await act(async () => {
@@ -399,7 +417,9 @@ describe('InputPrompt', () => {
       showSuggestions: false,
     });
     props.buffer.setText('some text');
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\u001B[A'); // Up arrow
@@ -629,7 +649,9 @@ describe('InputPrompt', () => {
       activeSuggestionIndex: activeIndex,
     });
     props.buffer.setText(bufferText);
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => stdin.write('\t'));
     await waitFor(() =>
@@ -649,7 +671,9 @@ describe('InputPrompt', () => {
     });
     props.buffer.setText('/mem');
 
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\r');
@@ -681,7 +705,9 @@ describe('InputPrompt', () => {
     });
     props.buffer.setText('/?');
 
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\t'); // Press Tab for autocomplete
@@ -695,7 +721,9 @@ describe('InputPrompt', () => {
   it('should not submit on Enter when the buffer is empty or only contains whitespace', async () => {
     props.buffer.setText('   '); // Set buffer to whitespace
 
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\r'); // Press Enter
@@ -715,7 +743,9 @@ describe('InputPrompt', () => {
     });
     props.buffer.setText('/clear');
 
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\r');
@@ -732,7 +762,9 @@ describe('InputPrompt', () => {
     });
     props.buffer.setText('/clear');
 
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\r');
@@ -750,7 +782,9 @@ describe('InputPrompt', () => {
     });
     props.buffer.setText('@src/components/');
 
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\r');
@@ -768,7 +802,9 @@ describe('InputPrompt', () => {
     mockBuffer.cursor = [0, 11];
     mockBuffer.lines = ['first line\\'];
 
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\r');
@@ -786,7 +822,9 @@ describe('InputPrompt', () => {
     await act(async () => {
       props.buffer.setText('some text to clear');
     });
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\x03'); // Ctrl+C character
@@ -801,7 +839,9 @@ describe('InputPrompt', () => {
 
   it('should NOT clear the buffer on Ctrl+C if it is empty', async () => {
     props.buffer.text = '';
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\x03'); // Ctrl+C character
@@ -814,7 +854,9 @@ describe('InputPrompt', () => {
   });
 
   it('should call setBannerVisible(false) when clear screen key is pressed', async () => {
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
 
     await act(async () => {
       stdin.write('\x0C'); // Ctrl+L
@@ -919,7 +961,9 @@ describe('InputPrompt', () => {
           : [],
       });
 
-      const { unmount } = renderWithProviders(<InputPrompt {...props} />);
+      const { unmount } = renderWithProviders(<InputPrompt {...props} />, {
+        uiActions,
+      });
 
       await waitFor(() => {
         expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
@@ -1991,7 +2035,7 @@ describe('InputPrompt', () => {
 
         const { stdin, stdout, unmount } = renderWithProviders(
           <InputPrompt {...props} />,
-          { mouseEventsEnabled: true },
+          { mouseEventsEnabled: true, uiActions },
         );
 
         // Wait for initial render
@@ -2015,6 +2059,33 @@ describe('InputPrompt', () => {
         unmount();
       },
     );
+
+    it('should unfocus embedded shell on click', async () => {
+      props.buffer.text = 'hello';
+      props.buffer.lines = ['hello'];
+      props.buffer.viewportVisualLines = ['hello'];
+      props.buffer.visualToLogicalMap = [[0, 0]];
+      props.isEmbeddedShellFocused = true;
+
+      const { stdin, stdout, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+        { mouseEventsEnabled: true, uiActions },
+      );
+      await waitFor(() => {
+        expect(stdout.lastFrame()).toContain('hello');
+      });
+
+      await act(async () => {
+        // Click somewhere in the prompt
+        stdin.write(`\x1b[<0;5;2M`);
+      });
+
+      await waitFor(() => {
+        expect(mockSetEmbeddedShellFocused).toHaveBeenCalledWith(false);
+      });
+
+      unmount();
+    });
   });
 
   describe('queued message editing', () => {

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -7,7 +7,7 @@
 import type React from 'react';
 import clipboardy from 'clipboardy';
 import { useCallback, useEffect, useState, useRef } from 'react';
-import { Box, Text, getBoundingBox, type DOMElement } from 'ink';
+import { Box, Text, type DOMElement } from 'ink';
 import { SuggestionsDisplay, MAX_WIDTH } from './SuggestionsDisplay.js';
 import { theme } from '../semantic-colors.js';
 import { useInputHistory } from '../hooks/useInputHistory.js';
@@ -368,37 +368,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   useMouseClick(
     innerBoxRef,
-    (_event, _mouseX, mouseY) => {
+    (_event, relX, relY) => {
       if (isEmbeddedShellFocused) {
         setEmbeddedShellFocused(false);
       }
-      // The x coordinate in the handler is relative to the container (mouseX - x).
-      // but useMouseClick passes (mouseX - x) as the second argument?
-      // Let's check useMouseClick implementation:
-      // handler(event, mouseX, mouseY);
-      // wait, mouseX in useMouseClick is event.col - 1. It is NOT relative to the container.
-      // I need to check the implementation of useMouseClick I wrote.
-      // const mouseX = event.col - 1;
-      // const mouseY = event.row - 1;
-      // handler(event, mouseX, mouseY);
-      // So it passes absolute terminal coordinates (0-based).
-
-      // In the original code:
-      // const { x, y, width, height } = getBoundingBox(innerBoxRef.current);
-      // const relX = mouseX - x;
-      // const relY = mouseY - y;
-      // const visualRow = buffer.visualScrollRow + relY;
-      // buffer.moveToVisualPosition(visualRow, relX);
-
-      // So I need to recalculate relative coordinates here because useMouseClick passes absolute ones.
-      if (innerBoxRef.current) {
-        const { x, y } = getBoundingBox(innerBoxRef.current);
-        // _mouseX and mouseY are 0-based absolute coordinates passed from useMouseClick
-        const relX = _mouseX - x;
-        const relY = mouseY - y;
-        const visualRow = buffer.visualScrollRow + relY;
-        buffer.moveToVisualPosition(visualRow, relX);
-      }
+      const visualRow = buffer.visualScrollRow + relY;
+      buffer.moveToVisualPosition(visualRow, relX);
     },
     { isActive: focus },
   );

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -42,6 +42,7 @@ import { useUIState } from '../contexts/UIStateContext.js';
 import { StreamingState } from '../types.js';
 import { isSlashCommand } from '../utils/commandUtils.js';
 import { useMouse, type MouseEvent } from '../contexts/MouseContext.js';
+import { useUIActions } from '../contexts/UIActionsContext.js';
 
 /**
  * Returns if the terminal can be trusted to handle paste events atomically
@@ -126,6 +127,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 }) => {
   const kittyProtocol = useKittyKeyboardProtocol();
   const isShellFocused = useShellFocusState();
+  const { setEmbeddedShellFocused } = useUIActions();
   const { mainAreaWidth } = useUIState();
   const [justNavigatedHistory, setJustNavigatedHistory] = useState(false);
   const escPressCount = useRef(0);
@@ -376,6 +378,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           mouseY >= y &&
           mouseY < y + height
         ) {
+          if (isEmbeddedShellFocused) {
+            setEmbeddedShellFocused(false);
+          }
           const relX = mouseX - x;
           const relY = mouseY - y;
           const visualRow = buffer.visualScrollRow + relY;
@@ -387,10 +392,15 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
       return false;
     },
-    [buffer, handleClipboardPaste],
+    [
+      buffer,
+      isEmbeddedShellFocused,
+      setEmbeddedShellFocused,
+      handleClipboardPaste,
+    ],
   );
 
-  useMouse(handleMouse, { isActive: focus && !isEmbeddedShellFocused });
+  useMouse(handleMouse, { isActive: focus });
 
   const handleInput = useCallback(
     (key: Key) => {

--- a/packages/cli/src/ui/components/messages/ShellToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ShellToolMessage.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { act } from 'react';
+import type { ToolMessageProps } from './ToolMessage.js';
+import { ShellToolMessage } from './ShellToolMessage.js';
+import { StreamingState, ToolCallStatus } from '../../types.js';
+import { Text } from 'ink';
+import type { Config } from '@google/gemini-cli-core';
+import { renderWithProviders } from '../../../test-utils/render.js';
+import { waitFor } from '../../../test-utils/async.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SHELL_TOOL_NAME } from '@google/gemini-cli-core';
+import { SHELL_COMMAND_NAME } from '../../constants.js';
+import { StreamingContext } from '../../contexts/StreamingContext.js';
+
+vi.mock('../TerminalOutput.js', () => ({
+  TerminalOutput: function MockTerminalOutput({
+    cursor,
+  }: {
+    cursor: { x: number; y: number } | null;
+  }) {
+    return (
+      <Text>
+        MockCursor:({cursor?.x},{cursor?.y})
+      </Text>
+    );
+  },
+}));
+
+// Mock child components or utilities if they are complex or have side effects
+vi.mock('../GeminiRespondingSpinner.js', () => ({
+  GeminiRespondingSpinner: ({
+    nonRespondingDisplay,
+  }: {
+    nonRespondingDisplay?: string;
+  }) => {
+    const streamingState = React.useContext(StreamingContext)!;
+    if (streamingState === StreamingState.Responding) {
+      return <Text>MockRespondingSpinner</Text>;
+    }
+    return nonRespondingDisplay ? <Text>{nonRespondingDisplay}</Text> : null;
+  },
+}));
+
+vi.mock('../../utils/MarkdownDisplay.js', () => ({
+  MarkdownDisplay: function MockMarkdownDisplay({ text }: { text: string }) {
+    return <Text>MockMarkdown:{text}</Text>;
+  },
+}));
+
+describe('<ShellToolMessage />', () => {
+  const baseProps: ToolMessageProps = {
+    callId: 'tool-123',
+    name: SHELL_COMMAND_NAME,
+    description: 'A shell command',
+    resultDisplay: 'Test result',
+    status: ToolCallStatus.Executing,
+    terminalWidth: 80,
+    confirmationDetails: undefined,
+    emphasis: 'medium',
+    isFirst: true,
+    borderColor: 'green',
+    borderDimColor: false,
+    config: {
+      getEnableInteractiveShell: () => true,
+    } as unknown as Config,
+  };
+
+  const mockSetEmbeddedShellFocused = vi.fn();
+  const uiActions = {
+    setEmbeddedShellFocused: mockSetEmbeddedShellFocused,
+  };
+
+  // Helper to render with context
+  const renderWithContext = (
+    ui: React.ReactElement,
+    streamingState: StreamingState,
+  ) =>
+    renderWithProviders(ui, {
+      uiActions,
+      uiState: { streamingState },
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('interactive shell focus', () => {
+    const shellProps: ToolMessageProps = {
+      ...baseProps,
+    };
+
+    it('clicks inside the shell area sets focus to true', async () => {
+      const { stdin, lastFrame, simulateClick } = renderWithProviders(
+        <ShellToolMessage {...shellProps} />,
+        {
+          mouseEventsEnabled: true,
+          uiActions,
+        },
+      );
+
+      await waitFor(() => {
+        expect(lastFrame()).toContain('A shell command'); // Wait for render
+      });
+
+      await simulateClick(stdin, 2, 2); // Click at column 2, row 2 (1-based)
+
+      await waitFor(() => {
+        expect(mockSetEmbeddedShellFocused).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it('handles focus for SHELL_TOOL_NAME (core shell tool)', async () => {
+      const coreShellProps: ToolMessageProps = {
+        ...shellProps,
+        name: SHELL_TOOL_NAME,
+      };
+
+      const { stdin, lastFrame, simulateClick } = renderWithProviders(
+        <ShellToolMessage {...coreShellProps} />,
+        {
+          mouseEventsEnabled: true,
+          uiActions,
+        },
+      );
+
+      await waitFor(() => {
+        expect(lastFrame()).toContain('A shell command');
+      });
+
+      await simulateClick(stdin, 2, 2);
+
+      await waitFor(() => {
+        expect(mockSetEmbeddedShellFocused).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it('resets focus when shell finishes', async () => {
+      let updateStatus: (s: ToolCallStatus) => void = () => {};
+
+      const Wrapper = () => {
+        const [status, setStatus] = React.useState(ToolCallStatus.Executing);
+        updateStatus = setStatus;
+        return (
+          <ShellToolMessage
+            {...shellProps}
+            status={status}
+            embeddedShellFocused={true}
+            activeShellPtyId={1}
+            ptyId={1}
+          />
+        );
+      };
+
+      const { lastFrame } = renderWithContext(<Wrapper />, StreamingState.Idle);
+
+      // Verify it is initially focused
+      await waitFor(() => {
+        expect(lastFrame()).toContain('(Focused)');
+      });
+
+      // Now update status to Success
+      await act(async () => {
+        updateStatus(ToolCallStatus.Success);
+      });
+
+      // Should call setEmbeddedShellFocused(false) because isThisShellFocused became false
+      await waitFor(() => {
+        expect(mockSetEmbeddedShellFocused).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+});

--- a/packages/cli/src/ui/components/messages/ShellToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ShellToolMessage.test.tsx
@@ -5,8 +5,10 @@
  */
 
 import React, { act } from 'react';
-import type { ToolMessageProps } from './ToolMessage.js';
-import { ShellToolMessage } from './ShellToolMessage.js';
+import {
+  ShellToolMessage,
+  type ShellToolMessageProps,
+} from './ShellToolMessage.js';
 import { StreamingState, ToolCallStatus } from '../../types.js';
 import { Text } from 'ink';
 import type { Config } from '@google/gemini-cli-core';
@@ -53,7 +55,7 @@ vi.mock('../../utils/MarkdownDisplay.js', () => ({
 }));
 
 describe('<ShellToolMessage />', () => {
-  const baseProps: ToolMessageProps = {
+  const baseProps: ShellToolMessageProps = {
     callId: 'tool-123',
     name: SHELL_COMMAND_NAME,
     description: 'A shell command',
@@ -90,7 +92,7 @@ describe('<ShellToolMessage />', () => {
   });
 
   describe('interactive shell focus', () => {
-    const shellProps: ToolMessageProps = {
+    const shellProps: ShellToolMessageProps = {
       ...baseProps,
     };
 
@@ -115,7 +117,7 @@ describe('<ShellToolMessage />', () => {
     });
 
     it('handles focus for SHELL_TOOL_NAME (core shell tool)', async () => {
-      const coreShellProps: ToolMessageProps = {
+      const coreShellProps: ShellToolMessageProps = {
         ...shellProps,
         name: SHELL_TOOL_NAME,
       };

--- a/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
@@ -22,10 +22,12 @@ import {
   STATUS_INDICATOR_WIDTH,
 } from './ToolShared.js';
 import type { ToolMessageProps } from './ToolMessage.js';
+import type { Config } from '@google/gemini-cli-core';
 
-interface ShellToolMessageProps extends ToolMessageProps {
+export interface ShellToolMessageProps extends ToolMessageProps {
   activeShellPtyId?: number | null;
   embeddedShellFocused?: boolean;
+  config?: Config;
 }
 
 export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({

--- a/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
@@ -6,52 +6,29 @@
 
 import React from 'react';
 import { Box, Text, type DOMElement } from 'ink';
-import type { IndividualToolCallDisplay } from '../../types.js';
 import { ToolCallStatus } from '../../types.js';
-import { DiffRenderer } from './DiffRenderer.js';
-import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
-import { AnsiOutputText } from '../AnsiOutput.js';
-import { GeminiRespondingSpinner } from '../GeminiRespondingSpinner.js';
-import { MaxSizedBox } from '../shared/MaxSizedBox.js';
 import { ShellInputPrompt } from '../ShellInputPrompt.js';
 import { StickyHeader } from '../StickyHeader.js';
-import {
-  SHELL_COMMAND_NAME,
-  SHELL_NAME,
-  TOOL_STATUS,
-} from '../../constants.js';
+import { SHELL_COMMAND_NAME, SHELL_NAME } from '../../constants.js';
 import { theme } from '../../semantic-colors.js';
-import type { AnsiOutput, Config } from '@google/gemini-cli-core';
 import { SHELL_TOOL_NAME } from '@google/gemini-cli-core';
-import { useUIState } from '../../contexts/UIStateContext.js';
-import { useAlternateBuffer } from '../../hooks/useAlternateBuffer.js';
 import { useUIActions } from '../../contexts/UIActionsContext.js';
 import { useMouseClick } from '../../hooks/useMouseClick.js';
+import { ToolResultDisplay } from './ToolResultDisplay.js';
+import {
+  ToolStatusIndicator,
+  ToolInfo,
+  TrailingIndicator,
+  STATUS_INDICATOR_WIDTH,
+} from './ToolShared.js';
+import type { ToolMessageProps } from './ToolMessage.js';
 
-const STATIC_HEIGHT = 1;
-const RESERVED_LINE_COUNT = 5; // for tool name, status, padding etc.
-const STATUS_INDICATOR_WIDTH = 3;
-const MIN_LINES_SHOWN = 2; // show at least this many lines
-
-// Large threshold to ensure we don't cause performance issues for very large
-// outputs that will get truncated further MaxSizedBox anyway.
-const MAXIMUM_RESULT_DISPLAY_CHARACTERS = 1000000;
-export type TextEmphasis = 'high' | 'medium' | 'low';
-
-export interface ToolMessageProps extends IndividualToolCallDisplay {
-  availableTerminalHeight?: number;
-  terminalWidth: number;
-  emphasis?: TextEmphasis;
-  renderOutputAsMarkdown?: boolean;
+interface ShellToolMessageProps extends ToolMessageProps {
   activeShellPtyId?: number | null;
   embeddedShellFocused?: boolean;
-  isFirst: boolean;
-  borderColor: string;
-  borderDimColor: boolean;
-  config?: Config;
 }
 
-export const ShellToolMessage: React.FC<ToolMessageProps> = ({
+export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
   name,
   description,
   resultDisplay,
@@ -68,11 +45,9 @@ export const ShellToolMessage: React.FC<ToolMessageProps> = ({
   borderColor,
   borderDimColor,
 }) => {
-  const { renderMarkdown } = useUIState();
-  const isAlternateBuffer = useAlternateBuffer();
   const isThisShellFocused =
     (name === SHELL_COMMAND_NAME ||
-      name === 'Shell' ||
+      name === SHELL_NAME ||
       name === SHELL_TOOL_NAME) &&
     status === ToolCallStatus.Executing &&
     ptyId === activeShellPtyId &&
@@ -83,7 +58,7 @@ export const ShellToolMessage: React.FC<ToolMessageProps> = ({
   // The shell is focusable if it's the shell command, it's executing, and the interactive shell is enabled.
   const isThisShellFocusable =
     (name === SHELL_COMMAND_NAME ||
-      name === 'Shell' ||
+      name === SHELL_NAME ||
       name === SHELL_TOOL_NAME) &&
     status === ToolCallStatus.Executing &&
     config?.getEnableInteractiveShell();
@@ -141,95 +116,6 @@ export const ShellToolMessage: React.FC<ToolMessageProps> = ({
   const shouldShowFocusHint =
     isThisShellFocusable && (showFocusHint || userHasFocused);
 
-  const availableHeight = availableTerminalHeight
-    ? Math.max(
-        availableTerminalHeight - STATIC_HEIGHT - RESERVED_LINE_COUNT,
-        MIN_LINES_SHOWN + 1, // enforce minimum lines shown
-      )
-    : undefined;
-
-  // Long tool call response in MarkdownDisplay doesn't respect availableTerminalHeight properly,
-  // so if we aren't using alternate buffer mode, we're forcing it to not render as markdown when the response is too long, it will fallback
-  // to render as plain text, which is contained within the terminal using MaxSizedBox
-  if (availableHeight && !isAlternateBuffer) {
-    renderOutputAsMarkdown = false;
-  }
-  const combinedPaddingAndBorderWidth = 4;
-  const childWidth = terminalWidth - combinedPaddingAndBorderWidth;
-
-  const truncatedResultDisplay = React.useMemo(() => {
-    if (typeof resultDisplay === 'string') {
-      if (resultDisplay.length > MAXIMUM_RESULT_DISPLAY_CHARACTERS) {
-        return '...' + resultDisplay.slice(-MAXIMUM_RESULT_DISPLAY_CHARACTERS);
-      }
-    }
-    return resultDisplay;
-  }, [resultDisplay]);
-
-  const renderedResult = React.useMemo(() => {
-    if (!truncatedResultDisplay) return null;
-
-    return (
-      <Box width={childWidth} flexDirection="column">
-        <Box flexDirection="column">
-          {typeof truncatedResultDisplay === 'string' &&
-          renderOutputAsMarkdown ? (
-            <Box flexDirection="column">
-              <MarkdownDisplay
-                text={truncatedResultDisplay}
-                terminalWidth={childWidth}
-                renderMarkdown={renderMarkdown}
-                isPending={false}
-              />
-            </Box>
-          ) : typeof truncatedResultDisplay === 'string' &&
-            !renderOutputAsMarkdown ? (
-            isAlternateBuffer ? (
-              <Box flexDirection="column" width={childWidth}>
-                <Text wrap="wrap" color={theme.text.primary}>
-                  {truncatedResultDisplay}
-                </Text>
-              </Box>
-            ) : (
-              <MaxSizedBox maxHeight={availableHeight} maxWidth={childWidth}>
-                <Box>
-                  <Text wrap="wrap" color={theme.text.primary}>
-                    {truncatedResultDisplay}
-                  </Text>
-                </Box>
-              </MaxSizedBox>
-            )
-          ) : typeof truncatedResultDisplay === 'object' &&
-            'fileDiff' in truncatedResultDisplay ? (
-            <DiffRenderer
-              diffContent={truncatedResultDisplay.fileDiff}
-              filename={truncatedResultDisplay.fileName}
-              availableTerminalHeight={availableHeight}
-              terminalWidth={childWidth}
-            />
-          ) : typeof truncatedResultDisplay === 'object' &&
-            'todos' in truncatedResultDisplay ? (
-            // display nothing, as the TodoTray will handle rendering todos
-            <></>
-          ) : (
-            <AnsiOutputText
-              data={truncatedResultDisplay as AnsiOutput}
-              availableTerminalHeight={availableHeight}
-              width={childWidth}
-            />
-          )}
-        </Box>
-      </Box>
-    );
-  }, [
-    truncatedResultDisplay,
-    renderOutputAsMarkdown,
-    childWidth,
-    renderMarkdown,
-    isAlternateBuffer,
-    availableHeight,
-  ]);
-
   return (
     <Box ref={containerRef} flexDirection="column" width={terminalWidth}>
       <StickyHeader
@@ -266,7 +152,12 @@ export const ShellToolMessage: React.FC<ToolMessageProps> = ({
         paddingX={1}
         flexDirection="column"
       >
-        {renderedResult}
+        <ToolResultDisplay
+          resultDisplay={resultDisplay}
+          availableTerminalHeight={availableTerminalHeight}
+          terminalWidth={terminalWidth}
+          renderOutputAsMarkdown={renderOutputAsMarkdown}
+        />
         {isThisShellFocused && config && (
           <Box paddingLeft={STATUS_INDICATOR_WIDTH} marginTop={1}>
             <ShellInputPrompt
@@ -279,98 +170,3 @@ export const ShellToolMessage: React.FC<ToolMessageProps> = ({
     </Box>
   );
 };
-
-type ToolStatusIndicatorProps = {
-  status: ToolCallStatus;
-  name: string;
-};
-
-const ToolStatusIndicator: React.FC<ToolStatusIndicatorProps> = ({
-  status,
-  name,
-}) => {
-  const isShell =
-    name === SHELL_COMMAND_NAME ||
-    name === SHELL_NAME ||
-    name === SHELL_TOOL_NAME;
-  const statusColor = isShell ? theme.ui.symbol : theme.status.warning;
-
-  return (
-    <Box minWidth={STATUS_INDICATOR_WIDTH}>
-      {status === ToolCallStatus.Pending && (
-        <Text color={theme.status.success}>{TOOL_STATUS.PENDING}</Text>
-      )}
-      {status === ToolCallStatus.Executing && (
-        <GeminiRespondingSpinner
-          spinnerType="toggle"
-          nonRespondingDisplay={TOOL_STATUS.EXECUTING}
-        />
-      )}
-      {status === ToolCallStatus.Success && (
-        <Text color={theme.status.success} aria-label={'Success:'}>
-          {TOOL_STATUS.SUCCESS}
-        </Text>
-      )}
-      {status === ToolCallStatus.Confirming && (
-        <Text color={statusColor} aria-label={'Confirming:'}>
-          {TOOL_STATUS.CONFIRMING}
-        </Text>
-      )}
-      {status === ToolCallStatus.Canceled && (
-        <Text color={statusColor} aria-label={'Canceled:'} bold>
-          {TOOL_STATUS.CANCELED}
-        </Text>
-      )}
-      {status === ToolCallStatus.Error && (
-        <Text color={theme.status.error} aria-label={'Error:'} bold>
-          {TOOL_STATUS.ERROR}
-        </Text>
-      )}
-    </Box>
-  );
-};
-
-type ToolInfo = {
-  name: string;
-  description: string;
-  status: ToolCallStatus;
-  emphasis: TextEmphasis;
-};
-const ToolInfo: React.FC<ToolInfo> = ({
-  name,
-  description,
-  status,
-  emphasis,
-}) => {
-  const nameColor = React.useMemo<string>(() => {
-    switch (emphasis) {
-      case 'high':
-        return theme.text.primary;
-      case 'medium':
-        return theme.text.primary;
-      case 'low':
-        return theme.text.secondary;
-      default: {
-        const exhaustiveCheck: never = emphasis;
-        return exhaustiveCheck;
-      }
-    }
-  }, [emphasis]);
-  return (
-    <Box overflow="hidden" height={1} flexGrow={1} flexShrink={1}>
-      <Text strikethrough={status === ToolCallStatus.Canceled} wrap="truncate">
-        <Text color={nameColor} bold>
-          {name}
-        </Text>{' '}
-        <Text color={theme.text.secondary}>{description}</Text>
-      </Text>
-    </Box>
-  );
-};
-
-const TrailingIndicator: React.FC = () => (
-  <Text color={theme.text.primary} wrap="truncate">
-    {' '}
-    ←
-  </Text>
-);

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -10,9 +10,11 @@ import { Box, Text } from 'ink';
 import type { IndividualToolCallDisplay } from '../../types.js';
 import { ToolCallStatus } from '../../types.js';
 import { ToolMessage } from './ToolMessage.js';
+import { ShellToolMessage } from './ShellToolMessage.js';
 import { ToolConfirmationMessage } from './ToolConfirmationMessage.js';
 import { theme } from '../../semantic-colors.js';
 import { SHELL_COMMAND_NAME, SHELL_NAME } from '../../constants.js';
+import { SHELL_TOOL_NAME } from '@google/gemini-cli-core';
 import { useConfig } from '../../contexts/ConfigContext.js';
 
 interface ToolGroupMessageProps {
@@ -103,6 +105,12 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
       {toolCalls.map((tool, index) => {
         const isConfirming = toolAwaitingApproval?.callId === tool.callId;
         const isFirst = index === 0;
+        const isShellTool =
+          tool.name === SHELL_COMMAND_NAME ||
+          tool.name === SHELL_NAME ||
+          tool.name === SHELL_TOOL_NAME;
+        const ToolComponent = isShellTool ? ShellToolMessage : ToolMessage;
+
         return (
           <Box
             key={tool.callId}
@@ -110,7 +118,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
             minHeight={1}
             width={terminalWidth}
           >
-            <ToolMessage
+            <ToolComponent
               {...tool}
               availableTerminalHeight={availableTerminalHeightPerToolMessage}
               terminalWidth={terminalWidth}

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -119,7 +119,6 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
             : toolAwaitingApproval
               ? ('low' as const)
               : ('medium' as const),
-          config,
           isFirst,
           borderColor,
           borderDimColor,
@@ -137,6 +136,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
                 {...commonProps}
                 activeShellPtyId={activeShellPtyId}
                 embeddedShellFocused={embeddedShellFocused}
+                config={config}
               />
             ) : (
               <ToolMessage {...commonProps} />

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -109,7 +109,21 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
           tool.name === SHELL_COMMAND_NAME ||
           tool.name === SHELL_NAME ||
           tool.name === SHELL_TOOL_NAME;
-        const ToolComponent = isShellTool ? ShellToolMessage : ToolMessage;
+
+        const commonProps = {
+          ...tool,
+          availableTerminalHeight: availableTerminalHeightPerToolMessage,
+          terminalWidth,
+          emphasis: isConfirming
+            ? ('high' as const)
+            : toolAwaitingApproval
+              ? ('low' as const)
+              : ('medium' as const),
+          config,
+          isFirst,
+          borderColor,
+          borderDimColor,
+        };
 
         return (
           <Box
@@ -118,20 +132,15 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
             minHeight={1}
             width={terminalWidth}
           >
-            <ToolComponent
-              {...tool}
-              availableTerminalHeight={availableTerminalHeightPerToolMessage}
-              terminalWidth={terminalWidth}
-              emphasis={
-                isConfirming ? 'high' : toolAwaitingApproval ? 'low' : 'medium'
-              }
-              activeShellPtyId={activeShellPtyId}
-              embeddedShellFocused={embeddedShellFocused}
-              config={config}
-              isFirst={isFirst}
-              borderColor={borderColor}
-              borderDimColor={borderDimColor}
-            />
+            {isShellTool ? (
+              <ShellToolMessage
+                {...commonProps}
+                activeShellPtyId={activeShellPtyId}
+                embeddedShellFocused={embeddedShellFocused}
+              />
+            ) : (
+              <ToolMessage {...commonProps} />
+            )}
             <Box
               borderLeft={true}
               borderRight={true}

--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -4,18 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { act } from 'react';
+import React from 'react';
 import type { ToolMessageProps } from './ToolMessage.js';
 import { ToolMessage } from './ToolMessage.js';
 import { StreamingState, ToolCallStatus } from '../../types.js';
 import { Text } from 'ink';
 import { StreamingContext } from '../../contexts/StreamingContext.js';
-import type { AnsiOutput, Config } from '@google/gemini-cli-core';
+import type { AnsiOutput } from '@google/gemini-cli-core';
 import { renderWithProviders } from '../../../test-utils/render.js';
-import { waitFor } from '../../../test-utils/async.js';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { SHELL_TOOL_NAME } from '@google/gemini-cli-core';
-import { SHELL_COMMAND_NAME } from '../../constants.js';
 
 vi.mock('../TerminalOutput.js', () => ({
   TerminalOutput: function MockTerminalOutput({
@@ -94,15 +91,11 @@ describe('<ToolMessage />', () => {
   const renderWithContext = (
     ui: React.ReactElement,
     streamingState: StreamingState,
-  ) => {
-    const contextValue: StreamingState = streamingState;
-    return renderWithProviders(
-      <StreamingContext.Provider value={contextValue}>
-        {ui}
-      </StreamingContext.Provider>,
-      { uiActions },
-    );
-  };
+  ) =>
+    renderWithProviders(ui, {
+      uiActions,
+      uiState: { streamingState },
+    });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -244,125 +237,5 @@ describe('<ToolMessage />', () => {
       StreamingState.Idle,
     );
     expect(lastFrame()).toContain('MockAnsiOutput:hello');
-  });
-
-  describe('interactive shell focus', () => {
-    const shellProps: ToolMessageProps = {
-      ...baseProps,
-      name: SHELL_COMMAND_NAME,
-      status: ToolCallStatus.Executing,
-      config: {
-        getEnableInteractiveShell: () => true,
-      } as unknown as Config,
-    };
-
-    it('clicks inside the shell area sets focus to true', async () => {
-      const { stdin, lastFrame } = renderWithProviders(
-        <ToolMessage {...shellProps} />,
-        {
-          mouseEventsEnabled: true,
-          uiActions,
-        },
-      );
-
-      await waitFor(() => {
-        expect(lastFrame()).toContain('A tool for testing'); // Wait for render
-      });
-
-      await act(async () => {
-        // Simulate a click inside the shell box
-        // Assuming the box starts at (0,0) because it's the root component in the test
-        stdin.write('\x1b[<0;2;2M'); // Click at column 2, row 2 (1-based)
-      });
-
-      await waitFor(() => {
-        expect(mockSetEmbeddedShellFocused).toHaveBeenCalledWith(true);
-      });
-    });
-
-    it('handles focus for SHELL_TOOL_NAME (core shell tool)', async () => {
-      const coreShellProps: ToolMessageProps = {
-        ...shellProps,
-        name: SHELL_TOOL_NAME,
-      };
-
-      const { stdin, lastFrame } = renderWithProviders(
-        <ToolMessage {...coreShellProps} />,
-        {
-          mouseEventsEnabled: true,
-          uiActions,
-        },
-      );
-
-      await waitFor(() => {
-        expect(lastFrame()).toContain('A tool for testing');
-      });
-
-      await act(async () => {
-        stdin.write('\x1b[<0;2;2M');
-      });
-
-      await waitFor(() => {
-        expect(mockSetEmbeddedShellFocused).toHaveBeenCalledWith(true);
-      });
-    });
-
-    it('clicks outside the shell area sets focus to false', async () => {
-      const { stdin, lastFrame } = renderWithProviders(
-        <ToolMessage {...shellProps} />,
-        {
-          mouseEventsEnabled: true,
-          uiActions,
-        },
-      );
-
-      await waitFor(() => {
-        expect(lastFrame()).toContain('A tool for testing'); // Wait for render
-      });
-
-      await act(async () => {
-        // Simulate a click outside the shell box
-        stdin.write('\x1b[<0;100;100M'); // Click at column 100, row 100
-      });
-
-      await waitFor(() => {
-        expect(mockSetEmbeddedShellFocused).toHaveBeenCalledWith(false);
-      });
-    });
-
-    it('resets focus when shell finishes', async () => {
-      let updateStatus: (s: ToolCallStatus) => void = () => {};
-
-      const Wrapper = () => {
-        const [status, setStatus] = React.useState(ToolCallStatus.Executing);
-        updateStatus = setStatus;
-        return (
-          <ToolMessage
-            {...shellProps}
-            status={status}
-            embeddedShellFocused={true}
-            activeShellPtyId={1}
-            ptyId={1}
-          />
-        );
-      };
-
-      const { lastFrame } = renderWithContext(<Wrapper />, StreamingState.Idle);
-
-      // Verify it is initially focused
-      await waitFor(() => {
-        expect(lastFrame()).toContain('(Focused)');
-      });
-
-      // Now update status to Success
-      await act(async () => {
-        updateStatus(ToolCallStatus.Success);
-      });
-
-      // Should call setEmbeddedShellFocused(false) because isThisShellFocused became false
-      await waitFor(() => {
-        expect(mockSetEmbeddedShellFocused).toHaveBeenCalledWith(false);
-      });
-    });
   });
 });

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -8,7 +8,6 @@ import type React from 'react';
 import { Box } from 'ink';
 import type { IndividualToolCallDisplay } from '../../types.js';
 import { StickyHeader } from '../StickyHeader.js';
-import type { Config } from '@google/gemini-cli-core';
 import { ToolResultDisplay } from './ToolResultDisplay.js';
 import {
   ToolStatusIndicator,
@@ -27,7 +26,6 @@ export interface ToolMessageProps extends IndividualToolCallDisplay {
   isFirst: boolean;
   borderColor: string;
   borderDimColor: boolean;
-  config?: Config;
 }
 
 export const ToolMessage: React.FC<ToolMessageProps> = ({

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -4,44 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { Box, Text } from 'ink';
+import type React from 'react';
+import { Box } from 'ink';
 import type { IndividualToolCallDisplay } from '../../types.js';
-import { ToolCallStatus } from '../../types.js';
-import { DiffRenderer } from './DiffRenderer.js';
-import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
-import { AnsiOutputText } from '../AnsiOutput.js';
-import { GeminiRespondingSpinner } from '../GeminiRespondingSpinner.js';
-import { MaxSizedBox } from '../shared/MaxSizedBox.js';
 import { StickyHeader } from '../StickyHeader.js';
+import type { Config } from '@google/gemini-cli-core';
+import { ToolResultDisplay } from './ToolResultDisplay.js';
 import {
-  SHELL_COMMAND_NAME,
-  SHELL_NAME,
-  TOOL_STATUS,
-} from '../../constants.js';
-import { theme } from '../../semantic-colors.js';
-import type { AnsiOutput, Config } from '@google/gemini-cli-core';
-import { SHELL_TOOL_NAME } from '@google/gemini-cli-core';
-import { useUIState } from '../../contexts/UIStateContext.js';
-import { useAlternateBuffer } from '../../hooks/useAlternateBuffer.js';
+  ToolStatusIndicator,
+  ToolInfo,
+  TrailingIndicator,
+  type TextEmphasis,
+} from './ToolShared.js';
 
-const STATIC_HEIGHT = 1;
-const RESERVED_LINE_COUNT = 5; // for tool name, status, padding etc.
-const STATUS_INDICATOR_WIDTH = 3;
-const MIN_LINES_SHOWN = 2; // show at least this many lines
-
-// Large threshold to ensure we don't cause performance issues for very large
-// outputs that will get truncated further MaxSizedBox anyway.
-const MAXIMUM_RESULT_DISPLAY_CHARACTERS = 1000000;
-export type TextEmphasis = 'high' | 'medium' | 'low';
+export type { TextEmphasis };
 
 export interface ToolMessageProps extends IndividualToolCallDisplay {
   availableTerminalHeight?: number;
   terminalWidth: number;
   emphasis?: TextEmphasis;
   renderOutputAsMarkdown?: boolean;
-  activeShellPtyId?: number | null; // Kept for compatibility/prop spreading, but unused
-  embeddedShellFocused?: boolean; // Kept for compatibility/prop spreading, but unused
   isFirst: boolean;
   borderColor: string;
   borderDimColor: boolean;
@@ -60,225 +42,41 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   isFirst,
   borderColor,
   borderDimColor,
-}) => {
-  const { renderMarkdown } = useUIState();
-  const isAlternateBuffer = useAlternateBuffer();
-
-  const availableHeight = availableTerminalHeight
-    ? Math.max(
-        availableTerminalHeight - STATIC_HEIGHT - RESERVED_LINE_COUNT,
-        MIN_LINES_SHOWN + 1, // enforce minimum lines shown
-      )
-    : undefined;
-
-  // Long tool call response in MarkdownDisplay doesn't respect availableTerminalHeight properly,
-  // so if we aren't using alternate buffer mode, we're forcing it to not render as markdown when the response is too long, it will fallback
-  // to render as plain text, which is contained within the terminal using MaxSizedBox
-  if (availableHeight && !isAlternateBuffer) {
-    renderOutputAsMarkdown = false;
-  }
-  const combinedPaddingAndBorderWidth = 4;
-  const childWidth = terminalWidth - combinedPaddingAndBorderWidth;
-
-  const truncatedResultDisplay = React.useMemo(() => {
-    if (typeof resultDisplay === 'string') {
-      if (resultDisplay.length > MAXIMUM_RESULT_DISPLAY_CHARACTERS) {
-        return '...' + resultDisplay.slice(-MAXIMUM_RESULT_DISPLAY_CHARACTERS);
-      }
-    }
-    return resultDisplay;
-  }, [resultDisplay]);
-
-  const renderedResult = React.useMemo(() => {
-    if (!truncatedResultDisplay) return null;
-
-    return (
-      <Box width={childWidth} flexDirection="column">
-        <Box flexDirection="column">
-          {typeof truncatedResultDisplay === 'string' &&
-          renderOutputAsMarkdown ? (
-            <Box flexDirection="column">
-              <MarkdownDisplay
-                text={truncatedResultDisplay}
-                terminalWidth={childWidth}
-                renderMarkdown={renderMarkdown}
-                isPending={false}
-              />
-            </Box>
-          ) : typeof truncatedResultDisplay === 'string' &&
-            !renderOutputAsMarkdown ? (
-            isAlternateBuffer ? (
-              <Box flexDirection="column" width={childWidth}>
-                <Text wrap="wrap" color={theme.text.primary}>
-                  {truncatedResultDisplay}
-                </Text>
-              </Box>
-            ) : (
-              <MaxSizedBox maxHeight={availableHeight} maxWidth={childWidth}>
-                <Box>
-                  <Text wrap="wrap" color={theme.text.primary}>
-                    {truncatedResultDisplay}
-                  </Text>
-                </Box>
-              </MaxSizedBox>
-            )
-          ) : typeof truncatedResultDisplay === 'object' &&
-            'fileDiff' in truncatedResultDisplay ? (
-            <DiffRenderer
-              diffContent={truncatedResultDisplay.fileDiff}
-              filename={truncatedResultDisplay.fileName}
-              availableTerminalHeight={availableHeight}
-              terminalWidth={childWidth}
-            />
-          ) : typeof truncatedResultDisplay === 'object' &&
-            'todos' in truncatedResultDisplay ? (
-            // display nothing, as the TodoTray will handle rendering todos
-            <></>
-          ) : (
-            <AnsiOutputText
-              data={truncatedResultDisplay as AnsiOutput}
-              availableTerminalHeight={availableHeight}
-              width={childWidth}
-            />
-          )}
-        </Box>
-      </Box>
-    );
-  }, [
-    truncatedResultDisplay,
-    renderOutputAsMarkdown,
-    childWidth,
-    renderMarkdown,
-    isAlternateBuffer,
-    availableHeight,
-  ]);
-
-  return (
-    <Box flexDirection="column" width={terminalWidth}>
-      <StickyHeader
-        width={terminalWidth}
-        isFirst={isFirst}
-        borderColor={borderColor}
-        borderDimColor={borderDimColor}
-      >
-        <ToolStatusIndicator status={status} name={name} />
-        <ToolInfo
-          name={name}
-          status={status}
-          description={description}
-          emphasis={emphasis}
-        />
-        {emphasis === 'high' && <TrailingIndicator />}
-      </StickyHeader>
-      <Box
-        width={terminalWidth}
-        borderStyle="round"
-        borderColor={borderColor}
-        borderDimColor={borderDimColor}
-        borderTop={false}
-        borderBottom={false}
-        borderLeft={true}
-        borderRight={true}
-        paddingX={1}
-        flexDirection="column"
-      >
-        {renderedResult}
-      </Box>
+}) => (
+  <Box flexDirection="column" width={terminalWidth}>
+    <StickyHeader
+      width={terminalWidth}
+      isFirst={isFirst}
+      borderColor={borderColor}
+      borderDimColor={borderDimColor}
+    >
+      <ToolStatusIndicator status={status} name={name} />
+      <ToolInfo
+        name={name}
+        status={status}
+        description={description}
+        emphasis={emphasis}
+      />
+      {emphasis === 'high' && <TrailingIndicator />}
+    </StickyHeader>
+    <Box
+      width={terminalWidth}
+      borderStyle="round"
+      borderColor={borderColor}
+      borderDimColor={borderDimColor}
+      borderTop={false}
+      borderBottom={false}
+      borderLeft={true}
+      borderRight={true}
+      paddingX={1}
+      flexDirection="column"
+    >
+      <ToolResultDisplay
+        resultDisplay={resultDisplay}
+        availableTerminalHeight={availableTerminalHeight}
+        terminalWidth={terminalWidth}
+        renderOutputAsMarkdown={renderOutputAsMarkdown}
+      />
     </Box>
-  );
-};
-
-type ToolStatusIndicatorProps = {
-  status: ToolCallStatus;
-  name: string;
-};
-
-const ToolStatusIndicator: React.FC<ToolStatusIndicatorProps> = ({
-  status,
-  name,
-}) => {
-  const isShell =
-    name === SHELL_COMMAND_NAME ||
-    name === SHELL_NAME ||
-    name === SHELL_TOOL_NAME;
-  const statusColor = isShell ? theme.ui.symbol : theme.status.warning;
-
-  return (
-    <Box minWidth={STATUS_INDICATOR_WIDTH}>
-      {status === ToolCallStatus.Pending && (
-        <Text color={theme.status.success}>{TOOL_STATUS.PENDING}</Text>
-      )}
-      {status === ToolCallStatus.Executing && (
-        <GeminiRespondingSpinner
-          spinnerType="toggle"
-          nonRespondingDisplay={TOOL_STATUS.EXECUTING}
-        />
-      )}
-      {status === ToolCallStatus.Success && (
-        <Text color={theme.status.success} aria-label={'Success:'}>
-          {TOOL_STATUS.SUCCESS}
-        </Text>
-      )}
-      {status === ToolCallStatus.Confirming && (
-        <Text color={statusColor} aria-label={'Confirming:'}>
-          {TOOL_STATUS.CONFIRMING}
-        </Text>
-      )}
-      {status === ToolCallStatus.Canceled && (
-        <Text color={statusColor} aria-label={'Canceled:'} bold>
-          {TOOL_STATUS.CANCELED}
-        </Text>
-      )}
-      {status === ToolCallStatus.Error && (
-        <Text color={theme.status.error} aria-label={'Error:'} bold>
-          {TOOL_STATUS.ERROR}
-        </Text>
-      )}
-    </Box>
-  );
-};
-
-type ToolInfo = {
-  name: string;
-  description: string;
-  status: ToolCallStatus;
-  emphasis: TextEmphasis;
-};
-const ToolInfo: React.FC<ToolInfo> = ({
-  name,
-  description,
-  status,
-  emphasis,
-}) => {
-  const nameColor = React.useMemo<string>(() => {
-    switch (emphasis) {
-      case 'high':
-        return theme.text.primary;
-      case 'medium':
-        return theme.text.primary;
-      case 'low':
-        return theme.text.secondary;
-      default: {
-        const exhaustiveCheck: never = emphasis;
-        return exhaustiveCheck;
-      }
-    }
-  }, [emphasis]);
-  return (
-    <Box overflow="hidden" height={1} flexGrow={1} flexShrink={1}>
-      <Text strikethrough={status === ToolCallStatus.Canceled} wrap="truncate">
-        <Text color={nameColor} bold>
-          {name}
-        </Text>{' '}
-        <Text color={theme.text.secondary}>{description}</Text>
-      </Text>
-    </Box>
-  );
-};
-
-const TrailingIndicator: React.FC = () => (
-  <Text color={theme.text.primary} wrap="truncate">
-    {' '}
-    ←
-  </Text>
+  </Box>
 );

--- a/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { DiffRenderer } from './DiffRenderer.js';
+import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
+import { AnsiOutputText } from '../AnsiOutput.js';
+import { MaxSizedBox } from '../shared/MaxSizedBox.js';
+import { theme } from '../../semantic-colors.js';
+import type { AnsiOutput } from '@google/gemini-cli-core';
+import { useUIState } from '../../contexts/UIStateContext.js';
+import { useAlternateBuffer } from '../../hooks/useAlternateBuffer.js';
+
+const STATIC_HEIGHT = 1;
+const RESERVED_LINE_COUNT = 5; // for tool name, status, padding etc.
+const MIN_LINES_SHOWN = 2; // show at least this many lines
+
+// Large threshold to ensure we don't cause performance issues for very large
+// outputs that will get truncated further MaxSizedBox anyway.
+const MAXIMUM_RESULT_DISPLAY_CHARACTERS = 1000000;
+
+export interface ToolResultDisplayProps {
+  resultDisplay: string | object | undefined;
+  availableTerminalHeight?: number;
+  terminalWidth: number;
+  renderOutputAsMarkdown?: boolean;
+}
+
+interface FileDiffResult {
+  fileDiff: string;
+  fileName: string;
+}
+
+export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({
+  resultDisplay,
+  availableTerminalHeight,
+  terminalWidth,
+  renderOutputAsMarkdown = true,
+}) => {
+  const { renderMarkdown } = useUIState();
+  const isAlternateBuffer = useAlternateBuffer();
+
+  const availableHeight = availableTerminalHeight
+    ? Math.max(
+        availableTerminalHeight - STATIC_HEIGHT - RESERVED_LINE_COUNT,
+        MIN_LINES_SHOWN + 1, // enforce minimum lines shown
+      )
+    : undefined;
+
+  // Long tool call response in MarkdownDisplay doesn't respect availableTerminalHeight properly,
+  // so if we aren't using alternate buffer mode, we're forcing it to not render as markdown when the response is too long, it will fallback
+  // to render as plain text, which is contained within the terminal using MaxSizedBox
+  if (availableHeight && !isAlternateBuffer) {
+    renderOutputAsMarkdown = false;
+  }
+
+  const combinedPaddingAndBorderWidth = 4;
+  const childWidth = terminalWidth - combinedPaddingAndBorderWidth;
+
+  const truncatedResultDisplay = React.useMemo(() => {
+    if (typeof resultDisplay === 'string') {
+      if (resultDisplay.length > MAXIMUM_RESULT_DISPLAY_CHARACTERS) {
+        return '...' + resultDisplay.slice(-MAXIMUM_RESULT_DISPLAY_CHARACTERS);
+      }
+    }
+    return resultDisplay;
+  }, [resultDisplay]);
+
+  if (!truncatedResultDisplay) return null;
+
+  return (
+    <Box width={childWidth} flexDirection="column">
+      <Box flexDirection="column">
+        {typeof truncatedResultDisplay === 'string' &&
+        renderOutputAsMarkdown ? (
+          <Box flexDirection="column">
+            <MarkdownDisplay
+              text={truncatedResultDisplay}
+              terminalWidth={childWidth}
+              renderMarkdown={renderMarkdown}
+              isPending={false}
+            />
+          </Box>
+        ) : typeof truncatedResultDisplay === 'string' &&
+          !renderOutputAsMarkdown ? (
+          isAlternateBuffer ? (
+            <Box flexDirection="column" width={childWidth}>
+              <Text wrap="wrap" color={theme.text.primary}>
+                {truncatedResultDisplay}
+              </Text>
+            </Box>
+          ) : (
+            <MaxSizedBox maxHeight={availableHeight} maxWidth={childWidth}>
+              <Box>
+                <Text wrap="wrap" color={theme.text.primary}>
+                  {truncatedResultDisplay}
+                </Text>
+              </Box>
+            </MaxSizedBox>
+          )
+        ) : typeof truncatedResultDisplay === 'object' &&
+          'fileDiff' in truncatedResultDisplay ? (
+          <DiffRenderer
+            diffContent={(truncatedResultDisplay as FileDiffResult).fileDiff}
+            filename={(truncatedResultDisplay as FileDiffResult).fileName}
+            availableTerminalHeight={availableHeight}
+            terminalWidth={childWidth}
+          />
+        ) : typeof truncatedResultDisplay === 'object' &&
+          'todos' in truncatedResultDisplay ? (
+          // display nothing, as the TodoTray will handle rendering todos
+          <></>
+        ) : (
+          <AnsiOutputText
+            data={truncatedResultDisplay as AnsiOutput}
+            availableTerminalHeight={availableHeight}
+            width={childWidth}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/messages/ToolShared.tsx
+++ b/packages/cli/src/ui/components/messages/ToolShared.tsx
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { ToolCallStatus } from '../../types.js';
+import { GeminiRespondingSpinner } from '../GeminiRespondingSpinner.js';
+import {
+  SHELL_COMMAND_NAME,
+  SHELL_NAME,
+  TOOL_STATUS,
+} from '../../constants.js';
+import { theme } from '../../semantic-colors.js';
+import { SHELL_TOOL_NAME } from '@google/gemini-cli-core';
+
+export const STATUS_INDICATOR_WIDTH = 3;
+
+export type TextEmphasis = 'high' | 'medium' | 'low';
+
+type ToolStatusIndicatorProps = {
+  status: ToolCallStatus;
+  name: string;
+};
+
+export const ToolStatusIndicator: React.FC<ToolStatusIndicatorProps> = ({
+  status,
+  name,
+}) => {
+  const isShell =
+    name === SHELL_COMMAND_NAME ||
+    name === SHELL_NAME ||
+    name === SHELL_TOOL_NAME;
+  const statusColor = isShell ? theme.ui.symbol : theme.status.warning;
+
+  return (
+    <Box minWidth={STATUS_INDICATOR_WIDTH}>
+      {status === ToolCallStatus.Pending && (
+        <Text color={theme.status.success}>{TOOL_STATUS.PENDING}</Text>
+      )}
+      {status === ToolCallStatus.Executing && (
+        <GeminiRespondingSpinner
+          spinnerType="toggle"
+          nonRespondingDisplay={TOOL_STATUS.EXECUTING}
+        />
+      )}
+      {status === ToolCallStatus.Success && (
+        <Text color={theme.status.success} aria-label={'Success:'}>
+          {TOOL_STATUS.SUCCESS}
+        </Text>
+      )}
+      {status === ToolCallStatus.Confirming && (
+        <Text color={statusColor} aria-label={'Confirming:'}>
+          {TOOL_STATUS.CONFIRMING}
+        </Text>
+      )}
+      {status === ToolCallStatus.Canceled && (
+        <Text color={statusColor} aria-label={'Canceled:'} bold>
+          {TOOL_STATUS.CANCELED}
+        </Text>
+      )}
+      {status === ToolCallStatus.Error && (
+        <Text color={theme.status.error} aria-label={'Error:'} bold>
+          {TOOL_STATUS.ERROR}
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+type ToolInfoProps = {
+  name: string;
+  description: string;
+  status: ToolCallStatus;
+  emphasis: TextEmphasis;
+};
+
+export const ToolInfo: React.FC<ToolInfoProps> = ({
+  name,
+  description,
+  status,
+  emphasis,
+}) => {
+  const nameColor = React.useMemo<string>(() => {
+    switch (emphasis) {
+      case 'high':
+        return theme.text.primary;
+      case 'medium':
+        return theme.text.primary;
+      case 'low':
+        return theme.text.secondary;
+      default: {
+        const exhaustiveCheck: never = emphasis;
+        return exhaustiveCheck;
+      }
+    }
+  }, [emphasis]);
+  return (
+    <Box overflow="hidden" height={1} flexGrow={1} flexShrink={1}>
+      <Text strikethrough={status === ToolCallStatus.Canceled} wrap="truncate">
+        <Text color={nameColor} bold>
+          {name}
+        </Text>{' '}
+        <Text color={theme.text.secondary}>{description}</Text>
+      </Text>
+    </Box>
+  );
+};
+
+export const TrailingIndicator: React.FC = () => (
+  <Text color={theme.text.primary} wrap="truncate">
+    {' '}
+    ←
+  </Text>
+);

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -50,6 +50,7 @@ export interface UIActions {
   handleApiKeySubmit: (apiKey: string) => Promise<void>;
   handleApiKeyCancel: () => void;
   setBannerVisible: (visible: boolean) => void;
+  setEmbeddedShellFocused: (value: boolean) => void;
 }
 
 export const UIActionsContext = createContext<UIActions | null>(null);

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.tsx
@@ -419,11 +419,10 @@ describe('useShellCommandProcessor', () => {
     });
     await act(async () => await execPromise);
 
-    const finalHistoryItem = addItemToHistoryMock.mock.calls[1][0];
-    expect(finalHistoryItem.tools[0].status).toBe(ToolCallStatus.Canceled);
-    expect(finalHistoryItem.tools[0].resultDisplay).toContain(
-      'Command was cancelled.',
-    );
+    // With the new logic, cancelled commands are not added to history by this hook
+    // to avoid duplication/flickering, as they are handled by useGeminiStream.
+    expect(addItemToHistoryMock).toHaveBeenCalledTimes(1);
+    expect(setPendingHistoryItemMock).toHaveBeenCalledWith(null);
     expect(setShellInputFocusedMock).toHaveBeenCalledWith(false);
   });
 

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -284,13 +284,17 @@ export const useShellCommandProcessor = (
               };
 
               // Add the complete, contextual result to the local UI history.
-              addItemToHistory(
-                {
-                  type: 'tool_group',
-                  tools: [finalToolDisplay],
-                } as HistoryItemWithoutId,
-                userMessageTimestamp,
-              );
+              // We skip this for cancelled commands because useGeminiStream handles the
+              // immediate addition of the cancelled item to history to prevent flickering/duplicates.
+              if (finalStatus !== ToolCallStatus.Canceled) {
+                addItemToHistory(
+                  {
+                    type: 'tool_group',
+                    tools: [finalToolDisplay],
+                  } as HistoryItemWithoutId,
+                  userMessageTimestamp,
+                );
+              }
 
               // Add the same complete, contextual result to the LLM's history.
               addShellCommandToGeminiHistory(

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -54,6 +54,7 @@ import { findLastSafeSplitPoint } from '../utils/markdownUtilities.js';
 import { useStateAndRef } from './useStateAndRef.js';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { useLogger } from './useLogger.js';
+import { SHELL_COMMAND_NAME } from '../constants.js';
 import {
   useReactToolScheduler,
   mapToDisplay as mapTrackedToolCallsToDisplay,
@@ -232,6 +233,22 @@ export const useGeminiStream = (
     }
   }, [activePtyId, setShellInputFocused]);
 
+  const prevActiveShellPtyIdRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (
+      turnCancelledRef.current &&
+      prevActiveShellPtyIdRef.current !== null &&
+      activeShellPtyId === null
+    ) {
+      addItem(
+        { type: MessageType.INFO, text: 'Request cancelled.' },
+        Date.now(),
+      );
+      setIsResponding(false);
+    }
+    prevActiveShellPtyIdRef.current = activeShellPtyId;
+  }, [activeShellPtyId, addItem]);
+
   const streamingState = useMemo(() => {
     if (toolCalls.some((tc) => tc.status === 'awaiting_approval')) {
       return StreamingState.WaitingForConfirmation;
@@ -306,7 +323,33 @@ export const useGeminiStream = (
     cancelAllToolCalls(abortControllerRef.current.signal);
 
     if (pendingHistoryItemRef.current) {
-      addItem(pendingHistoryItemRef.current, Date.now());
+      const isShellCommand =
+        pendingHistoryItemRef.current.type === 'tool_group' &&
+        pendingHistoryItemRef.current.tools.some(
+          (t) => t.name === SHELL_COMMAND_NAME,
+        );
+
+      // If it is a shell command, we update the status to Canceled and clear the output
+      // to avoid artifacts, then add it to history immediately.
+      if (isShellCommand) {
+        const toolGroup = pendingHistoryItemRef.current as HistoryItemToolGroup;
+        const updatedTools = toolGroup.tools.map((tool) => {
+          if (tool.name === SHELL_COMMAND_NAME) {
+            return {
+              ...tool,
+              status: ToolCallStatus.Canceled,
+              resultDisplay: tool.resultDisplay,
+            };
+          }
+          return tool;
+        });
+        addItem(
+          { ...toolGroup, tools: updatedTools } as HistoryItemWithoutId,
+          Date.now(),
+        );
+      } else {
+        addItem(pendingHistoryItemRef.current, Date.now());
+      }
     }
     setPendingHistoryItem(null);
 
@@ -314,14 +357,18 @@ export const useGeminiStream = (
     // Otherwise, we let handleCompletedTools figure out the next step,
     // which might involve sending partial results back to the model.
     if (isFullCancellation) {
-      addItem(
-        {
-          type: MessageType.INFO,
-          text: 'Request cancelled.',
-        },
-        Date.now(),
-      );
-      setIsResponding(false);
+      // If shell is active, we delay this message to ensure correct ordering
+      // (Shell item first, then Info message).
+      if (!activeShellPtyId) {
+        addItem(
+          {
+            type: MessageType.INFO,
+            text: 'Request cancelled.',
+          },
+          Date.now(),
+        );
+        setIsResponding(false);
+      }
     }
 
     onCancelSubmit();
@@ -335,6 +382,7 @@ export const useGeminiStream = (
     setShellInputFocused,
     cancelAllToolCalls,
     toolCalls,
+    activeShellPtyId,
   ]);
 
   useKeypress(

--- a/packages/cli/src/ui/hooks/useMouseClick.test.ts
+++ b/packages/cli/src/ui/hooks/useMouseClick.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
+import { renderHook } from '../../test-utils/render.js';
+import { useMouseClick } from './useMouseClick.js';
+import { getBoundingBox, type DOMElement } from 'ink';
+import type React from 'react';
+
+// Mock ink
+vi.mock('ink', async () => ({
+  getBoundingBox: vi.fn(),
+}));
+
+// Mock MouseContext
+const mockUseMouse = vi.fn();
+vi.mock('../contexts/MouseContext.js', async () => ({
+  useMouse: (cb: unknown, opts: unknown) => mockUseMouse(cb, opts),
+}));
+
+describe('useMouseClick', () => {
+  let handler: Mock;
+  let containerRef: React.RefObject<DOMElement | null>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = vi.fn();
+    containerRef = { current: {} as DOMElement };
+  });
+
+  it('should call handler with relative coordinates when click is inside bounds', () => {
+    vi.mocked(getBoundingBox).mockReturnValue({
+      x: 10,
+      y: 5,
+      width: 20,
+      height: 10,
+    } as unknown as ReturnType<typeof getBoundingBox>);
+
+    renderHook(() => useMouseClick(containerRef, handler));
+
+    // Get the callback registered with useMouse
+    expect(mockUseMouse).toHaveBeenCalled();
+    const callback = mockUseMouse.mock.calls[0][0];
+
+    // Simulate click inside: x=15 (col 16), y=7 (row 8)
+    // Terminal events are 1-based. col 16 -> mouseX 15. row 8 -> mouseY 7.
+    // relativeX = 15 - 10 = 5
+    // relativeY = 7 - 5 = 2
+    callback({ name: 'left-press', col: 16, row: 8 });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'left-press' }),
+      5,
+      2,
+    );
+  });
+
+  it('should not call handler when click is outside bounds', () => {
+    vi.mocked(getBoundingBox).mockReturnValue({
+      x: 10,
+      y: 5,
+      width: 20,
+      height: 10,
+    } as unknown as ReturnType<typeof getBoundingBox>);
+
+    renderHook(() => useMouseClick(containerRef, handler));
+    const callback = mockUseMouse.mock.calls[0][0];
+
+    // Click outside: x=5 (col 6), y=7 (row 8) -> left of box
+    callback({ name: 'left-press', col: 6, row: 8 });
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/ui/hooks/useMouseClick.ts
+++ b/packages/cli/src/ui/hooks/useMouseClick.ts
@@ -10,7 +10,7 @@ import { useMouse, type MouseEvent } from '../contexts/MouseContext.js';
 
 export const useMouseClick = (
   containerRef: React.RefObject<DOMElement | null>,
-  handler: (event: MouseEvent, x: number, y: number) => void,
+  handler: (event: MouseEvent, relativeX: number, relativeY: number) => void,
   options: { isActive?: boolean; button?: 'left' | 'right' } = {},
 ) => {
   const { isActive = true, button = 'left' } = options;
@@ -24,13 +24,16 @@ export const useMouseClick = (
         const mouseX = event.col - 1;
         const mouseY = event.row - 1;
 
+        const relativeX = mouseX - x;
+        const relativeY = mouseY - y;
+
         if (
-          mouseX >= x &&
-          mouseX < x + width &&
-          mouseY >= y &&
-          mouseY < y + height
+          relativeX >= 0 &&
+          relativeX < width &&
+          relativeY >= 0 &&
+          relativeY < height
         ) {
-          handler(event, mouseX, mouseY);
+          handler(event, relativeX, relativeY);
         }
       }
     },

--- a/packages/cli/src/ui/hooks/useMouseClick.ts
+++ b/packages/cli/src/ui/hooks/useMouseClick.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getBoundingBox, type DOMElement } from 'ink';
+import type React from 'react';
+import { useMouse, type MouseEvent } from '../contexts/MouseContext.js';
+
+export const useMouseClick = (
+  containerRef: React.RefObject<DOMElement | null>,
+  handler: (event: MouseEvent, x: number, y: number) => void,
+  options: { isActive?: boolean; button?: 'left' | 'right' } = {},
+) => {
+  const { isActive = true, button = 'left' } = options;
+
+  useMouse(
+    (event: MouseEvent) => {
+      const eventName = button === 'left' ? 'left-press' : 'right-release';
+      if (event.name === eventName && containerRef.current) {
+        const { x, y, width, height } = getBoundingBox(containerRef.current);
+        // Terminal mouse events are 1-based, Ink layout is 0-based.
+        const mouseX = event.col - 1;
+        const mouseY = event.row - 1;
+
+        if (
+          mouseX >= x &&
+          mouseX < x + width &&
+          mouseY >= y &&
+          mouseY < y + height
+        ) {
+          handler(event, mouseX, mouseY);
+        }
+      }
+    },
+    { isActive },
+  );
+};


### PR DESCRIPTION
## Summary

This PR introduces click-to-focus functionality for the embedded interactive shell. Users can now click within the shell output area to focus it for input, and click on the main prompt area to return focus to the CLI prompt.

## Details

-   **`UIActionsContext`**: Added `setEmbeddedShellFocused` action to manage shell focus state globally.
-   **`ToolMessage`**: Implemented mouse event handling to detect clicks within the shell tool's bounding box, triggering focus.
-   **`InputPrompt`**: Added logic to unfocus the embedded shell when the user clicks on the prompt area.
-   **`useGeminiStream`**: Improved handling of cancelled shell commands to prevent duplicate entries in the history.
-   **Tests**: Added unit tests in `ToolMessage.test.tsx` and `InputPrompt.test.tsx` to verify focus switching behavior via mouse events.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

1.  Ensure `interactive_shell` is enabled in your configuration.
2.  Start the CLI: `npm run start`.
3.  Enter the shell mode or execute a shell command that stays open (e.g., ask "run top").
4.  **Test Focus**: Click inside the running shell output. Confirm that the shell becomes focused (e.g., you can interact with `top`).
5.  **Test Unfocus**: Click on the main input prompt at the bottom. Confirm that the shell loses focus and you can type in the main prompt.
6.  **Run Tests**: Execute `npm test` to ensure all new interaction tests pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
