### PR TITLE
feat: add auto-execute on Enter behavior to argumentless MCP prompts

### DIFF
--- a/packages/cli/src/services/McpPromptLoader.test.ts
+++ b/packages/cli/src/services/McpPromptLoader.test.ts
@@ -261,6 +261,58 @@ describe('McpPromptLoader', () => {
       expect(commands).toEqual([]);
     });
 
+    describe('autoExecute', () => {
+      it('should set autoExecute to true for prompts with no arguments (undefined)', async () => {
+        vi.spyOn(cliCore, 'getMCPServerPrompts').mockReturnValue([
+          { ...mockPrompt, arguments: undefined },
+        ]);
+        const loader = new McpPromptLoader(mockConfigWithPrompts);
+        const commands = await loader.loadCommands(
+          new AbortController().signal,
+        );
+        expect(commands[0].autoExecute).toBe(true);
+      });
+
+      it('should set autoExecute to true for prompts with empty arguments array', async () => {
+        vi.spyOn(cliCore, 'getMCPServerPrompts').mockReturnValue([
+          { ...mockPrompt, arguments: [] },
+        ]);
+        const loader = new McpPromptLoader(mockConfigWithPrompts);
+        const commands = await loader.loadCommands(
+          new AbortController().signal,
+        );
+        expect(commands[0].autoExecute).toBe(true);
+      });
+
+      it('should set autoExecute to false for prompts with only optional arguments', async () => {
+        vi.spyOn(cliCore, 'getMCPServerPrompts').mockReturnValue([
+          {
+            ...mockPrompt,
+            arguments: [{ name: 'optional', required: false }],
+          },
+        ]);
+        const loader = new McpPromptLoader(mockConfigWithPrompts);
+        const commands = await loader.loadCommands(
+          new AbortController().signal,
+        );
+        expect(commands[0].autoExecute).toBe(false);
+      });
+
+      it('should set autoExecute to false for prompts with required arguments', async () => {
+        vi.spyOn(cliCore, 'getMCPServerPrompts').mockReturnValue([
+          {
+            ...mockPrompt,
+            arguments: [{ name: 'required', required: true }],
+          },
+        ]);
+        const loader = new McpPromptLoader(mockConfigWithPrompts);
+        const commands = await loader.loadCommands(
+          new AbortController().signal,
+        );
+        expect(commands[0].autoExecute).toBe(false);
+      });
+    });
+
     describe('completion', () => {
       it('should suggest no arguments when using positional arguments', async () => {
         const loader = new McpPromptLoader(mockConfigWithPrompts);

--- a/packages/cli/src/services/McpPromptLoader.ts
+++ b/packages/cli/src/services/McpPromptLoader.ts
@@ -44,6 +44,7 @@ export class McpPromptLoader implements ICommandLoader {
           name: commandName,
           description: prompt.description || `Invoke prompt ${prompt.name}`,
           kind: CommandKind.MCP_PROMPT,
+          autoExecute: !prompt.arguments || prompt.arguments.length === 0,
           subCommands: [
             {
               name: 'help',


### PR DESCRIPTION
## Summary

In https://github.com/google-gemini/gemini-cli/pull/13985 we added `autoExecute` to the slash command interface to allow simple built-in slash commands to auto-execute instead of autocompleting to the prompt window.

This PR follows up with adding support for auto-executing argumentless MCP prompts, continuing the make Gemini CLI feel more smooth.

## Details

Enables MCP prompts without arguments to auto-execute when selected with Enter
in the suggestion UI, matching the behavior of built-in slash commands.

### Changes

- Set `autoExecute: true` for MCP prompts that have no arguments
- MCP prompts with any arguments (required or optional) still require Enter to
  autocomplete, then Enter again to submit

https://github.com/user-attachments/assets/f2723337-d5ac-4878-b23c-e9d48079a5ab

### Test plan

- Added unit tests for `autoExecute` flag on MCP prompts:
  - Prompts with no arguments (`undefined` or `[]`) → `autoExecute: true`
  - Prompts with optional-only arguments → `autoExecute: false`
  - Prompts with required arguments → `autoExecute: false`

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
