### PR TITLE
expose previewFeatures flag in a2a

### DIFF
--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -71,6 +71,7 @@ export async function loadConfig(
     ideMode: false,
     folderTrust: settings.folderTrust === true,
     extensionLoader,
+    previewFeatures: settings.previewFeatures,
   };
 
   const fileService = new FileDiscoveryService(workspaceDir);

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -71,7 +71,7 @@ export async function loadConfig(
     ideMode: false,
     folderTrust: settings.folderTrust === true,
     extensionLoader,
-    previewFeatures: settings.previewFeatures,
+    previewFeatures: settings.general?.previewFeatures,
   };
 
   const fileService = new FileDiscoveryService(workspaceDir);

--- a/packages/a2a-server/src/config/settings.test.ts
+++ b/packages/a2a-server/src/config/settings.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { loadSettings, USER_SETTINGS_PATH } from './settings.js';
+
+vi.mock('node:fs');
+vi.mock('node:os', () => ({
+  homedir: () => '/mock/home',
+}));
+vi.mock('@google/gemini-cli-core', () => ({
+  GEMINI_DIR: '.gemini',
+  debugLogger: {
+    error: vi.fn(),
+  },
+  getErrorMessage: (error: unknown) => String(error),
+}));
+
+describe('loadSettings', () => {
+  const mockWorkspaceDir = '/mock/workspace';
+  const mockWorkspaceSettingsPath = path.join(
+    mockWorkspaceDir,
+    '.gemini',
+    'settings.json',
+  );
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Default mock implementation for fs.existsSync to return false
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should load nested previewFeatures from user settings', () => {
+    vi.mocked(fs.existsSync).mockImplementation(
+      (p) => p === USER_SETTINGS_PATH,
+    );
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (p === USER_SETTINGS_PATH) {
+        return JSON.stringify({
+          general: {
+            previewFeatures: true,
+          },
+        });
+      }
+      return '';
+    });
+
+    const settings = loadSettings(mockWorkspaceDir);
+    expect(settings.general?.previewFeatures).toBe(true);
+  });
+
+  it('should load nested previewFeatures from workspace settings', () => {
+    vi.mocked(fs.existsSync).mockImplementation(
+      (p) => p === mockWorkspaceSettingsPath,
+    );
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (p === mockWorkspaceSettingsPath) {
+        return JSON.stringify({
+          general: {
+            previewFeatures: true,
+          },
+        });
+      }
+      return '';
+    });
+
+    const settings = loadSettings(mockWorkspaceDir);
+    expect(settings.general?.previewFeatures).toBe(true);
+  });
+
+  it('should prioritize workspace settings over user settings', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (p === USER_SETTINGS_PATH) {
+        return JSON.stringify({
+          general: {
+            previewFeatures: false,
+          },
+        });
+      }
+      if (p === mockWorkspaceSettingsPath) {
+        return JSON.stringify({
+          general: {
+            previewFeatures: true,
+          },
+        });
+      }
+      return '';
+    });
+
+    const settings = loadSettings(mockWorkspaceDir);
+    expect(settings.general?.previewFeatures).toBe(true);
+  });
+
+  it('should handle missing previewFeatures', () => {
+    vi.mocked(fs.existsSync).mockImplementation(
+      (p) => p === USER_SETTINGS_PATH,
+    );
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (p === USER_SETTINGS_PATH) {
+        return JSON.stringify({
+          general: {},
+        });
+      }
+      return '';
+    });
+
+    const settings = loadSettings(mockWorkspaceDir);
+    expect(settings.general?.previewFeatures).toBeUndefined();
+  });
+
+  it('should load other top-level settings correctly', () => {
+    vi.mocked(fs.existsSync).mockImplementation(
+      (p) => p === USER_SETTINGS_PATH,
+    );
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (p === USER_SETTINGS_PATH) {
+        return JSON.stringify({
+          showMemoryUsage: true,
+          coreTools: ['tool1', 'tool2'],
+          mcpServers: {
+            server1: {
+              command: 'cmd',
+              args: ['arg'],
+            },
+          },
+          fileFiltering: {
+            respectGitIgnore: true,
+          },
+        });
+      }
+      return '';
+    });
+
+    const settings = loadSettings(mockWorkspaceDir);
+    expect(settings.showMemoryUsage).toBe(true);
+    expect(settings.coreTools).toEqual(['tool1', 'tool2']);
+    expect(settings.mcpServers).toHaveProperty('server1');
+    expect(settings.fileFiltering?.respectGitIgnore).toBe(true);
+  });
+
+  it('should overwrite top-level settings from workspace (shallow merge)', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (p === USER_SETTINGS_PATH) {
+        return JSON.stringify({
+          showMemoryUsage: false,
+          fileFiltering: {
+            respectGitIgnore: true,
+            enableRecursiveFileSearch: true,
+          },
+        });
+      }
+      if (p === mockWorkspaceSettingsPath) {
+        return JSON.stringify({
+          showMemoryUsage: true,
+          fileFiltering: {
+            respectGitIgnore: false,
+          },
+        });
+      }
+      return '';
+    });
+
+    const settings = loadSettings(mockWorkspaceDir);
+    // Primitive value overwritten
+    expect(settings.showMemoryUsage).toBe(true);
+
+    // Object value completely replaced (shallow merge behavior)
+    expect(settings.fileFiltering?.respectGitIgnore).toBe(false);
+    expect(settings.fileFiltering?.enableRecursiveFileSearch).toBeUndefined();
+  });
+});

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -29,6 +29,7 @@ export interface Settings {
   showMemoryUsage?: boolean;
   checkpointing?: CheckpointingSettings;
   folderTrust?: boolean;
+  previewFeatures?: boolean;
 
   // Git-aware file filtering settings
   fileFiltering?: {

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -20,7 +20,9 @@ import stripJsonComments from 'strip-json-comments';
 export const USER_SETTINGS_DIR = path.join(homedir(), GEMINI_DIR);
 export const USER_SETTINGS_PATH = path.join(USER_SETTINGS_DIR, 'settings.json');
 
-// Reconcile with https://github.com/google-gemini/gemini-cli/blob/b09bc6656080d4d12e1d06734aae2ec33af5c1ed/packages/cli/src/config/settings.ts#L53
+// TODO: Ensure full compatibility with V2 nested settings structure (settings.schema.json).
+// This involves updating the interface and implementing migration logic to support legacy V1 (flat) settings,
+// similar to how packages/cli/src/config/settings.ts handles it.
 export interface Settings {
   mcpServers?: Record<string, MCPServerConfig>;
   coreTools?: string[];
@@ -29,7 +31,9 @@ export interface Settings {
   showMemoryUsage?: boolean;
   checkpointing?: CheckpointingSettings;
   folderTrust?: boolean;
-  previewFeatures?: boolean;
+  general?: {
+    previewFeatures?: boolean;
+  };
 
   // Git-aware file filtering settings
   fileFiltering?: {


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Expose previewFeatures flag in a2a to allow code assist agent mode to access gemini 3.
## Details
Without previewFeatures flag, a2a won't be able to trigger gemini 3 model.
## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
