### PR TITLE
Docs: Model routing clarification

### DIFF
--- a/docs/cli/model.md
+++ b/docs/cli/model.md
@@ -4,8 +4,9 @@ Select your Gemini CLI model. The `/model` command opens a dialog where you can
 configure the model used by Gemini CLI, giving you more control over your
 results.
 
-**Note:** The `/model` command (and the `--model` flag) sets the desired model
-for your commands, but does not affect sub-agents such as Code Investigator.
+**Note:** The `/model` command (and the `--model` flag) does not override the
+model used by sub-agents. Consequently, even when using the `/model` flag you
+may see other models used in your model usage reports.
 
 ## How to use the `/model` command
 

--- a/docs/cli/model.md
+++ b/docs/cli/model.md
@@ -4,6 +4,9 @@ Select your Gemini CLI model. The `/model` command opens a dialog where you can
 configure the model used by Gemini CLI, giving you more control over your
 results.
 
+**Note:** The `/model` command (and the `--model` flag) sets the desired model
+for your commands, but does not affect sub-agents such as Code Investigator.
+
 ## How to use the `/model` command
 
 Use the following command in Gemini CLI:


### PR DESCRIPTION
## Summary

Clarifies that the /model command will not override the models used by sub-agents. 

This PR adds a small note to /docs/cli/model.md specifying that the /model command and the --model (--m) flag do not override sub-agents, explaining some behaviors that users might see (such as additional models being listed in their model usage).