### PR TITLE
Code assist service metrics.

### DIFF
--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -173,6 +173,10 @@ describe('CodeAssistServer', () => {
             conversationOffered: expect.objectContaining({
               traceId: 'test-trace-id',
               status: ActionStatus.ACTION_STATUS_NO_ERROR,
+              streamingLatency: expect.objectContaining({
+                totalLatency: expect.stringMatching(/\d+s/),
+                firstMessageLatency: expect.stringMatching(/\d+s/),
+              }),
             }),
           }),
         ]),

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -138,8 +138,10 @@ export class CodeAssistServer implements ContentGenerator {
       ),
       req.config?.abortSignal,
     );
+    const duration = formatProtoJsonDuration(Date.now() - start);
     const streamingLatency: StreamingLatency = {
-      totalLatency: formatProtoJsonDuration(Date.now() - start),
+      totalLatency: duration,
+      firstMessageLatency: duration,
     };
 
     const translatedResponse = fromGenerateContentResponse(response);

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -16,23 +16,22 @@ import type {
   ClientMetadata,
   RetrieveUserQuotaRequest,
   RetrieveUserQuotaResponse,
-  RecordCodeAssistMetricsRequest,
-  CodeAssistMetric,
   ConversationOffered,
   ConversationInteraction,
   StreamingLatency,
+  RecordCodeAssistMetricsRequest,
 } from './types.js';
 import type {
   ListExperimentsRequest,
   ListExperimentsResponse,
 } from './experiments/types.js';
-import {
-  type CountTokensParameters,
-  type CountTokensResponse,
-  type EmbedContentParameters,
-  type EmbedContentResponse,
-  type GenerateContentParameters,
-  type GenerateContentResponse,
+import type {
+  CountTokensParameters,
+  CountTokensResponse,
+  EmbedContentParameters,
+  EmbedContentResponse,
+  GenerateContentParameters,
+  GenerateContentResponse,
 } from '@google/genai';
 import * as readline from 'node:readline';
 import type { ContentGenerator } from '../core/contentGenerator.js';
@@ -243,14 +242,10 @@ export class CodeAssistServer implements ContentGenerator {
       return;
     }
 
-    const metric: CodeAssistMetric = {
-      conversationOffered,
-    };
-
     await this.recordCodeAssistMetrics({
       project: this.projectId,
       metadata: await getClientMetadata(),
-      metrics: [metric],
+      metrics: [{ conversationOffered }],
     });
   }
 
@@ -261,21 +256,17 @@ export class CodeAssistServer implements ContentGenerator {
       return;
     }
 
-    const metric: CodeAssistMetric = {
-      conversationInteraction: interaction,
-    };
-
     await this.recordCodeAssistMetrics({
       project: this.projectId,
       metadata: await getClientMetadata(),
-      metrics: [metric],
+      metrics: [{ conversationInteraction: interaction }],
     });
   }
 
   async recordCodeAssistMetrics(
-    req: RecordCodeAssistMetricsRequest,
+    request: RecordCodeAssistMetricsRequest,
   ): Promise<void> {
-    return this.requestPost<void>('recordCodeAssistMetrics', req);
+    return this.requestPost<void>('recordCodeAssistMetrics', request);
   }
 
   async requestPost<T>(

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -26,13 +26,13 @@ import type {
   ListExperimentsRequest,
   ListExperimentsResponse,
 } from './experiments/types.js';
-import type {
-  CountTokensParameters,
-  CountTokensResponse,
-  EmbedContentParameters,
-  EmbedContentResponse,
-  GenerateContentParameters,
-  GenerateContentResponse,
+import {
+  type CountTokensParameters,
+  type CountTokensResponse,
+  type EmbedContentParameters,
+  type EmbedContentResponse,
+  type GenerateContentParameters,
+  type GenerateContentResponse,
 } from '@google/genai';
 import * as readline from 'node:readline';
 import type { ContentGenerator } from '../core/contentGenerator.js';
@@ -109,11 +109,8 @@ export class CodeAssistServer implements ContentGenerator {
         const translatedResponse = fromGenerateContentResponse(response);
 
         if (response.traceId) {
-          // TODO: figure out how to tell if there's an error.
-          const hasError = false;
           const offered = createConversationOffered(
             translatedResponse,
-            hasError,
             response.traceId,
             req.config?.abortSignal,
             streamingLatency,
@@ -131,7 +128,7 @@ export class CodeAssistServer implements ContentGenerator {
     userPromptId: string,
   ): Promise<GenerateContentResponse> {
     const start = Date.now();
-    const resp = await this.requestPost<CaGenerateContentResponse>(
+    const response = await this.requestPost<CaGenerateContentResponse>(
       'generateContent',
       toGenerateContentRequest(
         req,
@@ -145,15 +142,12 @@ export class CodeAssistServer implements ContentGenerator {
       totalLatency: formatProtoJsonDuration(Date.now() - start),
     };
 
-    const translatedResponse = fromGenerateContentResponse(resp);
+    const translatedResponse = fromGenerateContentResponse(response);
 
-    if (resp.traceId) {
-      // TODO: figure out how to tell if there's an error.
-      const hasError = false;
+    if (response.traceId) {
       const offered = createConversationOffered(
         translatedResponse,
-        hasError,
-        resp.traceId,
+        response.traceId,
         req.config?.abortSignal,
         streamingLatency,
       );

--- a/packages/core/src/code_assist/telemetry.test.ts
+++ b/packages/core/src/code_assist/telemetry.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createConversationOffered,
+  formatProtoJsonDuration,
+} from './telemetry.js';
+import { ActionStatus, type StreamingLatency } from './types.js';
+import { FinishReason, GenerateContentResponse } from '@google/genai';
+
+describe('telemetry', () => {
+  describe('createConversationOffered', () => {
+    it('should create a ConversationOffered object with correct values', () => {
+      const response = new GenerateContentResponse();
+      response.candidates = [
+        {
+          index: 0,
+          content: {
+            role: 'model',
+            parts: [{ text: 'response with ```code```' }],
+          },
+          citationMetadata: {
+            citations: [
+              { uri: 'https://example.com', startIndex: 0, endIndex: 10 },
+            ],
+          },
+          finishReason: FinishReason.STOP,
+        },
+      ];
+      response.sdkHttpResponse = {
+        responseInternal: {
+          ok: true,
+        } as unknown as Response,
+        json: async () => ({}),
+      };
+      const traceId = 'test-trace-id';
+      const streamingLatency: StreamingLatency = { totalLatency: '1s' };
+
+      const result = createConversationOffered(
+        response,
+        traceId,
+        undefined,
+        streamingLatency,
+      );
+
+      expect(result).toEqual({
+        citationCount: '1',
+        includedCode: true,
+        status: ActionStatus.ACTION_STATUS_NO_ERROR,
+        traceId,
+        streamingLatency,
+        isAgentic: true,
+      });
+    });
+
+    it('should set status to CANCELLED if signal is aborted', () => {
+      const response = new GenerateContentResponse();
+      response.candidates = [];
+      const signal = new AbortController().signal;
+      vi.spyOn(signal, 'aborted', 'get').mockReturnValue(true);
+
+      const result = createConversationOffered(
+        response,
+        'trace-id',
+        signal,
+        {},
+      );
+
+      expect(result.status).toBe(ActionStatus.ACTION_STATUS_CANCELLED);
+    });
+
+    it('should set status to ERROR_UNKNOWN if response has error (non-OK SDK response)', () => {
+      const response = new GenerateContentResponse();
+      response.sdkHttpResponse = {
+        responseInternal: {
+          ok: false,
+        } as unknown as Response,
+        json: async () => ({}),
+      };
+
+      const result = createConversationOffered(
+        response,
+        'trace-id',
+        undefined,
+        {},
+      );
+
+      expect(result.status).toBe(ActionStatus.ACTION_STATUS_ERROR_UNKNOWN);
+    });
+
+    it('should set status to ERROR_UNKNOWN if finishReason is not STOP or MAX_TOKENS', () => {
+      const response = new GenerateContentResponse();
+      response.candidates = [
+        {
+          index: 0,
+          finishReason: FinishReason.SAFETY,
+        },
+      ];
+      response.sdkHttpResponse = {
+        responseInternal: {
+          ok: true,
+        } as unknown as Response,
+        json: async () => ({}),
+      };
+
+      const result = createConversationOffered(
+        response,
+        'trace-id',
+        undefined,
+        {},
+      );
+
+      expect(result.status).toBe(ActionStatus.ACTION_STATUS_ERROR_UNKNOWN);
+    });
+
+    it('should set status to EMPTY if candidates is empty', () => {
+      const response = new GenerateContentResponse();
+      response.candidates = [];
+      response.sdkHttpResponse = {
+        responseInternal: {
+          ok: true,
+        } as unknown as Response,
+        json: async () => ({}),
+      };
+
+      const result = createConversationOffered(
+        response,
+        'trace-id',
+        undefined,
+        {},
+      );
+
+      expect(result.status).toBe(ActionStatus.ACTION_STATUS_EMPTY);
+    });
+
+    it('should detect code in response', () => {
+      const response = new GenerateContentResponse();
+      response.candidates = [
+        {
+          index: 0,
+          content: {
+            parts: [
+              { text: 'Here is some code:\n```js\nconsole.log("hi")\n```' },
+            ],
+          },
+        },
+      ];
+      response.sdkHttpResponse = {
+        responseInternal: {
+          ok: true,
+        } as unknown as Response,
+        json: async () => ({}),
+      };
+      const result = createConversationOffered(response, 'id', undefined, {});
+      expect(result.includedCode).toBe(true);
+    });
+
+    it('should not detect code if no backticks', () => {
+      const response = new GenerateContentResponse();
+      response.candidates = [
+        {
+          index: 0,
+          content: {
+            parts: [{ text: 'Here is some text.' }],
+          },
+        },
+      ];
+      response.sdkHttpResponse = {
+        responseInternal: {
+          ok: true,
+        } as unknown as Response,
+        json: async () => ({}),
+      };
+      const result = createConversationOffered(response, 'id', undefined, {});
+      expect(result.includedCode).toBe(false);
+    });
+  });
+
+  describe('formatProtoJsonDuration', () => {
+    it('should format milliseconds to seconds string', () => {
+      expect(formatProtoJsonDuration(1500)).toBe('1.5s');
+      expect(formatProtoJsonDuration(100)).toBe('0.1s');
+    });
+  });
+});

--- a/packages/core/src/code_assist/telemetry.ts
+++ b/packages/core/src/code_assist/telemetry.ts
@@ -72,7 +72,10 @@ export function formatProtoJsonDuration(milliseconds: number): string {
 
 function hasError(response: GenerateContentResponse): boolean {
   // Non-OK SDK results should be considered an error.
-  if (!response.sdkHttpResponse?.responseInternal?.ok) {
+  if (
+    response.sdkHttpResponse &&
+    !response.sdkHttpResponse?.responseInternal?.ok
+  ) {
     return true;
   }
 

--- a/packages/core/src/code_assist/telemetry.ts
+++ b/packages/core/src/code_assist/telemetry.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { GenerateContentResponse } from '@google/genai';
+import { getCitations } from '../utils/generateContentResponseUtilities.js';
+import {
+  ActionStatus,
+  type ConversationOffered,
+  type StreamingLatency,
+} from './types.js';
+
+export function createConversationOffered(
+  response: GenerateContentResponse,
+  hasError: boolean,
+  traceId: string,
+  signal: AbortSignal | undefined,
+  streamingLatency: StreamingLatency,
+): ConversationOffered {
+  return {
+    citationCount: String(getCitations(response).length),
+    includedCode: includesCode(response),
+    status: getStatus(hasError, signal),
+    traceId,
+    streamingLatency,
+    isAgentic: true,
+  };
+}
+
+export function measureStreamingLatency(
+  responses: AsyncGenerator<GenerateContentResponse>,
+): {
+  responses: AsyncGenerator<GenerateContentResponse>;
+  streamingLatency: StreamingLatency;
+} {
+  const start = Date.now();
+
+  const streamingLatency: StreamingLatency = {};
+
+  async function* measureLatency(): AsyncGenerator<GenerateContentResponse> {
+    let isFirst = true;
+    try {
+      for await (const response of responses) {
+        if (isFirst) {
+          isFirst = false;
+          streamingLatency.firstMessageLatency = formatProtoJsonDuration(
+            Date.now() - start,
+          );
+        }
+        yield response;
+      }
+    } finally {
+      streamingLatency.totalLatency = String(Date.now() - start);
+    }
+  }
+
+  return { responses: measureLatency(), streamingLatency };
+}
+
+function includesCode(resp: GenerateContentResponse): boolean {
+  if (!resp.candidates) {
+    return false;
+  }
+  for (const candidate of resp.candidates) {
+    if (!candidate.content || !candidate.content.parts) {
+      continue;
+    }
+    for (const part of candidate.content.parts) {
+      if ('text' in part && part?.text?.includes('```')) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function getStatus(
+  hasError: boolean,
+  signal: AbortSignal | undefined,
+): ActionStatus {
+  if (signal?.aborted) {
+    return ActionStatus.ACTION_STATUS_CANCELLED;
+  }
+
+  if (hasError) {
+    return ActionStatus.ACTION_STATUS_ERROR_UNKNOWN;
+  }
+
+  return ActionStatus.ACTION_STATUS_NO_ERROR;
+}
+
+export function formatProtoJsonDuration(milliseconds: number): string {
+  return `${milliseconds / 1000}s`;
+}

--- a/packages/core/src/code_assist/types.ts
+++ b/packages/core/src/code_assist/types.ts
@@ -177,7 +177,7 @@ export interface HelpLinkUrl {
 
 export interface SetCodeAssistGlobalUserSettingRequest {
   cloudaicompanionProject?: string;
-  freeTierDataCollectionOptin: boolean;
+  freeTierDataCollectionOptin?: boolean;
 }
 
 export interface CodeAssistGlobalUserSettingResponse {
@@ -216,4 +216,156 @@ export interface BucketInfo {
 
 export interface RetrieveUserQuotaResponse {
   buckets?: BucketInfo[];
+}
+
+export interface RecordCodeAssistMetricsRequest {
+  project: string;
+  requestId?: string;
+  metadata?: ClientMetadata;
+  metrics?: CodeAssistMetric[];
+}
+
+export interface CodeAssistMetric {
+  timestamp?: string;
+  metricMetadata?: Map<string, string>;
+
+  // The event tied to this metric. Only one of these should be set.
+  inlineCompletionAccepted?: InlineCompletionAccepted;
+  inlineCompletionOffered?: InlineCompletionOffered;
+  conversationOffered?: ConversationOffered;
+  generateCodeUI?: GenerateCodeUI;
+  conversationExplainUI?: ConversationExplainUI;
+  conversationGenerateTestUI?: ConversationGenerateTestUI;
+  conversationInteraction?: ConversationInteraction;
+  aiCharactersReports?: AiCharactersReports;
+}
+
+export enum ConversationInteractionType {
+  UNSPECIFIED = 'INTERACTION_TYPE_UNSPECIFIED',
+  ACCEPTANCE = 'ACCEPTANCE',
+  DISMISSAL = 'DISMISSAL',
+}
+
+export enum InlineCompletionAcceptedCompletionMethod {
+  UNKNOWN = 0,
+  GENERATE_CODE = 1,
+  COMPLETE_CODE = 2,
+  TRANSFORM_CODE = 3,
+  AUTOMATIC_GENERATION = 4,
+}
+
+export enum InlineCompletionOfferedCompletionMode {
+  UNKNOWN = 0,
+  LANGUAGE_CLIENT = 1,
+  TYPEOVER = 2,
+  TYPEOVER_NEWLINE = 3,
+  TRANSFORM_CODE = 4,
+}
+
+export enum InlineCompletionOfferedCompletionMethod {
+  COMPLETION_METHOD_UNKNOWN = 0,
+  COMPLETION_METHOD_GENERATE_CODE = 1,
+  COMPLETION_METHOD_COMPLETE_CODE = 2,
+  COMPLETION_METHOD_TRANSFORM_CODE = 3,
+  COMPLETION_METHOD_AUTOMATIC_GENERATION = 4,
+}
+
+export enum ConversationInteractionInteraction {
+  UNKNOWN = 0,
+  THUMBSUP = 1,
+  THUMBSDOWN = 2,
+  COPY = 3,
+  INSERT = 4,
+  ACCEPT_CODE_BLOCK = 5,
+  ACCEPT_ALL = 6,
+  ACCEPT_FILE = 7,
+  DIFF = 8,
+  ACCEPT_RANGE = 9,
+}
+
+export enum AiCharactersReportEditType {
+  EDIT_TYPE_UNSPECIFIED = 0,
+  USER_ADD = 1,
+  PASTE = 2,
+  DELETE = 3,
+  OTHER = 4,
+  AI_COMPLETION = 5,
+  AI_COMPLETION_PARTIAL = 6,
+  AI_GENERATION = 7,
+  AI_GENERATION_PARTIAL = 8,
+}
+
+export enum ActionStatus {
+  ACTION_STATUS_UNSPECIFIED = 0,
+  ACTION_STATUS_NO_ERROR = 1,
+  ACTION_STATUS_ERROR_UNKNOWN = 2,
+  ACTION_STATUS_CANCELLED = 3,
+  ACTION_STATUS_EMPTY = 4,
+}
+
+export interface InlineCompletionAccepted {
+  traceId?: string;
+  score?: number;
+  responseSize?: string;
+  responseLines?: string;
+  language?: string;
+  completionMethod?: InlineCompletionAcceptedCompletionMethod;
+  partialAcceptedCharacters?: string;
+  partialAcceptedLines?: string;
+  acceptedCommentLines?: string;
+  status?: ActionStatus;
+  responseAcceptedIndex?: string;
+}
+
+export interface InlineCompletionOffered {
+  traceId?: string;
+  resultCount?: string;
+  language?: string;
+  completionMode?: InlineCompletionOfferedCompletionMode;
+  displayLength?: string;
+  status?: ActionStatus;
+  completionMethod?: InlineCompletionOfferedCompletionMethod;
+  responseLatency?: string;
+  responseReceivedIndex?: string;
+}
+
+export interface ConversationOffered {
+  citationCount?: string;
+  includedCode?: boolean;
+  status?: ActionStatus;
+  traceId?: string;
+  streamingLatency?: StreamingLatency;
+  isAgentic?: boolean;
+}
+
+export interface StreamingLatency {
+  firstMessageLatency?: string;
+  totalLatency?: string;
+}
+
+export interface ConversationInteraction {
+  traceId: string;
+  status?: ActionStatus;
+  interaction?: ConversationInteractionInteraction;
+  acceptedLines?: string;
+  language?: string;
+  isAgentic?: boolean;
+}
+
+export type GenerateCodeUI = Record<string, never>;
+
+export type ConversationExplainUI = Record<string, never>;
+
+export type ConversationGenerateTestUI = Record<string, never>;
+
+export interface AiCharactersReports {
+  reports: AiCharactersReport[];
+}
+
+export interface AiCharactersReport {
+  language: string;
+  editType: AiCharactersReportEditType;
+  totalChars: string;
+  whitespaceChars: string;
+  timeIntervalIndex: string;
 }

--- a/packages/core/src/code_assist/types.ts
+++ b/packages/core/src/code_assist/types.ts
@@ -230,44 +230,8 @@ export interface CodeAssistMetric {
   metricMetadata?: Map<string, string>;
 
   // The event tied to this metric. Only one of these should be set.
-  inlineCompletionAccepted?: InlineCompletionAccepted;
-  inlineCompletionOffered?: InlineCompletionOffered;
   conversationOffered?: ConversationOffered;
-  generateCodeUI?: GenerateCodeUI;
-  conversationExplainUI?: ConversationExplainUI;
-  conversationGenerateTestUI?: ConversationGenerateTestUI;
   conversationInteraction?: ConversationInteraction;
-  aiCharactersReports?: AiCharactersReports;
-}
-
-export enum ConversationInteractionType {
-  UNSPECIFIED = 'INTERACTION_TYPE_UNSPECIFIED',
-  ACCEPTANCE = 'ACCEPTANCE',
-  DISMISSAL = 'DISMISSAL',
-}
-
-export enum InlineCompletionAcceptedCompletionMethod {
-  UNKNOWN = 0,
-  GENERATE_CODE = 1,
-  COMPLETE_CODE = 2,
-  TRANSFORM_CODE = 3,
-  AUTOMATIC_GENERATION = 4,
-}
-
-export enum InlineCompletionOfferedCompletionMode {
-  UNKNOWN = 0,
-  LANGUAGE_CLIENT = 1,
-  TYPEOVER = 2,
-  TYPEOVER_NEWLINE = 3,
-  TRANSFORM_CODE = 4,
-}
-
-export enum InlineCompletionOfferedCompletionMethod {
-  COMPLETION_METHOD_UNKNOWN = 0,
-  COMPLETION_METHOD_GENERATE_CODE = 1,
-  COMPLETION_METHOD_COMPLETE_CODE = 2,
-  COMPLETION_METHOD_TRANSFORM_CODE = 3,
-  COMPLETION_METHOD_AUTOMATIC_GENERATION = 4,
 }
 
 export enum ConversationInteractionInteraction {
@@ -283,50 +247,12 @@ export enum ConversationInteractionInteraction {
   ACCEPT_RANGE = 9,
 }
 
-export enum AiCharactersReportEditType {
-  EDIT_TYPE_UNSPECIFIED = 0,
-  USER_ADD = 1,
-  PASTE = 2,
-  DELETE = 3,
-  OTHER = 4,
-  AI_COMPLETION = 5,
-  AI_COMPLETION_PARTIAL = 6,
-  AI_GENERATION = 7,
-  AI_GENERATION_PARTIAL = 8,
-}
-
 export enum ActionStatus {
   ACTION_STATUS_UNSPECIFIED = 0,
   ACTION_STATUS_NO_ERROR = 1,
   ACTION_STATUS_ERROR_UNKNOWN = 2,
   ACTION_STATUS_CANCELLED = 3,
   ACTION_STATUS_EMPTY = 4,
-}
-
-export interface InlineCompletionAccepted {
-  traceId?: string;
-  score?: number;
-  responseSize?: string;
-  responseLines?: string;
-  language?: string;
-  completionMethod?: InlineCompletionAcceptedCompletionMethod;
-  partialAcceptedCharacters?: string;
-  partialAcceptedLines?: string;
-  acceptedCommentLines?: string;
-  status?: ActionStatus;
-  responseAcceptedIndex?: string;
-}
-
-export interface InlineCompletionOffered {
-  traceId?: string;
-  resultCount?: string;
-  language?: string;
-  completionMode?: InlineCompletionOfferedCompletionMode;
-  displayLength?: string;
-  status?: ActionStatus;
-  completionMethod?: InlineCompletionOfferedCompletionMethod;
-  responseLatency?: string;
-  responseReceivedIndex?: string;
 }
 
 export interface ConversationOffered {
@@ -350,22 +276,4 @@ export interface ConversationInteraction {
   acceptedLines?: string;
   language?: string;
   isAgentic?: boolean;
-}
-
-export type GenerateCodeUI = Record<string, never>;
-
-export type ConversationExplainUI = Record<string, never>;
-
-export type ConversationGenerateTestUI = Record<string, never>;
-
-export interface AiCharactersReports {
-  reports: AiCharactersReport[];
-}
-
-export interface AiCharactersReport {
-  language: string;
-  editType: AiCharactersReportEditType;
-  totalChars: string;
-  whitespaceChars: string;
-  timeIntervalIndex: string;
 }

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -36,13 +36,6 @@ vi.mock('../utils/errorReporting', () => ({
   reportError: vi.fn(),
 }));
 
-// Use the actual implementation from partUtils now that it's provided.
-vi.mock('../utils/generateContentResponseUtilities', () => ({
-  getResponseText: (resp: GenerateContentResponse) =>
-    resp.candidates?.[0]?.content?.parts?.map((part) => part.text).join('') ||
-    undefined,
-}));
-
 describe('Turn', () => {
   let turn: Turn;
   // Define a type for the mocked Chat instance for clarity

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -31,6 +31,7 @@ import { InvalidStreamError } from './geminiChat.js';
 import { parseThought, type ThoughtSummary } from '../utils/thoughtUtils.js';
 import { createUserContent } from '@google/genai';
 import type { ModelConfigKey } from '../services/modelConfigService.js';
+import { getCitations } from '../utils/generateContentResponseUtilities.js';
 
 // Define a structure for tools passed to the server
 export interface ServerTool {
@@ -404,15 +405,4 @@ export class Turn {
       .filter((text): text is string => text !== null)
       .join(' ');
   }
-}
-
-function getCitations(resp: GenerateContentResponse): string[] {
-  return (resp.candidates?.[0]?.citationMetadata?.citations ?? [])
-    .filter((citation) => citation.uri !== undefined)
-    .map((citation) => {
-      if (citation.title) {
-        return `(${citation.title}) ${citation.uri}`;
-      }
-      return citation.uri!;
-    });
 }

--- a/packages/core/src/utils/generateContentResponseUtilities.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.ts
@@ -105,3 +105,14 @@ export function getStructuredResponseFromParts(
   }
   return undefined;
 }
+
+export function getCitations(resp: GenerateContentResponse): string[] {
+  return (resp.candidates?.[0]?.citationMetadata?.citations ?? [])
+    .filter((citation) => citation.uri !== undefined)
+    .map((citation) => {
+      if (citation.title) {
+        return `(${citation.title}) ${citation.uri}`;
+      }
+      return citation.uri!;
+    });
+}


### PR DESCRIPTION
## Summary

This PR is the first part of a multi-part change that adds additional metrics for requests served by the Code Assist backend. This part includes just the metrics for 'ConversationOffered'.

I'll follow up with another PR for 'ConversationInteraction'.

## Related Issues

https://b.corp.google.com/issues/466196507

## How to Validate

Run the CLI, log in with a Google account, and validate that you are able to see telemetry transmitted without an error.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
