### PR TITLE
feat(CI): build and push multi-arch Docker images

### DIFF
--- a/.github/actions/push-docker/action.yml
+++ b/.github/actions/push-docker/action.yml
@@ -33,6 +33,8 @@ runs:
       run: 'npm install'
     - name: 'Set up Docker Buildx'
       uses: 'docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435' # ratchet:docker/setup-buildx-action@v3
+    - name: 'Set up QEMU'
+      uses: 'docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130' # ratchet:docker/setup-qemu-action@v3
     - name: 'build'
       shell: 'bash'
       run: 'npm run build'
@@ -61,6 +63,7 @@ runs:
         file: './Dockerfile'
         push: true
         provenance: false # avoid pushing 3 images to Aritfact Registry
+        platforms: 'linux/amd64,linux/arm64'
         tags: |
           ghcr.io/${{ github.repository }}/cli:${{ steps.branch_name.outputs.name }}
           ghcr.io/${{ github.repository }}/cli:${{ inputs.github-sha }}

--- a/.github/actions/push-sandbox/action.yml
+++ b/.github/actions/push-sandbox/action.yml
@@ -46,6 +46,8 @@ runs:
       run: 'npm run build'
     - name: 'Set up Docker Buildx'
       uses: 'docker/setup-buildx-action@v3'
+    - name: 'Set up QEMU'
+      uses: 'docker/setup-qemu-action@v3'
     - name: 'Log in to GitHub Container Registry'
       uses: 'docker/login-action@v3'
       with:
@@ -72,6 +74,7 @@ runs:
       env:
         GEMINI_SANDBOX_IMAGE_TAG: '${{ steps.image_tag.outputs.FINAL_TAG }}'
         GEMINI_SANDBOX: 'docker'
+        BUILD_SANDBOX_FLAGS: '--platform linux/amd64,linux/arm64'
       run: |-
         npm run build:sandbox -- \
           --image google/gemini-cli-sandbox:${{ steps.image_tag.outputs.FINAL_TAG }} \


### PR DESCRIPTION

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Build and push multi-arch Docker images (amd64 and arm64)

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

Updated the GitHub Actions

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

Fixes #3717

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

The changes in `push-sandbox` can be validated as follows:

```bash
# Register QEMU for building the multi-platform image (https://github.com/tonistiigi/binfmt)
docker run --privileged --rm tonistiigi/binfmt --install all
BUILD_SANDBOX_FLAGS="--platform linux/amd64,linux/arm64" npm run build:sandbox -- --image=localhost:8080/foo
docker push localhost:8080/foo
```

```console
$ docker buildx imagetools inspect localhost:8080/foo
Name:      localhost:8080/foo:latest
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:2d9b8f08408a48399a17fd97a2c711f50e4adb63e29fea93678fa017380368a1
           
Manifests: 
  Name:        localhost:8080/foo:latest@sha256:a9e624f30d9a9c1fc5ac361a3c5310147cf119d311633e54cfffc1d3fab60084
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/amd64
               
  Name:        localhost:8080/foo:latest@sha256:3ef0108d84fa9cdbc6b776102de57688f5d45acbacc6527a746f637d492ed916
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/arm64
[...]
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- (Not applicable) Updated relevant documentation and README (if needed)
- (Not applicable) Added/updated tests (if needed)
- (Not applicable) Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [X] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
