### PR TITLE
(bug) fix IDE extension support from docker container

### DIFF
--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -508,7 +508,7 @@ describe('IDEServer HTTP endpoints', () => {
     expect(response.statusCode).toBe(403);
   });
 
-  it('should allow requests with a valid host header', async () => {
+  it('should allow requests with a valid host header - localhost', async () => {
     const response = await request(
       port,
       {
@@ -516,6 +516,25 @@ describe('IDEServer HTTP endpoints', () => {
         method: 'POST',
         headers: {
           Host: `localhost:${port}`,
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-auth-token',
+        },
+      },
+      JSON.stringify({ jsonrpc: '2.0', method: 'initialize' }),
+    );
+    // We expect a 400 here because we are not sending a valid MCP request,
+    // but it's not a host error, which is what we are testing.
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should allow requests with a valid host header - docker', async () => {
+    const response = await request(
+      port,
+      {
+        path: '/mcp',
+        method: 'POST',
+        headers: {
+          Host: `host.docker.internal:${port}`,
           'Content-Type': 'application/json',
           Authorization: 'Bearer test-auth-token',
         },

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -159,6 +159,7 @@ export class IDEServer {
         const allowedHosts = [
           `localhost:${this.port}`,
           `127.0.0.1:${this.port}`,
+          `host.docker.internal:${this.port}`,
         ];
         if (!allowedHosts.includes(host)) {
           return res.status(403).json({ error: 'Invalid Host header' });


### PR DESCRIPTION
https://github.com/google-gemini/gemini-cli/blob/fc2a5a42ce66a5cd3209d118c0bc735ad86d9075/packages/core/src/ide/ide-client.ts#L849

## Summary

Fix IDE Companion Extension when running Gemini CLI from within a docker container. 

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/10541
Fixes https://github.com/google-gemini/gemini-cli/issues/10473
Fixes https://github.com/google-gemini/gemini-cli/issues/6297 (without having to update /etc/hosts)

## How to Validate
- Launch forked Gemini CLI companion
- Run Gemini CLI in a dev container or workstation (where fs.existsSync('/.dockerenv') || fs.existsSync('/run/.containerenv');)
- Type /ide status
- See it is connected

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [x] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
