### PR TITLE
feat: update thinking mode support to exclude gemini-2.0 models and simplify logic.

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -137,6 +137,7 @@ async function fromAsync<T>(promise: AsyncGenerator<T>): Promise<readonly T[]> {
 describe('isThinkingSupported', () => {
   it('should return true for gemini-2.5', () => {
     expect(isThinkingSupported('gemini-2.5')).toBe(true);
+    expect(isThinkingSupported('gemini-2.5-flash')).toBe(true);
   });
 
   it('should return true for gemini-2.5-pro', () => {
@@ -147,9 +148,13 @@ describe('isThinkingSupported', () => {
     expect(isThinkingSupported('gemini-3-pro')).toBe(true);
   });
 
-  it('should return false for other models', () => {
-    expect(isThinkingSupported('gemini-1.5-flash')).toBe(false);
-    expect(isThinkingSupported('some-other-model')).toBe(false);
+  it('should return false for gemini-2.0 models', () => {
+    expect(isThinkingSupported('gemini-2.0-flash')).toBe(false);
+    expect(isThinkingSupported('gemini-2.0-pro')).toBe(false);
+  });
+
+  it('should return true for other models', () => {
+    expect(isThinkingSupported('some-other-model')).toBe(true);
   });
 });
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -33,7 +33,6 @@ import type {
 import type { ContentGenerator } from './contentGenerator.js';
 import {
   DEFAULT_GEMINI_FLASH_MODEL,
-  DEFAULT_GEMINI_MODEL_AUTO,
   DEFAULT_THINKING_MODE,
   getEffectiveModel,
 } from '../config/models.js';
@@ -56,11 +55,7 @@ import { debugLogger } from '../utils/debugLogger.js';
 import type { ModelConfigKey } from '../services/modelConfigService.js';
 
 export function isThinkingSupported(model: string) {
-  return (
-    model.startsWith('gemini-2.5') ||
-    model.startsWith('gemini-3') ||
-    model === DEFAULT_GEMINI_MODEL_AUTO
-  );
+  return !model.startsWith('gemini-2.0');
 }
 
 const MAX_TURNS = 100;


### PR DESCRIPTION
## Summary

Simplify the logic for determining whether a model supports thinking config or not.

## Details

## Related Issues

## How to Validate

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
