### PR TITLE
feat: attempt more error parsing

### DIFF
--- a/packages/core/src/utils/googleErrors.test.ts
+++ b/packages/core/src/utils/googleErrors.test.ts
@@ -94,7 +94,12 @@ describe('parseGoogleApiError', () => {
         },
       },
     };
-    expect(parseGoogleApiError(mockError)).toBeNull();
+
+    expect(parseGoogleApiError(mockError)).toEqual({
+      code: 400,
+      message: 'Bad Request',
+      details: [],
+    });
   });
 
   it('should return null if there are no valid details', () => {
@@ -115,7 +120,11 @@ describe('parseGoogleApiError', () => {
         },
       },
     };
-    expect(parseGoogleApiError(mockError)).toBeNull();
+    expect(parseGoogleApiError(mockError)).toEqual({
+      code: 400,
+      message: 'Bad Request',
+      details: [],
+    });
   });
 
   it('should parse a doubly nested error in the message', () => {


### PR DESCRIPTION
## Summary

Attempts to parse error by looking for { }. This allows us to parse ModelNotFound Errors from Gemini API. 

## Related Issues

Fixes: https://github.com/google-gemini/maintainers-gemini-cli/issues/1130

## How to Validate

Login with Gemini API Key. Set model with -m not_exist. Say "hi"

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
