### PR TITLE
fix(cli): fix resume validation to correctly check for prompt input

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -262,7 +262,12 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
       if (argv['prompt'] && argv['promptInteractive']) {
         return 'Cannot use both --prompt (-p) and --prompt-interactive (-i) together';
       }
-      if (argv['resume'] && !argv['prompt'] && !process.stdin.isTTY) {
+      if (
+        argv['resume'] &&
+        !argv['prompt'] &&
+        !hasPositionalQuery &&
+        process.stdin.isTTY
+      ) {
         throw new Error(
           'When resuming a session, you must provide a message via --prompt (-p) or stdin',
         );


### PR DESCRIPTION
## Summary

There are 2 bugs in the --resume flag code:

1. The stdin check was inverted - it threw an error when stdin WAS being piped (!process.stdin.isTTY) instead of when it was NOT being piped (process.stdin.isTTY). This prevented `echo "msg" | gemini --resume`.

2. The check only looked at argv['prompt'], not positional query arguments. So `gemini "hello" --resume` would fail validation even though "hello" becomes the prompt. Added !hasPositionalQuery to the condition.

## Details

You can repro this by doing:

```
echo "hi" | gemini --resume --output-format stream-json
```
and

```
echo "hi" | gemini hello --resume --output-format stream-json
```

## How to Validate

```
echo "hello" | node packages/cli/dist/index.js
echo "hello again" | node packages/cli/dist/index.js --resume
```

##  Test plan

- Updated existing test to correctly test the error case (interactive mode with no prompt)
- Added test for positional query with --resume
- All existing tests pass