### PR TITLE
Clarify locations of system defaults file

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -42,11 +42,11 @@ locations for these files:
 > `https://raw.githubusercontent.com/google-gemini/gemini-cli/main/schemas/settings.schema.json`.
 
 - **System defaults file:**
-  - **Location:** `/etc/gemini-cli/system-defaults.json` (Linux),
-    `C:\ProgramData\gemini-cli\system-defaults.json` (Windows) or
-    `/Library/Application Support/GeminiCli/system-defaults.json` (macOS). The
-    path can be overridden using the `GEMINI_CLI_SYSTEM_DEFAULTS_PATH`
-    environment variable.
+  - **Locations:**
+    - **Linux:** `/etc/gemini-cli/system-defaults.json`
+    - **macOS:** `/Library/Application Support/GeminiCli/system-defaults.json`
+    - **Windows:** `C:\ProgramData\gemini-cli\system-defaults.json`
+  - The path can be overridden using the `GEMINI_CLI_SYSTEM_DEFAULTS_PATH` environment variable.
   - **Scope:** Provides a base layer of system-wide default settings. These
     settings have the lowest precedence and are intended to be overridden by
     user, project, or system override settings.


### PR DESCRIPTION
Reorganize system defaults file locations for clarity.

## Summary

This PR improves the readability of the "System defaults file" section in the README. By breaking down the paths for different operating systems into a structured list, users can more easily identify the correct location for their environment.

## Details

- Converted a dense paragraph of system paths into a nested list format.
- Grouped paths by OS (Linux, Windows, macOS) for better visual scanning.
- Separated the environment variable override note from the path list to reduce visual clutter.

## Related Issues

None. (This is a documentation-only improvement for better developer experience).

## How to Validate

1. Open the modified `README.md` in a Markdown viewer or via the GitHub "Files changed" preview.
2. Verify that:
   - All three system paths (Linux, Windows, macOS) are present and correct.
   - The formatting is consistent and the list levels are correctly rendered.
   - There are no broken links or missing backticks for code blocks.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) -> No breaking changes.
- [x] Validated on required platforms/methods:
  - [x] MacOS (Previewed README rendering)
  - [x] Windows (Previewed README rendering)
  - [x] Linux (Previewed README rendering)