### PR TITLE
feat: return partial tool output on cancellation

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -1838,7 +1838,7 @@ describe('CoreToolScheduler Sequential Execution', () => {
     const call3 = completedCalls.find((c) => c.request.callId === '3');
 
     expect(call1?.status).toBe('success');
-    expect(call2?.status).toBe('cancelled');
+    expect(call2?.status).toBe('success');
     expect(call3?.status).toBe('cancelled');
   });
 

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -1733,7 +1733,6 @@ describe('CoreToolScheduler Sequential Execution', () => {
           secondCallStarted = true;
           // This call will be cancelled while it's "running".
           await new Promise((resolve) => setTimeout(resolve, 100));
-          // It should not return a value because it will be cancelled.
           return { llmContent: 'Second call should not complete' };
         }
         if (args.call === 3) {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1165,7 +1165,16 @@ export class CoreToolScheduler {
             try {
               const toolResult: ToolResult = await promise;
               spanMetadata.output = toolResult;
-              if (signal.aborted) {
+              // If the tool invocation returned content (even if aborted), we prefer to show that content.
+              // This allows the agent to see partial outputs of cancelled commands (like shell commands).
+              const hasContent =
+                toolResult.llmContent !== undefined &&
+                toolResult.llmContent !== null &&
+                (typeof toolResult.llmContent === 'string'
+                  ? toolResult.llmContent.length > 0
+                  : true);
+
+              if (signal.aborted && !hasContent) {
                 this.setStatusInternal(
                   callId,
                   'cancelled',

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1165,8 +1165,7 @@ export class CoreToolScheduler {
             try {
               const toolResult: ToolResult = await promise;
               spanMetadata.output = toolResult;
-              // If the tool invocation returned content (even if aborted), we prefer to show that content.
-              // This allows the agent to see partial outputs of cancelled commands (like shell commands).
+
               const hasContent =
                 toolResult.llmContent !== undefined &&
                 toolResult.llmContent !== null &&

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1167,11 +1167,12 @@ export class CoreToolScheduler {
               spanMetadata.output = toolResult;
 
               const hasContent =
-                toolResult.llmContent !== undefined &&
-                toolResult.llmContent !== null &&
+                toolResult.llmContent != null &&
                 (typeof toolResult.llmContent === 'string'
                   ? toolResult.llmContent.length > 0
-                  : true);
+                  : Array.isArray(toolResult.llmContent)
+                    ? toolResult.llmContent.length > 0
+                    : true);
 
               if (signal.aborted && !hasContent) {
                 this.setStatusInternal(


### PR DESCRIPTION
Updates CoreToolScheduler to treat cancelled tool calls as successful if they have partial output (llmContent). This allows the agent to see the output of long-running commands (like shell commands) that were interrupted by the user.