### PR TITLE
feat(mcp): Inject GoogleCredentialProvider headers in McpClient

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,3 +18,4 @@ eslint.config.js
 gha-creds-*.json
 junit.xml
 Thumbs.db
+.pytest_cache

--- a/packages/core/src/mcp/auth-provider.ts
+++ b/packages/core/src/mcp/auth-provider.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+
+/**
+ * Extension of OAuthClientProvider that allows providers to inject custom headers
+ * into the transport request.
+ */
+export interface McpAuthProvider extends OAuthClientProvider {
+  /**
+   * Returns custom headers to be added to the request.
+   */
+  getRequestHeaders(): Promise<Record<string, string>>;
+}

--- a/packages/core/src/mcp/auth-provider.ts
+++ b/packages/core/src/mcp/auth-provider.ts
@@ -14,5 +14,5 @@ export interface McpAuthProvider extends OAuthClientProvider {
   /**
    * Returns custom headers to be added to the request.
    */
-  getRequestHeaders(): Promise<Record<string, string>>;
+  getRequestHeaders?(): Promise<Record<string, string>>;
 }

--- a/packages/core/src/mcp/google-auth-provider.test.ts
+++ b/packages/core/src/mcp/google-auth-provider.test.ts
@@ -204,7 +204,7 @@ describe('GoogleCredentialProvider', () => {
       );
       const headers = await providerWithHeaders.getRequestHeaders();
       expect(headers).toEqual({
-        'X-Goog-User-Project': 'config-project-id',
+        'x-goog-user-project': 'config-project-id',
       });
     });
   });

--- a/packages/core/src/mcp/google-auth-provider.test.ts
+++ b/packages/core/src/mcp/google-auth-provider.test.ts
@@ -174,5 +174,38 @@ describe('GoogleCredentialProvider', () => {
       const headers = await provider.getRequestHeaders();
       expect(headers).toEqual({});
     });
+
+    it('should prioritize config headers over quota project ID', async () => {
+      mockClient['quotaProjectId'] = 'quota-project-id';
+      const configWithHeaders = {
+        ...validConfig,
+        headers: {
+          'X-Goog-User-Project': 'config-project-id',
+        },
+      };
+      const providerWithHeaders = new GoogleCredentialProvider(
+        configWithHeaders,
+      );
+      const headers = await providerWithHeaders.getRequestHeaders();
+      expect(headers).toEqual({
+        'X-Goog-User-Project': 'config-project-id',
+      });
+    });
+    it('should prioritize config headers over quota project ID (case-insensitive)', async () => {
+      mockClient['quotaProjectId'] = 'quota-project-id';
+      const configWithHeaders = {
+        ...validConfig,
+        headers: {
+          'x-goog-user-project': 'config-project-id',
+        },
+      };
+      const providerWithHeaders = new GoogleCredentialProvider(
+        configWithHeaders,
+      );
+      const headers = await providerWithHeaders.getRequestHeaders();
+      expect(headers).toEqual({
+        'X-Goog-User-Project': 'config-project-id',
+      });
+    });
   });
 });

--- a/packages/core/src/mcp/google-auth-provider.test.ts
+++ b/packages/core/src/mcp/google-auth-provider.test.ts
@@ -86,6 +86,7 @@ describe('GoogleCredentialProvider', () => {
     let mockClient: {
       getAccessToken: Mock;
       credentials?: { expiry_date: number | null };
+      quotaProjectId?: string;
     };
 
     beforeEach(() => {
@@ -152,6 +153,26 @@ describe('GoogleCredentialProvider', () => {
       expect(mockGetAccessToken).toHaveBeenCalledTimes(2); // new fetch
 
       vi.useRealTimers();
+    });
+
+    it('should return quota project ID', async () => {
+      mockClient['quotaProjectId'] = 'test-project-id';
+      const quotaProjectId = await provider.getQuotaProjectId();
+      expect(quotaProjectId).toBe('test-project-id');
+    });
+
+    it('should return request headers with quota project ID', async () => {
+      mockClient['quotaProjectId'] = 'test-project-id';
+      const headers = await provider.getRequestHeaders();
+      expect(headers).toEqual({
+        'X-Goog-User-Project': 'test-project-id',
+      });
+    });
+
+    it('should return empty request headers if quota project ID is missing', async () => {
+      mockClient['quotaProjectId'] = undefined;
+      const headers = await provider.getRequestHeaders();
+      expect(headers).toEqual({});
     });
   });
 });

--- a/packages/core/src/mcp/google-auth-provider.ts
+++ b/packages/core/src/mcp/google-auth-provider.ts
@@ -141,8 +141,11 @@ export class GoogleCredentialProvider implements McpAuthProvider {
       (key) => key.toLowerCase() === 'x-goog-user-project',
     );
 
+    // If the header is present in the config (case-insensitive check), use the
+    // config's key and value. This prevents duplicate headers (e.g.
+    // 'x-goog-user-project' and 'X-Goog-User-Project') which can cause errors.
     if (userProjectHeaderKey) {
-      headers['X-Goog-User-Project'] = configHeaders[userProjectHeaderKey];
+      headers[userProjectHeaderKey] = configHeaders[userProjectHeaderKey];
     } else {
       const quotaProjectId = await this.getQuotaProjectId();
       if (quotaProjectId) {

--- a/packages/core/src/mcp/google-auth-provider.ts
+++ b/packages/core/src/mcp/google-auth-provider.ts
@@ -135,10 +135,19 @@ export class GoogleCredentialProvider implements McpAuthProvider {
    * Returns custom headers to be added to the request.
    */
   async getRequestHeaders(): Promise<Record<string, string>> {
-    const quotaProjectId = await this.getQuotaProjectId();
     const headers: Record<string, string> = {};
-    if (quotaProjectId) {
-      headers['X-Goog-User-Project'] = quotaProjectId;
+    const configHeaders = this.config?.headers ?? {};
+    const userProjectHeaderKey = Object.keys(configHeaders).find(
+      (key) => key.toLowerCase() === 'x-goog-user-project',
+    );
+
+    if (userProjectHeaderKey) {
+      headers['X-Goog-User-Project'] = configHeaders[userProjectHeaderKey];
+    } else {
+      const quotaProjectId = await this.getQuotaProjectId();
+      if (quotaProjectId) {
+        headers['X-Goog-User-Project'] = quotaProjectId;
+      }
     }
     return headers;
   }

--- a/packages/core/src/mcp/google-auth-provider.ts
+++ b/packages/core/src/mcp/google-auth-provider.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+import type { McpAuthProvider } from './auth-provider.js';
 import type {
   OAuthClientInformation,
   OAuthClientInformationFull,
@@ -18,7 +18,7 @@ import { coreEvents } from '../utils/events.js';
 
 const ALLOWED_HOSTS = [/^.+\.googleapis\.com$/, /^(.*\.)?luci\.app$/];
 
-export class GoogleCredentialProvider implements OAuthClientProvider {
+export class GoogleCredentialProvider implements McpAuthProvider {
   private readonly auth: GoogleAuth;
   private cachedToken?: OAuthTokens;
   private tokenExpiryTime?: number;

--- a/packages/core/src/mcp/google-auth-provider.ts
+++ b/packages/core/src/mcp/google-auth-provider.ts
@@ -123,4 +123,23 @@ export class GoogleCredentialProvider implements OAuthClientProvider {
     // No-op
     return '';
   }
+  /**
+   * Returns the project ID used for quota.
+   */
+  async getQuotaProjectId(): Promise<string | undefined> {
+    const client = await this.auth.getClient();
+    return client.quotaProjectId;
+  }
+
+  /**
+   * Returns custom headers to be added to the request.
+   */
+  async getRequestHeaders(): Promise<Record<string, string>> {
+    const quotaProjectId = await this.getQuotaProjectId();
+    const headers: Record<string, string> = {};
+    if (quotaProjectId) {
+      headers['X-Goog-User-Project'] = quotaProjectId;
+    }
+    return headers;
+  }
 }

--- a/packages/core/src/mcp/sa-impersonation-provider.ts
+++ b/packages/core/src/mcp/sa-impersonation-provider.ts
@@ -13,7 +13,7 @@ import type {
 import { GoogleAuth } from 'google-auth-library';
 import { OAuthUtils, FIVE_MIN_BUFFER_MS } from './oauth-utils.js';
 import type { MCPServerConfig } from '../config/config.js';
-import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+import type { McpAuthProvider } from './auth-provider.js';
 import { coreEvents } from '../utils/events.js';
 
 function createIamApiUrl(targetSA: string): string {
@@ -22,9 +22,14 @@ function createIamApiUrl(targetSA: string): string {
   )}:generateIdToken`;
 }
 
-export class ServiceAccountImpersonationProvider
-  implements OAuthClientProvider
-{
+export class ServiceAccountImpersonationProvider implements McpAuthProvider {
+  /**
+   * Returns custom headers to be added to the request.
+   */
+  async getRequestHeaders(): Promise<Record<string, string>> {
+    return {};
+  }
+
   private readonly targetServiceAccount: string;
   private readonly targetAudience: string; // OAuth Client Id
   private readonly auth: GoogleAuth;

--- a/packages/core/src/mcp/sa-impersonation-provider.ts
+++ b/packages/core/src/mcp/sa-impersonation-provider.ts
@@ -23,13 +23,6 @@ function createIamApiUrl(targetSA: string): string {
 }
 
 export class ServiceAccountImpersonationProvider implements McpAuthProvider {
-  /**
-   * Returns custom headers to be added to the request.
-   */
-  async getRequestHeaders(): Promise<Record<string, string>> {
-    return {};
-  }
-
   private readonly targetServiceAccount: string;
   private readonly targetAudience: string; // OAuth Client Id
   private readonly auth: GoogleAuth;

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -645,7 +645,7 @@ describe('mcp-client', () => {
         expect(headers['X-Goog-User-Project']).toBe('provider-project');
       });
 
-      it('should prioritize config headers over provider headers', async () => {
+      it('should prioritize provider headers over config headers', async () => {
         const mockGetRequestHeaders = vi.fn().mockResolvedValue({
           'X-Goog-User-Project': 'provider-project',
         });
@@ -672,7 +672,7 @@ describe('mcp-client', () => {
         expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const headers = (transport as any)._requestInit?.headers;
-        expect(headers['X-Goog-User-Project']).toBe('config-project');
+        expect(headers['X-Goog-User-Project']).toBe('provider-project');
       });
 
       it('should use GoogleCredentialProvider with SSE transport', async () => {

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -36,6 +36,8 @@ vi.mock('@google/genai');
 vi.mock('../mcp/oauth-provider.js');
 vi.mock('../mcp/oauth-token-storage.js');
 vi.mock('../mcp/oauth-utils.js');
+vi.mock('google-auth-library');
+import { GoogleAuth } from 'google-auth-library';
 
 vi.mock('../utils/events.js', () => ({
   coreEvents: {
@@ -578,6 +580,16 @@ describe('mcp-client', () => {
     });
 
     describe('useGoogleCredentialProvider', () => {
+      beforeEach(() => {
+        // Mock GoogleAuth client
+        const mockClient = {
+          getAccessToken: vi.fn().mockResolvedValue({ token: 'test-token' }),
+          quotaProjectId: 'myproject',
+        };
+
+        GoogleAuth.prototype.getClient = vi.fn().mockResolvedValue(mockClient);
+      });
+
       it('should use GoogleCredentialProvider when specified', async () => {
         const transport = await createTransport(
           'test-server',

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -605,6 +605,64 @@ describe('mcp-client', () => {
         expect(googUserProject).toBe('myproject');
       });
 
+      it('should use headers from GoogleCredentialProvider', async () => {
+        const mockGetRequestHeaders = vi.fn().mockResolvedValue({
+          'X-Goog-User-Project': 'provider-project',
+        });
+        vi.spyOn(
+          GoogleCredentialProvider.prototype,
+          'getRequestHeaders',
+        ).mockImplementation(mockGetRequestHeaders);
+
+        const transport = await createTransport(
+          'test-server',
+          {
+            httpUrl: 'http://test.googleapis.com',
+            authProviderType: AuthProviderType.GOOGLE_CREDENTIALS,
+            oauth: {
+              scopes: ['scope1'],
+            },
+          },
+          false,
+        );
+
+        expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
+        expect(mockGetRequestHeaders).toHaveBeenCalled();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const headers = (transport as any)._requestInit?.headers;
+        expect(headers['X-Goog-User-Project']).toBe('provider-project');
+      });
+
+      it('should prioritize config headers over provider headers', async () => {
+        const mockGetRequestHeaders = vi.fn().mockResolvedValue({
+          'X-Goog-User-Project': 'provider-project',
+        });
+        vi.spyOn(
+          GoogleCredentialProvider.prototype,
+          'getRequestHeaders',
+        ).mockImplementation(mockGetRequestHeaders);
+
+        const transport = await createTransport(
+          'test-server',
+          {
+            httpUrl: 'http://test.googleapis.com',
+            authProviderType: AuthProviderType.GOOGLE_CREDENTIALS,
+            oauth: {
+              scopes: ['scope1'],
+            },
+            headers: {
+              'X-Goog-User-Project': 'config-project',
+            },
+          },
+          false,
+        );
+
+        expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const headers = (transport as any)._requestInit?.headers;
+        expect(headers['X-Goog-User-Project']).toBe('config-project');
+      });
+
       it('should use GoogleCredentialProvider with SSE transport', async () => {
         const transport = await createTransport(
           'test-server',

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -410,12 +410,12 @@ async function handleAutomaticOAuth(
  */
 function createTransportRequestInit(
   mcpServerConfig: MCPServerConfig,
-  defaultHeaders: Record<string, string>,
+  headers: Record<string, string>,
 ): RequestInit {
   return {
     headers: {
-      ...defaultHeaders,
       ...mcpServerConfig.headers,
+      ...headers,
     },
   };
 }
@@ -1337,8 +1337,9 @@ export async function createTransport(
 
   if (mcpServerConfig.httpUrl || mcpServerConfig.url) {
     const authProvider = createAuthProvider(mcpServerConfig);
-    const customHeaders = (await authProvider?.getRequestHeaders()) ?? {};
-    const headers: Record<string, string> = { ...customHeaders };
+    const headers: Record<string, string> = {
+      ...((await authProvider?.getRequestHeaders?.()) ?? {}),
+    };
 
     if (authProvider === undefined) {
       // Check if we have OAuth configuration or stored tokens

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -35,6 +35,7 @@ import { DiscoveredMCPTool } from './mcp-tool.js';
 import type { CallableTool, FunctionCall, Part, Tool } from '@google/genai';
 import { basename } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import type { McpAuthProvider } from '../mcp/auth-provider.js';
 import { MCPOAuthProvider } from '../mcp/oauth-provider.js';
 import { MCPOAuthTokenStorage } from '../mcp/oauth-token-storage.js';
 import { OAuthUtils } from '../mcp/oauth-utils.js';
@@ -419,8 +420,6 @@ function createTransportRequestInit(
     },
   };
 }
-
-import type { McpAuthProvider } from '../mcp/auth-provider.js';
 
 /**
  * Create an AuthProvider for the MCP Transport.

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -1337,9 +1337,8 @@ export async function createTransport(
 
   if (mcpServerConfig.httpUrl || mcpServerConfig.url) {
     const authProvider = createAuthProvider(mcpServerConfig);
-    const headers: Record<string, string> = {
-      ...((await authProvider?.getRequestHeaders?.()) ?? {}),
-    };
+    const headers: Record<string, string> =
+      (await authProvider?.getRequestHeaders?.()) ?? {};
 
     if (authProvider === undefined) {
       // Check if we have OAuth configuration or stored tokens


### PR DESCRIPTION
## Summary

For `google_credentials` auth provider type, auth library is used to perform ADC and obtains access token, but quota project is not obtained from the ADC file currently.
Introducing a way to read quota project from ADC and use it in the `x-goog-user-project` header if the header is already not set through `settings.json`.

## Details

For `google_credentials` auth provider type, auth library is used to perform ADC and obtains access token, but quota project is not obtained from the ADC file currently.
Introducing a way to read quota project from ADC and use it in the `x-goog-user-project` header if the header is already not set through `settings.json`.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

Run gcloud to get xapi.zoo scope

```
gcloud auth application-default login --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/xapi.zoo
```

Setup an MCP server that uses ADC auth:

```
"echo": {
"httpUrl": "https://test-echo-pa.sandbox.googleapis.com/mcp",
"timeout": 10000,
"authProviderType": "google_credentials",
"oauth": {
"scopes": [
"https://www.googleapis.com/auth/xapi.zoo"
]
},
"headers": {
"X-Goog-User-Project": "myproject", // Causes GCP to check activation, quota on myproject
}
}
},
```

Then ask gemini-cli to "Call echo"

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
