### PR TITLE
Improve pty resize error handling for Windows

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -768,11 +768,13 @@ export class ShellExecutionService {
       } catch (e) {
         // Ignore errors if the pty has already exited, which can happen
         // due to a race condition between the exit event and this call.
-        if (
-          e instanceof Error &&
-          (('code' in e && e.code === 'ESRCH') ||
-            e.message.includes('Cannot resize a pty that has already exited'))
-        ) {
+        const err = e as { code?: string; message?: string };
+        const isEsrch = err.code === 'ESRCH';
+        const isWindowsPtyError = err.message?.includes(
+          'Cannot resize a pty that has already exited',
+        );
+
+        if (isEsrch || isWindowsPtyError) {
           // On Unix, we get an ESRCH error.
           // On Windows, we get a message-based error.
           // In both cases, it's safe to ignore.


### PR DESCRIPTION
  Refactor the error handling in ShellExecutionService to explicitly
  check for Windows-specific PTY resize errors, in addition to the
  existing ESRCH check for Unix. This ensures that errors related to
  resizing an exited PTY are gracefully ignored across both platforms,
  preventing crashes.

