### PR TITLE
fix(cli): enter vim normal mode without cancelling the active request

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -68,6 +68,7 @@ import path from 'node:path';
 import { useSessionStats } from '../contexts/SessionContext.js';
 import { useKeypress } from './useKeypress.js';
 import type { LoadedSettings } from '../../config/settings.js';
+import { useVimMode } from '../contexts/VimModeContext.js';
 
 enum StreamProcessingStatus {
   Completed,
@@ -116,6 +117,7 @@ export const useGeminiStream = (
   const turnCancelledRef = useRef(false);
   const activeQueryIdRef = useRef<string | null>(null);
   const [isResponding, setIsResponding] = useState<boolean>(false);
+  const { vimEnabled, vimMode } = useVimMode();
   const [thought, setThought] = useState<ThoughtSummary | null>(null);
   const [pendingHistoryItem, pendingHistoryItemRef, setPendingHistoryItem] =
     useStateAndRef<HistoryItemWithoutId | null>(null);
@@ -388,6 +390,10 @@ export const useGeminiStream = (
   useKeypress(
     (key) => {
       if (key.name === 'escape' && !isShellFocused) {
+        // In Vim INSERT mode, Esc should only switch to NORMAL mode, not cancel operations
+        if (vimEnabled && vimMode === 'INSERT') {
+          return; // Let Vim handle the mode switch
+        }
         cancelOngoingRequest();
       }
     },


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Fixed an issue where pressing the Escape key while in Vim INSERT mode would unintentionally cancel the ongoing model request.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

- Modified `useGeminiStream` to check the current Vim mode before triggering cancellation.
- When `vimEnabled` is true and the user is in `INSERT` mode, the Escape key is now ignored by the request cancellation logic.
- This allows the Escape key to correctly serve its primary purpose in Vim mode (switching from INSERT to NORMAL mode) without interrupting the active stream.
- Cancellation still works as expected when pressing Escape in normal mode or when Vim mode is disabled.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #13503, #13586

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
1. Enable Vim Mode: Ensure Vim mode is enabled in your configuration.
2. Start a Request: Send a prompt to Gemini that takes a few seconds to generate (e.g., "Write a long story").
3. Enter Insert Mode: While the response is streaming, press `i` to enter INSERT mode (if not already).
4. Press Escape: Press the Escape key.
	- Expected: The request should continue streaming. The editor state should switch to NORMAL mode.
5. Cancel in Normal Mode: Press Escape again (while in NORMAL mode).
	- Expected: The request should be cancelled.


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
