### PR TITLE
fix: rename tmp directory to data for saved chats - Fixes #14896

### DIFF
--- a/docs/cli/checkpointing.md
+++ b/docs/cli/checkpointing.md
@@ -33,7 +33,7 @@ All checkpoint data, including the Git snapshot and conversation history, is
 stored locally on your machine. The Git snapshot is stored in the shadow
 repository while the conversation history and tool calls are saved in a JSON
 file in your project's temporary directory, typically located at
-`~/.gemini/tmp/<project_hash>/checkpoints`.
+`~/.gemini/data/<project_hash>/checkpoints`.
 
 ## Enabling the feature
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -28,7 +28,7 @@ Slash commands provide meta-level control over the CLI itself.
       - **Usage:** `/chat save <tag>`
       - **Details on checkpoint location:** The default locations for saved chat
         checkpoints are:
-        - Linux/macOS: `~/.gemini/tmp/<project_hash>/`
+        - Linux/macOS: `~/.gemini/data/<project_hash>/`
         - Windows: `C:\Users\<YourUsername>\.gemini\tmp\<project_hash>\`
         - **Behavior:** Chats are saved into a project-specific directory,
           determined by where you run the CLI. Consequently, saved chats are

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -29,7 +29,7 @@ Slash commands provide meta-level control over the CLI itself.
       - **Details on checkpoint location:** The default locations for saved chat
         checkpoints are:
         - Linux/macOS: `~/.gemini/data/<project_hash>/`
-        - Windows: `C:\Users\<YourUsername>\.gemini\tmp\<project_hash>\`
+        - Windows: `C:\Users\<YourUsername>\.gemini\data\<project_hash>\`
         - **Behavior:** Chats are saved into a project-specific directory,
           determined by where you run the CLI. Consequently, saved chats are
           only accessible when working within that same project.

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -429,7 +429,7 @@ The CLI keeps a history of shell commands you run. To avoid conflicts between
 different projects, this history is stored in a project-specific directory
 within your user's home folder.
 
-- **Location:** `~/.gemini/tmp/<project_hash>/shell_history`
+- **Location:** `~/.gemini/data/<project_hash>/shell_history`
   - `<project_hash>` is a unique identifier generated from your project's root
     path.
   - The history is stored in a file named `shell_history`.

--- a/docs/cli/session-management.md
+++ b/docs/cli/session-management.md
@@ -15,7 +15,7 @@ This happens in the background without any manual intervention.
   - All tool executions (inputs and outputs).
   - Token usage statistics (input/output/cached, etc.).
   - Assistant thoughts/reasoning summaries (when available).
-- **Location:** Sessions are stored in `~/.gemini/tmp/<project_hash>/chats/`.
+- **Location:** Sessions are stored in `~/.gemini/data/<project_hash>/chats/`.
 - **Scope:** Sessions are project-specific. Switching directories to a different
   project will switch to that project's session history.
 

--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -202,7 +202,8 @@ forward data to Google Cloud.
    - Start a local OTEL collector that forwards to Google Cloud
    - Configure your workspace
    - Provide links to view traces, metrics, and logs in Google Cloud Console
-   - Save collector logs to `~/.gemini/tmp/<projectHash>/otel/collector-gcp.log`
+   - Save collector logs to
+     `~/.gemini/data/<projectHash>/otel/collector-gcp.log`
    - Stop collector on exit (e.g. `Ctrl+C`)
 3. Run Gemini CLI and send prompts.
 4. View logs and metrics:
@@ -210,7 +211,7 @@ forward data to Google Cloud.
      - Logs: https://console.cloud.google.com/logs/
      - Metrics: https://console.cloud.google.com/monitoring/metrics-explorer
      - Traces: https://console.cloud.google.com/traces/list
-   - Open `~/.gemini/tmp/<projectHash>/otel/collector-gcp.log` to view local
+   - Open `~/.gemini/data/<projectHash>/otel/collector-gcp.log` to view local
      collector logs.
 
 ## Local telemetry
@@ -243,7 +244,7 @@ For local development and debugging, you can capture telemetry data locally:
    - Download and start Jaeger and OTEL collector
    - Configure your workspace for local telemetry
    - Provide a Jaeger UI at http://localhost:16686
-   - Save logs/metrics to `~/.gemini/tmp/<projectHash>/otel/collector.log`
+   - Save logs/metrics to `~/.gemini/data/<projectHash>/otel/collector.log`
    - Stop collector on exit (e.g. `Ctrl+C`)
 2. Run Gemini CLI and send prompts.
 3. View traces at http://localhost:16686 and logs/metrics in the collector log

--- a/docs/get-started/configuration-v1.md
+++ b/docs/get-started/configuration-v1.md
@@ -544,7 +544,7 @@ The CLI keeps a history of shell commands you run. To avoid conflicts between
 different projects, this history is stored in a project-specific directory
 within your user's home folder.
 
-- **Location:** `~/.gemini/tmp/<project_hash>/shell_history`
+- **Location:** `~/.gemini/data/<project_hash>/shell_history`
   - `<project_hash>` is a unique identifier generated from your project's root
     path.
   - The history is stored in a file named `shell_history`.

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -1021,7 +1021,7 @@ The CLI keeps a history of shell commands you run. To avoid conflicts between
 different projects, this history is stored in a project-specific directory
 within your user's home folder.
 
-- **Location:** `~/.gemini/tmp/<project_hash>/shell_history`
+- **Location:** `~/.gemini/data/<project_hash>/shell_history`
   - `<project_hash>` is a unique identifier generated from your project's root
     path.
   - The history is stored in a file named `shell_history`.

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -222,7 +222,7 @@ export async function runNonInteractive({
           settings,
         );
         // If a slash command is found and returns a prompt, use it.
-        // Otherwise, slashCommandResult fall through to the default prompt
+        // Otherwise, slashCommandResult falls through to the default prompt
         // handling.
         if (slashCommandResult) {
           query = slashCommandResult as Part[];

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -55,7 +55,7 @@ describe('Storage – additional helpers', () => {
   });
 
   it('getGlobalBinDir returns ~/.gemini/tmp/bin', () => {
-    const expected = path.join(os.homedir(), GEMINI_DIR, 'tmp', 'bin');
+    const expected = path.join(os.homedir(), GEMINI_DIR, 'data', 'bin');
     expect(Storage.getGlobalBinDir()).toBe(expected);
   });
 });

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -54,7 +54,7 @@ describe('Storage – additional helpers', () => {
     expect(Storage.getMcpOAuthTokensPath()).toBe(expected);
   });
 
-  it('getGlobalBinDir returns ~/.gemini/tmp/bin', () => {
+  it('getGlobalBinDir returns ~/.gemini/data/bin', () => {
     const expected = path.join(os.homedir(), GEMINI_DIR, 'data', 'bin');
     expect(Storage.getGlobalBinDir()).toBe(expected);
   });

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -12,7 +12,7 @@ import { GEMINI_DIR } from '../utils/paths.js';
 
 export const GOOGLE_ACCOUNTS_FILENAME = 'google_accounts.json';
 export const OAUTH_FILE = 'oauth_creds.json';
-const TMP_DIR_NAME = 'tmp';
+const TMP_DIR_NAME = 'data';
 const BIN_DIR_NAME = 'bin';
 
 export class Storage {

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -14,6 +14,7 @@ export const GOOGLE_ACCOUNTS_FILENAME = 'google_accounts.json';
 export const OAUTH_FILE = 'oauth_creds.json';
 const TMP_DIR_NAME = 'data';
 const BIN_DIR_NAME = 'bin';
+const OLD_DIR_NAME = 'tmp';
 
 export class Storage {
   private readonly targetDir: string;
@@ -137,5 +138,14 @@ export class Storage {
 
   getHistoryFilePath(): string {
     return path.join(this.getProjectTempDir(), 'shell_history');
+  }
+}
+export function migrateStorage(): void {
+  const baseDir = Storage.getGlobalGeminiDir();
+  const oldPath = path.join(baseDir, OLD_DIR_NAME);
+  const newPath = path.join(baseDir, TMP_DIR_NAME);
+
+  if (fs.existsSync(oldPath) && !fs.existsSync(newPath)) {
+    fs.renameSync(oldPath, newPath);
   }
 }


### PR DESCRIPTION
## Summary
Fixes #14896

## Changes
- Renamed `TMP_DIR_NAME` from `'tmp'` to `'data'` in `storage.ts`
- Updated `storage.test.ts` to match
- Updated all documentation references (7 files)

## Why
The `tmp` directory name was confusing as it suggested temporary/volatile storage, which could lead to accidental deletion of valuable saved chats.
