### PR TITLE
fix(mcp): add connection timeout to prevent MCP server connection hangs

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -190,6 +190,8 @@ export class MCPServerConfig {
     readonly tcp?: string,
     // Common
     readonly timeout?: number,
+    // Timeout for initial connection handshake (default: 30 seconds)
+    readonly connectionTimeout?: number,
     readonly trust?: boolean,
     // Metadata
     readonly description?: string,


### PR DESCRIPTION
## Summary

Add a 30-second connection timeout to MCP server connections to prevent indefinite hangs when connecting to unresponsive or incompatible servers. Previously, connections would wait up to 10 minutes (the RPC timeout) before failing, leaving users stuck on "Initializing" state with no feedback.

## Details
Fixes #13986 

### Problem

When connecting to MCP servers, the CLI gets stuck on "Initializing..." indefinitely when:
- An MCP server is unresponsive or down
- Using SSE transport (`url` config) to connect to a Streamable HTTP server
- The server returns an incompatible response (e.g., JSON-RPC error instead of SSE stream)

**Root Cause:** The MCP SDK's `Client.connect()` method applies the timeout parameter only to RPC calls *after* the connection is established, not to the initial transport handshake. The `SSEClientTransport._startOrAuth()` Promise has no built-in timeout and may never resolve if:
1. The server doesn't send an SSE `endpoint` event
2. The `eventsource` package's error handling doesn't properly reject the Promise

**Impact:** Users see "Initializing... (first startup may take longer)" forever, with no way to know the connection has failed. The only way out is to kill the CLI process.

### Solution

Wrap `mcpClient.connect()` with `Promise.race()` to enforce a connection-specific timeout:

- Add `MCP_CONNECTION_TIMEOUT_MSEC` constant (30 seconds default)
- Add `connectionTimeout` property to `MCPServerConfig` for per-server configuration
- Properly clean up transport on timeout
- Provide clear error message on failure

### Changes

- `packages/core/src/tools/mcp-client.ts` - Add connection timeout wrapper
- `packages/core/src/config/config.ts` - Add `connectionTimeout` to `MCPServerConfig`
- `packages/core/src/tools/mcp-client.test.ts` - Add timeout behavior tests

##  Demo
https://github.com/user-attachments/assets/377a0cc7-6f30-4034-97ad-7f1a1404c499

## Related Issues

Fixes hanging "Initializing" state when MCP servers are misconfigured or unresponsive.

## How to Validate

**Before (reproduce the issue):**
1. Configure an MCP server with `url` pointing to an incompatible Streamable HTTP endpoint
2. Run gemini CLI
3. Observe CLI hangs on "Initializing..." indefinitely

**After (verify the fix):**
1. Apply the changes
2. Configure same incompatible MCP server
3. Run gemini CLI
4. Observe connection fails after 30 seconds with clear error message
5. CLI remains usable

**Test custom timeout:**

```
{
  "mcpServers": {
    "my-server": {
      "url": "http://example.com/mcp",
      "connectionTimeout": 5000
    }
  }
}
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) - None
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker