### PR TITLE
feat(core): add modelAvailabilityService for managing and tracking model health

### DIFF
--- a/packages/core/src/availability/modelAvailabilityService.test.ts
+++ b/packages/core/src/availability/modelAvailabilityService.test.ts
@@ -42,6 +42,15 @@ describe('ModelAvailabilityService', () => {
     });
   });
 
+  it('does not override terminal failure with sticky failure', () => {
+    service.markTerminal(model, 'quota');
+    service.markRetryOncePerTurn(model);
+    expect(service.snapshot(model)).toEqual({
+      available: false,
+      reason: 'quota',
+    });
+  });
+
   it('selects models respecting terminal and sticky states', () => {
     const stickyModel = 'stick-model';
     const healthyModel = 'healthy-model';

--- a/packages/core/src/availability/modelAvailabilityService.ts
+++ b/packages/core/src/availability/modelAvailabilityService.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type ModelId = string;
+
+export type TerminalAvailabilityReason = 'quota' | 'capacity';
+export type TurnAvailabilityReason = 'retry_once_per_turn';
+
+export type AvailabilityReason =
+  | TerminalAvailabilityReason
+  | TurnAvailabilityReason
+  | 'unknown';
+
+type HealthState =
+  | { status: 'terminal'; reason: TerminalAvailabilityReason }
+  | { status: 'sticky_retry'; reason: TurnAvailabilityReason };
+
+export interface ModelAvailabilitySnapshot {
+  available: boolean;
+  reason?: AvailabilityReason;
+}
+
+export interface ModelSelectionResult {
+  selected: ModelId | null;
+  attempts?: number;
+  skipped: Array<{
+    model: ModelId;
+    reason: AvailabilityReason;
+  }>;
+}
+
+export class ModelAvailabilityService {
+  private readonly health = new Map<ModelId, HealthState>();
+  private readonly consumedSticky = new Set<ModelId>();
+
+  markTerminal(model: ModelId, reason: TerminalAvailabilityReason) {
+    this.setState(model, {
+      status: 'terminal',
+      reason,
+    });
+  }
+
+  markHealthy(model: ModelId) {
+    this.clearState(model);
+  }
+
+  markRetryOncePerTurn(model: ModelId) {
+    // Only reset consumption if we are not already in the sticky_retry state.
+    // This prevents infinite loops if the model fails repeatedly in the same turn.
+    const currentState = this.health.get(model);
+    if (currentState?.status !== 'sticky_retry') {
+      this.consumedSticky.delete(model);
+    }
+
+    this.setState(model, {
+      status: 'sticky_retry',
+      reason: 'retry_once_per_turn',
+    });
+  }
+
+  consumeStickyAttempt(model: ModelId) {
+    if (this.health.get(model)?.status === 'sticky_retry') {
+      this.consumedSticky.add(model);
+    }
+  }
+
+  snapshot(model: ModelId): ModelAvailabilitySnapshot {
+    const state = this.health.get(model);
+    if (!state) {
+      return { available: true };
+    }
+    if (state.status === 'terminal') {
+      return { available: false, reason: state.reason };
+    }
+    const available = !this.consumedSticky.has(model);
+    return available
+      ? { available: true }
+      : { available: false, reason: state.reason };
+  }
+
+  selectFirstAvailable(models: ModelId[]): ModelSelectionResult {
+    const skipped: ModelSelectionResult['skipped'] = [];
+    for (const model of models) {
+      const state = this.health.get(model);
+      if (!state) {
+        return { selected: model, skipped };
+      }
+      if (state.status === 'terminal') {
+        skipped.push({ model, reason: state.reason });
+        continue;
+      }
+      if (state.status === 'sticky_retry') {
+        if (this.consumedSticky.has(model)) {
+          skipped.push({ model, reason: state.reason });
+          continue;
+        }
+        return { selected: model, attempts: 1, skipped };
+      }
+    }
+    return { selected: null, skipped };
+  }
+
+  resetTurn() {
+    this.consumedSticky.clear();
+  }
+
+  private setState(model: ModelId, nextState: HealthState) {
+    this.health.set(model, nextState);
+  }
+
+  private clearState(model: ModelId) {
+    this.health.delete(model);
+    this.consumedSticky.delete(model);
+  }
+}


### PR DESCRIPTION
## Summary

Introduces `ModelAvailabilityService` to track and manage the availability state of models

## Details

- **`ModelAvailabilityService`**: A centralized service to store and query model health.
- **Availability States**:
  - **Terminal**: Failures like `quota` or `capacity` that render a model unusable for the current session (or until cleared).
  - **Sticky Retry**: Transient failures that allow a "retry once per turn" behavior
- **Model Selection**: The `selectFirstAvailable` method iterates through a priority list of models and picks the first one that satisfies availability constraints, returning skipped reasons for others.

## Related Issues

Fixes: https://github.com/google-gemini/maintainers-gemini-cli/issues/1072

## How to Validate

npm run test

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
```
