### PR TITLE
Fix: Prevent freezing in non-interactive Gemini CLI when debug mode is enabled

### DIFF
--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -134,12 +134,14 @@ export function entrypoint(workdir: string, cliArgs: string[]): string[] {
   );
 
   const quotedCliArgs = cliArgs.slice(2).map((arg) => quote([arg]));
+  const isDebugMode =
+    process.env['DEBUG'] === 'true' || process.env['DEBUG'] === '1';
   const cliCmd =
     process.env['NODE_ENV'] === 'development'
-      ? process.env['DEBUG'] === 'true' || process.env['DEBUG'] === '1'
+      ? isDebugMode
         ? 'npm run debug --'
         : 'npm rebuild && npm run start --'
-      : process.env['DEBUG'] === 'true' || process.env['DEBUG'] === '1'
+      : isDebugMode
         ? `node --inspect-brk=0.0.0.0:${process.env['DEBUG_PORT'] || '9229'} $(which gemini)`
         : 'gemini';
 

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -136,10 +136,10 @@ export function entrypoint(workdir: string, cliArgs: string[]): string[] {
   const quotedCliArgs = cliArgs.slice(2).map((arg) => quote([arg]));
   const cliCmd =
     process.env['NODE_ENV'] === 'development'
-      ? process.env['DEBUG']
+      ? process.env['DEBUG'] === 'true' || process.env['DEBUG'] === '1'
         ? 'npm run debug --'
         : 'npm rebuild && npm run start --'
-      : process.env['DEBUG']
+      : process.env['DEBUG'] === 'true' || process.env['DEBUG'] === '1'
         ? `node --inspect-brk=0.0.0.0:${process.env['DEBUG_PORT'] || '9229'} $(which gemini)`
         : 'gemini';
 

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -46,7 +46,9 @@ try {
 // if debugging is enabled and sandboxing is disabled, use --inspect-brk flag
 // note with sandboxing this flag is passed to the binary inside the sandbox
 // inside sandbox SANDBOX should be set and sandbox_command.js should fail
-if (process.env.DEBUG && !sandboxCommand) {
+const isInDebugMode = process.env.DEBUG === '1' || process.env.DEBUG === 'true';
+
+if (isInDebugMode && !sandboxCommand) {
   if (process.env.SANDBOX) {
     const port = process.env.DEBUG_PORT || '9229';
     nodeArgs.push(`--inspect-brk=0.0.0.0:${port}`);
@@ -64,7 +66,7 @@ const env = {
   DEV: 'true',
 };
 
-if (process.env.DEBUG) {
+if (isInDebugMode) {
   // If this is not set, the debugger will pause on the outer process rather
   // than the relaunched process making it harder to debug.
   env.GEMINI_CLI_NO_RELAUNCH = 'true';


### PR DESCRIPTION
## Details

The CLI would hang indefinitely when the DEBUG env is used in non-interactive (e.g., scripting) mode. This was because of  waiting for debugger to connect. This change ensures that the debug output mechanism does not block the process flow in headless environments.

## Related Issues
Fixes https://github.com/google-github-actions/run-gemini-cli/issues/337

## How to Validate
check release-with-gemini.yaml workflow in https://github.com/parthasaradhie/run-gemini-cli/ repo
Action with issue: https://github.com/parthasaradhie/hello-world-rpm/actions/runs/19957624845/job/57230133922
shows 
```
Debugger listening on ws://0.0.0.0:9229/2b4a5dbd-2821-4368-8cc4-7b368241a4ef
```

Action with issue fixed :
https://github.com/parthasaradhie/hello-world-rpm/actions/runs/19964069457

