### PR TITLE
Always set status in chained_e2e workflow

### DIFF
--- a/.github/workflows/test_chained_e2e.yml
+++ b/.github/workflows/test_chained_e2e.yml
@@ -109,7 +109,6 @@ jobs:
   set_pending_status:
     runs-on: 'gemini-cli-ubuntu-16-core'
     permissions: 'write-all'
-    if: "${{github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run'}}"
     needs:
       - 'parse_run_context'
     steps:
@@ -298,7 +297,7 @@ jobs:
   set_workflow_status:
     runs-on: 'gemini-cli-ubuntu-16-core'
     permissions: 'write-all'
-    if: "${{always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run')}}"
+    if: 'always()'
     needs:
       - 'parse_run_context'
       - 'e2e'


### PR DESCRIPTION
## Summary

Always set status in chained_e2e workflow

## Details

Previously, we were not setting this in the merge queue and that was preventing us from making this a required workflow.

## Related Issues

For #10008
