### PR TITLE
feat: add get_git_status tool (Git integration)

### DIFF
--- a/docs/tools/git-status.md
+++ b/docs/tools/git-status.md
@@ -10,12 +10,12 @@ but not staged, and which are untracked, as well as basic branch and remote
 information. This helps the AI understand the state of your working directory
 before proposing commits or other Git operations.
 
-## Arguments
+### Arguments
 
 `get_git_status` takes no arguments. It always operates on the Git repository
 rooted at the current working directory (as configured by the CLI).
 
-## Behavior
+## How to use `get_git_status` with the Gemini CLI
 
 When the current directory is inside a Git repository, the tool returns:
 
@@ -31,10 +31,16 @@ When the current directory is inside a Git repository, the tool returns:
 If the current directory is **not** part of a Git repository, the tool returns a
 clear error indicating that no repository was found.
 
-## Usage
+Usage:
 
-get_git_status() The tool is intended to be called by the Gemini model rather
-than typed directly by the user. You can, for example, ask:
+```
+get_git_status()
+```
+
+## `get_git_status` examples
+
+The tool is intended to be called by the Gemini model rather than typed directly
+by the user. You can, for example, ask:
 
 > “Before making any changes, use the Git status tool to show what’s currently
 > modified in this repo.”

--- a/docs/tools/git-status.md
+++ b/docs/tools/git-status.md
@@ -5,10 +5,11 @@ This document describes the `get_git_status` tool for the Gemini CLI.
 ## Description
 
 The `get_git_status` tool retrieves the current status of a Git repository in
-your workspace. It tells the agent which files are staged, which are modified
-but not staged, and which are untracked, as well as basic branch and remote
-information. This helps the AI understand the state of your working directory
-before proposing commits or other Git operations.
+your workspace. It tells the agent which files are staged, which are modified or
+deleted but not staged, which are untracked, and which have merge conflicts, as
+well as basic branch and remote information. This helps the AI understand the
+state of your working directory before proposing commits or other Git
+operations.
 
 ### Arguments
 
@@ -24,9 +25,11 @@ When the current directory is inside a Git repository, the tool returns:
 - **Remote status**: Whether the current branch is ahead of or behind its remote
   tracking branch (if configured).
 - **Staged files**: A list of files that have changes staged for commit.
-- **Unstaged files**: A list of tracked files that have modifications not yet
-  staged.
+- **Unstaged files**: A list of tracked files that have modifications (including
+  deletions) not yet staged.
 - **Untracked files**: A list of new files that are not yet tracked by Git.
+- **Conflicted files**: A list of files with merge conflicts that require
+  resolution.
 
 If the current directory is **not** part of a Git repository, the tool returns a
 clear error indicating that no repository was found.

--- a/docs/tools/git-status.md
+++ b/docs/tools/git-status.md
@@ -1,0 +1,40 @@
+# Git Status tool (`get_git_status`)
+
+This document describes the `get_git_status` tool for the Gemini CLI.
+
+## Description
+
+The `get_git_status` tool retrieves the current status of a Git repository in
+your workspace. It tells the agent which files are staged, which are modified
+but not staged, and which are untracked, as well as basic branch and remote
+information. This helps the AI understand the state of your working directory
+before proposing commits or other Git operations.
+
+## Arguments
+
+`get_git_status` takes no arguments. It always operates on the Git repository
+rooted at the current working directory (as configured by the CLI).
+
+## Behavior
+
+When the current directory is inside a Git repository, the tool returns:
+
+- **Repository status**: Whether the working tree is clean or has changes.
+- **Current branch**: The name of the active branch (if available).
+- **Remote status**: Whether the current branch is ahead of or behind its remote
+  tracking branch (if configured).
+- **Staged files**: A list of files that have changes staged for commit.
+- **Unstaged files**: A list of tracked files that have modifications not yet
+  staged.
+- **Untracked files**: A list of new files that are not yet tracked by Git.
+
+If the current directory is **not** part of a Git repository, the tool returns a
+clear error indicating that no repository was found.
+
+## Usage
+
+get_git_status() The tool is intended to be called by the Gemini model rather
+than typed directly by the user. You can, for example, ask:
+
+> “Before making any changes, use the Git status tool to show what’s currently
+> modified in this repo.”

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -86,6 +86,8 @@ Gemini CLI's built-in tools can be broadly categorized as follows:
   information across sessions.
 - **[Todo Tool](./todos.md) (`write_todos`):** For managing subtasks of complex
   requests.
+- **[Git Status](./git-status.md) (`get_git_status`):** For inspecting the
+  current Git repository status.
 
 Additionally, these tools incorporate:
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -90,6 +90,7 @@ import { getExperiments } from '../code_assist/experiments/experiments.js';
 import { ExperimentFlags } from '../code_assist/experiments/flagNames.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { startupProfiler } from '../telemetry/startupProfiler.js';
+import { GitStatusTool } from '../tools/git-status.js';
 
 import { ApprovalMode } from '../policy/types.js';
 
@@ -1571,6 +1572,7 @@ export class Config {
     registerCoreTool(ShellTool, this);
     registerCoreTool(MemoryTool);
     registerCoreTool(WebSearchTool, this);
+    registerCoreTool(GitStatusTool, this);
     if (this.getUseWriteTodos()) {
       registerCoreTool(WriteTodosTool, this);
     }

--- a/packages/core/src/tools/git-status.test.ts
+++ b/packages/core/src/tools/git-status.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { GitStatusTool, type GitStatusToolParams } from './git-status.js';
+import type { Config } from '../config/config.js';
+import { makeFakeConfig } from '../test-utils/config.js';
+import { simpleGit } from 'simple-git';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+describe('GitStatusTool', () => {
+  let tempDir: string;
+  let config: Config;
+  let tool: GitStatusTool;
+
+  beforeEach(async () => {
+    // Create a temporary directory
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'git-status-test-'));
+
+    config = makeFakeConfig({
+      targetDir: tempDir,
+      cwd: tempDir,
+    });
+
+    tool = new GitStatusTool(config);
+  });
+
+  afterEach(async () => {
+    // Clean up temp directory
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('when not in a Git repository', () => {
+    it('should return an error indicating not in a repo', async () => {
+      const params: GitStatusToolParams = {};
+      const signal = new AbortController().signal;
+
+      const result = await tool.buildAndExecute(params, signal);
+
+      expect(result.error).toBeDefined();
+      expect(result.llmContent).toContain('Not in a Git repository');
+    });
+  });
+
+  describe('when in a Git repository', () => {
+    beforeEach(async () => {
+      // Initialize a Git repo
+      const git = simpleGit(tempDir);
+      await git.init();
+
+      // Create and commit an initial file
+      await fs.writeFile(path.join(tempDir, 'initial.txt'), 'initial content');
+      await git.add('initial.txt');
+      await git.commit('Initial commit');
+    });
+
+    it('should return clean status for a clean repo', async () => {
+      const params: GitStatusToolParams = {};
+      const signal = new AbortController().signal;
+
+      const result = await tool.buildAndExecute(params, signal);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('Clean');
+      expect(result.llmContent).toContain('Staged files (0)');
+    });
+
+    it('should detect staged files', async () => {
+      // Create a new file and stage it
+      await fs.writeFile(path.join(tempDir, 'staged.txt'), 'staged content');
+      const git = simpleGit(tempDir);
+      await git.add('staged.txt');
+
+      const params: GitStatusToolParams = {};
+      const signal = new AbortController().signal;
+
+      const result = await tool.buildAndExecute(params, signal);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('staged.txt');
+      expect(result.llmContent).toContain('Staged files (1)');
+    });
+
+    it('should detect unstaged files', async () => {
+      // Modify an existing file without staging
+      await fs.writeFile(path.join(tempDir, 'initial.txt'), 'modified content');
+
+      const params: GitStatusToolParams = {};
+      const signal = new AbortController().signal;
+
+      const result = await tool.buildAndExecute(params, signal);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('initial.txt');
+      expect(result.llmContent).toContain('Unstaged files (1)');
+    });
+
+    it('should detect untracked files', async () => {
+      // Create a new file without staging
+      await fs.writeFile(
+        path.join(tempDir, 'untracked.txt'),
+        'untracked content',
+      );
+
+      const params: GitStatusToolParams = {};
+      const signal = new AbortController().signal;
+
+      const result = await tool.buildAndExecute(params, signal);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('untracked.txt');
+      expect(result.llmContent).toContain('Untracked files (1)');
+    });
+  });
+});

--- a/packages/core/src/tools/git-status.ts
+++ b/packages/core/src/tools/git-status.ts
@@ -8,7 +8,7 @@ import type { ToolInvocation, ToolResult } from './tools.js';
 import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { GIT_STATUS_TOOL_NAME } from './tool-names.js';
-import { getGitStatus } from '../utils/git-utils.js';
+import { getGitStatus } from '../utils/git-status-utils.js';
 import type { Config } from '../config/config.js';
 import { ToolErrorType } from './tool-error.js';
 
@@ -91,6 +91,12 @@ class GitStatusToolInvocation extends BaseToolInvocation<
     } else {
       parts.push('  (none)');
     }
+    parts.push(`\nConflicted files (${status.conflicted.length}):`);
+    if (status.conflicted.length > 0) {
+      parts.push(status.conflicted.map((f) => `  ${f}`).join('\n'));
+    } else {
+      parts.push('  (none)');
+    }
 
     const llmContent = parts.join('\n');
 
@@ -107,10 +113,13 @@ class GitStatusToolInvocation extends BaseToolInvocation<
         counts.push(`${status.staged.length} staged`);
       }
       if (status.unstaged.length > 0) {
-        counts.push(`${status.unstaged.length} modified`);
+        counts.push(`${status.unstaged.length} unstaged`);
       }
       if (status.untracked.length > 0) {
         counts.push(`${status.untracked.length} untracked`);
+      }
+      if (status.conflicted.length > 0) {
+        counts.push(`${status.conflicted.length} conflicted`);
       }
       displayParts.push(counts.join(', '));
     }

--- a/packages/core/src/tools/git-status.ts
+++ b/packages/core/src/tools/git-status.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ToolInvocation, ToolResult } from './tools.js';
+import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import { GIT_STATUS_TOOL_NAME } from './tool-names.js';
+import { getGitStatus } from '../utils/git-utils.js';
+import type { Config } from '../config/config.js';
+import { ToolErrorType } from './tool-error.js';
+
+export type GitStatusToolParams = Record<string, never>;
+
+class GitStatusToolInvocation extends BaseToolInvocation<
+  GitStatusToolParams,
+  ToolResult
+> {
+  constructor(
+    private readonly config: Config,
+    params: GitStatusToolParams,
+    messageBus?: MessageBus,
+    _toolName?: string,
+    _toolDisplayName?: string,
+  ) {
+    super(params, messageBus, _toolName, _toolDisplayName);
+  }
+
+  getDescription(): string {
+    return 'Get Git repository status (staged, unstaged, untracked files)';
+  }
+
+  async execute(
+    _signal: AbortSignal,
+    _updateOutput?: (output: string) => void,
+  ): Promise<ToolResult> {
+    const status = await getGitStatus(this.config);
+
+    if (status === null) {
+      return {
+        llmContent:
+          'Not in a Git repository. The current directory is not a Git repository.',
+        returnDisplay:
+          'Not in a Git repository. The current directory is not a Git repository.',
+        error: {
+          message: 'Not in a Git repository',
+          type: ToolErrorType.GIT_NOT_REPO,
+        },
+      };
+    }
+
+    // Format for LLM
+    const parts: string[] = [];
+    parts.push(`Git Status: ${status.isClean ? 'Clean' : 'Has changes'}`);
+    if (status.branch) {
+      parts.push(`Branch: ${status.branch}`);
+      if (status.ahead !== undefined || status.behind !== undefined) {
+        if (status.ahead === 0 && status.behind === 0) {
+          parts.push(`Remote: up to date`);
+        } else {
+          const remoteParts: string[] = [];
+          if (status.ahead !== undefined && status.ahead > 0) {
+            remoteParts.push(`ahead ${status.ahead}`);
+          }
+          if (status.behind !== undefined && status.behind > 0) {
+            remoteParts.push(`behind ${status.behind}`);
+          }
+          if (remoteParts.length > 0) {
+            parts.push(`Remote: ${remoteParts.join(', ')}`);
+          }
+        }
+      }
+    }
+    parts.push(`\nStaged files (${status.staged.length}):`);
+    if (status.staged.length > 0) {
+      parts.push(status.staged.map((f) => `  ${f}`).join('\n'));
+    } else {
+      parts.push('  (none)');
+    }
+    parts.push(`\nUnstaged files (${status.unstaged.length}):`);
+    if (status.unstaged.length > 0) {
+      parts.push(status.unstaged.map((f) => `  ${f}`).join('\n'));
+    } else {
+      parts.push('  (none)');
+    }
+    parts.push(`\nUntracked files (${status.untracked.length}):`);
+    if (status.untracked.length > 0) {
+      parts.push(status.untracked.map((f) => `  ${f}`).join('\n'));
+    } else {
+      parts.push('  (none)');
+    }
+
+    const llmContent = parts.join('\n');
+
+    // Format for user display (more concise)
+    const displayParts: string[] = [];
+    if (status.branch) {
+      displayParts.push(`Branch: ${status.branch}`);
+    }
+    if (status.isClean) {
+      displayParts.push('Working tree clean');
+    } else {
+      const counts: string[] = [];
+      if (status.staged.length > 0) {
+        counts.push(`${status.staged.length} staged`);
+      }
+      if (status.unstaged.length > 0) {
+        counts.push(`${status.unstaged.length} modified`);
+      }
+      if (status.untracked.length > 0) {
+        counts.push(`${status.untracked.length} untracked`);
+      }
+      displayParts.push(counts.join(', '));
+    }
+
+    return {
+      llmContent,
+      returnDisplay: displayParts.join(' | '),
+    };
+  }
+}
+
+export class GitStatusTool extends BaseDeclarativeTool<
+  GitStatusToolParams,
+  ToolResult
+> {
+  static readonly Name = GIT_STATUS_TOOL_NAME;
+
+  constructor(
+    private readonly config: Config,
+    messageBus?: MessageBus,
+  ) {
+    super(
+      GitStatusTool.Name,
+      'GitStatus',
+      'Get the current Git repository status, including staged, unstaged, and untracked files. Use this to understand what changes exist in the working directory before making commits or other Git operations.',
+      Kind.Read,
+      {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+      true, // output is markdown
+      false, // output cannot be updated
+      messageBus,
+    );
+  }
+
+  protected override validateToolParamValues(
+    _params: GitStatusToolParams,
+  ): string | null {
+    // No parameters to validate
+    return null;
+  }
+
+  protected createInvocation(
+    params: GitStatusToolParams,
+    messageBus?: MessageBus,
+    _toolName?: string,
+    _toolDisplayName?: string,
+  ): ToolInvocation<GitStatusToolParams, ToolResult> {
+    return new GitStatusToolInvocation(
+      this.config,
+      params,
+      messageBus,
+      _toolName,
+      _toolDisplayName,
+    );
+  }
+}

--- a/packages/core/src/tools/git-status.ts
+++ b/packages/core/src/tools/git-status.ts
@@ -56,15 +56,15 @@ class GitStatusToolInvocation extends BaseToolInvocation<
     parts.push(`Git Status: ${status.isClean ? 'Clean' : 'Has changes'}`);
     if (status.branch) {
       parts.push(`Branch: ${status.branch}`);
-      if (status.ahead !== undefined || status.behind !== undefined) {
+      if (status.tracking) {
         if (status.ahead === 0 && status.behind === 0) {
           parts.push(`Remote: up to date`);
         } else {
           const remoteParts: string[] = [];
-          if (status.ahead !== undefined && status.ahead > 0) {
+          if (status.ahead > 0) {
             remoteParts.push(`ahead ${status.ahead}`);
           }
-          if (status.behind !== undefined && status.behind > 0) {
+          if (status.behind > 0) {
             remoteParts.push(`behind ${status.behind}`);
           }
           if (remoteParts.length > 0) {

--- a/packages/core/src/tools/tool-error.ts
+++ b/packages/core/src/tools/tool-error.ts
@@ -71,6 +71,9 @@ export enum ToolErrorType {
 
   // WebSearch-specific Errors
   WEB_SEARCH_FAILED = 'web_search_failed',
+
+  // Git-specific Errors
+  GIT_NOT_REPO = 'git_not_repo',
 }
 
 /**

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -22,3 +22,4 @@ export const LS_TOOL_NAME = 'list_directory';
 export const MEMORY_TOOL_NAME = 'save_memory';
 export const EDIT_TOOL_NAMES = new Set([EDIT_TOOL_NAME, WRITE_FILE_TOOL_NAME]);
 export const DELEGATE_TO_AGENT_TOOL_NAME = 'delegate_to_agent';
+export const GIT_STATUS_TOOL_NAME = 'get_git_status';

--- a/packages/core/src/utils/git-status-utils.ts
+++ b/packages/core/src/utils/git-status-utils.ts
@@ -14,6 +14,7 @@ export interface GitStatus {
   staged: string[];
   unstaged: string[];
   untracked: string[];
+  conflicted: string[];
   branch?: string;
   tracking?: string;
   ahead: number;
@@ -43,8 +44,9 @@ export async function getGitStatus(config: Config): Promise<GitStatus | null> {
       isRepo: true,
       isClean: status.isClean(),
       staged: status.staged,
-      unstaged: status.modified,
+      unstaged: [...status.modified, ...status.deleted],
       untracked: status.not_added,
+      conflicted: status.conflicted,
       branch: status.current ?? undefined,
       tracking: status.tracking ?? undefined,
       ahead: status.ahead,

--- a/packages/core/src/utils/git-utils.ts
+++ b/packages/core/src/utils/git-utils.ts
@@ -6,6 +6,7 @@
 
 import { simpleGit, type SimpleGit, type StatusResult } from 'simple-git';
 import type { Config } from '../config/config.js';
+import { debugLogger } from './debugLogger.js';
 
 export interface GitStatus {
   isRepo: boolean;
@@ -14,8 +15,9 @@ export interface GitStatus {
   unstaged: string[];
   untracked: string[];
   branch?: string;
-  ahead?: number;
-  behind?: number;
+  tracking?: string;
+  ahead: number;
+  behind: number;
 }
 
 /**
@@ -44,11 +46,13 @@ export async function getGitStatus(config: Config): Promise<GitStatus | null> {
       unstaged: status.modified,
       untracked: status.not_added,
       branch: status.current ?? undefined,
-      ahead: status.ahead ?? undefined,
-      behind: status.behind ?? undefined,
+      tracking: status.tracking ?? undefined,
+      ahead: status.ahead,
+      behind: status.behind,
     };
-  } catch {
+  } catch (e) {
     // If git status fails, we're likely not in a repo or git is not available
+    debugLogger.error('Failed to get git status', e);
     return null;
   }
 }

--- a/packages/core/src/utils/git-utils.ts
+++ b/packages/core/src/utils/git-utils.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { simpleGit, type SimpleGit, type StatusResult } from 'simple-git';
+import type { Config } from '../config/config.js';
+
+export interface GitStatus {
+  isRepo: boolean;
+  isClean: boolean;
+  staged: string[];
+  unstaged: string[];
+  untracked: string[];
+  branch?: string;
+  ahead?: number;
+  behind?: number;
+}
+
+/**
+ * Gets the Git status for the repository at the target directory.
+ * @param config The application configuration
+ * @returns Git status information, or null if not in a Git repository
+ */
+export async function getGitStatus(config: Config): Promise<GitStatus | null> {
+  const targetDir = config.getTargetDir();
+  const git: SimpleGit = simpleGit(targetDir);
+
+  try {
+    // Check if we're in a Git repository
+    const isRepo = await git.checkIsRepo();
+    if (!isRepo) {
+      return null;
+    }
+
+    // Get status
+    const status: StatusResult = await git.status();
+
+    return {
+      isRepo: true,
+      isClean: status.isClean(),
+      staged: status.staged,
+      unstaged: status.modified,
+      untracked: status.not_added,
+      branch: status.current ?? undefined,
+      ahead: status.ahead ?? undefined,
+      behind: status.behind ?? undefined,
+    };
+  } catch {
+    // If git status fails, we're likely not in a repo or git is not available
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Adds the `get_git_status` tool to Gemini CLI, enabling the AI agent to view Git repository status (staged, unstaged, untracked files) without shell commands. Provides structured output for repository state visibility.

## Details

**Implementation approach:**
- Tools extend `BaseDeclarativeTool` following existing patterns
- Uses `simple-git` library (already a dependency) for Git operations
- Helper functions in `packages/core/src/utils/git-utils.ts`
- Comprehensive unit tests and documentation for each tool

## Related Issues

Related to #15146.

## How to Validate

Example for current implementation -
<video src="https://github.com/user-attachments/assets/2282b910-0f71-44c3-a83e-41dd16a35724" controls="controls" style="max-width: 730px;">
</video>

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
  - [x] Added `docs/tools/git-status.md`
  - [x] Updated `docs/tools/index.md`
- [x] Added/updated tests (if needed)
  - [x] Unit tests for `get_git_status` covering all scenarios
- [x] Noted breaking changes (if any)
  - [x] No breaking changes - new feature addition
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker