### PR TITLE
Revert "feat(core): Fix bug with incorrect model overriding."

### DIFF
--- a/packages/core/src/routing/modelRouterService.test.ts
+++ b/packages/core/src/routing/modelRouterService.test.ts
@@ -152,7 +152,7 @@ describe('ModelRouterService', () => {
       );
     });
 
-    it('should NOT upgrade to Preview Model when preview features are enabled and model is 2.5 Pro', async () => {
+    it('should upgrade to Preview Model when preview features are enabled and model is 2.5 Pro', async () => {
       vi.spyOn(mockCompositeStrategy, 'route').mockResolvedValue({
         model: DEFAULT_GEMINI_MODEL,
         metadata: { source: 'test', latencyMs: 0, reasoning: 'test' },
@@ -162,7 +162,7 @@ describe('ModelRouterService', () => {
 
       const decision = await service.route(mockContext);
 
-      expect(decision.model).toBe(DEFAULT_GEMINI_MODEL);
+      expect(decision.model).toBe(PREVIEW_GEMINI_MODEL);
     });
 
     it('should NOT upgrade to Preview Model when preview features are disabled', async () => {
@@ -215,7 +215,7 @@ describe('ModelRouterService', () => {
       expect(decision.model).toBe(DEFAULT_GEMINI_MODEL);
     });
 
-    it('should NOT upgrade to Preview Model even if fallback mode is active (probing behavior)', async () => {
+    it('should upgrade to Preview Model even if fallback mode is active (probing behavior)', async () => {
       vi.spyOn(mockCompositeStrategy, 'route').mockResolvedValue({
         model: DEFAULT_GEMINI_MODEL,
         metadata: { source: 'default', latencyMs: 0, reasoning: 'Default' },
@@ -225,7 +225,7 @@ describe('ModelRouterService', () => {
 
       const decision = await service.route(mockContext);
 
-      expect(decision.model).toBe(DEFAULT_GEMINI_MODEL);
+      expect(decision.model).toBe(PREVIEW_GEMINI_MODEL);
     });
   });
 });

--- a/packages/core/src/routing/modelRouterService.ts
+++ b/packages/core/src/routing/modelRouterService.ts
@@ -72,7 +72,7 @@ export class ModelRouterService {
       if (
         decision.model === DEFAULT_GEMINI_MODEL &&
         this.config.getPreviewFeatures() &&
-        decision.metadata.source !== 'override'
+        !decision.metadata.source.includes('override')
       ) {
         // We ALWAYS attempt to upgrade to Preview Model here.
         // If we are in fallback mode, the 'previewModelBypassMode' flag (handled in handler.ts/geminiChat.ts)

--- a/packages/core/src/routing/modelRouterService.ts
+++ b/packages/core/src/routing/modelRouterService.ts
@@ -5,6 +5,10 @@
  */
 
 import type { Config } from '../config/config.js';
+import {
+  PREVIEW_GEMINI_MODEL,
+  DEFAULT_GEMINI_MODEL,
+} from '../config/models.js';
 import type {
   RoutingContext,
   RoutingDecision,
@@ -61,6 +65,23 @@ export class ModelRouterService {
         this.config,
         this.config.getBaseLlmClient(),
       );
+
+      // Unified Preview Model Logic:
+      // If the decision is to use 'gemini-2.5-pro' and preview features are enabled,
+      // we attempt to upgrade to 'gemini-3.0-pro' (Preview Model).
+      if (
+        decision.model === DEFAULT_GEMINI_MODEL &&
+        this.config.getPreviewFeatures() &&
+        decision.metadata.source !== 'override'
+      ) {
+        // We ALWAYS attempt to upgrade to Preview Model here.
+        // If we are in fallback mode, the 'previewModelBypassMode' flag (handled in handler.ts/geminiChat.ts)
+        // will ensure we downgrade to 2.5 Pro for the actual API call if needed.
+        // This allows us to "probe" Preview Model periodically (i.e., every new request tries Preview Model first).
+        decision.model = PREVIEW_GEMINI_MODEL;
+        decision.metadata.source += ' (Preview Model)';
+        decision.metadata.reasoning += ' (Upgraded to Preview Model)';
+      }
 
       const event = new ModelRoutingEvent(
         decision.model,


### PR DESCRIPTION
Reverts google-gemini/gemini-cli#13477

This prevents us from periodically retrying Gemini 3

The fix is to check `!decision.metadata.source.includes('override')` not !== override