### PR TITLE
fix(async): prevent missed async errors from bypassing catch handlers

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,6 +80,11 @@ export default tseslint.config(
       },
     },
     languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: projectRoot,
+      },
       globals: {
         ...globals.node,
         ...globals.es2021,
@@ -117,6 +122,8 @@ export default tseslint.config(
           caughtErrorsIgnorePattern: '^_',
         },
       ],
+      // Prevent async errors from bypassing catch handlers
+      '@typescript-eslint/return-await': ['error', 'in-try-catch'],
       'import/no-internal-modules': [
         'error',
         {

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -99,11 +99,7 @@ export class CoderAgentExecutor implements AgentExecutor {
     loadEnvironment(); // Will override any global env with workspace envs
     const settings = loadSettings(workspaceRoot);
     const extensions = loadExtensions(workspaceRoot);
-    return await loadConfig(
-      settings,
-      new SimpleExtensionLoader(extensions),
-      taskId,
-    );
+    return loadConfig(settings, new SimpleExtensionLoader(extensions), taskId);
   }
 
   /**

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -88,7 +88,7 @@ async function getServerStatus(
   server: MCPServerConfig,
 ): Promise<MCPServerStatus> {
   // Test all server types by attempting actual connection
-  return await testMCPConnection(serverName, server);
+  return testMCPConnection(serverName, server);
 }
 
 export async function listMcpServers(): Promise<void> {

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -1796,12 +1796,8 @@ This extension will run the following MCP servers:
     });
 
     it('should throw an error if you request system scope', async () => {
-      await expect(
-        async () =>
-          await extensionManager.disableExtension(
-            'my-extension',
-            SettingScope.System,
-          ),
+      await expect(async () =>
+        extensionManager.disableExtension('my-extension', SettingScope.System),
       ).rejects.toThrow('System and SystemDefaults scopes are not supported.');
     });
 

--- a/packages/cli/src/config/extensions/consent.ts
+++ b/packages/cli/src/config/extensions/consent.ts
@@ -45,7 +45,7 @@ export async function requestConsentInteractive(
   consentDescription: string,
   addExtensionUpdateConfirmationRequest: (value: ConfirmationRequest) => void,
 ): Promise<boolean> {
-  return await promptForConsentInteractive(
+  return promptForConsentInteractive(
     consentDescription + '\n\nDo you want to continue?',
     addExtensionUpdateConfirmationRequest,
   );
@@ -89,7 +89,7 @@ async function promptForConsentInteractive(
   prompt: string,
   addExtensionUpdateConfirmationRequest: (value: ConfirmationRequest) => void,
 ): Promise<boolean> {
-  return await new Promise<boolean>((resolve) => {
+  return new Promise<boolean>((resolve) => {
     addExtensionUpdateConfirmationRequest({
       prompt,
       onConfirm: (resolvedConfirmed) => {

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -138,7 +138,7 @@ export async function fetchReleaseFromGithub(
   allowPreRelease?: boolean,
 ): Promise<GithubReleaseData | null> {
   if (ref) {
-    return await fetchJson(
+    return fetchJson(
       `https://api.github.com/repos/${owner}/${repo}/releases/tags/${ref}`,
     );
   }

--- a/packages/cli/src/config/extensions/storage.ts
+++ b/packages/cli/src/config/extensions/storage.ts
@@ -40,8 +40,6 @@ export class ExtensionStorage {
   }
 
   static async createTmpDir(): Promise<string> {
-    return await fs.promises.mkdtemp(
-      path.join(os.tmpdir(), 'gemini-extension'),
-    );
+    return fs.promises.mkdtemp(path.join(os.tmpdir(), 'gemini-extension'));
   }
 }

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -22,10 +22,8 @@ vi.mock('./installationInfo.js', async () => {
   };
 });
 
-vi.mock(
-  './updateEventEmitter.js',
-  async (importOriginal) =>
-    await importOriginal<typeof import('./updateEventEmitter.js')>(),
+vi.mock('./updateEventEmitter.js', async (importOriginal) =>
+  importOriginal<typeof import('./updateEventEmitter.js')>(),
 );
 
 interface MockChildProcess extends EventEmitter {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -191,7 +191,7 @@ export async function start_sandbox(
       sandboxProcess = spawn(config.command, args, {
         stdio: 'inherit',
       });
-      return new Promise((resolve, reject) => {
+      return await new Promise((resolve, reject) => {
         sandboxProcess?.on('error', reject);
         sandboxProcess?.on('close', (code) => {
           process.stdin.resume();
@@ -666,7 +666,7 @@ export async function start_sandbox(
       stdio: 'inherit',
     });
 
-    return new Promise<number>((resolve, reject) => {
+    return await new Promise<number>((resolve, reject) => {
       sandboxProcess.on('error', (err) => {
         coreEvents.emitFeedback('error', 'Sandbox process error', err);
         reject(err);

--- a/packages/cli/src/zed-integration/acp.ts
+++ b/packages/cli/src/zed-integration/acp.ts
@@ -68,7 +68,7 @@ export class AgentSideConnection implements Client {
    * Streams new content to the client including text, tool calls, etc.
    */
   async sessionUpdate(params: schema.SessionNotification): Promise<void> {
-    return await this.#connection.sendNotification(
+    return this.#connection.sendNotification(
       schema.CLIENT_METHODS.session_update,
       params,
     );
@@ -83,7 +83,7 @@ export class AgentSideConnection implements Client {
   async requestPermission(
     params: schema.RequestPermissionRequest,
   ): Promise<schema.RequestPermissionResponse> {
-    return await this.#connection.sendRequest(
+    return this.#connection.sendRequest(
       schema.CLIENT_METHODS.session_request_permission,
       params,
     );
@@ -92,7 +92,7 @@ export class AgentSideConnection implements Client {
   async readTextFile(
     params: schema.ReadTextFileRequest,
   ): Promise<schema.ReadTextFileResponse> {
-    return await this.#connection.sendRequest(
+    return this.#connection.sendRequest(
       schema.CLIENT_METHODS.fs_read_text_file,
       params,
     );
@@ -101,7 +101,7 @@ export class AgentSideConnection implements Client {
   async writeTextFile(
     params: schema.WriteTextFileRequest,
   ): Promise<schema.WriteTextFileResponse> {
-    return await this.#connection.sendRequest(
+    return this.#connection.sendRequest(
       schema.CLIENT_METHODS.fs_write_text_file,
       params,
     );

--- a/packages/core/src/code_assist/experiments/client_metadata.ts
+++ b/packages/core/src/code_assist/experiments/client_metadata.ts
@@ -52,5 +52,5 @@ export async function getClientMetadata(): Promise<ClientMetadata> {
       updateChannel: await getReleaseChannel(__dirname),
     }))();
   }
-  return await clientMetadataPromise;
+  return clientMetadataPromise;
 }

--- a/packages/core/src/code_assist/experiments/experiments.ts
+++ b/packages/core/src/code_assist/experiments/experiments.ts
@@ -24,7 +24,7 @@ export async function getExperiments(
   server: CodeAssistServer,
 ): Promise<Experiments> {
   if (experimentsPromise) {
-    return await experimentsPromise;
+    return experimentsPromise;
   }
 
   experimentsPromise = (async () => {
@@ -32,7 +32,7 @@ export async function getExperiments(
     const response = await server.listExperiments(metadata);
     return parseExperiments(response);
   })();
-  return await experimentsPromise;
+  return experimentsPromise;
 }
 
 function parseExperiments(response: ListExperimentsResponse): Experiments {

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -546,7 +546,7 @@ async function fetchCachedCredentials(): Promise<
 > {
   const useEncryptedStorage = getUseEncryptedStorageFlag();
   if (useEncryptedStorage) {
-    return await OAuthCredentialStorage.loadCredentials();
+    return OAuthCredentialStorage.loadCredentials();
   }
 
   const pathsToTry = [

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -102,10 +102,7 @@ export class CodeAssistServer implements ContentGenerator {
   async onboardUser(
     req: OnboardUserRequest,
   ): Promise<LongRunningOperationResponse> {
-    return await this.requestPost<LongRunningOperationResponse>(
-      'onboardUser',
-      req,
-    );
+    return this.requestPost<LongRunningOperationResponse>('onboardUser', req);
   }
 
   async loadCodeAssist(
@@ -128,7 +125,7 @@ export class CodeAssistServer implements ContentGenerator {
   }
 
   async getCodeAssistGlobalUserSetting(): Promise<CodeAssistGlobalUserSettingResponse> {
-    return await this.requestGet<CodeAssistGlobalUserSettingResponse>(
+    return this.requestGet<CodeAssistGlobalUserSettingResponse>(
       'getCodeAssistGlobalUserSetting',
     );
   }
@@ -136,7 +133,7 @@ export class CodeAssistServer implements ContentGenerator {
   async setCodeAssistGlobalUserSetting(
     req: SetCodeAssistGlobalUserSettingRequest,
   ): Promise<CodeAssistGlobalUserSettingResponse> {
-    return await this.requestPost<CodeAssistGlobalUserSettingResponse>(
+    return this.requestPost<CodeAssistGlobalUserSettingResponse>(
       'setCodeAssistGlobalUserSetting',
       req,
     );
@@ -167,10 +164,7 @@ export class CodeAssistServer implements ContentGenerator {
       project: projectId,
       metadata: { ...metadata, duetProject: projectId },
     };
-    return await this.requestPost<ListExperimentsResponse>(
-      'listExperiments',
-      req,
-    );
+    return this.requestPost<ListExperimentsResponse>('listExperiments', req);
   }
 
   async retrieveUserQuota(

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -170,7 +170,7 @@ export class CodeAssistServer implements ContentGenerator {
   async retrieveUserQuota(
     req: RetrieveUserQuotaRequest,
   ): Promise<RetrieveUserQuotaResponse> {
-    return await this.requestPost<RetrieveUserQuotaResponse>(
+    return this.requestPost<RetrieveUserQuotaResponse>(
       'retrieveUserQuota',
       req,
     );

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -693,7 +693,7 @@ export class GeminiClient {
         error?: unknown,
       ) =>
         // Pass the captured model to the centralized handler.
-        await handleFallback(this.config, currentAttemptModel, authType, error);
+        handleFallback(this.config, currentAttemptModel, authType, error);
 
       const result = await retryWithBackoff(apiCall, {
         onPersistent429: onPersistent429Callback,

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1886,7 +1886,7 @@ describe('GeminiChat', () => {
             error,
           );
           if (shouldRetry) {
-            return await apiCall();
+            return apiCall();
           }
         }
         throw error; // Stop if callback returns false/null or doesn't exist

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -535,7 +535,7 @@ export class GeminiChat {
     const onPersistent429Callback = async (
       authType?: string,
       error?: unknown,
-    ) => await handleFallback(this.config, effectiveModel, authType, error);
+    ) => handleFallback(this.config, effectiveModel, authType, error);
 
     const streamResponse = await retryWithBackoff(apiCall, {
       onPersistent429: onPersistent429Callback,

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -268,7 +268,7 @@ export class HookEventHandler {
     };
 
     const context: HookEventContext = { toolName };
-    return await this.executeHooks(HookEventName.BeforeTool, input, context);
+    return this.executeHooks(HookEventName.BeforeTool, input, context);
   }
 
   /**
@@ -288,7 +288,7 @@ export class HookEventHandler {
     };
 
     const context: HookEventContext = { toolName };
-    return await this.executeHooks(HookEventName.AfterTool, input, context);
+    return this.executeHooks(HookEventName.AfterTool, input, context);
   }
 
   /**
@@ -301,7 +301,7 @@ export class HookEventHandler {
       prompt,
     };
 
-    return await this.executeHooks(HookEventName.BeforeAgent, input);
+    return this.executeHooks(HookEventName.BeforeAgent, input);
   }
 
   /**
@@ -319,7 +319,7 @@ export class HookEventHandler {
       details,
     };
 
-    return await this.executeHooks(HookEventName.Notification, input);
+    return this.executeHooks(HookEventName.Notification, input);
   }
 
   /**
@@ -338,7 +338,7 @@ export class HookEventHandler {
       stop_hook_active: stopHookActive,
     };
 
-    return await this.executeHooks(HookEventName.AfterAgent, input);
+    return this.executeHooks(HookEventName.AfterAgent, input);
   }
 
   /**
@@ -353,7 +353,7 @@ export class HookEventHandler {
     };
 
     const context: HookEventContext = { trigger: source };
-    return await this.executeHooks(HookEventName.SessionStart, input, context);
+    return this.executeHooks(HookEventName.SessionStart, input, context);
   }
 
   /**
@@ -368,7 +368,7 @@ export class HookEventHandler {
     };
 
     const context: HookEventContext = { trigger: reason };
-    return await this.executeHooks(HookEventName.SessionEnd, input, context);
+    return this.executeHooks(HookEventName.SessionEnd, input, context);
   }
 
   /**
@@ -383,7 +383,7 @@ export class HookEventHandler {
     };
 
     const context: HookEventContext = { trigger };
-    return await this.executeHooks(HookEventName.PreCompress, input, context);
+    return this.executeHooks(HookEventName.PreCompress, input, context);
   }
 
   /**
@@ -398,7 +398,7 @@ export class HookEventHandler {
       llm_request: defaultHookTranslator.toHookLLMRequest(llmRequest),
     };
 
-    return await this.executeHooks(HookEventName.BeforeModel, input);
+    return this.executeHooks(HookEventName.BeforeModel, input);
   }
 
   /**
@@ -415,7 +415,7 @@ export class HookEventHandler {
       llm_response: defaultHookTranslator.toHookLLMResponse(llmResponse),
     };
 
-    return await this.executeHooks(HookEventName.AfterModel, input);
+    return this.executeHooks(HookEventName.AfterModel, input);
   }
 
   /**
@@ -430,7 +430,7 @@ export class HookEventHandler {
       llm_request: defaultHookTranslator.toHookLLMRequest(llmRequest),
     };
 
-    return await this.executeHooks(HookEventName.BeforeToolSelection, input);
+    return this.executeHooks(HookEventName.BeforeToolSelection, input);
   }
 
   /**

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -81,7 +81,7 @@ export class HookRunner {
       this.executeHook(config, eventName, input),
     );
 
-    return await Promise.all(promises);
+    return Promise.all(promises);
   }
 
   /**

--- a/packages/core/src/mcp/token-storage/hybrid-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/hybrid-token-storage.ts
@@ -57,7 +57,7 @@ export class HybridTokenStorage extends BaseTokenStorage {
     }
 
     // Wait for initialization to complete
-    return await this.storageInitPromise;
+    return this.storageInitPromise;
   }
 
   async getCredentials(serverName: string): Promise<OAuthCredentials | null> {

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -192,7 +192,7 @@ export class LoopDetectionService {
       this.turnsInCurrentPrompt - this.lastCheckTurn >= this.llmCheckInterval
     ) {
       this.lastCheckTurn = this.turnsInCurrentPrompt;
-      return await this.checkForLoopWithLLM(signal);
+      return this.checkForLoopWithLLM(signal);
     }
 
     return false;

--- a/packages/core/src/tools/smart-edit.ts
+++ b/packages/core/src/tools/smart-edit.ts
@@ -966,7 +966,7 @@ A good instruction should concisely answer:
       getFilePath: (params: EditToolParams) => params.file_path,
       getCurrentContent: async (params: EditToolParams): Promise<string> => {
         try {
-          return this.config
+          return await this.config
             .getFileSystemService()
             .readTextFile(params.file_path);
         } catch (err) {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -307,7 +307,7 @@ ${textContent}
           this.config,
           new WebFetchFallbackAttemptEvent('primary_failed'),
         );
-        return this.executeFallback(signal);
+        return await this.executeFallback(signal);
       }
 
       const sourceListFormatted: string[] = [];

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -436,7 +436,7 @@ export async function loadEnvironmentMemory(
         `Loading environment memory for trusted root: ${resolvedRoot} (Stopping exactly here)`,
       );
     }
-    return await findUpwardGeminiFiles(resolvedRoot, resolvedRoot, debugMode);
+    return findUpwardGeminiFiles(resolvedRoot, resolvedRoot, debugMode);
   });
 
   const pathArrays = await Promise.all(traversalPromises);


### PR DESCRIPTION
## TLDR

Added @typescript-eslint/return-await ESLint rule to enforce
proper async/await usage in try-catch blocks, preventing errors
 from bypassing catch handlers. Also cleaned up unnecessary
return await in non-try-catch contexts.

> **Note:** This is a fresh implementation on top of the latest `main` branch.
> I previously created PR #8168 and even received one approval on it
> but I wasn't able to keep it updated, so I've redone this work from scratch to ensure
> compatibility with the current codebase.

## Dive Deeper

The rule addresses a subtle but important anti-pattern where
returning promises directly in try-catch blocks causes async
errors to escape the catch handler

```typescript
// Before: Error bypasses catch
try {
  return someAsyncFunc();
} catch (e) {
  // Never called for async errors
}
```

```typescript
// After: Error properly caught
try {
  return await someAsyncFunc();
} catch (e) {
  // Handles async errors correctly
}
```

This PR includes:
1. ESLint config update with the new rule
2. Fixed 23 files across the codebase:
    - Added `return await` in try-catch blocks to ensure errors are caught (19
  auto-fixed, 4 manual)
    - Removed unnecessary `await` where not needed (auto-fixed by ESLint)

## Reviewer Test Plan

1. Run `npm run lint` - should pass without errors
2. Check modified files for proper async/await usage

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
|----------|-----|-----|-----|
| npm run  | ✅   | ❓   | ❓   |
| npx      | ✅   | ❓   | ❓   |
| Docker   | ❓   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |

## Linked issues / bugs

- This PR Resolves on #8167 
