### PR TITLE
fix(ui): Prevent eager slash command completion hiding sibling commands

### DIFF
--- a/packages/cli/src/ui/hooks/useSlashCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.test.ts
@@ -390,7 +390,7 @@ describe('useSlashCompletion', () => {
       const { result } = renderHook(() =>
         useTestHarnessForSlashCompletion(
           true,
-          '/memory',
+          '/memory ',
           slashCommands,
           mockCommandContext,
         ),
@@ -413,6 +413,52 @@ describe('useSlashCompletion', () => {
           },
         ]),
       );
+    });
+
+    it('should suggest parent command (and siblings) instead of sub-commands when no trailing space', async () => {
+      const slashCommands = [
+        createTestCommand({
+          name: 'memory',
+          description: 'Manage memory',
+          subCommands: [
+            createTestCommand({ name: 'show', description: 'Show memory' }),
+          ],
+        }),
+        createTestCommand({
+          name: 'memory-leak',
+          description: 'Debug memory leaks',
+        }),
+      ];
+
+      const { result } = renderHook(() =>
+        useTestHarnessForSlashCompletion(
+          true,
+          '/memory',
+          slashCommands,
+          mockCommandContext,
+        ),
+      );
+
+      // Should verify that we see BOTH 'memory' and 'memory-leak'
+      await waitFor(() => {
+        expect(result.current.suggestions).toHaveLength(2);
+        expect(result.current.suggestions).toEqual(
+          expect.arrayContaining([
+            {
+              label: 'memory',
+              value: 'memory',
+              description: 'Manage memory',
+              commandKind: CommandKind.BUILT_IN,
+            },
+            {
+              label: 'memory-leak',
+              value: 'memory-leak',
+              description: 'Debug memory leaks',
+              commandKind: CommandKind.BUILT_IN,
+            },
+          ]),
+        );
+      });
     });
 
     it('should suggest all sub-commands when the query ends with the parent command and a space', async () => {
@@ -752,7 +798,7 @@ describe('useSlashCompletion', () => {
       const { result } = renderHook(() =>
         useTestHarnessForSlashCompletion(
           true,
-          '/memory',
+          '/memory ',
           slashCommands,
           mockCommandContext,
         ),

--- a/packages/cli/src/ui/hooks/useSlashCompletion.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.ts
@@ -116,12 +116,6 @@ function useCommandParser(
       exactMatchAsParent = currentLevel.find(
         (cmd) => matchesCommand(cmd, partial) && cmd.subCommands,
       );
-
-      if (exactMatchAsParent) {
-        leafCommand = exactMatchAsParent;
-        currentLevel = exactMatchAsParent.subCommands;
-        partial = '';
-      }
     }
 
     const depth = commandPathParts.length;


### PR DESCRIPTION
## TLDR

Fixes a bug where typing a full command name (e.g., `/review`) would immediately drill down into subcommands, hiding sibling commands that share the same prefix (e.g., `/review-frontend`).

## Dive Deeper

The `useSlashCompletion` hook previously contained logic that eagerly identified an exact match as a "parent" command even without a trailing space. This caused the autocompletion context to switch immediately to that command's scope.

This PR removes that eager check. Now, the logic waits for a trailing space (e.g., `/review `) before treating the command as a parent and showing its subcommands. This ensures that as long as the user is typing the command name, all matching commands (including siblings) remain visible.

Tests were updated to reflect this behavior, and a new regression test was added to verify sibling command visibility.

## Reviewer Test Plan

1. Run the CLI.
2. Type `/review`.
3. Observe that suggestions include sibling commands (e.g., `review`, `review-frontend`, `oncall:pr-review`) if they exist in your command set.
4. Type space (`/review `).
5. Observe that suggestions now switch to the subcommands of `/review` (e.g., arguments or subcommands).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓ |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

