### PR TITLE
fix(policy): allow codebase_investigator by default in read-only policy

### DIFF
--- a/packages/core/src/policy/policies/read-only.toml
+++ b/packages/core/src/policy/policies/read-only.toml
@@ -54,3 +54,8 @@ priority = 50
 toolName = "google_web_search"
 decision = "allow"
 priority = 50
+
+[[rule]]
+toolName = "codebase_investigator"
+decision = "allow"
+priority = 50


### PR DESCRIPTION
## Summary

Allowed `codebase_investigator` by default in the read-only policy configuration.

## Details

The `codebase_investigator` tool is a read-only analysis tool but was missing from the default allowlist in `packages/core/src/policy/policies/read-only.toml`. This resulted in it requiring explicit user permission or higher privilege modes to run, despite being safe. This PR adds it to the policy with priority 50, matching other read-only tools like `glob` and `read_file`.

## Related Issues

<!-- None specified -->

## How to Validate

1.  Build the core package: `npm run build -w packages/core`
2.  Verify that `codebase_investigator` can be used without prompting for permission in default mode.
3.  Review `packages/core/src/policy/policies/read-only.toml` to see the new entry.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (Verified locally with integration test)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker