### PR TITLE
feat: reset availabilityService on /auth

### DIFF
--- a/packages/core/src/availability/modelAvailabilityService.ts
+++ b/packages/core/src/availability/modelAvailabilityService.ts
@@ -123,6 +123,10 @@ export class ModelAvailabilityService {
     }
   }
 
+  reset() {
+    this.health.clear();
+  }
+
   private setState(model: ModelId, nextState: HealthState) {
     this.health.set(model, nextState);
   }

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -351,6 +351,21 @@ describe('Server Config (config.ts)', () => {
       expect(config.isInFallbackMode()).toBe(false);
     });
 
+    it('should reset model availability status', async () => {
+      const config = new Config(baseParams);
+      const service = config.getModelAvailabilityService();
+      const spy = vi.spyOn(service, 'reset');
+
+      vi.mocked(createContentGeneratorConfig).mockImplementation(
+        async (_: Config, authType: AuthType | undefined) =>
+          ({ authType }) as unknown as ContentGeneratorConfig,
+      );
+
+      await config.refreshAuth(AuthType.USE_GEMINI);
+
+      expect(spy).toHaveBeenCalled();
+    });
+
     it('should strip thoughts when switching from GenAI to Vertex', async () => {
       const config = new Config(baseParams);
 
@@ -1512,6 +1527,9 @@ describe('Config getHooks', () => {
   describe('setModel', () => {
     it('should allow setting a pro (any) model and disable fallback mode', () => {
       const config = new Config(baseParams);
+      const service = config.getModelAvailabilityService();
+      const spy = vi.spyOn(service, 'reset');
+
       config.setFallbackMode(true);
       expect(config.isInFallbackMode()).toBe(true);
 
@@ -1521,10 +1539,14 @@ describe('Config getHooks', () => {
       expect(config.getModel()).toBe(proModel);
       expect(config.isInFallbackMode()).toBe(false);
       expect(mockCoreEvents.emitModelChanged).toHaveBeenCalledWith(proModel);
+      expect(spy).toHaveBeenCalled();
     });
 
     it('should allow setting auto model from non-auto model and disable fallback mode', () => {
       const config = new Config(baseParams);
+      const service = config.getModelAvailabilityService();
+      const spy = vi.spyOn(service, 'reset');
+
       config.setFallbackMode(true);
       expect(config.isInFallbackMode()).toBe(true);
 
@@ -1533,6 +1555,7 @@ describe('Config getHooks', () => {
       expect(config.getModel()).toBe('auto');
       expect(config.isInFallbackMode()).toBe(false);
       expect(mockCoreEvents.emitModelChanged).toHaveBeenCalledWith('auto');
+      expect(spy).toHaveBeenCalled();
     });
 
     it('should allow setting auto model from auto model if it is in the fallback mode', () => {
@@ -1544,6 +1567,9 @@ describe('Config getHooks', () => {
         model: 'auto',
         usageStatisticsEnabled: false,
       });
+      const service = config.getModelAvailabilityService();
+      const spy = vi.spyOn(service, 'reset');
+
       config.setFallbackMode(true);
       expect(config.isInFallbackMode()).toBe(true);
 
@@ -1552,6 +1578,7 @@ describe('Config getHooks', () => {
       expect(config.getModel()).toBe('auto');
       expect(config.isInFallbackMode()).toBe(false);
       expect(mockCoreEvents.emitModelChanged).toHaveBeenCalledWith('auto');
+      expect(spy).toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -702,6 +702,9 @@ export class Config {
   }
 
   async refreshAuth(authMethod: AuthType) {
+    // Reset availability service when switching auth
+    this.modelAvailabilityService.reset();
+
     // Vertex and Genai have incompatible encryption and sending history with
     // thoughtSignature from Genai to Vertex will fail, we need to strip them
     if (
@@ -827,6 +830,7 @@ export class Config {
       coreEvents.emitModelChanged(newModel);
     }
     this.setFallbackMode(false);
+    this.modelAvailabilityService.reset();
   }
 
   getActiveModel(): string {


### PR DESCRIPTION
## Summary

Reset availabilityService when user selects /auth

## Related Issues

Fixes: https://github.com/google-gemini/maintainers-gemini-cli/issues/1133

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
