### PR TITLE
docs: Update uninstall command to reflect multiple extension support

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -54,10 +54,11 @@ gemini extensions install <source> [--ref <ref>] [--auto-update] [--pre-release]
 
 ### Uninstalling an extension
 
-To uninstall, run `gemini extensions uninstall <name>`:
+To uninstall one or more extensions, run
+`gemini extensions uninstall <name...>`:
 
 ```
-gemini extensions uninstall gemini-cli-security
+gemini extensions uninstall gemini-cli-security gemini-cli-another-extension
 ```
 
 ### Disabling an extension


### PR DESCRIPTION
## Summary

Updates the uninstall command documentation to reflect the new support for uninstalling **multiple extensions at once** in the Gemini CLI. This improves accuracy and helps users understand the updated behavior.

## Details

* Replaced the old single-extension uninstall example with a multi-extension example.
* Clarified wording to indicate that users can uninstall *one or more* extensions.
* Updated example command to include multiple extension names.


## How to Validate

1. Open the documentation page: `docs/extensions/index.md`.
2. Scroll to the **Uninstalling an extension** section.
3. Confirm:

   * The text now states you can uninstall “one or more” extensions.
   * The command example shows multiple extensions (e.g., `gemini extensions uninstall gemini-cli-security gemini-cli-another-extension`).
4. Verify that the updated command accurately reflects the current CLI behavior.

## Pre-Merge Checklist

* [x] Updated relevant documentation
* [ ] Added/updated tests (not required for docs-only change)
* [ ] Noted breaking changes (none)
* [x] Validated manually on:

  * [ ] MacOS

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
    * [ ] Podman
    * [ ] Seatbelt
  * [ ] Windows

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
  * [ ] Linux

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
