### PR TITLE
bug(cli): Stop swallowing invalid stream errors.

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -1731,4 +1731,24 @@ describe('runNonInteractive', () => {
     );
     expect(getWrittenOutput()).toContain('Done');
   });
+
+  it('should throw an error when GeminiEventType.InvalidStream is received', async () => {
+    const events: ServerGeminiStreamEvent[] = [
+      { type: GeminiEventType.InvalidStream },
+    ];
+    mockGeminiClient.sendMessageStream.mockReturnValue(
+      createStreamFromEvents(events),
+    );
+
+    const runPromise = runNonInteractive({
+      config: mockConfig,
+      settings: mockSettings,
+      input: 'Invalid stream test',
+      prompt_id: 'prompt-id-invalid-stream',
+    });
+
+    await expect(runPromise).rejects.toThrow(
+      'Stream ended with invalid content.',
+    );
+  });
 });

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -346,6 +346,8 @@ export async function runNonInteractive({
             }
           } else if (event.type === GeminiEventType.Error) {
             throw event.value.error;
+          } else if (event.type === GeminiEventType.InvalidStream) {
+            throw new Error('Stream ended with invalid content.');
           }
         }
 


### PR DESCRIPTION
Fixes a minor bug in the `nonInteractiveCli` where we were swallowing these error.