### PR TITLE
docs: Fix formatting issue in memport documentation

### DIFF
--- a/docs/core/memport.md
+++ b/docs/core/memport.md
@@ -83,7 +83,9 @@ The processor automatically detects and prevents circular imports:
 # file-a.md
 
 @./file-b.md
+```
 
+```markdown
 # file-b.md
 
 @./file-a.md <!-- This will be detected and prevented -->


### PR DESCRIPTION
There is currently a markdown file block that cannot be rendered correctly. It should be rendered as two different files. So I put them in separate blocks.