### PR TITLE
fix(policy): clear auto-edit rules on mode switch

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1176,6 +1176,30 @@ describe('setApprovalMode with folder trust', () => {
     expect(() => config.setApprovalMode(ApprovalMode.DEFAULT)).not.toThrow();
   });
 
+  it('should remove edit tool rules when transitioning from AUTO_EDIT to DEFAULT', () => {
+    const config = new Config(baseParams);
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+    const removeRulesSpy = vi.spyOn(
+      config.getPolicyEngine(),
+      'removeRulesForTool',
+    );
+
+    // Initial state
+    config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+    expect(config.getApprovalMode()).toBe(ApprovalMode.AUTO_EDIT);
+    removeRulesSpy.mockClear();
+
+    // Transition to DEFAULT
+    config.setApprovalMode(ApprovalMode.DEFAULT);
+
+    expect(config.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
+    expect(removeRulesSpy).toHaveBeenCalledTimes(3);
+    // We cannot easily check the arguments because tool names are imported constants,
+    // but we can verify it was called 3 times which matches our implementation
+    // for EDIT_TOOL_NAME, WRITE_FILE_TOOL_NAME, and WEB_FETCH_TOOL_NAME.
+  });
+
   describe('registerCoreTools', () => {
     beforeEach(() => {
       vi.clearAllMocks();

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -40,6 +40,11 @@ import {
   PREVIEW_GEMINI_MODEL,
   PREVIEW_GEMINI_MODEL_AUTO,
 } from './models.js';
+import {
+  EDIT_TOOL_NAME,
+  WEB_FETCH_TOOL_NAME,
+  WRITE_FILE_TOOL_NAME,
+} from '../tools/tool-names.js';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
@@ -1194,10 +1199,10 @@ describe('setApprovalMode with folder trust', () => {
     config.setApprovalMode(ApprovalMode.DEFAULT);
 
     expect(config.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
+    expect(removeRulesSpy).toHaveBeenCalledWith(EDIT_TOOL_NAME);
+    expect(removeRulesSpy).toHaveBeenCalledWith(WRITE_FILE_TOOL_NAME);
+    expect(removeRulesSpy).toHaveBeenCalledWith(WEB_FETCH_TOOL_NAME);
     expect(removeRulesSpy).toHaveBeenCalledTimes(3);
-    // We cannot easily check the arguments because tool names are imported constants,
-    // but we can verify it was called 3 times which matches our implementation
-    // for EDIT_TOOL_NAME, WRITE_FILE_TOOL_NAME, and WEB_FETCH_TOOL_NAME.
   });
 
   describe('registerCoreTools', () => {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1199,9 +1199,15 @@ describe('setApprovalMode with folder trust', () => {
     config.setApprovalMode(ApprovalMode.DEFAULT);
 
     expect(config.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
-    expect(removeRulesSpy).toHaveBeenCalledWith(EDIT_TOOL_NAME);
-    expect(removeRulesSpy).toHaveBeenCalledWith(WRITE_FILE_TOOL_NAME);
-    expect(removeRulesSpy).toHaveBeenCalledWith(WEB_FETCH_TOOL_NAME);
+    expect(removeRulesSpy).toHaveBeenCalledWith(EDIT_TOOL_NAME, {
+      isSessionOnly: true,
+    });
+    expect(removeRulesSpy).toHaveBeenCalledWith(WRITE_FILE_TOOL_NAME, {
+      isSessionOnly: true,
+    });
+    expect(removeRulesSpy).toHaveBeenCalledWith(WEB_FETCH_TOOL_NAME, {
+      isSessionOnly: true,
+    });
     expect(removeRulesSpy).toHaveBeenCalledTimes(3);
   });
 

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1200,13 +1200,13 @@ describe('setApprovalMode with folder trust', () => {
 
     expect(config.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
     expect(removeRulesSpy).toHaveBeenCalledWith(EDIT_TOOL_NAME, {
-      isSessionOnly: true,
+      temporary: true,
     });
     expect(removeRulesSpy).toHaveBeenCalledWith(WRITE_FILE_TOOL_NAME, {
-      isSessionOnly: true,
+      temporary: true,
     });
     expect(removeRulesSpy).toHaveBeenCalledWith(WEB_FETCH_TOOL_NAME, {
-      isSessionOnly: true,
+      temporary: true,
     });
     expect(removeRulesSpy).toHaveBeenCalledTimes(3);
   });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1139,9 +1139,15 @@ export class Config {
       this.approvalMode === ApprovalMode.AUTO_EDIT &&
       mode === ApprovalMode.DEFAULT
     ) {
-      this.policyEngine.removeRulesForTool(EDIT_TOOL_NAME);
-      this.policyEngine.removeRulesForTool(WRITE_FILE_TOOL_NAME);
-      this.policyEngine.removeRulesForTool(WEB_FETCH_TOOL_NAME);
+      this.policyEngine.removeRulesForTool(EDIT_TOOL_NAME, {
+        isSessionOnly: true,
+      });
+      this.policyEngine.removeRulesForTool(WRITE_FILE_TOOL_NAME, {
+        isSessionOnly: true,
+      });
+      this.policyEngine.removeRulesForTool(WEB_FETCH_TOOL_NAME, {
+        isSessionOnly: true,
+      });
     }
 
     this.approvalMode = mode;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1140,13 +1140,13 @@ export class Config {
       mode === ApprovalMode.DEFAULT
     ) {
       this.policyEngine.removeRulesForTool(EDIT_TOOL_NAME, {
-        isSessionOnly: true,
+        temporary: true,
       });
       this.policyEngine.removeRulesForTool(WRITE_FILE_TOOL_NAME, {
-        isSessionOnly: true,
+        temporary: true,
       });
       this.policyEngine.removeRulesForTool(WEB_FETCH_TOOL_NAME, {
-        isSessionOnly: true,
+        temporary: true,
       });
     }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -90,7 +90,12 @@ import type { Experiments } from '../code_assist/experiments/experiments.js';
 import { AgentRegistry } from '../agents/registry.js';
 import { setGlobalProxy } from '../utils/fetch.js';
 import { DelegateToAgentTool } from '../agents/delegate-to-agent-tool.js';
-import { DELEGATE_TO_AGENT_TOOL_NAME } from '../tools/tool-names.js';
+import {
+  DELEGATE_TO_AGENT_TOOL_NAME,
+  EDIT_TOOL_NAME,
+  WEB_FETCH_TOOL_NAME,
+  WRITE_FILE_TOOL_NAME,
+} from '../tools/tool-names.js';
 import { getExperiments } from '../code_assist/experiments/experiments.js';
 import { ExperimentFlags } from '../code_assist/experiments/flagNames.js';
 import { debugLogger } from '../utils/debugLogger.js';
@@ -1126,6 +1131,19 @@ export class Config {
         'Cannot enable privileged approval modes in an untrusted folder.',
       );
     }
+
+    // When transitioning specifically from AUTO_EDIT to DEFAULT, clear the session
+    // rules for the tools that trigger this mode. This ensures that "Always allow"
+    // doesn't persist after the user has explicitly toggled off the mode.
+    if (
+      this.approvalMode === ApprovalMode.AUTO_EDIT &&
+      mode === ApprovalMode.DEFAULT
+    ) {
+      this.policyEngine.removeRulesForTool(EDIT_TOOL_NAME);
+      this.policyEngine.removeRulesForTool(WRITE_FILE_TOOL_NAME);
+      this.policyEngine.removeRulesForTool(WEB_FETCH_TOOL_NAME);
+    }
+
     this.approvalMode = mode;
   }
 

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -277,7 +277,7 @@ export function createPolicyUpdater(
         // but still lose to admin policies (3.xxx) and settings excludes (200)
         priority: 2.95,
         argsPattern,
-        isSessionOnly: !message.persist,
+        temporary: !message.persist,
       });
 
       if (message.persist) {

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -277,6 +277,7 @@ export function createPolicyUpdater(
         // but still lose to admin policies (3.xxx) and settings excludes (200)
         priority: 2.95,
         argsPattern,
+        isSessionOnly: !message.persist,
       });
 
       if (message.persist) {

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -223,6 +223,28 @@ describe('PolicyEngine', () => {
       expect(remainingRules.some((r) => r.toolName === 'tool2')).toBe(true);
     });
 
+    it('should remove ONLY session-only rules when filter is applied', () => {
+      engine.addRule({
+        toolName: 'tool1',
+        decision: PolicyDecision.DENY,
+        isSessionOnly: false,
+      });
+      engine.addRule({
+        toolName: 'tool1',
+        decision: PolicyDecision.ALLOW,
+        isSessionOnly: true,
+      });
+
+      expect(engine.getRules()).toHaveLength(2);
+
+      engine.removeRulesForTool('tool1', { isSessionOnly: true });
+
+      const remainingRules = engine.getRules();
+      expect(remainingRules).toHaveLength(1);
+      expect(remainingRules[0].isSessionOnly).toBe(false);
+      expect(remainingRules[0].decision).toBe(PolicyDecision.DENY);
+    });
+
     it('should handle removing non-existent tool', () => {
       engine.addRule({ toolName: 'existing', decision: PolicyDecision.ALLOW });
 

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -227,21 +227,21 @@ describe('PolicyEngine', () => {
       engine.addRule({
         toolName: 'tool1',
         decision: PolicyDecision.DENY,
-        isSessionOnly: false,
+        temporary: false,
       });
       engine.addRule({
         toolName: 'tool1',
         decision: PolicyDecision.ALLOW,
-        isSessionOnly: true,
+        temporary: true,
       });
 
       expect(engine.getRules()).toHaveLength(2);
 
-      engine.removeRulesForTool('tool1', { isSessionOnly: true });
+      engine.removeRulesForTool('tool1', { temporary: true });
 
       const remainingRules = engine.getRules();
       expect(remainingRules).toHaveLength(1);
-      expect(remainingRules[0].isSessionOnly).toBe(false);
+      expect(remainingRules[0].temporary).toBe(false);
       expect(remainingRules[0].decision).toBe(PolicyDecision.DENY);
     });
 

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -289,14 +289,14 @@ export class PolicyEngine {
    */
   removeRulesForTool(
     toolName: string,
-    options: { isSessionOnly?: boolean } = {},
+    options: { temporary?: boolean } = {},
   ): void {
     this.rules = this.rules.filter((rule) => {
       const toolMatch = rule.toolName === toolName;
       if (!toolMatch) return true;
 
-      if (options.isSessionOnly !== undefined) {
-        return rule.isSessionOnly !== options.isSessionOnly;
+      if (options.temporary !== undefined) {
+        return rule.temporary !== options.temporary;
       }
 
       return false;

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -284,9 +284,23 @@ export class PolicyEngine {
 
   /**
    * Remove rules for a specific tool.
+   * @param toolName The name of the tool.
+   * @param options Optional filters for removal.
    */
-  removeRulesForTool(toolName: string): void {
-    this.rules = this.rules.filter((rule) => rule.toolName !== toolName);
+  removeRulesForTool(
+    toolName: string,
+    options: { isSessionOnly?: boolean } = {},
+  ): void {
+    this.rules = this.rules.filter((rule) => {
+      const toolMatch = rule.toolName === toolName;
+      if (!toolMatch) return true;
+
+      if (options.isSessionOnly !== undefined) {
+        return rule.isSessionOnly !== options.isSessionOnly;
+      }
+
+      return false;
+    });
   }
 
   /**

--- a/packages/core/src/policy/toml-loader.ts
+++ b/packages/core/src/policy/toml-loader.ts
@@ -377,6 +377,7 @@ export async function loadPoliciesFromToml(
                   toolName: effectiveToolName,
                   decision: rule.decision,
                   priority: transformPriority(rule.priority, tier),
+                  temporary: false,
                 };
 
                 // Compile regex pattern

--- a/packages/core/src/policy/types.ts
+++ b/packages/core/src/policy/types.ts
@@ -120,9 +120,9 @@ export interface PolicyRule {
 
   /**
    * Whether this rule is specific to the current interactive session.
-   * Session-only rules are cleared when switching approval modes.
+   * Temporary rules are cleared when switching approval modes.
    */
-  isSessionOnly?: boolean;
+  temporary?: boolean;
 }
 
 export interface SafetyCheckerRule {

--- a/packages/core/src/policy/types.ts
+++ b/packages/core/src/policy/types.ts
@@ -117,6 +117,12 @@ export interface PolicyRule {
    * Default is 0.
    */
   priority?: number;
+
+  /**
+   * Whether this rule is specific to the current interactive session.
+   * Session-only rules are cleared when switching approval modes.
+   */
+  isSessionOnly?: boolean;
 }
 
 export interface SafetyCheckerRule {


### PR DESCRIPTION
## Summary

Fixes a critical safety bug where "Always allow for session" permissions for edit tools persisted even after the user explicitly disabled "Auto-Edit" mode (via Shift+Tab). 

This refactored implementation uses **internal metadata tagging** to ensure that only temporary session rules are removed, while persistent user configuration (e.g., custom DENY rules) remains untouched.

## Details

The previous approach to "Always allow for session" added rules to the Policy Engine that were indistinguishable from persistent configuration. Toggling Auto-Edit OFF failed to clean up these rules.

**Key Improvements in this Refactor:**
1.  **Metadata Tagging**: Added `isSessionOnly` property to `PolicyRule` (internal memory representation only, does not affect TOML spec).
2.  **Safe Cleanup**: Updated `PolicyEngine.removeRulesForTool` to support targeted removal based on the `isSessionOnly` tag.
3.  **State Synchronization**: `Config.setApprovalMode` now triggers a cleanup of session-only rules for `replace`, `write_file`, and `web_fetch` when transitioning out of `AUTO_EDIT`.
4.  **Zero-Risk for User Config**: Because TOML-loaded rules never have the `isSessionOnly` tag, they are immune to this cleanup. This prevents security regressions where a user's persistent `DENY` rule could have been accidentally wiped.

## Related Issues

Fixes logic bug in Auto-Edit mode toggle.
Addresses reviewer concerns about over-aggressive rule removal.

## How to Validate

1. Start the CLI in a trusted folder.
2. Trigger an edit (e.g., `replace` tool).
3. In the confirmation dialog, select **"Allow for this session"**.
4. Verify the UI indicator shows "Auto-Edit Mode".
5. Press `Shift+Tab` to toggle Auto-Edit Mode **OFF**.
6. Trigger another edit.
7. **Expected Result:** The CLI **must** prompt for confirmation.
8. **Security Check:** Manually add a `DENY` rule for `replace` in a user policy file. Toggle Auto-Edit ON and then OFF. Verify the `DENY` rule still blocks the tool (or triggers a confirmation fallback).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
