### PR TITLE
Don't fail test if we can't cleanup

### DIFF
--- a/integration-tests/globalSetup.ts
+++ b/integration-tests/globalSetup.ts
@@ -74,6 +74,10 @@ export async function setup() {
 export async function teardown() {
   // Cleanup the test run directory unless KEEP_OUTPUT is set
   if (process.env['KEEP_OUTPUT'] !== 'true' && runDir) {
-    await rm(runDir, { recursive: true, force: true });
+    try {
+      await rm(runDir, { recursive: true, force: true });
+    } catch (e) {
+      console.warn('Failed to clean up test run directory:', e);
+    }
   }
 }


### PR DESCRIPTION
## Summary

We had a test fail because we couldn't cleanup a file. Instead the test should pass and log a warning.

## Details

See failure: https://github.com/google-gemini/gemini-cli/actions/runs/19842153215/job/56852720122
