### PR TITLE
fix: handle missing local extension config and skip hooks when disabled

### DIFF
--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -514,10 +514,13 @@ export class ExtensionManager extends ExtensionLoader {
         )
         .filter((contextFilePath) => fs.existsSync(contextFilePath));
 
-      const hooks = await this.loadExtensionHooks(effectiveExtensionPath, {
-        extensionPath: effectiveExtensionPath,
-        workspacePath: this.workspaceDir,
-      });
+      let hooks: { [K in HookEventName]?: HookDefinition[] } | undefined;
+      if (this.settings.tools?.enableHooks) {
+        hooks = await this.loadExtensionHooks(effectiveExtensionPath, {
+          extensionPath: effectiveExtensionPath,
+          workspacePath: this.workspaceDir,
+        });
+      }
 
       const extension = {
         name: config.name,

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -43,6 +43,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     debugLogger: {
       error: vi.fn(),
       log: vi.fn(),
+      warn: vi.fn(),
     },
   };
 });
@@ -261,6 +262,25 @@ describe('github.ts', () => {
       } as unknown as GeminiCLIExtension;
       expect(await checkForExtensionUpdate(ext, mockExtensionManager)).toBe(
         ExtensionUpdateState.UP_TO_DATE,
+      );
+    });
+
+    it('should return NOT_UPDATABLE if local extension config cannot be loaded', async () => {
+      vi.mocked(mockExtensionManager.loadExtensionConfig).mockImplementation(
+        () => {
+          throw new Error('Config not found');
+        },
+      );
+
+      const ext = {
+        name: 'local-ext',
+        version: '1.0.0',
+        path: '/path/to/installed/ext',
+        installMetadata: { type: 'local', source: '/path/to/source/ext' },
+      } as unknown as GeminiCLIExtension;
+
+      expect(await checkForExtensionUpdate(ext, mockExtensionManager)).toBe(
+        ExtensionUpdateState.NOT_UPDATABLE,
       );
     });
   });


### PR DESCRIPTION
## Summary

Fixes a crash that occurs during startup when checking for updates for local extensions that have missing or invalid configuration files. Also optimizes the extension loading process to skip loading hooks when the `enableHooks` setting is disabled.

## Details

- **Fix Crash**: Modified `checkForExtensionUpdate` in `packages/cli/src/config/extensions/github.ts` to wrap the configuration loading in a `try-catch` block. If loading fails for a local extension, it now logs a warning and returns `ExtensionUpdateState.NOT_UPDATABLE` instead of crashing. This prevents the CLI from failing to start if a local extension is in a bad state.
- **Optimize Hooks**: Modified `ExtensionManager` in `packages/cli/src/config/extension-manager.ts` to check `this.settings.tools?.enableHooks` before attempting to load hooks. This avoids unnecessary file I/O and processing when the feature is disabled.
- **Tests**: Added regression tests in `github.test.ts` (for the update check fix) and `extension.test.ts` (for the hooks loading optimization).

## Related Issues

Fixes crash on startup when local extension config is missing.

## How to Validate

1. **Automated Tests**:
   Run the relevant tests:
   ```bash
   npm run test -w @google/gemini-cli -- src/config/extensions/github.test.ts src/config/extension.test.ts
   ```

2. **Manual Verification (Crash Fix)**:
   - Install a local extension.
   - Delete or rename its `gemini-extension.json`.
   - Restart the CLI.
   - Verify that the CLI starts successfully and does not crash with an "Unhandled Promise Rejection".

3. **Manual Verification (Hooks Optimization)**:
   - Set `"tools": { "enableHooks": false }` in `settings.json`.
   - Install an extension with hooks.
   - Restart the CLI.
   - Verify that hooks are not loaded (e.g., by checking debug logs or observing that the hook doesn't fire).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
