### PR TITLE
chore: remove user query from footer in debug mode

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -418,7 +418,6 @@ export const useGeminiStream = (
 
       if (typeof query === 'string') {
         const trimmedQuery = query.trim();
-        onDebugMessage(`User query: '${trimmedQuery}'`);
         await logger?.logMessage(MessageSenderType.USER, trimmedQuery);
 
         if (!shellModeActive) {


### PR DESCRIPTION
## Summary

Removing user query from footer when in debug mode, it is clunky for large user queries

<img width="2464" height="594" alt="image" src="https://github.com/user-attachments/assets/17871452-9971-4a71-ba54-fbc389cc0967" />
