### PR TITLE
feat(core): Add markdown content negotiation to WebFetch fallback

### DIFF
--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -136,7 +136,12 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     try {
       const response = await retryWithBackoff(
         async () => {
-          const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS);
+          const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS, {
+            headers: {
+              // Prefer markdown, then anything.
+              Accept: 'text/markdown, */*',
+            },
+          });
           if (!res.ok) {
             const error = new Error(
               `Request failed with status code ${res.status} ${res.statusText}`,

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -38,15 +38,23 @@ export function isPrivateIp(url: string): boolean {
   }
 }
 
+/**
+ * Fetch with a hard timeout. Any provided RequestInit options are used
+ * except for `signal`, which is managed internally for the timeout.
+ */
 export async function fetchWithTimeout(
   url: string,
   timeout: number,
+  options?: Omit<RequestInit, 'signal'>,
 ): Promise<Response> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeout);
 
   try {
-    const response = await fetch(url, { signal: controller.signal });
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
     return response;
   } catch (error) {
     if (isNodeError(error) && error.code === 'ABORT_ERR') {


### PR DESCRIPTION
## Summary

Add `Accept: text/markdown, */*` header to WebFetch tool's fallback fetch requests, enabling servers that support markdown to return native markdown directly instead of HTML. This improves content quality by avoiding lossy HTML-to-text conversion while maintaining full backward compatibility.

## Details

The WebFetch tool's fallback mode now uses HTTP content negotiation to request markdown when available. This is achieved by:

1. **Updated `fetchWithTimeout()`** in `packages/core/src/utils/fetch.ts` to accept optional `RequestInit` options (typed as `Omit<RequestInit, 'signal'>` to prevent signal conflicts)
2. **Modified fallback fetch** in `packages/core/src/tools/web-fetch.ts` to pass `Accept: text/markdown, */*` header
3. **Added JSDoc** documenting the signal is managed internally for timeout behavior

Servers that support markdown will return it directly (no conversion needed). Servers without markdown support continue returning HTML, which is processed through `html-to-text` as before. The existing content-type detection logic ensures proper handling of all response types.

This follows standard HTTP content negotiation (RFC 7231) and aligns with practices used by other CLI agents like Claude Code.

## Related Issues

Closes #13513 

## How to Validate

**Run tests:**
```bash
npm run test --workspace @google/gemini-cli-core -- web-fetch.test.ts
```

Expected: All 34 tests pass, including the new test verifying the Accept header is sent.

**Run full core tests:**
```bash
npm run test --workspace @google/gemini-cli-core
```

Expected: All 3278+ tests pass.

**Build and typecheck:**
```bash
npm run build --workspace @google/gemini-cli-core
npm run typecheck --workspace @google/gemini-cli-core
```

Expected: Clean build with no errors.

**Manual validation (optional):**
Test fetching a URL from a server that supports markdown content negotiation (e.g., `https://bun.com/docs/runtime/http/server`) and verify the tool receives markdown instead of HTML in fallback mode.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) - N/A, internal change only
- [x] Added/updated tests (if needed) - Added test for Accept header
- [x] Noted breaking changes (if any) - None, fully backward compatible
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run (tests pass)
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker