### PR TITLE
docs: Fix grammar error in Release Cadence (Nightly section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm install -g @google/gemini-cli@latest
 
 ### Nightly
 
-- New releases will be published each week at UTC 0000 each day, This will be
+- New releases will be published each week at UTC 0000 each day. This will be
   all changes from the main branch as represented at time of release. It should
   be assumed there are pending validations and issues. Use `nightly` tag.
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ npm install -g @google/gemini-cli@latest
 
 ### Nightly
 
-- New releases will be published each day at UTC 0000. This will be
-  all changes from the main branch as represented at time of release. It should
-  be assumed there are pending validations and issues. Use `nightly` tag.
+- New releases will be published each day at UTC 0000. This will be all changes
+  from the main branch as represented at time of release. It should be assumed
+  there are pending validations and issues. Use `nightly` tag.
 
 ```bash
 npm install -g @google/gemini-cli@nightly

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm install -g @google/gemini-cli@latest
 
 ### Nightly
 
-- New releases will be published each week at UTC 0000 each day. This will be
+- New releases will be published each day at UTC 0000. This will be
   all changes from the main branch as represented at time of release. It should
   be assumed there are pending validations and issues. Use `nightly` tag.
 


### PR DESCRIPTION
Fixes #13854

## Description
Fixed comma splice error in the Nightly release cadence section of README.md.

## Changes
- Changed comma to period before "This" to fix grammatical error

## Testing
- Documentation change only, no code changes
- Verified markdown renders correctly