### PR TITLE
Fix multiple bugs with auth flow including using the implemented but unused restart support.

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -8,23 +8,26 @@
 
 import './src/gemini.js';
 import { main } from './src/gemini.js';
-import { debugLogger, FatalError } from '@google/gemini-cli-core';
+import { FatalError, writeToStderr } from '@google/gemini-cli-core';
+import { runExitCleanup } from './src/utils/cleanup.js';
 
 // --- Global Entry Point ---
-main().catch((error) => {
+main().catch(async (error) => {
+  await runExitCleanup();
+
   if (error instanceof FatalError) {
     let errorMessage = error.message;
     if (!process.env['NO_COLOR']) {
       errorMessage = `\x1b[31m${errorMessage}\x1b[0m`;
     }
-    debugLogger.error(errorMessage);
+    writeToStderr(errorMessage + '\n');
     process.exit(error.exitCode);
   }
-  debugLogger.error('An unexpected critical error occurred:');
+  writeToStderr('An unexpected critical error occurred:');
   if (error instanceof Error) {
-    debugLogger.error(error.stack);
+    writeToStderr(error.stack + '\n');
   } else {
-    debugLogger.error(String(error));
+    writeToStderr(String(error) + '\n');
   }
   process.exit(1);
 });

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -69,6 +69,8 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
       stdout: process.stdout,
       stderr: process.stderr,
     })),
+    enableMouseEvents: vi.fn(),
+    disableMouseEvents: vi.fn(),
   };
 });
 import type { LoadedSettings } from '../config/settings.js';
@@ -137,10 +139,6 @@ vi.mock('../utils/events.js');
 vi.mock('../utils/handleAutoUpdate.js');
 vi.mock('./utils/ConsolePatcher.js');
 vi.mock('../utils/cleanup.js');
-vi.mock('./utils/mouse.js', () => ({
-  enableMouseEvents: vi.fn(),
-  disableMouseEvents: vi.fn(),
-}));
 
 import { useHistory } from './hooks/useHistoryManager.js';
 import { useThemeCommand } from './hooks/useThemeCommand.js';
@@ -165,9 +163,13 @@ import { useLoadingIndicator } from './hooks/useLoadingIndicator.js';
 import { useKeypress, type Key } from './hooks/useKeypress.js';
 import { measureElement } from 'ink';
 import { useTerminalSize } from './hooks/useTerminalSize.js';
-import { ShellExecutionService, writeToStdout } from '@google/gemini-cli-core';
+import {
+  ShellExecutionService,
+  writeToStdout,
+  enableMouseEvents,
+  disableMouseEvents,
+} from '@google/gemini-cli-core';
 import { type ExtensionManager } from '../config/extension-manager.js';
-import { enableMouseEvents, disableMouseEvents } from './utils/mouse.js';
 
 describe('AppContainer State Management', () => {
   let mockConfig: Config;

--- a/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -25,6 +25,7 @@ import { validateAuthMethodWithSettings } from './useAuth.js';
 import { runExitCleanup } from '../../utils/cleanup.js';
 import { clearCachedCredentialFile } from '@google/gemini-cli-core';
 import { Text } from 'ink';
+import { RELAUNCH_EXIT_CODE } from '../../utils/processUtils.js';
 
 // Mocks
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
@@ -229,6 +230,7 @@ describe('AuthDialog', () => {
     });
 
     it('exits process for Login with Google when browser is suppressed', async () => {
+      vi.useFakeTimers();
       const exitSpy = vi
         .spyOn(process, 'exit')
         .mockImplementation(() => undefined as never);
@@ -241,14 +243,14 @@ describe('AuthDialog', () => {
         mockedRadioButtonSelect.mock.calls[0][0];
       await handleAuthSelect(AuthType.LOGIN_WITH_GOOGLE);
 
+      await vi.runAllTimersAsync();
+
       expect(mockedRunExitCleanup).toHaveBeenCalled();
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Please restart Gemini CLI'),
-      );
-      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(exitSpy).toHaveBeenCalledWith(RELAUNCH_EXIT_CODE);
 
       exitSpy.mockRestore();
       logSpy.mockRestore();
+      vi.useRealTimers();
     });
   });
 

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -18,6 +18,8 @@ import { ApiAuthDialog } from '../auth/ApiAuthDialog.js';
 import { EditorSettingsDialog } from './EditorSettingsDialog.js';
 import { PrivacyNotice } from '../privacy/PrivacyNotice.js';
 import { ProQuotaDialog } from './ProQuotaDialog.js';
+import { runExitCleanup } from '../../utils/cleanup.js';
+import { RELAUNCH_EXIT_CODE } from '../../utils/processUtils.js';
 import { PermissionsModifyTrustDialog } from './PermissionsModifyTrustDialog.js';
 import { ModelDialog } from './ModelDialog.js';
 import { theme } from '../semantic-colors.js';
@@ -137,7 +139,10 @@ export const DialogManager = ({
         <SettingsDialog
           settings={settings}
           onSelect={() => uiActions.closeSettingsDialog()}
-          onRestartRequest={() => process.exit(0)}
+          onRestartRequest={async () => {
+            await runExitCleanup();
+            process.exit(RELAUNCH_EXIT_CODE);
+          }}
           availableTerminalHeight={terminalHeight - staticExtraHeight}
           config={config}
         />

--- a/packages/cli/src/ui/utils/kittyProtocolDetector.ts
+++ b/packages/cli/src/ui/utils/kittyProtocolDetector.ts
@@ -97,6 +97,11 @@ export async function detectAndEnableKittyProtocol(): Promise<void> {
   });
 }
 
+import {
+  enableKittyKeyboardProtocol,
+  disableKittyKeyboardProtocol,
+} from '@google/gemini-cli-core';
+
 export function isKittyProtocolEnabled(): boolean {
   return kittyEnabled;
 }
@@ -104,8 +109,7 @@ export function isKittyProtocolEnabled(): boolean {
 function disableAllProtocols() {
   try {
     if (kittyEnabled) {
-      // use writeSync to avoid race conditions
-      fs.writeSync(process.stdout.fd, '\x1b[<u');
+      disableKittyKeyboardProtocol();
       kittyEnabled = false;
     }
   } catch {
@@ -120,8 +124,7 @@ function disableAllProtocols() {
 export function enableSupportedProtocol(): void {
   try {
     if (kittySupported) {
-      // use writeSync to avoid race conditions
-      fs.writeSync(process.stdout.fd, '\x1b[>1u');
+      enableKittyKeyboardProtocol();
       kittyEnabled = true;
     }
   } catch {

--- a/packages/cli/src/ui/utils/mouse.ts
+++ b/packages/cli/src/ui/utils/mouse.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { writeToStdout } from '@google/gemini-cli-core';
+import { enableMouseEvents, disableMouseEvents } from '@google/gemini-cli-core';
 import {
   SGR_MOUSE_REGEX,
   X11_MOUSE_REGEX,
@@ -230,14 +230,4 @@ export function isIncompleteMouseSequence(buffer: string): boolean {
   return true;
 }
 
-export function enableMouseEvents() {
-  // Enable mouse tracking with SGR format
-  // ?1002h = button event tracking (clicks + drags + scroll wheel)
-  // ?1006h = SGR extended mouse mode (better coordinate handling)
-  writeToStdout('\u001b[?1002h\u001b[?1006h');
-}
-
-export function disableMouseEvents() {
-  // Disable mouse tracking with SGR format
-  writeToStdout('\u001b[?1006l\u001b[?1002l');
-}
+export { enableMouseEvents, disableMouseEvents };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,3 +147,4 @@ export * from './hooks/types.js';
 
 // Export stdio utils
 export * from './utils/stdio.js';
+export * from './utils/terminal.js';

--- a/packages/core/src/utils/terminal.ts
+++ b/packages/core/src/utils/terminal.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { writeToStdout } from './stdio.js';
+
+export function enableMouseEvents() {
+  // Enable mouse tracking with SGR format
+  // ?1002h = button event tracking (clicks + drags + scroll wheel)
+  // ?1006h = SGR extended mouse mode (better coordinate handling)
+  writeToStdout('\u001b[?1002h\u001b[?1006h');
+}
+
+export function disableMouseEvents() {
+  // Disable mouse tracking with SGR format
+  writeToStdout('\u001b[?1006l\u001b[?1002l');
+}
+
+export function enableKittyKeyboardProtocol() {
+  writeToStdout('\x1b[>1u');
+}
+
+export function disableKittyKeyboardProtocol() {
+  writeToStdout('\x1b[<u');
+}
+
+export function enableLineWrapping() {
+  writeToStdout('\x1b[?7h');
+}
+
+export function disableLineWrapping() {
+  writeToStdout('\x1b[?7l');
+}
+
+export function enterAlternateScreen() {
+  writeToStdout('\x1b[?1049h');
+}
+
+export function exitAlternateScreen() {
+  writeToStdout('\x1b[?1049l');
+}
+
+export function shouldEnterAlternateScreen(
+  useAlternateBuffer: boolean,
+  isScreenReader: boolean,
+): boolean {
+  return useAlternateBuffer && !isScreenReader;
+}


### PR DESCRIPTION
## Summary

The auth flow was hard to read with important information sent to the debug console rather than displayed on the screen so users would have little indication of what was going on.

We were also neglecting to use the functionality @shrutip90 added to support restarting the IDE and so we were forcing users to restart manually in multiple places. Audited all places we were exiting adding the proper cleanup logic and calling the appropriate command to restart for cases where it was intended the user would restart.

## Details

* **Centralized Terminal Control**: Terminal interaction functions (mouse events, Kitty protocol, alternate screen, line wrapping) have been moved from `packages/cli` to a new shared `packages/core/src/utils/terminal.ts` module for improved reusability and consistency across the application.
* **Improved Authentication Flow**: The user code authentication process (when `NO_BROWSER=true`) has been enhanced by utilizing the alternate screen buffer for a cleaner user experience and providing clearer feedback messages directly to the terminal.
* **Structured CLI Restart Mechanism**: Direct `process.exit(0)` calls for scenarios requiring a CLI restart (e.g., after Google login when browser launch is suppressed) have been replaced with a specific `RELAUNCH_EXIT_CODE` and `runExitCleanup()`, enabling better external process management and a more graceful restart.
* **Enhanced Error Handling & User Feedback**: Core error handling now consistently uses `writeToStderr` for critical errors, and informational/error messages during authentication are communicated via `CoreEvent.UserFeedback`, improving user communication.

## Related Issues
Fixes: #12893

## How to Validate

Demo of auth flow with browser:
https://screencast.googleplex.com/cast/NjQyNzU5Mjg4MTA3ODI3Mnw3NzQ1OGIxZC05Nw 

Demo of auth flow with browser disabled:
https://screencast.googleplex.com/cast/NjIxNzg5Nzg2NDA2OTEyMHxkNWFiMGQxZC1mOA

Disable authentication with the browser via config and verify you can still authenticate seeing the whole auth string with correct line wrap in the console.

Validate cancelling the auth flow.

Validate that editing.a setting requiring restart now restarts automatically when you press r rather than making you do it.

The one known issue I wasn't able to fix is that ctrl-C does not work to exit with the readline based security code entry logic in core.