### PR TITLE
fix: use Gemini API supported image formats for clipboard

### DIFF
--- a/packages/cli/src/ui/utils/clipboardUtils.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.ts
@@ -9,6 +9,19 @@ import * as path from 'node:path';
 import { debugLogger, spawnAsync } from '@google/gemini-cli-core';
 
 /**
+ * Supported image file extensions based on Gemini API.
+ * See: https://ai.google.dev/gemini-api/docs/image-understanding
+ */
+export const IMAGE_EXTENSIONS = [
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.webp',
+  '.heic',
+  '.heif',
+];
+
+/**
  * Checks if the system clipboard contains an image (macOS only for now)
  * @returns true if clipboard contains an image
  */
@@ -51,11 +64,10 @@ export async function saveClipboardImage(
     const timestamp = new Date().getTime();
 
     // Try different image formats in order of preference
+    // Only formats supported by Gemini API: PNG, JPEG, WEBP, HEIC, HEIF
     const formats = [
       { class: 'PNGf', extension: 'png' },
       { class: 'JPEG', extension: 'jpg' },
-      { class: 'TIFF', extension: 'tiff' },
-      { class: 'GIFf', extension: 'gif' },
     ];
 
     for (const format of formats) {
@@ -125,13 +137,8 @@ export async function cleanupOldClipboardImages(
     const oneHourAgo = Date.now() - 60 * 60 * 1000;
 
     for (const file of files) {
-      if (
-        file.startsWith('clipboard-') &&
-        (file.endsWith('.png') ||
-          file.endsWith('.jpg') ||
-          file.endsWith('.tiff') ||
-          file.endsWith('.gif'))
-      ) {
+      const ext = path.extname(file).toLowerCase();
+      if (file.startsWith('clipboard-') && IMAGE_EXTENSIONS.includes(ext)) {
         const filePath = path.join(tempDir, file);
         const stats = await fs.stat(filePath);
         if (stats.mtimeMs < oneHourAgo) {

--- a/packages/cli/src/ui/utils/clipboardUtils.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.ts
@@ -63,8 +63,8 @@ export async function saveClipboardImage(
     // Generate a unique filename with timestamp
     const timestamp = new Date().getTime();
 
-    // Try different image formats in order of preference
-    // Only formats supported by Gemini API: PNG, JPEG, WEBP, HEIC, HEIF
+    // AppleScript clipboard classes to try, in order of preference.
+    // macOS converts clipboard images to these formats (WEBP/HEIC/HEIF not supported by osascript).
     const formats = [
       { class: 'PNGf', extension: 'png' },
       { class: 'JPEG', extension: 'jpg' },


### PR DESCRIPTION
## Summary

Updates clipboard image handling to only use formats supported by the Gemini API.

  Changes:
  - Remove TIFF and GIF from clipboard save formats (not supported by Gemini API)
  - Export `IMAGE_EXTENSIONS` constant for reuse across clipboard utilities
  - Refactor `cleanupOldClipboardImages` to use the shared constant

  Supported formats: PNG, JPEG, WEBP, HEIC, HEIF

Reference: https://ai.google.dev/gemini-api/docs/image-understanding#supported-formats

## Related Issues
Part 1 of breaking up #14706 into smaller chunks

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
