### PR TITLE
feat: Add /context command

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -14,6 +14,7 @@ import { bugCommand } from '../ui/commands/bugCommand.js';
 import { chatCommand } from '../ui/commands/chatCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
 import { compressCommand } from '../ui/commands/compressCommand.js';
+import { contextCommand } from '../ui/commands/contextCommand.js';
 import { copyCommand } from '../ui/commands/copyCommand.js';
 import { corgiCommand } from '../ui/commands/corgiCommand.js';
 import { docsCommand } from '../ui/commands/docsCommand.js';
@@ -62,6 +63,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       chatCommand,
       clearCommand,
       compressCommand,
+      contextCommand,
       copyCommand,
       corgiCommand,
       docsCommand,

--- a/packages/cli/src/services/contextInfoService.test.ts
+++ b/packages/cli/src/services/contextInfoService.test.ts
@@ -1,0 +1,235 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { getContextBreakdown } from './contextInfoService.js';
+import type { Config, GeminiClient } from '@google/gemini-cli-core';
+
+// Mock the core imports
+vi.mock('@google/gemini-cli-core', async () => {
+  const actual = await vi.importActual('@google/gemini-cli-core');
+  return {
+    ...actual,
+    tokenLimit: vi.fn((model: string) => {
+      if (model.includes('flash')) return 1000000;
+      return 2000000;
+    }),
+    getCoreSystemPrompt: vi.fn(
+      () => 'You are a helpful AI assistant with access to tools.',
+    ),
+  };
+});
+
+describe('getContextBreakdown', () => {
+  let mockConfig: Config;
+  let mockGeminiClient: GeminiClient;
+  let mockChat: {
+    getLastPromptTokenCount: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mockChat = {
+      getLastPromptTokenCount: vi.fn().mockReturnValue(5000),
+    };
+
+    mockGeminiClient = {
+      getChat: vi.fn().mockReturnValue(mockChat),
+      getHistory: vi.fn().mockReturnValue([
+        {
+          role: 'user',
+          parts: [{ text: 'Hello, how can you help me?' }],
+        },
+        {
+          role: 'model',
+          parts: [{ text: 'I can help you with many tasks!' }],
+        },
+      ]),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    mockConfig = {
+      getModel: vi.fn().mockReturnValue('gemini-2.5-pro'),
+      getToolRegistry: vi.fn().mockReturnValue({
+        getFunctionDeclarations: vi.fn().mockReturnValue([
+          {
+            name: 'read_file',
+            description: 'Reads a file from the filesystem',
+            parameters: {},
+          },
+          {
+            name: 'mcp__ide__getDiagnostics',
+            description: 'Gets IDE diagnostics',
+            parameters: {},
+          },
+          {
+            name: 'mcp__ide__executeCode',
+            description: 'Executes code',
+            parameters: {},
+          },
+        ]),
+      }),
+      getUserMemory: vi.fn().mockReturnValue('Remember to be helpful.'),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  });
+
+  it('should return null when config is null', async () => {
+    const result = await getContextBreakdown(null, mockGeminiClient);
+    expect(result).toBeNull();
+  });
+
+  it('should return null when geminiClient is undefined', async () => {
+    const result = await getContextBreakdown(mockConfig, undefined);
+    expect(result).toBeNull();
+  });
+
+  it('should return context breakdown with all components', async () => {
+    const result = await getContextBreakdown(mockConfig, mockGeminiClient);
+
+    expect(result).toBeDefined();
+    expect(result?.model).toBe('gemini-2.5-pro');
+    expect(result?.currentTokens).toBe(5000);
+    expect(result?.maxTokens).toBe(2000000);
+    expect(result?.systemPromptTokens).toBeGreaterThan(0);
+    expect(result?.toolsTokens).toBeGreaterThan(0);
+    expect(result?.mcpToolsTokens).toBeGreaterThan(0);
+    expect(result?.messagesTokens).toBeGreaterThan(0);
+  });
+
+  it('should separate MCP tools from system tools', async () => {
+    const result = await getContextBreakdown(mockConfig, mockGeminiClient);
+
+    expect(result?.mcpTools).toHaveLength(2);
+    expect(result?.mcpTools[0].name).toBe('mcp__ide__executeCode');
+    expect(result?.mcpTools[0].server).toBe('ide');
+    expect(result?.mcpTools[0].tokens).toBeGreaterThan(0);
+
+    expect(result?.mcpTools[1].name).toBe('mcp__ide__getDiagnostics');
+    expect(result?.mcpTools[1].server).toBe('ide');
+    expect(result?.mcpTools[1].tokens).toBeGreaterThan(0);
+  });
+
+  it('should sort MCP tools by server and name', async () => {
+    const mockConfigWithMultipleServers = {
+      ...mockConfig,
+      getToolRegistry: vi.fn().mockReturnValue({
+        getFunctionDeclarations: vi.fn().mockReturnValue([
+          {
+            name: 'mcp__zebra__tool',
+            description: 'Tool from zebra server',
+            parameters: {},
+          },
+          {
+            name: 'mcp__alpha__tool',
+            description: 'Tool from alpha server',
+            parameters: {},
+          },
+        ]),
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = await getContextBreakdown(
+      mockConfigWithMultipleServers,
+      mockGeminiClient,
+    );
+
+    expect(result?.mcpTools[0].server).toBe('alpha');
+    expect(result?.mcpTools[1].server).toBe('zebra');
+  });
+
+  it('should skip tools without a name', async () => {
+    const mockConfigWithInvalidTools = {
+      ...mockConfig,
+      getToolRegistry: vi.fn().mockReturnValue({
+        getFunctionDeclarations: vi.fn().mockReturnValue([
+          {
+            name: 'valid_tool',
+            description: 'Valid tool',
+            parameters: {},
+          },
+          {
+            description: 'Invalid tool without name',
+            parameters: {},
+          },
+        ]),
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = await getContextBreakdown(
+      mockConfigWithInvalidTools,
+      mockGeminiClient,
+    );
+
+    // Should not throw error and should process only the valid tool
+    expect(result).toBeDefined();
+    expect(result?.toolsTokens).toBeGreaterThan(0);
+  });
+
+  it('should estimate message tokens from history', async () => {
+    const result = await getContextBreakdown(mockConfig, mockGeminiClient);
+
+    // Messages should have some tokens based on the mocked history
+    expect(result?.messagesTokens).toBeGreaterThan(0);
+  });
+
+  it('should estimate system prompt tokens including user memory', async () => {
+    const result = await getContextBreakdown(mockConfig, mockGeminiClient);
+
+    expect(result?.systemPromptTokens).toBeGreaterThan(0);
+    // System prompt should be larger than just the memory
+    expect(result?.systemPromptTokens).toBeGreaterThan(
+      result?.memoryTokens || 0,
+    );
+  });
+
+  it('should handle errors gracefully', async () => {
+    const errorConfig = {
+      ...mockConfig,
+      getModel: vi.fn().mockImplementation(() => {
+        throw new Error('Failed to get model');
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const result = await getContextBreakdown(errorConfig, mockGeminiClient);
+
+    expect(result).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should return empty arrays for MCP tools and memory files when none exist', async () => {
+    const mockConfigWithoutMcp = {
+      ...mockConfig,
+      getToolRegistry: vi.fn().mockReturnValue({
+        getFunctionDeclarations: vi.fn().mockReturnValue([
+          {
+            name: 'read_file',
+            description: 'Reads a file',
+            parameters: {},
+          },
+        ]),
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = await getContextBreakdown(
+      mockConfigWithoutMcp,
+      mockGeminiClient,
+    );
+
+    expect(result?.mcpTools).toHaveLength(0);
+    expect(result?.mcpToolsTokens).toBe(0);
+    expect(result?.memoryFiles).toHaveLength(0);
+  });
+});

--- a/packages/cli/src/services/contextInfoService.ts
+++ b/packages/cli/src/services/contextInfoService.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config, GeminiClient } from '@google/gemini-cli-core';
+
+export interface ContextBreakdown {
+  model: string;
+  currentTokens: number;
+  maxTokens: number;
+  systemPromptTokens: number;
+  toolsTokens: number;
+  mcpToolsTokens: number;
+  memoryTokens: number;
+  messagesTokens: number;
+  mcpTools: Array<{ name: string; server: string; tokens: number }>;
+  memoryFiles: Array<{ path: string; tokens: number }>;
+  slashCommands: number;
+}
+
+/**
+ * Estimates token count for a string using a simple heuristic (4 chars ≈ 1 token)
+ */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Gathers detailed context information from the Gemini client
+ */
+export async function getContextBreakdown(
+  config: Config | null,
+  geminiClient: GeminiClient | undefined,
+): Promise<ContextBreakdown | null> {
+  if (!config || !geminiClient) {
+    return null;
+  }
+
+  try {
+    const model = config.getModel();
+    const { tokenLimit } = await import('@google/gemini-cli-core');
+    const maxTokens = tokenLimit(model);
+
+    // Get current prompt token count
+    const chat = geminiClient.getChat();
+    const currentTokens = chat.getLastPromptTokenCount();
+
+    // Get history to estimate message tokens
+    const history = geminiClient.getHistory();
+    let messagesTokens = 0;
+    for (const content of history) {
+      if (content.parts) {
+        for (const part of content.parts) {
+          if ('text' in part && part.text) {
+            messagesTokens += estimateTokens(part.text);
+          }
+        }
+      }
+    }
+
+    // Get tool registry to estimate tool tokens
+    const toolRegistry = config.getToolRegistry();
+    const toolDeclarations = toolRegistry.getFunctionDeclarations();
+
+    // Separate MCP tools from system tools
+    const mcpTools: Array<{ name: string; server: string; tokens: number }> =
+      [];
+    let mcpToolsTokens = 0;
+    let systemToolsTokens = 0;
+
+    for (const tool of toolDeclarations) {
+      // Skip tools without a name
+      if (!tool.name) continue;
+
+      const toolJson = JSON.stringify(tool);
+      const toolTokens = estimateTokens(toolJson);
+
+      if (tool.name.startsWith('mcp__') || tool.name.includes('_mcp_')) {
+        // Extract server name from tool name (e.g., "mcp__ide__getDiagnostics" -> "ide")
+        const parts = tool.name.split('__');
+        const serverName: string = parts.length > 1 ? parts[1] : 'unknown';
+        mcpTools.push({
+          name: tool.name,
+          server: serverName,
+          tokens: toolTokens,
+        });
+        mcpToolsTokens += toolTokens;
+      } else {
+        systemToolsTokens += toolTokens;
+      }
+    }
+
+    // Sort MCP tools by server name
+    mcpTools.sort((a, b) => {
+      if (a.server !== b.server) {
+        return a.server.localeCompare(b.server);
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    // Get user memory to estimate memory tokens
+    const userMemory = config.getUserMemory();
+    const memoryTokens = estimateTokens(userMemory);
+
+    // Estimate system prompt tokens
+    // System prompt includes the core prompt + user memory
+    const { getCoreSystemPrompt } = await import('@google/gemini-cli-core');
+    const systemPrompt = getCoreSystemPrompt(config, userMemory);
+    const systemPromptTokens = estimateTokens(systemPrompt);
+
+    // Get memory files (this is a simplification - actual implementation would need to track loaded files)
+    const memoryFiles: Array<{ path: string; tokens: number }> = [];
+
+    // Get slash commands count
+    const slashCommands = 0; // This would need to be retrieved from command service
+
+    return {
+      model,
+      currentTokens,
+      maxTokens,
+      systemPromptTokens,
+      toolsTokens: systemToolsTokens,
+      mcpToolsTokens,
+      memoryTokens,
+      messagesTokens,
+      mcpTools,
+      memoryFiles,
+      slashCommands,
+    };
+  } catch (error) {
+    console.error('Error gathering context breakdown:', error);
+    return null;
+  }
+}

--- a/packages/cli/src/ui/commands/contextCommand.test.ts
+++ b/packages/cli/src/ui/commands/contextCommand.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { contextCommand } from './contextCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import * as contextInfoService from '../../services/contextInfoService.js';
+import type { Config, GeminiClient } from '@google/gemini-cli-core';
+
+// Mock the context info service
+vi.mock('../../services/contextInfoService.js');
+
+describe('contextCommand', () => {
+  let mockContext: CommandContext;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockGetContextBreakdown: any;
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext();
+    mockGetContextBreakdown = vi
+      .spyOn(contextInfoService, 'getContextBreakdown')
+      .mockResolvedValue({
+        model: 'gemini-2.5-pro',
+        currentTokens: 5000,
+        maxTokens: 1000000,
+        systemPromptTokens: 500,
+        toolsTokens: 2000,
+        mcpToolsTokens: 1500,
+        memoryTokens: 500,
+        messagesTokens: 500,
+        mcpTools: [
+          { name: 'mcp__ide__getDiagnostics', server: 'ide', tokens: 750 },
+          { name: 'mcp__ide__executeCode', server: 'ide', tokens: 750 },
+        ],
+        memoryFiles: [{ path: '/project/memory.md', tokens: 500 }],
+        slashCommands: 0,
+      });
+  });
+
+  it('should have correct command metadata', () => {
+    expect(contextCommand.name).toBe('context');
+    expect(contextCommand.altNames).toEqual(['tokens']);
+    expect(contextCommand.description).toBe(
+      'Display context window and token usage information',
+    );
+  });
+
+  it('should call getContextBreakdown with config and geminiClient', async () => {
+    const mockConfig = { getModel: () => 'gemini-2.5-pro' } as Config;
+    const mockGeminiClient = {} as GeminiClient;
+
+    mockContext.services.config = {
+      ...mockConfig,
+      getGeminiClient: () => mockGeminiClient,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    if (!contextCommand.action) throw new Error('Command has no action');
+
+    await contextCommand.action(mockContext, '');
+
+    expect(mockGetContextBreakdown).toHaveBeenCalledWith(
+      mockContext.services.config,
+      mockGeminiClient,
+    );
+  });
+
+  it('should add context item with breakdown to UI', async () => {
+    const mockConfig = { getModel: () => 'gemini-2.5-pro' } as Config;
+    const mockGeminiClient = {} as GeminiClient;
+
+    mockContext.services.config = {
+      ...mockConfig,
+      getGeminiClient: () => mockGeminiClient,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    if (!contextCommand.action) throw new Error('Command has no action');
+
+    await contextCommand.action(mockContext, '');
+
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      {
+        type: 'context',
+        breakdown: expect.objectContaining({
+          model: 'gemini-2.5-pro',
+          currentTokens: 5000,
+          maxTokens: 1000000,
+          systemPromptTokens: 500,
+          toolsTokens: 2000,
+          mcpToolsTokens: 1500,
+          memoryTokens: 500,
+          messagesTokens: 500,
+        }),
+      },
+      expect.any(Number),
+    );
+  });
+
+  it('should handle null breakdown gracefully', async () => {
+    mockGetContextBreakdown.mockResolvedValue(null);
+
+    const mockConfig = { getModel: () => 'gemini-2.5-pro' } as Config;
+    const mockGeminiClient = {} as GeminiClient;
+
+    mockContext.services.config = {
+      ...mockConfig,
+      getGeminiClient: () => mockGeminiClient,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    if (!contextCommand.action) throw new Error('Command has no action');
+
+    await contextCommand.action(mockContext, '');
+
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      {
+        type: 'context',
+        breakdown: null,
+      },
+      expect.any(Number),
+    );
+  });
+
+  it('should work when config is null', async () => {
+    mockContext.services.config = null;
+
+    if (!contextCommand.action) throw new Error('Command has no action');
+
+    await contextCommand.action(mockContext, '');
+
+    expect(mockGetContextBreakdown).toHaveBeenCalledWith(null, undefined);
+    expect(mockContext.ui.addItem).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/ui/commands/contextCommand.ts
+++ b/packages/cli/src/ui/commands/contextCommand.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { HistoryItemContext } from '../types.js';
+import {
+  type CommandContext,
+  type SlashCommand,
+  CommandKind,
+} from './types.js';
+import { getContextBreakdown } from '../../services/contextInfoService.js';
+
+export const contextCommand: SlashCommand = {
+  name: 'context',
+  altNames: ['tokens'],
+  description: 'Display context window and token usage information',
+  kind: CommandKind.BUILT_IN,
+  action: async (context: CommandContext) => {
+    const geminiClient = context.services.config?.getGeminiClient();
+    const breakdown = await getContextBreakdown(
+      context.services.config,
+      geminiClient,
+    );
+
+    const contextItem: HistoryItemContext = {
+      type: 'context',
+      breakdown,
+    };
+
+    context.ui.addItem(contextItem, Date.now());
+  },
+};

--- a/packages/cli/src/ui/components/ContextDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ContextDisplay.test.tsx
@@ -1,0 +1,315 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from '../../test-utils/render.js';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { ContextDisplay } from './ContextDisplay.js';
+import type { HistoryItemContext } from '../types.js';
+
+describe('<ContextDisplay />', () => {
+  beforeAll(() => {
+    vi.spyOn(Number.prototype, 'toLocaleString').mockImplementation(function (
+      this: number,
+    ) {
+      // Use a stable 'en-US' format for test consistency.
+      return new Intl.NumberFormat('en-US').format(this);
+    });
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should display error message when breakdown is null', () => {
+    const item: HistoryItemContext = {
+      type: 'context',
+      breakdown: null,
+    };
+
+    const { lastFrame } = render(<ContextDisplay item={item} />);
+
+    expect(lastFrame()).toContain('Unable to gather context information');
+  });
+
+  it('should display context usage with all sections', () => {
+    const item: HistoryItemContext = {
+      type: 'context',
+      breakdown: {
+        model: 'gemini-2.5-pro',
+        currentTokens: 60000,
+        maxTokens: 200000,
+        systemPromptTokens: 2900,
+        toolsTokens: 13300,
+        mcpToolsTokens: 16800,
+        memoryTokens: 27000,
+        messagesTokens: 8,
+        mcpTools: [
+          { name: 'mcp__ide__getDiagnostics', server: 'ide', tokens: 428 },
+          { name: 'mcp__ide__executeCode', server: 'ide', tokens: 499 },
+        ],
+        memoryFiles: [
+          { path: '/project/CLAUDE.local.md', tokens: 584 },
+          { path: '/project/memory.md', tokens: 2200 },
+        ],
+        slashCommands: 681,
+      },
+    };
+
+    const { lastFrame } = render(<ContextDisplay item={item} />);
+
+    const output = lastFrame();
+
+    // Check header
+    expect(output).toContain('Context Usage');
+
+    // Check model and token info
+    expect(output).toContain('gemini-2.5-pro');
+    expect(output).toContain('60.0k/200.0k tokens');
+    expect(output).toContain('30%');
+
+    // Check breakdown sections
+    expect(output).toContain('System prompt:');
+    expect(output).toContain('2.9k tokens');
+
+    expect(output).toContain('System tools:');
+    expect(output).toContain('13.3k tokens');
+
+    expect(output).toContain('MCP tools:');
+    expect(output).toContain('16.8k tokens');
+
+    expect(output).toContain('Memory files:');
+    expect(output).toContain('27.0k tokens');
+
+    expect(output).toContain('Messages:');
+
+    expect(output).toContain('Free space:');
+    expect(output).toContain('140.0k');
+    expect(output).toContain('70.0%');
+  });
+
+  it('should display MCP tools section with server grouping', () => {
+    const item: HistoryItemContext = {
+      type: 'context',
+      breakdown: {
+        model: 'gemini-2.5-pro',
+        currentTokens: 5000,
+        maxTokens: 1000000,
+        systemPromptTokens: 500,
+        toolsTokens: 2000,
+        mcpToolsTokens: 1500,
+        memoryTokens: 500,
+        messagesTokens: 500,
+        mcpTools: [
+          { name: 'mcp__ide__getDiagnostics', server: 'ide', tokens: 750 },
+          {
+            name: 'mcp__playwright__browserClose',
+            server: 'playwright',
+            tokens: 390,
+          },
+        ],
+        memoryFiles: [],
+        slashCommands: 0,
+      },
+    };
+
+    const { lastFrame } = render(<ContextDisplay item={item} />);
+
+    const output = lastFrame();
+
+    // Check MCP tools section header
+    expect(output).toContain('MCP tools');
+    expect(output).toContain('/ide');
+    expect(output).toContain('/playwright');
+
+    // Check individual tools
+    expect(output).toContain('ide_getDiagnostics');
+    expect(output).toContain('(ide):');
+    expect(output).toContain('750 tokens');
+
+    expect(output).toContain('playwright_browserClose');
+    expect(output).toContain('(playwright):');
+    expect(output).toContain('390 tokens');
+  });
+
+  it('should display memory files section', () => {
+    const item: HistoryItemContext = {
+      type: 'context',
+      breakdown: {
+        model: 'gemini-2.5-pro',
+        currentTokens: 5000,
+        maxTokens: 1000000,
+        systemPromptTokens: 500,
+        toolsTokens: 2000,
+        mcpToolsTokens: 0,
+        memoryTokens: 2000,
+        messagesTokens: 500,
+        mcpTools: [],
+        memoryFiles: [
+          { path: '/project/memory.md', tokens: 1000 },
+          { path: '/project/notes.md', tokens: 1000 },
+        ],
+        slashCommands: 0,
+      },
+    };
+
+    const { lastFrame } = render(<ContextDisplay item={item} />);
+
+    const output = lastFrame();
+
+    // Check memory files section
+    expect(output).toContain('Memory files');
+    expect(output).toContain('/memory');
+    expect(output).toContain('/project/memory.md:');
+    expect(output).toContain('/project/notes.md:');
+    expect(output).toContain('1000 tokens');
+  });
+
+  it('should display slash commands section when present', () => {
+    const item: HistoryItemContext = {
+      type: 'context',
+      breakdown: {
+        model: 'gemini-2.5-pro',
+        currentTokens: 5000,
+        maxTokens: 1000000,
+        systemPromptTokens: 500,
+        toolsTokens: 2000,
+        mcpToolsTokens: 0,
+        memoryTokens: 0,
+        messagesTokens: 500,
+        mcpTools: [],
+        memoryFiles: [],
+        slashCommands: 681,
+      },
+    };
+
+    const { lastFrame } = render(<ContextDisplay item={item} />);
+
+    const output = lastFrame();
+
+    expect(output).toContain('SlashCommand Tool');
+    expect(output).toContain('681 commands');
+    expect(output).toContain('Total: 681 tokens');
+  });
+
+  it('should not display sections with zero tokens', () => {
+    const item: HistoryItemContext = {
+      type: 'context',
+      breakdown: {
+        model: 'gemini-2.5-flash',
+        currentTokens: 500,
+        maxTokens: 1000000,
+        systemPromptTokens: 500,
+        toolsTokens: 0,
+        mcpToolsTokens: 0,
+        memoryTokens: 0,
+        messagesTokens: 0,
+        mcpTools: [],
+        memoryFiles: [],
+        slashCommands: 0,
+      },
+    };
+
+    const { lastFrame } = render(<ContextDisplay item={item} />);
+
+    const output = lastFrame();
+
+    // Should show system prompt
+    expect(output).toContain('System prompt:');
+
+    // Should not show other sections
+    expect(output).not.toContain('System tools:');
+    expect(output).not.toContain('MCP tools:');
+    expect(output).not.toContain('Memory files:');
+    expect(output).not.toContain('Messages:');
+    expect(output).not.toContain('SlashCommand Tool');
+  });
+
+  it('should format large numbers with k suffix', () => {
+    const item: HistoryItemContext = {
+      type: 'context',
+      breakdown: {
+        model: 'gemini-2.5-pro',
+        currentTokens: 600000,
+        maxTokens: 2000000,
+        systemPromptTokens: 50000,
+        toolsTokens: 100000,
+        mcpToolsTokens: 200000,
+        memoryTokens: 150000,
+        messagesTokens: 100000,
+        mcpTools: [],
+        memoryFiles: [],
+        slashCommands: 0,
+      },
+    };
+
+    const { lastFrame } = render(<ContextDisplay item={item} />);
+
+    const output = lastFrame();
+
+    expect(output).toContain('600.0k/2000.0k tokens');
+    expect(output).toContain('50.0k tokens');
+    expect(output).toContain('100.0k tokens');
+    expect(output).toContain('200.0k tokens');
+    expect(output).toContain('150.0k tokens');
+  });
+
+  it('should display percentage for each component', () => {
+    const item: HistoryItemContext = {
+      type: 'context',
+      breakdown: {
+        model: 'gemini-2.5-pro',
+        currentTokens: 10000,
+        maxTokens: 100000,
+        systemPromptTokens: 2000,
+        toolsTokens: 3000,
+        mcpToolsTokens: 2000,
+        memoryTokens: 2000,
+        messagesTokens: 1000,
+        mcpTools: [],
+        memoryFiles: [],
+        slashCommands: 0,
+      },
+    };
+
+    const { lastFrame } = render(<ContextDisplay item={item} />);
+
+    const output = lastFrame();
+
+    expect(output).toContain('(2.0%)'); // System prompt: 2000/100000 = 2%
+    expect(output).toContain('(3.0%)'); // Tools: 3000/100000 = 3%
+    expect(output).toContain('(1.0%)'); // Messages: 1000/100000 = 1%
+  });
+
+  it('should match snapshot for complete breakdown', () => {
+    const item: HistoryItemContext = {
+      type: 'context',
+      breakdown: {
+        model: 'gemini-2.5-pro',
+        currentTokens: 60000,
+        maxTokens: 200000,
+        systemPromptTokens: 2900,
+        toolsTokens: 13300,
+        mcpToolsTokens: 16800,
+        memoryTokens: 27000,
+        messagesTokens: 8,
+        mcpTools: [
+          { name: 'mcp__ide__getDiagnostics', server: 'ide', tokens: 428 },
+          {
+            name: 'mcp__playwright__browserClose',
+            server: 'playwright',
+            tokens: 390,
+          },
+        ],
+        memoryFiles: [{ path: '/project/memory.md', tokens: 2200 }],
+        slashCommands: 681,
+      },
+    };
+
+    const { lastFrame } = render(<ContextDisplay item={item} />);
+
+    expect(lastFrame()).toMatchSnapshot();
+  });
+});

--- a/packages/cli/src/ui/components/ContextDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextDisplay.tsx
@@ -1,0 +1,310 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../semantic-colors.js';
+import type { HistoryItemContext } from '../types.js';
+
+const PROGRESS_BAR_WIDTH = 20;
+
+interface ContextDisplayProps {
+  item: HistoryItemContext;
+}
+
+/**
+ * Creates a visual progress bar with colored blocks
+ */
+const ProgressBar: React.FC<{
+  used: number;
+  total: number;
+  breakdown?: {
+    systemPrompt: number;
+    tools: number;
+    mcpTools: number;
+    memory: number;
+    messages: number;
+  };
+}> = ({ used, total, breakdown }) => {
+  const percentage = Math.min((used / total) * 100, 100);
+  const filledBlocks = Math.round((percentage / 100) * PROGRESS_BAR_WIDTH);
+
+  // If we have breakdown, color-code the blocks
+  if (breakdown) {
+    const blocks = [];
+    const colors = [
+      theme.text.link, // system prompt
+      theme.status.warning, // tools
+      '#8B5CF6', // mcp tools (purple)
+      '#06B6D4', // memory (cyan)
+      '#10B981', // messages (green)
+    ];
+
+    let blockIndex = 0;
+    const totalTokens = used;
+
+    // Calculate blocks for each component
+    const components = [
+      breakdown.systemPrompt,
+      breakdown.tools,
+      breakdown.mcpTools,
+      breakdown.memory,
+      breakdown.messages,
+    ];
+
+    components.forEach((componentTokens, i) => {
+      const componentBlocks = Math.round(
+        (componentTokens / totalTokens) * filledBlocks,
+      );
+      for (
+        let j = 0;
+        j < componentBlocks && blockIndex < PROGRESS_BAR_WIDTH;
+        j++
+      ) {
+        blocks.push(
+          <Text key={`filled-${blockIndex}`} color={colors[i]}>
+            ▓
+          </Text>,
+        );
+        blockIndex++;
+      }
+    });
+
+    // Fill remaining blocks as empty
+    for (let i = blockIndex; i < PROGRESS_BAR_WIDTH; i++) {
+      blocks.push(
+        <Text key={`empty-${i}`} dimColor>
+          ░
+        </Text>,
+      );
+    }
+
+    return <Box>{blocks}</Box>;
+  }
+
+  // Simple progress bar without breakdown
+  const blocks = [];
+  for (let i = 0; i < PROGRESS_BAR_WIDTH; i++) {
+    if (i < filledBlocks) {
+      const color =
+        percentage >= 90
+          ? theme.status.error
+          : percentage >= 70
+            ? theme.status.warning
+            : theme.status.success;
+      blocks.push(
+        <Text key={i} color={color}>
+          ▓
+        </Text>,
+      );
+    } else {
+      blocks.push(
+        <Text key={i} dimColor>
+          ░
+        </Text>,
+      );
+    }
+  }
+  return <Box>{blocks}</Box>;
+};
+
+export const ContextDisplay: React.FC<ContextDisplayProps> = ({ item }) => {
+  const { breakdown } = item;
+
+  if (!breakdown) {
+    return (
+      <Box paddingY={1}>
+        <Text color={theme.status.error}>
+          Unable to gather context information
+        </Text>
+      </Box>
+    );
+  }
+
+  const {
+    model,
+    currentTokens,
+    maxTokens,
+    systemPromptTokens,
+    toolsTokens,
+    mcpToolsTokens,
+    memoryTokens,
+    messagesTokens,
+    mcpTools,
+    memoryFiles,
+    slashCommands,
+  } = breakdown;
+
+  const usagePercent = (currentTokens / maxTokens) * 100;
+  const freeSpace = maxTokens - currentTokens;
+  const freeSpacePercent = (freeSpace / maxTokens) * 100;
+
+  // Format numbers with k suffix
+  const formatNumber = (num: number): string => {
+    if (num >= 1000) {
+      return `${(num / 1000).toFixed(1)}k`;
+    }
+    return num.toString();
+  };
+
+  // Group MCP tools by server
+  const toolsByServer = new Map<string, typeof mcpTools>();
+  mcpTools.forEach((tool) => {
+    if (!toolsByServer.has(tool.server)) {
+      toolsByServer.set(tool.server, []);
+    }
+    toolsByServer.get(tool.server)!.push(tool);
+  });
+
+  return (
+    <Box flexDirection="column" paddingY={1}>
+      {/* Header */}
+      <Text bold color={theme.text.accent}>
+        Context Usage
+      </Text>
+      <Box height={1} />
+
+      {/* Progress Bar */}
+      <Box flexDirection="row" gap={1}>
+        <ProgressBar
+          used={currentTokens}
+          total={maxTokens}
+          breakdown={{
+            systemPrompt: systemPromptTokens,
+            tools: toolsTokens,
+            mcpTools: mcpToolsTokens,
+            memory: memoryTokens,
+            messages: messagesTokens,
+          }}
+        />
+        <Text color={theme.text.primary}>
+          {model} • {formatNumber(currentTokens)}/{formatNumber(maxTokens)}{' '}
+          tokens ({usagePercent.toFixed(0)}%)
+        </Text>
+      </Box>
+
+      <Box height={1} />
+
+      {/* Breakdown */}
+      <Box flexDirection="column">
+        {systemPromptTokens > 0 && (
+          <Box>
+            <Text color={theme.text.link}>□ System prompt: </Text>
+            <Text color={theme.text.primary}>
+              {formatNumber(systemPromptTokens)} tokens (
+              {((systemPromptTokens / maxTokens) * 100).toFixed(1)}%)
+            </Text>
+          </Box>
+        )}
+
+        {toolsTokens > 0 && (
+          <Box>
+            <Text color={theme.status.warning}>□ System tools: </Text>
+            <Text color={theme.text.primary}>
+              {formatNumber(toolsTokens)} tokens (
+              {((toolsTokens / maxTokens) * 100).toFixed(1)}%)
+            </Text>
+          </Box>
+        )}
+
+        {mcpToolsTokens > 0 && (
+          <Box>
+            <Text color="#8B5CF6">□ MCP tools: </Text>
+            <Text color={theme.text.primary}>
+              {formatNumber(mcpToolsTokens)} tokens (
+              {((mcpToolsTokens / maxTokens) * 100).toFixed(1)}%)
+            </Text>
+          </Box>
+        )}
+
+        {memoryTokens > 0 && (
+          <Box>
+            <Text color="#06B6D4">□ Memory files: </Text>
+            <Text color={theme.text.primary}>
+              {formatNumber(memoryTokens)} tokens (
+              {((memoryTokens / maxTokens) * 100).toFixed(1)}%)
+            </Text>
+          </Box>
+        )}
+
+        {messagesTokens > 0 && (
+          <Box>
+            <Text color="#10B981">□ Messages: </Text>
+            <Text color={theme.text.primary}>
+              {formatNumber(messagesTokens)} tokens (
+              {((messagesTokens / maxTokens) * 100).toFixed(1)}%)
+            </Text>
+          </Box>
+        )}
+
+        <Box>
+          <Text dimColor>□ Free space: </Text>
+          <Text color={theme.text.primary}>
+            {formatNumber(freeSpace)} ({freeSpacePercent.toFixed(1)}%)
+          </Text>
+        </Box>
+      </Box>
+
+      {/* MCP Tools Section */}
+      {mcpTools.length > 0 && (
+        <>
+          <Box height={1} />
+          <Text bold color={theme.text.accent}>
+            MCP tools • /{Array.from(toolsByServer.keys()).join(', /')}
+          </Text>
+          <Box height={1} />
+          <Box flexDirection="column">
+            {Array.from(toolsByServer.entries()).map(([server, tools]) =>
+              tools.map((tool) => (
+                <Box key={tool.name}>
+                  <Text dimColor>└ </Text>
+                  <Text color={theme.text.primary}>
+                    {tool.name.replace('mcp__', '').replace(/__/g, '_')}{' '}
+                  </Text>
+                  <Text dimColor>({server}): </Text>
+                  <Text color={theme.text.primary}>{tool.tokens} tokens</Text>
+                </Box>
+              )),
+            )}
+          </Box>
+        </>
+      )}
+
+      {/* Memory Files Section */}
+      {memoryFiles.length > 0 && (
+        <>
+          <Box height={1} />
+          <Text bold color={theme.text.accent}>
+            Memory files • /memory
+          </Text>
+          <Box height={1} />
+          <Box flexDirection="column">
+            {memoryFiles.map((file) => (
+              <Box key={file.path}>
+                <Text dimColor>└ </Text>
+                <Text color={theme.text.primary}>{file.path}: </Text>
+                <Text dimColor>{file.tokens} tokens</Text>
+              </Box>
+            ))}
+          </Box>
+        </>
+      )}
+
+      {/* SlashCommand Tools Section */}
+      {slashCommands > 0 && (
+        <>
+          <Box height={1} />
+          <Text bold color={theme.text.accent}>
+            SlashCommand Tool • {slashCommands} commands
+          </Text>
+          <Box>
+            <Text dimColor>└ Total: {slashCommands} tokens</Text>
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -22,6 +22,7 @@ import { AboutBox } from './AboutBox.js';
 import { StatsDisplay } from './StatsDisplay.js';
 import { ModelStatsDisplay } from './ModelStatsDisplay.js';
 import { ToolStatsDisplay } from './ToolStatsDisplay.js';
+import { ContextDisplay } from './ContextDisplay.js';
 import { SessionSummaryDisplay } from './SessionSummaryDisplay.js';
 import { Help } from './Help.js';
 import type { SlashCommand } from '../commands/types.js';
@@ -119,6 +120,9 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
       )}
       {itemForDisplay.type === 'model_stats' && <ModelStatsDisplay />}
       {itemForDisplay.type === 'tool_stats' && <ToolStatsDisplay />}
+      {itemForDisplay.type === 'context' && (
+        <ContextDisplay item={itemForDisplay} />
+      )}
       {itemForDisplay.type === 'model' && (
         <ModelMessage model={itemForDisplay.model} />
       )}

--- a/packages/cli/src/ui/components/__snapshots__/ContextDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ContextDisplay.test.tsx.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<ContextDisplay /> > should match snapshot for complete breakdown 1`] = `
+"
+Context Usage
+
+▓▓▓▓▓▓░░░░░░░░░░░░░░ gemini-2.5-pro • 60.0k/200.0k tokens (30%)
+
+□ System prompt: 2.9k tokens (1.5%)
+□ System tools: 13.3k tokens (6.7%)
+□ MCP tools: 16.8k tokens (8.4%)
+□ Memory files: 27.0k tokens (13.5%)
+□ Messages: 8 tokens (0.0%)
+□ Free space: 140.0k (70.0%)
+
+MCP tools • /ide, /playwright
+
+└ ide_getDiagnostics (ide): 428 tokens
+└ playwright_browserClose (playwright): 390 tokens
+
+Memory files • /memory
+
+└ /project/memory.md: 2200 tokens
+
+SlashCommand Tool • 681 commands
+└ Total: 681 tokens
+"
+`;

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -152,6 +152,23 @@ export type HistoryItemToolStats = HistoryItemBase & {
   type: 'tool_stats';
 };
 
+export type HistoryItemContext = HistoryItemBase & {
+  type: 'context';
+  breakdown: {
+    model: string;
+    currentTokens: number;
+    maxTokens: number;
+    systemPromptTokens: number;
+    toolsTokens: number;
+    mcpToolsTokens: number;
+    memoryTokens: number;
+    messagesTokens: number;
+    mcpTools: Array<{ name: string; server: string; tokens: number }>;
+    memoryFiles: Array<{ path: string; tokens: number }>;
+    slashCommands: number;
+  } | null;
+};
+
 export type HistoryItemModel = HistoryItemBase & {
   type: 'model';
   model: string;
@@ -256,6 +273,7 @@ export type HistoryItemWithoutId =
   | HistoryItemStats
   | HistoryItemModelStats
   | HistoryItemToolStats
+  | HistoryItemContext
   | HistoryItemModel
   | HistoryItemQuit
   | HistoryItemCompression
@@ -277,6 +295,7 @@ export enum MessageType {
   STATS = 'stats',
   MODEL_STATS = 'model_stats',
   TOOL_STATS = 'tool_stats',
+  CONTEXT = 'context',
   QUIT = 'quit',
   GEMINI = 'gemini',
   COMPRESSION = 'compression',


### PR DESCRIPTION
## Summary

Add /context command and UI to display token usage and context breakdown.

## Related Issues

Fixes #13400 

## How to Validate

Run /context at various times while using the CLI.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
