### PR TITLE
Always set pending status in E2E tests

### DIFF
--- a/.github/workflows/chained_e2e.yml
+++ b/.github/workflows/chained_e2e.yml
@@ -111,6 +111,7 @@ jobs:
     permissions: 'write-all'
     needs:
       - 'parse_run_context'
+    if: 'always()'
     steps:
       - name: 'Set pending status'
         uses: 'myrotvorets/set-commit-status-action@16037e056d73b2d3c88e37e393ff369047f70886' # ratchet:myrotvorets/set-commit-status-action@master


### PR DESCRIPTION
## Summary

Ensure we always write the pending status, even in merge queue.

## Details

in the merge queue `download_repo_name` is skipped. Since it is a transitive dep of `set_pending_status` that leads to this being skipped unless it is marked with `always()`.

## Related Issues

For #10008