### PR TITLE
Fix: Correctly detect MCP tool errors

### DIFF
--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -133,6 +133,13 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     }
 
     if (response) {
+      // Check for top-level isError (MCP Spec compliant)
+      const isErrorTop = (response as { isError?: boolean | string }).isError;
+      if (isErrorTop === true || isErrorTop === 'true') {
+        return true;
+      }
+
+      // Legacy check for nested error object (keep for backward compatibility if any tools rely on it)
       const error = (response as { error?: McpError })?.error;
       const isError = error?.isError;
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where MCP tool errors were being interpreted as successes.

The disocveredMCPTool implementation was previously checking for a nested error.isError property (response.error.isError). However, the [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#calling-tools) places isError at the top level of the tool result object (response.isError). This mismatch caused valid error responses from MCP servers to be treated as successful executions.

## Details

## Related Issues

## How to Validate

Tested with local MCP tool that was returning an error.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
