### PR TITLE
feat(ide-mode): LSP tools integration

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -126,6 +126,7 @@ vi.mock('../ide/ide-client.js', () => ({
       getConnectionStatus: vi.fn(),
       initialize: vi.fn(),
       shutdown: vi.fn(),
+      getCurrentIde: vi.fn(),
     }),
   },
 }));

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -162,6 +162,7 @@ import {
   SimpleExtensionLoader,
 } from '../utils/extensionLoader.js';
 import { McpClientManager } from '../tools/mcp-client-manager.js';
+import { LSPWorkspaceSymbolsTool } from '../tools/lsp-workspace-symbols.js';
 
 export type { FileFilteringOptions };
 export {
@@ -1434,6 +1435,8 @@ export class Config {
     if (this.getUseWriteTodos()) {
       registerCoreTool(WriteTodosTool, this);
     }
+
+    registerCoreTool(LSPWorkspaceSymbolsTool);
 
     // Register Subagents as Tools
     if (this.getCodebaseInvestigatorSettings().enabled) {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -163,6 +163,7 @@ import {
 } from '../utils/extensionLoader.js';
 import { McpClientManager } from '../tools/mcp-client-manager.js';
 import { LSPWorkspaceSymbolsTool } from '../tools/lsp-workspace-symbols.js';
+import { LSPFindReferencesTool } from '../tools/lsp-find-references.js';
 
 export type { FileFilteringOptions };
 export {
@@ -1437,6 +1438,7 @@ export class Config {
     }
 
     registerCoreTool(LSPWorkspaceSymbolsTool);
+    registerCoreTool(LSPFindReferencesTool, this);
 
     // Register Subagents as Tools
     if (this.getCodebaseInvestigatorSettings().enabled) {

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -54,6 +54,7 @@ describe('Core System Prompt (prompts.ts)', () => {
       },
       isInteractive: vi.fn().mockReturnValue(true),
       isInteractiveShellEnabled: vi.fn().mockReturnValue(true),
+      isIdeConnected: vi.fn().mockReturnValue(false),
     } as unknown as Config;
   });
 
@@ -134,6 +135,7 @@ describe('Core System Prompt (prompts.ts)', () => {
         },
         isInteractive: vi.fn().mockReturnValue(false),
         isInteractiveShellEnabled: vi.fn().mockReturnValue(false),
+        isIdeConnected: vi.fn().mockReturnValue(false),
       } as unknown as Config;
 
       const prompt = getCoreSystemPrompt(testConfig);

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -11,6 +11,8 @@ import {
   EDIT_TOOL_NAME,
   GLOB_TOOL_NAME,
   GREP_TOOL_NAME,
+  LSP_FIND_REFERENCES_TOOL_NAME,
+  LSP_WORKSPACE_SYMBOLS_TOOL_NAME,
   MEMORY_TOOL_NAME,
   READ_FILE_TOOL_NAME,
   SHELL_TOOL_NAME,
@@ -112,6 +114,8 @@ export function getCoreSystemPrompt(
     .getAllToolNames()
     .includes(WriteTodosTool.Name);
 
+  const inIde = config.isIdeConnected();
+
   let basePrompt: string;
   if (systemMdEnabled) {
     basePrompt = fs.readFileSync(systemMdPath, 'utf8');
@@ -131,7 +135,16 @@ export function getCoreSystemPrompt(
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.`,
 
-      primaryWorkflows_prefix: `
+      primaryWorkflows_prefix: inIde
+        ? `
+# Primary Workflows
+
+## Software Engineering Tasks
+When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
+1. **Understand:** Think about the user's request and the relevant codebase context. First use '${LSP_WORKSPACE_SYMBOLS_TOOL_NAME}' to find relevant symbol locations, '${LSP_FIND_REFERENCES_TOOL_NAME}' to find references for those locations, otherwise fallback to '${GREP_TOOL_NAME}' and '${GLOB_TOOL_NAME}' (run in parallel if independent) to understand file structures, existing code patterns, and conventions. 
+Use '${READ_FILE_TOOL_NAME}' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to '${READ_FILE_TOOL_NAME}'.
+2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.`
+        : `
 # Primary Workflows
 
 ## Software Engineering Tasks
@@ -140,7 +153,15 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 Use '${READ_FILE_TOOL_NAME}' to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to '${READ_FILE_TOOL_NAME}'.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.`,
 
-      primaryWorkflows_prefix_ci: `
+      primaryWorkflows_prefix_ci: inIde
+        ? `
+# Primary Workflows
+
+## Software Engineering Tasks
+When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
+1. **Understand & Strategize:** Think about the user's request and the relevant codebase context. When the task involves **complex refactoring, codebase exploration or system-wide analysis**, your **first and primary tool** must be '${CodebaseInvestigatorAgent.name}'. Use it to build a comprehensive understanding of the code, its structure, and dependencies. For **simple, targeted searches** (like finding a specific function name, file path, or variable declaration), you should first use '${LSP_WORKSPACE_SYMBOLS_TOOL_NAME}' to find symbol locations, then '${LSP_FIND_REFERENCES_TOOL_NAME}' to find the references for those locations, otherwise fallback to '${GREP_TOOL_NAME}' and '${GLOB_TOOL_NAME}'.
+2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. If '${CodebaseInvestigatorAgent.name}' was used, do not ignore the output of '${CodebaseInvestigatorAgent.name}', you must use it as the foundation of your plan. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.`
+        : `
 # Primary Workflows
 
 ## Software Engineering Tasks
@@ -148,7 +169,15 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 1. **Understand & Strategize:** Think about the user's request and the relevant codebase context. When the task involves **complex refactoring, codebase exploration or system-wide analysis**, your **first and primary tool** must be '${CodebaseInvestigatorAgent.name}'. Use it to build a comprehensive understanding of the code, its structure, and dependencies. For **simple, targeted searches** (like finding a specific function name, file path, or variable declaration), you should use '${GREP_TOOL_NAME}' or '${GLOB_TOOL_NAME}' directly.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. If '${CodebaseInvestigatorAgent.name}' was used, do not ignore the output of '${CodebaseInvestigatorAgent.name}', you must use it as the foundation of your plan. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.`,
 
-      primaryWorkflows_prefix_ci_todo: `
+      primaryWorkflows_prefix_ci_todo: inIde
+        ? `
+# Primary Workflows
+
+## Software Engineering Tasks
+When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
+1. **Understand & Strategize:** Think about the user's request and the relevant codebase context. When the task involves **complex refactoring, codebase exploration or system-wide analysis**, your **first and primary tool** must be '${CodebaseInvestigatorAgent.name}'. Use it to build a comprehensive understanding of the code, its structure, and dependencies. For **simple, targeted searches** (like finding a specific function name, file path, or variable declaration), you should first use '${LSP_WORKSPACE_SYMBOLS_TOOL_NAME}' to find symbol locations, then '${LSP_FIND_REFERENCES_TOOL_NAME}' to find the references for those locations, otherwise fallback to '${GREP_TOOL_NAME}' and '${GLOB_TOOL_NAME}'.
+2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. If '${CodebaseInvestigatorAgent.name}' was used, do not ignore the output of '${CodebaseInvestigatorAgent.name}', you must use it as the foundation of your plan. For complex tasks, break them down into smaller, manageable subtasks and use the \`${WRITE_TODOS_TOOL_NAME}\` tool to track your progress. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.`
+        : `
 # Primary Workflows
 
 ## Software Engineering Tasks
@@ -156,7 +185,15 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 1. **Understand & Strategize:** Think about the user's request and the relevant codebase context. When the task involves **complex refactoring, codebase exploration or system-wide analysis**, your **first and primary tool** must be '${CodebaseInvestigatorAgent.name}'. Use it to build a comprehensive understanding of the code, its structure, and dependencies. For **simple, targeted searches** (like finding a specific function name, file path, or variable declaration), you should use '${GREP_TOOL_NAME}' or '${GLOB_TOOL_NAME}' directly.
 2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. If '${CodebaseInvestigatorAgent.name}' was used, do not ignore the output of '${CodebaseInvestigatorAgent.name}', you must use it as the foundation of your plan. For complex tasks, break them down into smaller, manageable subtasks and use the \`${WRITE_TODOS_TOOL_NAME}\` tool to track your progress. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.`,
 
-      primaryWorkflows_todo: `
+      primaryWorkflows_todo: inIde
+        ? `
+# Primary Workflows
+
+## Software Engineering Tasks
+When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this sequence:
+1. **Understand:** Think about the user's request and the relevant codebase context. Use '${GREP_TOOL_NAME}' and '${GLOB_TOOL_NAME}' search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. First use '${LSP_WORKSPACE_SYMBOLS_TOOL_NAME}' to find relevant symbol locations, '${LSP_FIND_REFERENCES_TOOL_NAME}' to find references for those locations, otherwise fallback to '${GREP_TOOL_NAME}' and '${GLOB_TOOL_NAME}' (run in parallel if independent) to understand file structures, existing code patterns, and conventions.
+2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. For complex tasks, break them down into smaller, manageable subtasks and use the \`${WRITE_TODOS_TOOL_NAME}\` tool to track your progress. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process. As part of the plan, you should use an iterative development process that includes writing unit tests to verify your changes. Use output logs or debug statements as part of this process to arrive at a solution.`
+        : `
 # Primary Workflows
 
 ## Software Engineering Tasks

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -402,7 +402,7 @@ export class IdeClient {
     character: number,
   ): Promise<LSPLocation[]> {
     if (!this.client) {
-      throw new Error('IDE client is not connected.');
+      throw new Error('IDE client is not connected');
     }
 
     const result = await this.client.request(
@@ -422,38 +422,28 @@ export class IdeClient {
     );
 
     if (!result) {
-      debugLogger.log('No response from IDE for find references request.');
-      return [];
+      throw new Error('No response from IDE for find references request');
     }
 
     if (result.isError) {
-      debugLogger.log(
-        'Error response from IDE for find references request.',
-        JSON.stringify(result),
-      );
-      return [];
+      throw new Error('Error response from IDE for find references request');
     }
 
     const textPart = result.content.find((part) => part.type === 'text');
     if (!textPart?.text) {
-      debugLogger.log('No text content in find references response from IDE.');
-      return [];
+      throw new Error('No text content in find references response from IDE');
     }
 
     try {
       return JSON.parse(textPart.text) as LSPLocation[];
-    } catch (error) {
-      debugLogger.log(
-        'Failed to parse find references response from IDE:',
-        error,
-      );
-      return [];
+    } catch (_error) {
+      throw new Error('Failed to parse find references response from IDE');
     }
   }
 
   async getWorkspaceSymbols(query: string): Promise<LSPSymbolInformation[]> {
     if (!this.client) {
-      throw new Error('IDE client is not connected.');
+      throw new Error('IDE client is not connected');
     }
 
     const result = await this.client.request(
@@ -471,31 +461,22 @@ export class IdeClient {
     );
 
     if (!result) {
-      debugLogger.log('No response from IDE for workspace symbols request.');
-      return [];
+      throw new Error('No response from IDE for workspace symbols request');
     }
 
     if (result.isError) {
-      debugLogger.log('Error response from IDE for workspace symbols request.');
-      return [];
+      throw new Error('Error response from IDE for workspace symbols request');
     }
 
     const textPart = result.content.find((part) => part.type === 'text');
     if (!textPart?.text) {
-      debugLogger.log(
-        'No text content in workspace symbols response from IDE.',
-      );
-      return [];
+      throw new Error('No text content in workspace symbols response from IDE');
     }
 
     try {
       return JSON.parse(textPart.text) as LSPSymbolInformation[];
-    } catch (error) {
-      debugLogger.log(
-        'Failed to parse workspace symbols response from IDE:',
-        error,
-      );
-      return [];
+    } catch (_error) {
+      throw new Error('Failed to parse workspace symbols response from IDE');
     }
   }
 

--- a/packages/core/src/ide/types.ts
+++ b/packages/core/src/ide/types.ts
@@ -146,3 +146,25 @@ export const CloseDiffRequestSchema = z.object({
    */
   suppressNotification: z.boolean().optional(),
 });
+
+export const GetWorkspaceSymbolsRequestSchema = z.object({
+  query: z.string(),
+});
+
+export const FindReferencesRequestSchema = z.object({
+  filePath: z.string(),
+  line: z.number(),
+  character: z.number(),
+});
+
+export interface LSPLocation {
+  filePath: string;
+  // 1-based line and character positions
+  line: number;
+  character: number;
+}
+
+export interface LSPSymbolInformation {
+  name: string;
+  location: LSPLocation;
+}

--- a/packages/core/src/tools/lsp-find-references.ts
+++ b/packages/core/src/tools/lsp-find-references.ts
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../config/config.js';
+import path from 'node:path';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import { IdeClient } from '../ide/ide-client.js';
+import { debugLogger } from '../utils/debugLogger.js';
+import { ToolErrorType } from './tool-error.js';
+import { LSP_FIND_REFERENCES_TOOL_NAME } from './tool-names.js';
+import {
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+  type ToolCallConfirmationDetails,
+  type ToolInvocation,
+  type ToolResult,
+} from './tools.js';
+
+export interface LSPFindReferencesToolParams {
+  /**
+   * The file path to search for references.
+   */
+  filePath: string;
+  /**
+   * The line number to search for references.
+   * 1-based.
+   */
+  line: number;
+  /**
+   * The character position to search for references.
+   * 1-based.
+   */
+  character: number;
+}
+
+class LSPFindReferencesToolInvocation extends BaseToolInvocation<
+  LSPFindReferencesToolParams,
+  ToolResult
+> {
+  private readonly resolvedPath: string;
+  constructor(
+    private config: Config,
+    params: LSPFindReferencesToolParams,
+    _toolName?: string,
+    _toolDisplayName?: string,
+    messageBus?: MessageBus,
+  ) {
+    super(params, messageBus, _toolName, _toolDisplayName);
+    this.resolvedPath = path.resolve(
+      this.config.getTargetDir(),
+      this.params.filePath,
+    );
+  }
+
+  override getDescription(): string {
+    return `Finding references at ${this.params.filePath}:${this.params.line}:${this.params.character}`;
+  }
+
+  override async shouldConfirmExecute(
+    _abortSignal: AbortSignal,
+  ): Promise<ToolCallConfirmationDetails | false> {
+    return false;
+  }
+
+  override async execute(): Promise<ToolResult> {
+    debugLogger.log(
+      'Executing LSPFindReferencesTool with params: ',
+      JSON.stringify(this.params),
+    );
+    const ideClient = await IdeClient.getInstance();
+    if (!ideClient) {
+      return {
+        llmContent: 'Error: IDE client is not connected.',
+        returnDisplay:
+          'Error: IDE client is not connected, ensure gemini-cli is running inside an IDE.',
+        error: {
+          message: 'IDE client is not connected',
+          type: ToolErrorType.LSP_ERROR,
+        },
+      };
+    }
+
+    try {
+      const references = await ideClient.findReferences(
+        this.resolvedPath,
+        this.params.line,
+        this.params.character,
+      );
+      return {
+        llmContent: `Found ${references.length} references for symbol at ${this.params.filePath}:${this.params.line}:${this.params.character}:\n${JSON.stringify(references)}.`,
+        returnDisplay: `Found ${references.length} references.`,
+      };
+    } catch (error) {
+      return {
+        llmContent: `Error executing LSP find references search: ${
+          (error as Error).message
+        }`,
+        returnDisplay: 'Error executing LSP find references search',
+        error: {
+          message: (error as Error).message,
+          type: ToolErrorType.LSP_ERROR,
+        },
+      };
+    }
+  }
+}
+
+export class LSPFindReferencesTool extends BaseDeclarativeTool<
+  LSPFindReferencesToolParams,
+  ToolResult
+> {
+  static readonly Name = LSP_FIND_REFERENCES_TOOL_NAME;
+
+  constructor(
+    private config: Config,
+    messageBus?: MessageBus,
+  ) {
+    super(
+      LSPFindReferencesTool.Name,
+      'LSPFindReferences',
+      'Find references for a symbol in a file, at a particular line, character using the Language Server Protocol (LSP).',
+      Kind.Search,
+      {
+        properties: {
+          filePath: {
+            description: 'The file path to search for references.',
+            type: 'string',
+          },
+          line: {
+            description: 'The line number to search for references. 1-based.',
+            type: 'number',
+          },
+          character: {
+            description:
+              'The character position to search for references. 1-based.',
+            type: 'number',
+          },
+        },
+        required: ['filePath', 'line', 'character'],
+        type: 'object',
+      },
+      false,
+      false,
+      messageBus,
+    );
+  }
+
+  protected override createInvocation(
+    params: LSPFindReferencesToolParams,
+    messageBus?: MessageBus,
+    _toolName?: string,
+    _toolDisplayName?: string,
+  ): ToolInvocation<LSPFindReferencesToolParams, ToolResult> {
+    return new LSPFindReferencesToolInvocation(
+      this.config,
+      params,
+      _toolName,
+      _toolDisplayName,
+      messageBus,
+    );
+  }
+}

--- a/packages/core/src/tools/lsp-find-references.ts
+++ b/packages/core/src/tools/lsp-find-references.ts
@@ -8,7 +8,6 @@ import type { Config } from '../config/config.js';
 import path from 'node:path';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { IdeClient } from '../ide/ide-client.js';
-import { debugLogger } from '../utils/debugLogger.js';
 import { ToolErrorType } from './tool-error.js';
 import { LSP_FIND_REFERENCES_TOOL_NAME } from './tool-names.js';
 import {
@@ -67,10 +66,6 @@ class LSPFindReferencesToolInvocation extends BaseToolInvocation<
   }
 
   override async execute(): Promise<ToolResult> {
-    debugLogger.log(
-      'Executing LSPFindReferencesTool with params: ',
-      JSON.stringify(this.params),
-    );
     const ideClient = await IdeClient.getInstance();
     if (!ideClient) {
       return {

--- a/packages/core/src/tools/lsp-workspace-symbols.ts
+++ b/packages/core/src/tools/lsp-workspace-symbols.ts
@@ -6,7 +6,6 @@
 
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { IdeClient } from '../ide/ide-client.js';
-import { debugLogger } from '../utils/debugLogger.js';
 import { ToolErrorType } from './tool-error.js';
 import { LSP_WORKSPACE_SYMBOLS_TOOL_NAME } from './tool-names.js';
 import {
@@ -49,11 +48,6 @@ class LSPWorkspaceSymbolsToolInvocation extends BaseToolInvocation<
   }
 
   override async execute(): Promise<ToolResult> {
-    // TODO: implement abort signal handling
-    debugLogger.log(
-      'Executing LSPWorkspaceSymbolsTool with query: ',
-      this.params.query,
-    );
     const ideClient = await IdeClient.getInstance();
     if (!ideClient) {
       return {

--- a/packages/core/src/tools/lsp-workspace-symbols.ts
+++ b/packages/core/src/tools/lsp-workspace-symbols.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import { IdeClient } from '../ide/ide-client.js';
+import { debugLogger } from '../utils/debugLogger.js';
+import { ToolErrorType } from './tool-error.js';
+import { LSP_WORKSPACE_SYMBOLS_TOOL_NAME } from './tool-names.js';
+import {
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+  type ToolCallConfirmationDetails,
+  type ToolInvocation,
+  type ToolResult,
+} from './tools.js';
+
+export interface LSPWorkspaceSymbolsToolParams {
+  /**
+   * The query string to search for symbols in the workspace.
+   */
+  query: string;
+}
+
+class LSPWorkspaceSymbolsToolInvocation extends BaseToolInvocation<
+  LSPWorkspaceSymbolsToolParams,
+  ToolResult
+> {
+  constructor(
+    params: LSPWorkspaceSymbolsToolParams,
+    _toolName?: string,
+    _toolDisplayName?: string,
+    messageBus?: MessageBus,
+  ) {
+    super(params, messageBus, _toolName, _toolDisplayName);
+  }
+
+  override getDescription(): string {
+    return `Searching the workspace for: \`${this.params.query}\``;
+  }
+
+  override async shouldConfirmExecute(
+    _abortSignal: AbortSignal,
+  ): Promise<ToolCallConfirmationDetails | false> {
+    return false;
+  }
+
+  override async execute(): Promise<ToolResult> {
+    // TODO: implement abort signal handling
+    debugLogger.log(
+      'Executing LSPWorkspaceSymbolsTool with query: ',
+      this.params.query,
+    );
+    const ideClient = await IdeClient.getInstance();
+    if (!ideClient) {
+      return {
+        llmContent: 'Error: IDE client is not connected.',
+        returnDisplay:
+          'Error: IDE client is not connected, ensure gemini-cli is running inside an IDE.',
+        error: {
+          message: 'IDE client is not connected',
+          type: ToolErrorType.LSP_ERROR,
+        },
+      };
+    }
+
+    try {
+      const symbols = await ideClient.getWorkspaceSymbols(this.params.query);
+      return {
+        llmContent: `Found ${symbols.length} symbols for query "${this.params.query}:\n${JSON.stringify(symbols)}".`,
+        returnDisplay: `Found ${symbols.length} symbols for query "${this.params.query}".`,
+      };
+    } catch (error) {
+      return {
+        llmContent: `Error executing LSP workspace symbols search: ${
+          (error as Error).message
+        }`,
+        returnDisplay: 'Error executing LSP workspace symbols search',
+        error: {
+          message: (error as Error).message,
+          type: ToolErrorType.LSP_ERROR,
+        },
+      };
+    }
+  }
+}
+
+export class LSPWorkspaceSymbolsTool extends BaseDeclarativeTool<
+  LSPWorkspaceSymbolsToolParams,
+  ToolResult
+> {
+  static readonly Name = LSP_WORKSPACE_SYMBOLS_TOOL_NAME;
+
+  constructor(messageBus?: MessageBus) {
+    super(
+      LSPWorkspaceSymbolsTool.Name,
+      'LSPWorkspaceSymbols',
+      'Search for symbols in the workspace using the Language Server Protocol (LSP).',
+      Kind.Search,
+      {
+        properties: {
+          query: {
+            description:
+              'The query string to search for symbols in the workspace.',
+            type: 'string',
+          },
+        },
+        required: ['query'],
+        type: 'object',
+      },
+      false,
+      false,
+      messageBus,
+    );
+  }
+
+  protected override createInvocation(
+    params: LSPWorkspaceSymbolsToolParams,
+    messageBus?: MessageBus,
+    _toolName?: string,
+    _toolDisplayName?: string,
+  ): ToolInvocation<LSPWorkspaceSymbolsToolParams, ToolResult> {
+    return new LSPWorkspaceSymbolsToolInvocation(
+      params,
+      _toolName,
+      _toolDisplayName,
+      messageBus,
+    );
+  }
+}

--- a/packages/core/src/tools/tool-error.ts
+++ b/packages/core/src/tools/tool-error.ts
@@ -71,6 +71,8 @@ export enum ToolErrorType {
 
   // WebSearch-specific Errors
   WEB_SEARCH_FAILED = 'web_search_failed',
+
+  LSP_ERROR = 'lsp_error',
 }
 
 /**

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -20,3 +20,5 @@ export const READ_MANY_FILES_TOOL_NAME = 'read_many_files';
 export const READ_FILE_TOOL_NAME = 'read_file';
 export const LS_TOOL_NAME = 'list_directory';
 export const MEMORY_TOOL_NAME = 'save_memory';
+export const LSP_WORKSPACE_SYMBOLS_TOOL_NAME = 'lsp_workspace_symbols';
+export const LSP_FIND_REFERENCES_TOOL_NAME = 'lsp_find_references';

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -545,29 +545,37 @@ const createMcpServer = (
       line,
       character,
     }: z.infer<typeof FindReferencesRequestSchema>) => {
-      const uri = vscode.Uri.file(filePath);
-      const position = new vscode.Position(line - 1, character - 1);
+      try {
+        const uri = vscode.Uri.file(filePath);
+        const position = new vscode.Position(line - 1, character - 1);
 
-      const references =
-        ((await vscode.commands.executeCommand(
-          'vscode.executeReferenceProvider',
-          uri,
-          position,
-        )) as vscode.Location[] | undefined) || [];
+        const references =
+          ((await vscode.commands.executeCommand(
+            'vscode.executeReferenceProvider',
+            uri,
+            position,
+          )) as vscode.Location[] | undefined) || [];
 
-      const response: LSPLocation[] = references.map((ref) => ({
-        filePath: ref.uri.fsPath,
-        line: ref.range.start.line + 1,
-        character: ref.range.start.character + 1,
-      }));
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(response),
-          },
-        ],
-      };
+        const response: LSPLocation[] = references.map((ref) => ({
+          filePath: ref.uri.fsPath,
+          line: ref.range.start.line + 1,
+          character: ref.range.start.character + 1,
+        }));
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(response),
+            },
+          ],
+        };
+      } catch (_error) {
+        return {
+          content: [],
+          isError: true,
+        };
+      }
     },
   );
   return server;

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -7,7 +7,8 @@
 import * as vscode from 'vscode';
 import type {
   LSPLocation,
-  LSPSymbolInformation} from '@google/gemini-cli-core/src/ide/types.js';
+  LSPSymbolInformation,
+} from '@google/gemini-cli-core/src/ide/types.js';
 import {
   CloseDiffRequestSchema,
   FindReferencesRequestSchema,


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
This PR adds two new core tools, `LSPFindReferences` and `LSPWorkspaceSymbols`, for `gemini-cli` when running in IDE mode within VSCode.

## Details

* Add IDE-detection logic during `Config` initialization.
* Implement new tools, `LSPWorkspaceSymbolsTool` and `LSPFindReferencesTool`, which delegate their calls to the `ideClient`, which then communicates with the companion MCP server.
* Dynamically register `LSPWorkspaceSymbolsTool` and `LSPFindReferencesTool` as core tools based on `Config.isIdeConnected()`.
* Update the core system prompt to prioritize LSP tools when they are available (when the CLI is running inside an IDE).
* Register new tools for workspace symbol and find references LSP functions within the VSCode companion extension's MCP server.

### Thoughts

VS Code does not expose APIs that directly call LSP functions. Instead, it has built-in commands such as `vscode.executeReferenceProvider`, `vscode.executeWorkspaceSymbolProvider`, etc. These commands operate on positions expressed as line/character offsets rather than symbol names, which I believe can be pretty unwieldly for agent to use.

My current approach is to specify in system prompt to first use `LSPWorkspaceSymbols` to locate candidate symbol positions (expressed in line/character offsets), then call `LSPFindReferences` on those locations. However, LSPWorkspaceSymbolsTool can return too large a set of results, many of which are unrelated to the intended target.

A possible workaround is to implement another tool `LSPDocumentSymbols` which calls `vscode.executeDocumentSymbolProvider` to obtain document-scoped symbols when the file path is provided, reducing the number of symbols before falling back to workspace-wide symbol queries.

## Related Issues

Related to #6690

## How to Validate

- Submit query asking for references / document symbols.
- Run slash command /tools when running inside / outside VSCode.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
