### PR TITLE
fix: similar to policy-engine, throw error in case of requiring tool execution confirmation for non-interactive mode

### DIFF
--- a/packages/a2a-server/src/utils/testing_utils.ts
+++ b/packages/a2a-server/src/utils/testing_utils.ts
@@ -32,6 +32,7 @@ export function createMockConfig(
     }),
     getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
     getIdeMode: vi.fn().mockReturnValue(false),
+    isInteractive: () => true,
     getAllowedTools: vi.fn().mockReturnValue([]),
     getWorkspaceContext: vi.fn().mockReturnValue({
       isPathWithinWorkspace: () => true,

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -6,11 +6,15 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Mock } from 'vitest';
-import type { ToolCall, WaitingToolCall } from './coreToolScheduler.js';
 import {
   CoreToolScheduler,
   convertToFunctionResponse,
   truncateAndSaveToFile,
+} from './coreToolScheduler.js';
+import type {
+  ToolCall,
+  WaitingToolCall,
+  ErroredToolCall,
 } from './coreToolScheduler.js';
 import type {
   ToolCallConfirmationDetails,
@@ -232,6 +236,7 @@ function createMockConfig(overrides: Partial<Config> = {}): Config {
     getSessionId: () => 'test-session-id',
     getUsageStatisticsEnabled: () => true,
     getDebugMode: () => false,
+    isInteractive: () => true,
     getApprovalMode: () => ApprovalMode.DEFAULT,
     setApprovalMode: () => {},
     getAllowedTools: () => [],
@@ -353,7 +358,6 @@ describe('CoreToolScheduler', () => {
 
     const mockConfig = createMockConfig({
       getToolRegistry: () => mockToolRegistry,
-      isInteractive: () => false,
       getHookSystem: () => undefined,
     });
 
@@ -455,7 +459,6 @@ describe('CoreToolScheduler', () => {
 
     const mockConfig = createMockConfig({
       getToolRegistry: () => mockToolRegistry,
-      isInteractive: () => false,
       getHookSystem: () => undefined,
     });
 
@@ -582,6 +585,67 @@ describe('CoreToolScheduler', () => {
     expect(statuses).not.toContain('error');
   });
 
+  it('should error when tool requires confirmation in non-interactive mode', async () => {
+    const mockTool = new MockTool({
+      name: 'mockTool',
+      shouldConfirmExecute: MOCK_TOOL_SHOULD_CONFIRM_EXECUTE,
+    });
+    const declarativeTool = mockTool;
+    const mockToolRegistry = {
+      getTool: () => declarativeTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => declarativeTool,
+      getToolByDisplayName: () => declarativeTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsComplete = vi.fn();
+    const onToolCallsUpdate = vi.fn();
+
+    const mockConfig = createMockConfig({
+      getToolRegistry: () => mockToolRegistry,
+      isInteractive: () => false,
+    });
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+    });
+
+    const abortController = new AbortController();
+    const request = {
+      callId: '1',
+      name: 'mockTool',
+      args: {},
+      isClientInitiated: false,
+      prompt_id: 'prompt-id-1',
+    };
+
+    await scheduler.schedule([request], abortController.signal);
+
+    expect(onAllToolCallsComplete).toHaveBeenCalled();
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls[0].status).toBe('error');
+
+    const erroredCall = completedCalls[0] as ErroredToolCall;
+    const errorResponse = erroredCall.response;
+    const errorParts = errorResponse.responseParts;
+    // @ts-expect-error - accessing internal structure of FunctionResponsePart
+    const errorMessage = errorParts[0].functionResponse.response.error;
+    expect(errorMessage).toContain(
+      'Tool execution for "mockTool" denied by policy.',
+    );
+  });
+
   describe('getToolSuggestion', () => {
     it('should suggest the top N closest tool names for a typo', () => {
       // Create mocked tool registry
@@ -643,7 +707,6 @@ describe('CoreToolScheduler with payload', () => {
 
     const mockConfig = createMockConfig({
       getToolRegistry: () => mockToolRegistry,
-      isInteractive: () => false,
     });
     const mockMessageBus = createMockMessageBus();
     mockConfig.getMessageBus = vi.fn().mockReturnValue(mockMessageBus);
@@ -950,7 +1013,6 @@ describe('CoreToolScheduler edit cancellation', () => {
 
     const mockConfig = createMockConfig({
       getToolRegistry: () => mockToolRegistry,
-      isInteractive: () => false,
     });
     const mockMessageBus = createMockMessageBus();
     mockConfig.getMessageBus = vi.fn().mockReturnValue(mockMessageBus);
@@ -1366,7 +1428,6 @@ describe('CoreToolScheduler request queueing', () => {
         terminalHeight: 24,
       }),
       getToolRegistry: () => toolRegistry,
-      isInteractive: () => false,
       getHookSystem: () => undefined,
     });
 
@@ -1423,7 +1484,6 @@ describe('CoreToolScheduler request queueing', () => {
     const mockConfig = createMockConfig({
       getToolRegistry: () => mockToolRegistry,
       getApprovalMode: () => ApprovalMode.YOLO,
-      isInteractive: () => false,
     });
     const mockMessageBus = createMockMessageBus();
     mockConfig.getMessageBus = vi.fn().mockReturnValue(mockMessageBus);
@@ -1484,7 +1544,6 @@ describe('CoreToolScheduler request queueing', () => {
       setApprovalMode: (mode: ApprovalMode) => {
         approvalMode = mode;
       },
-      isInteractive: () => false,
     });
     const mockMessageBus = createMockMessageBus();
     mockConfig.getMessageBus = vi.fn().mockReturnValue(mockMessageBus);

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -642,7 +642,7 @@ describe('CoreToolScheduler', () => {
     // @ts-expect-error - accessing internal structure of FunctionResponsePart
     const errorMessage = errorParts[0].functionResponse.response.error;
     expect(errorMessage).toContain(
-      'Tool execution for "mockTool" denied by policy.',
+      'Tool execution for "mockTool" requires user confirmation, which is not supported in non-interactive mode.',
     );
   });
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -870,10 +870,6 @@ export class CoreToolScheduler {
             );
             this.setStatusInternal(reqInfo.callId, 'scheduled', signal);
           } else {
-            // Following the similar logic of policy-engine defined in
-            // shouldConfirmExecute() method of packages/core/src/tools/tools.ts
-            // i.e. throw error in case of requiring confirmation for
-            // non-interactive mode.
             if (!this.config.isInteractive()) {
               throw new Error(
                 `Tool execution for "${

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -878,7 +878,7 @@ export class CoreToolScheduler {
               throw new Error(
                 `Tool execution for "${
                   toolCall.tool.displayName || toolCall.tool.name
-                }" requires user confirmation, which is not supported in non-interactive mode.`
+                }" requires user confirmation, which is not supported in non-interactive mode.`,
               );
             }
             // Fire Notification hook before showing confirmation to user

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -878,7 +878,7 @@ export class CoreToolScheduler {
               throw new Error(
                 `Tool execution for "${
                   toolCall.tool.displayName || toolCall.tool.name
-                }" denied by policy.`,
+                }" requires user confirmation, which is not supported in non-interactive mode.`
               );
             }
             // Fire Notification hook before showing confirmation to user

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -870,6 +870,17 @@ export class CoreToolScheduler {
             );
             this.setStatusInternal(reqInfo.callId, 'scheduled', signal);
           } else {
+            // Following the similar logic of policy-engine defined in
+            // shouldConfirmExecute() method of packages/core/src/tools/tools.ts
+            // i.e. throw error in case of requiring confirmation for
+            // non-interactive mode.
+            if (!this.config.isInteractive()) {
+              throw new Error(
+                `Tool execution for "${
+                  toolCall.tool.displayName || toolCall.tool.name
+                }" denied by policy.`,
+              );
+            }
             // Fire Notification hook before showing confirmation to user
             const messageBus = this.config.getMessageBus();
             const hooksEnabled = this.config.getEnableHooks();


### PR DESCRIPTION
## Summary

Replicate throwing error (inspired by DENY case of policy-engine) in case of non-interactive mode and requiring user confirmation for tool execution. This avoids non-interactive gemini-cli indefinitely waiting for mcp-server tool execution confirmation. This error is caught and an error response is shown to the user.

## Details

The issue #11459 is only observed in case the [Policy Engine](https://github.com/google-gemini/gemini-cli/blob/main/docs/core/policy-engine.md) is not enabled. Code flow:

When a tool call is scheduled and processed (inside `_processNextInQueue()` method of `packages/core/src/core/coreToolScheduler.ts`), it calls `shouldConfirmExecute()` method of `packages/core/src/tools/tools.ts` to determine if user approval is needed. For determining this, the flow splits here depending on whether the policy-engine is enabled or not. In case the policy-engine is not enabled, the legacy confirmation flow is used.
- In case policy-engine is enabled via messageBus, it automatically convert ASK_USER decisions to DENY (check shouldConfirmExecute() method of packages/core/src/tools/tools.ts).
- Else, as per the legacy flow of mcp-tools,  in case the server is not trusted, user confirmation message is required (check getConfirmationDetails() method of packages/core/src/tools/mcp-tool.ts).

Finally, if the user confirmation message is required, it is checked if the tool part of `--allowedTools` list. If not, user confirmation message is triggered (check `_processNextInQueue()` method of `packages/core/src/core/coreToolScheduler.ts`).

The user confirmation is required for executing mcp-tools (in case the server is not trusted or the tool is not explicitly allowed). This causes the indefinite waiting of non-interactive gemini-cli on executing mcp-tools.

To solve this, the exact same logic defined in policy-engine of throwing error in case of tool deny is used. This error is caught and an error response is shown to the user (check _processNextInQueue() method of `packages/core/src/core/coreToolScheduler.ts`)

## Related Issues

Fixes #11459 

## How to Validate

Follow steps to reproduce #11459 

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

Working as expected without indefinite wait on invoking mcp-server tool in non-interactive mode:
<img width="1631" height="314" alt="Screenshot 2025-12-08 at 8 18 53 PM" src="https://github.com/user-attachments/assets/01ab1e00-d614-4d40-bb21-05d103ca18d0" />