### PR TITLE
Disallow unnecessary awaits.

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -165,6 +165,7 @@ export default tseslint.config(
       'prefer-const': ['error', { destructuring: 'all' }],
       radix: 'error',
       'default-case': 'error',
+      '@typescript-eslint/await-thenable': ['error'],
       '@typescript-eslint/no-floating-promises': ['error'],
       '@typescript-eslint/no-unnecessary-type-assertion': ['error'],
     },

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -123,7 +123,7 @@ export class Task {
   // process. This is not scoped to the individual task but reflects the global connection
   // state managed within the @gemini-cli/core module.
   async getMetadata(): Promise<TaskMetadata> {
-    const toolRegistry = await this.config.getToolRegistry();
+    const toolRegistry = this.config.getToolRegistry();
     const mcpServers = this.config.getMcpClientManager()?.getMcpServers() || {};
     const serverStatuses = getAllMCPServerStatuses();
     const servers = Object.keys(mcpServers).map((serverName) => ({

--- a/packages/cli/src/commands/extensions/disable.test.ts
+++ b/packages/cli/src/commands/extensions/disable.test.ts
@@ -228,7 +228,9 @@ describe('extensions disable command', () => {
         _: [],
         $0: '',
       };
-      await (command.handler as unknown as (args: TestArgv) => void)(argv);
+      await (command.handler as unknown as (args: TestArgv) => Promise<void>)(
+        argv,
+      );
       expect(mockExtensionManager).toHaveBeenCalledWith(
         expect.objectContaining({
           workspaceDir: '/test/dir',

--- a/packages/cli/src/commands/extensions/enable.test.ts
+++ b/packages/cli/src/commands/extensions/enable.test.ts
@@ -205,7 +205,9 @@ describe('extensions enable command', () => {
         _: [],
         $0: '',
       };
-      await (command.handler as unknown as (args: TestArgv) => void)(argv);
+      await (command.handler as unknown as (args: TestArgv) => Promise<void>)(
+        argv,
+      );
 
       expect(
         mockExtensionManager.prototype.enableExtension,

--- a/packages/cli/src/commands/extensions/link.test.ts
+++ b/packages/cli/src/commands/extensions/link.test.ts
@@ -180,7 +180,9 @@ describe('extensions link command', () => {
         _: [],
         $0: '',
       };
-      await (command.handler as unknown as (args: TestArgv) => void)(argv);
+      await (command.handler as unknown as (args: TestArgv) => Promise<void>)(
+        argv,
+      );
 
       expect(
         mockExtensionManager.prototype.installOrUpdateExtension,

--- a/packages/cli/src/commands/extensions/settings.ts
+++ b/packages/cli/src/commands/extensions/settings.ts
@@ -49,7 +49,7 @@ const setCommand: CommandModule<object, SetArgs> = {
     if (!extension || !extensionManager) {
       return;
     }
-    const extensionConfig = extensionManager.loadExtensionConfig(
+    const extensionConfig = await extensionManager.loadExtensionConfig(
       extension.path,
     );
     if (!extensionConfig) {
@@ -89,7 +89,7 @@ const listCommand: CommandModule<object, ListArgs> = {
     if (!extension || !extensionManager) {
       return;
     }
-    const extensionConfig = extensionManager.loadExtensionConfig(
+    const extensionConfig = await extensionManager.loadExtensionConfig(
       extension.path,
     );
     if (

--- a/packages/cli/src/commands/extensions/uninstall.test.ts
+++ b/packages/cli/src/commands/extensions/uninstall.test.ts
@@ -287,7 +287,9 @@ describe('extensions uninstall command', () => {
         [key: string]: unknown;
       }
       const argv: TestArgv = { names: ['my-extension'], _: [], $0: '' };
-      await (command.handler as unknown as (args: TestArgv) => void)(argv);
+      await (command.handler as unknown as (args: TestArgv) => Promise<void>)(
+        argv,
+      );
 
       expect(mockUninstallExtension).toHaveBeenCalledWith(
         'my-extension',

--- a/packages/cli/src/commands/extensions/validate.ts
+++ b/packages/cli/src/commands/extensions/validate.ts
@@ -41,7 +41,7 @@ async function validateExtension(args: ValidateArgs) {
   });
   const absoluteInputPath = path.resolve(args.path);
   const extensionConfig: ExtensionConfig =
-    extensionManager.loadExtensionConfig(absoluteInputPath);
+    await extensionManager.loadExtensionConfig(absoluteInputPath);
   const warnings: string[] = [];
   const errors: string[] = [];
 

--- a/packages/cli/src/commands/mcp/add.test.ts
+++ b/packages/cli/src/commands/mcp/add.test.ts
@@ -4,7 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, type Mock, type MockInstance } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  type Mock,
+  type MockInstance,
+} from 'vitest';
 import yargs, { type Argv } from 'yargs';
 import { addCommand } from './add.js';
 import { loadSettings, SettingScope } from '../../config/settings.js';

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -220,7 +220,7 @@ export class ExtensionManager extends ExtensionLoader {
       }
 
       try {
-        newExtensionConfig = this.loadExtensionConfig(localSourcePath);
+        newExtensionConfig = await this.loadExtensionConfig(localSourcePath);
 
         if (isUpdate && installMetadata.autoUpdate) {
           const oldSettings = new Set(
@@ -364,7 +364,7 @@ export class ExtensionManager extends ExtensionLoader {
       // to get the name and version for logging.
       if (!newExtensionConfig && localSourcePath) {
         try {
-          newExtensionConfig = this.loadExtensionConfig(localSourcePath);
+          newExtensionConfig = await this.loadExtensionConfig(localSourcePath);
         } catch {
           // Ignore error, this is just for logging.
         }
@@ -491,7 +491,7 @@ export class ExtensionManager extends ExtensionLoader {
     }
 
     try {
-      let config = this.loadExtensionConfig(effectiveExtensionPath);
+      let config = await this.loadExtensionConfig(effectiveExtensionPath);
       if (
         this.getExtensions().find((extension) => extension.name === config.name)
       ) {
@@ -571,13 +571,13 @@ export class ExtensionManager extends ExtensionLoader {
     return this.maybeStopExtension(extension);
   }
 
-  loadExtensionConfig(extensionDir: string): ExtensionConfig {
+  async loadExtensionConfig(extensionDir: string): Promise<ExtensionConfig> {
     const configFilePath = path.join(extensionDir, EXTENSIONS_CONFIG_FILENAME);
     if (!fs.existsSync(configFilePath)) {
       throw new Error(`Configuration file not found at ${configFilePath}`);
     }
     try {
-      const configContent = fs.readFileSync(configFilePath, 'utf-8');
+      const configContent = await fs.promises.readFile(configFilePath, 'utf-8');
       const rawConfig = JSON.parse(configContent) as ExtensionConfig;
       if (!rawConfig.name || !rawConfig.version) {
         throw new Error(

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -1424,9 +1424,10 @@ This extension will run the following MCP servers:
         ],
       });
 
-      const previousExtensionConfig = extensionManager.loadExtensionConfig(
-        path.join(userExtensionsDir, 'my-local-extension'),
-      );
+      const previousExtensionConfig =
+        await extensionManager.loadExtensionConfig(
+          path.join(userExtensionsDir, 'my-local-extension'),
+        );
       mockPromptForSettings.mockResolvedValueOnce('new-setting-value');
 
       // 3. Call installOrUpdateExtension to perform the update.
@@ -1481,9 +1482,10 @@ This extension will run the following MCP servers:
         ],
       });
 
-      const previousExtensionConfig = extensionManager.loadExtensionConfig(
-        path.join(userExtensionsDir, 'my-auto-update-ext'),
-      );
+      const previousExtensionConfig =
+        await extensionManager.loadExtensionConfig(
+          path.join(userExtensionsDir, 'my-auto-update-ext'),
+        );
 
       // 3. Attempt to update and assert it fails
       await expect(
@@ -1967,7 +1969,7 @@ This extension will run the following MCP servers:
       expect(activeExtensions).toHaveLength(0);
 
       await extensionManager.enableExtension('ext1', SettingScope.User);
-      activeExtensions = await getActiveExtensions();
+      activeExtensions = getActiveExtensions();
       expect(activeExtensions).toHaveLength(1);
       expect(activeExtensions[0].name).toBe('ext1');
     });
@@ -1984,7 +1986,7 @@ This extension will run the following MCP servers:
       expect(activeExtensions).toHaveLength(0);
 
       await extensionManager.enableExtension('ext1', SettingScope.Workspace);
-      activeExtensions = await getActiveExtensions();
+      activeExtensions = getActiveExtensions();
       expect(activeExtensions).toHaveLength(1);
       expect(activeExtensions[0].name).toBe('ext1');
     });

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -221,9 +221,11 @@ describe('github.ts', () => {
     });
 
     it('should return NOT_UPDATABLE for non-git/non-release extensions', async () => {
-      vi.mocked(mockExtensionManager.loadExtensionConfig).mockReturnValue({
-        version: '1.0.0',
-      } as unknown as ExtensionConfig);
+      vi.mocked(mockExtensionManager.loadExtensionConfig).mockReturnValue(
+        Promise.resolve({
+          version: '1.0.0',
+        } as unknown as ExtensionConfig),
+      );
 
       const linkExt = {
         installMetadata: { type: 'link' },

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -175,7 +175,7 @@ export async function checkForExtensionUpdate(
   if (installMetadata?.type === 'local') {
     let latestConfig: ExtensionConfig | undefined;
     try {
-      latestConfig = extensionManager.loadExtensionConfig(
+      latestConfig = await extensionManager.loadExtensionConfig(
         installMetadata.source,
       );
     } catch (e) {

--- a/packages/cli/src/config/extensions/update.test.ts
+++ b/packages/cli/src/config/extensions/update.test.ts
@@ -145,10 +145,12 @@ describe('Extension Update Logic', () => {
     });
 
     it('should successfully update extension and set state to UPDATED_NEEDS_RESTART by default', async () => {
-      vi.mocked(mockExtensionManager.loadExtensionConfig).mockReturnValue({
-        name: 'test-extension',
-        version: '1.0.0',
-      });
+      vi.mocked(mockExtensionManager.loadExtensionConfig).mockReturnValue(
+        Promise.resolve({
+          name: 'test-extension',
+          version: '1.0.0',
+        }),
+      );
       vi.mocked(
         mockExtensionManager.installOrUpdateExtension,
       ).mockResolvedValue({
@@ -183,10 +185,12 @@ describe('Extension Update Logic', () => {
     });
 
     it('should set state to UPDATED if enableExtensionReloading is true', async () => {
-      vi.mocked(mockExtensionManager.loadExtensionConfig).mockReturnValue({
-        name: 'test-extension',
-        version: '1.0.0',
-      });
+      vi.mocked(mockExtensionManager.loadExtensionConfig).mockReturnValue(
+        Promise.resolve({
+          name: 'test-extension',
+          version: '1.0.0',
+        }),
+      );
       vi.mocked(
         mockExtensionManager.installOrUpdateExtension,
       ).mockResolvedValue({
@@ -212,10 +216,12 @@ describe('Extension Update Logic', () => {
     });
 
     it('should rollback and set state to ERROR if installation fails', async () => {
-      vi.mocked(mockExtensionManager.loadExtensionConfig).mockReturnValue({
-        name: 'test-extension',
-        version: '1.0.0',
-      });
+      vi.mocked(mockExtensionManager.loadExtensionConfig).mockReturnValue(
+        Promise.resolve({
+          name: 'test-extension',
+          version: '1.0.0',
+        }),
+      );
       vi.mocked(
         mockExtensionManager.installOrUpdateExtension,
       ).mockRejectedValue(new Error('Install failed'));
@@ -257,10 +263,12 @@ describe('Extension Update Logic', () => {
         ['ext3', { status: ExtensionUpdateState.UPDATE_AVAILABLE }],
       ]);
 
-      vi.mocked(mockExtensionManager.loadExtensionConfig).mockReturnValue({
-        name: 'ext',
-        version: '1.0.0',
-      });
+      vi.mocked(mockExtensionManager.loadExtensionConfig).mockReturnValue(
+        Promise.resolve({
+          name: 'ext',
+          version: '1.0.0',
+        }),
+      );
       vi.mocked(
         mockExtensionManager.installOrUpdateExtension,
       ).mockResolvedValue({ ...mockExtension, version: '1.1.0' });

--- a/packages/cli/src/config/extensions/update.ts
+++ b/packages/cli/src/config/extensions/update.ts
@@ -59,7 +59,7 @@ export async function updateExtension(
 
   const tempDir = await ExtensionStorage.createTmpDir();
   try {
-    const previousExtensionConfig = extensionManager.loadExtensionConfig(
+    const previousExtensionConfig = await extensionManager.loadExtensionConfig(
       extension.path,
     );
     let updatedExtension: GeminiCLIExtension;

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -48,7 +48,7 @@ describe('chatCommand', () => {
 
   beforeEach(() => {
     mockGetHistory = vi.fn().mockReturnValue([]);
-    mockGetChat = vi.fn().mockResolvedValue({
+    mockGetChat = vi.fn().mockReturnValue({
       getHistory: mockGetHistory,
     });
     mockSaveCheckpoint = vi.fn().mockResolvedValue(undefined);

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -121,7 +121,7 @@ const saveCommand: SlashCommand = {
       }
     }
 
-    const chat = await config?.getGeminiClient()?.getChat();
+    const chat = config?.getGeminiClient()?.getChat();
     if (!chat) {
       return {
         type: 'message',
@@ -332,7 +332,7 @@ const shareCommand: SlashCommand = {
       };
     }
 
-    const chat = await context.services.config?.getGeminiClient()?.getChat();
+    const chat = context.services.config?.getGeminiClient()?.getChat();
     if (!chat) {
       return {
         type: 'message',

--- a/packages/cli/src/ui/commands/copyCommand.ts
+++ b/packages/cli/src/ui/commands/copyCommand.ts
@@ -15,7 +15,7 @@ export const copyCommand: SlashCommand = {
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
   action: async (context, _args): Promise<SlashCommandActionReturn | void> => {
-    const chat = await context.services.config?.getGeminiClient()?.getChat();
+    const chat = context.services.config?.getGeminiClient()?.getChat();
     const history = chat?.getHistory();
 
     // Get the last message from the AI (model role)

--- a/packages/cli/src/ui/commands/mcpCommand.test.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.test.ts
@@ -85,7 +85,7 @@ describe('mcpCommand', () => {
       }),
       getMcpServers: vi.fn().mockReturnValue({}),
       getBlockedMcpServers: vi.fn().mockReturnValue([]),
-      getPromptRegistry: vi.fn().mockResolvedValue({
+      getPromptRegistry: vi.fn().mockReturnValue({
         getAllPrompts: vi.fn().mockReturnValue([]),
         getPromptsByServer: vi.fn().mockReturnValue([]),
       }),

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -216,7 +216,7 @@ const listAction = async (
   const allTools = toolRegistry.getAllTools();
   const mcpTools = allTools.filter((tool) => tool instanceof DiscoveredMCPTool);
 
-  const promptRegistry = await config.getPromptRegistry();
+  const promptRegistry = config.getPromptRegistry();
   const mcpPrompts = promptRegistry
     .getAllPrompts()
     .filter(

--- a/packages/cli/src/ui/commands/memoryCommand.ts
+++ b/packages/cli/src/ui/commands/memoryCommand.ts
@@ -85,7 +85,7 @@ export const memoryCommand: SlashCommand = {
         );
 
         try {
-          const config = await context.services.config;
+          const config = context.services.config;
           if (config) {
             const { memoryContent, fileCount } =
               await refreshServerHierarchicalMemory(config);

--- a/packages/cli/src/ui/commands/restoreCommand.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.ts
@@ -116,7 +116,7 @@ async function restoreAction(
       } else if (action.type === 'load_history' && loadHistory) {
         loadHistory(action.history);
         if (action.clientHistory) {
-          await config?.getGeminiClient()?.setHistory(action.clientHistory);
+          config?.getGeminiClient()?.setHistory(action.clientHistory);
         }
       }
     }

--- a/packages/cli/src/ui/components/MultiFolderTrustDialog.test.tsx
+++ b/packages/cli/src/ui/components/MultiFolderTrustDialog.test.tsx
@@ -89,7 +89,7 @@ describe('MultiFolderTrustDialog', () => {
 
     const keypressCallback = mockedUseKeypress.mock.calls[0][0];
     await act(async () => {
-      await keypressCallback({
+      keypressCallback({
         name: 'escape',
         ctrl: false,
         meta: false,
@@ -117,7 +117,7 @@ describe('MultiFolderTrustDialog', () => {
 
     const { onSelect } = mockedRadioButtonSelect.mock.calls[0][0];
     await act(async () => {
-      await onSelect(MultiFolderTrustChoice.NO);
+      onSelect(MultiFolderTrustChoice.NO);
     });
 
     expect(mockFinishAddingDirectories).toHaveBeenCalledWith(
@@ -145,7 +145,7 @@ describe('MultiFolderTrustDialog', () => {
 
     const { onSelect } = mockedRadioButtonSelect.mock.calls[0][0];
     await act(async () => {
-      await onSelect(MultiFolderTrustChoice.YES);
+      onSelect(MultiFolderTrustChoice.YES);
     });
 
     expect(mockAddDirectory).toHaveBeenCalledWith('/path/to/folder1');
@@ -166,7 +166,7 @@ describe('MultiFolderTrustDialog', () => {
 
     const { onSelect } = mockedRadioButtonSelect.mock.calls[0][0];
     await act(async () => {
-      await onSelect(MultiFolderTrustChoice.YES_AND_REMEMBER);
+      onSelect(MultiFolderTrustChoice.YES_AND_REMEMBER);
     });
 
     expect(mockAddDirectory).toHaveBeenCalledWith('/path/to/folder1');
@@ -192,7 +192,7 @@ describe('MultiFolderTrustDialog', () => {
     const { onSelect } = mockedRadioButtonSelect.mock.calls[0][0];
 
     await act(async () => {
-      await onSelect(MultiFolderTrustChoice.NO);
+      onSelect(MultiFolderTrustChoice.NO);
     });
 
     expect(lastFrame()).toContain('Applying trust settings...');
@@ -210,7 +210,7 @@ describe('MultiFolderTrustDialog', () => {
 
     const { onSelect } = mockedRadioButtonSelect.mock.calls[0][0];
     await act(async () => {
-      await onSelect(MultiFolderTrustChoice.YES);
+      onSelect(MultiFolderTrustChoice.YES);
     });
 
     expect(mockAddItem).toHaveBeenCalledWith(
@@ -243,7 +243,7 @@ describe('MultiFolderTrustDialog', () => {
 
     const { onSelect } = mockedRadioButtonSelect.mock.calls[0][0];
     await act(async () => {
-      await onSelect(MultiFolderTrustChoice.YES);
+      onSelect(MultiFolderTrustChoice.YES);
     });
 
     expect(mockAddDirectory).toHaveBeenCalledWith('/path/to/good');

--- a/packages/cli/src/ui/contexts/VimModeContext.tsx
+++ b/packages/cli/src/ui/contexts/VimModeContext.tsx
@@ -55,7 +55,7 @@ export const VimModeProvider = ({
     if (newValue) {
       setVimMode('NORMAL');
     }
-    await settings.setValue(SettingScope.User, 'general.vimMode', newValue);
+    settings.setValue(SettingScope.User, 'general.vimMode', newValue);
     return newValue;
   }, [vimEnabled, settings]);
 

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
@@ -1120,7 +1120,7 @@ describe('useSlashCommandProcessor', () => {
 
     // We should not see a change until we fire an event.
     await waitFor(() => expect(result.current.slashCommands).toEqual([]));
-    await act(() => {
+    act(() => {
       appEvents.emit('extensionsStarting');
     });
     await waitFor(() =>

--- a/packages/cli/src/ui/hooks/useFolderTrust.test.ts
+++ b/packages/cli/src/ui/hooks/useFolderTrust.test.ts
@@ -140,9 +140,7 @@ describe('useFolderTrust', () => {
     });
 
     await act(async () => {
-      await result.current.handleFolderTrustSelect(
-        FolderTrustChoice.TRUST_FOLDER,
-      );
+      result.current.handleFolderTrustSelect(FolderTrustChoice.TRUST_FOLDER);
     });
 
     await waitFor(() => {

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -136,7 +136,7 @@ describe('useQuotaAndFallback', () => {
           mockGoogleApiError,
           1000 * 60 * 5,
         ); // 5 minutes
-        await act(() => {
+        act(() => {
           promise = handler('gemini-pro', 'gemini-flash', error);
         });
 
@@ -155,7 +155,7 @@ describe('useQuotaAndFallback', () => {
         expect(mockHistoryManager.addItem).not.toHaveBeenCalled();
 
         // Simulate the user choosing to continue with the fallback model
-        await act(() => {
+        act(() => {
           result.current.handleProQuotaChoice('retry_always');
         });
 
@@ -182,7 +182,7 @@ describe('useQuotaAndFallback', () => {
           .calls[0][0] as FallbackModelHandler;
 
         let promise1: Promise<FallbackIntent | null>;
-        await act(() => {
+        act(() => {
           promise1 = handler(
             'gemini-pro',
             'gemini-flash',
@@ -206,7 +206,7 @@ describe('useQuotaAndFallback', () => {
         expect(result2!).toBe('stop');
         expect(result.current.proQuotaRequest).toBe(firstRequest);
 
-        await act(() => {
+        act(() => {
           result.current.handleProQuotaChoice('retry_always');
         });
 
@@ -247,7 +247,7 @@ describe('useQuotaAndFallback', () => {
             .calls[0][0] as FallbackModelHandler;
 
           let promise: Promise<FallbackIntent | null>;
-          await act(() => {
+          act(() => {
             promise = handler('model-A', 'model-B', error);
           });
 
@@ -265,7 +265,7 @@ describe('useQuotaAndFallback', () => {
           );
 
           // Simulate the user choosing to continue with the fallback model
-          await act(() => {
+          act(() => {
             result.current.handleProQuotaChoice('retry_always');
           });
 
@@ -303,7 +303,7 @@ describe('useQuotaAndFallback', () => {
         let promise: Promise<FallbackIntent | null>;
         const error = new ModelNotFoundError('model not found', 404);
 
-        await act(() => {
+        act(() => {
           promise = handler('gemini-3-pro-preview', 'gemini-2.5-pro', error);
         });
 
@@ -322,7 +322,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
         );
 
         // Simulate the user choosing to switch
-        await act(() => {
+        act(() => {
           result.current.handleProQuotaChoice('retry_always');
         });
 
@@ -364,7 +364,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
       const handler = setFallbackHandlerSpy.mock
         .calls[0][0] as FallbackModelHandler;
       let promise: Promise<FallbackIntent | null>;
-      await act(() => {
+      act(() => {
         promise = handler(
           'gemini-pro',
           'gemini-flash',
@@ -372,7 +372,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
         );
       });
 
-      await act(() => {
+      act(() => {
         result.current.handleProQuotaChoice('retry_later');
       });
 
@@ -395,7 +395,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
         .calls[0][0] as FallbackModelHandler;
 
       let promise: Promise<FallbackIntent | null>;
-      await act(() => {
+      act(() => {
         promise = handler(
           'gemini-pro',
           'gemini-flash',
@@ -403,7 +403,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
         );
       });
 
-      await act(() => {
+      act(() => {
         result.current.handleProQuotaChoice('retry_always');
       });
 
@@ -431,7 +431,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
       const handler = setFallbackHandlerSpy.mock
         .calls[0][0] as FallbackModelHandler;
       let promise: Promise<FallbackIntent | null>;
-      await act(() => {
+      act(() => {
         promise = handler(
           PREVIEW_GEMINI_MODEL,
           DEFAULT_GEMINI_MODEL,
@@ -439,7 +439,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
         );
       });
 
-      await act(() => {
+      act(() => {
         result.current.handleProQuotaChoice('retry_always');
       });
 
@@ -466,7 +466,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
       const handler = setFallbackHandlerSpy.mock
         .calls[0][0] as FallbackModelHandler;
       let promise: Promise<FallbackIntent | null>;
-      await act(() => {
+      act(() => {
         promise = handler(
           PREVIEW_GEMINI_MODEL,
           DEFAULT_GEMINI_FLASH_MODEL,
@@ -474,7 +474,7 @@ To disable Gemini 3, disable "Preview features" in /settings.`,
         );
       });
 
-      await act(() => {
+      act(() => {
         result.current.handleProQuotaChoice('retry_always');
       });
 

--- a/packages/core/src/agents/executor.test.ts
+++ b/packages/core/src/agents/executor.test.ts
@@ -270,9 +270,7 @@ describe('AgentExecutor', () => {
     );
     parentToolRegistry.registerTool(MOCK_TOOL_NOT_ALLOWED);
 
-    vi.spyOn(mockConfig, 'getToolRegistry').mockResolvedValue(
-      parentToolRegistry,
-    );
+    vi.spyOn(mockConfig, 'getToolRegistry').mockReturnValue(parentToolRegistry);
 
     mockedGetDirectoryContextString.mockResolvedValue(
       'Mocked Environment Context',

--- a/packages/core/src/agents/executor.ts
+++ b/packages/core/src/agents/executor.ts
@@ -106,7 +106,7 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
   ): Promise<AgentExecutor<TOutput>> {
     // Create an isolated tool registry for this agent instance.
     const agentToolRegistry = new ToolRegistry(runtimeContext);
-    const parentToolRegistry = await runtimeContext.getToolRegistry();
+    const parentToolRegistry = runtimeContext.getToolRegistry();
 
     if (definition.toolConfig) {
       for (const toolRef of definition.toolConfig.tools) {

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -189,7 +189,7 @@ describe('oauth2', () => {
         end: vi.fn(),
       } as unknown as http.ServerResponse;
 
-      await requestCallback(mockReq, mockRes);
+      requestCallback(mockReq, mockRes);
 
       const client = await clientPromise;
       expect(client).toBe(mockOAuth2Client);
@@ -203,7 +203,9 @@ describe('oauth2', () => {
 
       // Manually trigger the 'tokens' event listener
       if (tokensListener) {
-        await tokensListener(mockTokens);
+        await (
+          tokensListener as unknown as (tokens: Credentials) => Promise<void>
+        )(mockTokens);
       }
 
       // Verify Google Account was cached
@@ -575,9 +577,7 @@ describe('oauth2', () => {
         const mockExternalAccountClient = {
           getAccessToken: vi.fn().mockResolvedValue({ token: 'byoid-token' }),
         };
-        const mockFromJSON = vi
-          .fn()
-          .mockResolvedValue(mockExternalAccountClient);
+        const mockFromJSON = vi.fn().mockReturnValue(mockExternalAccountClient);
         const mockGoogleAuthInstance = {
           fromJSON: mockFromJSON,
         };
@@ -834,7 +834,7 @@ describe('oauth2', () => {
         } as unknown as http.ServerResponse;
 
         await expect(async () => {
-          await requestCallback(mockReq, mockRes);
+          requestCallback(mockReq, mockRes);
           await clientPromise;
         }).rejects.toThrow(
           'Google OAuth error: access_denied. User denied access',
@@ -891,7 +891,7 @@ describe('oauth2', () => {
         } as unknown as http.ServerResponse;
 
         await expect(async () => {
-          await requestCallback(mockReq, mockRes);
+          requestCallback(mockReq, mockRes);
           await clientPromise;
         }).rejects.toThrow(
           'Google OAuth error: server_error. No additional details provided',
@@ -954,7 +954,7 @@ describe('oauth2', () => {
         } as unknown as http.ServerResponse;
 
         await expect(async () => {
-          await requestCallback(mockReq, mockRes);
+          requestCallback(mockReq, mockRes);
           await clientPromise;
         }).rejects.toThrow(
           'Failed to exchange authorization code for tokens: Token exchange failed',
@@ -1038,7 +1038,7 @@ describe('oauth2', () => {
           end: vi.fn(),
         } as unknown as http.ServerResponse;
 
-        await requestCallback(mockReq, mockRes);
+        requestCallback(mockReq, mockRes);
         const client = await clientPromise;
 
         // Authentication should succeed even if fetchAndCacheUserInfo fails

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -120,7 +120,7 @@ async function initOauthClient(
     const auth = new GoogleAuth({
       scopes: OAUTH_SCOPE,
     });
-    const byoidClient = await auth.fromJSON({
+    const byoidClient = auth.fromJSON({
       ...credentials,
       refresh_token: credentials.refresh_token ?? undefined,
     });

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -304,12 +304,12 @@ describe('Gemini Client (client.ts)', () => {
     it('should create a new chat session, clearing the old history', async () => {
       // 1. Get the initial chat instance and add some history.
       const initialChat = client.getChat();
-      const initialHistory = await client.getHistory();
+      const initialHistory = client.getHistory();
       await client.addHistory({
         role: 'user',
         parts: [{ text: 'some old message' }],
       });
-      const historyWithOldMessage = await client.getHistory();
+      const historyWithOldMessage = client.getHistory();
       expect(historyWithOldMessage.length).toBeGreaterThan(
         initialHistory.length,
       );
@@ -319,7 +319,7 @@ describe('Gemini Client (client.ts)', () => {
 
       // 3. Get the new chat instance and its history.
       const newChat = client.getChat();
-      const newHistory = await client.getHistory();
+      const newHistory = client.getHistory();
 
       // 4. Assert that the chat instance is new and the history is reset.
       expect(newChat).not.toBe(initialChat);

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -540,7 +540,7 @@ export class GeminiClient {
     if (this.currentSequenceModel) {
       modelToUse = this.currentSequenceModel;
     } else {
-      const router = await this.config.getModelRouterService();
+      const router = this.config.getModelRouterService();
       const decision = await router.route(routingContext);
       modelToUse = decision.model;
     }

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -300,7 +300,7 @@ export async function initializeTelemetry(
   });
 
   try {
-    await sdk.start();
+    sdk.start();
     if (config.getDebugMode()) {
       debugLogger.log('OpenTelemetry SDK started successfully.');
     }
@@ -355,7 +355,7 @@ export async function shutdownTelemetry(
     return;
   }
   try {
-    await ClearcutLogger.getInstance()?.shutdown();
+    ClearcutLogger.getInstance()?.shutdown();
     await sdk.shutdown();
     if (config.getDebugMode() && fromProcessExit) {
       debugLogger.log('OpenTelemetry SDK shut down successfully.');

--- a/packages/core/src/utils/checkpointUtils.test.ts
+++ b/packages/core/src/utils/checkpointUtils.test.ts
@@ -149,7 +149,7 @@ describe('checkpoint utils', () => {
       ] as ToolCallRequestInfo[];
 
       (mockGitService.createFileSnapshot as Mock).mockResolvedValue('hash123');
-      (mockGeminiClient.getHistory as Mock).mockResolvedValue([
+      (mockGeminiClient.getHistory as Mock).mockReturnValue([
         { role: 'user', parts: [] },
       ]);
 

--- a/packages/core/src/utils/checkpointUtils.ts
+++ b/packages/core/src/utils/checkpointUtils.ts
@@ -125,7 +125,7 @@ export async function processRestorableToolCalls<HistoryType>(
         continue;
       }
 
-      const clientHistory = await geminiClient.getHistory();
+      const clientHistory = geminiClient.getHistory();
       const checkpointData: ToolCallData<HistoryType> = {
         history,
         clientHistory,

--- a/packages/core/src/utils/editCorrector.test.ts
+++ b/packages/core/src/utils/editCorrector.test.ts
@@ -237,7 +237,7 @@ describe('editCorrector', () => {
       mockGeminiClientInstance = new GeminiClient(
         mockConfigInstance,
       ) as Mocked<GeminiClient>;
-      mockGeminiClientInstance.getHistory = vi.fn().mockResolvedValue([]);
+      mockGeminiClientInstance.getHistory = vi.fn().mockReturnValue([]);
       mockBaseLlmClientInstance = {
         generateJson: mockGenerateJson,
         config: {
@@ -606,9 +606,7 @@ describe('editCorrector', () => {
             ],
           },
         ];
-        (mockGeminiClientInstance.getHistory as Mock).mockResolvedValue(
-          history,
-        );
+        (mockGeminiClientInstance.getHistory as Mock).mockReturnValue(history);
 
         const result = await ensureCorrectEdit(
           filePath,

--- a/packages/core/src/utils/editCorrector.ts
+++ b/packages/core/src/utils/editCorrector.ts
@@ -90,7 +90,7 @@ async function findLastEditTimestamp(
   filePath: string,
   client: GeminiClient,
 ): Promise<number> {
-  const history = (await client.getHistory()) ?? [];
+  const history = client.getHistory() ?? [];
 
   // Tools that may reference the file path in their FunctionResponse `output`.
   const toolsInResp = new Set([


### PR DESCRIPTION
## Summary

Disallows awaiting of non-thenables. While not fatal, this helps spot code that is cluttered by unnecessary awaits or is misleading and appears to be async but is not.

Also updates one such example, `loadExtension()`, which was previously `await`-ed in several places but utilized synchronous file IO to now be asynchronous, potentially helping with responsiveness during extension load.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
