### PR TITLE
[cli-ui] Keep header ASCII art colored on non-gradient terminals (#13373)

### DIFF
--- a/packages/cli/src/ui/components/Header.test.tsx
+++ b/packages/cli/src/ui/components/Header.test.tsx
@@ -117,12 +117,13 @@ describe('<Header />', () => {
   it('renders with no gradient when theme.ui.gradient is undefined', async () => {
     vi.spyOn(semanticColors, 'theme', 'get').mockReturnValue({
       ui: { gradient: undefined },
+      text: { accent: '#123456' },
     } as typeof semanticColors.theme);
     const Gradient = await import('ink-gradient');
     render(<Header version="1.0.0" nightly={false} />);
     expect(Gradient.default).not.toHaveBeenCalled();
     const textCalls = (Text as Mock).mock.calls;
-    expect(textCalls[0][0]).not.toHaveProperty('color');
+    expect(textCalls[0][0]).toHaveProperty('color', '#123456');
   });
 
   it('renders with a single color when theme.ui.gradient has one color', async () => {

--- a/packages/cli/src/ui/components/Header.test.tsx
+++ b/packages/cli/src/ui/components/Header.test.tsx
@@ -116,9 +116,33 @@ describe('<Header />', () => {
 
   it('renders with no gradient when theme.ui.gradient is undefined', async () => {
     vi.spyOn(semanticColors, 'theme', 'get').mockReturnValue({
-      ui: { gradient: undefined },
-      text: { accent: '#123456' },
-    } as typeof semanticColors.theme);
+      text: {
+        primary: '',
+        secondary: '',
+        link: '',
+        accent: '#123456',
+        response: '',
+      },
+      background: {
+        primary: '',
+        diff: { added: '', removed: '' },
+      },
+      border: {
+        default: '',
+        focused: '',
+      },
+      ui: {
+        comment: '',
+        symbol: '',
+        dark: '',
+        gradient: undefined,
+      },
+      status: {
+        error: '',
+        success: '',
+        warning: '',
+      },
+    });
     const Gradient = await import('ink-gradient');
     render(<Header version="1.0.0" nightly={false} />);
     expect(Gradient.default).not.toHaveBeenCalled();

--- a/packages/cli/src/ui/components/ThemedGradient.tsx
+++ b/packages/cli/src/ui/components/ThemedGradient.tsx
@@ -28,5 +28,10 @@ export const ThemedGradient: React.FC<TextProps> = ({ children, ...props }) => {
     );
   }
 
-  return <Text {...props}>{children}</Text>;
+  // Fallback to accent color if no gradient
+  return (
+    <Text color={theme.text.accent} {...props}>
+      {children}
+    </Text>
+  );
 };


### PR DESCRIPTION
**Closes #13373**

## Summary

This PR updates the `ThemedGradient` component so the header ASCII art always displays with color. When gradient support is unavailable, the component now falls back to the theme’s accent color instead of plain text.

## Motivation

As described in **Issue #13373**, the header ASCII art appears unstyled on terminals that do not support gradients. The fallback previously rendered plain text, reducing readability and overall UI consistency.

## Changes

* Updated `ThemedGradient.tsx`:

  * Use gradient when available
  * Use single gradient color when provided
  * **Fallback to `theme.text.accent` instead of plain text**
* Updated `Header.tsx` to reflect the improved fallback behavior.
* Updated `Header.test.tsx` to expect accent color when gradients are unavailable.

## Result

* Header ASCII art is always colorized.
* Improved readability and visual consistency across all terminal environments.
* No breaking changes.
* Accent color provides:

  * reliable contrast and accessibility
  * presence across all themes
  * correct adaptation to light/dark modes