### PR TITLE
feat :Extension uninstall will now remove lefover objects from mcp object making it holistic removal process.

### DIFF
--- a/packages/cli/src/commands/extensions/uninstall.test.ts
+++ b/packages/cli/src/commands/extensions/uninstall.test.ts
@@ -87,6 +87,8 @@ describe('extensions uninstall command', () => {
   beforeEach(async () => {
     mockLoadSettings.mockReturnValue({
       merged: {},
+      forScope: vi.fn().mockReturnValue({ settings: {} }),
+      setValue: vi.fn(),
     } as unknown as LoadedSettings);
   });
 

--- a/packages/cli/src/commands/extensions/uninstall.ts
+++ b/packages/cli/src/commands/extensions/uninstall.ts
@@ -36,9 +36,6 @@ export async function handleUninstall(args: UninstallArgs) {
     const errors: Array<{ name: string; error: string }> = [];
     for (const name of [...new Set(args.names)]) {
       try {
-        await extensionManager.uninstallExtension(name, false);
-        debugLogger.log(`Extension "${name}" successfully uninstalled.`);
-
         // Also remove any MCP server config for this extension
         const scopes: LoadableSettingScope[] = [
           SettingScope.User,
@@ -55,6 +52,9 @@ export async function handleUninstall(args: UninstallArgs) {
             );
           }
         }
+
+        await extensionManager.uninstallExtension(name, false);
+        debugLogger.log(`Extension "${name}" successfully uninstalled.`);
       } catch (error) {
         errors.push({ name, error: getErrorMessage(error) });
       }

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -134,6 +134,21 @@ describe('extensionsCommand', () => {
         expect.any(Number),
       );
     });
+
+    it('should show a message if no extensions are installed', async () => {
+      mockGetExtensions.mockReturnValue([]);
+      const command = extensionsCommand();
+      if (!command.action) throw new Error('Action not defined');
+      await command.action(mockContext, '');
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'No extensions installed. Run /extensions explore to check out the gallery',
+        },
+        expect.any(Number),
+      );
+    });
   });
 
   describe('completeExtensions', () => {
@@ -211,6 +226,19 @@ describe('extensionsCommand', () => {
         {
           type: MessageType.ERROR,
           text: 'Usage: /extensions update <extension-names>|--all',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should show a message if no extensions are installed', async () => {
+      mockGetExtensions.mockReturnValue([]);
+      await updateAction(mockContext, 'ext-one');
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'No extensions installed. Run /extensions explore to check out the gallery',
         },
         expect.any(Number),
       );
@@ -605,6 +633,25 @@ describe('extensionsCommand', () => {
           restartExtension: mockRestartExtension,
         }));
       mockContext.invocation!.name = 'restart';
+    });
+
+    it('should show a message if no extensions are installed', async () => {
+      mockContext.services.config!.getExtensionLoader = vi
+        .fn()
+        .mockImplementation(() => ({
+          getExtensions: () => [],
+          restartExtension: mockRestartExtension,
+        }));
+
+      await restartAction!(mockContext, '--all');
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'No extensions installed. Run /extensions explore to check out the gallery',
+        },
+        expect.any(Number),
+      );
     });
 
     it('restarts all active extensions when --all is provided', async () => {

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -25,11 +25,24 @@ import { SettingScope } from '../../config/settings.js';
 import { theme } from '../semantic-colors.js';
 
 async function listAction(context: CommandContext) {
+  const extensions = context.services.config
+    ? listExtensions(context.services.config)
+    : [];
+
+  if (extensions.length === 0) {
+    context.ui.addItem(
+      {
+        type: MessageType.INFO,
+        text: 'No extensions installed. Run /extensions explore to check out the gallery',
+      },
+      Date.now(),
+    );
+    return;
+  }
+
   const historyItem: HistoryItemExtensionsList = {
     type: MessageType.EXTENSIONS_LIST,
-    extensions: context.services.config
-      ? listExtensions(context.services.config)
-      : [],
+    extensions,
   };
 
   context.ui.addItem(historyItem, Date.now());
@@ -56,11 +69,24 @@ function updateAction(context: CommandContext, args: string): Promise<void> {
     (resolve) => (resolveUpdateComplete = resolve),
   );
 
+  const extensions = context.services.config
+    ? listExtensions(context.services.config)
+    : [];
+
+  if (extensions.length === 0) {
+    context.ui.addItem(
+      {
+        type: MessageType.INFO,
+        text: 'No extensions installed. Run /extensions explore to check out the gallery',
+      },
+      Date.now(),
+    );
+    return Promise.resolve();
+  }
+
   const historyItem: HistoryItemExtensionsList = {
     type: MessageType.EXTENSIONS_LIST,
-    extensions: context.services.config
-      ? listExtensions(context.services.config)
-      : [],
+    extensions,
   };
 
   updateComplete.then((updateInfos) => {
@@ -132,6 +158,18 @@ async function restartAction(
       {
         type: MessageType.ERROR,
         text: "Extensions are not yet loaded, can't restart yet",
+      },
+      Date.now(),
+    );
+    return;
+  }
+
+  const extensions = extensionLoader.getExtensions();
+  if (extensions.length === 0) {
+    context.ui.addItem(
+      {
+        type: MessageType.INFO,
+        text: 'No extensions installed. Run /extensions explore to check out the gallery',
       },
       Date.now(),
     );

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -24,11 +24,10 @@ import { ExtensionManager } from '../../config/extension-manager.js';
 import { SettingScope } from '../../config/settings.js';
 import { theme } from '../semantic-colors.js';
 
-async function listAction(context: CommandContext) {
-  const extensions = context.services.config
-    ? listExtensions(context.services.config)
-    : [];
-
+function showMessageIfNoExtensions(
+  context: CommandContext,
+  extensions: unknown[],
+): boolean {
   if (extensions.length === 0) {
     context.ui.addItem(
       {
@@ -37,6 +36,17 @@ async function listAction(context: CommandContext) {
       },
       Date.now(),
     );
+    return true;
+  }
+  return false;
+}
+
+async function listAction(context: CommandContext) {
+  const extensions = context.services.config
+    ? listExtensions(context.services.config)
+    : [];
+
+  if (showMessageIfNoExtensions(context, extensions)) {
     return;
   }
 
@@ -73,14 +83,7 @@ function updateAction(context: CommandContext, args: string): Promise<void> {
     ? listExtensions(context.services.config)
     : [];
 
-  if (extensions.length === 0) {
-    context.ui.addItem(
-      {
-        type: MessageType.INFO,
-        text: 'No extensions installed. Run /extensions explore to check out the gallery',
-      },
-      Date.now(),
-    );
+  if (showMessageIfNoExtensions(context, extensions)) {
     return Promise.resolve();
   }
 
@@ -165,14 +168,7 @@ async function restartAction(
   }
 
   const extensions = extensionLoader.getExtensions();
-  if (extensions.length === 0) {
-    context.ui.addItem(
-      {
-        type: MessageType.INFO,
-        text: 'No extensions installed. Run /extensions explore to check out the gallery',
-      },
-      Date.now(),
-    );
+  if (showMessageIfNoExtensions(context, extensions)) {
     return;
   }
 


### PR DESCRIPTION
## Summary

At present when uninstalling the extensions, it is just doing partial uninstall it is not removing the corresponinding objects from the mcp object from the settings.json.

this pr make sure it removes the corresponding mcp config removal making the uninstall process holistic.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
