### PR TITLE
feat: ensure codebase investigator uses preview model when main agent does

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -816,7 +816,7 @@ their corresponding top-level category object in your `settings.json` file.
 
 - **`experimental.codebaseInvestigatorSettings.model`** (string):
   - **Description:** The model to use for the Codebase Investigator agent.
-  - **Default:** `"gemini-2.5-pro"`
+  - **Default:** `"pro"`
   - **Requires restart:** Yes
 
 #### `hooks`

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -18,8 +18,8 @@ import type {
 import {
   DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
   DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
-  DEFAULT_GEMINI_MODEL,
   DEFAULT_MODEL_CONFIGS,
+  GEMINI_MODEL_ALIAS_PRO,
 } from '@google/gemini-cli-core';
 import type { CustomTheme } from '../ui/themes/theme.js';
 import type { SessionRetentionSettings } from './settings.js';
@@ -1384,7 +1384,7 @@ const SETTINGS_SCHEMA = {
             label: 'Model',
             category: 'Experimental',
             requiresRestart: true,
-            default: DEFAULT_GEMINI_MODEL,
+            default: GEMINI_MODEL_ALIAS_PRO,
             description:
               'The model to use for the Codebase Investigator agent.',
             showInDialog: false,

--- a/packages/core/src/agents/codebase-investigator.test.ts
+++ b/packages/core/src/agents/codebase-investigator.test.ts
@@ -12,7 +12,7 @@ import {
   LS_TOOL_NAME,
   READ_FILE_TOOL_NAME,
 } from '../tools/tool-names.js';
-import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
+import { GEMINI_MODEL_ALIAS_PRO } from '../config/models.js';
 
 describe('CodebaseInvestigatorAgent', () => {
   it('should have the correct agent definition', () => {
@@ -26,7 +26,7 @@ describe('CodebaseInvestigatorAgent', () => {
     ).toBe(true);
     expect(CodebaseInvestigatorAgent.outputConfig?.outputName).toBe('report');
     expect(CodebaseInvestigatorAgent.modelConfig?.model).toBe(
-      DEFAULT_GEMINI_MODEL,
+      GEMINI_MODEL_ALIAS_PRO,
     );
     expect(CodebaseInvestigatorAgent.toolConfig?.tools).toEqual([
       LS_TOOL_NAME,

--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -11,7 +11,7 @@ import {
   LS_TOOL_NAME,
   READ_FILE_TOOL_NAME,
 } from '../tools/tool-names.js';
-import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
+import { GEMINI_MODEL_ALIAS_PRO } from '../config/models.js';
 import { z } from 'zod';
 
 // Define a type that matches the outputConfig schema for type safety.
@@ -69,7 +69,7 @@ export const CodebaseInvestigatorAgent: AgentDefinition<
   processOutput: (output) => JSON.stringify(output, null, 2),
 
   modelConfig: {
-    model: DEFAULT_GEMINI_MODEL,
+    model: GEMINI_MODEL_ALIAS_PRO,
     temp: 0.1,
     top_p: 0.95,
     thinkingBudget: -1,

--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -72,6 +72,25 @@ describe('AgentRegistry', () => {
         `[AgentRegistry] Initialized with ${agentCount} agents.`,
       );
     });
+
+    it('should use preview model for codebase investigator if main model is preview', async () => {
+      const previewConfig = makeFakeConfig({
+        model: 'gemini-3-pro-preview',
+        codebaseInvestigatorSettings: {
+          enabled: true,
+          model: 'pro',
+        },
+      });
+      const previewRegistry = new TestableAgentRegistry(previewConfig);
+
+      await previewRegistry.initialize();
+
+      const investigatorDef = previewRegistry.getDefinition(
+        'codebase_investigator',
+      );
+      expect(investigatorDef).toBeDefined();
+      expect(investigatorDef?.modelConfig.model).toBe('gemini-3-pro-preview');
+    });
   });
 
   describe('registration logic', () => {

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -9,6 +9,11 @@ import type { AgentDefinition } from './types.js';
 import { CodebaseInvestigatorAgent } from './codebase-investigator.js';
 import { type z } from 'zod';
 import { debugLogger } from '../utils/debugLogger.js';
+import {
+  DEFAULT_GEMINI_MODEL_AUTO,
+  GEMINI_MODEL_ALIAS_PRO,
+  PREVIEW_GEMINI_MODEL,
+} from '../config/models.js';
 import type { ModelConfigAlias } from '../services/modelConfigService.js';
 
 /**
@@ -48,13 +53,26 @@ export class AgentRegistry {
 
     // Only register the agent if it's enabled in the settings.
     if (investigatorSettings?.enabled) {
+      let model =
+        investigatorSettings.model ??
+        CodebaseInvestigatorAgent.modelConfig.model;
+
+      // If the user is using the preview model for the main agent, force the sub-agent to use it too
+      // if it's configured to use 'pro' or 'auto'.
+      if (this.config.getModel() === PREVIEW_GEMINI_MODEL) {
+        if (
+          model === GEMINI_MODEL_ALIAS_PRO ||
+          model === DEFAULT_GEMINI_MODEL_AUTO
+        ) {
+          model = PREVIEW_GEMINI_MODEL;
+        }
+      }
+
       const agentDef = {
         ...CodebaseInvestigatorAgent,
         modelConfig: {
           ...CodebaseInvestigatorAgent.modelConfig,
-          model:
-            investigatorSettings.model ??
-            CodebaseInvestigatorAgent.modelConfig.model,
+          model,
           thinkingBudget:
             investigatorSettings.thinkingBudget ??
             CodebaseInvestigatorAgent.modelConfig.thinkingBudget,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -34,6 +34,7 @@ import { logRipgrepFallback } from '../telemetry/loggers.js';
 import { RipgrepFallbackEvent } from '../telemetry/types.js';
 import { ToolRegistry } from '../tools/tool-registry.js';
 import { DEFAULT_MODEL_CONFIGS } from './defaultModelConfigs.js';
+import { GEMINI_MODEL_ALIAS_PRO } from './models.js';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
@@ -886,6 +887,13 @@ describe('Server Config (config.ts)', () => {
       await config.initialize();
 
       expect(SubagentToolWrapperMock).not.toHaveBeenCalled();
+    });
+
+    it('should default codebase investigator model to PRO alias', () => {
+      const config = new Config(baseParams);
+      expect(config.getCodebaseInvestigatorSettings()?.model).toBe(
+        GEMINI_MODEL_ALIAS_PRO,
+      );
     });
 
     describe('with minified tool class names', () => {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -34,7 +34,6 @@ import { logRipgrepFallback } from '../telemetry/loggers.js';
 import { RipgrepFallbackEvent } from '../telemetry/types.js';
 import { ToolRegistry } from '../tools/tool-registry.js';
 import { DEFAULT_MODEL_CONFIGS } from './defaultModelConfigs.js';
-import { GEMINI_MODEL_ALIAS_PRO } from './models.js';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
@@ -889,11 +888,9 @@ describe('Server Config (config.ts)', () => {
       expect(SubagentToolWrapperMock).not.toHaveBeenCalled();
     });
 
-    it('should default codebase investigator model to PRO alias', () => {
+    it('should not set default codebase investigator model in config (defaults in registry)', () => {
       const config = new Config(baseParams);
-      expect(config.getCodebaseInvestigatorSettings()?.model).toBe(
-        GEMINI_MODEL_ALIAS_PRO,
-      );
+      expect(config.getCodebaseInvestigatorSettings()?.model).toBeUndefined();
     });
 
     describe('with minified tool class names', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -49,7 +49,6 @@ import {
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_THINKING_MODE,
-  GEMINI_MODEL_ALIAS_PRO,
 } from './models.js';
 import { shouldAttemptBrowserLaunch } from '../utils/browser.js';
 import type { MCPOAuthConfig } from '../mcp/oauth-provider.js';
@@ -573,8 +572,7 @@ export class Config {
       thinkingBudget:
         params.codebaseInvestigatorSettings?.thinkingBudget ??
         DEFAULT_THINKING_MODE,
-      model:
-        params.codebaseInvestigatorSettings?.model ?? GEMINI_MODEL_ALIAS_PRO,
+      model: params.codebaseInvestigatorSettings?.model,
     };
     this.continueOnFailedApiCall = params.continueOnFailedApiCall ?? true;
     this.enableShellOutputEfficiency =

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -48,8 +48,8 @@ import { tokenLimit } from '../core/tokenLimits.js';
 import {
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
-  DEFAULT_GEMINI_MODEL,
   DEFAULT_THINKING_MODE,
+  GEMINI_MODEL_ALIAS_PRO,
 } from './models.js';
 import { shouldAttemptBrowserLaunch } from '../utils/browser.js';
 import type { MCPOAuthConfig } from '../mcp/oauth-provider.js';
@@ -573,7 +573,8 @@ export class Config {
       thinkingBudget:
         params.codebaseInvestigatorSettings?.thinkingBudget ??
         DEFAULT_THINKING_MODE,
-      model: params.codebaseInvestigatorSettings?.model ?? DEFAULT_GEMINI_MODEL,
+      model:
+        params.codebaseInvestigatorSettings?.model ?? GEMINI_MODEL_ALIAS_PRO,
     };
     this.continueOnFailedApiCall = params.continueOnFailedApiCall ?? true;
     this.enableShellOutputEfficiency =

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1331,8 +1331,8 @@
             "model": {
               "title": "Model",
               "description": "The model to use for the Codebase Investigator agent.",
-              "markdownDescription": "The model to use for the Codebase Investigator agent.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `gemini-2.5-pro`",
-              "default": "gemini-2.5-pro",
+              "markdownDescription": "The model to use for the Codebase Investigator agent.\n\n- Category: `Experimental`\n- Requires restart: `yes`\n- Default: `pro`",
+              "default": "pro",
               "type": "string"
             }
           },


### PR DESCRIPTION
## Summary

Updates the Codebase Investigator subagent to correctly switch between `gemini-3-pro-preview` and `gemini-2.5-pro` based on the main agent's configuration. Previously, the subagent was effectively pinned to `gemini-2.5-pro` in many configurations. Now, it consistently matches the main agent's generation, ensuring `gemini-3-pro-preview` is used when appropriate, even if global preview features are disabled.

## Details

- **Dynamic Model Resolution**: The Codebase Investigator now uses the `GEMINI_MODEL_ALIAS_PRO` alias by default. This allows it to participate in the standard alias resolution logic.
- **Context-Aware Override**: Modified `AgentRegistry.loadBuiltInAgents` to check if the main agent is using `PREVIEW_GEMINI_MODEL` (`gemini-3-pro-preview`). If so, and the Codebase Investigator is configured to use `pro` or `auto`, it explicitly overrides the subagent's model to `PREVIEW_GEMINI_MODEL`. This ensures that if the user explicitly opts into the preview model for the main agent, the subagent follows suit.
- **Tests**:
  - Added a new test case in `packages/core/src/agents/registry.test.ts` to verify the model override logic works as expected.
  - Added a new test case in `packages/core/src/config/config.test.ts` to verify the correct default model alias is returned.

## Related Issues

<!-- N/A -->

## How to Validate

1.  **Run the new registry test**:

    ```bash
    npm test packages/core/src/agents/registry.test.ts
    ```

    Verify that the test named `should use preview model for codebase investigator if main model is preview` passes.

2.  **Run the config test**:
    ```bash
    npm test packages/core/src/config/config.test.ts
    ```
    Verify that `getCodebaseInvestigatorSettings` returns the correct default model.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
