### PR TITLE
Fix typo in write_todos methodology instructions

### DIFF
--- a/packages/core/src/test-utils/config.ts
+++ b/packages/core/src/test-utils/config.ts
@@ -21,7 +21,7 @@ export const DEFAULT_CONFIG_PARAMETERS: ConfigParameters = {
 };
 
 /**
- * Produces a config.  Default paramters are set to
+ * Produces a config.  Default parameters are set to
  * {@link DEFAULT_CONFIG_PARAMETERS}, optionally, fields can be specified to
  * override those defaults.
  */

--- a/packages/core/src/tools/write-todos.ts
+++ b/packages/core/src/tools/write-todos.ts
@@ -41,7 +41,7 @@ DO NOT use this tool for simple tasks that can be completed in less than 2 steps
 
 
 ## Methodology for using this tool
-1. Use this todo list list as soon as you receive a user request based on the complexity of the task.
+1. Use this todo list as soon as you receive a user request based on the complexity of the task.
 2. Keep track of every subtask that you update the list with.
 3. Mark a subtask as in_progress before you begin working on it. You should only have one subtask as in_progress at a time.
 4. Update the subtask list as you proceed in executing the task. The subtask list is not static and should reflect your progress and current plans, which may evolve as you acquire new information.

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -182,7 +182,7 @@ class RecursiveFileSearch implements FileSearch {
     this.resultCache = new ResultCache(this.allFiles);
     if (!this.options.disableFuzzySearch) {
       // The v1 algorithm is much faster since it only looks at the first
-      // occurence of the pattern. We use it for search spaces that have >20k
+      // occurrence of the pattern. We use it for search spaces that have >20k
       // files, because the v2 algorithm is just too slow in those cases.
       this.fzf = new AsyncFzf(this.allFiles, {
         fuzzy: this.allFiles.length > 20000 ? 'v1' : 'v2',


### PR DESCRIPTION
Fixed typo in packages/core/src/tools/write-todos.ts.

Also fixed typos in packages/core/src/test-utils/config.ts and packages/core/src/utils/filesearch/fileSearch.ts.