### PR TITLE
chore: add ESLint import ordering rule

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "vitest.disableWorkspaceWarning": true
+  "vitest.disableWorkspaceWarning": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "never"
+  }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -136,6 +136,25 @@ export default tseslint.config(
         },
       ],
       'import/no-relative-packages': 'error',
+      'import/order': [
+        'error',
+        {
+          groups: [
+            'builtin',   // Node.js built-in modules
+            'external',  // External npm packages
+            'internal',  // Internal modules (aliases, monorepo packages)
+            'parent',    // Parent directory imports
+            'sibling',   // Same directory imports
+            'index',     // Index file imports
+            'type',      // Type-only imports
+          ],
+          'newlines-between': 'never',
+          alphabetize: {
+            order: 'asc',
+            caseInsensitive: true,
+          },
+        },
+      ],
       'no-cond-assign': 'error',
       'no-debugger': 'error',
       'no-duplicate-case': 'error',


### PR DESCRIPTION
## Description
Adds ESLint `import/order` rule to enforce consistent import organization across the codebase, preventing diff noise from different editors auto-sorting imports differently.

## Changes
- Added `import/order` ESLint rule with configured groups and alphabetical sorting
- Disabled `source.organizeImports` in VS Code settings to prevent conflicts with ESLint
- Import groups are now organized: builtin → external → internal → parent → sibling → index → type
- Alphabetical sorting enabled within each group (case-insensitive)

## Benefits
- Prevents import reordering diff noise in PRs
- Consistent import order across all contributors
- Auto-fixable via `npm run lint -- --fix`
- Editor integration shows violations in real-time

## Note
This PR only adds the ESLint configuration. A follow-up PR may be needed to apply `--fix` across the codebase to resolve existing violations.