### PR TITLE
Add core tool that adds all context from the core package.

### DIFF
--- a/.gemini/commands/core.toml
+++ b/.gemini/commands/core.toml
@@ -1,0 +1,29 @@
+description="Injects context of all relevant cli files"
+prompt = """
+The following output contains the complete
+source code of packages/core.
+**Pay extremely close attention to these files.** They define the project's
+core architecture, component patterns, and testing standards.
+
+The source code contains the content of absolutely every source code file in
+packages/core.
+You should very rarely need to read any other files from packages/core to resolve
+prompts.
+
+!{find packages/core \\( -path packages/cli/dist -o -path packages/core/dist -o -name node_modules \\) -prune -o -type f \\( -name "*.ts" -o -name "*.tsx" \\) ! -name "*.test.ts" ! -name "*.test.tsx" ! -name "*.d.ts" -exec echo "--- {} ---" \\; -exec cat {} \\;}
+
+In addition to the code context, you MUST strictly adhere to the following frontend-specific development guidelines when writing code in packages/core.
+
+## Configuration & Settings
+*   **Settings vs Args**: Use settings for user-configurable options; do not add new CLI arguments.
+*   **Schema**: Add new settings to `packages/cli/src/config/settingsSchema.ts`.
+*   **Documentation**:
+    *   If `showInDialog: true`, document in `docs/get-started/configuration.md`.
+    *   Ensure `requiresRestart` is correctly set.
+
+## General
+*   **Logging**: Use `debugLogger` for errors. NEVER leave `console.log/warn/error` in the code.
+*   **TypeScript**: Avoid the non-null assertion operator (`!`).
+
+{{args}}. 
+ """


### PR DESCRIPTION
## Summary

packages/core is now too large to fit in the context window but sometimes it is handy to get all the context anyway
Added  a `/core` tool that only adds the source files from core without tests or other data files. This keeps it at less than 50% of the Gemini CLI context window rather than at 100%. I've had good results with this creating detailed plans for large refactors that have taken 2 hours to run with no manual intervention (https://github.com/google-gemini/gemini-cli/pull/15234).
