### PR TITLE
Fix: Process all parts in response chunks when thought is first

### DIFF
--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -290,15 +290,16 @@ export class Turn {
 
         const traceId = resp.responseId;
 
-        const thoughtPart = resp.candidates?.[0]?.content?.parts?.[0];
-        if (thoughtPart?.thought) {
-          const thought = parseThought(thoughtPart.text ?? '');
-          yield {
-            type: GeminiEventType.Thought,
-            value: thought,
-            traceId,
-          };
-          continue;
+        const parts = resp.candidates?.[0]?.content?.parts ?? [];
+        for (const part of parts) {
+          if (part.thought) {
+            const thought = parseThought(part.text ?? '');
+            yield {
+              type: GeminiEventType.Thought,
+              value: thought,
+              traceId,
+            };
+          }
         }
 
         const text = getResponseText(resp);

--- a/packages/core/src/utils/partUtils.ts
+++ b/packages/core/src/utils/partUtils.ts
@@ -81,7 +81,7 @@ export function getResponseText(
       candidate.content.parts.length > 0
     ) {
       return candidate.content.parts
-        .filter((part) => part.text)
+        .filter((part) => part.text && !part.thought)
         .map((part) => part.text)
         .join('');
     }


### PR DESCRIPTION
## Summary

Fixes a bug where response chunks containing a thought as the first part would skip processing of all other parts (text content, function calls, citations, and finish reasons) in the same chunk. This caused data loss when Gemini API sends thoughts mixed with other content.

## Details

When a Gemini API response chunk had a thought as the first part (`parts[0]`), the code would yield a `Thought` event and then execute `continue`, skipping all remaining processing. This could cause:
- Text content to not be emitted
- Function calls to not be processed
- Citations to not be collected
- Finish reasons to not be processed

The code only checked the first part (`parts[0]`) and assumed if it was a thought, the entire chunk was "thought-only". However, the Gemini API can send multiple parts in a single chunk, including thoughts mixed with other content. This happens e.g. in `geminiChat.test.ts:446`  which tests a chunk containing both a thought and visible text

**Solution:**
1. **Updated `turn.ts`**: 
   - Removed the `continue` statement after processing thoughts
   - Changed from checking only `parts[0]` to iterating through all parts
   - Process thoughts for any part that has them, then continue processing other parts

2. **Updated `getResponseText()` in `partUtils.ts`** (unrelated pre-existing bug fix):
   - Added filtering to exclude thought parts when extracting text
   - This fixes a separate, pre-existing bug where thought text could appear in content events when thoughts weren't the first part
   - Aligns with the pattern used elsewhere in the codebase:
     - `AgentExecutor.ts` (line 639): `parts?.filter((p) => !p.thought && p.text)`
     - `geminiChat.ts` (line 643): `...content.parts.filter((part) => !part.thought)`
   - Without this fix, thought text would appear in Content events even when thoughts were in later parts of the array

3. **Added test**:
   - Tests a chunk with thought as first part + text + function calls + citations + finishReason
   - Verifies all 5 event types are properly emitted (Thought, Content, ToolCallRequest, Citation, Finished)

## Related Issues

<!-- No related issues -->

## How to Validate

Run the tests including the new one:
  
```
   cd packages/core
   npm test -- src/core/turn.test.ts --run
   npm test -- src/utils/partUtils.test.ts --run
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) - None, backward compatible
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker