### PR TITLE
feat: Add image model routing and flash-lite support

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "pre-commit": "node scripts/pre-commit.js"
   },
   "overrides": {
-    "ink": "npm:@jrichman/ink@6.4.6",
     "wrap-ansi": "9.0.2",
     "cliui": {
       "wrap-ansi": "7.0.0"

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -83,6 +83,18 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
         model: 'gemini-2.5-flash-lite',
       },
     },
+    'gemini-2.5-image': {
+      extends: 'chat-base-2.5',
+      modelConfig: {
+        model: 'gemini-2.5-pro-image-preview',
+      },
+    },
+    'gemini-2.5-flash-lite-image': {
+      extends: 'chat-base-2.5',
+      modelConfig: {
+        model: 'gemini-2.5-flash-lite-image-preview',
+      },
+    },
     // Bases for the internal model configs.
     'gemini-2.5-flash-base': {
       extends: 'base',

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -15,6 +15,7 @@ export const DEFAULT_GEMINI_MODEL_AUTO = 'auto';
 export const GEMINI_MODEL_ALIAS_PRO = 'pro';
 export const GEMINI_MODEL_ALIAS_FLASH = 'flash';
 export const GEMINI_MODEL_ALIAS_FLASH_LITE = 'flash-lite';
+export const GEMINI_MODEL_ALIAS_IMAGE = 'image';
 
 export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';
 
@@ -45,6 +46,11 @@ export function resolveModel(
     }
     case GEMINI_MODEL_ALIAS_FLASH_LITE: {
       return DEFAULT_GEMINI_FLASH_LITE_MODEL;
+    }
+    case GEMINI_MODEL_ALIAS_IMAGE: {
+      return previewFeaturesEnabled
+        ? 'gemini-2.5-pro-image-preview'
+        : DEFAULT_GEMINI_MODEL;
     }
     default: {
       return requestedModel;

--- a/packages/core/src/routing/modelRouterService.ts
+++ b/packages/core/src/routing/modelRouterService.ts
@@ -19,6 +19,7 @@ import { ClassifierStrategy } from './strategies/classifierStrategy.js';
 import { CompositeStrategy } from './strategies/compositeStrategy.js';
 import { FallbackStrategy } from './strategies/fallbackStrategy.js';
 import { OverrideStrategy } from './strategies/overrideStrategy.js';
+import { ImageStrategy } from './strategies/ImageStrategy.js';
 
 import { logModelRouting } from '../telemetry/loggers.js';
 import { ModelRoutingEvent } from '../telemetry/types.js';
@@ -42,6 +43,7 @@ export class ModelRouterService {
       [
         new FallbackStrategy(),
         new OverrideStrategy(),
+        new ImageStrategy(),
         new ClassifierStrategy(),
         new DefaultStrategy(),
       ],

--- a/packages/core/src/routing/strategies/ImageStrategy.test.ts
+++ b/packages/core/src/routing/strategies/ImageStrategy.test.ts
@@ -1,0 +1,107 @@
+
+import { describe, it, expect } from 'vitest';
+import { ImageStrategy } from './ImageStrategy';
+import { GEMINI_MODEL_ALIAS_PRO, DEFAULT_GEMINI_MODEL } from '../../config/models';
+import { RoutingContext } from '../routingStrategy';
+import { Config } from '../../config/config';
+
+describe('ImageStrategy', () => {
+  it('should return an image model decision if the request contains an image and preview features are enabled', async () => {
+    const strategy = new ImageStrategy();
+    const context = {
+      request: {
+        parts: [
+          { text: 'Describe this image' },
+          { inlineData: { mimeType: 'image/png', data: 'base64...' } },
+        ],
+      },
+    } as RoutingContext;
+
+    const decision = await strategy.route(context, { getPreviewFeatures: () => true } as Config);
+
+    expect(decision).toEqual({
+      model: 'gemini-2.5-pro-image-preview',
+      metadata: {
+        source: 'ImageStrategy',
+        latencyMs: 0,
+        reasoning: 'Request contains an image.',
+      },
+    });
+  });
+
+  it('should return a pro model decision if the request contains an image and preview features are disabled', async () => {
+    const strategy = new ImageStrategy();
+    const context = {
+      request: {
+        parts: [
+          { text: 'Describe this image' },
+          { inlineData: { mimeType: 'image/png', data: 'base64...' } },
+        ],
+      },
+    } as RoutingContext;
+
+    const decision = await strategy.route(context, { getPreviewFeatures: () => false } as Config);
+
+    expect(decision).toEqual({
+        model: DEFAULT_GEMINI_MODEL,
+        metadata: {
+            source: 'ImageStrategy',
+            latencyMs: 0,
+            reasoning: 'Request contains an image.',
+        },
+    });
+  });
+
+  it('should return an image model decision if the request asks to generate an image and preview features are enabled', async () => {
+    const strategy = new ImageStrategy();
+    const context = {
+      request: {
+        parts: [{ text: 'generate an image of a cat' }],
+      },
+    } as RoutingContext;
+
+    const decision = await strategy.route(context, { getPreviewFeatures: () => true } as Config);
+
+    expect(decision).toEqual({
+      model: 'gemini-2.5-pro-image-preview',
+      metadata: {
+        source: 'ImageStrategy',
+        latencyMs: 0,
+        reasoning: 'Request for image generation.',
+      },
+    });
+  });
+
+  it('should return a pro model decision if the request asks to generate an image and preview features are disabled', async () => {
+    const strategy = new ImageStrategy();
+    const context = {
+      request: {
+        parts: [{ text: 'create an image of a dog' }],
+      },
+    } as RoutingContext;
+
+    const decision = await strategy.route(context, { getPreviewFeatures: () => false } as Config);
+
+    expect(decision).toEqual({
+        model: DEFAULT_GEMINI_MODEL,
+        metadata: {
+            source: 'ImageStrategy',
+            latencyMs: 0,
+            reasoning: 'Request for image generation.',
+        },
+    });
+  });
+
+  it('should return null if the request does not contain an image', async () => {
+    const strategy = new ImageStrategy();
+    const context = {
+      request: {
+        parts: [{ text: 'Hello, world!' }],
+      },
+    } as RoutingContext;
+
+    const decision = await strategy.route(context, {} as Config);
+
+    expect(decision).toBeNull();
+  });
+});

--- a/packages/core/src/routing/strategies/ImageStrategy.test.ts
+++ b/packages/core/src/routing/strategies/ImageStrategy.test.ts
@@ -1,7 +1,6 @@
-
 import { describe, it, expect } from 'vitest';
 import { ImageStrategy } from './ImageStrategy';
-import { GEMINI_MODEL_ALIAS_PRO, DEFAULT_GEMINI_MODEL } from '../../config/models';
+import { DEFAULT_GEMINI_MODEL } from '../../config/models';
 import { RoutingContext } from '../routingStrategy';
 import { Config } from '../../config/config';
 
@@ -17,7 +16,9 @@ describe('ImageStrategy', () => {
       },
     } as RoutingContext;
 
-    const decision = await strategy.route(context, { getPreviewFeatures: () => true } as Config);
+    const decision = await strategy.route(context, {
+      getPreviewFeatures: () => true,
+    } as Config);
 
     expect(decision).toEqual({
       model: 'gemini-2.5-pro-image-preview',
@@ -40,15 +41,17 @@ describe('ImageStrategy', () => {
       },
     } as RoutingContext;
 
-    const decision = await strategy.route(context, { getPreviewFeatures: () => false } as Config);
+    const decision = await strategy.route(context, {
+      getPreviewFeatures: () => false,
+    } as Config);
 
     expect(decision).toEqual({
-        model: DEFAULT_GEMINI_MODEL,
-        metadata: {
-            source: 'ImageStrategy',
-            latencyMs: 0,
-            reasoning: 'Request contains an image.',
-        },
+      model: DEFAULT_GEMINI_MODEL,
+      metadata: {
+        source: 'ImageStrategy',
+        latencyMs: 0,
+        reasoning: 'Request contains an image.',
+      },
     });
   });
 
@@ -60,7 +63,9 @@ describe('ImageStrategy', () => {
       },
     } as RoutingContext;
 
-    const decision = await strategy.route(context, { getPreviewFeatures: () => true } as Config);
+    const decision = await strategy.route(context, {
+      getPreviewFeatures: () => true,
+    } as Config);
 
     expect(decision).toEqual({
       model: 'gemini-2.5-pro-image-preview',
@@ -80,15 +85,17 @@ describe('ImageStrategy', () => {
       },
     } as RoutingContext;
 
-    const decision = await strategy.route(context, { getPreviewFeatures: () => false } as Config);
+    const decision = await strategy.route(context, {
+      getPreviewFeatures: () => false,
+    } as Config);
 
     expect(decision).toEqual({
-        model: DEFAULT_GEMINI_MODEL,
-        metadata: {
-            source: 'ImageStrategy',
-            latencyMs: 0,
-            reasoning: 'Request for image generation.',
-        },
+      model: DEFAULT_GEMINI_MODEL,
+      metadata: {
+        source: 'ImageStrategy',
+        latencyMs: 0,
+        reasoning: 'Request for image generation.',
+      },
     });
   });
 

--- a/packages/core/src/routing/strategies/ImageStrategy.ts
+++ b/packages/core/src/routing/strategies/ImageStrategy.ts
@@ -1,7 +1,9 @@
-
-import { RoutingStrategy, RoutingContext, RoutingDecision } from '../routingStrategy';
+import {
+  RoutingStrategy,
+  RoutingContext,
+  RoutingDecision,
+} from '../routingStrategy';
 import { Config } from '../../config/config';
-import { BaseLlmClient } from '../../core/baseLlmClient';
 import { GEMINI_MODEL_ALIAS_IMAGE, resolveModel } from '../../config/models';
 
 export class ImageStrategy implements RoutingStrategy {
@@ -12,25 +14,30 @@ export class ImageStrategy implements RoutingStrategy {
     config: Config,
   ): Promise<RoutingDecision | null> {
     const hasImage = context.request.parts.some(
-      (part) => 'inlineData' in part && part.inlineData?.mimeType.startsWith('image/'),
+      (part) =>
+        'inlineData' in part && part.inlineData?.mimeType.startsWith('image/'),
     );
 
     const textRequest = context.request.parts
       .map((part) => ('text' in part ? part.text : ''))
       .join(' ');
 
-    const requestsImageGeneration = /generate an image|create an image|draw a picture/i.test(
-      textRequest,
-    );
+    const requestsImageGeneration =
+      /generate an image|create an image|draw a picture/i.test(textRequest);
 
     if (hasImage || requestsImageGeneration) {
-      const model = resolveModel(GEMINI_MODEL_ALIAS_IMAGE, config.getPreviewFeatures());
+      const model = resolveModel(
+        GEMINI_MODEL_ALIAS_IMAGE,
+        config.getPreviewFeatures(),
+      );
       return {
         model,
         metadata: {
           source: 'ImageStrategy',
           latencyMs: 0,
-          reasoning: hasImage ? 'Request contains an image.' : 'Request for image generation.',
+          reasoning: hasImage
+            ? 'Request contains an image.'
+            : 'Request for image generation.',
         },
       };
     }

--- a/packages/core/src/routing/strategies/ImageStrategy.ts
+++ b/packages/core/src/routing/strategies/ImageStrategy.ts
@@ -1,0 +1,40 @@
+
+import { RoutingStrategy, RoutingContext, RoutingDecision } from '../routingStrategy';
+import { Config } from '../../config/config';
+import { BaseLlmClient } from '../../core/baseLlmClient';
+import { GEMINI_MODEL_ALIAS_IMAGE, resolveModel } from '../../config/models';
+
+export class ImageStrategy implements RoutingStrategy {
+  readonly name = 'image';
+
+  async route(
+    context: RoutingContext,
+    config: Config,
+  ): Promise<RoutingDecision | null> {
+    const hasImage = context.request.parts.some(
+      (part) => 'inlineData' in part && part.inlineData?.mimeType.startsWith('image/'),
+    );
+
+    const textRequest = context.request.parts
+      .map((part) => ('text' in part ? part.text : ''))
+      .join(' ');
+
+    const requestsImageGeneration = /generate an image|create an image|draw a picture/i.test(
+      textRequest,
+    );
+
+    if (hasImage || requestsImageGeneration) {
+      const model = resolveModel(GEMINI_MODEL_ALIAS_IMAGE, config.getPreviewFeatures());
+      return {
+        model,
+        metadata: {
+          source: 'ImageStrategy',
+          latencyMs: 0,
+          reasoning: hasImage ? 'Request contains an image.' : 'Request for image generation.',
+        },
+      };
+    }
+
+    return null;
+  }
+}

--- a/packages/core/src/services/test-data/resolved-aliases.golden.json
+++ b/packages/core/src/services/test-data/resolved-aliases.golden.json
@@ -85,6 +85,30 @@
       "topK": 64
     }
   },
+  "gemini-2.5-image": {
+    "model": "gemini-2.5-pro-image-preview",
+    "generateContentConfig": {
+      "temperature": 1,
+      "topP": 0.95,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingBudget": 8192
+      },
+      "topK": 64
+    }
+  },
+  "gemini-2.5-flash-lite-image": {
+    "model": "gemini-2.5-flash-lite-image-preview",
+    "generateContentConfig": {
+      "temperature": 1,
+      "topP": 0.95,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingBudget": 8192
+      },
+      "topK": 64
+    }
+  },
   "gemini-2.5-flash-base": {
     "model": "gemini-2.5-flash",
     "generateContentConfig": {


### PR DESCRIPTION
This PR adds support for flash-lite and image models. It also adds an ImageStrategy to route image-related prompts to the appropriate model. Preview features are now correctly gated for image models.