### PR TITLE
Support local experiment injection

### DIFF
--- a/packages/core/src/code_assist/experiments/experiments.ts
+++ b/packages/core/src/code_assist/experiments/experiments.ts
@@ -46,7 +46,9 @@ export async function getExperiments(
         const content = await fs.readFile(localPath, 'utf8');
         const response = JSON.parse(content) as ListExperimentsResponse;
         debugLogger.log('Successfully loaded local experiments');
-        return parseExperiments(response);
+        const parsed = parseExperiments(response);
+        debugLogger.log('Parsed local experiments:', parsed);
+        return parsed;
       } catch (error) {
         debugLogger.warn(
           'Failed to read local experiments, falling back to server',
@@ -61,7 +63,9 @@ export async function getExperiments(
 
     const metadata = await getClientMetadata();
     const response = await server.listExperiments(metadata);
-    return parseExperiments(response);
+    const parsed = parseExperiments(response);
+    debugLogger.log('Parsed server experiments:', parsed);
+    return parsed;
   })();
   return experimentsPromise;
 }

--- a/packages/core/src/code_assist/experiments/experiments.ts
+++ b/packages/core/src/code_assist/experiments/experiments.ts
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import type { CodeAssistServer } from '../server.js';
 import { getClientMetadata } from './client_metadata.js';
 import type { ListExperimentsResponse, Flag } from './types.js';
+import { Storage } from '../../config/storage.js';
 
 export interface Experiments {
   flags: Record<string, Flag>;
@@ -21,13 +24,31 @@ let experimentsPromise: Promise<Experiments> | undefined;
  * The experiments are cached so that they are only fetched once.
  */
 export async function getExperiments(
-  server: CodeAssistServer,
+  server?: CodeAssistServer,
 ): Promise<Experiments> {
   if (experimentsPromise) {
     return experimentsPromise;
   }
 
   experimentsPromise = (async () => {
+    if (process.env['GEMINI_LOCAL_EXP'] === 'true') {
+      try {
+        const localPath = path.join(
+          Storage.getGlobalGeminiDir(),
+          'experiments.json',
+        );
+        const content = await fs.readFile(localPath, 'utf8');
+        const response = JSON.parse(content) as ListExperimentsResponse;
+        return parseExperiments(response);
+      } catch (_error) {
+        // Fallback to server if file doesn't exist or is invalid.
+      }
+    }
+
+    if (!server) {
+      return { flags: {}, experimentIds: [] };
+    }
+
     const metadata = await getClientMetadata();
     const response = await server.listExperiments(metadata);
     return parseExperiments(response);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -741,27 +741,24 @@ export class Config {
       if (codeAssistServer.projectId) {
         await this.refreshUserQuota();
       }
-
-      this.experimentsPromise = getExperiments(codeAssistServer)
-        .then((experiments) => {
-          this.setExperiments(experiments);
-
-          // If preview features have not been set and the user authenticated through Google, we enable preview based on remote config only if it's true
-          if (this.getPreviewFeatures() === undefined) {
-            const remotePreviewFeatures =
-              experiments.flags[ExperimentFlags.ENABLE_PREVIEW]?.boolValue;
-            if (remotePreviewFeatures === true) {
-              this.setPreviewFeatures(remotePreviewFeatures);
-            }
-          }
-        })
-        .catch((e) => {
-          debugLogger.error('Failed to fetch experiments', e);
-        });
-    } else {
-      this.experiments = undefined;
-      this.experimentsPromise = undefined;
     }
+
+    this.experimentsPromise = getExperiments(codeAssistServer)
+      .then((experiments) => {
+        this.setExperiments(experiments);
+
+        // If preview features have not been set and the user authenticated through Google, we enable preview based on remote config only if it's true
+        if (this.getPreviewFeatures() === undefined) {
+          const remotePreviewFeatures =
+            experiments.flags[ExperimentFlags.ENABLE_PREVIEW]?.boolValue;
+          if (remotePreviewFeatures === true) {
+            this.setPreviewFeatures(remotePreviewFeatures);
+          }
+        }
+      })
+      .catch((e) => {
+        debugLogger.error('Failed to fetch experiments', e);
+      });
 
     const authType = this.contentGeneratorConfig.authType;
     if (
@@ -782,10 +779,7 @@ export class Config {
       return this.experiments;
     }
     const codeAssistServer = getCodeAssistServer(this);
-    if (codeAssistServer) {
-      return getExperiments(codeAssistServer);
-    }
-    return undefined;
+    return getExperiments(codeAssistServer);
   }
 
   getUserTier(): UserTierId | undefined {


### PR DESCRIPTION
## Summary

When GEMINI_LOCAL_EXP is true, we read experiments from experiments.json, regardless of the auth type.

## Details

## Related Issues

## How to Validate

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
