### PR TITLE
fix: Enable fetch error retries by default

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -659,7 +659,7 @@ export async function loadCliConfig(
       settings.experimental?.codebaseInvestigatorSettings,
     fakeResponses: argv.fakeResponses,
     recordResponses: argv.recordResponses,
-    retryFetchErrors: settings.general?.retryFetchErrors ?? false,
+    retryFetchErrors: settings.general?.retryFetchErrors ?? true,
     ptyInfo: ptyInfo?.name,
     modelConfigServiceConfig: settings.modelConfigs,
     // TODO: loading of hooks based on workspace trust


### PR DESCRIPTION
## Summary

Enable automatic retry for fetch errors by default to prevent CLI crashes on transient network failures.

## Details

Changed `retryFetchErrors` default from `false` to `true`. Fetch failures now retry automatically instead of hanging for 4 minutes and crashing.

## Related Issues

Fixes #13756

## How to Validate

1. Run `gemini` with a command that triggers API calls
2. Simulate network failure (brief disconnect)
3. Verify CLI retries automatically instead of crashing