### PR TITLE
docs: fix markdown toggle keybinding description

### DIFF
--- a/docs/changelogs/index.md
+++ b/docs/changelogs/index.md
@@ -128,7 +128,9 @@ notable changes to Gemini CLI.
   [pr](https://github.com/google-gemini/gemini-cli/pull/10883) by
   [@anj-s](https://github.com/anj-s))
 - **Markdown toggle:** Users can now switch between rendered and raw markdown
-  display using `alt+m `or` ctrl+m`. ([gif](https://imgur.com/a/lDNdLqr),
+  display using `Cmd+M` on macOS or `Ctrl+M` on Windows/Linux (pressing
+  `Option+M` on macOS also toggles Markdown because it emits the same `µ`
+  character). ([gif](https://imgur.com/a/lDNdLqr),
   [pr](https://github.com/google-gemini/gemini-cli/pull/10383) by
   [@srivatsj](https://github.com/srivatsj))
 - **Queued message editing:** Users can now quickly edit queued messages by


### PR DESCRIPTION
## Summary\n- correct the changelog entry for the Markdown toggle shortcut to mention the actual keybindings (Cmd+M / Ctrl+M) instead of "alt"\n- document that Option+M also toggles Markdown on macOS because it emits the same character\n\n## Testing\n- not run (docs change)