### PR TITLE
fix(core): Handle fatal: not a git repository (or any of the parent directories) in Apple Silicon Macs

### DIFF
--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -67,7 +67,13 @@ export class GitService {
     await fs.writeFile(gitConfigPath, gitConfigContent);
 
     const repo = simpleGit(repoDir);
-    const isRepoDefined = await repo.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
+    let isRepoDefined = false;
+    try {
+      isRepoDefined = await repo.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
+    } catch (error) {
+      // On M1 Macs, simple-git throws an error instead of returning false.
+      // We can safely ignore this error and proceed to initialize the repo.
+    }
 
     if (!isRepoDefined) {
       await repo.init(false, {

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -73,6 +73,9 @@ export class GitService {
     } catch (error) {
       // On M1 Macs, simple-git throws an error instead of returning false.
       // We can safely ignore this error and proceed to initialize the repo.
+      if (!(error instanceof Error && error.message.includes('fatal: not a git repository'))) {
+        throw error;
+      }
     }
 
     if (!isRepoDefined) {


### PR DESCRIPTION
On Apple Silicon (M1) Macs, the gemini-cli fails to initialize with an unhandled promise rejection. This is caused by the simple-git library throwing an exception when checking if a directory is a git repository, instead of returning false. The error is `fatal: not a git repository (or any of the parent directories): .git.` 

This patch wraps the call to repo.checkIsRepo() within a try...catch block in packages/core/src/services/gitService.ts. This change gracefully handles the exception thrown by simple-git on M1 Macs and allows the initialization process to proceed as intended.

The behavior on other platforms remains unaffected. If checkIsRepo() returns false or throws an error, the code will now correctly proceed to initialize the shadow repository.

**Summary**

On Apple Silicon (M1) Macs, gemini-cli fails to initialize in a non-git directory due to an unhandled exception from the simple-git library. This PR fixes the issue by catching the exception, allowing the CLI to function correctly on M1 devices.

**Details**

The simple-git library throws a fatal: not a git repository error instead of returning false when checkIsRepo() is called in a non-git directory on Apple Silicon Macs. This unhandled promise rejection crashes the gemini-cli during initialization.

This patch wraps the repo.checkIsRepo() call within a try...catch block in packages/core/src/services/gitService.ts. The change gracefully handles the exception and allows the initialization process to proceed as intended, creating a shadow repository. The behavior on other platforms is unaffected.

**Related Issues**
https://github.com/google-gemini/gemini-cli/issues/11570

How to Validate
   1. On an Apple Silicon (M1) Mac, navigate to a directory that is (and not is) a git repository.
   2. Run gemini-cli.
   3. Verify that the CLI starts up without any unhandled promise rejection errors related to git.
   4. Verify that the checkpointing feature works as expected.
