### PR TITLE
use consistent relative links to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,7 +256,7 @@ npm run test:e2e
 ```
 
 For more detailed information on the integration testing framework, please see
-the [Integration Tests documentation](./integration-tests.md).
+the [Integration Tests documentation](/docs/integration-tests.md).
 
 ### Linting and preflight checks
 
@@ -390,7 +390,7 @@ used for the CLI's interface, is compatible with React DevTools version 4.x.
     ```
 
     Your running CLI application should then connect to React DevTools.
-    ![](./assets/connected_devtools.png)
+    ![](/docs/assets/connected_devtools.png)
 
 ### Sandboxing
 
@@ -485,7 +485,7 @@ code.
 
 ### Documentation structure
 
-Our documentation is organized using [sidebar.json](./sidebar.json) as the
+Our documentation is organized using [sidebar.json](/docs/sidebar.json) as the
 table of contents. When adding new documentation:
 
 1. Create your markdown file **in the appropriate directory** under `/docs`.
@@ -537,7 +537,7 @@ Before submitting your documentation pull request, please:
 
 If you have questions about contributing documentation:
 
-- Check our [FAQ](./faq.md).
+- Check our [FAQ](/docs/faq.md).
 - Review existing documentation for examples.
 - Open [an issue](https://github.com/google-gemini/gemini-cli/issues) to discuss
   your proposed changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,7 +256,7 @@ npm run test:e2e
 ```
 
 For more detailed information on the integration testing framework, please see
-the [Integration Tests documentation](/docs/integration-tests.md).
+the [Integration Tests documentation](./docs/integration-tests.md).
 
 ### Linting and preflight checks
 
@@ -390,7 +390,7 @@ used for the CLI's interface, is compatible with React DevTools version 4.x.
     ```
 
     Your running CLI application should then connect to React DevTools.
-    ![](/docs/assets/connected_devtools.png)
+    ![](./docs/assets/connected_devtools.png)
 
 ### Sandboxing
 
@@ -485,7 +485,7 @@ code.
 
 ### Documentation structure
 
-Our documentation is organized using [sidebar.json](/docs/sidebar.json) as the
+Our documentation is organized using [sidebar.json](./docs/sidebar.json) as the
 table of contents. When adding new documentation:
 
 1. Create your markdown file **in the appropriate directory** under `/docs`.
@@ -537,7 +537,7 @@ Before submitting your documentation pull request, please:
 
 If you have questions about contributing documentation:
 
-- Check our [FAQ](/docs/faq.md).
+- Check our [FAQ](./docs/faq.md).
 - Review existing documentation for examples.
 - Open [an issue](https://github.com/google-gemini/gemini-cli/issues) to discuss
   your proposed changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,7 +256,7 @@ npm run test:e2e
 ```
 
 For more detailed information on the integration testing framework, please see
-the [Integration Tests documentation](./docs/integration-tests.md).
+the [Integration Tests documentation](./integration-tests.md).
 
 ### Linting and preflight checks
 
@@ -390,7 +390,7 @@ used for the CLI's interface, is compatible with React DevTools version 4.x.
     ```
 
     Your running CLI application should then connect to React DevTools.
-    ![](./docs/assets/connected_devtools.png)
+    ![](./assets/connected_devtools.png)
 
 ### Sandboxing
 
@@ -485,7 +485,7 @@ code.
 
 ### Documentation structure
 
-Our documentation is organized using [sidebar.json](./docs/sidebar.json) as the
+Our documentation is organized using [sidebar.json](./sidebar.json) as the
 table of contents. When adding new documentation:
 
 1. Create your markdown file **in the appropriate directory** under `/docs`.
@@ -537,7 +537,7 @@ Before submitting your documentation pull request, please:
 
 If you have questions about contributing documentation:
 
-- Check our [FAQ](./docs/faq.md).
+- Check our [FAQ](./faq.md).
 - Review existing documentation for examples.
 - Open [an issue](https://github.com/google-gemini/gemini-cli/issues) to discuss
   your proposed changes.

--- a/README.md
+++ b/README.md
@@ -360,13 +360,13 @@ for planned features and priorities.
 
 ### Uninstall
 
-See the [Uninstall Guide](docs/cli/uninstall.md) for removal instructions.
+See the [Uninstall Guide](./docs/cli/uninstall.md) for removal instructions.
 
 ## 📄 Legal
 
-- **License**: [Apache License 2.0](LICENSE)
+- **License**: [Apache License 2.0](./LICENSE)
 - **Terms of Service**: [Terms & Privacy](./docs/tos-privacy.md)
-- **Security**: [Security Policy](SECURITY.md)
+- **Security**: [Security Policy](./SECURITY.md)
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,11 +13,11 @@ input:
       as handling the initial user input, presenting the final output, and
       managing the overall user experience.
     - **Key functions contained in the package:**
-      - [Input processing](/docs/cli/commands.md)
+      - [Input processing](./cli/commands.md)
       - History management
       - Display rendering
-      - [Theme and UI customization](/docs/cli/themes.md)
-      - [CLI configuration settings](/docs/get-started/configuration.md)
+      - [Theme and UI customization](./cli/themes.md)
+      - [CLI configuration settings](./get-started/configuration.md)
 
 2.  **Core package (`packages/core`):**
     - **Purpose:** This acts as the backend for the Gemini CLI. It receives

--- a/docs/tos-privacy.md
+++ b/docs/tos-privacy.md
@@ -10,7 +10,7 @@ and Privacy Notices applicable to those services apply to such access and use.
 Your Gemini CLI Usage Statistics are handled in accordance with Google's Privacy
 Policy.
 
-**Note:** See [quotas and pricing](/docs/quota-and-pricing.md) for the quota and
+**Note:** See [quotas and pricing](./quota-and-pricing.md) for the quota and
 pricing details that apply to your usage of the Gemini CLI.
 
 ## Supported authentication methods


### PR DESCRIPTION
## Summary

Use relative paths for referencing other documentation files across all documentation

## Details

Relative links seem to work better with IDEs, the links work when relative (e.g. ./docs/architecture.md), but don't when absolute (e.g. /docs/architecture.md)

## Related Issues

## How to Validate

Can click links in changed files on this branch

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)

