### PR TITLE
Make trigger_e2e manually fireable.

### DIFF
--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -42,9 +42,10 @@ jobs:
 
   download_repo_name:
     runs-on: 'gemini-cli-ubuntu-16-core'
-    if: "github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run'"
+    if: "${{github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run'}}"
     outputs:
       repo_name: '${{ steps.output-repo-name.outputs.repo_name }}'
+      head_sha: '${{ steps.output-repo-name.outputs.head_sha }}'
     steps:
       - name: 'Mock Repo Artifact'
         if: "${{ github.event_name == 'workflow_dispatch' }}"
@@ -66,7 +67,7 @@ jobs:
           name: 'repo_name'
           run-id: '${{ env.RUN_ID }}'
           path: '${{ runner.temp }}/artifacts'
-      - name: 'Output Repo Name'
+      - name: 'Output Repo Name and SHA'
         id: 'output-repo-name'
         uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # ratchet:actions/github-script@v8
         with:
@@ -75,8 +76,16 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const temp = '${{ runner.temp }}/artifacts';
-            const repo_name = String(fs.readFileSync(path.join(temp, 'repo_name')));
-            core.setOutput('repo_name', repo_name);
+            const repoPath = path.join(temp, 'repo_name');
+            if (fs.existsSync(repoPath)) {
+              const repo_name = String(fs.readFileSync(repoPath)).trim();
+              core.setOutput('repo_name', repo_name);
+            }
+            const shaPath = path.join(temp, 'head_sha');
+            if (fs.existsSync(shaPath)) {
+              const head_sha = String(fs.readFileSync(shaPath)).trim();
+              core.setOutput('head_sha', head_sha);
+            }
 
   parse_run_context:
     name: 'Parse run context'
@@ -91,7 +100,7 @@ jobs:
         name: 'Set dynamic repository and SHA'
         env:
           REPO: '${{ needs.download_repo_name.outputs.repo_name || github.repository }}'
-          SHA: '${{ github.event.inputs.head_sha || github.event.workflow_run.head_sha || github.sha }}'
+          SHA: '${{ needs.download_repo_name.outputs.head_sha || github.event.inputs.head_sha || github.event.workflow_run.head_sha || github.sha }}'
         shell: 'bash'
         run: |
           echo "REPO=$REPO" >> "$GITHUB_OUTPUT"
@@ -100,7 +109,7 @@ jobs:
   set_pending_status:
     runs-on: 'gemini-cli-ubuntu-16-core'
     permissions: 'write-all'
-    if: "github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run'"
+    if: "${{github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run'}}"
     needs:
       - 'parse_run_context'
     steps:
@@ -113,6 +122,7 @@ jobs:
           sha: '${{ needs.parse_run_context.outputs.sha }}'
           token: '${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}'
           status: 'pending'
+          context: 'E2E (Chained)'
 
   e2e_linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'
@@ -150,7 +160,7 @@ jobs:
         run: 'npm run build'
 
       - name: 'Set up Docker'
-        if: "matrix.sandbox == 'sandbox:docker'"
+        if: "${{matrix.sandbox == 'sandbox:docker'}}"
         uses: 'docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435' # ratchet:docker/setup-buildx-action@v3
 
       - name: 'Run E2E tests'
@@ -193,11 +203,11 @@ jobs:
         run: 'npm run build'
 
       - name: 'Fix rollup optional dependencies on macOS'
-        if: "runner.os == 'macOS'"
+        if: "${{runner.os == 'macOS'}}"
         run: |
           npm cache clean --force
       - name: 'Run E2E tests (non-Windows)'
-        if: "runner.os != 'Windows'"
+        if: "${{runner.os != 'Windows'}}"
         env:
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
           KEEP_OUTPUT: 'true'
@@ -288,7 +298,7 @@ jobs:
   set_workflow_status:
     runs-on: 'gemini-cli-ubuntu-16-core'
     permissions: 'write-all'
-    if: "github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run'"
+    if: "${{github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run'}}"
     needs:
       - 'parse_run_context'
       - 'e2e'
@@ -302,3 +312,4 @@ jobs:
           sha: '${{ needs.parse_run_context.outputs.sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: '${{ job.status }}'
+          context: 'E2E (Chained)'

--- a/.github/workflows/trigger_e2e.yml
+++ b/.github/workflows/trigger_e2e.yml
@@ -3,11 +3,15 @@ name: 'Trigger E2E'
 on:
   workflow_dispatch:
     inputs:
-      branch_ref:
-        description: 'Branch to run on'
-        required: true
-        default: 'main'
+      repo_name:
+        description: 'Repository name (e.g., owner/repo)'
+        required: false
         type: 'string'
+      head_sha:
+        description: 'SHA of the commit to test'
+        required: false
+        type: 'string'
+  # pull_request:
 
 jobs:
   save_repo_name:
@@ -15,11 +19,14 @@ jobs:
     steps:
       - name: 'Save Repo name'
         env:
-          # Replace with github.event.pull_request.head.repo.full_name when switched to listen on pull request events. This repo name does not contain the org which is needed for checkout.
-          REPO_NAME: '${{ github.event.repository.name }}'
+          # add "|| github.event.pull_request.head.repo.full_name"
+          REPO_NAME: '${{ github.event.inputs.repo_name || github.event.repository.name }}'
+          # add "|| github.event.pull_request.head.sha"
+          HEAD_SHA: '${{ github.event.inputs.head_sha }}'
         run: |
           mkdir -p ./pr
           echo '${{ env.REPO_NAME }}' > ./pr/repo_name
+          echo '${{ env.HEAD_SHA }}' > ./pr/head_sha
       - uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'repo_name'


### PR DESCRIPTION
## Summary

To test this workflow we want to manually fire it before updating it to manually trigger on all forked branch PRs.

## Details

Note that this should not affect anything as neither of these workflows are triggered by anything yet.

Also updated this to pass the SHA as well as the repo name. 

Also: Fixed inconsistent if statement wrapping.

## Related Issues

for #10008
