### PR TITLE
chore(logging): log the problematic event for #12122

### DIFF
--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -658,7 +658,7 @@ export class Task {
           errorMessage,
         );
 
-        let errMessage = 'Unknown error from LLM stream';
+        let errMessage = `Unknown error from LLM stream: ${event}`;
         if (errorEvent.value) {
           errMessage = parseAndFormatApiError(errorEvent.value);
         }

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -658,7 +658,7 @@ export class Task {
           errorMessage,
         );
 
-        let errMessage = `Unknown error from LLM stream: ${event}`;
+        let errMessage = `Unknown error from LLM stream: ${JSON.stringify(event)}`;
         if (errorEvent.value) {
           errMessage = parseAndFormatApiError(errorEvent.value);
         }


### PR DESCRIPTION
## Summary

Log the entire event in this unknown-error case.

## Details

It appears from the #12122 that the error event being received doesn't have a `value.message`, so log the entire event.  From internal reports, we sometimes have a trace ID but those appear to be from the initial conversation trace and are successful.

## How to Validate

By inspection.  Unfortunately this doesn't seem to be reproducible.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
