### PR TITLE
fix(cli): Fix word navigation for CJK characters

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -2275,6 +2275,12 @@ describe('Unicode helper functions', () => {
       // Should be at start of "你好" (index 0)
       expect(result.current.cursor[1]).toBe(0);
 
+      // Move word left again (should stay at 0)
+      act(() => {
+        result.current.move('wordLeft');
+      });
+      expect(result.current.cursor[1]).toBe(0);
+
       // Move word right
       act(() => {
         result.current.move('wordRight');
@@ -2289,6 +2295,12 @@ describe('Unicode helper functions', () => {
       });
 
       // Should be at end of "世界" (index 4)
+      expect(result.current.cursor[1]).toBe(4);
+
+      // Move word right again (should stay at end)
+      act(() => {
+        result.current.move('wordRight');
+      });
       expect(result.current.cursor[1]).toBe(4);
     });
 
@@ -2320,6 +2332,10 @@ describe('Unicode helper functions', () => {
       expect(result.current.cursor[1]).toBe(5);
 
       // wordLeft -> start of "Hello" (index 0)
+      act(() => result.current.move('wordLeft'));
+      expect(result.current.cursor[1]).toBe(0);
+
+      // wordLeft -> start of line (should stay at 0)
       act(() => result.current.move('wordLeft'));
       expect(result.current.cursor[1]).toBe(0);
     });

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -2241,4 +2241,87 @@ describe('Unicode helper functions', () => {
       expect(cpLen('hello مرحبا world')).toBe(17);
     });
   });
+
+  describe('useTextBuffer CJK Navigation', () => {
+    const viewport = { width: 80, height: 24 };
+
+    it('should navigate by word in Chinese', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: '你好世界',
+          initialCursorOffset: 4, // End of string
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      // Initial state: cursor at end (index 2 in code points if 4 is length? wait. length is 2 code points? No. '你好世界' length is 4.)
+      // '你好世界' length is 4. Code points length is 4.
+
+      // Move word left
+      act(() => {
+        result.current.move('wordLeft');
+      });
+
+      // Should be at start of "世界" (index 2)
+      // "你好世界" -> "你好" | "世界"
+      expect(result.current.cursor[1]).toBe(2);
+
+      // Move word left again
+      act(() => {
+        result.current.move('wordLeft');
+      });
+
+      // Should be at start of "你好" (index 0)
+      expect(result.current.cursor[1]).toBe(0);
+
+      // Move word right
+      act(() => {
+        result.current.move('wordRight');
+      });
+
+      // Should be at end of "你好" (index 2)
+      expect(result.current.cursor[1]).toBe(2);
+
+      // Move word right again
+      act(() => {
+        result.current.move('wordRight');
+      });
+
+      // Should be at end of "世界" (index 4)
+      expect(result.current.cursor[1]).toBe(4);
+    });
+
+    it('should navigate mixed English and Chinese', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'Hello你好World',
+          initialCursorOffset: 10, // End
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      // Hello (5) + 你好 (2) + World (5) = 12 chars.
+      // initialCursorOffset 10? 'Hello你好World'.length is 12.
+      // Let's set it to end.
+
+      act(() => {
+        result.current.move('end');
+      });
+      expect(result.current.cursor[1]).toBe(12);
+
+      // wordLeft -> start of "World" (index 7)
+      act(() => result.current.move('wordLeft'));
+      expect(result.current.cursor[1]).toBe(7);
+
+      // wordLeft -> start of "你好" (index 5)
+      act(() => result.current.move('wordLeft'));
+      expect(result.current.cursor[1]).toBe(5);
+
+      // wordLeft -> start of "Hello" (index 0)
+      act(() => result.current.move('wordLeft'));
+      expect(result.current.cursor[1]).toBe(0);
+    });
+  });
 });

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -250,21 +250,15 @@ function findPrevWordBoundary(line: string, cursorCol: number): number {
   const prefix = codePoints.slice(0, cursorCol).join('');
   const cursorIdx = prefix.length;
 
-  const segments = Array.from(segmenter.segment(line));
   let targetIdx = 0;
 
-  // Search backwards for the start of the previous word
-  for (let i = segments.length - 1; i >= 0; i--) {
-    const seg = segments[i];
-    const segStart = seg.index;
+  for (const seg of segmenter.segment(line)) {
+    // We want the last word start strictly before the cursor.
+    // If we've reached or passed the cursor, we stop.
+    if (seg.index >= cursorIdx) break;
 
-    // We are looking for a word start strictly before the cursor
-    if (segStart >= cursorIdx) continue;
-
-    // If we found a word-like segment
     if (seg.isWordLike) {
-      targetIdx = segStart;
-      break;
+      targetIdx = seg.index;
     }
   }
 
@@ -276,18 +270,16 @@ function findNextWordBoundary(line: string, cursorCol: number): number {
   const prefix = codePoints.slice(0, cursorCol).join('');
   const cursorIdx = prefix.length;
 
-  const segments = Array.from(segmenter.segment(line));
   let targetIdx = line.length;
 
-  for (let i = 0; i < segments.length; i++) {
-    const seg = segments[i];
+  for (const seg of segmenter.segment(line)) {
     const segEnd = seg.index + seg.segment.length;
 
-    if (segEnd <= cursorIdx) continue;
-
-    if (seg.isWordLike) {
-      targetIdx = segEnd;
-      break;
+    if (segEnd > cursorIdx) {
+      if (seg.isWordLike) {
+        targetIdx = segEnd;
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
## TLDR

Fixes `Option + Left/Right` word navigation behavior for CJK (Chinese, Japanese, Korean) text by utilizing `Intl.Segmenter` for accurate word boundary detection.

## Dive Deeper

Previously, word navigation relied on a simple regex (`!/[\s,.;!?]/.test(ch)`) to identify word characters. This caused entire sentences in CJK languages (which often lack spaces) to be treated as a single word, causing the cursor to jump to the beginning or end of the line instead of the previous/next word.

This change replaces that logic with `Intl.Segmenter` (supported in Node.js >= 16), which provides locale-aware word segmentation. This ensures correct navigation for CJK languages as well as mixed-language content.

## Reviewer Test Plan

1.  Run the CLI: `npm run start`
2.  In the input prompt, type a sentence containing CJK characters, e.g., "你好世界" or mixed "Hello你好World".
3.  Use `Option + Left` and `Option + Right` (or `Ctrl + Left/Right` on Windows/Linux).
4.  **Verify**: The cursor should stop at logical word boundaries (e.g., between "你好" and "世界") rather than jumping to the start/end of the line.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves an issue where CJK input navigation was broken.