### PR TITLE
feat(ide): fallback to GEMINI_CLI_IDE_AUTH_TOKEN env var  

### DIFF
--- a/packages/core/src/ide/ide-client.test.ts
+++ b/packages/core/src/ide/ide-client.test.ts
@@ -59,6 +59,7 @@ describe('IdeClient', () => {
     delete process.env['GEMINI_CLI_IDE_SERVER_PORT'];
     delete process.env['GEMINI_CLI_IDE_SERVER_STDIO_COMMAND'];
     delete process.env['GEMINI_CLI_IDE_SERVER_STDIO_ARGS'];
+    delete process.env['GEMINI_CLI_IDE_AUTH_TOKEN'];
 
     // Mock dependencies
     vi.spyOn(process, 'cwd').mockReturnValue('/test/workspace/sub-dir');

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -154,6 +154,10 @@ export class IdeClient {
     if (this.connectionConfig?.authToken) {
       this.authToken = this.connectionConfig.authToken;
     }
+    this.authToken =
+      this.connectionConfig?.authToken ??
+      process.env['GEMINI_CLI_IDE_AUTH_TOKEN'];
+
     const workspacePath =
       this.connectionConfig?.workspacePath ??
       process.env['GEMINI_CLI_IDE_WORKSPACE_PATH'];

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -151,9 +151,6 @@ export class IdeClient {
     this.setState(IDEConnectionStatus.Connecting);
 
     this.connectionConfig = await this.getConnectionConfigFromFile();
-    if (this.connectionConfig?.authToken) {
-      this.authToken = this.connectionConfig.authToken;
-    }
     this.authToken =
       this.connectionConfig?.authToken ??
       process.env['GEMINI_CLI_IDE_AUTH_TOKEN'];


### PR DESCRIPTION
## TLDR

This PR updates the `IdeClient` to check the `GEMINI_CLI_IDE_AUTH_TOKEN` environment variable for an authentication token if one is not provided via the connection configuration file.