### PR TITLE
fix: improve retry logic for fetch errors and network codes

### DIFF
--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -16,9 +16,6 @@ import { delay, createAbortError } from './delay.js';
 import { debugLogger } from './debugLogger.js';
 import { getErrorStatus, ModelNotFoundError } from './httpErrors.js';
 
-const FETCH_FAILED_MESSAGE =
-  'exception TypeError: fetch failed sending request';
-
 export interface RetryOptions {
   maxAttempts: number;
   initialDelayMs: number;
@@ -41,6 +38,40 @@ const DEFAULT_RETRY_OPTIONS: RetryOptions = {
   shouldRetryOnError: defaultShouldRetry,
 };
 
+const RETRYABLE_NETWORK_CODES = [
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EPIPE',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+];
+
+function getNetworkErrorCode(error: unknown): string | undefined {
+  const getCode = (obj: unknown): string | undefined => {
+    if (typeof obj !== 'object' || obj === null) {
+      return undefined;
+    }
+    if ('code' in obj && typeof (obj as { code: unknown }).code === 'string') {
+      return (obj as { code: string }).code;
+    }
+    return undefined;
+  };
+
+  const directCode = getCode(error);
+  if (directCode) {
+    return directCode;
+  }
+
+  if (typeof error === 'object' && error !== null && 'cause' in error) {
+    return getCode((error as { cause: unknown }).cause);
+  }
+
+  return undefined;
+}
+
+const FETCH_FAILED_MESSAGE = 'fetch failed';
+
 /**
  * Default predicate function to determine if a retry should be attempted.
  * Retries on 429 (Too Many Requests) and 5xx server errors.
@@ -52,12 +83,17 @@ function defaultShouldRetry(
   error: Error | unknown,
   retryFetchErrors?: boolean,
 ): boolean {
-  if (
-    retryFetchErrors &&
-    error instanceof Error &&
-    error.message.includes(FETCH_FAILED_MESSAGE)
-  ) {
-    return true;
+  if (retryFetchErrors && error instanceof Error) {
+    // Check for generic fetch failed message (case-insensitive)
+    if (error.message.toLowerCase().includes(FETCH_FAILED_MESSAGE)) {
+      return true;
+    }
+
+    // Check for common network error codes
+    const errorCode = getNetworkErrorCode(error);
+    if (errorCode && RETRYABLE_NETWORK_CODES.includes(errorCode)) {
+      return true;
+    }
   }
 
   // Priority check for ApiError


### PR DESCRIPTION
## Summary

This pull request enhances the retry mechanism to be more resilient to transient network issues. The previous implementation only retried on a very specific fetch failed error message. This change expands the logic to also retry on a broader range of common network-related errors (such as ECONNRESET, ETIMEDOUT), improving the overall reliability of network requests.

## Details

The core changes are in `packages/core/src/utils/retry.ts`:
*   The error message check is now a case-insensitive search for the simpler "fetch failed" string, making it more robust.
*   A list of common, retryable network error codes has been introduced (`RETRYABLE_NETWORK_CODES`).
*   A new helper function, `getNetworkErrorCode`, has been added to inspect an error object and its `cause` property for one of these network codes.
*   The main `defaultShouldRetry` function now uses this logic to trigger a retry if a recognized network error occurs.
*   Corresponding unit tests have been added to validate the new retry behaviors.

## Related Issues

https://github.com/google-gemini/gemini-cli/issues/1088

## How to Validate

The new logic is covered by updated unit tests in `packages/core/src/utils/retry.test.ts`. You can validate the changes by reviewing the new tests, which now cover retries for:
1.  A generic `fetch failed` error.
2.  A direct network error code (e.g., `ECONNRESET`) on the error object.
3.  A nested network error code (e.g., `ETIMEDOUT`) within the error's `cause` property.