### PR TITLE
fix(auth): improve API key authentication flow

### DIFF
--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -116,6 +116,9 @@ export function AuthDialog({
         return;
       }
       if (authType) {
+        const isInitialAuthSelection =
+          !settings.merged.security?.auth?.selectedType;
+
         await clearCachedCredentialFile();
 
         settings.setValue(scope, 'security.auth.selectedType', authType);
@@ -130,10 +133,16 @@ export function AuthDialog({
           }, 100);
           return;
         }
-      }
-      if (authType === AuthType.USE_GEMINI) {
-        setAuthState(AuthState.AwaitingApiKeyInput);
-        return;
+
+        if (authType === AuthType.USE_GEMINI) {
+          if (isInitialAuthSelection && process.env['GEMINI_API_KEY']) {
+            setAuthState(AuthState.Unauthenticated);
+            return;
+          } else {
+            setAuthState(AuthState.AwaitingApiKeyInput);
+            return;
+          }
+        }
       }
       setAuthState(AuthState.Unauthenticated);
     },

--- a/packages/cli/src/ui/auth/useAuth.test.tsx
+++ b/packages/cli/src/ui/auth/useAuth.test.tsx
@@ -214,6 +214,23 @@ describe('useAuth', () => {
       });
     });
 
+    it('should prioritize env key over stored key when both are present', async () => {
+      mockLoadApiKey.mockResolvedValue('stored-key');
+      process.env['GEMINI_API_KEY'] = 'env-key';
+      const { result } = renderHook(() =>
+        useAuthCommand(createSettings(AuthType.USE_GEMINI), mockConfig),
+      );
+
+      await waitFor(() => {
+        expect(mockConfig.refreshAuth).toHaveBeenCalledWith(
+          AuthType.USE_GEMINI,
+        );
+        expect(result.current.authState).toBe(AuthState.Authenticated);
+        // The environment key should take precedence
+        expect(result.current.apiKeyDefaultValue).toBe('env-key');
+      });
+    });
+
     it('should set error if validation fails', async () => {
       mockValidateAuthMethod.mockReturnValue('Validation Failed');
       const { result } = renderHook(() =>

--- a/packages/cli/src/ui/auth/useAuth.ts
+++ b/packages/cli/src/ui/auth/useAuth.ts
@@ -57,10 +57,16 @@ export const useAuthCommand = (settings: LoadedSettings, config: Config) => {
   const reloadApiKey = useCallback(async () => {
     const storedKey = (await loadApiKey()) ?? '';
     const envKey = process.env['GEMINI_API_KEY'] ?? '';
-    const key = storedKey || envKey;
+    const key = envKey || storedKey;
     setApiKeyDefaultValue(key);
     return key; // Return the key for immediate use
   }, []);
+
+  useEffect(() => {
+    if (authState === AuthState.AwaitingApiKeyInput) {
+      reloadApiKey();
+    }
+  }, [authState, reloadApiKey]);
 
   useEffect(() => {
     (async () => {

--- a/packages/cli/src/ui/components/__snapshots__/EditorSettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/EditorSettingsDialog.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EditorSettingsDialog > renders correctly 1`] = `
 │   2. Vim                                     These editors are currently supported. Please note  │
 │                                              that some editors cannot be used in sandbox mode.   │
 │   Apply To                                                                                       │
-│ ● 1. User Settings                           Your preferred editor is: None.                     │
+│ ● 1. User Settings                           Your preferred editor is: VS Code.                  │
 │   2. Workspace Settings                                                                          │
 │                                                                                                  │
 │ (Use Enter to select, Tab to change                                                              │

--- a/packages/cli/src/ui/components/__snapshots__/EditorSettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/EditorSettingsDialog.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EditorSettingsDialog > renders correctly 1`] = `
 │   2. Vim                                     These editors are currently supported. Please note  │
 │                                              that some editors cannot be used in sandbox mode.   │
 │   Apply To                                                                                       │
-│ ● 1. User Settings                           Your preferred editor is: VS Code.                  │
+│ ● 1. User Settings                           Your preferred editor is: None.                  │
 │   2. Workspace Settings                                                                          │
 │                                                                                                  │
 │ (Use Enter to select, Tab to change                                                              │

--- a/packages/cli/src/ui/components/__snapshots__/EditorSettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/EditorSettingsDialog.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EditorSettingsDialog > renders correctly 1`] = `
 │   2. Vim                                     These editors are currently supported. Please note  │
 │                                              that some editors cannot be used in sandbox mode.   │
 │   Apply To                                                                                       │
-│ ● 1. User Settings                           Your preferred editor is: None.                  │
+│ ● 1. User Settings                           Your preferred editor is: None.                     │
 │   2. Workspace Settings                                                                          │
 │                                                                                                  │
 │ (Use Enter to select, Tab to change                                                              │


### PR DESCRIPTION
## Summary

This PR refines the API key authentication workflow to be more intuitive for both new and existing users. It fixes a bug where the API key input dialog would appear empty and introduces smarter logic to automatically use an existing `GEMINI_API_KEY` on initial setup, while still ensuring users can edit their key later via the `/auth` command.

## Details

The previous authentication flow had conflicting behaviors that could lead to a poor user experience. It could trap a user with an existing API key by never allowing them to edit it, or it could fail to populate the input dialog with the existing key.

This change introduces a more nuanced logic that differentiates between a first-time setup and a subsequent re-configuration:
- **Initial Setup:** If a `GEMINI_API_KEY` environment variable is found, it's used seamlessly for authentication, skipping the input prompt. If no key is found, the user is prompted to enter one.
- **Re-configuration (via `/auth`):** The API key input dialog is now always shown, pre-filled with the current key, to allow users to confirm or edit it.
- **Precedence:** The `GEMINI_API_KEY` environment variable is now always prioritized over any API key stored in the system's secure keychain.

This is achieved by making the `AuthDialog` component aware of the "initial setup" state and adding a `useEffect` in the `useAuth` hook to reliably pre-load the key data before rendering the input dialog.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

### Scenario 1: Initial Setup with Environment Variable (Auto-login)
1. Ensure no Gemini CLI auth settings are stored for your user.
2. In your shell, set the environment variable: `export GEMINI_API_KEY="your-api-key"`
3. Run the Gemini CLI.
4. The CLI should show the auth screen with a message like "Existing API key detected...".
5. Select "Use Gemini API Key" and press Enter.
6. **Expected Result:** You should be authenticated and taken directly to the main prompt. The API key input dialog should **not** appear.

### Scenario 2: Edit Existing Key
1. With the CLI running from the previous scenario, type `/auth` and press Enter.
2. Select "Use Gemini API Key" and press Enter.
3. **Expected Result:** The API key input dialog **should** appear, pre-filled with the value of `GEMINI_API_KEY` from your environment. You should be able to edit it or submit it.

### Scenario 3: Initial Setup with No Key
1. Ensure no Gemini CLI auth settings are stored and that the `GEMINI_API_KEY` environment variable is not set (`unset GEMINI_API_KEY`).
2. Run the Gemini CLI.
3. Select "Use Gemini API Key" and press Enter.
4. **Expected Result:** The API key input dialog **should** appear and be empty, prompting you to enter a key.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
