### PR TITLE
feat(cli): add filepath autosuggestion after slash commands

### DIFF
--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -585,4 +585,117 @@ describe('useCommandCompletion', () => {
       );
     });
   });
+
+  describe('@ completion after slash commands (issue #14420)', () => {
+    it('should show file suggestions when typing @path after a slash command', async () => {
+      setupMocks({
+        atSuggestions: [{ label: 'src/file.txt', value: 'src/file.txt' }],
+      });
+
+      const text = '/mycommand @src/fi';
+      const cursorOffset = text.length;
+
+      renderCommandCompletionHook(text, cursorOffset);
+
+      await waitFor(() => {
+        expect(useAtCompletion).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            enabled: true,
+            pattern: 'src/fi',
+          }),
+        );
+      });
+    });
+
+    it('should show slash suggestions when cursor is on command part (no @)', async () => {
+      setupMocks({
+        slashSuggestions: [{ label: 'mycommand', value: 'mycommand' }],
+      });
+
+      const text = '/mycom';
+      const cursorOffset = text.length;
+
+      const { result } = renderCommandCompletionHook(text, cursorOffset);
+
+      await waitFor(() => {
+        expect(result.current.suggestions).toHaveLength(1);
+        expect(result.current.suggestions[0]?.label).toBe('mycommand');
+      });
+    });
+
+    it('should switch to @ completion when typing @ after slash command', async () => {
+      setupMocks({
+        atSuggestions: [{ label: 'file.txt', value: 'file.txt' }],
+      });
+
+      const text = '/command @';
+      const cursorOffset = text.length;
+
+      renderCommandCompletionHook(text, cursorOffset);
+
+      await waitFor(() => {
+        expect(useAtCompletion).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            enabled: true,
+            pattern: '',
+          }),
+        );
+      });
+    });
+
+    it('should handle multiple @ references in a slash command', async () => {
+      setupMocks({
+        atSuggestions: [{ label: 'src/bar.ts', value: 'src/bar.ts' }],
+      });
+
+      const text = '/diff @src/foo.ts @src/ba';
+      const cursorOffset = text.length;
+
+      renderCommandCompletionHook(text, cursorOffset);
+
+      await waitFor(() => {
+        expect(useAtCompletion).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            enabled: true,
+            pattern: 'src/ba',
+          }),
+        );
+      });
+    });
+
+    it('should complete file path and add trailing space', async () => {
+      setupMocks({
+        atSuggestions: [{ label: 'src/file.txt', value: 'src/file.txt' }],
+      });
+
+      const { result } = renderCommandCompletionHook('/cmd @src/fi');
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBe(1);
+      });
+
+      act(() => {
+        result.current.handleAutocomplete(0);
+      });
+
+      expect(result.current.textBuffer.text).toBe('/cmd @src/file.txt ');
+    });
+
+    it('should stay in slash mode when slash command has trailing space but no @', async () => {
+      setupMocks({
+        slashSuggestions: [{ label: 'help', value: 'help' }],
+      });
+
+      const text = '/help ';
+      renderCommandCompletionHook(text);
+
+      await waitFor(() => {
+        expect(useSlashCompletion).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            enabled: true,
+          }),
+        );
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #14420

## Summary

Previously, when a prompt started with a slash command (e.g., `/mycommand`), filepath autosuggestions were completely disabled for the entire line. This made it difficult to specify files to include in the command's context.

This PR reorders the completion mode detection logic in `useCommandCompletion.tsx` to prioritize `@` symbol detection over slash command detection, allowing users to get file suggestions when typing `/cmd @src/file`.

## Details

The root cause was in the `useMemo` block in `useCommandCompletion.tsx`. The slash command check happened first and immediately returned `CompletionMode.SLASH` when the line started with `/`, preventing the code from ever scanning for `@` symbols.

**Changes made:**

1. Moved the `@` scanning loop to execute before the slash command check
2. The slash command check now only runs if no active `@` completion is found
3. Added 6 new unit tests covering the new behavior and regression cases

**Why this approach is safe:**

- The `@` scanning loop has built-in safeguards (stops at unescaped spaces)
- `/cmd @src/fi` → finds `@`, enters AT mode
- `/cmd ` (space, no @) → no `@` found, falls through to SLASH mode
- `/mycom` → no `@` found, falls through to SLASH mode

## Related Issues

Fixes #14420

## Testing Performed

### Automated Tests

All automated tests passed:

- **Unit tests:** 27 tests passed in `useCommandCompletion.test.tsx` (including 6 new tests for this fix)
- **Full CLI test suite:** 3816 tests passed across 286 test files
- **Lint:** Passed (eslint)
- **Format:** Passed (prettier)
- **Build:** Passed
- **Typecheck:** Passed (tsc --noEmit)

### Manual Testing (MacOS)

Verified the following scenarios:

**New behavior (the fix):**

- [x] `/help @` → shows file suggestions
- [x] `/cmd @src/fi` → shows files matching `src/fi`
- [x] `/diff @file1.txt @fi` → shows suggestions for second `@`

**Regression tests (existing behavior preserved):**

- [x] `/hel` → shows slash command suggestions
- [x] `@src/` → shows file suggestions (standalone)
- [x] `/cmd ` (space, no @) → stays in slash/argument mode
- [x] `// comment` → does NOT show slash suggestions
- [x] `@path/with\ space/fi` → handles escaped spaces correctly

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
