### PR TITLE
do not toggle the setting item when entering space

### DIFF
--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -466,20 +466,6 @@ describe('SettingsDialog', () => {
       });
     });
 
-    it('should toggle setting with Space key', async () => {
-      const settings = createMockSettings();
-      const onSelect = vi.fn();
-
-      const { stdin, unmount } = renderDialog(settings, onSelect);
-
-      // Press Space to toggle current setting
-      act(() => {
-        stdin.write(' '); // Space key
-      });
-
-      unmount();
-    });
-
     it('should handle vim mode setting specially', async () => {
       const settings = createMockSettings();
       const onSelect = vi.fn();

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -714,7 +714,7 @@ export function SettingsDialog({
           } else if (newIndex >= scrollOffset + effectiveMaxItemsToShow) {
             setScrollOffset(newIndex - effectiveMaxItemsToShow + 1);
           }
-        } else if (keyMatchers[Command.RETURN](key) || name === 'space') {
+        } else if (keyMatchers[Command.RETURN](key)) {
           const currentItem = items[activeSettingIndex];
           if (
             currentItem?.type === 'number' ||


### PR DESCRIPTION
## Summary
Do not toggle the setting when entering space.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
Users can enter space in the search bar, and that also triggers the toggle on the setting.  Disabling the space, and only allowing the enter key to modify the setting. We also show the user "Use Enter to select" prompt at the bottom.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->


https://github.com/user-attachments/assets/153062d4-099e-488e-8002-cd33fc52cd85


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
