### PR TITLE
feat: add tool timeout functionality

### DIFF
--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -276,6 +276,9 @@ export function mapToDisplay(
         name: displayName,
         description,
         renderOutputAsMarkdown,
+        timeout: trackedCall.request.timeout,
+        startTime:
+          'startTime' in trackedCall ? trackedCall.startTime : undefined,
       };
 
       switch (trackedCall.status) {

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -73,6 +73,8 @@ export interface IndividualToolCallDisplay {
   renderOutputAsMarkdown?: boolean;
   ptyId?: number;
   outputFile?: string;
+  timeout?: number;
+  startTime?: number;
 }
 
 export interface CompressionProps {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -2204,7 +2204,7 @@ describe('CoreToolScheduler Timeout', () => {
     const response =
       completedCalls[0].response.responseParts[0].functionResponse.response
         .output;
-    expect(response).toContain('Command timed out after 100ms');
+    expect(response).toContain('Command timed out after 0.1 seconds');
     expect(response).toContain('Partial output before timeout');
     expect(response).toContain('Tool aborted');
   });

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -2192,14 +2192,14 @@ describe('CoreToolScheduler Timeout', () => {
       args: { someArg: 'value' },
       isClientInitiated: false,
       prompt_id: 'prompt-1',
-      timeout: 100, // 100ms timeout
+      timeout: 100,
     };
 
     await scheduler.schedule([request], abortController.signal);
 
     expect(onAllToolCallsComplete).toHaveBeenCalled();
     const completedCalls = onAllToolCallsComplete.mock.calls[0][0];
-    expect(completedCalls[0].status).toBe('success'); // We treat timeout as success with message
+    expect(completedCalls[0].status).toBe('success');
 
     const response =
       completedCalls[0].response.responseParts[0].functionResponse.response

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1195,7 +1195,9 @@ export class CoreToolScheduler {
 
               if (timeoutController.signal.aborted) {
                 // Handle timeout
-                const message = `Command timed out after ${timeoutMs}ms. You can increase the timeout by passing a 'timeout' argument (in milliseconds).`;
+                const message = `Command timed out after ${
+                  timeoutMs / 1000
+                } seconds. The default timeout is 3 minutes. You can increase the timeout by passing a 'timeout' argument (in milliseconds).`;
 
                 // If we have content, append the message.
                 // Note: toolResult.llmContent is PartListUnion (string | Part | Part[])

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1184,14 +1184,14 @@ export class CoreToolScheduler {
               clearTimeout(timeoutId); // Clear timeout on completion
 
               spanMetadata.output = toolResult;
-              // If the tool invocation returned content (even if aborted), we prefer to show that content.
-              // This allows the agent to see partial outputs of cancelled commands (like shell commands).
+
               let hasContent =
-                toolResult.llmContent !== undefined &&
-                toolResult.llmContent !== null &&
+                toolResult.llmContent != null &&
                 (typeof toolResult.llmContent === 'string'
                   ? toolResult.llmContent.length > 0
-                  : true);
+                  : Array.isArray(toolResult.llmContent)
+                    ? toolResult.llmContent.length > 0
+                    : true);
 
               if (timeoutController.signal.aborted) {
                 // Handle timeout

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -107,6 +107,7 @@ export interface ToolCallRequestInfo {
   args: Record<string, unknown>;
   isClientInitiated: boolean;
   prompt_id: string;
+  timeout?: number;
 }
 
 export interface ToolCallResponseInfo {
@@ -375,12 +376,15 @@ export class Turn {
     const name = fnCall.name || 'undefined_tool_name';
     const args = (fnCall.args || {}) as Record<string, unknown>;
 
+    const { timeout, ...toolArgs } = args;
+
     const toolCallRequest: ToolCallRequestInfo = {
       callId,
       name,
-      args,
+      args: toolArgs,
       isClientInitiated: false,
       prompt_id: this.prompt_id,
+      timeout: typeof timeout === 'number' ? timeout : undefined,
     };
 
     this.pendingToolCalls.push(toolCallRequest);


### PR DESCRIPTION
Implements tool timeout logic allowing tools to be terminated after a specified duration (default 3 minutes). Agents can specify a custom timeout via the 'timeout' argument. If a tool times out, it returns any partial output along with a helpful message suggesting how to increase the timeout.