### PR TITLE
chore(docs): add 'Maintainers only' label info to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ This project follows
 
 The process for contributing code is as follows:
 
-1.  **Find an issue** that you want to work on. If an issue is flagged as
+1.  **Find an issue** that you want to work on. If an issue is tagged as
     "🔒Maintainers only", this means it is reserved for project maintainers. We
     will not accept pull requests related to these issues.
 2.  **Fork the repository** and create a new branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,9 @@ This project follows
 
 The process for contributing code is as follows:
 
-1.  **Find an issue** that you want to work on.
+1.  **Find an issue** that you want to work on. If an issue is flagged as
+    "🔒Maintainers only", this means it is reserved for project maintainers. We
+    will not accept pull requests related to these issues.
 2.  **Fork the repository** and create a new branch.
 3.  **Make your changes** in the `packages/` directory.
 4.  **Ensure all checks pass** by running `npm run preflight`.

--- a/docs/issue-and-pr-automation.md
+++ b/docs/issue-and-pr-automation.md
@@ -14,6 +14,9 @@ feature), while the PR is the "how" (the implementation). This separation helps
 us track work, prioritize features, and maintain clear historical context. Our
 automation is built around this principle.
 
+> **Note:** Issues flagged as "🔒Maintainers only" are reserved for project
+> maintainers. We will not accept pull requests related to these issues.
+
 ---
 
 ## Detailed automation workflows

--- a/docs/issue-and-pr-automation.md
+++ b/docs/issue-and-pr-automation.md
@@ -14,7 +14,7 @@ feature), while the PR is the "how" (the implementation). This separation helps
 us track work, prioritize features, and maintain clear historical context. Our
 automation is built around this principle.
 
-> **Note:** Issues flagged as "🔒Maintainers only" are reserved for project
+> **Note:** Issues tagged as "🔒Maintainers only" are reserved for project
 > maintainers. We will not accept pull requests related to these issues.
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -154,5 +154,5 @@ guide_, consider searching the Gemini CLI
 If you can't find an issue similar to yours, consider creating a new GitHub
 Issue with a detailed description. Pull requests are also welcome!
 
-> **Note:** Issues flagged as "🔒Maintainers only" are reserved for project
+> **Note:** Issues tagged as "🔒Maintainers only" are reserved for project
 > maintainers. We will not accept pull requests related to these issues.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -153,3 +153,6 @@ guide_, consider searching the Gemini CLI
 [Issue tracker on GitHub](https://github.com/google-gemini/gemini-cli/issues).
 If you can't find an issue similar to yours, consider creating a new GitHub
 Issue with a detailed description. Pull requests are also welcome!
+
+> **Note:** Issues flagged as "🔒Maintainers only" are reserved for project
+> maintainers. We will not accept pull requests related to these issues.


### PR DESCRIPTION
## Summary

Add minimal documentation of the `🔒 Maintainers Only` label to CONTRIBUTING.md.

