### PR TITLE
fix(ui): Correct mouse click cursor positioning for wide characters

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -353,9 +353,9 @@ describe('textBufferReducer', () => {
   });
 });
 
-const getBufferState = (result: { current: TextBuffer }) => {
-  expect(result.current).toHaveOnlyValidCharacters();
-  return {
+const getBufferState = (result: { current: TextBuffer }) => 
+  // expect(result.current).toHaveOnlyValidCharacters();
+   ({
     text: result.current.text,
     lines: [...result.current.lines], // Clone for safety
     cursor: [...result.current.cursor] as [number, number],
@@ -364,8 +364,8 @@ const getBufferState = (result: { current: TextBuffer }) => {
     visualCursor: [...result.current.visualCursor] as [number, number],
     visualScrollRow: result.current.visualScrollRow,
     preferredCol: result.current.preferredCol,
-  };
-};
+  })
+;
 
 describe('useTextBuffer', () => {
   let viewport: Viewport;
@@ -962,6 +962,58 @@ describe('useTextBuffer', () => {
       state = getBufferState(result);
       expect(state.cursor).toEqual([0, 1]);
       expect(state.visualCursor).toEqual([0, 1]);
+    });
+
+    it('moveToVisualPosition: should correctly handle wide characters (Chinese)', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: '你好', // 2 chars, width 4
+          viewport: { width: 10, height: 1 },
+          isValidPath: () => false,
+        }),
+      );
+
+      // '你' (width 2): visual 0-1. '好' (width 2): visual 2-3.
+
+      // Click on '你' (first half, x=0) -> index 0
+      act(() => result.current.moveToVisualPosition(0, 0));
+      expect(getBufferState(result).cursor).toEqual([0, 0]);
+
+      // Click on '你' (second half, x=1) -> index 1 (after first char)
+      act(() => result.current.moveToVisualPosition(0, 1));
+      expect(getBufferState(result).cursor).toEqual([0, 1]);
+
+      // Click on '好' (first half, x=2) -> index 1 (before second char)
+      act(() => result.current.moveToVisualPosition(0, 2));
+      expect(getBufferState(result).cursor).toEqual([0, 1]);
+
+      // Click on '好' (second half, x=3) -> index 2 (after second char)
+      act(() => result.current.moveToVisualPosition(0, 3));
+      expect(getBufferState(result).cursor).toEqual([0, 2]);
+    });
+
+    it('moveToVisualPosition: should handle regular ASCII characters correctly', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'abc',
+          viewport: { width: 10, height: 1 },
+          isValidPath: () => false,
+        }),
+      );
+
+      // 'a' (width 1): visual 0. 'b' (width 1): visual 1. 'c' (width 1): visual 2.
+
+      // Click on 'a' -> index 0 (before 'a')
+      act(() => result.current.moveToVisualPosition(0, 0));
+      expect(getBufferState(result).cursor).toEqual([0, 0]);
+
+      // Click on 'b' -> index 1 (before 'b')
+      act(() => result.current.moveToVisualPosition(0, 1));
+      expect(getBufferState(result).cursor).toEqual([0, 1]);
+
+      // Click on 'c' -> index 2 (before 'c')
+      act(() => result.current.moveToVisualPosition(0, 2));
+      expect(getBufferState(result).cursor).toEqual([0, 2]);
     });
   });
 

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -353,9 +353,9 @@ describe('textBufferReducer', () => {
   });
 });
 
-const getBufferState = (result: { current: TextBuffer }) => 
-  // expect(result.current).toHaveOnlyValidCharacters();
-   ({
+const getBufferState = (result: { current: TextBuffer }) => {
+  expect(result.current).toHaveOnlyValidCharacters();
+  return {
     text: result.current.text,
     lines: [...result.current.lines], // Clone for safety
     cursor: [...result.current.cursor] as [number, number],
@@ -364,8 +364,8 @@ const getBufferState = (result: { current: TextBuffer }) =>
     visualCursor: [...result.current.visualCursor] as [number, number],
     visualScrollRow: result.current.visualScrollRow,
     preferredCol: result.current.preferredCol,
-  })
-;
+  };
+};
 
 describe('useTextBuffer', () => {
   let viewport: Viewport;
@@ -989,30 +989,6 @@ describe('useTextBuffer', () => {
 
       // Click on '好' (second half, x=3) -> index 2 (after second char)
       act(() => result.current.moveToVisualPosition(0, 3));
-      expect(getBufferState(result).cursor).toEqual([0, 2]);
-    });
-
-    it('moveToVisualPosition: should handle regular ASCII characters correctly', () => {
-      const { result } = renderHook(() =>
-        useTextBuffer({
-          initialText: 'abc',
-          viewport: { width: 10, height: 1 },
-          isValidPath: () => false,
-        }),
-      );
-
-      // 'a' (width 1): visual 0. 'b' (width 1): visual 1. 'c' (width 1): visual 2.
-
-      // Click on 'a' -> index 0 (before 'a')
-      act(() => result.current.moveToVisualPosition(0, 0));
-      expect(getBufferState(result).cursor).toEqual([0, 0]);
-
-      // Click on 'b' -> index 1 (before 'b')
-      act(() => result.current.moveToVisualPosition(0, 1));
-      expect(getBufferState(result).cursor).toEqual([0, 1]);
-
-      // Click on 'c' -> index 2 (before 'c')
-      act(() => result.current.moveToVisualPosition(0, 2));
       expect(getBufferState(result).cursor).toEqual([0, 2]);
     });
   });


### PR DESCRIPTION
## TLDR

This PR fixes an issue where clicking on wide characters (e.g., CJK characters) in the input prompt would position the cursor incorrectly. Previously, the logic assumed a 1:1 mapping between visual columns and character indices, which is incorrect for characters taking up multiple columns.

## Dive Deeper

The `moveToVisualPosition` function in `text-buffer.ts` was updated to correctly calculate the logical cursor position from a visual click coordinate.
*   It now iterates through the characters of the line, summing up their visual widths (using `string-width`).
*   It checks if the clicked column falls within a character's visual range.
*   If the click is on the second half of a wide character (width >= 2), it snaps the cursor to the *after* position of that character.
*   `preferredCol` is updated to track the logical character offset rather than the raw visual column, improving vertical navigation consistency across lines with mixed character widths.

## Reviewer Test Plan

1.  Open the CLI.
2.  Type some wide characters, e.g., "你好世界" (Hello World in Chinese).
3.  Click on the left half of '好'. The cursor should appear between '你' and '好'.
4.  Click on the right half of '好'. The cursor should appear between '好' and '世'.
5.  Verify that clicking on regular ASCII text still works as expected.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

