### PR TITLE
fix: correct spelling errors in comments and documentation

### DIFF
--- a/docs/get-started/authentication.md
+++ b/docs/get-started/authentication.md
@@ -256,7 +256,7 @@ To avoid setting environment variables in every terminal session, you can:
 
 ## Non-interactive mode / headless environments
 
-Non-interative mode / headless environments will use your existing
+Non-interactive mode / headless environments will use your existing
 authentication method, if an existing authentication credential is cached.
 
 If you have not already logged in with an authentication credential (such as a

--- a/packages/a2a-server/development-extension-rfc.md
+++ b/packages/a2a-server/development-extension-rfc.md
@@ -153,7 +153,7 @@ syntax = "proto3";
 
 import "google/protobuf/struct.proto";
 
-// ToolCall is the central message represeting a tool's execution lifecycle.
+// ToolCall is the central message representing a tool's execution lifecycle.
 // The entire object is sent from the agent to client on every update.
 message ToolCall {
   // A unique identifier, assigned by the agent
@@ -197,7 +197,7 @@ enum ToolCallStatus {
   CANCELLED = 5;
 }
 
-// ToolOuput represents the final, successful, output of a tool
+// ToolOutput represents the final, successful, output of a tool
 message ToolOutput {
   oneof result {
     string text = 1;

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -461,7 +461,7 @@ export class Task {
   ): Message {
     const messageParts: Part[] = [];
 
-    // Create a serializable version of the ToolCall (pick necesssary
+    // Create a serializable version of the ToolCall (pick necessary
     // properties/avoid methods causing circular reference errors)
     const serializableToolCall: Partial<ToolCall> = this._pickFields(
       tc,

--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -88,7 +88,7 @@ export const createMockCommandContext = (
         const targetValue = output[key];
 
         if (
-          // We only want to recursivlty merge plain objects
+          // We only want to recursively merge plain objects
           Object.prototype.toString.call(sourceValue) === '[object Object]' &&
           Object.prototype.toString.call(targetValue) === '[object Object]'
         ) {

--- a/packages/cli/src/ui/components/DebugProfiler.tsx
+++ b/packages/cli/src/ui/components/DebugProfiler.tsx
@@ -208,7 +208,7 @@ export const DebugProfiler = () => {
       return;
     }
     // Only update the UX infrequently as updating the UX itself will cause
-    // frames to run so can disturb what we are measuing.
+    // frames to run so can disturb what we are measuring.
     const forceRefreshInterval = setInterval(() => {
       setForceRefresh((f) => f + 1);
       profiler.reportAction();

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -713,7 +713,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             // newline that was part of the paste.
             // This has the added benefit that in the worst case at least users
             // get some feedback that their keypress was handled rather than
-            // wondering why it was completey ignored.
+            // wondering why it was completely ignored.
             buffer.newline();
             return;
           }

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -19,7 +19,7 @@ import { type ReactNode } from 'react';
 export type { ThoughtSummary };
 
 export enum AuthState {
-  // Attemtping to authenticate or re-authenticate
+  // Attempting to authenticate or re-authenticate
   Unauthenticated = 'unauthenticated',
   // Auth dialog is open for user to select auth method
   Updating = 'updating',

--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -96,7 +96,7 @@ You are a sub-agent in a larger system. Your only responsibility is to provide d
 - **DO:** Find the key modules, classes, and functions that are part of the problem and its solution.
 - **DO:** Understand *why* the code is written the way it is. Question everything.
 - **DO:** Foresee the ripple effects of a change. If \`function A\` is modified, you must check its callers. If a data structure is altered, you must identify where its type definitions need to be updated.
-- **DO:** provide a conclusion and insights to the main agent that invoked you. If the agent is trying to solve a bug, you should provide the root cause of the bug, its impacts, how to fix it etc. If it's a new feature, you should provide insights on where to implement it, what chagnes are necessary etc. 
+- **DO:** provide a conclusion and insights to the main agent that invoked you. If the agent is trying to solve a bug, you should provide the root cause of the bug, its impacts, how to fix it etc. If it's a new feature, you should provide insights on where to implement it, what changes are necessary etc. 
 - **DO NOT:** Write the final implementation code yourself.
 - **DO NOT:** Stop at the first relevant file. Your goal is a comprehensive understanding of the entire relevant subsystem.
 You operate in a non-interactive loop and must reason based on the information provided and the output of your tools.

--- a/packages/core/src/telemetry/semantic.ts
+++ b/packages/core/src/telemetry/semantic.ts
@@ -109,7 +109,7 @@ export function toFinishReasons(candidates?: Candidate[]): OTelFinishReason[] {
 
 export function toOutputType(requested_mime?: string): string | undefined {
   switch (requested_mime) {
-    // explictly support the known good values of responseMimeType
+    // explicitly support the known good values of responseMimeType
     case 'text/plain':
       return OTelOutputType.TEXT;
     case 'application/json':

--- a/packages/core/src/test-utils/config.ts
+++ b/packages/core/src/test-utils/config.ts
@@ -21,7 +21,7 @@ export const DEFAULT_CONFIG_PARAMETERS: ConfigParameters = {
 };
 
 /**
- * Produces a config.  Default paramters are set to
+ * Produces a config.  Default parameters are set to
  * {@link DEFAULT_CONFIG_PARAMETERS}, optionally, fields can be specified to
  * override those defaults.
  */

--- a/packages/core/src/test-utils/mock-tool.ts
+++ b/packages/core/src/test-utils/mock-tool.ts
@@ -182,7 +182,7 @@ export class MockModifiableTool
   extends BaseDeclarativeTool<Record<string, unknown>, ToolResult>
   implements ModifiableDeclarativeTool<Record<string, unknown>>
 {
-  // Should be overrided in test file. Functionality will be updated in follow
+  // Should be overridden in test file. Functionality will be updated in follow
   // up PR which has MockModifiableTool expect MockTool
   executeFn: (params: Record<string, unknown>) => ToolResult | undefined = () =>
     undefined;

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -182,7 +182,7 @@ class RecursiveFileSearch implements FileSearch {
     this.resultCache = new ResultCache(this.allFiles);
     if (!this.options.disableFuzzySearch) {
       // The v1 algorithm is much faster since it only looks at the first
-      // occurence of the pattern. We use it for search spaces that have >20k
+      // occurrence of the pattern. We use it for search spaces that have >20k
       // files, because the v2 algorithm is just too slow in those cases.
       this.fzf = new AsyncFzf(this.allFiles, {
         fuzzy: this.allFiles.length > 20000 ? 'v1' : 'v2',

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -30,7 +30,7 @@ addFormatsFunc(ajValidator);
  */
 export class SchemaValidator {
   /**
-   * Returns null if the data confroms to the schema described by schema (or if schema
+   * Returns null if the data conforms to the schema described by schema (or if schema
    *  is null). Otherwise, returns a string describing the error.
    */
   static validate(schema: unknown | undefined, data: unknown): string | null {

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -453,7 +453,7 @@ const createMcpServer = (
     'openDiff',
     {
       description:
-        '(IDE Tool) Open a diff view to create or modify a file. Returns a notification once the diff has been accepted or rejcted.',
+        '(IDE Tool) Open a diff view to create or modify a file. Returns a notification once the diff has been accepted or rejected.',
       inputSchema: OpenDiffRequestSchema.shape,
     },
     async ({ filePath, newContent }: z.infer<typeof OpenDiffRequestSchema>) => {


### PR DESCRIPTION
## Summary

Fix 15 typos across multiple packages in comments, strings, and documentation.

### Changes
- `packages/cli/src/ui/types.ts` - Attemtping → Attempting
- `packages/a2a-server/src/agent/task.ts` - necesssary → necessary
- `packages/core/src/utils/filesearch/fileSearch.ts` - occurence → occurrence
- `packages/a2a-server/development-extension-rfc.md` - represeting → representing, ToolOuput → ToolOutput
- `docs/get-started/authentication.md` - interative → interactive
- `packages/core/src/telemetry/semantic.ts` - explictly → explicitly
- `packages/core/src/test-utils/mock-tool.ts` - overrided → overridden
- `packages/core/src/test-utils/config.ts` - paramters → parameters
- `packages/core/src/utils/schemaValidator.ts` - confroms → conforms
- `packages/cli/src/ui/components/InputPrompt.tsx` - completey → completely
- `packages/cli/src/test-utils/mockCommandContext.ts` - recursivlty → recursively
- `packages/core/src/agents/codebase-investigator.ts` - chagnes → changes
- `packages/cli/src/ui/components/DebugProfiler.tsx` - measuing → measuring
- `packages/vscode-ide-companion/src/ide-server.ts` - rejcted → rejected

## Test plan

- [x] All preflight checks pass (`npm run preflight`)
- [x] Changes are limited to comments and documentation strings - no functional impact

Fixes #13086