### PR TITLE
fix: Mark A2A requests as interactive

### DIFF
--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -75,6 +75,7 @@ export async function loadConfig(
       ? process.env['CHECKPOINTING'] === 'true'
       : settings.checkpointing?.enabled,
     previewFeatures: settings.general?.previewFeatures,
+    interactive: true,
   };
 
   const fileService = new FileDiscoveryService(workspaceDir);


### PR DESCRIPTION
## Details

The "Tool Call Lifecycle" section of [Gemini CLI A2A documentation](https://github.com/google-gemini/gemini-cli/blob/main/packages/a2a-server/development-extension-rfc.md) clearly states that the confirmation requirement is expected for tool calls. Hence the requests should be marked interactive after pr https://github.com/google-gemini/gemini-cli/pull/14702.

## Related Issues

Related to #11459 

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
