### PR TITLE
chore: improve error messages for --resume

### DIFF
--- a/packages/cli/src/utils/sessionUtils.test.ts
+++ b/packages/cli/src/utils/sessionUtils.test.ts
@@ -10,7 +10,7 @@ import {
   extractFirstUserMessage,
   formatRelativeTime,
   hasUserOrAssistantMessage,
-  InvalidSessionIdentifierError,
+  SessionError,
 } from './sessionUtils.js';
 import type { Config, MessageRecord } from '@google/gemini-cli-core';
 import { SESSION_FILE_PREFIX } from '@google/gemini-cli-core';
@@ -334,10 +334,10 @@ describe('SessionSelector', () => {
 
     await expect(
       sessionSelector.resolveSession('invalid-uuid'),
-    ).rejects.toThrow(InvalidSessionIdentifierError);
+    ).rejects.toThrow(SessionError);
 
     await expect(sessionSelector.resolveSession('999')).rejects.toThrow(
-      InvalidSessionIdentifierError,
+      SessionError,
     );
   });
 

--- a/packages/cli/src/utils/sessionUtils.test.ts
+++ b/packages/cli/src/utils/sessionUtils.test.ts
@@ -10,6 +10,7 @@ import {
   extractFirstUserMessage,
   formatRelativeTime,
   hasUserOrAssistantMessage,
+  InvalidSessionIdentifierError,
 } from './sessionUtils.js';
 import type { Config, MessageRecord } from '@google/gemini-cli-core';
 import { SESSION_FILE_PREFIX } from '@google/gemini-cli-core';
@@ -333,10 +334,10 @@ describe('SessionSelector', () => {
 
     await expect(
       sessionSelector.resolveSession('invalid-uuid'),
-    ).rejects.toThrow('Invalid session identifier "invalid-uuid"');
+    ).rejects.toThrow(InvalidSessionIdentifierError);
 
     await expect(sessionSelector.resolveSession('999')).rejects.toThrow(
-      'Invalid session identifier "999"',
+      InvalidSessionIdentifierError,
     );
   });
 

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -430,9 +430,14 @@ export class SessionSelector {
       try {
         selectedSession = await this.findSession(resumeArg);
       } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.includes('No previous sessions found')) {
+          throw error;
+        }
+
         // Re-throw with more detailed message for resume command
         throw new Error(
-          `Invalid session identifier "${resumeArg}". Use --list-sessions to see available sessions, then use --resume {number}, --resume {uuid}, or --resume latest.  Error: ${error}`,
+          `Invalid session identifier "${resumeArg}". Use --list-sessions to see available sessions, then use --resume {number}, --resume {uuid}, or --resume latest.`,
         );
       }
     }

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -39,7 +39,7 @@ export class NoSessionsFoundError extends Error {
 export class InvalidSessionIdentifierError extends Error {
   constructor(identifier: string) {
     super(
-      `Invalid session identifier "${identifier}". Use --list-sessions to see available sessions, then use --resume {number}, --resume {uuid}, or --resume latest.`,
+      `Invalid session identifier "${identifier}".\n  Use --list-sessions to see available sessions, then use --resume {number}, --resume {uuid}, or --resume latest.`,
     );
     this.name = 'InvalidSessionIdentifierError';
   }


### PR DESCRIPTION
## Summary

  This PR improves the error handling when a user attempts to resume a session with an invalid identifier (e.g., `gemini
  --resume bad-session-id`). 

Super long and redundant error message:
```
Error resuming session: Invalid session identifier "bad-session". Use --list-sessions to see available sessions, then use --resume {number}, --resume {uuid}, or --resume latest.  Error: Error: Invalid session identifier "bad-session". Use --list-sessions to see available sessions.
```

It removes redundant error nesting and refactored the error handling to use a single `SessionError` class with a code field instead of separate error classes.

## Details
  - Refactored the error handling to use a single `SessionError`class with a code field instead of separate error classes
  - Move detailed error messages to their source in `findSession()` instead of wrapping in `resolveSession()`

Following the established pattern in `packages/core/src/utils/errors.ts`, this PR creates typed error classes that are thrown at their source.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
