### PR TITLE
Fix TypeError: "URL.parse is not a function" for Node.js < v22

### DIFF
--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -89,7 +89,14 @@ export function tryParseGithubUrl(source: string): GithubRepoInfo | null {
     source = source.replace('git@github.com:', '');
   }
   // Default to a github repo path, so `source` can be just an org/repo
-  const parsedUrl = URL.parse(source, 'https://github.com');
+  let parsedUrl;
+  try {
+    // Usamos el constructor estándar compatible con versiones viejas
+    parsedUrl = new URL(source, 'https://github.com');
+  } catch (e) {
+    parsedUrl = null;
+  }
+
   if (!parsedUrl) {
     throw new Error(`Invalid repo URL: ${source}`);
   }

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -89,12 +89,14 @@ export function tryParseGithubUrl(source: string): GithubRepoInfo | null {
     source = source.replace('git@github.com:', '');
   }
   // Default to a github repo path, so `source` can be just an org/repo
-  let parsedUrl;
+  let parsedUrl: URL;
   try {
-    // Usamos el constructor estándar compatible con versiones viejas
+    // Use the standard URL constructor for backward compatibility.
     parsedUrl = new URL(source, 'https://github.com');
   } catch (e) {
-    parsedUrl = null;
+    // Throw a TypeError to maintain a consistent error contract for invalid URLs.
+    // This avoids a breaking change for consumers who might expect a TypeError.
+    throw new TypeError(`Invalid repo URL: ${source}`, { cause: e });
   }
 
   if (!parsedUrl) {


### PR DESCRIPTION
Fixes #13615

## Summary

Replaces the usage of the static method `URL.parse()` with the standard `new URL()` constructor (wrapped in a try-catch block). This change fixes the `TypeError: URL.parse is not a function` crash on Node.js LTS versions (v18, v20).

## Details

The codebase was using `URL.parse()`, a static method that was only recently added to the global `URL` object in Node.js v22. Consequently, users running the CLI on current LTS versions (like Node.js v20) experienced immediate crashes when this code path was executed.

While other parts of the project might have been updated or patched in later versions to support broader compatibility, this specific instance in `src/modules/extensions/github_download.ts` (inside `tryParseGithubUrl`) remained unchanged, causing the persistent error reported in the issue.

The fix involves replacing:
```typescript
const parsedUrl = URL.parse(source, 'https://github.com');
```
With the standard, backward-compatible approach:
```typescript
let parsedUrl: URL;
try {
  parsedUrl = new URL(source, 'https://github.com');
} catch (error) {
  // Error handling logic matches the previous flow
}
```

## Related Issues

Fixes #13615

## How to Validate

1.  Ensure you are using **Node.js v20** (or any version below v22).
2.  Checkout this branch and install dependencies.
3.  Run the CLI (or try to install/parse a GitHub extension URL).
4.  **Expected Result:** The CLI should execute without throwing `TypeError: URL.parse is not a function`.
5.  **Previous Result:** The CLI crashed immediately upon reaching the URL parsing logic.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker