### PR TITLE
Moved client id logging into createBasicLogEvent

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -259,8 +259,9 @@ export class ClearcutLogger {
     eventName: EventNames,
     data: EventValue[] = [],
   ): LogEvent {
+    const email = this.userAccountManager.getCachedGoogleAccount();
     const surface = determineSurface();
-    return {
+    const logEvent: LogEvent = {
       console_type: 'GEMINI_CLI',
       application: 102, // GEMINI_CLI
       event_name: eventName as string,
@@ -286,19 +287,6 @@ export class ClearcutLogger {
         ],
       ],
     };
-  }
-
-  createLogEvent(eventName: EventNames, data: EventValue[] = []): LogEvent {
-    const email = this.userAccountManager.getCachedGoogleAccount();
-
-    if (eventName !== EventNames.START_SESSION) {
-      data.push(...this.sessionData);
-    }
-    const totalAccounts = this.userAccountManager.getLifetimeGoogleAccounts();
-
-    data = this.addDefaultFields(data, totalAccounts);
-
-    const logEvent = this.createBasicLogEvent(eventName, data);
 
     // Should log either email or install ID, not both. See go/cloudmill-1p-oss-instrumentation#define-sessionable-id
     if (email) {
@@ -308,6 +296,17 @@ export class ClearcutLogger {
     }
 
     return logEvent;
+  }
+
+  createLogEvent(eventName: EventNames, data: EventValue[] = []): LogEvent {
+    if (eventName !== EventNames.START_SESSION) {
+      data.push(...this.sessionData);
+    }
+    const totalAccounts = this.userAccountManager.getLifetimeGoogleAccounts();
+
+    data = this.addDefaultFields(data, totalAccounts);
+
+    return this.createBasicLogEvent(eventName, data);
   }
 
   flushIfNeeded(): void {

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -295,7 +295,7 @@ export class ClearcutLogger {
     const email = this.userAccountManager.getCachedGoogleAccount();
     const surface = determineSurface();
     const ghWorkflowName = determineGHWorkflowName();
-    
+
     const baseMetadata: EventValue[] = [
       ...data,
       {


### PR DESCRIPTION
## Summary

Moved client id logging into createBasicLogEvent to ensure that extension events include a client identifier.

## Details

The lack of a client identifier may be causing the Clearcut pipeline to drop these events.

## Related Issues


## How to Validate

* Install or uninstall an extension.
* Wait ~8 hrs
* Check for a matching extension log event in Concord.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
