### PR TITLE
fix(cli): send gemini-cli version as mcp client version

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -451,7 +451,7 @@ export async function loadCliConfig(
     workspaceDir: cwd,
     enabledExtensionOverrides: argv.extensions,
     eventEmitter: appEvents as EventEmitter<ExtensionEvents>,
-    clientVersion: await getCliVersion(),
+    clientVersion: await getVersion(),
   });
   await extensionManager.loadExtensions();
 
@@ -654,7 +654,7 @@ export async function loadCliConfig(
 
   return new Config({
     sessionId,
-    clientVersion: await getCliVersion(),
+    clientVersion: await getVersion(),
     embeddingModel: DEFAULT_GEMINI_EMBEDDING_MODEL,
     sandbox: sandboxConfig,
     targetDir: cwd,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -451,6 +451,7 @@ export async function loadCliConfig(
     workspaceDir: cwd,
     enabledExtensionOverrides: argv.extensions,
     eventEmitter: appEvents as EventEmitter<ExtensionEvents>,
+    clientVersion: await getCliVersion(),
   });
   await extensionManager.loadExtensions();
 
@@ -653,7 +654,7 @@ export async function loadCliConfig(
 
   return new Config({
     sessionId,
-    clientVersion: getCliVersion(),
+    clientVersion: await getCliVersion(),
     embeddingModel: DEFAULT_GEMINI_EMBEDDING_MODEL,
     sandbox: sandboxConfig,
     targetDir: cwd,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -653,6 +653,7 @@ export async function loadCliConfig(
 
   return new Config({
     sessionId,
+    clientVersion: getCliVersion(),
     embeddingModel: DEFAULT_GEMINI_EMBEDDING_MODEL,
     sandbox: sandboxConfig,
     targetDir: cwd,

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -11,6 +11,7 @@ import chalk from 'chalk';
 import { ExtensionEnablementManager } from './extensions/extensionEnablement.js';
 import { type MergedSettings, SettingScope } from './settings.js';
 import { createHash, randomUUID } from 'node:crypto';
+import { getCliVersion } from '../utils/version.js';
 import { loadInstallMetadata, type ExtensionConfig } from './extension.js';
 import {
   isWorkspaceTrusted,
@@ -105,6 +106,7 @@ export class ExtensionManager extends ExtensionLoader {
       telemetry: options.settings.telemetry,
       interactive: false,
       sessionId: randomUUID(),
+      clientVersion: getCliVersion(),
       targetDir: options.workspaceDir,
       cwd: options.workspaceDir,
       model: '',

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -11,7 +11,6 @@ import chalk from 'chalk';
 import { ExtensionEnablementManager } from './extensions/extensionEnablement.js';
 import { type MergedSettings, SettingScope } from './settings.js';
 import { createHash, randomUUID } from 'node:crypto';
-import { getCliVersion } from '../utils/version.js';
 import { loadInstallMetadata, type ExtensionConfig } from './extension.js';
 import {
   isWorkspaceTrusted,
@@ -77,6 +76,7 @@ interface ExtensionManagerParams {
   requestSetting: ((setting: ExtensionSetting) => Promise<string>) | null;
   workspaceDir: string;
   eventEmitter?: EventEmitter<ExtensionEvents>;
+  clientVersion?: string;
 }
 
 /**
@@ -106,7 +106,7 @@ export class ExtensionManager extends ExtensionLoader {
       telemetry: options.settings.telemetry,
       interactive: false,
       sessionId: randomUUID(),
-      clientVersion: getCliVersion(),
+      clientVersion: options.clientVersion ?? 'unknown',
       targetDir: options.workspaceDir,
       cwd: options.workspaceDir,
       model: '',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -290,6 +290,7 @@ export interface SandboxConfig {
 
 export interface ConfigParameters {
   sessionId: string;
+  clientVersion?: string;
   embeddingModel?: string;
   sandbox?: SandboxConfig;
   targetDir: string;
@@ -415,6 +416,7 @@ export class Config {
   private agentRegistry!: AgentRegistry;
   private skillManager!: SkillManager;
   private sessionId: string;
+  private clientVersion: string;
   private fileSystemService: FileSystemService;
   private contentGeneratorConfig!: ContentGeneratorConfig;
   private contentGenerator!: ContentGenerator;
@@ -553,6 +555,7 @@ export class Config {
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
+    this.clientVersion = params.clientVersion ?? 'unknown';
     this.embeddingModel =
       params.embeddingModel ?? DEFAULT_GEMINI_EMBEDDING_MODEL;
     this.fileSystemService = new StandardFileSystemService();
@@ -810,6 +813,7 @@ export class Config {
     this.toolRegistry = await this.createToolRegistry();
     discoverToolsHandle?.end();
     this.mcpClientManager = new McpClientManager(
+      this.clientVersion,
       this.toolRegistry,
       this,
       this.eventEmitter,

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -62,11 +62,7 @@ describe('McpClientManager', () => {
     vi.restoreAllMocks();
   });
 
-  it('should discover tools from all configured', async () => {
-    mockConfig.getMcpServers.mockReturnValue({
-      'test-server': {},
-    });
-    const manager = new McpClientManager(toolRegistry, mockConfig);
+    const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
     await manager.startConfiguredMcpServers();
     expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
     expect(mockedMcpClient.discover).toHaveBeenCalledOnce();
@@ -107,7 +103,7 @@ describe('McpClientManager', () => {
       'test-server': {},
     });
     mockConfig.isTrustedFolder.mockReturnValue(false);
-    const manager = new McpClientManager(toolRegistry, mockConfig);
+    const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
     await manager.startConfiguredMcpServers();
     expect(mockedMcpClient.connect).not.toHaveBeenCalled();
     expect(mockedMcpClient.discover).not.toHaveBeenCalled();
@@ -118,7 +114,7 @@ describe('McpClientManager', () => {
       'test-server': {},
     });
     mockConfig.getBlockedMcpServers.mockReturnValue(['test-server']);
-    const manager = new McpClientManager(toolRegistry, mockConfig);
+    const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
     await manager.startConfiguredMcpServers();
     expect(mockedMcpClient.connect).not.toHaveBeenCalled();
     expect(mockedMcpClient.discover).not.toHaveBeenCalled();
@@ -130,14 +126,14 @@ describe('McpClientManager', () => {
       'another-server': {},
     });
     mockConfig.getAllowedMcpServers.mockReturnValue(['another-server']);
-    const manager = new McpClientManager(toolRegistry, mockConfig);
+    const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
     await manager.startConfiguredMcpServers();
     expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
     expect(mockedMcpClient.discover).toHaveBeenCalledOnce();
   });
 
   it('should start servers from extensions', async () => {
-    const manager = new McpClientManager(toolRegistry, mockConfig);
+    const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
     await manager.startExtension({
       name: 'test-extension',
       mcpServers: {
@@ -154,7 +150,7 @@ describe('McpClientManager', () => {
   });
 
   it('should not start servers from disabled extensions', async () => {
-    const manager = new McpClientManager(toolRegistry, mockConfig);
+    const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
     await manager.startExtension({
       name: 'test-extension',
       mcpServers: {
@@ -175,7 +171,7 @@ describe('McpClientManager', () => {
       'test-server': {},
     });
     mockConfig.getBlockedMcpServers.mockReturnValue(['test-server']);
-    const manager = new McpClientManager(toolRegistry, mockConfig);
+    const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
     await manager.startConfiguredMcpServers();
     expect(manager.getBlockedMcpServers()).toEqual([
       { name: 'test-server', extensionName: '' },
@@ -188,7 +184,7 @@ describe('McpClientManager', () => {
         'test-server': {},
       });
       mockedMcpClient.getServerConfig.mockReturnValue({});
-      const manager = new McpClientManager(toolRegistry, mockConfig);
+      const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
       await manager.startConfiguredMcpServers();
 
       expect(mockedMcpClient.connect).toHaveBeenCalledTimes(1);
@@ -207,7 +203,7 @@ describe('McpClientManager', () => {
         'test-server': {},
       });
       mockedMcpClient.getServerConfig.mockReturnValue({});
-      const manager = new McpClientManager(toolRegistry, mockConfig);
+      const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
       await manager.startConfiguredMcpServers();
 
       expect(mockedMcpClient.connect).toHaveBeenCalledTimes(1);
@@ -221,7 +217,7 @@ describe('McpClientManager', () => {
     });
 
     it('should throw an error if the server does not exist', async () => {
-      const manager = new McpClientManager(toolRegistry, mockConfig);
+      const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
       await expect(manager.restartServer('non-existent')).rejects.toThrow(
         'No MCP server registered with the name "non-existent"',
       );

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -75,7 +75,7 @@ describe('McpClientManager', () => {
       'server-2': {},
       'server-3': {},
     });
-    const manager = new McpClientManager(toolRegistry, mockConfig);
+    const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
     await manager.startConfiguredMcpServers();
 
     // Each client should be connected/discovered
@@ -90,7 +90,7 @@ describe('McpClientManager', () => {
     mockConfig.getMcpServers.mockReturnValue({
       'test-server': {},
     });
-    const manager = new McpClientManager(toolRegistry, mockConfig);
+    const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
     expect(manager.getDiscoveryState()).toBe(MCPDiscoveryState.NOT_STARTED);
     const promise = manager.startConfiguredMcpServers();
     expect(manager.getDiscoveryState()).toBe(MCPDiscoveryState.IN_PROGRESS);
@@ -278,7 +278,11 @@ describe('McpClientManager', () => {
         'test-server': {},
       });
 
-      const manager = new McpClientManager({} as ToolRegistry, mockConfig);
+      const manager = new McpClientManager(
+        '0.0.1',
+        {} as ToolRegistry,
+        mockConfig,
+      );
 
       await expect(manager.startConfiguredMcpServers()).resolves.not.toThrow();
     });
@@ -297,7 +301,11 @@ describe('McpClientManager', () => {
         'test-server': {},
       });
 
-      const manager = new McpClientManager({} as ToolRegistry, mockConfig);
+      const manager = new McpClientManager(
+        '0.0.1',
+        {} as ToolRegistry,
+        mockConfig,
+      );
       await manager.startConfiguredMcpServers();
 
       await expect(manager.restartServer('test-server')).resolves.not.toThrow();

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -62,6 +62,10 @@ describe('McpClientManager', () => {
     vi.restoreAllMocks();
   });
 
+  it('should discover tools from all configured', async () => {
+    mockConfig.getMcpServers.mockReturnValue({
+      'test-server': {},
+    });
     const manager = new McpClientManager('0.0.1', toolRegistry, mockConfig);
     await manager.startConfiguredMcpServers();
     expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
@@ -243,7 +247,11 @@ describe('McpClientManager', () => {
           }) as unknown as McpClient,
       );
 
-      const manager = new McpClientManager({} as ToolRegistry, mockConfig);
+      const manager = new McpClientManager(
+        '0.0.1',
+        {} as ToolRegistry,
+        mockConfig,
+      );
 
       mockConfig.getMcpServers.mockReturnValue({
         'server-with-instructions': {},

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -27,6 +27,7 @@ import { debugLogger } from '../utils/debugLogger.js';
  */
 export class McpClientManager {
   private clients: Map<string, McpClient> = new Map();
+  private readonly clientVersion: string;
   private readonly toolRegistry: ToolRegistry;
   private readonly cliConfig: Config;
   // If we have ongoing MCP client discovery, this completes once that is done.
@@ -40,10 +41,12 @@ export class McpClientManager {
   }> = [];
 
   constructor(
+    clientVersion: string,
     toolRegistry: ToolRegistry,
     cliConfig: Config,
     eventEmitter?: EventEmitter,
   ) {
+    this.clientVersion = clientVersion;
     this.toolRegistry = toolRegistry;
     this.cliConfig = cliConfig;
     this.eventEmitter = eventEmitter;
@@ -183,6 +186,7 @@ export class McpClientManager {
               this.cliConfig.getWorkspaceContext(),
               this.cliConfig,
               this.cliConfig.getDebugMode(),
+              this.clientVersion,
               async () => {
                 debugLogger.log('Tools changed, updating Gemini context...');
                 await this.scheduleMcpContextRefresh();

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -533,6 +533,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
       await client.connect();
       await client.discover({} as Config);
@@ -616,6 +617,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
       await client.connect();
       await client.discover({} as Config);
@@ -746,6 +748,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
 
       await client.connect();
@@ -782,6 +785,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
 
       await client.connect();
@@ -837,6 +841,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
         onToolsUpdatedSpy,
       );
 
@@ -907,6 +912,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
 
       await client.connect();
@@ -977,6 +983,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
         onToolsUpdatedSpy,
       );
 
@@ -989,6 +996,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
         onToolsUpdatedSpy,
       );
 
@@ -1071,6 +1079,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
 
       await client.connect();
@@ -1135,6 +1144,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
         onToolsUpdatedSpy,
       );
 
@@ -1784,6 +1794,7 @@ describe('connectToMcpServer - HTTP→SSE fallback', () => {
 
     await expect(
       connectToMcpServer(
+        '0.0.1',
         'test-server',
         { url: 'http://test-server', type: 'http' },
         false,
@@ -1803,6 +1814,7 @@ describe('connectToMcpServer - HTTP→SSE fallback', () => {
 
     await expect(
       connectToMcpServer(
+        '0.0.1',
         'test-server',
         { url: 'http://test-server', type: 'sse' },
         false,
@@ -1821,6 +1833,7 @@ describe('connectToMcpServer - HTTP→SSE fallback', () => {
       .mockResolvedValueOnce(undefined);
 
     const client = await connectToMcpServer(
+      '0.0.1',
       'test-server',
       { url: 'http://test-server' },
       false,
@@ -1843,6 +1856,7 @@ describe('connectToMcpServer - HTTP→SSE fallback', () => {
 
     await expect(
       connectToMcpServer(
+        '0.0.1',
         'test-server',
         { url: 'http://test-server' },
         false,
@@ -1860,6 +1874,7 @@ describe('connectToMcpServer - HTTP→SSE fallback', () => {
       .mockResolvedValueOnce(undefined);
 
     const client = await connectToMcpServer(
+      '0.0.1',
       'test-server',
       { url: 'http://test-server' },
       false,
@@ -1930,6 +1945,7 @@ describe('connectToMcpServer - OAuth with transport fallback', () => {
       .mockResolvedValueOnce(undefined);
 
     const client = await connectToMcpServer(
+      '0.0.1',
       'test-server',
       { url: 'http://test-server', oauth: { enabled: true } },
       false,

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -133,6 +133,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
       await client.connect();
       await client.discover({} as Config);
@@ -213,6 +214,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
       await client.connect();
       await client.discover({} as Config);
@@ -264,6 +266,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
       await client.connect();
       await expect(client.discover({} as Config)).rejects.toThrow(
@@ -319,6 +322,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
       await client.connect();
       await expect(client.discover({} as Config)).rejects.toThrow(
@@ -378,6 +382,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
       await client.connect();
       await client.discover({} as Config);
@@ -451,6 +456,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
       await client.connect();
       await client.discover({} as Config);
@@ -690,6 +696,7 @@ describe('mcp-client', () => {
         workspaceContext,
         { sanitizationConfig: EMPTY_CONFIG } as Config,
         false,
+        '0.0.1',
       );
       await client.connect();
       await client.discover({} as Config);
@@ -1675,6 +1682,7 @@ describe('connectToMcpServer with OAuth', () => {
     );
 
     const client = await connectToMcpServer(
+      '0.0.1',
       'test-server',
       { httpUrl: serverUrl, oauth: { enabled: true } },
       false,
@@ -1720,6 +1728,7 @@ describe('connectToMcpServer with OAuth', () => {
     );
 
     const client = await connectToMcpServer(
+      '0.0.1',
       'test-server',
       { httpUrl: serverUrl, oauth: { enabled: true } },
       false,

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -122,6 +122,7 @@ export class McpClient {
     private readonly workspaceContext: WorkspaceContext,
     private readonly cliConfig: Config,
     private readonly debugMode: boolean,
+    private readonly clientVersion: string,
     private readonly onToolsUpdated?: (signal?: AbortSignal) => Promise<void>,
   ) {}
 
@@ -137,6 +138,7 @@ export class McpClient {
     this.updateStatus(MCPServerStatus.CONNECTING);
     try {
       this.client = await connectToMcpServer(
+        this.clientVersion,
         this.serverName,
         this.serverConfig,
         this.debugMode,
@@ -715,6 +717,7 @@ async function createTransportWithOAuth(
  */
 
 export async function discoverMcpTools(
+  clientVersion: string,
   mcpServers: Record<string, MCPServerConfig>,
   mcpServerCommand: string | undefined,
   toolRegistry: ToolRegistry,
@@ -730,6 +733,7 @@ export async function discoverMcpTools(
     const discoveryPromises = Object.entries(mcpServers).map(
       ([mcpServerName, mcpServerConfig]) =>
         connectAndDiscover(
+          clientVersion,
           mcpServerName,
           mcpServerConfig,
           toolRegistry,
@@ -808,6 +812,7 @@ export function populateMcpServerCommand(
  * @returns Promise that resolves when discovery is complete
  */
 export async function connectAndDiscover(
+  clientVersion: string,
   mcpServerName: string,
   mcpServerConfig: MCPServerConfig,
   toolRegistry: ToolRegistry,
@@ -821,6 +826,7 @@ export async function connectAndDiscover(
   let mcpClient: Client | undefined;
   try {
     mcpClient = await connectToMcpServer(
+      clientVersion,
       mcpServerName,
       mcpServerConfig,
       debugMode,
@@ -1331,6 +1337,7 @@ async function retryWithOAuth(
  * @throws An error if the connection fails or the configuration is invalid.
  */
 export async function connectToMcpServer(
+  clientVersion: string,
   mcpServerName: string,
   mcpServerConfig: MCPServerConfig,
   debugMode: boolean,
@@ -1340,7 +1347,7 @@ export async function connectToMcpServer(
   const mcpClient = new Client(
     {
       name: 'gemini-cli-mcp-client',
-      version: '0.0.1',
+      version: clientVersion,
     },
     {
       // Use a tolerant validator so bad output schemas don't block discovery.


### PR DESCRIPTION
## Summary

Previously we were sending a constant version string to MCP servers. This makes it harder for servers to understand which gemini-cli client they are working with. While this is purely informational, it might help server operators to understand their clients better.

## Changes

- Thread `clientVersion` from CLI through Config to McpClientManager and McpClient
- Pass the actual gemini-cli version (from `getCliVersion()`) to the MCP SDK Client constructor
- Update all related tests to match the new constructor signature

## Test Plan

- All existing tests pass (3,275 tests)
- TypeScript compilation successful
- Verified version flows correctly through the system