### PR TITLE
feat: allow custom docker-compatible sandbox commands (nerdctl, etc.)

### DIFF
--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -73,9 +73,19 @@ gemini -p "run the test suite"
 ### Enable sandboxing (in order of precedence)
 
 1. **Command flag**: `-s` or `--sandbox`
-2. **Environment variable**: `GEMINI_SANDBOX=true|docker|podman|sandbox-exec`
+2. **Environment variable**:
+   `GEMINI_SANDBOX=true|docker|podman|sandbox-exec|...`
 3. **Settings file**: `"sandbox": true` in the `tools` object of your
    `settings.json` file (e.g., `{"tools": {"sandbox": true}}`).
+
+The `GEMINI_SANDBOX` environment variable can be set to either one of:
+
+- `true`: automaticlly detect `docker`, `podman`, or `sandbox-exec`
+- `docker`: Docker
+- `podman`: Podman
+- `sandbox-exec`: macOS Seatbelt
+- Other string: Docker-compatible CLI, such as `nerdctl`, `nerdctl.lima`, and
+  `finch`
 
 ### macOS Seatbelt profiles
 

--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -23,15 +23,6 @@ const __dirname = path.dirname(__filename);
 interface SandboxCliArgs {
   sandbox?: boolean | string | null;
 }
-const VALID_SANDBOX_COMMANDS: ReadonlyArray<SandboxConfig['command']> = [
-  'docker',
-  'podman',
-  'sandbox-exec',
-];
-
-function isSandboxCommand(value: string): value is SandboxConfig['command'] {
-  return (VALID_SANDBOX_COMMANDS as readonly string[]).includes(value);
-}
 
 function getSandboxCommand(
   sandbox?: boolean | string | null,
@@ -56,13 +47,6 @@ function getSandboxCommand(
   }
 
   if (typeof sandbox === 'string' && sandbox) {
-    if (!isSandboxCommand(sandbox)) {
-      throw new FatalSandboxError(
-        `Invalid sandbox command '${sandbox}'. Must be one of ${VALID_SANDBOX_COMMANDS.join(
-          ', ',
-        )}`,
-      );
-    }
     // confirm that specified command exists
     if (commandExists.sync(sandbox)) {
       return sandbox;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -223,7 +223,7 @@ export enum AuthProviderType {
 }
 
 export interface SandboxConfig {
-  command: 'docker' | 'podman' | 'sandbox-exec';
+  command: string;
   image: string;
 }
 


### PR DESCRIPTION


## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

Allows users to specify Docker-compatible CLIs

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

The `GEMINI_SANDBOX` environment variable can be now set to an arbitrary Docker-compatible CLI,
e.g.,
- `nerdctl`:  contaiNERD CTL (Docker-compatible CLI for containerd): https://github.com/containerd/nerdctl
- `nerdctl.lima`: nerdctl wrapped in Lima VM: https://github.com/lima-vm/lima/blob/master/cmd/nerdctl.lima
- `finch`: Amazon's distribution of nerdctl + Lima: https://runfinch.com


## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

Fixes #14484

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->



```bash
brew install lima
limactl start --mount-writable --rosetta
```

> [!NOTE]
> `--rosetta` is needed on ARM Mac, as there is still no native ARM support in
> `us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:X.Y.Z`:
> - https://github.com/google-gemini/gemini-cli/issues/3717

```bash
npm install
```

```bash
export GEMINI_SANDBOX_IMAGE=us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.19.0
export GEMINI_SANDBOX=nerdctl.lima
./bundle/gemini.js
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [X] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- (Not applicable) Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
    - [X] `nerdctl.lima` (new)
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
