### PR TITLE
feat(hooks): reduce log verbosity and improve error reporting in UI

### DIFF
--- a/packages/core/src/core/clientHookTriggers.ts
+++ b/packages/core/src/core/clientHookTriggers.ts
@@ -53,7 +53,7 @@ export async function fireBeforeAgentHook(
       ? createHookOutput('BeforeAgent', response.output)
       : undefined;
   } catch (error) {
-    debugLogger.warn(`BeforeAgent hook failed: ${error}`);
+    debugLogger.debug(`BeforeAgent hook failed: ${error}`);
     return undefined;
   }
 }
@@ -99,7 +99,7 @@ export async function fireAfterAgentHook(
       ? createHookOutput('AfterAgent', response.output)
       : undefined;
   } catch (error) {
-    debugLogger.warn(`AfterAgent hook failed: ${error}`);
+    debugLogger.debug(`AfterAgent hook failed: ${error}`);
     return undefined;
   }
 }

--- a/packages/core/src/core/coreToolHookTriggers.ts
+++ b/packages/core/src/core/coreToolHookTriggers.ts
@@ -145,7 +145,7 @@ export async function fireToolNotificationHook(
       MessageBusType.HOOK_EXECUTION_RESPONSE,
     );
   } catch (error) {
-    debugLogger.warn(
+    debugLogger.debug(
       `Notification hook failed for ${confirmationDetails.title}:`,
       error,
     );
@@ -185,7 +185,7 @@ export async function fireBeforeToolHook(
       ? createHookOutput('BeforeTool', response.output)
       : undefined;
   } catch (error) {
-    debugLogger.warn(`BeforeTool hook failed for ${toolName}:`, error);
+    debugLogger.debug(`BeforeTool hook failed for ${toolName}:`, error);
     return undefined;
   }
 }
@@ -230,7 +230,7 @@ export async function fireAfterToolHook(
       ? createHookOutput('AfterTool', response.output)
       : undefined;
   } catch (error) {
-    debugLogger.warn(`AfterTool hook failed for ${toolName}:`, error);
+    debugLogger.debug(`AfterTool hook failed for ${toolName}:`, error);
     return undefined;
   }
 }

--- a/packages/core/src/core/geminiChatHookTriggers.ts
+++ b/packages/core/src/core/geminiChatHookTriggers.ts
@@ -124,7 +124,7 @@ export async function fireBeforeModelHook(
 
     return { blocked: false };
   } catch (error) {
-    debugLogger.warn(`BeforeModel hook failed:`, error);
+    debugLogger.debug(`BeforeModel hook failed:`, error);
     return { blocked: false };
   }
 }
@@ -178,7 +178,7 @@ export async function fireBeforeToolSelectionHook(
 
     return {};
   } catch (error) {
-    debugLogger.warn(`BeforeToolSelection hook failed:`, error);
+    debugLogger.debug(`BeforeToolSelection hook failed:`, error);
     return {};
   }
 }
@@ -228,7 +228,7 @@ export async function fireAfterModelHook(
 
     return { response: chunk };
   } catch (error) {
-    debugLogger.warn(`AfterModel hook failed:`, error);
+    debugLogger.debug(`AfterModel hook failed:`, error);
     // On error, return original chunk to avoid interrupting the stream.
     return { response: chunk };
   }

--- a/packages/core/src/core/sessionHookTriggers.ts
+++ b/packages/core/src/core/sessionHookTriggers.ts
@@ -39,7 +39,7 @@ export async function fireSessionStartHook(
       MessageBusType.HOOK_EXECUTION_RESPONSE,
     );
   } catch (error) {
-    debugLogger.warn(`SessionStart hook failed:`, error);
+    debugLogger.debug(`SessionStart hook failed:`, error);
   }
 }
 
@@ -65,7 +65,7 @@ export async function fireSessionEndHook(
       MessageBusType.HOOK_EXECUTION_RESPONSE,
     );
   } catch (error) {
-    debugLogger.warn(`SessionEnd hook failed:`, error);
+    debugLogger.debug(`SessionEnd hook failed:`, error);
   }
 }
 
@@ -91,6 +91,6 @@ export async function firePreCompressHook(
       MessageBusType.HOOK_EXECUTION_RESPONSE,
     );
   } catch (error) {
-    debugLogger.warn(`PreCompress hook failed:`, error);
+    debugLogger.debug(`PreCompress hook failed:`, error);
   }
 }

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -235,7 +235,7 @@ export class HookRunner {
         child.stdin.on('error', (err: NodeJS.ErrnoException) => {
           // Ignore EPIPE errors which happen when the child process closes stdin early
           if (err.code !== 'EPIPE') {
-            debugLogger.warn(`Hook stdin error: ${err}`);
+            debugLogger.debug(`Hook stdin error: ${err}`);
           }
         });
 
@@ -247,7 +247,7 @@ export class HookRunner {
         } catch (err) {
           // Ignore EPIPE errors which happen when the child process closes stdin early
           if (err instanceof Error && 'code' in err && err.code !== 'EPIPE') {
-            debugLogger.warn(`Hook stdin write error: ${err}`);
+            debugLogger.debug(`Hook stdin write error: ${err}`);
           }
         }
       }


### PR DESCRIPTION
## Summary

This PR reduces hook logging noise in the debug drawer and improves user awareness by surfacing concise feedback in the main UI when hooks fail.

## Details

- Downgraded redundant or non-fatal `debugLogger.warn` calls to `debugLogger.debug` in `HookRunner` and various trigger files (`clientHookTriggers`, `coreToolHookTriggers`, etc.).
- Centralized failure reporting in `HookEventHandler`, which now emits a `coreEvents.emitFeedback` warning containing the names of failed hooks and a hint to use `F12` to open the debug drawer.
- Updated `README.md` to include 'abhi' as an author.
- Added unit tests to `hookEventHandler.test.ts` to verify the event emission logic.

## Related Issues

Closes #14716
Closes #15171

## How to Validate

1. Configure a failing hook in `.gemini/settings.json` (e.g., a `BeforeAgent` hook with a non-existent command).
2. Run `npm run start`.
3. Send any prompt.
4. Verify the UI surfaces a yellow warning: `Hook(s) [Hook-Name] failed for event BeforeAgent. Press F12 to see the debug drawer for more details.`
5. Verify that the debug drawer (F12) shows the summary and that logs in the drawer are less noisy.
6. Run `npm run test -- packages/core/src/hooks/hookEventHandler.test.ts`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run