### PR TITLE
fix(cli): allow non-GitHub SCP-styled URLs for extension installation

### DIFF
--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -136,8 +136,12 @@ describe('github.ts', () => {
       expect(tryParseGithubUrl(url)).toEqual({ owner, repo });
     });
 
-    it('should return null for non-GitHub URLs', () => {
-      expect(tryParseGithubUrl('https://gitlab.com/owner/repo')).toBeNull();
+    it.each([
+      'https://gitlab.com/owner/repo',
+      'https://my-git-host.com/owner/group/repo',
+      'git@gitlab.com:some-group/some-project/some-repo.git',
+    ])('should return null for non-GitHub URLs', (url) => {
+      expect(tryParseGithubUrl(url)).toBeNull();
     });
 
     it('should throw for invalid formats', () => {

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -84,9 +84,15 @@ export interface GithubRepoInfo {
 }
 
 export function tryParseGithubUrl(source: string): GithubRepoInfo | null {
-  // First step in normalizing a github ssh URI to the https form.
-  if (source.startsWith('git@github.com:')) {
-    source = source.replace('git@github.com:', '');
+  // Handle SCP-style SSH URLs.
+  if (source.startsWith('git@')) {
+    if (source.startsWith('git@github.com:')) {
+      // It's a GitHub SSH URL, so normalize it for the URL parser.
+      source = source.replace('git@github.com:', '');
+    } else {
+      // It's another provider's SSH URL (e.g., gitlab), so not a GitHub repo.
+      return null;
+    }
   }
   // Default to a github repo path, so `source` can be just an org/repo
   const parsedUrl = URL.parse(source, 'https://github.com');


### PR DESCRIPTION
## Summary

This fix allows installing extensions from non-GitHub SCP-styled URLs.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

Previously, non-GitHub SCP-styled URLs (e.g., git@gitlab.com:owner/repo.git) would cause an error in `tryParseGithubUrl` because they were being incorrectly processed as GitHub repository paths.

This change refactors the SSH URL parsing logic within `tryParseGithubUrl` to correctly identify and return `null` for non-GitHub SCP-styled URLs. This enables the extension installation process to gracefully fall back to a generic operation for repositories hosted on platforms other than GitHub, improving flexibility for extension sources.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

Fixes: #12291

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

```
gemini extensions install git@gitlab.com:my-base-group/subgroup1/subgroup2/gemini-cli-extensions/my-extension.git --ref v1.0.1
```
## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
