### PR TITLE
fix(core): Use atomic writes for session files to prevent data loss on crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4507,6 +4507,16 @@
         "boxen": "^7.1.1"
       }
     },
+    "node_modules/@types/write-file-atomic": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/write-file-atomic/-/write-file-atomic-4.0.3.tgz",
+      "integrity": "sha512-qdo+vZRchyJIHNeuI1nrpsLw+hnkgqP/8mlaN6Wle/NKhydHmUN9l4p3ZE8yP90AJNJW4uB8HQhedb4f1vNayQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -10302,7 +10312,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -17396,6 +17405,19 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/write-file-atomic": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-6.0.0.tgz",
+      "integrity": "sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==",
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -18152,6 +18174,7 @@
         "tree-sitter-bash": "^0.25.0",
         "undici": "^7.10.0",
         "web-tree-sitter": "^0.25.10",
+        "write-file-atomic": "^6.0.0",
         "ws": "^8.18.0",
         "zod": "^3.25.76"
       },
@@ -18162,6 +18185,7 @@
         "@types/fast-levenshtein": "^0.0.4",
         "@types/minimatch": "^5.1.2",
         "@types/picomatch": "^4.0.1",
+        "@types/write-file-atomic": "^4.0.3",
         "@types/ws": "^8.5.10",
         "msw": "^2.3.4",
         "typescript": "^5.3.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,6 +66,7 @@
     "tree-sitter-bash": "^0.25.0",
     "undici": "^7.10.0",
     "web-tree-sitter": "^0.25.10",
+    "write-file-atomic": "^6.0.0",
     "ws": "^8.18.0",
     "zod": "^3.25.76"
   },
@@ -81,6 +82,7 @@
   "devDependencies": {
     "@google/gemini-cli-test-utils": "file:../test-utils",
     "@types/diff": "^7.0.2",
+    "@types/write-file-atomic": "^4.0.3",
     "@types/dotenv": "^6.1.1",
     "@types/fast-levenshtein": "^0.0.4",
     "@types/minimatch": "^5.1.2",

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -11,6 +11,7 @@ import { getProjectHash } from '../utils/paths.js';
 import path from 'node:path';
 import fs from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import writeFileAtomic from 'write-file-atomic';
 import type {
   PartListUnion,
   GenerateContentResponseUsageMetadata,
@@ -418,7 +419,9 @@ export class ChatRecordingService {
         conversation.lastUpdated = new Date().toISOString();
         const newContent = JSON.stringify(conversation, null, 2);
         this.cachedLastConvData = newContent;
-        fs.writeFileSync(this.conversationFile, newContent);
+        // Use atomic write (temp file + rename) to prevent partial reads
+        // by external tools polling this file during active sessions
+        writeFileAtomic.sync(this.conversationFile, newContent);
       }
     } catch (error) {
       debugLogger.error('Error writing conversation file.', error);


### PR DESCRIPTION
### Problem

`ChatRecordingService.writeConversation()` currently uses `fs.writeFileSync()` directly:
```typescript
fs.writeFileSync(this.conversationFile, newContent);
```

This is vulnerable to data loss if the process crashes or is killed mid-write - the session file could be left truncated or corrupted, losing the user's chat history.

### Solution

Replace `fs.writeFileSync()` with `write-file-atomic`, which:
1. Writes to a temporary file first
2. Calls `fsync()` to ensure data is flushed to disk
3. Atomically renames the temp file to the target path

This guarantees that session files are always in a valid state - readers see either the previous complete version or the new complete version, never a partial write.

### Changes

- Add `write-file-atomic` dependency to `packages/core/package.json`
- Add `@types/write-file-atomic` to devDependencies for TypeScript support
- Update `ChatRecordingService.writeConversation()` to use `writeFileAtomic.sync()`

### Trade-offs

The performance overhead is minimal for session files (~10-50KB written once per message). `write-file-atomic` is widely used (40M+ weekly npm downloads) and is the standard solution for safe file writes in Node.js.

### Testing

- Built and ran Gemini CLI locally
- Verified session files are created and updated correctly
- Confirmed JSON files remain valid after multiple chat interactions