### PR TITLE
allow final:true to be returned on a2a server edit calls.

### DIFF
--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -751,7 +751,7 @@ export class Task {
             : undefined;
           this.skipFinalTrueAfterInlineEdit = !!payload;
           await confirmationDetails.onConfirm(confirmationOutcome, payload);
-          // Once confirmationDetails.onConfirm finishes witha payload reset
+          // Once confirmationDetails.onConfirm finishes with a payload, reset
           // skipFinalTrueAfterInlineEdit so that external callers receive
           // their call has been completed.
           this.skipFinalTrueAfterInlineEdit = false;

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -751,6 +751,10 @@ export class Task {
             : undefined;
           this.skipFinalTrueAfterInlineEdit = !!payload;
           await confirmationDetails.onConfirm(confirmationOutcome, payload);
+          // Once confirmationDetails.onConfirm finishes witha payload reset
+          // skipFinalTrueAfterInlineEdit so that external callers receive
+          // their call has been completed.
+          this.skipFinalTrueAfterInlineEdit = false;
         } else {
           await confirmationDetails.onConfirm(confirmationOutcome);
         }

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -750,11 +750,14 @@ export class Task {
               } as ToolConfirmationPayload)
             : undefined;
           this.skipFinalTrueAfterInlineEdit = !!payload;
-          await confirmationDetails.onConfirm(confirmationOutcome, payload);
-          // Once confirmationDetails.onConfirm finishes with a payload, reset
-          // skipFinalTrueAfterInlineEdit so that external callers receive
-          // their call has been completed.
-          this.skipFinalTrueAfterInlineEdit = false;
+          try {
+            await confirmationDetails.onConfirm(confirmationOutcome, payload);
+          } finally {
+            // Once confirmationDetails.onConfirm finishes (or fails) with a payload,
+            // reset skipFinalTrueAfterInlineEdit so that external callers receive
+            // their call has been completed.
+            this.skipFinalTrueAfterInlineEdit = false;
+          }
         } else {
           await confirmationDetails.onConfirm(confirmationOutcome);
         }


### PR DESCRIPTION
All edit calls with payload would previously appear hung after completing, and would only unstick when a non-edit request or an edit request with no payload was called. Now any edit call should still send a final:true message at the end of its response.

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker