### PR TITLE
Feat/mcp auto restart

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -101,6 +101,14 @@ they appear in the UI.
 | Tool Output Truncation Lines     | `tools.truncateToolOutputLines`      | The number of lines to keep when truncating tool output.                                                                                                                   | `1000`    |
 | Disable LLM Correction           | `tools.disableLLMCorrection`         | Disable LLM-based error correction for edit tools. When enabled, tools will fail immediately if exact string matches are not found, instead of attempting to self-correct. | `true`    |
 
+### Mcp
+
+| UI Label                   | Setting                                 | Description                                                      | Default |
+| -------------------------- | --------------------------------------- | ---------------------------------------------------------------- | ------- |
+| Enable Auto Restart        | `mcp.autoRestart.enabled`               | Enable auto-restarting of MCP servers.                           | `true`  |
+| Health Check Interval (ms) | `mcp.autoRestart.healthCheckIntervalMs` | The interval in milliseconds to check the health of MCP servers. | `15000` |
+| Unhealthy Timeout (ms)     | `mcp.autoRestart.unhealthyTimeoutMs`    | The timeout in milliseconds to consider an MCP server unhealthy. | `30000` |
+
 ### Security
 
 | UI Label                              | Setting                                         | Description                                                                     | Default |

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -733,6 +733,23 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `undefined`
   - **Requires restart:** Yes
 
+- **`mcp.autoRestart.enabled`** (boolean):
+  - **Description:** Enable auto-restarting of MCP servers.
+  - **Default:** `true`
+  - **Requires restart:** Yes
+
+- **`mcp.autoRestart.healthCheckIntervalMs`** (number):
+  - **Description:** The interval in milliseconds to check the health of MCP
+    servers.
+  - **Default:** `15000`
+  - **Requires restart:** Yes
+
+- **`mcp.autoRestart.unhealthyTimeoutMs`** (number):
+  - **Description:** The timeout in milliseconds to consider an MCP server
+    unhealthy.
+  - **Default:** `30000`
+  - **Requires restart:** Yes
+
 #### `useWriteTodos`
 
 - **`useWriteTodos`** (boolean):

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -912,6 +912,11 @@ describe('Settings Loading and Merging', () => {
       expect(settings.merged.mcp).toEqual({
         allowed: ['system-allowed'],
         excluded: ['workspace-excluded'],
+        autoRestart: {
+          enabled: true,
+          healthCheckIntervalMs: 15000,
+          unhealthyTimeoutMs: 30000,
+        },
       });
     });
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1183,6 +1183,46 @@ const SETTINGS_SCHEMA = {
         showInDialog: false,
         items: { type: 'string' },
       },
+      autoRestart: {
+        type: 'object',
+        label: 'MCP Auto Restart',
+        category: 'MCP',
+        requiresRestart: true,
+        default: {},
+        description: 'Settings for auto-restarting MCP servers.',
+        showInDialog: false,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Enable Auto Restart',
+            category: 'MCP',
+            requiresRestart: true,
+            default: true,
+            description: 'Enable auto-restarting of MCP servers.',
+            showInDialog: true,
+          },
+          healthCheckIntervalMs: {
+            type: 'number',
+            label: 'Health Check Interval (ms)',
+            category: 'MCP',
+            requiresRestart: true,
+            default: 15000,
+            description:
+              'The interval in milliseconds to check the health of MCP servers.',
+            showInDialog: true,
+          },
+          unhealthyTimeoutMs: {
+            type: 'number',
+            label: 'Unhealthy Timeout (ms)',
+            category: 'MCP',
+            requiresRestart: true,
+            default: 30000,
+            description:
+              'The timeout in milliseconds to consider an MCP server unhealthy.',
+            showInDialog: true,
+          },
+        },
+      },
     },
   },
   useWriteTodos: {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -341,6 +341,11 @@ export interface ConfigParameters {
   enableExtensionReloading?: boolean;
   allowedMcpServers?: string[];
   blockedMcpServers?: string[];
+  mcpAutoRestart?: {
+    enabled?: boolean;
+    healthCheckIntervalMs?: number;
+    unhealthyTimeoutMs?: number;
+  };
   allowedEnvironmentVariables?: string[];
   blockedEnvironmentVariables?: string[];
   enableEnvironmentVariableRedaction?: boolean;
@@ -410,6 +415,11 @@ export class Config {
   private mcpClientManager?: McpClientManager;
   private allowedMcpServers: string[];
   private blockedMcpServers: string[];
+  private readonly mcpAutoRestart: {
+    enabled: boolean;
+    healthCheckIntervalMs: number;
+    unhealthyTimeoutMs: number;
+  };
   private allowedEnvironmentVariables: string[];
   private blockedEnvironmentVariables: string[];
   private readonly enableEnvironmentVariableRedaction: boolean;
@@ -583,6 +593,12 @@ export class Config {
     this.extensionsEnabled = params.extensionsEnabled ?? true;
     this.allowedMcpServers = params.allowedMcpServers ?? [];
     this.blockedMcpServers = params.blockedMcpServers ?? [];
+    this.mcpAutoRestart = {
+      enabled: params.mcpAutoRestart?.enabled ?? true,
+      healthCheckIntervalMs:
+        params.mcpAutoRestart?.healthCheckIntervalMs ?? 15000,
+      unhealthyTimeoutMs: params.mcpAutoRestart?.unhealthyTimeoutMs ?? 30000,
+    };
     this.allowedEnvironmentVariables = params.allowedEnvironmentVariables ?? [];
     this.blockedEnvironmentVariables = params.blockedEnvironmentVariables ?? [];
     this.enableEnvironmentVariableRedaction =
@@ -1268,6 +1284,10 @@ export class Config {
 
   getBlockedMcpServers(): string[] | undefined {
     return this.blockedMcpServers;
+  }
+
+  getMcpAutoRestartConfig() {
+    return this.mcpAutoRestart;
   }
 
   get sanitizationConfig(): EnvironmentSanitizationConfig {

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -55,6 +55,9 @@ describe('McpClientManager', () => {
         isInitialized: vi.fn(),
       }),
       refreshMcpContext: vi.fn(),
+      getMcpAutoRestartConfig: vi.fn().mockReturnValue({
+        enabled: false,
+      }),
     } as unknown as Config);
     toolRegistry = {} as ToolRegistry;
   });

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1209,6 +1209,37 @@
           "items": {
             "type": "string"
           }
+        },
+        "autoRestart": {
+          "title": "MCP Auto Restart",
+          "description": "Settings for auto-restarting MCP servers.",
+          "markdownDescription": "Settings for auto-restarting MCP servers.\n\n- Category: `MCP`\n- Requires restart: `yes`\n- Default: `{}`",
+          "default": {},
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable Auto Restart",
+              "description": "Enable auto-restarting of MCP servers.",
+              "markdownDescription": "Enable auto-restarting of MCP servers.\n\n- Category: `MCP`\n- Requires restart: `yes`\n- Default: `true`",
+              "default": true,
+              "type": "boolean"
+            },
+            "healthCheckIntervalMs": {
+              "title": "Health Check Interval (ms)",
+              "description": "The interval in milliseconds to check the health of MCP servers.",
+              "markdownDescription": "The interval in milliseconds to check the health of MCP servers.\n\n- Category: `MCP`\n- Requires restart: `yes`\n- Default: `15000`",
+              "default": 15000,
+              "type": "number"
+            },
+            "unhealthyTimeoutMs": {
+              "title": "Unhealthy Timeout (ms)",
+              "description": "The timeout in milliseconds to consider an MCP server unhealthy.",
+              "markdownDescription": "The timeout in milliseconds to consider an MCP server unhealthy.\n\n- Category: `MCP`\n- Requires restart: `yes`\n- Default: `30000`",
+              "default": 30000,
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

This PR introduces an auto-restart mechanism for unhealthy MCP (Model Context Protocol) servers. It adds a health check to monitor running servers and automatically restarts them if they become unresponsive, improving the resilience and reliability of MCP integrations.

## Details

The implementation includes the following components:

   - Health Tracking: A health-tracking mechanism has been added to the McpClientManager. It records the timestamp of the last
     successful communication with each server. A successful tool discovery is used as the primary health indicator.
   - Periodic Health Checks: A periodic health checker, implemented using setInterval, runs within the McpClientManager. This checker
     iterates through all active MCP servers at a configurable interval.
   - Unhealthy Server Detection: A server is flagged as unhealthy if the time since its last successful health update exceeds a
     configurable timeout.
   - Automatic Restart: When a server is identified as unhealthy, the manager automatically triggers a restart using the existing
     restartServer() method, which is the same logic leveraged by the /mcp refresh command.
   - Configuration: The feature is configurable via new settings under mcp.autoRestart in the settings schema, allowing users to
     enable/disable the feature and adjust the health check interval and unhealthy timeout durations.

  This approach ensures that MCP servers that hang or crash are automatically recovered without manual intervention, leading to a more
  stable experience for users who rely on MCP-based tools.

## Related Issues

Closes: #16499

## How to Validate

To validate this feature, you can simulate an unresponsive MCP server:

   1. Configure an MCP Server: Set up any MCP server (e.g., a simple Node.js script) that can be easily stopped or made to hang.
   2. Start the CLI: Run the Gemini CLI with the configured MCP server.
   3. Verify Initial Connection: Use /mcp list to confirm that the server is connected and its tools are discovered.
   4. Simulate Unresponsiveness: Stop or kill the MCP server process without shutting it down gracefully from within the CLI.
   5. Observe Auto-Restart:
       - Wait for the configured unhealthyTimeoutMs (default is 30 seconds).
       - The CLI should output a message indicating that the server is unresponsive and is being restarted (e.g., MCP server
         'your-server' is unresponsive. Restarting...).
       - If the server's command is configured to restart it, you should see it come back online. You can verify this with another /mcp
         list command.
       - Check the debug logs for more detailed output on the health check and restart process.
   6. Test Disabling the Feature:
       - Set mcp.autoRestart.enabled to false in your settings.
       - Repeat steps 2-4.
       - The server should not be automatically restarted.

## Pre-Merge Checklist

- [X] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
