### PR TITLE
feat: deprecate legacy codebase investigator settings

### DIFF
--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -15,6 +15,7 @@ import {
   PREVIEW_GEMINI_MODEL,
 } from '../config/models.js';
 import type { ModelConfigAlias } from '../services/modelConfigService.js';
+import { coreEvents } from '../utils/events.js';
 
 /**
  * Returns the model config alias for a given agent definition.
@@ -71,7 +72,14 @@ export class AgentRegistry {
       model = investigatorSettings.model;
       thinkingBudget = investigatorSettings.thinkingBudget;
       maxTimeMinutes = investigatorSettings.maxTimeMinutes;
-      maxTurns = investigatorSettings.maxNumTurns;
+      maxTurns = investigatorSettings.maxNumTurns; // Note legacy property name
+
+      if (this.config.hasExplicitLegacyCodebaseInvestigatorSettings) {
+        coreEvents.emitFeedback(
+          'warning',
+          'The `experimental.codebaseInvestigatorSettings` configuration is deprecated and will be removed in v0.24.0. Please update your `settings.json` to use the new `agents.codebase_investigator` configuration instead.',
+        );
+      }
     }
 
     if (!isEnabled) {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -459,6 +459,7 @@ export class Config {
   private readonly experimentalJitContext: boolean;
   private contextManager?: ContextManager;
   readonly agents: Record<string, AgentConfig>;
+  readonly hasExplicitLegacyCodebaseInvestigatorSettings: boolean;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -608,6 +609,8 @@ export class Config {
     this.hooks = params.hooks;
     this.experiments = params.experiments;
     this.agents = params.agents ?? {};
+    this.hasExplicitLegacyCodebaseInvestigatorSettings =
+      !!params.codebaseInvestigatorSettings;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);


### PR DESCRIPTION
## Summary

Adds a deprecation warning when `experimental.codebaseInvestigatorSettings` is used in configuration.

## Details

- Adds `hasExplicitLegacyCodebaseInvestigatorSettings` to `Config` to track if legacy settings were explicitly provided.
- Updates `AgentRegistry` to emit a warning via `coreEvents` when legacy settings are detected (and not overridden by new settings).
- Warning includes removal target version (v0.24.0).

## Validation

1. Configure only `experimental.codebaseInvestigatorSettings` in `settings.json`.
2. Run the CLI.
3. Verify a warning message appears.
4. Configure `agents.codebase_investigator`.
5. Verify no warning message appears.