### PR TITLE
fix(ui): Disable alternate buffer by default on unsupported terminals

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -243,6 +243,12 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `true`
   - **Requires restart:** Yes
 
+- **`ui.forceAlternateBuffer`** (boolean):
+  - **Description:** Force the use of alternate screen buffer even on
+    unsupported terminals.
+  - **Default:** `false`
+  - **Requires restart:** Yes
+
 - **`ui.incrementalRendering`** (boolean):
   - **Description:** Enable incremental rendering for the UI. This option will
     reduce flickering but may cause rendering artifacts. Only supported when

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -521,6 +521,16 @@ const SETTINGS_SCHEMA = {
           'Use an alternate screen buffer for the UI, preserving shell history.',
         showInDialog: true,
       },
+      forceAlternateBuffer: {
+        type: 'boolean',
+        label: 'Force Alternate Screen Buffer',
+        category: 'UI',
+        requiresRestart: true,
+        default: false,
+        description:
+          'Force the use of alternate screen buffer even on unsupported terminals.',
+        showInDialog: true,
+      },
       incrementalRendering: {
         type: 'boolean',
         label: 'Incremental Rendering',

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -117,6 +117,7 @@ import { useAlternateBuffer } from './hooks/useAlternateBuffer.js';
 import { useSettings } from './contexts/SettingsContext.js';
 import { enableSupportedProtocol } from './utils/kittyProtocolDetector.js';
 import { enableBracketedPaste } from './utils/bracketedPaste.js';
+import { useAlternateBufferNudge } from './hooks/useAlternateBufferNudge.js';
 
 const WARNING_PROMPT_DURATION_MS = 1000;
 const QUEUE_ERROR_DISPLAY_DURATION_MS = 3000;
@@ -160,6 +161,7 @@ export const AppContainer = (props: AppContainerProps) => {
   useMemoryMonitor(historyManager);
   const settings = useSettings();
   const isAlternateBuffer = useAlternateBuffer();
+  useAlternateBufferNudge(settings);
   const [corgiMode, setCorgiMode] = useState(false);
   const [debugMessage, setDebugMessage] = useState<string>('');
   const [quittingMessages, setQuittingMessages] = useState<

--- a/packages/cli/src/ui/hooks/useAlternateBuffer.test.ts
+++ b/packages/cli/src/ui/hooks/useAlternateBuffer.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isAlternateBufferEnabled } from './useAlternateBuffer.js';
+import type { LoadedSettings } from '../../config/settings.js';
+import { shouldDisableAlternateBufferByDefault } from '../../utils/terminalEnvironment.js';
+
+// Mock the terminal environment utility
+vi.mock('../../utils/terminalEnvironment.js', () => ({
+  shouldDisableAlternateBufferByDefault: vi.fn(),
+}));
+
+describe('isAlternateBufferEnabled', () => {
+  let mockSettings: LoadedSettings;
+
+  beforeEach(() => {
+    mockSettings = {
+      merged: {
+        ui: {},
+      },
+    } as unknown as LoadedSettings;
+
+    vi.resetAllMocks();
+  });
+
+  it('should return false if useAlternateBuffer is explicitly false', () => {
+    mockSettings.merged.ui = { useAlternateBuffer: false };
+    // Environment shouldn't matter here
+    vi.mocked(shouldDisableAlternateBufferByDefault).mockReturnValue(false);
+    expect(isAlternateBufferEnabled(mockSettings)).toBe(false);
+  });
+
+  describe('when environment requires disablement (shouldDisableAlternateBufferByDefault = true)', () => {
+    beforeEach(() => {
+      vi.mocked(shouldDisableAlternateBufferByDefault).mockReturnValue(true);
+    });
+
+    it('should return false by default', () => {
+      mockSettings.merged.ui = { useAlternateBuffer: true }; // Default is true in schema
+      expect(isAlternateBufferEnabled(mockSettings)).toBe(false);
+    });
+
+    it('should return true if forceAlternateBuffer is true', () => {
+      mockSettings.merged.ui = {
+        useAlternateBuffer: true,
+        forceAlternateBuffer: true,
+      };
+      expect(isAlternateBufferEnabled(mockSettings)).toBe(true);
+    });
+
+    it('should return false if forceAlternateBuffer is false', () => {
+      mockSettings.merged.ui = {
+        useAlternateBuffer: true,
+        forceAlternateBuffer: false,
+      };
+      expect(isAlternateBufferEnabled(mockSettings)).toBe(false);
+    });
+  });
+
+  describe('when environment allows alternate buffer (shouldDisableAlternateBufferByDefault = false)', () => {
+    beforeEach(() => {
+      vi.mocked(shouldDisableAlternateBufferByDefault).mockReturnValue(false);
+    });
+
+    it('should return true by default', () => {
+      mockSettings.merged.ui = { useAlternateBuffer: true };
+      expect(isAlternateBufferEnabled(mockSettings)).toBe(true);
+    });
+
+    it('should return true if forceAlternateBuffer is true (redundant but safe)', () => {
+      mockSettings.merged.ui = {
+        useAlternateBuffer: true,
+        forceAlternateBuffer: true,
+      };
+      expect(isAlternateBufferEnabled(mockSettings)).toBe(true);
+    });
+  });
+});

--- a/packages/cli/src/ui/hooks/useAlternateBuffer.ts
+++ b/packages/cli/src/ui/hooks/useAlternateBuffer.ts
@@ -6,9 +6,20 @@
 
 import { useSettings } from '../contexts/SettingsContext.js';
 import type { LoadedSettings } from '../../config/settings.js';
+import { shouldDisableAlternateBufferByDefault } from '../../utils/terminalEnvironment.js';
 
-export const isAlternateBufferEnabled = (settings: LoadedSettings): boolean =>
-  settings.merged.ui?.useAlternateBuffer !== false;
+export const isAlternateBufferEnabled = (settings: LoadedSettings): boolean => {
+  const useAlt = settings.merged.ui?.useAlternateBuffer !== false;
+  const forceAlt = settings.merged.ui?.forceAlternateBuffer === true;
+
+  if (!useAlt) return false;
+
+  if (shouldDisableAlternateBufferByDefault()) {
+    return forceAlt;
+  }
+
+  return true;
+};
 
 export const useAlternateBuffer = (): boolean => {
   const settings = useSettings();

--- a/packages/cli/src/ui/hooks/useAlternateBufferNudge.ts
+++ b/packages/cli/src/ui/hooks/useAlternateBufferNudge.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect } from 'react';
+import { persistentState } from '../../utils/persistentState.js';
+import { coreEvents } from '@google/gemini-cli-core';
+import type { LoadedSettings } from '../../config/settings.js';
+import {
+  isJetBrainsTerminal,
+  shouldDisableAlternateBufferByDefault,
+} from '../../utils/terminalEnvironment.js';
+
+const MAX_NUDGE_COUNT = 3;
+
+export function useAlternateBufferNudge(settings: LoadedSettings) {
+  const useAlt = settings.merged.ui?.useAlternateBuffer;
+  const forceAlt = settings.merged.ui?.forceAlternateBuffer;
+
+  useEffect(() => {
+    const isUnsupportedEnv = shouldDisableAlternateBufferByDefault();
+    // Only show the nudge if the feature is enabled by the user (or by default)
+    // but is being automatically disabled by the environment detection.
+    const isAutoDisabled = useAlt !== false && isUnsupportedEnv && !forceAlt;
+
+    if (isAutoDisabled) {
+      const currentCount =
+        persistentState.get('alternateBufferNudgeCount') || 0;
+
+      if (currentCount < MAX_NUDGE_COUNT) {
+        let message: string;
+        if (isJetBrainsTerminal()) {
+          message =
+            'Alternate buffer is disabled in JetBrains terminal. Enable "Force Alternate Screen Buffer" in /settings to override. See https://github.com/google-gemini/gemini-cli/issues/13614 for details.';
+        } else {
+          message =
+            'Alternate buffer is disabled by default in this environment. Enable "Force Alternate Screen Buffer" in /settings to override.';
+        }
+
+        coreEvents.emitFeedback('info', message);
+
+        persistentState.set('alternateBufferNudgeCount', currentCount + 1);
+      }
+    }
+  }, [useAlt, forceAlt]);
+}

--- a/packages/cli/src/utils/persistentState.ts
+++ b/packages/cli/src/utils/persistentState.ts
@@ -12,6 +12,7 @@ const STATE_FILENAME = 'state.json';
 
 interface PersistentStateData {
   defaultBannerShownCount?: Record<string, number>;
+  alternateBufferNudgeCount?: number;
   // Add other persistent state keys here as needed
 }
 

--- a/packages/cli/src/utils/terminalEnvironment.ts
+++ b/packages/cli/src/utils/terminalEnvironment.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import os from 'node:os';
+
+export function isJetBrainsTerminal(): boolean {
+  return process.env['TERMINAL_EMULATOR'] === 'JetBrains-JediTerm';
+}
+
+/**
+ * Determines if the alternate buffer should be disabled by default based on the environment.
+ *
+ * Currently disabled for:
+ * - JetBrains terminals (scrolling issues)
+ * - Windows 10 (legacy console issues)
+ * - tmux (rendering artifacts)
+ * - Cmder (rendering artifacts)
+ */
+export function shouldDisableAlternateBufferByDefault(): boolean {
+  if (isJetBrainsTerminal()) {
+    return true;
+  }
+  if (process.env['TMUX']) {
+    return true;
+  }
+  if (process.env['CMDER_ROOT']) {
+    return true;
+  }
+  if (process.platform === 'win32') {
+    const release = os.release();
+    const [major, _, build] = release.split('.').map(Number);
+
+    // Windows 11 starts at build 22000.
+    // Windows 10 is major version 10.
+    // We disable for Windows 10 (build < 22000) as it often lacks decent VT support in the legacy console.
+    if (major === 10 && build < 22000) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -296,6 +296,13 @@
           "default": true,
           "type": "boolean"
         },
+        "forceAlternateBuffer": {
+          "title": "Force Alternate Screen Buffer",
+          "description": "Force the use of alternate screen buffer even on unsupported terminals.",
+          "markdownDescription": "Force the use of alternate screen buffer even on unsupported terminals.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
         "incrementalRendering": {
           "title": "Incremental Rendering",
           "description": "Enable incremental rendering for the UI. This option will reduce flickering but may cause rendering artifacts. Only supported when useAlternateBuffer is enabled.",


### PR DESCRIPTION
## TLDR

This PR disables the alternate screen buffer by default on terminals known to have rendering or scrolling issues (JetBrains, Windows 10, tmux, Cmder). It adds a new setting 'Force Alternate Screen Buffer' to override this behavior and provides a one-time nudge to inform users when the feature is auto-disabled.

## Dive Deeper

- **Detection Logic:** A new utility `terminalEnvironment.ts` detects unsupported environments via `TERMINAL_EMULATOR`, `TMUX`, `CMDER_ROOT`, and `os.release()`.
    - Specifically detects Windows 10 (build < 22000) to avoid disabling on Windows 11.
- **Settings Logic:** `isAlternateBufferEnabled` now returns false if the environment is unsupported, unless the new `ui.forceAlternateBuffer` setting is explicitly set to true.
- **User Feedback:** A new hook `useAlternateBufferNudge` emits an info message (max 3 times) if the alternate buffer is auto-disabled, linking JetBrains users to the relevant GitHub issue.

## Reviewer Test Plan

1.  **Mock Unsupported Environment:**
    ```bash
    export TERMINAL_EMULATOR=JetBrains-JediTerm
    npm run start
    ```
2.  **Verify Disablement:** Confirm the CLI does *not* enter the alternate buffer (scrollback is preserved).
3.  **Verify Nudge:** Check for the info message in the chat history linking to the issue.
4.  **Test Override:**
    - In `/settings`, enable "Force Alternate Screen Buffer".
    - Restart the CLI (still with the env var set).
    - Verify the alternate buffer is now *enabled*.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #13614