### PR TITLE
Allow telemetry exporters to GCP to utilize user's login credentials, if requested

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -74,16 +74,16 @@ observability framework — Gemini CLI's observability system provides:
 All telemetry behavior is controlled through your `.gemini/settings.json` file.
 Environment variables can be used to override the settings in the file.
 
-| Setting        | Environment Variable             | Description                                            | Values            | Default                 |
-| -------------- | -------------------------------- | ------------------------------------------------------ | ----------------- | ----------------------- |
-| `enabled`      | `GEMINI_TELEMETRY_ENABLED`       | Enable or disable telemetry                            | `true`/`false`    | `false`                 |
-| `target`       | `GEMINI_TELEMETRY_TARGET`        | Where to send telemetry data                           | `"gcp"`/`"local"` | `"local"`               |
-| `otlpEndpoint` | `GEMINI_TELEMETRY_OTLP_ENDPOINT` | OTLP collector endpoint                                | URL string        | `http://localhost:4317` |
-| `otlpProtocol` | `GEMINI_TELEMETRY_OTLP_PROTOCOL` | OTLP transport protocol                                | `"grpc"`/`"http"` | `"grpc"`                |
-| `outfile`      | `GEMINI_TELEMETRY_OUTFILE`       | Save telemetry to file (overrides `otlpEndpoint`)      | file path         | -                       |
-| `logPrompts`   | `GEMINI_TELEMETRY_LOG_PROMPTS`   | Include prompts in telemetry logs                      | `true`/`false`    | `true`                  |
-| `useCollector` | `GEMINI_TELEMETRY_USE_COLLECTOR` | Use external OTLP collector (advanced)                 | `true`/`false`    | `false`                 |
-| `useCliAuth`   | `GEMINI_TELEMETRY_USE_CLI_AUTH`  | Use CLI credentials for telemetry (GCP collector only) | `true`/`false`    | `false`                 |
+| Setting        | Environment Variable             | Description                                         | Values            | Default                 |
+| -------------- | -------------------------------- | --------------------------------------------------- | ----------------- | ----------------------- |
+| `enabled`      | `GEMINI_TELEMETRY_ENABLED`       | Enable or disable telemetry                         | `true`/`false`    | `false`                 |
+| `target`       | `GEMINI_TELEMETRY_TARGET`        | Where to send telemetry data                        | `"gcp"`/`"local"` | `"local"`               |
+| `otlpEndpoint` | `GEMINI_TELEMETRY_OTLP_ENDPOINT` | OTLP collector endpoint                             | URL string        | `http://localhost:4317` |
+| `otlpProtocol` | `GEMINI_TELEMETRY_OTLP_PROTOCOL` | OTLP transport protocol                             | `"grpc"`/`"http"` | `"grpc"`                |
+| `outfile`      | `GEMINI_TELEMETRY_OUTFILE`       | Save telemetry to file (overrides `otlpEndpoint`)   | file path         | -                       |
+| `logPrompts`   | `GEMINI_TELEMETRY_LOG_PROMPTS`   | Include prompts in telemetry logs                   | `true`/`false`    | `true`                  |
+| `useCollector` | `GEMINI_TELEMETRY_USE_COLLECTOR` | Use external OTLP collector (advanced)              | `true`/`false`    | `false`                 |
+| `useCliAuth`   | `GEMINI_TELEMETRY_USE_CLI_AUTH`  | Use CLI credentials for telemetry (GCP target only) | `true`/`false`    | `false`                 |
 
 **Note on boolean environment variables:** For the boolean settings (`enabled`,
 `logPrompts`, `useCollector`), setting the corresponding environment variable to
@@ -135,7 +135,7 @@ Before using either method below, complete these steps:
 
 By default, the telemetry collector for Google Cloud uses Application Default
 Credentials (ADC). However, you can configure it to use the same OAuth
-credentials that you use to log in to the Gemini CLI. This can be useful in
+credentials that you use to log in to the Gemini CLI. This is useful in
 environments where you don't have ADC set up.
 
 To enable this, set the `useCliAuth` property in your `telemetry` settings to
@@ -146,19 +146,18 @@ To enable this, set the `useCliAuth` property in your `telemetry` settings to
   "telemetry": {
     "enabled": true,
     "target": "gcp",
-    "useCollector": true,
     "useCliAuth": true
   }
 }
 ```
 
-When this setting is enabled and you run the collector-based export
-(`npm run telemetry -- --target=gcp`), the script will automatically point the
-OpenTelemetry collector to the CLI's cached credential file (located at
-`~/.gemini/oauth_creds.json`).
+**Important:**
 
-**Note:** This setting only applies when using the `gcp` target with the
-collector (`useCollector` is `true`).
+- This setting requires the use of **Direct Export** (in-process exporters).
+- It **cannot** be used with `useCollector: true`. If you enable both, telemetry
+  will be disabled and an error will be logged.
+- The CLI will automatically use your credentials to authenticate with Google
+  Cloud Trace, Metrics, and Logging APIs.
 
 ### Direct export (recommended)
 

--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -74,15 +74,16 @@ observability framework — Gemini CLI's observability system provides:
 All telemetry behavior is controlled through your `.gemini/settings.json` file.
 Environment variables can be used to override the settings in the file.
 
-| Setting        | Environment Variable             | Description                                       | Values            | Default                 |
-| -------------- | -------------------------------- | ------------------------------------------------- | ----------------- | ----------------------- |
-| `enabled`      | `GEMINI_TELEMETRY_ENABLED`       | Enable or disable telemetry                       | `true`/`false`    | `false`                 |
-| `target`       | `GEMINI_TELEMETRY_TARGET`        | Where to send telemetry data                      | `"gcp"`/`"local"` | `"local"`               |
-| `otlpEndpoint` | `GEMINI_TELEMETRY_OTLP_ENDPOINT` | OTLP collector endpoint                           | URL string        | `http://localhost:4317` |
-| `otlpProtocol` | `GEMINI_TELEMETRY_OTLP_PROTOCOL` | OTLP transport protocol                           | `"grpc"`/`"http"` | `"grpc"`                |
-| `outfile`      | `GEMINI_TELEMETRY_OUTFILE`       | Save telemetry to file (overrides `otlpEndpoint`) | file path         | -                       |
-| `logPrompts`   | `GEMINI_TELEMETRY_LOG_PROMPTS`   | Include prompts in telemetry logs                 | `true`/`false`    | `true`                  |
-| `useCollector` | `GEMINI_TELEMETRY_USE_COLLECTOR` | Use external OTLP collector (advanced)            | `true`/`false`    | `false`                 |
+| Setting        | Environment Variable             | Description                                            | Values            | Default                 |
+| -------------- | -------------------------------- | ------------------------------------------------------ | ----------------- | ----------------------- |
+| `enabled`      | `GEMINI_TELEMETRY_ENABLED`       | Enable or disable telemetry                            | `true`/`false`    | `false`                 |
+| `target`       | `GEMINI_TELEMETRY_TARGET`        | Where to send telemetry data                           | `"gcp"`/`"local"` | `"local"`               |
+| `otlpEndpoint` | `GEMINI_TELEMETRY_OTLP_ENDPOINT` | OTLP collector endpoint                                | URL string        | `http://localhost:4317` |
+| `otlpProtocol` | `GEMINI_TELEMETRY_OTLP_PROTOCOL` | OTLP transport protocol                                | `"grpc"`/`"http"` | `"grpc"`                |
+| `outfile`      | `GEMINI_TELEMETRY_OUTFILE`       | Save telemetry to file (overrides `otlpEndpoint`)      | file path         | -                       |
+| `logPrompts`   | `GEMINI_TELEMETRY_LOG_PROMPTS`   | Include prompts in telemetry logs                      | `true`/`false`    | `true`                  |
+| `useCollector` | `GEMINI_TELEMETRY_USE_COLLECTOR` | Use external OTLP collector (advanced)                 | `true`/`false`    | `false`                 |
+| `useCliAuth`   | `GEMINI_TELEMETRY_USE_CLI_AUTH`  | Use CLI credentials for telemetry (GCP collector only) | `true`/`false`    | `false`                 |
 
 **Note on boolean environment variables:** For the boolean settings (`enabled`,
 `logPrompts`, `useCollector`), setting the corresponding environment variable to
@@ -129,6 +130,35 @@ Before using either method below, complete these steps:
      logging.googleapis.com \
      --project="$OTLP_GOOGLE_CLOUD_PROJECT"
    ```
+
+### Authenticating with CLI Credentials
+
+By default, the telemetry collector for Google Cloud uses Application Default
+Credentials (ADC). However, you can configure it to use the same OAuth
+credentials that you use to log in to the Gemini CLI. This can be useful in
+environments where you don't have ADC set up.
+
+To enable this, set the `useCliAuth` property in your `telemetry` settings to
+`true`:
+
+```json
+{
+  "telemetry": {
+    "enabled": true,
+    "target": "gcp",
+    "useCollector": true,
+    "useCliAuth": true
+  }
+}
+```
+
+When this setting is enabled and you run the collector-based export
+(`npm run telemetry -- --target=gcp`), the script will automatically point the
+OpenTelemetry collector to the CLI's cached credential file (located at
+`~/.gemini/oauth_creds.json`).
+
+**Note:** This setting only applies when using the `gcp` target with the
+collector (`useCollector` is `true`).
 
 ### Direct export (recommended)
 

--- a/packages/cli/src/ui/components/EditorSettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/EditorSettingsDialog.test.tsx
@@ -13,6 +13,15 @@ import { KeypressProvider } from '../contexts/KeypressContext.js';
 import { act } from 'react';
 import { waitFor } from '../../test-utils/async.js';
 
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    isEditorAvailable: () => true, // Mock to behave predictably in CI
+  };
+});
+
 // Mock editorSettingsManager
 vi.mock('../editors/editorSettingsManager.js', () => ({
   editorSettingsManager: {

--- a/packages/cli/src/ui/components/__snapshots__/EditorSettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/EditorSettingsDialog.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EditorSettingsDialog > renders correctly 1`] = `
 │   2. Vim                                     These editors are currently supported. Please note  │
 │                                              that some editors cannot be used in sandbox mode.   │
 │   Apply To                                                                                       │
-│ ● 1. User Settings                           Your preferred editor is: None.                     │
+│ ● 1. User Settings                           Your preferred editor is: VS Code.                  │
 │   2. Workspace Settings                                                                          │
 │                                                                                                  │
 │ (Use Enter to select, Tab to change                                                              │

--- a/packages/cli/src/ui/utils/terminalSetup.test.ts
+++ b/packages/cli/src/ui/utils/terminalSetup.test.ts
@@ -16,6 +16,10 @@ const mocks = vi.hoisted(() => ({
   copyFile: vi.fn(),
   homedir: vi.fn(),
   platform: vi.fn(),
+  writeStream: {
+    write: vi.fn(),
+    on: vi.fn(),
+  },
 }));
 
 vi.mock('node:child_process', () => ({
@@ -24,6 +28,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 vi.mock('node:fs', () => ({
+  createWriteStream: () => mocks.writeStream,
   promises: {
     mkdir: mocks.mkdir,
     readFile: mocks.readFile,

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -109,13 +109,18 @@ describe('oauth2', () => {
       const mockGetAccessToken = vi
         .fn()
         .mockResolvedValue({ token: 'mock-access-token' });
+      let tokensListener: ((tokens: Credentials) => void) | undefined;
       const mockOAuth2Client = {
         generateAuthUrl: mockGenerateAuthUrl,
         getToken: mockGetToken,
         setCredentials: mockSetCredentials,
         getAccessToken: mockGetAccessToken,
         credentials: mockTokens,
-        on: vi.fn(),
+        on: vi.fn((event, listener) => {
+          if (event === 'tokens') {
+            tokensListener = listener;
+          }
+        }),
       } as unknown as OAuth2Client;
       vi.mocked(OAuth2Client).mockImplementation(() => mockOAuth2Client);
 
@@ -195,6 +200,11 @@ describe('oauth2', () => {
       });
       expect(mockSetCredentials).toHaveBeenCalledWith(mockTokens);
 
+      // Manually trigger the 'tokens' event listener
+      if (tokensListener) {
+        await tokensListener(mockTokens);
+      }
+
       // Verify Google Account was cached
       const googleAccountPath = path.join(
         tempHomeDir,
@@ -213,6 +223,112 @@ describe('oauth2', () => {
       expect(userAccountManager.getCachedGoogleAccount()).toBe(
         'test-google-account@gmail.com',
       );
+
+      // Verify ADC file was created
+      const adcPath = path.join(
+        tempHomeDir,
+        GEMINI_DIR,
+        'oauth_creds_adc.json',
+      );
+      expect(fs.existsSync(adcPath)).toBe(true);
+      const adcContent = JSON.parse(fs.readFileSync(adcPath, 'utf-8'));
+      expect(adcContent).toEqual({
+        client_id: expect.any(String),
+        client_secret: expect.any(String),
+        refresh_token: mockTokens.refresh_token,
+        type: 'authorized_user',
+      });
+    });
+
+    it('should clear ADC file when clearing credentials', async () => {
+      // Setup initial state with files
+      const credsPath = path.join(tempHomeDir, GEMINI_DIR, 'oauth_creds.json');
+      const adcPath = path.join(
+        tempHomeDir,
+        GEMINI_DIR,
+        'oauth_creds_adc.json',
+      );
+
+      await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
+      await fs.promises.writeFile(credsPath, '{}');
+      await fs.promises.writeFile(adcPath, '{}');
+
+      await clearCachedCredentialFile();
+
+      expect(fs.existsSync(credsPath)).toBe(false);
+      expect(fs.existsSync(adcPath)).toBe(false);
+    });
+
+    it('should create ADC file if missing when loading cached credentials', async () => {
+      const cachedCreds = { refresh_token: 'cached-token' };
+      const credsPath = path.join(tempHomeDir, GEMINI_DIR, 'oauth_creds.json');
+      await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
+      await fs.promises.writeFile(credsPath, JSON.stringify(cachedCreds));
+
+      // Ensure ADC file does not exist
+      const adcPath = path.join(
+        tempHomeDir,
+        GEMINI_DIR,
+        'oauth_creds_adc.json',
+      );
+      if (fs.existsSync(adcPath)) {
+        fs.rmSync(adcPath);
+      }
+
+      const mockClient = {
+        setCredentials: vi.fn(),
+        getAccessToken: vi.fn().mockResolvedValue({ token: 'test-token' }),
+        getTokenInfo: vi.fn().mockResolvedValue({}),
+        on: vi.fn(),
+      };
+      vi.mocked(OAuth2Client).mockImplementation(
+        () => mockClient as unknown as OAuth2Client,
+      );
+
+      await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfig);
+
+      expect(fs.existsSync(adcPath)).toBe(true);
+      const adcContent = JSON.parse(fs.readFileSync(adcPath, 'utf-8'));
+      expect(adcContent.refresh_token).toBe('cached-token');
+    });
+
+    it('should update ADC file if older than cached credentials', async () => {
+      const cachedCreds = { refresh_token: 'new-token' };
+      const credsPath = path.join(tempHomeDir, GEMINI_DIR, 'oauth_creds.json');
+      await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
+      await fs.promises.writeFile(credsPath, JSON.stringify(cachedCreds));
+
+      // Set mtime of creds file to now
+      const now = new Date();
+      await fs.promises.utimes(credsPath, now, now);
+
+      // Create older ADC file
+      const oldAdcContent = { refresh_token: 'old-token' };
+      const adcPath = path.join(
+        tempHomeDir,
+        GEMINI_DIR,
+        'oauth_creds_adc.json',
+      );
+      await fs.promises.writeFile(adcPath, JSON.stringify(oldAdcContent));
+
+      // Set mtime of ADC file to past
+      const past = new Date(now.getTime() - 10000);
+      await fs.promises.utimes(adcPath, past, past);
+
+      const mockClient = {
+        setCredentials: vi.fn(),
+        getAccessToken: vi.fn().mockResolvedValue({ token: 'test-token' }),
+        getTokenInfo: vi.fn().mockResolvedValue({}),
+        on: vi.fn(),
+      };
+      vi.mocked(OAuth2Client).mockImplementation(
+        () => mockClient as unknown as OAuth2Client,
+      );
+
+      await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfig);
+
+      const updatedAdcContent = JSON.parse(fs.readFileSync(adcPath, 'utf-8'));
+      expect(updatedAdcContent.refresh_token).toBe('new-token');
     });
 
     it('should perform login with user code', async () => {

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -181,7 +181,6 @@ async function initOauthClient(
           }
         }
         debugLogger.log('Loaded cached credentials.');
-        await ensureADCFileExists(credentials as Credentials);
         await triggerPostAuthCallbacks(credentials as Credentials);
 
         return client;
@@ -603,7 +602,6 @@ export async function clearCachedCredentialFile() {
       await OAuthCredentialStorage.clearCredentials();
     } else {
       await fs.rm(Storage.getOAuthCredsPath(), { force: true });
-      await fs.rm(Storage.getADCPath(), { force: true });
     }
     // Clear the Google Account ID cache when credentials are cleared
     await userAccountManager.clearCachedGoogleAccount();
@@ -661,42 +659,5 @@ async function cacheCredentials(credentials: Credentials) {
     await fs.chmod(filePath, 0o600);
   } catch {
     /* empty */
-  }
-
-  await ensureADCFileExists(credentials);
-}
-
-async function ensureADCFileExists(credentials: Credentials) {
-  const adcPath = Storage.getADCPath();
-  const credsPath = Storage.getOAuthCredsPath();
-
-  let shouldWrite = false;
-
-  try {
-    const adcStats = await fs.stat(adcPath);
-    const credsStats = await fs.stat(credsPath);
-    if (adcStats.mtimeMs < credsStats.mtimeMs) {
-      shouldWrite = true;
-    }
-  } catch {
-    // ADC file doesn't exist or we can't read it or the creds file
-    shouldWrite = true;
-  }
-
-  if (shouldWrite) {
-    const adcContent = {
-      client_id: OAUTH_CLIENT_ID,
-      client_secret: OAUTH_CLIENT_SECRET,
-      refresh_token: credentials.refresh_token,
-      type: 'authorized_user',
-    };
-    await fs.writeFile(adcPath, JSON.stringify(adcContent, null, 2), {
-      mode: 0o600,
-    });
-    try {
-      await fs.chmod(adcPath, 0o600);
-    } catch {
-      /* empty */
-    }
   }
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -465,7 +465,7 @@ export class Config {
       logPrompts: params.telemetry?.logPrompts ?? true,
       outfile: params.telemetry?.outfile,
       useCollector: params.telemetry?.useCollector,
-      useCliAuth: params.telemetry?.useCliAuth ?? false,
+      useCliAuth: params.telemetry?.useCliAuth,
     };
     this.usageStatisticsEnabled = params.usageStatisticsEnabled ?? true;
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -112,6 +112,7 @@ export interface TelemetrySettings {
   logPrompts?: boolean;
   outfile?: string;
   useCollector?: boolean;
+  useCliAuth?: boolean;
 }
 
 export interface OutputSettings {
@@ -464,6 +465,7 @@ export class Config {
       logPrompts: params.telemetry?.logPrompts ?? true,
       outfile: params.telemetry?.outfile,
       useCollector: params.telemetry?.useCollector,
+      useCliAuth: params.telemetry?.useCliAuth ?? false,
     };
     this.usageStatisticsEnabled = params.usageStatisticsEnabled ?? true;
 
@@ -1033,6 +1035,10 @@ export class Config {
 
   getTelemetryUseCollector(): boolean {
     return this.telemetrySettings.useCollector ?? false;
+  }
+
+  getTelemetryUseCliAuth(): boolean {
+    return this.telemetrySettings.useCliAuth ?? false;
   }
 
   getGeminiClient(): GeminiClient {

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -15,8 +15,6 @@ export const OAUTH_FILE = 'oauth_creds.json';
 const TMP_DIR_NAME = 'tmp';
 const BIN_DIR_NAME = 'bin';
 
-export const ADC_FILE = 'oauth_creds_adc.json';
-
 export class Storage {
   private readonly targetDir: string;
 
@@ -101,10 +99,6 @@ export class Storage {
 
   static getOAuthCredsPath(): string {
     return path.join(Storage.getGlobalGeminiDir(), OAUTH_FILE);
-  }
-
-  static getADCPath(): string {
-    return path.join(Storage.getGlobalGeminiDir(), ADC_FILE);
   }
 
   getProjectRoot(): string {

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -15,6 +15,8 @@ export const OAUTH_FILE = 'oauth_creds.json';
 const TMP_DIR_NAME = 'tmp';
 const BIN_DIR_NAME = 'bin';
 
+export const ADC_FILE = 'oauth_creds_adc.json';
+
 export class Storage {
   private readonly targetDir: string;
 
@@ -99,6 +101,10 @@ export class Storage {
 
   static getOAuthCredsPath(): string {
     return path.join(Storage.getGlobalGeminiDir(), OAUTH_FILE);
+  }
+
+  static getADCPath(): string {
+    return path.join(Storage.getGlobalGeminiDir(), ADC_FILE);
   }
 
   getProjectRoot(): string {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -65,6 +65,10 @@ vi.mock('node:fs', () => {
       });
     }),
     existsSync: vi.fn((path: string) => mockFileSystem.has(path)),
+    createWriteStream: vi.fn(() => ({
+      write: vi.fn(),
+      on: vi.fn(),
+    })),
   };
 
   return {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -48,6 +48,10 @@ vi.mock('node:fs', () => {
       });
     }),
     existsSync: vi.fn((path: string) => mockFileSystem.has(path)),
+    createWriteStream: vi.fn(() => ({
+      write: vi.fn(),
+      on: vi.fn(),
+    })),
   };
 
   return {

--- a/packages/core/src/telemetry/config.test.ts
+++ b/packages/core/src/telemetry/config.test.ts
@@ -120,7 +120,35 @@ describe('telemetry/config helpers', () => {
         logPrompts: false,
         outfile: 'argv.log',
         useCollector: true, // from env as no argv option
+        useCliAuth: undefined,
       });
+    });
+
+    it('resolves useCliAuth from settings', async () => {
+      const settings = {
+        useCliAuth: true,
+      };
+      const resolved = await resolveTelemetrySettings({ settings });
+      expect(resolved.useCliAuth).toBe(true);
+    });
+
+    it('resolves useCliAuth from env', async () => {
+      const env = {
+        GEMINI_TELEMETRY_USE_CLI_AUTH: 'true',
+      };
+      const resolved = await resolveTelemetrySettings({ env });
+      expect(resolved.useCliAuth).toBe(true);
+    });
+
+    it('env overrides settings for useCliAuth', async () => {
+      const settings = {
+        useCliAuth: false,
+      };
+      const env = {
+        GEMINI_TELEMETRY_USE_CLI_AUTH: 'true',
+      };
+      const resolved = await resolveTelemetrySettings({ env, settings });
+      expect(resolved.useCliAuth).toBe(true);
     });
 
     it('falls back to OTEL_EXPORTER_OTLP_ENDPOINT when GEMINI var is missing', async () => {

--- a/packages/core/src/telemetry/config.ts
+++ b/packages/core/src/telemetry/config.ts
@@ -116,5 +116,8 @@ export async function resolveTelemetrySettings(options: {
     logPrompts,
     outfile,
     useCollector,
+    useCliAuth:
+      parseBooleanEnvFlag(env['GEMINI_TELEMETRY_USE_CLI_AUTH']) ??
+      settings.useCliAuth,
   };
 }

--- a/packages/core/src/telemetry/gcp-exporters.ts
+++ b/packages/core/src/telemetry/gcp-exporters.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { type JWTInput } from 'google-auth-library';
 import { TraceExporter } from '@google-cloud/opentelemetry-cloud-trace-exporter';
 import { MetricExporter } from '@google-cloud/opentelemetry-cloud-monitoring-exporter';
 import { Logging } from '@google-cloud/logging';
@@ -20,9 +21,10 @@ import type {
  * Google Cloud Trace exporter that extends the official trace exporter
  */
 export class GcpTraceExporter extends TraceExporter {
-  constructor(projectId?: string) {
+  constructor(projectId?: string, credentials?: JWTInput) {
     super({
       projectId,
+      credentials,
       resourceFilter: /^gcp\./,
     });
   }
@@ -32,9 +34,10 @@ export class GcpTraceExporter extends TraceExporter {
  * Google Cloud Monitoring exporter that extends the official metrics exporter
  */
 export class GcpMetricExporter extends MetricExporter {
-  constructor(projectId?: string) {
+  constructor(projectId?: string, credentials?: JWTInput) {
     super({
       projectId,
+      credentials,
       prefix: 'custom.googleapis.com/gemini_cli',
     });
   }
@@ -48,8 +51,8 @@ export class GcpLogExporter implements LogRecordExporter {
   private log: Log;
   private pendingWrites: Array<Promise<void>> = [];
 
-  constructor(projectId?: string) {
-    this.logging = new Logging({ projectId });
+  constructor(projectId?: string, credentials?: JWTInput) {
+    this.logging = new Logging({ projectId, credentials });
     this.log = this.logging.log('gemini_cli');
   }
 

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -117,6 +117,7 @@ describe('loggers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(sdk, 'isTelemetrySdkInitialized').mockReturnValue(true);
+    vi.spyOn(sdk, 'bufferTelemetryEvent').mockImplementation((cb) => cb());
     vi.spyOn(logs, 'getLogger').mockReturnValue(mockLogger);
     vi.spyOn(uiTelemetry.uiTelemetryService, 'addEvent').mockImplementation(
       mockUiEvent.addEvent,
@@ -1719,6 +1720,7 @@ describe('loggers', () => {
 
     it('should only log to Clearcut if OTEL SDK is not initialized', () => {
       vi.spyOn(sdk, 'isTelemetrySdkInitialized').mockReturnValue(false);
+      vi.spyOn(sdk, 'bufferTelemetryEvent').mockImplementation(() => {});
       const event = new ModelRoutingEvent(
         'gemini-pro',
         'default',
@@ -2084,6 +2086,21 @@ describe('loggers', () => {
           reason: 'private_ip',
         },
       });
+    });
+  });
+  describe('Telemetry Buffering', () => {
+    it('should buffer events when SDK is not initialized', () => {
+      vi.spyOn(sdk, 'isTelemetrySdkInitialized').mockReturnValue(false);
+      const bufferSpy = vi
+        .spyOn(sdk, 'bufferTelemetryEvent')
+        .mockImplementation(() => {});
+
+      const mockConfig = makeFakeConfig();
+      const event = new StartSessionEvent(mockConfig);
+      logCliConfiguration(mockConfig, event);
+
+      expect(bufferSpy).toHaveBeenCalled();
+      expect(mockLogger.emit).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -69,7 +69,7 @@ import {
   recordLinesChanged,
   recordHookCallMetrics,
 } from './metrics.js';
-import { isTelemetrySdkInitialized } from './sdk.js';
+import { bufferTelemetryEvent } from './sdk.js';
 import type { UiEvent } from './uiTelemetry.js';
 import { uiTelemetryService } from './uiTelemetry.js';
 import { ClearcutLogger } from './clearcut-logger/clearcut-logger.js';
@@ -79,27 +79,27 @@ export function logCliConfiguration(
   event: StartSessionEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logStartSessionEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logUserPrompt(config: Config, event: UserPromptEvent): void {
   ClearcutLogger.getInstance(config)?.logNewPromptEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
 
-  const logger = logs.getLogger(SERVICE_NAME);
-
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logToolCall(config: Config, event: ToolCallEvent): void {
@@ -110,35 +110,35 @@ export function logToolCall(config: Config, event: ToolCallEvent): void {
   } as UiEvent;
   uiTelemetryService.addEvent(uiEvent);
   ClearcutLogger.getInstance(config)?.logToolCallEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+    recordToolCallMetrics(config, event.duration_ms, {
+      function_name: event.function_name,
+      success: event.success,
+      decision: event.decision,
+      tool_type: event.tool_type,
+    });
 
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
-  recordToolCallMetrics(config, event.duration_ms, {
-    function_name: event.function_name,
-    success: event.success,
-    decision: event.decision,
-    tool_type: event.tool_type,
+    if (event.metadata) {
+      const added = event.metadata['model_added_lines'];
+      if (typeof added === 'number' && added > 0) {
+        recordLinesChanged(config, added, 'added', {
+          function_name: event.function_name,
+        });
+      }
+      const removed = event.metadata['model_removed_lines'];
+      if (typeof removed === 'number' && removed > 0) {
+        recordLinesChanged(config, removed, 'removed', {
+          function_name: event.function_name,
+        });
+      }
+    }
   });
-
-  if (event.metadata) {
-    const added = event.metadata['model_added_lines'];
-    if (typeof added === 'number' && added > 0) {
-      recordLinesChanged(config, added, 'added', {
-        function_name: event.function_name,
-      });
-    }
-    const removed = event.metadata['model_removed_lines'];
-    if (typeof removed === 'number' && removed > 0) {
-      recordLinesChanged(config, removed, 'removed', {
-        function_name: event.function_name,
-      });
-    }
-  }
 }
 
 export function logToolOutputTruncated(
@@ -146,14 +146,14 @@ export function logToolOutputTruncated(
   event: ToolOutputTruncatedEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logToolOutputTruncatedEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logFileOperation(
@@ -161,31 +161,31 @@ export function logFileOperation(
   event: FileOperationEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logFileOperationEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
 
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
-
-  recordFileOperationMetric(config, {
-    operation: event.operation,
-    lines: event.lines,
-    mimetype: event.mimetype,
-    extension: event.extension,
-    programming_language: event.programming_language,
+    recordFileOperationMetric(config, {
+      operation: event.operation,
+      lines: event.lines,
+      mimetype: event.mimetype,
+      extension: event.extension,
+      programming_language: event.programming_language,
+    });
   });
 }
 
 export function logApiRequest(config: Config, event: ApiRequestEvent): void {
   ClearcutLogger.getInstance(config)?.logApiRequestEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  logger.emit(event.toLogRecord(config));
-  logger.emit(event.toSemanticLogRecord(config));
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    logger.emit(event.toLogRecord(config));
+    logger.emit(event.toSemanticLogRecord(config));
+  });
 }
 
 export function logFlashFallback(
@@ -193,14 +193,14 @@ export function logFlashFallback(
   event: FlashFallbackEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logFlashFallbackEvent();
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logRipgrepFallback(
@@ -208,14 +208,14 @@ export function logRipgrepFallback(
   event: RipgrepFallbackEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logRipgrepFallbackEvent();
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logApiError(config: Config, event: ApiErrorEvent): void {
@@ -226,26 +226,26 @@ export function logApiError(config: Config, event: ApiErrorEvent): void {
   } as UiEvent;
   uiTelemetryService.addEvent(uiEvent);
   ClearcutLogger.getInstance(config)?.logApiErrorEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    logger.emit(event.toLogRecord(config));
+    logger.emit(event.toSemanticLogRecord(config));
 
-  const logger = logs.getLogger(SERVICE_NAME);
-  logger.emit(event.toLogRecord(config));
-  logger.emit(event.toSemanticLogRecord(config));
+    recordApiErrorMetrics(config, event.duration_ms, {
+      model: event.model,
+      status_code: event.status_code,
+      error_type: event.error_type,
+    });
 
-  recordApiErrorMetrics(config, event.duration_ms, {
-    model: event.model,
-    status_code: event.status_code,
-    error_type: event.error_type,
-  });
-
-  // Record GenAI operation duration for errors
-  recordApiResponseMetrics(config, event.duration_ms, {
-    model: event.model,
-    status_code: event.status_code,
-    genAiAttributes: {
-      ...getConventionAttributes(event),
-      'error.type': event.error_type || 'unknown',
-    },
+    // Record GenAI operation duration for errors
+    recordApiResponseMetrics(config, event.duration_ms, {
+      model: event.model,
+      status_code: event.status_code,
+      genAiAttributes: {
+        ...getConventionAttributes(event),
+        'error.type': event.error_type || 'unknown',
+      },
+    });
   });
 }
 
@@ -257,35 +257,35 @@ export function logApiResponse(config: Config, event: ApiResponseEvent): void {
   } as UiEvent;
   uiTelemetryService.addEvent(uiEvent);
   ClearcutLogger.getInstance(config)?.logApiResponseEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    logger.emit(event.toLogRecord(config));
+    logger.emit(event.toSemanticLogRecord(config));
 
-  const logger = logs.getLogger(SERVICE_NAME);
-  logger.emit(event.toLogRecord(config));
-  logger.emit(event.toSemanticLogRecord(config));
+    const conventionAttributes = getConventionAttributes(event);
 
-  const conventionAttributes = getConventionAttributes(event);
-
-  recordApiResponseMetrics(config, event.duration_ms, {
-    model: event.model,
-    status_code: event.status_code,
-    genAiAttributes: conventionAttributes,
-  });
-
-  const tokenUsageData = [
-    { count: event.usage.input_token_count, type: 'input' as const },
-    { count: event.usage.output_token_count, type: 'output' as const },
-    { count: event.usage.cached_content_token_count, type: 'cache' as const },
-    { count: event.usage.thoughts_token_count, type: 'thought' as const },
-    { count: event.usage.tool_token_count, type: 'tool' as const },
-  ];
-
-  for (const { count, type } of tokenUsageData) {
-    recordTokenUsageMetrics(config, count, {
+    recordApiResponseMetrics(config, event.duration_ms, {
       model: event.model,
-      type,
+      status_code: event.status_code,
       genAiAttributes: conventionAttributes,
     });
-  }
+
+    const tokenUsageData = [
+      { count: event.usage.input_token_count, type: 'input' as const },
+      { count: event.usage.output_token_count, type: 'output' as const },
+      { count: event.usage.cached_content_token_count, type: 'cache' as const },
+      { count: event.usage.thoughts_token_count, type: 'thought' as const },
+      { count: event.usage.tool_token_count, type: 'tool' as const },
+    ];
+
+    for (const { count, type } of tokenUsageData) {
+      recordTokenUsageMetrics(config, count, {
+        model: event.model,
+        type,
+        genAiAttributes: conventionAttributes,
+      });
+    }
+  });
 }
 
 export function logLoopDetected(
@@ -293,14 +293,14 @@ export function logLoopDetected(
   event: LoopDetectedEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logLoopDetectedEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logLoopDetectionDisabled(
@@ -308,14 +308,14 @@ export function logLoopDetectionDisabled(
   event: LoopDetectionDisabledEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logLoopDetectionDisabledEvent();
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logNextSpeakerCheck(
@@ -323,14 +323,14 @@ export function logNextSpeakerCheck(
   event: NextSpeakerCheckEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logNextSpeakerCheck(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logSlashCommand(
@@ -338,14 +338,14 @@ export function logSlashCommand(
   event: SlashCommandEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logSlashCommandEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logIdeConnection(
@@ -353,14 +353,14 @@ export function logIdeConnection(
   event: IdeConnectionEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logIdeConnectionEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logConversationFinishedEvent(
@@ -368,14 +368,14 @@ export function logConversationFinishedEvent(
   event: ConversationFinishedEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logConversationFinishedEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logChatCompression(
@@ -402,14 +402,14 @@ export function logMalformedJsonResponse(
   event: MalformedJsonResponseEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logMalformedJsonResponseEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logInvalidChunk(
@@ -417,15 +417,15 @@ export function logInvalidChunk(
   event: InvalidChunkEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logInvalidChunkEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
-  recordInvalidChunk(config);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+    recordInvalidChunk(config);
+  });
 }
 
 export function logContentRetry(
@@ -433,15 +433,15 @@ export function logContentRetry(
   event: ContentRetryEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logContentRetryEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
-  recordContentRetry(config);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+    recordContentRetry(config);
+  });
 }
 
 export function logContentRetryFailure(
@@ -449,15 +449,15 @@ export function logContentRetryFailure(
   event: ContentRetryFailureEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logContentRetryFailureEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
-  recordContentRetryFailure(config);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+    recordContentRetryFailure(config);
+  });
 }
 
 export function logModelRouting(
@@ -465,15 +465,15 @@ export function logModelRouting(
   event: ModelRoutingEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logModelRoutingEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
-  recordModelRoutingMetrics(config, event);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+    recordModelRoutingMetrics(config, event);
+  });
 }
 
 export function logModelSlashCommand(
@@ -481,15 +481,15 @@ export function logModelSlashCommand(
   event: ModelSlashCommandEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logModelSlashCommandEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
-  recordModelSlashCommand(config, event);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+    recordModelSlashCommand(config, event);
+  });
 }
 
 export async function logExtensionInstallEvent(
@@ -497,14 +497,14 @@ export async function logExtensionInstallEvent(
   event: ExtensionInstallEvent,
 ): Promise<void> {
   await ClearcutLogger.getInstance(config)?.logExtensionInstallEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export async function logExtensionUninstall(
@@ -512,14 +512,14 @@ export async function logExtensionUninstall(
   event: ExtensionUninstallEvent,
 ): Promise<void> {
   await ClearcutLogger.getInstance(config)?.logExtensionUninstallEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export async function logExtensionUpdateEvent(
@@ -527,14 +527,14 @@ export async function logExtensionUpdateEvent(
   event: ExtensionUpdateEvent,
 ): Promise<void> {
   await ClearcutLogger.getInstance(config)?.logExtensionUpdateEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export async function logExtensionEnable(
@@ -542,14 +542,14 @@ export async function logExtensionEnable(
   event: ExtensionEnableEvent,
 ): Promise<void> {
   await ClearcutLogger.getInstance(config)?.logExtensionEnableEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export async function logExtensionDisable(
@@ -557,14 +557,14 @@ export async function logExtensionDisable(
   event: ExtensionDisableEvent,
 ): Promise<void> {
   await ClearcutLogger.getInstance(config)?.logExtensionDisableEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logSmartEditStrategy(
@@ -572,14 +572,14 @@ export function logSmartEditStrategy(
   event: SmartEditStrategyEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logSmartEditStrategyEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logSmartEditCorrectionEvent(
@@ -587,40 +587,40 @@ export function logSmartEditCorrectionEvent(
   event: SmartEditCorrectionEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logSmartEditCorrectionEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logAgentStart(config: Config, event: AgentStartEvent): void {
   ClearcutLogger.getInstance(config)?.logAgentStartEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logAgentFinish(config: Config, event: AgentFinishEvent): void {
   ClearcutLogger.getInstance(config)?.logAgentFinishEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
 
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
-
-  recordAgentRunMetrics(config, event);
+    recordAgentRunMetrics(config, event);
+  });
 }
 
 export function logRecoveryAttempt(
@@ -628,16 +628,16 @@ export function logRecoveryAttempt(
   event: RecoveryAttemptEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logRecoveryAttemptEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
 
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
-
-  recordRecoveryAttemptMetrics(config, event);
+    recordRecoveryAttemptMetrics(config, event);
+  });
 }
 
 export function logWebFetchFallbackAttempt(
@@ -645,14 +645,14 @@ export function logWebFetchFallbackAttempt(
   event: WebFetchFallbackAttemptEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logWebFetchFallbackAttemptEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logLlmLoopCheck(
@@ -660,14 +660,14 @@ export function logLlmLoopCheck(
   event: LlmLoopCheckEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logLlmLoopCheckEvent(event);
-  if (!isTelemetrySdkInitialized()) return;
-
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
+  });
 }
 
 export function logHookCall(config: Config, event: HookCallEvent): void {

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -671,20 +671,20 @@ export function logLlmLoopCheck(
 }
 
 export function logHookCall(config: Config, event: HookCallEvent): void {
-  if (!isTelemetrySdkInitialized()) return;
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
 
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
-
-  recordHookCallMetrics(
-    config,
-    event.hook_event_name,
-    event.hook_name,
-    event.duration_ms,
-    event.success,
-  );
+    recordHookCallMetrics(
+      config,
+      event.hook_event_name,
+      event.hook_name,
+      event.duration_ms,
+      event.success,
+    );
+  });
 }

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -6,14 +6,20 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Config } from '../config/config.js';
-import { initializeTelemetry, shutdownTelemetry } from './sdk.js';
+import {
+  initializeTelemetry,
+  shutdownTelemetry,
+  bufferTelemetryEvent,
+} from './sdk.js';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
 import { OTLPTraceExporter as OTLPTraceExporterHttp } from '@opentelemetry/exporter-trace-otlp-http';
 import { OTLPLogExporter as OTLPLogExporterHttp } from '@opentelemetry/exporter-logs-otlp-http';
 import { OTLPMetricExporter as OTLPMetricExporterHttp } from '@opentelemetry/exporter-metrics-otlp-http';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node';
 import { NodeSDK } from '@opentelemetry/sdk-node';
+import { GoogleAuth } from 'google-auth-library';
 import {
   GcpTraceExporter,
   GcpLogExporter,
@@ -24,20 +30,40 @@ import { TelemetryTarget } from './index.js';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import { authEvents } from '../code_assist/oauth2.js';
+import { debugLogger } from '../utils/debugLogger.js';
+
 vi.mock('@opentelemetry/exporter-trace-otlp-grpc');
 vi.mock('@opentelemetry/exporter-logs-otlp-grpc');
 vi.mock('@opentelemetry/exporter-metrics-otlp-grpc');
 vi.mock('@opentelemetry/exporter-trace-otlp-http');
 vi.mock('@opentelemetry/exporter-logs-otlp-http');
 vi.mock('@opentelemetry/exporter-metrics-otlp-http');
+vi.mock('@opentelemetry/sdk-trace-node');
 vi.mock('@opentelemetry/sdk-node');
 vi.mock('./gcp-exporters.js');
+vi.mock('google-auth-library');
+vi.mock('../utils/debugLogger.js', () => ({
+  debugLogger: {
+    log: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
 
 describe('Telemetry SDK', () => {
   let mockConfig: Config;
+  const mockGetApplicationDefault = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(GoogleAuth).mockImplementation(
+      () =>
+        ({
+          getApplicationDefault: mockGetApplicationDefault,
+        }) as unknown as GoogleAuth,
+    );
     mockConfig = {
       getTelemetryEnabled: () => true,
       getTelemetryOtlpEndpoint: () => 'http://localhost:4317',
@@ -47,6 +73,8 @@ describe('Telemetry SDK', () => {
       getTelemetryOutfile: () => undefined,
       getDebugMode: () => false,
       getSessionId: () => 'test-session',
+      getTelemetryUseCliAuth: () => false,
+      isInteractive: () => false,
     } as unknown as Config;
   });
 
@@ -54,8 +82,8 @@ describe('Telemetry SDK', () => {
     await shutdownTelemetry(mockConfig);
   });
 
-  it('should use gRPC exporters when protocol is grpc', () => {
-    initializeTelemetry(mockConfig);
+  it('should use gRPC exporters when protocol is grpc', async () => {
+    await initializeTelemetry(mockConfig);
 
     expect(OTLPTraceExporter).toHaveBeenCalledWith({
       url: 'http://localhost:4317',
@@ -72,14 +100,14 @@ describe('Telemetry SDK', () => {
     expect(NodeSDK.prototype.start).toHaveBeenCalled();
   });
 
-  it('should use HTTP exporters when protocol is http', () => {
+  it('should use HTTP exporters when protocol is http', async () => {
     vi.spyOn(mockConfig, 'getTelemetryEnabled').mockReturnValue(true);
     vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
     vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
       'http://localhost:4318',
     );
 
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
 
     expect(OTLPTraceExporterHttp).toHaveBeenCalledWith({
       url: 'http://localhost:4318/',
@@ -93,28 +121,29 @@ describe('Telemetry SDK', () => {
     expect(NodeSDK.prototype.start).toHaveBeenCalled();
   });
 
-  it('should parse gRPC endpoint correctly', () => {
+  it('should parse gRPC endpoint correctly', async () => {
     vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
       'https://my-collector.com',
     );
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
     expect(OTLPTraceExporter).toHaveBeenCalledWith(
       expect.objectContaining({ url: 'https://my-collector.com' }),
     );
   });
 
-  it('should parse HTTP endpoint correctly', () => {
+  it('should parse HTTP endpoint correctly', async () => {
     vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
     vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
       'https://my-collector.com',
     );
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
     expect(OTLPTraceExporterHttp).toHaveBeenCalledWith(
       expect.objectContaining({ url: 'https://my-collector.com/' }),
     );
   });
 
-  it('should use direct GCP exporters when target is gcp, project ID is set, and useCollector is false', () => {
+  it('should use direct GCP exporters when target is gcp, project ID is set, and useCollector is false', async () => {
+    mockGetApplicationDefault.mockResolvedValue(undefined); // Simulate ADC available
     vi.spyOn(mockConfig, 'getTelemetryTarget').mockReturnValue(
       TelemetryTarget.GCP,
     );
@@ -125,11 +154,11 @@ describe('Telemetry SDK', () => {
     process.env['OTLP_GOOGLE_CLOUD_PROJECT'] = 'test-project';
 
     try {
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
 
-      expect(GcpTraceExporter).toHaveBeenCalledWith('test-project');
-      expect(GcpLogExporter).toHaveBeenCalledWith('test-project');
-      expect(GcpMetricExporter).toHaveBeenCalledWith('test-project');
+      expect(GcpTraceExporter).toHaveBeenCalledWith('test-project', undefined);
+      expect(GcpLogExporter).toHaveBeenCalledWith('test-project', undefined);
+      expect(GcpMetricExporter).toHaveBeenCalledWith('test-project', undefined);
       expect(NodeSDK.prototype.start).toHaveBeenCalled();
     } finally {
       if (originalEnv) {
@@ -140,13 +169,13 @@ describe('Telemetry SDK', () => {
     }
   });
 
-  it('should use OTLP exporters when target is gcp but useCollector is true', () => {
+  it('should use OTLP exporters when target is gcp but useCollector is true', async () => {
     vi.spyOn(mockConfig, 'getTelemetryTarget').mockReturnValue(
       TelemetryTarget.GCP,
     );
     vi.spyOn(mockConfig, 'getTelemetryUseCollector').mockReturnValue(true);
 
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
 
     expect(OTLPTraceExporter).toHaveBeenCalledWith({
       url: 'http://localhost:4317',
@@ -162,7 +191,8 @@ describe('Telemetry SDK', () => {
     });
   });
 
-  it('should not use GCP exporters when project ID environment variable is not set', () => {
+  it('should use GCP exporters even when project ID environment variable is not set', async () => {
+    mockGetApplicationDefault.mockResolvedValue(undefined); // Simulate ADC available
     vi.spyOn(mockConfig, 'getTelemetryTarget').mockReturnValue(
       TelemetryTarget.GCP,
     );
@@ -175,11 +205,11 @@ describe('Telemetry SDK', () => {
     delete process.env['GOOGLE_CLOUD_PROJECT'];
 
     try {
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
 
-      expect(GcpTraceExporter).not.toHaveBeenCalled();
-      expect(GcpLogExporter).not.toHaveBeenCalled();
-      expect(GcpMetricExporter).not.toHaveBeenCalled();
+      expect(GcpTraceExporter).toHaveBeenCalledWith(undefined, undefined);
+      expect(GcpLogExporter).toHaveBeenCalledWith(undefined, undefined);
+      expect(GcpMetricExporter).toHaveBeenCalledWith(undefined, undefined);
       expect(NodeSDK.prototype.start).toHaveBeenCalled();
     } finally {
       if (originalOtlpEnv) {
@@ -191,7 +221,8 @@ describe('Telemetry SDK', () => {
     }
   });
 
-  it('should use GOOGLE_CLOUD_PROJECT as fallback when OTLP_GOOGLE_CLOUD_PROJECT is not set', () => {
+  it('should use GOOGLE_CLOUD_PROJECT as fallback when OTLP_GOOGLE_CLOUD_PROJECT is not set', async () => {
+    mockGetApplicationDefault.mockResolvedValue(undefined); // Simulate ADC available
     vi.spyOn(mockConfig, 'getTelemetryTarget').mockReturnValue(
       TelemetryTarget.GCP,
     );
@@ -204,11 +235,20 @@ describe('Telemetry SDK', () => {
     process.env['GOOGLE_CLOUD_PROJECT'] = 'fallback-project';
 
     try {
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
 
-      expect(GcpTraceExporter).toHaveBeenCalledWith('fallback-project');
-      expect(GcpLogExporter).toHaveBeenCalledWith('fallback-project');
-      expect(GcpMetricExporter).toHaveBeenCalledWith('fallback-project');
+      expect(GcpTraceExporter).toHaveBeenCalledWith(
+        'fallback-project',
+        undefined,
+      );
+      expect(GcpLogExporter).toHaveBeenCalledWith(
+        'fallback-project',
+        undefined,
+      );
+      expect(GcpMetricExporter).toHaveBeenCalledWith(
+        'fallback-project',
+        undefined,
+      );
       expect(NodeSDK.prototype.start).toHaveBeenCalled();
     } finally {
       if (originalOtlpEnv) {
@@ -222,11 +262,11 @@ describe('Telemetry SDK', () => {
     }
   });
 
-  it('should not use OTLP exporters when telemetryOutfile is set', () => {
+  it('should not use OTLP exporters when telemetryOutfile is set', async () => {
     vi.spyOn(mockConfig, 'getTelemetryOutfile').mockReturnValue(
       path.join(os.tmpdir(), 'test.log'),
     );
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
 
     expect(OTLPTraceExporter).not.toHaveBeenCalled();
     expect(OTLPLogExporter).not.toHaveBeenCalled();
@@ -235,5 +275,85 @@ describe('Telemetry SDK', () => {
     expect(OTLPLogExporterHttp).not.toHaveBeenCalled();
     expect(OTLPMetricExporterHttp).not.toHaveBeenCalled();
     expect(NodeSDK.prototype.start).toHaveBeenCalled();
+  });
+
+  it('should defer initialization when useCliAuth is true and no credentials are provided', async () => {
+    vi.spyOn(mockConfig, 'getTelemetryUseCliAuth').mockReturnValue(true);
+    vi.spyOn(mockConfig, 'getTelemetryTarget').mockReturnValue(
+      TelemetryTarget.GCP,
+    );
+    vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue('');
+
+    // 1. Initial state: No credentials.
+    // Should NOT initialize any exporters.
+    await initializeTelemetry(mockConfig);
+
+    // Verify nothing was initialized
+    expect(ConsoleSpanExporter).not.toHaveBeenCalled();
+    expect(GcpTraceExporter).not.toHaveBeenCalled();
+
+    // Verify deferral log
+    expect(debugLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining('deferring telemetry initialization'),
+    );
+  });
+
+  it('should initialize with GCP exporters when credentials are provided via post_auth', async () => {
+    vi.spyOn(mockConfig, 'getTelemetryUseCliAuth').mockReturnValue(true);
+    vi.spyOn(mockConfig, 'getTelemetryTarget').mockReturnValue(
+      TelemetryTarget.GCP,
+    );
+    vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue('');
+
+    // 1. Initial state: No credentials.
+    await initializeTelemetry(mockConfig);
+
+    // Verify nothing happened yet
+    expect(GcpTraceExporter).not.toHaveBeenCalled();
+
+    // 2. Set project ID and emit post_auth event
+    process.env['GOOGLE_CLOUD_PROJECT'] = 'test-project';
+
+    const mockCredentials = {
+      client_email: 'test@example.com',
+      private_key: '-----BEGIN PRIVATE KEY-----\n...',
+      type: 'authorized_user',
+    };
+
+    // Emit the event directly
+    authEvents.emit('post_auth', mockCredentials);
+
+    // Wait for the event loop to process the promise
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Check if debugLogger was called, which indicates the listener ran
+    expect(debugLogger.log).toHaveBeenCalledWith(
+      'Telemetry reinit with credentials: ',
+      mockCredentials,
+    );
+
+    // Should use GCP exporters now with the project ID
+    expect(GcpTraceExporter).toHaveBeenCalledWith(
+      'test-project',
+      mockCredentials,
+    );
+  });
+
+  describe('bufferTelemetryEvent', () => {
+    it('should execute immediately if SDK is initialized', async () => {
+      await initializeTelemetry(mockConfig);
+      const callback = vi.fn();
+      bufferTelemetryEvent(callback);
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should buffer if SDK is not initialized, and flush on initialization', async () => {
+      const callback = vi.fn();
+      bufferTelemetryEvent(callback);
+      expect(callback).not.toHaveBeenCalled();
+
+      await initializeTelemetry(mockConfig);
+      expect(callback).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -356,4 +356,18 @@ describe('Telemetry SDK', () => {
       expect(callback).toHaveBeenCalled();
     });
   });
+
+  it('should disable telemetry and log error if useCollector and useCliAuth are both true', async () => {
+    vi.spyOn(mockConfig, 'getTelemetryUseCollector').mockReturnValue(true);
+    vi.spyOn(mockConfig, 'getTelemetryUseCliAuth').mockReturnValue(true);
+
+    await initializeTelemetry(mockConfig);
+
+    expect(debugLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Telemetry configuration error: "useCollector" and "useCliAuth" cannot both be true',
+      ),
+    );
+    expect(NodeSDK.prototype.start).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -323,20 +323,20 @@ describe('Telemetry SDK', () => {
     // Emit the event directly
     authEvents.emit('post_auth', mockCredentials);
 
-    // Wait for the event loop to process the promise
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Wait for the event handler to process.
+    await vi.waitFor(() => {
+      // Check if debugLogger was called, which indicates the listener ran
+      expect(debugLogger.log).toHaveBeenCalledWith(
+        'Telemetry reinit with credentials: ',
+        mockCredentials,
+      );
 
-    // Check if debugLogger was called, which indicates the listener ran
-    expect(debugLogger.log).toHaveBeenCalledWith(
-      'Telemetry reinit with credentials: ',
-      mockCredentials,
-    );
-
-    // Should use GCP exporters now with the project ID
-    expect(GcpTraceExporter).toHaveBeenCalledWith(
-      'test-project',
-      mockCredentials,
-    );
+      // Should use GCP exporters now with the project ID
+      expect(GcpTraceExporter).toHaveBeenCalledWith(
+        'test-project',
+        mockCredentials,
+      );
+    });
   });
 
   describe('bufferTelemetryEvent', () => {

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -143,6 +143,15 @@ export async function initializeTelemetry(
     return;
   }
 
+  if (config.getTelemetryUseCollector() && config.getTelemetryUseCliAuth()) {
+    debugLogger.error(
+      'Telemetry configuration error: "useCollector" and "useCliAuth" cannot both be true. ' +
+        'CLI authentication is only supported with in-process exporters. ' +
+        'Disabling telemetry.',
+    );
+    return;
+  }
+
   // If using CLI auth and no credentials provided, defer initialization
   if (config.getTelemetryUseCliAuth() && !credentials) {
     // Register a callback to initialize telemetry when the user logs in.
@@ -175,6 +184,7 @@ export async function initializeTelemetry(
   const otlpProtocol = config.getTelemetryOtlpProtocol();
   const telemetryTarget = config.getTelemetryTarget();
   const useCollector = config.getTelemetryUseCollector();
+
   const parsedEndpoint = parseOtlpEndpoint(otlpEndpoint, otlpProtocol);
   const telemetryOutfile = config.getTelemetryOutfile();
   const useOtlp = !!parsedEndpoint && !telemetryOutfile;

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -4,7 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api';
+import {
+  DiagLogLevel,
+  diag,
+  trace,
+  context,
+  metrics,
+  propagation,
+} from '@opentelemetry/api';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
@@ -28,6 +35,7 @@ import {
   PeriodicExportingMetricReader,
 } from '@opentelemetry/sdk-metrics';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+import type { JWTInput } from 'google-auth-library';
 import type { Config } from '../config/config.js';
 import { SERVICE_NAME } from './constants.js';
 import { initializeMetrics } from './metrics.js';
@@ -44,15 +52,62 @@ import {
 } from './gcp-exporters.js';
 import { TelemetryTarget } from './index.js';
 import { debugLogger } from '../utils/debugLogger.js';
+import { authEvents } from '../code_assist/oauth2.js';
 
 // For troubleshooting, set the log level to DiagLogLevel.DEBUG
-diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
+class DiagLoggerAdapter {
+  error(message: string, ...args: unknown[]): void {
+    debugLogger.error(message, ...args);
+  }
+
+  warn(message: string, ...args: unknown[]): void {
+    debugLogger.warn(message, ...args);
+  }
+
+  info(message: string, ...args: unknown[]): void {
+    debugLogger.log(message, ...args);
+  }
+
+  debug(message: string, ...args: unknown[]): void {
+    debugLogger.debug(message, ...args);
+  }
+
+  verbose(message: string, ...args: unknown[]): void {
+    debugLogger.debug(message, ...args);
+  }
+}
+
+diag.setLogger(new DiagLoggerAdapter(), DiagLogLevel.INFO);
 
 let sdk: NodeSDK | undefined;
 let telemetryInitialized = false;
+let callbackRegistered = false;
+const telemetryBuffer: Array<() => void | Promise<void>> = [];
 
 export function isTelemetrySdkInitialized(): boolean {
   return telemetryInitialized;
+}
+
+export function bufferTelemetryEvent(fn: () => void | Promise<void>): void {
+  if (telemetryInitialized) {
+    fn();
+  } else {
+    telemetryBuffer.push(fn);
+  }
+}
+
+async function flushTelemetryBuffer(): Promise<void> {
+  if (!telemetryInitialized) return;
+  while (telemetryBuffer.length > 0) {
+    const fn = telemetryBuffer.shift();
+    if (fn) {
+      try {
+        await fn();
+      } catch (e) {
+        debugLogger.error('Error executing buffered telemetry event', e);
+      }
+    }
+  }
 }
 
 function parseOtlpEndpoint(
@@ -80,8 +135,33 @@ function parseOtlpEndpoint(
   }
 }
 
-export function initializeTelemetry(config: Config): void {
+export async function initializeTelemetry(
+  config: Config,
+  credentials?: JWTInput,
+): Promise<void> {
   if (telemetryInitialized || !config.getTelemetryEnabled()) {
+    return;
+  }
+
+  // If using CLI auth and no credentials provided, defer initialization
+  if (config.getTelemetryUseCliAuth() && !credentials) {
+    // Register a callback to initialize telemetry when the user logs in.
+    // This is done only once.
+    if (!callbackRegistered) {
+      callbackRegistered = true;
+      authEvents.on('post_auth', async (newCredentials: JWTInput) => {
+        if (config.getTelemetryEnabled() && config.getTelemetryUseCliAuth()) {
+          debugLogger.log(
+            'Telemetry reinit with credentials: ',
+            newCredentials,
+          );
+          await initializeTelemetry(config, newCredentials);
+        }
+      });
+    }
+    debugLogger.log(
+      'CLI auth is requested but no credentials, deferring telemetry initialization.',
+    );
     return;
   }
 
@@ -103,7 +183,18 @@ export function initializeTelemetry(config: Config): void {
     process.env['OTLP_GOOGLE_CLOUD_PROJECT'] ||
     process.env['GOOGLE_CLOUD_PROJECT'];
   const useDirectGcpExport =
-    telemetryTarget === TelemetryTarget.GCP && !!gcpProjectId && !useCollector;
+    telemetryTarget === TelemetryTarget.GCP && !useCollector;
+
+  debugLogger.log('Telemetry initialization config:', {
+    telemetryTarget,
+    gcpProjectId,
+    useCliAuth: config.getTelemetryUseCliAuth(),
+    hasCredentials: !!credentials,
+    useCollector,
+    useDirectGcpExport,
+    useOtlp,
+    hasOutfile: !!telemetryOutfile,
+  });
 
   let spanExporter:
     | OTLPTraceExporter
@@ -120,10 +211,16 @@ export function initializeTelemetry(config: Config): void {
   let metricReader: PeriodicExportingMetricReader;
 
   if (useDirectGcpExport) {
-    spanExporter = new GcpTraceExporter(gcpProjectId);
-    logExporter = new GcpLogExporter(gcpProjectId);
+    debugLogger.log(
+      'Creating GCP exporters with projectId:',
+      gcpProjectId,
+      'using',
+      credentials ? 'provided credentials' : 'ADC',
+    );
+    spanExporter = new GcpTraceExporter(gcpProjectId, credentials);
+    logExporter = new GcpLogExporter(gcpProjectId, credentials);
     metricReader = new PeriodicExportingMetricReader({
-      exporter: new GcpMetricExporter(gcpProjectId),
+      exporter: new GcpMetricExporter(gcpProjectId, credentials),
       exportIntervalMillis: 30000,
     });
   } else if (useOtlp) {
@@ -183,12 +280,13 @@ export function initializeTelemetry(config: Config): void {
   });
 
   try {
-    sdk.start();
+    await sdk.start();
     if (config.getDebugMode()) {
       debugLogger.log('OpenTelemetry SDK started successfully.');
     }
     telemetryInitialized = true;
     initializeMetrics(config);
+    void flushTelemetryBuffer();
   } catch (error) {
     console.error('Error starting OpenTelemetry SDK:', error);
   }
@@ -204,19 +302,31 @@ export function initializeTelemetry(config: Config): void {
   });
 }
 
-export async function shutdownTelemetry(config: Config): Promise<void> {
+export async function shutdownTelemetry(
+  config: Config,
+  fromProcessExit = true,
+): Promise<void> {
   if (!telemetryInitialized || !sdk) {
     return;
   }
   try {
-    ClearcutLogger.getInstance()?.shutdown();
+    await ClearcutLogger.getInstance()?.shutdown();
     await sdk.shutdown();
-    if (config.getDebugMode()) {
+    if (config.getDebugMode() && fromProcessExit) {
       debugLogger.log('OpenTelemetry SDK shut down successfully.');
     }
   } catch (error) {
     console.error('Error shutting down SDK:', error);
   } finally {
     telemetryInitialized = false;
+    sdk = undefined;
+    // Fully reset the global APIs to allow for re-initialization.
+    // This is primarily for testing environments where the SDK is started
+    // and stopped multiple times in the same process.
+    trace.disable();
+    context.disable();
+    metrics.disable();
+    propagation.disable();
+    diag.disable();
   }
 }

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -198,17 +198,6 @@ export async function initializeTelemetry(
   const useDirectGcpExport =
     telemetryTarget === TelemetryTarget.GCP && !useCollector;
 
-  debugLogger.log('Telemetry initialization config:', {
-    telemetryTarget,
-    gcpProjectId,
-    useCliAuth: config.getTelemetryUseCliAuth(),
-    hasCredentials: !!credentials,
-    useCollector,
-    useDirectGcpExport,
-    useOtlp,
-    hasOutfile: !!telemetryOutfile,
-  });
-
   let spanExporter:
     | OTLPTraceExporter
     | OTLPTraceExporterHttp

--- a/packages/core/src/telemetry/startupProfiler.test.ts
+++ b/packages/core/src/telemetry/startupProfiler.test.ts
@@ -23,6 +23,10 @@ vi.mock('node:os', () => ({
 // Mock fs module
 vi.mock('node:fs', () => ({
   existsSync: vi.fn(() => false),
+  createWriteStream: vi.fn(() => ({
+    write: vi.fn(),
+    on: vi.fn(),
+  })),
 }));
 
 describe('StartupProfiler', () => {

--- a/packages/core/src/utils/debugLogger.ts
+++ b/packages/core/src/utils/debugLogger.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'node:fs';
+import * as util from 'node:util';
+
 /**
  * A simple, centralized logger for developer-facing debug messages.
  *
@@ -17,19 +20,42 @@
  * will intercept these calls and route them to the debug drawer UI.
  */
 class DebugLogger {
+  private logFile: string | undefined;
+
+  constructor() {
+    this.logFile = process.env['GEMINI_DEBUG_LOG_FILE'];
+  }
+
+  private writeToFile(level: string, args: unknown[]) {
+    if (this.logFile) {
+      const message = util.format(...args);
+      const timestamp = new Date().toISOString();
+      const logEntry = `[${timestamp}] [${level}] ${message}\n`;
+      try {
+        fs.appendFileSync(this.logFile, logEntry);
+      } catch (_e) {
+        // Ignore errors writing to log file to prevent crashing the app
+      }
+    }
+  }
+
   log(...args: unknown[]): void {
+    this.writeToFile('LOG', args);
     console.log(...args);
   }
 
   warn(...args: unknown[]): void {
+    this.writeToFile('WARN', args);
     console.warn(...args);
   }
 
   error(...args: unknown[]): void {
+    this.writeToFile('ERROR', args);
     console.error(...args);
   }
 
   debug(...args: unknown[]): void {
+    this.writeToFile('DEBUG', args);
     console.debug(...args);
   }
 }

--- a/packages/core/src/utils/editCorrector.test.ts
+++ b/packages/core/src/utils/editCorrector.test.ts
@@ -22,6 +22,10 @@ let mockSendMessageStream: any;
 vi.mock('fs', () => ({
   statSync: vi.fn(),
   mkdirSync: vi.fn(),
+  createWriteStream: vi.fn(() => ({
+    write: vi.fn(),
+    on: vi.fn(),
+  })),
 }));
 
 vi.mock('../core/client.js', () => ({

--- a/packages/core/src/utils/nextSpeakerChecker.test.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.test.ts
@@ -32,6 +32,10 @@ vi.mock('node:fs', () => {
       });
     }),
     existsSync: vi.fn((path: string) => mockFileSystem.has(path)),
+    createWriteStream: vi.fn(() => ({
+      write: vi.fn(),
+      on: vi.fn(),
+    })),
   };
 
   return {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1503,6 +1503,12 @@
         "useCollector": {
           "type": "boolean",
           "description": "Whether to forward telemetry to an OTLP collector."
+        },
+        "useCliAuth": {
+          "type": "boolean",
+          "description": "Use the same credentials as the CLI for telemetry.",
+          "markdownDescription": "Use the same credentials as the CLI for telemetry.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `false`",
+          "default": false
         }
       }
     },

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1503,12 +1503,6 @@
         "useCollector": {
           "type": "boolean",
           "description": "Whether to forward telemetry to an OTLP collector."
-        },
-        "useCliAuth": {
-          "type": "boolean",
-          "description": "Use the same credentials as the CLI for telemetry.",
-          "markdownDescription": "Use the same credentials as the CLI for telemetry.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `false`",
-          "default": false
         }
       }
     },

--- a/scripts/telemetry.js
+++ b/scripts/telemetry.js
@@ -78,16 +78,7 @@ const scriptPath = join(projectRoot, 'scripts', targetScripts[target]);
 try {
   console.log(`🚀 Running telemetry script for target: ${target}.`);
   const env = { ...process.env };
-  if (telemetrySettings?.useCliAuth) {
-    const credsPath = join(USER_SETTINGS_DIR, 'oauth_creds_adc.json');
-    if (existsSync(credsPath)) {
-      env['GEMINI_CLI_CREDENTIALS_PATH'] = credsPath;
-    } else {
-      console.warn(
-        `🛑 WARNING: telemetry.useCliAuth is true, but credential file not found at ${credsPath}`,
-      );
-    }
-  }
+
   execSync(`node ${scriptPath}`, {
     stdio: 'inherit',
     cwd: projectRoot,

--- a/scripts/telemetry.js
+++ b/scripts/telemetry.js
@@ -20,15 +20,15 @@ const USER_SETTINGS_DIR = join(
 const USER_SETTINGS_PATH = join(USER_SETTINGS_DIR, 'settings.json');
 const WORKSPACE_SETTINGS_PATH = join(projectRoot, GEMINI_DIR, 'settings.json');
 
-let settingsTarget = undefined;
+let telemetrySettings = undefined;
 
-function loadSettingsValue(filePath) {
+function loadSettings(filePath) {
   try {
     if (existsSync(filePath)) {
       const content = readFileSync(filePath, 'utf-8');
       const jsonContent = content.replace(/\/\/[^\n]*/g, '');
       const settings = JSON.parse(jsonContent);
-      return settings.telemetry?.target;
+      return settings.telemetry;
     }
   } catch (e) {
     console.warn(
@@ -38,13 +38,13 @@ function loadSettingsValue(filePath) {
   return undefined;
 }
 
-settingsTarget = loadSettingsValue(WORKSPACE_SETTINGS_PATH);
+telemetrySettings = loadSettings(WORKSPACE_SETTINGS_PATH);
 
-if (!settingsTarget) {
-  settingsTarget = loadSettingsValue(USER_SETTINGS_PATH);
+if (!telemetrySettings) {
+  telemetrySettings = loadSettings(USER_SETTINGS_PATH);
 }
 
-let target = settingsTarget || 'local';
+let target = telemetrySettings?.target || 'local';
 const allowedTargets = ['local', 'gcp', 'genkit'];
 
 const targetArg = process.argv.find((arg) => arg.startsWith('--target='));
@@ -55,13 +55,15 @@ if (targetArg) {
     console.log(`⚙️  Using command-line target: ${target}`);
   } else {
     console.error(
-      `🛑 Error: Invalid target '${potentialTarget}'. Allowed targets are: ${allowedTargets.join(', ')}.`,
+      `🛑 Error: Invalid target '${potentialTarget}'. Allowed targets are: ${allowedTargets.join(
+        ', ',
+      )}.`,
     );
     process.exit(1);
   }
-} else if (settingsTarget) {
+} else if (telemetrySettings?.target) {
   console.log(
-    `⚙️ Using telemetry target from settings.json: ${settingsTarget}`,
+    `⚙️ Using telemetry target from settings.json: ${telemetrySettings.target}`,
   );
 }
 
@@ -75,7 +77,22 @@ const scriptPath = join(projectRoot, 'scripts', targetScripts[target]);
 
 try {
   console.log(`🚀 Running telemetry script for target: ${target}.`);
-  execSync(`node ${scriptPath}`, { stdio: 'inherit', cwd: projectRoot });
+  const env = { ...process.env };
+  if (telemetrySettings?.useCliAuth) {
+    const credsPath = join(USER_SETTINGS_DIR, 'oauth_creds_adc.json');
+    if (existsSync(credsPath)) {
+      env['GEMINI_CLI_CREDENTIALS_PATH'] = credsPath;
+    } else {
+      console.warn(
+        `🛑 WARNING: telemetry.useCliAuth is true, but credential file not found at ${credsPath}`,
+      );
+    }
+  }
+  execSync(`node ${scriptPath}`, {
+    stdio: 'inherit',
+    cwd: projectRoot,
+    env,
+  });
 } catch (error) {
   console.error(`🛑 Failed to run telemetry script for target: ${target}`);
   console.error(error);

--- a/scripts/telemetry_gcp.js
+++ b/scripts/telemetry_gcp.js
@@ -133,13 +133,6 @@ async function main() {
   console.log(`📄 Wrote OTEL collector config to ${OTEL_CONFIG_FILE}`);
 
   const spawnEnv = { ...process.env };
-  if (process.env.GEMINI_CLI_CREDENTIALS_PATH) {
-    spawnEnv['GOOGLE_APPLICATION_CREDENTIALS'] =
-      process.env.GEMINI_CLI_CREDENTIALS_PATH;
-    console.log(
-      `\n🔑 Using CLI credentials for telemetry: ${process.env.GEMINI_CLI_CREDENTIALS_PATH}`,
-    );
-  }
 
   console.log(`🚀 Starting OTEL collector for GCP... Logs: ${OTEL_LOG_FILE}`);
   collectorLogFd = fs.openSync(OTEL_LOG_FILE, 'a');

--- a/scripts/telemetry_gcp.js
+++ b/scripts/telemetry_gcp.js
@@ -7,7 +7,7 @@
  */
 
 import path from 'node:path';
-import fs from 'node:fs';
+import * as fs from 'node:fs';
 import { spawn, execSync } from 'node:child_process';
 import {
   OTEL_DIR,
@@ -132,11 +132,20 @@ async function main() {
   fs.writeFileSync(OTEL_CONFIG_FILE, getOtelConfigContent(projectId));
   console.log(`📄 Wrote OTEL collector config to ${OTEL_CONFIG_FILE}`);
 
+  const spawnEnv = { ...process.env };
+  if (process.env.GEMINI_CLI_CREDENTIALS_PATH) {
+    spawnEnv['GOOGLE_APPLICATION_CREDENTIALS'] =
+      process.env.GEMINI_CLI_CREDENTIALS_PATH;
+    console.log(
+      `\n🔑 Using CLI credentials for telemetry: ${process.env.GEMINI_CLI_CREDENTIALS_PATH}`,
+    );
+  }
+
   console.log(`🚀 Starting OTEL collector for GCP... Logs: ${OTEL_LOG_FILE}`);
   collectorLogFd = fs.openSync(OTEL_LOG_FILE, 'a');
   collectorProcess = spawn(otelcolPath, ['--config', OTEL_CONFIG_FILE], {
     stdio: ['ignore', collectorLogFd, collectorLogFd],
-    env: { ...process.env },
+    env: spawnEnv,
   });
 
   console.log(

--- a/scripts/tests/generate-settings-doc.test.ts
+++ b/scripts/tests/generate-settings-doc.test.ts
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { main as generateDocs } from '../generate-settings-doc.ts';
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn().mockReturnValue(''),
+  createWriteStream: vi.fn(() => ({
+    write: vi.fn(),
+    on: vi.fn(),
+  })),
+}));
 
 describe('generate-settings-doc', () => {
   it('keeps documentation in sync in check mode', async () => {

--- a/scripts/tests/generate-settings-schema.test.ts
+++ b/scripts/tests/generate-settings-schema.test.ts
@@ -4,11 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { main as generateSchema } from '../generate-settings-schema.ts';
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn().mockReturnValue(''),
+  writeFileSync: vi.fn(),
+  createWriteStream: vi.fn(() => ({
+    write: vi.fn(),
+    on: vi.fn(),
+  })),
+}));
 
 describe('generate-settings-schema', () => {
   it('keeps schema in sync in check mode', async () => {

--- a/scripts/tests/telemetry_gcp.test.ts
+++ b/scripts/tests/telemetry_gcp.test.ts
@@ -53,18 +53,4 @@ describe('telemetry_gcp.js', () => {
       'GOOGLE_APPLICATION_CREDENTIALS',
     );
   });
-
-  it('should set GOOGLE_APPLICATION_CREDENTIALS when env var is set', async () => {
-    const credsPath = '/path/to/creds.json';
-    process.env.GEMINI_CLI_CREDENTIALS_PATH = credsPath;
-
-    await import('../telemetry_gcp.js');
-
-    expect(mockSpawn).toHaveBeenCalled();
-    const spawnOptions = mockSpawn.mock.calls[0][2];
-    expect(spawnOptions?.env).toHaveProperty(
-      'GOOGLE_APPLICATION_CREDENTIALS',
-      credsPath,
-    );
-  });
 });

--- a/scripts/tests/telemetry_gcp.test.ts
+++ b/scripts/tests/telemetry_gcp.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const mockSpawn = vi.fn(() => ({ on: vi.fn(), pid: 123 }));
+
+vi.mock('node:child_process', () => ({
+  spawn: mockSpawn,
+  execSync: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  openSync: vi.fn(() => 1),
+  unlinkSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock('../telemetry_utils.js', () => ({
+  ensureBinary: vi.fn(() => Promise.resolve('/fake/path/to/otelcol-contrib')),
+  waitForPort: vi.fn(() => Promise.resolve()),
+  manageTelemetrySettings: vi.fn(),
+  registerCleanup: vi.fn(),
+  fileExists: vi.fn(() => true), // Assume all files exist for simplicity
+  OTEL_DIR: '/tmp/otel',
+  BIN_DIR: '/tmp/bin',
+}));
+
+describe('telemetry_gcp.js', () => {
+  beforeEach(() => {
+    vi.resetModules(); // This is key to re-run the script
+    vi.clearAllMocks();
+    process.env.OTLP_GOOGLE_CLOUD_PROJECT = 'test-project';
+    // Clear the env var before each test
+    delete process.env.GEMINI_CLI_CREDENTIALS_PATH;
+  });
+
+  afterEach(() => {
+    delete process.env.OTLP_GOOGLE_CLOUD_PROJECT;
+  });
+
+  it('should not set GOOGLE_APPLICATION_CREDENTIALS when env var is not set', async () => {
+    await import('../telemetry_gcp.js');
+
+    expect(mockSpawn).toHaveBeenCalled();
+    const spawnOptions = mockSpawn.mock.calls[0][2];
+    expect(spawnOptions?.env).not.toHaveProperty(
+      'GOOGLE_APPLICATION_CREDENTIALS',
+    );
+  });
+
+  it('should set GOOGLE_APPLICATION_CREDENTIALS when env var is set', async () => {
+    const credsPath = '/path/to/creds.json';
+    process.env.GEMINI_CLI_CREDENTIALS_PATH = credsPath;
+
+    await import('../telemetry_gcp.js');
+
+    expect(mockSpawn).toHaveBeenCalled();
+    const spawnOptions = mockSpawn.mock.calls[0][2];
+    expect(spawnOptions?.env).toHaveProperty(
+      'GOOGLE_APPLICATION_CREDENTIALS',
+      credsPath,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds the ability for the Open Telemetry direct exporters to GCP to utilize user's login credentials, rather than require the user to provide ADC with gcloud.  It represents a significant usability improvement for users on that path, especially those, whose organization require gcloud reauth.

## How to Validate

- Setup telemetry to (direct) export metrics to GCP and enable the new useCliAuth flag.  
-- Remove cached oauth creds, auth username/password, and verify that telemetry is getting exported.
-- Quit and restart the CLI.  Verify telemetry continues to be exported and oauth credentials are used.
- Now disable the new useCliAuth flag and obtain ADC with gcloud.  Verify telemetry continues to be exported.
- Now test exporting with external GCP collectors (by starting the standalone collector process). Verifies this path continues to work as before.
- Test that telemetry export works in Cloud Shell, where ADC is provided in the environment and does not require gcloud.

(In all of the above cases, make sure to set OTEL project to point to a project you own.) 

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
