### PR TITLE
refactor(telemetry): Improve previous PR that allows telemetry to use the CLI auth and add testing

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1738,6 +1738,11 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
         type: 'boolean',
         description: 'Whether to forward telemetry to an OTLP collector.',
       },
+      useCliAuth: {
+        type: 'boolean',
+        description:
+          'Whether to use CLI authentication for telemetry (only for in-process exporters).',
+      },
     },
   },
   BugCommandSettings: {

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -144,9 +144,12 @@ export async function initializeTelemetry(
   config: Config,
   credentials?: JWTInput,
 ): Promise<void> {
-  if (telemetryInitialized || !config.getTelemetryEnabled()) {
+  if (!config.getTelemetryEnabled()) {
+    return;
+  }
+
+  if (telemetryInitialized) {
     if (
-      telemetryInitialized &&
       credentials?.client_email &&
       activeTelemetryEmail &&
       credentials.client_email !== activeTelemetryEmail

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -87,6 +87,7 @@ let callbackRegistered = false;
 let authListener: ((newCredentials: JWTInput) => Promise<void>) | undefined =
   undefined;
 const telemetryBuffer: Array<() => void | Promise<void>> = [];
+let activeTelemetryEmail: string | undefined;
 
 export function isTelemetrySdkInitialized(): boolean {
   return telemetryInitialized;
@@ -144,6 +145,16 @@ export async function initializeTelemetry(
   credentials?: JWTInput,
 ): Promise<void> {
   if (telemetryInitialized || !config.getTelemetryEnabled()) {
+    if (
+      telemetryInitialized &&
+      credentials?.client_email &&
+      activeTelemetryEmail &&
+      credentials.client_email !== activeTelemetryEmail
+    ) {
+      const message = `Telemetry credentials have changed (from ${activeTelemetryEmail} to ${credentials.client_email}), but telemetry cannot be re-initialized in this process. Please restart the CLI to use the new account for telemetry.`;
+      debugLogger.error(message);
+      console.error(message);
+    }
     return;
   }
 
@@ -164,10 +175,7 @@ export async function initializeTelemetry(
       callbackRegistered = true;
       authListener = async (newCredentials: JWTInput) => {
         if (config.getTelemetryEnabled() && config.getTelemetryUseCliAuth()) {
-          debugLogger.log(
-            'Telemetry reinit with credentials: ',
-            newCredentials,
-          );
+          debugLogger.log('Telemetry reinit with credentials.');
           await initializeTelemetry(config, newCredentials);
         }
       };
@@ -293,6 +301,7 @@ export async function initializeTelemetry(
       debugLogger.log('OpenTelemetry SDK started successfully.');
     }
     telemetryInitialized = true;
+    activeTelemetryEmail = credentials?.client_email;
     initializeMetrics(config);
     void flushTelemetryBuffer();
   } catch (error) {
@@ -363,5 +372,6 @@ export async function shutdownTelemetry(
       authListener = undefined;
     }
     callbackRegistered = false;
+    activeTelemetryEmail = undefined;
   }
 }

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1609,6 +1609,10 @@
         "useCollector": {
           "type": "boolean",
           "description": "Whether to forward telemetry to an OTLP collector."
+        },
+        "useCliAuth": {
+          "type": "boolean",
+          "description": "Whether to use CLI authentication for telemetry (only for in-process exporters)."
         }
       }
     },


### PR DESCRIPTION
This commit is a  follow up to https://github.com/google-gemini/gemini-cli/pull/13778 to clean up a few edge cases and add the useCliAuth to the settings schema.

Specific changes:
- **Telemetry Re-authentication:** The telemetry SDK now detects when authentication credentials change and logs an error to prompt the user to restart if the user logged in with a different account.
- **User Info Caching:** Caches the user's Google account information after a successful manual (no-browser) login, ensuring the account is available for subsequent operations; this was previously missing.
- **Remove leftover debugging code** to avoid logging credentials.
- **Testing:**
    - Adds tests to verify the new credential change detection logic.
    - Adds a test to ensure Google account information is cached correctly after a manual login.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
