### PR TITLE
Add User email detail to about box

### DIFF
--- a/packages/cli/src/ui/commands/aboutCommand.test.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.test.ts
@@ -22,6 +22,9 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
         getDetectedIdeDisplayName: vi.fn().mockReturnValue('test-ide'),
       }),
     },
+    UserAccountManager: vi.fn().mockImplementation(() => ({
+      getCachedGoogleAccount: vi.fn().mockReturnValue('test-email@example.com'),
+    })),
   };
 });
 
@@ -98,6 +101,7 @@ describe('aboutCommand', () => {
         selectedAuthType: 'test-auth',
         gcpProject: 'test-gcp-project',
         ideClient: 'test-ide',
+        userEmail: 'test-email@example.com',
       },
       expect.any(Number),
     );

--- a/packages/cli/src/ui/commands/aboutCommand.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.ts
@@ -9,7 +9,11 @@ import type { CommandContext, SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 import process from 'node:process';
 import { MessageType, type HistoryItemAbout } from '../types.js';
-import { IdeClient, UserAccountManager } from '@google/gemini-cli-core';
+import {
+  IdeClient,
+  UserAccountManager,
+  debugLogger,
+} from '@google/gemini-cli-core';
 
 export const aboutCommand: SlashCommand = {
   name: 'about',
@@ -33,7 +37,11 @@ export const aboutCommand: SlashCommand = {
     const ideClient = await getIdeClientName(context);
 
     const userAccountManager = new UserAccountManager();
-    const userEmail = userAccountManager.getCachedGoogleAccount() ?? undefined;
+    const cachedAccount = userAccountManager.getCachedGoogleAccount();
+    debugLogger.log('AboutCommand: Retrieved cached Google account', {
+      cachedAccount,
+    });
+    const userEmail = cachedAccount ?? undefined;
 
     const aboutItem: Omit<HistoryItemAbout, 'id'> = {
       type: MessageType.ABOUT,

--- a/packages/cli/src/ui/commands/aboutCommand.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.ts
@@ -9,7 +9,7 @@ import type { CommandContext, SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 import process from 'node:process';
 import { MessageType, type HistoryItemAbout } from '../types.js';
-import { IdeClient } from '@google/gemini-cli-core';
+import { IdeClient, UserAccountManager } from '@google/gemini-cli-core';
 
 export const aboutCommand: SlashCommand = {
   name: 'about',
@@ -32,6 +32,9 @@ export const aboutCommand: SlashCommand = {
     const gcpProject = process.env['GOOGLE_CLOUD_PROJECT'] || '';
     const ideClient = await getIdeClientName(context);
 
+    const userAccountManager = new UserAccountManager();
+    const userEmail = userAccountManager.getCachedGoogleAccount() ?? undefined;
+
     const aboutItem: Omit<HistoryItemAbout, 'id'> = {
       type: MessageType.ABOUT,
       cliVersion,
@@ -41,6 +44,7 @@ export const aboutCommand: SlashCommand = {
       selectedAuthType,
       gcpProject,
       ideClient,
+      userEmail,
     };
 
     context.ui.addItem(aboutItem, Date.now());

--- a/packages/cli/src/ui/components/AboutBox.tsx
+++ b/packages/cli/src/ui/components/AboutBox.tsx
@@ -17,6 +17,7 @@ interface AboutBoxProps {
   selectedAuthType: string;
   gcpProject: string;
   ideClient: string;
+  userEmail?: string;
 }
 
 export const AboutBox: React.FC<AboutBoxProps> = ({
@@ -27,6 +28,7 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
   selectedAuthType,
   gcpProject,
   ideClient,
+  userEmail,
 }) => (
   <Box
     borderStyle="round"
@@ -105,6 +107,18 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
         </Text>
       </Box>
     </Box>
+    {userEmail && (
+      <Box flexDirection="row">
+        <Box width="35%">
+          <Text bold color={theme.text.link}>
+            User Email
+          </Text>
+        </Box>
+        <Box>
+          <Text color={theme.text.primary}>{userEmail}</Text>
+        </Box>
+      </Box>
+    )}
     {gcpProject && (
       <Box flexDirection="row">
         <Box width="35%">

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -108,6 +108,7 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           selectedAuthType={itemForDisplay.selectedAuthType}
           gcpProject={itemForDisplay.gcpProject}
           ideClient={itemForDisplay.ideClient}
+          userEmail={itemForDisplay.userEmail}
         />
       )}
       {itemForDisplay.type === 'help' && commands && (

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -131,6 +131,7 @@ export type HistoryItemAbout = HistoryItemBase & {
   selectedAuthType: string;
   gcpProject: string;
   ideClient: string;
+  userEmail?: string;
 };
 
 export type HistoryItemHelp = HistoryItemBase & {
@@ -302,6 +303,7 @@ export type Message =
       selectedAuthType: string;
       gcpProject: string;
       ideClient: string;
+      userEmail?: string;
       content?: string; // Optional content, not really used for ABOUT
     }
   | {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,7 @@ export * from './utils/gitIgnoreParser.js';
 export * from './utils/gitUtils.js';
 export * from './utils/editor.js';
 export * from './utils/quotaErrorDetection.js';
+export * from './utils/userAccountManager.js';
 export * from './utils/googleQuotaErrors.js';
 export * from './utils/fileUtils.js';
 export * from './utils/retry.js';


### PR DESCRIPTION
## Summary

If the user is authenticated with Google login, the /about box now displays the email of the logged in user
<img width="1078" height="300" alt="Screenshot 2025-11-19 at 3 36 15 PM" src="https://github.com/user-attachments/assets/7ccca605-5d67-4a39-9f0a-54927d8633c8" />


## Details

   1. `packages/core/src/index.ts`: Exported UserAccountManager so it can be used by the CLI.
   2. `packages/cli/src/ui/types.ts`: Updated HistoryItemAbout and Message types to include the optional userEmail field.
   3. `packages/cli/src/ui/commands/aboutCommand.ts`: Modified the about command to instantiate UserAccountManager, retrieve the cached user email, and include it
      in the aboutItem.
   4. `packages/cli/src/ui/components/AboutBox.tsx`: Updated the AboutBox component to conditionally render the "User Email" row if an email address is present.
   5. `packages/cli/src/ui/commands/aboutCommand.test.ts`: Updated unit tests to mock UserAccountManager and verify that the user email is correctly passed to the
      UI.

## Related Issues

fixes #13458

## How to Validate

login with different auth methods and ensure email is shown when, and only when logged in via oauth

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
