### PR TITLE
fix(ide): Update IDE extension to write auth token in env var

### DIFF
--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -108,7 +108,7 @@ describe('IDEServer', () => {
     await ideServer.start(mockContext);
 
     const replaceMock = mockContext.environmentVariableCollection.replace;
-    expect(replaceMock).toHaveBeenCalledTimes(2);
+    expect(replaceMock).toHaveBeenCalledTimes(3);
 
     expect(replaceMock).toHaveBeenNthCalledWith(
       1,
@@ -125,6 +125,12 @@ describe('IDEServer', () => {
       2,
       'GEMINI_CLI_IDE_WORKSPACE_PATH',
       expectedWorkspacePaths,
+    );
+
+    expect(replaceMock).toHaveBeenNthCalledWith(
+      3,
+      'GEMINI_CLI_IDE_AUTH_TOKEN',
+      'test-auth-token',
     );
 
     const port = getPortFromMock(replaceMock);
@@ -253,6 +259,10 @@ describe('IDEServer', () => {
     expect(replaceMock).toHaveBeenCalledWith(
       'GEMINI_CLI_IDE_WORKSPACE_PATH',
       expectedWorkspacePaths,
+    );
+    expect(replaceMock).toHaveBeenCalledWith(
+      'GEMINI_CLI_IDE_AUTH_TOKEN',
+      'test-auth-token',
     );
 
     const port = getPortFromMock(replaceMock);

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -38,6 +38,7 @@ class CORSError extends Error {
 const MCP_SESSION_ID_HEADER = 'mcp-session-id';
 const IDE_SERVER_PORT_ENV_VAR = 'GEMINI_CLI_IDE_SERVER_PORT';
 const IDE_WORKSPACE_PATH_ENV_VAR = 'GEMINI_CLI_IDE_WORKSPACE_PATH';
+const IDE_AUTH_TOKEN_ENV_VAR = 'GEMINI_CLI_IDE_AUTH_TOKEN';
 
 interface WritePortAndWorkspaceArgs {
   context: vscode.ExtensionContext;
@@ -69,6 +70,10 @@ async function writePortAndWorkspace({
   context.environmentVariableCollection.replace(
     IDE_WORKSPACE_PATH_ENV_VAR,
     workspacePath,
+  );
+  context.environmentVariableCollection.replace(
+    IDE_AUTH_TOKEN_ENV_VAR,
+    authToken,
   );
 
   const content = JSON.stringify({


### PR DESCRIPTION
This fixes a bug where the client would fail to connect if it was falling back on env variables