### PR TITLE
Separate home dirs for each integration test

### DIFF
--- a/integration-tests/extensions-install.test.ts
+++ b/integration-tests/extensions-install.test.ts
@@ -30,11 +30,11 @@ describe('extension install', () => {
 
   it('installs a local extension, verifies a command, and updates it', async () => {
     rig.setup('extension install test');
-    const testServerPath = join(rig.testDir!, 'gemini-extension.json');
+    const testServerPath = join(rig.workDir!, 'gemini-extension.json');
     writeFileSync(testServerPath, extension);
     try {
       const result = await rig.runCommand(
-        ['extensions', 'install', `${rig.testDir!}`],
+        ['extensions', 'install', `${rig.workDir!}`],
         { stdin: 'y\n' },
       );
       expect(result).toContain('test-extension-install');

--- a/integration-tests/extensions-reload.test.ts
+++ b/integration-tests/extensions-reload.test.ts
@@ -56,7 +56,7 @@ describe('extension reloading', () => {
           experimental: { extensionReloading: true },
         },
       });
-      const testServerPath = join(rig.testDir!, 'gemini-extension.json');
+      const testServerPath = join(rig.workDir!, 'gemini-extension.json');
       writeFileSync(testServerPath, safeJsonStringify(extension, 2));
       // defensive cleanup from previous tests.
       try {
@@ -66,7 +66,7 @@ describe('extension reloading', () => {
       }
 
       const result = await rig.runCommand(
-        ['extensions', 'install', `${rig.testDir!}`],
+        ['extensions', 'install', `${rig.workDir!}`],
         { stdin: 'y\n' },
       );
       expect(result).toContain('test-extension');

--- a/integration-tests/file-system.test.ts
+++ b/integration-tests/file-system.test.ts
@@ -277,7 +277,7 @@ describe('file-system', () => {
     ).toBeUndefined();
 
     // Final verification: ensure the file was not created.
-    const filePath = path.join(rig.testDir!, fileName);
+    const filePath = path.join(rig.workDir!, fileName);
     const fileExists = existsSync(filePath);
     expect(fileExists, 'The non-existent file should not be created').toBe(
       false,

--- a/integration-tests/hooks-system.test.ts
+++ b/integration-tests/hooks-system.test.ts
@@ -206,7 +206,7 @@ echo '{
   }
 }'`;
 
-      const scriptPath = join(rig.testDir!, 'before_model_hook.sh');
+      const scriptPath = join(rig.workDir!, 'before_model_hook.sh');
       writeFileSync(scriptPath, hookScript);
       // Make executable
       const { execSync } = await import('node:child_process');
@@ -290,7 +290,7 @@ echo '{
   }
 }'`;
 
-        const scriptPath = join(rig.testDir!, 'after_model_hook.sh');
+        const scriptPath = join(rig.workDir!, 'after_model_hook.sh');
         writeFileSync(scriptPath, hookScript);
         const { execSync } = await import('node:child_process');
         execSync(`chmod +x "${scriptPath}"`);
@@ -413,7 +413,7 @@ echo '{
   }
 }'`;
 
-      const scriptPath = join(rig.testDir!, 'before_agent_hook.sh');
+      const scriptPath = join(rig.workDir!, 'before_agent_hook.sh');
       writeFileSync(scriptPath, hookScript);
       const { execSync } = await import('node:child_process');
       execSync(`chmod +x "${scriptPath}"`);
@@ -634,7 +634,7 @@ else
   exit 0
 fi`;
 
-      const scriptPath = join(rig.testDir!, 'input_validation_hook.sh');
+      const scriptPath = join(rig.workDir!, 'input_validation_hook.sh');
       writeFileSync(scriptPath, hookScript);
       const { execSync } = await import('node:child_process');
       execSync(`chmod +x "${scriptPath}"`);
@@ -1303,8 +1303,8 @@ echo '{"decision": "allow", "systemMessage": "Enabled hook executed"}'`;
       const disabledHookScript = `#!/bin/bash
 echo '{"decision": "block", "systemMessage": "Disabled hook should not execute", "reason": "This hook should be disabled"}'`;
 
-      const enabledPath = join(rig.testDir!, 'enabled_hook.sh');
-      const disabledPath = join(rig.testDir!, 'disabled_hook.sh');
+      const enabledPath = join(rig.workDir!, 'enabled_hook.sh');
+      const disabledPath = join(rig.workDir!, 'disabled_hook.sh');
 
       writeFileSync(enabledPath, enabledHookScript);
       writeFileSync(disabledPath, disabledHookScript);
@@ -1386,8 +1386,8 @@ echo '{"decision": "allow", "systemMessage": "Active hook executed"}'`;
       const disabledHookScript = `#!/bin/bash
 echo '{"decision": "block", "systemMessage": "Disabled hook should not execute", "reason": "This hook is disabled"}'`;
 
-      const activePath = join(rig.testDir!, 'active_hook.sh');
-      const disabledPath = join(rig.testDir!, 'disabled_hook.sh');
+      const activePath = join(rig.workDir!, 'active_hook.sh');
+      const disabledPath = join(rig.workDir!, 'disabled_hook.sh');
 
       writeFileSync(activePath, activeHookScript);
       writeFileSync(disabledPath, disabledHookScript);

--- a/integration-tests/json-output.test.ts
+++ b/integration-tests/json-output.test.ts
@@ -110,7 +110,7 @@ describe('JSON output', () => {
     });
     const result = await rig.run({
       args: [
-        `Read the contents of ${rig.testDir}/path/to/nonexistent/file.txt and tell me what it says. ` +
+        `Read the contents of ${rig.workDir}/path/to/nonexistent/file.txt and tell me what it says. ` +
           'On error, respond to the user with exactly the text "File not found".',
         '--output-format',
         'json',

--- a/integration-tests/list_directory.test.ts
+++ b/integration-tests/list_directory.test.ts
@@ -35,8 +35,8 @@ describe('list_directory', () => {
     await poll(
       () => {
         // Check if the files exist in the test directory
-        const file1Path = join(rig.testDir!, 'file1.txt');
-        const subdirPath = join(rig.testDir!, 'subdir');
+        const file1Path = join(rig.workDir!, 'file1.txt');
+        const subdirPath = join(rig.workDir!, 'subdir');
         return existsSync(file1Path) && existsSync(subdirPath);
       },
       1000, // 1 second max wait

--- a/integration-tests/mcp_server_cyclic_schema.test.ts
+++ b/integration-tests/mcp_server_cyclic_schema.test.ts
@@ -188,7 +188,7 @@ describe('mcp server with cyclic tool schema is detected', () => {
     });
 
     // Create server script in the test directory
-    const testServerPath = join(rig.testDir!, 'mcp-server.cjs');
+    const testServerPath = join(rig.workDir!, 'mcp-server.cjs');
     writeFileSync(testServerPath, serverScript);
 
     // Make the script executable (though running with 'node' should work anyway)

--- a/integration-tests/simple-mcp-server.test.ts
+++ b/integration-tests/simple-mcp-server.test.ts
@@ -188,7 +188,7 @@ describe('simple-mcp-server', () => {
     });
 
     // Create server script in the test directory
-    const testServerPath = join(rig.testDir!, 'mcp-server.cjs');
+    const testServerPath = join(rig.workDir!, 'mcp-server.cjs');
     writeFileSync(testServerPath, serverScript);
 
     // Make the script executable (though running with 'node' should work anyway)

--- a/integration-tests/utf-bom-encoding.test.ts
+++ b/integration-tests/utf-bom-encoding.test.ts
@@ -64,7 +64,7 @@ describe('BOM end-to-end integraion', () => {
     content: Buffer,
     expectedText: string | null,
   ) {
-    writeFileSync(join(rig.testDir!, filename), content);
+    writeFileSync(join(rig.workDir!, filename), content);
     const prompt = `read the file ${filename} and output its exact contents`;
     const output = await rig.run({ args: prompt });
     await rig.waitForToolCall('read_file');
@@ -124,7 +124,7 @@ describe('BOM end-to-end integraion', () => {
     );
     const imageContent = readFileSync(imagePath);
     const filename = 'gemini-screenshot.png';
-    writeFileSync(join(rig.testDir!, filename), imageContent);
+    writeFileSync(join(rig.workDir!, filename), imageContent);
     const prompt = `What is shown in the image ${filename}?`;
     const output = await rig.run({ args: prompt });
     await rig.waitForToolCall('read_file');


### PR DESCRIPTION
## Summary

Separate home dirs for each integration test

## Details

Previously, all integration tests shared the same home dir which meant that extensions installed in one test, could interfere with another test.