### PR TITLE
Use synchronous writes when detecting keyboard modes

### DIFF
--- a/packages/cli/src/ui/utils/kittyProtocolDetector.ts
+++ b/packages/cli/src/ui/utils/kittyProtocolDetector.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'node:fs';
+
 let detectionComplete = false;
 
 let kittySupported = false;
@@ -91,9 +93,8 @@ export async function detectAndEnableKittyProtocol(): Promise<void> {
 
     process.stdin.on('data', handleData);
 
-    // Send queries
-    process.stdout.write('\x1b[?u'); // Query progressive enhancement
-    process.stdout.write('\x1b[c'); // Query device attributes
+    // Query progressive enhancement and device attributes
+    fs.writeSync(process.stdout.fd, '\x1b[?u\x1b[c');
 
     // Timeout after 200ms
     // When a iterm2 terminal does not have focus this can take over 90s on a
@@ -107,13 +108,17 @@ export function isKittyProtocolEnabled(): boolean {
 }
 
 function disableAllProtocols() {
-  if (kittyEnabled) {
-    process.stdout.write('\x1b[<u');
-    kittyEnabled = false;
-  }
-  if (sgrMouseEnabled) {
-    process.stdout.write('\x1b[?1006l'); // Disable SGR Mouse
-    sgrMouseEnabled = false;
+  try {
+    if (kittyEnabled) {
+      fs.writeSync(process.stdout.fd, '\x1b[<u');
+      kittyEnabled = false;
+    }
+    if (sgrMouseEnabled) {
+      fs.writeSync(process.stdout.fd, '\x1b[?1006l');
+      sgrMouseEnabled = false;
+    }
+  } catch {
+    // Ignore
   }
 }
 
@@ -122,12 +127,16 @@ function disableAllProtocols() {
  * change the mode.
  */
 export function enableSupportedProtocol(): void {
-  if (kittySupported) {
-    process.stdout.write('\x1b[>1u');
-    kittyEnabled = true;
-  }
-  if (sgrMouseSupported) {
-    process.stdout.write('\x1b[?1006h');
-    sgrMouseEnabled = true;
+  try {
+    if (kittySupported) {
+      fs.writeSync(process.stdout.fd, '\x1b[>1u');
+      kittyEnabled = true;
+    }
+    if (sgrMouseSupported) {
+      fs.writeSync(process.stdout.fd, '\x1b[?1006h');
+      sgrMouseEnabled = true;
+    }
+  } catch {
+    // Ignore
   }
 }


### PR DESCRIPTION
## Summary

Use synchronous writes when detecting/enabling/disabling keyboard modes

## Details

There's a slight chance this will fix the "9;5u" problem.
