### PR TITLE
feat(cli): Add support for Linux clipboard images (Wayland)

### DIFF
--- a/packages/cli/src/ui/utils/clipboardUtils.test.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.test.ts
@@ -15,34 +15,33 @@ import {
 
 describe('clipboardUtils', () => {
   describe('clipboardHasImage', () => {
-    it('should return false on non-macOS platforms', async () => {
-      if (process.platform !== 'darwin') {
+    it('should return false on unsupported platforms', async () => {
+      if (process.platform !== 'darwin' && process.platform !== 'linux') {
         const result = await clipboardHasImage();
         expect(result).toBe(false);
       } else {
-        // Skip on macOS as it would require actual clipboard state
+        // Skip on supported platforms as it would require actual clipboard state
         expect(true).toBe(true);
       }
     });
 
-    it('should return boolean on macOS', async () => {
-      if (process.platform === 'darwin') {
+    it('should return boolean on supported platforms', async () => {
+      if (process.platform === 'darwin' || process.platform === 'linux') {
         const result = await clipboardHasImage();
         expect(typeof result).toBe('boolean');
       } else {
-        // Skip on non-macOS
+        // Skip on unsupported platforms
         expect(true).toBe(true);
       }
     });
   });
-
   describe('saveClipboardImage', () => {
-    it('should return null on non-macOS platforms', async () => {
-      if (process.platform !== 'darwin') {
+    it('should return null on unsupported platforms', async () => {
+      if (process.platform !== 'darwin' && process.platform !== 'linux') {
         const result = await saveClipboardImage();
         expect(result).toBe(null);
       } else {
-        // Skip on macOS
+        // Skip on supported platforms
         expect(true).toBe(true);
       }
     });
@@ -53,8 +52,8 @@ describe('clipboardUtils', () => {
         '/invalid/path/that/does/not/exist',
       );
 
-      if (process.platform === 'darwin') {
-        // On macOS, might return null due to various errors
+      if (process.platform === 'darwin' || process.platform === 'linux') {
+        // On supported platforms, might return null due to various errors
         expect(result === null || typeof result === 'string').toBe(true);
       } else {
         // On other platforms, should always return null


### PR DESCRIPTION
Adds support for pasting images from clipboard on Linux (Wayland) using wl-paste. Verified with unit tests and manual testing.