### PR TITLE
chore: add closing reason to stale bug workflow

### DIFF
--- a/.github/workflows/gemini-scheduled-stale-issue-closer.yml
+++ b/.github/workflows/gemini-scheduled-stale-issue-closer.yml
@@ -142,7 +142,8 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue.number,
-                    state: 'closed'
+                    state: 'closed',
+                    state_reason: 'not_planned'
                   });
                 }
               }


### PR DESCRIPTION
Add closing reason to stale bug, so it closes as no planned and not completed. 