### PR TITLE
feat: add upgrade command hint to extension update notification

### DIFF
--- a/packages/cli/src/ui/hooks/useExtensionUpdates.test.tsx
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.test.tsx
@@ -107,7 +107,7 @@ describe('useExtensionUpdates', () => {
       expect(addItem).toHaveBeenCalledWith(
         {
           type: MessageType.INFO,
-          text: 'You have 1 extension with an update available, run "/extensions list" for more information.',
+          text: 'You have 1 extension with an update available. Run "/extensions list" to view details or "/extensions update <name>" to upgrade.',
         },
         expect.any(Number),
       );
@@ -319,7 +319,7 @@ describe('useExtensionUpdates', () => {
       expect(addItem).toHaveBeenCalledWith(
         {
           type: MessageType.INFO,
-          text: 'You have 2 extensions with an update available, run "/extensions list" for more information.',
+          text: 'You have 2 extensions with an update available. Run "/extensions list" to view details or "/extensions update <name>" to upgrade.',
         },
         expect.any(Number),
       );

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -194,7 +194,7 @@ export const useExtensionUpdates = (
       addItem(
         {
           type: MessageType.INFO,
-          text: `You have ${extensionsWithUpdatesCount} extension${s} with an update available, run "/extensions list" for more information.`,
+          text: `You have ${extensionsWithUpdatesCount} extension${s} with an update available. Run "/extensions list" to view details or "/extensions update <name>" to upgrade.`,
         },
         Date.now(),
       );


### PR DESCRIPTION
This PR improves the extension update notification message by adding clear instructions on how to upgrade extensions.

## Problem

When users receive a notification that extensions have updates available, the message only tells them to run `/extensions list` for more information, but doesn't tell them how to actually upgrade the extensions. This creates an extra step and friction in the user experience.

## Solution

Enhanced the notification message to include both commands:
- `/extensions list` - to view details about which extensions have updates
- `/extensions upgrade <name>` - to upgrade a specific extension

## Changes

**Before:**
```
You have 1 extension with an update available, run "/extensions list" for more information.
```

**After:**
```
You have 1 extension with an update available. Run "/extensions list" to view details or "/extensions upgrade <name>" to upgrade.
```

### Files Modified:
- `packages/cli/src/ui/hooks/useExtensionUpdates.ts` - Updated notification message
- `packages/cli/src/ui/hooks/useExtensionUpdates.test.tsx` - Updated test expectations (2 test cases)

## Testing

All existing tests have been updated to match the new message format. The logic remains unchanged - only the user-facing message text was improved.

Fixes #10906