### PR TITLE
Fix: Change shell focus key to Ctrl+Shift+F for VS Code compatibility on Windows/WSL

### DIFF
--- a/docs/cli/keyboard-shortcuts.md
+++ b/docs/cli/keyboard-shortcuts.md
@@ -91,15 +91,15 @@ available combinations.
 
 #### App Controls
 
-| Action                                                            | Keys       |
-| ----------------------------------------------------------------- | ---------- |
-| Toggle detailed error information.                                | `F12`      |
-| Toggle the full TODO list.                                        | `Ctrl + T` |
-| Toggle IDE context details.                                       | `Ctrl + G` |
-| Toggle Markdown rendering.                                        | `Cmd + M`  |
-| Toggle copy mode when the terminal is using the alternate buffer. | `Ctrl + S` |
-| Expand a height-constrained response to show additional lines.    | `Ctrl + S` |
-| Toggle focus between the shell and Gemini input.                  | `Ctrl + F` |
+| Action                                                            | Keys               |
+| ----------------------------------------------------------------- | ------------------ |
+| Toggle detailed error information.                                | `F12`              |
+| Toggle the full TODO list.                                        | `Ctrl + T`         |
+| Toggle IDE context details.                                       | `Ctrl + G`         |
+| Toggle Markdown rendering.                                        | `Cmd + M`          |
+| Toggle copy mode when the terminal is using the alternate buffer. | `Ctrl + S`         |
+| Expand a height-constrained response to show additional lines.    | `Ctrl + S`         |
+| Toggle focus between the shell and Gemini input.                  | `Ctrl + Shift + F` |
 
 #### Session Control
 
@@ -122,8 +122,8 @@ available combinations.
 - `Ctrl+Delete` / `Meta+Delete`: Delete the word to the right of the cursor.
 - `Ctrl+B` or `Left Arrow`: Move the cursor one character to the left while
   editing text.
-- `Ctrl+F` or `Right Arrow`: Move the cursor one character to the right; with an
-  embedded shell attached, `Ctrl+F` still toggles focus.
+- `Ctrl+F` or `Right Arrow`: Move the cursor one character to the right while
+  editing text.
 - `Ctrl+D` or `Delete`: Remove the character immediately to the right of the
   cursor.
 - `Ctrl+H` or `Backspace`: Remove the character immediately to the left of the

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -209,7 +209,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
   // Note: original logic ONLY checked ctrl=false, ignored meta/shift/paste
   [Command.SUBMIT_REVERSE_SEARCH]: [{ key: 'return', ctrl: false }],
   [Command.ACCEPT_SUGGESTION_REVERSE_SEARCH]: [{ key: 'tab' }],
-  [Command.TOGGLE_SHELL_INPUT_FOCUS]: [{ key: 'f', ctrl: true }],
+  [Command.TOGGLE_SHELL_INPUT_FOCUS]: [{ key: 'f', ctrl: true, shift: true }],
 
   // Suggestion expansion
   [Command.EXPAND_SUGGESTION]: [{ key: 'right' }],

--- a/packages/cli/src/ui/hooks/usePhraseCycler.ts
+++ b/packages/cli/src/ui/hooks/usePhraseCycler.ts
@@ -12,7 +12,7 @@ import { useInactivityTimer } from './useInactivityTimer.js';
 
 export const PHRASE_CHANGE_INTERVAL_MS = 15000;
 export const INTERACTIVE_SHELL_WAITING_PHRASE =
-  'Interactive shell awaiting input... press Ctrl+f to focus shell';
+  'Interactive shell awaiting input... press Ctrl+Shift+F to focus shell';
 
 /**
  * Custom hook to manage cycling through loading phrases.


### PR DESCRIPTION
## Summary
Change hot key to switch shells from `Ctrl+f` to `Ctrl+Shift+F` for cross platform compatibility. On Gemini CLI on Windows / WSL the current binding `Ctrl+f` is intercepted by the terminal Find feature, which blocks people from being able to use Gemini CLI on that configuration.


## Details

Gemini CLI shortcut to switch to a new shell is intercepted by the terminal "find" feature (Ctrl+f). [There's a workaround](https://github.com/google-gemini/gemini-cli/issues/14598#issuecomment-3620640815), but it requires permanently changing a VS Code shortcut.

In looking for alternatives, I noticed that Ctrl+F was already in conflict with [a tip constant](https://github.com/google-gemini/gemini-cli/blob/main/packages/cli/src/ui/constants/tips.ts#L105), which affects emacs users I believe.
> ./src/ui/constants/tips.ts:  'Move one character left or right with Ctrl+B/F or the arrow keys...',

So I propose switching it to `Ctrl+Shift+F`

## Related Issues

Fixes #14598

## How to Validate

1. open gemini
2. type prompt `start server with npm run dev in the foreground`
3. when prompted, enter `Ctrl+Shift+F` to switch shells

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->
(I don't have a dev env set up so couldn't validate this...)

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
