### PR TITLE
Fixes [API Error: Cannot read properties of undefined (reading 'error')]

### DIFF
--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -113,7 +113,11 @@ export function toFriendlyError(error: unknown): unknown {
 function parseResponseData(error: GaxiosError): ResponseData | undefined {
   // Inexplicably, Gaxios sometimes doesn't JSONify the response data.
   if (typeof error.response?.data === 'string') {
-    return JSON.parse(error.response?.data) as ResponseData;
+    try {
+      return JSON.parse(error.response?.data) as ResponseData;
+    } catch {
+      return undefined;
+    }
   }
   return error.response?.data as ResponseData | undefined;
 }

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -92,7 +92,7 @@ export function toFriendlyError(error: unknown): unknown {
   if (error && typeof error === 'object' && 'response' in error) {
     const gaxiosError = error as GaxiosError;
     const data = parseResponseData(gaxiosError);
-    if (data.error && data.error.message && data.error.code) {
+    if (data && data.error && data.error.message && data.error.code) {
       switch (data.error.code) {
         case 400:
           return new BadRequestError(data.error.message);
@@ -110,12 +110,12 @@ export function toFriendlyError(error: unknown): unknown {
   return error;
 }
 
-function parseResponseData(error: GaxiosError): ResponseData {
+function parseResponseData(error: GaxiosError): ResponseData | undefined {
   // Inexplicably, Gaxios sometimes doesn't JSONify the response data.
   if (typeof error.response?.data === 'string') {
     return JSON.parse(error.response?.data) as ResponseData;
   }
-  return error.response?.data as ResponseData;
+  return error.response?.data as ResponseData | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes https://github.com/google-gemini/gemini-cli/issues/14436 

The function parseResponseData returns error.response?.data cast as ResponseData. If error.response is undefined, or error.response.data is null/undefined, the return value data will be undefined.

In toFriendlyError, the code immediately attempts to access properties on this result and then throws the error 

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/14436 


## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
