### PR TITLE
fix: standardize settings naming to use positive phrasing

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -120,6 +120,14 @@ export interface SettingDefinition {
    * Optional reference identifier for generators that emit a `$ref`.
    */
   ref?: string;
+  /**
+   * Whether the setting value is inverted for display (e.g. "Disable X" -> "Enable X").
+   */
+  inverted?: boolean;
+  /**
+   * The label to show when the setting is inverted.
+   */
+  invertedLabel?: string;
 }
 
 export interface SettingsSchema {
@@ -193,8 +201,10 @@ const SETTINGS_SCHEMA = {
         category: 'General',
         requiresRestart: false,
         default: false,
-        description: 'Disable automatic updates',
+        description: 'Toggle automatic updates.',
         showInDialog: true,
+        inverted: true,
+        invertedLabel: 'Enable Auto Update',
       },
       disableUpdateNag: {
         type: 'boolean',
@@ -247,7 +257,7 @@ const SETTINGS_SCHEMA = {
       },
       debugKeystrokeLogging: {
         type: 'boolean',
-        label: 'Debug Keystroke Logging',
+        label: 'Enable Keystroke Logging',
         category: 'General',
         requiresRestart: false,
         default: false,
@@ -368,8 +378,10 @@ const SETTINGS_SCHEMA = {
         category: 'UI',
         requiresRestart: true,
         default: false,
-        description: 'Hide the window title bar',
+        description: 'Toggle visibility of the window title bar.',
         showInDialog: true,
+        inverted: true,
+        invertedLabel: 'Show Window Title',
       },
       showStatusInTitle: {
         type: 'boolean',
@@ -387,8 +399,10 @@ const SETTINGS_SCHEMA = {
         category: 'UI',
         requiresRestart: false,
         default: false,
-        description: 'Hide helpful tips in the UI',
+        description: 'Toggle visibility of helpful tips in the UI.',
         showInDialog: true,
+        inverted: true,
+        invertedLabel: 'Show Tips',
       },
       hideBanner: {
         type: 'boolean',
@@ -396,8 +410,10 @@ const SETTINGS_SCHEMA = {
         category: 'UI',
         requiresRestart: false,
         default: false,
-        description: 'Hide the application banner',
+        description: 'Toggle visibility of the application banner.',
         showInDialog: true,
+        inverted: true,
+        invertedLabel: 'Show Banner',
       },
       hideContextSummary: {
         type: 'boolean',
@@ -406,8 +422,10 @@ const SETTINGS_SCHEMA = {
         requiresRestart: false,
         default: false,
         description:
-          'Hide the context summary (GEMINI.md, MCP servers) above the input.',
+          'Toggle visibility of the context summary (GEMINI.md, MCP servers) above the input.',
         showInDialog: true,
+        inverted: true,
+        invertedLabel: 'Show Context Summary',
       },
       footer: {
         type: 'object',
@@ -425,8 +443,10 @@ const SETTINGS_SCHEMA = {
             requiresRestart: false,
             default: false,
             description:
-              'Hide the current working directory path in the footer.',
+              'Toggle visibility of the current working directory path in the footer.',
             showInDialog: true,
+            inverted: true,
+            invertedLabel: 'Show CWD',
           },
           hideSandboxStatus: {
             type: 'boolean',
@@ -434,8 +454,11 @@ const SETTINGS_SCHEMA = {
             category: 'UI',
             requiresRestart: false,
             default: false,
-            description: 'Hide the sandbox status indicator in the footer.',
+            description:
+              'Toggle visibility of the sandbox status indicator in the footer.',
             showInDialog: true,
+            inverted: true,
+            invertedLabel: 'Show Sandbox Status',
           },
           hideModelInfo: {
             type: 'boolean',
@@ -443,8 +466,11 @@ const SETTINGS_SCHEMA = {
             category: 'UI',
             requiresRestart: false,
             default: false,
-            description: 'Hide the model name and context usage in the footer.',
+            description:
+              'Toggle visibility of the model name and context usage in the footer.',
             showInDialog: true,
+            inverted: true,
+            invertedLabel: 'Show Model Info',
           },
           hideContextPercentage: {
             type: 'boolean',
@@ -452,8 +478,11 @@ const SETTINGS_SCHEMA = {
             category: 'UI',
             requiresRestart: false,
             default: true,
-            description: 'Hides the context window remaining percentage.',
+            description:
+              'Toggle visibility of the context window remaining percentage.',
             showInDialog: true,
+            inverted: true,
+            invertedLabel: 'Show Context Window Percentage',
           },
         },
       },
@@ -463,8 +492,10 @@ const SETTINGS_SCHEMA = {
         category: 'UI',
         requiresRestart: false,
         default: false,
-        description: 'Hide the footer from the UI',
+        description: 'Toggle visibility of the footer from the UI.',
         showInDialog: true,
+        inverted: true,
+        invertedLabel: 'Show Footer',
       },
       showMemoryUsage: {
         type: 'boolean',
@@ -559,8 +590,11 @@ const SETTINGS_SCHEMA = {
             category: 'UI',
             requiresRestart: true,
             default: false,
-            description: 'Disable loading phrases for accessibility',
+            description:
+              'Toggle visibility of loading phrases for accessibility.',
             showInDialog: true,
+            inverted: true,
+            invertedLabel: 'Show Loading Phrases',
           },
           screenReader: {
             type: 'boolean',
@@ -850,8 +884,10 @@ const SETTINGS_SCHEMA = {
             category: 'Context',
             requiresRestart: true,
             default: false,
-            description: 'Disable fuzzy search when searching for files.',
+            description: 'Toggle fuzzy search when searching for files.',
             showInDialog: true,
+            inverted: true,
+            invertedLabel: 'Enable Fuzzy Search',
           },
         },
       },
@@ -1130,6 +1166,8 @@ const SETTINGS_SCHEMA = {
         default: false,
         description: 'Disable YOLO mode, even if enabled by a flag.',
         showInDialog: true,
+        inverted: true,
+        invertedLabel: 'Enable YOLO Mode',
       },
       blockGitExtensions: {
         type: 'boolean',

--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -323,7 +323,7 @@ describe('SettingsDialog', () => {
       });
 
       await waitFor(() => {
-        expect(lastFrame()).toContain('Disable Auto Update');
+        expect(lastFrame()).toContain('Enable Auto Update');
       });
 
       // Navigate up

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -130,7 +130,10 @@ export function SettingsDialog({
       const definition = getSettingDefinition(key);
 
       return {
-        label: definition?.label || key,
+        label:
+          definition?.inverted && definition?.invertedLabel
+            ? definition.invertedLabel
+            : definition?.label || key,
         value: key,
         type: definition?.type,
         toggle: () => {

--- a/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
@@ -10,17 +10,17 @@ exports[`SettingsDialog > Initial Rendering > should render settings list with v
 │                                                                                                  │
 │   Vim Mode                                             false                                     │
 │                                                                                                  │
-│   Disable Auto Update                                  false                                     │
+│   Enable Auto Update                                   true                                      │
 │                                                                                                  │
 │   Enable Prompt Completion                             false                                     │
 │                                                                                                  │
-│   Debug Keystroke Logging                              false                                     │
+│   Enable Keystroke Logging                             false                                     │
 │                                                                                                  │
 │   Enable Session Cleanup                               false                                     │
 │                                                                                                  │
 │   Output Format                                        Text                                      │
 │                                                                                                  │
-│   Hide Window Title                                    false                                     │
+│   Show Window Title                                    true                                      │
 │                                                                                                  │
 │ ▼                                                                                                │
 │                                                                                                  │
@@ -45,17 +45,17 @@ exports[`SettingsDialog > Snapshot Tests > should render 'accessibility settings
 │                                                                                                  │
 │   Vim Mode                                             true*                                     │
 │                                                                                                  │
-│   Disable Auto Update                                  false                                     │
+│   Enable Auto Update                                   true                                      │
 │                                                                                                  │
 │   Enable Prompt Completion                             false                                     │
 │                                                                                                  │
-│   Debug Keystroke Logging                              false                                     │
+│   Enable Keystroke Logging                             false                                     │
 │                                                                                                  │
 │   Enable Session Cleanup                               false                                     │
 │                                                                                                  │
 │   Output Format                                        Text                                      │
 │                                                                                                  │
-│   Hide Window Title                                    false                                     │
+│   Show Window Title                                    true                                      │
 │                                                                                                  │
 │ ▼                                                                                                │
 │                                                                                                  │
@@ -80,17 +80,17 @@ exports[`SettingsDialog > Snapshot Tests > should render 'all boolean settings d
 │                                                                                                  │
 │   Vim Mode                                             false*                                    │
 │                                                                                                  │
-│   Disable Auto Update                                  false*                                    │
+│   Enable Auto Update                                   true*                                     │
 │                                                                                                  │
 │   Enable Prompt Completion                             false*                                    │
 │                                                                                                  │
-│   Debug Keystroke Logging                              false*                                    │
+│   Enable Keystroke Logging                             false*                                    │
 │                                                                                                  │
 │   Enable Session Cleanup                               false                                     │
 │                                                                                                  │
 │   Output Format                                        Text                                      │
 │                                                                                                  │
-│   Hide Window Title                                    false*                                    │
+│   Show Window Title                                    true*                                     │
 │                                                                                                  │
 │ ▼                                                                                                │
 │                                                                                                  │
@@ -115,17 +115,17 @@ exports[`SettingsDialog > Snapshot Tests > should render 'default state' correct
 │                                                                                                  │
 │   Vim Mode                                             false                                     │
 │                                                                                                  │
-│   Disable Auto Update                                  false                                     │
+│   Enable Auto Update                                   true                                      │
 │                                                                                                  │
 │   Enable Prompt Completion                             false                                     │
 │                                                                                                  │
-│   Debug Keystroke Logging                              false                                     │
+│   Enable Keystroke Logging                             false                                     │
 │                                                                                                  │
 │   Enable Session Cleanup                               false                                     │
 │                                                                                                  │
 │   Output Format                                        Text                                      │
 │                                                                                                  │
-│   Hide Window Title                                    false                                     │
+│   Show Window Title                                    true                                      │
 │                                                                                                  │
 │ ▼                                                                                                │
 │                                                                                                  │
@@ -150,17 +150,17 @@ exports[`SettingsDialog > Snapshot Tests > should render 'file filtering setting
 │                                                                                                  │
 │   Vim Mode                                             false                                     │
 │                                                                                                  │
-│   Disable Auto Update                                  false                                     │
+│   Enable Auto Update                                   true                                      │
 │                                                                                                  │
 │   Enable Prompt Completion                             false                                     │
 │                                                                                                  │
-│   Debug Keystroke Logging                              false                                     │
+│   Enable Keystroke Logging                             false                                     │
 │                                                                                                  │
 │   Enable Session Cleanup                               false                                     │
 │                                                                                                  │
 │   Output Format                                        Text                                      │
 │                                                                                                  │
-│   Hide Window Title                                    false                                     │
+│   Show Window Title                                    true                                      │
 │                                                                                                  │
 │ ▼                                                                                                │
 │                                                                                                  │
@@ -185,17 +185,17 @@ exports[`SettingsDialog > Snapshot Tests > should render 'focused on scope selec
 │                                                                                                  │
 │   Vim Mode                                             false                                     │
 │                                                                                                  │
-│   Disable Auto Update                                  false                                     │
+│   Enable Auto Update                                   true                                      │
 │                                                                                                  │
 │   Enable Prompt Completion                             false                                     │
 │                                                                                                  │
-│   Debug Keystroke Logging                              false                                     │
+│   Enable Keystroke Logging                             false                                     │
 │                                                                                                  │
 │   Enable Session Cleanup                               false                                     │
 │                                                                                                  │
 │   Output Format                                        Text                                      │
 │                                                                                                  │
-│   Hide Window Title                                    false                                     │
+│   Show Window Title                                    true                                      │
 │                                                                                                  │
 │ ▼                                                                                                │
 │                                                                                                  │
@@ -220,17 +220,17 @@ exports[`SettingsDialog > Snapshot Tests > should render 'mixed boolean and numb
 │                                                                                                  │
 │   Vim Mode                                             false*                                    │
 │                                                                                                  │
-│   Disable Auto Update                                  true*                                     │
+│   Enable Auto Update                                   false*                                    │
 │                                                                                                  │
 │   Enable Prompt Completion                             false                                     │
 │                                                                                                  │
-│   Debug Keystroke Logging                              false                                     │
+│   Enable Keystroke Logging                             false                                     │
 │                                                                                                  │
 │   Enable Session Cleanup                               false                                     │
 │                                                                                                  │
 │   Output Format                                        Text                                      │
 │                                                                                                  │
-│   Hide Window Title                                    false*                                    │
+│   Show Window Title                                    true*                                     │
 │                                                                                                  │
 │ ▼                                                                                                │
 │                                                                                                  │
@@ -255,17 +255,17 @@ exports[`SettingsDialog > Snapshot Tests > should render 'tools and security set
 │                                                                                                  │
 │   Vim Mode                                             false                                     │
 │                                                                                                  │
-│   Disable Auto Update                                  false                                     │
+│   Enable Auto Update                                   true                                      │
 │                                                                                                  │
 │   Enable Prompt Completion                             false                                     │
 │                                                                                                  │
-│   Debug Keystroke Logging                              false                                     │
+│   Enable Keystroke Logging                             false                                     │
 │                                                                                                  │
 │   Enable Session Cleanup                               false                                     │
 │                                                                                                  │
 │   Output Format                                        Text                                      │
 │                                                                                                  │
-│   Hide Window Title                                    false                                     │
+│   Show Window Title                                    true                                      │
 │                                                                                                  │
 │ ▼                                                                                                │
 │                                                                                                  │
@@ -290,17 +290,17 @@ exports[`SettingsDialog > Snapshot Tests > should render 'various boolean settin
 │                                                                                                  │
 │   Vim Mode                                             true*                                     │
 │                                                                                                  │
-│   Disable Auto Update                                  true*                                     │
+│   Enable Auto Update                                   false*                                    │
 │                                                                                                  │
 │   Enable Prompt Completion                             true*                                     │
 │                                                                                                  │
-│   Debug Keystroke Logging                              true*                                     │
+│   Enable Keystroke Logging                             true*                                     │
 │                                                                                                  │
 │   Enable Session Cleanup                               false                                     │
 │                                                                                                  │
 │   Output Format                                        Text                                      │
 │                                                                                                  │
-│   Hide Window Title                                    true*                                     │
+│   Show Window Title                                    false*                                    │
 │                                                                                                  │
 │ ▼                                                                                                │
 │                                                                                                  │

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -442,6 +442,17 @@ export function getDisplayValue(
     value = getDefaultValue(key);
   }
 
+  const originalValue = value;
+
+  // Handle inversion if configured
+  if (
+    definition?.type === 'boolean' &&
+    definition.inverted &&
+    typeof value === 'boolean'
+  ) {
+    value = !value;
+  }
+
   let valueString = String(value);
 
   if (definition?.type === 'enum' && definition.options) {
@@ -451,7 +462,7 @@ export function getDisplayValue(
 
   // Check if value is different from default OR if it's in modified settings OR if there are pending changes
   const defaultValue = getDefaultValue(key);
-  const isChangedFromDefault = value !== defaultValue;
+  const isChangedFromDefault = originalValue !== defaultValue;
   const isInModifiedSettings = modifiedSettings.has(key);
 
   // Mark as modified if setting exists in current scope OR is in modified settings


### PR DESCRIPTION
## Summary
Addresses issue #13380 by standardizing settings naming to use positive phrasing instead of negative/confusing double-negatives.

## Changes
- Added `inverted` property to settings schema for settings with negative naming (e.g., "Disable Auto Update")
- Added `invertedLabel` to display positive phrasing in the UI (e.g., "Enable Auto Update")
- Updated settings display logic to properly invert boolean values for inverted settings
- Updated all affected tests and snapshots

## Examples
- "Disable Auto Update" → "Enable Auto Update"
- "Hide Window Title" → "Show Window Title"
- "Hide Tips" → "Show Tips"
- "Disable Fuzzy Search" → "Enable Fuzzy Search"

This improves UX by eliminating confusing constructs like "Disable X: false" in favor of clearer "Enable X: true".

Fixes #13380