### PR TITLE
Use Robot PAT for chained e2e merge queue skipper

### DIFF
--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -37,7 +37,7 @@ jobs:
       - id: 'merge-queue-e2e-skipper'
         uses: 'cariad-tech/merge-queue-ci-skipper@1032489e59437862c90a08a2c92809c903883772' # ratchet:cariad-tech/merge-queue-ci-skipper@main
         with:
-          secret: '${{ secrets.GITHUB_TOKEN }}'
+          secret: '${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}'
     continue-on-error: true
 
   download_repo_name:


### PR DESCRIPTION
## Summary

Use Robot PAT for chained e2e merge queue skipper

## Details

`secrets.GITHUB_TOKEN` is not available in the chained execution context.

## Related Issues

For #10008