### PR TITLE
feat: expose existing hook registry capabilities to extensions

### DIFF
--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -514,6 +514,7 @@ export class ExtensionManager extends ExtensionLoader {
           this.workspaceDir,
         ),
         id: getExtensionId(config, installMetadata),
+        hooks: config.hooks,
       };
       this.loadedExtensions = [...this.loadedExtensions, extension];
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -7,6 +7,8 @@
 import type {
   MCPServerConfig,
   ExtensionInstallMetadata,
+  HookDefinition,
+  HookEventName,
 } from '@google/gemini-cli-core';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -27,6 +29,7 @@ export interface ExtensionConfig {
   contextFileName?: string | string[];
   excludeTools?: string[];
   settings?: ExtensionSetting[];
+  hooks?: { [K in HookEventName]?: HookDefinition[] };
 }
 
 export interface ExtensionUpdateInfo {

--- a/packages/cli/src/config/extensions/consent.ts
+++ b/packages/cli/src/config/extensions/consent.ts
@@ -130,6 +130,32 @@ function extensionConsentString(extensionConfig: ExtensionConfig): string {
       `This extension will exclude the following core tools: ${sanitizedConfig.excludeTools}`,
     );
   }
+
+  if (sanitizedConfig.hooks) {
+    const hookEvents = Object.keys(sanitizedConfig.hooks);
+    if (hookEvents.length > 0) {
+      output.push(
+        '\nWARNING: This extension configures EVENT HOOKS. These hooks can execute arbitrary commands on your machine and intercept agent communications.',
+      );
+      for (const eventName of hookEvents) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const definitions = sanitizedConfig.hooks[eventName as any];
+        if (definitions && definitions.length > 0) {
+          output.push(`  * Event: ${eventName}`);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          definitions.forEach((def: any) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            def.hooks.forEach((hook: any) => {
+              if (hook.type === 'command') {
+                output.push(`    - Command: ${hook.command}`);
+              }
+            });
+          });
+        }
+      }
+    }
+  }
+
   return output.join('\n');
 }
 


### PR DESCRIPTION
This PR enables extensions to utilize the existing Hook System by exposing the hooks configuration field in ExtensionConfig and passing it through the ExtensionManager.

  Context
  The HookRegistry (in core/src/hooks/hookRegistry.ts) already contains logic to load hooks from extensions:

   1 // Existing logic in HookRegistry.ts
   2 const extensions = this.config.getExtensions() || [];
   3 for (const extension of extensions) {
   4   if (extension.isActive && extension.hooks) {
   5      // logic to register hooks
   6   }
   7 }

  However, extensions were unable to actually use this feature because:
   1. The ExtensionConfig interface (in cli/src/config/extension.ts) was missing the hooks definition.
   2. The ExtensionManager (in cli/src/config/extension-manager.ts) was not passing the hooks field from the loaded JSON to the runtime extension object.

  Changes
   * `packages/cli/src/config/extension.ts`: Added optional hooks field to ExtensionConfig interface, importing HookDefinition and HookEventName from core.
   * `packages/cli/src/config/extension-manager.ts`: Updated loadExtension to assign hooks: config.hooks when initializing the extension object.

  Impact
  This change transforms extensions from static tool providers into capable agent interceptors. It unblocks critical enterprise use cases such as:
   * Custom Memory Systems: Capturing AfterAgent events to store history and BeforeModel events to inject context (e.g., RAG, Episodic Memory).
   * Safety & Compliance: Implementing PII scrubbing or policy checks via BeforeModel or BeforeTool hooks.
   * Audit Logging: Recording comprehensive session activity to external systems.

  Verification
  Verified locally by building the CLI and loading a test extension with BeforeModel and AfterAgent hooks. Confirmed that the HookRegistry correctly identified and registered the hooks from the extension's
  gemini-extension.json