### PR TITLE
bug(ui) showLineNumbers had the wrong default value.

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -224,7 +224,7 @@ their corresponding top-level category object in your `settings.json` file.
 
 - **`ui.showLineNumbers`** (boolean):
   - **Description:** Show line numbers in the chat.
-  - **Default:** `false`
+  - **Default:** `true`
 
 - **`ui.showCitations`** (boolean):
   - **Description:** Show citations for generated text in the chat.

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -480,7 +480,7 @@ const SETTINGS_SCHEMA = {
         label: 'Show Line Numbers',
         category: 'UI',
         requiresRestart: false,
-        default: false,
+        default: true,
         description: 'Show line numbers in the chat.',
         showInDialog: true,
       },

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -264,8 +264,8 @@
         "showLineNumbers": {
           "title": "Show Line Numbers",
           "description": "Show line numbers in the chat.",
-          "markdownDescription": "Show line numbers in the chat.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
+          "markdownDescription": "Show line numbers in the chat.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `true`",
+          "default": true,
           "type": "boolean"
         },
         "showCitations": {


### PR DESCRIPTION
## Summary

This setting had a default of false even though code treated it correctly as having a default of true

## Details

This lead to users believing the setting didn't work as the settings dialog behaved confusingly the first time it was set given the default value was wrong.

## Related Issues

Fixes #11831 
A g3 user also reported this but didn't file an issue.

## How to Validate

Ask Gemini CLI to 
```
Generate markdown with a title and a code sample that calculates fibonacci numbers in python
```
Verify that line numbers are not show when the setting is set to false from the UI.