### PR TITLE
Support 3-parameter modifyOtherKeys sequences

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -405,12 +405,21 @@ describe('KeypressContext', () => {
 
   describe('Parameterized functional keys', () => {
     it.each([
-      // Parameterized
+      // ModifyOtherKeys
+      { sequence: `\x1b[27;2;13~`, expected: { name: 'return', shift: true } },
+      { sequence: `\x1b[27;5;13~`, expected: { name: 'return', ctrl: true } },
+      { sequence: `\x1b[27;5;9~`, expected: { name: 'tab', ctrl: true } },
+      {
+        sequence: `\x1b[27;6;9~`,
+        expected: { name: 'tab', ctrl: true, shift: true },
+      },
+      // XTerm Function Key
       { sequence: `\x1b[1;129A`, expected: { name: 'up' } },
       { sequence: `\x1b[1;2H`, expected: { name: 'home', shift: true } },
       { sequence: `\x1b[1;5F`, expected: { name: 'end', ctrl: true } },
       { sequence: `\x1b[1;1P`, expected: { name: 'f1' } },
       { sequence: `\x1b[1;3Q`, expected: { name: 'f2', meta: true } },
+      // Tilde Function Keys
       { sequence: `\x1b[3~`, expected: { name: 'delete' } },
       { sequence: `\x1b[5~`, expected: { name: 'pageup' } },
       { sequence: `\x1b[6~`, expected: { name: 'pagedown' } },
@@ -441,6 +450,7 @@ describe('KeypressContext', () => {
         sequence: `\x1b[D`,
         expected: { name: 'left', ctrl: false, meta: false, shift: false },
       },
+
       // Legacy Home/End
       {
         sequence: `\x1b[H`,


### PR DESCRIPTION
## Summary

Support 3-parameter modifyOtherKeys sequences

## Details

This should improve support on some terminals and shouldn't hurt us on any of the others since we were ignoring these before.

## Related Issues

Inspired by #13029 (but is not a fix for it)

## How to Validate

When I hit `ctrl+x` to go into vim and then exit again it leaves me in a state where it's sendings keys using this system. We're probably going to fix that eventually anyways, but for now it reveals key sequences that we should support but don't.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
