### PR TITLE
feat(a2a): Urgent fix - Process modelInfo agent message

### DIFF
--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -66,6 +66,7 @@ export class Task {
   eventBus?: ExecutionEventBus;
   completedToolCalls: CompletedToolCall[];
   skipFinalTrueAfterInlineEdit = false;
+  modelInfo?: string;
 
   // For tool waiting logic
   private pendingToolCalls: Map<string, string> = new Map(); //toolCallId --> status
@@ -135,7 +136,7 @@ export class Task {
       id: this.id,
       contextId: this.contextId,
       taskState: this.taskState,
-      model: this.config.getModel(),
+      model: this.modelInfo || this.config.getModel(),
       mcpServers: servers,
       availableTools,
     };
@@ -230,7 +231,7 @@ export class Task {
       traceId?: string;
     } = {
       coderAgent: coderAgentMessage,
-      model: this.config.getModel(),
+      model: this.modelInfo || this.config.getModel(),
       userTier: this.config.getUserTier(),
     };
 
@@ -646,6 +647,9 @@ export class Task {
         break;
       case GeminiEventType.Finished:
         logger.info(`[Task ${this.id}] Agent finished its turn.`);
+        break;
+      case GeminiEventType.ModelInfo:
+        this.modelInfo = event.value;
         break;
       case GeminiEventType.Error:
       default: {

--- a/packages/a2a-server/src/utils/testing_utils.ts
+++ b/packages/a2a-server/src/utils/testing_utils.ts
@@ -27,6 +27,8 @@ export function createMockConfig(
     getToolRegistry: vi.fn().mockReturnValue({
       getTool: vi.fn(),
       getAllToolNames: vi.fn().mockReturnValue([]),
+      getAllTools: vi.fn().mockReturnValue([]),
+      getToolsByServer: vi.fn().mockReturnValue([]),
     }),
     getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
     getIdeMode: vi.fn().mockReturnValue(false),
@@ -57,6 +59,9 @@ export function createMockConfig(
     getPolicyEngine: vi.fn(),
     getEnableExtensionReloading: vi.fn().mockReturnValue(false),
     getEnableHooks: vi.fn().mockReturnValue(false),
+    getMcpClientManager: vi.fn().mockReturnValue({
+      getMcpServers: vi.fn().mockReturnValue({}),
+    }),
     ...overrides,
   } as unknown as Config;
   mockConfig.getMessageBus = vi.fn().mockReturnValue(createMockMessageBus());


### PR DESCRIPTION
Fix this error:

[ERROR] 2025-12-01 14:29:42.120 PM -- [CoderAgentExecutor] Error executing agent for task d9a13edf-95b1-4f01-bae8-c1f54cb0475f: Cannot read properties of undefined (reading 'message')
{
  "stack": "TypeError: Cannot read properties of undefined (reading 'message')\n    at Task.acceptAgentMessage (file:///usr/local/google/home/cocosheng/gemini-cli/packages/a2a-server/dist/src/agent/task.js:408:61)\n    at CoderAgentExecutor.execute (file:///usr/local/google/home/cocosheng/gemini-cli/packages/a2a-server/dist/src/agent/executor.js:330:39)"
}