### PR TITLE
fix: remove invalid type key in bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,7 +2,6 @@ name: 'Bug Report'
 description: 'Report a bug to help us improve Gemini CLI'
 labels:
   - 'status/need-triage'
-type: 'Bug'
 body:
   - type: 'markdown'
     attributes:


### PR DESCRIPTION
The top-level `type` key is not permitted in GitHub issue form schema and was causing a repository validation warning.

This PR removes the invalid `type: 'Bug'` key from the bug report template.

Fixes #13061