### PR TITLE
feat: add system instruction to API request telemetry logs

### DIFF
--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -761,6 +761,9 @@ describe('loggers', () => {
         attributes: expect.objectContaining({
           'event.name': EVENT_API_REQUEST,
           prompt_id: 'prompt-id-semantic-1',
+          system_instruction: JSON.stringify([
+            { type: 'text', content: 'be helpful' },
+          ]),
         }),
       });
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -388,6 +388,13 @@ export class ApiRequestEvent implements BaseTelemetryEvent {
       prompt_id: this.prompt.prompt_id,
       request_text: this.request_text,
     };
+    if (this.prompt.generate_content_config?.systemInstruction) {
+      attributes['system_instruction'] = JSON.stringify(
+        toSystemInstruction(
+          this.prompt.generate_content_config.systemInstruction,
+        ),
+      );
+    }
     return { body: `API request to ${this.model}.`, attributes };
   }
 


### PR DESCRIPTION
## Summary

Adds system instructions to telemetry logging - it is already logged in semantic logging.

## Details

## Related Issues

Fixes #12460

## How to Validate

Run GCLI with local telemetry and verify the system_instructions in the log file.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
