### PR TITLE
fix: fix path of cli companion server config

### DIFF
--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -340,11 +340,11 @@ export class IDEServer {
         if (address && typeof address !== 'string') {
           this.port = address.port;
           this.portFile = path.join(
-            os.tmpdir(),
+            os.tmpdir(), 'gemini', 'ide',
             `gemini-ide-server-${this.port}.json`,
           );
           this.ppidPortFile = path.join(
-            os.tmpdir(),
+            os.tmpdir(), 'gemini', 'ide',
             `gemini-ide-server-${process.ppid}.json`,
           );
           this.log(`IDE server listening on http://127.0.0.1:${this.port}`);

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -80,8 +80,12 @@ async function writePortAndWorkspace({
 
   log(`Writing port file to: ${portFile}`);
   log(`Writing ppid port file to: ${ppidPortFile}`);
-
+  
   try {
+    fs.promises.mkdir(
+      path.dirname(this.portFile),
+      { recursive: true }
+    )
     await Promise.all([
       fs.writeFile(portFile, content).then(() => fs.chmod(portFile, 0o600)),
       fs


### PR DESCRIPTION
fix path of cli companion server config to '`os.tmpdir()/gemini/ide/`' according to https://github.com/google-gemini/gemini-cli/blob/7a720375729cc1e5b92ec02910a2fa8be77aa05d/docs/ide-integration/ide-companion-spec.md?plain=1#L38

and

https://github.com/google-gemini/gemini-cli/blob/7a720375729cc1e5b92ec02910a2fa8be77aa05d/packages/core/src/ide/ide-client.ts#L598

## Summary
Fixes issue with connectiin to vscode cli companion and gemini running on remote ssh / inside container.

## Details

Gemini cli searches for IDEserver configs at '`os.tmpdir()/gemini/ide/`'. The companion extension previously created the files at '`os.tmpdir()`', leading to a mismatch of the expected file path and resulting connection issues.

## Related Issues

Fixes #10473 

## How to Validate

- Pull this patch
- cd gemini-cli
- npm install
- npm audit fix
- cd packages/vscode-ide-companion
- npm run build
- vsce package --no-dependencies
- code --install-extension gemini*.vsix

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
