### PR TITLE
fix(policy): fix bug where accepting-edits continued after it was turned off

### DIFF
--- a/packages/core/src/tools/confirmation-policy.test.ts
+++ b/packages/core/src/tools/confirmation-policy.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EditTool } from './edit.js';
+import { SmartEditTool } from './smart-edit.js';
+import { WriteFileTool } from './write-file.js';
+import { WebFetchTool } from './web-fetch.js';
+import { ToolConfirmationOutcome } from './tools.js';
+import { ApprovalMode } from '../policy/types.js';
+import { MessageBusType } from '../confirmation-bus/types.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import type { Config } from '../config/config.js';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+// Mock telemetry loggers to avoid failures
+vi.mock('../telemetry/loggers.js', () => ({
+  logSmartEditStrategy: vi.fn(),
+  logSmartEditCorrectionEvent: vi.fn(),
+  logFileOperation: vi.fn(),
+}));
+
+describe('Tool Confirmation Policy Updates', () => {
+  let mockConfig: any;
+  let mockMessageBus: MessageBus;
+  const rootDir = path.join(
+    os.tmpdir(),
+    `gemini-cli-policy-test-${Date.now()}`,
+  );
+
+  beforeEach(() => {
+    if (!fs.existsSync(rootDir)) {
+      fs.mkdirSync(rootDir, { recursive: true });
+    }
+
+    mockMessageBus = {
+      publish: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    } as unknown as MessageBus;
+
+    mockConfig = {
+      getTargetDir: () => rootDir,
+      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      setApprovalMode: vi.fn(),
+      getFileSystemService: () => ({
+        readTextFile: vi.fn().mockImplementation((p) => {
+          if (fs.existsSync(p)) {
+            return fs.readFileSync(p, 'utf8');
+          }
+          return 'existing content';
+        }),
+        writeTextFile: vi.fn().mockImplementation((p, c) => {
+          fs.writeFileSync(p, c);
+        }),
+      }),
+      getFileService: () => ({}),
+      getFileFilteringOptions: () => ({}),
+      getGeminiClient: () => ({}),
+      getBaseLlmClient: () => ({}),
+      getIdeMode: () => false,
+      getWorkspaceContext: () => ({
+        isPathWithinWorkspace: () => true,
+        getDirectories: () => [rootDir],
+      }),
+    };
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(rootDir)) {
+      fs.rmSync(rootDir, { recursive: true, force: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  const tools = [
+    {
+      name: 'EditTool',
+      create: (config: Config, bus: MessageBus) => new EditTool(config, bus),
+      params: {
+        file_path: 'test.txt',
+        old_string: 'existing',
+        new_string: 'new',
+      },
+    },
+    {
+      name: 'SmartEditTool',
+      create: (config: Config, bus: MessageBus) =>
+        new SmartEditTool(config, bus),
+      params: {
+        file_path: 'test.txt',
+        instruction: 'change content',
+        old_string: 'existing',
+        new_string: 'new',
+      },
+    },
+    {
+      name: 'WriteFileTool',
+      create: (config: Config, bus: MessageBus) =>
+        new WriteFileTool(config, bus),
+      params: {
+        file_path: path.join(rootDir, 'test.txt'),
+        content: 'new content',
+      },
+    },
+    {
+      name: 'WebFetchTool',
+      create: (config: Config, bus: MessageBus) =>
+        new WebFetchTool(config, bus),
+      params: {
+        prompt: 'fetch https://example.com',
+      },
+    },
+  ];
+
+  describe.each(tools)('$name policy updates', ({ create, params }) => {
+    it.each([
+      {
+        outcome: ToolConfirmationOutcome.ProceedAlways,
+        shouldPublish: false,
+        expectedApprovalMode: ApprovalMode.AUTO_EDIT,
+      },
+      {
+        outcome: ToolConfirmationOutcome.ProceedAlwaysAndSave,
+        shouldPublish: true,
+        persist: true,
+      },
+    ])(
+      'should handle $outcome correctly',
+      async ({ outcome, shouldPublish, persist, expectedApprovalMode }) => {
+        const tool = create(mockConfig, mockMessageBus);
+
+        // For file-based tools, ensure the file exists if needed
+        if (params.file_path) {
+          const fullPath = path.isAbsolute(params.file_path)
+            ? params.file_path
+            : path.join(rootDir, params.file_path);
+          fs.writeFileSync(fullPath, 'existing content');
+        }
+
+        const invocation = tool.build(params as any);
+
+        // Mock getMessageBusDecision to trigger ASK_USER flow
+        vi.spyOn(invocation as any, 'getMessageBusDecision').mockResolvedValue(
+          'ASK_USER',
+        );
+
+        const confirmation = await invocation.shouldConfirmExecute(
+          new AbortController().signal,
+        );
+        expect(confirmation).not.toBe(false);
+
+        if (confirmation) {
+          await confirmation.onConfirm(outcome);
+
+          if (shouldPublish) {
+            expect(mockMessageBus.publish).toHaveBeenCalledWith(
+              expect.objectContaining({
+                type: MessageBusType.UPDATE_POLICY,
+                persist,
+              }),
+            );
+          } else {
+            // Should not publish UPDATE_POLICY message for ProceedAlways
+            const publishCalls = (mockMessageBus.publish as any).mock.calls;
+            const hasUpdatePolicy = publishCalls.some(
+              (call: any) => call[0].type === MessageBusType.UPDATE_POLICY,
+            );
+            expect(hasUpdatePolicy).toBe(false);
+          }
+
+          if (expectedApprovalMode !== undefined) {
+            expect(mockConfig.setApprovalMode).toHaveBeenCalledWith(
+              expectedApprovalMode,
+            );
+          }
+        }
+      },
+    );
+  });
+});

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -311,9 +311,12 @@ class EditToolInvocation
       newContent: editData.newContent,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
+          // No need to publish a policy update as the default policy for
+          // AUTO_EDIT already reflects always approving edit.
           this.config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+        } else {
+          await this.publishPolicyUpdate(outcome);
         }
-        await this.publishPolicyUpdate(outcome);
 
         if (ideConfirmation) {
           const result = await ideConfirmation;

--- a/packages/core/src/tools/smart-edit.ts
+++ b/packages/core/src/tools/smart-edit.ts
@@ -681,9 +681,12 @@ class EditToolInvocation
       newContent: editData.newContent,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
+          // No need to publish a policy update as the default policy for
+          // AUTO_EDIT already reflects always approving smart-edit.
           this.config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+        } else {
+          await this.publishPolicyUpdate(outcome);
         }
-        await this.publishPolicyUpdate(outcome);
 
         if (ideConfirmation) {
           const result = await ideConfirmation;

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -242,9 +242,12 @@ ${textContent}
       urls,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
+          // No need to publish a policy update as the default policy for
+          // AUTO_EDIT already reflects always approving web-fetch.
           this.config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+        } else {
+          await this.publishPolicyUpdate(outcome);
         }
-        await this.publishPolicyUpdate(outcome);
       },
     };
     return confirmationDetails;

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -222,9 +222,12 @@ class WriteFileToolInvocation extends BaseToolInvocation<
       newContent: correctedContent,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
+          // No need to publish a policy update as the default policy for
+          // AUTO_EDIT already reflects always approving write-file.
           this.config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+        } else {
+          await this.publishPolicyUpdate(outcome);
         }
-        await this.publishPolicyUpdate(outcome);
 
         if (ideConfirmation) {
           const result = await ideConfirmation;


### PR DESCRIPTION
## Summary 
This pull request addresses an approval flow bug by refining the policy update mechanism for tool confirmations. It specifically modifies the `EditTool`, `SmartEditTool`, `WebFetchTool`, and `WriteFileTool` to ensure that choosing "Proceed Always" correctly sets a session-based auto-approval without triggering a redundant policy update broadcast. Persistent policy changes, such as those from "Proceed Always and Save," continue to publish policy updates. This change improves the accuracy and efficiency of policy management and is supported by new regression tests.

## Details

* **Refined Policy Update Logic**: The handling of tool confirmation outcomes has been updated to prevent redundant policy updates. When a user selects "Proceed Always" for a tool, the system now directly sets the session-based auto-approval mode without publishing a separate policy update message.
* **Persistent Policy Updates**: The `publishPolicyUpdate` mechanism is now specifically triggered only when a user chooses "Proceed Always and Save," ensuring that persistent policy changes are correctly broadcast.
* **Enhanced Test Coverage**: New regression tests have been added for `EditTool`, `SmartEditTool`, `WebFetchTool`, and `WriteFileTool` to validate the correct behavior of `onConfirm` policy updates, ensuring the distinction between session-based and persistent approval modes.

## How to Validate

1. Start the CLI in a trusted folder.
2. Trigger an edit (e.g., `replace` tool).
3. In the confirmation dialog, select **"Allow for this session"**.
4. Verify the UI indicator shows "Auto-Edit Mode".
5. Press `Shift+Tab` to toggle Auto-Edit Mode **OFF**.
6. Trigger another edit.
7. **Expected Result:** The CLI **must** prompt for confirmation.
8. **Security Check:** Manually add a `DENY` rule for `replace` in a user policy file. Toggle Auto-Edit ON and then OFF. Verify the `DENY` rule still blocks the tool (or triggers a confirmation fallback).
