### PR TITLE
feat: allow exit and quit commands without leading slash

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -215,7 +215,8 @@ Slash commands provide meta-level control over the CLI itself.
     purposes.
 
 - **`/quit`** (or **`/exit`**)
-  - **Description:** Exit Gemini CLI.
+  - **Description:** Exit Gemini CLI. You can also type `quit` or `exit` without
+    the leading slash.
 
 - **`/vim`**
   - **Description:** Toggle vim mode on or off. When vim mode is enabled, the

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
@@ -573,6 +573,25 @@ describe('useSlashCommandProcessor', () => {
 
       expect(mockSetQuittingMessages).toHaveBeenCalledWith(['bye']);
     });
+
+    it('should handle "exit" command without a slash', async () => {
+      const quitAction = vi
+        .fn()
+        .mockResolvedValue({ type: 'quit', messages: ['bye'] });
+      const command = createTestCommand({
+        name: 'exit',
+        action: quitAction,
+      });
+      const result = await setupProcessorHook([command]);
+
+      await waitFor(() => expect(result.current.slashCommands).toHaveLength(1));
+
+      await act(async () => {
+        await result.current.handleSlashCommand('exit');
+      });
+
+      expect(quitAction).toHaveBeenCalled();
+    });
     it('should handle "submit_prompt" action returned from a file-based command', async () => {
       const fileCommand = createTestCommand(
         {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -321,7 +321,12 @@ export const useSlashCommandProcessor = (
       }
 
       const trimmed = rawQuery.trim();
-      if (!trimmed.startsWith('/') && !trimmed.startsWith('?')) {
+      const isExitOrQuit = ['exit', 'quit'].includes(trimmed.toLowerCase());
+      if (
+        !trimmed.startsWith('/') &&
+        !trimmed.startsWith('?') &&
+        !isExitOrQuit
+      ) {
         return false;
       }
 
@@ -336,11 +341,12 @@ export const useSlashCommandProcessor = (
       }
 
       let hasError = false;
+      const commandToParse = isExitOrQuit ? `/${trimmed}` : trimmed;
       const {
         commandToExecute,
         args,
         canonicalPath: resolvedCommandPath,
-      } = parseSlashCommand(trimmed, commands);
+      } = parseSlashCommand(commandToParse, commands);
 
       const subcommand =
         resolvedCommandPath.length > 1

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -321,7 +321,9 @@ export const useSlashCommandProcessor = (
       }
 
       const trimmed = rawQuery.trim();
-      const isExitOrQuit = ['exit', 'quit'].includes(trimmed.toLowerCase());
+      const parts = trimmed.split(/\s+/);
+      const commandWord = parts[0].toLowerCase();
+      const isExitOrQuit = commandWord === 'exit' || commandWord === 'quit';
       if (
         !trimmed.startsWith('/') &&
         !trimmed.startsWith('?') &&
@@ -341,7 +343,15 @@ export const useSlashCommandProcessor = (
       }
 
       let hasError = false;
-      const commandToParse = isExitOrQuit ? `/${trimmed}` : trimmed;
+      let commandToParse = trimmed;
+      if (
+        isExitOrQuit &&
+        !trimmed.startsWith('/') &&
+        !trimmed.startsWith('?')
+      ) {
+        parts[0] = commandWord;
+        commandToParse = `/${parts.join(' ')}`;
+      }
       const {
         commandToExecute,
         args,


### PR DESCRIPTION
This PR updates the slash command processor to allow 'exit' and 'quit' commands to be used without a leading slash, improving user experience for those accustomed to other CLI tools. It also updates the documentation and adds a test case.