### PR TITLE
fix(a2a-server): fix grammar typos in task.ts comments

### DIFF
--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -738,7 +738,7 @@ export class Task {
         // This will trigger the scheduler to continue or cancel the specific tool.
         // The scheduler's onToolCallsUpdate will then reflect the new state (e.g., executing or cancelled).
 
-        // If `edit` tool call, pass updated payload if presesent
+        // If `edit` tool call, pass updated payload if present
         if (confirmationDetails.type === 'edit') {
           const payload = part.data['newContent']
             ? ({
@@ -856,7 +856,7 @@ export class Task {
     };
     // Set task state to working as we are about to call LLM
     this.setTaskStateAndPublishUpdate('working', stateChange);
-    // TODO: Determine what it mean to have, then add a prompt ID.
+    // TODO: Determine what it means to have, then add a prompt ID.
     yield* this.geminiClient.sendMessageStream(
       llmParts,
       aborted,
@@ -896,7 +896,7 @@ export class Task {
       };
       // Set task state to working as we are about to call LLM
       this.setTaskStateAndPublishUpdate('working', stateChange);
-      // TODO: Determine what it mean to have, then add a prompt ID.
+      // TODO: Determine what it means to have, then add a prompt ID.
       yield* this.geminiClient.sendMessageStream(
         llmParts,
         aborted,


### PR DESCRIPTION
  ## Summary

  Fix three grammar and spelling typos in comments within the a2a-server task.ts file. This is a documentation-only improvement with no functional changes.

  ## Details

  This PR fixes three typos in code comments:
  - Line 741: "presesent" → "present"
  - Lines 859 & 899: "what it mean" → "what it means"

  These are comment-only changes with zero impact on runtime behavior. The fixes improve code readability and maintain professional documentation standards.

  ## Related Issues

  Related to code quality improvements. No specific issue was filed for these typos.

  ## How to Validate

  1. Review the git diff to confirm only comment text has changed:
     ```bash
     git diff main...fix/typos-in-task-comments packages/a2a-server/src/agent/task.ts

  2. Verify the file still compiles without errors:
  npm run build --workspace @google/gemini-cli-a2a-server
  3. Confirm existing tests pass unchanged (since no logic was modified):
  npm run test --workspace @google/gemini-cli-a2a-server

  Expected result: All tests pass with no changes to functionality.
  
  4. `npm run preflight` executes successfully


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
