### PR TITLE
Feat/toggleable mcp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 !.gemini/config.yaml
 !.gemini/commands/
 
+.claude/
+
 # Note: .gemini-clipboard/ is NOT in gitignore so Gemini can access pasted images
 
 # Dependency directory

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -687,14 +687,22 @@ their corresponding top-level category object in your `settings.json` file.
   - **Requires restart:** Yes
 
 - **`mcp.allowed`** (array):
-  - **Description:** A list of MCP servers to allow.
+  - **Description:** A list of allowed MCP servers. If set, only servers in this
+    list can run (allowlist). Non-matching servers are blocked.
   - **Default:** `undefined`
   - **Requires restart:** Yes
 
 - **`mcp.excluded`** (array):
-  - **Description:** A list of MCP servers to exclude.
+  - **Description:** A list of excluded MCP servers. Servers in this list are
+    blocked even if allowed by other rules (blocklist).
   - **Default:** `undefined`
   - **Requires restart:** Yes
+
+- **`mcp.disabled`** (array):
+  - **Description:** List of MCP server names that are disabled by the user
+    (e.g. via /mcp disable). Disabled servers are not blocked, just turned off,
+    and can be re-enabled.
+  - **Default:** `[]`
 
 #### `useSmartEdit`
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -608,6 +608,7 @@ export async function loadCliConfig(
     blockedMcpServers: argv.allowedMcpServerNames
       ? [] // explicitly allowed servers overrides everything
       : settings.mcp?.excluded,
+    getDisabledMcpServers: () => settings.mcp?.disabled ?? [],
     userMemory: memoryContent,
     geminiMdFileCount: fileCount,
     geminiMdFilePaths: filePaths,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1102,7 +1102,8 @@ const SETTINGS_SCHEMA = {
         category: 'MCP',
         requiresRestart: true,
         default: undefined as string[] | undefined,
-        description: 'A list of MCP servers to allow.',
+        description:
+          'A list of allowed MCP servers. If set, only servers in this list can run (allowlist). Non-matching servers are blocked.',
         showInDialog: false,
         items: { type: 'string' },
       },
@@ -1112,7 +1113,8 @@ const SETTINGS_SCHEMA = {
         category: 'MCP',
         requiresRestart: true,
         default: undefined as string[] | undefined,
-        description: 'A list of MCP servers to exclude.',
+        description:
+          'A list of excluded MCP servers. Servers in this list are blocked even if allowed by other rules (blocklist).',
         showInDialog: false,
         items: { type: 'string' },
       },
@@ -1121,9 +1123,9 @@ const SETTINGS_SCHEMA = {
         label: 'Disabled MCP Servers',
         category: 'MCP',
         requiresRestart: false,
-        default: [] as string[],
+        default: [],
         description:
-          'List of MCP server names that are disabled. Disabled servers will not connect until re-enabled.',
+          'List of MCP server names that are disabled by the user (e.g. via /mcp disable). Disabled servers are not blocked, just turned off, and can be re-enabled.',
         showInDialog: false,
         items: { type: 'string' },
         mergeStrategy: MergeStrategy.UNION,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1116,6 +1116,18 @@ const SETTINGS_SCHEMA = {
         showInDialog: false,
         items: { type: 'string' },
       },
+      disabled: {
+        type: 'array',
+        label: 'Disabled MCP Servers',
+        category: 'MCP',
+        requiresRestart: false,
+        default: [] as string[],
+        description:
+          'List of MCP server names that are disabled. Disabled servers will not connect until re-enabled.',
+        showInDialog: false,
+        items: { type: 'string' },
+        mergeStrategy: MergeStrategy.UNION,
+      },
     },
   },
   useSmartEdit: {

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -71,6 +71,8 @@ export const handleSlashCommand = async (
         session: {
           stats: sessionStats,
           sessionShellAllowlist: new Set(),
+          sessionMountedMcpServers: new Set(),
+          sessionUnmountedMcpServers: new Set(),
         },
         invocation: {
           raw: trimmed,

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -73,6 +73,8 @@ export const handleSlashCommand = async (
           sessionShellAllowlist: new Set(),
           sessionMountedMcpServers: new Set(),
           sessionUnmountedMcpServers: new Set(),
+          setSessionMountedMcpServers: () => {},
+          setSessionUnmountedMcpServers: () => {},
         },
         invocation: {
           raw: trimmed,

--- a/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
@@ -82,6 +82,8 @@ describe('ShellProcessor', () => {
       },
       session: {
         sessionShellAllowlist: new Set(),
+        sessionMountedMcpServers: new Set(),
+        sessionUnmountedMcpServers: new Set(),
       },
     });
 

--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -56,12 +56,15 @@ export const createMockCommandContext = (
       toggleVimEnabled: vi.fn(),
       extensionsUpdateState: new Map(),
       setExtensionsUpdateState: vi.fn(),
+      reloadCommands: vi.fn(),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
     session: {
       sessionShellAllowlist: new Set<string>(),
       sessionMountedMcpServers: new Set<string>(),
       sessionUnmountedMcpServers: new Set<string>(),
+      setSessionMountedMcpServers: vi.fn(),
+      setSessionUnmountedMcpServers: vi.fn(),
       stats: {
         sessionStartTime: new Date(),
         lastPromptTokenCount: 0,

--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -60,6 +60,8 @@ export const createMockCommandContext = (
     } as any,
     session: {
       sessionShellAllowlist: new Set<string>(),
+      sessionMountedMcpServers: new Set<string>(),
+      sessionUnmountedMcpServers: new Set<string>(),
       stats: {
         sessionStartTime: new Date(),
         lastPromptTokenCount: 0,

--- a/packages/cli/src/ui/commands/mcpCommand.test.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.test.ts
@@ -21,9 +21,9 @@ import { MessageType } from '../types.js';
 
 // Define a type for the mocked parts of McpClientManager
 type MockMcpClientManager = {
-  getMcpServers: ReturnType<typeof vi.fn<[], Record<string, unknown>>>;
-  getAllMcpServerNames: ReturnType<typeof vi.fn<[], string[]>>;
-  getBlockedMcpServers: ReturnType<typeof vi.fn<[], Array<{ name: string }>>>;
+  getMcpServers: ReturnType<typeof vi.fn>;
+  getAllMcpServerNames: ReturnType<typeof vi.fn>;
+  getBlockedMcpServers: ReturnType<typeof vi.fn>;
   getServerConfig: ReturnType<typeof vi.fn>;
   disconnectServer: ReturnType<typeof vi.fn>;
   maybeDiscoverMcpServer: ReturnType<typeof vi.fn>;
@@ -214,7 +214,8 @@ describe('mcpCommand', () => {
         },
         setValue: vi.fn(),
       };
-      mockContext.services.settings = mockSettings;
+      mockContext.services.settings =
+        mockSettings as unknown as typeof mockContext.services.settings;
     });
 
     describe('enableAction', () => {

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -451,10 +451,11 @@ async function enableAction(
     let wasRemoved = false;
 
     // Check and remove from Workspace scope
-    const workspaceDisabled = settings.workspace.settings.mcp?.disabled || [];
+    const workspaceDisabled: string[] =
+      settings.workspace.settings.mcp?.disabled || [];
     if (workspaceDisabled.includes(serverName)) {
       const newWorkspaceDisabled = workspaceDisabled.filter(
-        (name: string) => name !== serverName,
+        (name) => name !== serverName,
       );
       settings.setValue(
         SettingScope.Workspace,
@@ -465,10 +466,10 @@ async function enableAction(
     }
 
     // Check and remove from User scope
-    const userDisabled = settings.user.settings.mcp?.disabled || [];
+    const userDisabled: string[] = settings.user.settings.mcp?.disabled || [];
     if (userDisabled.includes(serverName)) {
       const newUserDisabled = userDisabled.filter(
-        (name: string) => name !== serverName,
+        (name) => name !== serverName,
       );
       settings.setValue(SettingScope.User, 'mcp.disabled', newUserDisabled);
       wasRemoved = true;

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -571,10 +571,10 @@ async function disableAction(
 
   // Get current disabled servers from settings
   const settings = context.services.settings;
-  const disabledServers: string[] = settings.merged.mcp?.disabled || [];
+  const mergedDisabled: string[] = settings.merged.mcp?.disabled || [];
 
   // Check if already disabled
-  if (disabledServers.includes(serverName)) {
+  if (mergedDisabled.includes(serverName)) {
     return {
       type: 'message',
       messageType: 'info',
@@ -583,8 +583,9 @@ async function disableAction(
   }
 
   try {
-    // Add to disabled list
-    const newDisabledServers = [...disabledServers, serverName];
+    // Add to disabled list (use user-scope list to avoid copying workspace settings)
+    const userDisabled: string[] = settings.user.settings.mcp?.disabled || [];
+    const newDisabledServers = [...userDisabled, serverName];
 
     // Update settings (persists to file)
     settings.setValue(SettingScope.User, 'mcp.disabled', newDisabledServers);

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -88,11 +88,11 @@ export interface CommandContext {
     /** MCP servers temporarily unmounted for this session (overrides enabled state). */
     sessionUnmountedMcpServers: Set<string>;
     /** Updates the set of mounted MCP servers for this session. */
-    setSessionMountedMcpServers?: (
+    setSessionMountedMcpServers: (
       updater: (prev: Set<string>) => Set<string>,
     ) => void;
     /** Updates the set of unmounted MCP servers for this session. */
-    setSessionUnmountedMcpServers?: (
+    setSessionUnmountedMcpServers: (
       updater: (prev: Set<string>) => Set<string>,
     ) => void;
   };

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -83,6 +83,18 @@ export interface CommandContext {
     stats: SessionStatsState;
     /** A transient list of shell commands the user has approved for this session. */
     sessionShellAllowlist: Set<string>;
+    /** MCP servers temporarily mounted for this session (overrides disabled state). */
+    sessionMountedMcpServers: Set<string>;
+    /** MCP servers temporarily unmounted for this session (overrides enabled state). */
+    sessionUnmountedMcpServers: Set<string>;
+    /** Updates the set of mounted MCP servers for this session. */
+    setSessionMountedMcpServers?: (
+      updater: (prev: Set<string>) => Set<string>,
+    ) => void;
+    /** Updates the set of unmounted MCP servers for this session. */
+    setSessionUnmountedMcpServers?: (
+      updater: (prev: Set<string>) => Set<string>,
+    ) => void;
   };
   // Flag to indicate if an overwrite has been confirmed
   overwriteConfirmed?: boolean;

--- a/packages/cli/src/ui/components/views/McpStatus.test.tsx
+++ b/packages/cli/src/ui/components/views/McpStatus.test.tsx
@@ -38,6 +38,9 @@ describe('McpStatus', () => {
     prompts: [],
     resources: [],
     blockedServers: [],
+    disabledServers: [],
+    sessionMountedServers: [],
+    sessionUnmountedServers: [],
     serverStatus: () => MCPServerStatus.CONNECTED,
     authStatus: {},
     discoveryInProgress: false,
@@ -180,6 +183,25 @@ describe('McpStatus', () => {
   it('renders correctly with a connecting server', () => {
     const { lastFrame, unmount } = render(
       <McpStatus {...baseProps} connectingServers={['server-1']} />,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+    unmount();
+  });
+
+  it('renders correctly with disabled servers', () => {
+    const { lastFrame, unmount } = render(
+      <McpStatus {...baseProps} disabledServers={['disabled-server']} />,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+    unmount();
+  });
+
+  it('renders correctly with session unmounted servers', () => {
+    const { lastFrame, unmount } = render(
+      <McpStatus
+        {...baseProps}
+        sessionUnmountedServers={['unmounted-server']}
+      />,
     );
     expect(lastFrame()).toMatchSnapshot();
     unmount();

--- a/packages/cli/src/ui/components/views/McpStatus.tsx
+++ b/packages/cli/src/ui/components/views/McpStatus.tsx
@@ -22,6 +22,9 @@ interface McpStatusProps {
   prompts: JsonMcpPrompt[];
   resources: JsonMcpResource[];
   blockedServers: Array<{ name: string; extensionName: string }>;
+  disabledServers: string[];
+  sessionMountedServers: string[];
+  sessionUnmountedServers: string[];
   serverStatus: (serverName: string) => MCPServerStatus;
   authStatus: HistoryItemMcpStatus['authStatus'];
   discoveryInProgress: boolean;
@@ -36,6 +39,9 @@ export const McpStatus: React.FC<McpStatusProps> = ({
   prompts,
   resources,
   blockedServers,
+  disabledServers,
+  sessionMountedServers,
+  sessionUnmountedServers,
   serverStatus,
   authStatus,
   discoveryInProgress,
@@ -45,7 +51,12 @@ export const McpStatus: React.FC<McpStatusProps> = ({
 }) => {
   const serverNames = Object.keys(servers);
 
-  if (serverNames.length === 0 && blockedServers.length === 0) {
+  if (
+    serverNames.length === 0 &&
+    blockedServers.length === 0 &&
+    disabledServers.length === 0 &&
+    sessionUnmountedServers.length === 0
+  ) {
     return (
       <Box flexDirection="column">
         <Text>No MCP servers configured.</Text>
@@ -159,6 +170,12 @@ export const McpStatus: React.FC<McpStatusProps> = ({
           );
         }
 
+        // Show session-mounted indicator for servers temporarily enabled this session
+        const isSessionMounted = sessionMountedServers.includes(serverName);
+        const sessionMountedNode = isSessionMounted ? (
+          <Text color={theme.text.secondary}> [session-mounted]</Text>
+        ) : null;
+
         return (
           <Box key={serverName} flexDirection="column" marginBottom={1}>
             <Box>
@@ -172,6 +189,7 @@ export const McpStatus: React.FC<McpStatusProps> = ({
                   ` (${parts.join(', ')})`}
               </Text>
               {authStatusNode}
+              {sessionMountedNode}
             </Box>
             {status === MCPServerStatus.CONNECTING && (
               <Text> (tools and prompts will appear when ready)</Text>
@@ -289,6 +307,41 @@ export const McpStatus: React.FC<McpStatusProps> = ({
           <Text> - Blocked</Text>
         </Box>
       ))}
+
+      {disabledServers.length > 0 && (
+        <>
+          <Box height={1} />
+          <Text bold color={theme.text.secondary}>
+            Disabled servers (use /mcp enable to re-enable):
+          </Text>
+          {disabledServers.map((serverName) => (
+            <Box key={serverName} marginBottom={1}>
+              <Text color={theme.status.warning}>⏸️ </Text>
+              <Text bold>{serverName}</Text>
+              <Text color={theme.text.secondary}> - Disabled</Text>
+            </Box>
+          ))}
+        </>
+      )}
+
+      {sessionUnmountedServers.length > 0 && (
+        <>
+          <Box height={1} />
+          <Text bold color={theme.text.secondary}>
+            Session unmounted servers (use /mcp mount to reconnect):
+          </Text>
+          {sessionUnmountedServers.map((serverName) => (
+            <Box key={serverName} marginBottom={1}>
+              <Text color={theme.text.secondary}>⏸️ </Text>
+              <Text bold>{serverName}</Text>
+              <Text color={theme.text.secondary}>
+                {' '}
+                - Unmounted (this session)
+              </Text>
+            </Box>
+          ))}
+        </>
+      )}
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/views/__snapshots__/McpStatus.test.tsx.snap
+++ b/packages/cli/src/ui/components/views/__snapshots__/McpStatus.test.tsx.snap
@@ -71,6 +71,21 @@ A test server
 "
 `;
 
+exports[`McpStatus > renders correctly with disabled servers 1`] = `
+"Configured MCP servers:
+
+🟢 server-1 - Ready (1 tool)
+A test server
+  Tools:
+  - tool-1
+    A test tool
+
+
+Disabled servers (use /mcp enable to re-enable):
+⏸️ disabled-server - Disabled
+"
+`;
+
 exports[`McpStatus > renders correctly with expired OAuth status 1`] = `
 "Configured MCP servers:
 
@@ -147,6 +162,21 @@ A test server
           }
         }
       }
+"
+`;
+
+exports[`McpStatus > renders correctly with session unmounted servers 1`] = `
+"Configured MCP servers:
+
+🟢 server-1 - Ready (1 tool)
+A test server
+  Tools:
+  - tool-1
+    A test tool
+
+
+Session unmounted servers (use /mcp mount to reconnect):
+⏸️ unmounted-server - Unmounted (this session)
 "
 `;
 

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -107,6 +107,12 @@ export const useSlashCommandProcessor = (
   const [sessionShellAllowlist, setSessionShellAllowlist] = useState(
     new Set<string>(),
   );
+  const [sessionMountedMcpServers, setSessionMountedMcpServers] = useState(
+    new Set<string>(),
+  );
+  const [sessionUnmountedMcpServers, setSessionUnmountedMcpServers] = useState(
+    new Set<string>(),
+  );
   const gitService = useMemo(() => {
     if (!config?.getProjectRoot()) {
       return;
@@ -224,6 +230,10 @@ export const useSlashCommandProcessor = (
       session: {
         stats: session.stats,
         sessionShellAllowlist,
+        sessionMountedMcpServers,
+        sessionUnmountedMcpServers,
+        setSessionMountedMcpServers,
+        setSessionUnmountedMcpServers,
       },
     }),
     [
@@ -242,12 +252,27 @@ export const useSlashCommandProcessor = (
       setPendingItem,
       toggleVimEnabled,
       sessionShellAllowlist,
+      sessionMountedMcpServers,
+      sessionUnmountedMcpServers,
+      setSessionMountedMcpServers,
+      setSessionUnmountedMcpServers,
       reloadCommands,
       extensionsUpdateState,
       setBannerVisible,
       setCustomDialog,
     ],
   );
+
+  // Wire up session MCP callbacks so McpClientManager can check session state
+  useEffect(() => {
+    if (!config) {
+      return;
+    }
+    config.setSessionMcpCallbacks({
+      getSessionMounted: () => Array.from(sessionMountedMcpServers),
+      getSessionUnmounted: () => Array.from(sessionUnmountedMcpServers),
+    });
+  }, [config, sessionMountedMcpServers, sessionUnmountedMcpServers]);
 
   useEffect(() => {
     if (!config) {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useMemo, useEffect, useState } from 'react';
+import { useCallback, useMemo, useEffect, useState, useRef } from 'react';
 import { type PartListUnion } from '@google/genai';
 import process from 'node:process';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
@@ -263,16 +263,28 @@ export const useSlashCommandProcessor = (
     ],
   );
 
+  const sessionMountedMcpServersRef = useRef(sessionMountedMcpServers);
+  const sessionUnmountedMcpServersRef = useRef(sessionUnmountedMcpServers);
+
+  useEffect(() => {
+    sessionMountedMcpServersRef.current = sessionMountedMcpServers;
+  }, [sessionMountedMcpServers]);
+
+  useEffect(() => {
+    sessionUnmountedMcpServersRef.current = sessionUnmountedMcpServers;
+  }, [sessionUnmountedMcpServers]);
+
   // Wire up session MCP callbacks so McpClientManager can check session state
   useEffect(() => {
     if (!config) {
       return;
     }
     config.setSessionMcpCallbacks({
-      getSessionMounted: () => Array.from(sessionMountedMcpServers),
-      getSessionUnmounted: () => Array.from(sessionUnmountedMcpServers),
+      getSessionMounted: () => Array.from(sessionMountedMcpServersRef.current),
+      getSessionUnmounted: () =>
+        Array.from(sessionUnmountedMcpServersRef.current),
     });
-  }, [config, sessionMountedMcpServers, sessionUnmountedMcpServers]);
+  }, [config]);
 
   useEffect(() => {
     if (!config) {

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -243,6 +243,12 @@ export type HistoryItemMcpStatus = HistoryItemBase & {
     'authenticated' | 'expired' | 'unauthenticated' | 'not-configured'
   >;
   blockedServers: Array<{ name: string; extensionName: string }>;
+  /** Servers that are disabled (persistent - saved to settings) */
+  disabledServers: string[];
+  /** Servers that are mounted for this session only (overrides disabled) */
+  sessionMountedServers: string[];
+  /** Servers that are unmounted for this session only */
+  sessionUnmountedServers: string[];
   discoveryInProgress: boolean;
   connectingServers: string[];
   showDescriptions: boolean;

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -53,6 +53,9 @@ describe('McpClientManager', () => {
       getGeminiClient: vi.fn().mockReturnValue({
         isInitialized: vi.fn(),
       }),
+      getDisabledMcpServers: vi.fn().mockReturnValue([]),
+      getSessionMountedMcpServers: vi.fn().mockReturnValue([]),
+      getSessionUnmountedMcpServers: vi.fn().mockReturnValue([]),
     } as unknown as Config);
     toolRegistry = {} as ToolRegistry;
   });

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -152,6 +152,23 @@ export class McpClientManager {
     return this.knownServerConfigs;
   }
 
+  /**
+   * Returns all known MCP server names from configured, connected, and previously discovered sources.
+   */
+  getAllMcpServerNames(): string[] {
+    const configuredServers = this.cliConfig.getMcpServers() || {};
+    const connectedServers = this.getMcpServers(); // Note: This only returns *connected* server configs
+    const knownServers = this.getAllKnownServerConfigs();
+
+    const allServerNames = new Set([
+      ...Object.keys(configuredServers),
+      ...Object.keys(connectedServers),
+      ...knownServers.keys(),
+    ]);
+
+    return Array.from(allServerNames);
+  }
+
   private async disconnectClient(name: string) {
     const existing = this.clients.get(name);
     if (existing) {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1110,8 +1110,8 @@
         },
         "allowed": {
           "title": "Allow MCP Servers",
-          "description": "A list of MCP servers to allow.",
-          "markdownDescription": "A list of MCP servers to allow.\n\n- Category: `MCP`\n- Requires restart: `yes`",
+          "description": "A list of allowed MCP servers. If set, only servers in this list can run (allowlist). Non-matching servers are blocked.",
+          "markdownDescription": "A list of allowed MCP servers. If set, only servers in this list can run (allowlist). Non-matching servers are blocked.\n\n- Category: `MCP`\n- Requires restart: `yes`",
           "type": "array",
           "items": {
             "type": "string"
@@ -1119,8 +1119,18 @@
         },
         "excluded": {
           "title": "Exclude MCP Servers",
-          "description": "A list of MCP servers to exclude.",
-          "markdownDescription": "A list of MCP servers to exclude.\n\n- Category: `MCP`\n- Requires restart: `yes`",
+          "description": "A list of excluded MCP servers. Servers in this list are blocked even if allowed by other rules (blocklist).",
+          "markdownDescription": "A list of excluded MCP servers. Servers in this list are blocked even if allowed by other rules (blocklist).\n\n- Category: `MCP`\n- Requires restart: `yes`",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "disabled": {
+          "title": "Disabled MCP Servers",
+          "description": "List of MCP server names that are disabled by the user (e.g. via /mcp disable). Disabled servers are not blocked, just turned off, and can be re-enabled.",
+          "markdownDescription": "List of MCP server names that are disabled by the user (e.g. via /mcp disable). Disabled servers are not blocked, just turned off, and can be re-enabled.\n\n- Category: `MCP`\n- Requires restart: `no`\n- Default: `[]`",
+          "default": [],
           "type": "array",
           "items": {
             "type": "string"


### PR DESCRIPTION
## Summary

Add commands to enable/disable MCP servers persistently and mount/unmount them for the current session only. This gives users control over which servers connect automatically vs on-demand, helping reduce context bloat.

## Details

- `/mcp enable <server>` and `/mcp disable <server>` - persistent control saved to `mcp.disabled` in settings
- `/mcp mount <server>` and `/mcp unmount <server>` - session-only overrides that reset on restart
- `/mcp` status now shows disabled and session-unmounted servers in separate sections
- `enable` correctly handles servers disabled in multiple scopes (User + Workspace)
- `disable` writes only to User scope to avoid copying Workspace settings

## Related Issues

Closes #14472

## How to Validate

1. Configure an MCP server in settings
2. Run `/mcp` - server should show as connected
3. Run `/mcp disable <server>` - server disconnects, appears in "Disabled servers" section
4. Restart app - server stays disabled
5. Run `/mcp enable <server>` - server reconnects
6. Run `/mcp unmount <server>` - server disconnects, appears in "Session unmounted" section
7. Restart app - server reconnects (unmount was session-only)

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker

