### PR TITLE
feat: support custom ASCII art variants for header logo

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -544,6 +544,17 @@ const SETTINGS_SCHEMA = {
         showInDialog: false,
         items: { type: 'string' },
       },
+      customLogoVariantsFile: {
+        type: 'string',
+        label: 'Custom Logo Variants File',
+        category: 'UI',
+        requiresRestart: false,
+        default: undefined as string | undefined,
+        description: oneLine`
+          Path to a JSON file containing custom ASCII art variants for the header logo.
+        `,
+        showInDialog: false,
+      },
       accessibility: {
         type: 'object',
         label: 'Accessibility',

--- a/packages/cli/src/ui/components/AppHeader.tsx
+++ b/packages/cli/src/ui/components/AppHeader.tsx
@@ -12,6 +12,7 @@ import { useConfig } from '../contexts/ConfigContext.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { Banner } from './Banner.js';
 import { useBanner } from '../hooks/useBanner.js';
+import { useCustomLogo } from '../hooks/useCustomLogo.js';
 
 interface AppHeaderProps {
   version: string;
@@ -23,12 +24,19 @@ export const AppHeader = ({ version }: AppHeaderProps) => {
   const { nightly, mainAreaWidth, bannerData, bannerVisible } = useUIState();
 
   const { bannerText } = useBanner(bannerData, config);
+  const customLogoVariants = useCustomLogo(
+    settings.merged.ui?.customLogoVariantsFile,
+  );
 
   return (
     <Box flexDirection="column">
       {!(settings.merged.ui?.hideBanner || config.getScreenReader()) && (
         <>
-          <Header version={version} nightly={nightly} />
+          <Header
+            version={version}
+            nightly={nightly}
+            customLogoVariants={customLogoVariants}
+          />
           {bannerVisible && bannerText && (
             <Banner
               width={mainAreaWidth}

--- a/packages/cli/src/ui/components/Header.test.tsx
+++ b/packages/cli/src/ui/components/Header.test.tsx
@@ -74,7 +74,11 @@ describe('<Header />', () => {
   it('renders custom ASCII art when provided', () => {
     const customArt = 'CUSTOM ART';
     render(
-      <Header version="1.0.0" nightly={false} customAsciiArt={customArt} />,
+      <Header
+        version="1.0.0"
+        nightly={false}
+        customLogoVariants={{ longAsciiLogo: customArt }}
+      />,
     );
     expect(Text).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -88,7 +92,11 @@ describe('<Header />', () => {
     const customArt = 'CUSTOM ART';
     vi.mocked(terminalSetup.getTerminalProgram).mockReturnValue('vscode');
     render(
-      <Header version="1.0.0" nightly={false} customAsciiArt={customArt} />,
+      <Header
+        version="1.0.0"
+        nightly={false}
+        customLogoVariants={{ longAsciiLogoIde: customArt }}
+      />,
     );
     expect(Text).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/cli/src/ui/components/Header.tsx
+++ b/packages/cli/src/ui/components/Header.tsx
@@ -8,37 +8,50 @@ import type React from 'react';
 import { Box } from 'ink';
 import { ThemedGradient } from './ThemedGradient.js';
 import {
-  shortAsciiLogo,
-  longAsciiLogo,
-  tinyAsciiLogo,
-  shortAsciiLogoIde,
-  longAsciiLogoIde,
-  tinyAsciiLogoIde,
+  shortAsciiLogo as defaultShortAsciiLogo,
+  longAsciiLogo as defaultLongAsciiLogo,
+  tinyAsciiLogo as defaultTinyAsciiLogo,
+  shortAsciiLogoIde as defaultShortAsciiLogoIde,
+  longAsciiLogoIde as defaultLongAsciiLogoIde,
+  tinyAsciiLogoIde as defaultTinyAsciiLogoIde,
 } from './AsciiArt.js';
 import { getAsciiArtWidth } from '../utils/textUtils.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import { getTerminalProgram } from '../utils/terminalSetup.js';
+import type { LogoVariants } from '../hooks/useCustomLogo.js';
 
 interface HeaderProps {
-  customAsciiArt?: string; // For user-defined ASCII art
+  customLogoVariants?: LogoVariants;
   version: string;
   nightly: boolean;
 }
 
 export const Header: React.FC<HeaderProps> = ({
-  customAsciiArt,
+  customLogoVariants,
   version,
   nightly,
 }) => {
   const { columns: terminalWidth } = useTerminalSize();
   const isIde = getTerminalProgram();
+
+  const longAsciiLogo =
+    customLogoVariants?.longAsciiLogo ?? defaultLongAsciiLogo;
+  const shortAsciiLogo =
+    customLogoVariants?.shortAsciiLogo ?? defaultShortAsciiLogo;
+  const tinyAsciiLogo =
+    customLogoVariants?.tinyAsciiLogo ?? defaultTinyAsciiLogo;
+  const longAsciiLogoIde =
+    customLogoVariants?.longAsciiLogoIde ?? defaultLongAsciiLogoIde;
+  const shortAsciiLogoIde =
+    customLogoVariants?.shortAsciiLogoIde ?? defaultShortAsciiLogoIde;
+  const tinyAsciiLogoIde =
+    customLogoVariants?.tinyAsciiLogoIde ?? defaultTinyAsciiLogoIde;
+
   let displayTitle;
   const widthOfLongLogo = getAsciiArtWidth(longAsciiLogo);
   const widthOfShortLogo = getAsciiArtWidth(shortAsciiLogo);
 
-  if (customAsciiArt) {
-    displayTitle = customAsciiArt;
-  } else if (terminalWidth >= widthOfLongLogo) {
+  if (terminalWidth >= widthOfLongLogo) {
     displayTitle = isIde ? longAsciiLogoIde : longAsciiLogo;
   } else if (terminalWidth >= widthOfShortLogo) {
     displayTitle = isIde ? shortAsciiLogoIde : shortAsciiLogo;

--- a/packages/cli/src/ui/hooks/useCustomLogo.ts
+++ b/packages/cli/src/ui/hooks/useCustomLogo.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useState } from 'react';
+import * as fs from 'node:fs/promises';
+import { getErrorMessage, debugLogger } from '@google/gemini-cli-core';
+
+export interface LogoVariants {
+  longAsciiLogo?: string;
+  shortAsciiLogo?: string;
+  tinyAsciiLogo?: string;
+  longAsciiLogoIde?: string;
+  shortAsciiLogoIde?: string;
+  tinyAsciiLogoIde?: string;
+}
+
+export function useCustomLogo(
+  variantsFilePath: string | undefined,
+): LogoVariants | undefined {
+  const [variants, setVariants] = useState<LogoVariants | undefined>(undefined);
+
+  useEffect(() => {
+    if (!variantsFilePath) {
+      setVariants(undefined);
+      return;
+    }
+
+    const loadVariants = async () => {
+      try {
+        const content = await fs.readFile(variantsFilePath, 'utf-8');
+        const parsed = JSON.parse(content) as LogoVariants;
+        setVariants(parsed);
+      } catch (e) {
+        debugLogger.warn(
+          `Failed to load custom logo variants from "${variantsFilePath}": ${getErrorMessage(e)}`,
+        );
+        setVariants(undefined);
+      }
+    };
+
+    loadVariants();
+  }, [variantsFilePath]);
+
+  return variants;
+}

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -313,6 +313,12 @@
             "type": "string"
           }
         },
+        "customLogoVariantsFile": {
+          "title": "Custom Logo Variants File",
+          "description": "Path to a JSON file containing custom ASCII art variants for the header logo.",
+          "markdownDescription": "Path to a JSON file containing custom ASCII art variants for the header logo.\n\n- Category: `UI`\n- Requires restart: `no`",
+          "type": "string"
+        },
         "accessibility": {
           "title": "Accessibility",
           "description": "Accessibility settings.",


### PR DESCRIPTION
## Summary

This PR enables users to customize the ASCII art logo displayed in the CLI header by providing a path to a JSON file containing logo variants. This allows for consistent branding across different terminal sizes and environments (standard vs. IDE) while maintaining the CLI's responsive design.

## Details

-   **New Setting:** `ui.customLogoVariantsFile` (string). This setting accepts an absolute path to a JSON file.
-   **New Hook:** `useCustomLogo` was added to asynchronously load and parse the JSON file specified in the settings.
-   **Updated Component:** `Header.tsx` was updated to accept a `customLogoVariants` prop.
    -   It attempts to use the variant from the custom object first (e.g., `customLogoVariants.longAsciiLogo`).
    -   If a specific variant is missing in the custom object, it falls back to the hardcoded default for that variant.
-   **Schema Update:** Updated `settings.schema.json` and `settingsSchema.ts` to include the new setting.
-   **Interface:** The JSON file is expected to match the `LogoVariants` interface, supporting all 6 standard variants:
    ```typescript
    interface LogoVariants {
      longAsciiLogo?: string;
      shortAsciiLogo?: string;
      tinyAsciiLogo?: string;
      longAsciiLogoIde?: string;
      shortAsciiLogoIde?: string;
      tinyAsciiLogoIde?: string;
    }
    ```

## Related Issues

N/A

## How to Validate

1.  **Create a custom logo file** (e.g., `my-logo.json`) with the following content:
    ```json
    {
      "longAsciiLogo": "  MY  \n  LOGO  ",
      "shortAsciiLogo": " MY LOGO "
    }
    ```
2.  **Update Settings:** Add the following to your `settings.json`:
    ```json
    "ui": {
      "customLogoVariantsFile": "/absolute/path/to/my-logo.json"
    }
    ```
3.  **Run the CLI:** Start the CLI using `npm start`.
4.  **Verify:**
    -   Resize your terminal window.
    -   Verify that "MY LOGO" (long version) appears when the window is wide.
    -   Verify that "MY LOGO" (short version) appears when the window is narrower.
    -   Verify that the default "tiny" Gemini logo appears when the window is very small (since we didn't provide a tiny variant in the JSON).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
