### PR TITLE
Respect previewFeatures value from the remote flag if undefined

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -38,6 +38,7 @@ import {
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_MODEL_AUTO,
   PREVIEW_GEMINI_MODEL,
+  PREVIEW_GEMINI_MODEL_AUTO,
 } from './models.js';
 
 vi.mock('fs', async (importOriginal) => {
@@ -1860,6 +1861,15 @@ describe('Config Quota & Preview Model Access', () => {
       config.setPreviewFeatures(false);
 
       expect(config.getModel()).toBe(nonPreviewModel);
+    });
+
+    it('should switch to preview auto model if enabling preview features while using default auto model', () => {
+      config.setPreviewFeatures(false);
+      config.setModel(DEFAULT_GEMINI_MODEL_AUTO);
+
+      config.setPreviewFeatures(true);
+
+      expect(config.getModel()).toBe(PREVIEW_GEMINI_MODEL_AUTO);
     });
 
     it('should NOT reset model if enabling preview features', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -52,6 +52,7 @@ import {
   DEFAULT_THINKING_MODE,
   isPreviewModel,
   PREVIEW_GEMINI_MODEL,
+  PREVIEW_GEMINI_MODEL_AUTO,
 } from './models.js';
 import { shouldAttemptBrowserLaunch } from '../utils/browser.js';
 import type { MCPOAuthConfig } from '../mcp/oauth-provider.js';
@@ -975,14 +976,25 @@ export class Config {
   }
 
   setPreviewFeatures(previewFeatures: boolean) {
-    // If it's using a preview model and it's turning off previewFeatures,
-    // switch the model to the default auto mode.
-    if (this.previewFeatures && !previewFeatures) {
-      if (isPreviewModel(this.getModel())) {
-        this.setModel(DEFAULT_GEMINI_MODEL_AUTO);
-      }
-    }
+    const previousValue = this.previewFeatures;
     this.previewFeatures = previewFeatures;
+
+    // No change in state, no action needed
+    if (previousValue === previewFeatures) {
+      return;
+    }
+
+    const currentModel = this.getModel();
+
+    // Case 1: Disabling preview features while on a preview model
+    if (!previewFeatures && isPreviewModel(currentModel)) {
+      this.setModel(DEFAULT_GEMINI_MODEL_AUTO);
+    }
+
+    // Case 2: Enabling preview features while on the default auto model
+    else if (previewFeatures && currentModel === DEFAULT_GEMINI_MODEL_AUTO) {
+      this.setModel(PREVIEW_GEMINI_MODEL_AUTO);
+    }
   }
 
   getHasAccessToPreviewModel(): boolean {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -739,8 +739,6 @@ export class Config {
     // Initialize BaseLlmClient now that the ContentGenerator is available
     this.baseLlmClient = new BaseLlmClient(this.contentGenerator, this);
 
-    const previewFeatures = this.getPreviewFeatures();
-
     const codeAssistServer = getCodeAssistServer(this);
     if (codeAssistServer) {
       if (codeAssistServer.projectId) {
@@ -752,7 +750,7 @@ export class Config {
           this.setExperiments(experiments);
 
           // If preview features have not been set and the user authenticated through Google, we enable preview based on remote config only if it's true
-          if (previewFeatures === undefined) {
+          if (this.getPreviewFeatures() === undefined) {
             const remotePreviewFeatures =
               experiments.flags[ExperimentFlags.ENABLE_PREVIEW]?.boolValue;
             if (remotePreviewFeatures === true) {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -974,14 +974,11 @@ export class Config {
   }
 
   setPreviewFeatures(previewFeatures: boolean) {
-    const previousValue = this.previewFeatures;
-    this.previewFeatures = previewFeatures;
-
     // No change in state, no action needed
-    if (previousValue === previewFeatures) {
+    if (this.previewFeatures === previewFeatures) {
       return;
     }
-
+    this.previewFeatures = previewFeatures;
     const currentModel = this.getModel();
 
     // Case 1: Disabling preview features while on a preview model


### PR DESCRIPTION
## Summary
Respect previewFeatures value from the remote flag if user has not set it before.
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
To make some users automatically opt-in to use previewfeatures such as Gemini 3.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues
https://github.com/google-gemini/maintainers-gemini-cli/issues/1151
<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
