### PR TITLE
add cross-platform clipboard image pasting support (#14647)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -500,6 +500,150 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@crosscopy/clipboard": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@crosscopy/clipboard/-/clipboard-0.2.8.tgz",
+      "integrity": "sha512-0qRWscafAHzQ+DdfXX+YgPN2KDTIzWBNfN5Q6z1CgCWsRxtkwK8HfQUc00xIejfRWSGWPIxcCTg82hvg06bodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@crosscopy/clipboard-darwin-arm64": "0.2.8",
+        "@crosscopy/clipboard-darwin-universal": "0.2.8",
+        "@crosscopy/clipboard-darwin-x64": "0.2.8",
+        "@crosscopy/clipboard-linux-arm64-gnu": "0.2.8",
+        "@crosscopy/clipboard-linux-riscv64-gnu": "0.2.8",
+        "@crosscopy/clipboard-linux-x64-gnu": "0.2.8",
+        "@crosscopy/clipboard-win32-arm64-msvc": "0.2.8",
+        "@crosscopy/clipboard-win32-x64-msvc": "0.2.8"
+      }
+    },
+    "node_modules/@crosscopy/clipboard-darwin-arm64": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@crosscopy/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.2.8.tgz",
+      "integrity": "sha512-Y36ST9k5JZgtDE6SBT45bDNkPKBHd4UEIZgWnC0iC4kAWwdjPmsZ8Mn8e5W0YUKowJ/BDcO+EGm2tVTPQOQKXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@crosscopy/clipboard-darwin-universal": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@crosscopy/clipboard-darwin-universal/-/clipboard-darwin-universal-0.2.8.tgz",
+      "integrity": "sha512-btGV1tLpJWZ4iKa66niahvpZpVRJzgQnYUE+PUX3YYZzaWD0ESuHuVtKVC8sR+b4dsXIiWW5skXbcRmLsF4rtA==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@crosscopy/clipboard-darwin-x64": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@crosscopy/clipboard-darwin-x64/-/clipboard-darwin-x64-0.2.8.tgz",
+      "integrity": "sha512-0QMKf0XrLZrprYYXU4lgaTuzbnYPh9wH6PvsfDB1FZvWf6rOi0syTaBZYnoghbQe700qwLPEfBRjgljJ3Tn6oA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@crosscopy/clipboard-linux-arm64-gnu": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@crosscopy/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.2.8.tgz",
+      "integrity": "sha512-8YrU03MRsygymqEcHkNgqCqSCQbYRmJCnMXeS4i8FYeOkAxBEeRvPbHoNmI10uppXJZNZgfIKM7Qqk9tEHiwqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@crosscopy/clipboard-linux-riscv64-gnu": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@crosscopy/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.2.8.tgz",
+      "integrity": "sha512-/QWLhnb0QYVjEv5GOAC1q+1DaezYU8Th+IoDKUCsR5i43Cqm+g+N/I2K35yo3J+HHkK9XNbtIDZDXlFgK6tRUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@crosscopy/clipboard-linux-x64-gnu": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@crosscopy/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.2.8.tgz",
+      "integrity": "sha512-j17eaF/onP/6VAGGKtxA1KmmkErmdjta9gMdMV/yUmgeBYzJ9fMpWUzbk2vmaOyXfhaSzR/sk1P6VLBmvCpqHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@crosscopy/clipboard-win32-arm64-msvc": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@crosscopy/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.2.8.tgz",
+      "integrity": "sha512-MVkMyuYN3y5v0s4HrijM0iA8hZVmpUhHd8X4zKG30t4nE6MbOjOt/8EabMrVmGZlsLeOL2sa0o8Wo9bvhWU+vA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@crosscopy/clipboard-win32-x64-msvc": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@crosscopy/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.2.8.tgz",
+      "integrity": "sha512-/GpiB4B3lSgg7eCLDQw9NfFjtQFjo0S88IL+EK54Hx7ZgAP4Ad/ezP/8dw0cA+N/M6iPYy0reCIjW9st82/uxw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
@@ -17983,6 +18127,7 @@
       "name": "@google/gemini-cli",
       "version": "0.21.0-nightly.20251204.3da4fd5f7",
       "dependencies": {
+        "@crosscopy/clipboard": "^0.2.8",
         "@google/gemini-cli-core": "file:../core",
         "@google/genai": "1.30.0",
         "@iarna/toml": "^2.2.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
     "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.21.0-nightly.20251204.3da4fd5f7"
   },
   "dependencies": {
+    "@crosscopy/clipboard": "^0.2.8",
     "@google/gemini-cli-core": "file:../core",
     "@google/genai": "1.30.0",
     "@iarna/toml": "^2.2.5",

--- a/packages/cli/src/ui/utils/clipboardUtils.test.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.test.ts
@@ -4,73 +4,219 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
-  clipboardHasImage,
-  saveClipboardImage,
+  clipboardHasImage as hasClipboardImage,
+  saveClipboardImage as saveClipboard,
   cleanupOldClipboardImages,
 } from './clipboardUtils.js';
 
+// Mock @crosscopy/clipboard
+vi.mock('@crosscopy/clipboard', () => ({
+  hasImage: vi.fn(),
+  getImageBase64: vi.fn(),
+}));
+
+// Mock @google/gemini-cli-core
+vi.mock('@google/gemini-cli-core', () => ({
+  debugLogger: {
+    warn: vi.fn(),
+  },
+  spawnAsync: vi.fn(),
+}));
+
+// Mock fs/promises
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn(),
+  writeFile: vi.fn(),
+  stat: vi.fn(),
+  unlink: vi.fn(),
+  readdir: vi.fn(),
+}));
+
+import {
+  hasImage as nativeHasImage,
+  getImageBase64 as nativeGetImageBase64,
+} from '@crosscopy/clipboard';
+import { spawnAsync } from '@google/gemini-cli-core';
+import * as fs from 'node:fs/promises';
+import type { Stats } from 'node:fs';
+
 describe('clipboardUtils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('clipboardHasImage', () => {
-    it('should return false on non-macOS platforms', async () => {
-      if (process.platform !== 'darwin') {
-        const result = await clipboardHasImage();
-        expect(result).toBe(false);
-      } else {
-        // Skip on macOS as it would require actual clipboard state
-        expect(true).toBe(true);
-      }
+    it('should return true when clipboard has an image (cross-platform)', async () => {
+      vi.mocked(nativeHasImage).mockReturnValue(true);
+
+      const result = await hasClipboardImage();
+
+      expect(result).toBe(true);
+      expect(nativeHasImage).toHaveBeenCalled();
     });
 
-    it('should return boolean on macOS', async () => {
-      if (process.platform === 'darwin') {
-        const result = await clipboardHasImage();
-        expect(typeof result).toBe('boolean');
-      } else {
-        // Skip on non-macOS
-        expect(true).toBe(true);
-      }
+    it('should return false when clipboard does not have an image', async () => {
+      vi.mocked(nativeHasImage).mockReturnValue(false);
+
+      const result = await hasClipboardImage();
+
+      expect(result).toBe(false);
+      expect(nativeHasImage).toHaveBeenCalled();
+    });
+
+    it('should fallback to macOS osascript on error when on darwin', async () => {
+      // Save original platform
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+      vi.mocked(nativeHasImage).mockImplementation(() => {
+        throw new Error('Clipboard error');
+      });
+      vi.mocked(spawnAsync).mockResolvedValue({
+        stdout: '«class PNGf»',
+        stderr: '',
+      });
+
+      const result = await hasClipboardImage();
+
+      expect(result).toBe(true);
+      expect(spawnAsync).toHaveBeenCalledWith('osascript', [
+        '-e',
+        'clipboard info',
+      ]);
+
+      // Restore platform
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('should return false on error when not on macOS', async () => {
+      // Save original platform
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+
+      vi.mocked(nativeHasImage).mockImplementation(() => {
+        throw new Error('Clipboard error');
+      });
+
+      const result = await hasClipboardImage();
+
+      expect(result).toBe(false);
+
+      // Restore platform
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
     });
   });
 
   describe('saveClipboardImage', () => {
-    it('should return null on non-macOS platforms', async () => {
-      if (process.platform !== 'darwin') {
-        const result = await saveClipboardImage();
-        expect(result).toBe(null);
-      } else {
-        // Skip on macOS
-        expect(true).toBe(true);
-      }
+    it('should return null when clipboard does not have an image', async () => {
+      vi.mocked(nativeHasImage).mockReturnValue(false);
+
+      const result = await saveClipboard();
+
+      expect(result).toBe(null);
+    });
+
+    it('should save clipboard image successfully (cross-platform)', async () => {
+      const mockBase64 =
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+      vi.mocked(nativeHasImage).mockReturnValue(true);
+      vi.mocked(nativeGetImageBase64).mockResolvedValue(mockBase64);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(fs.stat).mockResolvedValue({ size: 100 } as Stats);
+
+      const result = await saveClipboard('/test/dir');
+
+      expect(result).toMatch(
+        /^\/test\/dir\/\.gemini-clipboard\/clipboard-\d+\.png$/,
+      );
+      expect(fs.mkdir).toHaveBeenCalled();
+      expect(fs.writeFile).toHaveBeenCalled();
+    });
+
+    it('should return null when image data is empty', async () => {
+      vi.mocked(nativeHasImage).mockReturnValue(true);
+      vi.mocked(nativeGetImageBase64).mockResolvedValue('');
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+
+      const result = await saveClipboard();
+
+      expect(result).toBe(null);
+    });
+
+    it('should clean up empty files', async () => {
+      const mockBase64 = 'mockbase64data';
+
+      vi.mocked(nativeHasImage).mockReturnValue(true);
+      vi.mocked(nativeGetImageBase64).mockResolvedValue(mockBase64);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(fs.stat).mockResolvedValue({ size: 0 } as Stats);
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+      const result = await saveClipboard();
+
+      expect(result).toBe(null);
+      expect(fs.unlink).toHaveBeenCalled();
     });
 
     it('should handle errors gracefully', async () => {
-      // Test with invalid directory (should not throw)
-      const result = await saveClipboardImage(
-        '/invalid/path/that/does/not/exist',
+      vi.mocked(nativeHasImage).mockReturnValue(true);
+      vi.mocked(nativeGetImageBase64).mockRejectedValue(
+        new Error('Clipboard error'),
       );
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
 
-      if (process.platform === 'darwin') {
-        // On macOS, might return null due to various errors
-        expect(result === null || typeof result === 'string').toBe(true);
-      } else {
-        // On other platforms, should always return null
-        expect(result).toBe(null);
-      }
+      const result = await saveClipboard();
+
+      // Should return null on error (or use macOS fallback if on darwin)
+      expect(result === null || typeof result === 'string').toBe(true);
     });
   });
 
   describe('cleanupOldClipboardImages', () => {
-    it('should not throw errors', async () => {
-      // Should handle missing directories gracefully
+    it('should not throw errors on missing directory', async () => {
+      vi.mocked(fs.readdir).mockRejectedValue(new Error('Directory not found'));
+
       await expect(
         cleanupOldClipboardImages('/path/that/does/not/exist'),
       ).resolves.not.toThrow();
     });
 
     it('should complete without errors on valid directory', async () => {
+      vi.mocked(fs.readdir).mockResolvedValue([]);
+
       await expect(cleanupOldClipboardImages('.')).resolves.not.toThrow();
+    });
+
+    it('should delete old clipboard images', async () => {
+      const oldTime = Date.now() - 2 * 60 * 60 * 1000; // 2 hours ago
+      const recentTime = Date.now() - 30 * 60 * 1000; // 30 minutes ago
+
+      vi.mocked(fs.readdir).mockResolvedValue([
+        'clipboard-123.png',
+        'clipboard-456.jpg',
+        'other-file.txt',
+      ] as string[]);
+      vi.mocked(fs.stat)
+        .mockResolvedValueOnce({ mtimeMs: oldTime } as Stats)
+        .mockResolvedValueOnce({ mtimeMs: recentTime } as Stats);
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+      await cleanupOldClipboardImages('/test/dir');
+
+      // Should delete old file but not recent file
+      expect(fs.unlink).toHaveBeenCalledTimes(1);
+      expect(fs.unlink).toHaveBeenCalledWith(
+        expect.stringContaining('clipboard-123.png'),
+      );
     });
   });
 });

--- a/packages/cli/src/ui/utils/clipboardUtils.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.ts
@@ -7,79 +7,155 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { debugLogger, spawnAsync } from '@google/gemini-cli-core';
+import {
+  hasImage as clipboardHasImageNative,
+  getImageBase64 as clipboardGetImageBase64,
+} from '@crosscopy/clipboard';
 
 /**
- * Checks if the system clipboard contains an image (macOS only for now)
+ * Checks if the system clipboard contains an image (Windows, macOS, Linux)
  * @returns true if clipboard contains an image
  */
 export async function clipboardHasImage(): Promise<boolean> {
-  if (process.platform !== 'darwin') {
-    return false;
-  }
-
   try {
-    // Use osascript to check clipboard type
-    const { stdout } = await spawnAsync('osascript', ['-e', 'clipboard info']);
-    const imageRegex =
-      /«class PNGf»|TIFF picture|JPEG picture|GIF picture|«class JPEG»|«class TIFF»/;
-    return imageRegex.test(stdout);
-  } catch {
+    // Use @crosscopy/clipboard for cross-platform support
+    // hasImage is synchronous, returns boolean directly
+    return clipboardHasImageNative();
+  } catch (error) {
+    // Fallback to macOS-specific implementation if @crosscopy/clipboard fails
+    if (process.platform === 'darwin') {
+      try {
+        const { stdout } = await spawnAsync('osascript', [
+          '-e',
+          'clipboard info',
+        ]);
+        const imageRegex =
+          /«class PNGf»|TIFF picture|JPEG picture|GIF picture|«class JPEG»|«class TIFF»/;
+        return imageRegex.test(stdout);
+      } catch {
+        return false;
+      }
+    }
+    debugLogger.warn('Error checking clipboard for image:', error);
     return false;
   }
 }
 
 /**
- * Saves the image from clipboard to a temporary file (macOS only for now)
+ * Saves the image from clipboard to a temporary file (Windows, macOS, Linux)
  * @param targetDir The target directory to create temp files within
  * @returns The path to the saved image file, or null if no image or error
  */
 export async function saveClipboardImage(
   targetDir?: string,
 ): Promise<string | null> {
-  if (process.platform !== 'darwin') {
-    return null;
-  }
-
   try {
+    // Check if clipboard has an image first
+    const hasImage = await clipboardHasImage();
+    if (!hasImage) {
+      return null;
+    }
+
     // Create a temporary directory for clipboard images within the target directory
-    // This avoids security restrictions on paths outside the target directory
     const baseDir = targetDir || process.cwd();
     const tempDir = path.join(baseDir, '.gemini-clipboard');
     await fs.mkdir(tempDir, { recursive: true });
 
     // Generate a unique filename with timestamp
     const timestamp = new Date().getTime();
+    const tempFilePath = path.join(tempDir, `clipboard-${timestamp}.png`);
 
-    // Try different image formats in order of preference
-    const formats = [
-      { class: 'PNGf', extension: 'png' },
-      { class: 'JPEG', extension: 'jpg' },
-      { class: 'TIFF', extension: 'tiff' },
-      { class: 'GIFf', extension: 'gif' },
-    ];
+    try {
+      // Get image data as base64 from clipboard
+      const imageBase64 = await clipboardGetImageBase64();
 
-    for (const format of formats) {
-      const tempFilePath = path.join(
-        tempDir,
-        `clipboard-${timestamp}.${format.extension}`,
-      );
+      if (!imageBase64) {
+        // Fallback to macOS-specific implementation
+        if (process.platform === 'darwin') {
+          return await saveMacOSClipboardImage(tempDir, timestamp);
+        }
+        return null;
+      }
 
-      // Try to save clipboard as this format
-      const script = `
+      // Convert base64 to buffer and save
+      const imageBuffer = Buffer.from(imageBase64, 'base64');
+      await fs.writeFile(tempFilePath, imageBuffer);
+
+      // Verify the file was created and has content
+      const stats = await fs.stat(tempFilePath);
+      if (stats.size > 0) {
+        return tempFilePath;
+      }
+
+      // Clean up if file is empty
+      await fs.unlink(tempFilePath).catch(() => {
+        // Ignore cleanup errors
+      });
+      return null;
+    } catch (error) {
+      // Fallback to macOS-specific implementation
+      if (process.platform === 'darwin') {
+        return await saveMacOSClipboardImage(tempDir, timestamp);
+      }
+
+      debugLogger.warn('Error saving clipboard image:', error);
+
+      // Clean up failed attempt
+      try {
+        await fs.unlink(tempFilePath);
+      } catch {
+        // Ignore cleanup errors
+      }
+      return null;
+    }
+  } catch (error) {
+    debugLogger.warn('Error in saveClipboardImage:', error);
+    return null;
+  }
+}
+
+/**
+ * Fallback function for macOS-specific clipboard image saving using osascript
+ * This is used when @crosscopy/clipboard fails or returns no data
+ * @param tempDir The temporary directory to save the image
+ * @param timestamp The timestamp to use for the filename
+ * @returns The path to the saved image file, or null if failed
+ */
+async function saveMacOSClipboardImage(
+  tempDir: string,
+  timestamp: number,
+): Promise<string | null> {
+  // Try different image formats in order of preference
+  const formats = [
+    { class: 'PNGf', extension: 'png' },
+    { class: 'JPEG', extension: 'jpg' },
+    { class: 'TIFF', extension: 'tiff' },
+    { class: 'GIFf', extension: 'gif' },
+  ];
+
+  for (const format of formats) {
+    const tempFilePath = path.join(
+      tempDir,
+      `clipboard-${timestamp}.${format.extension}`,
+    );
+
+    // Try to save clipboard as this format
+    const script = `
+      try
+        set imageData to the clipboard as «class ${format.class}»
+        set fileRef to open for access POSIX file "${tempFilePath}" with write permission
+        write imageData to fileRef
+        close access fileRef
+        return "success"
+      on error errMsg
         try
-          set imageData to the clipboard as «class ${format.class}»
-          set fileRef to open for access POSIX file "${tempFilePath}" with write permission
-          write imageData to fileRef
-          close access fileRef
-          return "success"
-        on error errMsg
-          try
-            close access POSIX file "${tempFilePath}"
-          end try
-          return "error"
+          close access POSIX file "${tempFilePath}"
         end try
-      `;
+        return "error"
+      end try
+    `;
 
+    try {
       const { stdout } = await spawnAsync('osascript', ['-e', script]);
 
       if (stdout.trim() === 'success') {
@@ -100,14 +176,13 @@ export async function saveClipboardImage(
       } catch {
         // Ignore cleanup errors
       }
+    } catch {
+      // Continue to next format
     }
-
-    // No format worked
-    return null;
-  } catch (error) {
-    debugLogger.warn('Error saving clipboard image:', error);
-    return null;
   }
+
+  // No format worked
+  return null;
 }
 
 /**


### PR DESCRIPTION
# feat: add cross-platform clipboard image pasting support (#14647)

- Added @crosscopy/clipboard package for Windows/Linux clipboard support
- Refactored clipboardUtils to support Windows, macOS, and Linux
- Maintained macOS fallback using osascript for reliability
- Added comprehensive test coverage (12 new tests)
- Users can now paste screenshots with Ctrl+V on all platforms

Fixes #14647

## Summary

Implements cross-platform clipboard image pasting support for Windows, macOS, and Linux. Users can now paste screenshots directly from the clipboard using Ctrl+V (or right-click) on all platforms, significantly improving workflow efficiency when working with visual content.

## Details

- **New Dependency**: Added `@crosscopy/clipboard@0.2.8` - a Rust-based native module providing clipboard access across all platforms
- **Cross-Platform Support**: 
  - Windows: Uses native Windows clipboard APIs via `@crosscopy/clipboard`
  - Linux: Supports both X11 and Wayland display systems
  - macOS: Uses `@crosscopy/clipboard` with osascript fallback for maximum reliability
- **Implementation**: 
  - Images retrieved as base64 and saved as PNG files in `.gemini-clipboard/` directory
  - Automatic cleanup of files older than 1 hour
  - Graceful error handling with platform-specific fallbacks
  - Maintains backward compatibility with existing macOS implementation

## Related Issues

Fixes #14647

## How to Validate

**Automated Testing:**
```bash
npm run build
npm run test -- clipboardUtils.test.ts
npm run typecheck