### PR TITLE
Restore keyboard mode when exiting the editor

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -110,6 +110,7 @@ import { isWorkspaceTrusted } from '../config/trustedFolders.js';
 import { disableMouseEvents, enableMouseEvents } from './utils/mouse.js';
 import { useAlternateBuffer } from './hooks/useAlternateBuffer.js';
 import { useSettings } from './contexts/SettingsContext.js';
+import { enableSupportedProtocol } from './utils/kittyProtocolDetector.js';
 
 const WARNING_PROMPT_DURATION_MS = 1000;
 const QUEUE_ERROR_DISPLAY_DURATION_MS = 3000;
@@ -380,6 +381,11 @@ export const AppContainer = (props: AppContainerProps) => {
     }
     setHistoryRemountKey((prev) => prev + 1);
   }, [setHistoryRemountKey, stdout, isAlternateBuffer]);
+
+  const handleEditorClose = useCallback(() => {
+    enableSupportedProtocol();
+    refreshStatic();
+  }, [refreshStatic]);
 
   const {
     isThemeDialogOpen,
@@ -687,7 +693,7 @@ Logging in with Google... Please restart Gemini CLI to continue.
     performMemoryRefresh,
     modelSwitchedFromQuotaError,
     setModelSwitchedFromQuotaError,
-    refreshStatic,
+    handleEditorClose,
     onCancelSubmit,
     setEmbeddedShellFocused,
     terminalWidth,

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -207,7 +207,6 @@ describe('InputPrompt', () => {
     );
 
     mockedUseKittyKeyboardProtocol.mockReturnValue({
-      supported: false,
       enabled: false,
       checking: false,
     });
@@ -1244,7 +1243,6 @@ describe('InputPrompt', () => {
     beforeEach(() => {
       vi.useFakeTimers();
       mockedUseKittyKeyboardProtocol.mockReturnValue({
-        supported: false,
         enabled: false,
         checking: false,
       });
@@ -1328,7 +1326,6 @@ describe('InputPrompt', () => {
         name: 'kitty',
         setup: () =>
           mockedUseKittyKeyboardProtocol.mockReturnValue({
-            supported: true,
             enabled: true,
             checking: false,
           }),

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -404,7 +404,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
       if (key.paste) {
         // Record paste time to prevent accidental auto-submission
-        if (!isTerminalPasteTrusted(kittyProtocol.supported)) {
+        if (!isTerminalPasteTrusted(kittyProtocol.enabled)) {
           setRecentUnsafePasteTime(Date.now());
 
           // Clear any existing paste timeout
@@ -820,7 +820,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       recentUnsafePasteTime,
       commandSearchActive,
       commandSearchCompletion,
-      kittyProtocol.supported,
+      kittyProtocol.enabled,
       tryLoadQueuedMessages,
       setBannerVisible,
     ],

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -20,6 +20,7 @@ import {
 import type { Key } from '../../contexts/KeypressContext.js';
 import type { VimAction } from './vim-buffer-actions.js';
 import { handleVimAction } from './vim-buffer-actions.js';
+import { enableSupportedProtocol } from '../../utils/kittyProtocolDetector.js';
 
 export type Direction =
   | 'left'
@@ -1891,6 +1892,7 @@ export function useTextBuffer({
       } catch (err) {
         console.error('[useTextBuffer] external editor error', err);
       } finally {
+        enableSupportedProtocol();
         if (wasRaw) setRawMode?.(true);
         try {
           fs.unlinkSync(filePath);

--- a/packages/cli/src/ui/hooks/useKittyKeyboardProtocol.ts
+++ b/packages/cli/src/ui/hooks/useKittyKeyboardProtocol.ts
@@ -5,13 +5,9 @@
  */
 
 import { useState } from 'react';
-import {
-  isKittyProtocolEnabled,
-  isKittyProtocolSupported,
-} from '../utils/kittyProtocolDetector.js';
+import { isKittyProtocolEnabled } from '../utils/kittyProtocolDetector.js';
 
 export interface KittyProtocolStatus {
-  supported: boolean;
   enabled: boolean;
   checking: boolean;
 }
@@ -22,7 +18,6 @@ export interface KittyProtocolStatus {
  */
 export function useKittyKeyboardProtocol(): KittyProtocolStatus {
   const [status] = useState<KittyProtocolStatus>({
-    supported: isKittyProtocolSupported(),
     enabled: isKittyProtocolEnabled(),
     checking: false,
   });


### PR DESCRIPTION
## Summary

Restore keyboard mode when exiting the editor

## How to Validate

hit `ctrl-x` to enter vim editor, exit (with `:q`) and verify that shift enter still works returns `\u001b[13;2u` instead of `\u001b[27;2;13~` or something else.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
