### PR TITLE
Handle all 429 as retryableQuotaError

### DIFF
--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -389,4 +389,35 @@ describe('classifyGoogleError', () => {
       });
     }
   });
+
+  it('should return RetryableQuotaError with 5s fallback for generic 429 without specific message', () => {
+    const generic429 = {
+      status: 429,
+      message: 'Resource exhausted. No specific retry info.',
+    };
+
+    const result = classifyGoogleError(generic429);
+
+    expect(result).toBeInstanceOf(RetryableQuotaError);
+    if (result instanceof RetryableQuotaError) {
+      expect(result.retryDelayMs).toBe(5000);
+    }
+  });
+
+  it('should return RetryableQuotaError with 5s fallback for 429 with empty details and no regex match', () => {
+    const errorWithEmptyDetails = {
+      error: {
+        code: 429,
+        message: 'A generic 429 error with no retry message.',
+        details: [],
+      },
+    };
+
+    const result = classifyGoogleError(errorWithEmptyDetails);
+
+    expect(result).toBeInstanceOf(RetryableQuotaError);
+    if (result instanceof RetryableQuotaError) {
+      expect(result.retryDelayMs).toBe(5000);
+    }
+  });
 });

--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -325,7 +325,7 @@ describe('classifyGoogleError', () => {
     expect(result).toBeInstanceOf(TerminalQuotaError);
   });
 
-  it('should return original error for 429 without specific details', () => {
+  it('should return RetryableQuotaError for any 429', () => {
     const apiError: GoogleApiError = {
       code: 429,
       message: 'Too many requests',
@@ -340,7 +340,10 @@ describe('classifyGoogleError', () => {
     vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(apiError);
     const originalError = new Error();
     const result = classifyGoogleError(originalError);
-    expect(result).toBe(originalError);
+    expect(result).toBeInstanceOf(RetryableQuotaError);
+    if (result instanceof RetryableQuotaError) {
+      expect(result.retryDelayMs).toBe(5000);
+    }
   });
 
   it('should classify nested JSON string 404 error as ModelNotFoundError', () => {

--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -420,4 +420,30 @@ describe('classifyGoogleError', () => {
       expect(result.retryDelayMs).toBe(5000);
     }
   });
+
+  it('should return RetryableQuotaError with 5s fallback for 429 with some detail', () => {
+    const errorWithEmptyDetails = {
+      error: {
+        code: 429,
+        message: 'A generic 429 error with no retry message.',
+        details: [
+          {
+            '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+            reason: 'QUOTA_EXCEEDED',
+            domain: 'googleapis.com',
+            metadata: {
+              quota_limit: '',
+            },
+          },
+        ],
+      },
+    };
+
+    const result = classifyGoogleError(errorWithEmptyDetails);
+
+    expect(result).toBeInstanceOf(RetryableQuotaError);
+    if (result instanceof RetryableQuotaError) {
+      expect(result.retryDelayMs).toBe(5000);
+    }
+  });
 });

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -13,6 +13,8 @@ import type {
 import { parseGoogleApiError } from './googleErrors.js';
 import { getErrorStatus, ModelNotFoundError } from './httpErrors.js';
 
+const DEFAULT_RETRYABLE_DELAY_SECOND = 5;
+
 /**
  * A non-retryable error indicating a hard quota limit has been reached (e.g., daily limit).
  */
@@ -122,7 +124,7 @@ export function classifyGoogleError(error: unknown): unknown {
           message: errorMessage,
           details: [],
         },
-        5,
+        DEFAULT_RETRYABLE_DELAY_SECOND,
       );
     }
 

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -112,6 +112,18 @@ export function classifyGoogleError(error: unknown): unknown {
           retryDelaySeconds,
         );
       }
+    } else if (status === 429) {
+      // Fallback: If it is a 429 but doesn't have a specific "retry in" message,
+      // assume it is a temporary rate limit and retry after 5 sec (same as DEFAULT_RETRY_OPTIONS).
+      return new RetryableQuotaError(
+        errorMessage,
+        googleApiError ?? {
+          code: 429,
+          message: errorMessage,
+          details: [],
+        },
+        5,
+      );
     }
 
     return error; // Not a 429 error we can handle with structured details or a parsable retry message.

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -246,5 +246,21 @@ export function classifyGoogleError(error: unknown): unknown {
       );
     }
   }
+
+  // If we reached this point and the status is still 429, we return retryable.
+  if (status === 429) {
+    const errorMessage =
+      googleApiError?.message ||
+      (error instanceof Error ? error.message : String(error));
+    return new RetryableQuotaError(
+      errorMessage,
+      googleApiError ?? {
+        code: 429,
+        message: errorMessage,
+        details: [],
+      },
+      DEFAULT_RETRYABLE_DELAY_SECOND,
+    );
+  }
   return error; // Fallback to original error if no specific classification fits.
 }


### PR DESCRIPTION
## Summary

This PR ensures that 429 Too Many Requests errors without explicit "retry-in" metadata are still retried. By defaulting to a 5-second delay, we improve system resilience against transient rate limits and prevent unnecessary request failures.

## Details
Fallback Retry: Implements a 5-second cooldown via RetryableQuotaError when specific timing headers are missing. Aligns manual 429 handling with the existing DEFAULT_RETRY_OPTIONS duration.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
