### PR TITLE
fix(acp): disable MessageBus in ACP mode to avoid 30s timeout

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -640,6 +640,14 @@ describe('loadCliConfig', () => {
     const config = await loadCliConfig(settings, 'test-session', argv);
     expect(config['enableMessageBusIntegration']).toBe(true);
   });
+
+  it('should disable enableMessageBusIntegration when experimentalAcp is true', async () => {
+    process.argv = ['node', 'script.js', '--experimental-acp'];
+    const argv = await parseArguments({} as Settings);
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, 'test-session', argv);
+    expect(config['enableMessageBusIntegration']).toBe(false);
+  });
 });
 
 describe('Hierarchical Memory Loading (config.ts) - Placeholder Suite', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -518,8 +518,12 @@ export async function loadCliConfig(
     approvalMode,
   );
 
-  const enableMessageBusIntegration =
-    settings.tools?.enableMessageBusIntegration ?? true;
+  // ACP mode uses requestPermission() JSON-RPC for tool confirmation,
+  // not the internal MessageBus/PolicyEngine/CoreToolScheduler pattern.
+  // Disabling MessageBus avoids a 30s timeout waiting for no subscriber.
+  const enableMessageBusIntegration = argv.experimentalAcp
+    ? false
+    : (settings.tools?.enableMessageBusIntegration ?? true);
 
   const allowedTools = argv.allowedTools || settings.tools?.allowed || [];
   const allowedToolsSet = new Set(allowedTools);


### PR DESCRIPTION
## Summary

Disables `enableMessageBusIntegration` when `--experimental-acp` is set, fixing a 30s delay before tool confirmation in ACP mode.

## Details

### Problem

In ACP mode, every tool requiring confirmation waits 30 seconds before proceeding.

### Cause

`getMessageBusDecision()` publishes `TOOL_CONFIRMATION_REQUEST` and waits for `CoreToolScheduler` to respond. In ACP mode, `zedIntegration.ts` handles tool confirmation via `requestPermission()` JSON-RPC instead - there's no subscriber. The 30s timeout fires before falling back to `ASK_USER`.

### Fix

```
Before (ACP mode):
+----------+  TOOL_CONFIRMATION_REQUEST  +--------------+
|  Tool    | --------------------------> |  MessageBus  |
|          |                             |  (no sub)    |
|          | <------ 30s timeout ------- |              |
|          |                             +--------------+
|          | then getConfirmationDetails()
|          | then requestPermission() to ACP client
+----------+

After (ACP mode, MessageBus disabled):
+----------+
|  Tool    | getConfirmationDetails() immediately
|          | then requestPermission() to ACP client
+----------+
```

Set `enableMessageBusIntegration=false` when `argv.experimentalAcp` is true.

## Pre-Merge Checklist

- [ ] Updated docs/README (if needed) - N/A
- [x] Added/updated tests - Added unit test in config.test.ts
- [ ] Noted breaking changes (if any) - None
