### PR TITLE
Grant chained workflows proper permission.

### DIFF
--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -111,7 +111,7 @@ jobs:
           allowForks: 'true'
           repo: '${{ needs.parse_run_context.outputs.repository }}'
           sha: '${{ needs.parse_run_context.outputs.sha }}'
-          token: '${{ secrets.GITHUB_TOKEN }}'
+          token: '${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}'
           status: 'pending'
 
   e2e_linux:


### PR DESCRIPTION
## Summary

Use the GEMINI_CLI_ROBOT_GITHUB_PAT here since the GITHUB_TOKEN is not available for chained workflows.

## Details

This is necessary to run E2E tests for external contributors. Normally this would be unsafe but it's ok because we only run workflows when approved by a privileged user.

## Related Issues

For #10008
