### PR TITLE
fix(core): fallback to 2.5-pro when 3-pro-preview hits quota limits

### DIFF
--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -162,13 +162,13 @@ describe('getEffectiveModel', () => {
     });
 
     describe('with preview features', () => {
-      it('should downgrade the Pro alias to the Flash model', () => {
+      it('should downgrade the Pro alias to the DEFAULT_GEMINI_MODEL model', () => {
         const model = getEffectiveModel(
           isInFallbackMode,
           GEMINI_MODEL_ALIAS_PRO,
           true,
         );
-        expect(model).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+        expect(model).toBe(DEFAULT_GEMINI_MODEL);
       });
 
       it('should return the Flash alias when requested', () => {

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -21,6 +21,22 @@ export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';
 // Cap the thinking at 8192 to prevent run-away thinking loops.
 export const DEFAULT_THINKING_MODE = 8192;
 
+export const FALLBACK_CHAIN: Record<string, string> = {
+  [PREVIEW_GEMINI_MODEL]: DEFAULT_GEMINI_MODEL,
+  [DEFAULT_GEMINI_MODEL]: DEFAULT_GEMINI_FLASH_MODEL,
+};
+
+/**
+ * Returns the fallback model for a given model.
+ * If no specific fallback is defined, returns the default Flash model.
+ *
+ * @param model The model to find a fallback for.
+ * @returns The fallback model.
+ */
+export function getFallbackModel(model: string): string {
+  return FALLBACK_CHAIN[model] ?? DEFAULT_GEMINI_FLASH_MODEL;
+}
+
 /**
  * Resolves the requested model alias (e.g., 'auto', 'pro', 'flash', 'flash-lite')
  * to a concrete model name, considering preview features.
@@ -84,8 +100,8 @@ export function getEffectiveModel(
     return resolvedModel;
   }
 
-  // Default fallback for Gemini CLI.
-  return DEFAULT_GEMINI_FLASH_MODEL;
+  // Use the defined fallback chain.
+  return getFallbackModel(resolvedModel);
 }
 
 /**

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -384,7 +384,7 @@ describe('handleFallback', () => {
       expect(mockConfig.setPreviewModelFallbackMode).toHaveBeenCalledWith(true);
     });
 
-    it('should activate regular fallback when handler returns "retry_always" and is TerminalQuotaError', async () => {
+    it('should activate regular fallback to DEFAULT_GEMINI_MODEL when handler returns "retry_always" and is TerminalQuotaError on PREVIEW_GEMINI_MODEL', async () => {
       mockHandler.mockResolvedValue('retry_always');
       const mockGoogleApiError = {
         code: 503,
@@ -404,8 +404,15 @@ describe('handleFallback', () => {
       );
 
       expect(result).toBe(true);
-      expect(mockConfig.setPreviewModelFallbackMode).not.toBeCalled();
+      expect(mockConfig.setPreviewModelFallbackMode).toHaveBeenCalledWith(
+        false,
+      );
       expect(mockConfig.setFallbackMode).toHaveBeenCalledWith(true);
+      expect(mockHandler).toHaveBeenCalledWith(
+        PREVIEW_GEMINI_MODEL,
+        DEFAULT_GEMINI_MODEL,
+        terminalError,
+      );
     });
 
     it('should NOT set fallback mode if user chooses "retry_once"', async () => {
@@ -478,7 +485,7 @@ describe('handleFallback', () => {
       );
     });
 
-    it('should pass DEFAULT_GEMINI_FLASH_MODEL as fallback when Preview Model fails with other error', async () => {
+    it('should pass DEFAULT_GEMINI_MODEL as fallback when Preview Model fails with TerminalQuotaError', async () => {
       const mockGoogleApiError = {
         code: 429,
         message: 'mock error',
@@ -498,7 +505,7 @@ describe('handleFallback', () => {
 
       expect(mockConfig.fallbackModelHandler).toHaveBeenCalledWith(
         PREVIEW_GEMINI_MODEL,
-        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_MODEL,
         terminalQuotaError,
       );
     });

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -8,7 +8,6 @@ import type { Config } from '../config/config.js';
 import { AuthType } from '../core/contentGenerator.js';
 import {
   DEFAULT_GEMINI_FLASH_MODEL,
-  DEFAULT_GEMINI_MODEL,
   PREVIEW_GEMINI_MODEL,
   getFallbackModel,
 } from '../config/models.js';
@@ -120,25 +119,8 @@ async function legacyHandleFallback(
   ) {
     return null;
   }
-  const shouldActivatePreviewFallback =
-    failedModel === PREVIEW_GEMINI_MODEL &&
-    !(error instanceof TerminalQuotaError);
-  // Preview Model Specific Logic
-  if (shouldActivatePreviewFallback) {
-    // Always set bypass mode for the immediate retry, for non-TerminalQuotaErrors.
-    // This ensures the next attempt uses 2.5 Pro.
-    config.setPreviewModelBypassMode(true);
 
-    // If we are already in Preview Model fallback mode (user previously said "Always"),
-    // we silently retry (which will use 2.5 Pro due to bypass mode).
-    if (config.isPreviewModelFallbackMode()) {
-      return true;
-    }
-  }
-
-  const fallbackModel = shouldActivatePreviewFallback
-    ? DEFAULT_GEMINI_MODEL
-    : DEFAULT_GEMINI_FLASH_MODEL;
+  const fallbackModel = DEFAULT_GEMINI_FLASH_MODEL;
 
   // Consult UI Handler for Intent
   const fallbackModelHandler = config.fallbackModelHandler;


### PR DESCRIPTION
## Summary

Updates the fallback logic for `gemini-3-pro-preview`. Previously, hitting a `TerminalQuotaError` (e.g., usage limits) with this model would incorrectly fallback to `gemini-2.5-flash`. This change ensures it falls back to `gemini-2.5-pro` (DEFAULT_GEMINI_MODEL), providing a better experience for users expecting a Pro-tier model.

## Details

- Introduced `FALLBACK_CHAIN` in `packages/core/src/config/models.ts` to define model-specific fallback targets.
- Updated `getEffectiveModel` to respect this fallback chain when in fallback mode.
- Added `handlePreviewModelFallback` in `packages/core/src/fallback/handler.ts` to handle `PREVIEW_GEMINI_MODEL` specific fallback logic separately from the legacy handler.
- Updated tests to verify the new fallback behavior.

## Related Issues

Fixes #13741

## How to Validate

1.  Enable preview features in settings (`/settings set general.previewFeatures true`).
2.  Set model to `gemini-3-pro-preview` (`/model gemini-3-pro-preview`).
3.  Simulate a `TerminalQuotaError` (this is hard to do manually against live API without actually hitting limits, but unit tests cover this scenario).
4.  Observe that the model switches to `gemini-2.5-pro` instead of `gemini-2.5-flash`.
5.  Run unit tests: `npm test packages/core/src/fallback/handler.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx