### PR TITLE
Disallow floating promises.

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -165,6 +165,7 @@ export default tseslint.config(
       'prefer-const': ['error', { destructuring: 'all' }],
       radix: 'error',
       'default-case': 'error',
+      '@typescript-eslint/no-floating-promises': ['error'],
     },
   },
   {

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -397,6 +397,7 @@ export class CoderAgentExecutor implements AgentExecutor {
           `[CoderAgentExecutor] Error creating task ${taskId}:`,
           error,
         );
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         pushTaskStateFailed(error, eventBus, taskId, contextId);
         return;
       }

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -395,6 +395,7 @@ export class Task {
       logger.info('[Task] YOLO mode enabled. Auto-approving all tool calls.');
       toolCalls.forEach((tc: ToolCall) => {
         if (tc.status === 'awaiting_approval' && tc.confirmationDetails) {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           tc.confirmationDetails.onConfirm(ToolConfirmationOutcome.ProceedOnce);
           this.pendingToolConfirmationDetails.delete(tc.request.callId);
         }
@@ -819,6 +820,7 @@ export class Task {
       } else {
         parts = [response];
       }
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.geminiClient.addHistory({
         role: 'user',
         parts,

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -346,6 +346,7 @@ export class ExtensionManager extends ExtensionLoader {
               'success',
             ),
           );
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           this.enableExtension(newExtensionConfig.name, SettingScope.User);
         }
       } finally {

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -799,6 +799,7 @@ export function migrateDeprecatedSettings(
         `Migrating deprecated extensions.disabled settings from ${scope} settings...`,
       );
       for (const extension of settings.extensions.disabled ?? []) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         extensionManager.disableExtension(extension, scope);
       }
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -294,6 +294,7 @@ export const AppContainer = (props: AppContainerProps) => {
   const staticExtraHeight = 3;
 
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     (async () => {
       // Note: the program will not work if this fails so let errors be
       // handled by the global catch.
@@ -384,6 +385,7 @@ export const AppContainer = (props: AppContainerProps) => {
 
   // Initialize input history from logger (past sessions)
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     initializeFromLogger(logger);
   }, [logger, initializeFromLogger]);
 
@@ -984,6 +986,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       const currentIde = ideClient.getCurrentIde();
       setCurrentIDE(currentIde || null);
     };
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     getIde();
   }, []);
   const shouldShowIdePrompt = Boolean(
@@ -1109,6 +1112,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       recordExitFail(config);
     }
     if (ctrlCPressCount > 1) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       handleSlashCommand('/quit', undefined, undefined, false);
     } else {
       ctrlCTimerRef.current = setTimeout(() => {
@@ -1127,6 +1131,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       recordExitFail(config);
     }
     if (ctrlDPressCount > 1) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       handleSlashCommand('/quit', undefined, undefined, false);
     } else {
       ctrlDTimerRef.current = setTimeout(() => {
@@ -1143,6 +1148,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
   const handleIdePromptComplete = useCallback(
     (result: IdeIntegrationNudgeResult) => {
       if (result.userSelection === 'yes') {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         handleSlashCommand('/ide install');
         settings.setValue(
           SettingScope.User,
@@ -1225,6 +1231,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
         config.getIdeMode() &&
         ideContextState
       ) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         handleSlashCommand('/ide status');
       } else if (
         keyMatchers[Command.SHOW_MORE_LINES](key) &&
@@ -1425,6 +1432,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
         }
       }
     };
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fetchBannerTexts();
 
     return () => {

--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -154,6 +154,7 @@ export function AuthDialog({
     if (error) {
       onAuthError(error);
     } else {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       onSelect(authMethod, SettingScope.User);
     }
   };
@@ -173,6 +174,7 @@ export function AuthDialog({
           );
           return;
         }
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         onSelect(undefined, SettingScope.User);
       }
     },

--- a/packages/cli/src/ui/auth/useAuth.ts
+++ b/packages/cli/src/ui/auth/useAuth.ts
@@ -64,11 +64,13 @@ export const useAuthCommand = (settings: LoadedSettings, config: Config) => {
 
   useEffect(() => {
     if (authState === AuthState.AwaitingApiKeyInput) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       reloadApiKey();
     }
   }, [authState, reloadApiKey]);
 
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     (async () => {
       if (authState !== AuthState.Unauthenticated) {
         return;

--- a/packages/cli/src/ui/commands/directoryCommand.test.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.test.tsx
@@ -72,6 +72,7 @@ describe('directoryCommand', () => {
   describe('show', () => {
     it('should display the list of directories', () => {
       if (!showCommand?.action) throw new Error('No action');
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       showCommand.action(mockContext, '');
       expect(mockWorkspaceContext.getDirectories).toHaveBeenCalled();
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
@@ -101,6 +102,7 @@ describe('directoryCommand', () => {
 
     it('should show an error if no path is provided', () => {
       if (!addCommand?.action) throw new Error('No action');
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       addCommand.action(mockContext, '');
       expect(mockContext.ui.addItem).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -92,6 +92,7 @@ function updateAction(context: CommandContext, args: string): Promise<void> {
     extensions,
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   updateComplete.then((updateInfos) => {
     if (updateInfos.length === 0) {
       context.ui.addItem(

--- a/packages/cli/src/ui/commands/statsCommand.test.ts
+++ b/packages/cli/src/ui/commands/statsCommand.test.ts
@@ -30,6 +30,7 @@ describe('statsCommand', () => {
   it('should display general session stats when run with no subcommand', () => {
     if (!statsCommand.action) throw new Error('Command has no action');
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     statsCommand.action(mockContext, '');
 
     const expectedDuration = formatDuration(
@@ -50,6 +51,7 @@ describe('statsCommand', () => {
     );
     if (!modelSubCommand?.action) throw new Error('Subcommand has no action');
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     modelSubCommand.action(mockContext, '');
 
     expect(mockContext.ui.addItem).toHaveBeenCalledWith(
@@ -66,6 +68,7 @@ describe('statsCommand', () => {
     );
     if (!toolsSubCommand?.action) throw new Error('Subcommand has no action');
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     toolsSubCommand.action(mockContext, '');
 
     expect(mockContext.ui.addItem).toHaveBeenCalledWith(

--- a/packages/cli/src/ui/components/FolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.tsx
@@ -41,6 +41,7 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
         }, 250);
       }
     };
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     doRelaunch();
   }, [isRestarting]);
 

--- a/packages/cli/src/ui/components/IdeTrustChangeDialog.tsx
+++ b/packages/cli/src/ui/components/IdeTrustChangeDialog.tsx
@@ -18,6 +18,7 @@ export const IdeTrustChangeDialog = ({ reason }: IdeTrustChangeDialogProps) => {
   useKeypress(
     (key) => {
       if (key.name === 'r' || key.name === 'R') {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         relaunchApp();
       }
     },

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -373,6 +373,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   useMouse(
     (event: MouseEvent) => {
       if (event.name === 'right-release') {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         handleClipboardPaste();
       }
     },
@@ -779,12 +780,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
       // External editor
       if (keyMatchers[Command.OPEN_EXTERNAL_EDITOR](key)) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         buffer.openInExternalEditor();
         return;
       }
 
       // Ctrl+V for clipboard paste
       if (keyMatchers[Command.PASTE_CLIPBOARD](key)) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         handleClipboardPaste();
         return;
       }

--- a/packages/cli/src/ui/components/MultiFolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/MultiFolderTrustDialog.tsx
@@ -66,6 +66,7 @@ export const MultiFolderTrustDialog: React.FC<MultiFolderTrustDialogProps> = ({
   useKeypress(
     (key) => {
       if (key.name === 'escape') {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         handleCancel();
       }
     },

--- a/packages/cli/src/ui/components/Notifications.tsx
+++ b/packages/cli/src/ui/components/Notifications.tsx
@@ -49,6 +49,7 @@ export const Notifications = () => {
     };
 
     if (isScreenReaderEnabled) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       checkScreenReader();
     }
   }, [isScreenReaderEnabled]);
@@ -69,6 +70,7 @@ export const Notifications = () => {
         }
       }
     };
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     writeScreenReaderNudgeFile();
   }, [showScreenReaderNudge]);
 

--- a/packages/cli/src/ui/components/PermissionsModifyTrustDialog.tsx
+++ b/packages/cli/src/ui/components/PermissionsModifyTrustDialog.tsx
@@ -70,6 +70,7 @@ export function PermissionsModifyTrustDialog({
       if (needsRestart && key.name === 'r') {
         const success = commitTrustLevelChange();
         if (success) {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           relaunchApp();
         } else {
           onExit();

--- a/packages/cli/src/ui/components/SessionBrowser.tsx
+++ b/packages/cli/src/ui/components/SessionBrowser.tsx
@@ -665,6 +665,7 @@ const useLoadSessions = (config: Config, state: SessionBrowserState) => {
       }
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     loadSessions();
   }, [config, setSessions, setLoading, setError]);
 
@@ -693,6 +694,7 @@ const useLoadSessions = (config: Config, state: SessionBrowserState) => {
       }
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     loadFullContent();
   }, [
     isSearchMode,

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -139,6 +139,7 @@ export function SettingsDialog({
       setScrollOffset(0);
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     doSearch();
 
     return () => {

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -57,6 +57,7 @@ export const ToolConfirmationMessage: React.FC<
           setIsDiffingEnabled(client?.isDiffingEnabled() ?? false);
         }
       };
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       getIdeClient();
     }
     return () => {
@@ -75,6 +76,7 @@ export const ToolConfirmationMessage: React.FC<
         );
       }
     }
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     onConfirm(outcome);
   };
 
@@ -84,6 +86,7 @@ export const ToolConfirmationMessage: React.FC<
     (key) => {
       if (!isFocused) return;
       if (key.name === 'escape' || (key.ctrl && key.name === 'c')) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         handleConfirm(ToolConfirmationOutcome.Cancel);
       }
     },

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -645,12 +645,14 @@ describe('KeypressContext', () => {
     expect(keyHandler).not.toHaveBeenCalled();
 
     // Advance time just before timeout
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     act(() => vi.advanceTimersByTime(ESC_TIMEOUT - 5));
 
     // Still shouldn't broadcast
     expect(keyHandler).not.toHaveBeenCalled();
 
     // Advance past timeout
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     act(() => vi.advanceTimersByTime(10));
 
     // Should now broadcast the incomplete sequence as regular input
@@ -789,12 +791,14 @@ describe('KeypressContext', () => {
     act(() => stdin.write('\x1b[97;13'));
 
     // Advance time partway
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     act(() => vi.advanceTimersByTime(30));
 
     // Add more to sequence
     act(() => stdin.write('5'));
 
     // Advance time from the first timeout point
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     act(() => vi.advanceTimersByTime(25));
 
     // Should not have timed out yet (timeout restarted)
@@ -878,6 +882,7 @@ describe('KeypressContext', () => {
       act(() => stdin.write('\x1b[<'));
 
       // Advance time past the normal kitty timeout (50ms)
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       act(() => vi.advanceTimersByTime(ESC_TIMEOUT + 10));
 
       // Send the rest
@@ -930,6 +935,8 @@ describe('KeypressContext', () => {
 
       for (const char of sequence) {
         act(() => stdin.write(char));
+
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         act(() => vi.advanceTimersByTime(0));
       }
 

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -40,6 +40,7 @@ function addShellCommandToGeminiHistory(
       ? resultText.substring(0, MAX_OUTPUT_LENGTH) + '\n... (truncated)'
       : resultText;
 
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   geminiClient.addHistory({
     role: 'user',
     parts: [
@@ -350,6 +351,7 @@ export const useShellCommandProcessor = (
       };
 
       const execPromise = new Promise<void>((resolve) => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         executeCommand(resolve);
       });
 

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -258,6 +258,7 @@ export const useSlashCommandProcessor = (
       reloadCommands();
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     (async () => {
       const ideClient = await IdeClient.getInstance();
       ideClient.addStatusChangeListener(listener);
@@ -278,6 +279,7 @@ export const useSlashCommandProcessor = (
     appEvents.on('extensionsStopping', extensionEventListener);
 
     return () => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       (async () => {
         const ideClient = await IdeClient.getInstance();
         ideClient.removeStatusChangeListener(listener);
@@ -290,6 +292,7 @@ export const useSlashCommandProcessor = (
   useEffect(() => {
     const controller = new AbortController();
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     (async () => {
       const commandService = await CommandService.create(
         [

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -223,8 +223,10 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
     };
 
     if (state.status === AtCompletionStatus.INITIALIZING) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       initialize();
     } else if (state.status === AtCompletionStatus.SEARCHING) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       search();
     }
 

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -98,6 +98,7 @@ export const useExtensionUpdates = (
       return !currentState || currentState === ExtensionUpdateState.UNKNOWN;
     });
     if (extensionsToCheck.length === 0) return;
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     checkForAllExtensionUpdates(
       extensionsToCheck,
       extensionManager,
@@ -200,6 +201,7 @@ export const useExtensionUpdates = (
       );
     }
     if (scheduledUpdate) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       Promise.all(updatePromises).then((results) => {
         const nonNullResults = results.filter((result) => result != null);
         scheduledUpdate.onCompleteCallbacks.forEach((callback) => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -977,6 +977,7 @@ describe('useGeminiStream', () => {
 
       // Start a query
       await act(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         result.current.submitQuery('test query');
       });
 
@@ -1036,6 +1037,7 @@ describe('useGeminiStream', () => {
 
       // Start a query
       await act(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         result.current.submitQuery('test query');
       });
 
@@ -1076,6 +1078,7 @@ describe('useGeminiStream', () => {
 
       // Start a query
       await act(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         result.current.submitQuery('test query');
       });
 
@@ -1117,6 +1120,7 @@ describe('useGeminiStream', () => {
       const { result } = renderTestHook();
 
       await act(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         result.current.submitQuery('long running query');
       });
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -993,6 +993,7 @@ export const useGeminiStream = (
                       );
 
                       if (lastQueryRef.current && lastPromptIdRef.current) {
+                        // eslint-disable-next-line @typescript-eslint/no-floating-promises
                         submitQuery(
                           lastQueryRef.current,
                           { isContinuation: true },
@@ -1176,6 +1177,7 @@ export const useGeminiStream = (
           const combinedParts = geminiTools.flatMap(
             (toolCall) => toolCall.response.responseParts,
           );
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           geminiClient.addHistory({
             role: 'user',
             parts: combinedParts,
@@ -1207,6 +1209,7 @@ export const useGeminiStream = (
         return;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       submitQuery(
         responsesToSend,
         {
@@ -1342,6 +1345,7 @@ export const useGeminiStream = (
         }
       }
     };
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     saveRestorableToolCalls();
   }, [
     toolCalls,

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -37,6 +37,7 @@ export function useGitBranchName(cwd: string): string | undefined {
   }, [cwd, setBranchName]);
 
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fetchBranchName(); // Initial fetch
 
     const gitLogsHeadPath = path.join(cwd, '.git', 'logs', 'HEAD');
@@ -52,6 +53,7 @@ export function useGitBranchName(cwd: string): string | undefined {
           // Changes to .git/logs/HEAD (appends) indicate HEAD has likely changed
           if (eventType === 'change' || eventType === 'rename') {
             // Handle rename just in case
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             fetchBranchName();
           }
         });
@@ -62,6 +64,7 @@ export function useGitBranchName(cwd: string): string | undefined {
       }
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     setupWatcher();
 
     return () => {

--- a/packages/cli/src/ui/hooks/useIdeTrustListener.ts
+++ b/packages/cli/src/ui/hooks/useIdeTrustListener.ts
@@ -49,6 +49,7 @@ export function useIdeTrustListener() {
       onStoreChange();
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     (async () => {
       const ideClient = await IdeClient.getInstance();
       ideClient.addTrustChangeListener(handleTrustChange);
@@ -56,6 +57,7 @@ export function useIdeTrustListener() {
       setConnectionStatus(ideClient.getConnectionStatus().status);
     })();
     return () => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       (async () => {
         const ideClient = await IdeClient.getInstance();
         ideClient.removeTrustChangeListener(handleTrustChange);

--- a/packages/cli/src/ui/hooks/useIncludeDirsTrust.tsx
+++ b/packages/cli/src/ui/hooks/useIncludeDirsTrust.tsx
@@ -87,6 +87,7 @@ export function useIncludeDirsTrust(
       }
 
       if (added.length > 0 || errors.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         finishAddingDirectories(config, addItem, added, errors);
       }
       config.clearPendingIncludeDirectories();
@@ -151,6 +152,7 @@ export function useIncludeDirsTrust(
         />,
       );
     } else if (added.length > 0 || errors.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       finishAddingDirectories(config, addItem, added, errors);
       config.clearPendingIncludeDirectories();
     }

--- a/packages/cli/src/ui/hooks/useLoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.test.tsx
@@ -23,6 +23,7 @@ describe('useLoadingIndicator', () => {
 
   afterEach(() => {
     vi.useRealTimers(); // Restore real timers after each test
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     act(() => vi.runOnlyPendingTimers);
     vi.restoreAllMocks();
   });

--- a/packages/cli/src/ui/hooks/usePrivacySettings.ts
+++ b/packages/cli/src/ui/hooks/usePrivacySettings.ts
@@ -58,6 +58,7 @@ export const usePrivacySettings = (config: Config) => {
         });
       }
     };
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fetchInitialState();
   }, [config]);
 

--- a/packages/cli/src/ui/hooks/usePromptCompletion.ts
+++ b/packages/cli/src/ui/hooks/usePromptCompletion.ts
@@ -181,6 +181,7 @@ export function usePromptCompletion({
       lastSelectedTextRef.current = '';
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     generatePromptSuggestions();
   }, [
     buffer.text,

--- a/packages/cli/src/ui/hooks/useSelectionList.test.tsx
+++ b/packages/cli/src/ui/hooks/useSelectionList.test.tsx
@@ -584,11 +584,13 @@ describe('useSelectionList', () => {
       });
 
       pressNumber('0');
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       act(() => vi.advanceTimersByTime(1000)); // Timeout the '0' input
 
       pressNumber('1');
       expect(mockOnSelect).not.toHaveBeenCalled(); // Should be waiting for second digit
 
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       act(() => vi.advanceTimersByTime(1000)); // Timeout '1'
       expect(mockOnSelect).toHaveBeenCalledWith('Item 1');
     });

--- a/packages/cli/src/ui/hooks/useSessionResume.ts
+++ b/packages/cli/src/ui/hooks/useSessionResume.ts
@@ -64,6 +64,7 @@ export function useSessionResume({
       refreshStaticRef.current(); // Force Static component to re-render with the updated history.
 
       // Give the history to the Gemini client.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       config.getGeminiClient()?.resumeChat(clientHistory, resumedData);
     },
     [config, isGeminiClientInitialized, setQuittingMessages],

--- a/packages/cli/src/ui/hooks/useShellHistory.ts
+++ b/packages/cli/src/ui/hooks/useShellHistory.ts
@@ -84,6 +84,7 @@ export function useShellHistory(
       const loadedHistory = await readHistoryFile(filePath);
       setHistory(loadedHistory.reverse()); // Newest first
     }
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     loadHistory();
   }, [projectRoot, storage]);
 
@@ -97,6 +98,7 @@ export function useShellHistory(
         .filter(Boolean);
       setHistory(newHistory);
       // Write to file in reverse order (oldest first)
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       writeHistoryFile(historyFilePath, [...newHistory].reverse());
       setHistoryIndex(-1);
     },

--- a/packages/cli/src/ui/hooks/useSlashCompletion.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.ts
@@ -232,6 +232,7 @@ function useCommandSuggestions(
           }
         }
       };
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       fetchAndSetSuggestions();
       return () => abortController.abort();
     }

--- a/packages/cli/src/ui/privacy/CloudFreePrivacyNotice.tsx
+++ b/packages/cli/src/ui/privacy/CloudFreePrivacyNotice.tsx
@@ -112,6 +112,7 @@ export const CloudFreePrivacyNotice = ({
           items={items}
           initialIndex={privacyState.dataCollectionOptIn ? 0 : 1}
           onSelect={(value) => {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             updateDataCollectionOptIn(value);
             // Only exit if there was no error.
             if (!privacyState.error) {

--- a/packages/cli/src/zed-integration/connection.ts
+++ b/packages/cli/src/zed-integration/connection.ts
@@ -105,6 +105,7 @@ export class Connection {
     this.#handler = handler;
     this.#peerInput = peerInput;
     this.#textEncoder = new TextEncoder();
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.#receive(peerOutput);
   }
 
@@ -121,6 +122,7 @@ export class Connection {
 
         if (trimmedLine) {
           const message = JSON.parse(trimmedLine);
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           this.#processMessage(message);
         }
       }

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -289,6 +289,7 @@ export class Session {
                 text: part.text,
               };
 
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
               this.sendUpdate({
                 sessionUpdate: part.thought
                   ? 'agent_thought_chunk'

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -599,6 +599,7 @@ export class Config {
     }
 
     if (this.telemetrySettings.enabled) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       initializeTelemetry(this);
     }
 

--- a/packages/core/src/confirmation-bus/message-bus.ts
+++ b/packages/core/src/confirmation-bus/message-bus.ts
@@ -183,6 +183,7 @@ export class MessageBus extends EventEmitter {
       this.subscribe<TResponse>(responseType, responseHandler);
 
       // Publish the request with correlation ID
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.publish({ ...request, correlationId } as TRequest);
     });
   }

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -1166,6 +1166,7 @@ describe('CoreToolScheduler request queueing', () => {
     };
 
     // Schedule the first call, which will pause execution.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     scheduler.schedule([request1], abortController.signal);
 
     // Wait for the first call to be in the 'executing' state.

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -381,6 +381,7 @@ export class CoreToolScheduler {
         const sharedHandler = (request: ToolConfirmationRequest) => {
           // When ASK_USER policy decision is made, respond with requiresUserConfirmation=true
           // to tell tools to use their legacy confirmation flow
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           messageBus.publish({
             type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
             correlationId: request.correlationId,
@@ -883,8 +884,10 @@ export class CoreToolScheduler {
               confirmationDetails.type === 'edit' &&
               confirmationDetails.ideConfirmation
             ) {
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
               confirmationDetails.ideConfirmation.then((resolution) => {
                 if (resolution.status === 'accepted') {
+                  // eslint-disable-next-line @typescript-eslint/no-floating-promises
                   this.handleConfirmationResponse(
                     reqInfo.callId,
                     confirmationDetails.onConfirm,
@@ -892,6 +895,7 @@ export class CoreToolScheduler {
                     signal,
                   );
                 } else {
+                  // eslint-disable-next-line @typescript-eslint/no-floating-promises
                   this.handleConfirmationResponse(
                     reqInfo.callId,
                     confirmationDetails.onConfirm,

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -776,6 +776,7 @@ export class HookEventHandler {
 
       // Publish response through MessageBus
       if (this.messageBus) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.messageBus.publish({
           type: MessageBusType.HOOK_EXECUTION_RESPONSE,
           correlationId: request.correlationId,
@@ -786,6 +787,7 @@ export class HookEventHandler {
     } catch (error) {
       // Publish error response
       if (this.messageBus) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.messageBus.publish({
           type: MessageBusType.HOOK_EXECUTION_RESPONSE,
           correlationId: request.correlationId,

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -278,6 +278,7 @@ export class IdeClient {
     });
 
     // Ensure the mutex is released only after the diff interaction is complete.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     promise.finally(release);
 
     return promise;
@@ -406,6 +407,7 @@ export class IdeClient {
       IDEConnectionStatus.Disconnected,
       'IDE integration disabled. To enable it again, run /ide enable.',
     );
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.client?.close();
   }
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -685,6 +685,7 @@ export class ShellExecutionService {
               });
             });
 
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             Promise.race([processingComplete, abortFired]).then(() => {
               finalize();
             });

--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -284,6 +284,7 @@ export class ClearcutLogger {
     event: LogEvent,
   ): Promise<void> {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.config?.getExperimentsAsync().then((experiments) => {
         if (experiments) {
           const exp_id_data: EventValue[] = [
@@ -557,6 +558,7 @@ export class ClearcutLogger {
     this.sessionData = data;
 
     // Flush after experiments finish loading from CCPA server
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.enqueueLogEventAfterExperimentsLoadAsync(
       this.createLogEvent(EventNames.START_SESSION, data),
     ).then(() => {
@@ -900,6 +902,7 @@ export class ClearcutLogger {
     ];
 
     // Flush after experiments finish loading from CCPA server
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.enqueueLogEventAfterExperimentsLoadAsync(
       this.createLogEvent(EventNames.START_SESSION, data),
     ).then(() => {

--- a/packages/core/src/telemetry/gcp-exporters.ts
+++ b/packages/core/src/telemetry/gcp-exporters.ts
@@ -96,6 +96,7 @@ export class GcpLogExporter implements LogRecordExporter {
         .finally(() => {
           const index = this.pendingWrites.indexOf(writePromise);
           if (index > -1) {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             this.pendingWrites.splice(index, 1);
           }
         });

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -94,6 +94,7 @@ export function isTelemetrySdkInitialized(): boolean {
 
 export function bufferTelemetryEvent(fn: () => void | Promise<void>): void {
   if (telemetryInitialized) {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fn();
   } else {
     telemetryBuffer.push(fn);
@@ -303,9 +304,11 @@ export async function initializeTelemetry(
   // and won't wait for the async shutdownTelemetry() to complete.
   // Instead, telemetry shutdown is handled in runExitCleanup() in cleanup.ts
   process.on('SIGTERM', () => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     shutdownTelemetry(config);
   });
   process.on('SIGINT', () => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     shutdownTelemetry(config);
   });
 }

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -160,6 +160,7 @@ export class McpClientManager {
     }
 
     const currentDiscoveryPromise = new Promise<void>((resolve, _reject) => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       (async () => {
         try {
           if (existing) {
@@ -228,6 +229,7 @@ export class McpClientManager {
     }
     this.eventEmitter?.emit('mcp-client-update', this.clients);
     const currentPromise = this.discoveryPromise;
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     currentPromise.then((_) => {
       // If we are the last recorded discoveryPromise, then we are done, reset
       // the world.

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -739,6 +739,7 @@ export async function connectAndDiscover(
     toolRegistry.sortTools();
   } catch (error) {
     if (mcpClient) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       mcpClient.close();
     }
     coreEvents.emitFeedback(

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -131,6 +131,7 @@ export abstract class BaseToolInvocation<
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
           if (this.messageBus && this._toolName) {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             this.messageBus.publish({
               type: MessageBusType.UPDATE_POLICY,
               toolName: this._toolName,
@@ -220,6 +221,7 @@ export abstract class BaseToolInvocation<
       };
 
       try {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.messageBus.publish(request);
       } catch (_error) {
         cleanup();

--- a/packages/vscode-ide-companion/eslint.config.mjs
+++ b/packages/vscode-ide-companion/eslint.config.mjs
@@ -20,6 +20,10 @@ export default [
       parser: tsParser,
       ecmaVersion: 2022,
       sourceType: 'module',
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
 
     rules: {
@@ -35,6 +39,7 @@ export default [
       eqeqeq: 'warn',
       'no-throw-literal': 'warn',
       semi: 'warn',
+      '@typescript-eslint/no-floating-promises': ['error'],
     },
   },
 ];

--- a/packages/vscode-ide-companion/src/diff-manager.ts
+++ b/packages/vscode-ide-companion/src/diff-manager.ts
@@ -62,9 +62,11 @@ export class DiffManager {
   ) {
     this.subscriptions.push(
       vscode.window.onDidChangeActiveTextEditor((editor) => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.onActiveEditorChange(editor);
       }),
     );
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.onActiveEditorChange(vscode.window.activeTextEditor);
   }
 

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -112,6 +112,7 @@ export async function activate(context: vscode.ExtensionContext) {
     detectIdeFromEnv().name,
   );
 
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   checkForUpdates(context, log, isManagedExtensionSurface);
 
   const diffContentProvider = new DiffContentProvider();
@@ -120,6 +121,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.workspace.onDidCloseTextDocument((doc) => {
       if (doc.uri.scheme === DIFF_SCHEME) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         diffManager.cancelDiff(doc.uri);
       }
     }),
@@ -127,11 +129,12 @@ export async function activate(context: vscode.ExtensionContext) {
       DIFF_SCHEME,
       diffContentProvider,
     ),
-    vscode.commands.registerCommand(
+    (vscode.commands.registerCommand(
       'gemini.diff.accept',
       (uri?: vscode.Uri) => {
         const docUri = uri ?? vscode.window.activeTextEditor?.document.uri;
         if (docUri && docUri.scheme === DIFF_SCHEME) {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           diffManager.acceptDiff(docUri);
         }
       },
@@ -141,10 +144,11 @@ export async function activate(context: vscode.ExtensionContext) {
       (uri?: vscode.Uri) => {
         const docUri = uri ?? vscode.window.activeTextEditor?.document.uri;
         if (docUri && docUri.scheme === DIFF_SCHEME) {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           diffManager.cancelDiff(docUri);
         }
       },
-    ),
+    )),
   );
 
   ideServer = new IDEServer(log, diffManager);
@@ -166,12 +170,14 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   context.subscriptions.push(
-    vscode.workspace.onDidChangeWorkspaceFolders(() => {
+    (vscode.workspace.onDidChangeWorkspaceFolders(() => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
     }),
     vscode.workspace.onDidGrantWorkspaceTrust(() => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
-    }),
+    })),
     vscode.commands.registerCommand('gemini-cli.runGeminiCLI', async () => {
       const workspaceFolders = vscode.workspace.workspaceFolders;
       if (!workspaceFolders || workspaceFolders.length === 0) {

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -107,6 +107,7 @@ function sendIdeContextUpdateNotification(
     params: ideContext,
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   transport.send(notification);
 }
 
@@ -196,6 +197,7 @@ export class IDEServer {
       const onDidChangeDiffSubscription = this.diffManager.onDidChange(
         (notification) => {
           for (const transport of Object.values(this.transports)) {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             transport.send(notification);
           }
         },
@@ -248,6 +250,8 @@ export class IDEServer {
               delete this.transports[transport.sessionId];
             }
           };
+
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           mcpServer.connect(transport);
         } else {
           this.log(


### PR DESCRIPTION
## Summary

Disallows floating promises in TypeScript code and suppresses all existing instances.

Floating promises are instances where a promise is created but not `await`-ed. When this happens, and the code tracked by the promise contains an `await`, the work potentially ends up interleaved with subsequent asynchronous code.

This can lead to subtle race conditions, unexpected sequence of execution, code not completing before exit, and inability to test certain code paths reliably.

## Details

I chose to suppress each instance rather than fix them to avoid a functional change because this change touches a large number of files, because some floating promises might be intentional design decisions, and because even accidental instances might be 'load bearing' in that they prevent crashes due to promise rejection or performance issues in scenarios like extension load.

I propose that someone with expertise fix the instances as they touch the affected areas.

## Related Issues


## How to Validate

Run `npm run lint`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
