### PR TITLE
Write e2e status to local repo not forked repo

### DIFF
--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -118,7 +118,7 @@ jobs:
         if: 'always()'
         with:
           allowForks: 'true'
-          repo: '${{ needs.parse_run_context.outputs.repository }}'
+          repo: '${{ github.repository }}'
           sha: '${{ needs.parse_run_context.outputs.sha }}'
           token: '${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}'
           status: 'pending'
@@ -308,7 +308,7 @@ jobs:
         if: 'always()'
         with:
           allowForks: 'true'
-          repo: '${{ needs.parse_run_context.outputs.repository }}'
+          repo: '${{ github.repository }}'
           sha: '${{ needs.parse_run_context.outputs.sha }}'
           token: '${{ secrets.GITHUB_TOKEN }}'
           status: '${{ job.status }}'


### PR DESCRIPTION
## Summary

Write e2e status to local repo not forked repo

## Details

We only have permission to do this on our own repo, not the forked repo. They're functionally equivalent though since we only use them for our own repo's Branch protection rules.

## Related Issues

for #10008
