### PR TITLE
docs: update showCitations default to true in documentation and settings json schema

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -52,7 +52,7 @@ they appear in the UI.
 | Hide Footer                    | `ui.hideFooter`                          | Hide the footer from the UI.                                         | `false` |
 | Show Memory Usage              | `ui.showMemoryUsage`                     | Display memory usage information in the UI.                          | `false` |
 | Show Line Numbers              | `ui.showLineNumbers`                     | Show line numbers in the chat.                                       | `false` |
-| Show Citations                 | `ui.showCitations`                       | Show citations for generated text in the chat.                       | `false` |
+| Show Citations                 | `ui.showCitations`                       | Show citations for generated text in the chat.                       | `true`  |
 | Use Full Width                 | `ui.useFullWidth`                        | Use the entire width of the terminal for output.                     | `true`  |
 | Use Alternate Screen Buffer    | `ui.useAlternateBuffer`                  | Use an alternate screen buffer for the UI, preserving shell history. | `true`  |
 | Disable Loading Phrases        | `ui.accessibility.disableLoadingPhrases` | Disable loading phrases for accessibility.                           | `false` |

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -227,7 +227,7 @@ their corresponding top-level category object in your `settings.json` file.
 
 - **`ui.showCitations`** (boolean):
   - **Description:** Show citations for generated text in the chat.
-  - **Default:** `false`
+  - **Default:** `true`
 
 - **`ui.showModelInfoInChat`** (boolean):
   - **Description:** Show the model name in the chat for each model turn.

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -492,7 +492,7 @@ const SETTINGS_SCHEMA = {
         label: 'Show Citations',
         category: 'UI',
         requiresRestart: false,
-        default: false,
+        default: true,
         description: 'Show citations for generated text in the chat.',
         showInDialog: true,
       },

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -277,8 +277,8 @@
         "showCitations": {
           "title": "Show Citations",
           "description": "Show citations for generated text in the chat.",
-          "markdownDescription": "Show citations for generated text in the chat.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `false`",
-          "default": false,
+          "markdownDescription": "Show citations for generated text in the chat.\n\n- Category: `UI`\n- Requires restart: `no`\n- Default: `true`",
+          "default": true,
           "type": "boolean"
         },
         "showModelInfoInChat": {


### PR DESCRIPTION
## Summary

This PR updates the default value of the `showCitations` setting from `false` to `true` in the configuration schema and documentation.

## Details

The `showCitations` setting was previously documented and defined in the schema with a default of `false`, while the underlying implementation (`useGeminiStream.ts`) utilized a fallback default of `true`. This discrepancy caused confusion regarding the actual default behavior. This change aligns the schema and documentation with the implementation and the intended user experience.

## How to Validate

1.  Review `packages/cli/src/config/settingsSchema.ts` and verify `showCitations` default is `true`.
2.  Review `schemas/settings.schema.json` and verify the default value is `true`.
3.  Check `docs/get-started/configuration.md` and `docs/cli/settings.md` to confirm the documentation reflects the new default.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
