### PR TITLE
feat(ui): add tool feedback flow

### DIFF
--- a/docs/cli/keyboard-shortcuts.md
+++ b/docs/cli/keyboard-shortcuts.md
@@ -91,15 +91,16 @@ available combinations.
 
 #### App Controls
 
-| Action                                                            | Keys       |
-| ----------------------------------------------------------------- | ---------- |
-| Toggle detailed error information.                                | `F12`      |
-| Toggle the full TODO list.                                        | `Ctrl + T` |
-| Toggle IDE context details.                                       | `Ctrl + G` |
-| Toggle Markdown rendering.                                        | `Cmd + M`  |
-| Toggle copy mode when the terminal is using the alternate buffer. | `Ctrl + S` |
-| Expand a height-constrained response to show additional lines.    | `Ctrl + S` |
-| Toggle focus between the shell and Gemini input.                  | `Ctrl + F` |
+| Action                                                            | Keys                  |
+| ----------------------------------------------------------------- | --------------------- |
+| Toggle detailed error information.                                | `F12`                 |
+| Toggle the full TODO list.                                        | `Ctrl + T`            |
+| Toggle IDE context details.                                       | `Ctrl + G`            |
+| Toggle Markdown rendering.                                        | `Cmd + M`             |
+| Toggle copy mode when the terminal is using the alternate buffer. | `Ctrl + S`            |
+| Expand a height-constrained response to show additional lines.    | `Ctrl + S`            |
+| Toggle focus between the shell and Gemini input.                  | `Ctrl + F`            |
+| Provide feedback on a tool call.                                  | `F (no Ctrl, no Cmd)` |
 
 #### Session Control
 

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -71,6 +71,7 @@ export enum Command {
   SUBMIT_REVERSE_SEARCH = 'submitReverseSearch',
   ACCEPT_SUGGESTION_REVERSE_SEARCH = 'acceptSuggestionReverseSearch',
   TOGGLE_SHELL_INPUT_FOCUS = 'toggleShellInputFocus',
+  TOGGLE_FEEDBACK = 'toggleFeedback',
 
   // Suggestion expansion
   EXPAND_SUGGESTION = 'expandSuggestion',
@@ -213,6 +214,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.SUBMIT_REVERSE_SEARCH]: [{ key: 'return', ctrl: false }],
   [Command.ACCEPT_SUGGESTION_REVERSE_SEARCH]: [{ key: 'tab' }],
   [Command.TOGGLE_SHELL_INPUT_FOCUS]: [{ key: 'f', ctrl: true }],
+  [Command.TOGGLE_FEEDBACK]: [{ key: 'f', ctrl: false, command: false }],
 
   // Suggestion expansion
   [Command.EXPAND_SUGGESTION]: [{ key: 'right' }],
@@ -307,6 +309,7 @@ export const commandCategories: readonly CommandCategory[] = [
       Command.TOGGLE_COPY_MODE,
       Command.SHOW_MORE_LINES,
       Command.TOGGLE_SHELL_INPUT_FOCUS,
+      Command.TOGGLE_FEEDBACK,
     ],
   },
   {
@@ -364,6 +367,7 @@ export const commandDescriptions: Readonly<Record<Command, string>> = {
     'Accept a suggestion while reverse searching.',
   [Command.TOGGLE_SHELL_INPUT_FOCUS]:
     'Toggle focus between the shell and Gemini input.',
+  [Command.TOGGLE_FEEDBACK]: 'Provide feedback on a tool call.',
   [Command.EXPAND_SUGGESTION]: 'Expand an inline suggestion.',
   [Command.COLLAPSE_SUGGESTION]: 'Collapse an inline suggestion.',
 };

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -88,7 +88,10 @@ export const ToolConfirmationMessage: React.FC<
     if (confirmationDetails.type === 'edit') {
       if (config.getIdeMode() && isDiffingEnabled) {
         const cliOutcome =
-          outcome === ToolConfirmationOutcome.Cancel ? 'rejected' : 'accepted';
+          outcome === ToolConfirmationOutcome.Cancel ||
+          outcome === ToolConfirmationOutcome.Feedback
+            ? 'rejected'
+            : 'accepted';
         await ideClient?.resolveDiffFromCli(
           confirmationDetails.filePath,
           cliOutcome,

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolConfirmationMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolConfirmationMessage.test.tsx.snap
@@ -10,9 +10,9 @@ Do you want to proceed?
 
 ● 1. Allow once
   2. Allow for this session
-  3. Give feedback (f)
-  4. No, suggest changes (esc)
-"
+  3. Provide feedback (f)
+
+(esc to cancel)"
 `;
 
 exports[`ToolConfirmationMessage > should not display urls if prompt and url are the same 1`] = `
@@ -22,9 +22,9 @@ Do you want to proceed?
 
 ● 1. Allow once
   2. Allow for this session
-  3. Give feedback (f)
-  4. No, suggest changes (esc)
-"
+  3. Provide feedback (f)
+
+(esc to cancel)"
 `;
 
 exports[`ToolConfirmationMessage > with folder trust > 'for edit confirmations' > should NOT show "allow always" when folder is untrusted 1`] = `
@@ -38,9 +38,9 @@ Apply this change?
 
 ● 1. Allow once
   2. Modify with external editor
-  3. Give feedback (f)
-  4. No, suggest changes (esc)
-"
+  3. Provide feedback (f)
+
+(esc to cancel)"
 `;
 
 exports[`ToolConfirmationMessage > with folder trust > 'for edit confirmations' > should show "allow always" when folder is trusted 1`] = `
@@ -55,9 +55,9 @@ Apply this change?
 ● 1. Allow once
   2. Allow for this session
   3. Modify with external editor
-  4. Give feedback (f)
-  5. No, suggest changes (esc)
-"
+  4. Provide feedback (f)
+
+(esc to cancel)"
 `;
 
 exports[`ToolConfirmationMessage > with folder trust > 'for exec confirmations' > should NOT show "allow always" when folder is untrusted 1`] = `
@@ -66,9 +66,9 @@ exports[`ToolConfirmationMessage > with folder trust > 'for exec confirmations' 
 Allow execution of: 'echo'?
 
 ● 1. Allow once
-  2. Give feedback (f)
-  3. No, suggest changes (esc)
-"
+  2. Provide feedback (f)
+
+(esc to cancel)"
 `;
 
 exports[`ToolConfirmationMessage > with folder trust > 'for exec confirmations' > should show "allow always" when folder is trusted 1`] = `
@@ -78,9 +78,9 @@ Allow execution of: 'echo'?
 
 ● 1. Allow once
   2. Allow for this session
-  3. Give feedback (f)
-  4. No, suggest changes (esc)
-"
+  3. Provide feedback (f)
+
+(esc to cancel)"
 `;
 
 exports[`ToolConfirmationMessage > with folder trust > 'for info confirmations' > should NOT show "allow always" when folder is untrusted 1`] = `
@@ -89,9 +89,9 @@ exports[`ToolConfirmationMessage > with folder trust > 'for info confirmations' 
 Do you want to proceed?
 
 ● 1. Allow once
-  2. Give feedback (f)
-  3. No, suggest changes (esc)
-"
+  2. Provide feedback (f)
+
+(esc to cancel)"
 `;
 
 exports[`ToolConfirmationMessage > with folder trust > 'for info confirmations' > should show "allow always" when folder is trusted 1`] = `
@@ -101,9 +101,9 @@ Do you want to proceed?
 
 ● 1. Allow once
   2. Allow for this session
-  3. Give feedback (f)
-  4. No, suggest changes (esc)
-"
+  3. Provide feedback (f)
+
+(esc to cancel)"
 `;
 
 exports[`ToolConfirmationMessage > with folder trust > 'for mcp confirmations' > should NOT show "allow always" when folder is untrusted 1`] = `
@@ -113,9 +113,9 @@ Tool: test-tool
 Allow execution of MCP tool "test-tool" from server "test-server"?
 
 ● 1. Allow once
-  2. Give feedback (f)
-  3. No, suggest changes (esc)
-"
+  2. Provide feedback (f)
+
+(esc to cancel)"
 `;
 
 exports[`ToolConfirmationMessage > with folder trust > 'for mcp confirmations' > should show "allow always" when folder is trusted 1`] = `
@@ -127,7 +127,7 @@ Allow execution of MCP tool "test-tool" from server "test-server"?
 ● 1. Allow once
   2. Allow tool for this session
   3. Allow all server tools for this session
-  4. Give feedback (f)
-  5. No, suggest changes (esc)
-"
+  4. Provide feedback (f)
+
+(esc to cancel)"
 `;

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolConfirmationMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolConfirmationMessage.test.tsx.snap
@@ -10,7 +10,8 @@ Do you want to proceed?
 
 ● 1. Allow once
   2. Allow for this session
-  3. No, suggest changes (esc)
+  3. Give feedback (f)
+  4. No, suggest changes (esc)
 "
 `;
 
@@ -21,7 +22,8 @@ Do you want to proceed?
 
 ● 1. Allow once
   2. Allow for this session
-  3. No, suggest changes (esc)
+  3. Give feedback (f)
+  4. No, suggest changes (esc)
 "
 `;
 
@@ -36,7 +38,8 @@ Apply this change?
 
 ● 1. Allow once
   2. Modify with external editor
-  3. No, suggest changes (esc)
+  3. Give feedback (f)
+  4. No, suggest changes (esc)
 "
 `;
 
@@ -52,7 +55,8 @@ Apply this change?
 ● 1. Allow once
   2. Allow for this session
   3. Modify with external editor
-  4. No, suggest changes (esc)
+  4. Give feedback (f)
+  5. No, suggest changes (esc)
 "
 `;
 
@@ -62,7 +66,8 @@ exports[`ToolConfirmationMessage > with folder trust > 'for exec confirmations' 
 Allow execution of: 'echo'?
 
 ● 1. Allow once
-  2. No, suggest changes (esc)
+  2. Give feedback (f)
+  3. No, suggest changes (esc)
 "
 `;
 
@@ -73,7 +78,8 @@ Allow execution of: 'echo'?
 
 ● 1. Allow once
   2. Allow for this session
-  3. No, suggest changes (esc)
+  3. Give feedback (f)
+  4. No, suggest changes (esc)
 "
 `;
 
@@ -83,7 +89,8 @@ exports[`ToolConfirmationMessage > with folder trust > 'for info confirmations' 
 Do you want to proceed?
 
 ● 1. Allow once
-  2. No, suggest changes (esc)
+  2. Give feedback (f)
+  3. No, suggest changes (esc)
 "
 `;
 
@@ -94,7 +101,8 @@ Do you want to proceed?
 
 ● 1. Allow once
   2. Allow for this session
-  3. No, suggest changes (esc)
+  3. Give feedback (f)
+  4. No, suggest changes (esc)
 "
 `;
 
@@ -105,7 +113,8 @@ Tool: test-tool
 Allow execution of MCP tool "test-tool" from server "test-server"?
 
 ● 1. Allow once
-  2. No, suggest changes (esc)
+  2. Give feedback (f)
+  3. No, suggest changes (esc)
 "
 `;
 
@@ -118,6 +127,7 @@ Allow execution of MCP tool "test-tool" from server "test-server"?
 ● 1. Allow once
   2. Allow tool for this session
   3. Allow all server tools for this session
-  4. No, suggest changes (esc)
+  4. Give feedback (f)
+  5. No, suggest changes (esc)
 "
 `;

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
@@ -39,9 +39,9 @@ exports[`<ToolGroupMessage /> > Confirmation Handling > renders confirmation wit
 │                                                                              │
 │ ● 1. Allow once                                                              │
 │   2. Allow for this session                                                  │
-│   3. Give feedback (f)                                                       │
-│   4. No, suggest changes (esc)                                               │
+│   3. Provide feedback (f)                                                    │
 │                                                                              │
+│ (esc to cancel)                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
 
@@ -57,9 +57,9 @@ exports[`<ToolGroupMessage /> > Confirmation Handling > renders confirmation wit
 │ ● 1. Allow once                                                              │
 │   2. Allow for this session                                                  │
 │   3. Allow for all future sessions                                           │
-│   4. Give feedback (f)                                                       │
-│   5. No, suggest changes (esc)                                               │
+│   4. Provide feedback (f)                                                    │
 │                                                                              │
+│ (esc to cancel)                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
 
@@ -74,9 +74,9 @@ exports[`<ToolGroupMessage /> > Confirmation Handling > shows confirmation dialo
 │                                                                              │
 │ ● 1. Allow once                                                              │
 │   2. Allow for this session                                                  │
-│   3. Give feedback (f)                                                       │
-│   4. No, suggest changes (esc)                                               │
+│   3. Provide feedback (f)                                                    │
 │                                                                              │
+│ (esc to cancel)                                                              │
 │                                                                              │
 │ ?  second-confirm A tool for testing                                         │
 │                                                                              │
@@ -158,9 +158,9 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders tool call awaiting co
 │                                                                              │
 │ ● 1. Allow once                                                              │
 │   2. Allow for this session                                                  │
-│   3. Give feedback (f)                                                       │
-│   4. No, suggest changes (esc)                                               │
+│   3. Provide feedback (f)                                                    │
 │                                                                              │
+│ (esc to cancel)                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
 

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
@@ -39,7 +39,8 @@ exports[`<ToolGroupMessage /> > Confirmation Handling > renders confirmation wit
 │                                                                              │
 │ ● 1. Allow once                                                              │
 │   2. Allow for this session                                                  │
-│   3. No, suggest changes (esc)                                               │
+│   3. Give feedback (f)                                                       │
+│   4. No, suggest changes (esc)                                               │
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
@@ -56,7 +57,8 @@ exports[`<ToolGroupMessage /> > Confirmation Handling > renders confirmation wit
 │ ● 1. Allow once                                                              │
 │   2. Allow for this session                                                  │
 │   3. Allow for all future sessions                                           │
-│   4. No, suggest changes (esc)                                               │
+│   4. Give feedback (f)                                                       │
+│   5. No, suggest changes (esc)                                               │
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
@@ -72,7 +74,8 @@ exports[`<ToolGroupMessage /> > Confirmation Handling > shows confirmation dialo
 │                                                                              │
 │ ● 1. Allow once                                                              │
 │   2. Allow for this session                                                  │
-│   3. No, suggest changes (esc)                                               │
+│   3. Give feedback (f)                                                       │
+│   4. No, suggest changes (esc)                                               │
 │                                                                              │
 │                                                                              │
 │ ?  second-confirm A tool for testing                                         │
@@ -155,7 +158,8 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders tool call awaiting co
 │                                                                              │
 │ ● 1. Allow once                                                              │
 │   2. Allow for this session                                                  │
-│   3. No, suggest changes (esc)                                               │
+│   3. Give feedback (f)                                                       │
+│   4. No, suggest changes (esc)                                               │
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;

--- a/packages/cli/src/ui/components/shared/BaseSelectionList.test.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSelectionList.test.tsx
@@ -125,6 +125,9 @@ describe('BaseSelectionList', () => {
         onHighlight: mockOnHighlight,
         isFocused,
         showNumbers,
+        isInputActive: false,
+        isAtTop: false,
+        isAtBottom: false,
       });
     });
 

--- a/packages/cli/src/ui/components/shared/BaseSelectionList.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSelectionList.tsx
@@ -30,6 +30,9 @@ export interface BaseSelectionListProps<
   showNumbers?: boolean;
   showScrollArrows?: boolean;
   maxItemsToShow?: number;
+  isInputActive?: boolean;
+  isAtTop?: boolean;
+  isAtBottom?: boolean;
   renderItem: (item: TItem, context: RenderItemContext) => React.ReactNode;
 }
 
@@ -59,6 +62,9 @@ export function BaseSelectionList<
   showNumbers = true,
   showScrollArrows = false,
   maxItemsToShow = 10,
+  isInputActive = false,
+  isAtTop = false,
+  isAtBottom = false,
   renderItem,
 }: BaseSelectionListProps<T, TItem>): React.JSX.Element {
   const { activeIndex } = useSelectionList({
@@ -68,6 +74,9 @@ export function BaseSelectionList<
     onHighlight,
     isFocused,
     showNumbers,
+    isInputActive,
+    isAtTop,
+    isAtBottom,
   });
 
   const [scrollOffset, setScrollOffset] = useState(0);

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -44,6 +44,12 @@ export interface RadioButtonSelectProps<T> {
   maxItemsToShow?: number;
   /** Whether to show numbers next to items. */
   showNumbers?: boolean;
+  /** Whether an input field within the active item is currently active. */
+  isInputActive?: boolean;
+  /** Whether the active input is at its top boundary (relevant for arrow key navigation). */
+  isAtTop?: boolean;
+  /** Whether the active input is at its bottom boundary (relevant for arrow key navigation). */
+  isAtBottom?: boolean;
   /** Optional custom renderer for items. */
   renderItem?: (
     item: RadioSelectItem<T>,
@@ -66,6 +72,9 @@ export function RadioButtonSelect<T>({
   showScrollArrows = false,
   maxItemsToShow = 10,
   showNumbers = true,
+  isInputActive = false,
+  isAtTop = false,
+  isAtBottom = false,
   renderItem,
 }: RadioButtonSelectProps<T>): React.JSX.Element {
   return (
@@ -78,6 +87,9 @@ export function RadioButtonSelect<T>({
       showNumbers={showNumbers}
       showScrollArrows={showScrollArrows}
       maxItemsToShow={maxItemsToShow}
+      isInputActive={isInputActive}
+      isAtTop={isAtTop}
+      isAtBottom={isAtBottom}
       renderItem={
         renderItem ||
         ((item, { titleColor }) => {

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -17,6 +17,8 @@ import { cpSlice } from '../../utils/textUtils.js';
 export interface TextInputProps {
   buffer: TextBuffer;
   placeholder?: string;
+  placeholderColor?: string;
+  placeholderFocusedColor?: string;
   onSubmit?: (value: string) => void;
   onCancel?: () => void;
   focus?: boolean;
@@ -25,6 +27,8 @@ export interface TextInputProps {
 export function TextInput({
   buffer,
   placeholder = '',
+  placeholderColor = theme.text.secondary,
+  placeholderFocusedColor = theme.text.secondary,
   onSubmit,
   onCancel,
   focus = true,
@@ -65,10 +69,10 @@ export function TextInput({
         {focus ? (
           <Text>
             {chalk.inverse(placeholder[0] || ' ')}
-            <Text color={theme.text.secondary}>{placeholder.slice(1)}</Text>
+            <Text color={placeholderFocusedColor}>{placeholder.slice(1)}</Text>
           </Text>
         ) : (
-          <Text color={theme.text.secondary}>{placeholder}</Text>
+          <Text color={placeholderColor}>{placeholder}</Text>
         )}
       </Box>
     );

--- a/packages/cli/src/ui/hooks/useSelectionList.test.tsx
+++ b/packages/cli/src/ui/hooks/useSelectionList.test.tsx
@@ -80,6 +80,9 @@ describe('useSelectionList', () => {
     initialIndex?: number;
     isFocused?: boolean;
     showNumbers?: boolean;
+    isInputActive?: boolean;
+    isAtTop?: boolean;
+    isAtBottom?: boolean;
   }) => {
     let hookResult: ReturnType<typeof useSelectionList>;
     function TestComponent(props: typeof initialProps) {
@@ -961,6 +964,84 @@ describe('useSelectionList', () => {
 
       await rerender({ items: newItems });
       expect(renderCount).toBe(2);
+    });
+  });
+
+  describe('Navigation Restriction (isInputActive=true)', () => {
+    it('should ignore j/k navigation when isInputActive is true', async () => {
+      const { result } = await renderSelectionListHook({
+        items,
+        onSelect: mockOnSelect,
+        isInputActive: true,
+      });
+      expect(result.current.activeIndex).toBe(0);
+
+      pressKey('j');
+      expect(result.current.activeIndex).toBe(0);
+
+      pressKey('k');
+      expect(result.current.activeIndex).toBe(0);
+    });
+
+    it('should ignore numeric shortcuts when isInputActive is true', async () => {
+      const { result } = await renderSelectionListHook({
+        items,
+        onSelect: mockOnSelect,
+        showNumbers: true,
+        isInputActive: true,
+      });
+      expect(result.current.activeIndex).toBe(0);
+
+      pressKey('3', '3');
+      expect(result.current.activeIndex).toBe(0);
+      expect(mockOnSelect).not.toHaveBeenCalled();
+    });
+
+    it('should ignore return key when isInputActive is true', async () => {
+      await renderSelectionListHook({
+        items,
+        onSelect: mockOnSelect,
+        isInputActive: true,
+      });
+
+      pressKey('return');
+      expect(mockOnSelect).not.toHaveBeenCalled();
+    });
+
+    it('should allow arrow key navigation when isInputActive is true but at boundaries', async () => {
+      const { result } = await renderSelectionListHook({
+        items,
+        onSelect: mockOnSelect,
+        isInputActive: true,
+        isAtTop: true,
+        isAtBottom: true,
+      });
+      expect(result.current.activeIndex).toBe(0);
+
+      // Down should leak because isAtBottom is true
+      pressKey('down');
+      expect(result.current.activeIndex).toBe(2);
+
+      // Up should leak because isAtTop is true
+      pressKey('up');
+      expect(result.current.activeIndex).toBe(0);
+    });
+
+    it('should ignore arrow key navigation when isInputActive is true and NOT at boundaries', async () => {
+      const { result } = await renderSelectionListHook({
+        items,
+        onSelect: mockOnSelect,
+        isInputActive: true,
+        isAtTop: false,
+        isAtBottom: false,
+      });
+      expect(result.current.activeIndex).toBe(0);
+
+      pressKey('down');
+      expect(result.current.activeIndex).toBe(0);
+
+      pressKey('up');
+      expect(result.current.activeIndex).toBe(0);
     });
   });
 

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -533,6 +533,7 @@ describe('useReactToolScheduler', () => {
 
     expect(mockOnUserConfirmForToolConfirmation).toHaveBeenCalledWith(
       ToolConfirmationOutcome.ProceedOnce,
+      undefined,
     );
     expect(mockToolRequiresConfirmation.execute).toHaveBeenCalled();
 
@@ -578,6 +579,7 @@ describe('useReactToolScheduler', () => {
 
     expect(mockOnUserConfirmForToolConfirmation).toHaveBeenCalledWith(
       ToolConfirmationOutcome.Cancel,
+      undefined,
     );
 
     const completedCalls = onComplete.mock.calls[0][0] as ToolCall[];

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -77,6 +77,8 @@ describe('keyMatchers', () => {
       key.name === 'tab',
     [Command.TOGGLE_SHELL_INPUT_FOCUS]: (key: Key) =>
       key.ctrl && key.name === 'f',
+    [Command.TOGGLE_FEEDBACK]: (key: Key) =>
+      key.name === 'f' && !key.ctrl && !key.meta,
     [Command.EXPAND_SUGGESTION]: (key: Key) => key.name === 'right',
     [Command.COLLAPSE_SUGGESTION]: (key: Key) => key.name === 'left',
   };
@@ -335,6 +337,11 @@ describe('keyMatchers', () => {
       command: Command.TOGGLE_SHELL_INPUT_FOCUS,
       positive: [createKey('f', { ctrl: true })],
       negative: [createKey('f')],
+    },
+    {
+      command: Command.TOGGLE_FEEDBACK,
+      positive: [createKey('f')],
+      negative: [createKey('f', { ctrl: true })],
     },
   ];
 

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -45,6 +45,8 @@ import { randomUUID } from 'node:crypto';
 import type { CliArgs } from '../config/config.js';
 import { loadCliConfig } from '../config/config.js';
 
+import { checkExhaustive } from '../utils/checks.js';
+
 export async function runZedIntegration(
   config: Config,
   settings: LoadedSettings,
@@ -486,10 +488,9 @@ export class Session {
             return errorResponse(
               new Error('Tool execution rejected with feedback.'),
             );
-          default: {
-            const resultOutcome: never = outcome;
-            throw new Error(`Unexpected: ${resultOutcome}`);
-          }
+          default:
+            checkExhaustive(outcome);
+            throw new Error(`Unexpected: ${outcome}`);
         }
       } else {
         await this.sendUpdate({

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -482,6 +482,10 @@ export class Session {
           case ToolConfirmationOutcome.ProceedAlwaysTool:
           case ToolConfirmationOutcome.ModifyWithEditor:
             break;
+          case ToolConfirmationOutcome.Feedback:
+            return errorResponse(
+              new Error('Tool execution rejected with feedback.'),
+            );
           default: {
             const resultOutcome: never = outcome;
             throw new Error(`Unexpected: ${resultOutcome}`);

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -801,6 +801,96 @@ describe('CoreToolScheduler with payload', () => {
       newContent: '',
     });
   });
+
+  it('should pass payload to onConfirm handler', async () => {
+    const onConfirmSpy = vi.fn();
+    const mockTool = new MockModifiableTool();
+    mockTool.executeFn = vi.fn();
+
+    // Monkey-patch createInvocation to return invocation with spied onConfirm
+    // @ts-expect-error - overriding protected method for testing
+    const originalCreateInvocation = mockTool.createInvocation.bind(mockTool);
+    // @ts-expect-error - overriding protected method for testing
+    mockTool.createInvocation = (params) => {
+      const invocation = originalCreateInvocation(params);
+      invocation.shouldConfirmExecute = async () => ({
+        type: 'edit',
+        title: 'Confirm',
+        fileName: 'test.txt',
+        filePath: 'test.txt',
+        fileDiff: 'diff',
+        originalContent: 'old',
+        newContent: 'new',
+        onConfirm: onConfirmSpy,
+      });
+      return invocation;
+    };
+
+    const declarativeTool = mockTool;
+    const mockToolRegistry = {
+      getTool: () => declarativeTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => declarativeTool,
+      getToolByDisplayName: () => declarativeTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsComplete = vi.fn();
+    const onToolCallsUpdate = vi.fn();
+
+    const mockConfig = createMockConfig({
+      getToolRegistry: () => mockToolRegistry,
+    });
+    const mockMessageBus = createMockMessageBus();
+    mockConfig.getMessageBus = vi.fn().mockReturnValue(mockMessageBus);
+    mockConfig.getEnableHooks = vi.fn().mockReturnValue(false);
+    mockConfig.getHookSystem = vi
+      .fn()
+      .mockReturnValue(new HookSystem(mockConfig));
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+    });
+
+    const abortController = new AbortController();
+    const request = {
+      callId: '1',
+      name: 'mockModifiableTool',
+      args: {},
+      isClientInitiated: false,
+      prompt_id: 'prompt-id-payload-check',
+    };
+
+    await scheduler.schedule([request], abortController.signal);
+
+    const awaitingCall = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+    const confirmationDetails = awaitingCall.confirmationDetails;
+
+    if (confirmationDetails) {
+      const payload: ToolConfirmationPayload = { newContent: 'updated' };
+      await confirmationDetails.onConfirm(
+        ToolConfirmationOutcome.ProceedOnce,
+        payload,
+      );
+
+      expect(onConfirmSpy).toHaveBeenCalledWith(
+        ToolConfirmationOutcome.ProceedOnce,
+        payload,
+      );
+    }
+  });
 });
 
 class MockEditToolInvocation extends BaseToolInvocation<

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -724,6 +724,83 @@ describe('CoreToolScheduler with payload', () => {
       newContent: 'final version',
     });
   });
+
+  it('should allow clearing content (empty string) via payload', async () => {
+    const mockTool = new MockModifiableTool();
+    mockTool.executeFn = vi.fn();
+    const declarativeTool = mockTool;
+    const mockToolRegistry = {
+      getTool: () => declarativeTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => declarativeTool,
+      getToolByDisplayName: () => declarativeTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsComplete = vi.fn();
+    const onToolCallsUpdate = vi.fn();
+
+    const mockConfig = createMockConfig({
+      getToolRegistry: () => mockToolRegistry,
+    });
+    const mockMessageBus = createMockMessageBus();
+    mockConfig.getMessageBus = vi.fn().mockReturnValue(mockMessageBus);
+    mockConfig.getEnableHooks = vi.fn().mockReturnValue(false);
+    mockConfig.getHookSystem = vi
+      .fn()
+      .mockReturnValue(new HookSystem(mockConfig));
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+    });
+
+    const abortController = new AbortController();
+    const request = {
+      callId: '1',
+      name: 'mockModifiableTool',
+      args: {},
+      isClientInitiated: false,
+      prompt_id: 'prompt-id-3',
+    };
+
+    await scheduler.schedule([request], abortController.signal);
+
+    const awaitingCall = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+    const confirmationDetails = awaitingCall.confirmationDetails;
+
+    if (confirmationDetails) {
+      // Send empty string as newContent to verify it's not treated as falsy
+      const payload: ToolConfirmationPayload = { newContent: '' };
+      await confirmationDetails.onConfirm(
+        ToolConfirmationOutcome.ProceedOnce,
+        payload,
+      );
+    }
+
+    // Wait for the tool execution to complete
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalled();
+    });
+
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls[0].status).toBe('success');
+    expect(mockTool.executeFn).toHaveBeenCalledWith({
+      newContent: '',
+    });
+  });
 });
 
 class MockEditToolInvocation extends BaseToolInvocation<

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -20,6 +20,7 @@ import type {
   Config,
   ToolRegistry,
   AnyToolInvocation,
+  ToolCallResponseInfo,
 } from '../index.js';
 import {
   DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
@@ -849,6 +850,96 @@ describe('CoreToolScheduler edit cancellation', () => {
       '--- test.txt\n+++ test.txt\n@@ -1,1 +1,1 @@\n-old content\n+new content',
     );
     expect(cancelledCall.response.resultDisplay.fileName).toBe('test.txt');
+  });
+
+  it('should handle user feedback correctly', async () => {
+    const mockEditTool = new MockEditTool();
+    const mockToolRegistry = {
+      getTool: () => mockEditTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => mockEditTool,
+      getToolByDisplayName: () => mockEditTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsComplete = vi.fn();
+    const onToolCallsUpdate = vi.fn();
+
+    const mockConfig = createMockConfig({
+      getToolRegistry: () => mockToolRegistry,
+    });
+    const mockMessageBus = createMockMessageBus();
+    mockConfig.getMessageBus = vi.fn().mockReturnValue(mockMessageBus);
+    mockConfig.getEnableHooks = vi.fn().mockReturnValue(false);
+    mockConfig.getHookSystem = vi
+      .fn()
+      .mockReturnValue(new HookSystem(mockConfig));
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+    });
+
+    const abortController = new AbortController();
+    const request = {
+      callId: 'feedback-1',
+      name: 'mockEditTool',
+      args: {},
+      isClientInitiated: false,
+      prompt_id: 'prompt-id-feedback',
+    };
+
+    await scheduler.schedule([request], abortController.signal);
+
+    const awaitingCall = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+
+    // Provide feedback
+    const confirmationDetails = awaitingCall.confirmationDetails;
+    if (confirmationDetails) {
+      await confirmationDetails.onConfirm(ToolConfirmationOutcome.Feedback, {
+        feedback: 'Please use a different file name',
+      });
+    }
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalled();
+    });
+
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+
+    expect(completedCalls[0].status).toBe('success');
+    const response = (
+      completedCalls[0] as unknown as {
+        response: ToolCallResponseInfo;
+      }
+    ).response;
+    expect(response.error).toBeDefined();
+    expect(response.errorType).toBe('user_feedback');
+    expect(response.resultDisplay).toBe(
+      'Feedback provided: Please use a different file name',
+    );
+    const functionResponse = response.responseParts[0].functionResponse;
+    expect(functionResponse).toBeDefined();
+    // @ts-expect-error accessing internal structure
+    const llmOutput = functionResponse.response['output'];
+    expect(llmOutput).toContain(
+      '[User Feedback] Please use a different file name',
+    );
+    expect(llmOutput).toContain(
+      'Instruction: The user provided corrective feedback',
+    );
   });
 });
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -798,7 +798,7 @@ export class CoreToolScheduler {
       }
     } else {
       // If the client provided new content, apply it before scheduling.
-      if (payload?.newContent && toolCall) {
+      if (payload?.newContent !== undefined && toolCall) {
         await this._applyInlineModify(
           toolCall as WaitingToolCall,
           payload,
@@ -833,7 +833,7 @@ export class CoreToolScheduler {
       toolCall.request.args,
     );
 
-    const newContent = payload.newContent || currentContent;
+    const newContent = payload.newContent ?? currentContent;
 
     const updatedParams = modifyContext.createUpdatedParams(
       currentContent,

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -710,7 +710,10 @@ export class CoreToolScheduler {
 
   async handleConfirmationResponse(
     callId: string,
-    originalOnConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>,
+    originalOnConfirm: (
+      outcome: ToolConfirmationOutcome,
+      payload?: ToolConfirmationPayload,
+    ) => Promise<void>,
     outcome: ToolConfirmationOutcome,
     signal: AbortSignal,
     payload?: ToolConfirmationPayload,
@@ -720,7 +723,7 @@ export class CoreToolScheduler {
     );
 
     if (toolCall && toolCall.status === 'awaiting_approval') {
-      await originalOnConfirm(outcome);
+      await originalOnConfirm(outcome, payload);
     }
 
     this.setToolCallOutcome(callId, outcome);

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -729,6 +729,34 @@ export class CoreToolScheduler {
       // Instead of just cancelling one tool, trigger the full cancel cascade.
       this.cancelAll(signal);
       return; // `cancelAll` calls `checkAndNotifyCompletion`, so we can exit here.
+    } else if (outcome === ToolConfirmationOutcome.Feedback) {
+      const feedback =
+        payload?.feedback ||
+        'User denied this action with unspecified feedback.';
+
+      const toolName = toolCall?.request.name || 'unknown_tool';
+      const requestCallId = toolCall?.request.callId || callId;
+
+      // Create a result that looks like a tool execution but contains the feedback
+      const feedbackResponse: ToolCallResponseInfo = {
+        callId: requestCallId,
+        responseParts: convertToFunctionResponse(
+          toolName,
+          requestCallId,
+          `[User Feedback] ${feedback}\nInstruction: The user provided corrective feedback for this specific tool call. Do not repeat the exact same call. Adjust your plan and parameters based on this feedback.`,
+          this.config.getActiveModel(),
+        ),
+        // We set an error property so consumers know it wasn't a "success" in the traditional sense,
+        // but the scheduler treats it as a "success" status because the *operation of handling the tool* is complete.
+        resultDisplay: `Feedback provided: ${feedback}`,
+        error: new Error(feedback),
+        errorType: ToolErrorType.USER_FEEDBACK,
+        contentLength: feedback.length,
+      };
+
+      this.setStatusInternal(callId, 'success', signal, feedbackResponse);
+      await this.checkAndNotifyCompletion(signal);
+      return;
     } else if (outcome === ToolConfirmationOutcome.ModifyWithEditor) {
       const waitingToolCall = toolCall as WaitingToolCall;
       if (isModifiableDeclarativeTool(waitingToolCall.tool)) {
@@ -805,15 +833,17 @@ export class CoreToolScheduler {
       toolCall.request.args,
     );
 
+    const newContent = payload.newContent || currentContent;
+
     const updatedParams = modifyContext.createUpdatedParams(
       currentContent,
-      payload.newContent,
+      newContent,
       toolCall.request.args,
     );
     const updatedDiff = Diff.createPatch(
       modifyContext.getFilePath(toolCall.request.args),
       currentContent,
-      payload.newContent,
+      newContent,
       'Current',
       'Proposed',
     );

--- a/packages/core/src/tools/tool-error.ts
+++ b/packages/core/src/tools/tool-error.ts
@@ -71,6 +71,9 @@ export enum ToolErrorType {
 
   // WebSearch-specific Errors
   WEB_SEARCH_FAILED = 'web_search_failed',
+
+  // User Feedback
+  USER_FEEDBACK = 'user_feedback',
 }
 
 /**

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -683,7 +683,8 @@ export interface ToolEditConfirmationDetails {
 export interface ToolConfirmationPayload {
   // used to override `modifiedProposedContent` for modifiable tools in the
   // inline modify flow
-  newContent: string;
+  newContent?: string;
+  feedback?: string;
 }
 
 export interface ToolExecuteConfirmationDetails {
@@ -725,6 +726,7 @@ export enum ToolConfirmationOutcome {
   ProceedAlwaysTool = 'proceed_always_tool',
   ModifyWithEditor = 'modify_with_editor',
   Cancel = 'cancel',
+  Feedback = 'feedback',
 }
 
 export enum Kind {

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -690,7 +690,10 @@ export interface ToolConfirmationPayload {
 export interface ToolExecuteConfirmationDetails {
   type: 'exec';
   title: string;
-  onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
+  onConfirm: (
+    outcome: ToolConfirmationOutcome,
+    payload?: ToolConfirmationPayload,
+  ) => Promise<void>;
   command: string;
   rootCommand: string;
 }
@@ -701,13 +704,19 @@ export interface ToolMcpConfirmationDetails {
   serverName: string;
   toolName: string;
   toolDisplayName: string;
-  onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
+  onConfirm: (
+    outcome: ToolConfirmationOutcome,
+    payload?: ToolConfirmationPayload,
+  ) => Promise<void>;
 }
 
 export interface ToolInfoConfirmationDetails {
   type: 'info';
   title: string;
-  onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
+  onConfirm: (
+    outcome: ToolConfirmationOutcome,
+    payload?: ToolConfirmationPayload,
+  ) => Promise<void>;
   prompt: string;
   urls?: string[];
 }


### PR DESCRIPTION
## Summary

This PR introduces a "Feedback" flow for tool confirmations, allowing users to reject a tool call with specific instructions (e.g., "Use a different file name") instead of just cancelling. This feedback is returned to the LLM as a tool result, enabling it to correct its course immediately.

## Details

- **Core Logic**: Implemented `ToolConfirmationOutcome.Feedback` handling in `CoreToolScheduler`. Instead of executing the tool, it returns a successful tool result containing the user's feedback as an error message, instructing the model to adjust.
- **CLI UI**: Updated `ToolConfirmationMessage` to include a "Give feedback (f)" option.
  - Pressing `f` (configurable via `toggleFeedback` command) switches the view to a text input.
  - Submitting feedback sends the payload to the core.
  - Cancelling feedback (Esc) returns to the standard confirmation options.
- **Key Bindings**: Added `toggleFeedback` command (default `f`) to `keyBindings.ts` and updated documentation.
- **Zed Integration**: Updated `zedIntegration.ts` to return an error response if `Feedback` is encountered, preventing accidental execution (though the UI option isn't exposed there yet).

## Demo

https://github.com/user-attachments/assets/d2395d95-d7c2-44b8-aca2-06c04fc706f3

## How to Validate

1. Run `npm start` to launch the CLI.
2. Prompt the model to perform an action that triggers a tool call (e.g., "List files in the current directory").
3. When the confirmation dialog appears:
   - Verify "Give feedback (f)" is listed.
   - Press `f` to enter feedback mode.
   - Type an instruction (e.g., "Don't list files, just say hello").
   - Press Enter.
4. Verify the model acknowledges the feedback and adjusts its behavior (e.g., says "Hello" instead of listing files).

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (Keybindings docs updated)
- [x] Added/updated tests (UI interaction tests and Core scheduler logic tests)
- [ ] Noted breaking changes (None)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
