### PR TITLE
fix(cli): handle PAT tokens and credentials in git remote URL parsing

### DIFF
--- a/packages/cli/src/utils/gitUtils.test.ts
+++ b/packages/cli/src/utils/gitUtils.test.ts
@@ -165,6 +165,13 @@ describe('getGitHubRepoInfo', async () => {
       getGitHubRepoInfo();
     }).toThrowError(/Owner & repo could not be extracted from remote URL/);
   });
+
+  it('handles repo names containing .git substring', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://github.com/owner/my.git.repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'my.git.repo' });
+  });
 });
 
 describe('getGitRepoRoot', async () => {

--- a/packages/cli/src/utils/gitUtils.test.ts
+++ b/packages/cli/src/utils/gitUtils.test.ts
@@ -170,7 +170,10 @@ describe('getGitHubRepoInfo', async () => {
     vi.mocked(child_process.execSync).mockReturnValueOnce(
       'https://github.com/owner/my.git.repo.git',
     );
-    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'my.git.repo' });
+    expect(getGitHubRepoInfo()).toEqual({
+      owner: 'owner',
+      repo: 'my.git.repo',
+    });
   });
 });
 

--- a/packages/cli/src/utils/gitUtils.test.ts
+++ b/packages/cli/src/utils/gitUtils.test.ts
@@ -76,6 +76,95 @@ describe('getGitHubRepoInfo', async () => {
     );
     expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
   });
+
+  // --- Tests for credential formats ---
+
+  it('returns the owner and repo for URL with classic PAT token (ghp_)', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@github.com/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('returns the owner and repo for URL with fine-grained PAT token (github_pat_)', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://github_pat_xxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@github.com/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('returns the owner and repo for URL with username:password format', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://username:password@github.com/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('returns the owner and repo for URL with OAuth token (oauth2:token)', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://oauth2:gho_xxxxxxxxxxxx@github.com/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('returns the owner and repo for URL with GitHub Actions token (x-access-token)', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://x-access-token:ghs_xxxxxxxxxxxx@github.com/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  // --- Tests for case insensitivity ---
+
+  it('returns the owner and repo for URL with uppercase GITHUB.COM', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://GITHUB.COM/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('returns the owner and repo for URL with mixed case GitHub.Com', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://GitHub.Com/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  // --- Tests for SSH format ---
+
+  it('returns the owner and repo for SSH URL', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'git@github.com:owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('throws for non-GitHub SSH URL', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'git@gitlab.com:owner/repo.git',
+    );
+    expect(() => {
+      getGitHubRepoInfo();
+    }).toThrowError(/Owner & repo could not be extracted from remote URL/);
+  });
+
+  // --- Tests for edge cases ---
+
+  it('returns the owner and repo for URL without .git suffix', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://github.com/owner/repo',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('throws for non-GitHub HTTPS URL', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://gitlab.com/owner/repo.git',
+    );
+    expect(() => {
+      getGitHubRepoInfo();
+    }).toThrowError(/Owner & repo could not be extracted from remote URL/);
+  });
 });
 
 describe('getGitRepoRoot', async () => {

--- a/packages/cli/src/utils/gitUtils.ts
+++ b/packages/cli/src/utils/gitUtils.ts
@@ -104,17 +104,38 @@ export function getGitHubRepoInfo(): { owner: string; repo: string } {
     encoding: 'utf-8',
   }).trim();
 
-  // Matches either https://github.com/owner/repo.git or git@github.com:owner/repo.git
-  const match = remoteUrl.match(
-    /(?:https?:\/\/|git@)github\.com(?::|\/)([^/]+)\/([^/]+?)(?:\.git)?$/,
-  );
-
-  // If the regex fails match, throw an error.
-  if (!match || !match[1] || !match[2]) {
+  // Handle SCP-style SSH URLs (git@github.com:owner/repo.git)
+  let urlToParse = remoteUrl;
+  if (remoteUrl.startsWith('git@github.com:')) {
+    urlToParse = remoteUrl.replace('git@github.com:', '');
+  } else if (remoteUrl.startsWith('git@')) {
+    // SSH URL for a different provider (GitLab, Bitbucket, etc.)
     throw new Error(
       `Owner & repo could not be extracted from remote URL: ${remoteUrl}`,
     );
   }
 
-  return { owner: match[1], repo: match[2] };
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(urlToParse, 'https://github.com');
+  } catch {
+    throw new Error(
+      `Owner & repo could not be extracted from remote URL: ${remoteUrl}`,
+    );
+  }
+
+  if (parsedUrl.host !== 'github.com') {
+    throw new Error(
+      `Owner & repo could not be extracted from remote URL: ${remoteUrl}`,
+    );
+  }
+
+  const parts = parsedUrl.pathname.split('/').filter((part) => part !== '');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(
+      `Owner & repo could not be extracted from remote URL: ${remoteUrl}`,
+    );
+  }
+
+  return { owner: parts[0], repo: parts[1].replace('.git', '') };
 }

--- a/packages/cli/src/utils/gitUtils.ts
+++ b/packages/cli/src/utils/gitUtils.ts
@@ -137,5 +137,5 @@ export function getGitHubRepoInfo(): { owner: string; repo: string } {
     );
   }
 
-  return { owner: parts[0], repo: parts[1].replace('.git', '') };
+  return { owner: parts[0], repo: parts[1].replace(/\.git$/, '') };
 }


### PR DESCRIPTION
## Summary

The `/setup-github` command fails when the git remote URL contains a personal access token (PAT) or other credentials. 

This PR replaces the fragile regex-based URL parser with the standard URL constructor, which properly handles credentials and is already used elsewhere in the codebase.

## Details

The previous regex `/(?:https?:\/\/|git@)github\.com(?::|\/)([^/]+)\/([^/]+?)(?:\.git)?$/` couldn't parse URLs like `https://ghp_xxx@github.com/owner/repo.git` because it didn't account for credentials between the protocol and hostname.

The new implementation:

- Uses JavaScript's native URL constructor (following the pattern in tryParseGithubUrl() from packages/cli/src/config/extensions/github.ts)
- Handles all credential formats: classic PAT (ghp_), fine-grained PAT (github_pat_), username:password, OAuth tokens, GitHub Actions tokens
- Fixes case sensitivity bug (uppercase GITHUB.COM now works)
- Properly handles SSH URLs (git@github.com:owner/repo.git)
- Rejects non-GitHub providers (GitLab, Bitbucket) with error


## Related Issues

Fixes #14556

## How to Validate

1. Run the new tests:
npx vitest run packages/cli/src/utils/gitUtils.test.ts

2. Manual test with a PAT URL:
```bash
git remote set-url origin https://ghp_testtoken@github.com/owner/repo.git
gemini
# Run /setup-github - should no longer fail with "Owner & repo could not be extracted"
git remote set-url origin https://github.com/owner/repo.git  # restore
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
