### PR TITLE
Enable switching preview features on/off without restart

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -101,7 +101,6 @@ their corresponding top-level category object in your `settings.json` file.
 - **`general.previewFeatures`** (boolean):
   - **Description:** Enable preview features (e.g., preview models).
   - **Default:** `false`
-  - **Requires restart:** Yes
 
 - **`general.preferredEditor`** (string):
   - **Description:** The preferred editor to open files in.

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -337,7 +337,7 @@ describe('SettingsSchema', () => {
       ).toBe(false);
       expect(
         getSettingsSchema().general.properties.previewFeatures.requiresRestart,
-      ).toBe(true);
+      ).toBe(false);
       expect(
         getSettingsSchema().general.properties.previewFeatures.showInDialog,
       ).toBe(true);

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -164,7 +164,7 @@ const SETTINGS_SCHEMA = {
         type: 'boolean',
         label: 'Preview Features (e.g., models)',
         category: 'General',
-        requiresRestart: true,
+        requiresRestart: false,
         default: false,
         description: 'Enable preview features (e.g., preview models).',
         showInDialog: true,

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -139,6 +139,7 @@ export const DialogManager = ({
           onSelect={() => uiActions.closeSettingsDialog()}
           onRestartRequest={() => process.exit(0)}
           availableTerminalHeight={terminalHeight - staticExtraHeight}
+          config={config}
         />
       </Box>
     );

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -44,6 +44,8 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
     { isActive: true },
   );
 
+  const isPreviewEnabled = config?.getPreviewFeatures();
+
   const options = useMemo(
     () => [
       {
@@ -54,7 +56,7 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
       },
       {
         value: GEMINI_MODEL_ALIAS_PRO,
-        title: config?.getPreviewFeatures()
+        title: isPreviewEnabled
           ? `Pro (${PREVIEW_GEMINI_MODEL}, ${DEFAULT_GEMINI_MODEL})`
           : `Pro (${DEFAULT_GEMINI_MODEL})`,
         description:
@@ -74,7 +76,7 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
         key: GEMINI_MODEL_ALIAS_FLASH_LITE,
       },
     ],
-    [config],
+    [isPreviewEnabled],
   );
 
   // Calculate the initial index based on the preferred model.

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -44,8 +44,6 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
     { isActive: true },
   );
 
-  const isPreviewEnabled = config?.getPreviewFeatures();
-
   const options = useMemo(
     () => [
       {
@@ -56,7 +54,7 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
       },
       {
         value: GEMINI_MODEL_ALIAS_PRO,
-        title: isPreviewEnabled
+        title: config?.getPreviewFeatures()
           ? `Pro (${PREVIEW_GEMINI_MODEL}, ${DEFAULT_GEMINI_MODEL})`
           : `Pro (${DEFAULT_GEMINI_MODEL})`,
         description:
@@ -76,7 +74,7 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
         key: GEMINI_MODEL_ALIAS_FLASH_LITE,
       },
     ],
-    [isPreviewEnabled],
+    [config],
   );
 
   // Calculate the initial index based on the preferred model.

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -43,12 +43,14 @@ import {
 } from '../../config/settingsSchema.js';
 import { debugLogger } from '@google/gemini-cli-core';
 import { keyMatchers, Command } from '../keyMatchers.js';
+import type { Config } from '@google/gemini-cli-core';
 
 interface SettingsDialogProps {
   settings: LoadedSettings;
   onSelect: (settingName: string | undefined, scope: SettingScope) => void;
   onRestartRequest?: () => void;
   availableTerminalHeight?: number;
+  config?: Config;
 }
 
 const maxItemsToShow = 8;
@@ -58,6 +60,7 @@ export function SettingsDialog({
   onSelect,
   onRestartRequest,
   availableTerminalHeight,
+  config,
 }: SettingsDialogProps): React.JSX.Element {
   // Get vim mode context to sync vim mode changes
   const { vimEnabled, toggleVimEnabled } = useVimMode();
@@ -208,6 +211,11 @@ export function SettingsDialog({
               next.delete(key);
               return next;
             });
+
+            if (key === 'general.previewFeatures') {
+              const current = config?.getPreviewFeatures();
+              config?.setPreviewFeatures(!current);
+            }
           } else {
             // For restart-required settings, track as modified
             setModifiedSettings((prev) => {

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -213,8 +213,7 @@ export function SettingsDialog({
             });
 
             if (key === 'general.previewFeatures') {
-              const current = config?.getPreviewFeatures();
-              config?.setPreviewFeatures(!current);
+              config?.setPreviewFeatures(newValue as boolean);
             }
           } else {
             // For restart-required settings, track as modified

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -26,7 +26,7 @@
         "previewFeatures": {
           "title": "Preview Features (e.g., models)",
           "description": "Enable preview features (e.g., preview models).",
-          "markdownDescription": "Enable preview features (e.g., preview models).\n\n- Category: `General`\n- Requires restart: `yes`\n- Default: `false`",
+          "markdownDescription": "Enable preview features (e.g., preview models).\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `false`",
           "default": false,
           "type": "boolean"
         },


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Enable switching preview features on/off without restart 
## Details
Some users can't see the message to restart Gemini CLI after enabling preview features, this PR brings changes to make sure they don't have to restart after enabling preview features

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Relates to https://github.com/google-gemini/gemini-cli/issues/13425
## How to Validate

https://github.com/user-attachments/assets/224ad2a0-fb15-448b-a449-c289db84e46a


<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
