### PR TITLE
Limit search depth in path corrector

### DIFF
--- a/packages/cli/src/zed-integration/fileSystemService.test.ts
+++ b/packages/cli/src/zed-integration/fileSystemService.test.ts
@@ -24,7 +24,6 @@ describe('AcpFileSystemService', () => {
     mockFallback = {
       readTextFile: vi.fn(),
       writeTextFile: vi.fn(),
-      findFiles: vi.fn(),
     };
   });
 
@@ -112,20 +111,5 @@ describe('AcpFileSystemService', () => {
 
       verify();
     });
-  });
-
-  it('should always use fallback for findFiles', () => {
-    service = new AcpFileSystemService(
-      mockClient,
-      'session-1',
-      { readTextFile: true, writeTextFile: true },
-      mockFallback,
-    );
-    mockFallback.findFiles.mockReturnValue(['file1', 'file2']);
-
-    const result = service.findFiles('pattern', ['/path']);
-
-    expect(mockFallback.findFiles).toHaveBeenCalledWith('pattern', ['/path']);
-    expect(result).toEqual(['file1', 'file2']);
   });
 });

--- a/packages/cli/src/zed-integration/fileSystemService.ts
+++ b/packages/cli/src/zed-integration/fileSystemService.ts
@@ -44,7 +44,4 @@ export class AcpFileSystemService implements FileSystemService {
       sessionId: this.sessionId,
     });
   }
-  findFiles(fileName: string, searchPaths: readonly string[]): string[] {
-    return this.fallback.findFiles(fileName, searchPaths);
-  }
 }

--- a/packages/core/src/services/fileSystemService.ts
+++ b/packages/core/src/services/fileSystemService.ts
@@ -5,8 +5,6 @@
  */
 
 import fs from 'node:fs/promises';
-import * as path from 'node:path';
-import { globSync } from 'glob';
 
 /**
  * Interface for file system operations that may be delegated to different implementations
@@ -27,15 +25,6 @@ export interface FileSystemService {
    * @param content - The content to write
    */
   writeTextFile(filePath: string, content: string): Promise<void>;
-
-  /**
-   * Finds files with a given name within specified search paths.
-   *
-   * @param fileName - The name of the file to find.
-   * @param searchPaths - An array of directory paths to search within.
-   * @returns An array of absolute paths to the found files.
-   */
-  findFiles(fileName: string, searchPaths: readonly string[]): string[];
 }
 
 /**
@@ -48,15 +37,5 @@ export class StandardFileSystemService implements FileSystemService {
 
   async writeTextFile(filePath: string, content: string): Promise<void> {
     await fs.writeFile(filePath, content, 'utf-8');
-  }
-
-  findFiles(fileName: string, searchPaths: readonly string[]): string[] {
-    return searchPaths.flatMap((searchPath) => {
-      const pattern = path.posix.join(searchPath, '**', fileName);
-      return globSync(pattern, {
-        nodir: true,
-        absolute: true,
-      });
-    });
   }
 }

--- a/packages/core/src/utils/bfsFileSearch.ts
+++ b/packages/core/src/utils/bfsFileSearch.ts
@@ -5,6 +5,7 @@
  */
 
 import * as fs from 'node:fs/promises';
+import * as fsSync from 'node:fs';
 import * as path from 'node:path';
 import type { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import type { FileFilteringOptions } from '../config/constants.js';
@@ -37,13 +38,7 @@ export async function bfsFileSearch(
   rootDir: string,
   options: BfsFileSearchOptions,
 ): Promise<string[]> {
-  const {
-    fileName,
-    ignoreDirs = [],
-    maxDirs = Infinity,
-    debug = false,
-    fileService,
-  } = options;
+  const { ignoreDirs = [], maxDirs = Infinity, debug = false } = options;
   const foundFiles: string[] = [];
   const queue: string[] = [rootDir];
   const visited = new Set<string>();
@@ -99,36 +94,109 @@ export async function bfsFileSearch(
     const results = await Promise.all(readPromises);
 
     for (const { currentDir, entries } of results) {
-      for (const entry of entries) {
-        const fullPath = path.join(currentDir, entry.name);
-        const isDirectory = entry.isDirectory();
-        const isMatchingFile = entry.isFile() && entry.name === fileName;
+      processDirEntries(
+        currentDir,
+        entries,
+        options,
+        ignoreDirsSet,
+        queue,
+        foundFiles,
+      );
+    }
+  }
 
-        if (!isDirectory && !isMatchingFile) {
-          continue;
-        }
-        if (isDirectory && ignoreDirsSet.has(entry.name)) {
-          continue;
-        }
+  return foundFiles;
+}
 
-        if (
-          fileService?.shouldIgnoreFile(fullPath, {
-            respectGitIgnore: options.fileFilteringOptions?.respectGitIgnore,
-            respectGeminiIgnore:
-              options.fileFilteringOptions?.respectGeminiIgnore,
-          })
-        ) {
-          continue;
-        }
+/**
+ * Performs a synchronous breadth-first search for a specific file within a directory structure.
+ *
+ * @param rootDir The directory to start the search from.
+ * @param options Configuration for the search.
+ * @returns An array of paths where the file was found.
+ */
+export function bfsFileSearchSync(
+  rootDir: string,
+  options: BfsFileSearchOptions,
+): string[] {
+  const { ignoreDirs = [], maxDirs = Infinity, debug = false } = options;
+  const foundFiles: string[] = [];
+  const queue: string[] = [rootDir];
+  const visited = new Set<string>();
+  let scannedDirCount = 0;
+  let queueHead = 0;
 
-        if (isDirectory) {
-          queue.push(fullPath);
-        } else {
-          foundFiles.push(fullPath);
-        }
+  const ignoreDirsSet = new Set(ignoreDirs);
+
+  while (queueHead < queue.length && scannedDirCount < maxDirs) {
+    const currentDir = queue[queueHead];
+    queueHead++;
+
+    if (!visited.has(currentDir)) {
+      visited.add(currentDir);
+      scannedDirCount++;
+
+      if (debug) {
+        logger.debug(
+          `Scanning Sync [${scannedDirCount}/${maxDirs}]: ${currentDir}`,
+        );
+      }
+
+      try {
+        const entries = fsSync.readdirSync(currentDir, { withFileTypes: true });
+        processDirEntries(
+          currentDir,
+          entries,
+          options,
+          ignoreDirsSet,
+          queue,
+          foundFiles,
+        );
+      } catch (error) {
+        const message = (error as Error)?.message ?? 'Unknown error';
+        debugLogger.warn(
+          `[WARN] Skipping unreadable directory: ${currentDir} (${message})`,
+        );
       }
     }
   }
 
   return foundFiles;
+}
+
+function processDirEntries(
+  currentDir: string,
+  entries: fsSync.Dirent[],
+  options: BfsFileSearchOptions,
+  ignoreDirsSet: Set<string>,
+  queue: string[],
+  foundFiles: string[],
+): void {
+  for (const entry of entries) {
+    const fullPath = path.join(currentDir, entry.name);
+    const isDirectory = entry.isDirectory();
+    const isMatchingFile = entry.isFile() && entry.name === options.fileName;
+
+    if (!isDirectory && !isMatchingFile) {
+      continue;
+    }
+    if (isDirectory && ignoreDirsSet.has(entry.name)) {
+      continue;
+    }
+
+    if (
+      options.fileService?.shouldIgnoreFile(fullPath, {
+        respectGitIgnore: options.fileFilteringOptions?.respectGitIgnore,
+        respectGeminiIgnore: options.fileFilteringOptions?.respectGeminiIgnore,
+      })
+    ) {
+      continue;
+    }
+
+    if (isDirectory) {
+      queue.push(fullPath);
+    } else {
+      foundFiles.push(fullPath);
+    }
+  }
 }

--- a/packages/core/src/utils/pathCorrector.test.ts
+++ b/packages/core/src/utils/pathCorrector.test.ts
@@ -10,7 +10,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import type { Config } from '../config/config.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
-import { StandardFileSystemService } from '../services/fileSystemService.js';
+import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { correctPath } from './pathCorrector.js';
 
 describe('pathCorrector', () => {
@@ -30,7 +30,11 @@ describe('pathCorrector', () => {
       getTargetDir: () => rootDir,
       getWorkspaceContext: () =>
         createMockWorkspaceContext(rootDir, [otherWorkspaceDir]),
-      getFileSystemService: () => new StandardFileSystemService(),
+      getFileService: () => new FileDiscoveryService(rootDir),
+      getFileFilteringOptions: () => ({
+        respectGitIgnore: true,
+        respectGeminiIgnore: true,
+      }),
     } as unknown as Config;
   });
 


### PR DESCRIPTION
## Summary

limit search depth in path corrector

## Details

This was causing the CLI to freeze (b466194131) for googlers working in very large, wide, and slow directories.

## Related Issues

Fixes #12650

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
