### PR TITLE
feat(cli): add terminal bell notification on response completion

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -259,6 +259,16 @@ const SETTINGS_SCHEMA = {
         description: 'Enable debug logging of keystrokes to the console.',
         showInDialog: true,
       },
+      terminalBell: {
+        type: 'boolean',
+        label: 'Terminal Bell on Completion',
+        category: 'General',
+        requiresRestart: false,
+        default: true,
+        description:
+          'Play terminal bell sound when response completes or needs approval.',
+        showInDialog: true,
+      },
       sessionRetention: {
         type: 'object',
         label: 'Session Retention',

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -3245,4 +3245,247 @@ describe('useGeminiStream', () => {
       expect(coreEvents.emitFeedback).not.toHaveBeenCalled();
     });
   });
+
+  describe('Terminal Bell', () => {
+    let stdoutWriteSpy: MockInstance;
+
+    beforeEach(() => {
+      stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      // Mock process.stdout.isTTY
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      stdoutWriteSpy.mockRestore();
+    });
+
+    it('should play terminal bell when waiting for tool approval and setting is enabled', () => {
+      const settingsWithBell: LoadedSettings = {
+        ...mockLoadedSettings,
+        merged: { ...mockLoadedSettings.merged, general: { terminalBell: true } },
+      } as LoadedSettings;
+
+      const toolCalls: TrackedToolCall[] = [
+        {
+          request: {
+            callId: 'call1',
+            name: 'replace',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-id-1',
+          },
+          status: 'awaiting_approval',
+          responseSubmittedToGemini: false,
+          tool: {
+            name: 'replace',
+            displayName: 'replace',
+            description: 'desc',
+            build: vi.fn(),
+          } as any,
+          invocation: {
+            getDescription: () => 'Mock description',
+          } as unknown as AnyToolInvocation,
+          startTime: Date.now(),
+          confirmationDetails: {
+            type: 'edit',
+            title: 'Confirm Edit',
+            onConfirm: vi.fn(),
+            fileName: 'file.txt',
+            filePath: '/test/file.txt',
+            fileDiff: 'fake diff',
+            originalContent: 'old',
+            newContent: 'new',
+          },
+        } as TrackedWaitingToolCall,
+      ];
+
+      mockUseReactToolScheduler.mockReturnValue([
+        toolCalls,
+        mockScheduleToolCalls,
+        mockMarkToolsAsSubmitted,
+        vi.fn(),
+        mockCancelAllToolCalls,
+      ]);
+
+      renderHook(() =>
+        useGeminiStream(
+          new MockedGeminiClientClass(mockConfig),
+          [],
+          mockAddItem,
+          mockConfig,
+          settingsWithBell,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          vi.fn(),
+          () => {},
+          () => {},
+          80,
+          24,
+        ),
+      );
+
+      expect(stdoutWriteSpy).toHaveBeenCalledWith('\x07');
+    });
+
+    it('should not play terminal bell when setting is disabled', () => {
+      const settingsWithoutBell: LoadedSettings = {
+        ...mockLoadedSettings,
+        merged: { ...mockLoadedSettings.merged, general: { terminalBell: false } },
+      } as LoadedSettings;
+
+      const toolCalls: TrackedToolCall[] = [
+        {
+          request: {
+            callId: 'call1',
+            name: 'replace',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-id-1',
+          },
+          status: 'awaiting_approval',
+          responseSubmittedToGemini: false,
+          tool: {
+            name: 'replace',
+            displayName: 'replace',
+            description: 'desc',
+            build: vi.fn(),
+          } as any,
+          invocation: {
+            getDescription: () => 'Mock description',
+          } as unknown as AnyToolInvocation,
+          startTime: Date.now(),
+          confirmationDetails: {
+            type: 'edit',
+            title: 'Confirm Edit',
+            onConfirm: vi.fn(),
+            fileName: 'file.txt',
+            filePath: '/test/file.txt',
+            fileDiff: 'fake diff',
+            originalContent: 'old',
+            newContent: 'new',
+          },
+        } as TrackedWaitingToolCall,
+      ];
+
+      mockUseReactToolScheduler.mockReturnValue([
+        toolCalls,
+        mockScheduleToolCalls,
+        mockMarkToolsAsSubmitted,
+        vi.fn(),
+        mockCancelAllToolCalls,
+      ]);
+
+      renderHook(() =>
+        useGeminiStream(
+          new MockedGeminiClientClass(mockConfig),
+          [],
+          mockAddItem,
+          mockConfig,
+          settingsWithoutBell,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          vi.fn(),
+          () => {},
+          () => {},
+          80,
+          24,
+        ),
+      );
+
+      expect(stdoutWriteSpy).not.toHaveBeenCalledWith('\x07');
+    });
+
+    it('should not play terminal bell when not in a TTY', () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: false,
+        writable: true,
+        configurable: true,
+      });
+
+      const settingsWithBell: LoadedSettings = {
+        ...mockLoadedSettings,
+        merged: { ...mockLoadedSettings.merged, general: { terminalBell: true } },
+      } as LoadedSettings;
+
+      const toolCalls: TrackedToolCall[] = [
+        {
+          request: {
+            callId: 'call1',
+            name: 'replace',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-id-1',
+          },
+          status: 'awaiting_approval',
+          responseSubmittedToGemini: false,
+          tool: {
+            name: 'replace',
+            displayName: 'replace',
+            description: 'desc',
+            build: vi.fn(),
+          } as any,
+          invocation: {
+            getDescription: () => 'Mock description',
+          } as unknown as AnyToolInvocation,
+          startTime: Date.now(),
+          confirmationDetails: {
+            type: 'edit',
+            title: 'Confirm Edit',
+            onConfirm: vi.fn(),
+            fileName: 'file.txt',
+            filePath: '/test/file.txt',
+            fileDiff: 'fake diff',
+            originalContent: 'old',
+            newContent: 'new',
+          },
+        } as TrackedWaitingToolCall,
+      ];
+
+      mockUseReactToolScheduler.mockReturnValue([
+        toolCalls,
+        mockScheduleToolCalls,
+        mockMarkToolsAsSubmitted,
+        vi.fn(),
+        mockCancelAllToolCalls,
+      ]);
+
+      renderHook(() =>
+        useGeminiStream(
+          new MockedGeminiClientClass(mockConfig),
+          [],
+          mockAddItem,
+          mockConfig,
+          settingsWithBell,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          vi.fn(),
+          () => {},
+          () => {},
+          80,
+          24,
+        ),
+      );
+
+      expect(stdoutWriteSpy).not.toHaveBeenCalledWith('\x07');
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -93,6 +93,15 @@ function showCitations(settings: LoadedSettings): boolean {
 }
 
 /**
+ * Play terminal bell if setting is enabled and we're in an interactive terminal.
+ */
+function playTerminalBell(settings: LoadedSettings): void {
+  if (settings?.merged?.general?.terminalBell && process.stdout.isTTY) {
+    process.stdout.write('\x07');
+  }
+}
+
+/**
  * Manages the Gemini stream, including user input, command processing,
  * API interaction, and tool call lifecycle.
  */
@@ -294,6 +303,13 @@ export const useGeminiStream = (
     }
     return StreamingState.Idle;
   }, [isResponding, toolCalls]);
+
+  // Play terminal bell when waiting for tool approval
+  useEffect(() => {
+    if (streamingState === StreamingState.WaitingForConfirmation) {
+      playTerminalBell(settings);
+    }
+  }, [streamingState, settings]);
 
   useEffect(() => {
     if (
@@ -1125,6 +1141,7 @@ export const useGeminiStream = (
             } finally {
               if (activeQueryIdRef.current === queryId) {
                 setIsResponding(false);
+                playTerminalBell(settings);
               }
             }
           });
@@ -1144,6 +1161,7 @@ export const useGeminiStream = (
       config,
       startNewPrompt,
       getPromptCount,
+      settings,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -101,8 +101,12 @@ function playTerminalBell(
   settings: LoadedSettings,
   stdout: NodeJS.WriteStream,
 ): void {
-  if (settings?.merged?.general?.terminalBell && stdout.isTTY) {
-    stdout.write('\x07');
+  try {
+    if (settings?.merged?.general?.terminalBell && stdout.isTTY) {
+      stdout.write('\x07');
+    }
+  } catch {
+    // Ignore errors if the stream is closed during shutdown.
   }
 }
 


### PR DESCRIPTION
## Summary

Adds an optional terminal bell notification (`\x07`) that plays when:

- A response completes
- The system awaits tool approval

The `general.terminalBell` setting is enabled by default and can be disabled in settings. Only triggers in TTY environments.

## Details

Writes \x07 (BEL character) to stderr when:

1. A response finishes (in the submitQuery finally block)
2. Waiting for tool approval (streamingState becomes WaitingForConfirmation)

Uses Ink's `useStdout()` hook rather than `process.stdout` to bypass `patchStdio()` which redirects stdout writes to event emitters.

Users who find it annoying can disable with general.terminalBell: false in settings.

## Related Issues

Closes #14643
Partially fixes #14696

## How to Validate

1. First check your terminal supports bell: echo -e "\a" (should beep)
2. Run gemini and submit any query - bell should sound when response completes
3. Trigger a tool that needs approval (e.g. file edit) - bell should sound when waiting
4. Set general.terminalBell: false in settings, repeat steps 2-3, no bell should sound
5. Pipe output somewhere (gemini --help | cat) - no bell (TTY check)

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
