### PR TITLE
docs: fix context.fileName property name in cli/configuration.md

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -57,12 +57,12 @@ contain other project-specific files related to Gemini CLI's operation, such as:
 
 ### Available settings in `settings.json`:
 
-- **`contextFileName`** (string or array of strings):
+- **`context.fileName`** (string or array of strings):
   - **Description:** Specifies the filename for context files (e.g.,
-    `GEMINI.md`, `AGENTS.md`). Can be a single filename or a list of accepted
+    `GEMINI.md`, `AGENTS.md`). Can be a single filename or an array of accepted
     filenames.
-  - **Default:** `GEMINI.md`
-  - **Example:** `"contextFileName": "AGENTS.md"`
+  - **Default:** `undefined` (falls back to `GEMINI.md`)
+  - **Example:** `"context": { "fileName": "AGENTS.md" }`
 
 - **`bugCommand`** (object):
   - **Description:** Overrides the default URL for the `/bug` command.
@@ -597,7 +597,7 @@ for that specific session.
 ## Context Files (Hierarchical Instructional Context)
 
 While not strictly configuration for the CLI's _behavior_, context files
-(defaulting to `GEMINI.md` but configurable via the `contextFileName` setting)
+(defaulting to `GEMINI.md` but configurable via the `context.fileName` setting)
 are crucial for configuring the _instructional context_ (also referred to as
 "memory") provided to the Gemini model. This powerful feature allows you to give
 project-specific instructions, coding style guides, or any relevant background


### PR DESCRIPTION
This PR fixes the incorrect property name in `docs/cli/configuration.md` to match the actual settings schema structure.

## Problem

Issue #12673 reported inconsistency between two documentation files:
- `docs/get-started/configuration.md` - ✅ Correctly uses `context.fileName`  
- `docs/cli/configuration.md` - ❌ Incorrectly uses `contextFileName`

## Root Cause

The `settings.schema.json` defines context-related properties under a nested `context` object:

```json
{
  "context": {
    "fileName": "GEMINI.md",
    "importFormat": "tree",
    "fileFiltering": { ... }
  }
}
```

While the internal `ConfigParameters` interface uses flat property names (`contextFileName`), users configure these settings using the nested structure in their `settings.json` files.

## Changes

- Line 60: `contextFileName` → `context.fileName`
- Updated example to show proper nested structure: `"context": { "fileName": "AGENTS.md" }`
- Line 600: Fixed reference to `context.fileName` setting

## Verification

Confirmed against:
- ✅ `schemas/settings.schema.json` (line 8-106) - uses nested `context.fileName`
- ✅ `docs/get-started/configuration.md` (line 330) - uses nested `context.fileName`

Fixes #12673

---

**Note:** My previous PR #13580 was incorrect as I misunderstood the configuration structure. This PR provides the correct fix.