### PR TITLE
fix(a2a-server): fix command-registry test timeout

### DIFF
--- a/packages/a2a-server/src/commands/command-registry.test.ts
+++ b/packages/a2a-server/src/commands/command-registry.test.ts
@@ -31,29 +31,52 @@ describe('CommandRegistry', () => {
       ExtensionsCommand: mockExtensionsCommand,
       ListExtensionsCommand: mockListExtensionsCommand,
     }));
+    vi.doMock('./init.js', () => ({
+      InitCommand: class {
+        name = 'init';
+        description = 'Initialize a new project.';
+        execute = vi.fn();
+      },
+    }));
+    vi.doMock('./restore.js', () => ({
+      RestoreCommand: class {
+        name = 'restore';
+        description = 'Restore a project.';
+        execute = vi.fn();
+      },
+    }));
   });
 
   it('should register ExtensionsCommand on initialization', async () => {
-    const { commandRegistry } = await import('./command-registry.js');
+    // Re-import CommandRegistry after mocking dependencies
+    const { CommandRegistry } = await import('./command-registry.js');
+    const commandRegistry = new CommandRegistry();
+
     expect(mockExtensionsCommand).toHaveBeenCalled();
     const command = commandRegistry.get('extensions');
     expect(command).toBe(mockExtensionsCommandInstance);
   });
 
   it('should register sub commands on initialization', async () => {
-    const { commandRegistry } = await import('./command-registry.js');
+    const { CommandRegistry } = await import('./command-registry.js');
+    const commandRegistry = new CommandRegistry();
+
     const command = commandRegistry.get('extensions list');
     expect(command).toBe(mockListExtensionsCommandInstance);
   });
 
   it('get() should return undefined for a non-existent command', async () => {
-    const { commandRegistry } = await import('./command-registry.js');
+    const { CommandRegistry } = await import('./command-registry.js');
+    const commandRegistry = new CommandRegistry();
+
     const command = commandRegistry.get('non-existent');
     expect(command).toBeUndefined();
   });
 
   it('register() should register a new command', async () => {
-    const { commandRegistry } = await import('./command-registry.js');
+    const { CommandRegistry } = await import('./command-registry.js');
+    const commandRegistry = new CommandRegistry();
+
     const mockCommand: Command = {
       name: 'test-command',
       description: '',
@@ -65,7 +88,9 @@ describe('CommandRegistry', () => {
   });
 
   it('register() should register a nested command', async () => {
-    const { commandRegistry } = await import('./command-registry.js');
+    const { CommandRegistry } = await import('./command-registry.js');
+    const commandRegistry = new CommandRegistry();
+
     const mockSubSubCommand: Command = {
       name: 'test-command-sub-sub',
       description: '',
@@ -96,7 +121,9 @@ describe('CommandRegistry', () => {
 
   it('register() should not enter an infinite loop with a cyclic command', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { commandRegistry } = await import('./command-registry.js');
+    const { CommandRegistry } = await import('./command-registry.js');
+    const commandRegistry = new CommandRegistry();
+
     const mockCommand: Command = {
       name: 'cyclic-command',
       description: '',

--- a/packages/a2a-server/src/commands/command-registry.test.ts
+++ b/packages/a2a-server/src/commands/command-registry.test.ts
@@ -8,6 +8,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Command } from './types.js';
 
 describe('CommandRegistry', () => {
+  let commandRegistry: CommandRegistry;
+
   const mockListExtensionsCommandInstance: Command = {
     name: 'extensions list',
     description: 'Lists all installed extensions.',
@@ -45,38 +47,28 @@ describe('CommandRegistry', () => {
         execute = vi.fn();
       },
     }));
+
+    const { CommandRegistry: Registry } = await import('./command-registry.js');
+    commandRegistry = new Registry();
   });
 
   it('should register ExtensionsCommand on initialization', async () => {
-    // Re-import CommandRegistry after mocking dependencies
-    const { CommandRegistry } = await import('./command-registry.js');
-    const commandRegistry = new CommandRegistry();
-
     expect(mockExtensionsCommand).toHaveBeenCalled();
     const command = commandRegistry.get('extensions');
     expect(command).toBe(mockExtensionsCommandInstance);
   });
 
   it('should register sub commands on initialization', async () => {
-    const { CommandRegistry } = await import('./command-registry.js');
-    const commandRegistry = new CommandRegistry();
-
     const command = commandRegistry.get('extensions list');
     expect(command).toBe(mockListExtensionsCommandInstance);
   });
 
   it('get() should return undefined for a non-existent command', async () => {
-    const { CommandRegistry } = await import('./command-registry.js');
-    const commandRegistry = new CommandRegistry();
-
     const command = commandRegistry.get('non-existent');
     expect(command).toBeUndefined();
   });
 
   it('register() should register a new command', async () => {
-    const { CommandRegistry } = await import('./command-registry.js');
-    const commandRegistry = new CommandRegistry();
-
     const mockCommand: Command = {
       name: 'test-command',
       description: '',
@@ -88,9 +80,6 @@ describe('CommandRegistry', () => {
   });
 
   it('register() should register a nested command', async () => {
-    const { CommandRegistry } = await import('./command-registry.js');
-    const commandRegistry = new CommandRegistry();
-
     const mockSubSubCommand: Command = {
       name: 'test-command-sub-sub',
       description: '',
@@ -121,8 +110,6 @@ describe('CommandRegistry', () => {
 
   it('register() should not enter an infinite loop with a cyclic command', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { CommandRegistry } = await import('./command-registry.js');
-    const commandRegistry = new CommandRegistry();
 
     const mockCommand: Command = {
       name: 'cyclic-command',

--- a/packages/a2a-server/src/commands/command-registry.ts
+++ b/packages/a2a-server/src/commands/command-registry.ts
@@ -9,7 +9,7 @@ import { InitCommand } from './init.js';
 import { RestoreCommand } from './restore.js';
 import type { Command } from './types.js';
 
-class CommandRegistry {
+export class CommandRegistry {
   private readonly commands = new Map<string, Command>();
 
   constructor() {


### PR DESCRIPTION
Refactor CommandRegistry to be exportable as a class, allowing for proper dependency injection in tests. This resolves a timeout issue in command-registry.test.ts caused by side effects during module import where dependencies were instantiated before mocks could be applied.