### PR TITLE
feat(zed-integration): Use default model routing for Zed integration

### DIFF
--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -27,11 +27,9 @@ import {
   DiscoveredMCPTool,
   StreamEventType,
   ToolCallEvent,
-  DEFAULT_GEMINI_MODEL,
-  DEFAULT_GEMINI_MODEL_AUTO,
-  DEFAULT_GEMINI_FLASH_MODEL,
   debugLogger,
   ReadManyFilesTool,
+  getEffectiveModel,
 } from '@google/gemini-cli-core';
 import * as acp from './acp.js';
 import { AcpFileSystemService } from './fileSystemService.js';
@@ -46,19 +44,6 @@ import { z } from 'zod';
 import { randomUUID } from 'node:crypto';
 import type { CliArgs } from '../config/config.js';
 import { loadCliConfig } from '../config/config.js';
-
-/**
- * Resolves the model to use based on the current configuration.
- *
- * If the model is set to "auto", it will use the flash model if in fallback
- * mode, otherwise it will use the default model.
- */
-export function resolveModel(model: string, isInFallbackMode: boolean): string {
-  if (model === DEFAULT_GEMINI_MODEL_AUTO) {
-    return isInFallbackMode ? DEFAULT_GEMINI_FLASH_MODEL : DEFAULT_GEMINI_MODEL;
-  }
-  return model;
-}
 
 export async function runZedIntegration(
   config: Config,
@@ -264,9 +249,10 @@ class Session {
       const functionCalls: FunctionCall[] = [];
 
       try {
-        const model = resolveModel(
-          this.config.getModel(),
+        const model = getEffectiveModel(
           this.config.isInFallbackMode(),
+          this.config.getModel(),
+          this.config.getPreviewFeatures(),
         );
         const responseStream = await chat.sendMessageStream(
           { model },


### PR DESCRIPTION
## Summary

Refactors the model selection to use the default `getEffectiveModel`
instead of the custom function in the Zed integration.

This has the benefit of allowing users to use Gemini 3 if they have
enabled the preview features.

## Details

Previously @skeshive did some work to allow the Zed integration to utilize the fallback model routing.

This updates this implementation to use the same logic as the core CLI in terms of choosing between fallback models and preview models.

## How to Validate

Run `npm run build` and put the following config in your Zed settings.json

```json
{
  "agent_servers": {
    "jimandi": {
      "command": "/path/to/your/repo/gemini-cli/packages/cli/dist/index.js",
      "args": ["--experimental-acp"]
    }
  }
}
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
