### PR TITLE
Remove references to deleted kind/bug label

### DIFF
--- a/.github/actions/push-docker/action.yml
+++ b/.github/actions/push-docker/action.yml
@@ -75,4 +75,4 @@ runs:
         gh issue create \
           --title "Docker build failed" \
           --body "The docker build failed. See the full run for details: ${DETAILS_URL}" \
-          --label "kind/bug,release-failure"
+          --label "release-failure"

--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -93,4 +93,4 @@ runs:
         gh issue create \
           --title "Docker build failed" \
           --body "The docker build failed. See the full run for details: ${DETAILS_URL}" \
-          --label "kind/bug,release-failure"
+          --label "release-failure"

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -132,4 +132,4 @@ jobs:
           gh issue create \
             --title 'Manual Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')' \
             --body 'The manual release workflow failed. See the full run for details: ${DETAILS_URL}' \
-            --label 'kind/bug,release-failure,priority/p0'
+            --label 'release-failure,priority/p0'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -157,4 +157,4 @@ jobs:
           gh issue create \
             --title "Nightly Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')" \
             --body "The nightly-release workflow failed. See the full run for details: ${DETAILS_URL}" \
-            --label 'kind/bug,release-failure,priority/p0'
+            --label 'release-failure,priority/p0'

--- a/.github/workflows/release-patch-3-release.yml
+++ b/.github/workflows/release-patch-3-release.yml
@@ -205,7 +205,7 @@ jobs:
           gh issue create \
             --title 'Patch Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')' \
             --body 'The patch-release workflow failed. See the full run for details: ${DETAILS_URL}' \
-            --label 'kind/bug,release-failure,priority/p0'
+            --label 'release-failure,priority/p0'
 
       - name: 'Comment Success on Original PR'
         if: '${{ success() && github.event.inputs.original_pr }}'

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -261,7 +261,7 @@ jobs:
           gh issue create \
             --title 'Promote Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')' \
             --body 'The promote-release workflow failed during preview publish. See the full run for details: ${DETAILS_URL}' \
-            --label 'kind/bug,release-failure,priority/p0'
+            --label 'release-failure,priority/p0'
 
   publish-stable:
     name: 'Publish stable'
@@ -327,7 +327,7 @@ jobs:
           gh issue create \
             --title 'Promote Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')' \
             --body 'The promote-release workflow failed during stable publish. See the full run for details: ${DETAILS_URL}' \
-            --label 'kind/bug,release-failure,priority/p0'
+            --label 'release-failure,priority/p0'
 
   nightly-pr:
     name: 'Create Nightly PR'
@@ -403,4 +403,4 @@ jobs:
           gh issue create \
             --title 'Promote Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')' \
             --body 'The promote-release workflow failed during nightly PR creation. See the full run for details: ${DETAILS_URL}' \
-            --label 'kind/bug,release-failure,priority/p0'
+            --label 'release-failure,priority/p0'

--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -46,4 +46,4 @@ jobs:
           gh issue create \
             --title 'Sandbox Release Failed on $(date +'%Y-%m-%d')' \
             --body 'The sandbox-release workflow failed. See the full run for details: ${DETAILS_URL}' \
-            --label 'kind/bug,release-failure,priority/p0'
+            --label 'release-failure,priority/p0'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -47,4 +47,4 @@ jobs:
           gh issue create \
             --title 'Smoke test failed on ${REF} @ $(date +'%Y-%m-%d')' \
             --body 'Smoke test build failed. See the full run for details: ${DETAILS_URL}' \
-            --label 'kind/bug,priority/p0'
+            --label 'priority/p0'


### PR DESCRIPTION
## Summary

Trying to add a label that doesn't exist causes the operation to fail. See example: https://github.com/google-gemini/gemini-cli/actions/runs/19842153215/job/56852720122