### PR TITLE
Add missing await.

### DIFF
--- a/packages/cli/src/config/extensions/extensionSettings.ts
+++ b/packages/cli/src/config/extensions/extensionSettings.ts
@@ -289,7 +289,7 @@ async function clearSettings(
   if (fsSync.existsSync(envFilePath)) {
     await fs.writeFile(envFilePath, '');
   }
-  if (!keychain.isAvailable()) {
+  if (!(await keychain.isAvailable())) {
     return;
   }
   const secrets = await keychain.listSecrets();


### PR DESCRIPTION
## Summary

Adds an await to clearSettings() function's `keychain.isAvailable()` branch. Previously, this code was inadvertently checking the truthiness of the returned promise instead of the underlying boolean resulting in it never being run.

I discovered this while trying to enable various eslint promise correctness rules. I am not sure there is user visible misbehavior but it looks as though it might cause an error to bubble up to the user when there is no keychain available.

As a follow up, we should enable a broader set of eslint rules to prevent similar pitfalls.

## How to Validate

Run the provided unit test before and after the change.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
