### PR TITLE
Remove flex from stats display. See snapshots for diffs.

### DIFF
--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -65,7 +65,7 @@ interface SectionProps {
 }
 
 const Section: React.FC<SectionProps> = ({ title, children }) => (
-  <Box flexDirection="column" width="100%" marginBottom={1}>
+  <Box flexDirection="column" marginBottom={1}>
     <Text bold color={theme.text.primary}>
       {title}
     </Text>
@@ -174,11 +174,18 @@ const ModelUsageTable: React.FC<{
     yellow: CACHE_EFFICIENCY_MEDIUM,
   });
 
+  const totalWidth =
+    nameWidth +
+    requestsWidth +
+    (showQuotaColumn
+      ? usageLimitWidth
+      : uncachedWidth + cachedWidth + outputTokensWidth);
+
   return (
     <Box flexDirection="column" marginTop={1}>
       {/* Header */}
       <Box alignItems="flex-end">
-        <Box width={nameWidth} flexGrow={1}>
+        <Box width={nameWidth}>
           <Text bold color={theme.text.primary} wrap="truncate-end">
             Model Usage
           </Text>
@@ -248,12 +255,12 @@ const ModelUsageTable: React.FC<{
         borderLeft={false}
         borderRight={false}
         borderColor={theme.border.default}
-        width="100%"
+        width={totalWidth}
       ></Box>
 
       {rows.map((row) => (
         <Box key={row.key}>
-          <Box width={nameWidth} flexGrow={1}>
+          <Box width={nameWidth}>
             <Text color={theme.text.primary} wrap="truncate-end">
               {row.modelName}
             </Text>

--- a/packages/cli/src/ui/components/__snapshots__/SessionSummaryDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SessionSummaryDisplay.test.tsx.snap
@@ -18,9 +18,9 @@ exports[`<SessionSummaryDisplay /> > renders the summary display with a title 1`
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │                                                                                                  │
-│  Model Usage                                   Reqs   Input Tokens   Cache Reads  Output Tokens  │
-│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
-│  gemini-2.5-pro                                  10            500           500          2,000  │
+│  Model Usage                 Reqs   Input Tokens   Cache Reads  Output Tokens                    │
+│  ────────────────────────────────────────────────────────────────────────────                    │
+│  gemini-2.5-pro                10            500           500          2,000                    │
 │                                                                                                  │
 │  Savings Highlight: 500 (50.0%) of input tokens were served from the cache, reducing costs.      │
 │                                                                                                  │

--- a/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
@@ -118,9 +118,9 @@ exports[`<StatsDisplay /> > Conditional Rendering Tests > hides Efficiency secti
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │                                                                                                  │
-│  Model Usage                                   Reqs   Input Tokens   Cache Reads  Output Tokens  │
-│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
-│  gemini-2.5-pro                                   1            100             0            100  │
+│  Model Usage                 Reqs   Input Tokens   Cache Reads  Output Tokens                    │
+│  ────────────────────────────────────────────────────────────────────────────                    │
+│  gemini-2.5-pro                 1            100             0            100                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
 `;
@@ -162,9 +162,9 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information for unused
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │                                                                                                  │
-│  Model Usage                                                   Reqs                  Usage left  │
-│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
-│  gemini-2.5-flash                                                 -        50.0% (Resets in 2h)  │
+│  Model Usage                 Reqs                  Usage left                                    │
+│  ────────────────────────────────────────────────────────────                                    │
+│  gemini-2.5-flash               -        50.0% (Resets in 2h)                                    │
 │                                                                                                  │
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
@@ -192,9 +192,9 @@ exports[`<StatsDisplay /> > Quota Display > renders quota information when quota
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │                                                                                                  │
-│  Model Usage                                                   Reqs                  Usage left  │
-│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
-│  gemini-2.5-pro                                                   1    75.0% (Resets in 1h 30m)  │
+│  Model Usage                 Reqs                  Usage left                                    │
+│  ────────────────────────────────────────────────────────────                                    │
+│  gemini-2.5-pro                 1    75.0% (Resets in 1h 30m)                                    │
 │                                                                                                  │
 │  Usage limits span all sessions and reset daily.                                                 │
 │  /auth to upgrade or switch to API key.                                                          │
@@ -262,10 +262,10 @@ exports[`<StatsDisplay /> > renders a table with two models correctly 1`] = `
 │    » Tool Time:              0s (0.0%)                                                           │
 │                                                                                                  │
 │                                                                                                  │
-│  Model Usage                                   Reqs   Input Tokens   Cache Reads  Output Tokens  │
-│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
-│  gemini-2.5-pro                                   3            500           500          2,000  │
-│  gemini-2.5-flash                                 5         15,000        10,000         15,000  │
+│  Model Usage                 Reqs   Input Tokens   Cache Reads  Output Tokens                    │
+│  ────────────────────────────────────────────────────────────────────────────                    │
+│  gemini-2.5-pro                 3            500           500          2,000                    │
+│  gemini-2.5-flash               5         15,000        10,000         15,000                    │
 │                                                                                                  │
 │  Savings Highlight: 10,500 (40.4%) of input tokens were served from the cache, reducing costs.   │
 │                                                                                                  │
@@ -290,9 +290,9 @@ exports[`<StatsDisplay /> > renders all sections when all data is present 1`] = 
 │    » Tool Time:              123ms (55.2%)                                                       │
 │                                                                                                  │
 │                                                                                                  │
-│  Model Usage                                   Reqs   Input Tokens   Cache Reads  Output Tokens  │
-│  ──────────────────────────────────────────────────────────────────────────────────────────────  │
-│  gemini-2.5-pro                                   1             50            50            100  │
+│  Model Usage                 Reqs   Input Tokens   Cache Reads  Output Tokens                    │
+│  ────────────────────────────────────────────────────────────────────────────                    │
+│  gemini-2.5-pro                 1             50            50            100                    │
 │                                                                                                  │
 │  Savings Highlight: 50 (50.0%) of input tokens were served from the cache, reducing costs.       │
 │                                                                                                  │


### PR DESCRIPTION
## Summary

See snapshot tests for demos of how the widths changed.
@sehoon38 pointed out the flex looked bad on an ultrawide terminal.
