### PR TITLE
Add one to the padding in settings dialog to avoid flicker.

### DIFF
--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -447,7 +447,7 @@ export function SettingsDialog({
   };
 
   // Height constraint calculations similar to ThemeDialog
-  const DIALOG_PADDING = 4;
+  const DIALOG_PADDING = 5;
   const SETTINGS_TITLE_HEIGHT = 2; // "Settings" title + spacing
   const SCROLL_ARROWS_HEIGHT = 2; // Up and down arrows
   const SPACING_HEIGHT = 1; // Space between settings list and scope


### PR DESCRIPTION
## Summary

When the input prompt was added to the settings dialog the height is sometimes 1 line higher than the terminal height causing classic ink flicker issues.

To verify:
scroll the settings dialog and verify that the settings dialog doesn't flicker badly.