### PR TITLE
fixed grammar mistake

### DIFF
--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -383,7 +383,7 @@ export abstract class DeclarativeTool<
    * A convenience method that builds and executes the tool in one step.
    * Never throws.
    * @param params The raw, untrusted parameters from the model.
-   * @params abortSignal a signal to abort.
+   * @param abortSignal a signal to abort.
    * @returns The result of the tool execution.
    */
   async validateBuildAndExecute(


### PR DESCRIPTION
## Summary

Fixes a syntax error in the JSDoc comments within the core package. specifically correcting an invalid tag in `tools.ts`.

## Details

Changed the JSDoc tag `@params` to the correct standard `@param` on line 384 of `/packages/core/src/tools/tools.ts`. This ensures that IDEs and documentation generators parse the function parameters correctly.

## Related Issues

N/A

## How to Validate

1.  Open `/packages/core/src/tools/tools.ts`.
2.  Navigate to line 384.
3.  Verify that the tag reads `@param` instead of `@params`.
4.  (Optional) Run `npm run build` or the project's lint command to ensure no regressions, though this is a comment-only change.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) - [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
    - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker