### PR TITLE
fix(zed-integration): Allow Zed integration to use stdio

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -539,7 +539,6 @@ export async function main() {
     }
 
     if (config.getExperimentalZedIntegration()) {
-      initializeOutputListenersAndFlush();
       return runZedIntegration(config, settings, argv);
     }
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -539,6 +539,7 @@ export async function main() {
     }
 
     if (config.getExperimentalZedIntegration()) {
+      initializeOutputListenersAndFlush();
       return runZedIntegration(config, settings, argv);
     }
 


### PR DESCRIPTION
## Summary

https://github.com/google-gemini/gemini-cli/pull/13247 introduced a change that broke the Zed integration's ability to communicate over stdio.

This adds the same functionality for using stdio as the non-interactive mode.

This is urgent as the 0.18 branch will be broken as-is.

## How to Validate


Run npm run build and put the following config in your Zed settings.json

```json
{
  "agent_servers": {
    "jimandi": {
      "command": "node",       
	"args": ["/path/to/your/repo/gemini-cli/packages/cli/dist/index.js", "--experimental-acp"]
    }
  }
}
```

In the command palette, run `dev: open acp logs`

Start a new prompt and verify that events are going back and forth.

If you do the same on main, you will see it hang, with no initialize response.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
