### PR TITLE
fix(zed-integration): Correctly handle cancellation errors

### DIFF
--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -318,6 +318,13 @@ class Session {
           );
         }
 
+        if (
+          pendingSend.signal.aborted ||
+          (error instanceof Error && error.name === 'AbortError')
+        ) {
+          return { stopReason: 'cancelled' };
+        }
+
         throw error;
       }
 


### PR DESCRIPTION
## Summary

When the user cancelled the request, there was an unhandled AbortError that should have been classified as a cancelled stop reason.

This fixes the issue.

## Related Issues

Closes: https://github.com/agentclientprotocol/agent-client-protocol/issues/171

## How to Validate

Run npm run build and put the following config in your Zed settings.json

```json
{
  "agent_servers": {
    "jimandi": {
      "command": "/path/to/your/repo/gemini-cli/packages/cli/dist/index.js",
      "args": ["--experimental-acp"]
    }
  }
}
```

In the command palette, run `dev: open acp logs`

Start a prompt and quickly hit `esc` to cancel the request.

Observe that there are no more errors returned from the prompt request, but rather a cancelled stop reason.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
