### PR TITLE
Add usage limit remaining in /stats

### DIFF
--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -115,7 +115,10 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
         <Help commands={commands} />
       )}
       {itemForDisplay.type === 'stats' && (
-        <StatsDisplay duration={itemForDisplay.duration} />
+        <StatsDisplay
+          duration={itemForDisplay.duration}
+          quotas={itemForDisplay.quotas}
+        />
       )}
       {itemForDisplay.type === 'model_stats' && <ModelStatsDisplay />}
       {itemForDisplay.type === 'tool_stats' && <ToolStatsDisplay />}

--- a/packages/cli/src/ui/components/StatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.test.tsx
@@ -445,7 +445,7 @@ describe('<StatsDisplay />', () => {
 
       expect(output).toContain('Usage limit remaining');
       expect(output).toContain('75.0%');
-      expect(output).toContain('(Resets in 1hr 30m)');
+      expect(output).toContain('(Resets in 1h 30m)');
       expect(output).toMatchSnapshot();
 
       vi.useRealTimers();

--- a/packages/cli/src/ui/components/StatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.test.tsx
@@ -9,7 +9,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { StatsDisplay } from './StatsDisplay.js';
 import * as SessionContext from '../contexts/SessionContext.js';
 import type { SessionMetrics } from '../contexts/SessionContext.js';
-import { ToolCallDecision } from '@google/gemini-cli-core';
+import {
+  ToolCallDecision,
+  type RetrieveUserQuotaResponse,
+} from '@google/gemini-cli-core';
 
 // Mock the context to provide controlled data for testing
 vi.mock('../contexts/SessionContext.js', async (importOriginal) => {
@@ -385,6 +388,67 @@ describe('<StatsDisplay />', () => {
       expect(output).toContain('Agent powering down. Goodbye!');
       expect(output).not.toContain('Session Stats');
       expect(output).toMatchSnapshot();
+    });
+  });
+
+  describe('Quota Display', () => {
+    it('renders quota information when quotas are provided', () => {
+      const now = new Date('2025-01-01T12:00:00Z');
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+
+      const metrics = createTestMetrics({
+        models: {
+          'gemini-2.5-pro': {
+            api: { totalRequests: 1, totalErrors: 0, totalLatencyMs: 100 },
+            tokens: {
+              prompt: 100,
+              candidates: 100,
+              total: 250,
+              cached: 50,
+              thoughts: 0,
+              tool: 0,
+            },
+          },
+        },
+      });
+
+      const resetTime = new Date(now.getTime() + 1000 * 60 * 90).toISOString(); // 1 hour 30 minutes from now
+
+      const quotas: RetrieveUserQuotaResponse = {
+        buckets: [
+          {
+            modelId: 'gemini-2.5-pro',
+            remainingFraction: 0.75,
+            resetTime,
+          },
+        ],
+      };
+
+      useSessionStatsMock.mockReturnValue({
+        stats: {
+          sessionId: 'test-session-id',
+          sessionStartTime: new Date(),
+          metrics,
+          lastPromptTokenCount: 0,
+          promptCount: 5,
+        },
+
+        getPromptCount: () => 5,
+        startNewPrompt: vi.fn(),
+      });
+
+      const { lastFrame } = render(
+        <StatsDisplay duration="1s" quotas={quotas} />,
+      );
+      const output = lastFrame();
+
+      expect(output).toContain('Usage limit remaining');
+      expect(output).toContain('75.0%');
+      expect(output).toContain('(Resets in 1hr 30m)');
+      expect(output).toMatchSnapshot();
+
+      vi.useRealTimers();
     });
   });
 });

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -78,14 +78,20 @@ const formatResetTime = (resetTime: string): string => {
   const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;
 
+  const fmt = (val: number, unit: 'hour' | 'minute') =>
+    new Intl.NumberFormat('en', {
+      style: 'unit',
+      unit,
+      unitDisplay: 'narrow',
+    }).format(val);
+
   if (hours > 0 && minutes > 0) {
-    return `(Resets in ${hours}hr ${minutes}m)`;
+    return `(Resets in ${fmt(hours, 'hour')} ${fmt(minutes, 'minute')})`;
   } else if (hours > 0) {
-    return `(Resets in ${hours}hr)`;
-  } else if (minutes > 0) {
-    return `(Resets in ${minutes}m)`;
+    return `(Resets in ${fmt(hours, 'hour')})`;
   }
-  return '';
+
+  return `(Resets in ${fmt(minutes, 'minute')})`;
 };
 
 const ModelUsageTable: React.FC<{

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -19,6 +19,7 @@ import {
   USER_AGREEMENT_RATE_MEDIUM,
 } from '../utils/displayUtils.js';
 import { computeSessionStats } from '../utils/computeStats.js';
+import type { RetrieveUserQuotaResponse } from '@google/gemini-cli-core';
 
 // A more flexible and powerful StatRow component
 interface StatRowProps {
@@ -69,15 +70,35 @@ const Section: React.FC<SectionProps> = ({ title, children }) => (
   </Box>
 );
 
+const formatResetTime = (resetTime: string): string => {
+  const diff = new Date(resetTime).getTime() - Date.now();
+  if (diff <= 0) return '';
+
+  const totalMinutes = Math.ceil(diff / (1000 * 60));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0 && minutes > 0) {
+    return `(Resets in ${hours}hr ${minutes}m)`;
+  } else if (hours > 0) {
+    return `(Resets in ${hours}hr)`;
+  } else if (minutes > 0) {
+    return `(Resets in ${minutes}m)`;
+  }
+  return '';
+};
+
 const ModelUsageTable: React.FC<{
   models: Record<string, ModelMetrics>;
   totalCachedTokens: number;
   cacheEfficiency: number;
-}> = ({ models, totalCachedTokens, cacheEfficiency }) => {
+  quotas?: RetrieveUserQuotaResponse;
+}> = ({ models, totalCachedTokens, cacheEfficiency, quotas }) => {
   const nameWidth = 25;
   const requestsWidth = 8;
   const inputTokensWidth = 15;
   const outputTokensWidth = 15;
+  const usageLimitWidth = quotas ? 30 : 0;
 
   return (
     <Box flexDirection="column" marginTop={1}>
@@ -103,6 +124,13 @@ const ModelUsageTable: React.FC<{
             Output Tokens
           </Text>
         </Box>
+        {quotas && (
+          <Box width={usageLimitWidth} justifyContent="flex-end">
+            <Text bold color={theme.text.primary}>
+              Usage limit remaining
+            </Text>
+          </Box>
+        )}
       </Box>
       {/* Divider */}
       <Box
@@ -112,32 +140,51 @@ const ModelUsageTable: React.FC<{
         borderLeft={false}
         borderRight={false}
         borderColor={theme.border.default}
-        width={nameWidth + requestsWidth + inputTokensWidth + outputTokensWidth}
+        width={
+          nameWidth +
+          requestsWidth +
+          inputTokensWidth +
+          outputTokensWidth +
+          usageLimitWidth
+        }
       ></Box>
 
       {/* Rows */}
-      {Object.entries(models).map(([name, modelMetrics]) => (
-        <Box key={name}>
-          <Box width={nameWidth}>
-            <Text color={theme.text.primary}>{name.replace('-001', '')}</Text>
+      {Object.entries(models).map(([name, modelMetrics]) => {
+        const modelName = name.replace('-001', '');
+        const bucket = quotas?.buckets?.find((b) => b.modelId === modelName);
+
+        return (
+          <Box key={name}>
+            <Box width={nameWidth}>
+              <Text color={theme.text.primary}>{modelName}</Text>
+            </Box>
+            <Box width={requestsWidth} justifyContent="flex-end">
+              <Text color={theme.text.primary}>
+                {modelMetrics.api.totalRequests}
+              </Text>
+            </Box>
+            <Box width={inputTokensWidth} justifyContent="flex-end">
+              <Text color={theme.status.warning}>
+                {modelMetrics.tokens.prompt.toLocaleString()}
+              </Text>
+            </Box>
+            <Box width={outputTokensWidth} justifyContent="flex-end">
+              <Text color={theme.status.warning}>
+                {modelMetrics.tokens.candidates.toLocaleString()}
+              </Text>
+            </Box>
+            <Box width={usageLimitWidth} justifyContent="flex-end">
+              {bucket && (
+                <Text color={theme.text.secondary}>
+                  {(bucket.remainingFraction! * 100).toFixed(1)}%{' '}
+                  {formatResetTime(bucket.resetTime!)}
+                </Text>
+              )}
+            </Box>
           </Box>
-          <Box width={requestsWidth} justifyContent="flex-end">
-            <Text color={theme.text.primary}>
-              {modelMetrics.api.totalRequests}
-            </Text>
-          </Box>
-          <Box width={inputTokensWidth} justifyContent="flex-end">
-            <Text color={theme.status.warning}>
-              {modelMetrics.tokens.prompt.toLocaleString()}
-            </Text>
-          </Box>
-          <Box width={outputTokensWidth} justifyContent="flex-end">
-            <Text color={theme.status.warning}>
-              {modelMetrics.tokens.candidates.toLocaleString()}
-            </Text>
-          </Box>
-        </Box>
-      ))}
+        );
+      })}
       {cacheEfficiency > 0 && (
         <Box flexDirection="column" marginTop={1}>
           <Text color={theme.text.primary}>
@@ -145,11 +192,19 @@ const ModelUsageTable: React.FC<{
             {totalCachedTokens.toLocaleString()} ({cacheEfficiency.toFixed(1)}
             %) of input tokens were served from the cache, reducing costs.
           </Text>
-          <Box height={1} />
+        </Box>
+      )}
+      {models && (
+        <>
+          <Box marginTop={1} marginBottom={2}>
+            <Text color={theme.text.primary}>
+              {`Usage limits span all sessions and reset daily.\n/auth to upgrade or switch to API key.`}
+            </Text>
+          </Box>
           <Text color={theme.text.secondary}>
             » Tip: For a full token breakdown, run `/stats model`.
           </Text>
-        </Box>
+        </>
       )}
     </Box>
   );
@@ -158,11 +213,13 @@ const ModelUsageTable: React.FC<{
 interface StatsDisplayProps {
   duration: string;
   title?: string;
+  quotas?: RetrieveUserQuotaResponse;
 }
 
 export const StatsDisplay: React.FC<StatsDisplayProps> = ({
   duration,
   title,
+  quotas,
 }) => {
   const { stats } = useSessionStats();
   const { metrics } = stats;
@@ -276,6 +333,7 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({
           models={models}
           totalCachedTokens={computed.totalCachedTokens}
           cacheEfficiency={computed.cacheEfficiency}
+          quotas={quotas}
         />
       )}
     </Box>

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -175,12 +175,14 @@ const ModelUsageTable: React.FC<{
               </Text>
             </Box>
             <Box width={usageLimitWidth} justifyContent="flex-end">
-              {bucket && (
-                <Text color={theme.text.secondary}>
-                  {(bucket.remainingFraction! * 100).toFixed(1)}%{' '}
-                  {formatResetTime(bucket.resetTime!)}
-                </Text>
-              )}
+              {bucket &&
+                bucket.remainingFraction != null &&
+                bucket.resetTime && (
+                  <Text color={theme.text.secondary}>
+                    {(bucket.remainingFraction * 100).toFixed(1)}%{' '}
+                    {formatResetTime(bucket.resetTime)}
+                  </Text>
+                )}
             </Box>
           </Box>
         );

--- a/packages/cli/src/ui/components/__snapshots__/SessionSummaryDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SessionSummaryDisplay.test.tsx.snap
@@ -24,6 +24,10 @@ exports[`<SessionSummaryDisplay /> > renders the summary display with a title 1`
 │                                                                                                  │
 │  Savings Highlight: 500 (50.0%) of input tokens were served from the cache, reducing costs.      │
 │                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│                                                                                                  │
 │  » Tip: For a full token breakdown, run \`/stats model\`.                                          │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"

--- a/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information when quota
 │                                                                                                  │
 │  Model Usage                  Reqs   Input Tokens  Output Tokens         Usage limit remaining   │
 │  ─────────────────────────────────────────────────────────────────────────────────────────────   │
-│  gemini-2.5-pro                  1            100            100     75.0% (Resets in 1hr 30m)   │
+│  gemini-2.5-pro                  1            100            100      75.0% (Resets in 1h 30m)   │
 │                                                                                                  │
 │  Savings Highlight: 50 (50.0%) of input tokens were served from the cache, reducing costs.       │
 │                                                                                                  │

--- a/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
@@ -145,6 +145,38 @@ exports[`<StatsDisplay /> > Conditional Rendering Tests > hides User Agreement w
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;
 
+exports[`<StatsDisplay /> > Quota Display > renders quota information when quotas are provided 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                  │
+│  Session Stats                                                                                   │
+│                                                                                                  │
+│  Interaction Summary                                                                             │
+│  Session ID:                 test-session-id                                                     │
+│  Tool Calls:                 0 ( ✓ 0 x 0 )                                                       │
+│  Success Rate:               0.0%                                                                │
+│                                                                                                  │
+│  Performance                                                                                     │
+│  Wall Time:                  1s                                                                  │
+│  Agent Active:               100ms                                                               │
+│    » API Time:               100ms (100.0%)                                                      │
+│    » Tool Time:              0s (0.0%)                                                           │
+│                                                                                                  │
+│                                                                                                  │
+│  Model Usage                  Reqs   Input Tokens  Output Tokens         Usage limit remaining   │
+│  ─────────────────────────────────────────────────────────────────────────────────────────────   │
+│  gemini-2.5-pro                  1            100            100     75.0% (Resets in 1hr 30m)   │
+│                                                                                                  │
+│  Savings Highlight: 50 (50.0%) of input tokens were served from the cache, reducing costs.       │
+│                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│                                                                                                  │
+│  » Tip: For a full token breakdown, run \`/stats model\`.                                          │
+│                                                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
 exports[`<StatsDisplay /> > Title Rendering > renders the custom title when a title prop is provided 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
 │                                                                                                  │
@@ -209,6 +241,10 @@ exports[`<StatsDisplay /> > renders a table with two models correctly 1`] = `
 │                                                                                                  │
 │  Savings Highlight: 10,500 (40.4%) of input tokens were served from the cache, reducing costs.   │
 │                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│                                                                                                  │
 │  » Tip: For a full token breakdown, run \`/stats model\`.                                          │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
@@ -237,6 +273,10 @@ exports[`<StatsDisplay /> > renders all sections when all data is present 1`] = 
 │  gemini-2.5-pro                  1            100            100                                 │
 │                                                                                                  │
 │  Savings Highlight: 50 (50.0%) of input tokens were served from the cache, reducing costs.       │
+│                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
 │                                                                                                  │
 │  » Tip: For a full token breakdown, run \`/stats model\`.                                          │
 │                                                                                                  │

--- a/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
@@ -122,6 +122,12 @@ exports[`<StatsDisplay /> > Conditional Rendering Tests > hides Efficiency secti
 │  ───────────────────────────────────────────────────────────────                                 │
 │  gemini-2.5-pro                  1            100            100                                 │
 │                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│                                                                                                  │
+│  » Tip: For a full token breakdown, run \`/stats model\`.                                          │
+│                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;
 

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -12,6 +12,7 @@ import type {
   ToolCallConfirmationDetails,
   ToolConfirmationOutcome,
   ToolResultDisplay,
+  RetrieveUserQuotaResponse,
 } from '@google/gemini-cli-core';
 import type { PartListUnion } from '@google/genai';
 import { type ReactNode } from 'react';
@@ -142,6 +143,7 @@ export type HistoryItemHelp = HistoryItemBase & {
 export type HistoryItemStats = HistoryItemBase & {
   type: 'stats';
   duration: string;
+  quotas?: RetrieveUserQuotaResponse;
 };
 
 export type HistoryItemModelStats = HistoryItemBase & {

--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -380,4 +380,38 @@ describe('CodeAssistServer', () => {
     });
     expect(response).toEqual(mockResponse);
   });
+
+  it('should call the retrieveUserQuota endpoint', async () => {
+    const client = new OAuth2Client();
+    const server = new CodeAssistServer(
+      client,
+      'test-project',
+      {},
+      'test-session',
+      UserTierId.FREE,
+    );
+    const mockResponse = {
+      buckets: [
+        {
+          modelId: 'gemini-2.5-pro',
+          tokenType: 'REQUESTS',
+          remainingFraction: 0.75,
+          resetTime: '2025-10-22T16:01:15Z',
+        },
+      ],
+    };
+    const requestPostSpy = vi
+      .spyOn(server, 'requestPost')
+      .mockResolvedValue(mockResponse);
+
+    const req = {
+      project: 'projects/my-cloudcode-project',
+      userAgent: 'CloudCodePlugin/1.0 (gaghosh)',
+    };
+
+    const response = await server.retrieveUserQuota(req);
+
+    expect(requestPostSpy).toHaveBeenCalledWith('retrieveUserQuota', req);
+    expect(response).toEqual(mockResponse);
+  });
 });

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -14,6 +14,8 @@ import type {
   OnboardUserRequest,
   SetCodeAssistGlobalUserSettingRequest,
   ClientMetadata,
+  RetrieveUserQuotaRequest,
+  RetrieveUserQuotaResponse,
 } from './types.js';
 import type {
   ListExperimentsRequest,
@@ -167,6 +169,15 @@ export class CodeAssistServer implements ContentGenerator {
     };
     return await this.requestPost<ListExperimentsResponse>(
       'listExperiments',
+      req,
+    );
+  }
+
+  async retrieveUserQuota(
+    req: RetrieveUserQuotaRequest,
+  ): Promise<RetrieveUserQuotaResponse> {
+    return await this.requestPost<RetrieveUserQuotaResponse>(
+      'retrieveUserQuota',
       req,
     );
   }

--- a/packages/core/src/code_assist/types.ts
+++ b/packages/core/src/code_assist/types.ts
@@ -200,3 +200,20 @@ export interface GoogleRpcResponse {
 interface GoogleRpcErrorInfo {
   reason?: string;
 }
+
+export interface RetrieveUserQuotaRequest {
+  project: string;
+  userAgent?: string;
+}
+
+export interface BucketInfo {
+  remainingAmount?: string;
+  remainingFraction?: number;
+  resetTime?: string;
+  tokenType?: string;
+  modelId?: string;
+}
+
+export interface RetrieveUserQuotaResponse {
+  buckets?: BucketInfo[];
+}


### PR DESCRIPTION
## Summary
To show usage limit remaing in /stats page.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
Shows percentage of quota remaining for each model, as well as time remaining to reset the quota.

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

<img width="710" height="445" alt="image" src="https://github.com/user-attachments/assets/921fe306-7232-4cec-9cd8-1e5c913e7d8b" />

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Related to #13842 13842

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
