### PR TITLE
feat: add JSONL session recording

### DIFF
--- a/docs/cli/session-management.md
+++ b/docs/cli/session-management.md
@@ -16,6 +16,9 @@ This happens in the background without any manual intervention.
   - Token usage statistics (input/output/cached, etc.).
   - Assistant thoughts/reasoning summaries (when available).
 - **Location:** Sessions are stored in `~/.gemini/tmp/<project_hash>/chats/`.
+- **Format:** New sessions are stored as newline-delimited JSON (`.jsonl`) using
+  append-only writes. Legacy `.json` sessions are still readable and will be
+  included in listing, resuming, and cleanup.
 - **Scope:** Sessions are project-specific. Switching directories to a different
   project will switch to that project's session history.
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -476,7 +476,7 @@ export const AppContainer = (props: AppContainerProps) => {
   // Wrap handleDeleteSession to return a Promise for UIActions interface
   const handleDeleteSession = useCallback(
     async (session: SessionInfo): Promise<void> => {
-      handleDeleteSessionSync(session);
+      await handleDeleteSessionSync(session);
     },
     [handleDeleteSessionSync],
   );

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -48,7 +48,7 @@ export const clearCommand: SlashCommand = {
     if (config && chatRecordingService) {
       const newSessionId = randomUUID();
       config.setSessionId(newSessionId);
-      chatRecordingService.initialize();
+      await chatRecordingService.initialize();
     }
 
     // Fire SessionStart hook after clearing

--- a/packages/cli/src/ui/hooks/useHistoryManager.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.ts
@@ -83,25 +83,31 @@ export function useHistory({
         switch (itemData.type) {
           case 'compression':
           case 'info':
-            chatRecordingService?.recordMessage({
-              model: undefined,
-              type: 'info',
-              content: itemData.text ?? '',
-            });
+            void chatRecordingService
+              ?.recordMessage({
+                model: undefined,
+                type: 'info',
+                content: itemData.text ?? '',
+              })
+              .catch(() => undefined);
             break;
           case 'warning':
-            chatRecordingService?.recordMessage({
-              model: undefined,
-              type: 'warning',
-              content: itemData.text ?? '',
-            });
+            void chatRecordingService
+              ?.recordMessage({
+                model: undefined,
+                type: 'warning',
+                content: itemData.text ?? '',
+              })
+              .catch(() => undefined);
             break;
           case 'error':
-            chatRecordingService?.recordMessage({
-              model: undefined,
-              type: 'error',
-              content: itemData.text ?? '',
-            });
+            void chatRecordingService
+              ?.recordMessage({
+                model: undefined,
+                type: 'error',
+                content: itemData.text ?? '',
+              })
+              .catch(() => undefined);
             break;
           case 'user':
           case 'gemini':

--- a/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
@@ -53,6 +53,11 @@ describe('useSessionBrowser', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.mocked(mockConfig.getGeminiClient).mockReturnValue({
+      getChatRecordingService: vi.fn().mockReturnValue({
+        deleteSession: mockDeleteSession,
+      }),
+    });
     mockedPath.join.mockImplementation((...args) => args.join('/'));
     vi.mocked(mockConfig.storage.getProjectTempDir).mockReturnValue(
       MOCKED_PROJECT_TEMP_DIR,

--- a/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
@@ -18,6 +18,7 @@ import type {
   Config,
   ConversationRecord,
   MessageRecord,
+  GeminiClient,
 } from '@google/gemini-cli-core';
 
 // Mock modules
@@ -46,7 +47,7 @@ describe('useSessionBrowser', () => {
       getChatRecordingService: vi.fn().mockReturnValue({
         deleteSession: mockDeleteSession,
       }),
-    }),
+    } as unknown as GeminiClient),
   } as unknown as Config;
 
   const mockOnLoadHistory = vi.fn();
@@ -57,7 +58,7 @@ describe('useSessionBrowser', () => {
       getChatRecordingService: vi.fn().mockReturnValue({
         deleteSession: mockDeleteSession,
       }),
-    });
+    } as unknown as GeminiClient);
     mockedPath.join.mockImplementation((...args) => args.join('/'));
     vi.mocked(mockConfig.storage.getProjectTempDir).mockReturnValue(
       MOCKED_PROJECT_TEMP_DIR,

--- a/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.test.ts
@@ -34,6 +34,7 @@ describe('useSessionBrowser', () => {
   const mockedFs = vi.mocked(fs);
   const mockedPath = vi.mocked(path);
   const mockedGetSessionFiles = vi.mocked(getSessionFiles);
+  const mockDeleteSession = vi.fn();
 
   const mockConfig = {
     storage: {
@@ -43,7 +44,7 @@ describe('useSessionBrowser', () => {
     getSessionId: vi.fn(),
     getGeminiClient: vi.fn().mockReturnValue({
       getChatRecordingService: vi.fn().mockReturnValue({
-        deleteSession: vi.fn(),
+        deleteSession: mockDeleteSession,
       }),
     }),
   } as unknown as Config;
@@ -182,6 +183,23 @@ describe('useSessionBrowser', () => {
     );
     expect(result.current.isSessionBrowserOpen).toBe(false);
     expect(mockOnLoadHistory).toHaveBeenCalled();
+  });
+
+  it('should delete a session by id', async () => {
+    const mockSession = {
+      id: MOCKED_SESSION_ID,
+      fileName: 'session-2025-01-01-test-session-123.json',
+    } as SessionInfo;
+
+    const { result } = renderHook(() =>
+      useSessionBrowser(mockConfig, mockOnLoadHistory),
+    );
+
+    await act(async () => {
+      await result.current.handleDeleteSession(mockSession);
+    });
+
+    expect(mockDeleteSession).toHaveBeenCalledWith(MOCKED_SESSION_ID);
   });
 });
 

--- a/packages/cli/src/ui/hooks/useSessionBrowser.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.ts
@@ -104,7 +104,7 @@ export const useSessionBrowser = (
             .getGeminiClient()
             ?.getChatRecordingService();
           if (chatRecordingService) {
-            await chatRecordingService.deleteSession(session.file);
+            await chatRecordingService.deleteSession(session.id);
           }
         } catch (error) {
           console.error('Error deleting session:', error);

--- a/packages/cli/src/ui/hooks/useSessionBrowser.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.ts
@@ -95,10 +95,8 @@ export const useSessionBrowser = (
      */
     handleDeleteSession: useCallback(
       async (session: SessionInfo) => {
-        // Note: Chat sessions are stored on disk using a filename derived from
-        // the session, e.g. "session-<timestamp>-<sessionIdPrefix>.json".
-        // The ChatRecordingService.deleteSession API expects this file basename
-        // (without the ".json" extension), not the full session UUID.
+        // Note: use the canonical session id so deleteSession can remove all
+        // related files across formats.
         try {
           const chatRecordingService = config
             .getGeminiClient()

--- a/packages/cli/src/utils/sessionCleanup.test.ts
+++ b/packages/cli/src/utils/sessionCleanup.test.ts
@@ -49,7 +49,7 @@ function createTestSessions(): SessionInfo[] {
     {
       id: 'current123',
       file: `${SESSION_FILE_PREFIX}2025-01-20T10-30-00-current12`,
-      fileName: `${SESSION_FILE_PREFIX}2025-01-20T10-30-00-current12.json`,
+      fileName: `${SESSION_FILE_PREFIX}2025-01-20T10-30-00-current12.jsonl`,
       startTime: now.toISOString(),
       lastUpdated: now.toISOString(),
       messageCount: 5,
@@ -61,7 +61,7 @@ function createTestSessions(): SessionInfo[] {
     {
       id: 'recent456',
       file: `${SESSION_FILE_PREFIX}2025-01-18T15-45-00-recent45`,
-      fileName: `${SESSION_FILE_PREFIX}2025-01-18T15-45-00-recent45.json`,
+      fileName: `${SESSION_FILE_PREFIX}2025-01-18T15-45-00-recent45.jsonl`,
       startTime: oneWeekAgo.toISOString(),
       lastUpdated: oneWeekAgo.toISOString(),
       messageCount: 10,
@@ -73,7 +73,7 @@ function createTestSessions(): SessionInfo[] {
     {
       id: 'old789abc',
       file: `${SESSION_FILE_PREFIX}2025-01-10T09-15-00-old789ab`,
-      fileName: `${SESSION_FILE_PREFIX}2025-01-10T09-15-00-old789ab.json`,
+      fileName: `${SESSION_FILE_PREFIX}2025-01-10T09-15-00-old789ab.jsonl`,
       startTime: twoWeeksAgo.toISOString(),
       lastUpdated: twoWeeksAgo.toISOString(),
       messageCount: 3,
@@ -85,7 +85,7 @@ function createTestSessions(): SessionInfo[] {
     {
       id: 'ancient12',
       file: `${SESSION_FILE_PREFIX}2024-12-25T12-00-00-ancient1`,
-      fileName: `${SESSION_FILE_PREFIX}2024-12-25T12-00-00-ancient1.json`,
+      fileName: `${SESSION_FILE_PREFIX}2024-12-25T12-00-00-ancient1.jsonl`,
       startTime: oneMonthAgo.toISOString(),
       lastUpdated: oneMonthAgo.toISOString(),
       messageCount: 15,
@@ -236,7 +236,7 @@ describe('Session Cleanup', () => {
       const currentSessionPath = path.join(
         '/tmp/test-project',
         'chats',
-        `${SESSION_FILE_PREFIX}2025-01-20T10-30-00-current12.json`,
+        `${SESSION_FILE_PREFIX}2025-01-20T10-30-00-current12.jsonl`,
       );
       expect(
         unlinkCalls.find((call) => call[0] === currentSessionPath),
@@ -440,7 +440,7 @@ describe('Session Cleanup', () => {
         {
           id: 'current',
           file: `${SESSION_FILE_PREFIX}current`,
-          fileName: `${SESSION_FILE_PREFIX}current.json`,
+          fileName: `${SESSION_FILE_PREFIX}current.jsonl`,
           startTime: now.toISOString(),
           lastUpdated: now.toISOString(),
           messageCount: 1,
@@ -452,7 +452,7 @@ describe('Session Cleanup', () => {
         {
           id: 'session5d',
           file: `${SESSION_FILE_PREFIX}5d`,
-          fileName: `${SESSION_FILE_PREFIX}5d.json`,
+          fileName: `${SESSION_FILE_PREFIX}5d.jsonl`,
           startTime: fiveDaysAgo.toISOString(),
           lastUpdated: fiveDaysAgo.toISOString(),
           messageCount: 1,
@@ -464,7 +464,7 @@ describe('Session Cleanup', () => {
         {
           id: 'session8d',
           file: `${SESSION_FILE_PREFIX}8d`,
-          fileName: `${SESSION_FILE_PREFIX}8d.json`,
+          fileName: `${SESSION_FILE_PREFIX}8d.jsonl`,
           startTime: eightDaysAgo.toISOString(),
           lastUpdated: eightDaysAgo.toISOString(),
           messageCount: 1,
@@ -476,7 +476,7 @@ describe('Session Cleanup', () => {
         {
           id: 'session15d',
           file: `${SESSION_FILE_PREFIX}15d`,
-          fileName: `${SESSION_FILE_PREFIX}15d.json`,
+          fileName: `${SESSION_FILE_PREFIX}15d.jsonl`,
           startTime: fifteenDaysAgo.toISOString(),
           lastUpdated: fifteenDaysAgo.toISOString(),
           messageCount: 1,
@@ -520,21 +520,21 @@ describe('Session Cleanup', () => {
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}8d.json`,
+          `${SESSION_FILE_PREFIX}8d.jsonl`,
         ),
       );
       expect(unlinkCalls).toContain(
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}15d.json`,
+          `${SESSION_FILE_PREFIX}15d.jsonl`,
         ),
       );
       expect(unlinkCalls).not.toContain(
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}5d.json`,
+          `${SESSION_FILE_PREFIX}5d.jsonl`,
         ),
       );
     });
@@ -562,7 +562,7 @@ describe('Session Cleanup', () => {
         {
           id: 'current',
           file: `${SESSION_FILE_PREFIX}current`,
-          fileName: `${SESSION_FILE_PREFIX}current.json`,
+          fileName: `${SESSION_FILE_PREFIX}current.jsonl`,
           startTime: now.toISOString(),
           lastUpdated: now.toISOString(),
           messageCount: 1,
@@ -574,7 +574,7 @@ describe('Session Cleanup', () => {
         {
           id: 'session1d',
           file: `${SESSION_FILE_PREFIX}1d`,
-          fileName: `${SESSION_FILE_PREFIX}1d.json`,
+          fileName: `${SESSION_FILE_PREFIX}1d.jsonl`,
           startTime: oneDayAgo.toISOString(),
           lastUpdated: oneDayAgo.toISOString(),
           messageCount: 1,
@@ -586,7 +586,7 @@ describe('Session Cleanup', () => {
         {
           id: 'session7d',
           file: `${SESSION_FILE_PREFIX}7d`,
-          fileName: `${SESSION_FILE_PREFIX}7d.json`,
+          fileName: `${SESSION_FILE_PREFIX}7d.jsonl`,
           startTime: sevenDaysAgo.toISOString(),
           lastUpdated: sevenDaysAgo.toISOString(),
           messageCount: 1,
@@ -598,7 +598,7 @@ describe('Session Cleanup', () => {
         {
           id: 'session13d',
           file: `${SESSION_FILE_PREFIX}13d`,
-          fileName: `${SESSION_FILE_PREFIX}13d.json`,
+          fileName: `${SESSION_FILE_PREFIX}13d.jsonl`,
           startTime: thirteenDaysAgo.toISOString(),
           lastUpdated: thirteenDaysAgo.toISOString(),
           messageCount: 1,
@@ -658,7 +658,7 @@ describe('Session Cleanup', () => {
         {
           id: 'current',
           file: `${SESSION_FILE_PREFIX}current`,
-          fileName: `${SESSION_FILE_PREFIX}current.json`,
+          fileName: `${SESSION_FILE_PREFIX}current.jsonl`,
           startTime: now.toISOString(),
           lastUpdated: now.toISOString(),
           messageCount: 1,
@@ -675,7 +675,7 @@ describe('Session Cleanup', () => {
         sessions.push({
           id: `session${i}`,
           file: `${SESSION_FILE_PREFIX}${i}d`,
-          fileName: `${SESSION_FILE_PREFIX}${i}d.json`,
+          fileName: `${SESSION_FILE_PREFIX}${i}d.jsonl`,
           startTime: daysAgo.toISOString(),
           lastUpdated: daysAgo.toISOString(),
           messageCount: 1,
@@ -719,21 +719,21 @@ describe('Session Cleanup', () => {
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}3d.json`,
+          `${SESSION_FILE_PREFIX}3d.jsonl`,
         ),
       );
       expect(unlinkCalls).toContain(
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}4d.json`,
+          `${SESSION_FILE_PREFIX}4d.jsonl`,
         ),
       );
       expect(unlinkCalls).toContain(
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}5d.json`,
+          `${SESSION_FILE_PREFIX}5d.jsonl`,
         ),
       );
 
@@ -742,21 +742,21 @@ describe('Session Cleanup', () => {
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}current.json`,
+          `${SESSION_FILE_PREFIX}current.jsonl`,
         ),
       );
       expect(unlinkCalls).not.toContain(
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}1d.json`,
+          `${SESSION_FILE_PREFIX}1d.jsonl`,
         ),
       );
       expect(unlinkCalls).not.toContain(
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}2d.json`,
+          `${SESSION_FILE_PREFIX}2d.jsonl`,
         ),
       );
     });
@@ -784,7 +784,7 @@ describe('Session Cleanup', () => {
         {
           id: 'current',
           file: `${SESSION_FILE_PREFIX}current`,
-          fileName: `${SESSION_FILE_PREFIX}current.json`,
+          fileName: `${SESSION_FILE_PREFIX}current.jsonl`,
           startTime: now.toISOString(),
           lastUpdated: now.toISOString(),
           messageCount: 1,
@@ -796,7 +796,7 @@ describe('Session Cleanup', () => {
         {
           id: 'session3d',
           file: `${SESSION_FILE_PREFIX}3d`,
-          fileName: `${SESSION_FILE_PREFIX}3d.json`,
+          fileName: `${SESSION_FILE_PREFIX}3d.jsonl`,
           startTime: threeDaysAgo.toISOString(),
           lastUpdated: threeDaysAgo.toISOString(),
           messageCount: 1,
@@ -808,7 +808,7 @@ describe('Session Cleanup', () => {
         {
           id: 'session5d',
           file: `${SESSION_FILE_PREFIX}5d`,
-          fileName: `${SESSION_FILE_PREFIX}5d.json`,
+          fileName: `${SESSION_FILE_PREFIX}5d.jsonl`,
           startTime: fiveDaysAgo.toISOString(),
           lastUpdated: fiveDaysAgo.toISOString(),
           messageCount: 1,
@@ -820,7 +820,7 @@ describe('Session Cleanup', () => {
         {
           id: 'session7d',
           file: `${SESSION_FILE_PREFIX}7d`,
-          fileName: `${SESSION_FILE_PREFIX}7d.json`,
+          fileName: `${SESSION_FILE_PREFIX}7d.jsonl`,
           startTime: sevenDaysAgo.toISOString(),
           lastUpdated: sevenDaysAgo.toISOString(),
           messageCount: 1,
@@ -832,7 +832,7 @@ describe('Session Cleanup', () => {
         {
           id: 'session12d',
           file: `${SESSION_FILE_PREFIX}12d`,
-          fileName: `${SESSION_FILE_PREFIX}12d.json`,
+          fileName: `${SESSION_FILE_PREFIX}12d.jsonl`,
           startTime: twelveDaysAgo.toISOString(),
           lastUpdated: twelveDaysAgo.toISOString(),
           messageCount: 1,
@@ -878,21 +878,21 @@ describe('Session Cleanup', () => {
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}5d.json`,
+          `${SESSION_FILE_PREFIX}5d.jsonl`,
         ),
       );
       expect(unlinkCalls).toContain(
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}7d.json`,
+          `${SESSION_FILE_PREFIX}7d.jsonl`,
         ),
       );
       expect(unlinkCalls).toContain(
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}12d.json`,
+          `${SESSION_FILE_PREFIX}12d.jsonl`,
         ),
       );
 
@@ -901,14 +901,14 @@ describe('Session Cleanup', () => {
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}current.json`,
+          `${SESSION_FILE_PREFIX}current.jsonl`,
         ),
       );
       expect(unlinkCalls).not.toContain(
         path.join(
           '/tmp/test-project',
           'chats',
-          `${SESSION_FILE_PREFIX}3d.json`,
+          `${SESSION_FILE_PREFIX}3d.jsonl`,
         ),
       );
     });
@@ -1699,11 +1699,11 @@ describe('Session Cleanup', () => {
       mockGetAllSessionFiles.mockResolvedValue([
         { fileName: validSession.fileName, sessionInfo: validSession },
         {
-          fileName: `${SESSION_FILE_PREFIX}2025-01-02T10-00-00-corrupt1.json`,
+          fileName: `${SESSION_FILE_PREFIX}2025-01-02T10-00-00-corrupt1.jsonl`,
           sessionInfo: null,
         },
         {
-          fileName: `${SESSION_FILE_PREFIX}2025-01-03T10-00-00-corrupt2.json`,
+          fileName: `${SESSION_FILE_PREFIX}2025-01-03T10-00-00-corrupt2.jsonl`,
           sessionInfo: null,
         },
       ]);
@@ -1719,10 +1719,10 @@ describe('Session Cleanup', () => {
 
       // Verify corrupted files were deleted
       expect(mockFs.unlink).toHaveBeenCalledWith(
-        expect.stringContaining('corrupt1.json'),
+        expect.stringContaining('corrupt1.jsonl'),
       );
       expect(mockFs.unlink).toHaveBeenCalledWith(
-        expect.stringContaining('corrupt2.json'),
+        expect.stringContaining('corrupt2.jsonl'),
       );
     });
 

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -11,10 +11,13 @@ import type {
 } from '@google/gemini-cli-core';
 import {
   partListUnionToString,
+  parseJsonl,
   SESSION_FILE_PREFIX,
 } from '@google/gemini-cli-core';
+import { createReadStream } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
+import readline from 'node:readline';
 import { stripUnsafeCharacters } from '../ui/utils/textUtils.js';
 
 /**
@@ -41,11 +44,11 @@ export interface TextMatch {
  * Session information for display and selection purposes.
  */
 export interface SessionInfo {
-  /** Unique session identifier (filename without .json) */
+  /** Unique session identifier (filename without .json/.jsonl) */
   id: string;
   /** Filename without extension */
   file: string;
-  /** Full filename including .json extension */
+  /** Full filename including .json or .jsonl extension */
   fileName: string;
   /** ISO timestamp when session started */
   startTime: string;
@@ -77,7 +80,7 @@ export interface SessionInfo {
  * Represents a session file, which may be valid or corrupted.
  */
 export interface SessionFileEntry {
-  /** Full filename including .json extension */
+  /** Full filename including .json or .jsonl extension */
   fileName: string;
   /** Parsed session info if valid, null if corrupted */
   sessionInfo: SessionInfo | null;
@@ -192,6 +195,142 @@ export interface GetSessionOptions {
   includeFullContent?: boolean;
 }
 
+const parseJsonlSummary = async (
+  filePath: string,
+): Promise<{
+  sessionId: string;
+  startTime: string;
+  lastUpdated: string;
+  messageCount: number;
+  firstUserMessage: string;
+  summary?: string;
+  hasUserOrAssistant: boolean;
+} | null> => {
+  const stream = createReadStream(filePath, { encoding: 'utf8' });
+  const reader = readline.createInterface({
+    input: stream,
+    crlfDelay: Infinity,
+  });
+  let sessionId = '';
+  let startTime: string | null = null;
+  let summary: string | undefined;
+  let messageCount = 0;
+  let firstUserMessage: string | null = null;
+  let fallbackUserMessage: string | null = null;
+  let hasUserOrAssistant = false;
+  let lastUpdatedMs: number | null = null;
+  let lastUpdatedValue: string | null = null;
+  let earliestTimestamp: string | null = null;
+
+  const updateLastUpdated = (timestamp?: string) => {
+    if (!timestamp) return;
+    const ms = Date.parse(timestamp);
+    if (Number.isNaN(ms)) return;
+    if (lastUpdatedMs === null || ms > lastUpdatedMs) {
+      lastUpdatedMs = ms;
+      lastUpdatedValue = timestamp;
+    }
+    if (!earliestTimestamp || timestamp < earliestTimestamp) {
+      earliestTimestamp = timestamp;
+    }
+  };
+
+  try {
+    for await (const line of reader) {
+      if (!line.trim()) continue;
+      let record: {
+        type?: string;
+        id?: string;
+        timestamp?: string;
+        content?: unknown;
+        sessionId?: string;
+        startTime?: string;
+        lastUpdated?: string;
+        summary?: string;
+      };
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      if (record.type === 'session_metadata') {
+        if (typeof record.sessionId === 'string') {
+          sessionId = record.sessionId;
+        }
+        if (typeof record.startTime === 'string') {
+          startTime = record.startTime;
+          updateLastUpdated(record.startTime);
+        }
+        if (typeof record.lastUpdated === 'string') {
+          updateLastUpdated(record.lastUpdated);
+        }
+        if (typeof record.summary === 'string') {
+          summary = record.summary;
+        }
+        continue;
+      }
+
+      if (record.type === 'message_update') {
+        updateLastUpdated(record.timestamp);
+        continue;
+      }
+
+      if (record.id && record.type) {
+        messageCount += 1;
+        updateLastUpdated(record.timestamp);
+        if (record.type === 'user') {
+          const content = cleanMessage(
+            partListUnionToString(record.content as MessageRecord['content']),
+          );
+          if (content.length > 0) {
+            if (!fallbackUserMessage) {
+              fallbackUserMessage = content;
+            }
+            if (
+              !content.startsWith('/') &&
+              !content.startsWith('?') &&
+              !firstUserMessage
+            ) {
+              firstUserMessage = content;
+            }
+          }
+        }
+        if (record.type === 'user' || record.type === 'gemini') {
+          hasUserOrAssistant = true;
+        }
+      }
+    }
+  } finally {
+    reader.close();
+    stream.destroy();
+  }
+
+  if (!hasUserOrAssistant) {
+    return null;
+  }
+
+  const resolvedStartTime = startTime ?? earliestTimestamp;
+  const resolvedLastUpdated =
+    lastUpdatedValue ?? earliestTimestamp ?? startTime;
+  if (!sessionId || !resolvedStartTime || !resolvedLastUpdated) {
+    return null;
+  }
+
+  const resolvedFirstUserMessage =
+    firstUserMessage ?? fallbackUserMessage ?? 'Empty conversation';
+
+  return {
+    sessionId,
+    startTime: resolvedStartTime,
+    lastUpdated: resolvedLastUpdated,
+    messageCount,
+    firstUserMessage: resolvedFirstUserMessage,
+    summary,
+    hasUserOrAssistant,
+  };
+};
+
 /**
  * Loads all session files (including corrupted ones) from the chats directory.
  * @returns Array of session file entries, with sessionInfo null for corrupted files
@@ -204,84 +343,128 @@ export const getAllSessionFiles = async (
   try {
     const files = await fs.readdir(chatsDir);
     const sessionFiles = files
-      .filter((f) => f.startsWith(SESSION_FILE_PREFIX) && f.endsWith('.json'))
+      .filter(
+        (f) =>
+          f.startsWith(SESSION_FILE_PREFIX) &&
+          (f.endsWith('.json') || f.endsWith('.jsonl')),
+      )
       .sort(); // Sort by filename, which includes timestamp
 
-    const sessionPromises = sessionFiles.map(
-      async (file): Promise<SessionFileEntry> => {
-        const filePath = path.join(chatsDir, file);
-        try {
-          const content: ConversationRecord = JSON.parse(
-            await fs.readFile(filePath, 'utf8'),
-          );
+    const sessionEntries: SessionFileEntry[] = [];
+    const maxConcurrentReads = 10;
 
-          // Validate required fields
-          if (
-            !content.sessionId ||
-            !content.messages ||
-            !Array.isArray(content.messages) ||
-            !content.startTime ||
-            !content.lastUpdated
-          ) {
-            // Missing required fields - treat as corrupted
+    const loadSessionFile = async (file: string): Promise<SessionFileEntry> => {
+      const filePath = path.join(chatsDir, file);
+      try {
+        if (file.endsWith('.jsonl') && !options.includeFullContent) {
+          const summary = await parseJsonlSummary(filePath);
+          if (!summary) {
             return { fileName: file, sessionInfo: null };
           }
-
-          // Skip sessions that only contain system messages (info, error, warning)
-          if (!hasUserOrAssistantMessage(content.messages)) {
-            return { fileName: file, sessionInfo: null };
-          }
-
-          const firstUserMessage = extractFirstUserMessage(content.messages);
           const isCurrentSession = currentSessionId
             ? file.includes(currentSessionId.slice(0, 8))
             : false;
 
-          let fullContent: string | undefined;
-          let messages:
-            | Array<{ role: 'user' | 'assistant'; content: string }>
-            | undefined;
-
-          if (options.includeFullContent) {
-            fullContent = content.messages
-              .map((msg) => partListUnionToString(msg.content))
-              .join(' ');
-            messages = content.messages.map((msg) => ({
-              role:
-                msg.type === 'user'
-                  ? ('user' as const)
-                  : ('assistant' as const),
-              content: partListUnionToString(msg.content),
-            }));
-          }
-
           const sessionInfo: SessionInfo = {
-            id: content.sessionId,
-            file: file.replace('.json', ''),
+            id: summary.sessionId,
+            file: file.replace(/\.jsonl?$/, ''),
             fileName: file,
-            startTime: content.startTime,
-            lastUpdated: content.lastUpdated,
-            messageCount: content.messages.length,
-            displayName: content.summary
-              ? stripUnsafeCharacters(content.summary)
-              : firstUserMessage,
-            firstUserMessage,
+            startTime: summary.startTime,
+            lastUpdated: summary.lastUpdated,
+            messageCount: summary.messageCount,
+            displayName: summary.summary
+              ? stripUnsafeCharacters(summary.summary)
+              : summary.firstUserMessage,
+            firstUserMessage: summary.firstUserMessage,
             isCurrentSession,
-            index: 0, // Will be set after sorting valid sessions
-            summary: content.summary,
-            fullContent,
-            messages,
+            index: 0,
+            summary: summary.summary,
           };
-
           return { fileName: file, sessionInfo };
-        } catch {
-          // File is corrupted (can't read or parse JSON)
+        }
+
+        const rawContent = await fs.readFile(filePath, 'utf8');
+        let content: ConversationRecord;
+        if (file.endsWith('.jsonl')) {
+          // We don't have sessionId and projectHash handy here easily without parsing first,
+          // but parseJsonl will update them if metadata record is present.
+          content = parseJsonl(rawContent, '', '');
+        } else {
+          content = JSON.parse(rawContent);
+        }
+
+        // Validate required fields
+        if (
+          !content.sessionId ||
+          !content.messages ||
+          !Array.isArray(content.messages) ||
+          !content.startTime ||
+          !content.lastUpdated
+        ) {
+          // Missing required fields - treat as corrupted
           return { fileName: file, sessionInfo: null };
         }
-      },
-    );
 
-    return await Promise.all(sessionPromises);
+        // Skip sessions that only contain system messages (info, error, warning)
+        if (!hasUserOrAssistantMessage(content.messages)) {
+          return { fileName: file, sessionInfo: null };
+        }
+
+        const firstUserMessage = extractFirstUserMessage(content.messages);
+        const isCurrentSession = currentSessionId
+          ? file.includes(currentSessionId.slice(0, 8))
+          : false;
+
+        let fullContent: string | undefined;
+        let messages:
+          | Array<{ role: 'user' | 'assistant'; content: string }>
+          | undefined;
+
+        if (options.includeFullContent) {
+          fullContent = content.messages
+            .map((msg) => partListUnionToString(msg.content))
+            .join(' ');
+          messages = content.messages.map((msg) => ({
+            role:
+              msg.type === 'user' ? ('user' as const) : ('assistant' as const),
+            content: partListUnionToString(msg.content),
+          }));
+        }
+
+        const sessionInfo: SessionInfo = {
+          id: content.sessionId,
+          file: file.replace(/\.jsonl?$/, ''),
+          fileName: file,
+          startTime: content.startTime,
+          lastUpdated: content.lastUpdated,
+          messageCount: content.messages.length,
+          displayName: content.summary
+            ? stripUnsafeCharacters(content.summary)
+            : firstUserMessage,
+          firstUserMessage,
+          isCurrentSession,
+          index: 0, // Will be set after sorting valid sessions
+          summary: content.summary,
+          fullContent,
+          messages,
+        };
+
+        return { fileName: file, sessionInfo };
+      } catch {
+        // File is corrupted (can't read or parse JSON)
+        return { fileName: file, sessionInfo: null };
+      }
+    };
+
+    for (let i = 0; i < sessionFiles.length; i += maxConcurrentReads) {
+      const chunk = sessionFiles.slice(i, i + maxConcurrentReads);
+      const chunkResults = await Promise.all(
+        chunk.map((file) => loadSessionFile(file)),
+      );
+      sessionEntries.push(...chunkResults);
+    }
+
+    return sessionEntries;
   } catch (error) {
     // It's expected that the directory might not exist, which is not an error.
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
@@ -453,9 +636,13 @@ export class SessionSelector {
     const sessionPath = path.join(chatsDir, sessionInfo.fileName);
 
     try {
-      const sessionData: ConversationRecord = JSON.parse(
-        await fs.readFile(sessionPath, 'utf8'),
-      );
+      const rawContent = await fs.readFile(sessionPath, 'utf8');
+      let sessionData: ConversationRecord;
+      if (sessionInfo.fileName.endsWith('.jsonl')) {
+        sessionData = parseJsonl(rawContent, sessionInfo.id, '');
+      } else {
+        sessionData = JSON.parse(rawContent);
+      }
 
       const displayInfo = `Session ${sessionInfo.index}: ${sessionInfo.firstUserMessage} (${sessionInfo.messageCount} messages, ${formatRelativeTime(sessionInfo.lastUpdated)})`;
 

--- a/packages/cli/src/utils/sessions.test.ts
+++ b/packages/cli/src/utils/sessions.test.ts
@@ -345,7 +345,7 @@ describe('deleteSession', () => {
 
     // Create mock methods
     mockListSessions = vi.fn();
-    mockDeleteSession = vi.fn();
+    mockDeleteSession = vi.fn().mockResolvedValue(undefined);
 
     // Mock SessionSelector constructor
     vi.mocked(SessionSelector).mockImplementation(
@@ -408,8 +408,6 @@ describe('deleteSession', () => {
     ];
 
     mockListSessions.mockResolvedValue(mockSessions);
-    mockDeleteSession.mockImplementation(() => {});
-
     // Act
     await deleteSession(mockConfig, 'session-uuid-123');
 
@@ -455,8 +453,6 @@ describe('deleteSession', () => {
     ];
 
     mockListSessions.mockResolvedValue(mockSessions);
-    mockDeleteSession.mockImplementation(() => {});
-
     // Act
     await deleteSession(mockConfig, '2');
 
@@ -637,9 +633,7 @@ describe('deleteSession', () => {
     ];
 
     mockListSessions.mockResolvedValue(mockSessions);
-    mockDeleteSession.mockImplementation(() => {
-      throw new Error('File deletion failed');
-    });
+    mockDeleteSession.mockRejectedValue(new Error('File deletion failed'));
 
     // Act
     await deleteSession(mockConfig, '1');
@@ -670,10 +664,7 @@ describe('deleteSession', () => {
     ];
 
     mockListSessions.mockResolvedValue(mockSessions);
-    mockDeleteSession.mockImplementation(() => {
-      // eslint-disable-next-line no-restricted-syntax
-      throw 'Unknown error type';
-    });
+    mockDeleteSession.mockRejectedValue('Unknown error type');
 
     // Act
     await deleteSession(mockConfig, '1');
@@ -730,8 +721,6 @@ describe('deleteSession', () => {
     ];
 
     mockListSessions.mockResolvedValue(mockSessions);
-    mockDeleteSession.mockImplementation(() => {});
-
     // Act - delete index 1 (should be oldest session after sorting)
     await deleteSession(mockConfig, '1');
 

--- a/packages/cli/src/utils/sessions.test.ts
+++ b/packages/cli/src/utils/sessions.test.ts
@@ -413,7 +413,7 @@ describe('deleteSession', () => {
 
     // Assert
     expect(mockListSessions).toHaveBeenCalledOnce();
-    expect(mockDeleteSession).toHaveBeenCalledWith('session-file-123');
+    expect(mockDeleteSession).toHaveBeenCalledWith('session-uuid-123');
     expect(consoleLogSpy).toHaveBeenCalledWith(
       'Deleted session 1: Test session (some time ago)',
     );
@@ -458,7 +458,7 @@ describe('deleteSession', () => {
 
     // Assert
     expect(mockListSessions).toHaveBeenCalledOnce();
-    expect(mockDeleteSession).toHaveBeenCalledWith('session-file-2');
+    expect(mockDeleteSession).toHaveBeenCalledWith('session-2');
     expect(consoleLogSpy).toHaveBeenCalledWith(
       'Deleted session 2: Second session (some time ago)',
     );
@@ -639,7 +639,7 @@ describe('deleteSession', () => {
     await deleteSession(mockConfig, '1');
 
     // Assert
-    expect(mockDeleteSession).toHaveBeenCalledWith('session-file-1');
+    expect(mockDeleteSession).toHaveBeenCalledWith('session-1');
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'Failed to delete session: File deletion failed',
     );
@@ -725,7 +725,7 @@ describe('deleteSession', () => {
     await deleteSession(mockConfig, '1');
 
     // Assert
-    expect(mockDeleteSession).toHaveBeenCalledWith('session-file-1');
+    expect(mockDeleteSession).toHaveBeenCalledWith('session-1');
     expect(consoleLogSpy).toHaveBeenCalledWith(
       expect.stringContaining('Oldest session'),
     );

--- a/packages/cli/src/utils/sessions.ts
+++ b/packages/cli/src/utils/sessions.ts
@@ -93,7 +93,7 @@ export async function deleteSession(
   try {
     // Use ChatRecordingService to delete the session
     const chatRecordingService = new ChatRecordingService(config);
-    await chatRecordingService.deleteSession(sessionToDelete.file);
+    await chatRecordingService.deleteSession(sessionToDelete.id);
 
     const time = formatRelativeTime(sessionToDelete.lastUpdated);
     console.log(

--- a/packages/cli/src/utils/sessions.ts
+++ b/packages/cli/src/utils/sessions.ts
@@ -93,7 +93,7 @@ export async function deleteSession(
   try {
     // Use ChatRecordingService to delete the session
     const chatRecordingService = new ChatRecordingService(config);
-    chatRecordingService.deleteSession(sessionToDelete.file);
+    await chatRecordingService.deleteSession(sessionToDelete.file);
 
     const time = formatRelativeTime(sessionToDelete.lastUpdated);
     console.log(

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -238,7 +238,7 @@ describe('Gemini Client (client.ts)', () => {
       getContinueOnFailedApiCall: vi.fn(),
       getProjectRoot: vi.fn().mockReturnValue('/test/project/root'),
       storage: {
-        getProjectTempDir: vi.fn().mockReturnValue('/test/temp'),
+        getProjectTempDir: vi.fn().mockReturnValue('/tmp/test-temp'),
       },
       getContentGenerator: vi.fn().mockReturnValue(mockContentGenerator),
       getBaseLlmClient: vi.fn().mockReturnValue({

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -146,7 +146,7 @@ describe('GeminiChat', () => {
       flashFallbackHandler: undefined,
       getProjectRoot: vi.fn().mockReturnValue('/test/project/root'),
       storage: {
-        getProjectTempDir: vi.fn().mockReturnValue('/test/temp'),
+        getProjectTempDir: vi.fn().mockReturnValue('/tmp/test-temp'),
       },
       getToolRegistry: vi.fn().mockReturnValue({
         getTool: vi.fn(),

--- a/packages/core/src/core/geminiChat_network_retry.test.ts
+++ b/packages/core/src/core/geminiChat_network_retry.test.ts
@@ -84,7 +84,7 @@ describe('GeminiChat Network Retries', () => {
       getQuotaErrorOccurred: vi.fn().mockReturnValue(false),
       getProjectRoot: vi.fn().mockReturnValue('/test/project/root'),
       storage: {
-        getProjectTempDir: vi.fn().mockReturnValue('/test/temp'),
+        getProjectTempDir: vi.fn().mockReturnValue('/tmp/test-temp'),
       },
       getToolRegistry: vi.fn().mockReturnValue({ getTool: vi.fn() }),
       getContentGenerator: vi.fn().mockReturnValue(mockContentGenerator),

--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -58,7 +58,7 @@ describe('HookEventHandler', () => {
         getChatRecordingService: vi.fn().mockReturnValue({
           getConversationFilePath: vi
             .fn()
-            .mockReturnValue('/test/project/.gemini/tmp/chats/session.json'),
+            .mockReturnValue('/test/project/.gemini/tmp/chats/session.jsonl'),
         }),
       }),
     } as unknown as Config;
@@ -576,7 +576,7 @@ describe('HookEventHandler', () => {
         HookEventName.BeforeTool,
         expect.objectContaining({
           session_id: 'test-session',
-          transcript_path: '/test/project/.gemini/tmp/chats/session.json',
+          transcript_path: '/test/project/.gemini/tmp/chats/session.jsonl',
           cwd: '/test/project',
           hook_event_name: 'BeforeTool',
           timestamp: expect.any(String),

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -6,18 +6,18 @@
 
 import type { MockInstance } from 'vitest';
 import { expect, it, describe, vi, beforeEach, afterEach } from 'vitest';
-import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import type {
   ConversationRecord,
   ToolCallRecord,
 } from './chatRecordingService.js';
-import { ChatRecordingService } from './chatRecordingService.js';
+import { ChatRecordingService, parseJsonl } from './chatRecordingService.js';
 import type { Config } from '../config/config.js';
 import { getProjectHash } from '../utils/paths.js';
 
-vi.mock('node:fs');
+vi.mock('node:fs/promises');
 vi.mock('node:path');
 vi.mock('node:crypto', () => ({
   randomUUID: vi.fn(),
@@ -33,8 +33,10 @@ describe('ChatRecordingService', () => {
   let chatRecordingService: ChatRecordingService;
   let mockConfig: Config;
 
-  let mkdirSyncSpy: MockInstance<typeof fs.mkdirSync>;
-  let writeFileSyncSpy: MockInstance<typeof fs.writeFileSync>;
+  let mkdirSpy: MockInstance<typeof fsPromises.mkdir>;
+  let appendFileSpy: MockInstance<typeof fsPromises.appendFile>;
+  let writeFileSpy: MockInstance<typeof fsPromises.writeFile>;
+  let accessSpy: MockInstance<typeof fsPromises.access>;
 
   beforeEach(() => {
     mockConfig = {
@@ -62,13 +64,20 @@ describe('ChatRecordingService', () => {
 
     chatRecordingService = new ChatRecordingService(mockConfig);
 
-    mkdirSyncSpy = vi
-      .spyOn(fs, 'mkdirSync')
-      .mockImplementation(() => undefined);
+    mkdirSpy = vi.spyOn(fsPromises, 'mkdir').mockResolvedValue(undefined);
 
-    writeFileSyncSpy = vi
-      .spyOn(fs, 'writeFileSync')
-      .mockImplementation(() => undefined);
+    appendFileSpy = vi
+      .spyOn(fsPromises, 'appendFile')
+      .mockResolvedValue(undefined);
+
+    writeFileSpy = vi
+      .spyOn(fsPromises, 'writeFile')
+      .mockResolvedValue(undefined);
+
+    // Default: file does not exist
+    accessSpy = vi
+      .spyOn(fsPromises, 'access')
+      .mockRejectedValue(new Error('ENOENT'));
   });
 
   afterEach(() => {
@@ -76,112 +85,120 @@ describe('ChatRecordingService', () => {
   });
 
   describe('initialize', () => {
-    it('should create a new session if none is provided', () => {
-      chatRecordingService.initialize();
+    it('should create a new session if none is provided', async () => {
+      await chatRecordingService.initialize();
 
-      expect(mkdirSyncSpy).toHaveBeenCalledWith(
+      expect(mkdirSpy).toHaveBeenCalledWith(
         '/test/project/root/.gemini/tmp/chats',
         { recursive: true },
       );
-      expect(writeFileSyncSpy).not.toHaveBeenCalled();
+      expect(writeFileSpy).not.toHaveBeenCalled();
+      expect(appendFileSpy).not.toHaveBeenCalled();
     });
 
-    it('should resume from an existing session if provided', () => {
-      const readFileSyncSpy = vi.spyOn(fs, 'readFileSync').mockReturnValue(
-        JSON.stringify({
-          sessionId: 'old-session-id',
-          projectHash: 'test-project-hash',
-          messages: [],
-        }),
-      );
-      const writeFileSyncSpy = vi
-        .spyOn(fs, 'writeFileSync')
-        .mockImplementation(() => undefined);
-
-      chatRecordingService.initialize({
+    it('should resume from an existing JSON session if provided', async () => {
+      await chatRecordingService.initialize({
         filePath: '/test/project/root/.gemini/tmp/chats/session.json',
         conversation: {
           sessionId: 'old-session-id',
+          projectHash: 'test-project-hash',
+          startTime: new Date().toISOString(),
+          lastUpdated: new Date().toISOString(),
+          messages: [
+            {
+              id: 'existing-msg',
+              type: 'user',
+              content: 'Hello',
+              timestamp: new Date().toISOString(),
+            },
+          ],
         } as ConversationRecord,
       });
 
-      expect(mkdirSyncSpy).not.toHaveBeenCalled();
-      expect(readFileSyncSpy).toHaveBeenCalled();
-      expect(writeFileSyncSpy).not.toHaveBeenCalled();
+      expect(mkdirSpy).not.toHaveBeenCalled();
+      expect(writeFileSpy).toHaveBeenCalled();
+      expect(appendFileSpy).not.toHaveBeenCalled();
+    });
+
+    it('should resume from an existing JSONL session without appending metadata', async () => {
+      await chatRecordingService.initialize({
+        filePath: '/test/project/root/.gemini/tmp/chats/session.jsonl',
+        conversation: {
+          sessionId: 'old-session-id',
+          projectHash: 'test-project-hash',
+          startTime: new Date().toISOString(),
+          lastUpdated: new Date().toISOString(),
+          messages: [],
+        } as ConversationRecord,
+      });
+
+      expect(mkdirSpy).not.toHaveBeenCalled();
+      expect(appendFileSpy).not.toHaveBeenCalled();
     });
   });
 
   describe('recordMessage', () => {
-    beforeEach(() => {
-      chatRecordingService.initialize();
-      vi.spyOn(fs, 'readFileSync').mockReturnValue(
-        JSON.stringify({
-          sessionId: 'test-session-id',
-          projectHash: 'test-project-hash',
-          messages: [],
-        }),
-      );
+    beforeEach(async () => {
+      await chatRecordingService.initialize();
     });
 
-    it('should record a new message', () => {
-      const writeFileSyncSpy = vi
-        .spyOn(fs, 'writeFileSync')
-        .mockImplementation(() => undefined);
-      chatRecordingService.recordMessage({
+    it('should record a new message', async () => {
+      await chatRecordingService.recordMessage({
         type: 'user',
         content: 'Hello',
         model: 'gemini-pro',
       });
-      expect(mkdirSyncSpy).toHaveBeenCalled();
-      expect(writeFileSyncSpy).toHaveBeenCalled();
-      const conversation = JSON.parse(
-        writeFileSyncSpy.mock.calls[0][1] as string,
-      ) as ConversationRecord;
-      expect(conversation.messages).toHaveLength(1);
-      expect(conversation.messages[0].content).toBe('Hello');
-      expect(conversation.messages[0].type).toBe('user');
+      expect(mkdirSpy).toHaveBeenCalled();
+      expect(appendFileSpy).toHaveBeenCalledTimes(2);
+      const metadata = JSON.parse(
+        (appendFileSpy.mock.calls[0][1] as string).trim(),
+      ) as { type: string; sessionId: string };
+      expect(metadata.type).toBe('session_metadata');
+      expect(metadata.sessionId).toBe('test-session-id');
+      const message = JSON.parse(
+        (appendFileSpy.mock.calls[1][1] as string).trim(),
+      ) as { content: string; type: string };
+      expect(message.content).toBe('Hello');
+      expect(message.type).toBe('user');
     });
 
-    it('should create separate messages when recording multiple messages', () => {
-      const writeFileSyncSpy = vi
-        .spyOn(fs, 'writeFileSync')
-        .mockImplementation(() => undefined);
-      const initialConversation = {
-        sessionId: 'test-session-id',
-        projectHash: 'test-project-hash',
-        messages: [
-          {
-            id: '1',
-            type: 'user',
-            content: 'Hello',
-            timestamp: new Date().toISOString(),
-          },
-        ],
-      };
-      vi.spyOn(fs, 'readFileSync').mockReturnValue(
-        JSON.stringify(initialConversation),
-      );
+    it('should create separate messages when recording multiple messages', async () => {
+      vi.mocked(randomUUID)
+        .mockReturnValueOnce(
+          'msg-1-uuid-1-uuid' as `${string}-${string}-${string}-${string}-${string}`,
+        )
+        .mockReturnValueOnce(
+          'msg-2-uuid-2-uuid' as `${string}-${string}-${string}-${string}-${string}`,
+        );
 
-      chatRecordingService.recordMessage({
+      await chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'Hello',
+        model: 'gemini-pro',
+      });
+      await chatRecordingService.recordMessage({
         type: 'user',
         content: 'World',
         model: 'gemini-pro',
       });
 
-      expect(mkdirSyncSpy).toHaveBeenCalled();
-      expect(writeFileSyncSpy).toHaveBeenCalled();
-      const conversation = JSON.parse(
-        writeFileSyncSpy.mock.calls[0][1] as string,
-      ) as ConversationRecord;
-      expect(conversation.messages).toHaveLength(2);
-      expect(conversation.messages[0].content).toBe('Hello');
-      expect(conversation.messages[1].content).toBe('World');
+      expect(mkdirSpy).toHaveBeenCalled();
+      // Metadata once + two messages = 3 appends
+      expect(appendFileSpy).toHaveBeenCalledTimes(3);
+      const firstMessage = JSON.parse(
+        (appendFileSpy.mock.calls[1][1] as string).trim(),
+      ) as { content: string };
+      const secondMessage = JSON.parse(
+        (appendFileSpy.mock.calls[2][1] as string).trim(),
+      ) as { content: string };
+      expect(firstMessage.content).toBe('Hello');
+      expect(secondMessage.content).toBe('World');
     });
   });
 
   describe('recordThought', () => {
-    it('should queue a thought', () => {
-      chatRecordingService.initialize();
+    it('should queue a thought', async () => {
+      await chatRecordingService.initialize();
       chatRecordingService.recordThought({
         subject: 'Thinking',
         description: 'Thinking...',
@@ -198,74 +215,61 @@ describe('ChatRecordingService', () => {
   });
 
   describe('recordMessageTokens', () => {
-    beforeEach(() => {
-      chatRecordingService.initialize();
+    beforeEach(async () => {
+      await chatRecordingService.initialize();
     });
 
-    it('should update the last message with token info', () => {
-      const writeFileSyncSpy = vi
-        .spyOn(fs, 'writeFileSync')
-        .mockImplementation(() => undefined);
-      const initialConversation = {
-        sessionId: 'test-session-id',
-        projectHash: 'test-project-hash',
-        messages: [
-          {
-            id: '1',
-            type: 'gemini',
-            content: 'Response',
-            timestamp: new Date().toISOString(),
-          },
-        ],
-      };
-      vi.spyOn(fs, 'readFileSync').mockReturnValue(
-        JSON.stringify(initialConversation),
+    it('should update the last message with token info', async () => {
+      vi.mocked(randomUUID).mockReturnValueOnce(
+        'msg-1-uuid-1-uuid' as `${string}-${string}-${string}-${string}-${string}`,
       );
+      await chatRecordingService.recordMessage({
+        type: 'gemini',
+        content: 'Response',
+        model: 'gemini-pro',
+      });
 
-      chatRecordingService.recordMessageTokens({
+      await chatRecordingService.recordMessageTokens({
         promptTokenCount: 1,
         candidatesTokenCount: 2,
         totalTokenCount: 3,
         cachedContentTokenCount: 0,
       });
 
-      expect(mkdirSyncSpy).toHaveBeenCalled();
-      expect(writeFileSyncSpy).toHaveBeenCalled();
-      const conversation = JSON.parse(
-        writeFileSyncSpy.mock.calls[0][1] as string,
-      ) as ConversationRecord;
-      expect(conversation.messages[0]).toEqual({
-        ...initialConversation.messages[0],
-        tokens: {
-          input: 1,
-          output: 2,
-          total: 3,
-          cached: 0,
-          thoughts: 0,
-          tool: 0,
-        },
+      expect(mkdirSpy).toHaveBeenCalled();
+      // Metadata once + message + update = 3 appends
+      expect(appendFileSpy).toHaveBeenCalledTimes(3);
+      const update = JSON.parse(
+        (appendFileSpy.mock.calls[2][1] as string).trim(),
+      ) as { type: string; tokens: Record<string, number> };
+      expect(update.type).toBe('message_update');
+      expect(update.tokens).toEqual({
+        input: 1,
+        output: 2,
+        total: 3,
+        cached: 0,
+        thoughts: 0,
+        tool: 0,
       });
     });
 
-    it('should queue token info if the last message already has tokens', () => {
-      const initialConversation = {
-        sessionId: 'test-session-id',
-        projectHash: 'test-project-hash',
-        messages: [
-          {
-            id: '1',
-            type: 'gemini',
-            content: 'Response',
-            timestamp: new Date().toISOString(),
-            tokens: { input: 1, output: 1, total: 2, cached: 0 },
-          },
-        ],
-      };
-      vi.spyOn(fs, 'readFileSync').mockReturnValue(
-        JSON.stringify(initialConversation),
+    it('should queue token info if the last message already has tokens', async () => {
+      vi.mocked(randomUUID).mockReturnValueOnce(
+        'msg-1-uuid-1-uuid' as `${string}-${string}-${string}-${string}-${string}`,
       );
+      await chatRecordingService.recordMessage({
+        type: 'gemini',
+        content: 'Response',
+        model: 'gemini-pro',
+      });
+      await chatRecordingService.recordMessageTokens({
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+        totalTokenCount: 2,
+        cachedContentTokenCount: 0,
+      });
 
-      chatRecordingService.recordMessageTokens({
+      await chatRecordingService.recordMessageTokens({
         promptTokenCount: 2,
         candidatesTokenCount: 2,
         totalTokenCount: 4,
@@ -282,123 +286,816 @@ describe('ChatRecordingService', () => {
         tool: 0,
       });
     });
+
+    it('should write metadata before message_update even if tokens arrive before message', async () => {
+      // This tests the race condition fix: metadata must be written before any update
+      vi.mocked(randomUUID).mockReturnValueOnce(
+        'msg-1-uuid-1-uuid' as `${string}-${string}-${string}-${string}-${string}`,
+      );
+
+      // Record a gemini message first (this writes metadata + message)
+      await chatRecordingService.recordMessage({
+        type: 'gemini',
+        content: 'Response',
+        model: 'gemini-pro',
+      });
+
+      // Clear the spy to check fresh calls
+      appendFileSpy.mockClear();
+
+      // Now record tokens - since metadata is already written via flag, it should NOT write metadata again
+      await chatRecordingService.recordMessageTokens({
+        promptTokenCount: 5,
+        candidatesTokenCount: 10,
+        totalTokenCount: 15,
+        cachedContentTokenCount: 0,
+      });
+
+      // Should only write the update, not metadata again
+      expect(appendFileSpy).toHaveBeenCalledTimes(1);
+      const record = JSON.parse(
+        (appendFileSpy.mock.calls[0][1] as string).trim(),
+      ) as { type: string };
+      expect(record.type).toBe('message_update');
+    });
+  });
+
+  describe('writeMessageUpdate ordering', () => {
+    it('should write session_metadata once before message_update when update is first write', async () => {
+      await chatRecordingService.initialize();
+
+      let fileExists = false;
+      accessSpy.mockImplementation(async () => {
+        if (fileExists) {
+          return;
+        }
+        throw new Error('ENOENT');
+      });
+
+      const records: Array<{ type?: string }> = [];
+      appendFileSpy.mockImplementation(async (_filePath, data) => {
+        const record = JSON.parse(String(data)) as { type?: string };
+        records.push(record);
+        if (record.type === 'session_metadata') {
+          fileExists = true;
+        }
+      });
+
+      // @ts-expect-error testing private method ordering
+      await chatRecordingService.writeMessageUpdate({
+        id: 'msg-1',
+        tokens: {
+          input: 1,
+          output: 2,
+          total: 3,
+          cached: 0,
+          thoughts: 0,
+          tool: 0,
+        },
+      });
+
+      const metadataIndices = records
+        .map((record, index) =>
+          record.type === 'session_metadata' ? index : -1,
+        )
+        .filter((index) => index >= 0);
+      const updateIndex = records.findIndex(
+        (record) => record.type === 'message_update',
+      );
+
+      expect(metadataIndices).toHaveLength(1);
+      expect(updateIndex).toBeGreaterThan(-1);
+      expect(metadataIndices[0]).toBeLessThan(updateIndex);
+    });
+
+    it('should write session_metadata exactly once even with concurrent calls', async () => {
+      await chatRecordingService.initialize();
+
+      const records: Array<{ type?: string }> = [];
+      appendFileSpy.mockImplementation(async (_filePath, data) => {
+        // Simulate slow I/O to increase chance of race
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        const record = JSON.parse(String(data)) as { type?: string };
+        records.push(record);
+      });
+
+      // Fire multiple concurrent writes - all should await the same metadata write
+      await Promise.all([
+        // @ts-expect-error testing private method
+        chatRecordingService.writeMessageUpdate({
+          id: 'msg-1',
+          tokens: {
+            input: 1,
+            output: 2,
+            total: 3,
+            cached: 0,
+            thoughts: 0,
+            tool: 0,
+          },
+        }),
+        // @ts-expect-error testing private method
+        chatRecordingService.writeMessageUpdate({
+          id: 'msg-2',
+          tokens: {
+            input: 3,
+            output: 4,
+            total: 7,
+            cached: 0,
+            thoughts: 0,
+            tool: 0,
+          },
+        }),
+        // @ts-expect-error testing private method
+        chatRecordingService.writeMessageUpdate({
+          id: 'msg-3',
+          tokens: {
+            input: 5,
+            output: 6,
+            total: 11,
+            cached: 0,
+            thoughts: 0,
+            tool: 0,
+          },
+        }),
+      ]);
+
+      const metadataCount = records.filter(
+        (r) => r.type === 'session_metadata',
+      ).length;
+      const updateCount = records.filter(
+        (r) => r.type === 'message_update',
+      ).length;
+
+      // Should have exactly 1 metadata and 3 updates
+      expect(metadataCount).toBe(1);
+      expect(updateCount).toBe(3);
+    });
+  });
+
+  describe('ensureMetadataWritten', () => {
+    it('should write session_metadata once under concurrent writes', async () => {
+      await chatRecordingService.initialize();
+
+      // Seed a Gemini message so recordMessageTokens produces a message_update.
+      // @ts-expect-error private property
+      chatRecordingService.conversation = {
+        sessionId: 'test-session-id',
+        projectHash: 'test-project-hash',
+        startTime: '2025-01-01T00:00:00.000Z',
+        lastUpdated: '2025-01-01T00:00:00.000Z',
+        messages: [
+          {
+            id: 'msg-1',
+            type: 'gemini',
+            content: '',
+            timestamp: '2025-01-01T00:00:01.000Z',
+          },
+        ],
+      } as ConversationRecord;
+      // @ts-expect-error private property
+      chatRecordingService.conversationFile =
+        '/test/project/root/.gemini/tmp/chats/session-test.jsonl';
+      // @ts-expect-error private property
+      chatRecordingService.fileInitialized = false;
+
+      let metadataWrites = 0;
+      let resolveFirstMetadata: (() => void) | null = null;
+      const firstMetadataPromise = new Promise<void>((resolve) => {
+        resolveFirstMetadata = resolve;
+      });
+
+      appendFileSpy.mockImplementation(async (_filePath, data) => {
+        const record = JSON.parse(String(data)) as { type?: string };
+        if (record.type === 'session_metadata') {
+          metadataWrites += 1;
+          if (metadataWrites === 1) {
+            return firstMetadataPromise;
+          }
+        }
+        return undefined;
+      });
+
+      const tokensPromise = chatRecordingService.recordMessageTokens({
+        promptTokenCount: 1,
+        candidatesTokenCount: 2,
+        totalTokenCount: 3,
+        cachedContentTokenCount: 0,
+      });
+      await Promise.resolve();
+
+      const messagePromise = chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'Hello',
+        model: 'gemini-pro',
+      });
+      await Promise.resolve();
+
+      resolveFirstMetadata!();
+      await Promise.all([tokensPromise, messagePromise]);
+
+      expect(metadataWrites).toBe(1);
+    });
+  });
+
+  describe('getConversation', () => {
+    it('should read a JSON session via fs.promises.readFile', async () => {
+      const jsonConversation: ConversationRecord = {
+        sessionId: 'json-session-id',
+        projectHash: 'json-project-hash',
+        startTime: '2025-01-01T00:00:00.000Z',
+        lastUpdated: '2025-01-01T00:00:01.000Z',
+        messages: [
+          {
+            id: 'msg-1',
+            type: 'user',
+            content: 'Hello',
+            timestamp: '2025-01-01T00:00:00.500Z',
+          },
+        ],
+      };
+
+      const readFileSpy = vi
+        .spyOn(fsPromises, 'readFile')
+        .mockResolvedValue(JSON.stringify(jsonConversation));
+
+      // @ts-expect-error private property
+      chatRecordingService.conversationFile =
+        '/test/project/root/.gemini/tmp/chats/session.json';
+      // @ts-expect-error private property
+      chatRecordingService.conversation = null;
+
+      const conversation = await chatRecordingService.getConversation();
+
+      expect(readFileSpy).toHaveBeenCalledWith(
+        '/test/project/root/.gemini/tmp/chats/session.json',
+        'utf8',
+      );
+      expect(conversation).toEqual(jsonConversation);
+    });
+
+    it('should read a JSONL session via fs.promises.readFile', async () => {
+      const metadata = {
+        type: 'session_metadata',
+        sessionId: 'jsonl-session-id',
+        projectHash: 'jsonl-project-hash',
+        startTime: '2025-01-01T00:00:00.000Z',
+        lastUpdated: '2025-01-01T00:00:00.000Z',
+      };
+      const message = {
+        id: 'msg-1',
+        type: 'user',
+        content: 'Hello',
+        timestamp: '2025-01-01T00:00:01.000Z',
+      };
+      const jsonlContent = `${JSON.stringify(metadata)}\n${JSON.stringify(message)}\n`;
+
+      const readFileSpy = vi
+        .spyOn(fsPromises, 'readFile')
+        .mockResolvedValue(jsonlContent);
+
+      // @ts-expect-error private property
+      chatRecordingService.conversationFile =
+        '/test/project/root/.gemini/tmp/chats/session.jsonl';
+      // @ts-expect-error private property
+      chatRecordingService.conversation = null;
+
+      const conversation = await chatRecordingService.getConversation();
+
+      expect(readFileSpy).toHaveBeenCalledWith(
+        '/test/project/root/.gemini/tmp/chats/session.jsonl',
+        'utf8',
+      );
+      expect(conversation).toMatchObject({
+        sessionId: 'jsonl-session-id',
+        projectHash: 'jsonl-project-hash',
+        messages: [{ id: 'msg-1', type: 'user', content: 'Hello' }],
+      });
+    });
+
+    it('should return empty conversation when readFile throws ENOENT', async () => {
+      const error = new Error('ENOENT') as NodeJS.ErrnoException;
+      error.code = 'ENOENT';
+      const readFileSpy = vi
+        .spyOn(fsPromises, 'readFile')
+        .mockRejectedValue(error);
+
+      // @ts-expect-error private property
+      chatRecordingService.conversationFile =
+        '/test/project/root/.gemini/tmp/chats/missing.json';
+      // @ts-expect-error private property
+      chatRecordingService.conversation = null;
+
+      const conversation = await chatRecordingService.getConversation();
+
+      expect(readFileSpy).toHaveBeenCalledWith(
+        '/test/project/root/.gemini/tmp/chats/missing.json',
+        'utf8',
+      );
+      expect(conversation).toMatchObject({
+        sessionId: 'test-session-id',
+        projectHash: 'test-project-hash',
+        messages: [],
+      });
+    });
+  });
+
+  describe('saveSummary', () => {
+    it('should rewrite JSON session files with summary', async () => {
+      const jsonConversation: ConversationRecord = {
+        sessionId: 'json-session-id',
+        projectHash: 'json-project-hash',
+        startTime: '2025-01-01T00:00:00.000Z',
+        lastUpdated: '2025-01-01T00:00:01.000Z',
+        messages: [
+          {
+            id: 'msg-1',
+            type: 'user',
+            content: 'Hello',
+            timestamp: '2025-01-01T00:00:00.500Z',
+          },
+        ],
+      };
+
+      const readFileSpy = vi
+        .spyOn(fsPromises, 'readFile')
+        .mockResolvedValue(JSON.stringify(jsonConversation));
+
+      // @ts-expect-error private property
+      chatRecordingService.conversationFile =
+        '/test/project/root/.gemini/tmp/chats/session.json';
+      // @ts-expect-error private property
+      chatRecordingService.conversation = null;
+
+      await chatRecordingService.saveSummary('Summary text');
+
+      expect(readFileSpy).toHaveBeenCalledWith(
+        '/test/project/root/.gemini/tmp/chats/session.json',
+        'utf8',
+      );
+      expect(writeFileSpy).toHaveBeenCalledTimes(1);
+      const written = JSON.parse(
+        writeFileSpy.mock.calls[0][1] as string,
+      ) as ConversationRecord;
+      expect(written.summary).toBe('Summary text');
+      expect(written.messages).toHaveLength(1);
+      expect(appendFileSpy).not.toHaveBeenCalled();
+    });
+
+    it('should append summary metadata for JSONL session files', async () => {
+      const metadata = {
+        type: 'session_metadata',
+        sessionId: 'jsonl-session-id',
+        projectHash: 'jsonl-project-hash',
+        startTime: '2025-01-01T00:00:00.000Z',
+        lastUpdated: '2025-01-01T00:00:00.000Z',
+      };
+      const message = {
+        id: 'msg-1',
+        type: 'user',
+        content: 'Hello',
+        timestamp: '2025-01-01T00:00:01.000Z',
+      };
+      const jsonlContent = `${JSON.stringify(metadata)}\n${JSON.stringify(message)}\n`;
+
+      const readFileSpy = vi
+        .spyOn(fsPromises, 'readFile')
+        .mockResolvedValue(jsonlContent);
+
+      // @ts-expect-error private property
+      chatRecordingService.conversationFile =
+        '/test/project/root/.gemini/tmp/chats/session.jsonl';
+      // @ts-expect-error private property
+      chatRecordingService.conversation = null;
+
+      await chatRecordingService.saveSummary('Summary text');
+
+      expect(readFileSpy).toHaveBeenCalledWith(
+        '/test/project/root/.gemini/tmp/chats/session.jsonl',
+        'utf8',
+      );
+      expect(writeFileSpy).not.toHaveBeenCalled();
+      expect(appendFileSpy).toHaveBeenCalled();
+      const records = appendFileSpy.mock.calls.map((call) =>
+        JSON.parse(call[1] as string),
+      ) as Array<{ type?: string; summary?: string }>;
+      const summaryRecord = records.find(
+        (record) => record.type === 'session_metadata' && record.summary,
+      );
+      expect(summaryRecord).toMatchObject({
+        type: 'session_metadata',
+        summary: 'Summary text',
+      });
+    });
+  });
+
+  describe('parseJsonl', () => {
+    it('should apply a message_update that appears before its message record', () => {
+      const updateLine = JSON.stringify({
+        type: 'message_update',
+        id: 'msg-1',
+        timestamp: '2025-01-01T00:00:02.000Z',
+        tokens: {
+          input: 1,
+          output: 2,
+          total: 3,
+          cached: 0,
+          thoughts: 0,
+          tool: 0,
+        },
+      });
+      const messageLine = JSON.stringify({
+        id: 'msg-1',
+        type: 'gemini',
+        content: 'Hello',
+        timestamp: '2025-01-01T00:00:01.000Z',
+      });
+      const content = `${updateLine}\n${messageLine}\n`;
+
+      const conversation = parseJsonl(content, 'session-1', 'project-hash');
+
+      expect(conversation.messages).toHaveLength(1);
+      expect(conversation.messages[0]).toMatchObject({
+        id: 'msg-1',
+        type: 'gemini',
+        tokens: {
+          input: 1,
+          output: 2,
+          total: 3,
+          cached: 0,
+          thoughts: 0,
+          tool: 0,
+        },
+      });
+    });
+
+    it('should apply multiple message_updates that appear before their message', () => {
+      const update1 = JSON.stringify({
+        type: 'message_update',
+        id: 'msg-1',
+        timestamp: '2025-01-01T00:00:02.000Z',
+        tokens: {
+          input: 1,
+          output: 2,
+          total: 3,
+          cached: 0,
+          thoughts: 0,
+          tool: 0,
+        },
+      });
+      const update2 = JSON.stringify({
+        type: 'message_update',
+        id: 'msg-1',
+        timestamp: '2025-01-01T00:00:03.000Z',
+        toolCalls: [{ id: 'tc-1', name: 'test' }],
+      });
+      const messageLine = JSON.stringify({
+        id: 'msg-1',
+        type: 'gemini',
+        content: 'Hello',
+        timestamp: '2025-01-01T00:00:01.000Z',
+      });
+      const content = `${update1}\n${update2}\n${messageLine}\n`;
+
+      const conversation = parseJsonl(content, 'session-1', 'project-hash');
+
+      expect(conversation.messages).toHaveLength(1);
+      expect(conversation.messages[0]).toMatchObject({
+        id: 'msg-1',
+        type: 'gemini',
+        tokens: {
+          input: 1,
+          output: 2,
+          total: 3,
+          cached: 0,
+          thoughts: 0,
+          tool: 0,
+        },
+        toolCalls: [{ id: 'tc-1', name: 'test' }],
+      });
+    });
+
+    it('should track lastUpdated from message_updates that precede messages', () => {
+      const updateLine = JSON.stringify({
+        type: 'message_update',
+        id: 'msg-1',
+        timestamp: '2025-01-01T00:00:05.000Z',
+        tokens: {
+          input: 1,
+          output: 2,
+          total: 3,
+          cached: 0,
+          thoughts: 0,
+          tool: 0,
+        },
+      });
+      const messageLine = JSON.stringify({
+        id: 'msg-1',
+        type: 'gemini',
+        content: 'Hello',
+        timestamp: '2025-01-01T00:00:01.000Z',
+      });
+      const content = `${updateLine}\n${messageLine}\n`;
+
+      const conversation = parseJsonl(content, 'session-1', 'project-hash');
+
+      expect(conversation.lastUpdated).toBe('2025-01-01T00:00:05.000Z');
+    });
+
+    it('should preserve applied updates when duplicate message records appear', () => {
+      const messageLine = JSON.stringify({
+        id: 'msg-1',
+        type: 'gemini',
+        content: 'Hello',
+        timestamp: '2025-01-01T00:00:01.000Z',
+      });
+      const updateLine = JSON.stringify({
+        type: 'message_update',
+        id: 'msg-1',
+        timestamp: '2025-01-01T00:00:02.000Z',
+        tokens: {
+          input: 1,
+          output: 2,
+          total: 3,
+          cached: 0,
+          thoughts: 0,
+          tool: 0,
+        },
+      });
+      const duplicateLine = JSON.stringify({
+        id: 'msg-1',
+        type: 'gemini',
+        content: 'Hello again',
+        timestamp: '2025-01-01T00:00:03.000Z',
+      });
+      const content = `${messageLine}\n${updateLine}\n${duplicateLine}\n`;
+
+      const conversation = parseJsonl(content, 'session-1', 'project-hash');
+
+      expect(conversation.messages).toHaveLength(1);
+      expect(conversation.messages[0]).toMatchObject({
+        id: 'msg-1',
+        type: 'gemini',
+        content: 'Hello again',
+        tokens: {
+          input: 1,
+          output: 2,
+          total: 3,
+          cached: 0,
+          thoughts: 0,
+          tool: 0,
+        },
+      });
+      expect(conversation.lastUpdated).toBe('2025-01-01T00:00:03.000Z');
+    });
   });
 
   describe('recordToolCalls', () => {
-    beforeEach(() => {
-      chatRecordingService.initialize();
+    beforeEach(async () => {
+      await chatRecordingService.initialize();
     });
 
-    it('should add new tool calls to the last message', () => {
-      const writeFileSyncSpy = vi
-        .spyOn(fs, 'writeFileSync')
-        .mockImplementation(() => undefined);
-      const initialConversation = {
-        sessionId: 'test-session-id',
-        projectHash: 'test-project-hash',
-        messages: [
-          {
-            id: '1',
-            type: 'gemini',
-            content: '',
-            timestamp: new Date().toISOString(),
-          },
-        ],
-      };
-      vi.spyOn(fs, 'readFileSync').mockReturnValue(
-        JSON.stringify(initialConversation),
+    it('should add new tool calls to the last message', async () => {
+      vi.mocked(randomUUID).mockReturnValueOnce(
+        'msg-1-uuid-1-uuid' as `${string}-${string}-${string}-${string}-${string}`,
       );
-
-      const toolCall: ToolCallRecord = {
-        id: 'tool-1',
-        name: 'testTool',
-        args: {},
-        status: 'awaiting_approval',
-        timestamp: new Date().toISOString(),
-      };
-      chatRecordingService.recordToolCalls('gemini-pro', [toolCall]);
-
-      expect(mkdirSyncSpy).toHaveBeenCalled();
-      expect(writeFileSyncSpy).toHaveBeenCalled();
-      const conversation = JSON.parse(
-        writeFileSyncSpy.mock.calls[0][1] as string,
-      ) as ConversationRecord;
-      expect(conversation.messages[0]).toEqual({
-        ...initialConversation.messages[0],
-        toolCalls: [
-          {
-            ...toolCall,
-            displayName: 'Test Tool',
-            description: 'A test tool',
-            renderOutputAsMarkdown: false,
-          },
-        ],
-      });
-    });
-
-    it('should create a new message if the last message is not from gemini', () => {
-      const writeFileSyncSpy = vi
-        .spyOn(fs, 'writeFileSync')
-        .mockImplementation(() => undefined);
-      const initialConversation = {
-        sessionId: 'test-session-id',
-        projectHash: 'test-project-hash',
-        messages: [
-          {
-            id: 'a-uuid',
-            type: 'user',
-            content: 'call a tool',
-            timestamp: new Date().toISOString(),
-          },
-        ],
-      };
-      vi.spyOn(fs, 'readFileSync').mockReturnValue(
-        JSON.stringify(initialConversation),
-      );
-
-      const toolCall: ToolCallRecord = {
-        id: 'tool-1',
-        name: 'testTool',
-        args: {},
-        status: 'awaiting_approval',
-        timestamp: new Date().toISOString(),
-      };
-      chatRecordingService.recordToolCalls('gemini-pro', [toolCall]);
-
-      expect(mkdirSyncSpy).toHaveBeenCalled();
-      expect(writeFileSyncSpy).toHaveBeenCalled();
-      const conversation = JSON.parse(
-        writeFileSyncSpy.mock.calls[0][1] as string,
-      ) as ConversationRecord;
-      expect(conversation.messages).toHaveLength(2);
-      expect(conversation.messages[1]).toEqual({
-        ...conversation.messages[1],
-        id: 'this-is-a-test-uuid',
-        model: 'gemini-pro',
+      await chatRecordingService.recordMessage({
         type: 'gemini',
-        thoughts: [],
         content: '',
-        toolCalls: [
-          {
-            ...toolCall,
-            displayName: 'Test Tool',
-            description: 'A test tool',
-            renderOutputAsMarkdown: false,
-          },
-        ],
+        model: 'gemini-pro',
       });
+
+      const toolCall: ToolCallRecord = {
+        id: 'tool-1',
+        name: 'testTool',
+        args: {},
+        status: 'awaiting_approval',
+        timestamp: new Date().toISOString(),
+      };
+      await chatRecordingService.recordToolCalls('gemini-pro', [toolCall]);
+
+      expect(mkdirSpy).toHaveBeenCalled();
+      // Metadata + message + tool call update = 3 appends
+      expect(appendFileSpy).toHaveBeenCalledTimes(3);
+      const update = JSON.parse(
+        (appendFileSpy.mock.calls[2][1] as string).trim(),
+      ) as { type: string; toolCalls: ToolCallRecord[] };
+      expect(update.type).toBe('message_update');
+      expect(update.toolCalls).toEqual([
+        {
+          ...toolCall,
+          displayName: 'Test Tool',
+          description: 'A test tool',
+          renderOutputAsMarkdown: false,
+        },
+      ]);
+    });
+
+    it('should create a new message if the last message is not from gemini', async () => {
+      vi.mocked(randomUUID)
+        .mockReturnValueOnce(
+          'user-1-msg-1-uuid' as `${string}-${string}-${string}-${string}-${string}`,
+        )
+        .mockReturnValueOnce(
+          'gemini-2-msg-2-uuid' as `${string}-${string}-${string}-${string}-${string}`,
+        );
+      await chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'call a tool',
+        model: 'gemini-pro',
+      });
+
+      const toolCall: ToolCallRecord = {
+        id: 'tool-1',
+        name: 'testTool',
+        args: {},
+        status: 'awaiting_approval',
+        timestamp: new Date().toISOString(),
+      };
+      await chatRecordingService.recordToolCalls('gemini-pro', [toolCall]);
+
+      expect(mkdirSpy).toHaveBeenCalled();
+      // Metadata + user message + gemini message with tool call = 3 appends
+      expect(appendFileSpy).toHaveBeenCalledTimes(3);
+      const newMessage = JSON.parse(
+        (appendFileSpy.mock.calls[2][1] as string).trim(),
+      ) as {
+        type: string;
+        model?: string;
+        content: string;
+        toolCalls?: ToolCallRecord[];
+      };
+      expect(newMessage.type).toBe('gemini');
+      expect(newMessage.model).toBe('gemini-pro');
+      expect(newMessage.content).toBe('');
+      expect(newMessage.toolCalls).toEqual([
+        {
+          ...toolCall,
+          displayName: 'Test Tool',
+          description: 'A test tool',
+          renderOutputAsMarkdown: false,
+        },
+      ]);
     });
   });
 
   describe('deleteSession', () => {
-    it('should delete the session file', () => {
-      const unlinkSyncSpy = vi
-        .spyOn(fs, 'unlinkSync')
-        .mockImplementation(() => undefined);
-      chatRecordingService.deleteSession('test-session-id');
-      expect(unlinkSyncSpy).toHaveBeenCalledWith(
-        '/test/project/root/.gemini/tmp/chats/test-session-id.json',
+    const makeEnoent = () => {
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      return err;
+    };
+
+    it('should delete all matching session files by scanning for shortId', async () => {
+      const sessionId = 'abcd1234-5678-1234-9abc-1234567890ab';
+      const expectedFiles = [
+        'session-2025-01-01T10-00-abcd1234.jsonl',
+        'session-2025-01-01T09-00-abcd1234.json',
+      ];
+
+      accessSpy.mockImplementation(async (filePath) => {
+        // chats directory exists
+        if (String(filePath).endsWith('/chats')) return;
+        throw makeEnoent();
+      });
+
+      const readdirSpy = vi
+        .spyOn(fsPromises, 'readdir')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockResolvedValue(expectedFiles as any);
+
+      const readFileSpy = vi
+        .spyOn(fsPromises, 'readFile')
+        .mockImplementation(async (filePath) => {
+          const file = String(filePath);
+          if (file.endsWith('.jsonl')) {
+            return (
+              JSON.stringify({
+                type: 'session_metadata',
+                sessionId,
+                startTime: new Date().toISOString(),
+                lastUpdated: new Date().toISOString(),
+              }) + '\n'
+            );
+          }
+          return JSON.stringify({ sessionId, messages: [] });
+        });
+
+      const unlinkSpy = vi
+        .spyOn(fsPromises, 'unlink')
+        .mockResolvedValue(undefined);
+
+      await chatRecordingService.deleteSession(sessionId);
+
+      expect(accessSpy).toHaveBeenCalled();
+      expect(readdirSpy).toHaveBeenCalledWith(
+        '/test/project/root/.gemini/tmp/chats',
       );
+      expect(readFileSpy).toHaveBeenCalled();
+      for (const file of expectedFiles) {
+        expect(unlinkSpy).toHaveBeenCalledWith(
+          `/test/project/root/.gemini/tmp/chats/${file}`,
+        );
+      }
+    });
+
+    it('should delete by direct filename when provided', async () => {
+      const filename = 'session-2025-01-01T10-00-abcd1234.jsonl';
+
+      accessSpy.mockImplementation(async (filePath) => {
+        if (String(filePath).endsWith(filename)) return;
+        throw makeEnoent();
+      });
+
+      const unlinkSpy = vi
+        .spyOn(fsPromises, 'unlink')
+        .mockResolvedValue(undefined);
+
+      await chatRecordingService.deleteSession(filename);
+
+      expect(accessSpy).toHaveBeenCalled();
+      expect(unlinkSpy).toHaveBeenCalledWith(
+        `/test/project/root/.gemini/tmp/chats/${filename}`,
+      );
+    });
+
+    it('should delete by session filename base without extension', async () => {
+      const filenameBase = 'session-2025-01-01T10-00-abcd1234';
+      const expectedJsonlPath = `/test/project/root/.gemini/tmp/chats/${filenameBase}.jsonl`;
+      const expectedJsonPath = `/test/project/root/.gemini/tmp/chats/${filenameBase}.json`;
+
+      accessSpy.mockImplementation(async (filePath) => {
+        const file = String(filePath);
+        if (
+          file.endsWith(`${filenameBase}.jsonl`) ||
+          file.endsWith(`${filenameBase}.json`)
+        ) {
+          return;
+        }
+        throw makeEnoent();
+      });
+
+      const unlinkSpy = vi
+        .spyOn(fsPromises, 'unlink')
+        .mockResolvedValue(undefined);
+
+      await chatRecordingService.deleteSession(filenameBase);
+
+      expect(accessSpy).toHaveBeenCalled();
+      expect(unlinkSpy).toHaveBeenCalledWith(expectedJsonlPath);
+      expect(unlinkSpy).toHaveBeenCalledWith(expectedJsonPath);
+    });
+
+    it('should not fall through to shortId scan when session filename not found', async () => {
+      // This tests the critical bug fix: if sessionId starts with SESSION_FILE_PREFIX
+      // but files don't exist, we should NOT fall through to shortId scan,
+      // as shortId would be "session-" which could delete ALL session files.
+      const filenameBase = 'session-2025-01-01T10-00-abcd1234';
+
+      accessSpy.mockImplementation(async (filePath) => {
+        if (String(filePath).endsWith('/chats')) {
+          return;
+        }
+        throw makeEnoent();
+      });
+
+      const readdirSpy = vi.spyOn(fsPromises, 'readdir');
+
+      const unlinkSpy = vi.spyOn(fsPromises, 'unlink');
+
+      await chatRecordingService.deleteSession(filenameBase);
+
+      expect(accessSpy).toHaveBeenCalled();
+      // Should NOT have called readdir (shortId scan)
+      expect(readdirSpy).not.toHaveBeenCalled();
+      // Should NOT have deleted anything
+      expect(unlinkSpy).not.toHaveBeenCalled();
+    });
+
+    it('should delete both jsonl and json in fallback path', async () => {
+      const sessionId = 'abcd1234-efgh-5678-ijkl-9012mnop3456';
+      const expectedJsonlPath = `/test/project/root/.gemini/tmp/chats/${sessionId}.jsonl`;
+      const expectedJsonPath = `/test/project/root/.gemini/tmp/chats/${sessionId}.json`;
+
+      const accessSpy = vi
+        .spyOn(fsPromises, 'access')
+        .mockImplementation(async (filePath) => {
+          const file = String(filePath);
+          if (file === expectedJsonlPath || file === expectedJsonPath) {
+            return;
+          }
+          // Force shortId scan to be skipped
+          throw makeEnoent();
+        });
+
+      const unlinkSpy = vi
+        .spyOn(fsPromises, 'unlink')
+        .mockResolvedValue(undefined);
+
+      await chatRecordingService.deleteSession(sessionId);
+
+      expect(accessSpy).toHaveBeenCalled();
+      expect(unlinkSpy).toHaveBeenCalledWith(expectedJsonlPath);
+      expect(unlinkSpy).toHaveBeenCalledWith(expectedJsonPath);
     });
   });
 });

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -9,7 +9,7 @@ import { type Status } from '../core/coreToolScheduler.js';
 import { type ThoughtSummary } from '../utils/thoughtUtils.js';
 import { getProjectHash } from '../utils/paths.js';
 import path from 'node:path';
-import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import type {
   PartListUnion,
@@ -98,6 +98,155 @@ export interface ResumedSessionData {
 }
 
 /**
+ * Parses a JSONL string into a ConversationRecord.
+ */
+export function parseJsonl(
+  content: string,
+  sessionId: string,
+  projectHash: string,
+): ConversationRecord {
+  const lines = content.split('\n');
+  let lastUpdatedMs: number | null = null;
+  let lastUpdatedValue: string | null = null;
+  let earliestTimestamp: string | null = null;
+  let hasStartTime = false;
+  let parseErrors = 0;
+  const conversation: ConversationRecord = {
+    sessionId,
+    projectHash,
+    startTime: new Date().toISOString(),
+    lastUpdated: new Date().toISOString(),
+    messages: [],
+  };
+
+  // Queue for message_update records that arrive before their target message
+  const pendingUpdates = new Map<
+    string,
+    Array<Partial<MessageRecord> & { id: string }>
+  >();
+  const messageIndex = new Map<string, MessageRecord>();
+
+  const updateLastUpdated = (timestamp?: string) => {
+    if (!timestamp) return;
+    const ms = Date.parse(timestamp);
+    if (Number.isNaN(ms)) return;
+    if (lastUpdatedMs === null || ms > lastUpdatedMs) {
+      lastUpdatedMs = ms;
+      lastUpdatedValue = timestamp;
+    }
+    if (!earliestTimestamp || timestamp < earliestTimestamp) {
+      earliestTimestamp = timestamp;
+    }
+  };
+
+  // Helper to apply an update to a message
+  const applyUpdate = (
+    msg: MessageRecord,
+    update: Partial<MessageRecord> & { id: string },
+  ) => {
+    // Exclude the type field from the update merge to avoid overwriting the message type
+    const { type: _type, ...updateData } = update;
+    Object.assign(msg, updateData);
+  };
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const record = JSON.parse(line);
+      // Handle session metadata
+      if (record.type === 'session_metadata') {
+        if (typeof record.sessionId === 'string') {
+          conversation.sessionId = record.sessionId;
+        }
+        if (typeof record.projectHash === 'string') {
+          conversation.projectHash = record.projectHash;
+        }
+        if (typeof record.startTime === 'string') {
+          conversation.startTime = record.startTime;
+        }
+        if (typeof record.lastUpdated === 'string') {
+          conversation.lastUpdated = record.lastUpdated;
+        }
+        if (typeof record.summary === 'string') {
+          conversation.summary = record.summary;
+        }
+        if (typeof record.startTime === 'string') {
+          const startMs = Date.parse(record.startTime);
+          if (!Number.isNaN(startMs)) {
+            hasStartTime = true;
+            updateLastUpdated(record.startTime);
+          }
+        }
+        if (typeof record.lastUpdated === 'string') {
+          updateLastUpdated(record.lastUpdated);
+        }
+        continue;
+      }
+
+      // Handle message updates
+      if (record.type === 'message_update') {
+        const update = record as Partial<MessageRecord> & { id: string };
+        const existingMsg = messageIndex.get(update.id);
+        if (existingMsg) {
+          applyUpdate(existingMsg, update);
+        } else {
+          // Queue the update for when the message arrives
+          const queue = pendingUpdates.get(update.id) ?? [];
+          queue.push(update);
+          pendingUpdates.set(update.id, queue);
+        }
+        updateLastUpdated(record.timestamp);
+        continue;
+      }
+
+      // Handle standard messages (user, gemini, info, error, warning)
+      // We assume anything else with an 'id' is a message record
+      if (record.id && record.type) {
+        const msg = record as MessageRecord;
+        const existingMsg = messageIndex.get(msg.id);
+        let targetMsg: MessageRecord;
+        if (existingMsg) {
+          Object.assign(existingMsg, msg);
+          targetMsg = existingMsg;
+        } else {
+          conversation.messages.push(msg);
+          messageIndex.set(msg.id, msg);
+          targetMsg = msg;
+        }
+
+        // Apply any pending updates for this message
+        const pending = pendingUpdates.get(targetMsg.id);
+        if (pending) {
+          for (const update of pending) {
+            applyUpdate(targetMsg, update);
+          }
+          pendingUpdates.delete(targetMsg.id);
+        }
+
+        updateLastUpdated(targetMsg.timestamp);
+      }
+    } catch (e) {
+      debugLogger.error('Error parsing JSONL line', e);
+      parseErrors += 1;
+    }
+  }
+  if (!hasStartTime && earliestTimestamp) {
+    conversation.startTime = earliestTimestamp;
+  }
+  if (lastUpdatedValue) {
+    conversation.lastUpdated = lastUpdatedValue;
+  } else if (earliestTimestamp) {
+    conversation.lastUpdated = earliestTimestamp;
+  }
+  if (parseErrors > 0) {
+    debugLogger.warn(
+      `[SessionRecording] Failed to parse ${parseErrors} JSONL line(s) for session ${sessionId || 'unknown'}. Some messages may be missing.`,
+    );
+  }
+  return conversation;
+}
+
+/**
  * Service for automatically recording chat conversations to disk.
  *
  * This service provides comprehensive conversation recording that captures:
@@ -110,12 +259,16 @@ export interface ResumedSessionData {
  */
 export class ChatRecordingService {
   private conversationFile: string | null = null;
-  private cachedLastConvData: string | null = null;
+  private conversation: ConversationRecord | null = null;
   private sessionId: string;
   private projectHash: string;
   private queuedThoughts: Array<ThoughtSummary & { timestamp: string }> = [];
   private queuedTokens: TokensSummary | null = null;
   private config: Config;
+  /** Tracks whether session_metadata has been written to the file */
+  private fileInitialized: boolean = false;
+  /** Promise gate to prevent concurrent metadata writes */
+  private metadataWritePromise: Promise<void> | null = null;
 
   constructor(config: Config) {
     this.config = config;
@@ -127,50 +280,66 @@ export class ChatRecordingService {
    * Initializes the chat recording service: creates a new conversation file and associates it with
    * this service instance, or resumes from an existing session if resumedSessionData is provided.
    */
-  initialize(resumedSessionData?: ResumedSessionData): void {
+  async initialize(resumedSessionData?: ResumedSessionData): Promise<void> {
     try {
       if (resumedSessionData) {
         // Resume from existing session
         this.conversationFile = resumedSessionData.filePath;
-        this.sessionId = resumedSessionData.conversation.sessionId;
+        this.conversation = resumedSessionData.conversation;
+        if (!this.conversation.messages) {
+          this.conversation.messages = [];
+        }
+        this.sessionId = this.conversation.sessionId;
+        // Resumed sessions already have metadata written
+        this.fileInitialized = true;
 
-        // Update the session ID in the existing file
-        this.updateConversation((conversation) => {
-          conversation.sessionId = this.sessionId;
-        });
-
-        // Clear any cached data to force fresh reads
-        this.cachedLastConvData = null;
+        // If it's an old .json file, we'll keep using it as JSON for now to avoid complexity,
+        // or we could convert it. But let's check the extension.
+        if (this.conversationFile.endsWith('.json')) {
+          // Force an update to the session ID in the existing file
+          await this.updateConversation((conversation) => {
+            conversation.sessionId = this.sessionId;
+          });
+        } else {
+          // For .jsonl, keep the existing metadata; don't update lastUpdated on resume
+          this.conversation.sessionId = this.sessionId;
+        }
       } else {
         // Create new session
         const chatsDir = path.join(
           this.config.storage.getProjectTempDir(),
           'chats',
         );
-        fs.mkdirSync(chatsDir, { recursive: true });
+        await fsPromises.mkdir(chatsDir, { recursive: true });
 
         const timestamp = new Date()
           .toISOString()
           .slice(0, 16)
           .replace(/:/g, '-');
+        // Use .jsonl for new sessions
         const filename = `${SESSION_FILE_PREFIX}${timestamp}-${this.sessionId.slice(
           0,
           8,
-        )}.json`;
+        )}.jsonl`;
         this.conversationFile = path.join(chatsDir, filename);
 
-        this.writeConversation({
+        this.conversation = {
           sessionId: this.sessionId,
           projectHash: this.projectHash,
           startTime: new Date().toISOString(),
           lastUpdated: new Date().toISOString(),
           messages: [],
-        });
+        };
+        // New sessions haven't written metadata yet
+        this.fileInitialized = false;
+        // We don't write anything yet until there's at least one message,
+        // similar to previous implementation.
       }
 
-      // Clear any queued data since this is a fresh start
+      // Clear any queued data and reset promise gate since this is a fresh start
       this.queuedThoughts = [];
       this.queuedTokens = null;
+      this.metadataWritePromise = null;
     } catch (error) {
       debugLogger.error('Error initializing chat recording service:', error);
       throw error;
@@ -198,31 +367,38 @@ export class ChatRecordingService {
   /**
    * Records a message in the conversation.
    */
-  recordMessage(message: {
+  async recordMessage(message: {
     model: string | undefined;
     type: ConversationRecordExtra['type'];
     content: PartListUnion;
-  }): void {
+  }): Promise<void> {
     if (!this.conversationFile) return;
 
     try {
-      this.updateConversation((conversation) => {
+      let msgToWrite: MessageRecord | null = null;
+      await this.updateConversation((conversation) => {
         const msg = this.newMessage(message.type, message.content);
         if (msg.type === 'gemini') {
           // If it's a new Gemini message then incorporate any queued thoughts.
-          conversation.messages.push({
+          const fullMsg: MessageRecord = {
             ...msg,
             thoughts: this.queuedThoughts,
             tokens: this.queuedTokens,
             model: message.model,
-          });
+          };
+          conversation.messages.push(fullMsg);
           this.queuedThoughts = [];
           this.queuedTokens = null;
+          msgToWrite = fullMsg;
         } else {
           // Or else just add it.
           conversation.messages.push(msg);
+          msgToWrite = msg;
         }
       });
+      if (msgToWrite) {
+        await this.writeMessageRecord(msgToWrite);
+      }
     } catch (error) {
       debugLogger.error('Error saving message to chat history.', error);
       throw error;
@@ -249,9 +425,9 @@ export class ChatRecordingService {
   /**
    * Updates the tokens for the last message in the conversation (which should be by Gemini).
    */
-  recordMessageTokens(
+  async recordMessageTokens(
     respUsageMetadata: GenerateContentResponseUsageMetadata,
-  ): void {
+  ): Promise<void> {
     if (!this.conversationFile) return;
 
     try {
@@ -263,17 +439,29 @@ export class ChatRecordingService {
         tool: respUsageMetadata.toolUsePromptTokenCount ?? 0,
         total: respUsageMetadata.totalTokenCount ?? 0,
       };
-      this.updateConversation((conversation) => {
+      let updateData: { id: string; tokens: typeof tokens } | null = null;
+      let msgToWrite: MessageRecord | null = null;
+      await this.updateConversation((conversation) => {
         const lastMsg = this.getLastMessage(conversation);
         // If the last message already has token info, it's because this new token info is for a
         // new message that hasn't been recorded yet.
         if (lastMsg && lastMsg.type === 'gemini' && !lastMsg.tokens) {
           lastMsg.tokens = tokens;
           this.queuedTokens = null;
+          if (this.conversationFile?.endsWith('.jsonl')) {
+            updateData = { id: lastMsg.id, tokens };
+          } else {
+            msgToWrite = lastMsg;
+          }
         } else {
           this.queuedTokens = tokens;
         }
       });
+      if (updateData) {
+        await this.writeMessageUpdate(updateData);
+      } else if (msgToWrite) {
+        await this.writeMessageRecord(msgToWrite);
+      }
     } catch (error) {
       debugLogger.error(
         'Error updating message tokens in chat history.',
@@ -287,7 +475,10 @@ export class ChatRecordingService {
    * Adds tool calls to the last message in the conversation (which should be by Gemini).
    * This method enriches tool calls with metadata from the ToolRegistry.
    */
-  recordToolCalls(model: string, toolCalls: ToolCallRecord[]): void {
+  async recordToolCalls(
+    model: string,
+    toolCalls: ToolCallRecord[],
+  ): Promise<void> {
     if (!this.conversationFile) return;
 
     // Enrich tool calls with metadata from the ToolRegistry
@@ -303,7 +494,12 @@ export class ChatRecordingService {
     });
 
     try {
-      this.updateConversation((conversation) => {
+      let msgToWrite: MessageRecord | null = null;
+      let updateData: {
+        id: string;
+        toolCalls: ToolCallRecord[];
+      } | null = null;
+      await this.updateConversation((conversation) => {
         const lastMsg = this.getLastMessage(conversation);
         // If a tool call was made, but the last message isn't from Gemini, it's because Gemini is
         // calling tools without starting the message with text.  So the user submits a prompt, and
@@ -339,6 +535,7 @@ export class ChatRecordingService {
             this.queuedTokens = null;
           }
           conversation.messages.push(newMsg);
+          msgToWrite = newMsg;
         } else {
           // The last message is an existing Gemini message that we need to update.
 
@@ -369,8 +566,21 @@ export class ChatRecordingService {
               lastMsg.toolCalls.push(toolCall);
             }
           }
+          if (this.conversationFile?.endsWith('.jsonl')) {
+            updateData = {
+              id: lastMsg.id,
+              toolCalls: lastMsg.toolCalls,
+            };
+          } else {
+            msgToWrite = lastMsg;
+          }
         }
       });
+      if (msgToWrite) {
+        await this.writeMessageRecord(msgToWrite);
+      } else if (updateData) {
+        await this.writeMessageUpdate(updateData);
+      }
     } catch (error) {
       debugLogger.error(
         'Error adding tool call to message in chat history.',
@@ -383,10 +593,17 @@ export class ChatRecordingService {
   /**
    * Loads up the conversation record from disk.
    */
-  private readConversation(): ConversationRecord {
+  private async readConversation(): Promise<ConversationRecord> {
+    if (!this.conversationFile) {
+      throw new Error('Conversation file not set');
+    }
+
     try {
-      this.cachedLastConvData = fs.readFileSync(this.conversationFile!, 'utf8');
-      return JSON.parse(this.cachedLastConvData);
+      const content = await fsPromises.readFile(this.conversationFile, 'utf8');
+      const result = this.conversationFile.endsWith('.jsonl')
+        ? parseJsonl(content, this.sessionId, this.projectHash)
+        : JSON.parse(content);
+      return result;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
         debugLogger.error('Error reading conversation file.', error);
@@ -405,21 +622,30 @@ export class ChatRecordingService {
   }
 
   /**
-   * Saves the conversation record; overwrites the file.
+   * Saves the conversation record; overwrites the file for .json, appends for .jsonl.
    */
-  private writeConversation(conversation: ConversationRecord): void {
+  private async writeConversation(
+    conversation: ConversationRecord,
+  ): Promise<void> {
     try {
       if (!this.conversationFile) return;
       // Don't write the file yet until there's at least one message.
-      if (conversation.messages.length === 0) return;
+      if (!conversation.messages || conversation.messages.length === 0) return;
 
-      // Only write the file if this change would change the file.
-      if (this.cachedLastConvData !== JSON.stringify(conversation, null, 2)) {
+      if (this.conversationFile.endsWith('.jsonl')) {
+        // In JSONL mode, we should have already written the individual records
+        // via writeMessageRecord or writeMetadataUpdate.
+        // We just update the lastUpdated timestamp in memory.
         conversation.lastUpdated = new Date().toISOString();
-        const newContent = JSON.stringify(conversation, null, 2);
-        this.cachedLastConvData = newContent;
-        fs.writeFileSync(this.conversationFile, newContent);
+        return;
       }
+
+      // Legacy .json support (overwrites file)
+      conversation.lastUpdated = new Date().toISOString();
+      const newContent = JSON.stringify(conversation, null, 2);
+      const tmpPath = `${this.conversationFile}.tmp`;
+      await fsPromises.writeFile(tmpPath, newContent);
+      await fsPromises.rename(tmpPath, this.conversationFile);
     } catch (error) {
       debugLogger.error('Error writing conversation file.', error);
       throw error;
@@ -427,27 +653,131 @@ export class ChatRecordingService {
   }
 
   /**
+   * Ensures session_metadata is written to the file exactly once.
+   * Uses a promise gate to prevent concurrent writes from racing.
+   */
+  private async ensureMetadataWritten(): Promise<void> {
+    if (this.fileInitialized) return;
+    if (!this.conversationFile || !this.conversationFile.endsWith('.jsonl'))
+      return;
+
+    // If another call is already writing metadata, wait for it
+    if (this.metadataWritePromise) {
+      await this.metadataWritePromise;
+      return;
+    }
+
+    // Create promise gate for concurrent callers
+    this.metadataWritePromise = (async () => {
+      try {
+        const metadata = {
+          type: 'session_metadata',
+          sessionId: this.conversation?.sessionId,
+          projectHash: this.conversation?.projectHash,
+          startTime: this.conversation?.startTime,
+          lastUpdated: new Date().toISOString(),
+        };
+        await fsPromises.appendFile(
+          this.conversationFile!,
+          JSON.stringify(metadata) + '\n',
+        );
+        this.fileInitialized = true;
+      } finally {
+        this.metadataWritePromise = null;
+      }
+    })();
+
+    await this.metadataWritePromise;
+  }
+
+  private async writeMessageRecord(message: MessageRecord): Promise<void> {
+    if (!this.conversationFile || !this.conversationFile.endsWith('.jsonl'))
+      return;
+
+    try {
+      await this.ensureMetadataWritten();
+      await fsPromises.appendFile(
+        this.conversationFile,
+        JSON.stringify(message) + '\n',
+      );
+    } catch (error) {
+      debugLogger.error('Error appending message to JSONL', error);
+    }
+  }
+
+  private async writeMessageUpdate(
+    update: Partial<MessageRecord> & { id: string },
+  ): Promise<void> {
+    if (!this.conversationFile || !this.conversationFile.endsWith('.jsonl'))
+      return;
+
+    try {
+      // Ensure metadata is written first to prevent race conditions
+      await this.ensureMetadataWritten();
+      const record = {
+        type: 'message_update',
+        ...update,
+        timestamp: new Date().toISOString(),
+      };
+      await fsPromises.appendFile(
+        this.conversationFile,
+        JSON.stringify(record) + '\n',
+      );
+    } catch (error) {
+      debugLogger.error('Error appending message update to JSONL', error);
+    }
+  }
+
+  private async writeMetadataUpdate(
+    data: Partial<ConversationRecord>,
+  ): Promise<void> {
+    if (!this.conversationFile || !this.conversationFile.endsWith('.jsonl'))
+      return;
+
+    try {
+      // Ensure metadata is written first to prevent race conditions
+      await this.ensureMetadataWritten();
+      const record = {
+        type: 'session_metadata',
+        ...data,
+        lastUpdated: new Date().toISOString(),
+      };
+      await fsPromises.appendFile(
+        this.conversationFile,
+        JSON.stringify(record) + '\n',
+      );
+    } catch (error) {
+      debugLogger.error('Error appending metadata update to JSONL', error);
+    }
+  }
+
+  /**
    * Convenient helper for updating the conversation without file reading and writing and time
    * updating boilerplate.
    */
-  private updateConversation(
+  private async updateConversation(
     updateFn: (conversation: ConversationRecord) => void,
-  ) {
-    const conversation = this.readConversation();
-    updateFn(conversation);
-    this.writeConversation(conversation);
+  ): Promise<void> {
+    if (!this.conversation) {
+      this.conversation = await this.readConversation();
+    }
+    updateFn(this.conversation);
+    await this.writeConversation(this.conversation);
   }
 
   /**
    * Saves a summary for the current session.
    */
-  saveSummary(summary: string): void {
+  async saveSummary(summary: string): Promise<void> {
     if (!this.conversationFile) return;
 
     try {
-      this.updateConversation((conversation) => {
+      await this.updateConversation((conversation) => {
         conversation.summary = summary;
       });
+      if (this.conversationFile.endsWith('.jsonl')) {
+        await this.writeMetadataUpdate({ summary });
+      }
     } catch (error) {
       debugLogger.error('Error saving summary to chat history.', error);
       // Don't throw - we want graceful degradation
@@ -457,11 +787,14 @@ export class ChatRecordingService {
   /**
    * Gets the current conversation data (for summary generation).
    */
-  getConversation(): ConversationRecord | null {
+  async getConversation(): Promise<ConversationRecord | null> {
     if (!this.conversationFile) return null;
 
     try {
-      return this.readConversation();
+      if (!this.conversation) {
+        this.conversation = await this.readConversation();
+      }
+      return this.conversation;
     } catch (error) {
       debugLogger.error('Error reading conversation for summary.', error);
       return null;
@@ -478,15 +811,128 @@ export class ChatRecordingService {
 
   /**
    * Deletes a session file by session ID.
+   * Session files are named: session-{timestamp}-{sessionId.slice(0,8)}.jsonl
    */
-  deleteSession(sessionId: string): void {
+  async deleteSession(sessionId: string): Promise<void> {
     try {
       const chatsDir = path.join(
         this.config.storage.getProjectTempDir(),
         'chats',
       );
-      const sessionPath = path.join(chatsDir, `${sessionId}.json`);
-      fs.unlinkSync(sessionPath);
+
+      // Helper to check if a file exists
+      const fileExists = async (filePath: string): Promise<boolean> => {
+        try {
+          await fsPromises.access(filePath);
+          return true;
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return false;
+          }
+          throw error;
+        }
+      };
+
+      // If sessionId looks like a full filename with path, try that first
+      if (sessionId.includes('/') || sessionId.includes('\\')) {
+        const resolvedPath = path.resolve(sessionId);
+        const resolvedChatsDir = `${path.resolve(chatsDir)}${path.sep}`;
+        if (!resolvedPath.startsWith(resolvedChatsDir)) {
+          throw new Error('Session path is outside of the chats directory.');
+        }
+        const baseName = path.basename(resolvedPath);
+        if (
+          !baseName.startsWith(SESSION_FILE_PREFIX) ||
+          (!baseName.endsWith('.json') && !baseName.endsWith('.jsonl'))
+        ) {
+          throw new Error('Session path is not a valid session file.');
+        }
+        if (await fileExists(resolvedPath)) {
+          await fsPromises.unlink(resolvedPath);
+          return;
+        }
+      }
+
+      // If sessionId is a full filename (with extension), try it directly
+      if (sessionId.endsWith('.json') || sessionId.endsWith('.jsonl')) {
+        const directPath = path.join(chatsDir, sessionId);
+        if (await fileExists(directPath)) {
+          await fsPromises.unlink(directPath);
+          return;
+        }
+      }
+
+      // If sessionId already looks like a session filename without extension,
+      // delete it directly and return. Do NOT fall through to shortId scan,
+      // as shortId would be "session-" which could match all session files.
+      if (sessionId.startsWith(SESSION_FILE_PREFIX)) {
+        const jsonlPath = path.join(chatsDir, `${sessionId}.jsonl`);
+        const jsonPath = path.join(chatsDir, `${sessionId}.json`);
+        if (await fileExists(jsonlPath)) {
+          await fsPromises.unlink(jsonlPath);
+        }
+        if (await fileExists(jsonPath)) {
+          await fsPromises.unlink(jsonPath);
+        }
+        // Always return here to prevent fall-through to shortId scan
+        return;
+      }
+
+      // Session files use the first 8 chars of the UUID in the filename
+      // Pattern: session-{timestamp}-{sessionId.slice(0,8)}.jsonl
+      const shortId = sessionId.slice(0, 8);
+      const shortIdIsHex = /^[0-9a-fA-F]{8}$/.test(shortId);
+
+      // Scan chats directory for matching files
+      if (shortIdIsHex && (await fileExists(chatsDir))) {
+        const files = await fsPromises.readdir(chatsDir);
+        let deleted = false;
+        const jsonlSuffix = `-${shortId}.jsonl`;
+        const jsonSuffix = `-${shortId}.json`;
+        const sessionMatches = async (filePath: string): Promise<boolean> => {
+          try {
+            const content = await fsPromises.readFile(filePath, 'utf8');
+            if (filePath.endsWith('.jsonl')) {
+              const parsed = parseJsonl(content, '', '');
+              return parsed.sessionId === sessionId;
+            }
+            const parsed = JSON.parse(content) as ConversationRecord;
+            return parsed.sessionId === sessionId;
+          } catch (error) {
+            debugLogger.warn(
+              `[SessionRecording] Failed to verify sessionId for ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            return false;
+          }
+        };
+        for (const file of files) {
+          // Match files that end with the short session ID segment
+          if (
+            file.startsWith(SESSION_FILE_PREFIX) &&
+            (file.endsWith(jsonlSuffix) || file.endsWith(jsonSuffix))
+          ) {
+            const filePath = path.join(chatsDir, file);
+            if (await sessionMatches(filePath)) {
+              await fsPromises.unlink(filePath);
+              deleted = true;
+            }
+          }
+        }
+        if (deleted) {
+          return;
+        }
+      }
+
+      // Fallback: try direct paths with sessionId as filename
+      const jsonlPath = path.join(chatsDir, `${sessionId}.jsonl`);
+      const jsonPath = path.join(chatsDir, `${sessionId}.json`);
+
+      if (await fileExists(jsonlPath)) {
+        await fsPromises.unlink(jsonlPath);
+      }
+      if (await fileExists(jsonPath)) {
+        await fsPromises.unlink(jsonPath);
+      }
     } catch (error) {
       debugLogger.error('Error deleting session file.', error);
       throw error;

--- a/packages/core/src/utils/nextSpeakerChecker.test.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.test.ts
@@ -66,7 +66,7 @@ describe('checkNextSpeaker', () => {
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
       getModel: () => 'test-model',
       storage: {
-        getProjectTempDir: vi.fn().mockReturnValue('/test/temp'),
+        getProjectTempDir: vi.fn().mockReturnValue('/tmp/test-temp'),
       },
       modelConfigService: {
         getResolvedConfig: vi.fn().mockReturnValue(mockResolvedConfig),

--- a/scripts/convert-session.ts
+++ b/scripts/convert-session.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import process from 'node:process';
+import { parseJsonl, type ConversationRecord } from '@google/gemini-cli-core';
+
+/**
+ * Debug tool to convert Gemini session files between JSON and JSONL.
+ *
+ * Usage:
+ *   npx tsx scripts/convert-session.ts <path-to-session.json> > session.jsonl
+ *   npx tsx scripts/convert-session.ts <path-to-session.jsonl> > session.json
+ *   npx tsx scripts/convert-session.ts --to jsonl <path> > session.jsonl
+ *   npx tsx scripts/convert-session.ts --to json <path> > session.json
+ */
+
+type Format = 'json' | 'jsonl';
+
+function usage(exitCode = 0): void {
+  const lines = [
+    'Usage:',
+    '  npx tsx scripts/convert-session.ts <path-to-session.json> > session.jsonl',
+    '  npx tsx scripts/convert-session.ts <path-to-session.jsonl> > session.json',
+    '  npx tsx scripts/convert-session.ts --to jsonl <path> > session.jsonl',
+    '  npx tsx scripts/convert-session.ts --to json <path> > session.json',
+  ];
+  console.error(lines.join('\n'));
+  process.exit(exitCode);
+}
+
+function parseArgs(argv: string[]): { filePath: string; toFormat?: Format } {
+  let toFormat: Format | undefined;
+  const positional: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      usage(0);
+    }
+    if (arg === '--to') {
+      const value = argv[i + 1];
+      if (!value || (value !== 'json' && value !== 'jsonl')) {
+        console.error('Error: --to must be "json" or "jsonl".');
+        usage(1);
+      }
+      toFormat = value;
+      i++;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      console.error(`Error: Unknown option "${arg}".`);
+      usage(1);
+    }
+    positional.push(arg);
+  }
+
+  if (positional.length !== 1) {
+    usage(1);
+  }
+
+  return { filePath: positional[0], toFormat };
+}
+
+function detectFormat(filePath: string): Format | null {
+  if (filePath.endsWith('.jsonl')) return 'jsonl';
+  if (filePath.endsWith('.json')) return 'json';
+  return null;
+}
+
+function toJsonl(session: ConversationRecord): string {
+  const metadata = {
+    type: 'session_metadata',
+    sessionId: session.sessionId,
+    projectHash: session.projectHash,
+    startTime: session.startTime,
+    lastUpdated: session.lastUpdated,
+    summary: session.summary,
+  };
+
+  const lines: string[] = [JSON.stringify(metadata)];
+  for (const msg of session.messages) {
+    lines.push(JSON.stringify(msg));
+  }
+  return lines.join('\n') + '\n';
+}
+
+const { filePath, toFormat } = parseArgs(process.argv.slice(2));
+
+if (!fs.existsSync(filePath)) {
+  console.error(`File not found: ${filePath}`);
+  process.exit(1);
+}
+
+const fromFormat = detectFormat(filePath);
+if (!fromFormat) {
+  console.error('Error: Input file must end with .json or .jsonl.');
+  process.exit(1);
+}
+
+const targetFormat = toFormat ?? (fromFormat === 'json' ? 'jsonl' : 'json');
+if (targetFormat === fromFormat) {
+  console.error('Error: Target format must differ from input format.');
+  process.exit(1);
+}
+
+const content = fs.readFileSync(filePath, 'utf8');
+
+if (fromFormat === 'json') {
+  const session = JSON.parse(content) as ConversationRecord;
+  if (!session.sessionId || !Array.isArray(session.messages)) {
+    console.error('Error: Invalid session file format.');
+    process.exit(1);
+  }
+
+  process.stdout.write(toJsonl(session));
+} else {
+  const session = parseJsonl(content, '', '');
+  if (!session.sessionId || !Array.isArray(session.messages)) {
+    console.error('Error: Invalid JSONL session file format.');
+    process.exit(1);
+  }
+
+  process.stdout.write(JSON.stringify(session, null, 2));
+}


### PR DESCRIPTION
## Summary
Switch session storage to JSONL (append-only) while preserving legacy JSON read compatibility. This improves performance and crash safety for long sessions.

## Details
- New sessions write `.jsonl` with `session_metadata`, message records, and  `message_update` entries.
- Summary generation appends JSONL metadata instead of rewriting files.
- Session list/resume/cleanup parse JSONL via core `parseJsonl`.
- Hook `transcript_path` now points at `.jsonl` for new sessions.
- Robust timestamp derivation: if JSONL metadata omits timestamps, startTime is derived from earliest message and lastUpdated from latest message/update.

Performance (local benches):
- Standard payloads: JSON rewrite ~1.07ms vs JSONL append ~0.04ms (~25x).
- Large payloads (~50KB): JSON rewrite ~17.88ms vs JSONL append ~0.17ms (~100x).

## Related Issues
Closes #15292

## How to Validate
1) Lint:
   - `node scripts/lint.js --setup`
   - `node scripts/lint.js --eslint --actionlint --shellcheck --yamllint --prettier`
   - `npm run predocs:settings`
   - `npm run docs:settings -- --check`
   - `node scripts/lint.js --sensitive-keywords`
2) Build + test:
   - `npm run build`
   - `npm run test:ci`
3) Bundle smoke test:
   - `npm run bundle`
   - `node ./bundle/gemini.js --version`
4) (Optional) Run targeted JSONL tests:
   - `npx vitest run packages/core/src/services/chatRecordingService.test.ts`
   - `npx vitest run packages/core/src/services/sessionSummaryUtils.test.ts`
   - `npx vitest run packages/cli/src/utils/sessionUtils.test.ts`
   - `npx vitest run packages/cli/src/utils/sessionCleanup.test.ts`
   - `npx vitest run packages/cli/src/utils/sessionCleanup.integration.test.ts`
   - `npx vitest run packages/core/src/hooks/hookEventHandler.test.ts`

## Pre-Merge Checklist
- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
