### PR TITLE
feat: add option to disable automatic model fallback

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -72,6 +72,7 @@ export interface CliArgs {
   useWriteTodos: boolean | undefined;
   outputFormat: string | undefined;
   fakeResponses: string | undefined;
+  modelFallback: boolean | undefined;
   recordResponses: string | undefined;
 }
 
@@ -236,6 +237,12 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           type: 'string',
           description: 'Path to a file to record model responses for testing.',
           hidden: true,
+        })
+        .option('model-fallback', {
+          type: 'boolean',
+          default: true,
+          description:
+            'Enable automatic fallback to Flash model on rate limit (use --no-model-fallback to disable).',
         })
         .deprecateOption(
           'prompt',

--- a/packages/cli/src/config/disableModelFallback.test.ts
+++ b/packages/cli/src/config/disableModelFallback.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseArguments } from './config.js';
+import type { LoadedSettings } from './settings.js';
+
+describe('Disable Model Fallback Feature', () => {
+  let mockSettings: LoadedSettings;
+  const mockExit = vi
+    .spyOn(process, 'exit')
+    .mockImplementation(() => undefined as never);
+
+  // Mock dependencies
+  vi.mock('@google/gemini-cli-core', async () => {
+    const actual = await vi.importActual('@google/gemini-cli-core');
+    return {
+      ...actual,
+      runExitCleanup: vi.fn(),
+      debugLogger: {
+        error: vi.fn((msg) => console.error('DEBUG LOGGER ERROR:', msg)),
+        log: vi.fn(),
+        warn: vi.fn(),
+      },
+    };
+  });
+
+  beforeEach(() => {
+    mockExit.mockClear();
+    mockSettings = {
+      merged: {
+        general: {
+          disableModelFallback: false,
+        },
+      },
+      applyCliOverrides: vi.fn((overrides) => {
+        (mockSettings as { merged: LoadedSettings['merged'] }).merged = {
+          ...mockSettings.merged,
+          ...overrides,
+        };
+      }),
+    } as unknown as LoadedSettings;
+  });
+
+  it('should parse --no-model-fallback flag', async () => {
+    const originalArgv = process.argv;
+    process.argv = ['node', 'gemini', '--no-model-fallback'];
+
+    const args = await parseArguments(mockSettings.merged);
+    expect(args.modelFallback).toBe(false);
+
+    process.argv = originalArgv;
+  });
+
+  it('should apply CLI override when flag is present', async () => {
+    // Simulate the logic in gemini.tsx
+    const args = { modelFallback: false };
+
+    if (args.modelFallback === false) {
+      mockSettings.applyCliOverrides({
+        general: {
+          disableModelFallback: true,
+        },
+      });
+    }
+
+    expect(mockSettings.applyCliOverrides).toHaveBeenCalledWith({
+      general: {
+        disableModelFallback: true,
+      },
+    });
+    expect(mockSettings.merged.general?.disableModelFallback).toBe(true);
+  });
+
+  it('should not apply CLI override when flag is absent', async () => {
+    const args = { modelFallback: true };
+
+    if (args.modelFallback === false) {
+      mockSettings.applyCliOverrides({
+        general: {
+          disableModelFallback: true,
+        },
+      });
+    }
+
+    expect(mockSettings.applyCliOverrides).not.toHaveBeenCalled();
+    expect(mockSettings.merged.general?.disableModelFallback).toBe(false);
+  });
+});

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -488,6 +488,15 @@ export class LoadedSettings {
     this._merged = this.computeMergedSettings();
     saveSettings(settingsFile);
   }
+
+  applyCliOverrides(overrides: Partial<Settings>): void {
+    this._merged = customDeepMerge(
+      getMergeStrategyForPath,
+      {},
+      this._merged,
+      overrides,
+    ) as Settings;
+  }
 }
 
 function findEnvFile(startDir: string): string | null {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -205,6 +205,15 @@ const SETTINGS_SCHEMA = {
         description: 'Disable update notification prompts.',
         showInDialog: false,
       },
+      disableModelFallback: {
+        type: 'boolean',
+        label: 'Disable Model Fallback',
+        category: 'General',
+        requiresRestart: false,
+        default: false,
+        description: 'Disable automatic fallback to Flash model on rate limit.',
+        showInDialog: true,
+      },
       checkpointing: {
         type: 'object',
         label: 'Checkpointing',

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -314,6 +314,14 @@ export async function main() {
   const argv = await parseArguments(settings.merged);
   parseArgsHandle?.end();
 
+  if (argv.modelFallback === false) {
+    settings.applyCliOverrides({
+      general: {
+        disableModelFallback: true,
+      },
+    });
+  }
+
   // Check for invalid input combinations early to prevent crashes
   if (argv.promptInteractive && !process.stdin.isTTY) {
     writeToStderr(

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -408,6 +408,7 @@ export const AppContainer = (props: AppContainerProps) => {
     historyManager,
     userTier,
     setModelSwitchedFromQuotaError,
+    settings,
   });
 
   // Derive auth state variables for backward compatibility with UIStateContext

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -33,6 +33,7 @@ import {
 import { useQuotaAndFallback } from './useQuotaAndFallback.js';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { MessageType } from '../types.js';
+import type { LoadedSettings } from '../../config/settings.js';
 
 // Use a type alias for SpyInstance as it's not directly exported
 type SpyInstance = ReturnType<typeof vi.spyOn>;
@@ -43,9 +44,23 @@ describe('useQuotaAndFallback', () => {
   let mockSetModelSwitchedFromQuotaError: Mock;
   let setFallbackHandlerSpy: SpyInstance;
   let mockGoogleApiError: GoogleApiError;
+  let mockSettings: LoadedSettings;
 
   beforeEach(() => {
     mockConfig = makeFakeConfig();
+    mockSettings = {
+      merged: {
+        general: {
+          disableModelFallback: false,
+        },
+      },
+      applyCliOverrides: vi.fn((overrides) => {
+        (mockSettings as { merged: LoadedSettings['merged'] }).merged = {
+          ...mockSettings.merged,
+          ...overrides,
+        };
+      }),
+    } as unknown as LoadedSettings;
     mockGoogleApiError = {
       code: 429,
       message: 'mock error',
@@ -82,6 +97,7 @@ describe('useQuotaAndFallback', () => {
         historyManager: mockHistoryManager,
         userTier: UserTierId.FREE,
         setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+        settings: mockSettings,
       }),
     );
 
@@ -98,6 +114,7 @@ describe('useQuotaAndFallback', () => {
           historyManager: mockHistoryManager,
           userTier: UserTierId.FREE,
           setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+          settings: mockSettings,
         }),
       );
       return setFallbackHandlerSpy.mock.calls[0][0] as FallbackModelHandler;
@@ -124,6 +141,7 @@ describe('useQuotaAndFallback', () => {
             historyManager: mockHistoryManager,
             userTier: UserTierId.FREE,
             setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+            settings: mockSettings,
           }),
         );
 
@@ -175,6 +193,7 @@ describe('useQuotaAndFallback', () => {
             historyManager: mockHistoryManager,
             userTier: UserTierId.FREE,
             setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+            settings: mockSettings,
           }),
         );
 
@@ -240,6 +259,7 @@ describe('useQuotaAndFallback', () => {
               userTier: UserTierId.FREE,
               setModelSwitchedFromQuotaError:
                 mockSetModelSwitchedFromQuotaError,
+              settings: mockSettings,
             }),
           );
 
@@ -294,6 +314,7 @@ describe('useQuotaAndFallback', () => {
             historyManager: mockHistoryManager,
             userTier: UserTierId.FREE,
             setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+            settings: mockSettings,
           }),
         );
 
@@ -341,6 +362,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
           historyManager: mockHistoryManager,
           userTier: UserTierId.FREE,
           setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+          settings: mockSettings,
         }),
       );
 
@@ -358,6 +380,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
           historyManager: mockHistoryManager,
           userTier: UserTierId.FREE,
           setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+          settings: mockSettings,
         }),
       );
 
@@ -388,6 +411,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
           historyManager: mockHistoryManager,
           userTier: UserTierId.FREE,
           setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+          settings: mockSettings,
         }),
       );
 
@@ -425,6 +449,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
           historyManager: mockHistoryManager,
           userTier: UserTierId.FREE,
           setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+          settings: mockSettings,
         }),
       );
 
@@ -460,6 +485,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
           historyManager: mockHistoryManager,
           userTier: UserTierId.FREE,
           setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+          settings: mockSettings,
         }),
       );
 

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -19,12 +19,14 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { type UseHistoryManagerReturn } from './useHistoryManager.js';
 import { MessageType } from '../types.js';
 import { type ProQuotaDialogRequest } from '../contexts/UIStateContext.js';
+import { type LoadedSettings } from '../../config/settings.js';
 
 interface UseQuotaAndFallbackArgs {
   config: Config;
   historyManager: UseHistoryManagerReturn;
   userTier: UserTierId | undefined;
   setModelSwitchedFromQuotaError: (value: boolean) => void;
+  settings: LoadedSettings;
 }
 
 export function useQuotaAndFallback({
@@ -32,6 +34,7 @@ export function useQuotaAndFallback({
   historyManager,
   userTier,
   setModelSwitchedFromQuotaError,
+  settings,
 }: UseQuotaAndFallbackArgs) {
   const [proQuotaRequest, setProQuotaRequest] =
     useState<ProQuotaDialogRequest | null>(null);
@@ -50,6 +53,10 @@ export function useQuotaAndFallback({
         !contentGeneratorConfig ||
         contentGeneratorConfig.authType !== AuthType.LOGIN_WITH_GOOGLE
       ) {
+        return null;
+      }
+
+      if (settings.merged.general?.disableModelFallback) {
         return null;
       }
 
@@ -108,7 +115,13 @@ export function useQuotaAndFallback({
     };
 
     config.setFallbackModelHandler(fallbackHandler);
-  }, [config, historyManager, userTier, setModelSwitchedFromQuotaError]);
+  }, [
+    config,
+    historyManager,
+    userTier,
+    setModelSwitchedFromQuotaError,
+    settings,
+  ]);
 
   const handleProQuotaChoice = useCallback(
     (choice: FallbackIntent) => {


### PR DESCRIPTION
## Description
Adds the ability to disable automatic model fallback from Pro to Flash models when rate limits are encountered.

## Changes
- Added `--no-model-fallback` CLI flag (implemented as `--model-fallback` boolean option with default `true`)
- Added `disableModelFallback` setting in `settings.json` under `general` section
- Modified fallback logic in `useQuotaAndFallback.ts` to check the setting and abort fallback if disabled
- Added comprehensive tests for the new feature

## Usage
### Via CLI flag:
```bash
gemini --no-model-fallback
```

### Via settings.json:
```json
{
  "general": {
    "disableModelFallback": true
  }
}
```

Closes #2208