### PR TITLE
fix: http keep-alive to resolve intermittent 'fetch failed' errors

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -577,17 +577,15 @@ export class Config {
       initializeTelemetry(this);
     }
 
-    const proxy = this.getProxy();
-    if (proxy) {
-      try {
-        setGlobalProxy(proxy);
-      } catch (error) {
-        coreEvents.emitFeedback(
-          'error',
-          'Invalid proxy configuration detected. Check debug drawer for more details (F12)',
-          error,
-        );
-      }
+            const proxy = this.getProxy();
+    try {
+      setGlobalProxy(proxy);
+    } catch (error) {
+      coreEvents.emitFeedback(
+        'error',
+        'Invalid proxy/network configuration detected. Check debug drawer for more details (F12)',
+        error,
+      );
     }
     this.geminiClient = new GeminiClient(this);
     this.modelRouterService = new ModelRouterService(this);


### PR DESCRIPTION
## Summary
The CLI was experiencing frequent TypeError: fetch failed errors (~50% rate), particularly on Windows. Diagnosis pointed to undici's keep-alive mechanism attempting to reuse sockets that had been silently closed by the OS or network intermediaries.

This change:
- Updates setGlobalProxy in fetch.ts to configure a robust global Dispatcher (Agent) when no proxy is set.
- Explicitly sets keepAlive: false and adds connection timeouts to prevent stale connection reuse.
- Applies this configuration globally in Config initialization to ensure stability across all platforms (Windows, macOS, Linux).
## Details

Already Included

## Related Issues

Fixes #14148
Fixes #8092
Fixes #13734
Fixes #3664
Fixes #5542

## How to Validate

1. Clean Environment: Ensure you are running on a Windows machine (where the issue was most prevalent) or simulate an unstable network environment.
2. Build: Run npm run build to ensure the changes are compiled.
3. Run CLI: Execute the CLI using npm start (or the built executable).
4. Repeat Requests: Perform a sequence of at least 10-20 standard prompt commands (e.g., "Hello", "What is the time?", "Explain code").
   * Without fix: You would expect a percentage of these requests to fail with [API Error: exception TypeError: fetch failed sending request]. On Windows Machines that happens much more often
   * With fix: All requests should complete successfully without network errors.
5. Proxy Check (Optional): If you have access to a proxy, configure the HTTPS_PROXY environment variable and verify that the CLI still connects correctly (confirming the setGlobalProxy logic still handles proxies).

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker
