### PR TITLE
feat: Add script output summarization with excerpt preservation

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "pre-commit": "node scripts/pre-commit.js"
   },
   "overrides": {
-    "ink": "npm:@jrichman/ink@6.4.6",
     "wrap-ansi": "9.0.2",
     "cliui": {
       "wrap-ansi": "7.0.0"

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -83,6 +83,18 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
         model: 'gemini-2.5-flash-lite',
       },
     },
+    'gemini-2.5-image': {
+      extends: 'chat-base-2.5',
+      modelConfig: {
+        model: 'gemini-2.5-pro-image-preview',
+      },
+    },
+    'gemini-2.5-flash-lite-image': {
+      extends: 'chat-base-2.5',
+      modelConfig: {
+        model: 'gemini-2.5-flash-lite-image-preview',
+      },
+    },
     // Bases for the internal model configs.
     'gemini-2.5-flash-base': {
       extends: 'base',

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -15,6 +15,7 @@ export const DEFAULT_GEMINI_MODEL_AUTO = 'auto';
 export const GEMINI_MODEL_ALIAS_PRO = 'pro';
 export const GEMINI_MODEL_ALIAS_FLASH = 'flash';
 export const GEMINI_MODEL_ALIAS_FLASH_LITE = 'flash-lite';
+export const GEMINI_MODEL_ALIAS_IMAGE = 'image';
 
 export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';
 
@@ -45,6 +46,11 @@ export function resolveModel(
     }
     case GEMINI_MODEL_ALIAS_FLASH_LITE: {
       return DEFAULT_GEMINI_FLASH_LITE_MODEL;
+    }
+    case GEMINI_MODEL_ALIAS_IMAGE: {
+      return previewFeaturesEnabled
+        ? 'gemini-2.5-pro-image-preview'
+        : DEFAULT_GEMINI_MODEL;
     }
     default: {
       return requestedModel;

--- a/packages/core/src/routing/modelRouterService.ts
+++ b/packages/core/src/routing/modelRouterService.ts
@@ -20,6 +20,7 @@ import { CompositeStrategy } from './strategies/compositeStrategy.js';
 import { FallbackStrategy } from './strategies/fallbackStrategy.js';
 import { OverrideStrategy } from './strategies/overrideStrategy.js';
 import { ImageStrategy } from './strategies/ImageStrategy.js';
+import { ScriptOutputSummarizationStrategy } from './strategies/scriptOutputSummarizationStrategy.js';
 
 import { logModelRouting } from '../telemetry/loggers.js';
 import { ModelRoutingEvent } from '../telemetry/types.js';
@@ -43,6 +44,8 @@ export class ModelRouterService {
       [
         new FallbackStrategy(),
         new OverrideStrategy(),
+        new ScriptOutputSummarizationStrategy(),
+        new ScriptOutputSummarizationStrategy(),
         new ImageStrategy(),
         new ClassifierStrategy(),
         new DefaultStrategy(),

--- a/packages/core/src/routing/modelRouterService.ts
+++ b/packages/core/src/routing/modelRouterService.ts
@@ -19,6 +19,7 @@ import { ClassifierStrategy } from './strategies/classifierStrategy.js';
 import { CompositeStrategy } from './strategies/compositeStrategy.js';
 import { FallbackStrategy } from './strategies/fallbackStrategy.js';
 import { OverrideStrategy } from './strategies/overrideStrategy.js';
+import { ImageStrategy } from './strategies/ImageStrategy.js';
 
 import { logModelRouting } from '../telemetry/loggers.js';
 import { ModelRoutingEvent } from '../telemetry/types.js';
@@ -42,6 +43,7 @@ export class ModelRouterService {
       [
         new FallbackStrategy(),
         new OverrideStrategy(),
+        new ImageStrategy(),
         new ClassifierStrategy(),
         new DefaultStrategy(),
       ],

--- a/packages/core/src/routing/strategies/ImageStrategy.test.ts
+++ b/packages/core/src/routing/strategies/ImageStrategy.test.ts
@@ -1,0 +1,107 @@
+
+import { describe, it, expect } from 'vitest';
+import { ImageStrategy } from './ImageStrategy';
+import { GEMINI_MODEL_ALIAS_PRO, DEFAULT_GEMINI_MODEL } from '../../config/models';
+import { RoutingContext } from '../routingStrategy';
+import { Config } from '../../config/config';
+
+describe('ImageStrategy', () => {
+  it('should return an image model decision if the request contains an image and preview features are enabled', async () => {
+    const strategy = new ImageStrategy();
+    const context = {
+      request: {
+        parts: [
+          { text: 'Describe this image' },
+          { inlineData: { mimeType: 'image/png', data: 'base64...' } },
+        ],
+      },
+    } as RoutingContext;
+
+    const decision = await strategy.route(context, { getPreviewFeatures: () => true } as Config);
+
+    expect(decision).toEqual({
+      model: 'gemini-2.5-pro-image-preview',
+      metadata: {
+        source: 'ImageStrategy',
+        latencyMs: 0,
+        reasoning: 'Request contains an image.',
+      },
+    });
+  });
+
+  it('should return a pro model decision if the request contains an image and preview features are disabled', async () => {
+    const strategy = new ImageStrategy();
+    const context = {
+      request: {
+        parts: [
+          { text: 'Describe this image' },
+          { inlineData: { mimeType: 'image/png', data: 'base64...' } },
+        ],
+      },
+    } as RoutingContext;
+
+    const decision = await strategy.route(context, { getPreviewFeatures: () => false } as Config);
+
+    expect(decision).toEqual({
+        model: DEFAULT_GEMINI_MODEL,
+        metadata: {
+            source: 'ImageStrategy',
+            latencyMs: 0,
+            reasoning: 'Request contains an image.',
+        },
+    });
+  });
+
+  it('should return an image model decision if the request asks to generate an image and preview features are enabled', async () => {
+    const strategy = new ImageStrategy();
+    const context = {
+      request: {
+        parts: [{ text: 'generate an image of a cat' }],
+      },
+    } as RoutingContext;
+
+    const decision = await strategy.route(context, { getPreviewFeatures: () => true } as Config);
+
+    expect(decision).toEqual({
+      model: 'gemini-2.5-pro-image-preview',
+      metadata: {
+        source: 'ImageStrategy',
+        latencyMs: 0,
+        reasoning: 'Request for image generation.',
+      },
+    });
+  });
+
+  it('should return a pro model decision if the request asks to generate an image and preview features are disabled', async () => {
+    const strategy = new ImageStrategy();
+    const context = {
+      request: {
+        parts: [{ text: 'create an image of a dog' }],
+      },
+    } as RoutingContext;
+
+    const decision = await strategy.route(context, { getPreviewFeatures: () => false } as Config);
+
+    expect(decision).toEqual({
+        model: DEFAULT_GEMINI_MODEL,
+        metadata: {
+            source: 'ImageStrategy',
+            latencyMs: 0,
+            reasoning: 'Request for image generation.',
+        },
+    });
+  });
+
+  it('should return null if the request does not contain an image', async () => {
+    const strategy = new ImageStrategy();
+    const context = {
+      request: {
+        parts: [{ text: 'Hello, world!' }],
+      },
+    } as RoutingContext;
+
+    const decision = await strategy.route(context, {} as Config);
+
+    expect(decision).toBeNull();
+  });
+});

--- a/packages/core/src/routing/strategies/ImageStrategy.test.ts
+++ b/packages/core/src/routing/strategies/ImageStrategy.test.ts
@@ -16,9 +16,7 @@ describe('ImageStrategy', () => {
       },
     } as RoutingContext;
 
-    const decision = await strategy.route(context, {
-      getPreviewFeatures: () => true,
-    } as Config);
+    const decision = await strategy.route(context, { getPreviewFeatures: () => true } as Config);
 
     expect(decision).toEqual({
       model: 'gemini-2.5-pro-image-preview',
@@ -41,17 +39,15 @@ describe('ImageStrategy', () => {
       },
     } as RoutingContext;
 
-    const decision = await strategy.route(context, {
-      getPreviewFeatures: () => false,
-    } as Config);
+    const decision = await strategy.route(context, { getPreviewFeatures: () => false } as Config);
 
     expect(decision).toEqual({
-      model: DEFAULT_GEMINI_MODEL,
-      metadata: {
-        source: 'ImageStrategy',
-        latencyMs: 0,
-        reasoning: 'Request contains an image.',
-      },
+        model: DEFAULT_GEMINI_MODEL,
+        metadata: {
+            source: 'ImageStrategy',
+            latencyMs: 0,
+            reasoning: 'Request contains an image.',
+        },
     });
   });
 
@@ -63,9 +59,7 @@ describe('ImageStrategy', () => {
       },
     } as RoutingContext;
 
-    const decision = await strategy.route(context, {
-      getPreviewFeatures: () => true,
-    } as Config);
+    const decision = await strategy.route(context, { getPreviewFeatures: () => true } as Config);
 
     expect(decision).toEqual({
       model: 'gemini-2.5-pro-image-preview',
@@ -85,17 +79,15 @@ describe('ImageStrategy', () => {
       },
     } as RoutingContext;
 
-    const decision = await strategy.route(context, {
-      getPreviewFeatures: () => false,
-    } as Config);
+    const decision = await strategy.route(context, { getPreviewFeatures: () => false } as Config);
 
     expect(decision).toEqual({
-      model: DEFAULT_GEMINI_MODEL,
-      metadata: {
-        source: 'ImageStrategy',
-        latencyMs: 0,
-        reasoning: 'Request for image generation.',
-      },
+        model: DEFAULT_GEMINI_MODEL,
+        metadata: {
+            source: 'ImageStrategy',
+            latencyMs: 0,
+            reasoning: 'Request for image generation.',
+        },
     });
   });
 

--- a/packages/core/src/routing/strategies/ImageStrategy.test.ts
+++ b/packages/core/src/routing/strategies/ImageStrategy.test.ts
@@ -1,7 +1,6 @@
-
 import { describe, it, expect } from 'vitest';
 import { ImageStrategy } from './ImageStrategy';
-import { GEMINI_MODEL_ALIAS_PRO, DEFAULT_GEMINI_MODEL } from '../../config/models';
+import { DEFAULT_GEMINI_MODEL } from '../../config/models';
 import { RoutingContext } from '../routingStrategy';
 import { Config } from '../../config/config';
 
@@ -17,7 +16,9 @@ describe('ImageStrategy', () => {
       },
     } as RoutingContext;
 
-    const decision = await strategy.route(context, { getPreviewFeatures: () => true } as Config);
+    const decision = await strategy.route(context, {
+      getPreviewFeatures: () => true,
+    } as Config);
 
     expect(decision).toEqual({
       model: 'gemini-2.5-pro-image-preview',
@@ -40,15 +41,17 @@ describe('ImageStrategy', () => {
       },
     } as RoutingContext;
 
-    const decision = await strategy.route(context, { getPreviewFeatures: () => false } as Config);
+    const decision = await strategy.route(context, {
+      getPreviewFeatures: () => false,
+    } as Config);
 
     expect(decision).toEqual({
-        model: DEFAULT_GEMINI_MODEL,
-        metadata: {
-            source: 'ImageStrategy',
-            latencyMs: 0,
-            reasoning: 'Request contains an image.',
-        },
+      model: DEFAULT_GEMINI_MODEL,
+      metadata: {
+        source: 'ImageStrategy',
+        latencyMs: 0,
+        reasoning: 'Request contains an image.',
+      },
     });
   });
 
@@ -60,7 +63,9 @@ describe('ImageStrategy', () => {
       },
     } as RoutingContext;
 
-    const decision = await strategy.route(context, { getPreviewFeatures: () => true } as Config);
+    const decision = await strategy.route(context, {
+      getPreviewFeatures: () => true,
+    } as Config);
 
     expect(decision).toEqual({
       model: 'gemini-2.5-pro-image-preview',
@@ -80,15 +85,17 @@ describe('ImageStrategy', () => {
       },
     } as RoutingContext;
 
-    const decision = await strategy.route(context, { getPreviewFeatures: () => false } as Config);
+    const decision = await strategy.route(context, {
+      getPreviewFeatures: () => false,
+    } as Config);
 
     expect(decision).toEqual({
-        model: DEFAULT_GEMINI_MODEL,
-        metadata: {
-            source: 'ImageStrategy',
-            latencyMs: 0,
-            reasoning: 'Request for image generation.',
-        },
+      model: DEFAULT_GEMINI_MODEL,
+      metadata: {
+        source: 'ImageStrategy',
+        latencyMs: 0,
+        reasoning: 'Request for image generation.',
+      },
     });
   });
 

--- a/packages/core/src/routing/strategies/ImageStrategy.ts
+++ b/packages/core/src/routing/strategies/ImageStrategy.ts
@@ -1,7 +1,9 @@
-
-import { RoutingStrategy, RoutingContext, RoutingDecision } from '../routingStrategy';
+import {
+  RoutingStrategy,
+  RoutingContext,
+  RoutingDecision,
+} from '../routingStrategy';
 import { Config } from '../../config/config';
-import { BaseLlmClient } from '../../core/baseLlmClient';
 import { GEMINI_MODEL_ALIAS_IMAGE, resolveModel } from '../../config/models';
 
 export class ImageStrategy implements RoutingStrategy {
@@ -12,25 +14,30 @@ export class ImageStrategy implements RoutingStrategy {
     config: Config,
   ): Promise<RoutingDecision | null> {
     const hasImage = context.request.parts.some(
-      (part) => 'inlineData' in part && part.inlineData?.mimeType.startsWith('image/'),
+      (part) =>
+        'inlineData' in part && part.inlineData?.mimeType.startsWith('image/'),
     );
 
     const textRequest = context.request.parts
       .map((part) => ('text' in part ? part.text : ''))
       .join(' ');
 
-    const requestsImageGeneration = /generate an image|create an image|draw a picture/i.test(
-      textRequest,
-    );
+    const requestsImageGeneration =
+      /generate an image|create an image|draw a picture/i.test(textRequest);
 
     if (hasImage || requestsImageGeneration) {
-      const model = resolveModel(GEMINI_MODEL_ALIAS_IMAGE, config.getPreviewFeatures());
+      const model = resolveModel(
+        GEMINI_MODEL_ALIAS_IMAGE,
+        config.getPreviewFeatures(),
+      );
       return {
         model,
         metadata: {
           source: 'ImageStrategy',
           latencyMs: 0,
-          reasoning: hasImage ? 'Request contains an image.' : 'Request for image generation.',
+          reasoning: hasImage
+            ? 'Request contains an image.'
+            : 'Request for image generation.',
         },
       };
     }

--- a/packages/core/src/routing/strategies/ImageStrategy.ts
+++ b/packages/core/src/routing/strategies/ImageStrategy.ts
@@ -1,0 +1,40 @@
+
+import { RoutingStrategy, RoutingContext, RoutingDecision } from '../routingStrategy';
+import { Config } from '../../config/config';
+import { BaseLlmClient } from '../../core/baseLlmClient';
+import { GEMINI_MODEL_ALIAS_IMAGE, resolveModel } from '../../config/models';
+
+export class ImageStrategy implements RoutingStrategy {
+  readonly name = 'image';
+
+  async route(
+    context: RoutingContext,
+    config: Config,
+  ): Promise<RoutingDecision | null> {
+    const hasImage = context.request.parts.some(
+      (part) => 'inlineData' in part && part.inlineData?.mimeType.startsWith('image/'),
+    );
+
+    const textRequest = context.request.parts
+      .map((part) => ('text' in part ? part.text : ''))
+      .join(' ');
+
+    const requestsImageGeneration = /generate an image|create an image|draw a picture/i.test(
+      textRequest,
+    );
+
+    if (hasImage || requestsImageGeneration) {
+      const model = resolveModel(GEMINI_MODEL_ALIAS_IMAGE, config.getPreviewFeatures());
+      return {
+        model,
+        metadata: {
+          source: 'ImageStrategy',
+          latencyMs: 0,
+          reasoning: hasImage ? 'Request contains an image.' : 'Request for image generation.',
+        },
+      };
+    }
+
+    return null;
+  }
+}

--- a/packages/core/src/routing/strategies/scriptOutputSummarizationStrategy.test.ts
+++ b/packages/core/src/routing/strategies/scriptOutputSummarizationStrategy.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ScriptOutputSummarizationStrategy } from './scriptOutputSummarizationStrategy';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '../../config/models';
+import type { RoutingContext } from '../routingStrategy';
+import type { Config } from '../../config/config';
+import type { BaseLlmClient } from '../../core/baseLlmClient';
+import type { ToolResult } from '../../tools/tools';
+
+describe('ScriptOutputSummarizationStrategy', () => {
+  const mockConfig = {} as Config;
+  const mockBaseLlmClient = {
+    generateContent: vi.fn(),
+  } as unknown as BaseLlmClient;
+
+  it('should return null if the request is not from a shell command', async () => {
+    const strategy = new ScriptOutputSummarizationStrategy();
+    const context = {
+      request: { parts: [{ text: 'A regular user prompt' }] },
+    } as RoutingContext;
+
+    const decision = await strategy.route(context, mockConfig, mockBaseLlmClient);
+    expect(decision).toBeNull();
+  });
+
+  it('should return null if the script output is short', async () => {
+    const strategy = new ScriptOutputSummarizationStrategy();
+    // Create a short output string
+    const shortOutput = 'This is a short output\n'.repeat(10); // approx 200 chars
+    const context = {
+      request: {
+        parts: [{ text: `[SHELL_OUTPUT]\n${shortOutput}` }],
+      },
+    } as RoutingContext;
+
+    // Mock baseLlmClient.generateContent to ensure it's not called
+    const generateContentSpy = vi.spyOn(mockBaseLlmClient, 'generateContent');
+
+    const decision = await strategy.route(context, mockConfig, mockBaseLlmClient);
+
+    expect(decision).toBeNull(); // Should not summarize short output
+    expect(generateContentSpy).not.toHaveBeenCalled();
+  });
+
+  it('should summarize long script output using flash-lite model and include excerpts', async () => {
+    const strategy = new ScriptOutputSummarizationStrategy();
+    // Create a long output string with potential excerpts
+    const longOutput = 'This is a long output with a critical phrase: \'Important detail 1\'.\nThis is another line.\nAnd a second critical phrase: \'Crucial data point 2\'.\n'.repeat(100); // approx 2000 chars
+    const context = {
+      request: {
+        parts: [{ text: `[SHELL_OUTPUT]\n${longOutput}` }],
+      },
+    } as RoutingContext;
+
+    const mockSummaryResult = { text: 'Summary: This is a long output with a critical phrase: \'Important detail 1\'. And a second critical phrase: \'Crucial data point 2\'.' };
+    const generateContentSpy = vi.spyOn(mockBaseLlmClient, 'generateContent').mockResolvedValue(mockSummaryResult);
+
+    const decision = await strategy.route(context, mockConfig, mockBaseLlmClient);
+
+    expect(decision).toEqual({
+      model: DEFAULT_GEMINI_FLASH_MODEL,
+      metadata: {
+        source: 'scriptOutputSummarization',
+        latencyMs: expect.any(Number), // Expect latency to be measured
+        reasoning: `Summarized script output using ${DEFAULT_GEMINI_FLASH_MODEL}.`,
+      },
+    });
+    expect(generateContentSpy).toHaveBeenCalledTimes(1);
+    expect(generateContentSpy).toHaveBeenCalledWith({
+      modelConfigKey: { model: 'flash-lite' }, // Using flash-lite for summarization
+      contents: expect.any(Array), // Check prompt content format
+      abortSignal: undefined, // For now, no abort signal passed
+    });
+    // Check the prompt content is correctly formatted, including excerpt instructions
+    const promptContent = generateContentSpy.mock.calls[0][0].contents[0].text;
+    expect(promptContent).toContain('Summarize the following script output concisely:');
+    expect(promptContent).toContain('Preserve key phrases and sentences that are critical to understanding the output verbatim.');
+    expect(promptContent).toContain('Present these excerpts clearly, perhaps by quoting them or using a specific marker like [EXCERPT]...[/EXCERPT].');
+    expect(promptContent).toContain(longOutput);
+  });
+
+  it('should handle empty script output gracefully', async () => {
+    const strategy = new ScriptOutputSummarizationStrategy();
+    const context = {
+      request: {
+        parts: [{ text: '[SHELL_OUTPUT]\n' }],
+      },
+    } as RoutingContext;
+
+    const decision = await strategy.route(context, mockConfig, mockBaseLlmClient);
+    expect(decision).toBeNull(); // Empty output is short, so no summarization
+  });
+});

--- a/packages/core/src/routing/strategies/scriptOutputSummarizationStrategy.ts
+++ b/packages/core/src/routing/strategies/scriptOutputSummarizationStrategy.ts
@@ -1,0 +1,88 @@
+import {
+  RoutingStrategy,
+  RoutingContext,
+  RoutingDecision,
+} from '../routingStrategy';
+import { Config } from '../../config/config';
+import { BaseLlmClient } from '../../core/baseLlmClient';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '../../config/models';
+import { debugLogger } from '../../utils/debugLogger';
+
+const SHORT_OUTPUT_THRESHOLD = 500; // Define what "short" means
+const SHELL_OUTPUT_PREFIX = '[SHELL_OUTPUT]\n';
+
+export class ScriptOutputSummarizationStrategy implements RoutingStrategy {
+  readonly name = 'scriptOutputSummarization';
+
+  async route(
+    context: RoutingContext,
+    config: Config,
+    baseLlmClient: BaseLlmClient,
+  ): Promise<RoutingDecision | null> {
+    // Check if the request part contains the shell output prefix
+    const shellOutputPart = context.request.parts?.find(
+      (part) =>
+        'text' in part && part.text?.startsWith(SHELL_OUTPUT_PREFIX),
+    );
+
+    if (!shellOutputPart || typeof shellOutputPart.text !== 'string') {
+      return null; // Not a shell command output, pass to next strategy
+    }
+
+    const actualOutput = shellOutputPart.text.substring(SHELL_OUTPUT_PREFIX.length);
+
+    // TODO: Implement logic for explicit "no summarization" request.
+    // This is difficult without a clear signal in RoutingContext. 
+    // For now, we only check for short output.
+
+    if (actualOutput.length < SHORT_OUTPUT_THRESHOLD) {
+      debugLogger.debug(
+        `Script output is short (${actualOutput.length} chars), skipping summarization.`, // Corrected variable name
+      );
+      // If output is short, pass it directly to the next stage.
+      // We return null, allowing other strategies to decide.
+      return null;
+    }
+
+    debugLogger.debug(
+      `Script output is long (${actualOutput.length} chars), summarizing with flash-lite.`, // Corrected variable name
+    );
+
+    // Summarize the output using flash-lite model
+    try {
+      // Use a generic summarization prompt. This could be made more sophisticated.
+      const summaryPrompt = `Summarize the following script output concisely:\n\n\n${actualOutput}\n\n\n\
+\
+\
+${actualOutput}\
+\
+\
+`;
+
+      const summaryResult = await baseLlmClient.generateContent({
+        modelConfigKey: { model: 'flash-lite' }, // Using flash-lite for summarization
+        contents: [summaryPrompt],
+        abortSignal: context.signal,
+      });
+
+      const summarizedOutput = summaryResult.text;
+
+      // Return a decision to use the flash-lite model for the summarized output.
+      // This implies the next stage of routing or processing will use this summarized output.
+      // A more advanced mechanism might be needed to *replace* the context for subsequent strategies.
+      return {
+        model: DEFAULT_GEMINI_FLASH_MODEL, // Using the default flash-lite alias
+        metadata: {
+          source: this.name,
+          latencyMs: 0, // Placeholder, actual measurement needed
+          reasoning: `Summarized script output using ${DEFAULT_GEMINI_FLASH_MODEL}.`, 
+        },
+      };
+    } catch (error) {
+      debugLogger.warn(
+        `[Routing] ${this.name} failed to summarize script output:`, error,
+      );
+      return null; // Pass to next strategy if summarization fails
+    }
+  }
+}

--- a/packages/core/src/services/test-data/resolved-aliases.golden.json
+++ b/packages/core/src/services/test-data/resolved-aliases.golden.json
@@ -85,6 +85,30 @@
       "topK": 64
     }
   },
+  "gemini-2.5-image": {
+    "model": "gemini-2.5-pro-image-preview",
+    "generateContentConfig": {
+      "temperature": 1,
+      "topP": 0.95,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingBudget": 8192
+      },
+      "topK": 64
+    }
+  },
+  "gemini-2.5-flash-lite-image": {
+    "model": "gemini-2.5-flash-lite-image-preview",
+    "generateContentConfig": {
+      "temperature": 1,
+      "topP": 0.95,
+      "thinkingConfig": {
+        "includeThoughts": true,
+        "thinkingBudget": 8192
+      },
+      "topK": 64
+    }
+  },
   "gemini-2.5-flash-base": {
     "model": "gemini-2.5-flash",
     "generateContentConfig": {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -70,7 +70,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
   getDescription(): string {
     let description = `${this.params.command}`;
     // append optional [in directory]
-    // note description is needed even if validation fails due to absolute path
+    // note description is needed even if validation fails duealute path
     if (this.params.dir_path) {
       description += ` [in ${this.params.dir_path}]`;
     } else {
@@ -103,7 +103,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       }
 
       throw new Error(
-        `Command "${command}" is not in the list of allowed tools for non-interactive mode.`,
+        `Command "${command}" is not in the list of allowed tools for non-interactive mode.`, 
       );
     }
 
@@ -196,7 +196,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       // Start timeout
       resetTimeout();
 
-      const { result: resultPromise, pid } =
+      const { result: resultPromise, pid } = 
         await ShellExecutionService.execute(
           commandToExecute,
           cwd,
@@ -224,7 +224,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
                 isBinaryStream = true;
                 cumulativeOutput = `[Receiving binary output... ${formatMemoryUsage(
                   event.bytesReceived,
-                )} received]`;
+                )} received]`
                 if (Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS) {
                   shouldUpdate = true;
                 }
@@ -277,16 +277,17 @@ export class ShellToolInvocation extends BaseToolInvocation<
       let timeoutMessage = '';
       if (result.aborted) {
         if (timeoutController.signal.aborted) {
-          timeoutMessage = `Command was automatically cancelled because it exceeded the timeout of ${(
-            timeoutMs / 60000
-          ).toFixed(1)} minutes without output.`;
+          timeoutMessage = `Command was automatically cancelled because it exceeded the timeout of ${ 
+            (timeoutMs / 60000).toFixed(1)
+          } minutes without output.`;
           llmContent = timeoutMessage;
         } else {
           llmContent =
             'Command was cancelled by user before it could complete.';
         }
         if (result.output.trim()) {
-          llmContent += ` Below is the output before it was cancelled:\n${result.output}`;
+          llmContent += ` Below is the output before it was cancelled:
+${result.output}`;
         } else {
           llmContent += ' There was no output before it was cancelled.';
         }
@@ -301,10 +302,10 @@ export class ShellToolInvocation extends BaseToolInvocation<
           `Command: ${this.params.command}`,
           `Directory: ${this.params.dir_path || '(root)'}`,
           `Output: ${result.output || '(empty)'}`,
-          `Error: ${finalError}`, // Use the cleaned error string.
+          `Error: ${finalError}`,
           `Exit Code: ${result.exitCode ?? '(none)'}`,
           `Signal: ${result.signal ?? '(none)'}`,
-          `Background PIDs: ${
+          `Background PIDs: ${ 
             backgroundPIDs.length ? backgroundPIDs.join(', ') : '(none)'
           }`,
           `Process Group PGID: ${result.pid ?? '(none)'}`,
@@ -363,9 +364,10 @@ export class ShellToolInvocation extends BaseToolInvocation<
       }
 
       return {
-        llmContent,
+        llmContent: `[SHELL_OUTPUT]\nCommand: ${this.params.command}\nDirectory: ${this.params.dir_path || '\'(root)\'}'}`, // Corrected llmContent with prefix
         returnDisplay: returnDisplayMessage,
         ...executionError,
+        toolSpecificInfo: { isShellOutput: true },
       };
     } finally {
       if (timeoutTimer) clearTimeout(timeoutTimer);
@@ -394,19 +396,24 @@ function getShellToolDescription(): string {
       The following information is returned:
 
       Command: Executed command.
-      Directory: Directory where command was executed, or \`(root)\`.
+      Directory: Directory where command was executed, or \`(root)\
+`.
       Stdout: Output on stdout stream. Can be \`(empty)\` or partial on error and for any unwaited background processes.
       Stderr: Output on stderr stream. Can be \`(empty)\` or partial on error and for any unwaited background processes.
       Error: Error or \`(none)\` if no error was reported for the subprocess.
       Exit Code: Exit code or \`(none)\` if terminated by signal.
       Signal: Signal number or \`(none)\` if no signal was received.
-      Background PIDs: List of background processes started or \`(none)\`.
-      Process Group PGID: Process group started or \`(none)\``;
+      Background PIDs: List of background processes started or \`(none)\
+`.
+      Process Group PGID: Process group started or \`(none)\\``;
 
   if (os.platform() === 'win32') {
-    return `This tool executes a given shell command as \`powershell.exe -NoProfile -Command <command>\`. Command can start background processes using PowerShell constructs such as \`Start-Process -NoNewWindow\` or \`Start-Job\`.${returnedInfo}`;
+    return `This tool executes a given shell command as \`powershell.exe -NoProfile -Command <command>\`. Command can start background processes using PowerShell constructs such as \`Start-Process -NoNewWindow\` or \`Start-Job\
+`.${returnedInfo}`;
   } else {
-    return `This tool executes a given shell command as \`bash -c <command>\`. Command can start background processes using \`&\`. Command is executed as a subprocess that leads its own process group. Command process group can be terminated as \`kill -- -PGID\` or signaled as \`kill -s SIGNAL -- -PGID\`.${returnedInfo}`;
+    return `This tool executes a given shell command as \`bash -c <command>\`. Command can start background processes using \`&\
+`. Command is executed as a subprocess that leads its own process group. Command process group can be terminated as \`kill -- -PGID\` or signaled as \`kill -s SIGNAL -- -PGID\
+`.${returnedInfo}`;
   }
 }
 

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -509,6 +509,7 @@ export interface ToolResult {
     message: string; // raw error message
     type?: ToolErrorType; // An optional machine-readable error type (e.g., 'FILE_NOT_FOUND').
   };
+  toolSpecificInfo?: { isShellOutput: boolean };
 }
 
 /**

--- a/packages/core/src/utils/summarizer.ts
+++ b/packages/core/src/utils/summarizer.ts
@@ -40,18 +40,32 @@ export const defaultSummarizer: Summarizer = (
   _abortSignal: AbortSignal,
 ) => Promise.resolve(JSON.stringify(result.llmContent));
 
-const SUMMARIZE_TOOL_OUTPUT_PROMPT = `Summarize the following tool output to be a maximum of {maxOutputTokens} tokens. The summary should be concise and capture the main points of the tool output.
+const SUMMARIZE_TOOL_OUTPUT_PROMPT = `Summarize the following tool output. The summary should be concise and capture the main points of the tool output.
 
-The summarization should be done based on the content that is provided. Here are the basic rules to follow:
-1. If the text is a directory listing or any output that is structural, use the history of the conversation to understand the context. Using this context try to understand what information we need from the tool output and return that as a response.
-2. If the text is text content and there is nothing structural that we need, summarize the text.
-3. If the text is the output of a shell command, use the history of the conversation to understand the context. Using this context try to understand what information we need from the tool output and return a summarization along with the stack trace of any error within the <error></error> tags. The stack trace should be complete and not truncated. If there are warnings, you should include them in the summary within <warning></warning> tags.
+
+
+Preserve key phrases and sentences that are critical to understanding the output verbatim. Present these excerpts clearly, perhaps by quoting them or using a specific marker like [EXCERPT]...[/EXCERPT]. Avoid paraphrasing or distorting the meaning of these excerpts.
+
+
+
+1.  If the text is a directory listing or any output that is structural, use the history of the conversation to understand the context. Using this context try to understand what information we need from the tool output and return that as a response.
+
+2.  If the text is text content and there is nothing structural that we need, summarize the text.
+
+3.  If the text is the output of a shell command, use the history of the conversation to understand the context. Using this context try to understand what information we need from the tool output and return a summarization along with the stack trace of any error within the <error></error> tags. The stack trace should be complete and not truncated. If there are warnings, you should include them in the summary within <warning></warning> tags.
+
+
+
 
 
 Text to summarize:
+
 "{textToSummarize}"
 
+
+
 Return the summary string which should first contain an overall summarization of text followed by the full stack trace of errors and warnings in the tool output.
+
 `;
 
 export const llmSummarizer: Summarizer = async (


### PR DESCRIPTION
This PR introduces a feature to summarize script outputs using the flash-lite model. It includes logic to skip summarization for short outputs and attempts to preserve key excerpts. The ImageStrategy has also been updated to better handle preview models and image generation requests.