### PR TITLE
feat(shell): Standardize pager to 'cat' for shell execution by model

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -221,6 +221,7 @@ export class ShellExecutionService {
           GEMINI_CLI: '1',
           TERM: 'xterm-256color',
           PAGER: 'cat',
+          GIT_PAGER: 'cat',
         },
       });
 
@@ -434,6 +435,7 @@ export class ShellExecutionService {
           GEMINI_CLI: '1',
           TERM: 'xterm-256color',
           PAGER: shellExecutionConfig.pager ?? 'cat',
+          GIT_PAGER: shellExecutionConfig.pager ?? 'cat',
         },
         handleFlowControl: true,
       });

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -222,7 +222,7 @@ describe('ShellTool', () => {
         expect.any(Function),
         expect.any(AbortSignal),
         false,
-        {},
+        { pager: 'cat' },
       );
       expect(result.llmContent).toContain('Background PIDs: 54322');
       // The file should be deleted by the tool
@@ -247,7 +247,7 @@ describe('ShellTool', () => {
         expect.any(Function),
         expect.any(AbortSignal),
         false,
-        {},
+        { pager: 'cat' },
       );
     });
 
@@ -268,7 +268,7 @@ describe('ShellTool', () => {
         expect.any(Function),
         expect.any(AbortSignal),
         false,
-        {},
+        { pager: 'cat' },
       );
     });
 
@@ -295,7 +295,7 @@ describe('ShellTool', () => {
           expect.any(Function),
           expect.any(AbortSignal),
           false,
-          {},
+          { pager: 'cat' },
         );
       },
       20000,

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -241,7 +241,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
           },
           combinedController.signal,
           this.config.getEnableInteractiveShell(),
-          shellExecutionConfig ?? {},
+          { ...shellExecutionConfig, pager: 'cat' },
         );
 
       if (pid && setPidCallback) {


### PR DESCRIPTION
## Summary

Explicitly sets the 'GIT_PAGER' environment variable and the 'pager' config for all shell executions from model to 'cat', ensuring consistent output capturing by the CLI.

## Details

This change addresses an issue where external pagers (e.g., `less`) could interfere with the CLI's ability to capture and process the full output of shell commands when executed by the model. By explicitly setting `GIT_PAGER` and the `pager` configuration for all shell executions to `cat`, we ensure that command output is always streamed directly, preventing interactive pagination from blocking or altering the output stream. This is crucial for the CLI to correctly capture, summarize, and display shell command results.

## Related Issues

#13590 

## How to Validate

1.  Run `git log` or any command that typically invokes a pager within the CLI.
2.  Observe that the full output is immediately available and not presented in an interactive pager.
3.  Ensure that the existing unit tests for `packages/core/src/tools/shell.test.ts` and `packages/core/src/services/shellExecutionService.test.ts` continue to pass, as they have been updated to reflect these changes.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker