### PR TITLE
feat: enable extensions to configure includeDirectories

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -152,9 +152,10 @@ The file has the following structure:
     }
   },
   "contextFileName": "GEMINI.md",
-  "contextFileName": "GEMINI.md",
   "excludeTools": ["run_shell_command"],
-  "includeDirectories": ["/path/to/include"]
+  "context": {
+    "includeDirectories": ["/path/to/include"]
+  }
 }
 ```
 
@@ -183,9 +184,10 @@ The file has the following structure:
   `"excludeTools": ["run_shell_command(rm -rf)"]` will block the `rm -rf`
   command. Note that this differs from the MCP server `excludeTools`
   functionality, which can be listed in the MCP server config.
-- `includeDirectories`: An array of directories to include in the context. These
-  directories will be added to the CLI's `includeDirectories` setting when the
-  extension is active.
+- `context.includeDirectories`: An array of directories to include in the
+  context. These directories will be added to the CLI's `includeDirectories`
+  setting when the extension is active. Relative paths are resolved relative to
+  the extension's directory.
 
 When Gemini CLI starts, it loads all the extensions and merges their
 configurations. If there are any conflicts, the workspace configuration takes

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -152,7 +152,9 @@ The file has the following structure:
     }
   },
   "contextFileName": "GEMINI.md",
-  "excludeTools": ["run_shell_command"]
+  "contextFileName": "GEMINI.md",
+  "excludeTools": ["run_shell_command"],
+  "includeDirectories": ["/path/to/include"]
 }
 ```
 
@@ -181,6 +183,9 @@ The file has the following structure:
   `"excludeTools": ["run_shell_command(rm -rf)"]` will block the `rm -rf`
   command. Note that this differs from the MCP server `excludeTools`
   functionality, which can be listed in the MCP server config.
+- `includeDirectories`: An array of directories to include in the context. These
+  directories will be added to the CLI's `includeDirectories` setting when the
+  extension is active.
 
 When Gemini CLI starts, it loads all the extensions and merges their
 configurations. If there are any conflicts, the workspace configuration takes

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -514,7 +514,11 @@ export class ExtensionManager extends ExtensionLoader {
           this.workspaceDir,
         ),
         id: getExtensionId(config, installMetadata),
-        includeDirectories: config.includeDirectories,
+        includeDirectories: config.context?.includeDirectories?.map((dir) =>
+          path.isAbsolute(dir) || dir.startsWith('~')
+            ? dir
+            : path.resolve(effectiveExtensionPath, dir),
+        ),
       };
       this.loadedExtensions = [...this.loadedExtensions, extension];
 

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -514,6 +514,7 @@ export class ExtensionManager extends ExtensionLoader {
           this.workspaceDir,
         ),
         id: getExtensionId(config, installMetadata),
+        includeDirectories: config.includeDirectories,
       };
       this.loadedExtensions = [...this.loadedExtensions, extension];
 

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -310,6 +310,19 @@ describe('extension tests', () => {
       expect(extensions[0].mcpServers?.['test-server'].cwd).toBe(expectedCwd);
     });
 
+    it('should load includeDirectories from extension config', async () => {
+      createExtension({
+        extensionsDir: userExtensionsDir,
+        name: 'test-extension',
+        version: '1.0.0',
+        includeDirectories: ['/extension/dir'],
+      });
+
+      const extensions = await extensionManager.loadExtensions();
+      expect(extensions).toHaveLength(1);
+      expect(extensions[0].includeDirectories).toEqual(['/extension/dir']);
+    });
+
     it('should load a linked extension correctly', async () => {
       const sourceExtDir = createExtension({
         extensionsDir: tempWorkspaceDir,

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -26,7 +26,9 @@ export interface ExtensionConfig {
   mcpServers?: Record<string, MCPServerConfig>;
   contextFileName?: string | string[];
   excludeTools?: string[];
-  includeDirectories?: string[];
+  context?: {
+    includeDirectories?: string[];
+  };
   settings?: ExtensionSetting[];
 }
 

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -26,6 +26,7 @@ export interface ExtensionConfig {
   mcpServers?: Record<string, MCPServerConfig>;
   contextFileName?: string | string[];
   excludeTools?: string[];
+  includeDirectories?: string[];
   settings?: ExtensionSetting[];
 }
 

--- a/packages/cli/src/config/extensions/consent.test.ts
+++ b/packages/cli/src/config/extensions/consent.test.ts
@@ -188,6 +188,26 @@ describe('consent', () => {
         await maybeRequestConsentOrFail(newConfig, requestConsent, prevConfig);
         expect(requestConsent).toHaveBeenCalledTimes(1);
       });
+
+      it('should request consent if includeDirectories changes', async () => {
+        const prevConfig: ExtensionConfig = { ...baseConfig };
+        const newConfig: ExtensionConfig = {
+          ...baseConfig,
+          context: {
+            includeDirectories: ['/path/to/include'],
+          },
+        };
+        const requestConsent = vi.fn().mockResolvedValue(true);
+        await maybeRequestConsentOrFail(newConfig, requestConsent, prevConfig);
+
+        const expectedConsentString = [
+          'Installing extension "test-ext".',
+          INSTALL_WARNING_MESSAGE,
+          'This extension will add the following directories to your context (while active): /path/to/include',
+        ].join('\n');
+
+        expect(requestConsent).toHaveBeenCalledWith(expectedConsentString);
+      });
     });
   });
 });

--- a/packages/cli/src/config/extensions/consent.ts
+++ b/packages/cli/src/config/extensions/consent.ts
@@ -130,6 +130,11 @@ function extensionConsentString(extensionConfig: ExtensionConfig): string {
       `This extension will exclude the following core tools: ${sanitizedConfig.excludeTools}`,
     );
   }
+  if (sanitizedConfig.context?.includeDirectories) {
+    output.push(
+      `This extension will add the following directories to your context (while active): ${sanitizedConfig.context.includeDirectories.join(', ')}`,
+    );
+  }
   return output.join('\n');
 }
 

--- a/packages/cli/src/test-utils/createExtension.ts
+++ b/packages/cli/src/test-utils/createExtension.ts
@@ -25,12 +25,20 @@ export function createExtension({
   mcpServers = {} as Record<string, MCPServerConfig>,
   installMetadata = undefined as ExtensionInstallMetadata | undefined,
   settings = undefined as ExtensionSetting[] | undefined,
+  includeDirectories = undefined as string[] | undefined,
 } = {}): string {
   const extDir = path.join(extensionsDir, name);
   fs.mkdirSync(extDir, { recursive: true });
   fs.writeFileSync(
     path.join(extDir, EXTENSIONS_CONFIG_FILENAME),
-    JSON.stringify({ name, version, contextFileName, mcpServers, settings }),
+    JSON.stringify({
+      name,
+      version,
+      contextFileName,
+      mcpServers,
+      settings,
+      includeDirectories,
+    }),
   );
 
   if (addContextFile) {

--- a/packages/cli/src/test-utils/createExtension.ts
+++ b/packages/cli/src/test-utils/createExtension.ts
@@ -37,7 +37,7 @@ export function createExtension({
       contextFileName,
       mcpServers,
       settings,
-      includeDirectories,
+      context: includeDirectories ? { includeDirectories } : undefined,
     }),
   );
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -143,6 +143,7 @@ export interface GeminiCLIExtension {
   excludeTools?: string[];
   id: string;
   hooks?: { [K in HookEventName]?: HookDefinition[] };
+  includeDirectories?: string[];
 }
 
 export interface ExtensionInstallMetadata {


### PR DESCRIPTION
Partially addresses #12634. Supersedes #12676.

Implements the `context.includeDirectories` configuration for extensions, allowing them to contribute to the CLI's context.
- Adds `includeDirectories` to `GeminiCLIExtension` and `ExtensionConfig`.
- Updates `ExtensionManager` to load and resolve these directories (supporting relative paths).
- Updates `loadCliConfig` to merge extension directories with user settings.
- Includes comprehensive tests for path resolution and precedence.