### PR TITLE
feat(ui): Show waiting MCP servers in ConfigInitDisplay

### DIFF
--- a/packages/cli/src/ui/components/ConfigInitDisplay.tsx
+++ b/packages/cli/src/ui/components/ConfigInitDisplay.tsx
@@ -21,12 +21,28 @@ export const ConfigInitDisplay = () => {
         return;
       }
       let connected = 0;
-      for (const client of clients.values()) {
+      const connecting: string[] = [];
+      for (const [name, client] of clients.entries()) {
         if (client.getStatus() === MCPServerStatus.CONNECTED) {
           connected++;
+        } else {
+          connecting.push(name);
         }
       }
-      setMessage(`Connecting to MCP servers... (${connected}/${clients.size})`);
+
+      if (connecting.length > 0) {
+        const maxDisplay = 3;
+        const displayedServers = connecting.slice(0, maxDisplay).join(', ');
+        const remaining = connecting.length - maxDisplay;
+        const suffix = remaining > 0 ? `, +${remaining} more` : '';
+        setMessage(
+          `Connecting to MCP servers... (${connected}/${clients.size}) - Waiting for: ${displayedServers}${suffix}`,
+        );
+      } else {
+        setMessage(
+          `Connecting to MCP servers... (${connected}/${clients.size})`,
+        );
+      }
     };
 
     appEvents.on(AppEvent.McpClientUpdate, onChange);

--- a/packages/cli/src/ui/components/__snapshots__/ConfigInitDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ConfigInitDisplay.test.tsx.snap
@@ -10,7 +10,12 @@ exports[`ConfigInitDisplay > renders initial state 1`] = `
 Spinner Initializing..."
 `;
 
+exports[`ConfigInitDisplay > truncates list of waiting servers if too many 1`] = `
+"
+Spinner Connecting to MCP servers... (0/5) - Waiting for: s1, s2, s3, +2 more"
+`;
+
 exports[`ConfigInitDisplay > updates message on McpClientUpdate event 1`] = `
 "
-Spinner Connecting to MCP servers... (1/2)"
+Spinner Connecting to MCP servers... (1/2) - Waiting for: server2"
 `;


### PR DESCRIPTION
## Summary

Shows which MCP servers are currently waiting to connect in the `ConfigInitDisplay` component during initialization.

## Details

Previously, the UI only showed a count of connected/connecting servers. This change lists the names of the servers that are still in the "CONNECTING" state, making it easier to identify which server might be hanging or taking a long time. It truncates the list if there are too many servers waiting.

## Related Issues

Fixes #13542

## How to Validate

1. Configure multiple MCP servers in your config, some of which might take a moment to connect.
2. Start the CLI.
3. Observe the initialization spinner. It should now list the servers it is waiting for (e.g., "Waiting for: server1, server2").

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker