### PR TITLE
fallback to flash for TerminalQuota errors

### DIFF
--- a/packages/cli/src/ui/components/ProQuotaDialog.tsx
+++ b/packages/cli/src/ui/components/ProQuotaDialog.tsx
@@ -12,7 +12,7 @@ import { theme } from '../semantic-colors.js';
 import {
   DEFAULT_GEMINI_FLASH_LITE_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
-  PREVIEW_GEMINI_MODEL,
+  DEFAULT_GEMINI_MODEL,
   UserTierId,
 } from '@google/gemini-cli-core';
 
@@ -127,7 +127,7 @@ export function ProQuotaDialog({
         <RadioButtonSelect items={items} onSelect={handleSelect} />
       </Box>
       <Text color={theme.text.primary}>
-        {failedModel === PREVIEW_GEMINI_MODEL && !isModelNotFoundError
+        {fallbackModel === DEFAULT_GEMINI_MODEL && !isModelNotFoundError
           ? 'Note: We will periodically retry Preview Model to see if congestion has cleared.'
           : 'Note: You can always use /model to select a different option.'}
       </Text>

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -13,6 +13,7 @@ import {
   ModelNotFoundError,
   type UserTierId,
   PREVIEW_GEMINI_MODEL,
+  DEFAULT_GEMINI_MODEL,
 } from '@google/gemini-cli-core';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { type UseHistoryManagerReturn } from './useHistoryManager.js';
@@ -116,10 +117,13 @@ export function useQuotaAndFallback({
       if (choice === 'retry_always') {
         // If we were recovering from a Preview Model failure, show a specific message.
         if (proQuotaRequest.failedModel === PREVIEW_GEMINI_MODEL) {
+          const showPeriodicalCheckMessage =
+            !proQuotaRequest.isModelNotFoundError &&
+            proQuotaRequest.fallbackModel === DEFAULT_GEMINI_MODEL;
           historyManager.addItem(
             {
               type: MessageType.INFO,
-              text: `Switched to fallback model ${proQuotaRequest.fallbackModel}. ${!proQuotaRequest.isModelNotFoundError ? `We will periodically check if ${PREVIEW_GEMINI_MODEL} is available again.` : ''}`,
+              text: `Switched to fallback model ${proQuotaRequest.fallbackModel}. ${showPeriodicalCheckMessage ? `We will periodically check if ${PREVIEW_GEMINI_MODEL} is available again.` : ''}`,
             },
             Date.now(),
           );

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -59,7 +59,7 @@ export function useQuotaAndFallback({
       const usageLimitReachedModel =
         failedModel === DEFAULT_GEMINI_MODEL ||
         failedModel === PREVIEW_GEMINI_MODEL
-          ? 'pro'
+          ? 'all Pro models'
           : failedModel;
       if (error instanceof TerminalQuotaError) {
         isTerminalQuotaError = true;

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -56,11 +56,16 @@ export function useQuotaAndFallback({
       let message: string;
       let isTerminalQuotaError = false;
       let isModelNotFoundError = false;
+      const usageLimitReachedModel =
+        failedModel === DEFAULT_GEMINI_MODEL ||
+        failedModel === PREVIEW_GEMINI_MODEL
+          ? 'pro'
+          : failedModel;
       if (error instanceof TerminalQuotaError) {
         isTerminalQuotaError = true;
         // Common part of the message for both tiers
         const messageLines = [
-          `Usage limit reached for ${failedModel}.`,
+          `Usage limit reached for ${usageLimitReachedModel}.`,
           error.retryDelayMs ? getResetTimeMessage(error.retryDelayMs) : null,
           `/stats for usage details`,
           `/auth to switch to API key.`,

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -39,8 +39,11 @@ export async function handleFallback(
   }
 
   // Preview Model Specific Logic
-  if (failedModel === PREVIEW_GEMINI_MODEL) {
-    // Always set bypass mode for the immediate retry.
+  if (
+    failedModel === PREVIEW_GEMINI_MODEL &&
+    error instanceof RetryableQuotaError
+  ) {
+    // Always set bypass mode for the immediate retry, for RetryableQuotaError.
     // This ensures the next attempt uses 2.5 Pro.
     config.setPreviewModelBypassMode(true);
 

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -37,12 +37,11 @@ export async function handleFallback(
   ) {
     return null;
   }
-
-  // Preview Model Specific Logic
-  if (
+  const shouldSetPreviewBypassMode =
     failedModel === PREVIEW_GEMINI_MODEL &&
-    error instanceof RetryableQuotaError
-  ) {
+    error instanceof RetryableQuotaError;
+  // Preview Model Specific Logic
+  if (shouldSetPreviewBypassMode) {
     // Always set bypass mode for the immediate retry, for RetryableQuotaError.
     // This ensures the next attempt uses 2.5 Pro.
     config.setPreviewModelBypassMode(true);
@@ -54,10 +53,9 @@ export async function handleFallback(
     }
   }
 
-  const fallbackModel =
-    failedModel === PREVIEW_GEMINI_MODEL
-      ? DEFAULT_GEMINI_MODEL
-      : DEFAULT_GEMINI_FLASH_MODEL;
+  const fallbackModel = shouldSetPreviewBypassMode
+    ? DEFAULT_GEMINI_MODEL
+    : DEFAULT_GEMINI_FLASH_MODEL;
 
   // Consult UI Handler for Intent
   const fallbackModelHandler = config.fallbackModelHandler;


### PR DESCRIPTION
## Summary
For Terminal Quota errors (where user runs out of quotas), we should fallback to flash instead of 2.5 pro.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
When users run out of daily quotas, we should fallback to flash instead of trying to use 2.5 pro. For a temporary failure, we will fallback to 2.5 pro.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
