### PR TITLE
feat(ui): add Windows clipboard image support and Alt+V paste workaround

### DIFF
--- a/docs/cli/keyboard-shortcuts.md
+++ b/docs/cli/keyboard-shortcuts.md
@@ -84,10 +84,10 @@ available combinations.
 
 #### External Tools
 
-| Action                                         | Keys       |
-| ---------------------------------------------- | ---------- |
-| Open the current prompt in an external editor. | `Ctrl + X` |
-| Paste from the clipboard.                      | `Ctrl + V` |
+| Action                                         | Keys                      |
+| ---------------------------------------------- | ------------------------- |
+| Open the current prompt in an external editor. | `Ctrl + X`                |
+| Paste from the clipboard.                      | `Ctrl + V`<br />`Cmd + V` |
 
 #### App Controls
 

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -192,7 +192,10 @@ export const defaultKeyBindings: KeyBindingConfig = {
     { key: 'x', ctrl: true },
     { sequence: '\x18', ctrl: true },
   ],
-  [Command.PASTE_CLIPBOARD]: [{ key: 'v', ctrl: true }],
+  [Command.PASTE_CLIPBOARD]: [
+    { key: 'v', ctrl: true },
+    { key: 'v', command: true },
+  ],
 
   // App level bindings
   [Command.SHOW_ERROR_DETAILS]: [{ key: 'f12' }],

--- a/packages/cli/src/ui/utils/clipboardUtils.test.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.test.ts
@@ -15,34 +15,34 @@ import {
 
 describe('clipboardUtils', () => {
   describe('clipboardHasImage', () => {
-    it('should return false on non-macOS platforms', async () => {
-      if (process.platform !== 'darwin') {
+    it('should return false on unsupported platforms', async () => {
+      if (process.platform !== 'darwin' && process.platform !== 'win32') {
         const result = await clipboardHasImage();
         expect(result).toBe(false);
       } else {
-        // Skip on macOS as it would require actual clipboard state
+        // Skip on macOS/Windows as it would require actual clipboard state
         expect(true).toBe(true);
       }
     });
 
-    it('should return boolean on macOS', async () => {
-      if (process.platform === 'darwin') {
+    it('should return boolean on macOS or Windows', async () => {
+      if (process.platform === 'darwin' || process.platform === 'win32') {
         const result = await clipboardHasImage();
         expect(typeof result).toBe('boolean');
       } else {
-        // Skip on non-macOS
+        // Skip on unsupported platforms
         expect(true).toBe(true);
       }
-    });
+    }, 10000);
   });
 
   describe('saveClipboardImage', () => {
-    it('should return null on non-macOS platforms', async () => {
-      if (process.platform !== 'darwin') {
+    it('should return null on unsupported platforms', async () => {
+      if (process.platform !== 'darwin' && process.platform !== 'win32') {
         const result = await saveClipboardImage();
         expect(result).toBe(null);
       } else {
-        // Skip on macOS
+        // Skip on macOS/Windows
         expect(true).toBe(true);
       }
     });
@@ -53,8 +53,8 @@ describe('clipboardUtils', () => {
         '/invalid/path/that/does/not/exist',
       );
 
-      if (process.platform === 'darwin') {
-        // On macOS, might return null due to various errors
+      if (process.platform === 'darwin' || process.platform === 'win32') {
+        // On macOS/Windows, might return null due to various errors
         expect(result === null || typeof result === 'string').toBe(true);
       } else {
         // On other platforms, should always return null

--- a/packages/cli/src/ui/utils/clipboardUtils.windows.test.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.windows.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import { saveClipboardImage } from './clipboardUtils.js';
+
+// Mock dependencies
+vi.mock('node:fs/promises');
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    spawnAsync: vi.fn(),
+  };
+});
+
+describe('saveClipboardImage Windows Path Escaping', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+    });
+
+    // Mock fs calls to succeed
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(fs.stat).mockResolvedValue({ size: 100 } as any);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+    });
+  });
+
+  it('should escape single quotes in path for PowerShell script', async () => {
+    const { spawnAsync } = await import('@google/gemini-cli-core');
+    vi.mocked(spawnAsync).mockResolvedValue({
+      stdout: 'success',
+      stderr: '',
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    const targetDir = "C:\\User's Files";
+    await saveClipboardImage(targetDir);
+
+    expect(spawnAsync).toHaveBeenCalled();
+    const args = vi.mocked(spawnAsync).mock.calls[0][1];
+    const script = args[2];
+
+    // The path C:\User's Files\.gemini-clipboard\clipboard-....png
+    // should be escaped in the script as 'C:\User''s Files\...'
+
+    // Check if the script contains the escaped path
+    expect(script).toMatch(/'C:\\User''s Files/);
+  });
+});


### PR DESCRIPTION
This is a clone of https://github.com/google-gemini/gemini-cli/pull/13997 where I have run the script to update the markdown.
@sgeraldes you will still get credit for the PR as the commits are attributed to you aside for the small one I added.


- **feat(ui): add Windows clipboard image support and Alt+V workaround**
- **Run npm run docs:keybindings**

Co-authored-by: sgeraldes