### PR TITLE
feat(config): add isModelAvailabilityServiceEnabled setting

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -772,6 +772,11 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `false`
   - **Requires restart:** Yes
 
+- **`experimental.isModelAvailabilityServiceEnabled`** (boolean):
+  - **Description:** Enable model routing using new availability service.
+  - **Default:** `false`
+  - **Requires restart:** Yes
+
 - **`experimental.codebaseInvestigatorSettings.enabled`** (boolean):
   - **Description:** Enable the Codebase Investigator agent.
   - **Default:** `true`

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -636,6 +636,8 @@ export async function loadCliConfig(
     enabledExtensions: argv.extensions,
     extensionLoader: extensionManager,
     enableExtensionReloading: settings.experimental?.extensionReloading,
+    enableModelAvailabilityService:
+      settings.experimental?.isModelAvailabilityServiceEnabled,
     noBrowser: !!process.env['NO_BROWSER'],
     summarizeToolOutput: settings.model?.summarizeToolOutput,
     ideMode,

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -345,6 +345,21 @@ describe('SettingsSchema', () => {
         getSettingsSchema().general.properties.previewFeatures.description,
       ).toBe('Enable preview features (e.g., preview models).');
     });
+
+    it('should have isModelAvailabilityServiceEnabled setting in schema', () => {
+      const setting =
+        getSettingsSchema().experimental.properties
+          .isModelAvailabilityServiceEnabled;
+      expect(setting).toBeDefined();
+      expect(setting.type).toBe('boolean');
+      expect(setting.category).toBe('Experimental');
+      expect(setting.default).toBe(false);
+      expect(setting.requiresRestart).toBe(true);
+      expect(setting.showInDialog).toBe(false);
+      expect(setting.description).toBe(
+        'Enable model routing using new availability service.',
+      );
+    });
   });
 
   it('has JSON schema definitions for every referenced ref', () => {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1291,6 +1291,15 @@ const SETTINGS_SCHEMA = {
           'Enables extension loading/unloading within the CLI session.',
         showInDialog: false,
       },
+      isModelAvailabilityServiceEnabled: {
+        type: 'boolean',
+        label: 'Enable Model Availability Service',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: false,
+        description: 'Enable model routing using new availability service.',
+        showInDialog: false,
+      },
       codebaseInvestigatorSettings: {
         type: 'object',
         label: 'Codebase Investigator Settings',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -305,6 +305,7 @@ export interface ConfigParameters {
     [K in HookEventName]?: HookDefinition[];
   };
   previewFeatures?: boolean;
+  enableModelAvailabilityService?: boolean;
 }
 
 export class Config {
@@ -420,6 +421,7 @@ export class Config {
 
   private previewModelFallbackMode = false;
   private previewModelBypassMode = false;
+  private readonly enableModelAvailabilityService: boolean;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -477,6 +479,8 @@ export class Config {
     this.fileDiscoveryService = params.fileDiscoveryService ?? null;
     this.bugCommand = params.bugCommand;
     this.model = params.model;
+    this.enableModelAvailabilityService =
+      params.enableModelAvailabilityService ?? false;
     this.previewFeatures = params.previewFeatures ?? undefined;
     this.maxSessionTurns = params.maxSessionTurns ?? -1;
     this.experimentalZedIntegration =
@@ -1138,6 +1142,10 @@ export class Config {
 
   getEnableExtensionReloading(): boolean {
     return this.enableExtensionReloading;
+  }
+
+  isModelAvailabilityServiceEnabled(): boolean {
+    return this.enableModelAvailabilityService;
   }
 
   getNoBrowser(): boolean {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1259,6 +1259,13 @@
           "default": false,
           "type": "boolean"
         },
+        "isModelAvailabilityServiceEnabled": {
+          "title": "Enable Model Availability Service",
+          "description": "Enable model routing using new availability service.",
+          "markdownDescription": "Enable model routing using new availability service.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
         "codebaseInvestigatorSettings": {
           "title": "Codebase Investigator Settings",
           "description": "Configuration for Codebase Investigator.",


### PR DESCRIPTION
## Summary

 Introduces a new configuration setting, `isModelAvailabilityServiceEnabled`, to the global settings schema and configuration interfaces. This setting allows for the explicit enabling or disabling of model availability routing logic, currently a work in progress.

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1074

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
