### PR TITLE
Fix privacy screen for legacy tier users

### DIFF
--- a/packages/cli/src/ui/hooks/usePrivacySettings.test.tsx
+++ b/packages/cli/src/ui/hooks/usePrivacySettings.test.tsx
@@ -7,11 +7,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { act } from 'react';
 import { render } from '../../test-utils/render.js';
-import type {
-  Config,
-  CodeAssistServer,
-  LoadCodeAssistResponse,
-} from '@google/gemini-cli-core';
+import type { Config, CodeAssistServer } from '@google/gemini-cli-core';
 import { UserTierId, getCodeAssistServer } from '@google/gemini-cli-core';
 import { usePrivacySettings } from './usePrivacySettings.js';
 import { waitFor } from '../../test-utils/async.js';
@@ -65,10 +61,7 @@ describe('usePrivacySettings', () => {
     // Mock paid tier response
     vi.mocked(getCodeAssistServer).mockReturnValue({
       projectId: 'test-project-id',
-      loadCodeAssist: () =>
-        ({
-          currentTier: { id: UserTierId.STANDARD },
-        }) as unknown as LoadCodeAssistResponse,
+      userTier: UserTierId.STANDARD,
     } as unknown as CodeAssistServer);
 
     const { result } = renderPrivacySettingsHook();
@@ -84,10 +77,7 @@ describe('usePrivacySettings', () => {
 
   it('should throw error when CodeAssistServer has no projectId', async () => {
     vi.mocked(getCodeAssistServer).mockReturnValue({
-      loadCodeAssist: () =>
-        ({
-          currentTier: { id: UserTierId.FREE },
-        }) as unknown as LoadCodeAssistResponse,
+      userTier: UserTierId.FREE,
     } as unknown as CodeAssistServer);
 
     const { result } = renderPrivacySettingsHook();
@@ -110,10 +100,7 @@ describe('usePrivacySettings', () => {
       setCodeAssistGlobalUserSetting: vi.fn().mockResolvedValue({
         freeTierDataCollectionOptin: false,
       }),
-      loadCodeAssist: () =>
-        ({
-          currentTier: { id: UserTierId.FREE },
-        }) as unknown as LoadCodeAssistResponse,
+      userTier: UserTierId.FREE,
     } as unknown as CodeAssistServer;
     vi.mocked(getCodeAssistServer).mockReturnValue(mockCodeAssistServer);
 

--- a/packages/cli/src/ui/hooks/usePrivacySettings.ts
+++ b/packages/cli/src/ui/hooks/usePrivacySettings.ts
@@ -31,7 +31,10 @@ export const usePrivacySettings = (config: Config) => {
       });
       try {
         const server = getCodeAssistServerOrFail(config);
-        const tier = await getTier(server);
+        const tier = server.userTier;
+        if (tier === undefined) {
+          throw new Error('Could not determine user tier.');
+        }
         if (tier !== UserTierId.FREE) {
           // We don't need to fetch opt-out info since non-free tier
           // data gathering is already worked out some other way.
@@ -92,22 +95,6 @@ function getCodeAssistServerOrFail(config: Config): CodeAssistServer {
     throw new Error('CodeAssist server is missing a project ID');
   }
   return server;
-}
-
-async function getTier(server: CodeAssistServer): Promise<UserTierId> {
-  const loadRes = await server.loadCodeAssist({
-    cloudaicompanionProject: server.projectId,
-    metadata: {
-      ideType: 'IDE_UNSPECIFIED',
-      platform: 'PLATFORM_UNSPECIFIED',
-      pluginType: 'GEMINI',
-      duetProject: server.projectId,
-    },
-  });
-  if (!loadRes.currentTier) {
-    throw new Error('User does not have a current tier');
-  }
-  return loadRes.currentTier.id;
 }
 
 async function getRemoteDataCollectionOptIn(


### PR DESCRIPTION
## Summary

Instead of requesting the tier again (and not properly falling back to legacy tier), get the tier stored on the server object.

## Related Issues

Fixes #2407

## How to Validate

Login with a legacy account (like mine!) and verify that it works.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
