### PR TITLE
chore: update a2a-js to 0.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,9 +74,10 @@
       }
     },
     "node_modules/@a2a-js/sdk": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.2.tgz",
-      "integrity": "sha512-maqxdZ/xeuSRywObfBTvwXbXvkDMmKVkiY8K9rCHDwm0QYUJuu512GnNrwuxkKTwXpNyByzEPg3RYfBveRl96w==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.7.tgz",
+      "integrity": "sha512-1WBghkOjgiKt4rPNje8jlB9VateVQXqyjlc887bY/H8yM82Hlf0+5JW8zB98BPExKAplI5XqtXVH980J6vqi+w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "uuid": "^11.1.0"
       },
@@ -84,7 +85,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "express": "^4.21.2"
+        "express": "^4.21.2 || ^5.1.0"
       },
       "peerDependenciesMeta": {
         "express": {
@@ -17692,7 +17693,7 @@
       "name": "@google/gemini-cli-a2a-server",
       "version": "0.21.0-nightly.20251216.bb0c0d8ee",
       "dependencies": {
-        "@a2a-js/sdk": "^0.3.2",
+        "@a2a-js/sdk": "^0.3.7",
         "@google-cloud/storage": "^7.16.0",
         "@google/gemini-cli-core": "file:../core",
         "express": "^5.1.0",

--- a/packages/a2a-server/package.json
+++ b/packages/a2a-server/package.json
@@ -25,7 +25,7 @@
     "dist"
   ],
   "dependencies": {
-    "@a2a-js/sdk": "^0.3.2",
+    "@a2a-js/sdk": "^0.3.7",
     "@google-cloud/storage": "^7.16.0",
     "@google/gemini-cli-core": "file:../core",
     "express": "^5.1.0",


### PR DESCRIPTION
## Summary

Update a2a-js to 0.3.7
New version supports HTTP+JSON/REST transport support on the client. 

https://github.com/a2aproject/a2a-js/releases/tag/v0.3.7

## Related Issues

Relates/Progress towards

## How to Validate

npm run preflight

## Pre-Merge Checklist


- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
