### PR TITLE
Revert to default LICENSE (Revert #13449) 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Google LLC
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Reverts #13449 which added license info. Apparently, we just want the raw template.

## Related Issues

See this comment: https://github.com/google-gemini/gemini-cli/issues/13443#issuecomment-3583569520