### PR TITLE
Skip pre-commit hooks for shadow repo (#13331)

### DIFF
--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -245,4 +245,15 @@ describe('GitService', () => {
       expect(hoistedMockCommit).not.toHaveBeenCalled();
     });
   });
+
+  describe('createFileSnapshot', () => {
+    it('should commit with --no-verify flag', async () => {
+      const service = new GitService(projectRoot, storage);
+      await service.initialize();
+      await service.createFileSnapshot('test commit');
+      expect(hoistedMockCommit).toHaveBeenCalledWith('test commit', {
+        '--no-verify': null,
+      });
+    });
+  });
 });

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -112,7 +112,9 @@ export class GitService {
     try {
       const repo = this.shadowGitRepository;
       await repo.add('.');
-      const commitResult = await repo.commit(message);
+      const commitResult = await repo.commit(message, {
+        '--no-verify': null,
+      });
       return commitResult.commit;
     } catch (error) {
       throw new Error(


### PR DESCRIPTION
## Summary

When there is a globally configured pre-commit hook installed in the system it can cause commits to the shadow repository to fail. The easiest way to work around this is to run the commit with --no-verify.

## Details

It is possible that we want to note his issue with documentation instead of running with --no-verify, but I don't know that there is an easy way to fix this in corporate settings where the system administrator globally enforces pre-commit hooks.

## Related Issues

Partial for #13331.

## How to Validate

Turn on checkpointing and make changes. Note that failures happen silently unless you also include #13486. You can go into the shadow git directory in .gemini/history/<sha>/ and manually add a failing pre-commit hook:

```
printf "#!/bin/sh\nexit 1" > .git/hooks/pre-commit
chmod +x .git/hooks/pre-commit
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [X] Linux
    - [X] npm run
    - [ ] npx
    - [ ] Docker
