### PR TITLE
feat(cli): show setting descriptions in settings dialog

### DIFF
--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -301,6 +301,39 @@ describe('SettingsDialog', () => {
       // Use snapshot to capture visual layout including indicators
       expect(output).toMatchSnapshot();
     });
+
+    it('should display description for the active setting', () => {
+      const settings = createMockSettings();
+      const onSelect = vi.fn();
+
+      const { lastFrame } = renderDialog(settings, onSelect);
+
+      const output = lastFrame();
+      // First setting is "Preview Features" which has a description
+      expect(output).toContain('Enable preview features');
+    });
+
+    it('should update description when navigating to a different setting', async () => {
+      const settings = createMockSettings();
+      const onSelect = vi.fn();
+
+      const { lastFrame, stdin, unmount } = renderDialog(settings, onSelect);
+
+      // Initial description for first setting
+      expect(lastFrame()).toContain('Enable preview features');
+
+      // Navigate down to Vim Mode setting
+      act(() => {
+        stdin.write(TerminalKeys.DOWN_ARROW);
+      });
+
+      await waitFor(() => {
+        // Should now show Vim Mode description
+        expect(lastFrame()).toContain('Enable Vim keybindings');
+      });
+
+      unmount();
+    });
   });
 
   describe('Setting Descriptions', () => {

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -489,7 +489,8 @@ export function SettingsDialog({
   const SCOPE_SELECTION_HEIGHT = 4; // Apply To section height
   const BOTTOM_HELP_TEXT_HEIGHT = 1; // Help text
   const RESTART_PROMPT_HEIGHT = showRestartPrompt ? 1 : 0;
-  const DESCRIPTION_HEIGHT = 2; // Description text area for active setting
+  // Description text area for active setting (allows for wrapping)
+  const DESCRIPTION_HEIGHT = 3;
 
   let currentAvailableTerminalHeight =
     availableTerminalHeight ?? Number.MAX_SAFE_INTEGER;

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -489,6 +489,7 @@ export function SettingsDialog({
   const SCOPE_SELECTION_HEIGHT = 4; // Apply To section height
   const BOTTOM_HELP_TEXT_HEIGHT = 1; // Help text
   const RESTART_PROMPT_HEIGHT = showRestartPrompt ? 1 : 0;
+  const DESCRIPTION_HEIGHT = 2; // Description text area for active setting
 
   let currentAvailableTerminalHeight =
     availableTerminalHeight ?? Number.MAX_SAFE_INTEGER;
@@ -500,6 +501,7 @@ export function SettingsDialog({
     SETTINGS_TITLE_HEIGHT +
     SCROLL_ARROWS_HEIGHT +
     SPACING_HEIGHT +
+    DESCRIPTION_HEIGHT +
     BOTTOM_HELP_TEXT_HEIGHT +
     RESTART_PROMPT_HEIGHT;
 
@@ -1074,6 +1076,16 @@ export function SettingsDialog({
               </Box>
             )}
           </>
+        )}
+
+        {/* Description for active setting */}
+        {items[activeSettingIndex] && (
+          <Box marginTop={1}>
+            <Text color={theme.text.secondary} wrap="wrap">
+              {getSettingDefinition(items[activeSettingIndex].value)
+                ?.description || ''}
+            </Text>
+          </Box>
         )}
 
         <Box height={1} />

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -489,8 +489,8 @@ export function SettingsDialog({
   const SCOPE_SELECTION_HEIGHT = 4; // Apply To section height
   const BOTTOM_HELP_TEXT_HEIGHT = 1; // Help text
   const RESTART_PROMPT_HEIGHT = showRestartPrompt ? 1 : 0;
-  // Description text area for active setting (allows for wrapping)
-  const DESCRIPTION_HEIGHT = 3;
+  // Description text area for active setting (truncated with ellipsis if needed)
+  const DESCRIPTION_HEIGHT = 2;
 
   let currentAvailableTerminalHeight =
     availableTerminalHeight ?? Number.MAX_SAFE_INTEGER;
@@ -1081,8 +1081,8 @@ export function SettingsDialog({
 
         {/* Description for active setting */}
         {items[activeSettingIndex] && (
-          <Box marginTop={1}>
-            <Text color={theme.text.secondary} wrap="wrap">
+          <Box marginTop={1} height={1} overflowY="hidden">
+            <Text color={theme.text.secondary} wrap="truncate-end">
               {getSettingDefinition(items[activeSettingIndex].value)
                 ?.description || ''}
             </Text>

--- a/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
@@ -34,9 +34,9 @@ exports[`SettingsDialog > Initial Rendering > should render settings list with v
 │    Hide Window Title                                                                      false  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
-│ Enable preview features (e.g., preview models).                                                  │
-│                                                                                                  │
 │  ▼                                                                                               │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │    Apply To                                                                                      │
 │  ● User Settings                                                                                 │
@@ -82,9 +82,9 @@ exports[`SettingsDialog > Snapshot Tests > should render 'accessibility settings
 │    Hide Window Title                                                                      false  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
-│ Enable preview features (e.g., preview models).                                                  │
-│                                                                                                  │
 │  ▼                                                                                               │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │    Apply To                                                                                      │
 │  ● User Settings                                                                                 │
@@ -130,9 +130,9 @@ exports[`SettingsDialog > Snapshot Tests > should render 'all boolean settings d
 │    Hide Window Title                                                                     false*  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
-│ Enable preview features (e.g., preview models).                                                  │
-│                                                                                                  │
 │  ▼                                                                                               │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │    Apply To                                                                                      │
 │  ● User Settings                                                                                 │
@@ -178,9 +178,9 @@ exports[`SettingsDialog > Snapshot Tests > should render 'default state' correct
 │    Hide Window Title                                                                      false  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
-│ Enable preview features (e.g., preview models).                                                  │
-│                                                                                                  │
 │  ▼                                                                                               │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │    Apply To                                                                                      │
 │  ● User Settings                                                                                 │
@@ -226,9 +226,9 @@ exports[`SettingsDialog > Snapshot Tests > should render 'file filtering setting
 │    Hide Window Title                                                                      false  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
-│ Enable preview features (e.g., preview models).                                                  │
-│                                                                                                  │
 │  ▼                                                                                               │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │    Apply To                                                                                      │
 │  ● User Settings                                                                                 │
@@ -274,9 +274,9 @@ exports[`SettingsDialog > Snapshot Tests > should render 'focused on scope selec
 │    Hide Window Title                                                                      false  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
-│ Enable preview features (e.g., preview models).                                                  │
-│                                                                                                  │
 │  ▼                                                                                               │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │  > Apply To                                                                                      │
 │  ● 1. User Settings                                                                              │
@@ -322,9 +322,9 @@ exports[`SettingsDialog > Snapshot Tests > should render 'mixed boolean and numb
 │    Hide Window Title                                                                     false*  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
-│ Enable preview features (e.g., preview models).                                                  │
-│                                                                                                  │
 │  ▼                                                                                               │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │    Apply To                                                                                      │
 │  ● User Settings                                                                                 │
@@ -370,9 +370,9 @@ exports[`SettingsDialog > Snapshot Tests > should render 'tools and security set
 │    Hide Window Title                                                                      false  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
-│ Enable preview features (e.g., preview models).                                                  │
-│                                                                                                  │
 │  ▼                                                                                               │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │    Apply To                                                                                      │
 │  ● User Settings                                                                                 │
@@ -418,9 +418,9 @@ exports[`SettingsDialog > Snapshot Tests > should render 'various boolean settin
 │    Hide Window Title                                                                      true*  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
-│ Enable preview features (e.g., preview models).                                                  │
-│                                                                                                  │
 │  ▼                                                                                               │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │    Apply To                                                                                      │
 │  ● User Settings                                                                                 │

--- a/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
@@ -34,6 +34,8 @@ exports[`SettingsDialog > Initial Rendering > should render settings list with v
 │    Hide Window Title                                                                      false  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
+│                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
 │    Apply To                                                                                      │
@@ -79,6 +81,8 @@ exports[`SettingsDialog > Snapshot Tests > should render 'accessibility settings
 │                                                                                                  │
 │    Hide Window Title                                                                      false  │
 │    Hide the window title bar                                                                     │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
@@ -126,6 +130,8 @@ exports[`SettingsDialog > Snapshot Tests > should render 'all boolean settings d
 │    Hide Window Title                                                                     false*  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
+│                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
 │    Apply To                                                                                      │
@@ -171,6 +177,8 @@ exports[`SettingsDialog > Snapshot Tests > should render 'default state' correct
 │                                                                                                  │
 │    Hide Window Title                                                                      false  │
 │    Hide the window title bar                                                                     │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
@@ -218,6 +226,8 @@ exports[`SettingsDialog > Snapshot Tests > should render 'file filtering setting
 │    Hide Window Title                                                                      false  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
+│                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
 │    Apply To                                                                                      │
@@ -263,6 +273,8 @@ exports[`SettingsDialog > Snapshot Tests > should render 'focused on scope selec
 │                                                                                                  │
 │    Hide Window Title                                                                      false  │
 │    Hide the window title bar                                                                     │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
@@ -310,6 +322,8 @@ exports[`SettingsDialog > Snapshot Tests > should render 'mixed boolean and numb
 │    Hide Window Title                                                                     false*  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
+│                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
 │    Apply To                                                                                      │
@@ -356,6 +370,8 @@ exports[`SettingsDialog > Snapshot Tests > should render 'tools and security set
 │    Hide Window Title                                                                      false  │
 │    Hide the window title bar                                                                     │
 │                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
+│                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │
 │    Apply To                                                                                      │
@@ -401,6 +417,8 @@ exports[`SettingsDialog > Snapshot Tests > should render 'various boolean settin
 │                                                                                                  │
 │    Hide Window Title                                                                      true*  │
 │    Hide the window title bar                                                                     │
+│                                                                                                  │
+│ Enable preview features (e.g., preview models).                                                  │
 │                                                                                                  │
 │  ▼                                                                                               │
 │                                                                                                  │


### PR DESCRIPTION
## Summary

Display the description of the currently selected setting in the settings dialog. The descriptions were already defined in the schema but never shown to users.

## Details

- Added a text area below the settings list that shows the description of the active setting
- Adjusted height calculations to account for the new description area
- Descriptions update as user navigates through settings with arrow keys
- Added tests to verify description displays and updates on navigation
  
## Related Issues

Fixes #14394

## How to Validate

1. Run `npm run build && npm start`
2. Type `/settings` to open the settings dialog
3. Navigate up/down with arrow keys
4. Verify the description text changes for each setting
5. Test with search (`/`) to confirm descriptions work for filtered results

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
