### PR TITLE
fix: Bundle default policies for npx distribution

### DIFF
--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -31,10 +31,26 @@ if (!existsSync(bundleDir)) {
   mkdirSync(bundleDir);
 }
 
-// Find and copy all .sb files from packages to the root of the bundle directory
+// 1. Copy Sandbox definitions (.sb)
 const sbFiles = glob.sync('packages/**/*.sb', { cwd: root });
 for (const file of sbFiles) {
   copyFileSync(join(root, file), join(bundleDir, basename(file)));
 }
 
+// 2. Copy Policy definitions (.toml)
+const policyDir = join(bundleDir, 'policies');
+if (!existsSync(policyDir)) {
+  mkdirSync(policyDir);
+}
+
+// Locate policy files specifically in the core package
+const policyFiles = glob.sync('packages/core/src/policy/policies/*.toml', {
+  cwd: root,
+});
+
+for (const file of policyFiles) {
+  copyFileSync(join(root, file), join(policyDir, basename(file)));
+}
+
+console.log(`Copied ${policyFiles.length} policy files to bundle/policies/`);
 console.log('Assets copied to bundle/');


### PR DESCRIPTION
When running the CLI via `npx` (bundled), the default policy files were missing, causing the CLI to fail to load default security rules. This change updates `scripts/copy_bundle_assets.js` to explicitly copy `.toml` policy files from `packages/core` to the bundle output.