### PR TITLE
Docs: Fix incorrect slug path for releases in sidebar

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -261,7 +261,7 @@
       },
       {
         "label": "Changelog",
-        "slug": "docs/changelog/releases"
+        "slug": "docs/changelogs/releases"
       }
     ]
   },


### PR DESCRIPTION
Fixed slug path for releases in sidebar