### PR TITLE
Restore bracketed paste mode after external editor exit

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -62,6 +62,10 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
         write: vi.fn(),
       },
     })),
+    enableMouseEvents: vi.fn(),
+    disableMouseEvents: vi.fn(),
+    enterAlternateScreen: vi.fn(),
+    disableLineWrapping: vi.fn(),
   };
 });
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -116,6 +116,7 @@ import { isWorkspaceTrusted } from '../config/trustedFolders.js';
 import { useAlternateBuffer } from './hooks/useAlternateBuffer.js';
 import { useSettings } from './contexts/SettingsContext.js';
 import { enableSupportedProtocol } from './utils/kittyProtocolDetector.js';
+import { enableBracketedPaste } from './utils/bracketedPaste.js';
 
 const WARNING_PROMPT_DURATION_MS = 1000;
 const QUEUE_ERROR_DISPLAY_DURATION_MS = 3000;
@@ -387,6 +388,7 @@ export const AppContainer = (props: AppContainerProps) => {
       disableLineWrapping();
       app.rerender();
     }
+    enableBracketedPaste();
     enableSupportedProtocol();
     refreshStatic();
   }, [refreshStatic, isAlternateBuffer, app, config]);

--- a/packages/cli/src/ui/hooks/useBracketedPaste.ts
+++ b/packages/cli/src/ui/hooks/useBracketedPaste.ts
@@ -5,10 +5,10 @@
  */
 
 import { useEffect } from 'react';
-import { writeToStdout } from '@google/gemini-cli-core';
-
-const ENABLE_BRACKETED_PASTE = '\x1b[?2004h';
-const DISABLE_BRACKETED_PASTE = '\x1b[?2004l';
+import {
+  disableBracketedPaste,
+  enableBracketedPaste,
+} from '../utils/bracketedPaste.js';
 
 /**
  * Enables and disables bracketed paste mode in the terminal.
@@ -18,11 +18,11 @@ const DISABLE_BRACKETED_PASTE = '\x1b[?2004l';
  */
 export const useBracketedPaste = () => {
   const cleanup = () => {
-    writeToStdout(DISABLE_BRACKETED_PASTE);
+    disableBracketedPaste();
   };
 
   useEffect(() => {
-    writeToStdout(ENABLE_BRACKETED_PASTE);
+    enableBracketedPaste();
 
     process.on('exit', cleanup);
     process.on('SIGINT', cleanup);

--- a/packages/cli/src/ui/utils/bracketedPaste.ts
+++ b/packages/cli/src/ui/utils/bracketedPaste.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { writeToStdout } from '@google/gemini-cli-core';
+
+const ENABLE_BRACKETED_PASTE = '\x1b[?2004h';
+const DISABLE_BRACKETED_PASTE = '\x1b[?2004l';
+
+export const enableBracketedPaste = () => {
+  writeToStdout(ENABLE_BRACKETED_PASTE);
+};
+
+export const disableBracketedPaste = () => {
+  writeToStdout(DISABLE_BRACKETED_PASTE);
+};


### PR DESCRIPTION
## Summary

Restore bracketed paste mode after external editor exit

## Details

Also fixed `gemini.test.tsx` bug that left the keyboard in a bad state after running.

## Related Issues

Fixes #12920

## How to Validate

Enter and exit edit mode with `ctrl+x`.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
