### PR TITLE
fix(core): handle EPIPE error in hook runner when writing to stdin

### DIFF
--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -64,6 +64,7 @@ describe('HookRunner', () => {
       stdin: {
         write: vi.fn(),
         end: vi.fn(),
+        on: vi.fn(),
       } as unknown as Writable,
       stdout: {
         on: mockStdoutOn,

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -232,6 +232,13 @@ export class HookRunner {
 
       // Send input to stdin
       if (child.stdin) {
+        child.stdin.on('error', (err) => {
+          // Ignore EPIPE errors which happen when the child process closes stdin early
+          // @ts-expect-error - code is not defined on Error type but exists on Node errors
+          if (err.code !== 'EPIPE') {
+            debugLogger.warn(`Hook stdin error: ${err}`);
+          }
+        });
         child.stdin.write(JSON.stringify(input));
         child.stdin.end();
       }

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -232,9 +232,8 @@ export class HookRunner {
 
       // Send input to stdin
       if (child.stdin) {
-        child.stdin.on('error', (err) => {
+        child.stdin.on('error', (err: NodeJS.ErrnoException) => {
           // Ignore EPIPE errors which happen when the child process closes stdin early
-          // @ts-expect-error - code is not defined on Error type but exists on Node errors
           if (err.code !== 'EPIPE') {
             debugLogger.warn(`Hook stdin error: ${err}`);
           }

--- a/packages/core/src/hooks/hookSystem.test.ts
+++ b/packages/core/src/hooks/hookSystem.test.ts
@@ -96,6 +96,7 @@ describe('HookSystem Integration', () => {
       stdin: {
         write: vi.fn(),
         end: vi.fn(),
+        on: vi.fn(),
       } as unknown as Writable,
       stdout: {
         on: mockStdoutOn,


### PR DESCRIPTION
## TLDR

Fixes a crash (unhandled EPIPE error) in the CLI that occurs when a hook process exits before the CLI finishes writing input to its stdin. This race condition was causing flaky failures in nightly releases on slower runners.

## Dive Deeper

When `HookRunner` spawns a child process (e.g., a simple `echo` command as a hook), it attempts to write the tool's execution context (as a JSON string) to the child's `stdin`.

If the hook command is fast and ignores `stdin` (like `echo`), it may exit and close its `stdin` stream while the Node.js process is still trying to write data. This triggers an `EPIPE` error. Previously, there was no error listener on the `stdin` stream, causing the error to bubble up as an unhandled exception and crash the main CLI process.

This fix adds an error listener to `child.stdin` to catch and ignore `EPIPE` errors, ensuring the CLI is robust against hooks that do not consume their input.

## Reviewer Test Plan

1.  Review the code changes in `packages/core/src/hooks/hookRunner.ts` to verify the error handler is added.
2.  Review the updated test mocks in `packages/core/src/hooks/hookRunner.test.ts`.
3.  The change fixes the flaky `hooks-system.test.ts` integration test ('should add additional context from AfterTool hooks') which was failing in CI.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes the nightly release workflow failure observed in run 19807234483.