### PR TITLE
feat(core): add draft-2020-12 JSON Schema support with lenient fallback

### DIFF
--- a/packages/core/src/utils/schemaValidator.test.ts
+++ b/packages/core/src/utils/schemaValidator.test.ts
@@ -161,9 +161,7 @@ describe('SchemaValidator', () => {
       // Valid data should pass
       expect(SchemaValidator.validate(schema, { message: 'hello' })).toBeNull();
       // Invalid data should fail (proves validation actually works)
-      expect(
-        SchemaValidator.validate(schema, { message: 123 }),
-      ).not.toBeNull();
+      expect(SchemaValidator.validate(schema, { message: 123 })).not.toBeNull();
     });
 
     it('validates draft-2020-12 schema with prefixItems', () => {

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -4,30 +4,62 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import AjvPkg, { type AnySchema } from 'ajv';
+import AjvPkg, { type AnySchema, type Ajv } from 'ajv';
+// Ajv2020 is the documented way to use draft-2020-12: https://ajv.js.org/json-schema.html#draft-2020-12
+// eslint-disable-next-line import/no-internal-modules
+import Ajv2020Pkg from 'ajv/dist/2020';
 import * as addFormats from 'ajv-formats';
 import { debugLogger } from './debugLogger.js';
+
 // Ajv's ESM/CJS interop: use 'any' for compatibility as recommended by Ajv docs
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const AjvClass = (AjvPkg as any).default || AjvPkg;
-const ajValidator = new AjvClass(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Ajv2020Class = (Ajv2020Pkg as any).default || Ajv2020Pkg;
+
+const ajvOptions = {
   // See: https://ajv.js.org/options.html#strict-mode-options
-  {
-    // strictSchema defaults to true and prevents use of JSON schemas that
-    // include unrecognized keywords. The JSON schema spec specifically allows
-    // for the use of non-standard keywords and the spec-compliant behavior
-    // is to ignore those keywords. Note that setting this to false also
-    // allows use of non-standard or custom formats (the unknown format value
-    // will be logged but the schema will still be considered valid).
-    strictSchema: false,
-  },
-);
+  // strictSchema defaults to true and prevents use of JSON schemas that
+  // include unrecognized keywords. The JSON schema spec specifically allows
+  // for the use of non-standard keywords and the spec-compliant behavior
+  // is to ignore those keywords. Note that setting this to false also
+  // allows use of non-standard or custom formats (the unknown format value
+  // will be logged but the schema will still be considered valid).
+  strictSchema: false,
+};
+
+// Draft-07 validator (default)
+const ajvDefault: Ajv = new AjvClass(ajvOptions);
+
+// Draft-2020-12 validator for MCP servers using rmcp
+const ajv2020: Ajv = new Ajv2020Class(ajvOptions);
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const addFormatsFunc = (addFormats as any).default || addFormats;
-addFormatsFunc(ajValidator);
+addFormatsFunc(ajvDefault);
+addFormatsFunc(ajv2020);
+
+// Canonical draft-2020-12 meta-schema URI (used by rmcp MCP servers)
+const DRAFT_2020_12_SCHEMA = 'https://json-schema.org/draft/2020-12/schema';
 
 /**
- * Simple utility to validate objects against JSON Schemas
+ * Returns the appropriate validator based on schema's $schema field.
+ */
+function getValidator(schema: AnySchema): Ajv {
+  if (
+    typeof schema === 'object' &&
+    schema !== null &&
+    '$schema' in schema &&
+    schema.$schema === DRAFT_2020_12_SCHEMA
+  ) {
+    return ajv2020;
+  }
+  return ajvDefault;
+}
+
+/**
+ * Simple utility to validate objects against JSON Schemas.
+ * Supports both draft-07 (default) and draft-2020-12 schemas.
  */
 export class SchemaValidator {
   /**
@@ -42,13 +74,16 @@ export class SchemaValidator {
       return 'Value of params must be an object';
     }
 
+    const anySchema = schema as AnySchema;
+    const validator = getValidator(anySchema);
+
     // Try to compile and validate; skip validation if schema can't be compiled.
     // This handles schemas using JSON Schema versions AJV doesn't support
-    // (e.g., draft-2020-12, draft-2019-09, future versions).
+    // (e.g., draft-2019-09, future versions).
     // This matches LenientJsonSchemaValidator behavior in mcp-client.ts.
     let validate;
     try {
-      validate = ajValidator.compile(schema);
+      validate = validator.compile(anySchema);
     } catch (error) {
       // Schema compilation failed (unsupported version, invalid $ref, etc.)
       // Skip validation rather than blocking tool usage.
@@ -64,7 +99,7 @@ export class SchemaValidator {
 
     const valid = validate(data);
     if (!valid && validate.errors) {
-      return ajValidator.errorsText(validate.errors, { dataVar: 'params' });
+      return validator.errorsText(validate.errors, { dataVar: 'params' });
     }
     return null;
   }
@@ -77,7 +112,20 @@ export class SchemaValidator {
     if (!schema) {
       return null;
     }
-    const isValid = ajValidator.validateSchema(schema);
-    return isValid ? null : ajValidator.errorsText(ajValidator.errors);
+    const validator = getValidator(schema);
+    try {
+      const isValid = validator.validateSchema(schema);
+      return isValid ? null : validator.errorsText(validator.errors);
+    } catch (error) {
+      // Schema validation failed (unsupported version, etc.)
+      // Skip validation rather than blocking tool usage.
+      debugLogger.warn(
+        `Failed to validate schema (${
+          (schema as Record<string, unknown>)?.['$schema'] ?? '<no $schema>'
+        }): ${error instanceof Error ? error.message : String(error)}. ` +
+          'Skipping schema validation.',
+      );
+      return null;
+    }
   }
 }

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -7,7 +7,7 @@
 import AjvPkg, { type AnySchema, type Ajv } from 'ajv';
 // Ajv2020 is the documented way to use draft-2020-12: https://ajv.js.org/json-schema.html#draft-2020-12
 // eslint-disable-next-line import/no-internal-modules
-import Ajv2020Pkg from 'ajv/dist/2020';
+import Ajv2020Pkg from 'ajv/dist/2020.js';
 import * as addFormats from 'ajv-formats';
 import { debugLogger } from './debugLogger.js';
 


### PR DESCRIPTION
## Summary

Add JSON Schema draft-2020-12 validation support for MCP servers (e.g., rmcp/Rust SDK), while keeping a lenient fallback for unknown future schema versions:

| Schema Version | Validator | Behavior |
|----------------|-----------|----------|
| draft-07 (default) | `ajvDefault` | Strict - rejects invalid data |
| draft-2020-12 | `ajv2020` | Strict - rejects invalid data |
| Other/future versions | try-catch fallback | Lenient - logs warning, skips validation |

## Related Issues

Fixes #14970
Related to https://github.com/modelcontextprotocol/rust-sdk/issues/587

## How to Validate

1. Run unit tests: `npm run test -- packages/core/src/utils/schemaValidator.test.ts`
2. Build an rmcp MCP server (e.g., from https://github.com/modelcontextprotocol/rust-sdk):
```bash
     cd ~/rust-sdk
     cargo build --example servers_counter_stdio -p mcp-server-examples
```
3. Configure in ~/.gemini/settings.json:
`{"mcpServers": {"counter": {"command": "/path/to/servers_counter_stdio"}}}`
4. Run gemini, then /mcp schema should show tools without errors
5. Invoke a tool like sum - should succeed instead of failing with schema error


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
