### PR TITLE
feat: Display an interacitve spinner during `WaitingForConfirmation` state instead of a static character.

### DIFF
--- a/packages/cli/src/ui/components/GeminiRespondingSpinner.test.tsx
+++ b/packages/cli/src/ui/components/GeminiRespondingSpinner.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { render } from '../../test-utils/render.js';
+import { GeminiRespondingSpinner } from './GeminiRespondingSpinner.js';
+import { StreamingContext } from '../contexts/StreamingContext.js';
+import { StreamingState } from '../types.js';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import * as ink from 'ink';
+import {
+  SCREEN_READER_RESPONDING,
+  SCREEN_READER_WAITING_FOR_CONFIRMATION,
+} from '../textConstants.js';
+
+vi.mock('ink', async () => {
+  const actual = await vi.importActual('ink');
+  return {
+    ...actual,
+    useIsScreenReaderEnabled: vi.fn(),
+  };
+});
+
+const useIsScreenReaderEnabledMock = vi.mocked(ink.useIsScreenReaderEnabled);
+
+const renderWithContext = (
+  ui: React.ReactElement,
+  streamingStateValue: StreamingState,
+) =>
+  render(
+    <StreamingContext.Provider value={streamingStateValue}>
+      {ui}
+    </StreamingContext.Provider>,
+  );
+
+describe('GeminiRespondingSpinner', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should render responding alt text when Responding and screen reader is enabled', () => {
+    useIsScreenReaderEnabledMock.mockReturnValue(true);
+    const { lastFrame } = renderWithContext(
+      <GeminiRespondingSpinner />,
+      StreamingState.Responding,
+    );
+    expect(lastFrame()).toContain(SCREEN_READER_RESPONDING);
+  });
+
+  it('should render waiting alt text when WaitingForConfirmation and screen reader is enabled', () => {
+    useIsScreenReaderEnabledMock.mockReturnValue(true);
+    const { lastFrame } = renderWithContext(
+      <GeminiRespondingSpinner />,
+      StreamingState.WaitingForConfirmation,
+    );
+    expect(lastFrame()).toContain(SCREEN_READER_WAITING_FOR_CONFIRMATION);
+  });
+});

--- a/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
+++ b/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
@@ -13,6 +13,7 @@ import { StreamingState } from '../types.js';
 import {
   SCREEN_READER_LOADING,
   SCREEN_READER_RESPONDING,
+  SCREEN_READER_WAITING_FOR_CONFIRMATION,
 } from '../textConstants.js';
 import { theme } from '../semantic-colors.js';
 
@@ -37,7 +38,11 @@ export const GeminiRespondingSpinner: React.FC<
     return (
       <GeminiSpinner
         spinnerType={spinnerType}
-        altText={SCREEN_READER_RESPONDING}
+        altText={
+          streamingState === StreamingState.WaitingForConfirmation
+            ? SCREEN_READER_WAITING_FOR_CONFIRMATION
+            : SCREEN_READER_RESPONDING
+        }
       />
     );
   } else if (nonRespondingDisplay) {

--- a/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
+++ b/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
@@ -30,7 +30,10 @@ export const GeminiRespondingSpinner: React.FC<
 > = ({ nonRespondingDisplay, spinnerType = 'dots' }) => {
   const streamingState = useStreamingContext();
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
-  if (streamingState === StreamingState.Responding) {
+  if (
+    streamingState === StreamingState.Responding ||
+    streamingState === StreamingState.WaitingForConfirmation
+  ) {
     return (
       <GeminiSpinner
         spinnerType={spinnerType}

--- a/packages/cli/src/ui/components/LoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.test.tsx
@@ -21,7 +21,10 @@ vi.mock('./GeminiRespondingSpinner.js', () => ({
     nonRespondingDisplay?: string;
   }) => {
     const streamingState = React.useContext(StreamingContext)!;
-    if (streamingState === StreamingState.Responding) {
+    if (
+      streamingState === StreamingState.Responding ||
+      streamingState === StreamingState.WaitingForConfirmation
+    ) {
       return <Text>MockRespondingSpinner</Text>;
     } else if (nonRespondingDisplay) {
       return <Text>{nonRespondingDisplay}</Text>;
@@ -86,7 +89,7 @@ describe('<LoadingIndicator />', () => {
       StreamingState.WaitingForConfirmation,
     );
     const output = lastFrame();
-    expect(output).toContain('⠏'); // Static char for WaitingForConfirmation
+    expect(output).toContain('MockRespondingSpinner'); // Should now use the spinner
     expect(output).toContain('Confirm action');
     expect(output).not.toContain('(esc to cancel)');
     expect(output).not.toContain(', 10s');
@@ -172,7 +175,7 @@ describe('<LoadingIndicator />', () => {
       </StreamingContext.Provider>,
     );
     output = lastFrame();
-    expect(output).toContain('⠏');
+    expect(output).toContain('MockRespondingSpinner');
     expect(output).toContain('Please Confirm');
     expect(output).not.toContain('(esc to cancel)');
     expect(output).not.toContain(', 15s');

--- a/packages/cli/src/ui/components/LoadingIndicator.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.tsx
@@ -53,13 +53,7 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
       >
         <Box>
           <Box marginRight={1}>
-            <GeminiRespondingSpinner
-              nonRespondingDisplay={
-                streamingState === StreamingState.WaitingForConfirmation
-                  ? '⠏'
-                  : ''
-              }
-            />
+            <GeminiRespondingSpinner />
           </Box>
           {primaryText && (
             <Text color={theme.text.accent} wrap="truncate-end">

--- a/packages/cli/src/ui/textConstants.ts
+++ b/packages/cli/src/ui/textConstants.ts
@@ -11,3 +11,6 @@ export const SCREEN_READER_MODEL_PREFIX = 'Model: ';
 export const SCREEN_READER_LOADING = 'loading';
 
 export const SCREEN_READER_RESPONDING = 'responding';
+
+export const SCREEN_READER_WAITING_FOR_CONFIRMATION =
+  'waiting for user confirmation';


### PR DESCRIPTION
## Summary
![simplescreenrecorder-2025-11-19_15 27 31](https://github.com/user-attachments/assets/5c52ea8e-e2b2-4873-b356-6354f09c7017)


This PR replaces the static `"⠏"` character shown during the **Waiting for user confirmation** state with an animated spinner. This improves the usability and consistency of the CLI by clearly indicating that the application is active and awaiting user input.

## Details

* Updated **`GeminiRespondingSpinner.tsx`** so that `GeminiRespondingSpinner` now renders `GeminiSpinner` when `streamingState === WaitingForConfirmation`, matching the behavior used for the `Responding` state.
* Updated **`LoadingIndicator.tsx`** by removing the `nonRespondingDisplay="⠏"` prop for the WaitingForConfirmation state, since spinner display is now handled internally by `GeminiRespondingSpinner`.
* Updated component tests to expect an animated spinner instead of static text for WaitingForConfirmation.

## Related Issues

Related to:   #13395

## How to Validate

1. **Run automated tests**

   * `npm test packages/cli/src/ui/components/LoadingIndicator.test.tsx`
   * `npm test packages/cli/src/ui/hooks/useLoadingIndicator.test.tsx` (if affected)
2. **Manual verification**

   * Run the CLI and initiate any flow that triggers a confirmation prompt.
   * Confirm that:

     * A spinner is displayed next to “Waiting for user confirmation…”
     * The spinner animates correctly.
     * No static `"⠏"` character is shown.

## Pre-Merge Checklist

* [ ] Updated relevant documentation and README (if needed)
* [ ] Added/updated tests (if needed)
* [ ] Noted breaking changes (if any)
* [ ] Validated on required platforms/methods:

  * [ ] MacOS

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
    * [ ] Podman
    * [ ] Seatbelt
  * [ ] Windows

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
  * [ ] Linux

    * [x] npm run
    * [ ] npx
    * [ ] Docker

