### PR TITLE
Turn off alternate buffer mode by default.

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -240,7 +240,7 @@ their corresponding top-level category object in your `settings.json` file.
 - **`ui.useAlternateBuffer`** (boolean):
   - **Description:** Use an alternate screen buffer for the UI, preserving shell
     history.
-  - **Default:** `true`
+  - **Default:** `false`
   - **Requires restart:** Yes
 
 - **`ui.incrementalRendering`** (boolean):

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -321,6 +321,9 @@ export class TestRig {
           selectedType: 'gemini-api-key',
         },
       },
+      ui: {
+        useAlternateBuffer: true,
+      },
       model: DEFAULT_GEMINI_MODEL,
       sandbox:
         env['GEMINI_SANDBOX'] !== 'false' ? env['GEMINI_SANDBOX'] : false,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -516,7 +516,7 @@ const SETTINGS_SCHEMA = {
         label: 'Use Alternate Screen Buffer',
         category: 'UI',
         requiresRestart: true,
-        default: true,
+        default: false,
         description:
           'Use an alternate screen buffer for the UI, preserving shell history.',
         showInDialog: true,

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -509,6 +509,7 @@ describe('startInteractiveUI', () => {
     merged: {
       ui: {
         hideWindowTitle: false,
+        useAlternateBuffer: true,
       },
     },
   } as LoadedSettings;

--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -176,7 +176,7 @@ export const renderWithProviders = (
     width,
     mouseEventsEnabled = false,
     config = configProxy as unknown as Config,
-    useAlternateBuffer,
+    useAlternateBuffer = true,
     uiActions,
   }: {
     shellFocus?: boolean;

--- a/packages/cli/src/ui/hooks/useAlternateBuffer.ts
+++ b/packages/cli/src/ui/hooks/useAlternateBuffer.ts
@@ -8,7 +8,7 @@ import { useSettings } from '../contexts/SettingsContext.js';
 import type { LoadedSettings } from '../../config/settings.js';
 
 export const isAlternateBufferEnabled = (settings: LoadedSettings): boolean =>
-  settings.merged.ui?.useAlternateBuffer !== false;
+  settings.merged.ui?.useAlternateBuffer === true;
 
 export const useAlternateBuffer = (): boolean => {
   const settings = useSettings();

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -292,8 +292,8 @@
         "useAlternateBuffer": {
           "title": "Use Alternate Screen Buffer",
           "description": "Use an alternate screen buffer for the UI, preserving shell history.",
-          "markdownDescription": "Use an alternate screen buffer for the UI, preserving shell history.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `true`",
-          "default": true,
+          "markdownDescription": "Use an alternate screen buffer for the UI, preserving shell history.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `false`",
+          "default": false,
           "type": "boolean"
         },
         "incrementalRendering": {


### PR DESCRIPTION
## Summary

We're setting the default  for useAlternateBuffer back to false for now.

We'll plan to re-enable once we support selection without ctrl-S, speed up scrolling on terminals that report fewer scroll events than ideal, and optimize performance issues related to very large tool messages. When we re-enable we will also ship with detection logic to disable on terminals that don't support mouse scroll well enough.

If you want to keep the feature in the meantime, you can always enable it right now by going to.

`/settings`
and set
`Use Alternate Screen Buffer` to true.
