### PR TITLE
feat: auto-execute on slash command completion functions

### DIFF
--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -157,7 +157,7 @@ const resumeCommand: SlashCommand = {
   description:
     'Resume a conversation from a checkpoint. Usage: /chat resume <tag>',
   kind: CommandKind.BUILT_IN,
-  autoExecute: false,
+  autoExecute: true,
   action: async (context, args) => {
     const tag = args.trim();
     if (!tag) {
@@ -241,7 +241,7 @@ const deleteCommand: SlashCommand = {
   name: 'delete',
   description: 'Delete a conversation checkpoint. Usage: /chat delete <tag>',
   kind: CommandKind.BUILT_IN,
-  autoExecute: false,
+  autoExecute: true,
   action: async (context, args): Promise<MessageActionReturn> => {
     const tag = args.trim();
     if (!tag) {

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -481,7 +481,7 @@ const updateExtensionsCommand: SlashCommand = {
   name: 'update',
   description: 'Update extensions. Usage: update <extension-names>|--all',
   kind: CommandKind.BUILT_IN,
-  autoExecute: true,
+  autoExecute: false,
   action: updateAction,
   completion: completeExtensions,
 };
@@ -516,7 +516,7 @@ const restartCommand: SlashCommand = {
   name: 'restart',
   description: 'Restart all extensions',
   kind: CommandKind.BUILT_IN,
-  autoExecute: true,
+  autoExecute: false,
   action: restartAction,
   completion: completeExtensions,
 };

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -481,7 +481,7 @@ const updateExtensionsCommand: SlashCommand = {
   name: 'update',
   description: 'Update extensions. Usage: update <extension-names>|--all',
   kind: CommandKind.BUILT_IN,
-  autoExecute: false,
+  autoExecute: true,
   action: updateAction,
   completion: completeExtensions,
 };
@@ -516,7 +516,7 @@ const restartCommand: SlashCommand = {
   name: 'restart',
   description: 'Restart all extensions',
   kind: CommandKind.BUILT_IN,
-  autoExecute: false,
+  autoExecute: true,
   action: restartAction,
   completion: completeExtensions,
 };

--- a/packages/cli/src/ui/commands/hooksCommand.ts
+++ b/packages/cli/src/ui/commands/hooksCommand.ts
@@ -228,6 +228,7 @@ const enableCommand: SlashCommand = {
   name: 'enable',
   description: 'Enable a hook by name',
   kind: CommandKind.BUILT_IN,
+  autoExecute: true,
   action: enableAction,
   completion: completeHookNames,
 };
@@ -236,6 +237,7 @@ const disableCommand: SlashCommand = {
   name: 'disable',
   description: 'Disable a hook by name',
   kind: CommandKind.BUILT_IN,
+  autoExecute: true,
   action: disableAction,
   completion: completeHookNames,
 };

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -31,7 +31,7 @@ const authCommand: SlashCommand = {
   name: 'auth',
   description: 'Authenticate with an OAuth-enabled MCP server',
   kind: CommandKind.BUILT_IN,
-  autoExecute: false,
+  autoExecute: true,
   action: async (
     context: CommandContext,
     args: string,

--- a/packages/cli/src/ui/commands/restoreCommand.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.ts
@@ -189,7 +189,7 @@ export const restoreCommand = (config: Config | null): SlashCommand | null => {
     description:
       'Restore a tool call. This will reset the conversation and file history to the state it was in when the tool call was suggested',
     kind: CommandKind.BUILT_IN,
-    autoExecute: false,
+    autoExecute: true,
     action: restoreAction,
     completion,
   };

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -196,6 +196,8 @@ describe('InputPrompt', () => {
         completionStart: -1,
         completionEnd: -1,
         getCommandFromSuggestion: vi.fn().mockReturnValue(undefined),
+        isArgumentCompletion: false,
+        leafCommand: null,
       },
       getCompletedText: vi.fn().mockReturnValue(null),
     };
@@ -807,6 +809,8 @@ describe('InputPrompt', () => {
         completionStart: 1,
         completionEnd: 3, // "/ab" -> start at 1, end at 3
         getCommandFromSuggestion: vi.fn(),
+        isArgumentCompletion: false,
+        leafCommand: null,
       },
     });
 
@@ -946,6 +950,158 @@ describe('InputPrompt', () => {
 
     await waitFor(() => {
       // Should autocomplete (not execute) since autoExecute is undefined
+      expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
+      expect(props.onSubmit).not.toHaveBeenCalled();
+    });
+    unmount();
+  });
+
+  it('should auto-execute argument completion when command has autoExecute: true', async () => {
+    // Simulates: /mcp auth <server> where user selects a server from completions
+    const authCommand: SlashCommand = {
+      name: 'auth',
+      kind: CommandKind.BUILT_IN,
+      description: 'Authenticate with MCP server',
+      action: vi.fn(),
+      autoExecute: true,
+      completion: vi.fn().mockResolvedValue(['server1', 'server2']),
+    };
+
+    const suggestion = { label: 'server1', value: 'server1' };
+
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [suggestion],
+      activeSuggestionIndex: 0,
+      getCommandFromSuggestion: vi.fn().mockReturnValue(authCommand),
+      getCompletedText: vi.fn().mockReturnValue('/mcp auth server1'),
+      slashCompletionRange: {
+        completionStart: 10,
+        completionEnd: 10,
+        getCommandFromSuggestion: vi.fn(),
+        isArgumentCompletion: true,
+        leafCommand: authCommand,
+      },
+    });
+
+    props.buffer.setText('/mcp auth ');
+    props.buffer.lines = ['/mcp auth '];
+    props.buffer.cursor = [0, 10];
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
+
+    await act(async () => {
+      stdin.write('\r'); // Enter
+    });
+
+    await waitFor(() => {
+      // Should auto-execute with the completed command
+      expect(props.onSubmit).toHaveBeenCalledWith('/mcp auth server1');
+      expect(mockCommandCompletion.handleAutocomplete).not.toHaveBeenCalled();
+    });
+    unmount();
+  });
+
+  it('should autocomplete argument completion when command has autoExecute: false', async () => {
+    // Simulates: /extensions enable <ext> where multi-arg completions should NOT auto-execute
+    const enableCommand: SlashCommand = {
+      name: 'enable',
+      kind: CommandKind.BUILT_IN,
+      description: 'Enable an extension',
+      action: vi.fn(),
+      autoExecute: false,
+      completion: vi.fn().mockResolvedValue(['ext1 --scope user']),
+    };
+
+    const suggestion = {
+      label: 'ext1 --scope user',
+      value: 'ext1 --scope user',
+    };
+
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [suggestion],
+      activeSuggestionIndex: 0,
+      getCommandFromSuggestion: vi.fn().mockReturnValue(enableCommand),
+      getCompletedText: vi
+        .fn()
+        .mockReturnValue('/extensions enable ext1 --scope user'),
+      slashCompletionRange: {
+        completionStart: 19,
+        completionEnd: 19,
+        getCommandFromSuggestion: vi.fn(),
+        isArgumentCompletion: true,
+        leafCommand: enableCommand,
+      },
+    });
+
+    props.buffer.setText('/extensions enable ');
+    props.buffer.lines = ['/extensions enable '];
+    props.buffer.cursor = [0, 19];
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
+
+    await act(async () => {
+      stdin.write('\r'); // Enter
+    });
+
+    await waitFor(() => {
+      // Should autocomplete (not execute) to allow user to modify
+      expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
+      expect(props.onSubmit).not.toHaveBeenCalled();
+    });
+    unmount();
+  });
+
+  it('should autocomplete command name even with autoExecute: true if command has completion function', async () => {
+    // Simulates: /chat resu -> should NOT auto-execute, should autocomplete to show arg completions
+    const resumeCommand: SlashCommand = {
+      name: 'resume',
+      kind: CommandKind.BUILT_IN,
+      description: 'Resume a conversation',
+      action: vi.fn(),
+      autoExecute: true,
+      completion: vi.fn().mockResolvedValue(['chat1', 'chat2']),
+    };
+
+    const suggestion = { label: 'resume', value: 'resume' };
+
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [suggestion],
+      activeSuggestionIndex: 0,
+      getCommandFromSuggestion: vi.fn().mockReturnValue(resumeCommand),
+      getCompletedText: vi.fn().mockReturnValue('/chat resume'),
+      slashCompletionRange: {
+        completionStart: 6,
+        completionEnd: 10,
+        getCommandFromSuggestion: vi.fn(),
+        isArgumentCompletion: false,
+        leafCommand: null,
+      },
+    });
+
+    props.buffer.setText('/chat resu');
+    props.buffer.lines = ['/chat resu'];
+    props.buffer.cursor = [0, 10];
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
+      uiActions,
+    });
+
+    await act(async () => {
+      stdin.write('\r'); // Enter
+    });
+
+    await waitFor(() => {
+      // Should autocomplete to allow selecting an argument, NOT auto-execute
       expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
       expect(props.onSubmit).not.toHaveBeenCalled();
     });

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -620,15 +620,40 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
               const isEnterKey = key.name === 'return' && !key.ctrl;
 
               if (isEnterKey && buffer.text.startsWith('/')) {
-                const command = completion.getCommandFromSuggestion(suggestion);
+                const { isArgumentCompletion, leafCommand } =
+                  completion.slashCompletionRange;
 
-                if (command && isAutoExecutableCommand(command)) {
+                if (
+                  isArgumentCompletion &&
+                  isAutoExecutableCommand(leafCommand)
+                ) {
+                  // isArgumentCompletion guarantees leafCommand exists
                   const completedText = completion.getCompletedText(suggestion);
-
                   if (completedText) {
                     setExpandedSuggestionIndex(-1);
                     handleSubmit(completedText.trim());
                     return;
+                  }
+                } else if (!isArgumentCompletion) {
+                  // Existing logic for command name completion
+                  const command =
+                    completion.getCommandFromSuggestion(suggestion);
+
+                  // Only auto-execute if the command has no completion function
+                  // (i.e., it doesn't require an argument to be selected)
+                  if (
+                    command &&
+                    isAutoExecutableCommand(command) &&
+                    !command.completion
+                  ) {
+                    const completedText =
+                      completion.getCompletedText(suggestion);
+
+                    if (completedText) {
+                      setExpandedSuggestionIndex(-1);
+                      handleSubmit(completedText.trim());
+                      return;
+                    }
                   }
                 }
               }

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -51,6 +51,8 @@ export interface UseCommandCompletionReturn {
     getCommandFromSuggestion: (
       suggestion: Suggestion,
     ) => SlashCommand | undefined;
+    isArgumentCompletion: boolean;
+    leafCommand: SlashCommand | null;
   };
   getCompletedText: (suggestion: Suggestion) => string | null;
 }

--- a/packages/cli/src/ui/hooks/useSlashCompletion.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.ts
@@ -418,6 +418,8 @@ export function useSlashCompletion(props: UseSlashCompletionProps): {
   getCommandFromSuggestion: (
     suggestion: Suggestion,
   ) => SlashCommand | undefined;
+  isArgumentCompletion: boolean;
+  leafCommand: SlashCommand | null;
 } {
   const {
     enabled,
@@ -567,5 +569,7 @@ export function useSlashCompletion(props: UseSlashCompletionProps): {
     completionEnd,
     getCommandFromSuggestion: (suggestion: Suggestion) =>
       getCommandFromSuggestion(suggestion, parserResult),
+    isArgumentCompletion: parserResult.isArgumentCompletion,
+    leafCommand: parserResult.leafCommand,
   };
 }

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -225,7 +225,7 @@ export const getUrlOpenCommand = (): string => {
  * @returns true if the command should auto-execute on Enter
  */
 export function isAutoExecutableCommand(
-  command: SlashCommand | undefined,
+  command: SlashCommand | undefined | null,
 ): boolean {
   if (!command) {
     return false;


### PR DESCRIPTION
## Summary

This is the third PR in the auto-execute saga. This PR allows slash commands with completion functions that take a single argument to auto-execute.

Think `/mcp auth` where you then are suggested which server to auth too:

<img width="500" height="245" alt="image" src="https://github.com/user-attachments/assets/b8563780-b31e-4d66-9698-e41fe2fc90be" />

This PR let's the command auto-execute once you hit Enter on the completion function suggestion.

Previous work:

1. Auto-execute simple built-in slash commands: https://github.com/google-gemini/gemini-cli/pull/13985
2. Auto-execute argumentless MCP prompts: https://github.com/google-gemini/gemini-cli/pull/14510


## Details

Allow built-in slash commands with completion functions to auto-execute when a completion suggestion is selected with Enter.

**Before:** `/mcp auth ` → select server → autocompletes to `/mcp auth my-server ` → requires Enter again to execute

**After:** `/mcp auth ` → select server → executes immediately

### Changes

- Exposed `isArgumentCompletion` and `leafCommand` from the slash completion hooks
- Modified Enter key handler to auto-execute argument completions when the command has `autoExecute: true`
- Set `autoExecute: true` on 6 single-arg completion commands: `/mcp auth`, `/chat resume`, `/chat delete`, `/hooks enable`, `/hooks disable`, `/restore`
- Multi-arg completion commands (`/extensions enable`, `/extensions disable`) keep `autoExecute: false`

### Test Plan

- Added 3 new tests for argument completion auto-execute behavior
- Verified all existing tests pass

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

Hit enter on completion suggestion for arg for command like `/chat resume` or `/mcp auth` --> should auto-execute.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
