### PR TITLE
feat(hooks): add support for friendly names and descriptions

### DIFF
--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -411,13 +411,22 @@ precedence rules.
 
 ### Configuration layers
 
-Hook configurations are applied in the following order of precedence (higher
-numbers override lower numbers):
+Hook configurations are applied in the following order of execution (lower
+numbers run first):
 
-1. **System defaults:** Built-in default settings (lowest precedence)
-2. **User settings:** `~/.gemini/settings.json`
-3. **Project settings:** `.gemini/settings.json` in your project directory
-4. **System settings:** `/etc/gemini-cli/settings.json` (highest precedence)
+1.  **Project settings:** `.gemini/settings.json` in your project directory
+    (highest priority)
+2.  **User settings:** `~/.gemini/settings.json`
+3.  **System settings:** `/etc/gemini-cli/settings.json`
+4.  **Extensions:** Internal hooks defined by installed extensions (lowest
+    priority)
+
+#### Deduplication and shadowing
+
+If multiple hooks with the identical **name** and **command** are discovered
+across different configuration layers, Gemini CLI deduplicates them. The hook
+from the higher-priority layer (e.g., Project) will be kept, and others will be
+ignored.
 
 Within each level, hooks run in the order they are declared in the
 configuration.
@@ -447,8 +456,9 @@ configuration.
 
 **Configuration properties:**
 
-- **`name`** (string, required): Unique identifier for the hook used in
-  `/hooks enable/disable` commands
+- **`name`** (string, recommended): Unique identifier for the hook used in
+  `/hooks enable/disable` commands. If omitted, the `command` path is used as
+  the identifier.
 - **`type`** (string, required): Hook type - currently only `"command"` is
   supported
 - **`command`** (string, required): Path to the script or command to execute
@@ -495,6 +505,8 @@ You can temporarily enable or disable individual hooks using commands:
 
 These commands allow you to control hook execution without editing configuration
 files. The hook name should match the `name` field in your hook configuration.
+Changes made via these commands are persisted to your global User settings
+(`~/.gemini/settings.json`).
 
 ### Disabled hooks configuration
 

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -369,6 +369,18 @@ describe('SettingsSchema', () => {
         'Enable model routing using new availability service.',
       );
     });
+
+    it('should have name and description in hook definitions', () => {
+      const hookDef = SETTINGS_SCHEMA_DEFINITIONS['HookDefinitionArray'];
+      expect(hookDef).toBeDefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const hookItemProperties = (hookDef as any).items.properties.hooks.items
+        .properties;
+      expect(hookItemProperties.name).toBeDefined();
+      expect(hookItemProperties.name.type).toBe('string');
+      expect(hookItemProperties.description).toBeDefined();
+      expect(hookItemProperties.description.type).toBe('string');
+    });
   });
 
   it('has JSON schema definitions for every referenced ref', () => {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1899,6 +1899,10 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
             type: 'object',
             description: 'Individual hook configuration.',
             properties: {
+              name: {
+                type: 'string',
+                description: 'Unique identifier for the hook.',
+              },
               type: {
                 type: 'string',
                 description:
@@ -1908,6 +1912,10 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
                 type: 'string',
                 description:
                   'Shell command to execute. Receives JSON input via stdin and returns JSON output via stdout.',
+              },
+              description: {
+                type: 'string',
+                description: 'A description of the hook.',
               },
               timeout: {
                 type: 'number',

--- a/packages/cli/src/ui/commands/hooksCommand.test.ts
+++ b/packages/cli/src/ui/commands/hooksCommand.test.ts
@@ -309,6 +309,24 @@ describe('hooksCommand', () => {
         content: 'Failed to enable hook: Failed to save settings',
       });
     });
+
+    it('should complete hook names using friendly names', () => {
+      const enableCmd = hooksCommand.subCommands!.find(
+        (cmd) => cmd.name === 'enable',
+      )!;
+
+      const hookEntry = createMockHook(
+        './hooks/test.sh',
+        HookEventName.BeforeTool,
+        true,
+      );
+      hookEntry.config.name = 'friendly-name';
+
+      mockHookSystem.getAllHooks.mockReturnValue([hookEntry]);
+
+      const completions = enableCmd.completion!(mockContext, 'frie');
+      expect(completions).toContain('friendly-name');
+    });
   });
 
   describe('disable subcommand', () => {

--- a/packages/cli/src/ui/commands/hooksCommand.ts
+++ b/packages/cli/src/ui/commands/hooksCommand.ts
@@ -213,7 +213,7 @@ function completeHookNames(
  * Get a display name for a hook
  */
 function getHookDisplayName(hook: HookRegistryEntry): string {
-  return hook.config.command || 'unknown-hook';
+  return hook.config.name || hook.config.command || 'unknown-hook';
 }
 
 const panelCommand: SlashCommand = {

--- a/packages/cli/src/ui/components/views/HooksList.tsx
+++ b/packages/cli/src/ui/components/views/HooksList.tsx
@@ -9,7 +9,13 @@ import { Box, Text } from 'ink';
 
 interface HooksListProps {
   hooks: ReadonlyArray<{
-    config: { command?: string; type: string; timeout?: number };
+    config: {
+      command?: string;
+      type: string;
+      name?: string;
+      description?: string;
+      timeout?: number;
+    };
     source: string;
     eventName: string;
     matcher?: string;
@@ -50,7 +56,8 @@ export const HooksList: React.FC<HooksListProps> = ({ hooks }) => {
             </Text>
             <Box flexDirection="column" paddingLeft={2}>
               {eventHooks.map((hook, index) => {
-                const hookName = hook.config.command || 'unknown';
+                const hookName =
+                  hook.config.name || hook.config.command || 'unknown';
                 const statusColor = hook.enabled ? 'green' : 'gray';
                 const statusText = hook.enabled ? 'enabled' : 'disabled';
 
@@ -63,8 +70,14 @@ export const HooksList: React.FC<HooksListProps> = ({ hooks }) => {
                       </Text>
                     </Box>
                     <Box paddingLeft={2} flexDirection="column">
+                      {hook.config.description && (
+                        <Text italic>{hook.config.description}</Text>
+                      )}
                       <Text dimColor>
                         Source: {hook.source}
+                        {hook.config.name &&
+                          hook.config.command &&
+                          ` | Command: ${hook.config.command}`}
                         {hook.matcher && ` | Matcher: ${hook.matcher}`}
                         {hook.sequential && ` | Sequential`}
                         {hook.config.timeout &&

--- a/packages/core/src/hooks/hookPlanner.ts
+++ b/packages/core/src/hooks/hookPlanner.ts
@@ -141,7 +141,9 @@ export class HookPlanner {
    * Generate a unique key for a hook entry
    */
   private getHookKey(entry: HookRegistryEntry): string {
-    return `command:${entry.config.command}`;
+    const name = entry.config.name || '';
+    const command = entry.config.command || '';
+    return `${name}:${command}`;
   }
 }
 

--- a/packages/core/src/hooks/hookRegistry.test.ts
+++ b/packages/core/src/hooks/hookRegistry.test.ts
@@ -190,6 +190,39 @@ describe('HookRegistry', () => {
       expect(hookRegistry.getAllHooks()).toHaveLength(0);
       expect(mockDebugLogger.warn).toHaveBeenCalled(); // At least some warnings should be logged
     });
+
+    it('should respect disabled hooks using friendly name', async () => {
+      const mockHooksConfig = {
+        BeforeTool: [
+          {
+            hooks: [
+              {
+                name: 'disabled-hook',
+                type: 'command',
+                command: './hooks/test.sh',
+              },
+            ],
+          },
+        ],
+      };
+
+      // Update mock to return the hooks configuration
+      vi.mocked(mockConfig.getHooks).mockReturnValue(
+        mockHooksConfig as unknown as {
+          [K in HookEventName]?: HookDefinition[];
+        },
+      );
+      vi.mocked(mockConfig.getDisabledHooks).mockReturnValue(['disabled-hook']);
+
+      await hookRegistry.initialize();
+
+      const hooks = hookRegistry.getAllHooks();
+      expect(hooks).toHaveLength(1);
+      expect(hooks[0].enabled).toBe(false);
+      expect(
+        hookRegistry.getHooksForEvent(HookEventName.BeforeTool),
+      ).toHaveLength(0);
+    });
   });
 
   describe('getHooksForEvent', () => {
@@ -304,6 +337,77 @@ describe('HookRegistry', () => {
       expect(mockDebugLogger.warn).toHaveBeenCalledWith(
         'No hooks found matching "non-existent-hook"',
       );
+    });
+
+    it('should prefer hook name over command for identification', async () => {
+      const mockHooksConfig = {
+        BeforeTool: [
+          {
+            hooks: [
+              {
+                name: 'friendly-name',
+                type: 'command',
+                command: './hooks/test.sh',
+              },
+            ],
+          },
+        ],
+      };
+
+      vi.mocked(mockConfig.getHooks).mockReturnValue(
+        mockHooksConfig as unknown as {
+          [K in HookEventName]?: HookDefinition[];
+        },
+      );
+
+      await hookRegistry.initialize();
+
+      // Should be enabled initially
+      let hooks = hookRegistry.getHooksForEvent(HookEventName.BeforeTool);
+      expect(hooks).toHaveLength(1);
+
+      // Disable using friendly name
+      hookRegistry.setHookEnabled('friendly-name', false);
+      hooks = hookRegistry.getHooksForEvent(HookEventName.BeforeTool);
+      expect(hooks).toHaveLength(0);
+
+      // Identification by command should NOT work when name is present
+      hookRegistry.setHookEnabled('./hooks/test.sh', true);
+      expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+        'No hooks found matching "./hooks/test.sh"',
+      );
+    });
+
+    it('should use command as identifier when name is missing', async () => {
+      const mockHooksConfig = {
+        BeforeTool: [
+          {
+            hooks: [
+              {
+                type: 'command',
+                command: './hooks/no-name.sh',
+              },
+            ],
+          },
+        ],
+      };
+
+      vi.mocked(mockConfig.getHooks).mockReturnValue(
+        mockHooksConfig as unknown as {
+          [K in HookEventName]?: HookDefinition[];
+        },
+      );
+
+      await hookRegistry.initialize();
+
+      // Should be enabled initially
+      let hooks = hookRegistry.getHooksForEvent(HookEventName.BeforeTool);
+      expect(hooks).toHaveLength(1);
+
+      // Disable using command
+      hookRegistry.setHookEnabled('./hooks/no-name.sh', false);
+      hooks = hookRegistry.getHooksForEvent(HookEventName.BeforeTool);
+      expect(hooks).toHaveLength(0);
     });
   });
 

--- a/packages/core/src/hooks/hookRegistry.ts
+++ b/packages/core/src/hooks/hookRegistry.ts
@@ -96,10 +96,12 @@ export class HookRegistry {
   }
 
   /**
-   * Get hook name for display purposes
+   * Get hook name for identification and display purposes
    */
-  private getHookName(entry: HookRegistryEntry): string {
-    return entry.config.command || 'unknown-command';
+  private getHookName(
+    entry: HookRegistryEntry | { config: HookConfig },
+  ): string {
+    return entry.config.name || entry.config.command || 'unknown-command';
   }
 
   /**

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -55,8 +55,8 @@ export class HookRunner {
       );
     } catch (error) {
       const duration = Date.now() - startTime;
-      const hookSource = hookConfig.command || 'unknown';
-      const errorMessage = `Hook execution failed for event '${eventName}' (source: ${hookSource}): ${error}`;
+      const hookId = hookConfig.name || hookConfig.command || 'unknown';
+      const errorMessage = `Hook execution failed for event '${eventName}' (hook: ${hookId}): ${error}`;
       debugLogger.warn(`Hook execution error (non-fatal): ${errorMessage}`);
 
       return {

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -40,6 +40,8 @@ export enum HookEventName {
 export interface CommandHookConfig {
   type: HookType.Command;
   command: string;
+  name?: string;
+  description?: string;
   timeout?: number;
 }
 

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1852,6 +1852,10 @@
               "type": "object",
               "description": "Individual hook configuration.",
               "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Unique identifier for the hook."
+                },
                 "type": {
                   "type": "string",
                   "description": "Type of hook (currently only \"command\" supported)."
@@ -1859,6 +1863,10 @@
                 "command": {
                   "type": "string",
                   "description": "Shell command to execute. Receives JSON input via stdin and returns JSON output via stdout."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "A description of the hook."
                 },
                 "timeout": {
                   "type": "number",


### PR DESCRIPTION
## Summary

This PR adds support for friendly names and descriptions in hook configurations, aligning the implementation with the official documentation. It fixes a bug where hooks disabled by name in settings were being ignored because the system only recognized command paths as identifiers.

## Details

- **Naming Support**: Hooks now support optional `name` and `description` fields in `settings.json` and extension `hooks.json`.
- **Identification**: `HookRegistry` now prefers the user-defined `name` for identification and disabling logic, with a fallback to the `command` string for backward compatibility.
- **Enhanced Deduplication**: Improved `HookPlanner` to deduplicate hooks based on the combination of `name` and `command`, preventing accidental shadowing of distinct hooks sharing a script.
- **UI Improvements**: Updated the `/hooks panel` and tab-completion to display friendly names as primary identifiers and included descriptions for better context.
- **Documentation**: Updated `docs/hooks/index.md` and regenerated the settings schema to accurately describe the new behavior, execution order, and persistent storage.

## Related Issues

Resolves issue #15063.

## How to Validate

1. **Verify Friendly Names**:
   - Add a hook with a `name` property to your `.gemini/settings.json`.
   - Run `/hooks panel` and verify that the friendly name is displayed as the title.
   - Run `/hooks disable <name>` and verify the hook is disabled and recorded in `~/.gemini/settings.json`.

2. **Verify Backward Compatibility**:
   - Add a hook without a `name` property.
   - Verify it still appears in `/hooks panel` (using the command path).
   - Verify it can still be disabled using its command string.

3. **Verify Deduplication**:
   - Add two hooks with the same command but different names.
   - Verify both appear and execute independently.

4. **Run Unit Tests**:
   ```bash
   npx vitest packages/core/src/hooks/hookRegistry.test.ts packages/core/src/hooks/hookPlanner.test.ts packages/cli/src/ui/commands/hooksCommand.test.ts
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
