### PR TITLE
Use polling for extensions-reload integration test

### DIFF
--- a/integration-tests/extensions-reload.test.ts
+++ b/integration-tests/extensions-reload.test.ts
@@ -77,7 +77,7 @@ describe('extension reloading', () => {
         'test-extension (v0.0.1) - active (update available)',
       );
       // Wait a bit for the UI to settle
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 3000));
       await run.sendKeys('\u0015/mcp list\r');
       await run.expectText(
         'test-server (from test-extension) - Ready (1 tool)',
@@ -101,7 +101,7 @@ describe('extension reloading', () => {
       await run.sendKeys('\u0015/extensions list\r');
       await run.expectText('test-extension (v0.0.2) - active (updated)');
       // Wait a bit for the UI to settle
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 3000));
       await run.sendKeys('\u0015/mcp list\r');
       await run.expectText(
         'test-server (from test-extension) - Ready (1 tool)',

--- a/integration-tests/extensions-reload.test.ts
+++ b/integration-tests/extensions-reload.test.ts
@@ -5,13 +5,14 @@
  */
 
 import { expect, it, describe } from 'vitest';
-import { TestRig } from './test-helper.js';
+import { TestRig, poll } from './test-helper.js';
 import { TestMcpServer } from './test-mcp-server.js';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { safeJsonStringify } from '@google/gemini-cli-core/src/utils/safeJsonStringify.js';
 import { env } from 'node:process';
 import { platform } from 'node:os';
+import stripAnsi from 'strip-ansi';
 
 const itIf = (condition: boolean) => (condition ? it : it.skip);
 
@@ -76,20 +77,18 @@ describe('extension reloading', () => {
       await run.expectText(
         'test-extension (v0.0.1) - active (update available)',
       );
-      // Wait a bit for the UI to settle
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-      await run.sendKeys('\u0015/mcp list\r');
+      // Wait for the prompt to reappear.
+      await poll(() => stripAnsi(run.output).trim().endsWith('>'), 5000, 200);
+      await run.sendText('/mcp list');
+      await run.type('\r');
       await run.expectText(
         'test-server (from test-extension) - Ready (1 tool)',
       );
       await run.expectText('- hello');
 
       // Update the extension, expect the list to update, and mcp servers as well.
-      await run.sendKeys('\u0015/extensions update test-extension');
-      await run.expectText('/extensions update test-extension');
-      await run.sendKeys('\r');
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      await run.sendKeys('\r');
+      await run.sendText('/extensions update test-extension');
+      await run.type('\r');
       await run.expectText(
         ` * test-server (remote): http://localhost:${portB}/mcp`,
       );
@@ -97,18 +96,21 @@ describe('extension reloading', () => {
       await run.expectText(
         'Extension "test-extension" successfully updated: 0.0.1 → 0.0.2',
       );
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-      await run.sendKeys('\u0015/extensions list\r');
+      // Wait for the prompt to reappear.
+      await poll(() => stripAnsi(run.output).trim().endsWith('>'), 5000, 200);
+      await run.sendText('/extensions list');
+      await run.type('\r');
       await run.expectText('test-extension (v0.0.2) - active (updated)');
-      // Wait a bit for the UI to settle
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-      await run.sendKeys('\u0015/mcp list\r');
+      // Wait for the prompt to reappear.
+      await poll(() => stripAnsi(run.output).trim().endsWith('>'), 5000, 200);
+      await run.sendText('/mcp list');
+      await run.type('\r');
       await run.expectText(
         'test-server (from test-extension) - Ready (1 tool)',
       );
       await run.expectText('- goodbye');
       await run.sendText('/quit');
-      await run.sendKeys('\r');
+      await run.type('\r');
 
       // Clean things up.
       await serverA.stop();


### PR DESCRIPTION
## Summary

Migrates from static time-based waits to a dynamic polling approach. This change ensures that the test accurately synchronizes with the application's state, specifically waiting for the command prompt to be ready, thereby reducing test flakiness and improving overall test suite reliability.

Highlights
Improved Test Reliability: Replaced fixed setTimeout delays with a polling mechanism in the extensions-reload integration test to prevent flakiness.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
