### PR TITLE
feat(edit): Remove flexible indentation handling in smart edit

### DIFF
--- a/packages/core/src/tools/smart-edit.test.ts
+++ b/packages/core/src/tools/smart-edit.test.ts
@@ -189,8 +189,16 @@ describe('SmartEditTool', () => {
         name: 'perform a flexible, whitespace-insensitive replacement',
         content: '  hello\n    world\n',
         old_string: 'hello\nworld',
-        new_string: 'goodbye\nmoon',
+        new_string: '  goodbye\n  moon',
         expected: '  goodbye\n  moon\n',
+        occurrences: 1,
+      },
+      {
+        name: 'perform a flexible, whitespace-insensitive replacement respecting new_string indentation',
+        content: '  hello\n    world\n',
+        old_string: '  hello\n  world',
+        new_string: '  goodbye\n    moon',
+        expected: '  goodbye\n    moon\n',
         occurrences: 1,
       },
       {

--- a/packages/core/src/tools/smart-edit.ts
+++ b/packages/core/src/tools/smart-edit.ts
@@ -144,16 +144,10 @@ async function calculateFlexibleReplacement(
 
     if (isMatch) {
       flexibleOccurrences++;
-      const firstLineInMatch = window[0];
-      const indentationMatch = firstLineInMatch.match(/^(\s*)/);
-      const indentation = indentationMatch ? indentationMatch[1] : '';
-      const newBlockWithIndent = replaceLines.map(
-        (line: string) => `${indentation}${line}`,
-      );
       sourceLines.splice(
         i,
         searchLinesStripped.length,
-        newBlockWithIndent.join('\n'),
+        replaceLines.join('\n'),
       );
       i += replaceLines.length;
     } else {


### PR DESCRIPTION
## Summary

This PR removes the flexible indentation handling in smart edit to prevent double indentation issues where both the new_string's own indentation and the old_string's indentation are applied together, resulting in doubled indentation. Using single indentation is sufficient for proper formatting.

## Details

The previous implementation of flexible indentation handling in the smart edit feature was causing issues with doubled indentation. When performing replacements, both the indentation from the original code (old_string) and the indentation already present in the new_string were being applied, resulting in twice the intended indentation.

This change simplifies the replacement logic by removing the complex indentation handling code and relying on the caller to provide properly formatted new_string values with appropriate indentation. This approach is more predictable and avoids the double indentation problem.

The modification affects the calculateFlexibleReplacement function in smart-edit.ts, which previously attempted to preserve indentation by extracting it from matching lines and applying it to replacement lines. This logic has been simplified to directly use the replacement lines as provided.

## Related Issues

## How to Validate

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker
