### PR TITLE
fix(cli): fix right border overflow in trust dialogs

### DIFF
--- a/packages/cli/src/ui/components/FolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/FolderTrustDialog.tsx
@@ -80,14 +80,14 @@ export const FolderTrustDialog: React.FC<FolderTrustDialogProps> = ({
   ];
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" width="100%">
       <Box
         flexDirection="column"
         borderStyle="round"
         borderColor={theme.status.warning}
         padding={1}
-        width="100%"
         marginLeft={1}
+        marginRight={1}
       >
         <Box flexDirection="column" marginBottom={1}>
           <Text bold color={theme.text.primary}>

--- a/packages/cli/src/ui/components/MultiFolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/MultiFolderTrustDialog.tsx
@@ -138,14 +138,14 @@ export const MultiFolderTrustDialog: React.FC<MultiFolderTrustDialogProps> = ({
   };
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" width="100%">
       <Box
         flexDirection="column"
         borderStyle="round"
         borderColor={theme.status.warning}
         padding={1}
-        width="100%"
         marginLeft={1}
+        marginRight={1}
       >
         <Box flexDirection="column" marginBottom={1}>
           <Text bold color={theme.text.primary}>


### PR DESCRIPTION
## Summary

Fixes a visual bug in the folder trust dialogs where the right border was being cut off/not visible.

## Details

In `FolderTrustDialog` and `MultiFolderTrustDialog`, the inner `Box` was set to `width="100%"` with a `marginLeft`. This caused the content to overflow the parent container, hiding the right border.

The fix involves:
- Removing `width="100%"` from the inner `Box`.
- Adding `marginRight={1}` to balance the `marginLeft={1}`.
- Ensuring the outer wrapper `Box` has `width="100%"` to correctly fill the terminal width.

## Related Issues

N/A

## How to Validate

1. Clear your trusted folders or navigate to a new, untrusted directory.
2. Run the CLI: `npm start`.
3. Verify that the "Do you trust this folder?" dialog is fully visible, including the right-side border.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
