### PR TITLE
feat(ui): smarter path truncation to show package names over generic dirs

### DIFF
--- a/packages/cli/src/ui/components/__snapshots__/SessionBrowser.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SessionBrowser.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`SessionBrowser component > enters search mode, filters sessions, and re
  Search: query (Esc to cancel)
 
    Index │ Msgs │ Age  │ Match
- ❯ #1    │ 1    │ 10mo │ You:    Query is here a… (+1 more)
+ ❯ #1    │ 1    │ 11mo │ You:    Query is here a… (+1 more)
  ▼"
 `;
 
@@ -16,8 +16,8 @@ exports[`SessionBrowser component > renders a list of sessions and marks current
  Sort: s         Reverse: r      First/Last: g/G
 
    Index │ Msgs │ Age  │ Name
- ❯ #1    │ 5    │ 10mo │ Second conversation about dogs (current)
-   #2    │ 2    │ 10mo │ First conversation about cats
+ ❯ #1    │ 5    │ 11mo │ Second conversation about dogs (current)
+   #2    │ 2    │ 11mo │ First conversation about cats
  ▼"
 `;
 

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -415,6 +415,17 @@ describe('shortenPath', () => {
       expect(result).toBe('.../lodash/.../lodash.js');
       expect(result.length).toBeLessThanOrEqual(25);
     });
+
+    it('should not select filename as distinguishing segment when all dirs are generic', () => {
+      // Edge case: /src/lib/dist/index.ts - all directories are generic
+      // Should fall back to first segment (src), not select 'index.ts' as distinguishing
+      const p = '/src/lib/dist/index.ts';
+      const result = shortenPath(p, 20);
+      expect(result).toBe('/src/.../index.ts');
+      expect(result.length).toBeLessThanOrEqual(20);
+      // Ensure we don't get something like '.../index.ts/.../index.ts'
+      expect(result).not.toContain('index.ts/');
+    });
   });
 
   describe.skipIf(process.platform !== 'win32')('on Windows', () => {

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -70,8 +70,9 @@ function findDistinguishingSegmentIndex(segments: string[]): number {
     return 0;
   }
 
-  // First segment is generic, find the first non-generic one
-  for (let i = 0; i < segments.length - 1; i++) {
+  // First segment is generic, find the first non-generic directory (not filename)
+  // Use segments.length - 2 to exclude the filename from consideration
+  for (let i = 0; i < segments.length - 2; i++) {
     if (
       GENERIC_DIRS.has(segments[i].toLowerCase()) &&
       !GENERIC_DIRS.has(segments[i + 1].toLowerCase())


### PR DESCRIPTION
## Summary

  When paths are truncated for display, shortenPath() now keeps distinguishing segments (like package names) instead of
  generic parent directories (like packages). This makes truncated paths much more useful in monorepos where
  packages/.../file.ts could match multiple packages.



## Details

  Added a set of generic directory names (packages, apps, libs, src, node_modules, etc.) that are deprioritized when
  truncating paths. The algorithm now finds the first non-generic segment and uses that as the anchor point.

  Before: packages/.../src/router/index.ts
  After: .../frontend/src/router/index.ts

  Also updated unrelated SessionBrowser snapshots that were failing due to month rollover (10mo -> 11mo).

## Related Issues

  Fixes #13973


## How to Validate

  1. Run npm run test -- packages/core/src/utils/paths.test.ts
  2. Check the new monorepo-specific tests pass
  3. Verify existing path truncation tests still pass

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
