### PR TITLE
Always use MCP server instructions

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -156,8 +156,6 @@ Each server configuration supports the following properties:
 - **`targetServiceAccount`** (string): The email address of the Google Cloud
   Service Account to impersonate. Used with
   `authProviderType: 'service_account_impersonation'`.
-- **`useInstructions`** (boolean): If true will include the MCP server's
-  initialization instructions in the system instructions.
 
 ### OAuth Support for Remote MCP Servers
 
@@ -1011,3 +1009,9 @@ gemini mcp remove my-server
 
 This will find and delete the "my-server" entry from the `mcpServers` object in
 the appropriate `settings.json` file based on the scope (`-s, --scope`).
+
+## Instructions
+
+Gemini CLI supports
+[MCP server instructions](https://modelcontextprotocol.io/specification/2025-06-18/schema#initializeresult),
+which will be appended to the system instructions.

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1526,11 +1526,6 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
         description:
           'Service account email to impersonate (name@project.iam.gserviceaccount.com).',
       },
-      useInstructions: {
-        type: 'boolean',
-        description:
-          'If true, instructions from this server will be included in the system prompt.',
-      },
     },
   },
   TelemetrySettings: {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -204,8 +204,6 @@ export class MCPServerConfig {
     readonly targetAudience?: string,
     /* targetServiceAccount format: <service-account-name>@<project-num>.iam.gserviceaccount.com */
     readonly targetServiceAccount?: string,
-    // Include the MCP server initialization instructions in the system instructions
-    readonly useInstructions?: boolean,
   ) {}
 }
 

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -327,14 +327,11 @@ export class McpClientManager {
   getMcpInstructions(): string {
     const instructions: string[] = [];
     for (const [name, client] of this.clients) {
-      // Only include instructions if explicitly enabled in config
-      if (client.getServerConfig().useInstructions) {
-        const clientInstructions = client.getInstructions();
-        if (clientInstructions) {
-          instructions.push(
-            `# Instructions for MCP Server '${name}'\n${clientInstructions}`,
-          );
-        }
+      const clientInstructions = client.getInstructions();
+      if (clientInstructions) {
+        instructions.push(
+          `# Instructions for MCP Server '${name}'\n${clientInstructions}`,
+        );
       }
     }
     return instructions.join('\n\n');

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1467,10 +1467,6 @@
         "targetServiceAccount": {
           "type": "string",
           "description": "Service account email to impersonate (name@project.iam.gserviceaccount.com)."
-        },
-        "useInstructions": {
-          "type": "boolean",
-          "description": "If true, instructions from this server will be included in the system prompt."
         }
       }
     },


### PR DESCRIPTION
## Summary

We decided that instead of introducing a setting for this, we should always consume instructions.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
