### PR TITLE
chore(core): remove legacy fallback flags and migrate loop detection

### DIFF
--- a/docs/cli/model-routing.md
+++ b/docs/cli/model-routing.md
@@ -6,24 +6,20 @@ and provides resilience when the primary model is unavailable.
 
 ## How it works
 
-Model routing is not based on prompt complexity, but is a fallback mechanism.
-Here's how it works:
+Model routing is managed by the `ModelAvailabilityService`, which monitors model
+health and automatically routes requests to available models based on defined
+policies.
 
-1.  **Model failure:** If the currently selected model fails to respond (for
-    example, due to a server error or other issue), the CLI will initiate the
-    fallback process.
+1.  **Model failure:** If the currently selected model fails (e.g., due to quota
+    or server errors), the CLI will iniate the fallback process.
 
-2.  **User consent:** The CLI will prompt you to ask if you want to switch to
-    the fallback model. This is handled by the `fallbackModelHandler`.
+2.  **User consent:** Depending on the failure and the model's policy, the CLI
+    may prompt you to switch to a fallback model (by default always prompts
+    you).
 
-3.  **Fallback activation:** If you consent, the CLI will activate the fallback
-    mode by calling `config.setFallbackMode(true)`.
-
-4.  **Model switch:** On the next request, the CLI will use the
-    `DEFAULT_GEMINI_FLASH_MODEL` as the fallback model. This is handled by the
-    `resolveModel` function in
-    `packages/cli/src/zed-integration/zedIntegration.ts` which checks if
-    `isInFallbackMode()` is true.
+3.  **Model switch:** If approved, or if the policy allows for silent fallback,
+    the CLI will use an available fallback model for the current turn or the
+    remainder of the session.
 
 ### Model selection precedence
 

--- a/packages/cli/src/zed-integration/zedIntegration.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.test.ts
@@ -280,7 +280,6 @@ describe('Session', () => {
       getTool: vi.fn().mockReturnValue(mockTool),
     };
     mockConfig = {
-      isInFallbackMode: vi.fn().mockReturnValue(false),
       getModel: vi.fn().mockReturnValue('gemini-pro'),
       getPreviewFeatures: vi.fn().mockReturnValue({}),
       getToolRegistry: vi.fn().mockReturnValue(mockToolRegistry),

--- a/packages/core/src/availability/policyHelpers.test.ts
+++ b/packages/core/src/availability/policyHelpers.test.ts
@@ -19,7 +19,6 @@ const createMockConfig = (overrides: Partial<Config> = {}): Config =>
     getPreviewFeatures: () => false,
     getUserTier: () => undefined,
     getModel: () => 'gemini-2.5-pro',
-    isInFallbackMode: () => false,
     ...overrides,
   }) as unknown as Config;
 

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -343,10 +343,6 @@ describe('Server Config (config.ts)', () => {
         mockContentConfig,
       );
 
-      // Set fallback mode to true to ensure it gets reset
-      config.setFallbackMode(true);
-      expect(config.isInFallbackMode()).toBe(true);
-
       await config.refreshAuth(authType);
 
       expect(createContentGeneratorConfig).toHaveBeenCalledWith(
@@ -356,8 +352,6 @@ describe('Server Config (config.ts)', () => {
       // Verify that contentGeneratorConfig is updated
       expect(config.getContentGeneratorConfig()).toEqual(mockContentConfig);
       expect(GeminiClient).toHaveBeenCalledWith(config);
-      // Verify that fallback mode is reset
-      expect(config.isInFallbackMode()).toBe(false);
     });
 
     it('should reset model availability status', async () => {
@@ -1568,40 +1562,32 @@ describe('Config getHooks', () => {
   });
 
   describe('setModel', () => {
-    it('should allow setting a pro (any) model and disable fallback mode', () => {
+    it('should allow setting a pro (any) model and reset availability', () => {
       const config = new Config(baseParams);
       const service = config.getModelAvailabilityService();
       const spy = vi.spyOn(service, 'reset');
-
-      config.setFallbackMode(true);
-      expect(config.isInFallbackMode()).toBe(true);
 
       const proModel = 'gemini-2.5-pro';
       config.setModel(proModel);
 
       expect(config.getModel()).toBe(proModel);
-      expect(config.isInFallbackMode()).toBe(false);
       expect(mockCoreEvents.emitModelChanged).toHaveBeenCalledWith(proModel);
       expect(spy).toHaveBeenCalled();
     });
 
-    it('should allow setting auto model from non-auto model and disable fallback mode', () => {
+    it('should allow setting auto model from non-auto model and reset availability', () => {
       const config = new Config(baseParams);
       const service = config.getModelAvailabilityService();
       const spy = vi.spyOn(service, 'reset');
 
-      config.setFallbackMode(true);
-      expect(config.isInFallbackMode()).toBe(true);
-
       config.setModel('auto');
 
       expect(config.getModel()).toBe('auto');
-      expect(config.isInFallbackMode()).toBe(false);
       expect(mockCoreEvents.emitModelChanged).toHaveBeenCalledWith('auto');
       expect(spy).toHaveBeenCalled();
     });
 
-    it('should allow setting auto model from auto model if it is in the fallback mode', () => {
+    it('should allow setting auto model from auto model and reset availability', () => {
       const config = new Config({
         cwd: '/tmp',
         targetDir: '/path/to/target',
@@ -1613,14 +1599,9 @@ describe('Config getHooks', () => {
       const service = config.getModelAvailabilityService();
       const spy = vi.spyOn(service, 'reset');
 
-      config.setFallbackMode(true);
-      expect(config.isInFallbackMode()).toBe(true);
-
       config.setModel('auto');
 
       expect(config.getModel()).toBe('auto');
-      expect(config.isInFallbackMode()).toBe(false);
-      expect(mockCoreEvents.emitModelChanged).toHaveBeenCalledWith('auto');
       expect(spy).toHaveBeenCalled();
     });
   });

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1604,6 +1604,20 @@ describe('Config getHooks', () => {
       expect(config.getModel()).toBe('auto');
       expect(spy).toHaveBeenCalled();
     });
+
+    it('should reset active model when setModel is called with the current model after a fallback', () => {
+      const config = new Config(baseParams);
+      const originalModel = config.getModel();
+      const fallbackModel = 'fallback-model';
+
+      config.setActiveModel(fallbackModel);
+      expect(config.getActiveModel()).toBe(fallbackModel);
+
+      config.setModel(originalModel);
+
+      expect(config.getModel()).toBe(originalModel);
+      expect(config.getActiveModel()).toBe(originalModel);
+    });
   });
 });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -387,7 +387,6 @@ export class Config {
   private readonly folderTrust: boolean;
   private ideMode: boolean;
 
-  private inFallbackMode = false;
   private _activeModel: string;
   private readonly maxSessionTurns: number;
   private readonly listSessions: boolean;
@@ -446,8 +445,6 @@ export class Config {
   private experimentsPromise: Promise<void> | undefined;
   private hookSystem?: HookSystem;
 
-  private previewModelFallbackMode = false;
-  private previewModelBypassMode = false;
   private readonly enableAgents: boolean;
 
   private readonly experimentalJitContext: boolean;
@@ -775,9 +772,6 @@ export class Config {
       this.setHasAccessToPreviewModel(true);
     }
 
-    // Reset the session flag since we're explicitly changing auth and using default model
-    this.inFallbackMode = false;
-
     // Update model if user no longer has access to the preview model
     if (!this.hasAccessToPreviewModel && isPreviewModel(this.model)) {
       this.setModel(DEFAULT_GEMINI_MODEL_AUTO);
@@ -848,13 +842,12 @@ export class Config {
   }
 
   setModel(newModel: string): void {
-    if (this.model !== newModel || this.inFallbackMode) {
+    if (this.model !== newModel) {
       this.model = newModel;
       // When the user explicitly sets a model, that becomes the active model.
       this._activeModel = newModel;
       coreEvents.emitModelChanged(newModel);
     }
-    this.setFallbackMode(false);
     this.modelAvailabilityService.reset();
   }
 
@@ -868,18 +861,6 @@ export class Config {
     }
   }
 
-  resetTurn(): void {
-    this.modelAvailabilityService.resetTurn();
-  }
-
-  isInFallbackMode(): boolean {
-    return this.inFallbackMode;
-  }
-
-  setFallbackMode(active: boolean): void {
-    this.inFallbackMode = active;
-  }
-
   setFallbackModelHandler(handler: FallbackModelHandler): void {
     this.fallbackModelHandler = handler;
   }
@@ -888,20 +869,8 @@ export class Config {
     return this.fallbackModelHandler;
   }
 
-  isPreviewModelFallbackMode(): boolean {
-    return this.previewModelFallbackMode;
-  }
-
-  setPreviewModelFallbackMode(active: boolean): void {
-    this.previewModelFallbackMode = active;
-  }
-
-  isPreviewModelBypassMode(): boolean {
-    return this.previewModelBypassMode;
-  }
-
-  setPreviewModelBypassMode(active: boolean): void {
-    this.previewModelBypassMode = active;
+  resetTurn(): void {
+    this.modelAvailabilityService.resetTurn();
   }
 
   getMaxSessionTurns(): number {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -842,7 +842,7 @@ export class Config {
   }
 
   setModel(newModel: string): void {
-    if (this.model !== newModel) {
+    if (this.model !== newModel || this._activeModel !== newModel) {
       this.model = newModel;
       // When the user explicitly sets a model, that becomes the active model.
       this._activeModel = newModel;

--- a/packages/core/src/config/flashFallback.test.ts
+++ b/packages/core/src/config/flashFallback.test.ts
@@ -37,27 +37,6 @@ describe('Flash Model Fallback Configuration', () => {
     };
   });
 
-  // These tests do not actually test fallback. isInFallbackMode() only returns true,
-  // when setFallbackMode is marked as true. This is to decouple setting a model
-  // with the fallback mechanism. This will be necessary we introduce more
-  // intelligent model routing.
-  describe('setModel', () => {
-    it('should only mark as switched if contentGeneratorConfig exists', () => {
-      // Create config without initializing contentGeneratorConfig
-      const newConfig = new Config({
-        sessionId: 'test-session-2',
-        targetDir: '/test',
-        debugMode: false,
-        cwd: '/test',
-        model: DEFAULT_GEMINI_MODEL,
-      });
-
-      // Should not crash when contentGeneratorConfig is undefined
-      newConfig.setModel(DEFAULT_GEMINI_FLASH_MODEL);
-      expect(newConfig.isInFallbackMode()).toBe(false);
-    });
-  });
-
   describe('getModel', () => {
     it('should return contentGeneratorConfig model if available', () => {
       // Simulate initialized content generator config
@@ -76,28 +55,6 @@ describe('Flash Model Fallback Configuration', () => {
       });
 
       expect(newConfig.getModel()).toBe('custom-model');
-    });
-  });
-
-  describe('isInFallbackMode', () => {
-    it('should start as false for new session', () => {
-      expect(config.isInFallbackMode()).toBe(false);
-    });
-
-    it('should remain false if no model switch occurs', () => {
-      // Perform other operations that don't involve model switching
-      expect(config.isInFallbackMode()).toBe(false);
-    });
-
-    it('should persist switched state throughout session', () => {
-      config.setModel(DEFAULT_GEMINI_FLASH_MODEL);
-      // Setting state for fallback mode as is expected of clients
-      config.setFallbackMode(true);
-      expect(config.isInFallbackMode()).toBe(true);
-
-      // Should remain true even after getting model
-      config.getModel();
-      expect(config.isInFallbackMode()).toBe(true);
     });
   });
 });

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -117,7 +117,6 @@ describe('BaseLlmClient', () => {
       setActiveModel: vi.fn(),
       getPreviewFeatures: vi.fn().mockReturnValue(false),
       getUserTier: vi.fn().mockReturnValue(undefined),
-      isInFallbackMode: vi.fn().mockReturnValue(false),
       getModel: vi.fn().mockReturnValue('test-model'),
       getActiveModel: vi.fn().mockReturnValue('test-model'),
     } as unknown as Mocked<Config>;

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -31,7 +31,6 @@ const mockConfig = {
   getModel: vi.fn().mockReturnValue('gemini-pro'),
   getProxy: vi.fn().mockReturnValue(undefined),
   getUsageStatisticsEnabled: vi.fn().mockReturnValue(true),
-  isInFallbackMode: vi.fn().mockReturnValue(false),
   getPreviewFeatures: vi.fn().mockReturnValue(false),
 } as unknown as Config;
 
@@ -120,7 +119,6 @@ describe('createContentGenerator', () => {
       getModel: vi.fn().mockReturnValue('gemini-pro'),
       getProxy: vi.fn().mockReturnValue(undefined),
       getUsageStatisticsEnabled: () => true,
-      isInFallbackMode: vi.fn().mockReturnValue(false),
       getPreviewFeatures: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
@@ -189,7 +187,6 @@ describe('createContentGenerator', () => {
       getModel: vi.fn().mockReturnValue('gemini-pro'),
       getProxy: vi.fn().mockReturnValue(undefined),
       getUsageStatisticsEnabled: () => false,
-      isInFallbackMode: vi.fn().mockReturnValue(false),
       getPreviewFeatures: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
@@ -237,7 +234,6 @@ describe('createContentGenerator', () => {
       getModel: vi.fn().mockReturnValue('gemini-pro'),
       getProxy: vi.fn().mockReturnValue(undefined),
       getUsageStatisticsEnabled: () => false,
-      isInFallbackMode: vi.fn().mockReturnValue(false),
       getPreviewFeatures: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
@@ -272,7 +268,6 @@ describe('createContentGenerator', () => {
       getModel: vi.fn().mockReturnValue('gemini-pro'),
       getProxy: vi.fn().mockReturnValue(undefined),
       getUsageStatisticsEnabled: () => false,
-      isInFallbackMode: vi.fn().mockReturnValue(false),
       getPreviewFeatures: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
@@ -315,7 +310,6 @@ describe('createContentGenerator', () => {
     const mockConfig = {
       getModel: vi.fn().mockReturnValue('gemini-pro'),
       getUsageStatisticsEnabled: () => false,
-      isInFallbackMode: vi.fn().mockReturnValue(false),
       getPreviewFeatures: vi.fn().mockReturnValue(false),
     } as unknown as Config;
     const mockGenerator = {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -17,12 +17,7 @@ import {
 } from './geminiChat.js';
 import type { Config } from '../config/config.js';
 import { setSimulate429 } from '../utils/testUtils.js';
-import {
-  DEFAULT_GEMINI_FLASH_MODEL,
-  DEFAULT_THINKING_MODE,
-  PREVIEW_GEMINI_MODEL,
-  PREVIEW_GEMINI_FLASH_MODEL,
-} from '../config/models.js';
+import { DEFAULT_THINKING_MODE } from '../config/models.js';
 import { AuthType } from './contentGenerator.js';
 import { TerminalQuotaError } from '../utils/googleQuotaErrors.js';
 import { type RetryOptions } from '../utils/retry.js';
@@ -146,7 +141,6 @@ describe('GeminiChat', () => {
         // When model is explicitly set, active model usually resets or updates to it
         currentActiveModel = m;
       }),
-      isInFallbackMode: vi.fn().mockReturnValue(false),
       getQuotaErrorOccurred: vi.fn().mockReturnValue(false),
       setQuotaErrorOccurred: vi.fn(),
       flashFallbackHandler: undefined,
@@ -179,10 +173,6 @@ describe('GeminiChat', () => {
           };
         }),
       },
-      isPreviewModelBypassMode: vi.fn().mockReturnValue(false),
-      setPreviewModelBypassMode: vi.fn(),
-      isPreviewModelFallbackMode: vi.fn().mockReturnValue(false),
-      setPreviewModelFallbackMode: vi.fn(),
       isInteractive: vi.fn().mockReturnValue(false),
       getEnableHooks: vi.fn().mockReturnValue(false),
       getActiveModel: vi.fn().mockImplementation(() => currentActiveModel),
@@ -545,105 +535,6 @@ describe('GeminiChat', () => {
       expect(modelTurn?.parts?.length).toBe(1);
       expect(modelTurn?.parts![0].text).toBe(
         'This is the visible text that should not be lost.',
-      );
-    });
-
-    it('should use maxAttempts=1 for retryWithBackoff when in Preview Model Fallback Mode', async () => {
-      vi.mocked(mockConfig.isPreviewModelFallbackMode).mockReturnValue(true);
-      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
-        (async function* () {
-          yield {
-            candidates: [
-              {
-                content: { parts: [{ text: 'Success' }] },
-                finishReason: 'STOP',
-              },
-            ],
-          } as unknown as GenerateContentResponse;
-        })(),
-      );
-
-      const stream = await chat.sendMessageStream(
-        { model: PREVIEW_GEMINI_MODEL },
-        'test',
-        'prompt-id-fast-retry',
-        new AbortController().signal,
-      );
-      for await (const _ of stream) {
-        // consume stream
-      }
-
-      expect(mockRetryWithBackoff).toHaveBeenCalledWith(
-        expect.any(Function),
-        expect.objectContaining({
-          maxAttempts: 1,
-        }),
-      );
-    });
-
-    it('should use maxAttempts=1 for retryWithBackoff when in Preview Model Fallback Mode (Flash)', async () => {
-      vi.mocked(mockConfig.isPreviewModelFallbackMode).mockReturnValue(true);
-      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
-        (async function* () {
-          yield {
-            candidates: [
-              {
-                content: { parts: [{ text: 'Success' }] },
-                finishReason: 'STOP',
-              },
-            ],
-          } as unknown as GenerateContentResponse;
-        })(),
-      );
-
-      const stream = await chat.sendMessageStream(
-        { model: PREVIEW_GEMINI_FLASH_MODEL },
-        'test',
-        'prompt-id-fast-retry-flash',
-        new AbortController().signal,
-      );
-      for await (const _ of stream) {
-        // consume stream
-      }
-
-      expect(mockRetryWithBackoff).toHaveBeenCalledWith(
-        expect.any(Function),
-        expect.objectContaining({
-          maxAttempts: 1,
-        }),
-      );
-    });
-
-    it('should NOT use maxAttempts=1 for other models even in Preview Model Fallback Mode', async () => {
-      vi.mocked(mockConfig.isPreviewModelFallbackMode).mockReturnValue(true);
-      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
-        (async function* () {
-          yield {
-            candidates: [
-              {
-                content: { parts: [{ text: 'Success' }] },
-                finishReason: 'STOP',
-              },
-            ],
-          } as unknown as GenerateContentResponse;
-        })(),
-      );
-
-      const stream = await chat.sendMessageStream(
-        { model: DEFAULT_GEMINI_FLASH_MODEL },
-        'test',
-        'prompt-id-normal-retry',
-        new AbortController().signal,
-      );
-      for await (const _ of stream) {
-        // consume stream
-      }
-
-      expect(mockRetryWithBackoff).toHaveBeenCalledWith(
-        expect.any(Function),
-        expect.objectContaining({
-          maxAttempts: undefined, // Should use default
-        }),
       );
     });
 
@@ -1880,9 +1771,6 @@ describe('GeminiChat', () => {
         authType,
       });
 
-      const isInFallbackModeSpy = vi.spyOn(mockConfig, 'isInFallbackMode');
-      isInFallbackModeSpy.mockReturnValue(false);
-
       vi.mocked(mockContentGenerator.generateContentStream)
         .mockRejectedValueOnce(error429) // Attempt 1 fails
         .mockResolvedValueOnce(
@@ -1899,10 +1787,9 @@ describe('GeminiChat', () => {
           })(),
         );
 
-      mockHandleFallback.mockImplementation(async () => {
-        isInFallbackModeSpy.mockReturnValue(true);
-        return true; // Signal retry
-      });
+      mockHandleFallback.mockImplementation(async () => 
+         true // Signal retry
+      );
 
       const stream = await chat.sendMessageStream(
         { model: 'test-model' },
@@ -1930,34 +1817,6 @@ describe('GeminiChat', () => {
       const history = chat.getHistory();
       const modelTurn = history[1];
       expect(modelTurn.parts![0].text).toBe('Success on retry');
-    });
-
-    it('should stop retrying if handleFallback returns false (e.g., auth intent)', async () => {
-      vi.mocked(mockConfig.getModel).mockReturnValue('gemini-pro');
-      vi.mocked(mockContentGenerator.generateContentStream).mockRejectedValue(
-        error429,
-      );
-      mockHandleFallback.mockResolvedValue(false);
-
-      const stream = await chat.sendMessageStream(
-        { model: 'gemini-2.0-flash' },
-        'test stop',
-        'prompt-id-fb2',
-        new AbortController().signal,
-      );
-
-      await expect(
-        (async () => {
-          for await (const _ of stream) {
-            /* consume stream */
-          }
-        })(),
-      ).rejects.toThrow(error429);
-
-      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
-        1,
-      );
-      expect(mockHandleFallback).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -265,10 +265,6 @@ export class GeminiChat {
   ): Promise<AsyncGenerator<StreamEvent>> {
     await this.sendPromise;
 
-    // Preview Model Bypass mode for the new request.
-    // This ensures that we attempt to use Preview Model for every new user turn
-    // (unless the "Always" fallback mode is active, which is handled separately).
-    this.config.setPreviewModelBypassMode(false);
     let streamDoneResolver: () => void;
     const streamDonePromise = new Promise<void>((resolve) => {
       streamDoneResolver = resolve;
@@ -302,12 +298,7 @@ export class GeminiChat {
       try {
         let lastError: unknown = new Error('Request failed after all retries.');
 
-        let maxAttempts = INVALID_CONTENT_RETRY_OPTIONS.maxAttempts;
-        // If we are in Preview Model Fallback Mode, we want to fail fast (1 attempt)
-        // when probing the Preview Model.
-        if (this.config.isPreviewModelFallbackMode() && isPreviewModel(model)) {
-          maxAttempts = 1;
-        }
+        const maxAttempts = INVALID_CONTENT_RETRY_OPTIONS.maxAttempts;
 
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
           let isConnectionPhase = true;
@@ -380,15 +371,6 @@ export class GeminiChat {
             );
           }
           throw lastError;
-        } else {
-          // Preview Model successfully used, disable fallback mode.
-          // We only do this if we didn't bypass Preview Model (i.e. we actually used it).
-          if (
-            isPreviewModel(model) &&
-            !this.config.isPreviewModelBypassMode()
-          ) {
-            this.config.setPreviewModelFallbackMode(false);
-          }
         }
       } finally {
         streamDoneResolver!();
@@ -577,11 +559,7 @@ export class GeminiChat {
       authType: this.config.getContentGeneratorConfig()?.authType,
       retryFetchErrors: this.config.getRetryFetchErrors(),
       signal: generateContentConfig.abortSignal,
-      maxAttempts:
-        availabilityMaxAttempts ??
-        (this.config.isPreviewModelFallbackMode() && isPreviewModel(model)
-          ? 1
-          : undefined),
+      maxAttempts: availabilityMaxAttempts,
       getAvailabilityContext,
     });
 

--- a/packages/core/src/core/geminiChat_network_retry.test.ts
+++ b/packages/core/src/core/geminiChat_network_retry.test.ts
@@ -81,7 +81,6 @@ describe('GeminiChat Network Retries', () => {
       getModel: vi.fn().mockReturnValue('gemini-pro'),
       getActiveModel: vi.fn().mockReturnValue('gemini-pro'),
       setActiveModel: vi.fn(),
-      isInFallbackMode: vi.fn().mockReturnValue(false),
       getQuotaErrorOccurred: vi.fn().mockReturnValue(false),
       getProjectRoot: vi.fn().mockReturnValue('/test/project/root'),
       storage: {
@@ -96,11 +95,7 @@ describe('GeminiChat Network Retries', () => {
           generateContentConfig: { temperature: 0 },
         })),
       },
-      isPreviewModelBypassMode: vi.fn().mockReturnValue(false),
-      setPreviewModelBypassMode: vi.fn(),
-      isPreviewModelFallbackMode: vi.fn().mockReturnValue(false),
       getEnableHooks: vi.fn().mockReturnValue(false),
-      setPreviewModelFallbackMode: vi.fn(),
       getModelAvailabilityService: vi
         .fn()
         .mockReturnValue(createAvailabilityServiceMock()),

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -69,7 +69,6 @@ describe('Core System Prompt (prompts.ts)', () => {
       getModel: vi.fn().mockReturnValue(DEFAULT_GEMINI_MODEL_AUTO),
       getActiveModel: vi.fn().mockReturnValue(DEFAULT_GEMINI_MODEL),
       getPreviewFeatures: vi.fn().mockReturnValue(false),
-      isInFallbackMode: vi.fn().mockReturnValue(false),
       getAgentRegistry: vi.fn().mockReturnValue({
         getDirectoryContext: vi.fn().mockReturnValue('Mock Agent Directory'),
       }),
@@ -173,7 +172,6 @@ describe('Core System Prompt (prompts.ts)', () => {
         getModel: vi.fn().mockReturnValue('auto'),
         getActiveModel: vi.fn().mockReturnValue(DEFAULT_GEMINI_MODEL),
         getPreviewFeatures: vi.fn().mockReturnValue(false),
-        isInFallbackMode: vi.fn().mockReturnValue(false),
         getAgentRegistry: vi.fn().mockReturnValue({
           getDirectoryContext: vi.fn().mockReturnValue('Mock Agent Directory'),
         }),

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -472,7 +472,9 @@ export class LoopDetectionService {
       return false;
     }
 
-    if (this.config.isInFallbackMode()) {
+    const availability = this.config.getModelAvailabilityService();
+
+    if (!availability.snapshot(doubleCheckModelName).available) {
       const flashModelName = this.config.modelConfigService.getResolvedConfig({
         model: 'loop-detection',
       }).model;

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -35,16 +35,6 @@ export interface UserFeedbackPayload {
 }
 
 /**
- * Payload for the 'fallback-mode-changed' event.
- */
-export interface FallbackModeChangedPayload {
-  /**
-   * Whether fallback mode is now active.
-   */
-  isInFallbackMode: boolean;
-}
-
-/**
  * Payload for the 'model-changed' event.
  */
 export interface ModelChangedPayload {
@@ -78,7 +68,6 @@ export type MemoryChangedPayload = LoadServerHierarchicalMemoryResponse;
 
 export enum CoreEvent {
   UserFeedback = 'user-feedback',
-  FallbackModeChanged = 'fallback-mode-changed',
   ModelChanged = 'model-changed',
   ConsoleLog = 'console-log',
   Output = 'output',
@@ -88,7 +77,6 @@ export enum CoreEvent {
 
 export interface CoreEvents {
   [CoreEvent.UserFeedback]: [UserFeedbackPayload];
-  [CoreEvent.FallbackModeChanged]: [FallbackModeChangedPayload];
   [CoreEvent.ModelChanged]: [ModelChangedPayload];
   [CoreEvent.ConsoleLog]: [ConsoleLogPayload];
   [CoreEvent.Output]: [OutputPayload];
@@ -164,15 +152,6 @@ export class CoreEventEmitter extends EventEmitter<CoreEvents> {
   ): void {
     const payload: OutputPayload = { isStderr, chunk, encoding };
     this._emitOrQueue(CoreEvent.Output, payload);
-  }
-
-  /**
-   * Notifies subscribers that fallback mode has changed.
-   * This is synchronous and doesn't use backlog (UI should already be initialized).
-   */
-  emitFallbackModeChanged(isInFallbackMode: boolean): void {
-    const payload: FallbackModeChangedPayload = { isInFallbackMode };
-    this.emit(CoreEvent.FallbackModeChanged, payload);
   }
 
   /**


### PR DESCRIPTION
## Summary

Removes unused legacy fallback flags (`inFallbackMode`, `previewModelFallbackMode`, `previewModelBypassMode`) and associated logic from thecore configuration, and migrates `LoopDetectionService` to utilize the `ModelAvailabilityService`.

## Details

This PR mostly just cleanup tech debt. In addition to the flags above I also removed fallbackMode event as it is no longer relevant.
The LoopDetection also now correctly uses the availabilityService.

## Related Issues

Fixes: https://github.com/google-gemini/maintainers-gemini-cli/issues/1152
Fixes: https://github.com/google-gemini/maintainers-gemini-cli/issues/1153

## How to Validate

npm run preflight

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
