### PR TITLE
feat: display quota stats for unused models in /stats

### DIFF
--- a/packages/cli/src/ui/components/StatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.test.tsx
@@ -77,7 +77,6 @@ describe('<StatsDisplay />', () => {
     expect(output).toContain('Performance');
     expect(output).toContain('Interaction Summary');
     expect(output).not.toContain('Efficiency & Optimizations');
-    expect(output).not.toContain('Model'); // The table header
     expect(output).toMatchSnapshot();
   });
 
@@ -446,6 +445,52 @@ describe('<StatsDisplay />', () => {
       expect(output).toContain('Usage limit remaining');
       expect(output).toContain('75.0%');
       expect(output).toContain('(Resets in 1h 30m)');
+      expect(output).toMatchSnapshot();
+
+      vi.useRealTimers();
+    });
+
+    it('renders quota information for unused models', () => {
+      const now = new Date('2025-01-01T12:00:00Z');
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+
+      // No models in metrics, but a quota for gemini-2.5-flash
+      const metrics = createTestMetrics();
+
+      const resetTime = new Date(now.getTime() + 1000 * 60 * 120).toISOString(); // 2 hours from now
+
+      const quotas: RetrieveUserQuotaResponse = {
+        buckets: [
+          {
+            modelId: 'gemini-2.5-flash',
+            remainingFraction: 0.5,
+            resetTime,
+          },
+        ],
+      };
+
+      useSessionStatsMock.mockReturnValue({
+        stats: {
+          sessionId: 'test-session-id',
+          sessionStartTime: new Date(),
+          metrics,
+          lastPromptTokenCount: 0,
+          promptCount: 5,
+        },
+        getPromptCount: () => 5,
+        startNewPrompt: vi.fn(),
+      });
+
+      const { lastFrame } = render(
+        <StatsDisplay duration="1s" quotas={quotas} />,
+      );
+      const output = lastFrame();
+
+      expect(output).toContain('gemini-2.5-flash');
+      expect(output).toContain('-'); // for requests
+      expect(output).toContain('50.0%');
+      expect(output).toContain('(Resets in 2h)');
       expect(output).toMatchSnapshot();
 
       vi.useRealTimers();

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -19,7 +19,10 @@ import {
   USER_AGREEMENT_RATE_MEDIUM,
 } from '../utils/displayUtils.js';
 import { computeSessionStats } from '../utils/computeStats.js';
-import type { RetrieveUserQuotaResponse } from '@google/gemini-cli-core';
+import {
+  type RetrieveUserQuotaResponse,
+  VALID_GEMINI_MODELS,
+} from '@google/gemini-cli-core';
 
 // A more flexible and powerful StatRow component
 interface StatRowProps {
@@ -69,6 +72,51 @@ const Section: React.FC<SectionProps> = ({ title, children }) => (
     {children}
   </Box>
 );
+
+// Logic for building the unified list of table rows
+const buildModelRows = (
+  models: Record<string, ModelMetrics>,
+  quotas?: RetrieveUserQuotaResponse,
+) => {
+  const usedModelNames = new Set(
+    Object.keys(models).map((name) => name.replace('-001', '')),
+  );
+
+  // 1. Models with active usage
+  const activeRows = Object.entries(models).map(([name, metrics]) => {
+    const modelName = name.replace('-001', '');
+    return {
+      key: name,
+      modelName,
+      requests: metrics.api.totalRequests,
+      inputTokens: metrics.tokens.prompt.toLocaleString(),
+      outputTokens: metrics.tokens.candidates.toLocaleString(),
+      bucket: quotas?.buckets?.find((b) => b.modelId === modelName),
+      isActive: true,
+    };
+  });
+
+  // 2. Models with quota only
+  const quotaRows =
+    quotas?.buckets
+      ?.filter(
+        (b) =>
+          b.modelId &&
+          VALID_GEMINI_MODELS.has(b.modelId) &&
+          !usedModelNames.has(b.modelId),
+      )
+      .map((bucket) => ({
+        key: bucket.modelId!,
+        modelName: bucket.modelId!,
+        requests: '-',
+        inputTokens: '-',
+        outputTokens: '-',
+        bucket,
+        isActive: false,
+      })) || [];
+
+  return [...activeRows, ...quotaRows];
+};
 
 const formatResetTime = (resetTime: string): string => {
   const diff = new Date(resetTime).getTime() - Date.now();
@@ -138,6 +186,7 @@ const ModelUsageTable: React.FC<{
           </Box>
         )}
       </Box>
+
       {/* Divider */}
       <Box
         borderStyle="round"
@@ -155,44 +204,45 @@ const ModelUsageTable: React.FC<{
         }
       ></Box>
 
-      {/* Rows */}
-      {Object.entries(models).map(([name, modelMetrics]) => {
-        const modelName = name.replace('-001', '');
-        const bucket = quotas?.buckets?.find((b) => b.modelId === modelName);
-
-        return (
-          <Box key={name}>
-            <Box width={nameWidth}>
-              <Text color={theme.text.primary}>{modelName}</Text>
-            </Box>
-            <Box width={requestsWidth} justifyContent="flex-end">
-              <Text color={theme.text.primary}>
-                {modelMetrics.api.totalRequests}
-              </Text>
-            </Box>
-            <Box width={inputTokensWidth} justifyContent="flex-end">
-              <Text color={theme.status.warning}>
-                {modelMetrics.tokens.prompt.toLocaleString()}
-              </Text>
-            </Box>
-            <Box width={outputTokensWidth} justifyContent="flex-end">
-              <Text color={theme.status.warning}>
-                {modelMetrics.tokens.candidates.toLocaleString()}
-              </Text>
-            </Box>
-            <Box width={usageLimitWidth} justifyContent="flex-end">
-              {bucket &&
-                bucket.remainingFraction != null &&
-                bucket.resetTime && (
-                  <Text color={theme.text.secondary}>
-                    {(bucket.remainingFraction * 100).toFixed(1)}%{' '}
-                    {formatResetTime(bucket.resetTime)}
-                  </Text>
-                )}
-            </Box>
+      {buildModelRows(models, quotas).map((row) => (
+        <Box key={row.key}>
+          <Box width={nameWidth}>
+            <Text color={theme.text.primary}>{row.modelName}</Text>
           </Box>
-        );
-      })}
+          <Box width={requestsWidth} justifyContent="flex-end">
+            <Text
+              color={row.isActive ? theme.text.primary : theme.text.secondary}
+            >
+              {row.requests}
+            </Text>
+          </Box>
+          <Box width={inputTokensWidth} justifyContent="flex-end">
+            <Text
+              color={row.isActive ? theme.status.warning : theme.text.secondary}
+            >
+              {row.inputTokens}
+            </Text>
+          </Box>
+          <Box width={outputTokensWidth} justifyContent="flex-end">
+            <Text
+              color={row.isActive ? theme.status.warning : theme.text.secondary}
+            >
+              {row.outputTokens}
+            </Text>
+          </Box>
+          <Box width={usageLimitWidth} justifyContent="flex-end">
+            {row.bucket &&
+              row.bucket.remainingFraction != null &&
+              row.bucket.resetTime && (
+                <Text color={theme.text.secondary}>
+                  {(row.bucket.remainingFraction * 100).toFixed(1)}%{' '}
+                  {formatResetTime(row.bucket.resetTime)}
+                </Text>
+              )}
+          </Box>
+        </Box>
+      ))}
+
       {cacheEfficiency > 0 && (
         <Box flexDirection="column" marginTop={1}>
           <Text color={theme.text.primary}>
@@ -202,6 +252,7 @@ const ModelUsageTable: React.FC<{
           </Text>
         </Box>
       )}
+
       {models && (
         <>
           <Box marginTop={1} marginBottom={2}>
@@ -335,15 +386,12 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({
           </Text>
         </SubStatRow>
       </Section>
-
-      {Object.keys(models).length > 0 && (
-        <ModelUsageTable
-          models={models}
-          totalCachedTokens={computed.totalCachedTokens}
-          cacheEfficiency={computed.cacheEfficiency}
-          quotas={quotas}
-        />
-      )}
+      <ModelUsageTable
+        models={models}
+        totalCachedTokens={computed.totalCachedTokens}
+        cacheEfficiency={computed.cacheEfficiency}
+        quotas={quotas}
+      />
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -148,6 +148,12 @@ const ModelUsageTable: React.FC<{
   cacheEfficiency: number;
   quotas?: RetrieveUserQuotaResponse;
 }> = ({ models, totalCachedTokens, cacheEfficiency, quotas }) => {
+  const rows = buildModelRows(models, quotas);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
   const nameWidth = 25;
   const requestsWidth = 8;
   const inputTokensWidth = 15;
@@ -204,7 +210,7 @@ const ModelUsageTable: React.FC<{
         }
       ></Box>
 
-      {buildModelRows(models, quotas).map((row) => (
+      {rows.map((row) => (
         <Box key={row.key}>
           <Box width={nameWidth}>
             <Text color={theme.text.primary}>{row.modelName}</Text>

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -78,13 +78,12 @@ const buildModelRows = (
   models: Record<string, ModelMetrics>,
   quotas?: RetrieveUserQuotaResponse,
 ) => {
-  const usedModelNames = new Set(
-    Object.keys(models).map((name) => name.replace('-001', '')),
-  );
+  const getBaseModelName = (name: string) => name.replace('-001', '');
+  const usedModelNames = new Set(Object.keys(models).map(getBaseModelName));
 
   // 1. Models with active usage
   const activeRows = Object.entries(models).map(([name, metrics]) => {
-    const modelName = name.replace('-001', '');
+    const modelName = getBaseModelName(name);
     return {
       key: name,
       modelName,

--- a/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
@@ -151,6 +151,36 @@ exports[`<StatsDisplay /> > Conditional Rendering Tests > hides User Agreement w
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;
 
+exports[`<StatsDisplay /> > Quota Display > renders quota information for unused models 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                  │
+│  Session Stats                                                                                   │
+│                                                                                                  │
+│  Interaction Summary                                                                             │
+│  Session ID:                 test-session-id                                                     │
+│  Tool Calls:                 0 ( ✓ 0 x 0 )                                                       │
+│  Success Rate:               0.0%                                                                │
+│                                                                                                  │
+│  Performance                                                                                     │
+│  Wall Time:                  1s                                                                  │
+│  Agent Active:               0s                                                                  │
+│    » API Time:               0s (0.0%)                                                           │
+│    » Tool Time:              0s (0.0%)                                                           │
+│                                                                                                  │
+│                                                                                                  │
+│  Model Usage                  Reqs   Input Tokens  Output Tokens         Usage limit remaining   │
+│  ─────────────────────────────────────────────────────────────────────────────────────────────   │
+│  gemini-2.5-flash                -              -              -          50.0% (Resets in 2h)   │
+│                                                                                                  │
+│  Usage limits span all sessions and reset daily.                                                 │
+│  /auth to upgrade or switch to API key.                                                          │
+│                                                                                                  │
+│                                                                                                  │
+│  » Tip: For a full token breakdown, run \`/stats model\`.                                          │
+│                                                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
 exports[`<StatsDisplay /> > Quota Display > renders quota information when quotas are provided 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
 │                                                                                                  │

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -9,6 +9,13 @@ export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
 export const DEFAULT_GEMINI_FLASH_LITE_MODEL = 'gemini-2.5-flash-lite';
 
+export const VALID_GEMINI_MODELS = new Set([
+  PREVIEW_GEMINI_MODEL,
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_GEMINI_FLASH_MODEL,
+  DEFAULT_GEMINI_FLASH_LITE_MODEL,
+]);
+
 export const DEFAULT_GEMINI_MODEL_AUTO = 'auto';
 
 // Model aliases for user convenience.


### PR DESCRIPTION
## Summary
Display quota stats for all availabel models even if they haven't been used yet in the current session

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
The quota info from the backend returns a list of quota for all the models the users have access to. We should display quota stats for all the models even if the model has not been used in the current session.
<img width="702" height="457" alt="image" src="https://github.com/user-attachments/assets/fd722489-0fa3-4c3e-b9b9-3fd0648f4714" />

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
