### PR TITLE
Add license field into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@google/gemini-cli",
   "version": "0.21.0-nightly.20251202.2d935b379",
-  "license": "Apache-2.0",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@google/gemini-cli",
   "version": "0.21.0-nightly.20251202.2d935b379",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,7 @@
   "name": "@google/gemini-cli",
   "version": "0.21.0-nightly.20251202.2d935b379",
   "description": "Gemini CLI",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/google-gemini/gemini-cli.git"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@google/gemini-cli-core",
   "version": "0.21.0-nightly.20251202.2d935b379",
   "description": "Gemini CLI Core",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/google-gemini/gemini-cli.git"


### PR DESCRIPTION
Add the license field in the package.json to reflect the project license.

## Summary

Add the license information into the package.json to reflect the project license.

## Details

License field is used by different systems to quickly identify the project license.

## How to Validate

Verify license property is present.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
