### PR TITLE
fix(ui): Add mouse interaction toggle to restore native text selection

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -521,6 +521,16 @@ const SETTINGS_SCHEMA = {
           'Use an alternate screen buffer for the UI, preserving shell history.',
         showInDialog: true,
       },
+      enableMouseInteraction: {
+        type: 'boolean',
+        label: 'Enable Mouse Interaction',
+        category: 'UI',
+        requiresRestart: true,
+        default: false,
+        description:
+          'Enable mouse support for scrolling and clicking in the CLI. Disabling allows native terminal text selection and copy/paste. Requires alternate buffer mode.',
+        showInDialog: true,
+      },
       incrementalRendering: {
         type: 'boolean',
         label: 'Incremental Rendering',

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -182,7 +182,10 @@ export async function startInteractiveUI(
     isAlternateBufferEnabled(settings),
     config.getScreenReader(),
   );
-  const mouseEventsEnabled = useAlternateBuffer;
+  // Mouse interaction is only enabled if explicitly requested AND alternate buffer is active
+  // Setting defaults to false to preserve native terminal text selection/copy/paste
+  const mouseEventsEnabled =
+    useAlternateBuffer && settings.merged.ui?.enableMouseInteraction === true;
   if (mouseEventsEnabled) {
     enableMouseEvents();
     registerCleanup(() => {


### PR DESCRIPTION
Fixes #13057 #13074

## 🐛 The Problem

**v0.15.0 broke native terminal text selection and copy/paste** for 17+ users by unconditionally enabling mouse event capture when alternate buffer mode is active.

**User Impact**:
- Cannot select text with mouse (click+drag does nothing)
- Copy/paste broken (right-click menus don't work)
- Only workaround: Shift+drag (non-standard) or rollback to v0.14.0

---

## 🔍 Root Cause

In `gemini.tsx` (line 185), mouse events are unconditionally enabled when alternate buffer is true:

```typescript
const mouseEventsEnabled = useAlternateBuffer;  // <-- Problem!
if (mouseEventsEnabled) {
  enableMouseEvents();  // Captures ALL mouse events
}
```

When mouse events are enabled, the terminal forwards mouse interactions to the app instead of handling them natively. This **breaks standard terminal clipboard workflows**.

---

## ✅ The Solution

Add a new setting `ui.enableMouseInteraction` that **decouples mouse support from alternate buffer mode**:

### New Setting
- **Name**: `enableMouseInteraction`
- **Default**: `false` (preserves native terminal behavior)
- **Location**: `/settings` → UI section
- **Requires Restart**: Yes

### Updated Logic
```typescript
const mouseEventsEnabled =
  useAlternateBuffer && (settings.merged.ui?.enableMouseInteraction === true);
```

Now users can:
1. ✅ **Use alternate buffer WITHOUT mouse capture** (default): Native text selection works
2. ✅ **Opt-in to mouse interaction**: Explicitly enable for mouse scrolling/clicking

---

## 📊 Benefits

- ✅ Restores native text selection and copy/paste by default
- ✅ Backwards compatible (no breaking changes)
- ✅ Gives users explicit control
- ✅ Fixes both #13057 (12👍) and #13074 (5👍) with one change
- ✅ Zero impact on users without alternate buffer

---

## 🔬 Testing

- ✅ `npm run build` passes
- ✅ All existing tests pass
- ✅ When `enableMouseInteraction = false` (default), native selection works
- ✅ When `useAlternateBuffer = false`, no behavior change

---

**Ready to mergeecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }* 🎉