### PR TITLE
docs: fix typo 'socus' to 'focus' in todos.md

### DIFF
--- a/docs/tools/todos.md
+++ b/docs/tools/todos.md
@@ -26,7 +26,7 @@ plan.
 
 - **Progress tracking:** The agent updates this list as it works, marking tasks
   as `completed` when done.
-- **Single socus:** Only one task will be marked `in_progress` at a time,
+- **Single focus:** Only one task will be marked `in_progress` at a time,
   indicating exactly what the agent is currently working on.
 - **Dynamic updates:** The plan may evolve as the agent discovers new
   information, leading to new tasks being added or unnecessary ones being


### PR DESCRIPTION
## Summary

Fixes a typo in the write_todos tool documentation where "Single socus" should be "Single focus" on line 29 of docs/tools/todos.md. This is a simple spelling correction that improves documentation clarity.


## Details

The typo appears in the "Behavior" section describing how the todo tool maintains focus on a single task. Changed "Single socus" to "Single focus" to correct the spelling error.

## Related Issues

N/A - This is a minor documentation typo fix with no associated issue.

## How to Validate

  1. Open docs/tools/todos.md
  2. Navigate to line 29
  3. Verify the text reads "Single focus:" (not "socus")
  4. Confirm the sentence is grammatically correct and clear
  5. `npm run preflight` is still green

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
